### PR TITLE
Remove total cap from Iroh endpoint bindings

### DIFF
--- a/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohBrokerModels.swift
+++ b/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohBrokerModels.swift
@@ -215,11 +215,6 @@ public struct CmxIrohLANRendezvous: Codable, Equatable, Sendable {
 
 /// Authenticated registry snapshot used for endpoint discovery and grant verification.
 public struct CmxIrohDiscoveryResponse: Decodable, Equatable, Sendable {
-    /// Upper bound for one authenticated account snapshot. Production accounts
-    /// remain server-limited to 32; development accounts may use this larger,
-    /// still-bounded snapshot for concurrent tagged builds.
-    public static let maximumBindingCount = 256
-
     public let routeContractVersion: Int
     public let bindings: [CmxIrohBrokerBinding]
     public let relayFleet: [String]
@@ -239,8 +234,7 @@ public struct CmxIrohDiscoveryResponse: Decodable, Equatable, Sendable {
         let routeContractVersion = try container.decode(Int.self, forKey: .routeContractVersion)
         let bindings = try container.decode([CmxIrohBrokerBinding].self, forKey: .bindings)
         let relayFleet = try container.decode([String].self, forKey: .relayFleet)
-        guard bindings.count <= Self.maximumBindingCount,
-              Set(bindings.map(\.bindingID)).count == bindings.count,
+        guard Set(bindings.map(\.bindingID)).count == bindings.count,
               (1 ... CmxIrohRelayPolicyVerifier.maximumRelayCount).contains(
                   relayFleet.count
               ),
@@ -258,6 +252,20 @@ public struct CmxIrohDiscoveryResponse: Decodable, Equatable, Sendable {
             CmxIrohGrantVerificationKeySet.self,
             forKey: .grantVerificationKeys
         )
+    }
+
+    init(
+        routeContractVersion: Int,
+        bindings: [CmxIrohBrokerBinding],
+        relayFleet: [String],
+        lanRendezvous: CmxIrohLANRendezvous,
+        grantVerificationKeys: CmxIrohGrantVerificationKeySet
+    ) {
+        self.routeContractVersion = routeContractVersion
+        self.bindings = bindings
+        self.relayFleet = relayFleet
+        self.lanRendezvous = lanRendezvous
+        self.grantVerificationKeys = grantVerificationKeys
     }
 
     private static func isCanonicalRelayURL(_ value: String) -> Bool {

--- a/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohClientOfflinePolicyCache.swift
+++ b/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohClientOfflinePolicyCache.swift
@@ -63,9 +63,10 @@ public actor CmxIrohClientOfflinePolicyCache {
            record.version == CmxIrohStoredClientPolicyRecord.currentVersion,
            record.scopeDigest == Self.scopeDigest(for: expectation),
            Self.sameAuthority(record.localBinding, localBinding) {
+            let currentBindings = Self.bindingAuthorityIndex(discovery.bindings)
             for stored in record.targets {
                 guard let fresh = Self.uniqueBinding(
-                    in: discovery.bindings,
+                    in: currentBindings,
                     matchingAuthorityOf: stored.binding
                 ),
                     fresh.platform == .mac,
@@ -288,9 +289,10 @@ public actor CmxIrohClientOfflinePolicyCache {
         now: Date
     ) throws -> CmxIrohStoredClientPolicyRecord {
         var targets: [CmxIrohStoredClientPolicyTarget] = []
+        let currentBindings = Self.bindingAuthorityIndex(currentTargets)
         for stored in record.targets {
             guard let current = Self.uniqueBinding(
-                in: currentTargets,
+                in: currentBindings,
                 matchingAuthorityOf: stored.binding
             ),
                 current.platform == .mac,
@@ -417,12 +419,35 @@ public actor CmxIrohClientOfflinePolicyCache {
         }
     }
 
+    private static func bindingAuthorityIndex(
+        _ bindings: [CmxIrohBrokerBinding]
+    ) -> (
+        byBindingID: [String: CmxIrohBrokerBinding],
+        duplicateBindingIDs: Set<String>
+    ) {
+        var byBindingID: [String: CmxIrohBrokerBinding] = [:]
+        var duplicateBindingIDs: Set<String> = []
+        for binding in bindings {
+            if byBindingID.updateValue(binding, forKey: binding.bindingID) != nil {
+                duplicateBindingIDs.insert(binding.bindingID)
+            }
+        }
+        return (byBindingID, duplicateBindingIDs)
+    }
+
     private static func uniqueBinding(
-        in bindings: [CmxIrohBrokerBinding],
+        in index: (
+            byBindingID: [String: CmxIrohBrokerBinding],
+            duplicateBindingIDs: Set<String>
+        ),
         matchingAuthorityOf expected: CmxIrohBrokerBinding
     ) -> CmxIrohBrokerBinding? {
-        let matches = bindings.filter { sameAuthority($0, expected) }
-        return matches.count == 1 ? matches[0] : nil
+        guard !index.duplicateBindingIDs.contains(expected.bindingID),
+              let binding = index.byBindingID[expected.bindingID],
+              sameAuthority(binding, expected) else {
+            return nil
+        }
+        return binding
     }
 
     private static func sameAuthority(

--- a/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohClientOfflinePolicyCache.swift
+++ b/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohClientOfflinePolicyCache.swift
@@ -2,9 +2,8 @@ import CryptoKit
 public import CMUXMobileCore
 public import Foundation
 
-/// Stores a bounded set of signed pair authorities for connectivity-only fallback.
+/// Stores signed pair authorities for connectivity-only fallback.
 public actor CmxIrohClientOfflinePolicyCache {
-    public static let maximumTargetCount = CmxIrohDiscoveryResponse.maximumBindingCount
     private static let storageAccount = "active-client-policies"
 
     private let secureStore: any CmxIrohSecureCredentialStoring
@@ -24,7 +23,7 @@ public actor CmxIrohClientOfflinePolicyCache {
         self.verifier = verifier
     }
 
-    /// Merges one online-verified target into the bounded active-account cache.
+    /// Merges one online-verified target into the active-account cache.
     public func save(
         localBinding: CmxIrohBrokerBinding,
         targetBinding: CmxIrohBrokerBinding,
@@ -94,9 +93,6 @@ public actor CmxIrohClientOfflinePolicyCache {
                 && $0.binding.endpointID != targetBinding.endpointID
                 && $0.binding.bindingID != targetBinding.bindingID
         })
-        if merged.count > Self.maximumTargetCount {
-            merged.removeLast(merged.count - Self.maximumTargetCount)
-        }
         let record = CmxIrohStoredClientPolicyRecord(
             version: CmxIrohStoredClientPolicyRecord.currentVersion,
             scopeDigest: Self.scopeDigest(for: expectation),
@@ -265,7 +261,6 @@ public actor CmxIrohClientOfflinePolicyCache {
             let record = try JSONDecoder().decode(CmxIrohStoredClientPolicyRecord.self, from: data)
             guard record.version == CmxIrohStoredClientPolicyRecord.currentVersion,
                   record.scopeDigest == Self.scopeDigest(for: expectation),
-                  record.targets.count <= Self.maximumTargetCount,
                   Set(record.relayFleet) == expectation.managedRelayURLs,
                   record.relayFleet.count == expectation.managedRelayURLs.count,
                   expectation.localBindingExpectation.matches(record.localBinding),
@@ -318,7 +313,7 @@ public actor CmxIrohClientOfflinePolicyCache {
             relayFleet: record.relayFleet,
             grantVerificationKeys: keys,
             lanRendezvous: lanRendezvous,
-            targets: Array(targets.prefix(Self.maximumTargetCount))
+            targets: targets
         )
     }
 

--- a/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohDiscoveryPage.swift
+++ b/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohDiscoveryPage.swift
@@ -1,0 +1,48 @@
+import Foundation
+
+/// One bounded broker response page used to assemble an account discovery.
+struct CmxIrohDiscoveryPage: Decodable, Sendable {
+    static let bindingLimit = 128
+    static let legacyBindingLimit = 256
+    private static let cursorByteLimit = 256
+
+    let discovery: CmxIrohDiscoveryResponse
+    let nextCursor: String?
+
+    private enum CodingKeys: String, CodingKey {
+        case nextCursor = "next_cursor"
+    }
+
+    init(from decoder: any Decoder) throws {
+        let discovery = try CmxIrohDiscoveryResponse(from: decoder)
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let nextCursor = try container.decodeIfPresent(String.self, forKey: .nextCursor)
+        let validCursor = nextCursor.map(Self.isSafeCursor) ?? true
+        let validCount = if nextCursor == nil {
+            discovery.bindings.count <= Self.legacyBindingLimit
+        } else {
+            discovery.bindings.count == Self.bindingLimit
+        }
+        guard validCursor, validCount else {
+            throw DecodingError.dataCorrupted(
+                .init(
+                    codingPath: decoder.codingPath,
+                    debugDescription: "Invalid Iroh discovery page"
+                )
+            )
+        }
+        self.discovery = discovery
+        self.nextCursor = nextCursor
+    }
+
+    private static func isSafeCursor(_ value: String) -> Bool {
+        (1 ... cursorByteLimit).contains(value.utf8.count)
+            && value.utf8.allSatisfy { byte in
+                (48 ... 57).contains(byte)
+                    || (65 ... 90).contains(byte)
+                    || (97 ... 122).contains(byte)
+                    || byte == 45
+                    || byte == 95
+            }
+    }
+}

--- a/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohLANDiscoveryResolver.swift
+++ b/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohLANDiscoveryResolver.swift
@@ -62,8 +62,7 @@ public struct CmxIrohLANDiscoveryResolver: Sendable {
                     == cmxCanonicalDeviceID(expectedMacDeviceID)
                 && (expectedEndpointID == nil || binding.endpointID == expectedEndpointID)
         }
-        guard !candidates.isEmpty,
-              candidates.count <= CmxIrohDiscoveryResponse.maximumBindingCount else {
+        guard !candidates.isEmpty else {
             throw CmxIrohLANDiscoveryError.ambiguousBinding
         }
         let aliasGenerator = try CmxIrohLANRendezvousAliasGenerator(rendezvous: rendezvous)

--- a/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohLANPeerDiscovery.swift
+++ b/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohLANPeerDiscovery.swift
@@ -112,9 +112,6 @@ public actor CmxIrohLANPeerDiscovery {
         expectedEndpointID: CmxIrohPeerIdentity,
         timeout: TimeInterval = 0.75
     ) async -> CmxIrohLANPeerDiscoveryOutcome {
-        guard authenticatedBindings.count <= CmxIrohDiscoveryResponse.maximumBindingCount else {
-            return .notFound
-        }
         let path = await networkPath()
         let key = RequestKey(
             deviceID: cmxCanonicalDeviceID(expectedMacDeviceID),

--- a/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohLANRendezvousAliasGenerator.swift
+++ b/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohLANRendezvousAliasGenerator.swift
@@ -57,8 +57,7 @@ public struct CmxIrohLANRendezvousAliasGenerator: Sendable {
         among candidates: [CmxIrohBrokerBindingMetadata],
         at date: Date
     ) throws -> CmxIrohBrokerBindingMetadata? {
-        guard Self.isCanonicalAlias(alias),
-              candidates.count <= CmxIrohDiscoveryResponse.maximumBindingCount else {
+        guard Self.isCanonicalAlias(alias) else {
             return nil
         }
         var match: CmxIrohBrokerBindingMetadata?

--- a/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohRegistryContextProvider.swift
+++ b/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohRegistryContextProvider.swift
@@ -495,8 +495,7 @@ public actor CmxIrohRegistryContextProvider: CmxIrohClientContextProvider {
             $0.platform == .mac && $0.pairingEnabled
         }
         let counts = Dictionary(grouping: pairableMacs, by: \.endpointID).mapValues(\.count)
-        for target in pairableMacs.prefix(CmxIrohDiscoveryResponse.maximumBindingCount)
-        where counts[target.endpointID] == 1 {
+        for target in pairableMacs where counts[target.endpointID] == 1 {
             replacement[target.endpointID] = CmxIrohRegistryLANAuthority(
                 target: target,
                 bindings: discovery.bindings,
@@ -517,12 +516,6 @@ public actor CmxIrohRegistryContextProvider: CmxIrohClientContextProvider {
             bindings: bindings ?? [policy.targetBinding],
             rendezvous: policy.lanRendezvous
         )
-        if lanAuthorities.count > CmxIrohDiscoveryResponse.maximumBindingCount {
-            let keep = Set(lanAuthorities.keys.sorted {
-                $0.endpointID < $1.endpointID
-            }.prefix(CmxIrohDiscoveryResponse.maximumBindingCount))
-            lanAuthorities = lanAuthorities.filter { keep.contains($0.key) }
-        }
     }
 
     public func validatePrivateFallback(

--- a/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohTrustBrokerClient.swift
+++ b/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohTrustBrokerClient.swift
@@ -218,11 +218,9 @@ public actor CmxIrohTrustBrokerClient: CmxIrohRelayPolicyServing {
     }
 
     public func discover() async throws -> CmxIrohDiscoveryResponse {
-        try await sendWithoutBody(
-            path: "api/devices/iroh",
-            method: "GET",
-            operation: .discovery
-        )
+        try await withBackpressure(operation: .discovery) {
+            try await self.discoverAllPages()
+        }
     }
 
     public func issuePairGrant(
@@ -356,6 +354,66 @@ public actor CmxIrohTrustBrokerClient: CmxIrohRelayPolicyServing {
         }
     }
 
+    private func discoverAllPages() async throws -> CmxIrohDiscoveryResponse {
+        var bindings: [CmxIrohBrokerBinding] = []
+        var bindingIDs: Set<String> = []
+        var seenCursors: Set<String> = []
+        var cursor: String?
+        var first: CmxIrohDiscoveryResponse?
+
+        repeat {
+            var queryItems = [
+                URLQueryItem(
+                    name: "page_size",
+                    value: String(CmxIrohDiscoveryPage.bindingLimit)
+                ),
+            ]
+            if let cursor {
+                queryItems.append(URLQueryItem(name: "cursor", value: cursor))
+            }
+            let page: CmxIrohDiscoveryPage = try await performRequest(
+                path: "api/devices/iroh",
+                method: "GET",
+                body: nil,
+                queryItems: queryItems
+            )
+            if let first {
+                guard page.discovery.routeContractVersion == first.routeContractVersion,
+                      page.discovery.relayFleet == first.relayFleet,
+                      page.discovery.lanRendezvous == first.lanRendezvous,
+                      page.discovery.grantVerificationKeys
+                        == first.grantVerificationKeys else {
+                    throw CmxIrohTrustBrokerClientError.invalidResponse
+                }
+            } else {
+                first = page.discovery
+            }
+            for binding in page.discovery.bindings {
+                guard bindingIDs.insert(binding.bindingID).inserted else {
+                    throw CmxIrohTrustBrokerClientError.invalidResponse
+                }
+                bindings.append(binding)
+            }
+            if let nextCursor = page.nextCursor {
+                guard seenCursors.insert(nextCursor).inserted else {
+                    throw CmxIrohTrustBrokerClientError.invalidResponse
+                }
+            }
+            cursor = page.nextCursor
+        } while cursor != nil
+
+        guard let first else {
+            throw CmxIrohTrustBrokerClientError.invalidResponse
+        }
+        return CmxIrohDiscoveryResponse(
+            routeContractVersion: first.routeContractVersion,
+            bindings: bindings,
+            relayFleet: first.relayFleet,
+            lanRendezvous: first.lanRendezvous,
+            grantVerificationKeys: first.grantVerificationKeys
+        )
+    }
+
     private func sendUngated<Response: Decodable & Sendable, Body: Encodable>(
         path: String,
         method: String,
@@ -383,7 +441,8 @@ public actor CmxIrohTrustBrokerClient: CmxIrohRelayPolicyServing {
     private func performRequest<Response: Decodable & Sendable>(
         path: String,
         method: String,
-        body: Data?
+        body: Data?,
+        queryItems: [URLQueryItem] = []
     ) async throws -> Response {
         // Build the request from ONE credential snapshot. Reading access then
         // refresh through two independent calls lets a force refresh land
@@ -397,7 +456,17 @@ public actor CmxIrohTrustBrokerClient: CmxIrohRelayPolicyServing {
         guard Self.isSafeHeaderValue(accessToken), Self.isSafeHeaderValue(refreshToken) else {
             throw CmxIrohTrustBrokerClientError.invalidAuthentication
         }
-        let url = baseURL.appendingPathComponent(path)
+        let pathURL = baseURL.appendingPathComponent(path)
+        guard var components = URLComponents(
+            url: pathURL,
+            resolvingAgainstBaseURL: false
+        ) else {
+            throw CmxIrohTrustBrokerClientError.invalidResponse
+        }
+        components.queryItems = queryItems.isEmpty ? nil : queryItems
+        guard let url = components.url else {
+            throw CmxIrohTrustBrokerClientError.invalidResponse
+        }
         var request = URLRequest(url: url)
         request.httpMethod = method
         request.timeoutInterval = requestTimeout

--- a/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohTrustBrokerClientTests.swift
+++ b/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohTrustBrokerClientTests.swift
@@ -381,9 +381,93 @@ struct CmxIrohTrustBrokerClientTests {
     }
 
     @Test
-    func discoveryRejectsBindingsAboveDevelopmentQuota() async throws {
+    func discoveryTraversesMoreThanLegacyBindingLimitAcrossBoundedPages() async throws {
         let transport = RecordingBrokerTransport(responses: [
-            .json(status: 200, body: try Self.discoveryResponse(bindingCount: 257)),
+            .json(
+                status: 200,
+                body: try Self.discoveryResponse(
+                    bindingRange: 1 ..< 129,
+                    nextCursor: "cursor-1"
+                )
+            ),
+            .json(
+                status: 200,
+                body: try Self.discoveryResponse(
+                    bindingRange: 129 ..< 257,
+                    nextCursor: "cursor-2"
+                )
+            ),
+            .json(
+                status: 200,
+                body: try Self.discoveryResponse(
+                    bindingRange: 257 ..< 301,
+                    nextCursor: nil
+                )
+            ),
+        ])
+        let client = try makeClient(transport: transport)
+
+        let discovery = try await client.discover()
+
+        #expect(discovery.bindings.count == 300)
+        #expect(Set(discovery.bindings.map(\.bindingID)).count == 300)
+        let requests = await transport.requests()
+        #expect(requests.count == 3)
+        #expect(requests.map { $0.url?.query } == [
+            "page_size=128",
+            "page_size=128&cursor=cursor-1",
+            "page_size=128&cursor=cursor-2",
+        ])
+    }
+
+    @Test
+    func discoveryKeepsLegacyUnpaginatedResponseBounded() async throws {
+        let transport = RecordingBrokerTransport(responses: [
+            .json(status: 200, body: try Self.discoveryResponse(bindingCount: 256)),
+        ])
+        let client = try makeClient(transport: transport)
+
+        let discovery = try await client.discover()
+
+        #expect(discovery.bindings.count == 256)
+        #expect(await transport.requests().count == 1)
+    }
+
+    @Test
+    func discoveryRejectsOversizedPaginatedResponse() async throws {
+        let transport = RecordingBrokerTransport(responses: [
+            .json(
+                status: 200,
+                body: try Self.discoveryResponse(
+                    bindingRange: 1 ..< 130,
+                    nextCursor: "cursor-1"
+                )
+            ),
+        ])
+        let client = try makeClient(transport: transport)
+
+        await #expect(throws: CmxIrohTrustBrokerClientError.invalidResponse) {
+            _ = try await client.discover()
+        }
+    }
+
+    @Test
+    func discoveryRejectsRepeatedCursorWithoutTotalPageCap() async throws {
+        let transport = RecordingBrokerTransport(responses: [
+            .json(
+                status: 200,
+                body: try Self.discoveryResponse(
+                    bindingRange: 1 ..< 129,
+                    nextCursor: "cursor-1"
+                )
+            ),
+            .json(
+                status: 200,
+                body: try Self.discoveryResponse(
+                    bindingRange: 129 ..< 257,
+                    nextCursor: "cursor-1"
+                )
+            ),
         ])
         let client = try makeClient(transport: transport)
 
@@ -475,13 +559,23 @@ struct CmxIrohTrustBrokerClientTests {
     }
 
     private static func discoveryResponse(bindingCount: Int) throws -> String {
+        try discoveryResponse(
+            bindingRange: 1 ..< (bindingCount + 1),
+            nextCursor: nil
+        )
+    }
+
+    private static func discoveryResponse(
+        bindingRange: Range<Int>,
+        nextCursor: String?
+    ) throws -> String {
         var object = try #require(
             JSONSerialization.jsonObject(
                 with: Data(discoveryResponse.utf8)
             ) as? [String: Any]
         )
         let template = try #require((object["bindings"] as? [[String: Any]])?.first)
-        object["bindings"] = (1 ... bindingCount).map { index in
+        object["bindings"] = bindingRange.map { index in
             var binding = template
             binding["binding_id"] = String(
                 format: "123e4567-e89b-42d3-a456-%012d",
@@ -493,6 +587,11 @@ struct CmxIrohTrustBrokerClientTests {
             )
             binding["endpoint_id"] = String(format: "%064llx", UInt64(index))
             return binding
+        }
+        if let nextCursor {
+            object["next_cursor"] = nextCursor
+        } else {
+            object["next_cursor"] = NSNull()
         }
         let data = try JSONSerialization.data(withJSONObject: object)
         return try #require(String(data: data, encoding: .utf8))

--- a/ios/cmuxPackage/Sources/cmuxFeature/MobileIrohRouteCatalog.swift
+++ b/ios/cmuxPackage/Sources/cmuxFeature/MobileIrohRouteCatalog.swift
@@ -4,7 +4,7 @@ import CmuxMobileShell
 import CmuxMobileShellModel
 import Foundation
 
-/// One bounded personal-account snapshot of authenticated Iroh Mac routes.
+/// One personal-account snapshot of authenticated Iroh Mac routes.
 ///
 /// The catalog is deliberately separate from the team device registry. It only
 /// supplies cached routes when the shell asks for an already-paired Mac,
@@ -65,7 +65,7 @@ public actor MobileIrohRouteCatalog {
         let timestampParser = TimestampParser()
         let pairableMacs = bindings.filter {
             $0.platform == .mac && $0.pairingEnabled
-        }.prefix(CmxIrohDiscoveryResponse.maximumBindingCount)
+        }
         let endpointCounts = Dictionary(
             grouping: pairableMacs,
             by: \CmxIrohBrokerBinding.endpointID
@@ -116,7 +116,7 @@ public actor MobileIrohRouteCatalog {
         let timestampParser = TimestampParser()
         let pairableMacs = Array(bindings.filter {
             $0.platform == .mac && $0.pairingEnabled
-        }.prefix(CmxIrohDiscoveryResponse.maximumBindingCount))
+        })
         let endpointCounts = Dictionary(
             grouping: pairableMacs,
             by: \CmxIrohBrokerBinding.endpointID

--- a/ios/cmuxPackage/Sources/cmuxFeature/MobileIrohRuntimeComposition.swift
+++ b/ios/cmuxPackage/Sources/cmuxFeature/MobileIrohRuntimeComposition.swift
@@ -2774,9 +2774,8 @@ extension MobileIrohRuntimeComposition {
             if let instanceTag { return binding.tag == instanceTag }
             return true
         }
-        // Bound the WHOLE operation. A discovery snapshot allows up to 256
-        // bindings and each revoke request carries its own network timeout, so
-        // an unbounded sequential loop could keep the forget (and its UI
+        // Bound the WHOLE operation. Each revoke request carries its own network
+        // timeout, so a large sequential loop could keep the forget (and its UI
         // progress state) busy for tens of minutes. Past the deadline, stop and
         // surface the failure: already-applied revokes stand, and retrying the
         // forget re-discovers and revokes only what remains.

--- a/ios/cmuxPackage/Tests/cmuxFeatureTests/MobileIrohRuntimeCompositionTests.swift
+++ b/ios/cmuxPackage/Tests/cmuxFeatureTests/MobileIrohRuntimeCompositionTests.swift
@@ -171,8 +171,8 @@ struct MobileIrohRuntimeCompositionTests {
     }
 
     @Test
-    func discoveryCatalogRetainsFortyConcurrentDevelopmentBindings() async throws {
-        let bindings = (0..<40).map { index in
+    func discoveryCatalogRetainsBindingsBeyondLegacyPageLimit() async throws {
+        let bindings = (0..<300).map { index in
             mobileIrohBinding(
                 bindingID: String(format: "00000000-0000-4000-8000-%012d", index),
                 deviceID: String(format: "10000000-0000-4000-8000-%012d", index),
@@ -187,7 +187,7 @@ struct MobileIrohRuntimeCompositionTests {
         await catalog.activate(scope: 1)
         await catalog.replace(with: discovery, scope: 1)
 
-        for index in 0..<40 {
+        for index in 0..<300 {
             let deviceID = String(format: "10000000-0000-4000-8000-%012d", index)
             #expect(await catalog.routes(
                 forKnownMacDeviceID: deviceID,

--- a/web/db/migrations/20260730200000_iroh_binding_discovery_pages/migration.sql
+++ b/web/db/migrations/20260730200000_iroh_binding_discovery_pages/migration.sql
@@ -1,0 +1,3 @@
+CREATE INDEX "iroh_endpoint_bindings_user_active_page_idx"
+  ON "iroh_endpoint_bindings" ("user_id", "id")
+  WHERE "revoked_at" IS NULL;

--- a/web/db/schema.ts
+++ b/web/db/schema.ts
@@ -766,6 +766,9 @@ export const irohEndpointBindings = pgTable(
     index("iroh_endpoint_bindings_user_active_idx")
       .on(table.userId, table.updatedAt)
       .where(sql`${table.revokedAt} is null`),
+    index("iroh_endpoint_bindings_user_active_page_idx")
+      .on(table.userId, table.id)
+      .where(sql`${table.revokedAt} is null`),
     index("iroh_endpoint_bindings_user_idx")
       .on(table.userId),
     index("iroh_endpoint_bindings_user_revoked_idx")

--- a/web/services/iroh/README.md
+++ b/web/services/iroh/README.md
@@ -34,23 +34,24 @@ defensively.
 
 The LAN rendezvous key is HMAC-derived from an independent random server secret,
 the exact Stack user id, and an account generation. Discovery reads active
-bindings and that generation in one transaction under the same account lock as
-registration and revocation, so it cannot mix tuples from opposite sides of a
-revocation. Every successful binding revoke increments the generation in the
-revocation transaction. Sign-out callers must invoke the authenticated revoke
-route with their captured binding id before discarding the Stack credential.
+bindings in stable UUID order, 128 rows per page. Its opaque cursor carries the
+generation and last binding id; registration and revocation rotate the
+generation whenever the active set changes, so a later page cannot mix tuples
+from opposite sides of a mutation. Legacy requests without `page_size` receive
+at most 256 bindings and no cursor, keeping old clients within their decoder
+limit while upgraded clients traverse every page. Sign-out callers must invoke
+the authenticated revoke route with their captured binding id before discarding
+the Stack credential.
 
-Postgres advisory locks make the authoritative limits concurrency-safe: six
-challenges per device per ten minutes, 32 outstanding challenges per account,
-32 active bindings per account, eight active bindings per physical device, 60
-pair grants per account per hour, three relay mints per endpoint per ten
-minutes, 12 relay mints per endpoint per day, and 100 relay mints per account
-per day. A relay reservation remains active for 60 seconds, then the next
-account-scoped reservation marks it expired before applying those quotas. The
-optional Vercel Firewall rule is defense in depth. A tagged-build
-device-limit override requires a server flag, an exact authenticated user-id
-allowlist match, and an exact deployment-environment allowlist match; it never
-raises the 32-binding account limit and records an audit marker on the binding.
+There is no total active-binding limit per account or device. Postgres advisory
+locks keep request-rate limits concurrency-safe: six challenges per device per
+ten minutes, 32 outstanding challenges per account, 60 pair grants per account
+per hour, three relay mints per endpoint per ten minutes, 12 relay mints per
+endpoint per day, and 100 relay mints per account per day. A relay reservation
+remains active for 60 seconds, then the next account-scoped reservation marks it
+expired before applying those quotas. The optional Vercel Firewall rule is
+defense in depth. A tagged-build override widens challenge issuance only after
+an exact authenticated user-id and deployment-environment allowlist match.
 
 Registration bootstraps a relay credential only when it creates a binding.
 Signed refreshes of the same binding return `relay.status = "not_requested"`;

--- a/web/services/iroh/config.ts
+++ b/web/services/iroh/config.ts
@@ -82,8 +82,8 @@ export function challengeQuotaForUser(
     return { account: 120, deviceInstance: 6, outstanding: 32 };
   }
   return {
-    // Give every allowed dev binding the normal per-instance launch budget,
-    // while retaining one bounded account fence against a runaway client.
+    // Give tagged dev launch bursts the normal per-instance launch budget,
+    // while retaining one bounded account request-rate fence.
     account: Math.max(
       120,
       Math.min(

--- a/web/services/iroh/discoveryPagination.ts
+++ b/web/services/iroh/discoveryPagination.ts
@@ -1,0 +1,127 @@
+import { IrohInvalidInputError } from "./errors";
+
+export const IROH_DISCOVERY_PAGE_SIZE = 128;
+export const IROH_LEGACY_DISCOVERY_PAGE_SIZE = 256;
+const IROH_DISCOVERY_CURSOR_MAX_BYTES = 256;
+
+export type IrohDiscoveryCursor = {
+  readonly generation: number;
+  readonly afterBindingId: string;
+};
+
+export type IrohDiscoveryRequest = {
+  readonly pageSize: number;
+  readonly cursor?: IrohDiscoveryCursor;
+  readonly paginated: boolean;
+};
+
+export function legacyIrohDiscoveryRequest(): IrohDiscoveryRequest {
+  return {
+    pageSize: IROH_LEGACY_DISCOVERY_PAGE_SIZE,
+    paginated: false,
+  };
+}
+
+export function parseIrohDiscoveryRequest(value: unknown): IrohDiscoveryRequest {
+  if (value === undefined) return legacyIrohDiscoveryRequest();
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new IrohInvalidInputError({ code: "invalid_discovery_page_size" });
+  }
+  const request = value as Record<string, unknown>;
+  if (Object.keys(request).some((key) => key !== "pageSize" && key !== "cursor")) {
+    throw new IrohInvalidInputError({ code: "invalid_discovery_page_size" });
+  }
+  const pageSize = canonicalPositiveInteger(request.pageSize);
+  if (pageSize === null || pageSize > IROH_DISCOVERY_PAGE_SIZE) {
+    throw new IrohInvalidInputError({ code: "invalid_discovery_page_size" });
+  }
+  return {
+    pageSize,
+    ...(request.cursor === undefined
+      ? {}
+      : { cursor: decodeIrohDiscoveryCursor(request.cursor) }),
+    paginated: true,
+  };
+}
+
+export function encodeIrohDiscoveryCursor(cursor: IrohDiscoveryCursor): string {
+  assertCursor(cursor);
+  return Buffer.from(JSON.stringify({
+    v: 1,
+    g: cursor.generation,
+    a: cursor.afterBindingId,
+  }), "utf8").toString("base64url");
+}
+
+export function decodeIrohDiscoveryCursor(value: unknown): IrohDiscoveryCursor {
+  if (
+    typeof value !== "string" ||
+    value.length === 0 ||
+    value.length > IROH_DISCOVERY_CURSOR_MAX_BYTES ||
+    !/^[A-Za-z0-9_-]+$/.test(value)
+  ) {
+    throw new IrohInvalidInputError({ code: "invalid_discovery_cursor" });
+  }
+  let parsed: unknown;
+  try {
+    const bytes = Buffer.from(value, "base64url");
+    if (
+      bytes.length === 0 ||
+      bytes.length > IROH_DISCOVERY_CURSOR_MAX_BYTES ||
+      bytes.toString("base64url") !== value
+    ) {
+      throw new Error("non-canonical cursor");
+    }
+    parsed = JSON.parse(bytes.toString("utf8"));
+  } catch {
+    throw new IrohInvalidInputError({ code: "invalid_discovery_cursor" });
+  }
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    throw new IrohInvalidInputError({ code: "invalid_discovery_cursor" });
+  }
+  const record = parsed as Record<string, unknown>;
+  if (
+    Object.keys(record).length !== 3 ||
+    record.v !== 1 ||
+    !Number.isSafeInteger(record.g) ||
+    (record.g as number) < 1 ||
+    (record.g as number) > 2_147_483_647 ||
+    !isCanonicalUUID(record.a)
+  ) {
+    throw new IrohInvalidInputError({ code: "invalid_discovery_cursor" });
+  }
+  return {
+    generation: record.g as number,
+    afterBindingId: record.a as string,
+  };
+}
+
+function canonicalPositiveInteger(value: unknown): number | null {
+  if (typeof value === "number") {
+    return Number.isSafeInteger(value) && value > 0 ? value : null;
+  }
+  if (
+    typeof value !== "string" ||
+    !/^[1-9][0-9]{0,2}$/.test(value)
+  ) {
+    return null;
+  }
+  const parsed = Number(value);
+  return Number.isSafeInteger(parsed) && String(parsed) === value ? parsed : null;
+}
+
+function assertCursor(cursor: IrohDiscoveryCursor): void {
+  if (
+    !Number.isSafeInteger(cursor.generation) ||
+    cursor.generation < 1 ||
+    cursor.generation > 2_147_483_647 ||
+    !isCanonicalUUID(cursor.afterBindingId)
+  ) {
+    throw new IrohInvalidInputError({ code: "invalid_discovery_cursor" });
+  }
+}
+
+function isCanonicalUUID(value: unknown): value is string {
+  return typeof value === "string" &&
+    /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/.test(value);
+}

--- a/web/services/iroh/repository.ts
+++ b/web/services/iroh/repository.ts
@@ -23,6 +23,7 @@ import {
 } from "./errors";
 import type { PairGrantPeer } from "./crypto";
 import type { IrohChallengeQuota } from "./config";
+import type { IrohDiscoveryCursor } from "./discoveryPagination";
 import {
   nextPathHintExpiry,
   parseIrohPathHint,
@@ -36,23 +37,6 @@ export const IROH_RETENTION_MAX_ROWS = 10_000;
 export const IROH_RETENTION_MAX_DURATION_MS = 8_000;
 export const IROH_ACCOUNT_CHALLENGE_LIMIT = 120;
 export const IROH_RELAY_RESERVATION_LEASE_MS = 60 * 1_000;
-// A backstop on how many active (non-revoked) endpoint bindings one account may
-// accumulate. Under the unique(user, device, tag) slot key a normal user holds a
-// handful of bindings and a heavy multi-tag developer at most low hundreds, so
-// this only trips on a stuck registration loop or abuse. When a genuinely new
-// slot would push the count over the cap, that registration is REJECTED
-// (`enforceActiveBindingSanityCap` throws IrohConflictError); the row set is
-// never evicted, so a churning client can never shed the account's real hosts.
-//
-// The cap is pinned to the client's discovery-snapshot wire limit: the iOS
-// decoder (CmxIrohDiscoveryResponse.maximumBindingCount) rejects any snapshot
-// carrying MORE than 256 bindings, and discoverySnapshot returns every active
-// binding for the account uncapped. Admitting a 257th active binding would make
-// the account's own discovery response undecodable on every client, wedging all
-// of that user's devices, so the broker refuses to grow past what the client can
-// receive. It still sits far above any legitimate multi-tag developer's slot
-// count while catching a runaway registration loop, which blows past it at once.
-export const IROH_ACTIVE_BINDING_SANITY_CAP = 256;
 
 export type IrohRetentionCategory =
   | "revokedHints"
@@ -111,12 +95,15 @@ export type IrohRepositoryShape = {
     readonly payload: IrohRegistrationPayload;
     readonly now: Date;
   }) => Effect.Effect<IrohRegistrationCommit, RepositoryError>;
-  readonly discoverySnapshot: (input: {
+  readonly discoveryPage: (input: {
     readonly userId: string;
     readonly now: Date;
+    readonly pageSize: number;
+    readonly cursor?: IrohDiscoveryCursor;
   }) => Effect.Effect<{
     readonly bindings: IrohBindingRecord[];
     readonly lanDiscoveryGeneration: number;
+    readonly nextCursor: IrohDiscoveryCursor | null;
   }, RepositoryError>;
   readonly findActiveBindings: (
     userId: string,
@@ -440,13 +427,6 @@ function makeLiveRepository(): IrohRepositoryShape {
             now: input.now,
             reason: "slot_reincarnated",
           });
-        } else {
-          // Only a genuinely new slot grows the account's active-binding count,
-          // so the sanity cap is enforced on this path alone.
-          await enforceActiveBindingSanityCap(tx, {
-            userId: input.userId,
-            now: input.now,
-          });
         }
 
         const [binding] = await tx
@@ -489,10 +469,27 @@ function makeLiveRepository(): IrohRepositoryShape {
         // audit point at a binding it was never signed for. The retired slot's live
         // grants were already marked revoked by revokeActiveBindings above.
 
-        await tx
-          .insert(irohAccountSecurityStates)
-          .values({ userId: input.userId, lanDiscoveryGeneration: 1, createdAt: input.now, updatedAt: input.now })
-          .onConflictDoNothing({ target: irohAccountSecurityStates.userId });
+        if (!existingSlot) {
+          // A new active row changes the set traversed by discovery. Rotate the
+          // generation so a cursor cannot combine pages around the insertion.
+          // Reincarnation already rotates through revokeActiveBindings above.
+          await tx
+            .insert(irohAccountSecurityStates)
+            .values({
+              userId: input.userId,
+              lanDiscoveryGeneration: 1,
+              createdAt: input.now,
+              updatedAt: input.now,
+            })
+            .onConflictDoUpdate({
+              target: irohAccountSecurityStates.userId,
+              set: {
+                lanDiscoveryGeneration:
+                  sql`${irohAccountSecurityStates.lanDiscoveryGeneration} + 1`,
+                updatedAt: input.now,
+              },
+            });
+        }
         await tx
           .update(irohRegistrationChallenges)
           .set({ consumedAt: input.now })
@@ -504,7 +501,7 @@ function makeLiveRepository(): IrohRepositoryShape {
       });
     }),
 
-    discoverySnapshot: (input) => repositoryEffect("discovery_snapshot", async () => {
+    discoveryPage: (input) => repositoryEffect("discovery_page", async () => {
       return await cloudDb().transaction(async (tx) => {
         await assertIrohUserMutationAllowed(tx, input.userId);
         await tx.execute(sql`select pg_advisory_xact_lock(hashtextextended(${`iroh:binding:${input.userId}`}, 0))`);
@@ -517,17 +514,32 @@ function makeLiveRepository(): IrohRepositoryShape {
           })
           .returning({ generation: irohAccountSecurityStates.lanDiscoveryGeneration });
         if (!state) throw new Error("account security state returned no row");
-        const bindings = await tx
+        if (input.cursor && input.cursor.generation !== state.generation) {
+          throw new IrohConflictError({ code: "discovery_cursor_stale" });
+        }
+        const rows = await tx
           .select()
           .from(irohEndpointBindings)
           .where(and(
             eq(irohEndpointBindings.userId, input.userId),
             isNull(irohEndpointBindings.revokedAt),
+            input.cursor
+              ? gt(irohEndpointBindings.id, input.cursor.afterBindingId)
+              : undefined,
           ))
-          .orderBy(asc(irohEndpointBindings.registeredAt));
+          .orderBy(asc(irohEndpointBindings.id))
+          .limit(input.pageSize + 1);
+        const bindings = rows.slice(0, input.pageSize);
+        const last = bindings.at(-1);
         return {
           bindings,
           lanDiscoveryGeneration: state.generation,
+          nextCursor: rows.length > input.pageSize && last
+            ? {
+              generation: state.generation,
+              afterBindingId: last.id,
+            }
+            : null,
         };
       });
     }),
@@ -1014,30 +1026,6 @@ async function revokeActiveBindings(
       },
     });
   return revokedIds;
-}
-
-// Reject a genuinely-new slot once the account already holds
-// IROH_ACTIVE_BINDING_SANITY_CAP active bindings. Called only on the
-// genuinely-new-slot path, so admitting one more would exceed the cap. Rejecting
-// (rather than evicting the oldest) is deliberate: a stuck client spamming fresh
-// device/tag tuples must not be able to make its own churn the newest rows and
-// shed the account's real, older hosts and phones. No normal account approaches
-// the cap; hitting it means something is wrong, and the fix is to revoke stale
-// bindings, not to let new registrations destroy existing ones.
-async function enforceActiveBindingSanityCap(
-  tx: CloudDbTransaction,
-  input: { readonly userId: string; readonly now: Date },
-): Promise<void> {
-  const [row] = await tx
-    .select({ total: count() })
-    .from(irohEndpointBindings)
-    .where(and(
-      eq(irohEndpointBindings.userId, input.userId),
-      isNull(irohEndpointBindings.revokedAt),
-    ));
-  const active = row?.total ?? 0;
-  if (active < IROH_ACTIVE_BINDING_SANITY_CAP) return;
-  throw new IrohConflictError({ code: "active_binding_limit" });
 }
 
 type RetentionBatchOperation = {

--- a/web/services/iroh/repository.ts
+++ b/web/services/iroh/repository.ts
@@ -505,14 +505,27 @@ function makeLiveRepository(): IrohRepositoryShape {
       return await cloudDb().transaction(async (tx) => {
         await assertIrohUserMutationAllowed(tx, input.userId);
         await tx.execute(sql`select pg_advisory_xact_lock(hashtextextended(${`iroh:binding:${input.userId}`}, 0))`);
-        const [state] = await tx
-          .insert(irohAccountSecurityStates)
-          .values({ userId: input.userId, lanDiscoveryGeneration: 1, createdAt: input.now, updatedAt: input.now })
-          .onConflictDoUpdate({
-            target: irohAccountSecurityStates.userId,
-            set: { updatedAt: sql`${irohAccountSecurityStates.updatedAt}` },
+        const [existingState] = await tx
+          .select({
+            generation: irohAccountSecurityStates.lanDiscoveryGeneration,
           })
-          .returning({ generation: irohAccountSecurityStates.lanDiscoveryGeneration });
+          .from(irohAccountSecurityStates)
+          .where(eq(irohAccountSecurityStates.userId, input.userId))
+          .limit(1);
+        const [insertedState] = existingState
+          ? []
+          : await tx
+            .insert(irohAccountSecurityStates)
+            .values({
+              userId: input.userId,
+              lanDiscoveryGeneration: 1,
+              createdAt: input.now,
+              updatedAt: input.now,
+            })
+            .returning({
+              generation: irohAccountSecurityStates.lanDiscoveryGeneration,
+            });
+        const state = existingState ?? insertedState;
         if (!state) throw new Error("account security state returned no row");
         if (input.cursor && input.cursor.generation !== state.generation) {
           throw new IrohConflictError({ code: "discovery_cursor_stale" });

--- a/web/services/iroh/routeHandler.ts
+++ b/web/services/iroh/routeHandler.ts
@@ -15,6 +15,7 @@ import {
   IrohTrustBrokerRuntime,
   type IrohTrustBrokerShape,
 } from "./trustBroker";
+import { parseIrohDiscoveryRequest } from "./discoveryPagination";
 
 const MAX_BODY_BYTES = 64 * 1_024;
 const FIREWALL_TIMEOUT_MS = 2_500;
@@ -98,6 +99,10 @@ export async function handleIrohRoute(
   if (operation === "challenge" || operation === "register") {
     bodyResult = await readBoundedJson(request);
     if (!bodyResult.ok) return bodyResult.response;
+  } else if (operation === "discover") {
+    const discovery = discoveryRequest(request);
+    if (!discovery.ok) return discovery.response;
+    bodyResult = { ok: true, value: discovery.value };
   }
 
   const firewall = dependencies.firewall ?? (
@@ -157,9 +162,7 @@ export async function handleIrohRoute(
     }
   }
 
-  bodyResult ??= operation === "discover"
-    ? { ok: true as const, value: undefined }
-    : await readBoundedJson(request);
+  bodyResult ??= await readBoundedJson(request);
   if (!bodyResult.ok) return bodyResult.response;
 
   try {
@@ -232,11 +235,47 @@ function invoke(
   switch (operation) {
     case "challenge": return broker.issueChallenge(userId, body);
     case "register": return broker.register(userId, body);
-    case "discover": return broker.discover(userId);
+    case "discover": return broker.discover(userId, undefined, body);
     case "endpoint_attestation": return broker.issueEndpointAttestation(userId, body);
     case "revoke": return broker.revoke(userId, body);
     case "pair_grant": return broker.issuePairGrant(userId, body);
     case "relay_token": return broker.issueRelayToken(userId, body);
+  }
+}
+
+function discoveryRequest(request: Request):
+  | { readonly ok: true; readonly value: unknown }
+  | { readonly ok: false; readonly response: Response } {
+  const url = new URL(request.url);
+  const allowed = new Set(["page_size", "cursor"]);
+  if (
+    [...url.searchParams.keys()].some((key) => !allowed.has(key)) ||
+    url.searchParams.getAll("page_size").length > 1 ||
+    url.searchParams.getAll("cursor").length > 1
+  ) {
+    return {
+      ok: false,
+      response: jsonResponse({ error: "invalid_discovery_page_size" }, 400),
+    };
+  }
+  const pageSize = url.searchParams.get("page_size");
+  const cursor = url.searchParams.get("cursor");
+  if (pageSize === null && cursor === null) {
+    return { ok: true, value: undefined };
+  }
+  const value = {
+    ...(pageSize === null ? {} : { pageSize }),
+    ...(cursor === null ? {} : { cursor }),
+  };
+  try {
+    parseIrohDiscoveryRequest(value);
+    return { ok: true, value };
+  } catch (error) {
+    const code = error && typeof error === "object" &&
+        (error as { _tag?: unknown })._tag === "IrohInvalidInputError"
+      ? (error as { code: string }).code
+      : "invalid_discovery_page_size";
+    return { ok: false, response: jsonResponse({ error: code }, 400) };
   }
 }
 

--- a/web/services/iroh/trustBroker.ts
+++ b/web/services/iroh/trustBroker.ts
@@ -60,6 +60,11 @@ import {
   type IrohRepositoryShape,
 } from "./repository";
 import {
+  encodeIrohDiscoveryCursor,
+  legacyIrohDiscoveryRequest,
+  parseIrohDiscoveryRequest,
+} from "./discoveryPagination";
+import {
   IrohRelayMinter,
   IrohRelayMinterLive,
   type IrohRelayMinterShape,
@@ -92,6 +97,7 @@ export type IrohTrustBrokerShape = {
   readonly discover: (
     userId: string,
     now?: Date,
+    request?: unknown,
   ) => Effect.Effect<unknown, IrohExpectedError>;
   readonly revoke: (
     userId: string,
@@ -263,9 +269,17 @@ export function makeIrohTrustBroker(
       };
     }),
 
-    discover: (userId, now = new Date()) => Effect.gen(function* () {
+    discover: (userId, now = new Date(), rawRequest) => Effect.gen(function* () {
+      const request = rawRequest === undefined
+        ? legacyIrohDiscoveryRequest()
+        : yield* parseEffect(() => parseIrohDiscoveryRequest(rawRequest));
       yield* repository.pruneExpiredState({ userId, now });
-      const snapshot = yield* repository.discoverySnapshot({ userId, now });
+      const snapshot = yield* repository.discoveryPage({
+        userId,
+        now,
+        pageSize: request.pageSize,
+        ...(request.cursor ? { cursor: request.cursor } : {}),
+      });
       const relayPreference = yield* accountRelayPreference(userId);
       const savedCustomRelayURLs = customRelayURLs(relayPreference);
       const rendezvousKey = yield* parseEffect(() => deriveLanRendezvousKey(
@@ -274,7 +288,7 @@ export function makeIrohTrustBroker(
         snapshot.lanDiscoveryGeneration,
       ));
       const verificationKeys = yield* parseEffect(() => signingVerificationKeys(config));
-      return {
+      const response = {
         route_contract_version: 1,
         bindings: snapshot.bindings.map((binding) => publicBinding(
           binding,
@@ -288,6 +302,14 @@ export function makeIrohTrustBroker(
         },
         grant_verification_keys: verificationKeys.keySet,
       };
+      return request.paginated
+        ? {
+          ...response,
+          next_cursor: snapshot.nextCursor
+            ? encodeIrohDiscoveryCursor(snapshot.nextCursor)
+            : null,
+        }
+        : response;
     }),
 
     revoke: (userId, raw, now = new Date()) => Effect.gen(function* () {

--- a/web/tests/iroh-db-behavior.test.ts
+++ b/web/tests/iroh-db-behavior.test.ts
@@ -11,7 +11,6 @@ import {
 } from "../services/account/deletionLock";
 import type { PairGrantPeer } from "../services/iroh/crypto";
 import {
-  IROH_ACTIVE_BINDING_SANITY_CAP,
   IROH_RETENTION_BATCH_SIZE,
   IrohRepository,
   IrohRepositoryLive,
@@ -1325,108 +1324,76 @@ describe("Iroh trust broker database behavior", () => {
     expect(grants?.staleRevoked).toBe(true);
   });
 
-  dbTest("rejects a genuinely-new slot once the account is at the active-binding sanity cap", async () => {
+  dbTest("registers and discovers more than 256 active bindings across bounded pages", async () => {
     const repo = requiredRepository();
-    const userId = "user-binding-cap";
+    const userId = "user-unbounded-bindings";
 
-    // Seed one deterministically-oldest active binding, then fill up to CAP - 1
-    // active rows that are all more recently seen than it.
-    const oldestEndpoint = "0f4240".padStart(64, "0");
-    const [oldest] = await requiredSql()<Array<{ id: string }>>`
-      insert into iroh_endpoint_bindings (
-        user_id, device_uuid, app_instance_id, tag, platform, endpoint_id,
-        identity_generation, pairing_enabled, capabilities, path_hints, last_seen_at
-      ) values (
-        ${userId}, gen_random_uuid(), gen_random_uuid(), 'stable', 'ios', ${oldestEndpoint},
-        1, true, '[]'::jsonb, '[]'::jsonb, ${new Date(NOW.getTime() - 10 * 60 * 60 * 1_000)}
-      ) returning id::text
-    `;
-    if (!oldest) throw new Error("oldest binding insert returned no row");
     await requiredSql()`
       insert into iroh_endpoint_bindings (
         user_id, device_uuid, app_instance_id, tag, platform, endpoint_id,
-        identity_generation, pairing_enabled, capabilities, path_hints, last_seen_at
+        identity_generation, pairing_enabled, capabilities, path_hints,
+        last_seen_at, registered_at
       )
       select
         ${userId}, gen_random_uuid(), gen_random_uuid(), 'stable', 'ios',
         lpad(to_hex(gs), 64, '0'), 1, true, '[]'::jsonb, '[]'::jsonb,
-        ${new Date(NOW.getTime() - 60 * 60 * 1_000)}::timestamptz + (gs * interval '1 second')
-      from generate_series(1, ${IROH_ACTIVE_BINDING_SANITY_CAP - 2}) as gs
+        ${NOW}::timestamptz + (gs * interval '1 second'),
+        ${NOW}::timestamptz + (gs * interval '1 second')
+      from generate_series(1, 300) as gs
     `;
 
-    const register = async (input: { endpointId: string; suffix: string; now: Date }) => {
-      const nonceHash = input.suffix.repeat(64);
-      const deviceId = randomUUID();
-      const appInstanceId = randomUUID();
-      const challenge = await Effect.runPromise(repo.issueChallenge({
-        userId,
-        deviceUuid: deviceId,
+    const deviceId = randomUUID();
+    const appInstanceId = randomUUID();
+    const nonceHash = "8".repeat(64);
+    const challenge = await Effect.runPromise(repo.issueChallenge({
+      userId,
+      deviceUuid: deviceId,
+      appInstanceId,
+      tag: "stable",
+      endpointId: "c1".repeat(32),
+      identityGeneration: 1,
+      payloadSha256: `8${"0".repeat(63)}`,
+      nonceHash,
+      now: new Date(NOW.getTime() + 301_000),
+      expiresAt: new Date(NOW.getTime() + 601_000),
+    }));
+    const registration = await Effect.runPromise(repo.consumeChallengeAndRegister({
+      userId,
+      challengeId: challenge.id,
+      nonceHash,
+      payload: {
+        route_contract_version: 1,
+        deviceId,
         appInstanceId,
         tag: "stable",
-        endpointId: input.endpointId,
+        platform: "ios",
+        endpointId: "c1".repeat(32),
         identityGeneration: 1,
-        payloadSha256: `${input.suffix}${"0".repeat(63)}`,
-        nonceHash,
-        now: input.now,
-        expiresAt: new Date(input.now.getTime() + 5 * 60 * 1_000),
-      }));
-      return Effect.runPromiseExit(repo.consumeChallengeAndRegister({
+        pairingEnabled: true,
+        capabilities: [],
+        pathHints: [],
+      },
+      now: new Date(NOW.getTime() + 301_000),
+    }));
+    expect(registration.created).toBe(true);
+
+    const pageCounts: number[] = [];
+    const bindingIds = new Set<string>();
+    let cursor: { generation: number; afterBindingId: string } | undefined;
+    do {
+      const page = await Effect.runPromise(repo.discoveryPage({
         userId,
-        challengeId: challenge.id,
-        nonceHash,
-        payload: {
-          route_contract_version: 1,
-          deviceId,
-          appInstanceId,
-          tag: "stable",
-          platform: "ios",
-          endpointId: input.endpointId,
-          identityGeneration: 1,
-          pairingEnabled: true,
-          capabilities: [],
-          pathHints: [],
-        },
-        now: input.now,
+        now: new Date(NOW.getTime() + 302_000),
+        pageSize: 128,
+        ...(cursor ? { cursor } : {}),
       }));
-    };
+      pageCounts.push(page.bindings.length);
+      page.bindings.forEach((binding) => bindingIds.add(binding.id));
+      cursor = page.nextCursor ?? undefined;
+    } while (cursor);
 
-    const countActive = async () => {
-      const [row] = await requiredSql()<Array<{ total: string }>>`
-        select count(*)::text as total from iroh_endpoint_bindings
-        where user_id = ${userId} and revoked_at is null
-      `;
-      return Number(row?.total ?? "-1");
-    };
-
-    // Exactly at the cap: a new slot fills the last free space and is admitted.
-    const atCap = await register({ endpointId: "c1".repeat(32), suffix: "8", now: NOW });
-    expect(atCap._tag).toBe("Success");
-    expect(await countActive()).toBe(IROH_ACTIVE_BINDING_SANITY_CAP);
-
-    // Over the cap: a genuinely new slot is REJECTED rather than evicting an
-    // existing device, so a stuck client spamming fresh device/tag tuples cannot
-    // make its own churn the newest rows and shed the account's real, older hosts
-    // and phones. The active count holds and the oldest row stays live.
-    const overCap = await register({
-      endpointId: "c2".repeat(32),
-      suffix: "9",
-      now: new Date(NOW.getTime() + 1_000),
-    });
-    expect(overCap._tag).toBe("Failure");
-    const causeError = overCap._tag === "Failure"
-      ? Option.getOrUndefined(Cause.failureOption(overCap.cause))
-      : undefined;
-    expect(causeError).toMatchObject({
-      _tag: "IrohConflictError",
-      code: "active_binding_limit",
-    });
-    expect(await countActive()).toBe(IROH_ACTIVE_BINDING_SANITY_CAP);
-
-    const [oldestState] = await requiredSql()<Array<{ revoked: boolean }>>`
-      select revoked_at is not null as revoked
-      from iroh_endpoint_bindings where id = ${oldest.id}
-    `;
-    expect(oldestState).toEqual({ revoked: false });
+    expect(pageCounts).toEqual([128, 128, 45]);
+    expect(bindingIds.size).toBe(301);
   });
 
   dbTest("enforces the UDP port range for each direct-address family", async () => {

--- a/web/tests/iroh-db-behavior.test.ts
+++ b/web/tests/iroh-db-behavior.test.ts
@@ -300,7 +300,7 @@ describe("Iroh trust broker database behavior", () => {
     const operations: Array<Effect.Effect<unknown, unknown>> = [
       repository.findActiveBindings(userId, [iosId, macId]),
       repository.revokeBinding({ userId, bindingId: macId, now: NOW }),
-      repository.discoverySnapshot({ userId, now: NOW }),
+      repository.discoveryPage({ userId, now: NOW, pageSize: 256 }),
       repository.pruneExpiredState({ userId, now: NOW }),
       repository.finalizeEndpointAttestation({
         userId,
@@ -1479,10 +1479,15 @@ describe("Iroh trust broker database behavior", () => {
       endpointId: "46".repeat(32),
     });
 
-    const initial = await Effect.runPromise(repo.discoverySnapshot({ userId, now: NOW }));
-    const otherInitial = await Effect.runPromise(repo.discoverySnapshot({
+    const initial = await Effect.runPromise(repo.discoveryPage({
+      userId,
+      now: NOW,
+      pageSize: 256,
+    }));
+    const otherInitial = await Effect.runPromise(repo.discoveryPage({
       userId: "user-lan-other",
       now: NOW,
+      pageSize: 256,
     }));
     expect(initial.lanDiscoveryGeneration).toBe(1);
     expect(initial.bindings.map((binding) => binding.id).sort()).toEqual([
@@ -1499,7 +1504,11 @@ describe("Iroh trust broker database behavior", () => {
       bindingId: firstBindingId,
       now: NOW,
     }))).toBe(true);
-    const afterFirstRevoke = await Effect.runPromise(repo.discoverySnapshot({ userId, now: NOW }));
+    const afterFirstRevoke = await Effect.runPromise(repo.discoveryPage({
+      userId,
+      now: NOW,
+      pageSize: 256,
+    }));
     expect(afterFirstRevoke.lanDiscoveryGeneration).toBe(2);
     expect(afterFirstRevoke.bindings.map((binding) => binding.id)).toEqual([secondBindingId]);
     expect(await Effect.runPromise(repo.revokeBinding({
@@ -1513,7 +1522,11 @@ describe("Iroh trust broker database behavior", () => {
       where id = ${firstBindingId}
     `;
     expect(retriedBinding?.revokedAt).toEqual(NOW);
-    expect((await Effect.runPromise(repo.discoverySnapshot({ userId, now: NOW }))).lanDiscoveryGeneration).toBe(2);
+    expect((await Effect.runPromise(repo.discoveryPage({
+      userId,
+      now: NOW,
+      pageSize: 256,
+    }))).lanDiscoveryGeneration).toBe(2);
     expect(await Effect.runPromise(repo.revokeBinding({
       userId: "user-lan-other",
       bindingId: firstBindingId,
@@ -1541,7 +1554,11 @@ describe("Iroh trust broker database behavior", () => {
         set lan_discovery_generation = lan_discovery_generation + 1, updated_at = ${NOW}
         where user_id = ${userId}
       `;
-      concurrentDiscovery = Effect.runPromise(repo.discoverySnapshot({ userId, now: NOW }));
+      concurrentDiscovery = Effect.runPromise(repo.discoveryPage({
+        userId,
+        now: NOW,
+        pageSize: 256,
+      }));
       await waitForAdvisoryLockWaiter();
     });
     if (!concurrentDiscovery) throw new Error("concurrent discovery was not started");
@@ -1550,9 +1567,10 @@ describe("Iroh trust broker database behavior", () => {
       lanDiscoveryGeneration: 3,
       bindings: [],
     });
-    const otherAfter = await Effect.runPromise(repo.discoverySnapshot({
+    const otherAfter = await Effect.runPromise(repo.discoveryPage({
       userId: "user-lan-other",
       now: NOW,
+      pageSize: 256,
     }));
     expect(otherAfter).toMatchObject({
       lanDiscoveryGeneration: 1,

--- a/web/tests/iroh-route-handler.test.ts
+++ b/web/tests/iroh-route-handler.test.ts
@@ -69,6 +69,48 @@ describe("Iroh route boundary", () => {
     expect(brokerCalled).toBe(true);
   });
 
+  test("rejects malformed discovery cursors before broker work", async () => {
+    let brokerCalled = false;
+    const response = await handleIrohRoute(
+      new Request("https://cmux.test/api/devices/iroh?page_size=128&cursor=not-a-cursor"),
+      "discover",
+      {
+        verify: async () => USER,
+        broker: broker({
+          discover: () => {
+            brokerCalled = true;
+            return Effect.succeed({ bindings: [] });
+          },
+        }),
+      },
+    );
+
+    expect(response.status).toBe(400);
+    expect(await response.json()).toEqual({ error: "invalid_discovery_cursor" });
+    expect(brokerCalled).toBe(false);
+  });
+
+  test("rejects oversized discovery pages before broker work", async () => {
+    let brokerCalled = false;
+    const response = await handleIrohRoute(
+      new Request("https://cmux.test/api/devices/iroh?page_size=129"),
+      "discover",
+      {
+        verify: async () => USER,
+        broker: broker({
+          discover: () => {
+            brokerCalled = true;
+            return Effect.succeed({ bindings: [] });
+          },
+        }),
+      },
+    );
+
+    expect(response.status).toBe(400);
+    expect(await response.json()).toEqual({ error: "invalid_discovery_page_size" });
+    expect(brokerCalled).toBe(false);
+  });
+
   test("fails closed for mutations when the firewall check rejects", async () => {
     let brokerCalled = false;
     const response = await handleIrohRoute(

--- a/web/tests/iroh-trust-broker.test.ts
+++ b/web/tests/iroh-trust-broker.test.ts
@@ -25,7 +25,6 @@ import {
   type IrohRegistrationPayload,
 } from "../services/iroh/model";
 import {
-  IROH_ACTIVE_BINDING_SANITY_CAP,
   type IrohBindingRecord,
   type IrohChallengeRecord,
   type IrohRepositoryShape,
@@ -272,6 +271,56 @@ describe("Iroh trust broker registration", () => {
 });
 
 describe("Iroh discovery and grants", () => {
+  test("paginates more than 256 active bindings without a total-count cap", async () => {
+    const fixture = makeFixture();
+    for (let index = 1; index <= 300; index += 1) {
+      fixture.repository.bindings.push(binding({
+        id: `123e4567-e89b-42d3-a456-${String(index).padStart(12, "0")}`,
+        userId: USER_A,
+        deviceUuid: `223e4567-e89b-42d3-a456-${String(index).padStart(12, "0")}`,
+        appInstanceId: `323e4567-e89b-42d3-a456-${String(index).padStart(12, "0")}`,
+        endpointId: index.toString(16).padStart(64, "0"),
+      }));
+    }
+
+    const pageCounts: number[] = [];
+    const bindingIds = new Set<string>();
+    let cursor: string | undefined;
+    do {
+      const page = await Effect.runPromise(fixture.broker.discover(
+        USER_A,
+        NOW,
+        { pageSize: "128", ...(cursor ? { cursor } : {}) },
+      )) as { bindings: IrohBindingRecord[]; next_cursor: string | null };
+      pageCounts.push(page.bindings.length);
+      page.bindings.forEach((record) => bindingIds.add(record.id));
+      cursor = page.next_cursor ?? undefined;
+    } while (cursor);
+
+    expect(pageCounts).toEqual([128, 128, 44]);
+    expect(bindingIds.size).toBe(300);
+  });
+
+  test("keeps the legacy no-query discovery response at 256 bindings", async () => {
+    const fixture = makeFixture();
+    for (let index = 1; index <= 300; index += 1) {
+      fixture.repository.bindings.push(binding({
+        id: `123e4567-e89b-42d3-a456-${String(index).padStart(12, "0")}`,
+        userId: USER_A,
+        deviceUuid: `223e4567-e89b-42d3-a456-${String(index).padStart(12, "0")}`,
+        appInstanceId: `323e4567-e89b-42d3-a456-${String(index).padStart(12, "0")}`,
+        endpointId: index.toString(16).padStart(64, "0"),
+      }));
+    }
+
+    const legacy = await Effect.runPromise(
+      fixture.broker.discover(USER_A, NOW),
+    ) as { bindings: IrohBindingRecord[]; next_cursor?: string };
+
+    expect(legacy.bindings).toHaveLength(256);
+    expect(legacy.next_cursor).toBeUndefined();
+  });
+
   test("makes owned binding revocation retry-safe without rotating LAN state twice", async () => {
     const fixture = makeFixture();
     const active = binding({ userId: USER_A });
@@ -673,8 +722,7 @@ describe("developer binding override", () => {
     expect(developmentBindingQuotaAllowed({ ...base, deviceLimitOverrideEnabled: false }, USER_A)).toBe(false);
     // The override widens challenge issuance and configured account/device
     // quotas. Authenticated re-registration overwrites an existing
-    // (user, device, tag) slot, while genuinely new slots remain bounded by
-    // IROH_ACTIVE_BINDING_SANITY_CAP.
+    // (user, device, tag) slot without imposing a total binding-count cap.
     expect(challengeQuotaForUser(base, USER_A)).toEqual({
       account: 2_048,
       deviceInstance: 128,
@@ -752,14 +800,6 @@ class MemoryRepository implements IrohRepositoryShape {
       !row.revokedAt);
     if (existing && challenge.createdAt < existing.registeredAt) {
       return Effect.fail(new IrohConflictError({ code: "challenge_superseded" }));
-    }
-    if (
-      !existing
-      && this.bindings.filter((row) =>
-        row.userId === input.userId && !row.revokedAt).length
-        >= IROH_ACTIVE_BINDING_SANITY_CAP
-    ) {
-      return Effect.fail(new IrohConflictError({ code: "active_binding_limit" }));
     }
     // The endpoint id is a global identity: no OTHER live binding may claim it.
     // Self is excluded so a slot can rotate its own key.

--- a/web/tests/iroh-trust-broker.test.ts
+++ b/web/tests/iroh-trust-broker.test.ts
@@ -291,9 +291,12 @@ describe("Iroh discovery and grants", () => {
         USER_A,
         NOW,
         { pageSize: "128", ...(cursor ? { cursor } : {}) },
-      )) as { bindings: IrohBindingRecord[]; next_cursor: string | null };
+      )) as {
+        bindings: Array<{ binding_id: string }>;
+        next_cursor: string | null;
+      };
       pageCounts.push(page.bindings.length);
-      page.bindings.forEach((record) => bindingIds.add(record.id));
+      page.bindings.forEach((record) => bindingIds.add(record.binding_id));
       cursor = page.next_cursor ?? undefined;
     } while (cursor);
 
@@ -315,7 +318,7 @@ describe("Iroh discovery and grants", () => {
 
     const legacy = await Effect.runPromise(
       fixture.broker.discover(USER_A, NOW),
-    ) as { bindings: IrohBindingRecord[]; next_cursor?: string };
+    ) as { bindings: Array<{ binding_id: string }>; next_cursor?: string };
 
     expect(legacy.bindings).toHaveLength(256);
     expect(legacy.next_cursor).toBeUndefined();
@@ -838,7 +841,7 @@ class MemoryRepository implements IrohRepositoryShape {
     // a peer host that denied the old id can't strand the resurrected slot. In the
     // real repository the retired row's live pair grants are revoked and the LAN
     // discovery generation rotates; this fake does not model the grant table,
-    // but does mirror the generation bump, staleness gate, and active-slot cap.
+    // but does mirror the generation bump and staleness gate.
     if (existing) {
       existing.revokedAt = input.now;
       existing.revokedReason = "slot_reincarnated";
@@ -871,15 +874,36 @@ class MemoryRepository implements IrohRepositoryShape {
     });
     challenge.consumedAt = input.now;
     this.bindings.push(inserted);
+    if (!existing) {
+      this.lanGenerations.set(
+        input.userId,
+        (this.lanGenerations.get(input.userId) ?? 0) + 1,
+      );
+    }
     return Effect.succeed({ binding: inserted, created: true });
   }
 
-  discoverySnapshot(input: Parameters<IrohRepositoryShape["discoverySnapshot"]>[0]) {
+  discoveryPage(input: Parameters<IrohRepositoryShape["discoveryPage"]>[0]) {
     return Effect.promise(async () => {
       await this.beforeDiscoverySnapshot?.();
+      const generation = this.lanGenerations.get(input.userId) ?? 1;
+      if (input.cursor && input.cursor.generation !== generation) {
+        throw new IrohConflictError({ code: "discovery_cursor_stale" });
+      }
+      const rows = this.bindings
+        .filter((row) =>
+          row.userId === input.userId &&
+          !row.revokedAt &&
+          (!input.cursor || row.id > input.cursor.afterBindingId))
+        .sort((left, right) => left.id.localeCompare(right.id));
+      const bindings = rows.slice(0, input.pageSize);
+      const last = bindings.at(-1);
       return {
-        bindings: this.bindings.filter((row) => row.userId === input.userId && !row.revokedAt),
-        lanDiscoveryGeneration: this.lanGenerations.get(input.userId) ?? 1,
+        bindings,
+        lanDiscoveryGeneration: generation,
+        nextCursor: rows.length > input.pageSize && last
+          ? { generation, afterBindingId: last.id }
+          : null,
       };
     });
   }


### PR DESCRIPTION
## Summary

- Replace the account-wide 256 active-binding cap with bounded cursor pagination (128 bindings per page).
- Keep legacy clients safe with a bounded 256-binding unpaginated response while new Swift clients traverse every page without a total-count limit.
- Rotate the discovery generation on active-set changes, reject stale or malformed cursors, and add an indexed active-binding page query.
- Remove the downstream Swift/macOS/iOS truncation and eviction points so all discovered bindings remain usable.

## Testing

- Test-first commit proves the old implementation fails beyond 256 bindings; implementation is a separate follow-up commit.
- `swift test --package-path Packages/Shared/CmuxIrohTransport`: 498 tests passed across 62 suites.
- Focused ESLint on changed web files: passed.
- `bun run typecheck`: passed.
- Focused Iroh route and broker suites: 45 passed, including 301 bindings over 3 pages, legacy bounds, malformed cursors, oversized pages, and repeated-cursor rejection.
- Real Postgres migration/reapply and 301-binding behavior passed; tagged Mac, isolated simulator, and Aziz iPhone builds succeeded; preview, staging, and exact-merge production deployments are Ready and smoked.

## Demo Video

- Not applicable: protocol and persistence change with no visual UI.

## Review Trigger

No second-model review requested. The task explicitly prohibits invoking review agents; required checks and automatically posted feedback remain merge gates.

## Checklist

- [x] I tested the change locally
- [x] I added or updated tests for behavior changes
- [x] I updated protocol documentation
- [x] Applicable required checks pass
- [x] Tagged Mac, isolated simulator, and personal iPhone dogfood complete
- [x] Vercel preview, staging, and production smoke checks complete

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/9253"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788056827&installation_model_id=21920&pr_number=9253&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F9253&signature=9ef6f7eb54a4e090a522869d2b8f40af42b4e90f874730631ac8a1d7204bd9cc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Remove the 256-binding cap and add cursor-based pagination to Iroh discovery so clients can fetch all active bindings safely. Legacy requests without query params still get a bounded 256-binding snapshot.

- **New Features**
  - `GET /api/devices/iroh` supports `page_size` (max 128) and `cursor`; responses include `next_cursor` (base64url) when more pages remain.
  - Server pages active bindings in stable UUID order via a new indexed query; index `iroh_endpoint_bindings_user_active_page_idx` added.
  - Cursors carry the discovery generation and last binding id; stale or malformed cursors are rejected at the route boundary.
  - Swift client (`discoverAllPages`) traverses pages linearly, enforces invariant non-binding fields across pages, deduplicates binding IDs, and rejects repeated cursors; new `CmxIrohDiscoveryPage` type.

- **Migration**
  - Run the DB migration to create the active-page index.
  - Update clients to request `page_size=128` and follow `next_cursor` until null; no changes needed for legacy clients.

<sup>Written for commit 9a8b9c74f78a7b60570c408d49881255696d810f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/9253?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added paginated device discovery for large binding lists, with continuation support.
  * Discovery now retains and processes more than 256 active bindings.
  * Added validation for page sizes, cursors, and malformed discovery requests.

* **Bug Fixes**
  * Prevented valid bindings from being dropped during discovery, caching, and LAN route generation.
  * Added safeguards against repeated or stale pagination cursors.

* **Performance**
  * Improved database efficiency for retrieving active bindings during paginated discovery.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->