### PR TITLE
Fix iOS TestFlight Release archive: guard DEBUG-only evidence probe

### DIFF
--- a/ios/cmuxPackage/Sources/cmuxFeature/MobileIrohRuntimeComposition.swift
+++ b/ios/cmuxPackage/Sources/cmuxFeature/MobileIrohRuntimeComposition.swift
@@ -65,6 +65,7 @@ private actor MobileIrohDurableDeviceIDResolver {
     }
 }
 
+#if DEBUG
 /// DEBUG same-device evidence: dev builds keep iroh endpoint identities in a
 /// development FILE store, not the Keychain, so continuity is proven by any
 /// record in that store. The filesystem is always readable, so the verdict is
@@ -82,6 +83,7 @@ struct MobileIrohDevelopmentFileEvidenceProbe: SameDeviceEvidenceProbing {
         return exists ? .present : .absent
     }
 }
+#endif
 
 /// Resolves connection waiters only when the latest lifecycle revision settles.
 @MainActor


### PR DESCRIPTION
The internal TestFlight lane has been red for 6 consecutive runs (first failure 21:48 UTC Jul 30, run 30584813716). Every run fails the Release archive with:

```
MobileIrohRuntimeComposition.swift:77:53: error: type 'MobileIrohRuntimeComposition' has no member 'developmentStoreDirectory'
** ARCHIVE FAILED **
```

`MobileIrohDevelopmentFileEvidenceProbe` (added in https://github.com/manaflow-ai/cmux/pull/8888) references `developmentStoreDirectory`, which is defined inside `#if DEBUG`, but the struct itself was unguarded. Debug builds compile, so local dev and PR-level checks never caught it; only the Release archive does. Its sole call site, `sameDeviceEvidenceProbe()`, is already `#if DEBUG`-gated (Release uses `IrohEndpointIdentityEvidenceProbe`), so the struct is dead code in Release and the fix wraps it in `#if DEBUG`.

No behavior change in either configuration: Debug keeps the same probe, Release never instantiated it. No practical behavior test exists for a Release-archive compile gate; the verification is dispatching ios-testflight.yml after merge and confirming the archive goes green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/9254"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788060881&installation_model_id=21920&pr_number=9254&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F9254&signature=7c1d3d92c0380ba51b3a423e95959ad8606c1e4b9be2cdc83c7b122e6095f05e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Guarded the DEBUG-only same-device evidence probe with `#if DEBUG` to fix Release archive failures in the iOS TestFlight lane. No behavior change; Release never uses this probe.

- **Bug Fixes**
  - Wrapped `MobileIrohDevelopmentFileEvidenceProbe` in `#if DEBUG` to avoid referencing `developmentStoreDirectory` in Release.
  - Release archive in `ios-testflight.yml` should pass.

<sup>Written for commit 6715908af8c645c78e53beeddf08cbc2a9ba9521. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/9254?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Development-only diagnostics are now limited to debug builds, keeping them out of production releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->