### PR TITLE
Guarantee bounded iOS foreground reconnect

### DIFF
--- a/Packages/Shared/CMUXMobileCore/Sources/CMUXMobileCore/DiagnosticReport.swift
+++ b/Packages/Shared/CMUXMobileCore/Sources/CMUXMobileCore/DiagnosticReport.swift
@@ -128,10 +128,15 @@ public struct DiagnosticReport: Sendable, Codable, Equatable {
     }
 
     /// The latest event that marks a failed connection/lifecycle milestone.
+    /// A `cancelled` outcome is an abandoned attempt, not a failure: callers
+    /// cancel dials on supersession and teardown, so surfacing one here would
+    /// report routine churn as the connection's latest problem.
     public var lastFailureEvent: DiagnosticEvent? {
         events.last(where: { event in
-            event.code.isDiagnosticFailure
-                || event.diagnosticFailureKind.map { $0 != .none } == true
+            if let kind = event.diagnosticFailureKind {
+                return kind != .none && kind != .cancelled
+            }
+            return event.code.isDiagnosticFailure
         })
     }
 

--- a/Packages/Shared/CMUXMobileCore/Sources/CMUXMobileCore/DiagnosticTaxonomy.swift
+++ b/Packages/Shared/CMUXMobileCore/Sources/CMUXMobileCore/DiagnosticTaxonomy.swift
@@ -71,6 +71,11 @@ public enum DiagnosticFailureKind: Int, Sendable, Codable, CaseIterable {
     /// event queue overflowed while the transport stopped draining (for
     /// example the peer's network path died mid-write).
     case sendQueueOverflow = 24
+    /// The connect-attempt registry refused a dial because the route was held
+    /// by an in-flight or recently abandoned dial, or hard-gated after
+    /// repeated abandoned attempts. Distinguishes gate refusals from genuine
+    /// dial timeouts in exports.
+    case routeGated = 25
     case unknown = 255
 
     /// Reduces a typed or system error to the bounded diagnostic vocabulary.
@@ -201,6 +206,12 @@ public enum DiagnosticSessionLifecycleKind: Int, Sendable, Codable, CaseIterable
     case runtimeReconfigured = 9
     /// A caller explicitly invalidated one exact peer session.
     case explicitlyInvalidated = 10
+    /// The pool evicted a session that reported no usable network path for a
+    /// full bounded grace window while its closure callback never fired.
+    case allPathsClosed = 11
+    /// Foreground validation found a pooled session with no usable path before
+    /// the first post-wake caller could reuse it.
+    case foregroundValidationFailed = 12
 }
 
 /// Which component produced a diagnostic report.

--- a/Packages/Shared/CMUXMobileCore/Tests/CMUXMobileCoreTests/DiagnosticLogTests.swift
+++ b/Packages/Shared/CMUXMobileCore/Tests/CMUXMobileCoreTests/DiagnosticLogTests.swift
@@ -271,6 +271,7 @@ import Testing
         #expect(DiagnosticFailureKind.admissionLeaseExpired.rawValue == 22)
         #expect(DiagnosticFailureKind.admissionRevalidationFailed.rawValue == 23)
         #expect(DiagnosticFailureKind.sendQueueOverflow.rawValue == 24)
+        #expect(DiagnosticFailureKind.routeGated.rawValue == 25)
         #expect(
             Set(DiagnosticFailureKind.allCases.map(\.rawValue)).count
                 == DiagnosticFailureKind.allCases.count
@@ -286,6 +287,8 @@ import Testing
         #expect(DiagnosticSessionLifecycleKind.runtimeDeactivated.rawValue == 8)
         #expect(DiagnosticSessionLifecycleKind.runtimeReconfigured.rawValue == 9)
         #expect(DiagnosticSessionLifecycleKind.explicitlyInvalidated.rawValue == 10)
+        #expect(DiagnosticSessionLifecycleKind.allPathsClosed.rawValue == 11)
+        #expect(DiagnosticSessionLifecycleKind.foregroundValidationFailed.rawValue == 12)
 
         #expect(DiagnosticPathKind(.unavailable) == .unknown)
         #expect(DiagnosticPathKind(.direct) == .direct)
@@ -437,6 +440,38 @@ import Testing
             #expect(report.lastFailureKind == .protocolViolation)
             #expect(report.lastFailureDate != nil)
         }
+    }
+
+    @Test func cancelledDialOutcomesDoNotCountAsFailures() {
+        let realFailure = DiagnosticEvent(
+            code: .rpcFailed,
+            tNanos: 2,
+            b: DiagnosticFailureKind.protocolViolation.rawValue
+        )
+        let abandonedDial = DiagnosticEvent(
+            code: .transportDialFailed,
+            tNanos: 3,
+            a: DiagnosticTransportKind.iroh.rawValue,
+            b: DiagnosticFailureKind.cancelled.rawValue,
+            c: 7
+        )
+
+        let onlyAbandoned = DiagnosticReport(
+            anchorWallNanos: 1_000_000_000,
+            anchorMonotonicNanos: 1,
+            events: [abandonedDial]
+        )
+        #expect(onlyAbandoned.lastFailureEvent == nil)
+        #expect(onlyAbandoned.lastFailureKind == nil)
+        #expect(onlyAbandoned.lastFailureDate == nil)
+
+        let abandonedAfterRealFailure = DiagnosticReport(
+            anchorWallNanos: 1_000_000_000,
+            anchorMonotonicNanos: 1,
+            events: [realFailure, abandonedDial]
+        )
+        #expect(abandonedAfterRealFailure.lastFailureEvent == realFailure)
+        #expect(abandonedAfterRealFailure.lastFailureKind == .protocolViolation)
     }
 
     @Test func clearStartsFreshBoundedSessionAndResetsAnchors() async {

--- a/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohClientSessionPool.swift
+++ b/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohClientSessionPool.swift
@@ -64,10 +64,22 @@ actor CmxIrohClientSessionPool {
     private var controlOwners: [SessionKey: ControlOwner] = [:]
     private var controlWaiters: [SessionKey: [ControlWaiter]] = [:]
     private var selectedPathContinuations: [UUID: AsyncStream<Void>.Continuation] = [:]
+    private var allPathsClosedEvictions: [
+        SessionKey: (sessionID: UUID, task: Task<Void, Never>)
+    ] = [:]
 
     /// Never-hit safety bound for a dial that ignores cancellation, retained so
     /// one wedged dial can never become a permanent connect outage.
     static var retiredDialSettleWaitLimitSeconds: TimeInterval { 10 }
+
+    /// Grace a pooled session gets with no usable path before the pool
+    /// declares it dead. The iroh boundary normally reports closure itself
+    /// (dead-path failover, QUIC idle timeout), so this is the level-triggered
+    /// backstop for a session whose closure callback never fires; the
+    /// 2026-07-29 outage session lost both paths and stayed pooled for 73+s
+    /// (https://github.com/manaflow-ai/cmux/issues/9178). Sized above a normal
+    /// path migration, below the point where recovery visibly stalls.
+    static var allPathsClosedEvictionGraceSeconds: TimeInterval { 15 }
 
     init(
         supervisor: CmxIrohEndpointSupervisor,
@@ -84,7 +96,10 @@ actor CmxIrohClientSessionPool {
     }
 
     func activate(runtimeGeneration: UInt64) async {
-        guard self.runtimeGeneration != runtimeGeneration else { return }
+        guard self.runtimeGeneration != runtimeGeneration else {
+            await validatePooledSessionsForForeground()
+            return
+        }
         await invalidateAll(reason: .runtimeReconfigured)
         self.runtimeGeneration = runtimeGeneration
     }
@@ -202,9 +217,10 @@ actor CmxIrohClientSessionPool {
             }
             let pathObservationTask = Task { [weak self] in
                 let changes = await connected.observedSelectedPathChanges()
-                for await _ in changes {
+                for await observed in changes {
                     guard !Task.isCancelled else { return }
-                    await self?.publishSelectedPathChange(
+                    await self?.handleObservedSelectedPathChange(
+                        observed,
                         key: key,
                         sessionID: sessionID
                     )
@@ -360,6 +376,10 @@ actor CmxIrohClientSessionPool {
         for key in Array(connectionTasks.keys) {
             retirePendingConnection(for: key)
         }
+        for pending in allPathsClosedEvictions.values {
+            pending.task.cancel()
+        }
+        allPathsClosedEvictions.removeAll(keepingCapacity: false)
         let closing = sessions
         let closingOwners = controlOwners
         sessions.removeAll(keepingCapacity: false)
@@ -381,6 +401,30 @@ actor CmxIrohClientSessionPool {
             )
         }
         publishSelectedPathChange()
+    }
+
+    private func validatePooledSessionsForForeground() async {
+        for key in Array(sessionOrder) {
+            guard let pooled = sessions[key] else { continue }
+            if await pooled.session.isClosed() {
+                await invalidateSession(
+                    for: key,
+                    matching: pooled.id,
+                    reason: .closedSessionEvicted,
+                    failure: .connectionClosed
+                )
+                continue
+            }
+            guard await pooled.session.observedSelectedPath() == .unavailable else {
+                continue
+            }
+            await invalidateSession(
+                for: key,
+                matching: pooled.id,
+                reason: .foregroundValidationFailed,
+                failure: .noRoute
+            )
+        }
     }
 
     func selectedObservedPath() async -> CmxIrohObservedConnectionPath {
@@ -412,9 +456,76 @@ actor CmxIrohClientSessionPool {
         return controlWaiters[key]?.count ?? 0
     }
 
+    /// Reacts to one session's selected-path evidence. `.unavailable` arms a
+    /// bounded eviction so a session whose closure callback never fires cannot
+    /// sit in the pool as a corpse; any usable path disarms it.
+    private func handleObservedSelectedPathChange(
+        _ observed: CmxIrohObservedConnectionPath,
+        key: SessionKey,
+        sessionID: UUID
+    ) {
+        if observed == .unavailable {
+            armAllPathsClosedEviction(for: key, sessionID: sessionID)
+        } else {
+            cancelAllPathsClosedEviction(for: key, sessionID: sessionID)
+        }
+        publishSelectedPathChange(key: key, sessionID: sessionID)
+    }
+
+    private func armAllPathsClosedEviction(for key: SessionKey, sessionID: UUID) {
+        guard sessions[key]?.id == sessionID else { return }
+        if let pending = allPathsClosedEvictions[key], pending.sessionID == sessionID {
+            return
+        }
+        allPathsClosedEvictions[key]?.task.cancel()
+        let clock = clock
+        let deadline = clock.now()
+            .addingTimeInterval(Self.allPathsClosedEvictionGraceSeconds)
+        let task = Task { [weak self] in
+            // Injected-clock sleep bounds the grace window; the task is
+            // cancelled when a usable path returns or the session leaves the
+            // pool, so a recovered connection never pays for this deadline.
+            try? await clock.sleep(until: deadline)
+            guard !Task.isCancelled else { return }
+            await self?.evictIfPathsStillClosed(for: key, sessionID: sessionID)
+        }
+        allPathsClosedEvictions[key] = (sessionID: sessionID, task: task)
+    }
+
+    private func cancelAllPathsClosedEviction(for key: SessionKey, sessionID: UUID) {
+        guard let pending = allPathsClosedEvictions[key],
+              pending.sessionID == sessionID else { return }
+        pending.task.cancel()
+        allPathsClosedEvictions[key] = nil
+    }
+
+    private func clearAllPathsClosedEviction(for key: SessionKey) {
+        allPathsClosedEvictions[key]?.task.cancel()
+        allPathsClosedEvictions[key] = nil
+    }
+
+    private func evictIfPathsStillClosed(for key: SessionKey, sessionID: UUID) async {
+        if let pending = allPathsClosedEvictions[key], pending.sessionID == sessionID {
+            allPathsClosedEvictions[key] = nil
+        }
+        guard let pooled = sessions[key], pooled.id == sessionID else { return }
+        // Level-triggered: re-read live path state at the deadline instead of
+        // trusting the event that armed this eviction.
+        guard await pooled.session.observedSelectedPath() == .unavailable else {
+            return
+        }
+        await invalidateSession(
+            for: key,
+            matching: sessionID,
+            reason: .allPathsClosed,
+            failure: .noRoute
+        )
+    }
+
     private func sessionDidClose(key: SessionKey, sessionID: UUID) async {
         guard let pooled = sessions[key], pooled.id == sessionID else { return }
         let owner = controlOwners[key]
+        clearAllPathsClosedEviction(for: key)
         sessions[key] = nil
         sessionOrder.removeAll { $0 == key }
         pooled.pathObservationTask.cancel()
@@ -457,6 +568,7 @@ actor CmxIrohClientSessionPool {
         if let expectedID, sessions[key]?.id != expectedID { return }
         let currentOwner = controlOwners[key]
         let owner = releasesControlOwner ? currentOwner : nil
+        clearAllPathsClosedEviction(for: key)
         retirePendingConnection(for: key)
         let pooled = sessions.removeValue(forKey: key)
         sessionOrder.removeAll { $0 == key }

--- a/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohConnectionCloseAttribution.swift
+++ b/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohConnectionCloseAttribution.swift
@@ -60,10 +60,37 @@ public struct CmxIrohConnectionCloseAttribution: Sendable, Equatable {
             || cause.contains("ConnectionLost(Reset)") {
             return .remote
         }
+        // Connection.closed()/close_reason() cross the uniffi boundary as
+        // quinn ConnectionError DISPLAY strings, which start with the variant
+        // text. Prefix-anchoring keeps a peer-chosen close reason from
+        // spoofing a different initiator.
+        if cause.hasPrefix("closed by peer")
+            || cause.hasPrefix("aborted by peer")
+            || cause.hasPrefix("reset by peer") {
+            return .remote
+        }
+        if cause == "timed out" {
+            return .timedOut
+        }
+        if cause == "closed" {
+            return .local
+        }
         return .unknown
     }
 
     private static func applicationErrorCode(in cause: String) -> Int64? {
+        // Display format of a peer application close is either
+        // "closed by peer: {code}" or "closed by peer: {reason} (code {code})";
+        // the formatter always appends the authentic code last, so a code-like
+        // fragment inside the peer-chosen reason cannot shadow it.
+        let displayPeerClose = "closed by peer: "
+        if cause.hasPrefix(displayPeerClose) {
+            let payload = cause.dropFirst(displayPeerClose.count)
+            if let range = payload.range(of: "(code ", options: .backwards) {
+                return firstInteger(in: payload[range.upperBound...])
+            }
+            return firstInteger(in: payload)
+        }
         guard cause.contains("ApplicationClosed(") else { return nil }
         for label in [
             "application error code",
@@ -103,11 +130,18 @@ public struct CmxIrohConnectionCloseAttribution: Sendable, Equatable {
     }
 
     private static func failureKind(in cause: String) -> DiagnosticFailureKind {
-        if cause.contains("ConnectionLost(TimedOut)") {
+        if cause.contains("ConnectionLost(TimedOut)") || cause == "timed out" {
             return .transportIdleTimedOut
         }
-        if cause.contains("ConnectionLost(LocallyClosed)") {
+        if cause.contains("ConnectionLost(LocallyClosed)") || cause == "closed" {
             return .cancelled
+        }
+        // Display-format peer closes are prefix-anchored so a peer-chosen
+        // reason cannot rewrite the kind via the keyword fallbacks below.
+        if cause.hasPrefix("closed by peer")
+            || cause.hasPrefix("aborted by peer")
+            || cause.hasPrefix("reset by peer") {
+            return .connectionClosed
         }
         if cause.contains("ConnectionLost(TransportError(")
             && (cause.contains("Code::crypto(")

--- a/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohClientSessionPoolPathEvictionTests.swift
+++ b/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohClientSessionPoolPathEvictionTests.swift
@@ -1,0 +1,155 @@
+import CMUXMobileCore
+import Foundation
+import Testing
+@testable import CmuxIrohTransport
+
+/// Completes eviction grace windows immediately so the all-paths-closed
+/// deadline fires as soon as it is armed.
+private struct ImmediateGraceClock: CmxIrohRelayClock {
+    private let date = Date(timeIntervalSince1970: 1_800_000_000)
+
+    func now() -> Date { date }
+    func sleep(until _: Date) async throws {}
+}
+
+/// Holds every grace-window sleep until the test releases it, so path
+/// recovery can be observed disarming the eviction deterministically.
+private actor HoldingGraceClock: CmxIrohRelayClock {
+    private let date = Date(timeIntervalSince1970: 1_800_000_000)
+    private var waiters: [CheckedContinuation<Void, Never>] = []
+    private var sleepCount = 0
+
+    nonisolated func now() -> Date { date }
+
+    func sleep(until _: Date) async throws {
+        sleepCount += 1
+        await withCheckedContinuation { waiters.append($0) }
+    }
+
+    func release() {
+        let resumable = waiters
+        waiters = []
+        for waiter in resumable { waiter.resume() }
+    }
+
+    func observedSleepCount() -> Int { sleepCount }
+
+    func waitForSleeper() async -> Bool {
+        for _ in 0..<400 {
+            if sleepCount > 0 { return true }
+            try? await Task.sleep(nanoseconds: 5_000_000)
+        }
+        return sleepCount > 0
+    }
+}
+
+@Suite
+struct CmxIrohClientSessionPoolPathEvictionTests {
+    @Test
+    func sessionWithNoUsablePathIsEvictedAndAttributedAfterGrace() async throws {
+        let fixture = try PoolFixture()
+        let connection = TestIrohConnection(
+            remoteIdentity: fixture.remoteIdentity,
+            bidirectionalStreams: [fixture.controlStream()],
+            selectedPath: .privateNetwork
+        )
+        let endpoint = TestDialingIrohEndpoint(
+            localIdentity: fixture.localIdentity,
+            dialResults: [.connection(connection)]
+        )
+        let diagnosticLog = DiagnosticLog()
+        let pool = try await fixture.pool(
+            endpoint: endpoint,
+            generation: 1,
+            diagnosticLog: diagnosticLog,
+            clock: ImmediateGraceClock()
+        )
+
+        let transport = try CmxIrohByteTransportFactory(sessionPool: pool)
+            .makeTransport(for: fixture.request)
+        try await transport.connect()
+        #expect(await pool.selectedObservedPath() == .privateNetwork)
+
+        await connection.setObservedSelectedPath(.unavailable)
+
+        let evicted = await pollUntilTrue {
+            let pathUnavailable = await pool.selectedObservedPath() == .unavailable
+            let closed = await connection.observedCloseCallCount() > 0
+            return pathUnavailable && closed
+        }
+        #expect(evicted)
+
+        let events = await drainedEvents(from: diagnosticLog)
+        let closure = events.last { $0.code == .sessionClosed }
+        #expect(closure != nil)
+        #expect(closure?.diagnosticFailureKind == .noRoute)
+        let lifecycleRemoval = events.last { event in
+            event.code == .transportSessionLifecycle
+                && event.diagnosticSessionLifecycleKind == .allPathsClosed
+        }
+        #expect(lifecycleRemoval != nil)
+    }
+
+    @Test
+    func pathRecoveryWithinGraceDisarmsTheEviction() async throws {
+        let fixture = try PoolFixture()
+        let connection = TestIrohConnection(
+            remoteIdentity: fixture.remoteIdentity,
+            bidirectionalStreams: [fixture.controlStream()],
+            selectedPath: .privateNetwork
+        )
+        let endpoint = TestDialingIrohEndpoint(
+            localIdentity: fixture.localIdentity,
+            dialResults: [.connection(connection)]
+        )
+        let clock = HoldingGraceClock()
+        let pool = try await fixture.pool(
+            endpoint: endpoint,
+            generation: 1,
+            clock: clock
+        )
+
+        let transport = try CmxIrohByteTransportFactory(sessionPool: pool)
+            .makeTransport(for: fixture.request)
+        try await transport.connect()
+
+        await connection.setObservedSelectedPath(.unavailable)
+        #expect(await clock.waitForSleeper())
+
+        // The path recovers while the grace window is still pending; releasing
+        // the window afterwards must not evict the healthy session.
+        await connection.setObservedSelectedPath(.relay(url: "https://relay.example"))
+        let recovered = await pollUntilTrue {
+            await pool.selectedObservedPath() == .relay(url: "https://relay.example")
+        }
+        #expect(recovered)
+        await clock.release()
+
+        // Give a mistaken eviction every chance to land before asserting.
+        await Task.yield()
+        try await Task.sleep(nanoseconds: 50_000_000)
+        #expect(await connection.observedCloseCallCount() == 0)
+        #expect(await pool.selectedObservedPath() == .relay(url: "https://relay.example"))
+    }
+}
+
+private func pollUntilTrue(
+    _ condition: @escaping () async -> Bool
+) async -> Bool {
+    for _ in 0..<400 {
+        if await condition() { return true }
+        try? await Task.sleep(nanoseconds: 5_000_000)
+    }
+    return await condition()
+}
+
+private func drainedEvents(from log: DiagnosticLog) async -> [DiagnosticEvent] {
+    for _ in 0..<400 {
+        let report = await log.snapshot()
+        if report.events.contains(where: { $0.code == .sessionClosed }) {
+            return report.events
+        }
+        try? await Task.sleep(nanoseconds: 5_000_000)
+    }
+    return await log.snapshot().events
+}

--- a/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohClientSessionPoolTests.swift
+++ b/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohClientSessionPoolTests.swift
@@ -568,6 +568,97 @@ struct CmxIrohClientSessionPoolTests {
     }
 
     @Test
+    func sameGenerationWakeEvictsSilentIdleDeathBeforeFirstReuse() async throws {
+        let fixture = try PoolFixture()
+        let firstConnection = TestIrohConnection(
+            remoteIdentity: fixture.remoteIdentity,
+            bidirectionalStreams: [fixture.controlStream()],
+            selectedPath: .privateNetwork,
+            reportsClosureToWaiters: false
+        )
+        let replacementConnection = TestIrohConnection(
+            remoteIdentity: fixture.remoteIdentity,
+            bidirectionalStreams: [fixture.controlStream()],
+            selectedPath: .relay(url: "https://relay.example.com/")
+        )
+        let endpoint = TestDialingIrohEndpoint(
+            localIdentity: fixture.localIdentity,
+            dialResults: [
+                .connection(firstConnection),
+                .connection(replacementConnection),
+            ]
+        )
+        let clock = HoldingWakeValidationClock()
+        let pool = try await fixture.pool(
+            endpoint: endpoint,
+            generation: 1,
+            clock: clock
+        )
+        let firstSession = try await pool.session(for: fixture.request)
+
+        await firstConnection.setObservedSelectedPath(.unavailable)
+        let wakeStartedAt = clock.now()
+        await pool.activate(runtimeGeneration: 1)
+        let postWakeSession = try await pool.session(for: fixture.request)
+
+        #expect(postWakeSession !== firstSession)
+        #expect(await endpoint.observedDialedAddresses().count == 2)
+        #expect(await firstConnection.observedCloseCallCount() == 1)
+        #expect(
+            clock.now().timeIntervalSince(wakeStartedAt) <= 3,
+            "wake validation must not consume the 30s retry ladder"
+        )
+        await pool.deactivate()
+        await clock.releaseAll()
+    }
+
+    @Test
+    func overlappingPostWakeReconnectsCoalesceBehindOneReplacementDial() async throws {
+        let fixture = try PoolFixture()
+        let firstConnection = TestIrohConnection(
+            remoteIdentity: fixture.remoteIdentity,
+            bidirectionalStreams: [fixture.controlStream()],
+            selectedPath: .privateNetwork,
+            reportsClosureToWaiters: false
+        )
+        let replacementConnection = TestIrohConnection(
+            remoteIdentity: fixture.remoteIdentity,
+            bidirectionalStreams: [fixture.controlStream()],
+            selectedPath: .relay(url: "https://relay.example.com/")
+        )
+        let endpoint = TestGatedDialEndpoint(localIdentity: fixture.localIdentity)
+        let clock = HoldingWakeValidationClock()
+        let pool = try await fixture.pool(
+            endpoint: endpoint,
+            generation: 1,
+            clock: clock
+        )
+        let initialTask = Task {
+            try await pool.session(for: fixture.request)
+        }
+        #expect(await waitForDialCount(endpoint, atLeast: 1))
+        await endpoint.releaseNextDial(with: firstConnection)
+        let firstSession = try await initialTask.value
+
+        await firstConnection.setObservedSelectedPath(.unavailable)
+        await pool.activate(runtimeGeneration: 1)
+
+        async let firstReconnect = pool.session(for: fixture.request)
+        async let secondReconnect = pool.session(for: fixture.request)
+        #expect(await waitForDialCount(endpoint, atLeast: 2))
+        await endpoint.releaseNextDial(with: replacementConnection)
+        let (firstReplacement, secondReplacement) =
+            try await (firstReconnect, secondReconnect)
+
+        #expect(firstReplacement !== firstSession)
+        #expect(firstReplacement === secondReplacement)
+        #expect(await endpoint.observedDialCount() == 2)
+        #expect(await firstConnection.observedCloseCallCount() == 1)
+        await pool.deactivate()
+        await clock.releaseAll()
+    }
+
+    @Test
     func pooledSessionStartsPublicThenRefreshesAndValidatesLANFallback() async throws {
         let fixture = try PoolFixture()
         let now = Date()
@@ -981,6 +1072,34 @@ private func waitForSelectedPathChangeCount(
     return false
 }
 
+private func waitForDialCount(
+    _ endpoint: TestGatedDialEndpoint,
+    atLeast expectedCount: Int
+) async -> Bool {
+    for _ in 0 ..< 1_000 {
+        if await endpoint.observedDialCount() >= expectedCount { return true }
+        await Task.yield()
+    }
+    return false
+}
+
+private actor HoldingWakeValidationClock: CmxIrohRelayClock {
+    private static let fixedNow = Date(timeIntervalSince1970: 1_800_000_000)
+    private var waiters: [CheckedContinuation<Void, Never>] = []
+
+    nonisolated func now() -> Date { Self.fixedNow }
+
+    func sleep(until _: Date) async throws {
+        await withCheckedContinuation { waiters.append($0) }
+    }
+
+    func releaseAll() {
+        let resumable = waiters
+        waiters = []
+        for waiter in resumable { waiter.resume() }
+    }
+}
+
 private struct PoolFixture {
     let localIdentity: CmxIrohPeerIdentity
     let remoteIdentity: CmxIrohPeerIdentity
@@ -1013,7 +1132,8 @@ private struct PoolFixture {
         endpoint: any CmxIrohEndpoint,
         generation: UInt64,
         contextProvider: (any CmxIrohClientContextProvider)? = nil,
-        diagnosticLog: DiagnosticLog? = nil
+        diagnosticLog: DiagnosticLog? = nil,
+        clock: (any CmxIrohRelayClock)? = nil
     ) async throws -> CmxIrohClientSessionPool {
         let configuration = try CmxIrohEndpointConfiguration(
             secretKey: CmxIrohSecretKey(bytes: Data(repeating: 7, count: 32)),
@@ -1031,7 +1151,8 @@ private struct PoolFixture {
             contextProvider: contextProvider
                 ?? TestIrohClientContextProvider(context: context),
             protocolConfiguration: .testApplicationLanes,
-            diagnosticLog: diagnosticLog
+            diagnosticLog: diagnosticLog,
+            clock: clock ?? CmxIrohSystemRelayClock()
         )
         await pool.activate(runtimeGeneration: generation)
         return pool

--- a/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohClientSessionPoolTests.swift
+++ b/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohClientSessionPoolTests.swift
@@ -1100,7 +1100,7 @@ private actor HoldingWakeValidationClock: CmxIrohRelayClock {
     }
 }
 
-private struct PoolFixture {
+struct PoolFixture {
     let localIdentity: CmxIrohPeerIdentity
     let remoteIdentity: CmxIrohPeerIdentity
     let request: CmxByteTransportRequest

--- a/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohConnectionCloseAttributionTests.swift
+++ b/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohConnectionCloseAttributionTests.swift
@@ -70,6 +70,99 @@ struct CmxIrohConnectionCloseAttributionTests {
         )
     }
 
+    // The uniffi boundary returns quinn ConnectionError DISPLAY strings from
+    // Connection.closed()/close_reason() ("timed out", "closed",
+    // "closed by peer: ..."), not the Debug fragments matched above. Every
+    // production close cause fell through to unknown/unknown until these
+    // formats were recognized (https://github.com/manaflow-ai/cmux/issues/9169).
+
+    @Test
+    func classifiesDisplayIdleTimeout() {
+        #expect(
+            CmxIrohConnectionCloseAttribution.classify("timed out")
+                == CmxIrohConnectionCloseAttribution(
+                    initiator: .timedOut,
+                    applicationErrorCode: nil,
+                    failureKind: .transportIdleTimedOut
+                )
+        )
+    }
+
+    @Test
+    func classifiesDisplayLocalClose() {
+        #expect(
+            CmxIrohConnectionCloseAttribution.classify("closed")
+                == CmxIrohConnectionCloseAttribution(
+                    initiator: .local,
+                    applicationErrorCode: nil,
+                    failureKind: .cancelled
+                )
+        )
+    }
+
+    @Test
+    func classifiesDisplayPeerApplicationCloseWithBareCode() {
+        #expect(
+            CmxIrohConnectionCloseAttribution.classify("closed by peer: 42")
+                == CmxIrohConnectionCloseAttribution(
+                    initiator: .remote,
+                    applicationErrorCode: 42,
+                    failureKind: .connectionClosed
+                )
+        )
+    }
+
+    @Test
+    func classifiesDisplayPeerApplicationCloseWithReasonAndCode() {
+        #expect(
+            CmxIrohConnectionCloseAttribution.classify(
+                "closed by peer: going away (code 42)"
+            ) == CmxIrohConnectionCloseAttribution(
+                initiator: .remote,
+                applicationErrorCode: 42,
+                failureKind: .connectionClosed
+            )
+        )
+    }
+
+    @Test
+    func classifiesDisplayPeerReset() {
+        #expect(
+            CmxIrohConnectionCloseAttribution.classify("reset by peer")
+                == CmxIrohConnectionCloseAttribution(
+                    initiator: .remote,
+                    applicationErrorCode: nil,
+                    failureKind: .connectionClosed
+                )
+        )
+    }
+
+    @Test
+    func classifiesDisplayPeerTransportAbortWithoutStealingApplicationCode() {
+        #expect(
+            CmxIrohConnectionCloseAttribution.classify(
+                "aborted by peer: CONNECTION_REFUSED: server busy"
+            ) == CmxIrohConnectionCloseAttribution(
+                initiator: .remote,
+                applicationErrorCode: nil,
+                failureKind: .connectionClosed
+            )
+        )
+    }
+
+    @Test
+    func displayPeerReasonCannotSpoofInitiatorOrTimeoutKind() {
+        #expect(
+            CmxIrohConnectionCloseAttribution.classify(
+                "closed by peer: timed out (code 7)"
+            ) == CmxIrohConnectionCloseAttribution(
+                initiator: .remote,
+                applicationErrorCode: 7,
+                failureKind: .connectionClosed
+            )
+        )
+    }
+
     @Test
     func authoritativeDriverCauseSupersedesTentativeLocalClose() async {
         let store = CmxIrohConnectionCloseAttributionStore()

--- a/Packages/iOS/CmuxMobileRPC/Sources/CmuxMobileRPC/MobileCoreRPCSession+RequestSettlement.swift
+++ b/Packages/iOS/CmuxMobileRPC/Sources/CmuxMobileRPC/MobileCoreRPCSession+RequestSettlement.swift
@@ -33,7 +33,7 @@ private extension MobileShellConnectionError {
         case .authorizationFailed, .accountMismatch, .rpcError:
             true
         case .invalidResponse, .connectionClosed, .requestTimedOut, .transportWriteTimedOut,
-             .routeCleanupBlocked, .insecureManualRoute, .attachTicketExpired:
+             .routeCleanupBlocked, .connectAttemptGated, .insecureManualRoute, .attachTicketExpired:
             false
         }
     }

--- a/Packages/iOS/CmuxMobileRPC/Sources/CmuxMobileRPC/MobileCoreRPCSession.swift
+++ b/Packages/iOS/CmuxMobileRPC/Sources/CmuxMobileRPC/MobileCoreRPCSession.swift
@@ -470,7 +470,7 @@ actor MobileCoreRPCSession {
         // their cooperative-cancellation retry semantics.
         if connectAttemptKey != nil,
            !abandonedConnectionCleanupTasks.isEmpty {
-            throw MobileShellConnectionError.requestTimedOut
+            throw MobileShellConnectionError.routeCleanupBlocked
         }
         let waiterID = UUID()
         let connectionID: UUID
@@ -490,7 +490,7 @@ actor MobileCoreRPCSession {
             case .granted(let lease):
                 connectLease = lease
             case .busy:
-                throw MobileShellConnectionError.requestTimedOut
+                throw MobileShellConnectionError.connectAttemptGated
             case .cleanupBlocked:
                 throw MobileShellConnectionError.routeCleanupBlocked
             }
@@ -499,6 +499,20 @@ actor MobileCoreRPCSession {
             let diagnosticTransport = diagnosticTransport
             let transportConnectObserver = transportConnectObserver
             let initialSessionPurpose = transportSessionPurpose
+            let reportCancelledConnect: @Sendable () -> Void = {
+                if let diagnosticTransport, let transportConnectObserver {
+                    transportConnectObserver(
+                        .failed(
+                            attemptID: connectAttemptID,
+                            transport: diagnosticTransport,
+                            failure: .cancelled,
+                            elapsedMilliseconds: Self.elapsedMilliseconds(
+                                since: connectStartedAt
+                            )
+                        )
+                    )
+                }
+            }
             if let diagnosticTransport, let transportConnectObserver {
                 transportConnectObserver(
                     .attempt(
@@ -517,6 +531,7 @@ actor MobileCoreRPCSession {
                     await rejected.task.value
                 }
                 if Task.isCancelled {
+                    reportCancelledConnect()
                     throw CancellationError()
                 }
                 let error = MobileShellConnectionError.connectionClosed
@@ -537,6 +552,7 @@ actor MobileCoreRPCSession {
             } catch {
                 await connectAttemptRegistry.finishConnect(lease: connectLease)
                 if error is CancellationError || Task.isCancelled {
+                    reportCancelledConnect()
                     throw CancellationError()
                 }
                 if let diagnosticTransport, let transportConnectObserver {
@@ -580,18 +596,20 @@ actor MobileCoreRPCSession {
                     // A cancellation-ignoring transport must still return its
                     // late candidate to the existing abandoned-connect cleanup
                     // path so that path can close it again after completion.
-                    // Suppress the success event without replacing that result
-                    // with `CancellationError`.
-                    if !Task.isCancelled,
-                       let diagnosticTransport,
-                       let transportConnectObserver {
+                    // Report the abandoned attempt as cancelled without
+                    // replacing that result with `CancellationError`.
+                    if Task.isCancelled {
+                        reportCancelledConnect()
+                    } else if let diagnosticTransport,
+                              let transportConnectObserver {
                         transportConnectObserver(
                             .connected(
                                 attemptID: connectAttemptID,
                                 transport: diagnosticTransport,
-                                elapsedMilliseconds: Self.elapsedMilliseconds(
-                                    since: connectStartedAt
-                                )
+                                elapsedMilliseconds:
+                                    Self.elapsedMilliseconds(
+                                        since: connectStartedAt
+                                    )
                             )
                         )
                     }
@@ -602,14 +620,17 @@ actor MobileCoreRPCSession {
                     } else {
                         await cancellationClose.finishWithoutClose()
                     }
+                    reportCancelledConnect()
                     throw CancellationError()
                 } catch {
                     // Some transports surface their close error instead of
                     // `CancellationError` after the cancellation handler closes
                     // them. Treat the task's cancellation bit as authoritative
-                    // so an abandoned dial never becomes a false failure event.
+                    // so an abandoned dial reports cancelled, never a false
+                    // transport failure.
                     if Task.isCancelled {
                         _ = await cancellationClose.task()
+                        reportCancelledConnect()
                         throw CancellationError()
                     }
                     await cancellationClose.finishWithoutClose()

--- a/Packages/iOS/CmuxMobileRPC/Sources/CmuxMobileRPC/MobileRPCConnectAttemptRegistry.swift
+++ b/Packages/iOS/CmuxMobileRPC/Sources/CmuxMobileRPC/MobileRPCConnectAttemptRegistry.swift
@@ -101,6 +101,16 @@ public actor MobileRPCConnectAttemptRegistry {
         routeStates[key] = state
     }
 
+    public func resetRouteHealthForNetworkChange() {
+        // Current main keeps only active leases and physical cleanup debt. Those
+        // are ownership facts, not route-health strikes, so a network change must
+        // not erase them and accidentally admit duplicate dials.
+        for (key, state) in routeStates
+            where state.activeLeaseID == nil && state.physicalCleanupTasks.isEmpty {
+            routeStates[key] = nil
+        }
+    }
+
     private func physicalCleanupDidFinish(
         key: MobileRPCConnectAttemptKey,
         cleanupID: UUID

--- a/Packages/iOS/CmuxMobileRPC/Sources/CmuxMobileRPC/MobileShellConnectionError.swift
+++ b/Packages/iOS/CmuxMobileRPC/Sources/CmuxMobileRPC/MobileShellConnectionError.swift
@@ -17,6 +17,8 @@ public enum MobileShellConnectionError: LocalizedError, DiagnosticFailureProvidi
     /// remain blocked to cap retained transports until cleanup finishes or the
     /// app process restarts.
     case routeCleanupBlocked
+    /// This exact route already has a connect attempt in flight.
+    case connectAttemptGated
     /// A manual host did not advertise a secure route.
     case insecureManualRoute
     /// The attach ticket expired and no fallback was available.
@@ -46,6 +48,11 @@ public enum MobileShellConnectionError: LocalizedError, DiagnosticFailureProvidi
                 "mobile.connection.routeCleanupBlocked",
                 defaultValue: "Connection cleanup is stuck. Restart cmux on this device before reconnecting."
             )
+        case .connectAttemptGated:
+            return L10n.string(
+                "mobile.connection.connectAttemptGated",
+                defaultValue: "Connection is already reconnecting"
+            )
         case .insecureManualRoute:
             return "Manual host did not advertise a secure mobile sync route"
         case .attachTicketExpired:
@@ -67,6 +74,8 @@ public enum MobileShellConnectionError: LocalizedError, DiagnosticFailureProvidi
             .connectionClosed
         case .requestTimedOut, .transportWriteTimedOut:
             .timedOut
+        case .connectAttemptGated:
+            .routeGated
         case .routeCleanupBlocked:
             .admissionDenied
         case .insecureManualRoute:

--- a/Packages/iOS/CmuxMobileRPC/Tests/CmuxMobileRPCTests/MobileCoreRPCAbandonedConnectTests.swift
+++ b/Packages/iOS/CmuxMobileRPC/Tests/CmuxMobileRPCTests/MobileCoreRPCAbandonedConnectTests.swift
@@ -195,7 +195,7 @@ import Testing
             allowsStackAuthFallback: true
         )
 
-        for id in ["stuck-connect-1", "stuck-connect-2", "stuck-connect-3"] {
+        for (index, id) in ["stuck-connect-1", "stuck-connect-2", "stuck-connect-3"].enumerated() {
             let request = try MobileCoreRPCClient.requestData(
                 method: "terminal.input",
                 params: [
@@ -207,10 +207,11 @@ import Testing
             )
             do {
                 _ = try await client.sendRequest(request)
-                Issue.record("Expected \(id) to time out")
-            } catch MobileShellConnectionError.requestTimedOut {
+                Issue.record("Expected \(id) to fail")
+            } catch MobileShellConnectionError.requestTimedOut where index == 0 {
+            } catch MobileShellConnectionError.routeCleanupBlocked where index > 0 {
             } catch {
-                Issue.record("Expected requestTimedOut for \(id), got \(error)")
+                Issue.record("Expected bounded admission failure for \(id), got \(error)")
             }
         }
 
@@ -278,9 +279,9 @@ import Testing
             do {
                 _ = try await client.sendRequest(retryRequest)
                 Issue.record("Expected \(id) to be rejected while cancelled connect cleanup is stuck")
-            } catch MobileShellConnectionError.requestTimedOut {
+            } catch MobileShellConnectionError.routeCleanupBlocked {
             } catch {
-                Issue.record("Expected requestTimedOut for \(id), got \(error)")
+                Issue.record("Expected routeCleanupBlocked for \(id), got \(error)")
             }
         }
 
@@ -521,6 +522,60 @@ import Testing
             return
         }
         await registry.finishConnect(lease: nextLease)
+    }
+
+    @Test func activeRouteAdmissionReportsRouteGatedInsteadOfTimedOut()
+        async throws {
+        let registry = MobileRPCConnectAttemptRegistry()
+        let key = debugConnectAttemptKey(port: 59_134)
+        let firstTransport = ReleasableConnectTransport()
+        let firstSession = MobileCoreRPCSession(
+            connectAttemptKey: key,
+            connectAttemptRegistry: registry,
+            makeTransport: { firstTransport }
+        )
+        let secondSession = MobileCoreRPCSession(
+            connectAttemptKey: key,
+            connectAttemptRegistry: registry,
+            makeTransport: {
+                Issue.record("Gated route must not allocate transport")
+                return ReleasableConnectTransport()
+            }
+        )
+        let firstTask = Task {
+            try await firstSession.send(
+                payload: MobileCoreRPCClient.requestData(
+                    method: "mobile.host.status",
+                    id: "active-route-owner"
+                ),
+                requestID: "active-route-owner",
+                deadlineUptimeNanoseconds:
+                    DispatchTime.now().uptimeNanoseconds
+                    + 60_000_000_000
+            )
+        }
+        #expect(await firstTransport.waitUntilConnectStarted())
+
+        do {
+            _ = try await secondSession.send(
+                payload: MobileCoreRPCClient.requestData(
+                    method: "mobile.host.status",
+                    id: "active-route-contender"
+                ),
+                requestID: "active-route-contender",
+                deadlineUptimeNanoseconds:
+                    DispatchTime.now().uptimeNanoseconds
+                    + 60_000_000_000
+            )
+            Issue.record("Expected route gate to reject concurrent admission")
+        } catch MobileShellConnectionError.connectAttemptGated {
+        } catch {
+            Issue.record("Expected connectAttemptGated, got \(error)")
+        }
+
+        await firstTransport.releaseConnect()
+        _ = try await firstTask.value
+        await firstSession.tearDown(error: .connectionClosed)
     }
 
     @Test func connectAttemptKeySeparatesPeersAndIgnoresIrohHintChurn()

--- a/Packages/iOS/CmuxMobileRPC/Tests/CmuxMobileRPCTests/MobileCoreRPCAbandonedConnectTests.swift
+++ b/Packages/iOS/CmuxMobileRPC/Tests/CmuxMobileRPCTests/MobileCoreRPCAbandonedConnectTests.swift
@@ -105,7 +105,11 @@ import Testing
             do {
                 retryData = try await client.sendRequest(second)
                 break
-            } catch MobileShellConnectionError.requestTimedOut {
+            } catch MobileShellConnectionError.requestTimedOut,
+                    MobileShellConnectionError.routeCleanupBlocked {
+                // Cleanup of the abandoned first connect may still be in
+                // flight; the session reports that as routeCleanupBlocked
+                // until the transport finishes closing.
                 try await Task.sleep(nanoseconds: 1_000_000)
             }
         }

--- a/Packages/iOS/CmuxMobileRPC/Tests/CmuxMobileRPCTests/MobileRPCTransportConnectEventTests.swift
+++ b/Packages/iOS/CmuxMobileRPC/Tests/CmuxMobileRPCTests/MobileRPCTransportConnectEventTests.swift
@@ -52,7 +52,7 @@ import Testing
         #expect(failure == .unsupportedRoute)
     }
 
-    @Test func callerCancellationSuppressesCloseInducedFailureAndRetryConnects() async throws {
+    @Test func abandonedDialEmitsCancelledOutcomeAndRetryConnects() async throws {
         let transport = FirstConnectClosedErrorThenSucceedsTransport()
         let (events, continuation) = AsyncStream<MobileRPCTransportConnectEvent>.makeStream()
         let session = MobileCoreRPCSession(
@@ -64,17 +64,17 @@ import Testing
         )
         let first = try MobileCoreRPCClient.requestData(
             method: "mobile.host.status",
-            id: "cancelled-closed-connect"
+            id: "abandoned-connect"
         )
         let second = try MobileCoreRPCClient.requestData(
             method: "mobile.host.status",
-            id: "retry-after-closed-connect"
+            id: "retry-after-abandoned-connect"
         )
         let deadline = DispatchTime.now().uptimeNanoseconds + 60 * 1_000_000_000
         let firstTask = Task {
             try await session.send(
                 payload: first,
-                requestID: "cancelled-closed-connect",
+                requestID: "abandoned-connect",
                 deadlineUptimeNanoseconds: deadline
             )
         }
@@ -92,34 +92,31 @@ import Testing
 
         let data = try await session.send(
             payload: second,
-            requestID: "retry-after-closed-connect",
+            requestID: "retry-after-abandoned-connect",
             deadlineUptimeNanoseconds: deadline
         )
         let response = try #require(JSONSerialization.jsonObject(with: data) as? [String: String])
         #expect(response["status"] == "ok")
-        #expect(await transport.connectCount() == 2)
-        #expect(try await transport.sentRequests().map(\.id) == ["retry-after-closed-connect"])
 
         continuation.finish()
         let recorded = await collect(events)
-        #expect(recorded.count == 3)
-        guard recorded.count == 3 else {
+        #expect(recorded.count == 4)
+        guard recorded.count == 4 else {
             await session.tearDown(error: .connectionClosed)
             return
         }
-        guard case let .attempt(firstAttemptID, firstTransport) = recorded[0],
-              case let .attempt(secondAttemptID, secondTransport) = recorded[1],
-              case let .connected(connectedID, connectedTransport, _) = recorded[2] else {
-            Issue.record("Expected attempt, attempt, connected with no failure")
+        guard case let .attempt(firstAttemptID, _) = recorded[0],
+              case let .failed(abandonedID, abandonedTransport, abandonedFailure, _) = recorded[1],
+              case let .attempt(secondAttemptID, _) = recorded[2],
+              case let .connected(connectedID, _, _) = recorded[3] else {
+            Issue.record("Expected attempt, failed(cancelled), attempt, connected")
             await session.tearDown(error: .connectionClosed)
             return
         }
-        #expect(firstAttemptID > 0)
-        #expect(secondAttemptID > 0)
-        #expect(firstTransport == .debugLoopback)
-        #expect(secondTransport == .debugLoopback)
+        #expect(abandonedID == firstAttemptID)
+        #expect(abandonedTransport == .debugLoopback)
+        #expect(abandonedFailure == .cancelled)
         #expect(connectedID == secondAttemptID)
-        #expect(connectedTransport == .debugLoopback)
         await session.tearDown(error: .connectionClosed)
     }
 
@@ -128,6 +125,7 @@ import Testing
         #expect(MobileShellConnectionError.connectionClosed.diagnosticFailureKind == .connectionClosed)
         #expect(MobileShellConnectionError.requestTimedOut.diagnosticFailureKind == .timedOut)
         #expect(MobileShellConnectionError.transportWriteTimedOut.diagnosticFailureKind == .timedOut)
+        #expect(MobileShellConnectionError.connectAttemptGated.diagnosticFailureKind == .routeGated)
         #expect(
             MobileShellConnectionError.routeCleanupBlocked.diagnosticFailureKind
                 == .admissionDenied

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileChatEventSource.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileChatEventSource.swift
@@ -460,7 +460,7 @@ public actor MobileChatEventSource: ChatEventSource {
         }
         switch connectionError {
         case .invalidResponse, .connectionClosed, .requestTimedOut,
-             .transportWriteTimedOut,
+             .transportWriteTimedOut, .connectAttemptGated,
              .insecureManualRoute, .attachTicketExpired,
              .authorizationFailed, .accountMismatch, .routeCleanupBlocked:
             return .macUnreachable

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobilePairingFailure.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobilePairingFailure.swift
@@ -413,7 +413,7 @@ extension MobilePairingFailureCategory {
 
         if let connectionError = error as? MobileShellConnectionError {
             switch connectionError {
-            case .requestTimedOut:
+            case .requestTimedOut, .connectAttemptGated:
                 return .handshakeTimedOut(host: host, port: port)
             case .insecureManualRoute:
                 return .unsupportedRoute

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobilePresencePushRecoveryThrottle.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobilePresencePushRecoveryThrottle.swift
@@ -1,0 +1,49 @@
+import Foundation
+
+/// Decides whether one presence delivery may start another recovery pass.
+///
+/// Presence heartbeats about an online Mac arrive roughly every 15 seconds.
+/// While the phone is disconnected, each heartbeat used to restart connection
+/// recovery, so during a persistent outage the phone kept abandoning its own
+/// in-flight dials on the heartbeat cadence and each abandoned dial fed the
+/// connect-registry hard gate
+/// (https://github.com/manaflow-ai/cmux/issues/9177).
+///
+/// Changed evidence (new routes, a Mac coming online) always passes: that is
+/// the wake-up signal presence exists for. Unchanged heartbeats pass at most
+/// once per ``minimumUnchangedEvidenceInterval`` so an already-failing
+/// recovery loop gets its full dial budget between presence-triggered
+/// restarts.
+struct MobilePresencePushRecoveryThrottle {
+    /// Chosen above the ~15s presence heartbeat cadence and the dial budget a
+    /// recovery pass needs, below the point where a stalled recovery would be
+    /// user-visible next to the 30-60s automatic backoff ladder.
+    static let minimumUnchangedEvidenceInterval: TimeInterval = 45
+
+    private var lastRecoveryAt: Date?
+
+    /// Records and reports whether a presence-triggered recovery may start.
+    mutating func shouldRecover(evidenceChanged: Bool, now: Date) -> Bool {
+        if evidenceChanged {
+            lastRecoveryAt = now
+            return true
+        }
+        guard let lastRecoveryAt else {
+            self.lastRecoveryAt = now
+            return true
+        }
+        let elapsed = now.timeIntervalSince(lastRecoveryAt)
+        // A rewound wall clock (negative elapsed) must not freeze the
+        // throttle until the clock catches back up; treat it as expired.
+        guard elapsed >= 0, elapsed < Self.minimumUnchangedEvidenceInterval else {
+            self.lastRecoveryAt = now
+            return true
+        }
+        return false
+    }
+
+    /// Forgets throttle history at an account or session boundary.
+    mutating func reset() {
+        lastRecoveryAt = nil
+    }
+}

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+ConnectionRecovery.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+ConnectionRecovery.swift
@@ -40,6 +40,11 @@ extension MobileShellComposite {
                     .reachabilityChanged,
                     a: isOnline ? 1 : 0
                 ))
+                // Route strikes and hard gates accumulated on the old path
+                // predict nothing about the new one; drop them before this
+                // recovery pass so it is not refused by stale poisoning.
+                await self.connectAttemptRegistry.resetRouteHealthForNetworkChange()
+                guard !Task.isCancelled else { return }
                 self.recoverMobileConnection(trigger: .networkChange)
             }
         }
@@ -52,6 +57,10 @@ extension MobileShellComposite {
         guard connectionState == .connected,
               let client = remoteClient,
               pairedMacStore != nil else { return }
+        guard foregroundRefreshIsActive else {
+            pendingInactiveRecoveryTrigger = .foreground
+            return
+        }
         beginConnectionRecovery(
             trigger: .foreground,
             expectedClient: client,
@@ -68,6 +77,10 @@ extension MobileShellComposite {
     /// shows Retry and the next network change re-attempts automatically.
     func recoverMobileConnection(trigger: RecoveryTrigger) {
         guard remoteClient != nil || pairedMacStore != nil else { return }
+        guard foregroundRefreshIsActive else {
+            pendingInactiveRecoveryTrigger = trigger
+            return
+        }
         if let accountID = identityProvider?.currentUserID {
             switch trigger {
             case .manual, .networkChange, .foreground:
@@ -102,6 +115,10 @@ extension MobileShellComposite {
         expectedClient: MobileCoreRPCClient
     ) {
         guard remoteClient === expectedClient, connectionState == .connected else { return }
+        guard foregroundRefreshIsActive else {
+            pendingInactiveRecoveryTrigger = trigger
+            return
+        }
 
         if connectionRecoveryOwner.isRedialingOrValidating {
             let replacementIsInstalled = connectionRecoveryOwner.isValidatingReplacement
@@ -126,6 +143,13 @@ extension MobileShellComposite {
             resyncAfterHealthy: false,
             preclaimedAttempt: superseding
         )
+    }
+
+    func recoverPendingInactiveRecoveryIfNeeded() {
+        guard foregroundRefreshIsActive,
+              let trigger = pendingInactiveRecoveryTrigger else { return }
+        pendingInactiveRecoveryTrigger = nil
+        recoverMobileConnection(trigger: trigger)
     }
 
     private func beginConnectionRecovery(

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+PresenceRouteSync.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+PresenceRouteSync.swift
@@ -216,6 +216,14 @@ extension MobileShellComposite {
         }
         // Presence is only a wake-up signal. The recovery pass still obtains
         // first-pair candidates from the authenticated personal broker.
+        // Unchanged heartbeats are throttled so a persistent outage cannot
+        // restart an in-flight recovery on the presence cadence.
+        guard presencePushRecoveryThrottle.shouldRecover(
+            evidenceChanged: evidenceChanged,
+            now: runtime?.now() ?? Date()
+        ) else {
+            return
+        }
         recoverMobileConnection(trigger: .presencePush)
     }
 

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+ReconnectRoutes.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+ReconnectRoutes.swift
@@ -251,6 +251,7 @@ extension MobileShellComposite {
 
     /// Resume foreground-only refresh loops after the app becomes active.
     public func resumeForegroundRefresh() {
+        foregroundRefreshIsActive = true
         foregroundResumeEpoch &+= 1
         startObservingNetworkPathChanges()
         // Covers stores constructed already-signed-in (no isSignedIn edge) and
@@ -269,6 +270,7 @@ extension MobileShellComposite {
         restartActiveMobileBrowserStreams()
         recoverForegroundConnectionIfNeeded(resyncAfterHealthy: shouldResync)
         recoverDisconnectedOnForegroundIfNeeded()
+        recoverPendingInactiveRecoveryIfNeeded()
         // The foreground Mac's workspace list updates live over the sync stream,
         // but the other Macs are a read-only snapshot. Re-aggregate them on
         // foreground so workspaces created on another Mac while backgrounded
@@ -280,6 +282,7 @@ extension MobileShellComposite {
 
     /// Record that the app left the active scene phase.
     public func suspendForegroundRefresh() {
+        foregroundRefreshIsActive = false
         if connectionRecoveryOwner.cancelProbing() {
             applyConnectionRecoveryOwnerState()
         }

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+TaskComposer.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+TaskComposer.swift
@@ -77,6 +77,7 @@ extension MobileShellComposite {
             ].contains(code?.lowercased() ?? ""):
                 return .failure(.unsupported)
             case .requestTimedOut,
+                 .connectAttemptGated,
                  .rpcError("request_timeout", _):
                 return .failure(.timedOut)
             case .authorizationFailed,

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+TaskDirectoryList.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+TaskDirectoryList.swift
@@ -77,6 +77,7 @@ extension MobileShellComposite {
             ].contains(code?.lowercased() ?? ""):
                 return .failure(.unsupported)
             case .requestTimedOut,
+                 .connectAttemptGated,
                  .rpcError("request_timeout", _):
                 return .failure(.timedOut)
             case .authorizationFailed,

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+WorkspaceActions.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+WorkspaceActions.swift
@@ -499,7 +499,7 @@ extension MobileShellComposite {
         case .connectionClosed, .transportWriteTimedOut,
              .routeCleanupBlocked:
             return .notConnected(hostDisplayName: hostDisplayName)
-        case .requestTimedOut:
+        case .requestTimedOut, .connectAttemptGated:
             return .requestTimedOut(hostDisplayName: hostDisplayName)
         case .attachTicketExpired, .authorizationFailed, .accountMismatch, .insecureManualRoute:
             return .authorizationFailed(hostDisplayName: hostDisplayName)

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
@@ -301,6 +301,7 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         scope: MobileShellScopeSnapshot,
         instances: [MobilePresenceReconnectEvidence]
     )?
+    var presencePushRecoveryThrottle = MobilePresencePushRecoveryThrottle()
     /// Whether the current attach ticket has a non-empty auth token and has not expired.
     public var hasActiveUnexpiredAttachTicket: Bool {
         guard let activeTicket,
@@ -1572,6 +1573,8 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         // projections.
         resetStateSyncForAccountBoundary()
         lastPresenceReconnectEvidence = nil
+        presencePushRecoveryThrottle.reset()
+        pendingInactiveRecoveryTrigger = nil
         connectionRecoveryOwner.cancel()
         applyConnectionRecoveryOwnerState()
         invalidatePairingAttempt()
@@ -1955,6 +1958,8 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
     var networkPathObservationTask: Task<Void, Never>?
     let connectionRecoveryOwner = MobileConnectionRecoveryOwner()
     var lastReconnectStackUserID: String?
+    var foregroundRefreshIsActive = true
+    var pendingInactiveRecoveryTrigger: RecoveryTrigger?
 
     enum RecoveryTrigger: CustomStringConvertible {
         case networkChange
@@ -8793,6 +8798,7 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
     private func preparePairingConnectionAttempt() {
         // Any explicit connect supersedes launch/network recovery, including a
         // recovery suspended in a registry refresh for the same device id.
+        pendingInactiveRecoveryTrigger = nil
         connectionRecoveryOwner.cancel()
         applyConnectionRecoveryOwnerState()
         invalidateStoredMacReconnectAttempt()
@@ -11810,7 +11816,7 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
                 || normalizedMessage.contains("expired token")
                 || normalizedMessage.contains("token expired")
         case .invalidResponse, .connectionClosed, .requestTimedOut,
-             .transportWriteTimedOut, .routeCleanupBlocked,
+             .transportWriteTimedOut, .routeCleanupBlocked, .connectAttemptGated,
              .insecureManualRoute:
             return false
         }

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellMacAvailabilityFailureClassifier.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellMacAvailabilityFailureClassifier.swift
@@ -13,9 +13,9 @@ struct MobileShellMacAvailabilityFailureClassifier {
         case .connectionClosed, .transportWriteTimedOut,
              .routeCleanupBlocked:
             return true
-        case .invalidResponse, .requestTimedOut, .insecureManualRoute,
-             .attachTicketExpired, .authorizationFailed, .accountMismatch,
-             .rpcError:
+        case .invalidResponse, .requestTimedOut, .connectAttemptGated,
+             .insecureManualRoute, .attachTicketExpired, .authorizationFailed,
+             .accountMismatch, .rpcError:
             // .accountMismatch means the Mac is reachable but signed in to a
             // different account; that is an auth problem, not a Mac-availability one.
             return false

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/SecondaryControlAttemptPolicy.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/SecondaryControlAttemptPolicy.swift
@@ -35,8 +35,8 @@ func secondaryControlAttemptIsTransient(_ error: any Error) -> Bool {
     case .connectionClosed, .requestTimedOut, .transportWriteTimedOut,
          .routeCleanupBlocked:
         return true
-    case .invalidResponse, .insecureManualRoute, .attachTicketExpired,
-         .authorizationFailed, .accountMismatch:
+    case .invalidResponse, .connectAttemptGated, .insecureManualRoute,
+         .attachTicketExpired, .authorizationFailed, .accountMismatch:
         return false
     case let .rpcError(code, _):
         let permanentCodes: Set<String> = [

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/WorkspaceCreatePinnedContext.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/WorkspaceCreatePinnedContext.swift
@@ -58,6 +58,7 @@ extension MobileShellComposite {
             case is CancellationError,
                  MobileShellConnectionError.connectionClosed,
                  MobileShellConnectionError.requestTimedOut,
+                 MobileShellConnectionError.connectAttemptGated,
                  MobileShellConnectionError.transportWriteTimedOut,
                  MobileShellConnectionError.invalidResponse:
                 isAmbiguous = true

--- a/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/MobilePresencePushRecoveryThrottleTests.swift
+++ b/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/MobilePresencePushRecoveryThrottleTests.swift
@@ -1,0 +1,94 @@
+import Foundation
+import Testing
+@testable import CmuxMobileShell
+
+@Suite
+struct MobilePresencePushRecoveryThrottleTests {
+    private let now = Date(timeIntervalSince1970: 1_700_000_000)
+    private let interval = MobilePresencePushRecoveryThrottle.minimumUnchangedEvidenceInterval
+
+    @Test
+    func firstUnchangedHeartbeatRecoversThenHeartbeatCadenceIsThrottled() {
+        var throttle = MobilePresencePushRecoveryThrottle()
+
+        let first = throttle.shouldRecover(evidenceChanged: false, now: now)
+        // ~15s presence heartbeats inside the interval must not restart
+        // recovery; this cadence starved in-flight dials during the outage.
+        let heartbeat15 = throttle.shouldRecover(
+            evidenceChanged: false,
+            now: now.addingTimeInterval(15)
+        )
+        let heartbeat30 = throttle.shouldRecover(
+            evidenceChanged: false,
+            now: now.addingTimeInterval(30)
+        )
+        let afterInterval = throttle.shouldRecover(
+            evidenceChanged: false,
+            now: now.addingTimeInterval(interval)
+        )
+
+        #expect(first)
+        #expect(!heartbeat15)
+        #expect(!heartbeat30)
+        #expect(afterInterval)
+    }
+
+    @Test
+    func changedEvidenceAlwaysRecoversAndReArmsTheThrottle() {
+        var throttle = MobilePresencePushRecoveryThrottle()
+
+        let first = throttle.shouldRecover(evidenceChanged: false, now: now)
+        let changed = throttle.shouldRecover(
+            evidenceChanged: true,
+            now: now.addingTimeInterval(5)
+        )
+        // The changed-evidence pass restarts the unchanged-heartbeat window.
+        let unchangedAfterChanged = throttle.shouldRecover(
+            evidenceChanged: false,
+            now: now.addingTimeInterval(6)
+        )
+        let afterReArmedInterval = throttle.shouldRecover(
+            evidenceChanged: false,
+            now: now.addingTimeInterval(5 + interval)
+        )
+
+        #expect(first)
+        #expect(changed)
+        #expect(!unchangedAfterChanged)
+        #expect(afterReArmedInterval)
+    }
+
+    @Test
+    func rewoundWallClockDoesNotFreezeTheThrottle() {
+        var throttle = MobilePresencePushRecoveryThrottle()
+
+        let first = throttle.shouldRecover(evidenceChanged: false, now: now)
+        let afterRewind = throttle.shouldRecover(
+            evidenceChanged: false,
+            now: now.addingTimeInterval(-3600)
+        )
+
+        #expect(first)
+        #expect(afterRewind)
+    }
+
+    @Test
+    func resetForgetsHistorySoTheNextHeartbeatRecoversImmediately() {
+        var throttle = MobilePresencePushRecoveryThrottle()
+
+        let first = throttle.shouldRecover(evidenceChanged: false, now: now)
+        let throttled = throttle.shouldRecover(
+            evidenceChanged: false,
+            now: now.addingTimeInterval(1)
+        )
+        throttle.reset()
+        let afterReset = throttle.shouldRecover(
+            evidenceChanged: false,
+            now: now.addingTimeInterval(2)
+        )
+
+        #expect(first)
+        #expect(!throttled)
+        #expect(afterReset)
+    }
+}

--- a/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/MobileShellForegroundResumeTests.swift
+++ b/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/MobileShellForegroundResumeTests.swift
@@ -199,7 +199,7 @@ struct MobileShellForegroundConnectionRecoveryTests {
 }
 
 @MainActor
-@Test func foregroundResumeAbandonsProbeStartedDuringBackgroundAndProbesAgain() async throws {
+@Test func foregroundRecoveryRequestedDuringBackgroundWaitsForForegroundProbe() async throws {
     let router = LivenessHostRouter()
     let box = TransportBox()
     let clock = TestClock()
@@ -219,16 +219,14 @@ struct MobileShellForegroundConnectionRecoveryTests {
 
     store.suspendForegroundRefresh()
     store.recoverForegroundConnectionIfNeeded(resyncAfterHealthy: false)
-    #expect(await router.waitForCount(
-        of: "mobile.workspace.list",
-        atLeast: probeCount + 1
-    ))
+    #expect(await router.count(of: "mobile.workspace.list") == probeCount)
     store.resumeForegroundRefresh()
 
     #expect(await router.waitForCount(
         of: "mobile.workspace.list",
-        atLeast: probeCount + 2
+        atLeast: probeCount + 1
     ))
+    await router.releaseAllHeld()
     #expect(try await pollUntil {
         store.connectionRecoveryOwner.phase == .idle
     })
@@ -252,7 +250,7 @@ struct MobileShellForegroundConnectionRecoveryTests {
         try? FileManager.default.removeItem(at: directory)
     }
     store.connectionState = .disconnected
-    store.clearRemoteConnectionContext()
+    await store.releaseRemoteClientForReplacement()
     let failedAttempt = try #require(store.connectionRecoveryOwner.begin(
         trigger: "background-failure",
         sourceConnectionGeneration: store.connectionGeneration,

--- a/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/MobileShellWorkspaceCreateTests.swift
+++ b/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/MobileShellWorkspaceCreateTests.swift
@@ -165,6 +165,7 @@ import Testing
         for error in [
             MobileShellConnectionError.connectionClosed,
             MobileShellConnectionError.requestTimedOut,
+            MobileShellConnectionError.connectAttemptGated,
             MobileShellConnectionError.invalidResponse,
         ] {
             #expect(

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MobileIrohSettingsView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MobileIrohSettingsView.swift
@@ -367,6 +367,8 @@ private extension MobileIrohSettingsView {
             L10n.string("mobile.iroh.diagnostics.failure.unsupportedRoute", defaultValue: "Unsupported Route")
         case .some(.noRoute):
             L10n.string("mobile.iroh.diagnostics.failure.noRoute", defaultValue: "No Route Available")
+        case .some(.routeGated):
+            L10n.string("mobile.iroh.diagnostics.failure.routeGated", defaultValue: "Route Gated")
         case .some(.credentialUnavailable):
             L10n.string(
                 "mobile.iroh.diagnostics.failure.credentialUnavailable",

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/Resources/Localizable.xcstrings
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/Resources/Localizable.xcstrings
@@ -1126,6 +1126,13 @@
         "ja" : { "stringUnit" : { "state" : "translated", "value" : "利用可能な経路がありません" } }
       }
     },
+    "mobile.iroh.diagnostics.failure.routeGated" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Route Gated" } },
+        "ja" : { "stringUnit" : { "state" : "translated", "value" : "経路が制限されています" } }
+      }
+    },
     "mobile.iroh.diagnostics.failure.credentialUnavailable" : {
       "extractionState" : "manual",
       "localizations" : {

--- a/Packages/macOS/CmuxSettingsUI/Sources/CmuxSettingsUI/Sections/IrohNetworkingSection.swift
+++ b/Packages/macOS/CmuxSettingsUI/Sources/CmuxSettingsUI/Sections/IrohNetworkingSection.swift
@@ -598,6 +598,11 @@ private struct IrohDiagnosticsReportRows: View {
                 localized: "settings.networking.diagnostics.failure.superseded",
                 defaultValue: "Replaced by a Newer Attempt"
             )
+        case .some(.routeGated):
+            String(
+                localized: "settings.networking.diagnostics.failure.routeGated",
+                defaultValue: "Connection Attempt Held"
+            )
         case .some(.cancelled):
             String(localized: "settings.networking.diagnostics.failure.cancelled", defaultValue: "Cancelled")
         case .some(.unknown):

--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -172907,6 +172907,23 @@
         }
       }
     },
+    "settings.networking.diagnostics.failure.routeGated": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Connection Attempt Held"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "接続試行が一時的に保留されました"
+          }
+        }
+      }
+    },
     "settings.networking.diagnostics.failure.secureChannelFailed": {
       "extractionState": "manual",
       "localizations": {

--- a/ios/cmux/Resources/Localizable.xcstrings
+++ b/ios/cmux/Resources/Localizable.xcstrings
@@ -2092,6 +2092,23 @@
         }
       }
     },
+    "mobile.connection.connectAttemptGated": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mobile sync connection is retrying"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "モバイル同期接続を再試行しています"
+          }
+        }
+      }
+    },
     "mobile.computers.role.foreground": {
       "extractionState": "manual",
       "localizations": {


### PR DESCRIPTION
## Summary
- Rebased and combined the reconnect stack from https://github.com/manaflow-ai/cmux/pull/9190, https://github.com/manaflow-ai/cmux/pull/9188, https://github.com/manaflow-ai/cmux/pull/9186, and close-attribution coverage from https://github.com/manaflow-ai/cmux/pull/9192.
- Validates pooled Iroh sessions during same-generation foreground activation, evicting closed or all-paths-unavailable sessions before the first post-wake reuse.
- Defers recovery triggers while the iOS scene is inactive and replays one pending recovery only after the app is active, which avoids dials launched into the inactive/background bounce.
- Preserves the dial gate and recovery throttle behavior from the stack, including cancelled dial outcomes, route-gated classification, presence recovery throttling, and all-paths-closed eviction.

## Regression structure
- Commit 1 adds the failing `CmuxIrohTransport` regressions only.
- Commit 2 lands the fix plus the rebased reconnect stack.

## Test plan
- `swift test --package-path Packages/Shared/CmuxIrohTransport`
- `swift test --package-path Packages/iOS/CmuxMobileRPC --filter MobileCoreRPCAbandonedConnectTests`
- `swift test --package-path Packages/iOS/CmuxMobileRPC --filter MobileRPCTransportConnectEventTests`
- `swift test --package-path Packages/Shared/CMUXMobileCore --filter DiagnosticLogTests`
- `swift test --package-path Packages/iOS/CmuxMobileShell --filter MobileShellForegroundResumeTests`
- `swift test --package-path Packages/iOS/CmuxMobileShell --filter MobilePresencePushRecoveryThrottleTests`
- `swift test --package-path Packages/iOS/CmuxMobileShell --filter MobileShellWorkspaceCreateTests`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/9256"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788061284&installation_model_id=21920&pr_number=9256&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F9256&signature=f45aeb4bd87d86181bd4a0604494edb4a124d8070faa1a807b64cc3770588705"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Guarantees a bounded iOS foreground reconnect by validating pooled Iroh sessions on wake, evicting dead/no-route sessions, and deferring recovery until the app is active to avoid background bounce. Adds grace-based path-closed eviction and clearer diagnostics so recovery is reliable and easy to reason about.

- New Features
  - `CmuxIrohTransport`: Foreground validation evicts closed or `.unavailable` sessions before first reuse; adds 15s grace eviction for “all paths closed.”
  - `CmuxMobileShell`: Defers recovery triggers while inactive and replays one pending trigger on foreground; throttles presence-driven recovery (unchanged evidence at most every 45s); resets route-health gates on network changes.
  - `CmuxMobileRPC`: Surfaces `connectAttemptGated` when a route already has an in-flight dial; reports cancelled dial outcomes to avoid false failures; drops stale gates on network changes.
  - Diagnostics/UI: Adds `routeGated` failure kind, new lifecycle events (`allPathsClosed`, `foregroundValidationFailed`), and localized strings/UI for gated attempts; updates `CmuxMobileShellUI` and `CmuxSettingsUI` to display route-gated diagnostics.

- Bug Fixes
  - `CmuxIrohTransport`: Correctly attributes display-format iroh closes (“timed out”, “closed”, “closed/aborted/reset by peer …”) with prefix-anchored parsing to prevent spoofing; corpse sessions are evicted; overlapping post-wake reconnects coalesce behind one replacement dial.
  - `CMUXMobileCore`: Cancelled dials no longer count as the latest failure in reports.
  - Reconnect flow: Selected-path change handling no longer leaves corpse sessions pooled; foreground recovery waits until active; tests updated and expanded, including path-closed eviction, wake validation, cancelled-outcome emission, presence throttle, and connect-timeout retry now handling `routeCleanupBlocked`.

<sup>Written for commit 5cbf2381a81d8156597dfa487601357bd00b2b76. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/9256?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added clearer connection status reporting when another connection attempt is already in progress.
  * Improved recovery after network changes, backgrounding, and unavailable connection paths.
  * Added safeguards to prevent repeated recovery attempts during persistent outages.
  * Added diagnostic classifications for cancelled attempts, blocked routes, and closed paths.

* **Bug Fixes**
  * Improved connection failure attribution, timeout handling, and session cleanup.
  * Prevented cancelled attempts from appearing as the latest failure when a real failure exists.
  * Added English and Japanese localized messages for new connection states.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->