### PR TITLE
Recover Iroh registration after cached host activation

### DIFF
--- a/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohHostRuntime+PolicyRefresh.swift
+++ b/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohHostRuntime+PolicyRefresh.swift
@@ -169,7 +169,8 @@ extension CmxIrohHostRuntime {
             grantVerificationKeys: discovery.grantVerificationKeys,
             attestation: attestation,
             relayBootstrap: configuration.cachedRelayCredential,
-            lanRendezvous: discovery.lanRendezvous
+            lanRendezvous: discovery.lanRendezvous,
+            registrationRetryAfterSeconds: nil
         )
     }
 
@@ -207,7 +208,10 @@ extension CmxIrohHostRuntime {
             grantVerificationKeys: cached.grantVerificationKeys,
             attestation: cached.endpointAttestation,
             relayBootstrap: relayBootstrap ?? configuration.cachedRelayCredential,
-            lanRendezvous: cached.lanRendezvous
+            lanRendezvous: cached.lanRendezvous,
+            registrationRetryAfterSeconds: (
+                error as? any CmxRetryAfterProviding
+            )?.retryAfterSeconds
         )
     }
 
@@ -353,16 +357,15 @@ extension CmxIrohHostRuntime {
         await registrationRefreshTask?.value
     }
 
-    private func scheduleRegistrationRetry(
+    func scheduleRegistrationRetry(
         revision: UInt64,
-        error: any Error
+        retryAfterSeconds: Int?
     ) {
         guard lifecyclePhase == .active,
               lifecycleRevision == revision else { return }
         let delay = registrationRetrySchedule.delay(
             failureCount: registrationRefreshFailureCount,
-            retryAfterSeconds: (error as? any CmxRetryAfterProviding)?
-                .retryAfterSeconds,
+            retryAfterSeconds: retryAfterSeconds,
             jitterUnitInterval: registrationRetryJitter()
         )
         registrationRefreshFailureCount = min(
@@ -473,7 +476,12 @@ extension CmxIrohHostRuntime {
             // endpoint, so address changes observed during this failed round are
             // already included without an immediate duplicate broker request.
             registrationRefreshPending = false
-            scheduleRegistrationRetry(revision: revision, error: error)
+            scheduleRegistrationRetry(
+                revision: revision,
+                retryAfterSeconds: (
+                    error as? any CmxRetryAfterProviding
+                )?.retryAfterSeconds
+            )
         }
     }
 

--- a/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohHostRuntime.swift
+++ b/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohHostRuntime.swift
@@ -38,6 +38,7 @@ public actor CmxIrohHostRuntime {
         let attestation: CmxIrohEndpointAttestationResponse?
         let relayBootstrap: CmxIrohRelayTokenResponse?
         let lanRendezvous: CmxIrohLANRendezvous
+        let registrationRetryAfterSeconds: Int?
     }
 
     enum LifecyclePhase: Equatable, Sendable {
@@ -302,6 +303,7 @@ public actor CmxIrohHostRuntime {
                 // into `readyPolicy`; do not immediately publish a third copy.
                 registrationRefreshPending = false
             }
+            let publishedFreshBinding: Bool
             if let registration = publishedPolicy.registration,
                let discovery = publishedPolicy.discovery {
                 await handleBinding(registration, discovery, publishedPolicy.attestation)
@@ -309,9 +311,22 @@ public actor CmxIrohHostRuntime {
                     binding: registration.binding,
                     revision: revision
                 )
+                publishedFreshBinding = true
+            } else {
+                publishedFreshBinding = false
             }
             registrationRefreshEnabled = true
-            if registrationRefreshPending {
+            if !publishedFreshBinding {
+                // Cached policy keeps the endpoint available while the broker
+                // recovers, but it does not publish a discoverable binding.
+                // Feed that incomplete activation into the lifecycle-owned
+                // retry path while preserving the broker's Retry-After floor.
+                registrationRefreshPending = false
+                scheduleRegistrationRetry(
+                    revision: revision,
+                    retryAfterSeconds: publishedPolicy.registrationRetryAfterSeconds
+                )
+            } else if registrationRefreshPending {
                 registrationRefreshPending = false
                 scheduleRegistrationRefresh(revision: revision)
             }

--- a/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohHostRuntimeLifecycleTests.swift
+++ b/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohHostRuntimeLifecycleTests.swift
@@ -433,6 +433,47 @@ extension CmxIrohHostRuntimeTests {
     }
 
     @Test
+    func cachedActivationRecoversBrokerRegistrationWithoutRestartingEndpoint() async throws {
+        let fixture = try HostRuntimeFixture()
+        let cachedFixture = try fixture.cachedPolicyFixture()
+        let now = cachedFixture.now
+        let cachedPolicy = try cachedFixture.policy()
+        let factory = TestIrohEndpointFactory(
+            endpoints: [TestIrohEndpoint(identity: fixture.endpointID)]
+        )
+        let broker = TestIrohHostBroker(
+            registrationBinding: fixture.binding,
+            discovery: fixture.discovery,
+            registrationError: .connectivity
+        )
+        let clock = RecordingImmediateHostActivationClock(now: now)
+        let bindings = HostRuntimeBindingRecorder()
+        let runtime = CmxIrohHostRuntime(
+            factory: factory,
+            broker: broker,
+            configuration: fixture.configuration(cachedHostPolicy: cachedPolicy),
+            pendingRevocations: fixture.pendingRevocations(),
+            now: { now },
+            registrationClock: clock,
+            registrationRetryJitter: { 0 },
+            handleTransport: { session, _ in await session.close() },
+            handleBinding: { _, _, _ in await bindings.record() }
+        )
+
+        try await runtime.start()
+
+        #expect(await runtime.snapshot().state == .active)
+        #expect(await runtime.snapshot().bindingID == cachedPolicy.binding.bindingID)
+        #expect(
+            await broker.waitForRegistrationCount(2, timeout: .seconds(1))
+        )
+        #expect(await bindings.waitForCount(1, timeout: .seconds(1)))
+        #expect(await factory.observedConfigurations().count == 1)
+        #expect(clock.observedSleepDeadlines() == [now.addingTimeInterval(30)])
+        await runtime.stop()
+    }
+
+    @Test
     func restoredBrokerCooldownUsesVerifiedCacheBeforeRegistration() async throws {
         let fixture = try HostRuntimeFixture()
         let cachedFixture = try fixture.cachedPolicyFixture()

--- a/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohHostRuntimeLifecycleTests.swift
+++ b/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohHostRuntimeLifecycleTests.swift
@@ -412,6 +412,7 @@ extension CmxIrohHostRuntimeTests {
             discovery: fixture.discovery,
             registrationError: failure
         )
+        let clock = HostRegistrationRenewalClock(now: now)
         let runtime = CmxIrohHostRuntime(
             factory: TestIrohEndpointFactory(
                 endpoints: [TestIrohEndpoint(identity: fixture.endpointID)]
@@ -420,15 +421,23 @@ extension CmxIrohHostRuntimeTests {
             configuration: fixture.configuration(cachedHostPolicy: cachedPolicy),
             pendingRevocations: fixture.pendingRevocations(),
             now: { now },
-            registrationClock: ImmediateHostActivationClock(),
+            registrationClock: clock,
+            registrationRetryJitter: { 0 },
             handleTransport: { session, _ in await session.close() }
         )
 
         try await runtime.start()
+        await clock.waitUntilSleeping()
 
         #expect(await broker.observedRegistrationCount() == 1)
         #expect(await runtime.snapshot().state == .active)
         #expect(await runtime.snapshot().bindingID == cachedPolicy.binding.bindingID)
+        let retryDeadline = try #require(clock.observedSleepDeadlines().first)
+        #expect(
+            retryDeadline == now.addingTimeInterval(
+                TimeInterval(failure.retryAfterSeconds ?? 30)
+            )
+        )
         await runtime.stop()
     }
 

--- a/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohHostRuntimeTests.swift
+++ b/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohHostRuntimeTests.swift
@@ -463,9 +463,62 @@ actor TestIrohHostBroker: CmxIrohHostBrokerServing {
 
 actor HostRuntimeBindingRecorder {
     private var recordedCount = 0
+    private var waiters: [
+        UUID: (minimum: Int, continuation: CheckedContinuation<Void, Never>)
+    ] = [:]
 
-    func record() { recordedCount += 1 }
+    func record() {
+        recordedCount += 1
+        let readyIDs = waiters.compactMap { id, waiter in
+            recordedCount >= waiter.minimum ? id : nil
+        }
+        for id in readyIDs {
+            waiters.removeValue(forKey: id)?.continuation.resume()
+        }
+    }
+
     func count() -> Int { recordedCount }
+
+    func waitForCount(_ count: Int, timeout: Duration) async -> Bool {
+        if recordedCount >= count { return true }
+        return await withTaskGroup(of: Bool.self) { group in
+            group.addTask {
+                await self.waitForCount(count)
+                return !Task.isCancelled
+            }
+            group.addTask {
+                do {
+                    try await ContinuousClock().sleep(for: timeout)
+                } catch {
+                    return false
+                }
+                return false
+            }
+            let result = await group.next() ?? false
+            group.cancelAll()
+            return result
+        }
+    }
+
+    private func waitForCount(_ count: Int) async {
+        if recordedCount >= count { return }
+        let id = UUID()
+        await withTaskCancellationHandler {
+            await withCheckedContinuation { continuation in
+                if Task.isCancelled {
+                    continuation.resume()
+                } else {
+                    waiters[id] = (count, continuation)
+                }
+            }
+        } onCancel: {
+            Task { await self.cancelWaiter(id) }
+        }
+    }
+
+    private func cancelWaiter(_ id: UUID) {
+        waiters.removeValue(forKey: id)?.continuation.resume()
+    }
 }
 
 actor HostRuntimeLANRefreshRecorder {


### PR DESCRIPTION
## Summary
- schedule broker registration recovery when host startup falls back to verified cached policy
- preserve server Retry-After floors through the lifecycle retry owner
- verify recovery publishes a binding without rebuilding the endpoint

## Testing
- pending isolated AWS package test
- hosted checks pending

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/9271"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788070169&installation_model_id=21920&pr_number=9271&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F9271&signature=768cd3ac950a95d2c5389b37fd9385769a6060316981b44f4af175863b4b319d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Recover broker registration when a host boots from a verified cached policy. Preserve broker Retry-After and retry registration without rebuilding the endpoint, keeping the host available and publishing a binding once the broker recovers.

- **Bug Fixes**
  - On cached activation, schedule broker registration retry and honor server Retry-After via lifecycle-owned scheduling.
  - Avoid endpoint rebuild; publish a fresh binding after registration succeeds.
  - Plumb Retry-After through `PublishedPolicy.registrationRetryAfterSeconds` and refactor retry API to accept `retryAfterSeconds`.
  - Add tests for cached-activation recovery, Retry-After sleep timing, single endpoint build, and binding publish.

<sup>Written for commit 714ad573141812344ab35e4c45f4f52c6aeda5dd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/9271?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved connection recovery by honoring broker-provided retry delays after registration failures.
  * Kept active endpoints available when cached policy is used during startup.
  * Restored broker registration automatically without requiring endpoint recreation.
  * Continued registration refresh and renewal after recovering from temporary failures.

* **Tests**
  * Expanded coverage for retry timing, cached activation, registration recovery, and binding restoration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->