### PR TITLE
Fix inline code escaping in markdown viewer

### DIFF
--- a/Resources/markdown-viewer/shell.html
+++ b/Resources/markdown-viewer/shell.html
@@ -1011,21 +1011,21 @@ html { scroll-behavior: smooth; }
   function normalizedCodespanText(token) {
     // Invalid boundaries mean marked's token contract changed. Never fall back
     // to token.text here: a future version may supply either raw or pre-escaped
-    // text. Throwing routes the whole document through the existing escaped
-    // render-error fallback instead of risking HTML injection.
+    // text. Returning raw source keeps the failure visible and span-local; the
+    // renderer still escapes it before inserting it into HTML.
     if (!token || typeof token.raw !== 'string') {
-      throw new Error('marked codespan token is missing raw source');
+      return '[invalid code span]';
     }
     var openingDelimiter = token.raw.match(/^`+/);
     if (!openingDelimiter) {
-      throw new Error('marked codespan token is missing an opening delimiter');
+      return token.raw;
     }
     var delimiter = openingDelimiter[0];
     if (
       token.raw.length < delimiter.length * 2 ||
       token.raw.slice(-delimiter.length) !== delimiter
     ) {
-      throw new Error('marked codespan token has mismatched delimiters');
+      return token.raw;
     }
 
     // Own codespan normalization here instead of relying on marked's token.text,

--- a/Resources/markdown-viewer/shell.html
+++ b/Resources/markdown-viewer/shell.html
@@ -1014,18 +1014,18 @@ html { scroll-behavior: smooth; }
     // text. A diagnostic sentinel keeps the failure visible and span-local; the
     // renderer still escapes it before inserting it into HTML.
     if (!token || typeof token.raw !== 'string') {
-      return '[invalid code span]';
+      return '\uFFFD';
     }
     var openingDelimiter = token.raw.match(/^`+/);
     if (!openingDelimiter) {
-      return '[invalid code span]';
+      return '\uFFFD';
     }
     var delimiter = openingDelimiter[0];
     if (
       token.raw.length < delimiter.length * 2 ||
       token.raw.slice(-delimiter.length) !== delimiter
     ) {
-      return '[invalid code span]';
+      return '\uFFFD';
     }
 
     // Own codespan normalization here instead of relying on marked's token.text,

--- a/Resources/markdown-viewer/shell.html
+++ b/Resources/markdown-viewer/shell.html
@@ -994,8 +994,8 @@ html { scroll-behavior: smooth; }
   // (text, level, raw / code, lang, escaped / href, title, text)
   // — NOT a single token object. Inline children are already
   // rendered to HTML and passed in as `text`. Codespan text is the
-  // exception below: walkTokens replaces marked's pre-escaped text
-  // with normalized raw source before the renderer escapes it once.
+  // exception below: processAllTokens replaces marked's pre-escaped
+  // text with normalized raw source before the renderer escapes it once.
   var headingSlugCounts = Object.create(null);
   function uniqueHeadingSlug(raw) {
     var base = String(raw || '').toLowerCase()
@@ -1040,13 +1040,52 @@ html { scroll-behavior: smooth; }
     return text;
   }
 
+  function normalizeCodespanTokens(tokens) {
+    // marked's public walkTokens helper accumulates callback results with
+    // repeated Array.concat calls, making a registered walkTokens hook
+    // quadratic in the number of tokens. Traverse the token tree directly so
+    // normalization remains linear for large, untrusted markdown documents.
+    var pendingArrays = [tokens];
+    var visitedArrays = new WeakSet();
+    while (pendingArrays.length > 0) {
+      var siblings = pendingArrays.pop();
+      if (!Array.isArray(siblings) || visitedArrays.has(siblings)) {
+        continue;
+      }
+      visitedArrays.add(siblings);
+
+      for (var i = siblings.length - 1; i >= 0; i--) {
+        var token = siblings[i];
+        if (Array.isArray(token)) {
+          pendingArrays.push(token);
+          continue;
+        }
+        if (!token || typeof token !== 'object') {
+          continue;
+        }
+        if (token.type === 'codespan') {
+          token.text = normalizedCodespanText(token);
+        }
+
+        var keys = Object.keys(token);
+        for (var keyIndex = 0; keyIndex < keys.length; keyIndex++) {
+          var child = token[keys[keyIndex]];
+          if (Array.isArray(child)) {
+            pendingArrays.push(child);
+          }
+        }
+      }
+    }
+    return tokens;
+  }
+
   marked.use({
     gfm: true,
     breaks: false,
     pedantic: false,
-    walkTokens: function(token) {
-      if (token.type === 'codespan') {
-        token.text = normalizedCodespanText(token);
+    hooks: {
+      processAllTokens: function(tokens) {
+        return normalizeCodespanTokens(tokens);
       }
     },
     renderer: {

--- a/Resources/markdown-viewer/shell.html
+++ b/Resources/markdown-viewer/shell.html
@@ -1009,6 +1009,10 @@ html { scroll-behavior: smooth; }
   }
 
   function normalizedCodespanText(token) {
+    // Invalid boundaries mean marked's token contract changed. Never fall back
+    // to token.text here: a future version may supply either raw or pre-escaped
+    // text. Throwing routes the whole document through the existing escaped
+    // render-error fallback instead of risking HTML injection.
     if (!token || typeof token.raw !== 'string') {
       throw new Error('marked codespan token is missing raw source');
     }

--- a/Resources/markdown-viewer/shell.html
+++ b/Resources/markdown-viewer/shell.html
@@ -1011,21 +1011,21 @@ html { scroll-behavior: smooth; }
   function normalizedCodespanText(token) {
     // Invalid boundaries mean marked's token contract changed. Never fall back
     // to token.text here: a future version may supply either raw or pre-escaped
-    // text. Returning raw source keeps the failure visible and span-local; the
+    // text. A diagnostic sentinel keeps the failure visible and span-local; the
     // renderer still escapes it before inserting it into HTML.
     if (!token || typeof token.raw !== 'string') {
       return '[invalid code span]';
     }
     var openingDelimiter = token.raw.match(/^`+/);
     if (!openingDelimiter) {
-      return token.raw;
+      return '[invalid code span]';
     }
     var delimiter = openingDelimiter[0];
     if (
       token.raw.length < delimiter.length * 2 ||
       token.raw.slice(-delimiter.length) !== delimiter
     ) {
-      return token.raw;
+      return '[invalid code span]';
     }
 
     // Own codespan normalization here instead of relying on marked's token.text,

--- a/Resources/markdown-viewer/shell.html
+++ b/Resources/markdown-viewer/shell.html
@@ -993,7 +993,9 @@ html { scroll-behavior: smooth; }
   // calls these methods with the *legacy* positional signature
   // (text, level, raw / code, lang, escaped / href, title, text)
   // — NOT a single token object. Inline children are already
-  // rendered to HTML and passed in as `text`.
+  // rendered to HTML and passed in as `text`. Codespan text is the
+  // exception below: walkTokens replaces marked's pre-escaped text
+  // with normalized raw source before the renderer escapes it once.
   var headingSlugCounts = Object.create(null);
   function uniqueHeadingSlug(raw) {
     var base = String(raw || '').toLowerCase()
@@ -1006,14 +1008,47 @@ html { scroll-behavior: smooth; }
     return count === 0 ? base : base + '-' + count;
   }
 
+  function normalizedCodespanText(token) {
+    if (!token || typeof token.raw !== 'string') {
+      throw new Error('marked codespan token is missing raw source');
+    }
+    var openingDelimiter = token.raw.match(/^`+/);
+    if (!openingDelimiter) {
+      throw new Error('marked codespan token is missing an opening delimiter');
+    }
+    var delimiter = openingDelimiter[0];
+    if (
+      token.raw.length < delimiter.length * 2 ||
+      token.raw.slice(-delimiter.length) !== delimiter
+    ) {
+      throw new Error('marked codespan token has mismatched delimiters');
+    }
+
+    // Own codespan normalization here instead of relying on marked's token.text,
+    // which marked 13.0.3 has already HTML-escaped. This mirrors CommonMark's
+    // newline and single outer-space normalization before our renderer performs
+    // the one and only HTML escape.
+    var text = token.raw.slice(delimiter.length, -delimiter.length)
+      .replace(/\n/g, ' ');
+    if (/[^ ]/.test(text) && /^ /.test(text) && / $/.test(text)) {
+      text = text.slice(1, -1);
+    }
+    return text;
+  }
+
   marked.use({
     gfm: true,
     breaks: false,
     pedantic: false,
+    walkTokens: function(token) {
+      if (token.type === 'codespan') {
+        token.text = normalizedCodespanText(token);
+      }
+    },
     renderer: {
       codespan(code) {
-        var raw = code || '';
-        return '<code>' + escapeHtml(raw) + '</code>';
+        var text = code || '';
+        return '<code>' + escapeHtml(text) + '</code>';
       },
       code(code, infostring, escaped) {
         var raw = code || '';

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -1226,6 +1226,7 @@ C0DE71B10000000000000001 /* AppDelegate+AgentChatNotifications.swift in Sources 
 		730600000000000000000001 /* MainWindowVisibleFrameFitCoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 730600010000000000000001 /* MainWindowVisibleFrameFitCoreTests.swift */; };
 		730600020000000000000002 /* MainWindowVisibleFrameFitRescue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 730600020000000000000001 /* MainWindowVisibleFrameFitRescue.swift */; };
 		A9D9000000000000000F0017 /* markdown-viewer in Resources */ = {isa = PBXBuildFile; fileRef = A9D9000000000000000F0016 /* markdown-viewer */; };
+		D9154002D9154002D9154002 /* MarkdownCodespanRenderingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D9154001D9154001D9154001 /* MarkdownCodespanRenderingTests.swift */; };
 		A28B087F0000000000000003 /* MarkdownEditableFocusMessageHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = A28B087F0000000000000004 /* MarkdownEditableFocusMessageHandler.swift */; };
 		F5168A040000000000000001 /* MarkdownFontFamily.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5168A040000000000000002 /* MarkdownFontFamily.swift */; };
 		F5168A070000000000000001 /* MarkdownFontFamilyCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5168A070000000000000002 /* MarkdownFontFamilyCache.swift */; };
@@ -3770,6 +3771,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 		730600010000000000000001 /* MainWindowVisibleFrameFitCoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainWindowVisibleFrameFitCoreTests.swift; sourceTree = "<group>"; };
 		730600020000000000000001 /* MainWindowVisibleFrameFitRescue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = App/MainWindowVisibleFrameFitRescue.swift; sourceTree = "<group>"; };
 		A9D9000000000000000F0016 /* markdown-viewer */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = folder; path = "markdown-viewer"; sourceTree = "<group>"; };
+		D9154001D9154001D9154001 /* MarkdownCodespanRenderingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkdownCodespanRenderingTests.swift; sourceTree = "<group>"; };
 		A28B087F0000000000000004 /* MarkdownEditableFocusMessageHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/MarkdownEditableFocusMessageHandler.swift; sourceTree = "<group>"; };
 		F5168A040000000000000002 /* MarkdownFontFamily.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/MarkdownFontFamily.swift; sourceTree = "<group>"; };
 		F5168A070000000000000002 /* MarkdownFontFamilyCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/MarkdownFontFamilyCache.swift; sourceTree = "<group>"; };
@@ -7468,6 +7470,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				4C1A7E10B2D34F56A8C90014 /* MobileHostStatusVerificationLimiterTests.swift */,
 				C0DEFB300000000000000002 /* FocusSurfaceBroadcasterTests.swift */,
 				A5001435A5001435A5001435 /* FilePreviewPDFThumbnailSidebarTests.swift */,
+				D9154001D9154001D9154001 /* MarkdownCodespanRenderingTests.swift */,
 				D7470001D7470001D7470001 /* MarkdownLinkBoundaryRegressionTests.swift */,
 				D8072A01D8072A01D8072A01 /* BrowserViewportRuntimeLoadDelegate.swift */,
 				D8072A03D8072A03D8072A03 /* BrowserViewportRuntimeTests.swift */,
@@ -10381,6 +10384,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				17C9F5BA0DD14EDC8C3E5001 /* MainWindowVisibilityControllerTests.swift in Sources */,
 				A6D1F0100000000000000002 /* MainWindowVisibilityLifecycleTests.swift in Sources */,
 				730600000000000000000001 /* MainWindowVisibleFrameFitCoreTests.swift in Sources */,
+				D9154002D9154002D9154002 /* MarkdownCodespanRenderingTests.swift in Sources */,
 				D7470002D7470002D7470002 /* MarkdownLinkBoundaryRegressionTests.swift in Sources */,
 				D6069002D6069002D6069002 /* MarkdownMermaidZoomTests.swift in Sources */,
 				D3664002D3664002D3664002 /* MarkdownPanelTests.swift in Sources */,

--- a/cmuxTests/MarkdownCodespanRenderingTests.swift
+++ b/cmuxTests/MarkdownCodespanRenderingTests.swift
@@ -106,8 +106,8 @@ final class MarkdownCodespanRenderingTests {
                 """
             )
             let raw = try #require(result as? [String: Any])
-            #expect(raw["paragraphText"] as? String == "Before [invalid code span] after.")
-            #expect(raw["codeText"] as? String == "[invalid code span]")
+            #expect(raw["paragraphText"] as? String == "Before \u{FFFD} after.")
+            #expect(raw["codeText"] as? String == "\u{FFFD}")
             #expect((raw["codeChildElementCount"] as? NSNumber)?.intValue == 0)
             #expect((raw["documentImageCount"] as? NSNumber)?.intValue == 0)
             #expect(raw["hasRenderError"] as? Bool == false)

--- a/cmuxTests/MarkdownCodespanRenderingTests.swift
+++ b/cmuxTests/MarkdownCodespanRenderingTests.swift
@@ -101,8 +101,8 @@ final class MarkdownCodespanRenderingTests {
                 """
             )
             let raw = try #require(result as? [String: Any])
-            #expect(raw["paragraphText"] as? String == "Before <img src=x onerror=alert(1)> after.")
-            #expect(raw["codeText"] as? String == "<img src=x onerror=alert(1)>")
+            #expect(raw["paragraphText"] as? String == "Before [invalid code span] after.")
+            #expect(raw["codeText"] as? String == "[invalid code span]")
             #expect((raw["codeChildElementCount"] as? NSNumber)?.intValue == 0)
             #expect((raw["documentImageCount"] as? NSNumber)?.intValue == 0)
             #expect(raw["hasRenderError"] as? Bool == false)

--- a/cmuxTests/MarkdownCodespanRenderingTests.swift
+++ b/cmuxTests/MarkdownCodespanRenderingTests.swift
@@ -32,6 +32,12 @@ final class MarkdownCodespanRenderingTests {
 
                 Hostile lifecycle: `<cmux-codespan-execution-probe></cmux-codespan-execution-probe>`
 
+                - Nested list codespan: `<nested-list>`
+
+                | Nested table codespan |
+                | --- |
+                | `<nested-table>` |
+
                 Fenced block:
                 ```bash
                 aws lambda invoke --function-name foo --payload '{"action":"db_state"}' /dev/stdout
@@ -61,6 +67,7 @@ final class MarkdownCodespanRenderingTests {
                 ]
             )
             #expect(snapshot.inlineChildElementCounts == [0, 0, 0, 0, 0, 0, 0, 0, 0])
+            #expect(snapshot.nestedInlineTexts == ["<nested-list>", "<nested-table>"])
             #expect(
                 snapshot.fencedTexts == [
                     #"aws lambda invoke --function-name foo --payload '{"action":"db_state"}' /dev/stdout"#,
@@ -71,6 +78,7 @@ final class MarkdownCodespanRenderingTests {
             #expect(snapshot.documentImageCount == 0)
             #expect(snapshot.hostileProbeElementCount == 0)
             #expect(snapshot.hostileProbeConnected == false)
+            #expect(snapshot.markedWalkerEnabled == false)
         }
     }
 
@@ -165,6 +173,9 @@ final class MarkdownCodespanRenderingTests {
               var inlineCodes = Array.prototype.slice.call(
                 document.querySelectorAll('#content p code:not(.hljs)')
               );
+              var nestedInlineCodes = Array.prototype.slice.call(
+                document.querySelectorAll('#content li code:not(.hljs), #content td code:not(.hljs)')
+              );
               var fencedCodes = Array.prototype.slice.call(
                 document.querySelectorAll('#content pre > code.hljs')
               );
@@ -173,6 +184,7 @@ final class MarkdownCodespanRenderingTests {
                 proseChildElementCount: prose ? prose.children.length : null,
                 inlineTexts: inlineCodes.map(function(code) { return code.textContent; }),
                 inlineChildElementCounts: inlineCodes.map(function(code) { return code.children.length; }),
+                nestedInlineTexts: nestedInlineCodes.map(function(code) { return code.textContent; }),
                 fencedTexts: fencedCodes.map(function(code) { return code.textContent; }),
                 fencedImageCounts: fencedCodes.map(function(code) {
                   return code.querySelectorAll('img').length;
@@ -181,7 +193,8 @@ final class MarkdownCodespanRenderingTests {
                 hostileProbeElementCount: document.querySelectorAll(
                   '#content ' + hostileProbeTag
                 ).length,
-                hostileProbeConnected: !!window.__cmuxCodespanHostileProbeConnected
+                hostileProbeConnected: !!window.__cmuxCodespanHostileProbeConnected,
+                markedWalkerEnabled: !!window.marked.defaults.walkTokens
               };
             })(\(literal)[0]);
             """
@@ -191,22 +204,26 @@ final class MarkdownCodespanRenderingTests {
         let proseChildElementCount = try #require(raw["proseChildElementCount"] as? NSNumber)
         let inlineTexts = try #require(raw["inlineTexts"] as? [String])
         let inlineChildElementCounts = try #require(raw["inlineChildElementCounts"] as? [NSNumber])
+        let nestedInlineTexts = try #require(raw["nestedInlineTexts"] as? [String])
         let fencedTexts = try #require(raw["fencedTexts"] as? [String])
         let fencedImageCounts = try #require(raw["fencedImageCounts"] as? [NSNumber])
         let documentImageCount = try #require(raw["documentImageCount"] as? NSNumber)
         let hostileProbeElementCount = try #require(raw["hostileProbeElementCount"] as? NSNumber)
         let hostileProbeConnected = try #require(raw["hostileProbeConnected"] as? Bool)
+        let markedWalkerEnabled = try #require(raw["markedWalkerEnabled"] as? Bool)
 
         return MarkdownCodespanSnapshot(
             proseText: proseText,
             proseChildElementCount: proseChildElementCount.intValue,
             inlineTexts: inlineTexts,
             inlineChildElementCounts: inlineChildElementCounts.map(\.intValue),
+            nestedInlineTexts: nestedInlineTexts,
             fencedTexts: fencedTexts,
             fencedImageCounts: fencedImageCounts.map(\.intValue),
             documentImageCount: documentImageCount.intValue,
             hostileProbeElementCount: hostileProbeElementCount.intValue,
-            hostileProbeConnected: hostileProbeConnected
+            hostileProbeConnected: hostileProbeConnected,
+            markedWalkerEnabled: markedWalkerEnabled
         )
     }
 }
@@ -216,11 +233,13 @@ private struct MarkdownCodespanSnapshot {
     let proseChildElementCount: Int
     let inlineTexts: [String]
     let inlineChildElementCounts: [Int]
+    let nestedInlineTexts: [String]
     let fencedTexts: [String]
     let fencedImageCounts: [Int]
     let documentImageCount: Int
     let hostileProbeElementCount: Int
     let hostileProbeConnected: Bool
+    let markedWalkerEnabled: Bool
 }
 
 private final class MarkdownCodespanShellLoadDelegate: NSObject, WKNavigationDelegate {

--- a/cmuxTests/MarkdownCodespanRenderingTests.swift
+++ b/cmuxTests/MarkdownCodespanRenderingTests.swift
@@ -74,6 +74,41 @@ final class MarkdownCodespanRenderingTests {
         }
     }
 
+    @Test
+    func malformedCodespanTokensRemainSpanLocalAndEscaped() async throws {
+        try await withLoadedMarkdownShell { webView in
+            let result = try await webView.evaluateJavaScript(
+                """
+                window.marked.use({
+                  walkTokens: function(token) {
+                    if (token.type === 'codespan' && token.text === 'cmux-malformed-codespan') {
+                      token.raw = '<img src=x onerror=alert(1)>';
+                      token.text = token.raw;
+                    }
+                  }
+                });
+                window.__cmuxRenderMarkdown('Before `cmux-malformed-codespan` after.');
+                var content = document.querySelector('#content');
+                var paragraph = content.querySelector('p');
+                var code = paragraph.querySelector('code');
+                ({
+                  paragraphText: paragraph.textContent,
+                  codeText: code.textContent,
+                  codeChildElementCount: code.children.length,
+                  documentImageCount: content.querySelectorAll('img').length,
+                  hasRenderError: content.textContent.indexOf('markdown render error:') !== -1
+                });
+                """
+            )
+            let raw = try #require(result as? [String: Any])
+            #expect(raw["paragraphText"] as? String == "Before <img src=x onerror=alert(1)> after.")
+            #expect(raw["codeText"] as? String == "<img src=x onerror=alert(1)>")
+            #expect((raw["codeChildElementCount"] as? NSNumber)?.intValue == 0)
+            #expect((raw["documentImageCount"] as? NSNumber)?.intValue == 0)
+            #expect(raw["hasRenderError"] as? Bool == false)
+        }
+    }
+
     private func withLoadedMarkdownShell<T>(
         _ body: (WKWebView) async throws -> T
     ) async throws -> T {

--- a/cmuxTests/MarkdownCodespanRenderingTests.swift
+++ b/cmuxTests/MarkdownCodespanRenderingTests.swift
@@ -80,10 +80,15 @@ final class MarkdownCodespanRenderingTests {
             let result = try await webView.evaluateJavaScript(
                 """
                 window.marked.use({
-                  walkTokens: function(token) {
-                    if (token.type === 'codespan' && token.text === 'cmux-malformed-codespan') {
-                      token.raw = '<img src=x onerror=alert(1)>';
-                      token.text = token.raw;
+                  hooks: {
+                    processAllTokens: function(tokens) {
+                      window.marked.walkTokens(tokens, function(token) {
+                        if (token.type === 'codespan' && token.text === 'cmux-malformed-codespan') {
+                          token.raw = '<img src=x onerror=alert(1)>';
+                          token.text = token.raw;
+                        }
+                      });
+                      return tokens;
                     }
                   }
                 });

--- a/cmuxTests/MarkdownCodespanRenderingTests.swift
+++ b/cmuxTests/MarkdownCodespanRenderingTests.swift
@@ -16,11 +16,17 @@ final class MarkdownCodespanRenderingTests {
         try await withLoadedMarkdownShell { webView in
             let snapshot = try await renderSnapshot(
                 """
+                Plain prose control: 2 < 3 & 4 > 1, "quote" and 'apostrophe'.
+
                 Privileged verbs each require the typed `"<verb> <env>"` confirmation phrase (e.g. `"reset dev"`).
 
                 Inline JSON: `'{"action":"db_state"}'`
 
                 Issue 4144: `<>&"'`
+
+                Literal entity text: `&lt;`
+
+                Delimiter normalization: `` `tick` `` and ` code `.
 
                 Hostile inline: `<img src=x onerror=alert(1)>`
 
@@ -37,16 +43,21 @@ final class MarkdownCodespanRenderingTests {
                 in: webView
             )
 
+            #expect(snapshot.proseText == #"Plain prose control: 2 < 3 & 4 > 1, "quote" and 'apostrophe'."#)
+            #expect(snapshot.proseChildElementCount == 0)
             #expect(
                 snapshot.inlineTexts == [
                     #""<verb> <env>""#,
                     #""reset dev""#,
                     "'{\"action\":\"db_state\"}'",
                     #"<>&"'"#,
+                    "&lt;",
+                    "`tick`",
+                    "code",
                     #"<img src=x onerror=alert(1)>"#,
                 ]
             )
-            #expect(snapshot.inlineChildElementCounts == [0, 0, 0, 0, 0])
+            #expect(snapshot.inlineChildElementCounts == [0, 0, 0, 0, 0, 0, 0, 0])
             #expect(
                 snapshot.fencedTexts == [
                     #"aws lambda invoke --function-name foo --payload '{"action":"db_state"}' /dev/stdout"#,
@@ -98,6 +109,7 @@ final class MarkdownCodespanRenderingTests {
                 window.__cmuxCodespanHostileHandlerExecuted = true;
               };
               window.__cmuxRenderMarkdown(md);
+              var prose = document.querySelector('#content p');
               var inlineCodes = Array.prototype.slice.call(
                 document.querySelectorAll('#content p code:not(.hljs)')
               );
@@ -105,6 +117,8 @@ final class MarkdownCodespanRenderingTests {
                 document.querySelectorAll('#content pre > code.hljs')
               );
               return {
+                proseText: prose ? prose.textContent : null,
+                proseChildElementCount: prose ? prose.children.length : null,
                 inlineTexts: inlineCodes.map(function(code) { return code.textContent; }),
                 inlineChildElementCounts: inlineCodes.map(function(code) { return code.children.length; }),
                 fencedTexts: fencedCodes.map(function(code) { return code.textContent; }),
@@ -118,6 +132,8 @@ final class MarkdownCodespanRenderingTests {
             """
         )
         let raw = try #require(result as? [String: Any])
+        let proseText = try #require(raw["proseText"] as? String)
+        let proseChildElementCount = try #require(raw["proseChildElementCount"] as? NSNumber)
         let inlineTexts = try #require(raw["inlineTexts"] as? [String])
         let inlineChildElementCounts = try #require(raw["inlineChildElementCounts"] as? [NSNumber])
         let fencedTexts = try #require(raw["fencedTexts"] as? [String])
@@ -126,6 +142,8 @@ final class MarkdownCodespanRenderingTests {
         let hostileHandlerExecuted = try #require(raw["hostileHandlerExecuted"] as? Bool)
 
         return MarkdownCodespanSnapshot(
+            proseText: proseText,
+            proseChildElementCount: proseChildElementCount.intValue,
             inlineTexts: inlineTexts,
             inlineChildElementCounts: inlineChildElementCounts.map(\.intValue),
             fencedTexts: fencedTexts,
@@ -137,6 +155,8 @@ final class MarkdownCodespanRenderingTests {
 }
 
 private struct MarkdownCodespanSnapshot {
+    let proseText: String
+    let proseChildElementCount: Int
     let inlineTexts: [String]
     let inlineChildElementCounts: [Int]
     let fencedTexts: [String]

--- a/cmuxTests/MarkdownCodespanRenderingTests.swift
+++ b/cmuxTests/MarkdownCodespanRenderingTests.swift
@@ -30,6 +30,8 @@ final class MarkdownCodespanRenderingTests {
 
                 Hostile inline: `<img src=x onerror=alert(1)>`
 
+                Hostile lifecycle: `<cmux-codespan-execution-probe></cmux-codespan-execution-probe>`
+
                 Fenced block:
                 ```bash
                 aws lambda invoke --function-name foo --payload '{"action":"db_state"}' /dev/stdout
@@ -55,9 +57,10 @@ final class MarkdownCodespanRenderingTests {
                     "`tick`",
                     "code",
                     #"<img src=x onerror=alert(1)>"#,
+                    #"<cmux-codespan-execution-probe></cmux-codespan-execution-probe>"#,
                 ]
             )
-            #expect(snapshot.inlineChildElementCounts == [0, 0, 0, 0, 0, 0, 0, 0])
+            #expect(snapshot.inlineChildElementCounts == [0, 0, 0, 0, 0, 0, 0, 0, 0])
             #expect(
                 snapshot.fencedTexts == [
                     #"aws lambda invoke --function-name foo --payload '{"action":"db_state"}' /dev/stdout"#,
@@ -66,7 +69,8 @@ final class MarkdownCodespanRenderingTests {
             )
             #expect(snapshot.fencedImageCounts == [0, 0])
             #expect(snapshot.documentImageCount == 0)
-            #expect(snapshot.hostileHandlerExecuted == false)
+            #expect(snapshot.hostileProbeElementCount == 0)
+            #expect(snapshot.hostileProbeConnected == false)
         }
     }
 
@@ -104,10 +108,18 @@ final class MarkdownCodespanRenderingTests {
         let result = try await webView.evaluateJavaScript(
             """
             (function(md) {
-              window.__cmuxCodespanHostileHandlerExecuted = false;
-              window.alert = function() {
-                window.__cmuxCodespanHostileHandlerExecuted = true;
-              };
+              var hostileProbeTag = 'cmux-codespan-execution-probe';
+              window.__cmuxCodespanHostileProbeConnected = false;
+              if (!window.customElements.get(hostileProbeTag)) {
+                window.customElements.define(
+                  hostileProbeTag,
+                  class extends HTMLElement {
+                    connectedCallback() {
+                      window.__cmuxCodespanHostileProbeConnected = true;
+                    }
+                  }
+                );
+              }
               window.__cmuxRenderMarkdown(md);
               var prose = document.querySelector('#content p');
               var inlineCodes = Array.prototype.slice.call(
@@ -126,7 +138,10 @@ final class MarkdownCodespanRenderingTests {
                   return code.querySelectorAll('img').length;
                 }),
                 documentImageCount: document.querySelectorAll('#content img').length,
-                hostileHandlerExecuted: !!window.__cmuxCodespanHostileHandlerExecuted
+                hostileProbeElementCount: document.querySelectorAll(
+                  '#content ' + hostileProbeTag
+                ).length,
+                hostileProbeConnected: !!window.__cmuxCodespanHostileProbeConnected
               };
             })(\(literal)[0]);
             """
@@ -139,7 +154,8 @@ final class MarkdownCodespanRenderingTests {
         let fencedTexts = try #require(raw["fencedTexts"] as? [String])
         let fencedImageCounts = try #require(raw["fencedImageCounts"] as? [NSNumber])
         let documentImageCount = try #require(raw["documentImageCount"] as? NSNumber)
-        let hostileHandlerExecuted = try #require(raw["hostileHandlerExecuted"] as? Bool)
+        let hostileProbeElementCount = try #require(raw["hostileProbeElementCount"] as? NSNumber)
+        let hostileProbeConnected = try #require(raw["hostileProbeConnected"] as? Bool)
 
         return MarkdownCodespanSnapshot(
             proseText: proseText,
@@ -149,7 +165,8 @@ final class MarkdownCodespanRenderingTests {
             fencedTexts: fencedTexts,
             fencedImageCounts: fencedImageCounts.map(\.intValue),
             documentImageCount: documentImageCount.intValue,
-            hostileHandlerExecuted: hostileHandlerExecuted
+            hostileProbeElementCount: hostileProbeElementCount.intValue,
+            hostileProbeConnected: hostileProbeConnected
         )
     }
 }
@@ -162,7 +179,8 @@ private struct MarkdownCodespanSnapshot {
     let fencedTexts: [String]
     let fencedImageCounts: [Int]
     let documentImageCount: Int
-    let hostileHandlerExecuted: Bool
+    let hostileProbeElementCount: Int
+    let hostileProbeConnected: Bool
 }
 
 private final class MarkdownCodespanShellLoadDelegate: NSObject, WKNavigationDelegate {

--- a/cmuxTests/MarkdownCodespanRenderingTests.swift
+++ b/cmuxTests/MarkdownCodespanRenderingTests.swift
@@ -1,0 +1,175 @@
+import AppKit
+import Testing
+import WebKit
+
+#if canImport(cmux_DEV)
+@testable import cmux_DEV
+#elseif canImport(cmux)
+@testable import cmux
+#endif
+
+@MainActor
+@Suite
+final class MarkdownCodespanRenderingTests {
+    @Test
+    func inlineCodespansRenderDecodedTextWhileCodeBlocksStayEscaped() async throws {
+        try await withLoadedMarkdownShell { webView in
+            let snapshot = try await renderSnapshot(
+                """
+                Privileged verbs each require the typed `"<verb> <env>"` confirmation phrase (e.g. `"reset dev"`).
+
+                Inline JSON: `'{"action":"db_state"}'`
+
+                Issue 4144: `<>&"'`
+
+                Hostile inline: `<img src=x onerror=alert(1)>`
+
+                Fenced block:
+                ```bash
+                aws lambda invoke --function-name foo --payload '{"action":"db_state"}' /dev/stdout
+                ```
+
+                Unknown-language hostile fence:
+                ```unknown-cmux-language
+                <img src=x onerror=alert(1)> & "'
+                ```
+                """,
+                in: webView
+            )
+
+            #expect(
+                snapshot.inlineTexts == [
+                    #""<verb> <env>""#,
+                    #""reset dev""#,
+                    "'{\"action\":\"db_state\"}'",
+                    #"<>&"'"#,
+                    #"<img src=x onerror=alert(1)>"#,
+                ]
+            )
+            #expect(snapshot.inlineChildElementCounts == [0, 0, 0, 0, 0])
+            #expect(
+                snapshot.fencedTexts == [
+                    #"aws lambda invoke --function-name foo --payload '{"action":"db_state"}' /dev/stdout"#,
+                    #"<img src=x onerror=alert(1)> & "'"#,
+                ]
+            )
+            #expect(snapshot.fencedImageCounts == [0, 0])
+            #expect(snapshot.documentImageCount == 0)
+            #expect(snapshot.hostileHandlerExecuted == false)
+        }
+    }
+
+    private func withLoadedMarkdownShell<T>(
+        _ body: (WKWebView) async throws -> T
+    ) async throws -> T {
+        let markdownURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cmux-markdown-codespan-\(UUID().uuidString).md")
+        let frame = NSRect(x: 0, y: 0, width: 1_000, height: 600)
+        let webView = WKWebView(frame: frame, configuration: WKWebViewConfiguration())
+        let window = NSWindow(contentRect: frame, styleMask: [.borderless], backing: .buffered, defer: false)
+        window.contentView = webView
+        window.orderFrontRegardless()
+        defer {
+            webView.navigationDelegate = nil
+            window.close()
+        }
+
+        let loadDelegate = MarkdownCodespanShellLoadDelegate()
+        webView.navigationDelegate = loadDelegate
+        try await loadDelegate.load(
+            MarkdownViewerAssets.shared.shellHTML(isDark: true),
+            in: webView,
+            baseURL: markdownURL
+        )
+        return try await body(webView)
+    }
+
+    private func renderSnapshot(
+        _ markdown: String,
+        in webView: WKWebView
+    ) async throws -> MarkdownCodespanSnapshot {
+        let data = try JSONSerialization.data(withJSONObject: [markdown])
+        let literal = try #require(String(data: data, encoding: .utf8))
+        let result = try await webView.evaluateJavaScript(
+            """
+            (function(md) {
+              window.__cmuxCodespanHostileHandlerExecuted = false;
+              window.alert = function() {
+                window.__cmuxCodespanHostileHandlerExecuted = true;
+              };
+              window.__cmuxRenderMarkdown(md);
+              var inlineCodes = Array.prototype.slice.call(
+                document.querySelectorAll('#content p code:not(.hljs)')
+              );
+              var fencedCodes = Array.prototype.slice.call(
+                document.querySelectorAll('#content pre > code.hljs')
+              );
+              return {
+                inlineTexts: inlineCodes.map(function(code) { return code.textContent; }),
+                inlineChildElementCounts: inlineCodes.map(function(code) { return code.children.length; }),
+                fencedTexts: fencedCodes.map(function(code) { return code.textContent; }),
+                fencedImageCounts: fencedCodes.map(function(code) {
+                  return code.querySelectorAll('img').length;
+                }),
+                documentImageCount: document.querySelectorAll('#content img').length,
+                hostileHandlerExecuted: !!window.__cmuxCodespanHostileHandlerExecuted
+              };
+            })(\(literal)[0]);
+            """
+        )
+        let raw = try #require(result as? [String: Any])
+        let inlineTexts = try #require(raw["inlineTexts"] as? [String])
+        let inlineChildElementCounts = try #require(raw["inlineChildElementCounts"] as? [NSNumber])
+        let fencedTexts = try #require(raw["fencedTexts"] as? [String])
+        let fencedImageCounts = try #require(raw["fencedImageCounts"] as? [NSNumber])
+        let documentImageCount = try #require(raw["documentImageCount"] as? NSNumber)
+        let hostileHandlerExecuted = try #require(raw["hostileHandlerExecuted"] as? Bool)
+
+        return MarkdownCodespanSnapshot(
+            inlineTexts: inlineTexts,
+            inlineChildElementCounts: inlineChildElementCounts.map(\.intValue),
+            fencedTexts: fencedTexts,
+            fencedImageCounts: fencedImageCounts.map(\.intValue),
+            documentImageCount: documentImageCount.intValue,
+            hostileHandlerExecuted: hostileHandlerExecuted
+        )
+    }
+}
+
+private struct MarkdownCodespanSnapshot {
+    let inlineTexts: [String]
+    let inlineChildElementCounts: [Int]
+    let fencedTexts: [String]
+    let fencedImageCounts: [Int]
+    let documentImageCount: Int
+    let hostileHandlerExecuted: Bool
+}
+
+private final class MarkdownCodespanShellLoadDelegate: NSObject, WKNavigationDelegate {
+    private var continuation: CheckedContinuation<Void, Error>?
+
+    func load(_ html: String, in webView: WKWebView, baseURL: URL) async throws {
+        try await withCheckedThrowingContinuation { continuation in
+            self.continuation = continuation
+            webView.loadHTMLString(html, baseURL: baseURL)
+        }
+    }
+
+    private func finish(_ result: Result<Void, Error>) {
+        guard let continuation else { return }
+        self.continuation = nil
+        continuation.resume(with: result)
+    }
+
+    func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
+        finish(.success(()))
+    }
+
+    func webView(_ webView: WKWebView, didFail navigation: WKNavigation!, withError error: Error) {
+        finish(.failure(error))
+    }
+
+    func webView(_ webView: WKWebView, didFailProvisionalNavigation navigation: WKNavigation!, withError error: Error) {
+        finish(.failure(error))
+    }
+}


### PR DESCRIPTION
## Summary

- make the markdown viewer own inline-code normalization and HTML escaping at one explicit boundary
- render #9154 and #4144 characters literally while keeping hostile inline markup inert
- preserve the fenced-code renderer, which already receives raw source and escapes it exactly once

## Root cause and fix

Bundled marked 13.0.3 HTML-escapes `codespan` token text before invoking a legacy custom renderer. The viewer escaped that value again, turning entities such as `&quot;` into `&amp;quot;` and displaying the entity spelling.

Simply deleting the second escape would make safety depend on an undocumented marked invariant. Instead, a linear `processAllTokens` traversal now derives code-span text from `token.raw`, validates matching backtick delimiters, applies marked/CommonMark newline and outer-space normalization, and passes raw text to the renderer. The renderer remains the sole HTML-escaping boundary. If a future marked version changes the raw-token contract, only that span renders a diagnostic sentinel; it never falls back to text of unknown escaping and never blanks the rest of the document.

I also audited the sibling overrides: `heading()` correctly receives rendered inline HTML before whole-document sanitization, and `link()` correctly sanitizes rendered label HTML while decoding and attribute-escaping titles.

## Fenced-code finding

The fenced portion of #9154 is not reproducible against the bundled production assets. Marked passes fenced-block content to `code(code, infostring, escaped)` as raw text. The exact `bash` example, the unknown-language `highlightAuto` path, and the Mermaid/Vega `escapeHtml` branches therefore escape exactly once. Those paths are intentionally unchanged and covered by rendered-DOM controls, including hostile markup.

The issue record is corrected here: https://github.com/manaflow-ai/cmux/issues/9154#issuecomment-5140112140

## Regression proof

The regression test is the first commit (`206eda77e1`) and the implementation is the separate second commit (`dce2168c58`). The test-only SHA executed one hosted test and failed on the expected visible entities: https://github.com/manaflow-ai/cmux/actions/runs/30609325420

The implementation SHA then passed the same hosted test: https://github.com/manaflow-ai/cmux/actions/runs/30610449383

Review follow-ups make hostile execution proof synchronous and deterministic, contain malformed parser tokens to one span, avoid hook-order coupling, and keep token traversal linear. Final HEAD is `dc448db522`; its hosted run is https://github.com/manaflow-ai/cmux/actions/runs/30613632137

## Test plan

- [x] full production-shell/jsdom rendering: #9154 inline cases
- [x] #4144 exact `<>&"'` case
- [x] literal entity text plus CommonMark delimiter/space normalization
- [x] hostile inline text creates no element; a custom-element lifecycle probe never connects
- [x] malformed codespan tokens remain escaped and span-local
- [x] exact `bash` fence and hostile unknown-language fence stay escaped once
- [x] plain prose retains `<`, `>`, `&`, double quotes, and apostrophes
- [x] markdown-viewer asset compression test
- [x] Swift frontend parse and zero new Swift warnings
- [x] pbxproj normalization, test wiring, workspace grouping, and lockfile policy checks
- [x] targeted hosted test on final HEAD

Localization audit: no ordinary user-facing strings were added or changed; the only new diagnostic is the fail-closed malformed-token sentinel.

Closes #9154
Closes #4144


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved inline code rendering for decoded content, escaped fenced code, newlines, and surrounding spaces.
  - Improved handling of malformed Markdown codespan structures with a clear diagnostic placeholder.
  - Prevented hostile markup and custom elements from being interpreted as executable content during rendering.

- **Tests**
  - Added coverage for codespan rendering, malformed tokens, escaped code, and potentially unsafe markup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->



