### PR TITLE
Unbreak workflow-guard-tests: fake iOS archives need dSYMs and Symbols

### DIFF
--- a/tests/test_ios_appstore_lane_identity.py
+++ b/tests/test_ios_appstore_lane_identity.py
@@ -320,6 +320,8 @@ if "archive" in args:
             "CMUXCrashReportingEnabled": crash_reporting_enabled,
         }},
     )
+    # upload-testflight.sh refuses archives without dSYM bundles.
+    (archive / "dSYMs" / "cmux.app.dSYM" / "Contents").mkdir(parents=True, exist_ok=True)
     sys.exit(0)
 
 if "-exportArchive" in args:
@@ -343,10 +345,16 @@ if "-exportArchive" in args:
         )
     profile_marker = "beta profile" if bundle_id == BETA_BUNDLE_ID else "fake profile"
     (app / "embedded.mobileprovision").write_text(profile_marker, encoding="utf-8")
+    # upload-testflight.sh refuses IPAs without Symbols/*.symbols.
+    symbols_root = export_path / "Symbols"
+    symbols_root.mkdir(parents=True, exist_ok=True)
+    (symbols_root / "cmux.symbols").write_text("fake symbols", encoding="utf-8")
     ipa = export_path / "cmux.ipa"
     ipa.parent.mkdir(parents=True, exist_ok=True)
     with zipfile.ZipFile(ipa, "w") as zf:
         for item in payload_root.rglob("*"):
+            zf.write(item, item.relative_to(export_path))
+        for item in symbols_root.rglob("*"):
             zf.write(item, item.relative_to(export_path))
     sys.exit(0)
 
@@ -517,6 +525,8 @@ def _write_fake_archive(path: Path, *, bundle_id: str, build_number: str, market
     }
     (path).mkdir(parents=True, exist_ok=True)
     app.mkdir(parents=True, exist_ok=True)
+    # upload-testflight.sh refuses archives without dSYM bundles.
+    (path / "dSYMs" / "cmux.app.dSYM" / "Contents").mkdir(parents=True, exist_ok=True)
     (path / "Info.plist").write_bytes(
         _plist_bytes(
             {


### PR DESCRIPTION
workflow-guard-tests is red on every PR gate since https://github.com/manaflow-ai/cmux/pull/9236: upload-testflight.sh now refuses archives without dSYM bundles and IPAs without Symbols/*.symbols, but the App Store lane identity guard's fake xcodebuild/archive fixtures were never taught about either gate ("FAIL: beta export-only lane succeeds with fake Apple tools"). Because the guard is the cheap CI layer, its failure also short-circuits tests, release-build, and the other required checks for every PR (observed identically on unrelated branches, e.g. https://github.com/manaflow-ai/cmux/actions/runs/30608830115).

Fix: the fake archive now contains dSYMs/cmux.app.dSYM and the fake export writes Symbols/cmux.symbols into the IPA, so the guard exercises the new symbolication gates instead of tripping them. Test-fixture-only change; `python3 tests/test_ios_appstore_lane_identity.py` goes from the CI failure to "all ios appstore lane identity tests passed" locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/9279"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788071912&installation_model_id=21920&pr_number=9279&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F9279&signature=62bcf95bece19ee4d3a2db650b14a516b94dcd0039fbecbc4f9aca409f2e1dff"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes workflow-guard-tests by updating the App Store lane identity guard’s fake iOS archive/export to include required dSYMs and Symbols, so upload-testflight.sh passes the new gates. Test-fixture-only change that restores the CI gate and downstream checks.

<sup>Written for commit b3ea50353d552c2e98a44af3c1ce0c344980014f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/9279?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated iOS app store upload test fixtures to include debug symbols in archives and exported app packages.
  * Improved test coverage for symbol upload requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->