### PR TITLE
Fix sender-relative key-window routing for restored windows

### DIFF
--- a/Sources/App/MainWindowVisibilityController.swift
+++ b/Sources/App/MainWindowVisibilityController.swift
@@ -18,6 +18,7 @@ final class MainWindowVisibilityController {
         case notification
         case rightSidebarFocus
         case rightSidebarToggle
+        case senderRelativeAction
         case titlebarDismiss
         case socketActivate
         case workspaceCreation

--- a/Sources/AppDelegate+ShortcutRoutingWindow.swift
+++ b/Sources/AppDelegate+ShortcutRoutingWindow.swift
@@ -34,8 +34,8 @@ extension AppDelegate {
     }
 
     func activeTabManagerForCommands(preferredWindow: NSWindow? = nil) -> TabManager? {
-        if let context = contextForMainWindow(preferredWindow) {
-            return context.tabManager
+        if let preferredWindow {
+            return senderRelativeMainWindowContext(for: preferredWindow)?.tabManager
         }
         if let context = contextForMainWindow(shortcutRoutingKeyWindow) {
             return context.tabManager
@@ -50,6 +50,22 @@ extension AppDelegate {
         return mainWindowContexts.values.first { context in
             resolvedWindow(for: context) != nil
         }?.tabManager
+    }
+
+    /// Resolves an in-window action from the exact AppKit window that emitted
+    /// it. Sender-relative actions must never fall through to the process-wide
+    /// key/main/active-manager chain: a consumed first-mouse event can leave
+    /// those globals pointing at a different window.
+    func senderRelativeMainWindowContext(for window: NSWindow) -> MainWindowContext? {
+        guard let context = mainWindowContexts[ObjectIdentifier(window)],
+              context.window === window else {
+            return nil
+        }
+        if let windowId = mainWindowId(from: window),
+           context.windowId != windowId {
+            return nil
+        }
+        return context
     }
 
     func repairFocusedTerminalKeyboardRoutingIfNeeded(

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -6613,6 +6613,23 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         return mainWindowContexts.values.first
     }
 
+    /// Establishes the AppKit and cmux focus owners for an action originating
+    /// inside a particular main window. Custom titlebar controls consume their
+    /// mouse-down before AppKit's normal dispatch, so they explicitly assume
+    /// responsibility for the key-window transfer that dispatch would have
+    /// performed.
+    @discardableResult
+    func prepareSenderRelativeMainWindowAction(in window: NSWindow) -> MainWindowContext? {
+        guard let context = senderRelativeMainWindowContext(for: window) else {
+            return nil
+        }
+        mainWindowVisibilityController.focusForInWindowCommand(
+            window,
+            reason: .senderRelativeAction
+        )
+        return context
+    }
+
     func preferredRegisteredMainWindowContext(preferredWindow: NSWindow? = nil) -> MainWindowContext? {
         if let preferredWindow,
            let context = contextForMainWindow(preferredWindow) {
@@ -6658,9 +6675,13 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
             return true
         }
 
-        if let preferredWindow,
-           let preferredContext = contextForMainTerminalWindow(preferredWindow),
-           toggle(preferredContext) {
+        if let preferredWindow {
+            guard let preferredContext = prepareSenderRelativeMainWindowAction(
+                in: preferredWindow
+            ) else {
+                return false
+            }
+            preferredContext.sidebarState.toggle()
             return true
         }
         if let keyWindow = shortcutRoutingKeyWindow,
@@ -16514,7 +16535,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
     }
 
     func setActiveMainWindow(_ window: NSWindow) {
-        guard let context = contextForMainTerminalWindow(window) else { return }
+        guard let context = senderRelativeMainWindowContext(for: window) else { return }
 #if DEBUG
         let beforeManagerToken = debugManagerToken(tabManager)
 #endif

--- a/Sources/CmuxLifecycleEventPublishing.swift
+++ b/Sources/CmuxLifecycleEventPublishing.swift
@@ -262,7 +262,7 @@ extension AppDelegate {
     func handleCmuxWindowBecameKey(_ note: Notification) {
         guard let window = note.object as? NSWindow else { return }
         MainActor.assumeIsolated {
-            let context = contextForMainTerminalWindow(window)
+            let context = senderRelativeMainWindowContext(for: window)
             setActiveMainWindow(window)
             if let windowId = mainWindowId(from: window) {
                 publishCmuxWindowLifecycle(name: "window.keyed", windowId: windowId, origin: "appkit_key")

--- a/Sources/Update/UpdateTitlebarAccessory.swift
+++ b/Sources/Update/UpdateTitlebarAccessory.swift
@@ -1807,18 +1807,33 @@ final class TitlebarControlsAccessoryViewController: NSTitlebarAccessoryViewCont
         let containerView = TitlebarAccessoryContainerView()
         self.containerView = containerView
         self.notificationStore = notificationStore
+        let prepareOriginatingAction: () -> AppDelegate.MainWindowContext? = { [weak containerView] in
+            guard let appDelegate = AppDelegate.shared,
+                  let window = containerView?.window else {
+                return nil
+            }
+            return appDelegate.prepareSenderRelativeMainWindowAction(in: window)
+        }
         let toggleSidebar = { [weak containerView] in
             _ = AppDelegate.shared?.toggleSidebarInActiveMainWindow(preferredWindow: containerView?.window)
         }
         let toggleNotifications: () -> Void = { [weak containerView] in
+            guard prepareOriginatingAction() != nil else { return }
             _ = AppDelegate.shared?.toggleNotificationsPopover(animated: true, anchorView: containerView)
         }
-        let newTab = { _ = AppDelegate.shared?.performNewWorkspaceAction(debugSource: "titlebar.accessoryNewWorkspace") }
-        let focusHistoryBack = { [weak containerView] in
-            _ = AppDelegate.shared?.activeTabManagerForCommands(preferredWindow: containerView?.window)?.navigateBack()
+        let newTab = {
+            guard let appDelegate = AppDelegate.shared,
+                  let context = prepareOriginatingAction() else { return }
+            _ = appDelegate.performNewWorkspaceAction(
+                tabManager: context.tabManager,
+                debugSource: "titlebar.accessoryNewWorkspace"
+            )
         }
-        let focusHistoryForward = { [weak containerView] in
-            _ = AppDelegate.shared?.activeTabManagerForCommands(preferredWindow: containerView?.window)?.navigateForward()
+        let focusHistoryBack = {
+            _ = prepareOriginatingAction()?.tabManager.navigateBack()
+        }
+        let focusHistoryForward = {
+            _ = prepareOriginatingAction()?.tabManager.navigateForward()
         }
         let rootView = TitlebarControlsView(
             notificationStore: notificationStore,

--- a/Sources/WindowDecorationsController.swift
+++ b/Sources/WindowDecorationsController.swift
@@ -335,34 +335,37 @@ final class WindowDecorationsController {
         #endif
 
         Task { @MainActor [weak window] in
-            guard let window else { return }
+            guard let window,
+                  let appDelegate = AppDelegate.shared,
+                  let context = appDelegate.prepareSenderRelativeMainWindowAction(in: window) else {
+                return
+            }
             switch slot {
             case .toggleSidebar:
-                _ = AppDelegate.shared?.toggleSidebarInActiveMainWindow(preferredWindow: window)
+                context.sidebarState.toggle()
             case .showNotifications:
                 let resolvedAnchorView = NotificationsAnchorRegistry.shared.closestAnchor(
                     in: window,
                     to: locationInWindow
                 ) ?? anchorView
-                AppDelegate.shared?.toggleNotificationsPopover(animated: true, anchorView: resolvedAnchorView)
+                appDelegate.toggleNotificationsPopover(animated: true, anchorView: resolvedAnchorView)
             case .newTab:
-                let targetTabManager = AppDelegate.shared?.activeTabManagerForCommands(preferredWindow: window)
-                _ = AppDelegate.shared?.performNewWorkspaceAction(
-                    tabManager: targetTabManager,
+                _ = appDelegate.performNewWorkspaceAction(
+                    tabManager: context.tabManager,
                     debugSource: "titlebar.minimalSidebarControl"
                 )
             case .cloudVM:
                 guard let anchorView else { return }
-                _ = AppDelegate.shared?.showNewWorkspaceContextMenu(
+                _ = appDelegate.showNewWorkspaceContextMenu(
                     anchorView: anchorView,
                     debugSource: "titlebar.minimalSidebar.cloudMenu"
                 )
             case .focusHistoryBack:
-                guard focusHistoryNavigationAvailability(preferredWindow: window).canNavigateBack else { return }
-                AppDelegate.shared?.activeTabManagerForCommands(preferredWindow: window)?.navigateBack()
+                guard context.tabManager.canNavigateBack else { return }
+                context.tabManager.navigateBack()
             case .focusHistoryForward:
-                guard focusHistoryNavigationAvailability(preferredWindow: window).canNavigateForward else { return }
-                AppDelegate.shared?.activeTabManagerForCommands(preferredWindow: window)?.navigateForward()
+                guard context.tabManager.canNavigateForward else { return }
+                context.tabManager.navigateForward()
             }
         }
     }

--- a/cmuxTests/AppDelegateShortcutRoutingTests.swift
+++ b/cmuxTests/AppDelegateShortcutRoutingTests.swift
@@ -1149,6 +1149,55 @@ final class AppDelegateShortcutRoutingTests: XCTestCase {
         )
     }
 
+    func testSenderRelativeSidebarActionKeysItsOriginatingWindowBeforeMutation() {
+        guard let appDelegate = AppDelegate.shared else {
+            XCTFail("Expected AppDelegate.shared")
+            return
+        }
+
+        let originatingWindowId = appDelegate.createMainWindow()
+        let previouslyFocusedWindowId = appDelegate.createMainWindow()
+
+        defer {
+            closeWindow(withId: originatingWindowId)
+            closeWindow(withId: previouslyFocusedWindowId)
+        }
+
+        guard let originatingWindow = window(withId: originatingWindowId),
+              let previouslyFocusedWindow = window(withId: previouslyFocusedWindowId),
+              let originatingVisibilityBefore = appDelegate.sidebarVisibility(windowId: originatingWindowId),
+              let previouslyFocusedVisibilityBefore = appDelegate.sidebarVisibility(windowId: previouslyFocusedWindowId) else {
+            XCTFail("Expected both window contexts to exist")
+            return
+        }
+
+        originatingWindow.orderFront(nil)
+        previouslyFocusedWindow.makeKeyAndOrderFront(nil)
+        RunLoop.main.run(until: Date(timeIntervalSinceNow: 0.05))
+
+        XCTAssertTrue(appDelegate.shortcutRoutingKeyWindow === previouslyFocusedWindow)
+
+        XCTAssertTrue(
+            appDelegate.toggleSidebarInActiveMainWindow(preferredWindow: originatingWindow)
+        )
+        RunLoop.main.run(until: Date(timeIntervalSinceNow: 0.05))
+
+        XCTAssertTrue(
+            appDelegate.shortcutRoutingKeyWindow === originatingWindow,
+            "An in-window action must request key status for its originating window before mutating window state"
+        )
+        XCTAssertEqual(
+            appDelegate.sidebarVisibility(windowId: originatingWindowId),
+            !originatingVisibilityBefore,
+            "The originating window should receive the sidebar mutation"
+        )
+        XCTAssertEqual(
+            appDelegate.sidebarVisibility(windowId: previouslyFocusedWindowId),
+            previouslyFocusedVisibilityBefore,
+            "The previously focused window must remain unchanged"
+        )
+    }
+
     func testWelcomeWindowSidebarShortcutsUseSharedToggleCommands() {
         guard let appDelegate = AppDelegate.shared else {
             XCTFail("Expected AppDelegate.shared")


### PR DESCRIPTION
Fixes #9229

## Summary

- Resolve in-window actions from the exact `NSWindow` that originated them, with no fallback to `NSApp.keyWindow`, `NSApp.mainWindow`, the cached active manager, or the first registered context.
- Transfer AppKit key status through the shared `MainWindowVisibilityController` before mutating sidebar state or dispatching titlebar actions.
- Apply exact sender identity to key-window lifecycle activation so a stale `MainWindowContext` dictionary entry cannot shadow the live window.
- Route standard and minimal titlebar actions through the same sender-relative ingress.

## Root cause

Fresh windows mask the bug because creation makes them key. Restored windows can be presented without becoming key, and husks have no terminal content left to activate. cmux's custom/minimal titlebar paths can consume mouse-down before normal AppKit dispatch, so AppKit never performs the clicked-window key transfer. Global key/main/active-manager state therefore remains pointed at the previously focused window.

The old context resolver could also accept an object-identifier dictionary hit without verifying that the context's weak `window` was the actual sender. That made stale context bookkeeping capable of routing a sender-aware action to the wrong state.

The new sender-relative resolver requires one exact `context.window === senderWindow` match and validates the window UUID when available. If that invariant is not satisfied, the action fails closed instead of mutating another window.

## Related issues

- This does **not** fix #4579's last-workspace/window teardown behavior; it fixes action routing and key transfer for the husk that issue can leave behind.
- This does **not** complete #8349's ghost-context/PTTY lifecycle cleanup. It prevents a stale context from shadowing a live sender for this class of action.
- It applies the same sender-relative routing principle as #6365, but does not subsume every workspace-close path.

## Testing

- Test-first commit: `c811bb6aef` adds `testSenderRelativeSidebarActionKeysItsOriginatingWindowBeforeMutation`.
- Red proof: [GitHub Actions run 30610125920](https://github.com/manaflow-ai/cmux/actions/runs/30610125920), against the byte-identical test-only commit before its unrelated base rebase, executed one test and failed only at the new sender key-request assertion.
- Green proof after the initial fix: [GitHub Actions run 30611051051](https://github.com/manaflow-ai/cmux/actions/runs/30611051051) executed exactly the selected regression and passed with 1 test, 0 failures.
- Current-HEAD rerun after review cleanup: [GitHub Actions run 30612229983](https://github.com/manaflow-ai/cmux/actions/runs/30612229983) and [artifact report #7131](https://github.com/manaflow-ai/cmux-dev-artifacts/issues/7131) confirm SHA `966ce5b2532b`, 1 selected test, and 0 failures.
- The repository's manually dispatched full `CI` workflow is currently blocked on `origin/main` before macOS jobs: #9236's iOS dSYM guard rejects its own untouched fake-archive fixture. This branch changes none of the failing workflow, test, or iOS upload script paths; #9279 is the scoped fix.
- `./scripts/lint-pbxproj-test-wiring.sh`
- `git diff --check`
- No local `xcodebuild` or XCUITest was run, per repository machine-safety policy.

## Demo Video

- Video unavailable. A cloud Mac was provisioned through [loader run 30608851564](https://github.com/manaflow-ai/cmux-loader/actions/runs/30608851564), but the runner joined a different/unreachable Switchboard tailnet, so restored-window and husk visual capture could not be completed.

## Localization audit

- No user-facing strings, message catalogs, or localization resources changed.

## Review Trigger (Copy/Paste as PR comment)

```text
@codex review
@coderabbitai review
@greptile-apps review
@cubic-dev-ai review
```

## Checklist

- [ ] I tested the change locally (prohibited for this task; hosted test used instead)
- [x] I added or updated tests for behavior changes
- [x] I updated docs/changelog if needed (not needed)
- [x] I requested bot reviews after my latest commit
- [ ] All code review bot comments are resolved
- [ ] All human review comments are resolved
