### PR TITLE
Fix pinned workspace grouping and group reordering

### DIFF
--- a/Packages/macOS/CmuxFoundation/Sources/CmuxFoundation/SidebarDrop/SidebarDragLifecyclePolicies.swift
+++ b/Packages/macOS/CmuxFoundation/Sources/CmuxFoundation/SidebarDrop/SidebarDragLifecyclePolicies.swift
@@ -64,7 +64,6 @@ public struct SidebarWorkspaceDragActivationPolicy: Sendable {
         isLocalWorkspace: Bool,
         isSourceGroupAnchor: Bool
     ) -> Bool {
-        _ = isLocalWorkspace
-        return isSourceGroupAnchor
+        !isLocalWorkspace && isSourceGroupAnchor
     }
 }

--- a/Packages/macOS/CmuxFoundation/Sources/CmuxFoundation/SidebarDrop/SidebarDragLifecyclePolicies.swift
+++ b/Packages/macOS/CmuxFoundation/Sources/CmuxFoundation/SidebarDrop/SidebarDragLifecyclePolicies.swift
@@ -51,3 +51,20 @@ public struct SidebarDragFailsafePolicy {
         eventType == .leftMouseUp
     }
 }
+
+/// Decides whether a native sidebar drag whose transient state was cleared
+/// may be recovered from the workspace id still carried by AppKit's active
+/// pasteboard session.
+public struct SidebarWorkspaceDragActivationPolicy: Sendable {
+    public init() {}
+
+    /// Group anchors cannot move across windows because moving only the anchor
+    /// would dissolve the source group and strand its members.
+    public func shouldRejectRecovery(
+        isLocalWorkspace: Bool,
+        isSourceGroupAnchor: Bool
+    ) -> Bool {
+        _ = isLocalWorkspace
+        return isSourceGroupAnchor
+    }
+}

--- a/Packages/macOS/CmuxFoundation/Sources/CmuxFoundation/SidebarDrop/SidebarWorkspaceReorderDropResolver.swift
+++ b/Packages/macOS/CmuxFoundation/Sources/CmuxFoundation/SidebarDrop/SidebarWorkspaceReorderDropResolver.swift
@@ -560,7 +560,7 @@ public struct SidebarWorkspaceReorderDropResolver: Sendable {
                lastIndexByGroupId[groupId] == index {
                 nextRootTargetByGroupId[groupId] = nextRootTarget
             }
-            if target.groupId == nil {
+            if target.groupId == nil || target.isGroupHeader {
                 nextRootTarget = target
             }
         }

--- a/Packages/macOS/CmuxFoundation/Tests/CmuxFoundationTests/SidebarDropPlannerTests.swift
+++ b/Packages/macOS/CmuxFoundation/Tests/CmuxFoundationTests/SidebarDropPlannerTests.swift
@@ -5,6 +5,72 @@ import Testing
 @testable import CmuxFoundation
 
 @Suite struct SidebarDropPlannerPackageTests {
+    @Test func pinnedGroupDropAfterItselfBeforeNextPinnedGroupIsNoOp() {
+        let firstGroupId = UUID()
+        let firstAnchorId = UUID()
+        let firstChildId = UUID()
+        let secondGroupId = UUID()
+        let secondAnchorId = UUID()
+        let secondChildId = UUID()
+
+        let plan = SidebarWorkspaceReorderDropResolver().plan(
+            for: SidebarWorkspaceReorderDropRequest(
+                point: CGPoint(x: 12, y: 31),
+                draggedWorkspaceId: firstAnchorId,
+                workspaces: [
+                    SidebarWorkspaceReorderWorkspaceSnapshot(
+                        id: firstAnchorId,
+                        isPinned: false,
+                        groupId: firstGroupId
+                    ),
+                    SidebarWorkspaceReorderWorkspaceSnapshot(
+                        id: firstChildId,
+                        isPinned: false,
+                        groupId: firstGroupId
+                    ),
+                    SidebarWorkspaceReorderWorkspaceSnapshot(
+                        id: secondAnchorId,
+                        isPinned: false,
+                        groupId: secondGroupId
+                    ),
+                    SidebarWorkspaceReorderWorkspaceSnapshot(
+                        id: secondChildId,
+                        isPinned: false,
+                        groupId: secondGroupId
+                    ),
+                ],
+                groups: [
+                    SidebarWorkspaceReorderGroupSnapshot(
+                        id: firstGroupId,
+                        anchorWorkspaceId: firstAnchorId,
+                        isPinned: true
+                    ),
+                    SidebarWorkspaceReorderGroupSnapshot(
+                        id: secondGroupId,
+                        anchorWorkspaceId: secondAnchorId,
+                        isPinned: true
+                    ),
+                ],
+                targets: [
+                    SidebarWorkspaceReorderDropTarget(
+                        workspaceId: firstAnchorId,
+                        groupId: firstGroupId,
+                        isGroupHeader: true,
+                        frame: CGRect(x: 0, y: 0, width: 180, height: 32)
+                    ),
+                    SidebarWorkspaceReorderDropTarget(
+                        workspaceId: secondAnchorId,
+                        groupId: secondGroupId,
+                        isGroupHeader: true,
+                        frame: CGRect(x: 0, y: 40, width: 180, height: 32)
+                    ),
+                ]
+            )
+        )
+
+        #expect(plan == nil)
+    }
+
     @Test func orderedWorkspaceDropTargetsMatchArrayWorkspaceAction() {
         let first = UUID()
         let second = UUID()

--- a/Packages/macOS/CmuxFoundation/Tests/CmuxFoundationTests/SidebarWorkspaceDragActivationPolicyTests.swift
+++ b/Packages/macOS/CmuxFoundation/Tests/CmuxFoundationTests/SidebarWorkspaceDragActivationPolicyTests.swift
@@ -1,0 +1,29 @@
+import Testing
+
+@testable import CmuxFoundation
+
+@Suite struct SidebarWorkspaceDragActivationPolicyTests {
+    private let policy = SidebarWorkspaceDragActivationPolicy()
+
+    @Test func localGroupAnchorCanRecoverFromTheActiveNativeSession() {
+        #expect(!policy.shouldRejectRecovery(
+            isLocalWorkspace: true,
+            isSourceGroupAnchor: true
+        ))
+    }
+
+    @Test func foreignGroupAnchorRemainsRejected() {
+        #expect(policy.shouldRejectRecovery(
+            isLocalWorkspace: false,
+            isSourceGroupAnchor: true
+        ))
+    }
+
+    @Test(arguments: [true, false])
+    func regularWorkspaceRecoveryRemainsAllowed(isLocalWorkspace: Bool) {
+        #expect(!policy.shouldRejectRecovery(
+            isLocalWorkspace: isLocalWorkspace,
+            isSourceGroupAnchor: false
+        ))
+    }
+}

--- a/Packages/macOS/CmuxWorkspaces/Sources/CmuxWorkspaces/Coordinators/WorkspaceGroupCoordinator.swift
+++ b/Packages/macOS/CmuxWorkspaces/Sources/CmuxWorkspaces/Coordinators/WorkspaceGroupCoordinator.swift
@@ -50,8 +50,7 @@ public final class WorkspaceGroupCoordinator<Tab: WorkspaceTabRepresenting> {
         // reject those silently and let the user explicitly ungroup first.
         let existingAnchorIds = Set(model.workspaceGroups.map(\.anchorWorkspaceId))
         let eligibleChildren = childWorkspaceIds.compactMap { id -> UUID? in
-            guard let tab = model.tabs.first(where: { $0.id == id }),
-                  !tab.isPinned,
+            guard model.tabs.contains(where: { $0.id == id }),
                   !existingAnchorIds.contains(id) else { return nil }
             return id
         }

--- a/Packages/macOS/CmuxWorkspaces/Tests/CmuxWorkspacesTests/WorkspaceCoordinatorTests.swift
+++ b/Packages/macOS/CmuxWorkspaces/Tests/CmuxWorkspacesTests/WorkspaceCoordinatorTests.swift
@@ -789,6 +789,33 @@ struct WorkspaceCoordinatorTests {
     }
 
     @Test
+    func createWorkspaceGroupAdoptsPinnedChildren() throws {
+        let (model, host, groups, _) = makeWorld()
+        let pinnedChild = CoordinatorStubTab(isPinned: true)
+        let unpinnedChild = CoordinatorStubTab()
+        model.tabs = [pinnedChild, unpinnedChild]
+
+        let groupId = try #require(groups.createWorkspaceGroup(
+            name: "Mixed",
+            childWorkspaceIds: [pinnedChild.id, unpinnedChild.id]
+        ))
+        let group = try #require(model.workspaceGroups.first { $0.id == groupId })
+
+        #expect(pinnedChild.groupId == groupId)
+        #expect(unpinnedChild.groupId == groupId)
+        #expect(model.tabs.filter { $0.groupId == groupId }.map(\.id) == [
+            group.anchorWorkspaceId,
+            pinnedChild.id,
+            unpinnedChild.id,
+        ])
+        #expect(host.orderChanges.last == [
+            group.anchorWorkspaceId,
+            pinnedChild.id,
+            unpinnedChild.id,
+        ])
+    }
+
+    @Test
     func createWorkspaceGroupRefusesForeignAnchorsAsChildren() {
         let (model, host, groups, _) = makeWorld()
         _ = host

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -13311,14 +13311,28 @@ struct VerticalTabsSidebar: View, Equatable {
             // drag is alive, so re-arm instead of rejecting every update
             // (which left the rest of the drag indicator-less and made the
             // final drop a silent no-op).
-            guard !tabManager.workspaceGroups.contains(where: { $0.anchorWorkspaceId == dragId }) else {
+            let isSourceGroupAnchor = tabManager.workspaceGroups.contains {
+                $0.anchorWorkspaceId == dragId
+            }
+            guard !SidebarWorkspaceDragActivationPolicy().shouldRejectRecovery(
+                isLocalWorkspace: true,
+                isSourceGroupAnchor: isSourceGroupAnchor
+            ) else {
                 return false
             }
             dragState.beginDragging(tabId: dragId)
             return true
         }
-        guard let sourceManager = AppDelegate.shared?.tabManagerFor(tabId: dragId),
-              !sourceManager.workspaceGroups.contains(where: { $0.anchorWorkspaceId == dragId }) else {
+        guard let sourceManager = AppDelegate.shared?.tabManagerFor(tabId: dragId) else {
+            return false
+        }
+        let isSourceGroupAnchor = sourceManager.workspaceGroups.contains {
+            $0.anchorWorkspaceId == dragId
+        }
+        guard !SidebarWorkspaceDragActivationPolicy().shouldRejectRecovery(
+            isLocalWorkspace: false,
+            isSourceGroupAnchor: isSourceGroupAnchor
+        ) else {
             return false
         }
         dragState.foreignDraggedIsPinned = sourceManager.tabs.first { $0.id == dragId }?.isPinned ?? false

--- a/cmuxTests/WorkspaceGroupTests.swift
+++ b/cmuxTests/WorkspaceGroupTests.swift
@@ -924,7 +924,7 @@ struct WorkspaceGroupTests {
         #expect(manager.tabs.allSatisfy { $0.groupId == nil })
     }
 
-    @Test func pinnedWorkspaceCannotJoinGroupViaCreate() {
+    @Test func pinnedWorkspaceCanJoinGroupViaCreate() {
         let manager = makeTabManager()
         let pinnedWs = manager.tabs[0]
         manager.setPinned(pinnedWs, pinned: true)
@@ -935,7 +935,7 @@ struct WorkspaceGroupTests {
             childWorkspaceIds: [pinnedWs.id, unpinnedWs.id]
         )
         #expect(groupId != nil)
-        #expect(pinnedWs.groupId == nil)
+        #expect(pinnedWs.groupId == groupId)
         #expect(unpinnedWs.groupId == groupId)
     }
 


### PR DESCRIPTION
## Summary

- allow pinned workspaces to become children of a newly created workspace group
- recover local workspace-group header drags while continuing to reject foreign group anchors
- resolve adjacent group headers as top-level neighbors so dropping a pinned group immediately after itself is rejected as a no-op

## Verification

- added separate regression commits for pinned workspace grouping, local group-header drag activation, and adjacent pinned-group self drops
- macOS Debug build passed for the tagged pinned-workspace-groups app via XcodeBuildMCP
- git diff --check refs/autoreview/cmux-main...HEAD passed
- trusted autoreview passed clean with gpt-5.6-sol at high effort

Local tests were not run per the repository policy; the regression/fix commit split is preserved for CI red/green evidence.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/9288"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788075545&installation_model_id=21920&pr_number=9288&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F9288&signature=836389b8e9031d7e17c0bfe28eb2749f51890b0e6821e2b317f0a67ca667b142"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes pinned workspace grouping and stabilizes sidebar group reordering. Pinned tabs can join new groups, local group-header drags recover correctly, and no-op self-drops on pinned groups are prevented.

- **Bug Fixes**
  - Allow pinned workspaces to be adopted as children when creating a group.
  - Restore local group-header drag recovery via `SidebarWorkspaceDragActivationPolicy`; still reject cross-window anchor drags.
  - Treat adjacent group headers as top-level neighbors to block dropping a pinned group immediately after itself.

<sup>Written for commit d839d476c443cff32101e95ad7a662ffc4c20cdd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/9288?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Pinned workspaces can now be added to workspace groups alongside unpinned workspaces.
  * Drag-and-drop recovery now handles local and remote group anchors with improved validation.

* **Bug Fixes**
  * Corrected sidebar group reorder targeting, including pinned group headers.
  * Prevented unnecessary reorder operations when dropping a group in its existing position.

* **Tests**
  * Added coverage for workspace grouping, drag recovery, and sidebar reorder scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->