### PR TITLE
iOS: fix Hidden Computers Forget swipe crash (destructive role on confirm-first button)

### DIFF
--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/CMUXMobileRootView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/CMUXMobileRootView.swift
@@ -105,6 +105,14 @@ struct CMUXMobileRootView: View {
         #endif
     }
 
+    private var shouldShowHiddenComputersPreview: Bool {
+        #if os(iOS) && DEBUG
+        return UITestConfig.hiddenComputersPreviewEnabled
+        #else
+        return false
+        #endif
+    }
+
     private var shouldShowOnboardingPreview: Bool {
         #if os(iOS) && DEBUG
         return UITestConfig.onboardingPreviewEnabled
@@ -152,6 +160,14 @@ struct CMUXMobileRootView: View {
     @ViewBuilder private var changesPreview: some View {
         #if os(iOS) && DEBUG
         ChangesPreviewView()
+        #else
+        EmptyView()
+        #endif
+    }
+
+    @ViewBuilder private var hiddenComputersPreview: some View {
+        #if os(iOS) && DEBUG
+        HiddenComputersPreviewView()
         #else
         EmptyView()
         #endif
@@ -296,6 +312,8 @@ struct CMUXMobileRootView: View {
             terminalLayoutPreview
         } else if shouldShowWorkspaceListLayoutPreview {
             workspaceListLayoutPreview
+        } else if shouldShowHiddenComputersPreview {
+            hiddenComputersPreview
         } else if shouldShowStreamingChatPreview {
             streamingChatPreview
         } else if shouldShowOnboardingPreview {

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/HiddenComputerRow.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/HiddenComputerRow.swift
@@ -118,8 +118,15 @@ struct HiddenComputerRow: View {
         .accessibilityHidden(true)
     }
 
+    /// Red like a destructive swipe action, but deliberately WITHOUT
+    /// `role: .destructive`: a destructive-role swipe button makes SwiftUI
+    /// batch-delete the row on tap, and this tap only presents the
+    /// confirmation dialog, so the unchanged model count aborted in
+    /// UIKit's item-count assertion (TestFlight crash, build
+    /// 20260731052644). Same pattern as `WorkspaceNavigationRow`'s
+    /// confirm-first Delete.
     private var forgetSwipeButton: some View {
-        Button(role: .destructive) {
+        Button {
             showForgetConfirm = true
         } label: {
             Label(
@@ -127,6 +134,7 @@ struct HiddenComputerRow: View {
                 systemImage: "trash"
             )
         }
+        .tint(.red)
         .disabled(isBusy)
         .accessibilityIdentifier("MobileComputerForgetSwipeButton-\(computer.id)")
     }

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/HiddenComputersPreviewView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/HiddenComputersPreviewView.swift
@@ -1,0 +1,50 @@
+#if canImport(UIKit) && DEBUG
+import CmuxMobileShell
+import SwiftUI
+
+/// DEBUG fixture list for the Hidden Computers rows
+/// (`CMUX_UITEST_HIDDEN_COMPUTERS_PREVIEW=1`), so UI tests can exercise the
+/// rows' swipe actions without sign-in or Mac pairing.
+///
+/// The closures mirror production semantics exactly: a Forget swipe tap only
+/// presents the row's confirmation dialog (no synchronous model mutation —
+/// the regression surface for the destructive-role swipe crash), the dialog's
+/// confirm removes the row, and Unhide removes it immediately.
+struct HiddenComputersPreviewView: View {
+    @State private var computers: [MobileHiddenComputer] = [
+        MobileHiddenComputer(
+            id: "preview-mac-1",
+            macDeviceID: "preview-mac-1",
+            instanceTag: nil,
+            displayName: "Preview Mac",
+            customColor: nil,
+            customIcon: nil
+        ),
+        MobileHiddenComputer(
+            id: "preview-mac-2",
+            macDeviceID: "preview-mac-2",
+            instanceTag: nil,
+            displayName: "Studio Mac",
+            customColor: nil,
+            customIcon: nil
+        ),
+    ]
+
+    var body: some View {
+        NavigationStack {
+            List {
+                HiddenComputersSection(
+                    computers: computers,
+                    unhide: { computer in remove(computer.id) },
+                    forget: { computer in remove(computer.id) }
+                )
+            }
+            .navigationTitle(HiddenComputersCopy.title)
+        }
+    }
+
+    private func remove(_ id: String) {
+        computers.removeAll { $0.id == id }
+    }
+}
+#endif

--- a/Packages/iOS/CmuxMobileSupport/Sources/CmuxMobileSupport/UITestConfig.swift
+++ b/Packages/iOS/CmuxMobileSupport/Sources/CmuxMobileSupport/UITestConfig.swift
@@ -97,6 +97,19 @@ public struct UITestConfig {
         #endif
     }
 
+    /// When `CMUX_UITEST_HIDDEN_COMPUTERS_PREVIEW=1`, the root view renders a
+    /// static Hidden Computers list with fixture rows so UI tests can exercise
+    /// the rows' swipe actions (the confirm-first Forget flow) without sign-in
+    /// or Mac pairing. DEBUG-only.
+    public static var hiddenComputersPreviewEnabled: Bool {
+        #if DEBUG
+        return ProcessInfo.processInfo.environment["CMUX_UITEST_HIDDEN_COMPUTERS_PREVIEW"] == "1"
+            || ProcessInfo.processInfo.arguments.contains("CMUX_UITEST_HIDDEN_COMPUTERS_PREVIEW=1")
+        #else
+        return false
+        #endif
+    }
+
     /// Changes preview mode selected by `CMUX_UITEST_CHANGES_PREVIEW`.
     ///
     /// Supported DEBUG-only values are `1`, `diff`, `empty`, and `states`.

--- a/ios/cmuxUITests/cmuxUITests.swift
+++ b/ios/cmuxUITests/cmuxUITests.swift
@@ -562,6 +562,58 @@ final class cmuxUITests: XCTestCase {
     }
 
     @MainActor
+    func testHiddenComputersForgetSwipeConfirmsWithoutRemovingRow() throws {
+        let app = launchApp(mockData: false, environment: [
+            "CMUX_UITEST_HIDDEN_COMPUTERS_PREVIEW": "1",
+        ])
+        defer { app.terminate() }
+
+        let rowID = "preview-mac-1"
+        let row = app.staticTexts["Preview Mac"]
+        XCTAssertTrue(row.waitForExistence(timeout: 8))
+
+        row.swipeLeft()
+        let forgetSwipeAction = app.buttons["MobileComputerForgetSwipeButton-\(rowID)"]
+        XCTAssertTrue(forgetSwipeAction.waitForExistence(timeout: 3))
+        forgetSwipeAction.tap()
+
+        // The Forget tap is confirm-first: it must only present the dialog. A
+        // destructive-role swipe button here makes SwiftUI batch-delete the row
+        // while the model still contains it, which aborts in UIKit's
+        // item-count assertion (TestFlight crash on build 20260731052644) or
+        // ghosts the row out of the list on runtimes that tolerate it.
+        XCTAssertEqual(
+            app.state, .runningForeground,
+            "Tapping Forget must not crash the app."
+        )
+        let confirmButton = app.buttons["MobileComputerForgetConfirmButton-\(rowID)"]
+        XCTAssertTrue(
+            confirmButton.waitForExistence(timeout: 3),
+            "Forget must request confirmation before revoking."
+        )
+        XCTAssertTrue(
+            row.exists,
+            "The hidden computer must stay listed until the confirmation action runs."
+        )
+        let attachment = XCTAttachment(screenshot: app.screenshot())
+        attachment.name = "hidden-computers-forget-swipe-confirmation"
+        attachment.lifetime = .keepAlways
+        add(attachment)
+
+        // The dialog's destructive confirm is the tap that actually removes
+        // the row; the model-driven removal must animate out cleanly.
+        // firstMatch: action-sheet buttons surface twice in the accessibility
+        // tree (button plus its sheet wrapper), so a bare tap is ambiguous.
+        confirmButton.firstMatch.tap()
+        XCTAssertTrue(
+            row.waitForNonExistence(timeout: 3),
+            "Confirming Forget must remove the row."
+        )
+        XCTAssertEqual(app.state, .runningForeground)
+        XCTAssertTrue(app.staticTexts["Studio Mac"].exists)
+    }
+
+    @MainActor
     func testWorkspaceListRapidDirectionChangesAndBoundariesRemainResponsive() throws {
         let app = launchApp(mockData: false, environment: [
             "CMUX_UITEST_WORKSPACE_LIST_PREVIEW": "1",


### PR DESCRIPTION
Fixes the newest INTERNAL TestFlight crash family: main-thread abort in `UICollectionView _Bug_Detected_In_Client_Of_UICollectionView_Invalid_Number_Of_Items_In_Section` on build 20260731052644 (iOS 27.0, crash submission `AI23Y8OqUTOAAh7afC796gc`, reported via TestFlight feedback).

Mechanism: `HiddenComputerRow`'s Forget swipe button (added in https://github.com/manaflow-ai/cmux/pull/9071) had `role: .destructive` but its tap only presents the confirmation dialog. SwiftUI treats a destructive-role swipe button as "this tap removes the row" and eagerly batch-deletes it from the backing collection view while the model still contains it. On iOS 27.0 that aborts in UIKit's item-count assertion (the TestFlight crash); on iOS 26.x CI simulators the eager removal instead makes the confirmation dialog never present, so Forget was silently non-functional there too. The fix drops the role and keeps the red styling with `.tint(.red)`, the same confirm-first pattern `WorkspaceNavigationRow` already uses. The dialog flow is unchanged and its own destructive confirm still removes the row; the context-menu Forget keeps its role because menus do not drive row removal.

Audit of every other destructive-role swipe action and `.onDelete` in the iOS app found no other violation: `TerminalShortcutsSettingsView` and `TaskTemplateEditorView` remove their rows synchronously, `WorkspaceGroupHeaderRow` confirms via context menu plus dialog, and the remaining swipe buttons carry no destructive role.

Regression test (two commits, red then green): commit 1 adds `CMUX_UITEST_HIDDEN_COMPUTERS_PREVIEW` (fixture Hidden Computers list with production closure semantics) and `cmuxUITests/cmuxUITests/testHiddenComputersForgetSwipeConfirmsWithoutRemovingRow`, which swipes, taps Forget, and requires the app alive, the dialog shown, the row still listed, and removal only after the dialog confirm.

CI proof, `ios-simulator (iphone)` job (test-ios.yml): red on the test-only commit, failing at "Forget must request confirmation before revoking" — https://github.com/manaflow-ai/cmux/actions/runs/30617373462; green on head — https://github.com/manaflow-ai/cmux/actions/runs/30617394687. Both runs' overall conclusions are red from pre-existing main breakage unrelated to this change (`package-conventions-lint` errors and `CmuxMobileShell` package-test failures reproduce on the concurrent main run https://github.com/manaflow-ai/cmux/actions/runs/30615647449); judge by the iphone simulator job.

Localization audit: no new user-facing strings; the DEBUG-only preview reuses the existing localized Hidden Computers copy and row labels.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
