### PR TITLE
test: repair lifecycle and descriptor cleanup contracts

### DIFF
--- a/Packages/macOS/CmuxFoundation/Tests/CmuxFoundationTests/Process/CommandRunnerDescriptorLifecycleTests.swift
+++ b/Packages/macOS/CmuxFoundation/Tests/CmuxFoundationTests/Process/CommandRunnerDescriptorLifecycleTests.swift
@@ -10,10 +10,8 @@ struct CommandRunnerDescriptorLifecycleTests {
 
     @Test("Capture pipes are close-on-exec and close before success returns")
     func capturePipesAreCloseOnExecAndCloseAfterSuccess() async throws {
-        weak var releasedProcess: Process?
-        var execution: CommandExecution? = try makeExecution(executable: "/usr/bin/true")
-        releasedProcess = execution?.process
-        let descriptors = try snapshotDescriptors(of: #require(execution))
+        let execution = try makeExecution(executable: "/usr/bin/true")
+        let descriptors = try snapshotDescriptors(of: execution)
         #expect(descriptors.count == 8)
         for descriptor in descriptors {
             let flags = fcntl(descriptor.fileDescriptor, F_GETFD)
@@ -24,15 +22,10 @@ struct CommandRunnerDescriptorLifecycleTests {
             )
         }
 
-        let result: CommandResult
-        do {
-            let activeExecution = try #require(execution)
-            result = await activeExecution.run(timeout: 5)
-        }
+        let result = await execution.run(timeout: 5)
         #expect(result.exitStatus == 0)
         expectDescriptorsClosed(descriptors)
-        execution = nil
-        #expect(releasedProcess == nil)
+        #expect(execution.process.terminationHandler == nil)
     }
 
     @Test("Launch failure closes capture pipes")

--- a/cmuxTests/AgentNotificationMutationBoundaryTests.swift
+++ b/cmuxTests/AgentNotificationMutationBoundaryTests.swift
@@ -186,6 +186,7 @@ extension AgentNotificationRegressionTests {
         )
         bus.drainForTesting()
         #expect(dock.agentRuntimeByPanelId[fixture.panelId]?.statusEntries["omp"] == nil)
+        #expect(dock.agentRuntimeByPanelId[fixture.panelId]?.agentLifecycleStates["omp"] == nil)
 
         TerminalController.shared.controlSidebarScheduleStatusUpsert(
             target: .workspace(dockOwnerId),
@@ -199,7 +200,14 @@ extension AgentNotificationRegressionTests {
             panelID: fixture.panelId,
             pid: nil
         )
+        TerminalController.shared.controlSidebarScheduleAgentLifecycle(
+            target: .workspace(dockOwnerId),
+            key: "omp",
+            lifecycleRawValue: AgentHibernationLifecycleState.running.rawValue,
+            panelID: fixture.panelId
+        )
         bus.drainForTesting()
+        #expect(dock.agentRuntimeByPanelId[fixture.panelId]?.agentLifecycleStates["omp"] == .running)
 
         let workspaceTransfer = try #require(dock.detachSurface(panelId: fixture.panelId))
         #expect(dock.agentRuntimeByPanelId[fixture.panelId] == nil)


### PR DESCRIPTION
## Summary

- Update the Dock runtime-transfer fixture to reflect that clearing an agent status intentionally clears its lifecycle, then re-report `.running` before asserting lifecycle transfer.
- Keep the command-runner descriptor test focused on deterministic cleanup contracts: capture descriptors are closed and the `Process` termination handler is cleared when `run()` returns.
- Preserve Lawrence Chen's authorship by cherry-picking the existing focused commits from #8811 into a dedicated current-`main` repair.

No production code changes.

## Why

Current `main` has two independent full-CI failures that are unrelated to the feature branches being tested:

- `AgentNotificationMutationBoundaryTests.swift`: the fixture re-added only the visible status after a status clear, then incorrectly expected the intentionally-cleared lifecycle to transfer.
- `CommandRunnerDescriptorLifecycleTests.swift`: a weak `Foundation.Process` assertion depended on asynchronous `NSConcreteTask` deallocation timing instead of the file-descriptor cleanup contract.

These failures blocked full CI for #9266 after its own focused red/green proof passed.

## Evidence

- Current `main` + the unrelated workflow-guard repair, without #9266, failed the lifecycle assertion: https://github.com/manaflow-ai/cmux/actions/runs/30614187843
- Current `main` + #9266 + the workflow-guard repair failed both stale assertions: https://github.com/manaflow-ai/cmux/actions/runs/30614778238
- `CommandExecution.completeIfReady()` closes the cancellation/stdout/stderr descriptors, clears `process.terminationHandler`, and only then resumes the continuation; the repaired test asserts that deterministic post-`await run()` contract.

## Validation

- `git diff --check origin/main...HEAD`
- `./scripts/lint-pbxproj-test-wiring.sh` — passed (642 files)
- Focused lifecycle suite: [run 30617539181](https://github.com/manaflow-ai/cmux/actions/runs/30617539181) — passed (40 tests; the repaired Dock-owned terminal lifecycle test passed).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/9293"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788078516&installation_model_id=21920&pr_number=9293&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F9293&signature=7f523949de983417fe304f753b823d09178bc14aebfb4ebac3f1ffa92e570e2e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Repair failing CI tests by fixing agent lifecycle transfer expectations and making command runner cleanup assertions deterministic. No production code changes.

- **Bug Fixes**
  - Dock runtime transfer test: after a status clear (which also clears lifecycle), re-reports `.running` and asserts lifecycle state before verifying transfer.
  - Command runner test: removes ARC-timing check on a weak `Process`; now asserts capture FDs are closed and `process.terminationHandler` is nil after `await run()` returns.

<sup>Written for commit 75b29be06b9f9dd3f726a6cce53b0e17457daa03. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/9293?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded coverage for command execution cleanup, including descriptor closure and termination-handler reset after successful completion.
  * Added validation that clearing agent status also clears its lifecycle state.
  * Verified that restoring agent status and applying a lifecycle update correctly returns the status to a running state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->