### PR TITLE
Stabilize remote tmux app-host test teardown

### DIFF
--- a/cmuxTests/RemoteTmuxMirrorCloseDetachTests.swift
+++ b/cmuxTests/RemoteTmuxMirrorCloseDetachTests.swift
@@ -490,7 +490,7 @@ import Testing
         func closeWindow(_ id: UUID) {
             let identifier = "cmux.main.\(id.uuidString)"
             if let window = NSApp.windows.first(where: { $0.identifier?.rawValue == identifier }) {
-                window.performClose(nil)
+                window.close()
                 RunLoop.main.run(until: Date(timeIntervalSinceNow: 0.05))
             }
         }

--- a/cmuxTests/RemoteTmuxMirrorCloseDetachTests.swift
+++ b/cmuxTests/RemoteTmuxMirrorCloseDetachTests.swift
@@ -489,10 +489,15 @@ import Testing
 
         func closeWindow(_ id: UUID) {
             let identifier = "cmux.main.\(id.uuidString)"
-            if let window = NSApp.windows.first(where: { $0.identifier?.rawValue == identifier }) {
-                window.close()
-                RunLoop.main.run(until: Date(timeIntervalSinceNow: 0.05))
+            if let manager = appDelegate.tabManagerFor(windowId: id) {
+                manager.tabs.forEach { $0.teardownAllPanels() }
             }
+            if let window = NSApp.windows.first(where: { $0.identifier?.rawValue == identifier }) {
+                appDelegate.suppressClosedWindowHistoryForTesting(windowId: id)
+                window.close()
+            }
+            appDelegate.forgetRecoverableMainWindowRoute(windowId: id)
+            RunLoop.main.run(until: Date(timeIntervalSinceNow: 0.05))
         }
     }
 }


### PR DESCRIPTION
## Summary

- close fixture-owned windows through non-interactive `NSWindow.close()` so test teardown never enters cmux’s final-window quit path
- explicitly tear down every workspace panel before closing each fixture window
- suppress closed-window history and retire the temporary recoverable route so terminal surfaces cannot accumulate across the serialized suite
- leave all production remote-tmux close, detach, placement, and focus-neutral behavior under test unchanged

## Failure evidence

- current-main focused run https://github.com/manaflow-ai/cmux/actions/runs/30617925589 passed seven tests, then the app host exited during `dedicatedWindowSocketDefaultsToFocusNeutral()` and restarted with zero selected tests
- synthetic full-CI attempt 2 https://github.com/manaflow-ai/cmux/actions/runs/30619565146 repeated the final-test app-host exit after the first `close()` repair, showing window close alone was insufficient under full-suite pressure
- the harness was closing windows without explicitly tearing down their workspaces; recoverable routing intentionally retains closed-window terminal state while surfaces stay registered

## Validation

- final focused suite https://github.com/manaflow-ai/cmux/actions/runs/30624091140 on `756cc69b57`: 8 tests in 1 suite passed in one app-host launch (4.234s), including the prior crash boundary; `TEST SUCCEEDED`
- no review threads or actionable CodeRabbit findings
- `cmux-policy-check --mode branch --base origin/main`
- `git diff --check`
- `./scripts/lint-pbxproj-test-wiring.sh` (642 files)
- local build intentionally skipped because the shared machine has only ~3 GiB free; CI compiled and ran the app-host suite

The same commit is included in the disposable full-CI integration run for #9266; that shard is still in progress.