### PR TITLE
Fail iOS filters that execute zero tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -163,6 +163,9 @@ jobs:
       - name: Validate CMUX INTERNAL main-push path filter
         run: python3 tests/test_ios_testflight_main_push_filter.py
 
+      - name: Validate iOS selected-test log guard
+        run: ./tests/test_ci_ios_selected_tests_log.sh
+
       - name: Validate external TestFlight group assignment helper
         run: python3 tests/test_ios_testflight_external_distribution.py
 

--- a/.github/workflows/test-ios.yml
+++ b/.github/workflows/test-ios.yml
@@ -9,7 +9,7 @@ on:
         required: false
         default: ""
       test_filter:
-        description: "UI test class or class/method, for example cmuxUITests/testSignInPairingAndWorkspaceShell"
+        description: "UI test target/class or target/class/method, for example cmuxUITests/cmuxUITests/testSignInPairingAndWorkspaceShell"
         required: false
         default: ""
       device_family:
@@ -382,17 +382,7 @@ jobs:
             XCODEBUILD_ARGS+=(-skip-testing:cmuxUITests)
           fi
           XCODEBUILD_ARGS+=(test)
-          selected_tests_passed_despite_xcodebuild_status() {
-            local log_path="$1"
-            # The negative grep must catch BOTH XCTest failure output and Swift
-            # Testing failure output (✘ markers): the final "Failing tests:"
-            # section is not always flushed into the tee'd log, and without the
-            # ✘ patterns a real Swift Testing failure exiting 65 was
-            # misclassified as a runner cleanup failure and turned the job green.
-            grep -Eq "Test Suite 'Selected tests' passed|Test Suite 'cmuxUITests' passed" "$log_path" &&
-              grep -Eq "Executed [1-9][0-9]* tests, with 0 failures \\(0 unexpected\\)" "$log_path" &&
-              ! grep -Eq "Test Suite '.*' failed|Test Case '.*' failed|Assertion Failure|Failing tests:|with [1-9][0-9]* failures|with [0-9]+ failures \\([1-9][0-9]* unexpected\\)|✘ Test|✘ Suite" "$log_path"
-          }
+          SELECTED_TEST_LOG_VALIDATOR="$GITHUB_WORKSPACE/scripts/ci/validate-ios-selected-tests-log.sh"
           for attempt in 1 2; do
             LOG_PATH="$IOS_DERIVED_DATA/logs/attempt-${attempt}.log"
             echo "Preparing $SIMULATOR_NAME ($SIMULATOR_ID), attempt $attempt"
@@ -401,10 +391,16 @@ jobs:
             xcrun simctl boot "$SIMULATOR_ID" >/dev/null 2>&1 || true
             xcrun simctl bootstatus "$SIMULATOR_ID" -b
             if xcodebuild "${XCODEBUILD_ARGS[@]}" 2>&1 | tee "$LOG_PATH"; then
+              if [ -n "${TEST_FILTER:-}" ]; then
+                "$SELECTED_TEST_LOG_VALIDATOR" "$LOG_PATH" || {
+                  echo "::error title=No selected iOS tests executed::test_filter '$TEST_FILTER' did not execute a passing test. Use target/class or target/class/method."
+                  exit 1
+                }
+              fi
               exit 0
             fi
             status="${PIPESTATUS[0]}"
-            if selected_tests_passed_despite_xcodebuild_status "$LOG_PATH"; then
+            if "$SELECTED_TEST_LOG_VALIDATOR" "$LOG_PATH"; then
               echo "xcodebuild exited $status after XCTest reported the selected tests passed with zero failures; treating this as a runner cleanup failure."
               exit 0
             fi

--- a/.github/workflows/test-ios.yml
+++ b/.github/workflows/test-ios.yml
@@ -393,7 +393,7 @@ jobs:
             if xcodebuild "${XCODEBUILD_ARGS[@]}" 2>&1 | tee "$LOG_PATH"; then
               if [ -n "${TEST_FILTER:-}" ]; then
                 "$SELECTED_TEST_LOG_VALIDATOR" "$LOG_PATH" || {
-                  echo "::error title=No selected iOS tests executed::test_filter '$TEST_FILTER' did not execute a passing test. Use target/class or target/class/method."
+                  echo "::error title=No selected iOS tests executed::The selected test filter did not execute a passing test. Use target/class or target/class/method."
                   exit 1
                 }
               fi

--- a/scripts/ci/validate-ios-selected-tests-log.sh
+++ b/scripts/ci/validate-ios-selected-tests-log.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+log_path="${1:-}"
+if [[ -z "$log_path" || ! -f "$log_path" ]]; then
+  printf 'validate-ios-selected-tests-log: test log not found: %s\n' "${log_path:-<empty>}" >&2
+  exit 2
+fi
+
+if ! grep -Eq "Test Suite 'Selected tests' passed|Test Suite 'cmuxUITests' passed" "$log_path"; then
+  printf 'validate-ios-selected-tests-log: selected XCTest suite did not pass\n' >&2
+  exit 1
+fi
+
+if ! grep -Eq "Executed [1-9][0-9]* tests?, with 0 failures \\(0 unexpected\\)" "$log_path"; then
+  printf 'validate-ios-selected-tests-log: selected filter executed no passing tests\n' >&2
+  exit 1
+fi
+
+if grep -Eq "Test Suite '.*' failed|Test Case '.*' failed|Assertion Failure|Failing tests:|with [1-9][0-9]* failures?|with [0-9]+ failures? \\([1-9][0-9]* unexpected\\)|✘ Test|✘ Suite" "$log_path"; then
+  printf 'validate-ios-selected-tests-log: selected test log contains a failure\n' >&2
+  exit 1
+fi
+
+printf 'validate-ios-selected-tests-log: selected tests passed\n'

--- a/tests/test_ci_ios_selected_tests_log.sh
+++ b/tests/test_ci_ios_selected_tests_log.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+VALIDATOR="$ROOT_DIR/scripts/ci/validate-ios-selected-tests-log.sh"
+TMP_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/cmux-ios-selected-tests.XXXXXX")"
+trap 'rm -rf "$TMP_ROOT"' EXIT
+
+fail() {
+  printf 'FAIL: %s\n' "$*" >&2
+  exit 1
+}
+
+[[ -x "$VALIDATOR" ]] || fail "missing executable validator: $VALIDATOR"
+
+cat > "$TMP_ROOT/passed.log" <<'EOF'
+Test Suite 'cmuxUITests' passed at 2026-07-31 07:41:27.524.
+Executed 1 test, with 0 failures (0 unexpected) in 40.253 seconds
+Test Suite 'Selected tests' passed at 2026-07-31 07:41:27.525.
+EOF
+"$VALIDATOR" "$TMP_ROOT/passed.log" \
+  || fail "one passing selected test should validate"
+
+cat > "$TMP_ROOT/zero.log" <<'EOF'
+Test Suite 'Selected tests' passed at 2026-07-31 07:41:27.525.
+Executed 0 tests, with 0 failures (0 unexpected) in 0.000 seconds
+EOF
+if "$VALIDATOR" "$TMP_ROOT/zero.log"; then
+  fail "zero selected tests must not validate"
+fi
+
+cat > "$TMP_ROOT/failed.log" <<'EOF'
+Test Case '-[cmuxUITests.cmuxUITests testExample]' failed (1.000 seconds).
+Test Suite 'Selected tests' failed at 2026-07-31 07:41:27.525.
+Executed 1 test, with 1 failure (0 unexpected) in 1.000 seconds
+EOF
+if "$VALIDATOR" "$TMP_ROOT/failed.log"; then
+  fail "a failing selected test must not validate"
+fi
+
+printf 'PASS: iOS selected-test log validation rejects zero and failed tests\n'


### PR DESCRIPTION
A successful xcodebuild can execute zero tests when `-only-testing` is misspelled. Require every manual `test_filter` run to report at least one passing XCTest, centralize the log validation shared with the runner-cleanup exception, and document the full target/class/method syntax.

Verification: `./tests/test_ci_ios_selected_tests_log.sh`, `bash -n`, and ShellCheck pass. Commit 1 fails because the validator is absent; commit 2 adds the validator and workflow guard.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/9302"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788083634&installation_model_id=21920&pr_number=9302&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F9302&signature=471ab0f68bd9d0c4a20773631265630ba7c48f3c3a9a7c9ea8ef750eeca3b234"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fail the iOS selected-test job when a `test_filter` runs zero tests, and centralize log validation to avoid false greens. Adds a static GitHub error annotation when no selected tests execute.

- **Bug Fixes**
  - Added `scripts/ci/validate-ios-selected-tests-log.sh` to verify that selected tests pass with at least one executed test and no failures.
  - Updated `test-ios.yml` to:
    - Guard selected runs: validate success when `test_filter` is set; fail with a static "::error" title if zero tests ran.
    - Reuse the validator to treat the runner-cleanup case as success when XCTest passed.
    - Clarify `test_filter` input: use target/class or target/class/method (e.g., `cmuxUITests/cmuxUITests/testSignInPairingAndWorkspaceShell`).
  - Added `tests/test_ci_ios_selected_tests_log.sh` and wired it into `.github/workflows/ci.yml`.

<sup>Written for commit 2b12359a8848500133e87660894016f1083415fa. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/9302?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of filtered iOS test runs by validating selected-test results, including runs that exit with errors.
  * Prevented incomplete, empty, or failed test logs from being treated as successful results.

* **Tests**
  * Added automated coverage for successful, empty, and failed iOS selected-test logs.
  * Added continuous integration checks to ensure test-result validation remains dependable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->