### PR TITLE
CI: fail test-ios when test_filter selects zero tests

### DIFF
--- a/.github/workflows/test-ios.yml
+++ b/.github/workflows/test-ios.yml
@@ -9,7 +9,7 @@ on:
         required: false
         default: ""
       test_filter:
-        description: "UI test class or class/method, for example cmuxUITests/testSignInPairingAndWorkspaceShell"
+        description: "xcodebuild -only-testing id: Target, Target/Class, or Target/Class/method, for example cmuxUITests/cmuxUITests/testSignInPairingAndWorkspaceShell (a two-part Class/method form silently selects nothing)"
         required: false
         default: ""
       device_family:
@@ -382,6 +382,16 @@ jobs:
             XCODEBUILD_ARGS+=(-skip-testing:cmuxUITests)
           fi
           XCODEBUILD_ARGS+=(test)
+          # A test_filter that matches nothing is a SUCCESSFUL xcodebuild run
+          # ("Executed 0 tests", exit 0), so without this guard a typo'd filter
+          # (for example the Class/method form missing the target) turns the
+          # job green while running nothing.
+          filter_selected_zero_tests() {
+            local log_path="$1"
+            [ -n "${TEST_FILTER:-}" ] &&
+              grep -Eq "Executed 0 tests" "$log_path" &&
+              ! grep -Eq "Executed [1-9][0-9]* tests?," "$log_path"
+          }
           selected_tests_passed_despite_xcodebuild_status() {
             local log_path="$1"
             # The negative grep must catch BOTH XCTest failure output and Swift
@@ -401,6 +411,10 @@ jobs:
             xcrun simctl boot "$SIMULATOR_ID" >/dev/null 2>&1 || true
             xcrun simctl bootstatus "$SIMULATOR_ID" -b
             if xcodebuild "${XCODEBUILD_ARGS[@]}" 2>&1 | tee "$LOG_PATH"; then
+              if filter_selected_zero_tests "$LOG_PATH"; then
+                echo "::error::test_filter '$TEST_FILTER' selected no tests (Executed 0 tests). Use the full Target/Class/method -only-testing form, e.g. cmuxUITests/cmuxUITests/testMethod." >&2
+                exit 1
+              fi
               exit 0
             fi
             status="${PIPESTATUS[0]}"


### PR DESCRIPTION
`workflow_dispatch` runs of test-ios.yml with a `test_filter` that matches nothing were reported green: xcodebuild treats an `-only-testing:` id that selects no tests as a successful run ("Executed 0 tests", exit 0), and the job only inspected the log on nonzero exits. A filter in the Class/method form (missing the target, which the old input description itself suggested) hit exactly this tonight while validating https://github.com/manaflow-ai/cmux/pull/9291: run https://github.com/manaflow-ai/cmux/actions/runs/30613726896 passed the iphone simulator job having executed nothing.

The fix requires at least one executed test whenever a filter was given, failing with an actionable message otherwise, and corrects the input description to the Target/Class/method `-only-testing` form. Runs without a filter are unaffected, and the existing nonzero-exit reclassification path already required a nonzero executed count.

Verification (workflow definition dispatched from this branch with `--ref`): a deliberately bad two-part filter now fails the simulator job with the new error, and a correct three-part filter still passes — run links in the PR comments after dispatch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/9306"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788087564&installation_model_id=21920&pr_number=9306&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F9306&signature=c61bb46ab0ea58f016eb68621a8e6042f2de94def72699eb3eac075a269ce8ee"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops green CI runs when `test_filter` matches no tests by failing the iOS test job if `xcodebuild` reports "Executed 0 tests". Also clarifies the input docs to require the full `Target/Class/method` `-only-testing` form.

- **Bug Fixes**
  - Detect zero executed tests when `TEST_FILTER` is set and exit with an actionable error; runs without a filter are unchanged.
  - Update `test_filter` description to the correct `xcodebuild -only-testing` id: `Target`, `Target/Class`, or `Target/Class/method` (note: `Class/method` without target selects nothing).

<sup>Written for commit 61dda395fbbd0d5763540f98b017f44ceedef377. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/9306?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved iOS test filtering validation.
  * Test runs now fail when a provided filter matches no tests.
  * Added clearer guidance on the required test filter format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->