### PR TITLE
fix(file-preview): text files misclassified as binary at the 4 KB sniff boundary

### DIFF
--- a/Sources/Panels/FilePreviewPanel.swift
+++ b/Sources/Panels/FilePreviewPanel.swift
@@ -889,8 +889,13 @@ enum FilePreviewKindResolver {
     private static func sniffLooksLikeText(url: URL) -> Bool {
         guard let handle = try? FileHandle(forReadingFrom: url) else { return false }
         defer { try? handle.close() }
-        let data = (try? handle.read(upToCount: sniffPrefixByteCount)) ?? Data()
-        return prefixLooksLikeText(data)
+        // One byte past the window, so a truncated tail is observed rather than
+        // inferred from the prefix length.
+        let probe = (try? handle.read(upToCount: sniffPrefixByteCount + 1)) ?? Data()
+        return prefixLooksLikeText(
+            probe.prefix(sniffPrefixByteCount),
+            hasMoreBytes: probe.count > sniffPrefixByteCount
+        )
     }
 
     /// Classifies the head of a file that neither its name nor its UTType could
@@ -902,7 +907,10 @@ enum FilePreviewKindResolver {
     /// still source. The control-byte gate applies only to the single-byte
     /// fallback below, where a successful decode proves nothing because
     /// ISO Latin-1 maps every byte.
-    static func prefixLooksLikeText(_ data: Data) -> Bool {
+    /// - Parameter hasMoreBytes: whether the file continues past this prefix.
+    ///   Only then can the tail have been cut mid-scalar; otherwise a malformed
+    ///   tail is a defect in the file rather than an artifact of the read.
+    static func prefixLooksLikeText(_ data: Data, hasMoreBytes: Bool = false) -> Bool {
         guard !data.isEmpty else { return true }
         if hasUTF16ByteOrderMark(data), String(data: data, encoding: .utf16) != nil {
             return true
@@ -913,10 +921,7 @@ enum FilePreviewKindResolver {
         if String(data: data, encoding: .utf8) != nil {
             return true
         }
-        // Only a prefix that filled the read window can have been cut mid-scalar.
-        // A shorter prefix is the whole file, where a malformed tail is a defect
-        // and not an artifact of the read.
-        if data.count == sniffPrefixByteCount,
+        if hasMoreBytes,
            let completedSequences = droppingTrailingPartialUTF8Sequence(data),
            String(data: completedSequences, encoding: .utf8) != nil {
             return true
@@ -927,19 +932,41 @@ enum FilePreviewKindResolver {
     }
 
     /// Drops the trailing UTF-8 sequence that the fixed-size read cut in half.
-    /// Returns nil when the tail is not a truncated sequence.
+    /// Returns nil when the tail is malformed rather than truncated, so the
+    /// caller keeps classifying the bytes it actually has.
     private static func droppingTrailingPartialUTF8Sequence(_ data: Data) -> Data? {
-        var continuationCount = 0
+        var continuations: [UInt8] = []
         for byte in Array(data.suffix(maximumUTF8SequenceLength)).reversed() {
             if byte & 0b1100_0000 == 0b1000_0000 {
-                continuationCount += 1
+                continuations.append(byte)
                 continue
             }
             guard let sequenceLength = utf8SequenceLength(leadByte: byte),
-                  sequenceLength > continuationCount + 1 else { return nil }
-            return data.dropLast(continuationCount + 1)
+                  sequenceLength > continuations.count + 1,
+                  isTruncatedSequence(leadByte: byte, continuations: continuations) else { return nil }
+            return data.dropLast(continuations.count + 1)
         }
         return nil
+    }
+
+    /// The byte after the lead carries a lead-specific range: it rules out
+    /// overlong forms after 0xE0 and 0xF0, surrogates after 0xED, and scalars
+    /// past U+10FFFF after 0xF4. A sequence that violates it was never valid,
+    /// so it cannot be the start of a scalar the read cut in half.
+    ///
+    /// - Parameter continuations: the trailing continuation bytes in reverse
+    ///   order, so the byte right after the lead is the last element.
+    private static func isTruncatedSequence(leadByte: UInt8, continuations: [UInt8]) -> Bool {
+        guard let byteAfterLead = continuations.last else { return true }
+        let allowed: ClosedRange<UInt8>
+        switch leadByte {
+        case 0xE0: allowed = 0xA0...0xBF
+        case 0xED: allowed = 0x80...0x9F
+        case 0xF0: allowed = 0x90...0xBF
+        case 0xF4: allowed = 0x80...0x8F
+        default: allowed = 0x80...0xBF
+        }
+        return allowed.contains(byteAfterLead)
     }
 
     /// Valid UTF-8 lead bytes only. 0xC0 and 0xC1 encode overlong forms and

--- a/Sources/Panels/FilePreviewPanel.swift
+++ b/Sources/Panels/FilePreviewPanel.swift
@@ -654,6 +654,12 @@ enum FilePreviewKindResolver {
         case needsSniff
     }
 
+    /// Bytes read from the head of a file when neither the filename nor the
+    /// UTType decides between text and binary.
+    static let sniffPrefixByteCount = 4096
+
+    private static let maximumUTF8SequenceLength = 4
+
     private static let textFilenames: Set<String> = [
         ".env",
         ".gitignore",
@@ -883,7 +889,14 @@ enum FilePreviewKindResolver {
     private static func sniffLooksLikeText(url: URL) -> Bool {
         guard let handle = try? FileHandle(forReadingFrom: url) else { return false }
         defer { try? handle.close() }
-        let data = (try? handle.read(upToCount: 4096)) ?? Data()
+        let data = (try? handle.read(upToCount: sniffPrefixByteCount)) ?? Data()
+        return prefixLooksLikeText(data)
+    }
+
+    /// Classifies the head of a file that neither its name nor its UTType could
+    /// resolve. The prefix is a fixed-size read, so a failed decode is not on
+    /// its own evidence of binary content.
+    static func prefixLooksLikeText(_ data: Data) -> Bool {
         guard !data.isEmpty else { return true }
         if hasUTF16ByteOrderMark(data), String(data: data, encoding: .utf16) != nil {
             return true
@@ -891,7 +904,60 @@ enum FilePreviewKindResolver {
         if data.contains(0) {
             return false
         }
-        return String(data: data, encoding: .utf8) != nil
+        if String(data: data, encoding: .utf8) != nil {
+            return true
+        }
+        if let completedSequences = droppingTrailingPartialUTF8Sequence(data),
+           String(data: completedSequences, encoding: .utf8) != nil {
+            return true
+        }
+        // FilePreviewTextLoader falls back to ISO Latin-1 once UTF-8 and UTF-16
+        // fail, so classification has to accept the same files.
+        return isSingleByteEncodedText(data)
+    }
+
+    /// Drops the trailing UTF-8 sequence that the fixed-size read cut in half.
+    /// Returns nil when the tail is not a truncated sequence.
+    private static func droppingTrailingPartialUTF8Sequence(_ data: Data) -> Data? {
+        var continuationCount = 0
+        for byte in Array(data.suffix(maximumUTF8SequenceLength)).reversed() {
+            if byte & 0b1100_0000 == 0b1000_0000 {
+                continuationCount += 1
+                continue
+            }
+            guard let sequenceLength = utf8SequenceLength(leadByte: byte),
+                  sequenceLength > continuationCount + 1 else { return nil }
+            return data.dropLast(continuationCount + 1)
+        }
+        return nil
+    }
+
+    private static func utf8SequenceLength(leadByte: UInt8) -> Int? {
+        switch leadByte {
+        case 0b0000_0000...0b0111_1111: return 1
+        case 0b1100_0000...0b1101_1111: return 2
+        case 0b1110_0000...0b1110_1111: return 3
+        case 0b1111_0000...0b1111_0111: return 4
+        default: return nil
+        }
+    }
+
+    /// Matches the ISO-8859 test in `file(1)`: printable bytes plus the usual
+    /// whitespace and escape controls. NUL is rejected before this runs.
+    private static func isSingleByteEncodedText(_ data: Data) -> Bool {
+        for byte in data {
+            switch byte {
+            case 0x09, 0x0A, 0x0B, 0x0C, 0x0D, 0x1B:
+                continue
+            case 0x20...0x7E:
+                continue
+            case 0x80...0xFF:
+                continue
+            default:
+                return false
+            }
+        }
+        return true
     }
 
     private static func hasUTF16ByteOrderMark(_ data: Data) -> Bool {

--- a/Sources/Panels/FilePreviewPanel.swift
+++ b/Sources/Panels/FilePreviewPanel.swift
@@ -896,6 +896,12 @@ enum FilePreviewKindResolver {
     /// Classifies the head of a file that neither its name nor its UTType could
     /// resolve. The prefix is a fixed-size read, so a failed decode is not on
     /// its own evidence of binary content.
+    ///
+    /// A successful UTF-8 decode is accepted as is, control bytes included:
+    /// bundled JavaScript and captured terminal output carry C0 bytes and are
+    /// still source. The control-byte gate applies only to the single-byte
+    /// fallback below, where a successful decode proves nothing because
+    /// ISO Latin-1 maps every byte.
     static func prefixLooksLikeText(_ data: Data) -> Bool {
         guard !data.isEmpty else { return true }
         if hasUTF16ByteOrderMark(data), String(data: data, encoding: .utf16) != nil {

--- a/Sources/Panels/FilePreviewPanel.swift
+++ b/Sources/Panels/FilePreviewPanel.swift
@@ -913,7 +913,11 @@ enum FilePreviewKindResolver {
         if String(data: data, encoding: .utf8) != nil {
             return true
         }
-        if let completedSequences = droppingTrailingPartialUTF8Sequence(data),
+        // Only a prefix that filled the read window can have been cut mid-scalar.
+        // A shorter prefix is the whole file, where a malformed tail is a defect
+        // and not an artifact of the read.
+        if data.count == sniffPrefixByteCount,
+           let completedSequences = droppingTrailingPartialUTF8Sequence(data),
            String(data: completedSequences, encoding: .utf8) != nil {
             return true
         }
@@ -938,12 +942,15 @@ enum FilePreviewKindResolver {
         return nil
     }
 
+    /// Valid UTF-8 lead bytes only. 0xC0 and 0xC1 encode overlong forms and
+    /// 0xF5 through 0xFF exceed U+10FFFF, so a prefix ending in one of those is
+    /// malformed rather than truncated.
     private static func utf8SequenceLength(leadByte: UInt8) -> Int? {
         switch leadByte {
-        case 0b0000_0000...0b0111_1111: return 1
-        case 0b1100_0000...0b1101_1111: return 2
-        case 0b1110_0000...0b1110_1111: return 3
-        case 0b1111_0000...0b1111_0111: return 4
+        case 0x00...0x7F: return 1
+        case 0xC2...0xDF: return 2
+        case 0xE0...0xEF: return 3
+        case 0xF0...0xF4: return 4
         default: return nil
         }
     }

--- a/cmuxTests/FilePreviewKindResolverTests.swift
+++ b/cmuxTests/FilePreviewKindResolverTests.swift
@@ -106,6 +106,37 @@ struct FilePreviewKindResolverTests {
         )
     }
 
+    @Test("A file that ends exactly at the read window keeps its malformed tail")
+    func aFileThatEndsExactlyAtTheReadWindowKeepsItsMalformedTail() throws {
+        var payload = Data(repeating: 0x61, count: FilePreviewKindResolver.sniffPrefixByteCount - 2)
+        payload.append(0x07)
+        payload.append(0xC3)
+        let url = try temporaryFile(extension: "bin", data: payload)
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        #expect(payload.count == FilePreviewKindResolver.sniffPrefixByteCount)
+        #expect(
+            FilePreviewKindResolver.mode(for: url) == .quickLook,
+            "Nothing follows this prefix, so the lone lead byte is a defect and the control byte decides."
+        )
+    }
+
+    @Test("A tail that violates its lead-specific range is not treated as truncated")
+    func aTailThatViolatesItsLeadSpecificRangeIsNotTreatedAsTruncated() throws {
+        var payload = Data(repeating: 0x61, count: FilePreviewKindResolver.sniffPrefixByteCount - 3)
+        payload.append(0x07)
+        payload.append(0xE0)
+        payload.append(0x80)  // 0xE0 admits 0xA0...0xBF only; this is an overlong form
+        payload.append(contentsOf: Data(repeating: 0x61, count: 16))
+        let url = try temporaryFile(extension: "bin", data: payload)
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        #expect(
+            FilePreviewKindResolver.mode(for: url) == .quickLook,
+            "Dropping a sequence that was never valid would hide the control byte behind a clean UTF-8 decode."
+        )
+    }
+
     @Test("Valid UTF-8 carrying a control byte still resolves to text")
     func validUTF8CarryingAControlByteStillResolvesToText() throws {
         let url = try temporaryFile(extension: "dat", contents: "ring \u{07} and continue\n")

--- a/cmuxTests/FilePreviewKindResolverTests.swift
+++ b/cmuxTests/FilePreviewKindResolverTests.swift
@@ -26,64 +26,6 @@ struct FilePreviewKindResolverTests {
         }
     }
 
-    @Test("Movie file extensions keep media preview")
-    func movieFileExtensionsKeepMediaPreview() throws {
-        for fileExtension in ["mov", "mp4"] {
-            let url = try temporaryFile(
-                extension: fileExtension,
-                contents: "not a source file\n"
-            )
-            defer { try? FileManager.default.removeItem(at: url) }
-
-            #expect(FilePreviewKindResolver.initialMode(for: url) == .media)
-            #expect(FilePreviewKindResolver.mode(for: url) == .media)
-        }
-    }
-
-    @Test("MTS binary transport streams keep media preview after sniffing")
-    func mtsBinaryTransportStreamsKeepMediaPreviewAfterSniffing() throws {
-        let url = try temporaryFile(
-            extension: "mts",
-            data: mpegTransportStreamData(packetSize: 192, syncOffset: 4)
-        )
-        defer { try? FileManager.default.removeItem(at: url) }
-
-        #expect(FilePreviewKindResolver.initialMode(for: url) == .text)
-        #expect(FilePreviewKindResolver.mode(for: url) == .media)
-    }
-
-    @MainActor
-    @Test("Media previews ignore stale text-load completions")
-    func mediaPreviewsIgnoreStaleTextLoadCompletions() async throws {
-        let url = try temporaryOversizedMPEGTransportStream(
-            extension: "mts",
-            packetSize: 192,
-            syncOffset: 4
-        )
-        defer { try? FileManager.default.removeItem(at: url) }
-        let loader = DeferredTextLoader(result: .unavailable)
-
-        let panel = FilePreviewPanel(
-            workspaceId: UUID(),
-            filePath: url.path,
-            textLoader: { url in await loader.load(url: url) }
-        )
-        defer { panel.close() }
-
-        #expect(panel.previewMode == .text)
-        await loader.waitUntilStarted()
-        let resolvedAsMedia = await waitForPreviewMode(panel, .media)
-        #expect(resolvedAsMedia)
-        #expect(panel.isFileUnavailable == false)
-
-        await loader.release()
-        await loader.waitUntilCompleted()
-
-        #expect(panel.previewMode == .media)
-        #expect(panel.isFileUnavailable == false)
-        #expect(panel.textContent.isEmpty)
-    }
-
     @Test("Source files stay text when a multi-byte character straddles the sniff window")
     func sourceFilesStayTextWhenMultiByteCharacterStraddlesSniffWindow() throws {
         let url = try temporaryFile(
@@ -183,6 +125,64 @@ struct FilePreviewKindResolverTests {
             count: FilePreviewKindResolver.sniffPrefixByteCount - prefix.utf8.count - 1
         )
         return Data((prefix + padding + "ä" + suffix).utf8)
+    }
+
+    @Test("Movie file extensions keep media preview")
+    func movieFileExtensionsKeepMediaPreview() throws {
+        for fileExtension in ["mov", "mp4"] {
+            let url = try temporaryFile(
+                extension: fileExtension,
+                contents: "not a source file\n"
+            )
+            defer { try? FileManager.default.removeItem(at: url) }
+
+            #expect(FilePreviewKindResolver.initialMode(for: url) == .media)
+            #expect(FilePreviewKindResolver.mode(for: url) == .media)
+        }
+    }
+
+    @Test("MTS binary transport streams keep media preview after sniffing")
+    func mtsBinaryTransportStreamsKeepMediaPreviewAfterSniffing() throws {
+        let url = try temporaryFile(
+            extension: "mts",
+            data: mpegTransportStreamData(packetSize: 192, syncOffset: 4)
+        )
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        #expect(FilePreviewKindResolver.initialMode(for: url) == .text)
+        #expect(FilePreviewKindResolver.mode(for: url) == .media)
+    }
+
+    @MainActor
+    @Test("Media previews ignore stale text-load completions")
+    func mediaPreviewsIgnoreStaleTextLoadCompletions() async throws {
+        let url = try temporaryOversizedMPEGTransportStream(
+            extension: "mts",
+            packetSize: 192,
+            syncOffset: 4
+        )
+        defer { try? FileManager.default.removeItem(at: url) }
+        let loader = DeferredTextLoader(result: .unavailable)
+
+        let panel = FilePreviewPanel(
+            workspaceId: UUID(),
+            filePath: url.path,
+            textLoader: { url in await loader.load(url: url) }
+        )
+        defer { panel.close() }
+
+        #expect(panel.previewMode == .text)
+        await loader.waitUntilStarted()
+        let resolvedAsMedia = await waitForPreviewMode(panel, .media)
+        #expect(resolvedAsMedia)
+        #expect(panel.isFileUnavailable == false)
+
+        await loader.release()
+        await loader.waitUntilCompleted()
+
+        #expect(panel.previewMode == .media)
+        #expect(panel.isFileUnavailable == false)
+        #expect(panel.textContent.isEmpty)
     }
 
     private func temporaryFile(extension fileExtension: String, contents: String) throws -> URL {

--- a/cmuxTests/FilePreviewKindResolverTests.swift
+++ b/cmuxTests/FilePreviewKindResolverTests.swift
@@ -84,6 +84,68 @@ struct FilePreviewKindResolverTests {
         #expect(panel.textContent.isEmpty)
     }
 
+    @Test("Source files stay text when a multi-byte character straddles the sniff window")
+    func sourceFilesStayTextWhenMultiByteCharacterStraddlesSniffWindow() throws {
+        let url = try temporaryFile(
+            extension: "ts",
+            data: multiByteCharacterAtSniffBoundary(
+                prefix: "// ",
+                suffix: "\nexport const value: number = 42;\n"
+            )
+        )
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        #expect(
+            FilePreviewKindResolver.mode(for: url) == .text,
+            "A TypeScript file must not fall back to the media player because the 4 KB read cut a scalar in half."
+        )
+    }
+
+    @Test("Unknown extensions stay text when a multi-byte character straddles the sniff window")
+    func unknownExtensionsStayTextWhenMultiByteCharacterStraddlesSniffWindow() throws {
+        let url = try temporaryFile(
+            extension: "typ",
+            data: multiByteCharacterAtSniffBoundary(
+                prefix: "= ",
+                suffix: "\nÜberschrift\n"
+            )
+        )
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        #expect(FilePreviewKindResolver.mode(for: url) == .text)
+    }
+
+    @Test("Single-byte encoded text resolves to the text editor")
+    func singleByteEncodedTextResolvesToTextEditor() throws {
+        let data = try #require("Straße;Grüße;Übung\n".data(using: .isoLatin1))
+        let url = try temporaryFile(extension: "dat", data: data)
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        #expect(
+            FilePreviewKindResolver.mode(for: url) == .text,
+            "FilePreviewTextLoader decodes ISO Latin-1, so the resolver has to route the same files to the editor."
+        )
+    }
+
+    @Test("Binary payloads without NUL bytes keep the QuickLook backend")
+    func binaryPayloadsWithoutNulBytesKeepQuickLookBackend() throws {
+        var data = Data()
+        for index in 0..<4096 {
+            data.append(index.isMultiple(of: 2) ? 0xFE : 0x07)
+        }
+        let url = try temporaryFile(extension: "bin", data: data)
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        #expect(FilePreviewKindResolver.mode(for: url) == .quickLook)
+    }
+
+    /// UTF-8 whose first 4096 bytes end on the lead byte of a two-byte scalar,
+    /// which is what the fixed-size sniff read cuts in half.
+    private func multiByteCharacterAtSniffBoundary(prefix: String, suffix: String) -> Data {
+        let padding = String(repeating: "a", count: 4096 - prefix.utf8.count - 1)
+        return Data((prefix + padding + "ä" + suffix).utf8)
+    }
+
     private func temporaryFile(extension fileExtension: String, contents: String) throws -> URL {
         try temporaryFile(extension: fileExtension, data: Data(contents.utf8))
     }

--- a/cmuxTests/FilePreviewKindResolverTests.swift
+++ b/cmuxTests/FilePreviewKindResolverTests.swift
@@ -139,10 +139,24 @@ struct FilePreviewKindResolverTests {
         #expect(FilePreviewKindResolver.mode(for: url) == .quickLook)
     }
 
-    /// UTF-8 whose first 4096 bytes end on the lead byte of a two-byte scalar,
+    @Test("Valid UTF-8 carrying a control byte still resolves to text")
+    func validUTF8CarryingAControlByteStillResolvesToText() throws {
+        let url = try temporaryFile(extension: "dat", contents: "ring \u{07} and continue\n")
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        #expect(
+            FilePreviewKindResolver.mode(for: url) == .text,
+            "Bundled JavaScript and terminal captures carry C0 bytes; a valid UTF-8 decode still means text."
+        )
+    }
+
+    /// UTF-8 whose sniff prefix ends on the lead byte of a two-byte scalar,
     /// which is what the fixed-size sniff read cuts in half.
     private func multiByteCharacterAtSniffBoundary(prefix: String, suffix: String) -> Data {
-        let padding = String(repeating: "a", count: 4096 - prefix.utf8.count - 1)
+        let padding = String(
+            repeating: "a",
+            count: FilePreviewKindResolver.sniffPrefixByteCount - prefix.utf8.count - 1
+        )
         return Data((prefix + padding + "ä" + suffix).utf8)
     }
 

--- a/cmuxTests/FilePreviewKindResolverTests.swift
+++ b/cmuxTests/FilePreviewKindResolverTests.swift
@@ -139,6 +139,31 @@ struct FilePreviewKindResolverTests {
         #expect(FilePreviewKindResolver.mode(for: url) == .quickLook)
     }
 
+    @Test("A file shorter than the read window keeps its malformed tail")
+    func aFileShorterThanTheReadWindowKeepsItsMalformedTail() throws {
+        let url = try temporaryFile(extension: "bin", data: Data([0x07, 0xC3]))
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        #expect(
+            FilePreviewKindResolver.mode(for: url) == .quickLook,
+            "The read never truncated this file, so the lone lead byte is a defect and the control byte decides."
+        )
+    }
+
+    @Test("A prefix ending in an invalid lead byte is not treated as truncated")
+    func aPrefixEndingInAnInvalidLeadByteIsNotTreatedAsTruncated() throws {
+        var payload = Data(repeating: 0x61, count: FilePreviewKindResolver.sniffPrefixByteCount - 2)
+        payload.append(0x07)
+        payload.append(0xC0)  // overlong lead, never starts a valid sequence
+        let url = try temporaryFile(extension: "bin", data: payload)
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        #expect(
+            FilePreviewKindResolver.mode(for: url) == .quickLook,
+            "Dropping 0xC0 as a cut scalar would hide the control byte behind a clean UTF-8 decode."
+        )
+    }
+
     @Test("Valid UTF-8 carrying a control byte still resolves to text")
     func validUTF8CarryingAControlByteStillResolvesToText() throws {
         let url = try temporaryFile(extension: "dat", contents: "ring \u{07} and continue\n")


### PR DESCRIPTION
## Summary

A file preview can be classified as binary and open in the media player or in QuickLook instead of the text editor. Whether it happens depends on where a non-ASCII character sits in the file.

Repro, no build needed to see the input:

```bash
python3 -c "open('/tmp/a.ts','w').write('// '+'a'*4092+'ä\nexport const value = 1\n')"
python3 -c "open('/tmp/b.ts','w').write('// ä'+'a'*4092+'\nexport const value = 1\n')"
```

Open both in cmux. `b.ts` opens in the editor. `a.ts` opens in the AVPlayer media preview. Same bytes, one character moved.

## Cause

`FilePreviewKindResolver.sniffLooksLikeText` reads a fixed 4096-byte prefix and decodes it in one shot:

```swift
let data = (try? handle.read(upToCount: 4096)) ?? Data()
...
return String(data: data, encoding: .utf8) != nil
```

The read stops at byte 4096 regardless of what is there. In `a.ts` the `ä` starts at byte 4095, so its continuation byte is in the next chunk, the decode fails, and the file is called binary.

What that costs depends on the extension. `.ts` resolves to `public.mpeg-2-transport-stream`, which conforms to `.movie`, so `knownTextResolutionBeforeMedia` hands the file to the media backend once the sniff says binary. Every other extension falls through to QuickLook.

Second gap, same function: `FilePreviewTextLoader.decodeText` tries UTF-8, then UTF-16, then ISO Latin-1, but the sniff accepts only UTF-8 and BOM'd UTF-16. A single-byte-encoded file the loader would render fine never reaches it.

## Fix

- Retry the decode after dropping a trailing sequence the read cut in half, but only when the prefix filled the read window. A shorter prefix is the whole file, so a malformed tail there is a defect and not a read artifact.
- Accept only valid UTF-8 lead bytes when measuring that tail. `0xC0`/`0xC1` are overlong and `0xF5` upward exceeds U+10FFFF.
- Accept single-byte encoded text, matching the loader's ISO Latin-1 fallback. The accepted byte set is the one `file(1)` calls "ISO-8859 text".
- NUL bytes and C0 control bytes still mean binary, unchanged.

## Blast radius

Ran both the old and the new classifier over every regular file under `Sources/`, `web/`, and `Resources/`, 4 KB prefix each:

- 60002 files scanned
- 45 classification changes, all binary → text
- 0 text → binary

Every one of the 45 is an i18n source or message file cut mid-character at the boundary, for example `web/node_modules/zod/src/v4/locales/ru.ts` (media player today) and `web/node_modules/zod/v4/locales/th.cjs` (QuickLook today).

## Review round

CodeRabbit found a real bug in the first version of the retry: it dropped a trailing partial sequence without checking whether the read had cut anything, so `Data([0x07, 0xC3])` lost the `0xC3` and returned text on the remaining control byte. Both bounds above are the fix, with regression tests for the short case and for a full window ending in `0xC0`. Corpus re-run after the fix, 92368 files: 47 binary → text, 0 text → binary.

The one suggestion I did not take was rejecting C0 bytes before the UTF-8 decode. Measured over 80004 files: that variant moves three real JavaScript sources (drizzle-kit, next/cli-select, postal-mime) from the editor to QuickLook. Control bytes are valid UTF-8 and upstream already routes those files to the editor today, so the gate stays on the single-byte fallback, where a decode proves nothing because ISO Latin-1 maps every byte. A test pins that expectation and `prefixLooksLikeText` carries a comment explaining why the two paths differ.

## Changes

- `Sources/Panels/FilePreviewPanel.swift`: `sniffLooksLikeText` split into a testable `prefixLooksLikeText`, plus the truncated-sequence retry and the single-byte acceptance.
- `cmuxTests/FilePreviewKindResolverTests.swift`: seven cases, four of them guards that have to stay binary or stay text.

## Test plan

Two commits per the regression policy in `CLAUDE.md`:

1. `test(file-preview): cover text sniffing across the 4 KB read boundary` — red.
2. `fix(file-preview): keep text files out of the media and QuickLook backends` — green.

- [ ] CI: the seven new cases in `FilePreviewKindResolverTests` fail on commit 1, pass on commit 2
- [ ] Manual: open `/tmp/a.ts` from the repro above and confirm the text editor
- [ ] Manual: open a PNG, an MP4, and a PDF and confirm the backends did not move


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved file type detection for text files with truncated UTF-8 characters.
  * Added support for valid single-byte text, including ISO-8859-1 content.
  * More accurately distinguishes binary files, malformed data, and text containing control characters.
  * Improved handling of short files and text encoded as UTF-8 or UTF-16.

* **Tests**
  * Added coverage for boundary-split characters, invalid encodings, short files, control characters, and binary data without null bytes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->