### PR TITLE
feat(command-palette): open and reveal the focused file preview

### DIFF
--- a/Packages/macOS/CmuxCommandPalette/Sources/CmuxCommandPalette/Context/CommandPaletteContextKeys.swift
+++ b/Packages/macOS/CmuxCommandPalette/Sources/CmuxCommandPalette/Context/CommandPaletteContextKeys.swift
@@ -59,6 +59,8 @@ public struct CommandPaletteContextKeys: Hashable, Sendable {
     public static let panelIsSimulator = CommandPaletteContextKeys(rawValue: "panel.isSimulator")
     /// Whether the focused panel is a text file preview editor.
     public static let panelIsFilePreviewTextEditor = CommandPaletteContextKeys(rawValue: "panel.isFilePreviewTextEditor")
+    /// Whether the focused panel previews a file in any backend.
+    public static let panelIsFilePreview = CommandPaletteContextKeys(rawValue: "panel.isFilePreview")
     /// Whether the focused panel is a terminal.
     public static let panelIsTerminal = CommandPaletteContextKeys(rawValue: "panel.isTerminal")
     /// Whether the focused panel sits in a pane.

--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -58490,6 +58490,40 @@
         }
       }
     },
+    "command.filePreviewOpenExternally.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Open File in Default App"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ファイルをデフォルトのアプリで開く"
+          }
+        }
+      }
+    },
+    "command.filePreviewRevealInFinder.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Reveal File in Finder"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ファイルをFinderで表示"
+          }
+        }
+      }
+    },
     "command.findInDirectory.subtitle": {
       "extractionState": "manual",
       "localizations": {
@@ -71047,6 +71081,23 @@
           "stringUnit": {
             "state": "translated",
             "value": "瀏覽器 • %@"
+          }
+        }
+      }
+    },
+    "commandPalette.subtitle.filePreviewWithName": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "File • %@"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ファイル • %@"
           }
         }
       }

--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -58493,10 +58493,52 @@
     "command.filePreviewOpenExternally.title": {
       "extractionState": "manual",
       "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "فتح الملف في التطبيق الافتراضي"
+          }
+        },
+        "bs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Otvori datoteku u zadanoj aplikaciji"
+          }
+        },
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Åbn fil i standardprogram"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Datei in Standard-App öffnen"
+          }
+        },
         "en": {
           "stringUnit": {
             "state": "translated",
             "value": "Open File in Default App"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Abrir archivo en la app predeterminada"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ouvrir le fichier dans l'app par défaut"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Apri file nell'app predefinita"
           }
         },
         "ja": {
@@ -58504,22 +58546,196 @@
             "state": "translated",
             "value": "ファイルをデフォルトのアプリで開く"
           }
+        },
+        "km": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "បើកឯកសារក្នុងកម្មវិធីលំនាំដើម"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "기본 앱으로 파일 열기"
+          }
+        },
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Åpne fil i standardprogram"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Otwórz plik w domyślnej aplikacji"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Abrir arquivo no app padrão"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Открыть файл в приложении по умолчанию"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "เปิดไฟล์ในแอปเริ่มต้น"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dosyayı Varsayılan Uygulamada Aç"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Відкрити файл у програмі за замовчуванням"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "在默认应用中打开文件"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "在預設應用程式中打開檔案"
+          }
         }
       }
     },
     "command.filePreviewRevealInFinder.title": {
       "extractionState": "manual",
       "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "إظهار الملف في Finder"
+          }
+        },
+        "bs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Prikaži datoteku u Finderu"
+          }
+        },
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vis fil i Finder"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Datei im Finder zeigen"
+          }
+        },
         "en": {
           "stringUnit": {
             "state": "translated",
             "value": "Reveal File in Finder"
           }
         },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mostrar archivo en el Finder"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Afficher le fichier dans le Finder"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mostra file nel Finder"
+          }
+        },
         "ja": {
           "stringUnit": {
             "state": "translated",
             "value": "ファイルをFinderで表示"
+          }
+        },
+        "km": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "បង្ហាញឯកសារក្នុង Finder"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Finder에서 파일 보기"
+          }
+        },
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vis fil i Finder"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pokaż plik w Finderze"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mostrar arquivo no Finder"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Показать файл в Finder"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "แสดงไฟล์ใน Finder"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dosyayı Finder'da Göster"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Показати файл у Finder"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "在访达中显示文件"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "在Finder中顯示檔案"
           }
         }
       }
@@ -71088,7 +71304,49 @@
     "commandPalette.subtitle.filePreviewWithName": {
       "extractionState": "manual",
       "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ملف • %@"
+          }
+        },
+        "bs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Datoteka • %@"
+          }
+        },
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fil • %@"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Datei • %@"
+          }
+        },
         "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "File • %@"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Archivo • %@"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fichier • %@"
+          }
+        },
+        "it": {
           "stringUnit": {
             "state": "translated",
             "value": "File • %@"
@@ -71098,6 +71356,72 @@
           "stringUnit": {
             "state": "translated",
             "value": "ファイル • %@"
+          }
+        },
+        "km": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ឯកសារ • %@"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "파일 • %@"
+          }
+        },
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fil • %@"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Plik • %@"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Arquivo • %@"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Файл • %@"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ไฟล์ • %@"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dosya • %@"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Файл • %@"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "文件 • %@"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "檔案 • %@"
           }
         }
       }

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -6808,6 +6808,10 @@ struct ContentView: View {
                 (panelContext.panel as? FilePreviewPanel)?.previewMode == .text
             )
             snapshot.setBool(
+                CommandPaletteContextKeys.panelIsFilePreview,
+                panelContext.panel is FilePreviewPanel
+            )
+            snapshot.setBool(
                 CommandPaletteContextKeys.panelBrowserOmnibarVisible,
                 (panelContext.panel as? BrowserPanel)?.isOmnibarVisible ?? true
             )
@@ -6902,6 +6906,11 @@ struct ContentView: View {
         func markdownPanelSubtitle(_ context: CommandPaletteContextSnapshot) -> String {
             let name = context.string(CommandPaletteContextKeys.panelName) ?? String(localized: "commandPalette.subtitle.tabFallback", defaultValue: "Tab")
             return String(localized: "commandPalette.subtitle.markdownWithName", defaultValue: "Markdown • \(name)")
+        }
+
+        func filePreviewPanelSubtitle(_ context: CommandPaletteContextSnapshot) -> String {
+            let name = context.string(CommandPaletteContextKeys.panelName) ?? String(localized: "commandPalette.subtitle.tabFallback", defaultValue: "Tab")
+            return String(localized: "commandPalette.subtitle.filePreviewWithName", defaultValue: "File • \(name)")
         }
 
         func workspaceColorCommandTitle(_ paletteName: String) -> String {
@@ -7693,6 +7702,24 @@ struct ContentView: View {
                 subtitle: markdownPanelSubtitle,
                 keywords: ["markdown", "zoom", "reset", "actual size", "font", "default"],
                 when: { $0.bool(CommandPaletteContextKeys.panelIsMarkdown) }
+            )
+        )
+        contributions.append(
+            CommandPaletteCommandContribution(
+                commandId: "palette.filePreviewOpenExternally",
+                title: constant(String(localized: "command.filePreviewOpenExternally.title", defaultValue: "Open File in Default App")),
+                subtitle: filePreviewPanelSubtitle,
+                keywords: ["file", "open", "default", "external", "app", "application", "preview"],
+                when: { $0.bool(CommandPaletteContextKeys.panelIsFilePreview) }
+            )
+        )
+        contributions.append(
+            CommandPaletteCommandContribution(
+                commandId: "palette.filePreviewRevealInFinder",
+                title: constant(String(localized: "command.filePreviewRevealInFinder.title", defaultValue: "Reveal File in Finder")),
+                subtitle: filePreviewPanelSubtitle,
+                keywords: ["file", "reveal", "finder", "show", "folder", "preview"],
+                when: { $0.bool(CommandPaletteContextKeys.panelIsFilePreview) }
             )
         )
         contributions.append(
@@ -8600,6 +8627,16 @@ struct ContentView: View {
         }
         registry.register(commandId: "palette.markdownZoomReset") {
             if !tabManager.resetZoomFocusedMarkdown() {
+                NSSound.beep()
+            }
+        }
+        registry.register(commandId: "palette.filePreviewOpenExternally") {
+            if !openFocusedFilePreviewExternally() {
+                NSSound.beep()
+            }
+        }
+        registry.register(commandId: "palette.filePreviewRevealInFinder") {
+            if !revealFocusedFilePreviewInFinder() {
                 NSSound.beep()
             }
         }
@@ -9957,6 +9994,21 @@ struct ContentView: View {
             return false
         }
         return NSWorkspace.shared.open(url)
+    }
+
+    private func focusedFilePreviewFileURL() -> URL? {
+        FilePreviewCommandTarget.fileURL(for: focusedPanelContext?.panel)
+    }
+
+    private func openFocusedFilePreviewExternally() -> Bool {
+        guard let fileURL = focusedFilePreviewFileURL() else { return false }
+        return FileExternalOpenAction.openDefault(fileURL: fileURL)
+    }
+
+    private func revealFocusedFilePreviewInFinder() -> Bool {
+        guard let fileURL = focusedFilePreviewFileURL() else { return false }
+        FileExternalOpenAction.revealInFinder(fileURL: fileURL)
+        return true
     }
 
     private func openWorkspacePullRequestsInConfiguredBrowser() -> Bool {

--- a/Sources/Panels/FilePreviewPanel.swift
+++ b/Sources/Panels/FilePreviewPanel.swift
@@ -126,6 +126,23 @@ enum FileExternalOpenAction {
     }
 }
 
+/// Resolves the file that the command palette's file actions operate on.
+@MainActor
+enum FilePreviewCommandTarget {
+    /// Returns nil for any panel that is not a file preview, and for a preview
+    /// whose file is gone, so callers can report failure instead of asking
+    /// Launch Services to open a stale path.
+    static func fileURL(
+        for panel: (any Panel)?,
+        fileExists: (String) -> Bool = { FileManager.default.fileExists(atPath: $0) }
+    ) -> URL? {
+        guard let filePreviewPanel = panel as? FilePreviewPanel else { return nil }
+        let fileURL = URL(fileURLWithPath: filePreviewPanel.filePath)
+        guard fileExists(fileURL.path) else { return nil }
+        return fileURL
+    }
+}
+
 enum FileExternalOpenText {
     static var openWithMenu: String {
         String(localized: "filePreview.openWith.menu", defaultValue: "Open With")

--- a/cmuxTests/FilePreviewKindResolverTests.swift
+++ b/cmuxTests/FilePreviewKindResolverTests.swift
@@ -84,6 +84,34 @@ struct FilePreviewKindResolverTests {
         #expect(panel.textContent.isEmpty)
     }
 
+    @MainActor
+    @Test("File commands target the focused preview's file")
+    func fileCommandsTargetTheFocusedPreviewsFile() throws {
+        let url = try temporaryFile(extension: "md", contents: "# title\n")
+        defer { try? FileManager.default.removeItem(at: url) }
+        let panel = FilePreviewPanel(workspaceId: UUID(), filePath: url.path, startFileWatcher: false)
+        defer { panel.close() }
+
+        #expect(FilePreviewCommandTarget.fileURL(for: panel)?.path == url.path)
+    }
+
+    @MainActor
+    @Test("File commands ignore a preview whose file no longer exists")
+    func fileCommandsIgnoreAPreviewWhoseFileNoLongerExists() throws {
+        let url = try temporaryFile(extension: "md", contents: "# title\n")
+        let panel = FilePreviewPanel(workspaceId: UUID(), filePath: url.path, startFileWatcher: false)
+        defer { panel.close() }
+        try FileManager.default.removeItem(at: url)
+
+        #expect(FilePreviewCommandTarget.fileURL(for: panel) == nil)
+    }
+
+    @MainActor
+    @Test("File commands ignore panels that are not file previews")
+    func fileCommandsIgnorePanelsThatAreNotFilePreviews() {
+        #expect(FilePreviewCommandTarget.fileURL(for: nil) == nil)
+    }
+
     private func temporaryFile(extension fileExtension: String, contents: String) throws -> URL {
         try temporaryFile(extension: fileExtension, data: Data(contents.utf8))
     }

--- a/cmuxTests/FilePreviewKindResolverTests.swift
+++ b/cmuxTests/FilePreviewKindResolverTests.swift
@@ -53,38 +53,6 @@ struct FilePreviewKindResolverTests {
     }
 
     @MainActor
-    @Test("Media previews ignore stale text-load completions")
-    func mediaPreviewsIgnoreStaleTextLoadCompletions() async throws {
-        let url = try temporaryOversizedMPEGTransportStream(
-            extension: "mts",
-            packetSize: 192,
-            syncOffset: 4
-        )
-        defer { try? FileManager.default.removeItem(at: url) }
-        let loader = DeferredTextLoader(result: .unavailable)
-
-        let panel = FilePreviewPanel(
-            workspaceId: UUID(),
-            filePath: url.path,
-            textLoader: { url in await loader.load(url: url) }
-        )
-        defer { panel.close() }
-
-        #expect(panel.previewMode == .text)
-        await loader.waitUntilStarted()
-        let resolvedAsMedia = await waitForPreviewMode(panel, .media)
-        #expect(resolvedAsMedia)
-        #expect(panel.isFileUnavailable == false)
-
-        await loader.release()
-        await loader.waitUntilCompleted()
-
-        #expect(panel.previewMode == .media)
-        #expect(panel.isFileUnavailable == false)
-        #expect(panel.textContent.isEmpty)
-    }
-
-    @MainActor
     @Test("File commands target the focused preview's file")
     func fileCommandsTargetTheFocusedPreviewsFile() throws {
         let url = try temporaryFile(extension: "md", contents: "# title\n")
@@ -123,6 +91,38 @@ struct FilePreviewKindResolverTests {
     @Test("File commands ignore an unfocused pane")
     func fileCommandsIgnoreAnUnfocusedPane() {
         #expect(FilePreviewCommandTarget.fileURL(for: nil) == nil)
+    }
+
+    @MainActor
+    @Test("Media previews ignore stale text-load completions")
+    func mediaPreviewsIgnoreStaleTextLoadCompletions() async throws {
+        let url = try temporaryOversizedMPEGTransportStream(
+            extension: "mts",
+            packetSize: 192,
+            syncOffset: 4
+        )
+        defer { try? FileManager.default.removeItem(at: url) }
+        let loader = DeferredTextLoader(result: .unavailable)
+
+        let panel = FilePreviewPanel(
+            workspaceId: UUID(),
+            filePath: url.path,
+            textLoader: { url in await loader.load(url: url) }
+        )
+        defer { panel.close() }
+
+        #expect(panel.previewMode == .text)
+        await loader.waitUntilStarted()
+        let resolvedAsMedia = await waitForPreviewMode(panel, .media)
+        #expect(resolvedAsMedia)
+        #expect(panel.isFileUnavailable == false)
+
+        await loader.release()
+        await loader.waitUntilCompleted()
+
+        #expect(panel.previewMode == .media)
+        #expect(panel.isFileUnavailable == false)
+        #expect(panel.textContent.isEmpty)
     }
 
     private func temporaryFile(extension fileExtension: String, contents: String) throws -> URL {

--- a/cmuxTests/FilePreviewKindResolverTests.swift
+++ b/cmuxTests/FilePreviewKindResolverTests.swift
@@ -107,8 +107,21 @@ struct FilePreviewKindResolverTests {
     }
 
     @MainActor
-    @Test("File commands ignore panels that are not file previews")
-    func fileCommandsIgnorePanelsThatAreNotFilePreviews() {
+    @Test("File commands ignore a panel that previews the file some other way")
+    func fileCommandsIgnoreAPanelThatPreviewsTheFileSomeOtherWay() throws {
+        let url = try temporaryFile(extension: "md", contents: "# title\n")
+        defer { try? FileManager.default.removeItem(at: url) }
+        let panel = MarkdownPanel(workspaceId: UUID(), filePath: url.path)
+
+        #expect(
+            FilePreviewCommandTarget.fileURL(for: panel) == nil,
+            "A markdown panel points at a real file, so the guard has to be the panel type, not the path."
+        )
+    }
+
+    @MainActor
+    @Test("File commands ignore an unfocused pane")
+    func fileCommandsIgnoreAnUnfocusedPane() {
         #expect(FilePreviewCommandTarget.fileURL(for: nil) == nil)
     }
 


### PR DESCRIPTION
## Summary

Refs #7060, #4111.

A browser panel has **Open Current Page in Default Browser** in the palette. The Files sidebar has **Open in Default Editor** and **Reveal in Finder** in its context menu. A file already open in a preview pane had neither.

The only route from an open preview to Finder or to Preview.app is the header's Open With menu: mouse only, and in PDF mode the header is not rendered at all, so there is no route.

This adds the two commands the other surfaces already have:

- **Open File in Default App**
- **Reveal File in Finder**

Both are gated on a new `panel.isFilePreview` context key, so they appear only while a preview pane has focus, the same way the browser commands are gated on `panel.isBrowser`.

## Why the palette first

#7060 asks for two things: a click modifier, and a bindable action that promotes an already-open preview to the native app. This PR is the second one, at the palette layer, where the routing is a three-line addition next to `palette.browserOpenDefault`.

Making them bindable is the natural follow-up and touches ten more files across `KeyboardShortcutSettings`, the `CmuxSettings` package, `web/data/cmux-shortcuts.ts`, and the shortcut docs. Happy to do that in a second PR if you want the action IDs; splitting it keeps this one reviewable, and the shortcut side is where the default-binding discussion belongs. Prior art for how I would write that up: #6248.

## Behavior

`FilePreviewCommandTarget.fileURL(for:)` resolves the focused panel's file and returns nil when the panel is not a preview or when the file is gone, so a deleted file beeps instead of asking Launch Services to open a stale path. Both commands then go through the existing `FileExternalOpenAction`, so the palette, the header menu, and the Files context menu stay one behavior.

## Changes

- `Packages/macOS/CmuxCommandPalette/…/CommandPaletteContextKeys.swift`: `panelIsFilePreview`
- `Sources/ContentView.swift`: context snapshot, two contributions, two registry handlers, the focused-file helpers
- `Sources/Panels/FilePreviewPanel.swift`: `FilePreviewCommandTarget`
- `Resources/Localizable.xcstrings`: three keys, translated for all 20 locales the catalog carries

## Test plan

- [ ] CI: four new cases in `FilePreviewKindResolverTests` covering the focused-file resolution, the deleted-file case, a `MarkdownPanel` that points at a real file, and an unfocused pane
- [ ] Manual: open a PDF in a pane, run **Reveal File in Finder** from the palette, confirm Finder selects it
- [ ] Manual: run **Open File in Default App** on the same PDF, confirm Preview opens it
- [ ] Manual: focus a terminal and confirm neither command is offered


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added file preview capabilities to the command palette, enabling users to open files in their default application.
  * Added ability to reveal files in Finder directly from the command palette.
  * Added multilingual support for file-related command strings.

* **Tests**
  * Added test coverage for file preview command resolution and handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->