### PR TITLE
feat(file-preview): widen the text allowlist for source and project files

### DIFF
--- a/Sources/Panels/FilePreviewPanel.swift
+++ b/Sources/Panels/FilePreviewPanel.swift
@@ -655,23 +655,58 @@ enum FilePreviewKindResolver {
     }
 
     private static let textFilenames: Set<String> = [
+        ".bash_profile",
+        ".bashrc",
+        ".dockerignore",
+        ".editorconfig",
         ".env",
-        ".gitignore",
+        ".envrc",
         ".gitattributes",
+        ".gitconfig",
+        ".gitignore",
+        ".gitmodules",
+        ".npmignore",
         ".npmrc",
+        ".nvmrc",
+        ".prettierrc",
+        ".profile",
+        ".tool-versions",
         ".zshrc",
+        "authors",
+        "berksfile",
+        "brewfile",
+        "changelog",
+        "codeowners",
+        "contributing",
+        "copying",
         "dockerfile",
-        "makefile",
         "gemfile",
-        "podfile"
+        "justfile",
+        "license",
+        "makefile",
+        "notice",
+        "podfile",
+        "procfile",
+        "rakefile",
+        "readme",
+        "vagrantfile"
     ]
 
+    /// Environment files are versioned by suffix (`.env.local`, `.env.production`).
+    private static let textFilenamePrefixes: Set<String> = [".env."]
+
     private static let textExtensions: Set<String> = [
-        "bash", "c", "cc", "cfg", "conf", "cpp", "cs", "css", "csv", "cts", "env",
-        "fish", "go", "h", "hpp", "htm", "html", "ini", "java", "js", "json",
-        "jsx", "kt", "log", "m", "markdown", "md", "mdx", "mm", "mts", "plist",
-        "py", "rb", "rs", "sh", "sql", "swift", "toml", "ts", "tsx", "tsv", "txt",
-        "xml", "yaml", "yml", "zsh"
+        "adoc", "astro", "bash", "bat", "bib", "c", "cc", "cfg", "cjs", "clj",
+        "cmake", "conf", "cpp", "cs", "css", "csv", "cts", "dart", "ejs", "elm",
+        "env", "erb", "erl", "ex", "exs", "fish", "gd", "gleam", "go", "gql",
+        "gradle", "graphql", "groovy", "h", "hbs", "hcl", "hpp", "hs", "htm",
+        "html", "ini", "java", "jl", "js", "json", "jsonc", "jsonl", "jsx", "kt",
+        "kts", "less", "log", "lua", "m", "markdown", "md", "mdx", "mm", "mts",
+        "nim", "nix", "plist", "po", "properties", "proto", "ps1", "purs", "py",
+        "rb", "rs", "rst", "sass", "sbt", "scala", "scss", "sh", "sol", "sql",
+        "sty", "styl", "sv", "svelte", "swift", "tex", "tf", "tfvars", "toml",
+        "ts", "tsv", "tsx", "txt", "typ", "vim", "vue", "xcconfig", "xml",
+        "yaml", "yml", "zig", "zsh"
     ]
 
     static func mode(for url: URL) -> FilePreviewMode {
@@ -793,9 +828,14 @@ enum FilePreviewKindResolver {
         return types
     }
 
+    private static func isKnownTextFilename(_ filename: String) -> Bool {
+        textFilenames.contains(filename)
+            || textFilenamePrefixes.contains { filename.hasPrefix($0) }
+    }
+
     private static func knownTextFile(url: URL, includeResourceContentType: Bool) -> Bool {
         let filename = url.lastPathComponent.lowercased()
-        if textFilenames.contains(filename) {
+        if isKnownTextFilename(filename) {
             return true
         }
         let ext = url.pathExtension.lowercased()
@@ -818,7 +858,7 @@ enum FilePreviewKindResolver {
         let filename = url.lastPathComponent.lowercased()
         let ext = url.pathExtension.lowercased()
         guard ext != "plist",
-              textFilenames.contains(filename) || textExtensions.contains(ext) else {
+              isKnownTextFilename(filename) || textExtensions.contains(ext) else {
             return nil
         }
 

--- a/cmuxTests/FilePreviewKindResolverTests.swift
+++ b/cmuxTests/FilePreviewKindResolverTests.swift
@@ -84,6 +84,42 @@ struct FilePreviewKindResolverTests {
         #expect(panel.textContent.isEmpty)
     }
 
+    @Test(
+        "Common source and config extensions route straight to text preview",
+        arguments: ["exs", "nix", "tf", "typ", "zig", "svelte", "lua", "gradle", "cjs", "sty"]
+    )
+    func commonSourceAndConfigExtensionsRouteStraightToTextPreview(fileExtension: String) throws {
+        let url = try temporaryFile(extension: fileExtension, contents: "value = 1\n")
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        #expect(
+            FilePreviewKindResolver.initialMode(for: url) == .text,
+            "Expected .\(fileExtension) to open in the editor without a QuickLook round trip."
+        )
+        #expect(FilePreviewKindResolver.mode(for: url) == .text)
+    }
+
+    @Test(
+        "Extensionless project files route to text preview",
+        arguments: ["LICENSE", "Justfile", "Procfile", "CODEOWNERS", ".env.production"]
+    )
+    func extensionlessProjectFilesRouteToTextPreview(filename: String) throws {
+        let url = try temporaryFile(named: filename, contents: "value = 1\n")
+        defer { try? FileManager.default.removeItem(at: url.deletingLastPathComponent()) }
+
+        #expect(FilePreviewKindResolver.initialMode(for: url) == .text)
+        #expect(FilePreviewKindResolver.mode(for: url) == .text)
+    }
+
+    private func temporaryFile(named filename: String, contents: String) throws -> URL {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cmux-file-preview-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        let url = directory.appendingPathComponent(filename)
+        try Data(contents.utf8).write(to: url, options: .atomic)
+        return url
+    }
+
     private func temporaryFile(extension fileExtension: String, contents: String) throws -> URL {
         try temporaryFile(extension: fileExtension, data: Data(contents.utf8))
     }


### PR DESCRIPTION
## Summary

`FilePreviewKindResolver` picks the preview backend twice. `initialMode` runs synchronously off the filename, and `mode` runs off the main thread and can sniff the file. An extension missing from the allowlist means the pane shows QuickLook first and swaps to the editor a moment later.

Two cases are worse than a flash:

- `.exs` resolves to `com.apple.logic.exs`, a Logic Pro sampler instrument, which conforms to an audio type. Elixir scripts open in the media player.
- `.env.local` and `.env.production` miss the `.env` entry, which matches the exact filename.

## Changes

- Extensions: the source, config, and markup formats that show up next to an agent. `astro cjs clj cmake dart ejs elm erb erl ex exs gd gleam gradle graphql gql groovy hbs hcl hs jl jsonc jsonl kts less lua nim nix po properties proto ps1 purs rst sass sbt scala scss sol sty styl sv svelte tex tf tfvars typ vim vue xcconfig zig adoc bat bib`
- Filenames: `LICENSE README CHANGELOG CONTRIBUTING COPYING NOTICE AUTHORS CODEOWNERS Justfile Procfile Rakefile Brewfile Berksfile Vagrantfile`, plus the dotfiles `.bashrc .bash_profile .profile .editorconfig .dockerignore .envrc .gitconfig .gitmodules .npmignore .nvmrc .prettierrc .tool-versions`
- A `.env.` prefix rule, so `.env.local` and friends follow `.env`

Extensions already covered by a text or source-code UTType (`diff patch php pl r mjs`) are deliberately left out; the resolver reaches them through `knownTextFile`.

## Collision check

Every added extension was checked against `UTType(filenameExtension:)` before adding it. One collides with a media type:

| extension | UTType | conforms to |
|---|---|---|
| `exs` | `com.apple.logic.exs` | audio |

That is the case `knownTextResolutionBeforeMedia` already handles for `.ts` and `.mts`: extension-only routing up front, sniff off the main thread to settle it. A real Logic sampler instrument still resolves to the media backend.

## Test plan

- [ ] CI: two parameterized cases in `FilePreviewKindResolverTests` — ten extensions and five extensionless project files, each asserted on both `initialMode` and `mode`
- [ ] CI: the existing movie and MTS cases still pass, which is the guard against an allowlist entry stealing a media type
- [ ] Manual: open a `.exs` file and confirm the editor, not the media player
- [ ] Manual: open `.env.local` and confirm the editor with no QuickLook flash

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/9310"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788087594&installation_model_id=21920&pr_number=9310&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F9310&signature=880da9d766f4c6b191e289eed4f9a5e0486bffdbd77eb521939f52689ed3fa5b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expands the text allowlist so more source, config, and project files open directly in the editor with no QuickLook flash. Fixes wrong routing for .exs and .env.* so Elixir scripts and env variants open as text.

- **Bug Fixes**
  - Added common text extensions and project filenames (e.g., LICENSE, README, Justfile, Procfile, CODEOWNERS) to the allowlist for immediate editor preview.
  - Added a ".env." prefix rule so ".env.local", ".env.production", etc. open as text without flicker.
  - Resolved the `.exs` media-type collision: prefer text first; async sniff keeps real Logic Pro `.exs` instruments on the media backend.

<sup>Written for commit b8419acdc2caee57219ac0dbdde198fccb1ddbae. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/9310?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved text-file detection for additional dotfiles, project files, configuration files, environment variants, and source-code extensions.
  * Ensured matching files consistently open in text preview, including cases where media content has a conflicting filename.

* **Tests**
  * Added coverage for extensionless project files and additional source/configuration file types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->