### PR TITLE
Stabilize socket ACL settings lifecycle test

### DIFF
--- a/cmuxTests/SocketConfigurationLifecycleTests.swift
+++ b/cmuxTests/SocketConfigurationLifecycleTests.swift
@@ -40,16 +40,17 @@ extension SocketACLReloadRegressionTests {
     func malformedAutomationSectionPreservesManagedPassword(section: String) throws {
         let defaults = UserDefaults.standard
         let originalDefaults = capturedSocketDefaults(defaults)
-        let originalAppearance = defaults.object(forKey: AppearanceSettings.appearanceModeKey)
+        let preferredEditorKey = AppCatalogSection().preferredEditor.userDefaultsKey
+        let originalPreferredEditor = defaults.object(forKey: preferredEditorKey)
         let directory = lifecycleTemporaryDirectory(prefix: "scfa")
         try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
         let configURL = directory.appendingPathComponent("cmux.json")
         defer {
             restoreSocketDefaults(originalDefaults, in: defaults)
-            if let originalAppearance {
-                defaults.set(originalAppearance, forKey: AppearanceSettings.appearanceModeKey)
+            if let originalPreferredEditor {
+                defaults.set(originalPreferredEditor, forKey: preferredEditorKey)
             } else {
-                defaults.removeObject(forKey: AppearanceSettings.appearanceModeKey)
+                defaults.removeObject(forKey: preferredEditorKey)
             }
             try? FileManager.default.removeItem(at: directory)
         }
@@ -64,13 +65,13 @@ extension SocketACLReloadRegressionTests {
         )
         #expect(defaults.string(forKey: SocketControlSettings.appStorageKey) == SocketControlMode.password.rawValue)
 
-        defaults.set("system", forKey: AppearanceSettings.appearanceModeKey)
-        try "{\"app\":{\"appearance\":\"dark\"},\"automation\":\(section)}"
+        defaults.set("vim", forKey: preferredEditorKey)
+        try "{\"app\":{\"preferredEditor\":\"code\"},\"automation\":\(section)}"
             .write(to: configURL, atomically: true, encoding: .utf8)
         store.reload()
 
         #expect(defaults.string(forKey: SocketControlSettings.appStorageKey) == SocketControlMode.password.rawValue)
-        #expect(defaults.string(forKey: AppearanceSettings.appearanceModeKey) == "dark")
+        #expect(defaults.string(forKey: preferredEditorKey) == "code")
     }
 
     @Test(arguments: [SocketControlMode.cmuxOnly, .off])


### PR DESCRIPTION
## Summary

- keep the malformed automation-section regression focused on socket policy
- use the inert `app.preferredEditor` setting as the independently managed sibling value
- avoid triggering the live appearance observer and Ghostty theme reload from the app-host test fixture

## Root cause

The parameterized parser test changed `app.appearance` while the full app-host test process was running. The app-wide `UserDefaults` observer treated that fixture mutation as a real live appearance change and synchronized Ghostty terminal themes. In full CI the first host exited during that reload; Xcode restarted the test process, so the remaining cases passed but the invocation exited 65.

The test only needs to prove a malformed `automation` section does not block another managed section. `app.preferredEditor` exercises the same settings-store merge/apply path without renderer lifecycle side effects.

## Validation

- `git diff --check`
- `./scripts/lint-pbxproj-test-wiring.sh`
- `python3 scripts/check-package-resolved-policy.py`
- focused `SocketACLReloadRegressionTests` workflow proof pending

Found while validating the integration branch for #9222. No production code changes.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/9311"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788088483&installation_model_id=21920&pr_number=9311&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F9311&signature=37a632fd428a2ee2d6f6b6837cb34d5ce93477e5795f630e5749590c20fefa0a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stabilizes the socket ACL lifecycle test by replacing `app.appearance` with `app.preferredEditor` to avoid triggering the live appearance observer and theme reload. Keeps the test focused on socket policy behavior, removes CI flakiness, and makes no production code changes.

<sup>Written for commit 6d94fa7bb0f528c8e4fed4515aeb2e83b8af15e2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/9311?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated automation lifecycle coverage to verify preferred-editor settings are preserved and restored correctly.
  * Confirmed socket control remains password-protected during configuration import.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->