### PR TITLE
Reject zero-test iOS workflow runs

### DIFF
--- a/.github/workflows/test-ios.yml
+++ b/.github/workflows/test-ios.yml
@@ -9,7 +9,7 @@ on:
         required: false
         default: ""
       test_filter:
-        description: "Full xcodebuild UI selector, for example cmuxUITests/cmuxUITests/testSignInPairingAndWorkspaceShell"
+        description: "UI test class or class/method; full target/class/method selectors also work"
         required: false
         default: ""
       device_family:
@@ -372,8 +372,12 @@ jobs:
             -destination "platform=iOS Simulator,id=$SIMULATOR_ID"
             -derivedDataPath "$IOS_DERIVED_DATA"
           )
+          TEST_SELECTOR=""
           if [ -n "${TEST_FILTER:-}" ]; then
-            XCODEBUILD_ARGS+=(-only-testing:"$TEST_FILTER")
+            TEST_SELECTOR="$(python3 scripts/ci/normalize_ios_ui_test_selector.py "$TEST_FILTER")"
+            echo "Requested test filter: $TEST_FILTER"
+            echo "Normalized test selector: $TEST_SELECTOR"
+            XCODEBUILD_ARGS+=(-only-testing:"$TEST_SELECTOR")
           else
             # Full UI tests currently exceed the pull-request simulator budget
             # on macos-26. Keep them runnable via workflow_dispatch +
@@ -395,8 +399,8 @@ jobs:
           }
           require_requested_tests_ran() {
             local log_path="$1"
-            if [ -n "${TEST_FILTER:-}" ]; then
-              python3 scripts/ci/require_xcode_tests_ran.py "$log_path" "$TEST_FILTER"
+            if [ -n "$TEST_SELECTOR" ]; then
+              python3 scripts/ci/require_xcode_tests_ran.py "$log_path" "$TEST_SELECTOR"
             fi
           }
           for attempt in 1 2; do

--- a/.github/workflows/test-ios.yml
+++ b/.github/workflows/test-ios.yml
@@ -9,7 +9,7 @@ on:
         required: false
         default: ""
       test_filter:
-        description: "UI test class or class/method, for example cmuxUITests/testSignInPairingAndWorkspaceShell"
+        description: "Full xcodebuild UI selector, for example cmuxUITests/cmuxUITests/testSignInPairingAndWorkspaceShell"
         required: false
         default: ""
       device_family:
@@ -393,6 +393,12 @@ jobs:
               grep -Eq "Executed [1-9][0-9]* tests, with 0 failures \\(0 unexpected\\)" "$log_path" &&
               ! grep -Eq "Test Suite '.*' failed|Test Case '.*' failed|Assertion Failure|Failing tests:|with [1-9][0-9]* failures|with [0-9]+ failures \\([1-9][0-9]* unexpected\\)|✘ Test|✘ Suite" "$log_path"
           }
+          require_requested_tests_ran() {
+            local log_path="$1"
+            if [ -n "${TEST_FILTER:-}" ]; then
+              python3 scripts/ci/require_xcode_tests_ran.py "$log_path" "$TEST_FILTER"
+            fi
+          }
           for attempt in 1 2; do
             LOG_PATH="$IOS_DERIVED_DATA/logs/attempt-${attempt}.log"
             echo "Preparing $SIMULATOR_NAME ($SIMULATOR_ID), attempt $attempt"
@@ -400,11 +406,16 @@ jobs:
             xcrun simctl erase "$SIMULATOR_ID"
             xcrun simctl boot "$SIMULATOR_ID" >/dev/null 2>&1 || true
             xcrun simctl bootstatus "$SIMULATOR_ID" -b
-            if xcodebuild "${XCODEBUILD_ARGS[@]}" 2>&1 | tee "$LOG_PATH"; then
+            set +e
+            xcodebuild "${XCODEBUILD_ARGS[@]}" 2>&1 | tee "$LOG_PATH"
+            status="${PIPESTATUS[0]}"
+            set -e
+            if [ "$status" -eq 0 ]; then
+              require_requested_tests_ran "$LOG_PATH"
               exit 0
             fi
-            status="${PIPESTATUS[0]}"
             if selected_tests_passed_despite_xcodebuild_status "$LOG_PATH"; then
+              require_requested_tests_ran "$LOG_PATH"
               echo "xcodebuild exited $status after XCTest reported the selected tests passed with zero failures; treating this as a runner cleanup failure."
               exit 0
             fi

--- a/scripts/ci/normalize_ios_ui_test_selector.py
+++ b/scripts/ci/normalize_ios_ui_test_selector.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+"""Normalize an iOS UI test filter into xcodebuild's target/class/method form."""
+
+from __future__ import annotations
+
+import re
+import sys
+
+
+TEST_TARGET = "cmuxUITests"
+IDENTIFIER = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+
+
+def normalize(selector: str) -> str:
+    selector = selector.strip()
+    components = selector.split("/")
+    if (
+        not selector
+        or len(components) > 3
+        or any(not IDENTIFIER.fullmatch(component) for component in components)
+    ):
+        raise ValueError(f"invalid iOS UI test selector: {selector!r}")
+
+    if len(components) == 1:
+        return f"{TEST_TARGET}/{selector}"
+
+    if len(components) == 2:
+        first, second = components
+        # target/class is already complete. The previously documented
+        # cmuxUITests/testMethod form instead names the cmuxUITests class and
+        # one method, so it still needs the target prefix.
+        if first == TEST_TARGET and not second.startswith("test"):
+            return selector
+        return f"{TEST_TARGET}/{selector}"
+
+    if components[0] != TEST_TARGET:
+        raise ValueError(
+            f"invalid iOS UI test target {components[0]!r}; expected {TEST_TARGET!r}"
+        )
+    return selector
+
+
+def main() -> int:
+    if len(sys.argv) != 2:
+        print(
+            "usage: normalize_ios_ui_test_selector.py <class-or-selector>",
+            file=sys.stderr,
+        )
+        return 2
+
+    try:
+        print(normalize(sys.argv[1]))
+    except ValueError as error:
+        print(f"::error::{error}", file=sys.stderr)
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ci/require_xcode_tests_ran.py
+++ b/scripts/ci/require_xcode_tests_ran.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+"""Fail a selected-test run unless xcodebuild reports at least one test."""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+
+def executed_test_count(log: str) -> int | None:
+    xctest_counts = [
+        int(value) for value in re.findall(r"Executed\s+(\d+)\s+tests?\b", log)
+    ]
+    swift_testing_counts = [
+        int(value)
+        for value in re.findall(r"Test run with\s+(\d+)\s+tests?\b", log)
+    ]
+    counts = xctest_counts + swift_testing_counts
+    return max(counts) if counts else None
+
+
+def main() -> int:
+    if len(sys.argv) != 3:
+        print(
+            "usage: require_xcode_tests_ran.py <xcodebuild-log> <test-selector>",
+            file=sys.stderr,
+        )
+        return 2
+
+    log_path = Path(sys.argv[1])
+    selector = sys.argv[2]
+    try:
+        log = log_path.read_text(encoding="utf-8", errors="replace")
+    except OSError as error:
+        print(f"::error::Could not read xcodebuild log {log_path}: {error}", file=sys.stderr)
+        return 1
+
+    count = executed_test_count(log)
+    if count is None:
+        print(
+            f"::error::Could not determine executed test count for {selector} "
+            "from xcodebuild output",
+            file=sys.stderr,
+        )
+        return 1
+    if count == 0:
+        print(f"::error::{selector} executed 0 tests", file=sys.stderr)
+        return 1
+
+    print(f"Executed tests for {selector}: {count}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_ci_normalize_ios_ui_test_selector.py
+++ b/tests/test_ci_normalize_ios_ui_test_selector.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+"""Behavioral tests for iOS UI test selector normalization."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+NORMALIZER = ROOT / "scripts" / "ci" / "normalize_ios_ui_test_selector.py"
+
+
+def normalize(selector: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, str(NORMALIZER), selector],
+        cwd=ROOT,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+
+def test_normalizes_the_previously_documented_class_method_form() -> None:
+    result = normalize("cmuxUITests/testMockHostInstanceTagFollowsTargetBuildScope")
+
+    assert result.returncode == 0
+    assert (
+        result.stdout.strip()
+        == "cmuxUITests/cmuxUITests/testMockHostInstanceTagFollowsTargetBuildScope"
+    )
+
+
+def test_normalizes_another_ui_test_class_and_method() -> None:
+    result = normalize("SnapshotUITests/testCaptureAppStoreScreenshots")
+
+    assert result.returncode == 0
+    assert (
+        result.stdout.strip()
+        == "cmuxUITests/SnapshotUITests/testCaptureAppStoreScreenshots"
+    )
+
+
+def test_preserves_full_target_class_and_method_selector() -> None:
+    selector = "cmuxUITests/TerminalThemeParityUITests/testChromeRepaintsForLiveThemes"
+    result = normalize(selector)
+
+    assert result.returncode == 0
+    assert result.stdout.strip() == selector
+
+
+def test_preserves_full_target_and_class_selector() -> None:
+    selector = "cmuxUITests/SnapshotUITests"
+    result = normalize(selector)
+
+    assert result.returncode == 0
+    assert result.stdout.strip() == selector
+
+
+def test_rejects_empty_selector_components() -> None:
+    result = normalize("cmuxUITests//testSomething")
+
+    assert result.returncode == 2
+    assert "invalid iOS UI test selector" in result.stderr
+
+
+if __name__ == "__main__":
+    for name, value in sorted(globals().items()):
+        if name.startswith("test_") and callable(value):
+            value()
+    print("PASS: iOS UI test selector normalization")

--- a/tests/test_ci_require_xcode_tests_ran.py
+++ b/tests/test_ci_require_xcode_tests_ran.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+"""Behavioral tests for the selected-test count gate."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+VALIDATOR = ROOT / "scripts" / "ci" / "require_xcode_tests_ran.py"
+
+
+def run_validator(log: str) -> subprocess.CompletedProcess[str]:
+    with tempfile.TemporaryDirectory() as temporary_directory:
+        log_path = Path(temporary_directory) / "xcodebuild.log"
+        log_path.write_text(log)
+        return subprocess.run(
+            [
+                sys.executable,
+                str(VALIDATOR),
+                str(log_path),
+                "cmuxUITests/cmuxUITests/testEdgeSwipeBackDoesNotScrollTerminal",
+            ],
+            cwd=ROOT,
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+
+
+def test_rejects_zero_executed_tests() -> None:
+    result = run_validator(
+        """
+        Test Suite 'Selected tests' passed at 2026-07-31 00:00:00.000.
+             Executed 0 tests, with 0 failures (0 unexpected) in 0.000 seconds
+        ** TEST SUCCEEDED **
+        """
+    )
+
+    assert result.returncode == 1
+    assert "executed 0 tests" in result.stderr
+
+
+def test_accepts_a_selected_xctest() -> None:
+    result = run_validator(
+        """
+        Test Case '-[cmuxUITests.cmuxUITests testEdgeSwipeBackDoesNotScrollTerminal]' passed.
+        Test Suite 'Selected tests' passed at 2026-07-31 00:00:00.000.
+             Executed 1 test, with 0 failures (0 unexpected) in 1.000 seconds
+        ** TEST SUCCEEDED **
+        """
+    )
+
+    assert result.returncode == 0
+    assert "Executed tests" in result.stdout
+
+
+def test_rejects_missing_test_summaries() -> None:
+    result = run_validator("** TEST SUCCEEDED **\n")
+
+    assert result.returncode == 1
+    assert "could not determine" in result.stderr.lower()
+
+
+if __name__ == "__main__":
+    for name, value in sorted(globals().items()):
+        if name.startswith("test_") and callable(value):
+            value()
+    print("PASS: xcode selected-test count gate")

--- a/tests/test_ci_require_xcode_tests_ran.py
+++ b/tests/test_ci_require_xcode_tests_ran.py
@@ -58,6 +58,20 @@ def test_accepts_a_selected_xctest() -> None:
     assert "Executed tests" in result.stdout
 
 
+def test_accepts_a_selected_swift_test_when_xctest_reports_zero() -> None:
+    result = run_validator(
+        """
+        Test Suite 'Selected tests' passed at 2026-07-31 00:00:00.000.
+             Executed 0 tests, with 0 failures (0 unexpected) in 0.000 seconds
+        Test run with 4 tests in 1 suite passed after 1.000 seconds.
+        ** TEST SUCCEEDED **
+        """
+    )
+
+    assert result.returncode == 0
+    assert "Executed tests" in result.stdout
+
+
 def test_rejects_missing_test_summaries() -> None:
     result = run_validator("** TEST SUCCEEDED **\n")
 


### PR DESCRIPTION
## Summary
- Parse xcodebuild summaries for explicitly selected iOS tests.
- Fail successful xcodebuild runs when zero tests or no test count was reported.
- Preserve the existing simulator retry and post-test cleanup recovery paths.
- Document the full target/class/method selector shape.

This is a principled CI gate. A passing selected-test job now proves at least one matching test executed.

## Verification
- Red test-only commit: 3efe0709a0
- Green implementation commit: 6b7200b79a
- Local behavioral test: python3 tests/test_ci_require_xcode_tests_ran.py
- Python bytecode compilation
- Ruby YAML parse of .github/workflows/test-ios.yml
- Missing selector: xcodebuild reported success and zero tests, then the new guard failed the job: https://github.com/manaflow-ai/cmux/actions/runs/30627743623/job/91146947242
- Real selector: one XCTest passed and the new guard accepted count 1: https://github.com/manaflow-ai/cmux/actions/runs/30627904294/job/91147480161

The broad workflow remains red only from current-main package-convention debt and timing-sensitive mobile package failures. The broad self-hosted guard also reports an unrelated ubuntu-latest runner in .github/workflows/cmux-tui-spec.yml on current main.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved iOS UI test filtering with complete Xcode test selectors.
  * Normalized shorthand selectors and rejected invalid test filters.
  * Prevented filtered runs from succeeding when no matching tests execute.
  * Preserved retry behavior and accurate pipeline status reporting.

* **Tests**
  * Added validation for XCTest and Swift Testing execution results.
  * Added coverage for successful runs, zero-test results, missing summaries, selector normalization, and invalid filters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->