### PR TITLE
Fix socket UI tests on headless runners

### DIFF
--- a/cmuxUITests/AutomationSocketUITests.swift
+++ b/cmuxUITests/AutomationSocketUITests.swift
@@ -37,7 +37,7 @@ final class AutomationSocketUITests: XCTestCase {
 
     func testSocketToggleDisablesAndEnables() {
         let app = configuredApp(mode: "cmuxOnly")
-        app.launch()
+        app.launchAllowingHeadlessBackgroundActivation()
         XCTAssertTrue(
             ensureRunningAfterLaunch(app, timeout: 12.0),
             "Expected app to launch for socket toggle test. state=\(app.state.rawValue)"
@@ -54,7 +54,7 @@ final class AutomationSocketUITests: XCTestCase {
 
     func testSocketPathDeletionRecreatesListener() throws {
         let app = configuredApp(mode: "automation")
-        app.launch()
+        app.launchAllowingHeadlessBackgroundActivation()
         XCTAssertTrue(
             ensureRunningAfterLaunch(app, timeout: 12.0),
             "Expected app to launch for socket path recreation test. state=\(app.state.rawValue)"
@@ -81,7 +81,7 @@ final class AutomationSocketUITests: XCTestCase {
         // Backgrounded apps on CI runners get App Nap throttled and can stall
         // main-thread hops indefinitely; simulate_shortcut replies after a main hop.
         app.launchArguments += ["-NSAppSleepDisabled", "YES"]
-        app.launch()
+        app.launchAllowingHeadlessBackgroundActivation()
         XCTAssertTrue(
             ensureRunningAfterLaunch(app, timeout: 12.0),
             "Expected app to launch for plain-char simulation test. state=\(app.state.rawValue)"
@@ -138,7 +138,7 @@ final class AutomationSocketUITests: XCTestCase {
 
     func testSocketDisabledWhenSettingOff() {
         let app = configuredApp(mode: "off")
-        app.launch()
+        app.launchAllowingHeadlessBackgroundActivation()
         XCTAssertTrue(
             ensureRunningAfterLaunch(app, timeout: 12.0),
             "Expected app to launch for socket off test. state=\(app.state.rawValue)"
@@ -159,7 +159,7 @@ final class AutomationSocketUITests: XCTestCase {
         let app = XCUIApplication.cmuxTestApplication()
         configureTextBoxMentionLaunchEnvironment(app)
         defer { app.terminate() }
-        app.launch()
+        app.launchAllowingHeadlessBackgroundActivation()
 
         XCTAssertTrue(
             ensureForegroundAfterLaunch(app, timeout: 12.0),

--- a/cmuxUITests/BrowserFixtureInteractionUITests.swift
+++ b/cmuxUITests/BrowserFixtureInteractionUITests.swift
@@ -63,22 +63,7 @@ class BrowserFixtureSocketTestCase: XCTestCase {
             app.launchEnvironment["PATH"] = path
         }
         self.app = app
-        // On headless CI runners (no GUI session), XCUIApplication.launch()
-        // blocks ~60s then fails with "Failed to activate application
-        // (current state: Running Background)". Mark this as an expected
-        // failure so the test can continue: these tests are socket-driven and
-        // browser webviews mount in the app windows regardless of activation.
-        let activationOptions = XCTExpectedFailure.Options()
-        activationOptions.isStrict = false
-        XCTExpectFailure("App activation may fail on headless CI runners", options: activationOptions) {
-            app.launch()
-        }
-        if app.state != .runningForeground {
-            XCTAssertTrue(
-                app.state == .runningBackground,
-                "Expected app to be running for browser fixture test. state=\(app.state.rawValue)"
-            )
-        }
+        app.launchAllowingHeadlessBackgroundActivation()
         XCTAssertTrue(
             waitForSocketPong(timeout: 12.0),
             "Expected socket ping at \(socketPath). diagnostics=\(loadDiagnostics())"

--- a/cmuxUITests/BrowserPaneNavigationKeybindUITests.swift
+++ b/cmuxUITests/BrowserPaneNavigationKeybindUITests.swift
@@ -1470,28 +1470,8 @@ final class BrowserPaneNavigationKeybindUITests: XCTestCase {
         "data:text/html,%3Ctitle%3EIssue%201144%3C/title%3E%3Cbody%20style%3D%22margin:0;background:%231d1f24;color:white;font-family:system-ui;height:2200px%22%3E%3Cmain%20style%3D%22padding:32px%22%3E%3Ch1%3EIssue%201144%20Regression%20Page%3C/h1%3E%3Cp%3EZoom%20should%20not%20leave%20stale%20split%20chrome%20above%20the%20browser%20omnibar.%3C/p%3E%3C/main%3E%3C/body%3E"
     }
 
-    private func launchAndEnsureForeground(_ app: XCUIApplication, timeout: TimeInterval = 12.0) {
-        // On headless CI runners (no GUI session), XCUIApplication.launch()
-        // blocks ~60s then fails with "Failed to activate application
-        // (current state: Running Background)". Mark this as an expected
-        // failure so the test can continue — keyboard and element APIs work
-        // via accessibility even when the app is in .runningBackground.
-        let options = XCTExpectedFailure.Options()
-        options.isStrict = false
-        XCTExpectFailure("App activation may fail on headless CI runners", options: options) {
-            app.launch()
-        }
-
-        if app.state == .runningForeground { return }
-
-        if app.state == .runningBackground {
-            // App launched but couldn't activate — continue in background.
-            // XCUIElement queries and keyboard input work through the
-            // accessibility framework regardless of activation state.
-            return
-        }
-
-        XCTFail("App failed to start. state=\(app.state.rawValue)")
+    private func launchAndEnsureForeground(_ app: XCUIApplication) {
+        app.launchAllowingHeadlessBackgroundActivation()
     }
 
     private func waitForData(keys: [String], timeout: TimeInterval) -> Bool {

--- a/cmuxUITests/RemoteTmuxSizingUITests+Socket.swift
+++ b/cmuxUITests/RemoteTmuxSizingUITests+Socket.swift
@@ -37,16 +37,7 @@ extension RemoteTmuxSizingUITests {
         if let path = ProcessInfo.processInfo.environment["PATH"], !path.isEmpty {
             app.launchEnvironment["PATH"] = path
         }
-        // Activation can fail on a headless or lock-screen session
-        // ("Running Background"). The suite is socket-driven end to end and
-        // the sizing oracle follows view LAYOUT (which advances for
-        // background apps), not visible painting — so treat activation as
-        // best-effort, exactly like the browser-fixture suites.
-        let activationOptions = XCTExpectedFailure.Options()
-        activationOptions.isStrict = false
-        XCTExpectFailure("App activation may fail on headless/locked sessions", options: activationOptions) {
-            app.launch()
-        }
+        app.launchAllowingHeadlessBackgroundActivation()
         _ = app.wait(for: .runningForeground, timeout: 10)
         XCTAssertTrue(
             waitForSocket(timeout: 12),

--- a/cmuxUITests/XCUIApplication+CmuxTestApplication.swift
+++ b/cmuxUITests/XCUIApplication+CmuxTestApplication.swift
@@ -18,7 +18,7 @@ extension XCUIApplication {
         let options = XCTExpectedFailure.Options()
         options.isStrict = false
         options.issueMatcher = { issue in
-            guard issue.type == .system else { return false }
+            guard issue.type == .assertionFailure || issue.type == .system else { return false }
 
             let description = [
                 issue.compactDescription,

--- a/cmuxUITests/XCUIApplication+CmuxTestApplication.swift
+++ b/cmuxUITests/XCUIApplication+CmuxTestApplication.swift
@@ -17,6 +17,18 @@ extension XCUIApplication {
     func launchAllowingHeadlessBackgroundActivation() {
         let options = XCTExpectedFailure.Options()
         options.isStrict = false
+        options.issueMatcher = { issue in
+            guard issue.type == .system else { return false }
+
+            let description = [
+                issue.compactDescription,
+                issue.detailedDescription ?? "",
+                issue.associatedError?.localizedDescription ?? "",
+            ].joined(separator: "\n")
+
+            return description.contains("Failed to activate application") &&
+                description.contains("Running Background")
+        }
         XCTExpectFailure("App activation may fail on headless CI runners", options: options) {
             launch()
         }

--- a/cmuxUITests/XCUIApplication+CmuxTestApplication.swift
+++ b/cmuxUITests/XCUIApplication+CmuxTestApplication.swift
@@ -6,4 +6,24 @@ extension XCUIApplication {
         application.launchEnvironment["CMUX_UI_TEST_PROCESS"] = "1"
         return application
     }
+
+    /// Launches a socket-driven test app without treating a headless runner's
+    /// background activation as a launch failure.
+    ///
+    /// XCUITest can report a failure from `launch()` after the process starts
+    /// successfully but remains in `.runningBackground`. Socket-driven suites
+    /// can continue in that state, so record that one runner limitation as an
+    /// expected failure while still failing if no app process is running.
+    func launchAllowingHeadlessBackgroundActivation() {
+        let options = XCTExpectedFailure.Options()
+        options.isStrict = false
+        XCTExpectFailure("App activation may fail on headless CI runners", options: options) {
+            launch()
+        }
+
+        guard state == .runningForeground || state == .runningBackground else {
+            XCTFail("App failed to start. state=\(state.rawValue)")
+            return
+        }
+    }
 }


### PR DESCRIPTION
Socket-driven UI tests abort when `XCUIApplication.launch()` starts cmux in the background on headless runners. The process and socket are healthy, but XCTest records activation as a launch failure before the behavior assertions run.

This centralizes the existing expected-failure launch policy in `XCUIApplication`, adopts it in AutomationSocket, browser fixture, browser navigation, and remote tmux suites, and still fails when no app process is running.

Before evidence:
- https://github.com/manaflow-ai/cmux/actions/runs/30624856468
- https://github.com/manaflow-ai/cmux/actions/runs/30624860007
- https://github.com/manaflow-ai/cmux/actions/runs/30624862197

Verification will use the exact affected hosted UI methods on this head. No app runtime code or user-facing strings changed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/9314"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788092471&installation_model_id=21920&pr_number=9314&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F9314&signature=97eed383f8a377dd2b2a15f91ae5aadf186c1489ccdd6d64fe217a1528965e5b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes socket-driven UI tests on headless runners by allowing background activation without treating it as a launch failure. Centralizes this in `XCUIApplication`, scoped only to background-activation errors, and still fails when no app process starts.

- **Bug Fixes**
  - Added `XCUIApplication.launchAllowingHeadlessBackgroundActivation()` that records only “Failed to activate application (Running Background)” as an expected failure (matching XCTest assertion or system issues), then asserts `.runningForeground` or `.runningBackground`.
  - Replaced ad-hoc `XCTExpectFailure` launch code in AutomationSocket, browser fixture, browser navigation, and remote tmux sizing tests.

<sup>Written for commit 816203ea47ff4ee303bfe2e64a1f19a08ff2b234. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/9314?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved application launching in headless environments.
  * Standardized startup handling across UI test suites.
  * Preserved existing foreground, readiness, navigation, and interaction checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->