### PR TITLE
Run Intel Iroh compatibility on standard Sonoma

### DIFF
--- a/.github/workflows/ci-macos-compat.yml
+++ b/.github/workflows/ci-macos-compat.yml
@@ -9,7 +9,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: macos-14-large
+          - os: macos-14
             timeout: 60
             run_unit_tests: false
             startup_smoke: true


### PR DESCRIPTION
The Intel Sonoma lane used `macos-14-large`, which GitHub refused to start while the org billing account is restricted. cmux is public, so use the standard `macos-14` x86_64 runner instead.

The lane still asserts `uname -m == x86_64` and macOS major 14 before running CMUXMobileCore, CmuxIrohTransport, the x86_64 iOS Simulator package tests, and the startup smoke.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/9316"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788121122&installation_model_id=21920&pr_number=9316&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F9316&signature=da1cccc63644c6f2ed6399cea8451279dbc8e11028e468fc0c1f680e2405f083"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Run the Intel Sonoma compatibility lane on the standard `macos-14` runner instead of `macos-14-large` to avoid large-runner restrictions. The lane still enforces x86_64 on macOS 14 and runs `CMUXMobileCore`, `CmuxIrohTransport`, x86_64 iOS Simulator package tests, and the startup smoke.

<sup>Written for commit 447d4588a5ca6783f9f7a08795984e0726a4e985. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/9316?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated macOS compatibility checks to run on the standard macOS 14 environment.
  * All other continuous integration behavior remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->