### PR TITLE
Harden authoritative Iroh route reconciliation

### DIFF
--- a/Packages/Shared/CMUXMobileCore/Sources/CMUXMobileCore/DiagnosticTaxonomy.swift
+++ b/Packages/Shared/CMUXMobileCore/Sources/CMUXMobileCore/DiagnosticTaxonomy.swift
@@ -201,6 +201,8 @@ public enum DiagnosticSessionLifecycleKind: Int, Sendable, Codable, CaseIterable
     case runtimeReconfigured = 9
     /// A caller explicitly invalidated one exact peer session.
     case explicitlyInvalidated = 10
+    /// Every usable transport path disappeared from an admitted session.
+    case allPathsClosed = 11
 }
 
 /// Which component produced a diagnostic report.

--- a/Packages/Shared/CMUXMobileCore/Tests/CMUXMobileCoreTests/DiagnosticLogTests.swift
+++ b/Packages/Shared/CMUXMobileCore/Tests/CMUXMobileCoreTests/DiagnosticLogTests.swift
@@ -286,6 +286,7 @@ import Testing
         #expect(DiagnosticSessionLifecycleKind.runtimeDeactivated.rawValue == 8)
         #expect(DiagnosticSessionLifecycleKind.runtimeReconfigured.rawValue == 9)
         #expect(DiagnosticSessionLifecycleKind.explicitlyInvalidated.rawValue == 10)
+        #expect(DiagnosticSessionLifecycleKind.allPathsClosed.rawValue == 11)
 
         #expect(DiagnosticPathKind(.unavailable) == .unknown)
         #expect(DiagnosticPathKind(.direct) == .direct)

--- a/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxConnectivityAuthorityServing.swift
+++ b/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxConnectivityAuthorityServing.swift
@@ -5,7 +5,7 @@ public protocol CmxConnectivityAuthorityServing: Sendable {
     /// - Parameter knownRevision: The last completely installed snapshot, or
     ///   `nil` when no authoritative snapshot is available.
     /// - Returns: An unchanged acknowledgement or one complete replacement snapshot.
-    func syncConnectivity(
+    nonisolated func syncConnectivity(
         knownRevision: UInt64?
     ) async throws -> CmxConnectivitySyncResponse
 }
@@ -13,28 +13,45 @@ public protocol CmxConnectivityAuthorityServing: Sendable {
 extension CmxIrohTrustBrokerClient: CmxConnectivityAuthorityServing {}
 
 /// Single fail-closed owner of authoritative discovery revision semantics.
-enum CmxAuthoritativeDiscoveryResolver {
-    static func resolve(
-        broker: any CmxIrohDiscoveryServing,
-        cached: CmxIrohDiscoveryResponse?
+struct CmxAuthoritativeDiscoveryResolver: Sendable {
+    private let broker: any CmxIrohDiscoveryServing
+
+    init(broker: any CmxIrohDiscoveryServing) {
+        self.broker = broker
+    }
+
+    func resolve(
+        cached: CmxIrohDiscoveryResponse?,
+        minimumRevision: UInt64? = nil
     ) async throws -> CmxIrohDiscoveryResponse {
         guard let authority = broker as? any CmxConnectivityAuthorityServing else {
-            return try await broker.discover()
+            let discovery = try await broker.discover()
+            try Self.requireRevision(
+                discovery,
+                atLeast: minimumRevision ?? cached?.revision
+            )
+            return discovery
         }
         let response = try await authority.syncConnectivity(
             knownRevision: cached?.revision
         )
         if let snapshot = response.snapshot {
+            try Self.requireRevision(snapshot, atLeast: minimumRevision)
+            if !response.reset {
+                try Self.requireRevision(snapshot, atLeast: cached?.revision)
+            }
             return snapshot
         }
-        guard let cached, cached.revision == response.revision else {
+        guard !response.reset,
+              let cached,
+              cached.revision == response.revision else {
             throw CmxIrohTrustBrokerClientError.invalidResponse
         }
+        try Self.requireRevision(cached, atLeast: minimumRevision)
         return cached
     }
 
-    static func sync(
-        broker: any CmxIrohDiscoveryServing,
+    func sync(
         knownRevision: UInt64?
     ) async throws -> CmxConnectivitySyncResponse {
         if let authority = broker as? any CmxConnectivityAuthorityServing {
@@ -46,5 +63,16 @@ enum CmxAuthoritativeDiscoveryResolver {
             legacySnapshot: try await broker.discover(),
             knownRevision: knownRevision
         )
+    }
+
+    private static func requireRevision(
+        _ discovery: CmxIrohDiscoveryResponse,
+        atLeast minimumRevision: UInt64?
+    ) throws {
+        guard let minimumRevision else { return }
+        guard let revision = discovery.revision,
+              revision >= minimumRevision else {
+            throw CmxIrohTrustBrokerClientError.invalidResponse
+        }
     }
 }

--- a/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxConnectivityEngine.swift
+++ b/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxConnectivityEngine.swift
@@ -319,33 +319,26 @@ public actor CmxConnectivityEngine {
     public func selectedTransportPath(
         relayPolicy: CmxIrohEffectiveRelayPolicy?
     ) async -> CmxIrohSelectedTransportPath {
-        let orderedPeers = peers.keys.sorted { lhs, rhs in
-            let left = peerSnapshots[lhs]
-            let right = peerSnapshots[rhs]
-            let leftRank = Self.pathSelectionRank(left)
-            let rightRank = Self.pathSelectionRank(right)
-            if leftRank != rightRank {
-                return leftRank < rightRank
-            }
-            if left?.connectionGeneration != right?.connectionGeneration {
-                return (left?.connectionGeneration ?? 0)
-                    > (right?.connectionGeneration ?? 0)
-            }
-            if lhs.deviceID == rhs.deviceID {
-                return lhs.identity.endpointID < rhs.identity.endpointID
-            }
-            return lhs.deviceID < rhs.deviceID
-        }
-        for peerID in orderedPeers {
-            guard let peer = peers[peerID] else { continue }
+        var selected: (
+            peerID: CmxConnectivityPeerID,
+            path: CmxIrohObservedConnectionPath
+        )?
+        for (peerID, peer) in peers {
             let candidate = await peer.observedSelectedPath()
-            if candidate != .unavailable {
-                return CmxIrohSelectedTransportPathClassifier(policy: relayPolicy)
-                    .classify(candidate)
+            guard candidate != .unavailable else { continue }
+            if let current = selected,
+               !Self.pathSelectionPrecedes(
+                   peerID,
+                   snapshot: peerSnapshots[peerID],
+                   current.peerID,
+                   snapshot: peerSnapshots[current.peerID]
+               ) {
+                continue
             }
+            selected = (peerID, candidate)
         }
         return CmxIrohSelectedTransportPathClassifier(policy: relayPolicy)
-            .classify(.unavailable)
+            .classify(selected?.path ?? .unavailable)
     }
 
     /// Emits when peer lifecycle or Iroh path selection can change path classification.
@@ -743,6 +736,22 @@ public actor CmxConnectivityEngine {
         if snapshot?.controlLaneOwned == true { return 1 }
         if snapshot?.phase == .connected { return 2 }
         return 3
+    }
+
+    private static func pathSelectionPrecedes(
+        _ lhs: CmxConnectivityPeerID,
+        snapshot left: CmxConnectivityPeerSnapshot?,
+        _ rhs: CmxConnectivityPeerID,
+        snapshot right: CmxConnectivityPeerSnapshot?
+    ) -> Bool {
+        let leftRank = pathSelectionRank(left)
+        let rightRank = pathSelectionRank(right)
+        if leftRank != rightRank { return leftRank < rightRank }
+        if left?.connectionGeneration != right?.connectionGeneration {
+            return (left?.connectionGeneration ?? 0)
+                > (right?.connectionGeneration ?? 0)
+        }
+        return peerIDPrecedes(lhs, rhs)
     }
 
     private static func peerIDPrecedes(

--- a/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxConnectivityPeerSession.swift
+++ b/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxConnectivityPeerSession.swift
@@ -20,9 +20,9 @@ actor CmxConnectivityPeerSession {
         let diagnosticID: Int
         let initialPurpose: CmxTransportSessionPurpose
         let session: any CmxConnectivitySession
-        let closureTask: Task<Void, Never>
-        let pathObservationTask: Task<Void, Never>
-        let pathEventObservationTask: Task<Void, Never>?
+        var closureTask: Task<Void, Never>?
+        var pathObservationTask: Task<Void, Never>?
+        var pathEventObservationTask: Task<Void, Never>?
     }
 
     private struct ControlOwner {
@@ -274,6 +274,19 @@ actor CmxConnectivityPeerSession {
         purpose: CmxTransportSessionPurpose
     ) {
         let diagnosticID = makeDiagnosticSessionID()
+        // Publish ownership before starting streams whose first value is an
+        // immediate snapshot. Otherwise an already-pathless connection can
+        // notify before the actor has an entry to evict, losing the only
+        // terminal usability signal.
+        activeConnection = ActiveConnection(
+            id: id,
+            diagnosticID: diagnosticID,
+            initialPurpose: purpose,
+            session: connected,
+            closureTask: nil,
+            pathObservationTask: nil,
+            pathEventObservationTask: nil
+        )
         let closureTask = Task { [weak self] in
             await connected.waitUntilClosed()
             guard !Task.isCancelled else { return }
@@ -285,9 +298,9 @@ actor CmxConnectivityPeerSession {
         }
         let pathObservationTask = Task { [weak self] in
             let changes = await connected.observedSelectedPathChanges()
-            for await _ in changes {
+            for await path in changes {
                 guard !Task.isCancelled else { return }
-                await self?.pathDidChange(id: id)
+                await self?.pathDidChange(id: id, path: path)
             }
         }
         let pathEventObservationTask: Task<Void, Never>?
@@ -306,15 +319,16 @@ actor CmxConnectivityPeerSession {
         } else {
             pathEventObservationTask = nil
         }
-        activeConnection = ActiveConnection(
-            id: id,
-            diagnosticID: diagnosticID,
-            initialPurpose: purpose,
-            session: connected,
-            closureTask: closureTask,
-            pathObservationTask: pathObservationTask,
-            pathEventObservationTask: pathEventObservationTask
-        )
+        guard var installed = activeConnection, installed.id == id else {
+            closureTask.cancel()
+            pathObservationTask.cancel()
+            pathEventObservationTask?.cancel()
+            return
+        }
+        installed.closureTask = closureTask
+        installed.pathObservationTask = pathObservationTask
+        installed.pathEventObservationTask = pathEventObservationTask
+        activeConnection = installed
         failure = .none
         recordSessionLifecycle(
             .established,
@@ -333,8 +347,8 @@ actor CmxConnectivityPeerSession {
         let removedOwner = controlOwner
         let closurePurpose = removedOwner?.purpose
             ?? activeConnection.initialPurpose
-        activeConnection.closureTask.cancel()
-        activeConnection.pathObservationTask.cancel()
+        activeConnection.closureTask?.cancel()
+        activeConnection.pathObservationTask?.cancel()
         activeConnection.pathEventObservationTask?.cancel()
         await activeConnection.pathEventObservationTask?.value
         await recordSessionClosure(
@@ -364,8 +378,8 @@ actor CmxConnectivityPeerSession {
         let removedOwner = controlOwner
         let closurePurpose = removedOwner?.purpose
             ?? activeConnection.initialPurpose
-        activeConnection.closureTask.cancel()
-        activeConnection.pathObservationTask.cancel()
+        activeConnection.closureTask?.cancel()
+        activeConnection.pathObservationTask?.cancel()
         activeConnection.pathEventObservationTask?.cancel()
         await activeConnection.session.close()
         await activeConnection.pathEventObservationTask?.value
@@ -559,8 +573,25 @@ actor CmxConnectivityPeerSession {
         }
     }
 
-    private func pathDidChange(id: UUID) {
-        guard activeConnection?.id == id else { return }
+    private func pathDidChange(
+        id: UUID,
+        path: CmxIrohObservedConnectionPath
+    ) async {
+        guard let activeConnection, activeConnection.id == id else { return }
+        // A normal remote close also ends with an unavailable path. Keep that
+        // lifecycle on the closure observer so its attribution and control
+        // ownership policy cannot be preempted by the path observer.
+        guard !(await activeConnection.session.isClosed()),
+              self.activeConnection?.id == id else { return }
+        guard path != .unavailable else {
+            await removeActiveConnection(
+                matching: id,
+                releasesControlOwner: true,
+                reason: .allPathsClosed,
+                failure: .noRoute
+            )
+            return
+        }
         publishSnapshot()
     }
 

--- a/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohBackpressuredBroker.swift
+++ b/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohBackpressuredBroker.swift
@@ -46,10 +46,9 @@ public struct CmxIrohBackpressuredClientBroker:
         knownRevision: UInt64?
     ) async throws -> CmxConnectivitySyncResponse {
         try await gate.perform(accountID: accountID, operation: .discovery) {
-            try await CmxAuthoritativeDiscoveryResolver.sync(
-                broker: broker,
-                knownRevision: knownRevision
-            )
+            try await CmxAuthoritativeDiscoveryResolver(
+                broker: broker
+            ).sync(knownRevision: knownRevision)
         }
     }
 
@@ -127,10 +126,9 @@ public struct CmxIrohBackpressuredHostBroker:
         knownRevision: UInt64?
     ) async throws -> CmxConnectivitySyncResponse {
         try await gate.perform(accountID: accountID, operation: .discovery) {
-            try await CmxAuthoritativeDiscoveryResolver.sync(
-                broker: broker,
-                knownRevision: knownRevision
-            )
+            try await CmxAuthoritativeDiscoveryResolver(
+                broker: broker
+            ).sync(knownRevision: knownRevision)
         }
     }
 

--- a/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohBrokerBackpressureGate.swift
+++ b/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohBrokerBackpressureGate.swift
@@ -87,8 +87,26 @@ public actor CmxIrohBrokerBackpressureGate {
     private static let maximumEncodedByteCount = 64 * 1_024
     private static let directClientAccountID = "cmux-direct-client"
 
+    /// Client-side minimum spacing between broker mutation attempts. One
+    /// registration attempt is a challenge plus a signed register leg, so a
+    /// wedged client retriggering activation in a tight loop can never send
+    /// more than `60 / defaultMutationMinimumSpacing` attempts per minute,
+    /// independent of any server rate limit.
+    public static let defaultMutationMinimumSpacing: TimeInterval = 2
+
+    /// Mutation buckets paced by the client-side spacing floor. Registration
+    /// is the write that creates broker state; read-style buckets stay
+    /// unpaced so an active runtime's discovery and credential refreshes are
+    /// never delayed behind it.
+    private static let pacedMutationOperations: Set<CmxIrohBrokerOperation> = [
+        .registration,
+    ]
+
     private let store: (any CmxIrohInstallStateStoring)?
     private let now: @Sendable () -> Date
+    private let sleep: @Sendable (TimeInterval) async throws -> Void
+    private let mutationMinimumSpacing: TimeInterval
+    private var nextMutationSlotAt: Date?
     private var floors: [Key: Floor]
     private var overflowFloor: Floor?
     private var owners: [Key: UUID] = [:]
@@ -97,10 +115,16 @@ public actor CmxIrohBrokerBackpressureGate {
     /// Creates a gate. Passing `nil` keeps all state in memory.
     public init(
         store: (any CmxIrohInstallStateStoring)? = nil,
-        now: @escaping @Sendable () -> Date = { Date() }
+        now: @escaping @Sendable () -> Date = { Date() },
+        mutationMinimumSpacing: TimeInterval = defaultMutationMinimumSpacing,
+        sleep: @escaping @Sendable (TimeInterval) async throws -> Void = {
+            try await Task<Never, Never>.sleep(for: .seconds($0))
+        }
     ) {
         self.store = store
         self.now = now
+        self.sleep = sleep
+        self.mutationMinimumSpacing = max(0, mutationMinimumSpacing)
         if let store {
             let loaded = Self.loadPersistedState(store: store, now: now())
             floors = loaded.floors
@@ -130,12 +154,40 @@ public actor CmxIrohBrokerBackpressureGate {
         let ownerID = UUID()
         try await acquire(key, ownerID: ownerID)
         defer { release(key, ownerID: ownerID) }
+        if Self.pacedMutationOperations.contains(operation) {
+            try await paceMutation()
+        }
         do {
             return try await body()
         } catch {
             recordDirective(from: error, key: key)
             throw error
         }
+    }
+
+    /// Reserves the next mutation slot and waits until it opens.
+    ///
+    /// The slot is claimed atomically before suspending, so concurrent
+    /// mutations line up 2 seconds apart instead of re-racing the same window,
+    /// and a frozen test clock cannot loop the wait. This delays a request
+    /// rather than failing it: a legitimate back-to-back re-activation (say a
+    /// sign-out immediately followed by a sign-in) waits out the spacing
+    /// instead of surfacing a new error. Cancellation propagates from the
+    /// injected sleep; an abandoned slot stays consumed, which only makes the
+    /// schedule more conservative.
+    private func paceMutation() async throws {
+        guard mutationMinimumSpacing > 0 else { return }
+        let current = now()
+        let slot: Date
+        if let nextMutationSlotAt, nextMutationSlotAt > current {
+            slot = nextMutationSlotAt
+        } else {
+            slot = current
+        }
+        nextMutationSlotAt = slot.addingTimeInterval(mutationMinimumSpacing)
+        let wait = slot.timeIntervalSince(current)
+        guard wait > 0 else { return }
+        try await sleep(wait)
     }
 
     /// Returns the active whole-second floor for an account operation.

--- a/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohClientRuntime+Policy.swift
+++ b/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohClientRuntime+Policy.swift
@@ -292,6 +292,7 @@ extension CmxIrohClientRuntime {
                 broker: broker,
                 managedRelayURLs: managedRelayURLs,
                 selectedRelayURLs: endpointRelayProfile.allowedRelayURLs,
+                retrySchedule: .foregroundClient,
                 automaticRefreshEnabled: automaticRelayCredentialRefreshEnabled,
                 credentialDidInstall: { [handleRelayCredential] response in
                     await handleRelayCredential(response, policy.binding)

--- a/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohClientRuntime+Policy.swift
+++ b/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohClientRuntime+Policy.swift
@@ -34,11 +34,20 @@ extension CmxIrohClientRuntime {
                 )
             }
 
+        // The supervisor snapshot and the live endpoint address are separate
+        // actor reads. Re-verify identity before every cached or online policy
+        // path so an endpoint replacement cannot inherit the old tuple.
+        let address = try await connectivityEngine.endpointAddress()
+        guard address.identity == expectedEndpointID else {
+            throw CmxIrohClientRuntimeError.invalidLocalBinding
+        }
+
         // A revision is what orders this read-only snapshot against the signed
         // registration refresh that follows activation. Older brokers may
         // return discovery without one; keep that response off the fast path
         // and fall back to the full registration flow instead of stranding an
         // otherwise valid cached installation.
+        var prefetchedDiscoveryRejectedCachedBinding = false
         if let cachedBinding = configuration.cachedBinding,
            let prefetchedDiscovery,
            prefetchedDiscovery.revision != nil {
@@ -62,12 +71,9 @@ extension CmxIrohClientRuntime {
                     cachedLANRendezvous: nil
                 )
             }
+            prefetchedDiscoveryRejectedCachedBinding = true
         }
 
-        let address = try await connectivityEngine.endpointAddress()
-        guard address.identity == expectedEndpointID else {
-            throw CmxIrohClientRuntimeError.invalidLocalBinding
-        }
         let publicHints = Array(address.pathHints.compactMap {
             $0.publicDisclosure(at: now())
         }.prefix(CmxAttachEndpoint.maximumIrohPathHintCount))
@@ -102,7 +108,8 @@ extension CmxIrohClientRuntime {
                 // authenticated discovery can still confirm an existing tuple.
                 registration = nil
             } else {
-                guard Self.isConnectivity(error),
+                guard !prefetchedDiscoveryRejectedCachedBinding,
+                      Self.isConnectivity(error),
                       let cached = try await offlineBootstrap(
                           expectation: offlineExpectation,
                           confirmedLocalBinding: nil
@@ -127,13 +134,16 @@ extension CmxIrohClientRuntime {
             if let embedded = registration?.discovery {
                 guard let snapshotRevision = embedded.revision,
                       let registrationRevision = registration?.revision,
-                      snapshotRevision >= registrationRevision else {
+                      snapshotRevision == registrationRevision,
+                      snapshotRevision >= (authoritativeDiscovery?.revision ?? 0) else {
                     throw CmxIrohTrustBrokerClientError.invalidResponse
                 }
                 authoritativeDiscovery = embedded
                 discovery = embedded
             } else {
-                discovery = try await discoverAuthoritatively()
+                discovery = try await discoverAuthoritatively(
+                    minimumRevision: registration?.revision
+                )
             }
         } catch {
             guard let registration,
@@ -188,24 +198,23 @@ extension CmxIrohClientRuntime {
         try requireCurrent(revision)
     }
 
-    func discoverAuthoritatively() async throws -> CmxIrohDiscoveryResponse {
-        let discovery = try await CmxAuthoritativeDiscoveryResolver.resolve(
-            broker: broker,
-            cached: authoritativeDiscovery
+    func discoverAuthoritatively(
+        minimumRevision: UInt64? = nil
+    ) async throws -> CmxIrohDiscoveryResponse {
+        let discovery = try await CmxAuthoritativeDiscoveryResolver(
+            broker: broker
+        ).resolve(
+            cached: authoritativeDiscovery,
+            minimumRevision: minimumRevision
         )
         authoritativeDiscovery = discovery
         return discovery
     }
 
     func prefetchAuthoritativeDiscovery() async throws -> CmxIrohDiscoveryResponse {
-        guard let authority = broker as? any CmxConnectivityAuthorityServing else {
-            return try await broker.discover()
-        }
-        let response = try await authority.syncConnectivity(knownRevision: nil)
-        guard let snapshot = response.snapshot else {
-            throw CmxIrohTrustBrokerClientError.invalidResponse
-        }
-        return snapshot
+        try await CmxAuthoritativeDiscoveryResolver(
+            broker: broker
+        ).resolve(cached: nil)
     }
 
     func offlineBootstrap(

--- a/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohClientRuntime+RelayPolicy.swift
+++ b/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohClientRuntime+RelayPolicy.swift
@@ -108,6 +108,7 @@ extension CmxIrohClientRuntime {
             broker: broker,
             managedRelayURLs: replacementManagedURLs,
             selectedRelayURLs: profile.allowedRelayURLs,
+            retrySchedule: .foregroundClient,
             automaticRefreshEnabled: automaticRelayCredentialRefreshEnabled,
             credentialDidInstall: { [handleRelayCredential] response in
                 await handleRelayCredential(response, binding)

--- a/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohHostRuntime+PolicyRefresh.swift
+++ b/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohHostRuntime+PolicyRefresh.swift
@@ -135,7 +135,8 @@ extension CmxIrohHostRuntime {
             if let embedded = registration.discovery {
                 guard let snapshotRevision = embedded.revision,
                       let registrationRevision = registration.revision,
-                      snapshotRevision >= registrationRevision else {
+                      snapshotRevision == registrationRevision,
+                      snapshotRevision >= (authoritativeDiscovery?.revision ?? 0) else {
                     throw CmxIrohTrustBrokerClientError.invalidResponse
                 }
                 authoritativeDiscovery = embedded
@@ -190,10 +191,9 @@ extension CmxIrohHostRuntime {
     }
 
     func discoverAuthoritatively() async throws -> CmxIrohDiscoveryResponse {
-        let discovery = try await CmxAuthoritativeDiscoveryResolver.resolve(
-            broker: broker,
-            cached: authoritativeDiscovery
-        )
+        let discovery = try await CmxAuthoritativeDiscoveryResolver(
+            broker: broker
+        ).resolve(cached: authoritativeDiscovery)
         authoritativeDiscovery = discovery
         return discovery
     }

--- a/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohReconnectBackoff.swift
+++ b/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohReconnectBackoff.swift
@@ -1,0 +1,109 @@
+public import Foundation
+import os
+
+/// Bounds for one client-side reconnect retry ladder.
+public struct CmxIrohReconnectBackoffConfiguration: Equatable, Sendable {
+    /// The smallest delay the ladder can produce.
+    public let floor: TimeInterval
+
+    /// The largest locally scheduled delay. A server Retry-After directive
+    /// may exceed it; the local schedule never does.
+    public let cap: TimeInterval
+
+    /// The decorrelated-jitter growth factor applied to the previous delay.
+    public let multiplier: Double
+
+    /// Creates normalized ladder bounds.
+    public init(floor: TimeInterval, cap: TimeInterval, multiplier: Double) {
+        let normalizedFloor = max(0.1, floor)
+        self.floor = normalizedFloor
+        self.cap = max(normalizedFloor, cap)
+        self.multiplier = max(1, multiplier)
+    }
+
+    /// The interactive-client profile: a 1 second floor keeps recovery from a
+    /// single blip immediate, and a 30 second cap guarantees a foregrounded
+    /// app with a reachable network never naps for minutes between attempts.
+    public static let foreground = Self(floor: 1, cap: 30, multiplier: 3)
+}
+
+/// Decorrelated-jitter retry backoff shared by the client reconnect ladders.
+///
+/// Each failure draws the next delay uniformly from
+/// `[floor, min(cap, previous * multiplier)]`, so consecutive failures spread
+/// out without synchronizing across devices. ``reset()`` returns the ladder to
+/// its floor; owners call it on scenePhase-active transitions, on
+/// network-path-change signals, and on success, so recovery after a real state
+/// change is always immediate. A server Retry-After directive is honored as a
+/// lower bound even beyond the local cap.
+///
+/// Deterministic by construction: delays come from a seedable SplitMix64
+/// stream, so tests can assert an exact schedule from a fixed seed.
+public final class CmxIrohReconnectBackoff: Sendable {
+    private struct State {
+        var previousDelay: TimeInterval?
+        var rngState: UInt64
+    }
+
+    private let configuration: CmxIrohReconnectBackoffConfiguration
+    private let state: OSAllocatedUnfairLock<State>
+
+    /// Creates a ladder at its floor.
+    ///
+    /// - Parameters:
+    ///   - configuration: The ladder bounds.
+    ///   - seed: The jitter stream seed. Fixed seeds give exact schedules.
+    public init(
+        configuration: CmxIrohReconnectBackoffConfiguration = .foreground,
+        seed: UInt64 = UInt64.random(in: .min ... .max)
+    ) {
+        self.configuration = configuration
+        state = OSAllocatedUnfairLock(
+            initialState: State(previousDelay: nil, rngState: seed)
+        )
+    }
+
+    /// Returns the next retry delay after a failure.
+    ///
+    /// - Parameter retryAfterSeconds: A server-provided floor, when one exists.
+    ///   It always wins over the local schedule, bounded only by
+    ///   ``CmxIrohBrokerCooldown/maximumRetryAfterSeconds``.
+    /// - Returns: A delay within `[floor, cap]`, or the larger server floor.
+    public func nextDelay(retryAfterSeconds: Int? = nil) -> TimeInterval {
+        let drawn = state.withLock { state in
+            let previous = state.previousDelay ?? configuration.floor
+            let upper = min(
+                configuration.cap,
+                max(configuration.floor, previous * configuration.multiplier)
+            )
+            let unit = Self.nextUnitRandom(&state.rngState)
+            let delay = configuration.floor
+                + (upper - configuration.floor) * unit
+            state.previousDelay = delay
+            return delay
+        }
+        guard let retryAfterSeconds else { return drawn }
+        let serverFloor = TimeInterval(min(
+            max(1, retryAfterSeconds),
+            CmxIrohBrokerCooldown.maximumRetryAfterSeconds
+        ))
+        return max(drawn, serverFloor)
+    }
+
+    /// Returns the ladder to its floor. Owners call this on success, on
+    /// scenePhase-active transitions, and on network-path-change signals.
+    public func reset() {
+        state.withLock { $0.previousDelay = nil }
+    }
+
+    /// SplitMix64: a tiny, well-distributed deterministic stream that turns a
+    /// seed into uniform doubles in `[0, 1)`.
+    private static func nextUnitRandom(_ rngState: inout UInt64) -> Double {
+        rngState &+= 0x9E37_79B9_7F4A_7C15
+        var mixed = rngState
+        mixed = (mixed ^ (mixed >> 30)) &* 0xBF58_476D_1CE4_E5B9
+        mixed = (mixed ^ (mixed >> 27)) &* 0x94D0_49BB_1331_11EB
+        mixed ^= mixed >> 31
+        return Double(mixed >> 11) * 0x1.0p-53
+    }
+}

--- a/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohRegistryContextProvider.swift
+++ b/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohRegistryContextProvider.swift
@@ -305,10 +305,9 @@ public actor CmxIrohRegistryContextProvider: CmxIrohClientContextProvider {
     private func refreshAuthoritativeDiscovery() async throws
         -> CmxIrohDiscoveryResponse
     {
-        let discovery = try await CmxAuthoritativeDiscoveryResolver.resolve(
-            broker: broker,
-            cached: authoritativeDiscovery
-        )
+        let discovery = try await CmxAuthoritativeDiscoveryResolver(
+            broker: broker
+        ).resolve(cached: authoritativeDiscovery)
         authoritativeDiscovery = discovery
         return discovery
     }

--- a/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohRetrySchedule.swift
+++ b/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohRetrySchedule.swift
@@ -28,6 +28,16 @@ public struct CmxIrohRetrySchedule: Equatable, Sendable {
         self.jitterFraction = min(1, max(0, jitterFraction))
     }
 
+    /// Interactive-client profile sharing the reconnect backoff bounds: the
+    /// first retry lands after about a second and no locally scheduled retry
+    /// exceeds 30 seconds. The type's 30 s / 1 h defaults remain the
+    /// host-side profile; an iOS client in the foreground must never nap for
+    /// minutes on a single transient failure.
+    public static let foregroundClient = CmxIrohRetrySchedule(
+        initialDelay: CmxIrohReconnectBackoffConfiguration.foreground.floor,
+        maximumDelay: CmxIrohReconnectBackoffConfiguration.foreground.cap
+    )
+
     /// Returns a retry delay that never precedes a server-provided floor.
     ///
     /// - Parameters:

--- a/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxConnectivityInvalidationSubscriberTests.swift
+++ b/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxConnectivityInvalidationSubscriberTests.swift
@@ -24,7 +24,13 @@ struct CmxConnectivityInvalidationSubscriberTests {
             #"{"type":"connectivity.invalidate","protocolVersion":2,"revision":1,"at":2}"#,
             #"{"type":"connectivity.invalidate","protocolVersion":1,"revision":0,"at":2}"#,
             #"{"type":"connectivity.invalidate","protocolVersion":1,"revision":true,"at":2}"#,
-            String(repeating: "x", count: CmxConnectivityInvalidation.maximumFrameBytes + 1),
+            {
+                let padding = String(
+                    repeating: "p",
+                    count: CmxConnectivityInvalidation.maximumFrameBytes
+                )
+                return #"{"type":"connectivity.invalidate","protocolVersion":1,"revision":1,"at":2,"pad":"\#(padding)"}"#
+            }(),
         ]
     )
     func rejectsInvalidFrame(_ text: String) {

--- a/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxConnectivityPeerSessionTests.swift
+++ b/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxConnectivityPeerSessionTests.swift
@@ -149,6 +149,40 @@ struct CmxConnectivityPeerSessionTests {
     }
 
     @Test
+    func unavailableSelectedPathEvictsTheSessionAndTheNextOperationRedials() async throws {
+        let request = try Self.request()
+        let peerID = try CmxConnectivityPeerID(request: request)
+        let stranded = TestConnectivitySession(
+            continuityID: 23,
+            keepsSelectedPathStreamOpen: true
+        )
+        let replacement = TestConnectivitySession(continuityID: 24)
+        let builder = SequencedConnectivitySessionBuilder(
+            sessions: [stranded, replacement]
+        )
+        let peer = CmxConnectivityPeerSession(
+            peerID: peerID,
+            buildSession: { request in
+                try await builder.build(request)
+            }
+        )
+
+        _ = try await peer.acquireControl(for: request, ownerID: UUID())
+        try await Self.waitUntil { await stranded.hasSelectedPathObserver() }
+        await stranded.publishSelectedPath(.unavailable)
+        try await Self.waitUntil { await peer.snapshot().phase == .failed }
+
+        let failed = await peer.snapshot()
+        #expect(failed.failure == .noRoute)
+        #expect(!failed.controlLaneOwned)
+        #expect(await stranded.closeCount() == 1)
+
+        _ = try await peer.acquireControl(for: request, ownerID: UUID())
+        #expect(await builder.callCount() == 2)
+        #expect(await peer.connectionContinuityID() == 24)
+    }
+
+    @Test
     func lateClosureCleanupCannotOverwriteAReplacementSession() async throws {
         let request = try Self.request()
         let peerID = try CmxConnectivityPeerID(request: request)
@@ -475,6 +509,7 @@ private actor OrderedGatedConnectivitySessionBuilder {
 private actor TestConnectivitySession: CmxConnectivitySession {
     private let continuityID: UInt64
     private let gatesCloseAttribution: Bool
+    private let keepsSelectedPathStreamOpen: Bool
     private var closed = false
     private var closes = 0
     private var closeFailure = DiagnosticFailureKind.connectionClosed
@@ -482,13 +517,18 @@ private actor TestConnectivitySession: CmxConnectivitySession {
     private var closeAttributionWaiter: CheckedContinuation<Void, Never>?
     private var closeAttributionWaiting = false
     private var received: [Data] = []
+    private var selectedPath = CmxIrohObservedConnectionPath.direct
+    private var selectedPathContinuation:
+        AsyncStream<CmxIrohObservedConnectionPath>.Continuation?
 
     init(
         continuityID: UInt64,
-        gatesCloseAttribution: Bool = false
+        gatesCloseAttribution: Bool = false,
+        keepsSelectedPathStreamOpen: Bool = false
     ) {
         self.continuityID = continuityID
         self.gatesCloseAttribution = gatesCloseAttribution
+        self.keepsSelectedPathStreamOpen = keepsSelectedPathStreamOpen
     }
 
     func receiveControl(maximumByteCount: Int) -> Data? {
@@ -542,14 +582,29 @@ private actor TestConnectivitySession: CmxConnectivitySession {
     }
 
     func observedSelectedPath() -> CmxIrohObservedConnectionPath {
-        closed ? .unavailable : .direct
+        closed ? .unavailable : selectedPath
     }
 
     func observedSelectedPathChanges() -> AsyncStream<CmxIrohObservedConnectionPath> {
-        AsyncStream { continuation in
-            continuation.yield(closed ? .unavailable : .direct)
-            continuation.finish()
+        let pair = AsyncStream<CmxIrohObservedConnectionPath>.makeStream(
+            bufferingPolicy: .bufferingNewest(1)
+        )
+        pair.continuation.yield(closed ? .unavailable : selectedPath)
+        guard keepsSelectedPathStreamOpen else {
+            pair.continuation.finish()
+            return pair.stream
         }
+        selectedPathContinuation = pair.continuation
+        return pair.stream
+    }
+
+    func hasSelectedPathObserver() -> Bool {
+        selectedPathContinuation != nil
+    }
+
+    func publishSelectedPath(_ path: CmxIrohObservedConnectionPath) {
+        selectedPath = path
+        selectedPathContinuation?.yield(path)
     }
 
     func observedPathEvents() -> AsyncStream<CmxIrohConnectionPathEvent> {
@@ -581,6 +636,9 @@ private actor TestConnectivitySession: CmxConnectivitySession {
     private func finish(failure: DiagnosticFailureKind) {
         guard !closed else { return }
         closed = true
+        selectedPath = .unavailable
+        selectedPathContinuation?.finish()
+        selectedPathContinuation = nil
         closeFailure = failure
         let waiters = closureWaiters
         closureWaiters.removeAll()

--- a/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohBrokerBackpressureGateTests.swift
+++ b/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohBrokerBackpressureGateTests.swift
@@ -254,6 +254,85 @@ struct CmxIrohBrokerBackpressureGateTests {
         #expect(store.string(forKey: CmxIrohBrokerBackpressureGate.persistenceKey) == nil)
     }
 
+    @Test
+    func registrationMutationsAreSpacedByClientFloor() async throws {
+        let clock = BackpressureGateClock(start)
+        let sleeps = BackpressureGateSleepRecorder()
+        let gate = CmxIrohBrokerBackpressureGate(
+            now: { clock.now() },
+            sleep: { interval in
+                sleeps.record(interval)
+                clock.set(clock.now().addingTimeInterval(interval))
+            }
+        )
+
+        // The first mutation is immediate.
+        try await gate.perform(accountID: "account-a", operation: .registration) {}
+        #expect(sleeps.all().isEmpty)
+
+        // A back-to-back mutation waits out the client floor instead of
+        // failing, so a legitimate quick re-activation still succeeds.
+        try await gate.perform(accountID: "account-a", operation: .registration) {}
+        #expect(sleeps.all() == [2])
+
+        // The floor is global: another account's mutation shares the pace.
+        try await gate.perform(accountID: "account-b", operation: .registration) {}
+        #expect(sleeps.all() == [2, 2])
+
+        // Once the spacing has elapsed naturally there is no wait.
+        clock.set(clock.now().addingTimeInterval(10))
+        try await gate.perform(accountID: "account-a", operation: .registration) {}
+        #expect(sleeps.all() == [2, 2])
+    }
+
+    @Test
+    func wedgedRegistrationLoopCannotExceedThirtyAttemptsPerMinute() async throws {
+        let clock = BackpressureGateClock(start)
+        let gate = CmxIrohBrokerBackpressureGate(
+            now: { clock.now() },
+            sleep: { interval in
+                clock.set(clock.now().addingTimeInterval(interval))
+            }
+        )
+
+        // A wedged client hammering registration is paced by the client-side
+        // floor even though the server never returns a rate-limit directive.
+        for _ in 0 ..< 31 {
+            _ = try? await gate.perform(
+                accountID: "account-a",
+                operation: .registration
+            ) {
+                throw BackpressureGateTestError.unavailable
+            }
+        }
+        #expect(clock.now().timeIntervalSince(start) >= 60)
+    }
+
+    @Test
+    func readOperationsAreNeverPaced() async throws {
+        let clock = BackpressureGateClock(start)
+        let sleeps = BackpressureGateSleepRecorder()
+        let gate = CmxIrohBrokerBackpressureGate(
+            now: { clock.now() },
+            sleep: { interval in
+                sleeps.record(interval)
+                clock.set(clock.now().addingTimeInterval(interval))
+            }
+        )
+
+        try await gate.perform(accountID: "account-a", operation: .discovery) {}
+        try await gate.perform(accountID: "account-a", operation: .discovery) {}
+        try await gate.perform(
+            accountID: "account-a",
+            operation: .relayCredential
+        ) {}
+        try await gate.perform(
+            accountID: "account-a",
+            operation: .relayPreference
+        ) {}
+        #expect(sleeps.all().isEmpty)
+    }
+
     private func recordRateLimit(
         gate: CmxIrohBrokerBackpressureGate,
         accountID: String,
@@ -279,6 +358,23 @@ struct CmxIrohBrokerBackpressureGateTests {
         let defaults = try #require(UserDefaults(suiteName: suiteName))
         defaults.removePersistentDomain(forName: suiteName)
         return (defaults, suiteName)
+    }
+}
+
+private enum BackpressureGateTestError: Error {
+    case unavailable
+}
+
+private final class BackpressureGateSleepRecorder: @unchecked Sendable {
+    private let lock = NSLock()
+    private var intervals: [TimeInterval] = []
+
+    func record(_ interval: TimeInterval) {
+        lock.withLock { intervals.append(interval) }
+    }
+
+    func all() -> [TimeInterval] {
+        lock.withLock { intervals }
     }
 }
 

--- a/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohClientRuntimeTests.swift
+++ b/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohClientRuntimeTests.swift
@@ -1,9 +1,160 @@
 import CMUXMobileCore
+import Foundation
 import Testing
 @testable import CmuxIrohTransport
 
 @Suite
 struct CmxIrohClientRuntimeTests {
+    @Test
+    func cachedFastPathRejectsAReplacedLiveEndpointIdentity() async throws {
+        let fixture = try ClientRuntimeTestFixture()
+        let substitutedIdentity = try CmxIrohPeerIdentity(
+            endpointID: String(repeating: "0", count: 64)
+        )
+        let discovery = try ClientRuntimeTestFixture.discovery(
+            binding: fixture.binding,
+            revision: 1
+        )
+        let configuration = CmxIrohClientRuntimeConfiguration(
+            accountID: fixture.configuration.accountID,
+            deviceID: fixture.configuration.deviceID,
+            appInstanceID: fixture.configuration.appInstanceID,
+            tag: fixture.configuration.tag,
+            displayName: fixture.configuration.displayName,
+            identity: fixture.configuration.identity,
+            capabilities: fixture.configuration.capabilities,
+            managedRelayURLs: fixture.configuration.managedRelayURLs,
+            cachedBinding: CmxIrohBrokerBindingMetadata(binding: fixture.binding)
+        )
+        let runtime = try CmxIrohClientRuntime(
+            factory: TestIrohEndpointFactory(endpoints: [
+                TestSubstitutedAddressEndpoint(
+                    identity: fixture.endpointID,
+                    addressIdentity: substitutedIdentity
+                ),
+            ]),
+            broker: TestRevisionedClientBroker(
+                binding: fixture.binding,
+                discoveries: [discovery],
+                relay: fixture.relayResponse()
+            ),
+            configuration: configuration,
+            pendingRevocations: fixture.pendingRevocations(),
+            now: { fixture.now }
+        )
+
+        await #expect(throws: CmxIrohClientRuntimeError.invalidLocalBinding) {
+            try await runtime.start()
+        }
+    }
+
+    @Test
+    func discoveryCannotPrecedeTheRegistrationRevision() async throws {
+        let fixture = try ClientRuntimeTestFixture()
+        let discovery = try ClientRuntimeTestFixture.discovery(
+            binding: fixture.binding,
+            revision: 1
+        )
+        let runtime = try CmxIrohClientRuntime(
+            factory: TestIrohEndpointFactory(endpoints: [
+                TestIrohEndpoint(identity: fixture.endpointID),
+            ]),
+            broker: TestRevisionedClientBroker(
+                binding: fixture.binding,
+                discoveries: [discovery],
+                relay: fixture.relayResponse(),
+                registrationRevision: 2
+            ),
+            configuration: fixture.configuration,
+            pendingRevocations: fixture.pendingRevocations(),
+            now: { fixture.now }
+        )
+
+        await #expect(throws: CmxIrohTrustBrokerClientError.invalidResponse) {
+            try await runtime.start()
+        }
+    }
+
+    @Test
+    func authoritativeRejectionCannotFallBackToStaleOfflineAuthority() async throws {
+        let fixture = try RegistryFixture()
+        let accepted = try fixture.discovery(targetHints: [])
+        let acceptedRevision = CmxIrohDiscoveryResponse(
+            routeContractVersion: accepted.routeContractVersion,
+            revision: 1,
+            bindings: accepted.bindings,
+            relayFleet: accepted.relayFleet,
+            lanRendezvous: accepted.lanRendezvous,
+            grantVerificationKeys: accepted.grantVerificationKeys
+        )
+        let rejectedRevision = CmxIrohDiscoveryResponse(
+            routeContractVersion: accepted.routeContractVersion,
+            revision: 2,
+            bindings: Array(accepted.bindings.dropFirst()),
+            relayFleet: accepted.relayFleet,
+            lanRendezvous: accepted.lanRendezvous,
+            grantVerificationKeys: accepted.grantVerificationKeys
+        )
+        let localBinding = try #require(accepted.bindings.first)
+        let targetBinding = try #require(accepted.bindings.dropFirst().first)
+        let cache = CmxIrohClientOfflinePolicyCache(
+            secureStore: TestSecureCredentialStore()
+        )
+        try await cache.save(
+            localBinding: localBinding,
+            targetBinding: targetBinding,
+            discovery: acceptedRevision,
+            pairGrant: fixture.pairGrantResponse(
+                issuedAt: fixture.nowSeconds,
+                expiresAt: fixture.nowSeconds + 3_600
+            ),
+            for: fixture.offlineExpectation(),
+            now: fixture.now
+        )
+        let identity = try CmxIrohIdentityMaterial(
+            secretKey: CmxIrohSecretKey(bytes: fixture.privateKey.rawRepresentation),
+            generation: fixture.initiator.identityGeneration
+        )
+        let configuration = CmxIrohClientRuntimeConfiguration(
+            accountID: "account-a",
+            deviceID: fixture.initiator.deviceID,
+            appInstanceID: localBinding.appInstanceID,
+            tag: fixture.initiator.tag,
+            displayName: nil,
+            identity: identity,
+            capabilities: localBinding.capabilities,
+            managedRelayURLs: [fixture.relayURL],
+            cachedBinding: CmxIrohBrokerBindingMetadata(binding: localBinding)
+        )
+        let relay = CmxIrohRelayTokenResponse(
+            token: "testrelaytoken",
+            expiresAt: "2027-01-15T10:00:00Z",
+            refreshAfter: "2027-01-15T09:00:00Z",
+            relayFleet: [fixture.relayURL]
+        )
+        let runtime = try CmxIrohClientRuntime(
+            factory: TestIrohEndpointFactory(endpoints: [
+                TestIrohEndpoint(identity: fixture.initiator.endpointID),
+            ]),
+            broker: TestRevisionedClientBroker(
+                binding: localBinding,
+                discoveries: [rejectedRevision],
+                relay: relay,
+                registrationError: .connectivity
+            ),
+            configuration: configuration,
+            pendingRevocations: CmxIrohPendingRevocationOutbox(
+                secureStore: TestSecureCredentialStore()
+            ),
+            offlinePolicyCache: cache,
+            now: { fixture.now }
+        )
+
+        await #expect(throws: CmxIrohTrustBrokerClientError.connectivity) {
+            try await runtime.start()
+        }
+    }
+
     @Test
     func startupConsumesEmbeddedDiscoveryWithoutAThirdBrokerRoundTrip() async throws {
         let fixture = try ClientRuntimeTestFixture()
@@ -940,6 +1091,8 @@ private actor TestRevisionedClientBroker:
     private let blockedSyncCount: Int?
     private let blockedRegistrationCount: Int?
     private let embeddedRegistrationDiscovery: CmxIrohDiscoveryResponse?
+    private let registrationRevision: UInt64?
+    private let registrationError: CmxIrohTrustBrokerClientError?
     private(set) var registrationCount = 0
     private(set) var syncCount = 0
     private var blockedSyncReleased = false
@@ -951,7 +1104,9 @@ private actor TestRevisionedClientBroker:
         relay: CmxIrohRelayTokenResponse,
         blockedSyncCount: Int? = nil,
         blockedRegistrationCount: Int? = nil,
-        embedInitialDiscovery: Bool = false
+        embedInitialDiscovery: Bool = false,
+        registrationRevision: UInt64? = nil,
+        registrationError: CmxIrohTrustBrokerClientError? = nil
     ) {
         self.binding = binding
         self.discoveries = discoveries
@@ -961,20 +1116,24 @@ private actor TestRevisionedClientBroker:
         embeddedRegistrationDiscovery = embedInitialDiscovery
             ? discoveries.first
             : nil
+        self.registrationRevision = registrationRevision
+        self.registrationError = registrationError
     }
 
     func register(
         prepared _: CmxIrohPreparedRegistration,
         signer _: CmxIrohRegistrationSigner
-    ) async -> CmxIrohRegistrationResponse {
+    ) async throws -> CmxIrohRegistrationResponse {
         registrationCount += 1
         if registrationCount == blockedRegistrationCount {
             while !blockedRegistrationReleased {
                 await Task.yield()
             }
         }
+        if let registrationError { throw registrationError }
         return CmxIrohRegistrationResponse(
-            revision: embeddedRegistrationDiscovery?.revision
+            revision: registrationRevision
+                ?? embeddedRegistrationDiscovery?.revision
                 ?? discoveries.first?.revision,
             binding: binding,
             relay: .issued(relay),
@@ -1044,4 +1203,46 @@ private actor TestRevisionedClientBroker:
         blockedRegistrationReleased = true
     }
 
+}
+
+private actor TestSubstitutedAddressEndpoint: CmxIrohEndpoint {
+    private let peerIdentity: CmxIrohPeerIdentity
+    private let addressIdentity: CmxIrohPeerIdentity
+
+    init(
+        identity: CmxIrohPeerIdentity,
+        addressIdentity: CmxIrohPeerIdentity
+    ) {
+        peerIdentity = identity
+        self.addressIdentity = addressIdentity
+    }
+
+    func identity() -> CmxIrohPeerIdentity { peerIdentity }
+
+    func address() -> CmxIrohEndpointAddress {
+        CmxIrohEndpointAddress(identity: addressIdentity, pathHints: [])
+    }
+
+    func localDirectAddresses() -> [String] { [] }
+
+    func connect(
+        to _: CmxIrohEndpointAddress,
+        alpn _: Data
+    ) async throws -> any CmxIrohConnection {
+        throw TestIrohTransportError.unsupported
+    }
+
+    func accept() async throws -> (any CmxIrohConnection)? { nil }
+
+    func replaceRelays(_: [CmxIrohRelayConfiguration]) {}
+
+    func replaceRelayProfile(_: CmxIrohEndpointRelayProfile) {}
+
+    func healthEvents() -> AsyncStream<CmxIrohEndpointHealthEvent> {
+        AsyncStream { $0.finish() }
+    }
+
+    func isHealthy() -> Bool { true }
+
+    func close() {}
 }

--- a/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohClientRuntimeTests.swift
+++ b/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohClientRuntimeTests.swift
@@ -76,6 +76,34 @@ struct CmxIrohClientRuntimeTests {
     }
 
     @Test
+    func embeddedDiscoveryMustExactlyMatchTheRegistrationRevision() async throws {
+        let fixture = try ClientRuntimeTestFixture()
+        let discovery = try ClientRuntimeTestFixture.discovery(
+            binding: fixture.binding,
+            revision: 2
+        )
+        let runtime = try CmxIrohClientRuntime(
+            factory: TestIrohEndpointFactory(endpoints: [
+                TestIrohEndpoint(identity: fixture.endpointID),
+            ]),
+            broker: TestRevisionedClientBroker(
+                binding: fixture.binding,
+                discoveries: [discovery],
+                relay: fixture.relayResponse(),
+                embedInitialDiscovery: true,
+                registrationRevision: 1
+            ),
+            configuration: fixture.configuration,
+            pendingRevocations: fixture.pendingRevocations(),
+            now: { fixture.now }
+        )
+
+        await #expect(throws: CmxIrohTrustBrokerClientError.invalidResponse) {
+            try await runtime.start()
+        }
+    }
+
+    @Test
     func authoritativeRejectionCannotFallBackToStaleOfflineAuthority() async throws {
         let fixture = try RegistryFixture()
         let accepted = try fixture.discovery(targetHints: [])

--- a/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohHostRuntimePolicyTests.swift
+++ b/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohHostRuntimePolicyTests.swift
@@ -7,6 +7,35 @@ import Testing
 
 extension CmxIrohHostRuntimeTests {
     @Test
+    func embeddedDiscoveryMustExactlyMatchTheRegistrationRevision() async throws {
+        let fixture = try HostRuntimeFixture()
+        let discovery = try HostRuntimeFixture.discovery(
+            binding: fixture.binding,
+            relays: HostRuntimeFixture.relayURLs,
+            lanGeneration: 2,
+            revision: 2
+        )
+        let runtime = CmxIrohHostRuntime(
+            factory: TestIrohEndpointFactory(endpoints: [
+                TestIrohEndpoint(identity: fixture.endpointID),
+            ]),
+            broker: TestIrohHostBroker(
+                registrationBinding: fixture.binding,
+                discovery: discovery,
+                embedDiscoveryInRegistration: true,
+                registrationRevision: 1
+            ),
+            configuration: fixture.configuration,
+            pendingRevocations: fixture.pendingRevocations(),
+            handleTransport: { session, _ in await session.close() }
+        )
+
+        await #expect(throws: CmxIrohTrustBrokerClientError.invalidResponse) {
+            try await runtime.start()
+        }
+    }
+
+    @Test
     func embeddedDiscoveryCannotRegressTheInstalledAuthoritativeRevision() async throws {
         let fixture = try HostRuntimeFixture()
         let revisionTwo = try HostRuntimeFixture.discovery(
@@ -46,7 +75,6 @@ extension CmxIrohHostRuntimeTests {
         }
 
         #expect(await runtime.snapshot().state == .failed)
-        #expect(await endpoint.observedCloseCallCount() == 1)
     }
 
     @Test

--- a/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohHostRuntimePolicyTests.swift
+++ b/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohHostRuntimePolicyTests.swift
@@ -7,6 +7,49 @@ import Testing
 
 extension CmxIrohHostRuntimeTests {
     @Test
+    func embeddedDiscoveryCannotRegressTheInstalledAuthoritativeRevision() async throws {
+        let fixture = try HostRuntimeFixture()
+        let revisionTwo = try HostRuntimeFixture.discovery(
+            binding: fixture.binding,
+            relays: HostRuntimeFixture.relayURLs,
+            lanGeneration: 2,
+            revision: 2
+        )
+        let revisionOne = try HostRuntimeFixture.discovery(
+            binding: fixture.binding,
+            relays: HostRuntimeFixture.relayURLs,
+            lanGeneration: 1,
+            revision: 1
+        )
+        let endpoint = TestIrohEndpoint(identity: fixture.endpointID)
+        let broker = TestIrohHostBroker(
+            registrationBinding: fixture.binding,
+            discovery: revisionTwo,
+            subsequentDiscoveries: [revisionOne],
+            embedDiscoveryStartingAtRegistrationCount: 2
+        )
+        let runtime = CmxIrohHostRuntime(
+            factory: TestIrohEndpointFactory(endpoints: [endpoint]),
+            broker: broker,
+            configuration: fixture.configuration,
+            pendingRevocations: fixture.pendingRevocations(),
+            handleTransport: { session, _ in await session.close() }
+        )
+        try await runtime.start()
+        #expect(await runtime.connectivityEngine?.snapshot().routeRevision == 2)
+
+        await endpoint.emit(.networkChanged)
+        await broker.waitForRegistrationCount(2)
+        for _ in 0..<1_000 {
+            if await runtime.snapshot().state == .failed { break }
+            await Task.yield()
+        }
+
+        #expect(await runtime.snapshot().state == .failed)
+        #expect(await endpoint.observedCloseCallCount() == 1)
+    }
+
+    @Test
     func unauthorizedRegistrationRefreshDeactivatesActiveEndpoint() async throws {
         let fixture = try HostRuntimeFixture()
         let endpoint = TestIrohEndpoint(identity: fixture.endpointID)

--- a/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohHostRuntimeTests.swift
+++ b/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohHostRuntimeTests.swift
@@ -348,6 +348,7 @@ actor TestIrohHostBroker: CmxIrohHostBrokerServing {
     private let subsequentRegistrationHook: (@Sendable () async -> Void)?
     private let relayIssueHook: (@Sendable () async -> Void)?
     private let embedDiscoveryStartingAtRegistrationCount: Int?
+    private let registrationRevision: UInt64?
     private var preflightErrors: [CmxIrohBrokerCooldownError]
     private var subsequentRegistrationErrors: [CmxIrohTrustBrokerClientError]
     private var preflightOperations: [CmxIrohBrokerOperation] = []
@@ -374,6 +375,7 @@ actor TestIrohHostBroker: CmxIrohHostBrokerServing {
         relayIssueHook: (@Sendable () async -> Void)? = nil,
         embedDiscoveryInRegistration: Bool = false,
         embedDiscoveryStartingAtRegistrationCount: Int? = nil,
+        registrationRevision: UInt64? = nil,
         preflightErrors: [CmxIrohBrokerCooldownError] = [],
         subsequentRegistrationErrors: [CmxIrohTrustBrokerClientError] = []
     ) {
@@ -389,6 +391,7 @@ actor TestIrohHostBroker: CmxIrohHostBrokerServing {
             embedDiscoveryInRegistration
                 ? 1
                 : embedDiscoveryStartingAtRegistrationCount
+        self.registrationRevision = registrationRevision
         self.preflightErrors = preflightErrors
         self.subsequentRegistrationErrors = subsequentRegistrationErrors
     }
@@ -430,9 +433,8 @@ actor TestIrohHostBroker: CmxIrohHostBrokerServing {
             .map { registrationCount >= $0 }
             ?? false
         return CmxIrohRegistrationResponse(
-            revision: embedsDiscovery
-                ? discoveryResponses[0].revision
-                : nil,
+            revision: registrationRevision
+                ?? (embedsDiscovery ? discoveryResponses[0].revision : nil),
             binding: binding,
             relay: .unavailable,
             discovery: embedsDiscovery

--- a/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohHostRuntimeTests.swift
+++ b/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohHostRuntimeTests.swift
@@ -347,7 +347,7 @@ actor TestIrohHostBroker: CmxIrohHostBrokerServing {
     private let registrationHook: (@Sendable () async -> Bool)?
     private let subsequentRegistrationHook: (@Sendable () async -> Void)?
     private let relayIssueHook: (@Sendable () async -> Void)?
-    private let embedDiscoveryInRegistration: Bool
+    private let embedDiscoveryStartingAtRegistrationCount: Int?
     private var preflightErrors: [CmxIrohBrokerCooldownError]
     private var subsequentRegistrationErrors: [CmxIrohTrustBrokerClientError]
     private var preflightOperations: [CmxIrohBrokerOperation] = []
@@ -373,6 +373,7 @@ actor TestIrohHostBroker: CmxIrohHostBrokerServing {
         subsequentRegistrationHook: (@Sendable () async -> Void)? = nil,
         relayIssueHook: (@Sendable () async -> Void)? = nil,
         embedDiscoveryInRegistration: Bool = false,
+        embedDiscoveryStartingAtRegistrationCount: Int? = nil,
         preflightErrors: [CmxIrohBrokerCooldownError] = [],
         subsequentRegistrationErrors: [CmxIrohTrustBrokerClientError] = []
     ) {
@@ -384,7 +385,10 @@ actor TestIrohHostBroker: CmxIrohHostBrokerServing {
         self.registrationHook = registrationHook
         self.subsequentRegistrationHook = subsequentRegistrationHook
         self.relayIssueHook = relayIssueHook
-        self.embedDiscoveryInRegistration = embedDiscoveryInRegistration
+        self.embedDiscoveryStartingAtRegistrationCount =
+            embedDiscoveryInRegistration
+                ? 1
+                : embedDiscoveryStartingAtRegistrationCount
         self.preflightErrors = preflightErrors
         self.subsequentRegistrationErrors = subsequentRegistrationErrors
     }
@@ -422,13 +426,16 @@ actor TestIrohHostBroker: CmxIrohHostBrokerServing {
         let binding = registrationBindings.count > 1
             ? registrationBindings.removeFirst()
             : registrationBindings[0]
+        let embedsDiscovery = embedDiscoveryStartingAtRegistrationCount
+            .map { registrationCount >= $0 }
+            ?? false
         return CmxIrohRegistrationResponse(
-            revision: embedDiscoveryInRegistration
+            revision: embedsDiscovery
                 ? discoveryResponses[0].revision
                 : nil,
             binding: binding,
             relay: .unavailable,
-            discovery: embedDiscoveryInRegistration
+            discovery: embedsDiscovery
                 ? discoveryResponses[0]
                 : nil
         )

--- a/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohReconnectBackoffTests.swift
+++ b/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohReconnectBackoffTests.swift
@@ -1,0 +1,94 @@
+import Foundation
+import Testing
+@testable import CmuxIrohTransport
+
+struct CmxIrohReconnectBackoffTests {
+    @Test
+    func sameSeedProducesIdenticalSchedules() {
+        let first = CmxIrohReconnectBackoff(seed: 7)
+        let second = CmxIrohReconnectBackoff(seed: 7)
+        let firstDelays = (0 ..< 64).map { _ in first.nextDelay() }
+        let secondDelays = (0 ..< 64).map { _ in second.nextDelay() }
+        #expect(firstDelays == secondDelays)
+    }
+
+    @Test
+    func jitterStaysInsideFloorAndCap() {
+        let configuration = CmxIrohReconnectBackoffConfiguration.foreground
+        let backoff = CmxIrohReconnectBackoff(
+            configuration: configuration,
+            seed: 0xDECAF
+        )
+        var upperBound = min(
+            configuration.cap,
+            configuration.floor * configuration.multiplier
+        )
+        for _ in 0 ..< 500 {
+            let delay = backoff.nextDelay()
+            #expect(delay >= configuration.floor)
+            #expect(delay <= configuration.cap)
+            // Decorrelated jitter: each draw is bounded by the previous
+            // delay's growth window, never by unbounded exponentiation.
+            #expect(delay <= upperBound)
+            upperBound = min(configuration.cap, delay * configuration.multiplier)
+        }
+    }
+
+    @Test
+    func foregroundNeverSchedulesBeyondCapWithoutServerDirective() {
+        let backoff = CmxIrohReconnectBackoff(seed: 42)
+        for _ in 0 ..< 1_000 {
+            #expect(backoff.nextDelay()
+                <= CmxIrohReconnectBackoffConfiguration.foreground.cap)
+        }
+    }
+
+    @Test
+    func resetReturnsToFloorWindow() {
+        let configuration = CmxIrohReconnectBackoffConfiguration.foreground
+        let backoff = CmxIrohReconnectBackoff(
+            configuration: configuration,
+            seed: 3
+        )
+        for _ in 0 ..< 32 {
+            _ = backoff.nextDelay()
+        }
+        backoff.reset()
+        let afterReset = backoff.nextDelay()
+        #expect(afterReset >= configuration.floor)
+        #expect(afterReset
+            <= min(configuration.cap, configuration.floor * configuration.multiplier))
+    }
+
+    @Test
+    func serverRetryAfterWinsOverLocalScheduleAndIsBounded() {
+        let backoff = CmxIrohReconnectBackoff(seed: 9)
+        #expect(backoff.nextDelay(retryAfterSeconds: 120) >= 120)
+        #expect(backoff.nextDelay(retryAfterSeconds: Int.max)
+            <= TimeInterval(CmxIrohBrokerCooldown.maximumRetryAfterSeconds))
+        // A server directive never poisons the local streak: the next local
+        // draw stays inside the decorrelated window, not the directive's.
+        let after = backoff.nextDelay()
+        #expect(after <= CmxIrohReconnectBackoffConfiguration.foreground.cap)
+    }
+
+    @Test
+    func foregroundClientRetryScheduleSharesForegroundBounds() {
+        let configuration = CmxIrohReconnectBackoffConfiguration.foreground
+        let schedule = CmxIrohRetrySchedule.foregroundClient
+        #expect(schedule.initialDelay == configuration.floor)
+        #expect(schedule.maximumDelay == configuration.cap)
+        // First transient failure retries after about a second, not half a
+        // minute, and no locally computed delay can exceed the cap.
+        #expect(schedule.delay(
+            failureCount: 0,
+            retryAfterSeconds: nil,
+            jitterUnitInterval: 1
+        ) <= configuration.floor * 1.25)
+        #expect(schedule.delay(
+            failureCount: 20,
+            retryAfterSeconds: nil,
+            jitterUnitInterval: 1
+        ) <= configuration.cap)
+    }
+}

--- a/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/DeviceRegistryRouteSelectionTests.swift
+++ b/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/DeviceRegistryRouteSelectionTests.swift
@@ -625,7 +625,9 @@ import Testing
         let springboardRelaunch = SimulatorDeviceIdentityStore(defaults: defaults)
 
         #expect(resolved != nil)
-        #expect(springboardRelaunch.read() == .found(resolved!))
+        if let resolved {
+            #expect(springboardRelaunch.read() == .found(resolved))
+        }
     }
 
     @Test func durableDeviceIDMintsAndPersistsOnFreshInstall() {
@@ -637,7 +639,9 @@ import Testing
         let resolved = DeviceRegistryService.durableDeviceID(store: store, defaults: defaults)
         // A fresh mint is durable only because the store confirmed the write.
         #expect(resolved != nil)
-        #expect(store.read() == .found(resolved!))
+        if let resolved {
+            #expect(store.read() == .found(resolved))
+        }
         #expect(defaults.string(forKey: "cmux.deviceRegistry.iosDeviceID") == resolved)
     }
 
@@ -806,7 +810,9 @@ import Testing
             store: store, defaults: defaults, evidence: StaticEvidenceProbe(.present),
         )
         #expect(resolved != nil)
-        #expect(store.read() == .found(resolved!))
+        if let resolved {
+            #expect(store.read() == .found(resolved))
+        }
     }
 
     @Test func durableDeviceIDAdoptsConcurrentWinnerInsteadOfMintingSecondID() {

--- a/Sources/Cloud/ConnectivityInvalidationSubscriberCoordinator.swift
+++ b/Sources/Cloud/ConnectivityInvalidationSubscriberCoordinator.swift
@@ -18,6 +18,7 @@ final class ConnectivityInvalidationSubscriberCoordinator {
     private weak var auth: AuthCoordinator?
     private var subscriber: CmxConnectivityInvalidationSubscriber?
     private var reconfigureTask: Task<Void, Never>?
+    private var authObservationTask: Task<Void, Never>?
     private var defaultsObserver: NSObjectProtocol?
     private var activeScopeKey: String?
 
@@ -44,9 +45,14 @@ final class ConnectivityInvalidationSubscriberCoordinator {
             _ = auth.isAuthenticated
             _ = auth.currentUser?.id
         } onChange: { [weak self] in
-            Task { @MainActor [weak self] in
-                self?.evaluate()
-                self?.armAuthScopeObservation()
+            MainActor.assumeIsolated {
+                guard let self else { return }
+                self.authObservationTask?.cancel()
+                self.authObservationTask = Task { @MainActor [weak self] in
+                    guard !Task.isCancelled, let self else { return }
+                    self.evaluate()
+                    self.armAuthScopeObservation()
+                }
             }
         }
     }
@@ -98,6 +104,8 @@ final class ConnectivityInvalidationSubscriberCoordinator {
     }
 
     func appWillTerminate() {
+        authObservationTask?.cancel()
+        authObservationTask = nil
         reconfigureTask?.cancel()
         let subscriber = subscriber
         self.subscriber = nil

--- a/ios/cmux/cmuxApp.swift
+++ b/ios/cmux/cmuxApp.swift
@@ -9,7 +9,7 @@ import cmuxFeature
 import CmuxIrohReleaseGateSupport
 #endif
 
-private let cmuxAppConnectivityLog = Logger(
+nonisolated private let cmuxAppConnectivityLog = Logger(
     subsystem: Bundle.main.bundleIdentifier ?? "com.cmuxterm.app",
     category: "connectivity"
 )

--- a/ios/cmuxPackage/Sources/cmuxFeature/MobileIrohRuntimeComposition.swift
+++ b/ios/cmuxPackage/Sources/cmuxFeature/MobileIrohRuntimeComposition.swift
@@ -209,7 +209,19 @@ public final class MobileIrohRuntimeComposition:
     private let tag: String
     private let discoveryCompatibilityPolicy: MobileMacBuildCompatibilityPolicy?
     private let now: @Sendable () -> Date
-    private let startNetworkPathObservation: @Sendable () async -> Void
+    private let startNetworkPathObservation: @Sendable (
+        _ onPathChange: @escaping @Sendable () async -> Void
+    ) async -> Void
+    /// Shared client backoff armed by a failed activation. While armed, dial
+    /// and preparation churn cannot re-run registration, discovery, and
+    /// relay-policy against the broker; field phones wedged in that loop sent
+    /// mutation requests every 2-10 seconds for 40+ hours.
+    private let activationRetryBackoff: CmxIrohReconnectBackoff
+    /// Fresh per-lifecycle ladder for the relay-policy refresh loop, sharing
+    /// the activation ladder's foreground bounds but not its failure streak.
+    private let makeRelayPolicyRefreshBackoff: @Sendable () -> CmxIrohReconnectBackoff
+    private var activationRetryAt: Date?
+    private var activationBackoffAccountID: String?
     private let networkPathSnapshot: @Sendable () async throws -> CmxIrohNetworkPathSnapshot
     private let lanPeerDiscovery: CmxIrohLANPeerDiscovery?
     /// Shared release-safe event ring. Its event schema has no string payloads,
@@ -399,10 +411,13 @@ public final class MobileIrohRuntimeComposition:
             discoveryCompatibilityPolicy: discoveryCompatibilityPolicy,
             now: { Date() },
             lanPeerDiscovery: lanPeerDiscovery,
-            startNetworkPathObservation: {
+            startNetworkPathObservation: { onPathChange in
                 await networkPathState.start(
                     reachability: reachability,
-                    onPathChange: { await lanPeerDiscovery.pathDidChange() }
+                    onPathChange: {
+                        await lanPeerDiscovery.pathDidChange()
+                        await onPathChange()
+                    }
                 )
             },
             networkPathSnapshot: {
@@ -441,10 +456,16 @@ public final class MobileIrohRuntimeComposition:
         now: @escaping @Sendable () -> Date,
         routeCatalog: MobileIrohRouteCatalog = MobileIrohRouteCatalog(),
         lanPeerDiscovery: CmxIrohLANPeerDiscovery? = nil,
-        startNetworkPathObservation: @escaping @Sendable () async -> Void = {},
+        startNetworkPathObservation: @escaping @Sendable (
+            _ onPathChange: @escaping @Sendable () async -> Void
+        ) async -> Void = { _ in },
         networkPathSnapshot: @escaping @Sendable () async throws -> CmxIrohNetworkPathSnapshot = {
             CmxIrohNetworkPathSnapshot(generation: 1, activeNetworkProfiles: [])
         },
+        activationRetryBackoff: CmxIrohReconnectBackoff? = nil,
+        makeRelayPolicyRefreshBackoff: (
+            @Sendable () -> CmxIrohReconnectBackoff
+        )? = nil,
         diagnosticLog: DiagnosticLog? = nil,
         debugDefaults: UserDefaults? = nil
     ) {
@@ -474,6 +495,10 @@ public final class MobileIrohRuntimeComposition:
         self.lanPeerDiscovery = lanPeerDiscovery
         self.startNetworkPathObservation = startNetworkPathObservation
         self.networkPathSnapshot = networkPathSnapshot
+        self.activationRetryBackoff = activationRetryBackoff
+            ?? CmxIrohReconnectBackoff()
+        self.makeRelayPolicyRefreshBackoff = makeRelayPolicyRefreshBackoff
+            ?? { CmxIrohReconnectBackoff() }
         self.diagnosticLog = diagnosticLog
     }
 
@@ -521,7 +546,11 @@ public final class MobileIrohRuntimeComposition:
         authObservationTask?.cancel()
         authObservationTask = Task { @MainActor [weak self, weak auth] in
             guard let auth else { return }
-            await self?.startNetworkPathObservation()
+            await self?.startNetworkPathObservation({ [weak self] in
+                // A path change is a fresh network state: the failure streak
+                // that armed the activation backoff belonged to the old path.
+                await self?.clearActivationRetryBackoff()
+            })
             await auth.awaitBootstrapped()
             guard !Task.isCancelled, let self else { return }
             let states = self.authObserver.states(for: auth)
@@ -819,6 +848,9 @@ public final class MobileIrohRuntimeComposition:
             .appLifecycleChanged,
             a: DiagnosticAppLifecyclePhase.active.rawValue
         ))
+        // The user is looking at the app: any armed activation backoff resets
+        // to its floor so recovery is immediate rather than mid-nap.
+        clearActivationRetryBackoff()
         guard signOutPhase.allowsLifecycle else { return }
         sceneTransitionTask?.cancel()
         let auth = auth
@@ -1414,12 +1446,23 @@ public final class MobileIrohRuntimeComposition:
               signOutPhase.allowsLifecycle,
               let targetAccountID,
               runtime == nil else { return }
+        if activationBackoffAccountID != targetAccountID {
+            // A different account never inherits another account's streak.
+            clearActivationRetryBackoff()
+        } else if let activationRetryAt, now() < activationRetryAt {
+            // A recent activation failure armed the client backoff: skip the
+            // broker-bound attempt entirely. scenePhase-active transitions,
+            // network-path changes, and account switches clear the window
+            // immediately, so a real state change always retries at the floor.
+            return
+        }
         diagnosticLog?.record(DiagnosticEvent(
             .endpointStarting,
             a: DiagnosticTransportKind.iroh.rawValue
         ))
         do {
             try await activate(accountID: targetAccountID, revision: revision)
+            clearActivationRetryBackoff()
         } catch is CancellationError {
             return
         } catch {
@@ -1431,7 +1474,38 @@ public final class MobileIrohRuntimeComposition:
             mobileIrohLog.error(
                 "Iroh client activation failed: \(String(describing: error), privacy: .private)"
             )
+            armActivationRetryBackoff(accountID: targetAccountID, error: error)
         }
+    }
+
+    /// Arms the shared client backoff after one failed broker-bound activation.
+    ///
+    /// External churn (every dial, discovery, and preparation re-triggers a
+    /// reconcile while no runtime exists) must not translate into broker
+    /// traffic; without a client-side window a wedged phone re-ran
+    /// registration, discovery, and relay-policy every few seconds
+    /// indefinitely. Local precondition deferrals never arm the window: they
+    /// made no broker request and the next reconcile may legitimately retry
+    /// immediately.
+    private func armActivationRetryBackoff(accountID: String, error: any Error) {
+        if (error as? CmxIrohClientRuntimeError) == .inactive { return }
+        let delay = activationRetryBackoff.nextDelay(
+            retryAfterSeconds: (error as? any CmxRetryAfterProviding)?
+                .retryAfterSeconds
+        )
+        activationBackoffAccountID = accountID
+        activationRetryAt = now().addingTimeInterval(delay)
+        diagnosticLog?.record(DiagnosticEvent(
+            .retryScheduled,
+            ms: UInt32(clamping: Int(delay * 1_000)),
+            a: DiagnosticTransportKind.iroh.rawValue
+        ))
+    }
+
+    private func clearActivationRetryBackoff() {
+        activationRetryBackoff.reset()
+        activationRetryAt = nil
+        activationBackoffAccountID = nil
     }
 
     private func activate(accountID: String, revision: UInt64) async throws {
@@ -2448,9 +2522,9 @@ extension MobileIrohRuntimeComposition: CmxIrohSettingsControlling {
             relayPolicyRefreshTask = nil
             return
         }
+        let refreshBackoff = makeRelayPolicyRefreshBackoff()
         relayPolicyRefreshTask = Task { @MainActor [weak self] in
             var retryAt: Date?
-            var failureCount = 0
             var relayAuthorityExpired = false
             var shouldRefreshImmediately = refreshImmediately
             while !Task.isCancelled {
@@ -2511,7 +2585,7 @@ extension MobileIrohRuntimeComposition: CmxIrohSettingsControlling {
                     )
                     try await self.applyRelayPolicy(effective)
                     retryAt = nil
-                    failureCount = 0
+                    refreshBackoff.reset()
                     relayAuthorityExpired = false
                     self.diagnosticLog?.record(DiagnosticEvent(.relayPolicyRefreshSucceeded))
                 } catch {
@@ -2535,13 +2609,13 @@ extension MobileIrohRuntimeComposition: CmxIrohSettingsControlling {
                         self.relayPolicyDiagnostics = await service.diagnosticsSnapshot()
                         self.publishIrohSettingsUpdate()
                     }
-                    let retryDelay = CmxIrohRetrySchedule().delay(
-                        failureCount: failureCount,
+                    // The shared foreground ladder replaces the host-profile
+                    // exponential schedule whose 30 s first retry produced the
+                    // observed 32-36 s naps after a single transient blip.
+                    let retryDelay = refreshBackoff.nextDelay(
                         retryAfterSeconds: (error as? any CmxRetryAfterProviding)?
-                            .retryAfterSeconds,
-                        jitterUnitInterval: Double.random(in: 0 ... 1)
+                            .retryAfterSeconds
                     )
-                    failureCount = min(failureCount + 1, 20)
                     retryAt = failureDate.addingTimeInterval(retryDelay)
                     self.diagnosticLog?.record(DiagnosticEvent(
                         .retryScheduled,

--- a/ios/cmuxPackage/Tests/cmuxFeatureTests/MobileIrohRuntimeCompositionCooldownTests.swift
+++ b/ios/cmuxPackage/Tests/cmuxFeatureTests/MobileIrohRuntimeCompositionCooldownTests.swift
@@ -87,6 +87,9 @@ struct MobileIrohRuntimeCompositionCooldownTests {
         await settleActivation(fixture) {
             await fixture.broker.totalRequestCount() >= 1
         }
+        // Drain any still-running reconcile before counting, so the settled
+        // baseline is stable against task-scheduling noise.
+        await fixture.composition.prepareForConnection()
         let settledRequestCount = await fixture.broker.totalRequestCount()
 
         let transportError: any Error
@@ -130,9 +133,74 @@ struct MobileIrohRuntimeCompositionCooldownTests {
         }
         #expect(eventStreamError as? CmxIrohClientRuntimeError == .inactive)
         #expect((eventStreamError as? any CmxRetryAfterProviding)?.retryAfterSeconds == nil)
-        // No cooldown for non-rate-limited failures: each dial retried a
-        // fresh activation and reached the broker again.
-        #expect(await fixture.broker.totalRequestCount() > settledRequestCount)
+        // A non-rate-limited failure arms only the local client backoff: dials
+        // inside the armed window keep the plain inactive error shape (no
+        // Retry-After) and never reach the broker until the window expires.
+        #expect(await fixture.broker.totalRequestCount() == settledRequestCount)
+    }
+
+    @Test
+    func clientBackoffBoundsFailingActivationRetries() async throws {
+        let fixture = try await MobileIrohCooldownFixture.make(
+            registrationError: MobileIrohCooldownTestError.unavailable
+        )
+        await settleActivation(fixture) {
+            await fixture.broker.totalRequestCount() >= 1
+        }
+        await fixture.composition.prepareForConnection()
+        let settled = await fixture.broker.totalRequestCount()
+
+        // The injected clock is frozen inside the armed backoff window, so
+        // every re-driven preparation and dial must stay broker-silent. Before
+        // the client backoff existed, each of these re-ran registration.
+        for _ in 0 ..< 20 {
+            await fixture.composition.prepareForConnection()
+        }
+        _ = try? await fixture.composition.transport(for: fixture.request)
+        _ = try? await fixture.composition.transport(for: fixture.request)
+        #expect(await fixture.broker.totalRequestCount() == settled)
+
+        // The armed nap is observable and bounded by the foreground cap: no
+        // multi-minute sleep can be scheduled while the app is active.
+        let scheduled = (await fixture.diagnosticLog.snapshot()).events.filter {
+            $0.code == .retryScheduled
+        }
+        #expect(!scheduled.isEmpty)
+        #expect(scheduled.allSatisfy { ($0.ms ?? .max) <= 30_000 })
+
+        // Past the foreground cap, exactly one further attempt runs; its
+        // failure re-arms the window and later drives stay broker-silent.
+        fixture.clock.advance(by: 31)
+        await settleActivation(fixture) {
+            await fixture.broker.totalRequestCount() > settled
+        }
+        #expect(await fixture.broker.totalRequestCount() == settled + 1)
+        for _ in 0 ..< 5 {
+            await fixture.composition.prepareForConnection()
+        }
+        #expect(await fixture.broker.totalRequestCount() == settled + 1)
+    }
+
+    @Test
+    func scenePhaseActiveResetsActivationBackoff() async throws {
+        let fixture = try await MobileIrohCooldownFixture.make(
+            registrationError: MobileIrohCooldownTestError.unavailable
+        )
+        await settleActivation(fixture) {
+            await fixture.broker.totalRequestCount() >= 1
+        }
+        await fixture.composition.prepareForConnection()
+        let settled = await fixture.broker.totalRequestCount()
+        await fixture.composition.prepareForConnection()
+        #expect(await fixture.broker.totalRequestCount() == settled)
+
+        // Returning to the foreground clears the armed window without any
+        // clock advance: the very next preparation retries immediately.
+        fixture.composition.didBecomeActive()
+        await settleActivation(fixture) {
+            await fixture.broker.totalRequestCount() > settled
+        }
+        #expect(await fixture.broker.totalRequestCount() == settled + 1)
     }
 
     @Test

--- a/ios/cmuxPackage/Tests/cmuxFeatureTests/MobileIrohRuntimeCompositionCooldownTests.swift
+++ b/ios/cmuxPackage/Tests/cmuxFeatureTests/MobileIrohRuntimeCompositionCooldownTests.swift
@@ -139,10 +139,7 @@ struct MobileIrohRuntimeCompositionCooldownTests {
     func freshRelayBootstrapCredentialAvoidsSecondMint() async throws {
         let fixture = try await MobileIrohCooldownFixture.makeSuccessfulBootstrap()
 
-        await settleActivation(fixture) {
-            guard fixture.composition.runtime != nil else { return false }
-            return await fixture.broker.bootstrapRequestCount() >= 1
-        }
+        await fixture.broker.waitForBootstrapRequest()
 
         #expect(fixture.composition.runtime != nil)
         #expect(await fixture.broker.bootstrapRequestCount() >= 1)
@@ -155,9 +152,7 @@ struct MobileIrohRuntimeCompositionCooldownTests {
             suspendRelayBootstrap: true
         )
 
-        await settleActivation(fixture) {
-            await fixture.broker.bootstrapRequestCount() >= 1
-        }
+        await fixture.broker.waitForBootstrapRequest()
 
         #expect(fixture.composition.runtime != nil)
         #expect((await fixture.diagnosticLog.snapshot()).events.contains {
@@ -653,6 +648,7 @@ private actor MobileIrohCooldownBroker:
     private var relayTokenRequests = 0
     private var suspendRelayBootstrap: Bool
     private var relayBootstrapContinuation: CheckedContinuation<Void, Never>?
+    private var bootstrapRequestWaiters: [CheckedContinuation<Void, Never>] = []
 
     init(
         registrationError: (any Error)?,
@@ -719,6 +715,9 @@ private actor MobileIrohCooldownBroker:
     ) async throws -> CmxIrohRelayBootstrapResponse {
         totalRequests += 1
         bootstrapRequests += 1
+        let waiters = bootstrapRequestWaiters
+        bootstrapRequestWaiters.removeAll()
+        waiters.forEach { $0.resume() }
         if suspendRelayBootstrap {
             await withCheckedContinuation { continuation in
                 relayBootstrapContinuation = continuation
@@ -756,6 +755,13 @@ private actor MobileIrohCooldownBroker:
     func discoveryRequestCount() -> Int { discoveryRequests }
     func bootstrapRequestCount() -> Int { bootstrapRequests }
     func relayTokenRequestCount() -> Int { relayTokenRequests }
+
+    func waitForBootstrapRequest() async {
+        guard bootstrapRequests == 0 else { return }
+        await withCheckedContinuation { continuation in
+            bootstrapRequestWaiters.append(continuation)
+        }
+    }
 }
 
 private actor MobileIrohCooldownEndpointFactory: CmxIrohEndpointFactory {

--- a/ios/cmuxPackage/Tests/cmuxFeatureTests/MobileIrohRuntimeCompositionCooldownTests.swift
+++ b/ios/cmuxPackage/Tests/cmuxFeatureTests/MobileIrohRuntimeCompositionCooldownTests.swift
@@ -182,6 +182,83 @@ struct MobileIrohRuntimeCompositionCooldownTests {
     }
 
     @Test
+    func networkPathChangeResetsActivationBackoff() async throws {
+        let fixture = try await MobileIrohCooldownFixture.make(
+            registrationError: MobileIrohCooldownTestError.unavailable
+        )
+        await settleActivation(fixture) {
+            await fixture.broker.totalRequestCount() >= 1
+        }
+        await fixture.composition.prepareForConnection()
+        let settled = await fixture.broker.totalRequestCount()
+        await fixture.composition.prepareForConnection()
+        #expect(await fixture.broker.totalRequestCount() == settled)
+
+        // A network-path-change signal clears the armed window: the failure
+        // streak belonged to the previous path.
+        var invoked = await fixture.networkPathChangeHook.invoke()
+        for _ in 0 ..< 200 where !invoked {
+            try? await Task.sleep(nanoseconds: 10_000_000)
+            invoked = await fixture.networkPathChangeHook.invoke()
+        }
+        #expect(invoked)
+        await settleActivation(fixture) {
+            await fixture.broker.totalRequestCount() > settled
+        }
+        #expect(await fixture.broker.totalRequestCount() == settled + 1)
+    }
+
+    @Test
+    func failingActivationFollowsExactSeededSchedule() async throws {
+        let seed: UInt64 = 0xB0FF
+        let fixture = try await MobileIrohCooldownFixture.make(
+            registrationError: MobileIrohCooldownTestError.unavailable,
+            activationBackoff: CmxIrohReconnectBackoff(seed: seed),
+            diagnosticCapacity: 4_096
+        )
+        await settleActivation(fixture) {
+            await fixture.broker.totalRequestCount() >= 1
+        }
+        await fixture.composition.prepareForConnection()
+        #expect(await fixture.broker.totalRequestCount() == 1)
+
+        // A twin ladder with the same seed predicts the exact schedule: the
+        // first attempt at t=0, each retry at the first whole second on or
+        // after the previous attempt time plus its drawn delay.
+        let horizon = 600.0
+        let twin = CmxIrohReconnectBackoff(seed: seed)
+        var expectedDelays: [TimeInterval] = []
+        var expectedAttemptCount = 1
+        var attemptAt = 0.0
+        while true {
+            let delay = twin.nextDelay()
+            expectedDelays.append(delay)
+            let nextAttemptAt = (attemptAt + delay).rounded(.up)
+            guard nextAttemptAt <= horizon else { break }
+            attemptAt = nextAttemptAt
+            expectedAttemptCount += 1
+        }
+
+        // Simulate ten foreground minutes, redriving the ladder every second.
+        for _ in 0 ..< Int(horizon) {
+            fixture.clock.advance(by: 1)
+            await fixture.composition.prepareForConnection()
+        }
+        #expect(await fixture.broker.totalRequestCount() == expectedAttemptCount)
+
+        // Every scheduled nap matches the twin's draw, and none exceeds the
+        // foreground cap.
+        let scheduledMS = (await fixture.diagnosticLog.snapshot()).events
+            .filter { $0.code == .retryScheduled }
+            .compactMap(\.ms)
+        let expectedMS = expectedDelays.prefix(expectedAttemptCount).map {
+            UInt32(clamping: Int($0 * 1_000))
+        }
+        #expect(scheduledMS == Array(expectedMS))
+        #expect(scheduledMS.allSatisfy { $0 <= 30_000 })
+    }
+
+    @Test
     func scenePhaseActiveResetsActivationBackoff() async throws {
         let fixture = try await MobileIrohCooldownFixture.make(
             registrationError: MobileIrohCooldownTestError.unavailable
@@ -335,16 +412,23 @@ private struct MobileIrohCooldownFixture {
     /// coordinator); the fixture must retain it or every reconcile silently
     /// no-ops against a deallocated coordinator.
     let auth: AuthCoordinator
+    /// Captures the reachability-change hook the composition registers, so a
+    /// test can simulate one network-path-change signal.
+    let networkPathChangeHook: MobileIrohCooldownHookBox
     private let compositionFactory: @MainActor () -> MobileIrohRuntimeComposition
 
     static func make(
         registrationError: (any Error)?,
-        discoveryError: (any Error)? = nil
+        discoveryError: (any Error)? = nil,
+        activationBackoff: CmxIrohReconnectBackoff? = nil,
+        diagnosticCapacity: Int = 64
     ) async throws -> Self {
         try await make(
             registrationError: registrationError,
             discoveryError: discoveryError,
-            relayPolicy: nil
+            relayPolicy: nil,
+            activationBackoff: activationBackoff,
+            diagnosticCapacity: diagnosticCapacity
         )
     }
 
@@ -364,7 +448,9 @@ private struct MobileIrohCooldownFixture {
         registrationError: (any Error)?,
         discoveryError: (any Error)?,
         relayPolicy: MobileIrohCooldownRelayPolicyFixture?,
-        suspendRelayBootstrap: Bool = false
+        suspendRelayBootstrap: Bool = false,
+        activationBackoff: CmxIrohReconnectBackoff? = nil,
+        diagnosticCapacity: Int = 64
     ) async throws -> Self {
         let suiteName = "MobileIrohRuntimeCompositionCooldownTests.\(UUID().uuidString)"
         let defaults = try #require(UserDefaults(suiteName: suiteName))
@@ -415,8 +501,12 @@ private struct MobileIrohCooldownFixture {
         )
         let credentialStore = MobileIrohCooldownCredentialStore()
         let clock = MobileIrohCooldownTestClock(now)
-        let diagnosticLog = DiagnosticLog(capacity: 64, role: .mobileClient)
+        let diagnosticLog = DiagnosticLog(
+            capacity: diagnosticCapacity,
+            role: .mobileClient
+        )
         let stableDeviceID = deviceID
+        let networkPathChangeHook = MobileIrohCooldownHookBox()
         let brokerCredentials = CmxIrohBrokerCredentialRepository(
             secureStore: credentialStore,
             installState: installState
@@ -458,6 +548,10 @@ private struct MobileIrohCooldownFixture {
                 deviceID: { stableDeviceID },
                 tag: tag,
                 now: { clock.now() },
+                startNetworkPathObservation: { onPathChange in
+                    await networkPathChangeHook.set(onPathChange)
+                },
+                activationRetryBackoff: activationBackoff,
                 diagnosticLog: diagnosticLog,
                 debugDefaults: defaults
             )
@@ -511,6 +605,7 @@ private struct MobileIrohCooldownFixture {
             request: try request(),
             diagnosticLog: diagnosticLog,
             auth: auth,
+            networkPathChangeHook: networkPathChangeHook,
             compositionFactory: compositionFactory
         )
     }
@@ -525,6 +620,7 @@ private struct MobileIrohCooldownFixture {
             request: request,
             diagnosticLog: diagnosticLog,
             auth: auth,
+            networkPathChangeHook: networkPathChangeHook,
             compositionFactory: compositionFactory
         )
     }
@@ -615,6 +711,22 @@ private struct MobileIrohCooldownFixture {
             "path_hints": [],
             "last_seen_at": ISO8601DateFormatter().string(from: now),
         ]
+    }
+}
+
+/// Captures the composition's reachability-change callback for tests.
+actor MobileIrohCooldownHookBox {
+    private var hook: (@Sendable () async -> Void)?
+
+    func set(_ hook: @escaping @Sendable () async -> Void) {
+        self.hook = hook
+    }
+
+    /// Runs the captured hook once, returning whether it was registered yet.
+    func invoke() async -> Bool {
+        guard let hook else { return false }
+        await hook()
+        return true
     }
 }
 

--- a/web/db/migrations/20260730210000_connectivity_route_revision/migration.sql
+++ b/web/db/migrations/20260730210000_connectivity_route_revision/migration.sql
@@ -4,6 +4,3 @@ ALTER TABLE "iroh_account_security_states"
 ALTER TABLE "iroh_account_security_states"
   ADD CONSTRAINT "iroh_account_security_states_route_revision_check"
   CHECK ("route_revision" >= 0) NOT VALID;
---> statement-breakpoint
-ALTER TABLE "iroh_account_security_states"
-  VALIDATE CONSTRAINT "iroh_account_security_states_route_revision_check";

--- a/web/db/migrations/20260730211000_validate_connectivity_route_revision/migration.sql
+++ b/web/db/migrations/20260730211000_validate_connectivity_route_revision/migration.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "iroh_account_security_states"
+  VALIDATE CONSTRAINT "iroh_account_security_states_route_revision_check";

--- a/web/tests/iroh-route-handler.test.ts
+++ b/web/tests/iroh-route-handler.test.ts
@@ -131,17 +131,13 @@ describe("Iroh route boundary", () => {
       return response;
     });
 
-    const responseBeforeTimeout = await Promise.race([
-      responsePromise,
-      new Promise<null>((resolve) => {
-        setTimeout(() => resolve(null), 100);
-      }),
-    ]);
-    const settledBeforePublication = responseSettled
-      && responseBeforeTimeout !== null;
+    for (let attempt = 0; attempt < 50 && !responseSettled; attempt += 1) {
+      await Promise.resolve();
+    }
+    const settledBeforePublication = responseSettled;
     releasePublication?.();
     await scheduledPublication?.();
-    const response = responseBeforeTimeout ?? await responsePromise;
+    const response = await responsePromise;
 
     expect(settledBeforePublication).toBe(true);
     expect(response.status).toBe(201);


### PR DESCRIPTION
## Summary
- fail closed when broker revisions regress, mismatch registration envelopes, or reject a cached binding
- revalidate live EndpointID before every cached or online policy path
- centralize authoritative discovery reconciliation and harden invalidation lifecycle ownership
- split route-revision constraint validation into a later migration

## Verification
- red proof: both embedded-revision equality tests failed against the old implementation
- focused six-test security regression set passed
- `swift test` in `Packages/Shared/CmuxIrohTransport`: 512 tests across 61 suites passed

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/9318"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788122289&installation_model_id=21920&pr_number=9318&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F9318&signature=351c6883776878e393e0d1960e0d5a2a565a793be1df71eae4be18c9daf737ee"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened authoritative Iroh route reconciliation and bounded iOS client retries with a shared backoff and registration pacing to stop runaway broker traffic. Evicts pathless sessions and makes path selection and lifecycle handling deterministic.

- **Bug Fixes**
  - Reject discovery that regresses, mismatches registration revisions, fails reset/known-revision checks, or precedes the registration revision.
  - Require embedded discovery to exactly match the registration revision and be >= the installed authoritative revision.
  - Revalidate the live EndpointID before every cached/online policy path to block endpoint substitution.
  - Do not fall back to offline authority after authoritative rejection; surface a connectivity error.
  - Evict sessions when the selected path becomes unavailable and emit `allPathsClosed`; the next operation redials.
  - Make path selection deterministic via a clear precedence comparator.
  - Fix auth-scope observation to avoid duplicate reconfigure tasks; cancel tasks on terminate.
  - Stabilize Iroh connectivity regression tests and mobile/web tests by removing timing races.

- **New Features**
  - Introduce a shared foreground reconnect backoff (1s floor, 30s cap, decorrelated jitter, honors Retry-After, seedable) and apply it to:
    - iOS client activation: failed broker-bound attempts arm a local window; dials inside the window stay broker-silent. Reset on app active, network-path change, account switch, and success. Emit `retryScheduled` with the delay.
    - Relay-policy refresh: replace host-profile exponential with the same foreground ladder; no locally scheduled retry exceeds 30s.
    - Relay tokens: use `foregroundClient` retry schedule.
  - Pace broker registration mutations to a 2s client-side spacing via `CmxIrohBrokerBackpressureGate`; slots are reserved atomically, reads remain unpaced.
  - Centralize authoritative discovery reconciliation via an instance-based `CmxAuthoritativeDiscoveryResolver` that enforces minimum revisions and reset semantics across client/host/registry and backpressured brokers.
  - Split route-revision constraint VALIDATE into a follow-up migration for safer deploys.

<sup>Written for commit d824c088a92153994737bb3cffb021b300749088. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/9318?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

