### PR TITLE
Retire stale sidebar port badges despite vanished TTYs, privileged owners, and zombies

### DIFF
--- a/Sources/AgentPIDProcessIdentity.swift
+++ b/Sources/AgentPIDProcessIdentity.swift
@@ -11,16 +11,57 @@ struct AgentPIDProcessIdentity: Equatable, Hashable, Sendable {
         self.startMicroseconds = startMicroseconds
     }
 
+    /// Reads a live process's birth timestamp, which distinguishes it from a
+    /// later process that reused the same PID.
+    ///
+    /// Uses `sysctl` rather than `proc_pidinfo`, which refuses any process
+    /// whose effective UID differs from ours — including the root `login` that
+    /// heads every terminal's process group. `sysctl` reports the same
+    /// timestamp for those, so an unreadable identity means the process is
+    /// gone rather than merely privileged.
+    ///
+    /// `sysctl` also still describes a process that exited but has not been
+    /// reaped, which `proc_pidinfo` refused. Zombies are rejected explicitly so
+    /// a readable identity keeps meaning the process is running — callers such
+    /// as session restore treat it as proof the agent is still alive.
     init?(pid: pid_t) {
-        guard pid > 0 else { return nil }
-        var info = proc_bsdinfo()
-        let expectedSize = MemoryLayout<proc_bsdinfo>.stride
-        let size = proc_pidinfo(pid, PROC_PIDTBSDINFO, 0, &info, Int32(expectedSize))
-        guard size == expectedSize else { return nil }
+        guard let entry = Self.processTableEntry(pid: pid), !entry.hasExited else { return nil }
         self.init(
             pid: pid,
-            startSeconds: Int64(info.pbi_start_tvsec),
-            startMicroseconds: Int64(info.pbi_start_tvusec)
+            startSeconds: entry.startSeconds,
+            startMicroseconds: entry.startMicroseconds
+        )
+    }
+
+    /// Whether the process has exited but has not yet been reaped.
+    ///
+    /// A zombie still holds a process-table row and still accepts signals, so
+    /// `kill(pid, 0)` cannot distinguish it from a running process. It runs no
+    /// code and can own no resources, so callers weighing whether a PID might
+    /// still hold something read it as gone.
+    static func hasExitedWithoutReaping(pid: pid_t) -> Bool {
+        processTableEntry(pid: pid)?.hasExited ?? false
+    }
+
+    /// One read of the process table, shared so a second reader cannot drift
+    /// into different privilege or liveness behavior.
+    private static func processTableEntry(
+        pid: pid_t
+    ) -> (startSeconds: Int64, startMicroseconds: Int64, hasExited: Bool)? {
+        guard pid > 0 else { return nil }
+        var mib: [Int32] = [CTL_KERN, KERN_PROC, KERN_PROC_PID, pid]
+        var info = kinfo_proc()
+        var size = MemoryLayout<kinfo_proc>.stride
+        guard sysctl(&mib, UInt32(mib.count), &info, &size, nil, 0) == 0,
+              size > 0,
+              info.kp_proc.p_pid == pid else {
+            return nil
+        }
+        let started = info.kp_proc.p_un.__p_starttime
+        return (
+            Int64(started.tv_sec),
+            Int64(started.tv_usec),
+            info.kp_proc.p_stat == Int8(SZOMB)
         )
     }
 }

--- a/Sources/PIDPresence.swift
+++ b/Sources/PIDPresence.swift
@@ -8,6 +8,10 @@ enum PIDPresence: Equatable, Sendable {
 
     static func current(pid: pid_t) -> Self {
         guard pid > 0 else { return .absent }
+        // A zombie answers `kill(pid, 0)` like a running process, so ask the
+        // process table before trusting that answer. It has already exited and
+        // can hold nothing, which is absence for every caller here.
+        guard !AgentPIDProcessIdentity.hasExitedWithoutReaping(pid: pid) else { return .absent }
         errno = 0
         guard kill(pid, 0) != 0 else { return .present }
         switch errno {

--- a/Sources/PortScanner+Process.swift
+++ b/Sources/PortScanner+Process.swift
@@ -435,7 +435,11 @@ extension PortScanner {
         let result = await commandRunner.run(
             directory: "/",
             executable: "/usr/sbin/lsof",
-            arguments: ["-nP", "-a", "-p", pidsCsv, "-iTCP", "-sTCP:LISTEN", "-Fpn"],
+            // A PID-scoped TCP query does not depend on filesystem mount
+            // metadata. Suppress warning-class diagnostics such as lsof's
+            // Time Machine `can't stat()` warning so unrelated mounts cannot
+            // make every port miss permanently incomplete.
+            arguments: ["-nP", "-w", "-a", "-p", pidsCsv, "-iTCP", "-sTCP:LISTEN", "-Fpn"],
             timeout: Self.processScanTimeout
         )
 

--- a/Sources/PortScanner+Process.swift
+++ b/Sources/PortScanner+Process.swift
@@ -26,10 +26,10 @@ extension PortScanner {
         lsofScan: PortLsofScanResult?
     ) -> [PanelKey: PortScanCompleteness] {
         let pidsByTTY = pidToTTY.reduce(into: [String: Set<Int>]()) { result, item in
-            result[item.value, default: []].insert(item.key)
+            result[canonicalTTYName(item.value), default: []].insert(item.key)
         }
         return panelTTYs.reduce(into: [:]) { result, item in
-            let panelPIDs = pidsByTTY[item.value] ?? []
+            let panelPIDs = pidsByTTY[canonicalTTYName(item.value)] ?? []
             let lsofCompleteness: PortScanCompleteness
             if panelPIDs.isEmpty {
                 lsofCompleteness = .complete
@@ -331,7 +331,7 @@ extension PortScanner {
                     parsedEveryRow = false
                     continue
                 }
-                mapping[pid] = String(parts[1])
+                mapping[pid] = Self.canonicalTTYName(String(parts[1]))
             }
             if Self.isCompletePSResult(result) && parsedEveryRow {
                 return (mapping, .complete)
@@ -377,10 +377,10 @@ extension PortScanner {
     /// `ps` emits this exact text even under a non-English `LC_ALL`.
     static func vanishedTTYNames(inStderr stderr: String?, requested: Set<String>) -> Set<String> {
         guard let stderr, !stderr.isEmpty else { return [] }
-        // Terminals are registered verbatim, so both `ttys1` and `/dev/ttys1`
-        // can reach `ps`; match on the device name either form names.
+        // Direct callers can supply either `ttys1` or `/dev/ttys1`; match on
+        // the canonical device name either form names.
         let requestedByDeviceName = requested.reduce(into: [String: Set<String>]()) { result, name in
-            result[Self.deviceName(in: name), default: []].insert(name)
+            result[Self.canonicalTTYName(name), default: []].insert(name)
         }
         var vanished: Set<String> = []
         for line in stderr.split(separator: "\n") {
@@ -400,7 +400,9 @@ extension PortScanner {
         return vanished
     }
 
-    private static func deviceName(in ttyName: String) -> String {
+    /// Canonicalizes the shell's full device path and `ps`'s abbreviated TTY
+    /// field to one identity used by every scan join.
+    static func canonicalTTYName(_ ttyName: String) -> String {
         guard ttyName.hasPrefix(Self.deviceDirectoryPrefix) else { return ttyName }
         return String(ttyName.dropFirst(Self.deviceDirectoryPrefix.count))
     }

--- a/Sources/PortScanner+Process.swift
+++ b/Sources/PortScanner+Process.swift
@@ -5,6 +5,11 @@ import Foundation
 
 extension PortScanner {
     static let processScanTimeout: TimeInterval = 3
+    /// Bounds the retry loop that drops terminals `ps` reports as gone, so a
+    /// pty churning during a scan cannot spin the scanner.
+    static let maximumProcessScanAttempts = 3
+    private static let deviceDirectoryPrefix = "/dev/"
+    private static let missingDeviceDiagnosticSuffix = ": No such file or directory"
 
     static func combinedCompleteness(
         _ lhs: PortScanCompleteness,
@@ -307,25 +312,93 @@ extension PortScanner {
     }
 
     func runPS(ttyList: String) async -> (values: [Int: String], completeness: PortScanCompleteness) {
-        let result = await commandRunner.run(
-            directory: "/",
-            executable: "/bin/ps",
-            arguments: ["-t", ttyList, "-o", "pid=,tty="],
-            timeout: Self.processScanTimeout
-        )
+        var remaining = Self.orderedTTYNames(in: ttyList)
+        guard !remaining.isEmpty else { return ([:], .complete) }
 
-        var mapping: [Int: String] = [:]
-        var parsedEveryRow = true
-        for line in (result.stdout ?? "").split(separator: "\n") {
-            let parts = line.split(whereSeparator: \.isWhitespace)
-            guard parts.count == 2, let pid = Int(parts[0]), pid > 0 else {
-                parsedEveryRow = false
-                continue
+        for attempt in 0..<Self.maximumProcessScanAttempts {
+            let result = await commandRunner.run(
+                directory: "/",
+                executable: "/bin/ps",
+                arguments: ["-t", remaining.joined(separator: ","), "-o", "pid=,tty="],
+                timeout: Self.processScanTimeout
+            )
+
+            var mapping: [Int: String] = [:]
+            var parsedEveryRow = true
+            for line in (result.stdout ?? "").split(separator: "\n") {
+                let parts = line.split(whereSeparator: \.isWhitespace)
+                guard parts.count == 2, let pid = Int(parts[0]), pid > 0 else {
+                    parsedEveryRow = false
+                    continue
+                }
+                mapping[pid] = String(parts[1])
             }
-            mapping[pid] = String(parts[1])
+            if Self.isCompletePSResult(result) && parsedEveryRow {
+                return (mapping, .complete)
+            }
+
+            let vanished = Self.vanishedTTYNames(
+                inStderr: result.stderr,
+                requested: Set(remaining)
+            )
+            guard !vanished.isEmpty else { return (mapping, .incomplete) }
+            remaining.removeAll { vanished.contains($0) }
+            // Every terminal is gone, which is authoritative emptiness rather
+            // than a failed scan: no process can be attached to a freed pty.
+            // Emptiness outranks the retry budget so the verdict does not
+            // depend on which attempt the last pty happened to close during.
+            guard !remaining.isEmpty else { return ([:], .complete) }
+            guard attempt < Self.maximumProcessScanAttempts - 1 else {
+                return (mapping, .incomplete)
+            }
         }
-        let complete = Self.isCompletePSResult(result) && parsedEveryRow
-        return (mapping, complete ? .complete : .incomplete)
+        return ([:], .incomplete)
+    }
+
+    private static func orderedTTYNames(in ttyList: String) -> [String] {
+        var seen: Set<String> = []
+        return ttyList.split(separator: ",").compactMap { field in
+            let name = String(field)
+            guard !name.isEmpty, seen.insert(name).inserted else { return nil }
+            return name
+        }
+    }
+
+    /// Terminals that `ps` reported as no longer present on the filesystem.
+    ///
+    /// BSD `ps` abandons the whole `-t` query when any listed device is gone,
+    /// naming each one on stderr and writing nothing to stdout. Retrying
+    /// without them keeps one closed pty from erasing every other panel's
+    /// evidence. Only ENOENT is treated as absence; any other diagnostic
+    /// leaves the scan incomplete so ports are retained rather than dropped.
+    static func vanishedTTYNames(inStderr stderr: String?, requested: Set<String>) -> Set<String> {
+        guard let stderr, !stderr.isEmpty else { return [] }
+        // Terminals are registered verbatim, so both `ttys1` and `/dev/ttys1`
+        // can reach `ps`; match on the device name either form names.
+        let requestedByDeviceName = requested.reduce(into: [String: Set<String>]()) { result, name in
+            result[Self.deviceName(in: name), default: []].insert(name)
+        }
+        var vanished: Set<String> = []
+        for line in stderr.split(separator: "\n") {
+            guard line.hasSuffix(Self.missingDeviceDiagnosticSuffix) else { continue }
+            let paths = String(line.dropLast(Self.missingDeviceDiagnosticSuffix.count))
+            // For a name that does not already start with `tty`, `ps` stats
+            // both candidate devices and names them in one diagnostic:
+            // "ps: /dev/ttyfoo and /dev/foo: No such file or directory".
+            for path in paths.components(separatedBy: " and ") {
+                guard let devicePrefix = path.range(of: Self.deviceDirectoryPrefix) else { continue }
+                let deviceName = String(path[devicePrefix.upperBound...])
+                if let names = requestedByDeviceName[deviceName] {
+                    vanished.formUnion(names)
+                }
+            }
+        }
+        return vanished
+    }
+
+    private static func deviceName(in ttyName: String) -> String {
+        guard ttyName.hasPrefix(Self.deviceDirectoryPrefix) else { return ttyName }
+        return String(ttyName.dropFirst(Self.deviceDirectoryPrefix.count))
     }
 
     func runAllProcesses() async -> (values: [Int: Int], completeness: PortScanCompleteness) {

--- a/Sources/PortScanner+Process.swift
+++ b/Sources/PortScanner+Process.swift
@@ -371,6 +371,10 @@ extension PortScanner {
     /// without them keeps one closed pty from erasing every other panel's
     /// evidence. Only ENOENT is treated as absence; any other diagnostic
     /// leaves the scan incomplete so ports are retained rather than dropped.
+    ///
+    /// Matching the English `strerror(ENOENT)` suffix is safe regardless of the
+    /// user's locale: Darwin libc ships no localized message catalogs, so
+    /// `ps` emits this exact text even under a non-English `LC_ALL`.
     static func vanishedTTYNames(inStderr stderr: String?, requested: Set<String>) -> Set<String> {
         guard let stderr, !stderr.isEmpty else { return [] }
         // Terminals are registered verbatim, so both `ttys1` and `/dev/ttys1`

--- a/Sources/PortScanner.swift
+++ b/Sources/PortScanner.swift
@@ -103,10 +103,11 @@ final class PortScanner: @unchecked Sendable {
         ) else {
             return
         }
+        let scanTTYName = Self.canonicalTTYName(ttyName)
         queue.async { [self] in
             let previousTTY = ttyNames[key]
             panelPortSnapshot.remove(keys: [key])
-            ttyNames[key] = ttyName
+            ttyNames[key] = scanTTYName
             panelRevisionByKey[key] = revision
             if previousTTY != nil {
                 enqueuePanelPublication([

--- a/Sources/PortScanner.swift
+++ b/Sources/PortScanner.swift
@@ -13,8 +13,9 @@ import Foundation
 /// 1. `kick()` adds panel to `pendingKicks` set
 /// 2. If no burst is active, starts a 200ms coalesce timer
 /// 3. Coalesce fires → snapshots pending set → starts burst of 6 scans
-/// 4. New kicks during burst merge into the active burst
-/// 5. After last scan, if new kicks arrived, start a new coalesce cycle
+/// 4. New kicks during a burst require three later scan attempts
+/// 5. After the last scan, start a follow-up burst if the active burst did not
+///    have three attempts left for the most recent kick
 final class PortScanner: @unchecked Sendable {
     static let shared = PortScanner()
 
@@ -41,7 +42,9 @@ final class PortScanner: @unchecked Sendable {
     var trackedAgentWorkspaces: Set<UUID> = []
     var agentPublicationHistory = AgentPortPublicationHistory()
     /// Stable publication state shared by every best-effort local scan path.
-    private var panelPortSnapshot = PortScanSnapshotReconciler<PanelKey>()
+    private var panelPortSnapshot = PortScanSnapshotReconciler<PanelKey>(
+        missingPortRetentionLimit: PortScanner.panelMissingPortRetentionLimit
+    )
     var agentPortSnapshot = PortScanSnapshotReconciler<UUID>()
     var agentSnapshotReplacementState = AgentPortSnapshotReplacementState()
     var forceAgentResultWorkspaces: Set<UUID> = []
@@ -50,6 +53,10 @@ final class PortScanner: @unchecked Sendable {
     var publicationBuffer = PortScanPublicationBuffer()
 
     private var pendingKicks: Set<PanelKey> = []
+
+    /// Scan attempts still owed to the most recent kick. This keeps scheduling
+    /// coupled to the panel reconciler's complete-miss retention policy.
+    private var scansRemainingForPendingKicks = 0
 
     /// Whether a burst sequence is currently running.
     private var burstActive = false
@@ -62,6 +69,8 @@ final class PortScanner: @unchecked Sendable {
     /// Each scan fires at this absolute offset; the recursive scheduler
     /// converts to relative delays between consecutive scans.
     private static let burstOffsets: [Double] = [0.5, 1.5, 3, 5, 7.5, 10]
+    private static let panelMissingPortRetentionLimit = 2
+    private static let minimumScansPerKick = panelMissingPortRetentionLimit + 1
     private static let agentRescanInterval: TimeInterval = 2
 
     // MARK: - Public API
@@ -115,6 +124,9 @@ final class PortScanner: @unchecked Sendable {
             ttyNames.removeValue(forKey: key)
             panelRevisionByKey.removeValue(forKey: key)
             pendingKicks.remove(key)
+            if pendingKicks.isEmpty {
+                scansRemainingForPendingKicks = 0
+            }
             panelPortSnapshot.remove(keys: [key])
         }
     }
@@ -134,11 +146,13 @@ final class PortScanner: @unchecked Sendable {
             let key = PanelKey(workspaceId: workspaceId, panelId: panelId)
             guard ttyNames[key] != nil else { return }
             pendingKicks.insert(key)
+            scansRemainingForPendingKicks = Self.minimumScansPerKick
 
             if !burstActive {
                 startCoalesce()
             }
-            // If burst is active, the next scan iteration will pick up the new kick.
+            // If a burst is active, its later scans pay down this count. A
+            // follow-up burst starts when too few scans remained.
         }
     }
     @MainActor
@@ -230,13 +244,18 @@ final class PortScanner: @unchecked Sendable {
 
         guard !panelSnapshot.isEmpty else {
             pendingKicks.removeAll()
+            scansRemainingForPendingKicks = 0
             return
         }
 
         guard scanCoordination.beginPanelScan() else { return }
 
-        // Clear pending kicks — they're accounted for in this scan.
-        pendingKicks.removeAll()
+        if scansRemainingForPendingKicks > 0 {
+            scansRemainingForPendingKicks -= 1
+            if scansRemainingForPendingKicks == 0 {
+                pendingKicks.removeAll()
+            }
+        }
 
         let workspaceIds = Set(panelSnapshot.keys.map(\.workspaceId))
         let panelRevisions = panelSnapshot.keys.reduce(into: [PanelKey: UInt64]()) { result, key in

--- a/Sources/Workspace+PanelLifecycle.swift
+++ b/Sources/Workspace+PanelLifecycle.swift
@@ -250,17 +250,14 @@ extension Workspace {
         return currentIdentity == recordedIdentity
     }
 
+    /// Reads the identity the port scanner and session restore compare against.
+    ///
+    /// Delegates rather than reading the process table itself: a second reader
+    /// with different privilege behavior would record `nil` identities for
+    /// agents running under another euid, which `PortScanner.validateAgentRoots`
+    /// treats as permanently incomplete evidence.
     static func agentPIDProcessIdentity(pid: pid_t) -> AgentPIDProcessIdentity? {
-        guard pid > 0 else { return nil }
-        var info = proc_bsdinfo()
-        let expectedSize = MemoryLayout<proc_bsdinfo>.stride
-        let size = proc_pidinfo(pid, PROC_PIDTBSDINFO, 0, &info, Int32(expectedSize))
-        guard size == expectedSize else { return nil }
-        return AgentPIDProcessIdentity(
-            pid: pid,
-            startSeconds: Int64(info.pbi_start_tvsec),
-            startMicroseconds: Int64(info.pbi_start_tvusec)
-        )
+        AgentPIDProcessIdentity(pid: pid)
     }
 
     func suppressesRawTerminalNotification(panelId: UUID?) -> Bool {

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -1889,7 +1889,11 @@ extension Workspace {
             panelGitBranches.removeValue(forKey: panelId)
         }
 
-        surfaceListeningPorts[panelId] = Array(Set(snapshot.listeningPorts)).sorted()
+        if snapshot.terminal?.hibernation != nil {
+            surfaceListeningPorts.removeValue(forKey: panelId)
+        } else {
+            surfaceListeningPorts[panelId] = Array(Set(snapshot.listeningPorts)).sorted()
+        }
 
         if let ttyName = snapshot.ttyName?.trimmingCharacters(in: .whitespacesAndNewlines), !ttyName.isEmpty {
             surfaceTTYNames[panelId] = ttyName
@@ -5032,6 +5036,13 @@ final class Workspace: Identifiable, ObservableObject {
         restoredAgentSnapshotsByPanelId[panelId] = agent
         restoredAgentResumeStatesByPanelId[panelId] = .manualResumeAvailable
         invalidatedRestoredAgentFingerprintsByPanelId.removeValue(forKey: panelId)
+        if !isRemoteWorkspace {
+            // Hibernation destroys the local PTY. Clear its derived badge and
+            // reject any queued publication captured before that teardown.
+            surfaceListeningPorts.removeValue(forKey: panelId)
+            recomputeListeningPorts()
+            PortScanner.shared.unregisterPanel(workspaceId: id, panelId: panelId)
+        }
         let keys = agentPIDKeysByPanelId[panelId] ?? []
         for key in keys {
             _ = clearAgentPID(key: key, panelId: panelId, clearStatus: false, refreshPorts: false)

--- a/cmuxTests/AgentHibernationTests.swift
+++ b/cmuxTests/AgentHibernationTests.swift
@@ -892,6 +892,76 @@ struct AgentHibernationTests {
 
     @MainActor
     @Test
+    func testHibernationRetiresPanelPortsAndScannerLifecycle() throws {
+        let workspace = Workspace()
+        let panelId = try #require(workspace.focusedPanelId)
+        let agent = SessionRestorableAgentSnapshot(
+            kind: .codex,
+            sessionId: "codex-port-retirement",
+            workingDirectory: "/tmp/cmux-agent-hibernation",
+            launchCommand: launch("codex", "/usr/local/bin/codex", cwd: "/tmp/cmux-agent-hibernation")
+        )
+        let scannerKey = PortScanner.PanelKey(workspaceId: workspace.id, panelId: panelId)
+        let staleTTYName = "/dev/ttys9152"
+        PortScanner.shared.registerTTY(
+            workspaceId: workspace.id,
+            panelId: panelId,
+            ttyName: staleTTYName
+        )
+        defer {
+            PortScanner.shared.unregisterPanel(workspaceId: workspace.id, panelId: panelId)
+        }
+        workspace.surfaceListeningPorts[panelId] = [4321]
+        workspace.recomputeListeningPorts()
+
+        try #require(workspace.enterAgentHibernation(
+            panelId: panelId,
+            agent: agent,
+            lastActivityAt: Date(timeIntervalSince1970: 0)
+        ))
+
+        expectNil(workspace.surfaceListeningPorts[panelId])
+        expectTrue(workspace.listeningPorts.isEmpty)
+        expectNil(PortScanner.shared.publicationState.registeredPanelTTYName(for: scannerKey))
+        let persistedPanel = try #require(
+            workspace.sessionSnapshot(includeScrollback: false).panels.first { $0.id == panelId }
+        )
+        expectTrue(persistedPanel.listeningPorts.isEmpty)
+    }
+
+    @MainActor
+    @Test
+    func testRestoringHibernatedPanelDiscardsPersistedPorts() throws {
+        let source = Workspace()
+        let sourcePanelId = try #require(source.focusedPanelId)
+        let sourcePanel = try #require(source.panels[sourcePanelId] as? TerminalPanel)
+        let agent = SessionRestorableAgentSnapshot(
+            kind: .codex,
+            sessionId: "codex-restored-port-retirement",
+            workingDirectory: "/tmp/cmux-agent-hibernation",
+            launchCommand: launch("codex", "/usr/local/bin/codex", cwd: "/tmp/cmux-agent-hibernation")
+        )
+        try #require(sourcePanel.enterAgentHibernation(
+            agent: agent,
+            lastActivityAt: Date(timeIntervalSince1970: 0)
+        ))
+        var legacyPanelSnapshot = try #require(
+            source.sessionSnapshot(includeScrollback: false).panels.first { $0.id == sourcePanelId }
+        )
+        try #require(legacyPanelSnapshot.terminal?.hibernation != nil)
+        legacyPanelSnapshot.listeningPorts = [4321]
+
+        let restored = Workspace()
+        let restoredPanelId = try #require(restored.focusedPanelId)
+        restored.applySessionPanelMetadata(legacyPanelSnapshot, toPanelId: restoredPanelId)
+        restored.recomputeListeningPorts()
+
+        expectNil(restored.surfaceListeningPorts[restoredPanelId])
+        expectTrue(restored.listeningPorts.isEmpty)
+    }
+
+    @MainActor
+    @Test
     func testFocusingHibernatedTerminalAutomaticallyPreparesResume() throws {
         let workspace = Workspace()
         let panelId = try #require(workspace.focusedPanelId)

--- a/cmuxTests/PortScannerTests.swift
+++ b/cmuxTests/PortScannerTests.swift
@@ -1,5 +1,6 @@
 import CmuxCore
 import CmuxFoundation
+import Darwin
 import Foundation
 import os
 import Testing
@@ -83,6 +84,32 @@ struct PortScannerProcessCaptureTests {
         #expect(scan.completeness == .incomplete)
     }
 
+    @Test("Filesystem warnings do not poison lsof TCP evidence")
+    func filesystemWarningsAreSuppressedForLsofTCPScan() async {
+        let pid = 123
+        let identity = AgentPIDProcessIdentity(
+            pid: pid_t(pid),
+            startSeconds: 1,
+            startMicroseconds: 0
+        )
+        let runner = PortLifecycleCommandRunner(
+            ttyName: "ttys001",
+            sessionLeaderPID: 1,
+            pid: pid,
+            port: 4200
+        )
+        let scan = await PortScanner(
+            commandRunner: runner,
+            processIdentityProvider: { $0 == identity.pid ? identity : nil },
+            processPresenceProvider: { $0 == identity.pid ? .present : .absent }
+        ).runLsof(pidsCsv: String(pid))
+        let arguments = await runner.lastLsofArguments
+
+        #expect(scan.values == [pid: [4200]])
+        #expect(scan.completeness(for: [pid]) == .complete)
+        #expect(arguments?.contains("-w") == true)
+    }
+
     @Test("A confirmed absent PID is safe negative lsof evidence")
     func absentPIDIsCompleteNegativeEvidence() async {
         let runner = StubCommandRunner(result: CommandResult(
@@ -113,6 +140,18 @@ struct PortScannerProcessCaptureTests {
         // launchd is root-owned on every macOS system, so `proc_pidinfo`
         // refuses it for an unprivileged caller — the same refusal that hides
         // the root `login` process heading every terminal's process group.
+        try #require(geteuid() != 0, "the cross-user identity test must run unprivileged")
+        var legacyInfo = proc_bsdinfo()
+        let expectedLegacySize = MemoryLayout<proc_bsdinfo>.stride
+        let legacySize = proc_pidinfo(
+            1,
+            PROC_PIDTBSDINFO,
+            0,
+            &legacyInfo,
+            Int32(expectedLegacySize)
+        )
+        #expect(legacySize != expectedLegacySize, "proc_pidinfo unexpectedly read launchd")
+
         let identity = try #require(AgentPIDProcessIdentity(pid: 1))
 
         #expect(identity.pid == 1)
@@ -862,8 +901,8 @@ struct ProcessTerminationGateTests {
     }
 }
 
-/// Replays one scripted result per invocation so a test can drive a retry
-/// sequence, repeating the last result once the script is exhausted.
+/// Replays exactly one scripted result per invocation so unexpected retries
+/// fail instead of silently reusing stale evidence.
 private actor ScriptedCommandRunner: CommandRunning {
     private let results: [CommandResult]
     private(set) var recordedArguments: [[String]] = []
@@ -879,7 +918,16 @@ private actor ScriptedCommandRunner: CommandRunning {
         timeout: TimeInterval?
     ) async -> CommandResult {
         recordedArguments.append(arguments)
-        let index = min(recordedArguments.count - 1, results.count - 1)
+        let index = recordedArguments.count - 1
+        guard results.indices.contains(index) else {
+            return CommandResult(
+                stdout: nil,
+                stderr: nil,
+                exitStatus: nil,
+                timedOut: false,
+                executionError: "unexpected scripted command invocation \(recordedArguments.count)"
+            )
+        }
         return results[index]
     }
 }
@@ -889,7 +937,7 @@ struct PortScannerPortRetirementTests {
     /// Drives the whole scanner — TTY registration, kick, coalesce, burst,
     /// reconcile, publish — so a break anywhere in that chain surfaces even
     /// when every individual stage still passes its own test.
-    @Test("A published port is retired once its process stops listening")
+    @Test("A published port retires despite unrelated lsof filesystem warnings")
     func publishedPortIsRetiredAfterProcessStopsListening() async throws {
         let workspaceId = UUID()
         let panelId = UUID()
@@ -987,6 +1035,14 @@ private actor PortLifecycleCommandRunner: CommandRunning {
     private let pid: Int
     private let port: Int
     private var isListening = true
+    private(set) var lastLsofArguments: [String]?
+
+    private static let filesystemWarning = """
+    lsof: WARNING: can't stat() smbfs file system /Volumes/.timemachine/example
+          Output information may be incomplete.
+          assuming "dev=deadbeef" from mount table
+
+    """
 
     init(ttyName: String, sessionLeaderPID: Int, pid: Int, port: Int) {
         self.ttyName = ttyName
@@ -1016,10 +1072,15 @@ private actor PortLifecycleCommandRunner: CommandRunning {
             }
             return Self.output("\(sessionLeaderPID) \(ttyName)\n\(pid) \(ttyName)\n")
         }
+        lastLsofArguments = arguments
+        // `lsof -w` suppresses filesystem warnings. They are unrelated to a
+        // PID-scoped TCP socket query, but any stderr currently makes the
+        // scanner globally incomplete and prevents stale ports from aging out.
+        let stderr = arguments.contains("-w") ? "" : Self.filesystemWarning
         guard isListening, Self.selection(for: "-p", in: arguments).contains(String(pid)) else {
-            return Self.noSelectedFiles()
+            return Self.noSelectedFiles(stderr: stderr)
         }
-        return Self.output("p\(pid)\nf3\nn127.0.0.1:\(port)\n")
+        return Self.output("p\(pid)\nf3\nn127.0.0.1:\(port)\n", stderr: stderr)
     }
 
     /// The comma-separated values the command was asked to select on.
@@ -1030,10 +1091,10 @@ private actor PortLifecycleCommandRunner: CommandRunning {
         return Set(arguments[valueIndex].split(separator: ",").map(String.init))
     }
 
-    private static func output(_ stdout: String) -> CommandResult {
+    private static func output(_ stdout: String, stderr: String = "") -> CommandResult {
         CommandResult(
             stdout: stdout,
-            stderr: "",
+            stderr: stderr,
             exitStatus: 0,
             timedOut: false,
             executionError: nil
@@ -1042,10 +1103,10 @@ private actor PortLifecycleCommandRunner: CommandRunning {
 
     /// Both `ps` and `lsof` exit 1 with no output when a valid selector matches
     /// nothing.
-    private static func noSelectedFiles() -> CommandResult {
+    private static func noSelectedFiles(stderr: String = "") -> CommandResult {
         CommandResult(
             stdout: "",
-            stderr: "",
+            stderr: stderr,
             exitStatus: 1,
             timedOut: false,
             executionError: nil

--- a/cmuxTests/PortScannerTests.swift
+++ b/cmuxTests/PortScannerTests.swift
@@ -1038,7 +1038,8 @@ struct PortScannerPortRetirementTests {
         // The fifth scan is at 7.5 seconds in the six-scan burst. Stopping here
         // leaves only the 10-second scan in the original burst, so clearing the
         // kick at that scan strands the port after only one complete miss.
-        await runner.waitForLsofInvocation(5)
+        let reachedFifthScan = await runner.waitForLsofInvocation(5)
+        try #require(reachedFifthScan, "the scanner did not reach the fifth burst scan")
         let publicationsBeforeStop = publishedPorts.withLock { $0.count }
         await runner.stopListening()
         scanner.kick(workspaceId: workspaceId, panelId: panelId)
@@ -1052,6 +1053,55 @@ struct PortScannerPortRetirementTests {
         )
 
         #expect(didRetirePort, "a late-burst kick did not schedule enough complete misses")
+    }
+
+    /// `/bin/ps` accepts a full device path in `-t`, but reports the matching
+    /// process's TTY without `/dev/`. The scanner must still attribute the
+    /// listener to the panel that registered the full path.
+    @Test("A live full-path TTY still attributes its listener")
+    func liveFullPathTTYAttributesListener() async throws {
+        let workspaceId = UUID()
+        let panelId = UUID()
+        let registeredTTYName = "/dev/ttys903"
+        let processTTYName = "ttys903"
+        let listenerPID = Int(getpid())
+        let listeningPort = 4323
+        let runner = PortLifecycleCommandRunner(
+            ttyName: registeredTTYName,
+            processTTYName: processTTYName,
+            sessionLeaderPID: 1,
+            pid: listenerPID,
+            port: listeningPort
+        )
+        let listenerIdentity = try #require(AgentPIDProcessIdentity(pid: pid_t(listenerPID)))
+        let sessionIdentity = TerminalTTYSessionIdentity(processIdentity: listenerIdentity)
+        let scanner = PortScanner(
+            commandRunner: runner,
+            ttySessionIdentityProvider: { _ in sessionIdentity }
+        )
+        let publishedPorts = OSAllocatedUnfairLock(initialState: [[Int]]())
+
+        await MainActor.run {
+            scanner.onPortsUpdated = { publishedWorkspaceId, publishedPanelId, ports in
+                guard publishedWorkspaceId == workspaceId, publishedPanelId == panelId else { return }
+                publishedPorts.withLock { $0.append(ports) }
+            }
+            scanner.registerTTY(
+                workspaceId: workspaceId,
+                panelId: panelId,
+                ttyName: registeredTTYName
+            )
+        }
+        scanner.kick(workspaceId: workspaceId, panelId: panelId)
+
+        let didPublishListeningPort = await Self.waitForPublication(
+            in: publishedPorts,
+            matching: { $0 == [listeningPort] },
+            onKick: { scanner.kick(workspaceId: workspaceId, panelId: panelId) },
+            timeout: .seconds(6)
+        )
+
+        #expect(didPublishListeningPort, "the full-path TTY never received its listener")
     }
 
     /// Polls rather than sleeping a fixed interval, since the scan burst runs
@@ -1090,13 +1140,13 @@ struct PortScannerPortRetirementTests {
 /// the process is still alive but owns no sockets.
 private actor PortLifecycleCommandRunner: CommandRunning {
     private let ttyName: String
+    private let processTTYName: String
     private let sessionLeaderPID: Int
     private let pid: Int
     private let port: Int
     private var isListening = true
     private(set) var lastLsofArguments: [String]?
     private var lsofInvocationCount = 0
-    private var lsofInvocationWaiters: [Int: [CheckedContinuation<Void, Never>]] = [:]
 
     private static let filesystemWarning = """
     lsof: WARNING: can't stat() smbfs file system /Volumes/.timemachine/example
@@ -1105,8 +1155,15 @@ private actor PortLifecycleCommandRunner: CommandRunning {
 
     """
 
-    init(ttyName: String, sessionLeaderPID: Int, pid: Int, port: Int) {
+    init(
+        ttyName: String,
+        processTTYName: String? = nil,
+        sessionLeaderPID: Int,
+        pid: Int,
+        port: Int
+    ) {
         self.ttyName = ttyName
+        self.processTTYName = processTTYName ?? ttyName
         self.sessionLeaderPID = sessionLeaderPID
         self.pid = pid
         self.port = port
@@ -1116,11 +1173,16 @@ private actor PortLifecycleCommandRunner: CommandRunning {
         isListening = false
     }
 
-    func waitForLsofInvocation(_ target: Int) async {
-        guard lsofInvocationCount < target else { return }
-        await withCheckedContinuation { continuation in
-            lsofInvocationWaiters[target, default: []].append(continuation)
+    func waitForLsofInvocation(_ target: Int, timeout: Duration = .seconds(15)) async -> Bool {
+        let deadline = ContinuousClock.now + timeout
+        while lsofInvocationCount < target, ContinuousClock.now < deadline {
+            do {
+                try await Task.sleep(for: .milliseconds(50))
+            } catch {
+                return false
+            }
         }
+        return lsofInvocationCount >= target
     }
 
     func run(
@@ -1135,16 +1197,13 @@ private actor PortLifecycleCommandRunner: CommandRunning {
             }
             // Honor the `-t` selector: a scan that asks about another terminal
             // must not be handed this panel's processes.
-            guard Self.selection(for: "-t", in: arguments).contains(ttyName) else {
+            let selectedTTYs = Self.selection(for: "-t", in: arguments)
+            guard selectedTTYs.contains(ttyName) || selectedTTYs.contains(processTTYName) else {
                 return Self.noSelectedFiles()
             }
-            return Self.output("\(sessionLeaderPID) \(ttyName)\n\(pid) \(ttyName)\n")
+            return Self.output("\(sessionLeaderPID) \(processTTYName)\n\(pid) \(processTTYName)\n")
         }
         lsofInvocationCount += 1
-        let satisfiedTargets = lsofInvocationWaiters.keys.filter { $0 <= lsofInvocationCount }
-        for target in satisfiedTargets {
-            lsofInvocationWaiters.removeValue(forKey: target)?.forEach { $0.resume() }
-        }
         lastLsofArguments = arguments
         // `lsof -w` suppresses filesystem warnings. They are unrelated to a
         // PID-scoped TCP socket query, but any stderr currently makes the

--- a/cmuxTests/PortScannerTests.swift
+++ b/cmuxTests/PortScannerTests.swift
@@ -995,6 +995,65 @@ struct PortScannerPortRetirementTests {
         #expect(didRetirePort, "the port was never retired after its process stopped listening")
     }
 
+    /// A kick can arrive near the end of a burst that began for an earlier
+    /// shell event. The kick still needs enough later scans to supply the three
+    /// complete misses required by `PortScanSnapshotReconciler`.
+    @Test("A single late-burst kick still retires a stopped listener")
+    func lateBurstKickRetiresStoppedListener() async throws {
+        let workspaceId = UUID()
+        let panelId = UUID()
+        let ttyName = "ttys902"
+        let listenerPID = Int(getpid())
+        let listeningPort = 4322
+        let runner = PortLifecycleCommandRunner(
+            ttyName: ttyName,
+            sessionLeaderPID: 1,
+            pid: listenerPID,
+            port: listeningPort
+        )
+        let listenerIdentity = try #require(AgentPIDProcessIdentity(pid: pid_t(listenerPID)))
+        let sessionIdentity = TerminalTTYSessionIdentity(processIdentity: listenerIdentity)
+        let scanner = PortScanner(
+            commandRunner: runner,
+            ttySessionIdentityProvider: { _ in sessionIdentity }
+        )
+        let publishedPorts = OSAllocatedUnfairLock(initialState: [[Int]]())
+
+        await MainActor.run {
+            scanner.onPortsUpdated = { publishedWorkspaceId, publishedPanelId, ports in
+                guard publishedWorkspaceId == workspaceId, publishedPanelId == panelId else { return }
+                publishedPorts.withLock { $0.append(ports) }
+            }
+            scanner.registerTTY(workspaceId: workspaceId, panelId: panelId, ttyName: ttyName)
+        }
+        scanner.kick(workspaceId: workspaceId, panelId: panelId)
+
+        let didPublishListeningPort = await Self.waitForPublication(
+            in: publishedPorts,
+            matching: { $0 == [listeningPort] },
+            onKick: {}
+        )
+        try #require(didPublishListeningPort, "the listening port was never published")
+
+        // The fifth scan is at 7.5 seconds in the six-scan burst. Stopping here
+        // leaves only the 10-second scan in the original burst, so clearing the
+        // kick at that scan strands the port after only one complete miss.
+        await runner.waitForLsofInvocation(5)
+        let publicationsBeforeStop = publishedPorts.withLock { $0.count }
+        await runner.stopListening()
+        scanner.kick(workspaceId: workspaceId, panelId: panelId)
+
+        let didRetirePort = await Self.waitForPublication(
+            in: publishedPorts,
+            after: publicationsBeforeStop,
+            matching: \.isEmpty,
+            onKick: {},
+            timeout: .seconds(12)
+        )
+
+        #expect(didRetirePort, "a late-burst kick did not schedule enough complete misses")
+    }
+
     /// Polls rather than sleeping a fixed interval, since the scan burst runs
     /// on real timers whose spacing shifts under load.
     ///
@@ -1036,6 +1095,8 @@ private actor PortLifecycleCommandRunner: CommandRunning {
     private let port: Int
     private var isListening = true
     private(set) var lastLsofArguments: [String]?
+    private var lsofInvocationCount = 0
+    private var lsofInvocationWaiters: [Int: [CheckedContinuation<Void, Never>]] = [:]
 
     private static let filesystemWarning = """
     lsof: WARNING: can't stat() smbfs file system /Volumes/.timemachine/example
@@ -1055,6 +1116,13 @@ private actor PortLifecycleCommandRunner: CommandRunning {
         isListening = false
     }
 
+    func waitForLsofInvocation(_ target: Int) async {
+        guard lsofInvocationCount < target else { return }
+        await withCheckedContinuation { continuation in
+            lsofInvocationWaiters[target, default: []].append(continuation)
+        }
+    }
+
     func run(
         directory: String,
         executable: String,
@@ -1071,6 +1139,11 @@ private actor PortLifecycleCommandRunner: CommandRunning {
                 return Self.noSelectedFiles()
             }
             return Self.output("\(sessionLeaderPID) \(ttyName)\n\(pid) \(ttyName)\n")
+        }
+        lsofInvocationCount += 1
+        let satisfiedTargets = lsofInvocationWaiters.keys.filter { $0 <= lsofInvocationCount }
+        for target in satisfiedTargets {
+            lsofInvocationWaiters.removeValue(forKey: target)?.forEach { $0.resume() }
         }
         lastLsofArguments = arguments
         // `lsof -w` suppresses filesystem warnings. They are unrelated to a

--- a/cmuxTests/PortScannerTests.swift
+++ b/cmuxTests/PortScannerTests.swift
@@ -365,6 +365,43 @@ struct PortScannerProcessCaptureTests {
         #expect(arguments == [["-t", "ttys001,ttys011", "-o", "pid=,tty="]])
     }
 
+    @Test("A vanished TTY alongside an unreadable one keeps the scan incomplete")
+    func mixedVanishedAndUnreadableDiagnosticsStayIncomplete() async {
+        let runner = ScriptedCommandRunner(results: [
+            CommandResult(
+                stdout: "",
+                stderr: """
+                ps: /dev/ttys011: No such file or directory
+                ps: /dev/ttys001: Permission denied
+
+                """,
+                exitStatus: 1,
+                timedOut: false,
+                executionError: nil
+            ),
+            CommandResult(
+                stdout: "",
+                stderr: "ps: /dev/ttys001: Permission denied\n",
+                exitStatus: 1,
+                timedOut: false,
+                executionError: nil
+            )
+        ])
+
+        let scan = await PortScanner(commandRunner: runner).runPS(ttyList: "ttys001,ttys011")
+        let arguments = await runner.recordedArguments
+
+        // The vanished terminal must not launder the unreadable one into
+        // completeness: only the unreadable terminal is re-queried, and its
+        // persisting diagnostic leaves the scan incomplete.
+        #expect(scan.values.isEmpty)
+        #expect(scan.completeness == .incomplete)
+        #expect(arguments == [
+            ["-t", "ttys001,ttys011", "-o", "pid=,tty="],
+            ["-t", "ttys001", "-o", "pid=,tty="]
+        ])
+    }
+
     @Test("The two-device diagnostic form still identifies the vanished TTY")
     func combinedDeviceDiagnosticIdentifiesVanishedTTY() async {
         // `ps` stats both /dev/tty<name> and /dev/<name> for a name that does

--- a/cmuxTests/PortScannerTests.swift
+++ b/cmuxTests/PortScannerTests.swift
@@ -108,6 +108,101 @@ struct PortScannerProcessCaptureTests {
         #expect(scan.completeness(for: [200]) == .complete)
     }
 
+    @Test("A process owned by another user still has a readable birth identity")
+    func otherUsersProcessHasReadableIdentity() throws {
+        // launchd is root-owned on every macOS system, so `proc_pidinfo`
+        // refuses it for an unprivileged caller — the same refusal that hides
+        // the root `login` process heading every terminal's process group.
+        let identity = try #require(AgentPIDProcessIdentity(pid: 1))
+
+        #expect(identity.pid == 1)
+        #expect(identity.startSeconds > 0)
+        #expect(AgentPIDProcessIdentity(pid: getpid())?.pid == getpid())
+        #expect(AgentPIDProcessIdentity(pid: 999_999) == nil)
+    }
+
+    @Test("A zombie on a panel's TTY does not withhold negative port evidence")
+    func zombieProcessIsAuthoritativeAbsence() async throws {
+        // Rejecting zombies as identities is only half the story: a zombie is
+        // still signalable, so presence read it as live and `runLsof` filed it
+        // as a PID whose ports might have gone unseen. That is the same
+        // incompleteness that froze every panel behind the root `login`, and a
+        // zombie can hold no socket at all.
+        var pid: pid_t = 0
+        var arguments: [UnsafeMutablePointer<CChar>?] = [strdup("/usr/bin/true"), nil]
+        defer { arguments.compactMap { $0 }.forEach { free($0) } }
+        try #require(posix_spawn(&pid, "/usr/bin/true", nil, nil, &arguments, environ) == 0)
+        defer {
+            var status: Int32 = 0
+            waitpid(pid, &status, 0)
+        }
+
+        let deadline = ContinuousClock.now + .seconds(5)
+        while ContinuousClock.now < deadline, Self.processStatus(pid: pid) != SZOMB {
+            usleep(10_000)
+        }
+        try #require(Self.processStatus(pid: pid) == SZOMB, "the child never became a zombie")
+
+        let panel = PortScanner.PanelKey(workspaceId: UUID(), panelId: UUID())
+        let runner = StubCommandRunner(result: CommandResult(
+            stdout: "",
+            stderr: "",
+            exitStatus: 1,
+            timedOut: false,
+            executionError: nil
+        ))
+        let lsofScan = await PortScanner(commandRunner: runner).runLsof(pidsCsv: String(pid))
+        let completeness = PortScanner.panelCompletenessByKey(
+            panelTTYs: [panel: "ttys001"],
+            pidToTTY: [Int(pid): "ttys001"],
+            psCompleteness: .complete,
+            lsofScan: lsofScan
+        )
+
+        #expect(PIDPresence.current(pid: pid) == .absent)
+        #expect(lsofScan.completeness(for: [Int(pid)]) == .complete)
+        #expect(completeness[panel] == .complete)
+    }
+
+    /// The raw `p_stat` the process table reports, or `nil` when the process is
+    /// gone entirely.
+    private static func processStatus(pid: pid_t) -> Int32? {
+        var mib: [Int32] = [CTL_KERN, KERN_PROC, KERN_PROC_PID, pid]
+        var info = kinfo_proc()
+        var size = MemoryLayout<kinfo_proc>.stride
+        guard sysctl(&mib, UInt32(mib.count), &info, &size, nil, 0) == 0,
+              size > 0,
+              info.kp_proc.p_pid == pid else {
+            return nil
+        }
+        return Int32(info.kp_proc.p_stat)
+    }
+
+    @Test("A panel hosting a root-owned process can still retire its ports")
+    func panelWithRootOwnedProcessStaysComplete() async {
+        let panel = PortScanner.PanelKey(workspaceId: UUID(), panelId: UUID())
+        let rootOwnedPID = 1
+        let runner = StubCommandRunner(result: CommandResult(
+            stdout: "",
+            stderr: "",
+            exitStatus: 1,
+            timedOut: false,
+            executionError: nil
+        ))
+        let lsofScan = await PortScanner(commandRunner: runner)
+            .runLsof(pidsCsv: String(rootOwnedPID))
+
+        let completeness = PortScanner.panelCompletenessByKey(
+            panelTTYs: [panel: "ttys001"],
+            pidToTTY: [rootOwnedPID: "ttys001"],
+            psCompleteness: .complete,
+            lsofScan: lsofScan
+        )
+
+        #expect(lsofScan.completeness(for: [rootOwnedPID]) == .complete)
+        #expect(completeness[panel] == .complete)
+    }
+
     @Test("Panel lsof completeness is scoped to PIDs on that panel's TTY")
     func panelLsofCompletenessIsTTYScoped() {
         let workspaceID = UUID()
@@ -149,6 +244,160 @@ struct PortScannerProcessCaptureTests {
 
         #expect(complete[panel] == .complete)
         #expect(incomplete[panel] == .incomplete)
+    }
+
+    @Test("A vanished TTY device does not discard the surviving panels' processes")
+    func missingTTYDeviceDoesNotDiscardSurvivingPanels() async {
+        let runner = ScriptedCommandRunner(results: [
+            CommandResult(
+                stdout: "",
+                stderr: "ps: /dev/ttys011: No such file or directory\n",
+                exitStatus: 1,
+                timedOut: false,
+                executionError: nil
+            ),
+            CommandResult(
+                stdout: "123 ttys001\n",
+                stderr: "",
+                exitStatus: 0,
+                timedOut: false,
+                executionError: nil
+            )
+        ])
+
+        let scan = await PortScanner(commandRunner: runner).runPS(ttyList: "ttys001,ttys011")
+        let arguments = await runner.recordedArguments
+
+        #expect(scan.values == [123: "ttys001"])
+        #expect(scan.completeness == .complete)
+        #expect(arguments == [
+            ["-t", "ttys001,ttys011", "-o", "pid=,tty="],
+            ["-t", "ttys001", "-o", "pid=,tty="]
+        ])
+    }
+
+    @Test("Every TTY device vanishing is authoritative emptiness, not a failed scan")
+    func allTTYDevicesMissingIsCompleteAndEmpty() async {
+        let runner = ScriptedCommandRunner(results: [
+            CommandResult(
+                stdout: "",
+                stderr: """
+                ps: /dev/ttys011: No such file or directory
+                ps: /dev/ttys091: No such file or directory
+
+                """,
+                exitStatus: 1,
+                timedOut: false,
+                executionError: nil
+            )
+        ])
+
+        let scan = await PortScanner(commandRunner: runner).runPS(ttyList: "ttys011,ttys091")
+        let arguments = await runner.recordedArguments
+
+        #expect(scan.values.isEmpty)
+        #expect(scan.completeness == .complete)
+        #expect(arguments == [["-t", "ttys011,ttys091", "-o", "pid=,tty="]])
+    }
+
+    @Test("The two-device diagnostic form still identifies the vanished TTY")
+    func combinedDeviceDiagnosticIdentifiesVanishedTTY() async {
+        // `ps` stats both /dev/tty<name> and /dev/<name> for a name that does
+        // not already begin with "tty", and names both in one diagnostic.
+        let runner = ScriptedCommandRunner(results: [
+            CommandResult(
+                stdout: "",
+                stderr: "ps: /dev/ttyremote7 and /dev/remote7: No such file or directory\n",
+                exitStatus: 1,
+                timedOut: false,
+                executionError: nil
+            ),
+            CommandResult(
+                stdout: "123 ttys001\n",
+                stderr: "",
+                exitStatus: 0,
+                timedOut: false,
+                executionError: nil
+            )
+        ])
+
+        let scan = await PortScanner(commandRunner: runner).runPS(ttyList: "ttys001,remote7")
+        let arguments = await runner.recordedArguments
+
+        #expect(scan.values == [123: "ttys001"])
+        #expect(scan.completeness == .complete)
+        #expect(arguments == [
+            ["-t", "ttys001,remote7", "-o", "pid=,tty="],
+            ["-t", "ttys001", "-o", "pid=,tty="]
+        ])
+    }
+
+    @Test("A TTY registered by full device path is still recognized as vanished")
+    func fullDevicePathTTYIsRecognizedAsVanished() async {
+        // `registerTTY` stores whatever the shell reported, and `$(tty)` yields
+        // the full device path.
+        let runner = ScriptedCommandRunner(results: [
+            CommandResult(
+                stdout: "",
+                stderr: "ps: /dev/ttys011: No such file or directory\n",
+                exitStatus: 1,
+                timedOut: false,
+                executionError: nil
+            ),
+            CommandResult(
+                stdout: "123 ttys001\n",
+                stderr: "",
+                exitStatus: 0,
+                timedOut: false,
+                executionError: nil
+            )
+        ])
+
+        let scan = await PortScanner(commandRunner: runner).runPS(ttyList: "ttys001,/dev/ttys011")
+        let arguments = await runner.recordedArguments
+
+        #expect(scan.values == [123: "ttys001"])
+        #expect(scan.completeness == .complete)
+        #expect(arguments == [
+            ["-t", "ttys001,/dev/ttys011", "-o", "pid=,tty="],
+            ["-t", "ttys001", "-o", "pid=,tty="]
+        ])
+    }
+
+    @Test("The last TTY vanishing on the final attempt is still authoritative emptiness")
+    func lastTTYVanishingOnFinalAttemptIsComplete() async {
+        let runner = ScriptedCommandRunner(results: [
+            CommandResult(
+                stdout: "",
+                stderr: "ps: /dev/ttys011: No such file or directory\n",
+                exitStatus: 1,
+                timedOut: false,
+                executionError: nil
+            ),
+            CommandResult(
+                stdout: "",
+                stderr: "ps: /dev/ttys012: No such file or directory\n",
+                exitStatus: 1,
+                timedOut: false,
+                executionError: nil
+            ),
+            CommandResult(
+                stdout: "",
+                stderr: "ps: /dev/ttys013: No such file or directory\n",
+                exitStatus: 1,
+                timedOut: false,
+                executionError: nil
+            )
+        ])
+
+        let scan = await PortScanner(commandRunner: runner)
+            .runPS(ttyList: "ttys011,ttys012,ttys013")
+
+        // Whether the last pty closes on the first or the final attempt, no
+        // process can be attached to a freed device, so the empty result is
+        // evidence rather than a failed scan.
+        #expect(scan.values.isEmpty)
+        #expect(scan.completeness == .complete)
     }
 
     @Test("Process scan timeout is bounded and incomplete")
@@ -469,6 +718,197 @@ struct ProcessTerminationGateTests {
         gate.markFinished()
         let shouldTerminateAfterFinish = gate.markLaunched()
         #expect(shouldTerminateAfterFinish == false)
+    }
+}
+
+/// Replays one scripted result per invocation so a test can drive a retry
+/// sequence, repeating the last result once the script is exhausted.
+private actor ScriptedCommandRunner: CommandRunning {
+    private let results: [CommandResult]
+    private(set) var recordedArguments: [[String]] = []
+
+    init(results: [CommandResult]) {
+        self.results = results
+    }
+
+    func run(
+        directory: String,
+        executable: String,
+        arguments: [String],
+        timeout: TimeInterval?
+    ) async -> CommandResult {
+        recordedArguments.append(arguments)
+        let index = min(recordedArguments.count - 1, results.count - 1)
+        return results[index]
+    }
+}
+
+@Suite("Port scanner retirement end to end")
+struct PortScannerPortRetirementTests {
+    /// Drives the whole scanner — TTY registration, kick, coalesce, burst,
+    /// reconcile, publish — so a break anywhere in that chain surfaces even
+    /// when every individual stage still passes its own test.
+    @Test("A published port is retired once its process stops listening")
+    func publishedPortIsRetiredAfterProcessStopsListening() async throws {
+        let workspaceId = UUID()
+        let panelId = UUID()
+        let ttyName = "ttys901"
+        // A real terminal's process group is the root-owned session leader plus
+        // the user's own processes, so the panel is scanned with launchd
+        // standing in for `login` and the test process standing in for the
+        // server. Identity and presence stay on the real providers: substituting
+        // them is what makes an end-to-end port test pass over a broken scanner.
+        let sessionLeaderPID = 1
+        let listenerPID = Int(getpid())
+        let listeningPort = 4321
+        let runner = PortLifecycleCommandRunner(
+            ttyName: ttyName,
+            sessionLeaderPID: sessionLeaderPID,
+            pid: listenerPID,
+            port: listeningPort
+        )
+        let listenerIdentity = try #require(AgentPIDProcessIdentity(pid: pid_t(listenerPID)))
+        let sessionIdentity = TerminalTTYSessionIdentity(processIdentity: listenerIdentity)
+        let scanner = PortScanner(
+            commandRunner: runner,
+            ttySessionIdentityProvider: { _ in sessionIdentity }
+        )
+        let publishedPorts = OSAllocatedUnfairLock(initialState: [[Int]]())
+
+        await MainActor.run {
+            scanner.onPortsUpdated = { publishedWorkspaceId, publishedPanelId, ports in
+                guard publishedWorkspaceId == workspaceId, publishedPanelId == panelId else { return }
+                publishedPorts.withLock { $0.append(ports) }
+            }
+            scanner.registerTTY(workspaceId: workspaceId, panelId: panelId, ttyName: ttyName)
+        }
+        scanner.kick(workspaceId: workspaceId, panelId: panelId)
+
+        let didPublishListeningPort = await Self.waitForPublication(
+            in: publishedPorts,
+            matching: { $0 == [listeningPort] },
+            onKick: { scanner.kick(workspaceId: workspaceId, panelId: panelId) }
+        )
+        try #require(didPublishListeningPort, "the listening port was never published")
+
+        // Only publications recorded after the port stops being held count as
+        // retirement; an earlier empty publication is registration noise.
+        let publicationsBeforeStop = publishedPorts.withLock { $0.count }
+        await runner.stopListening()
+
+        let didRetirePort = await Self.waitForPublication(
+            in: publishedPorts,
+            after: publicationsBeforeStop,
+            matching: \.isEmpty,
+            onKick: { scanner.kick(workspaceId: workspaceId, panelId: panelId) }
+        )
+
+        #expect(didRetirePort, "the port was never retired after its process stopped listening")
+    }
+
+    /// Polls rather than sleeping a fixed interval, since the scan burst runs
+    /// on real timers whose spacing shifts under load.
+    ///
+    /// The interval must stay above the scanner's 200ms kick coalesce window:
+    /// each kick reschedules that timer, so polling faster than it starves the
+    /// burst and no scan ever runs.
+    private static func waitForPublication(
+        in publishedPorts: OSAllocatedUnfairLock<[[Int]]>,
+        after startIndex: Int = 0,
+        matching predicate: @Sendable ([Int]) -> Bool,
+        onKick: @Sendable () -> Void,
+        timeout: Duration = .seconds(20)
+    ) async -> Bool {
+        func isSatisfied() -> Bool {
+            publishedPorts.withLock { $0.dropFirst(startIndex).contains(where: predicate) }
+        }
+        let deadline = ContinuousClock.now + timeout
+        while ContinuousClock.now < deadline {
+            if isSatisfied() { return true }
+            onKick()
+            // Cancellation makes the sleep throw immediately; without this the
+            // poll would spin until the wall-clock deadline.
+            do {
+                try await Task.sleep(for: .milliseconds(500))
+            } catch {
+                break
+            }
+        }
+        return isSatisfied()
+    }
+}
+
+/// Reports one listening port on one TTY until `stopListening()`, after which
+/// the process is still alive but owns no sockets.
+private actor PortLifecycleCommandRunner: CommandRunning {
+    private let ttyName: String
+    private let sessionLeaderPID: Int
+    private let pid: Int
+    private let port: Int
+    private var isListening = true
+
+    init(ttyName: String, sessionLeaderPID: Int, pid: Int, port: Int) {
+        self.ttyName = ttyName
+        self.sessionLeaderPID = sessionLeaderPID
+        self.pid = pid
+        self.port = port
+    }
+
+    func stopListening() {
+        isListening = false
+    }
+
+    func run(
+        directory: String,
+        executable: String,
+        arguments: [String],
+        timeout: TimeInterval?
+    ) async -> CommandResult {
+        if executable.hasSuffix("ps") {
+            if arguments.first == "-ax" {
+                return Self.output("\(pid) 1\n")
+            }
+            // Honor the `-t` selector: a scan that asks about another terminal
+            // must not be handed this panel's processes.
+            guard Self.selection(for: "-t", in: arguments).contains(ttyName) else {
+                return Self.noSelectedFiles()
+            }
+            return Self.output("\(sessionLeaderPID) \(ttyName)\n\(pid) \(ttyName)\n")
+        }
+        guard isListening, Self.selection(for: "-p", in: arguments).contains(String(pid)) else {
+            return Self.noSelectedFiles()
+        }
+        return Self.output("p\(pid)\nf3\nn127.0.0.1:\(port)\n")
+    }
+
+    /// The comma-separated values the command was asked to select on.
+    private static func selection(for flag: String, in arguments: [String]) -> Set<String> {
+        guard let flagIndex = arguments.firstIndex(of: flag) else { return [] }
+        let valueIndex = arguments.index(after: flagIndex)
+        guard valueIndex < arguments.endIndex else { return [] }
+        return Set(arguments[valueIndex].split(separator: ",").map(String.init))
+    }
+
+    private static func output(_ stdout: String) -> CommandResult {
+        CommandResult(
+            stdout: stdout,
+            stderr: "",
+            exitStatus: 0,
+            timedOut: false,
+            executionError: nil
+        )
+    }
+
+    /// Both `ps` and `lsof` exit 1 with no output when a valid selector matches
+    /// nothing.
+    private static func noSelectedFiles() -> CommandResult {
+        CommandResult(
+            stdout: "",
+            stderr: "",
+            exitStatus: 1,
+            timedOut: false,
+            executionError: nil
+        )
     }
 }
 

--- a/cmuxTests/PortScannerTests.swift
+++ b/cmuxTests/PortScannerTests.swift
@@ -121,6 +121,29 @@ struct PortScannerProcessCaptureTests {
         #expect(AgentPIDProcessIdentity(pid: 999_999) == nil)
     }
 
+    @Test("An exited but unreaped process has no readable identity")
+    func zombieProcessHasNoReadableIdentity() throws {
+        // `sysctl` still describes a zombie, and reports its original birth
+        // timestamp, so a caller comparing identities would decide the dead
+        // process is the one it recorded and treat the agent as running.
+        var pid: pid_t = 0
+        var arguments: [UnsafeMutablePointer<CChar>?] = [strdup("/usr/bin/true"), nil]
+        defer { arguments.compactMap { $0 }.forEach { free($0) } }
+        try #require(posix_spawn(&pid, "/usr/bin/true", nil, nil, &arguments, environ) == 0)
+        defer {
+            var status: Int32 = 0
+            waitpid(pid, &status, 0)
+        }
+
+        let deadline = ContinuousClock.now + .seconds(5)
+        while ContinuousClock.now < deadline, Self.processStatus(pid: pid) != SZOMB {
+            usleep(10_000)
+        }
+
+        try #require(Self.processStatus(pid: pid) == SZOMB, "the child never became a zombie")
+        #expect(AgentPIDProcessIdentity(pid: pid) == nil)
+    }
+
     @Test("A zombie on a panel's TTY does not withhold negative port evidence")
     func zombieProcessIsAuthoritativeAbsence() async throws {
         // Rejecting zombies as identities is only half the story: a zombie is
@@ -300,6 +323,48 @@ struct PortScannerProcessCaptureTests {
         #expect(arguments == [["-t", "ttys011,ttys091", "-o", "pid=,tty="]])
     }
 
+    @Test("A diagnostic that names no requested TTY stays incomplete without retrying")
+    func unrecognizedPSDiagnosticsStayIncomplete() async {
+        let runner = ScriptedCommandRunner(results: [
+            CommandResult(
+                stdout: "123 ttys001\n",
+                stderr: "ps: unable to obtain kernel process table\n",
+                exitStatus: 1,
+                timedOut: false,
+                executionError: nil
+            )
+        ])
+
+        let scan = await PortScanner(commandRunner: runner).runPS(ttyList: "ttys001,ttys011")
+        let arguments = await runner.recordedArguments
+
+        #expect(scan.values == [123: "ttys001"])
+        #expect(scan.completeness == .incomplete)
+        #expect(arguments == [["-t", "ttys001,ttys011", "-o", "pid=,tty="]])
+    }
+
+    @Test("A diagnostic that names a requested TTY with another errno stays incomplete")
+    func nonMissingDeviceDiagnosticStaysIncomplete() async {
+        let runner = ScriptedCommandRunner(results: [
+            CommandResult(
+                stdout: "123 ttys001\n",
+                stderr: "ps: /dev/ttys011: Permission denied\n",
+                exitStatus: 1,
+                timedOut: false,
+                executionError: nil
+            )
+        ])
+
+        let scan = await PortScanner(commandRunner: runner).runPS(ttyList: "ttys001,ttys011")
+        let arguments = await runner.recordedArguments
+
+        // A device that exists but cannot be read is missing evidence, not
+        // absence: dropping it would retire live ports.
+        #expect(scan.values == [123: "ttys001"])
+        #expect(scan.completeness == .incomplete)
+        #expect(arguments == [["-t", "ttys001,ttys011", "-o", "pid=,tty="]])
+    }
+
     @Test("The two-device diagnostic form still identifies the vanished TTY")
     func combinedDeviceDiagnosticIdentifiesVanishedTTY() async {
         // `ps` stats both /dev/tty<name> and /dev/<name> for a name that does
@@ -398,6 +463,45 @@ struct PortScannerProcessCaptureTests {
         // evidence rather than a failed scan.
         #expect(scan.values.isEmpty)
         #expect(scan.completeness == .complete)
+    }
+
+    @Test("A TTY that stays unscannable after the retry budget stays incomplete")
+    func repeatedlyVanishingTTYsExhaustTheRetryBudget() async {
+        let runner = ScriptedCommandRunner(results: [
+            CommandResult(
+                stdout: "",
+                stderr: "ps: /dev/ttys011: No such file or directory\n",
+                exitStatus: 1,
+                timedOut: false,
+                executionError: nil
+            ),
+            CommandResult(
+                stdout: "",
+                stderr: "ps: /dev/ttys012: No such file or directory\n",
+                exitStatus: 1,
+                timedOut: false,
+                executionError: nil
+            ),
+            CommandResult(
+                stdout: "",
+                stderr: "ps: /dev/ttys013: No such file or directory\n",
+                exitStatus: 1,
+                timedOut: false,
+                executionError: nil
+            )
+        ])
+
+        let scan = await PortScanner(commandRunner: runner)
+            .runPS(ttyList: "ttys001,ttys011,ttys012,ttys013")
+        let arguments = await runner.recordedArguments
+
+        #expect(scan.values.isEmpty)
+        #expect(scan.completeness == .incomplete)
+        #expect(arguments == [
+            ["-t", "ttys001,ttys011,ttys012,ttys013", "-o", "pid=,tty="],
+            ["-t", "ttys001,ttys012,ttys013", "-o", "pid=,tty="],
+            ["-t", "ttys001,ttys013", "-o", "pid=,tty="]
+        ])
     }
 
     @Test("Process scan timeout is bounded and incomplete")


### PR DESCRIPTION
Fixes #9152: sidebar port badges accumulated dead ports for the lifetime of the app — a port, once discovered, could never retire.

## Root causes

Three independent mechanisms each left a panel's scan permanently incomplete, and `PortScanSnapshotReconciler` treats incomplete scans as non-evidence that only ever unions ports:

1. **One vanished pty poisoned the whole batch.** BSD `ps` aborts an entire batched `-t` query when any listed terminal device is gone, so a single closed panel made every panel's scan look incomplete.
2. **Privileged process-group leaders were unidentifiable.** `proc_pidinfo` refuses any process whose effective UID differs from ours, so the root-owned `/usr/bin/login` heading every terminal filed under `incompletePIDs` and scored its panel incomplete on every scan.
3. **Zombies read as present but unidentifiable.** An unreaped child answers `kill(pid, 0)` like a running process while holding no readable identity — the same incompleteness, reachable through any unreaped child.

## Fixes

- `runPS` drops terminals `ps` reports as ENOENT and retries with the rest (bounded). All terminals gone reports authoritative emptiness — a freed pty can hold no process — so closed panels' stale badges clear too. Any other diagnostic still yields incomplete, retaining ports rather than dropping them on weak evidence.
- Birth identities read through `sysctl(KERN_PROC_PID)` instead of `proc_pidinfo`: same birth timestamp regardless of owner, still nothing for an exited PID, `SZOMB` rejected explicitly so session restore does not treat a dead agent as alive.
- `PIDPresence` routes through the same process-table read that supplies identities, so liveness and identity cannot drift apart; a zombie reads as absent to every caller weighing whether it might still own a socket.

## Commit structure

Two commits per the regression-test policy: commit 1 adds nine failing tests (CI red) that reproduce all three mechanisms against `main` plus an end-to-end test driving the real scanner (registerTTY → kick → coalesce → burst → reconcile → publish); commit 2 adds the fix (CI green) with four additional tests pinning behavior the fix introduces (zombie identity rejection, diagnostic forms that must not trigger the retry, retry-budget exhaustion).

## Verification

- Red/green verified locally at each commit on the current `main` base (9 expected failures at commit 1, 27/27 pass at commit 2).
- Dogfooded in a tagged Debug build: port published, then a workspace opened/closed to leave a freshly-vanished pty in the scan batch, listener killed — badge retired; rediscovery of a new listener still works.
- Change-adjacent suites (`AgentSessionAutoResumeSwiftTests`, `SessionPersistenceResumeBindingTests`, `ClaudeHookPIDAuthenticationTests`) fail identically on this branch and `main` in the local environment (pre-existing/environmental only).
- Localization audit: N/A — no user-facing strings changed (scanner internals and tests only).

## Notes

- #3801 (libproc rewrite of the scanner) would eventually subsume the `ps -t` retry; this PR fixes the shipped behavior without waiting on that rewrite.
- Complementary, not addressed here: #9153 (excluding ephemeral ports from badges).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016pmrs1n9Z2UKquWcbXhmBe

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/9324"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788134931&installation_model_id=21920&pr_number=9324&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F9324&signature=87f0990317862bac8571f327353cc7fdf64e171adaa9ed22b327ff6c1c8f9171"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Retires stale sidebar port badges so ports clear when listeners stop and when a terminal panel hibernates. Fixes #9152.

- **Bug Fixes**
  - Process scan: drops vanished TTYs (ENOENT) with bounded retries; treats “all gone” as complete/empty; canonicalizes TTY names (full-path and short forms).
  - Identity/presence: reads via `sysctl(KERN_PROC_PID)`; rejects zombies; `PIDPresence` and `Workspace.agentPIDProcessIdentity` share the same reader.
  - `lsof`: adds `-w` to suppress unrelated filesystem warnings.
  - Scheduling: guarantees at least three complete-miss scans per kick; late kicks trigger a follow-up burst.
  - Hibernation: clears panel ports, recomputes, and unregisters the panel from the scanner on hibernate; discards persisted ports on restore.
  - Tests: adds unit and end-to-end coverage for vanished/unreadable TTYs, persistent `lsof` warnings, late-burst kicks, zombies, full-path TTY attribution, and hibernation/restore port retirement.

<sup>Written for commit e7c4253c71bf09f9c2cbed7046871e37f4a89f41. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/9324?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved process detection across different permission levels, including system-owned processes.
  - Correctly treats exited zombie processes as no longer present.
  - Made terminal and port scanning more reliable when devices disappear during a scan.
  - Prevented stale port information from persisting after processes exit or panels hibernate.
  - Improved handling of incomplete, malformed, or warning-producing scan results.
  - Improved port refresh behavior during rapid updates and terminal changes.

- **Tests**
  - Added coverage for process visibility, zombie handling, terminal changes, retries, hibernation, restoration, and port removal.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->