### PR TITLE
Fix iOS reload Simulator architecture

### DIFF
--- a/.github/workflows/reload-build.yml
+++ b/.github/workflows/reload-build.yml
@@ -188,6 +188,7 @@ jobs:
             -configuration Debug \
             -destination 'generic/platform=iOS Simulator' \
             -derivedDataPath "$RUNNER_TEMP/cmux-ios-dd" \
+            ARCHS=arm64 \
             PRODUCT_BUNDLE_IDENTIFIER="$bundle_id" \
             PRODUCT_DISPLAY_NAME="$display_name" \
             CMUX_GIT_SHA="$(git rev-parse --short HEAD)" \


### PR DESCRIPTION
The iOS reload workflow archived the phone app successfully, then failed while linking an x86_64 Simulator binary because GhosttyKit only ships an arm64 Simulator slice.

Constrain the packaged Simulator build to arm64. The hosted runner and supported verification Simulators are Apple Silicon.

Verification:
- `node --test scripts/lib/mobile-attach.test.mjs` (37 passed)
- exact hosted phone archive plus Simulator artifact: https://github.com/manaflow-ai/cmux/actions/runs/30675611310 (passed)