### PR TITLE
Fix missing return in restoreCLIArgument (main compile break)

### DIFF
--- a/Sources/SurfaceResumeCommandCanonicalizer+PortableAgentExecutable.swift
+++ b/Sources/SurfaceResumeCommandCanonicalizer+PortableAgentExecutable.swift
@@ -75,7 +75,7 @@ extension SurfaceResumeBindingSnapshot {
               !value.isEmpty else {
             return nil
         }
-        AgentRestoreCLIArgument(rawValue: value)?.rawValue
+        return AgentRestoreCLIArgument(rawValue: value)?.rawValue
     }
 
     private func resolvedStartupCommand(repairPortableAgentExecutable: Bool) -> String {


### PR DESCRIPTION
https://github.com/manaflow-ai/cmux/pull/9265 (5bf9595804) added `restoreCLIArgument`, a multi-statement method returning `String?` whose final expression has no explicit `return`. Swift only allows implicit return in single-expression bodies, so every target compiling `SurfaceResumeCommandCanonicalizer+PortableAgentExecutable.swift` fails; with ci.yml dispatch-only, the break landed silently and now fails every merge-gate run (first seen in https://github.com/manaflow-ai/cmux/actions/runs/30680626823, blocking https://github.com/manaflow-ai/cmux/pull/9329).

One line: add the `return`. Behavior is what #9265 intended; no test needed beyond compilation, which every gate run exercises.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/9334"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788145497&installation_model_id=21920&pr_number=9334&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F9334&signature=42fe35e18f00865ba12fd0ce3845637200ea682f5b40b9c920d011afa425096b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix Swift compile break by adding a missing explicit return in restoreCLIArgument. Builds now succeed for all targets and CI is unblocked; behavior is unchanged.

<sup>Written for commit 8994dd9edc2fe089d8226221c243acd43748d7ad. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/9334?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Restored command-line arguments now preserve and return their canonical raw values, improving consistency when resuming agent operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->