### PR TITLE
Keep company information page low key

### DIFF
--- a/web/app/[locale]/(legal)/company-information/page.tsx
+++ b/web/app/[locale]/(legal)/company-information/page.tsx
@@ -9,11 +9,17 @@ const locality = "Rowland Heights";
 const region = "CA";
 const postalCode = "91748-5142";
 
-export const metadata: Metadata = legalMetadata(
-  "/company-information",
-  "Company information — cmux",
-  "Legal entity, address, contact, and domain information for cmux and Manaflow",
-);
+export const metadata: Metadata = {
+  ...legalMetadata(
+    "/company-information",
+    "Company information — cmux",
+    "Legal entity, address, contact, and domain information for cmux and Manaflow",
+  ),
+  robots: {
+    index: false,
+    follow: false,
+  },
+};
 
 const organizationJsonLd = {
   "@context": "https://schema.org",

--- a/web/app/[locale]/components/site-footer.tsx
+++ b/web/app/[locale]/components/site-footer.tsx
@@ -56,11 +56,6 @@ export async function SiteFooter() {
     {
       heading: t("legal"),
       links: [
-        {
-          label: t("companyInformation"),
-          href: "/company-information",
-          unlocalized: true,
-        },
         { label: t("privacy"), href: "/privacy-policy" },
         { label: t("terms"), href: "/terms-of-service", unlocalized: true },
         { label: t("eula"), href: "/eula", unlocalized: true },

--- a/web/app/lib/agent-page-paths.ts
+++ b/web/app/lib/agent-page-paths.ts
@@ -82,7 +82,6 @@ const blockedPrefixes = [
   "/handler",
 ];
 const englishOnlyPages = [
-  "/company-information",
   "/privacy-policy",
   "/terms-of-service",
   "/eula",
@@ -233,7 +232,6 @@ export const agentReadablePages = [
   { path: "/agents/aider", title: "Terminal for Aider" },
   { path: "/agents/amp", title: "Terminal for Amp" },
   { path: "/agents/cursor-cli", title: "Terminal for Cursor CLI" },
-  { path: "/company-information", title: "Company Information" },
   { path: "/privacy-policy", title: "Privacy Policy" },
   { path: "/terms-of-service", title: "Terms of Service" },
   { path: "/eula", title: "EULA" },

--- a/web/app/sitemap.ts
+++ b/web/app/sitemap.ts
@@ -101,7 +101,6 @@ export default function sitemap(): MetadataRoute.Sitemap {
     { path: "/agents/aider", lastModified: "2026-06-23", changeFrequency: "monthly" as const, priority: 0.6 },
     { path: "/agents/amp", lastModified: "2026-06-23", changeFrequency: "monthly" as const, priority: 0.6 },
     { path: "/agents/cursor-cli", lastModified: "2026-06-23", changeFrequency: "monthly" as const, priority: 0.6 },
-    { path: "/company-information", lastModified: "2026-07-30", changeFrequency: "yearly" as const, priority: 0.3 },
     { path: "/privacy-policy", lastModified: "2026-07-10", changeFrequency: "yearly" as const, priority: 0.3 },
     { path: "/terms-of-service", lastModified: "2026-03-18", changeFrequency: "yearly" as const, priority: 0.3 },
     { path: "/eula", lastModified: "2026-03-18", changeFrequency: "yearly" as const, priority: 0.3 },
@@ -110,7 +109,6 @@ export default function sitemap(): MetadataRoute.Sitemap {
   // Legal pages are English-only, so they only get one entry.
   // The SEO landing pages are localized, so they go through the per-locale loop.
   const englishOnly = new Set([
-    "/company-information",
     "/terms-of-service",
     "/eula",
   ]);

--- a/web/tests/company-information.test.tsx
+++ b/web/tests/company-information.test.tsx
@@ -1,7 +1,10 @@
 import { expect, test } from "bun:test";
 import { renderToStaticMarkup } from "react-dom/server";
 import sitemap from "../app/sitemap";
-import CompanyInformationPage from "../app/[locale]/(legal)/company-information/page";
+import CompanyInformationPage, {
+  metadata,
+} from "../app/[locale]/(legal)/company-information/page";
+import { agentReadablePages } from "../app/lib/agent-page-paths";
 
 test("publishes the legal entity, contact, address, and both domains", () => {
   const html = renderToStaticMarkup(<CompanyInformationPage />);
@@ -16,10 +19,14 @@ test("publishes the legal entity, contact, address, and both domains", () => {
   expect(html).toContain("application/ld+json");
 });
 
-test("lists only the canonical English company-information page", () => {
+test("keeps the direct page out of discovery indexes", () => {
   const urls = sitemap()
     .map((entry) => entry.url)
     .filter((url) => url.endsWith("/company-information"));
 
-  expect(urls).toEqual(["https://cmux.com/company-information"]);
+  expect(urls).toEqual([]);
+  expect(
+    agentReadablePages.some((page) => page.path === "/company-information"),
+  ).toBe(false);
+  expect(metadata.robots).toEqual({ index: false, follow: false });
 });


### PR DESCRIPTION
Keeps the direct company-information URL live for Artifact Signing validation while removing footer and discovery links, removing the sitemap entry, and setting noindex metadata.\n\nVerification:\n- bun test tests/company-information.test.tsx\n- bun run typecheck\n- ESLint on changed files

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/9335"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788145849&installation_model_id=21920&pr_number=9335&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F9335&signature=f2281f7d464f948eb98ca62cdf17dc4cf449e6be98532d833e5073251d6d8582"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keep the company information page live for Artifact Signing validation while hiding it from SEO and navigation. Added noindex/nofollow robots metadata and removed references from the footer, sitemap, and agent-readable lists.

<sup>Written for commit f494a8073b0110f2788d8cc45dcb7e629aa53721. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/9335?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Removed the Company Information link from the site footer.
  * Excluded the Company Information page from the sitemap and agent-readable page listings.
  * Prevented search engines from indexing or following links on the page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->