### PR TITLE
Fix main compile break: missing return in restoreCLIArgument

### DIFF
--- a/Sources/SurfaceResumeCommandCanonicalizer+PortableAgentExecutable.swift
+++ b/Sources/SurfaceResumeCommandCanonicalizer+PortableAgentExecutable.swift
@@ -75,7 +75,7 @@ extension SurfaceResumeBindingSnapshot {
               !value.isEmpty else {
             return nil
         }
-        AgentRestoreCLIArgument(rawValue: value)?.rawValue
+        return AgentRestoreCLIArgument(rawValue: value)?.rawValue
     }
 
     private func resolvedStartupCommand(repairPortableAgentExecutable: Bool) -> String {


### PR DESCRIPTION
https://github.com/manaflow-ai/cmux/pull/9265 landed `restoreCLIArgument` with a guard plus a bare final expression. Swift's implicit return only applies to single-expression bodies, so every app-target build on main fails with `missing return in static method expected to return 'String?'` (the only unique compile error in a full build of `515a3119f5`). One-line fix: explicit `return`. CI is paused (workflow_dispatch only), which is how the break reached main - this also blocks every tagged dev build until merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/9338"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788149186&installation_model_id=21920&pr_number=9338&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F9338&signature=34dc19ff6f1fc959f5618508e6fdd3fae34bde5c72e243eea2b8f835ed92c8b0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the main compile break by adding an explicit return in `restoreCLIArgument`. This resolves the “missing return in static method expected to return 'String?'” error and unblocks all app-target builds.

<sup>Written for commit 62bb542aca7a3904f51f1075e7afa36d0e0b0f58. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/9338?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Restored command-line arguments now preserve and return their canonical raw values, improving consistency when processing portable agent commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->