### PR TITLE
Fix missing return in restoreCLIArgument breaking nightly Release build

### DIFF
--- a/Sources/SurfaceResumeCommandCanonicalizer+PortableAgentExecutable.swift
+++ b/Sources/SurfaceResumeCommandCanonicalizer+PortableAgentExecutable.swift
@@ -75,7 +75,7 @@ extension SurfaceResumeBindingSnapshot {
               !value.isEmpty else {
             return nil
         }
-        AgentRestoreCLIArgument(rawValue: value)?.rawValue
+        return AgentRestoreCLIArgument(rawValue: value)?.rawValue
     }
 
     private func resolvedStartupCommand(repairPortableAgentExecutable: Bool) -> String {


### PR DESCRIPTION
Nightly builds have been failing since #9265 merged: `build-nightly-app` dies with

```
Sources/SurfaceResumeCommandCanonicalizer+PortableAgentExecutable.swift:78:9: error: missing return in static method expected to return 'String?'
```

`restoreCLIArgument` has a multi-statement body (guard + expression), so Swift's implicit return does not apply; the final `AgentRestoreCLIArgument(rawValue:)?.rawValue` expression needs an explicit `return`. One-line fix, no behavior change beyond restoring the intended return value.

Verified against nightly run 30683617062 (first run to reach a runner after repointing `MACOS_RUNNER_26_NIGHTLY_BUILD` from the dead `blacksmith-12vcpu-macos-26` pool to `warp-macos-26-arm64-6x`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/9343"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788151036&installation_model_id=21920&pr_number=9343&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F9343&signature=912a41ea061e9851ce650ede14bc175f7e40ae57d23fc17c97408e02353cfb8d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix nightly Release build failure by adding an explicit return in restoreCLIArgument. Restores the intended String? return and unblocks nightly builds.

<sup>Written for commit 7b850352a798163c3a877369555d693a9f239dcf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/9343?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved consistency when restoring command-line arguments by preserving their canonical raw values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->