### PR TITLE
Auth plane: single credential authority with rejection-fenced recovery

### DIFF
--- a/Packages/Shared/CmuxAuthRuntime/Sources/CmuxAuthRuntime/Coordinator/AuthCoordinator+Tokens.swift
+++ b/Packages/Shared/CmuxAuthRuntime/Sources/CmuxAuthRuntime/Coordinator/AuthCoordinator+Tokens.swift
@@ -358,7 +358,59 @@ extension AuthCoordinator {
     ///   case also calls ``clearAuthState()`` so ``isAuthenticated`` flips to
     ///   `false` and the root scene routes to the sign-in page instead of
     ///   showing a stale shell.
+    /// Every caller coalesces onto one in-flight mint: Stack rotates the
+    /// refresh token on every mint, so N lanes minting concurrently invalidate
+    /// each other's in-flight requests. Single-flighting here makes rotation
+    /// happen at most once per genuine rejection instead of once per lane.
     public func forceRefreshAccessToken() async throws -> String {
+        if let inFlight = inFlightRejectionMint {
+            return try await inFlight.value
+        }
+        let mint = Task { @MainActor [weak self] () throws -> String in
+            guard let self else { throw AuthError.unauthorized }
+            return try await self.forceRefreshAccessTokenUncoalesced()
+        }
+        inFlightRejectionMint = mint
+        defer { inFlightRejectionMint = nil }
+        return try await mint.value
+    }
+
+    /// Recovers a credential pair the server just rejected as unauthorized.
+    ///
+    /// The rotation-race recovery for every Bearer+refresh boundary: a pair
+    /// that was coherent at capture can be rejected when another lane rotates
+    /// the session between capture and server-side validation. Recovery order:
+    /// 1. Re-capture. A fresh pair whose refresh token differs from the
+    ///    rejected one proves rotation already landed elsewhere — return it
+    ///    with no mint.
+    /// 2. Otherwise force-mint exactly once (coalesced with every concurrent
+    ///    rejecter via ``forceRefreshAccessToken()``) and return the
+    ///    re-captured pair.
+    /// A genuinely dead session exits through the mint's `unauthorized` state
+    /// clear, so transport layers never own sign-out decisions.
+    /// - Parameters:
+    ///   - accountID: The account the rejected request was pinned to; a
+    ///     mismatch after recovery fails closed.
+    ///   - rejectedRefreshToken: The refresh token of the rejected pair.
+    /// - Returns: A replacement snapshot for the same account.
+    public func credentialsAfterRejection(
+        accountID: String,
+        rejectedRefreshToken: String
+    ) async throws -> AuthenticatedSessionSnapshot {
+        if let current = try? await authenticatedSessionSnapshot(),
+           current.accountID == accountID,
+           current.refreshToken != rejectedRefreshToken {
+            return current
+        }
+        _ = try await forceRefreshAccessToken()
+        let refreshed = try await authenticatedSessionSnapshot()
+        guard refreshed.accountID == accountID else {
+            throw AuthError.unauthorized
+        }
+        return refreshed
+    }
+
+    private func forceRefreshAccessTokenUncoalesced() async throws -> String {
         do {
             return try await runTokenTouchingPhase(.forceRefreshAccessToken, timeout: timeouts.network) {
                 try await self.forceRefreshAccessTokenWithoutStateClear()

--- a/Packages/Shared/CmuxAuthRuntime/Sources/CmuxAuthRuntime/Coordinator/AuthCoordinator.swift
+++ b/Packages/Shared/CmuxAuthRuntime/Sources/CmuxAuthRuntime/Coordinator/AuthCoordinator.swift
@@ -128,6 +128,13 @@ public final class AuthCoordinator {
     @ObservationIgnored var latestSignInRefreshToken: String?
     @ObservationIgnored var activeSignInExchanges: [UInt64: AuthTrackedSignInExchange] = [:]
     @ObservationIgnored var activeSessionValidations: [UUID: AuthTrackedTokenWork] = [:]
+    /// The one in-flight rejection-driven force mint. Every
+    /// ``forceRefreshAccessToken()`` caller (RPC lane, broker lane,
+    /// ``credentialsAfterRejection(accountID:rejectedRefreshToken:)``)
+    /// coalesces onto this task, so N concurrent server rejections of the same
+    /// pair produce exactly one rotation instead of N mints racing each
+    /// other's in-flight requests.
+    @ObservationIgnored var inFlightRejectionMint: Task<String, any Error>?
     @ObservationIgnored var activePostSignInHooks: [UUID: AuthTrackedTokenWork] = [:]
     @ObservationIgnored var activeTokenTouchingPhases: [UUID: AuthTrackedTokenWork] = [:]
     @ObservationIgnored var timedOutTokenTouchingPhaseStates: [AuthPhase: AuthPhaseTimedOutState] = [:]

--- a/Packages/Shared/CmuxAuthRuntime/Tests/CmuxAuthRuntimeTests/AuthCoordinatorCredentialAuthorityTests.swift
+++ b/Packages/Shared/CmuxAuthRuntime/Tests/CmuxAuthRuntimeTests/AuthCoordinatorCredentialAuthorityTests.swift
@@ -1,0 +1,124 @@
+import CMUXAuthCore
+import Foundation
+import Testing
+@testable import CmuxAuthRuntime
+
+/// The credential authority: ``AuthCoordinator`` is the only component that
+/// may mint, and every rejection-driven recovery coalesces onto one in-flight
+/// mint.
+///
+/// Stack rotates the refresh token on every mint, so independent lanes (RPC
+/// retry, iroh broker recovery) minting past each other invalidate each
+/// other's in-flight credential pairs — the wake-time 401 storm from the
+/// 2026-07-31 field rings. Single-flighting the mint and recovering via
+/// ``AuthCoordinator/credentialsAfterRejection(accountID:rejectedRefreshToken:)``
+/// makes rotation happen at most once per genuine rejection, and a rejection
+/// whose pair already rotated recovers with zero mints.
+@MainActor
+@Suite struct AuthCoordinatorCredentialAuthorityTests {
+    private func makeCoordinator(client: FakeAuthClient) -> AuthCoordinator {
+        let store = FakeKeyValueStore()
+        return AuthCoordinator(
+            client: client,
+            sessionCache: CMUXAuthSessionCache(keyValueStore: store, key: "has_tokens"),
+            userCache: CMUXAuthIdentityStore(keyValueStore: store, key: "cached_user"),
+            teamSelection: CMUXAuthTeamSelectionStore(keyValueStore: store, key: "selected_team"),
+            anchor: FakeAnchor(),
+            config: .test,
+            launch: .plain(),
+            clock: ContinuousClock(),
+            isOnline: { true }
+        )
+    }
+
+    /// Two concurrent rejections of the same pair produce exactly one mint;
+    /// both callers receive the rotated pair.
+    @Test func concurrentRejectionsCoalesceOntoOneMint() async throws {
+        let user = CMUXAuthUser(id: "u1", primaryEmail: "a@b.com", displayName: "A")
+        let client = FakeAuthClient(access: "access-1", refresh: "refresh-1", user: user)
+        let coordinator = makeCoordinator(client: client)
+        coordinator.start()
+        // Prove the session is live before scripting the rejection.
+        _ = try await coordinator.authenticatedSessionSnapshot()
+
+        await client.armForceRefreshGate()
+        async let first = coordinator.credentialsAfterRejection(
+            accountID: "u1",
+            rejectedRefreshToken: "refresh-1"
+        )
+        await client.waitForParkedForceRefresh()
+        async let second = coordinator.credentialsAfterRejection(
+            accountID: "u1",
+            rejectedRefreshToken: "refresh-1"
+        )
+        // The mint rotates the pair, exactly like the live SDK.
+        await client.setTokens(access: "access-2", refresh: "refresh-2")
+        await client.setForceRefreshResult("access-2")
+        await client.releaseForceRefreshGate()
+
+        let recoveredFirst = try await first
+        let recoveredSecond = try await second
+        #expect(recoveredFirst.refreshToken == "refresh-2")
+        #expect(recoveredSecond.refreshToken == "refresh-2")
+        #expect(await client.forceRefreshCount == 1)
+    }
+
+    /// A rejection whose pair already rotated (another lane minted between
+    /// capture and validation) recovers from the store alone: zero mints.
+    @Test func rejectionOfAlreadyRotatedPairRecoversWithoutMinting() async throws {
+        let user = CMUXAuthUser(id: "u1", primaryEmail: "a@b.com", displayName: "A")
+        let client = FakeAuthClient(access: "access-2", refresh: "refresh-2", user: user)
+        let coordinator = makeCoordinator(client: client)
+        coordinator.start()
+
+        let recovered = try await coordinator.credentialsAfterRejection(
+            accountID: "u1",
+            rejectedRefreshToken: "refresh-1"
+        )
+
+        #expect(recovered.refreshToken == "refresh-2")
+        #expect(recovered.accessToken == "access-2")
+        #expect(await client.forceRefreshCount == 0)
+    }
+
+    /// Direct ``forceRefreshAccessToken()`` callers (the RPC lane) coalesce
+    /// with each other and with rejection recoveries on the same in-flight
+    /// mint.
+    @Test func concurrentForceRefreshCallsCoalesce() async throws {
+        let user = CMUXAuthUser(id: "u1", primaryEmail: "a@b.com", displayName: "A")
+        let client = FakeAuthClient(access: "access-1", refresh: "refresh-1", user: user)
+        let coordinator = makeCoordinator(client: client)
+        coordinator.start()
+        _ = try await coordinator.authenticatedSessionSnapshot()
+
+        await client.armForceRefreshGate()
+        async let first = coordinator.forceRefreshAccessToken()
+        await client.waitForParkedForceRefresh()
+        async let second = coordinator.forceRefreshAccessToken()
+        await client.setForceRefreshResult("access-2")
+        await client.releaseForceRefreshGate()
+
+        let firstToken = try await first
+        let secondToken = try await second
+        #expect(firstToken == "access-2")
+        #expect(secondToken == "access-2")
+        #expect(await client.forceRefreshCount == 1)
+    }
+
+    /// Recovery is account-fenced: a session that changed accounts between the
+    /// rejection and the recovery fails closed instead of handing account B's
+    /// credentials to account A's request.
+    @Test func recoveryForDifferentAccountFailsClosed() async throws {
+        let user = CMUXAuthUser(id: "u2", primaryEmail: "b@b.com", displayName: "B")
+        let client = FakeAuthClient(access: "access-2", refresh: "refresh-2", user: user)
+        let coordinator = makeCoordinator(client: client)
+        coordinator.start()
+
+        await #expect(throws: AuthError.unauthorized) {
+            _ = try await coordinator.credentialsAfterRejection(
+                accountID: "u1",
+                rejectedRefreshToken: "refresh-2"
+            )
+        }
+    }
+}

--- a/Packages/Shared/CmuxAuthRuntime/Tests/CmuxAuthRuntimeTests/Fakes.swift
+++ b/Packages/Shared/CmuxAuthRuntime/Tests/CmuxAuthRuntimeTests/Fakes.swift
@@ -81,7 +81,41 @@ actor FakeAuthClient: AuthClient {
     private(set) var mintedAccessTokenCount = 0
 
     func setStoredAccessTokenStale(_ stale: Bool) { storedAccessIsStale = stale }
+
+    /// Force-refresh instrumentation for single-flight coverage: a call count,
+    /// plus an optional gate that parks the mint mid-flight so a test can pile
+    /// concurrent callers onto one in-flight refresh before releasing it.
+    private(set) var forceRefreshCount = 0
+    private var forceRefreshGateArmed = false
+    private var isParkedInForceRefresh = false
+    private var forceRefreshParkObservers: [CheckedContinuation<Void, Never>] = []
+    private var forceRefreshReleaseWaiters: [CheckedContinuation<Void, Never>] = []
+
+    func armForceRefreshGate() { forceRefreshGateArmed = true }
+
+    /// Suspends until a force refresh is parked inside the armed gate.
+    func waitForParkedForceRefresh() async {
+        if isParkedInForceRefresh { return }
+        await withCheckedContinuation { forceRefreshParkObservers.append($0) }
+    }
+
+    func releaseForceRefreshGate() {
+        forceRefreshGateArmed = false
+        let waiters = forceRefreshReleaseWaiters
+        forceRefreshReleaseWaiters.removeAll()
+        waiters.forEach { $0.resume() }
+    }
+
     func forceRefreshAccessToken() async -> String? {
+        forceRefreshCount += 1
+        if forceRefreshGateArmed {
+            isParkedInForceRefresh = true
+            let observers = forceRefreshParkObservers
+            forceRefreshParkObservers.removeAll()
+            observers.forEach { $0.resume() }
+            await withCheckedContinuation { forceRefreshReleaseWaiters.append($0) }
+            isParkedInForceRefresh = false
+        }
         if case let .some(scripted) = forceRefreshResult {
             return scripted
         }

--- a/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohHostRuntime+PolicyRefresh.swift
+++ b/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohHostRuntime+PolicyRefresh.swift
@@ -209,9 +209,12 @@ extension CmxIrohHostRuntime {
            CmxIrohBrokerBindingMetadata(binding: confirmedBinding) != localBinding {
             throw CmxIrohHostRuntimeError.invalidLocalBinding
         }
+        // Availability-only: an authenticated denial must not unlock the
+        // cached host policy, mirroring the client-side rule that auth
+        // rejections never consult offline stores. (Teardown-avoidance below
+        // still uses the wider preserve set.)
         guard allowFallback,
-              CmxIrohTrustBrokerClientError
-                .preservesVerifiedPolicyDuringRefresh(error),
+              CmxIrohTrustBrokerClientError.isAvailabilityFailure(error),
               let cached = configuration.cachedHostPolicy else {
             throw error
         }

--- a/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohRegistryContextProvider.swift
+++ b/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohRegistryContextProvider.swift
@@ -720,6 +720,11 @@ public actor CmxIrohRegistryContextProvider: CmxIrohClientContextProvider {
     }
 
     private static func isConnectivity(_ error: any Error) -> Bool {
-        CmxIrohTrustBrokerClientError.preservesVerifiedPolicyDuringRefresh(error)
+        // Dial-time cached-policy fallbacks key on availability-only failures.
+        // Deliberately NOT `preservesVerifiedPolicyDuringRefresh`: that set now
+        // includes auth rejections (which preserve in-memory state during a
+        // refresh), but an authenticated denial must never unlock the cached
+        // grant store for a dial — revocation takes effect at the next dial.
+        CmxIrohTrustBrokerClientError.isAvailabilityFailure(error)
     }
 }

--- a/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohTrustBrokerClient.swift
+++ b/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohTrustBrokerClient.swift
@@ -49,11 +49,27 @@ public struct CmxIrohBrokerTokenSource: Sendable {
     /// Both tokens from ONE snapshot, so a request can never mix an old access
     /// token with a rotated refresh token.
     public let credentialPair: @Sendable () async throws -> CmxIrohBrokerCredentials?
+    /// Replaces a pair the broker just rejected as unauthorized.
+    ///
+    /// A pair that was coherent at capture can still be rejected when another
+    /// lane rotates the session between capture and server validation (the
+    /// RPC lane's rejection-driven force refresh, most commonly). Live sources
+    /// recover through the auth coordinator's single-flight rejection mint and
+    /// return the replacement pair; frozen pinned sources (sign-out
+    /// revocation) return nil so a destructive flow never silently switches
+    /// credentials. The client retries the rejected request at most once with
+    /// the recovered pair.
+    public let recoveredCredentialPair:
+        @Sendable (_ rejected: CmxIrohBrokerCredentials) async -> CmxIrohBrokerCredentials?
 
     public init(
-        credentialPair: @escaping @Sendable () async throws -> CmxIrohBrokerCredentials?
+        credentialPair: @escaping @Sendable () async throws -> CmxIrohBrokerCredentials?,
+        recoveredCredentialPair: @escaping @Sendable (
+            _ rejected: CmxIrohBrokerCredentials
+        ) async -> CmxIrohBrokerCredentials? = { _ in nil }
     ) {
         self.credentialPair = credentialPair
+        self.recoveredCredentialPair = recoveredCredentialPair
         self.accessToken = { try await credentialPair()?.accessToken }
         self.refreshToken = { try await credentialPair()?.refreshToken }
     }
@@ -518,8 +534,49 @@ public actor CmxIrohTrustBrokerClient: CmxIrohRelayPolicyServing {
         guard let pair = capturedPair else {
             throw CmxIrohTrustBrokerClientError.missingAuthentication
         }
-        let accessToken = pair.accessToken
-        let refreshToken = pair.refreshToken
+        do {
+            return try await performAuthenticatedRequest(
+                path: path,
+                method: method,
+                body: body,
+                queryItems: queryItems,
+                credentials: pair
+            )
+        } catch let error as CmxIrohTrustBrokerClientError
+            where Self.isUnauthorizedRejection(error) {
+            // A pair that was coherent at capture can be rejected when another
+            // lane rotated the session before the server validated it. Recover
+            // ONCE with a pair minted after the rejection; a second rejection
+            // is authoritative and propagates.
+            guard let recovered = await tokenSource.recoveredCredentialPair(pair) else {
+                throw error
+            }
+            return try await performAuthenticatedRequest(
+                path: path,
+                method: method,
+                body: body,
+                queryItems: queryItems,
+                credentials: recovered
+            )
+        }
+    }
+
+    private static func isUnauthorizedRejection(
+        _ error: CmxIrohTrustBrokerClientError
+    ) -> Bool {
+        guard case let .rejected(statusCode, _) = error else { return false }
+        return statusCode == 401
+    }
+
+    private func performAuthenticatedRequest<Response: Decodable & Sendable>(
+        path: String,
+        method: String,
+        body: Data?,
+        queryItems: [URLQueryItem],
+        credentials: CmxIrohBrokerCredentials
+    ) async throws -> Response {
+        let accessToken = credentials.accessToken
+        let refreshToken = credentials.refreshToken
         guard Self.isSafeHeaderValue(accessToken), Self.isSafeHeaderValue(refreshToken) else {
             throw CmxIrohTrustBrokerClientError.invalidAuthentication
         }

--- a/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohTrustBrokerClientError.swift
+++ b/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohTrustBrokerClientError.swift
@@ -28,7 +28,18 @@ public enum CmxIrohTrustBrokerClientError:
         case .rateLimited:
             return true
         case let .rejected(statusCode, _):
-            return statusCode == 408
+            // 401/403: an unauthorized rejection here already survived the
+            // broker client's single force-refresh retry, so it is a session
+            // transition still settling (rotation race, locked token store) or
+            // a server-side availability condition — not a trust change. The
+            // cached policy was verified when stored; tearing the runtime down
+            // buys nothing and turns a seconds-long auth blip into a full
+            // endpoint rebuild. A genuinely dead session clears auth state
+            // through the coordinator, which stops the runtime through the
+            // lifecycle owner instead.
+            return statusCode == 401
+                || statusCode == 403
+                || statusCode == 408
                 || statusCode == 425
                 || statusCode == 429
                 || (500...599).contains(statusCode)
@@ -53,6 +64,43 @@ public enum CmxIrohTrustBrokerClientError:
         case let .rejected(statusCode, _):
             // A server failure cannot establish trust, so retrying the request
             // is safe while the lifecycle-owned start task remains current.
+            // 401 joins the retriable set: it already survived the broker
+            // client's single force-refresh retry, so it is a session
+            // transition still settling; a dead session exits through the auth
+            // coordinator's state clear, not through this loop.
+            return statusCode == 401
+                || statusCode == 408
+                || statusCode == 425
+                || statusCode == 429
+                || (500...599).contains(statusCode)
+        case .invalidBaseURL,
+             .missingAuthentication,
+             .invalidAuthentication,
+             .nonHTTPResponse,
+             .invalidResponse:
+            return false
+        }
+    }
+
+    /// Availability-only failures: the broker could not answer, as opposed to
+    /// an authenticated denial.
+    ///
+    /// Dial-time cached-policy fallbacks key on this set so an authoritative
+    /// rejection — 401/403 INCLUDED — never unlocks cached grants or the
+    /// offline policy store: a revoked account or binding must stop dialing at
+    /// the next dial, not at grant expiry. Contrast with
+    /// ``preservesVerifiedPolicyDuringRefresh(_:)``, which additionally
+    /// accepts auth rejections because keeping already-verified IN-MEMORY
+    /// state during a refresh grants nothing new.
+    static func isAvailabilityFailure(_ error: any Error) -> Bool {
+        if (error as? any CmxRetryAfterProviding)?.retryAfterSeconds != nil {
+            return true
+        }
+        guard let brokerError = error as? Self else { return false }
+        switch brokerError {
+        case .connectivity, .rateLimited:
+            return true
+        case let .rejected(statusCode, _):
             return statusCode == 408
                 || statusCode == 425
                 || statusCode == 429

--- a/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohClientRuntimeTests.swift
+++ b/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohClientRuntimeTests.swift
@@ -814,9 +814,15 @@ struct CmxIrohClientRuntimeTests {
             }
         )
         try await runtime.start()
+        // 400 is a genuinely terminal rejection. A 401 is deliberately NOT
+        // terminal anymore: at wake the pair captured coherently a moment
+        // earlier can be rejected after another lane rotates the session, and
+        // revoking the verified local policy for that race turned a
+        // seconds-long token refresh into a full endpoint rebuild (and, with
+        // the offline cache deleted, an outage until the broker succeeded).
         let terminal = CmxIrohTrustBrokerClientError.rejected(
-            statusCode: 401,
-            code: "unauthorized"
+            statusCode: 400,
+            code: "bad_request"
         )
         await broker.setRegistrationError(terminal)
 
@@ -877,6 +883,11 @@ struct CmxIrohClientRuntimeTests {
             code: "challenge_rate_limited"
         ),
         .rejected(statusCode: 503, code: "unavailable"),
+        // Auth rejections joined the preserved set: they already survived the
+        // broker client's single force-refresh retry, so they are a session
+        // transition still settling, not a trust revocation.
+        .rejected(statusCode: 401, code: "unauthorized"),
+        .rejected(statusCode: 403, code: "forbidden"),
     ])
     func foregroundAvailabilityFailureKeepsLastVerifiedPolicy(
         _ failure: CmxIrohTrustBrokerClientError

--- a/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohHostRuntimeLifecycleTests.swift
+++ b/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohHostRuntimeLifecycleTests.swift
@@ -583,6 +583,11 @@ extension CmxIrohHostRuntimeTests {
             code: "challenge_rate_limited"
         ),
         .rejected(statusCode: 503, code: "unavailable"),
+        // Auth rejections joined the preserved set: they already survived the
+        // broker client's single force-refresh retry, so they are a session
+        // transition still settling, not a trust revocation.
+        .rejected(statusCode: 401, code: "unauthorized"),
+        .rejected(statusCode: 403, code: "forbidden"),
     ])
     func unavailableRegistrationRefreshPreservesActiveEndpoint(
         _ failure: CmxIrohTrustBrokerClientError

--- a/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohHostRuntimePolicyTests.swift
+++ b/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohHostRuntimePolicyTests.swift
@@ -78,14 +78,19 @@ extension CmxIrohHostRuntimeTests {
     }
 
     @Test
-    func unauthorizedRegistrationRefreshDeactivatesActiveEndpoint() async throws {
+    func terminalRegistrationRefreshDeactivatesActiveEndpoint() async throws {
         let fixture = try HostRuntimeFixture()
         let endpoint = TestIrohEndpoint(identity: fixture.endpointID)
+        // 400 is a genuinely terminal rejection. A 401 is deliberately NOT
+        // terminal anymore: a Mac that self-deactivates hosting because a
+        // token pair went stale across sleep/wake leaves every phone unable
+        // to attach until re-activation; auth rejections now preserve the
+        // active endpoint (see unavailableRegistrationRefreshPreservesActiveEndpoint).
         let broker = TestIrohHostBroker(
             registrationBinding: fixture.binding,
             discovery: fixture.discovery,
             subsequentRegistrationErrors: [
-                .rejected(statusCode: 401, code: "unauthorized"),
+                .rejected(statusCode: 400, code: "bad_request"),
             ]
         )
         let deactivations = HostRuntimeDeactivationRecorder()

--- a/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohTrustBrokerClientAuthClassifierTests.swift
+++ b/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohTrustBrokerClientAuthClassifierTests.swift
@@ -35,4 +35,29 @@ struct CmxIrohTrustBrokerClientAuthClassifierTests {
         ))
     }
 
+    @Test
+    func authRejectionsAreNotAvailabilityFailures() {
+        // The security boundary: an authenticated denial must never unlock
+        // dial-time cached grants or the offline policy store, even though
+        // the same rejection preserves in-memory verified state during a
+        // refresh. Revocation takes effect at the next dial.
+        #expect(!CmxIrohTrustBrokerClientError.isAvailabilityFailure(
+            CmxIrohTrustBrokerClientError.rejected(
+                statusCode: 401,
+                code: "unauthorized"
+            )
+        ))
+        #expect(!CmxIrohTrustBrokerClientError.isAvailabilityFailure(
+            CmxIrohTrustBrokerClientError.rejected(statusCode: 403, code: nil)
+        ))
+        #expect(CmxIrohTrustBrokerClientError.isAvailabilityFailure(
+            CmxIrohTrustBrokerClientError.connectivity
+        ))
+        #expect(CmxIrohTrustBrokerClientError.isAvailabilityFailure(
+            CmxIrohTrustBrokerClientError.rejected(statusCode: 503, code: nil)
+        ))
+        #expect(!CmxIrohTrustBrokerClientError.isAvailabilityFailure(
+            CmxIrohTrustBrokerClientError.invalidResponse
+        ))
+    }
 }

--- a/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohTrustBrokerClientAuthClassifierTests.swift
+++ b/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohTrustBrokerClientAuthClassifierTests.swift
@@ -1,0 +1,38 @@
+import Foundation
+import Testing
+@testable import CmuxIrohTransport
+
+/// Regression coverage for the wake-time authorization outage: a broker 401
+/// used to tear down the whole verified runtime (endpoint, routes, offline
+/// cache) and nap for 30s+ of backoff, turning a seconds-long token rotation
+/// race into a multi-minute connectivity gap on every app foreground.
+struct CmxIrohTrustBrokerClientAuthClassifierTests {
+    @Test
+    func unauthorizedRejectionPreservesVerifiedPolicyDuringRefresh() {
+        #expect(CmxIrohTrustBrokerClientError.preservesVerifiedPolicyDuringRefresh(
+            CmxIrohTrustBrokerClientError.rejected(
+                statusCode: 401,
+                code: "unauthorized"
+            )
+        ))
+        #expect(CmxIrohTrustBrokerClientError.preservesVerifiedPolicyDuringRefresh(
+            CmxIrohTrustBrokerClientError.rejected(statusCode: 403, code: nil)
+        ))
+    }
+
+    @Test
+    func unauthorizedRejectionRetriesInitialActivation() {
+        #expect(CmxIrohTrustBrokerClientError.retriesInitialActivation(
+            CmxIrohTrustBrokerClientError.rejected(
+                statusCode: 401,
+                code: "unauthorized"
+            )
+        ))
+        // 403 can be a durable permission denial; initial activation must not
+        // spin on it.
+        #expect(!CmxIrohTrustBrokerClientError.retriesInitialActivation(
+            CmxIrohTrustBrokerClientError.rejected(statusCode: 403, code: nil)
+        ))
+    }
+
+}

--- a/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohTrustBrokerClientAuthRecoveryTests.swift
+++ b/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohTrustBrokerClientAuthRecoveryTests.swift
@@ -1,0 +1,183 @@
+import Foundation
+import Testing
+@testable import CmuxIrohTransport
+
+/// The broker client's exactly-once credential recovery: a pair that was
+/// coherent at capture can still be rejected when another lane rotates the
+/// session between capture and server validation (the wake-time RPC force
+/// refresh, most commonly). One retry with a pair minted after the rejection
+/// absorbs the race; a second rejection is authoritative.
+@Suite(.serialized)
+struct CmxIrohTrustBrokerClientAuthRecoveryTests {
+    private actor RecoveryRecorder {
+        private(set) var rejectedPairs: [CmxIrohBrokerCredentials] = []
+        private let recovered: CmxIrohBrokerCredentials?
+
+        init(recovered: CmxIrohBrokerCredentials?) {
+            self.recovered = recovered
+        }
+
+        func recover(
+            _ rejected: CmxIrohBrokerCredentials
+        ) -> CmxIrohBrokerCredentials? {
+            rejectedPairs.append(rejected)
+            return recovered
+        }
+    }
+
+    @Test
+    func unauthorizedRejectionRetriesOnceWithRecoveredPair() async throws {
+        let transport = RecordingBrokerTransport(responses: [
+            .json(status: 401, body: #"{"error":"unauthorized"}"#),
+            .json(status: 201, body: Self.challengeBody),
+        ])
+        let recorder = RecoveryRecorder(recovered: CmxIrohBrokerCredentials(
+            accessToken: "fresh-access",
+            refreshToken: "fresh-refresh"
+        ))
+        let client = try makeClient(transport: transport, recorder: recorder)
+
+        let response = try await client.issueChallenge(try Self.challengeRequest)
+
+        #expect(response.challengeID == "123e4567-e89b-42d3-a456-426614174000")
+        let requests = await transport.requests()
+        #expect(requests.count == 2)
+        #expect(requests.first?.value(
+            forHTTPHeaderField: "Authorization"
+        ) == "Bearer stale-access")
+        #expect(requests.last?.value(
+            forHTTPHeaderField: "Authorization"
+        ) == "Bearer fresh-access")
+        #expect(requests.last?.value(
+            forHTTPHeaderField: "X-Stack-Refresh-Token"
+        ) == "fresh-refresh")
+        let rejected = await recorder.rejectedPairs
+        #expect(rejected.count == 1)
+        #expect(rejected.first?.accessToken == "stale-access")
+        #expect(rejected.first?.refreshToken == "stale-refresh")
+    }
+
+    @Test
+    func unauthorizedRejectionWithoutRecoveryPropagates() async throws {
+        let transport = RecordingBrokerTransport(responses: [
+            .json(status: 401, body: #"{"error":"unauthorized"}"#),
+        ])
+        let client = try CmxIrohTrustBrokerClient(
+            baseURL: #require(URL(string: "https://cmux.example")),
+            tokenSource: CmxIrohBrokerTokenSource(credentialPair: {
+                CmxIrohBrokerCredentials(
+                    accessToken: "stale-access",
+                    refreshToken: "stale-refresh"
+                )
+            }),
+            transport: transport
+        )
+
+        await #expect(throws: CmxIrohTrustBrokerClientError.rejected(
+            statusCode: 401,
+            code: "unauthorized"
+        )) {
+            _ = try await client.issueChallenge(try Self.challengeRequest)
+        }
+        #expect(await transport.requests().count == 1)
+    }
+
+    @Test
+    func repeatedUnauthorizedRejectionStopsAfterOneRetry() async throws {
+        let transport = RecordingBrokerTransport(responses: [
+            .json(status: 401, body: #"{"error":"unauthorized"}"#),
+            .json(status: 401, body: #"{"error":"unauthorized"}"#),
+        ])
+        let recorder = RecoveryRecorder(recovered: CmxIrohBrokerCredentials(
+            accessToken: "fresh-access",
+            refreshToken: "fresh-refresh"
+        ))
+        let client = try makeClient(transport: transport, recorder: recorder)
+
+        await #expect(throws: CmxIrohTrustBrokerClientError.rejected(
+            statusCode: 401,
+            code: "unauthorized"
+        )) {
+            _ = try await client.issueChallenge(try Self.challengeRequest)
+        }
+        #expect(await transport.requests().count == 2)
+        #expect(await recorder.rejectedPairs.count == 1)
+    }
+
+    @Test
+    func forbiddenRejectionDoesNotInvokeRecovery() async throws {
+        let transport = RecordingBrokerTransport(responses: [
+            .json(status: 403, body: #"{"error":"forbidden"}"#),
+        ])
+        let recorder = RecoveryRecorder(recovered: CmxIrohBrokerCredentials(
+            accessToken: "fresh-access",
+            refreshToken: "fresh-refresh"
+        ))
+        let client = try makeClient(transport: transport, recorder: recorder)
+
+        await #expect(throws: CmxIrohTrustBrokerClientError.rejected(
+            statusCode: 403,
+            code: "forbidden"
+        )) {
+            _ = try await client.issueChallenge(try Self.challengeRequest)
+        }
+        #expect(await transport.requests().count == 1)
+        #expect(await recorder.rejectedPairs.isEmpty)
+    }
+
+    private func makeClient(
+        transport: RecordingBrokerTransport,
+        recorder: RecoveryRecorder
+    ) throws -> CmxIrohTrustBrokerClient {
+        try CmxIrohTrustBrokerClient(
+            baseURL: #require(URL(string: "https://cmux.example")),
+            tokenSource: CmxIrohBrokerTokenSource(
+                credentialPair: {
+                    CmxIrohBrokerCredentials(
+                        accessToken: "stale-access",
+                        refreshToken: "stale-refresh"
+                    )
+                },
+                recoveredCredentialPair: { rejected in
+                    await recorder.recover(rejected)
+                }
+            ),
+            transport: transport
+        )
+    }
+
+    private static let challengeBody =
+        #"{"challenge_id":"123e4567-e89b-42d3-a456-426614174000","nonce":"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA","expires_at":"2026-07-10T01:00:00.000Z"}"#
+
+    private static let endpointID =
+        "03a107bff3ce10be1d70dd18e74bc09967e4d6309ba50d5f1ddc8664125531b8"
+
+    private static var challengeRequest: CmxIrohChallengeRequest {
+        get throws {
+            let secret = try CmxIrohSecretKey(
+                bytes: Data((0 ..< 32).map(UInt8.init))
+            )
+            let identity = try CmxIrohIdentityMaterial(
+                secretKey: secret,
+                generation: 1
+            )
+            let signer = try CmxIrohRegistrationSigner(
+                identity: identity,
+                endpointID: endpointID
+            )
+            let payload = try CmxIrohRegistrationPayload(
+                deviceID: "123e4567-e89b-42d3-a456-426614174001",
+                appInstanceID: "123e4567-e89b-42d3-a456-426614174002",
+                tag: "stable",
+                platform: .ios,
+                endpointID: endpointID,
+                identityGeneration: 1,
+                pairingEnabled: false,
+                capabilities: ["control"],
+                pathHints: [],
+                now: Date(timeIntervalSince1970: 1_782_000_000)
+            )
+            return try signer.prepare(payload: payload).challengeRequest
+        }
+    }
+}

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
@@ -4994,9 +4994,29 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
             supportedKinds: supportedRouteKinds,
             preferNonLoopback: Self.prefersNonLoopbackRoutes
         )
-        let foregroundIDSet: Set<String>
+        // During a bounded foreground redial, `clearRemoteConnectionContext()`
+        // has already nil'd `foregroundMacDeviceID`, which would make the very
+        // Mac being redialed eligible as a "secondary". That opens a duplicate
+        // background-control session the redial must then drain — one wasted
+        // QUIC dial plus up to the handoff-drain timeout of added reconnect
+        // latency. Exclude the in-flight recovery target exactly like a live
+        // foreground; once recovery settles the normal exclusion (success) or
+        // eligibility (terminal failure) resumes.
+        let exclusionMacDeviceID: String?
+        let exclusionTag: String?
         if let foregroundMacDeviceID {
-            let canonicalID = cmxCanonicalDeviceID(foregroundMacDeviceID)
+            exclusionMacDeviceID = foregroundMacDeviceID
+            exclusionTag = activeMacInstanceTag
+        } else if isReconnectingStoredMac || connectionRecoveryOwner.isActive {
+            exclusionMacDeviceID = recoveryTargetMacDeviceID
+            exclusionTag = recoveryTargetInstanceTag
+        } else {
+            exclusionMacDeviceID = nil
+            exclusionTag = nil
+        }
+        let foregroundIDSet: Set<String>
+        if let exclusionMacDeviceID {
+            let canonicalID = cmxCanonicalDeviceID(exclusionMacDeviceID)
             foregroundIDSet = physicalAliasIDsByCanonicalID[canonicalID]
                 ?? Set([canonicalID])
         } else {
@@ -5006,9 +5026,9 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         if case let .peer(identity, _)? = activeRoute?.endpoint {
             foregroundIrohEndpointIDs.insert(identity.endpointID)
         }
-        let activeTag = activeMacInstanceTag
-        if let foregroundMacDeviceID {
-            let canonicalForegroundID = cmxCanonicalDeviceID(foregroundMacDeviceID)
+        let activeTag = exclusionTag
+        if let exclusionMacDeviceID {
+            let canonicalForegroundID = cmxCanonicalDeviceID(exclusionMacDeviceID)
             // With no authenticated tag the foreground could be any of the
             // device's rows, so every row's endpoint is treated as the
             // foreground's own; with a tag, only the exact pairing's endpoints

--- a/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/MobileMacConnectionPoolTests.swift
+++ b/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/MobileMacConnectionPoolTests.swift
@@ -154,6 +154,33 @@ import Testing
         #expect(candidates.isEmpty)
     }
 
+    @Test func inFlightRecoveryTargetIsExcludedFromSecondaryAggregation() throws {
+        let shell = MobileShellComposite(
+            isSignedIn: false,
+            presence: IdlePresence()
+        )
+        let mac = try Self.pairedMac(
+            id: "mac-recovering",
+            instanceTag: "tag-recovering"
+        )
+        // A bounded redial records the recovery target through the live
+        // foreground assignment, then clears the foreground context before
+        // dialing. The Mac being redialed must not become a "secondary"
+        // aggregation candidate in that window: the duplicate
+        // background-control session would have to be drained by the very
+        // redial that is trying to reconnect it.
+        shell.foregroundMacDeviceID = mac.macDeviceID
+        shell.foregroundMacDeviceID = nil
+        shell.isReconnectingStoredMac = true
+
+        #expect(shell.secondaryAggregationCandidateMacs(from: [mac]).isEmpty)
+
+        // Once the reconnect attempt settles the Mac is aggregable again.
+        shell.isReconnectingStoredMac = false
+        #expect(shell.secondaryAggregationCandidateMacs(from: [mac])
+            .map(\.macDeviceID) == [mac.macDeviceID])
+    }
+
     @Test func onlineAliasKeepsLogicalMacInPool() async throws {
         let route = try CmxAttachRoute(
             id: "alias-route",

--- a/Sources/Mobile/MobileHostIrohRuntime+Activation.swift
+++ b/Sources/Mobile/MobileHostIrohRuntime+Activation.swift
@@ -133,6 +133,22 @@ extension MobileHostIrohRuntime {
                         accessToken: session.accessToken,
                         refreshToken: session.refreshToken
                     )
+                },
+                recoveredCredentialPair: { [weak auth] rejected in
+                    // Rotation-race recovery through the coordinator's
+                    // single-flight rejection mint: re-capture first (no mint
+                    // when another lane already rotated), coalesced force-mint
+                    // otherwise. A dead session exits through the
+                    // coordinator's state clear, never through this layer.
+                    guard let auth,
+                          let session = try? await auth.credentialsAfterRejection(
+                              accountID: accountID,
+                              rejectedRefreshToken: rejected.refreshToken
+                          ) else { return nil }
+                    return CmxIrohBrokerCredentials(
+                        accessToken: session.accessToken,
+                        refreshToken: session.refreshToken
+                    )
                 }
             ),
             backpressureMode: .callerOwned

--- a/docs/auth-credential-authority.md
+++ b/docs/auth-credential-authority.md
@@ -1,0 +1,77 @@
+# Auth plane: single credential authority
+
+## Problem
+
+Stack refresh tokens rotate on every mint. Multiple client lanes (RPC wake
+refresh, relay-policy loop, registration refresh, discovery, revocation)
+independently capture, present, and force-refresh one rotating credential
+pair. Any lane's refresh invalidates every other lane's in-flight pair, so
+the broker returns 401 for perfectly healthy sessions, most reliably at app
+wake when all lanes fire at once. Pre-v2 code treated that 401 as fatal
+(endpoint teardown + offline-cache deletion + 30-36s flat backoff), turning a
+microsecond rotation race into 30s-2.5min reconnect outages (field rings,
+build 20260731034828).
+
+## Design
+
+**One refresher.** `AuthCoordinator` is the only component that may mint.
+Rejection recovery is centralized and fenced:
+
+- `authorizedCredentials() -> AuthCredentialGrant` — one coherent capture:
+  `{ sessionGeneration, accountID, accessToken, refreshToken }`. A
+  transition-owned token store (launch/foreground revalidation) classifies as
+  retryable (`networkError`), never signed-out (absorbs PR 9259).
+- `credentialsAfterRejection(of grant) -> AuthCredentialGrant` — called after
+  a server rejected the grant:
+  1. Session-generation mismatch or signed out → `unauthorized`.
+  2. Re-capture. If the stored refresh token differs from the rejected
+     grant's, rotation already landed elsewhere → return the fresh grant, no
+     mint.
+  3. Otherwise force-mint exactly once, keyed on the rejected refresh token:
+     concurrent rejecters of the same pair coalesce onto one in-flight mint
+     (dedup task map). Re-capture, return.
+  4. A definitively dead session clears auth state (existing
+     `forceRefreshAccessToken` semantics), routing teardown through the auth
+     owner, not through transport-layer classifiers.
+- Legacy `forceRefreshAccessToken()` reroutes through the same single-flight
+  so stragglers coalesce; the ad-hoc unconditional wake refresh in the RPC
+  lane is deleted — recovery is rejection-driven only, so rotations happen at
+  most once per genuine expiry instead of once per lane per wake.
+
+**Uniform boundary protocol.** Every HTTP boundary that sends the
+Bearer+refresh pair (iroh trust-broker client, mobile RPC lane, Mac host)
+does: capture → send → on 401 → `credentialsAfterRejection` → retry once. A
+second 401 is authoritative. `CmxIrohBrokerTokenSource` keeps `credentialPair`
+(throwing = transient/busy → classify connectivity; nil = definitively
+absent) plus `recoveredCredentialPair(rejected:)`; frozen pinned sources
+(sign-out revocation) never recover.
+
+**Auth rejections preserve verified in-memory state** (rebased from PR 9263):
+- `preservesVerifiedPolicyDuringRefresh` includes 401/403 (client
+  registration refresh + host runtime keep endpoint/routes/last binding).
+- `retriesInitialActivation` includes 401.
+- SECURITY BOUNDARY unchanged: dial-time cached grants and the offline policy
+  store stay availability-only (`isAvailabilityFailure`, excludes 401/403);
+  an authenticated denial never unlocks cached credentials — revocation bites
+  at the next dial. Pinned by the `*NeverConsultsOfflinePolicy` suites.
+- Relay-policy retry ladder: cause-aware short schedule for auth failures
+  (superseded by PR 9301's `foregroundClient` bounds if that merges first;
+  keep whichever lands second consistent).
+
+## Supersedes / composes
+
+- Supersedes PR 9263 (conflicting after connectivity-v2).
+- Absorbs PR 9259's transition-window classification (same file, same seam;
+  one merge decision instead of two conflicting ones).
+- Orthogonal to PR 9301 (global backoff bounds) and the reconnect-hygiene
+  program (bgControl double-dial, watchdog); do not duplicate those here.
+
+## Invariants to test
+
+1. Concurrent rejections of the same pair → exactly one mint.
+2. Rejection of an already-rotated pair → fresh grant, zero mints.
+3. Dead session → `unauthorized` + auth state cleared once.
+4. Transition-owned store → retryable, not signed-out.
+5. Broker 401 → one retry with successor pair; second 401 propagates.
+6. 401/403 never consult offline/cached policy stores (existing suites).
+7. 401 during registration refresh keeps endpoint active (client + host).

--- a/ios/cmuxPackage/Sources/cmuxFeature/MobileIrohRuntimeComposition.swift
+++ b/ios/cmuxPackage/Sources/cmuxFeature/MobileIrohRuntimeComposition.swift
@@ -3008,6 +3008,22 @@ extension MobileIrohRuntimeComposition {
                     accessToken: session.accessToken,
                     refreshToken: session.refreshToken
                 )
+            },
+            recoveredCredentialPair: { [weak auth] rejected in
+                // Rotation-race recovery through the coordinator's
+                // single-flight rejection mint: re-capture first (no mint when
+                // another lane already rotated), coalesced force-mint
+                // otherwise. A dead session exits through the coordinator's
+                // state clear, never through this transport layer.
+                guard let auth,
+                      let session = try? await auth.credentialsAfterRejection(
+                          accountID: expectedAccountID,
+                          rejectedRefreshToken: rejected.refreshToken
+                      ) else { return nil }
+                return CmxIrohBrokerCredentials(
+                    accessToken: session.accessToken,
+                    refreshToken: session.refreshToken
+                )
             }
         )
     }


### PR DESCRIPTION
## Problem

Stack rotates the refresh token on every mint. Several client lanes (the RPC lane's rejection retry, relay-policy refresh, registration refresh, discovery) independently capture, present, and force-refresh one rotating credential pair, so any lane's mint invalidates every other lane's in-flight pair. At app wake all lanes fire at once: the broker rejects a perfectly healthy pair with 401, and the transport layer treated that as fatal — endpoint teardown, offline-cache deletion, and a 30s+ flat backoff per event. Field cmuxdiag rings (build 20260731034828, 2026-07-31) show 30s-2.5min reconnect outages per wake from exactly this: `relayPolicyFail fail=15` → `endpointFailed` → `retryScheduled ms=32331/36124/36683` → minutes of `policyUnavailable`/`endpointUnavailable`/`noRoute` dials.

Design doc: `docs/auth-credential-authority.md` on this branch.

## Fix

**One refresher.** `AuthCoordinator.forceRefreshAccessToken()` coalesces every caller onto a single in-flight mint, and the new `credentialsAfterRejection(accountID:rejectedRefreshToken:)` is the uniform recovery: re-capture first (a fresh pair whose refresh token differs proves rotation already landed — zero mints), one coalesced mint otherwise, account-fenced, with dead sessions still exiting through the coordinator's state clear so transport layers never own sign-out decisions.

**Uniform boundary protocol.** `CmxIrohBrokerTokenSource` gains `recoveredCredentialPair(rejected:)`; `CmxIrohTrustBrokerClient` retries a 401-rejected request exactly once with the recovered pair. Wired to the authority on iOS (`MobileIrohRuntimeComposition`) and the Mac host (`MobileHostIrohRuntime+Activation`); frozen pinned sources (sign-out revocation flows) keep the nil default and never switch credentials. The RPC lane needs no signature change — its existing rejection-driven `forceRefreshAccessToken()` now coalesces with everything else automatically.

**Auth rejections preserve verified in-memory state.** 401/403 join `preservesVerifiedPolicyDuringRefresh` and 401 joins `retriesInitialActivation`: a registration-refresh 401 keeps the endpoint, routes, and last verified binding alive on both platforms instead of tearing down the runtime.

**The never-consults-offline security boundary is preserved and now explicit.** Dial-time cached-grant fallbacks (`CmxIrohRegistryContextProvider`) and the host cached policy (`cachedPolicy(after:)`) key on a new strict `isAvailabilityFailure` classifier that excludes 401/403 — an authenticated denial never unlocks cached credentials, so revocation takes effect at the next dial. Pinned by the pre-existing `*NeverConsultsOfflinePolicy` suites (all green) plus `authRejectionsAreNotAvailabilityFailures`.

**No duplicate dial during recovery.** `secondaryAggregationCandidateMacs` excludes the in-flight recovery target (`recoveryTargetMacDeviceID`, gated on `isReconnectingStoredMac || connectionRecoveryOwner.isActive`) so the Mac being redialed is not also dialed as a warm background-control candidate and then drained by the very redial reconnecting it.

## Regression structure

Commit 1 adds the failing regressions only (classifier tests + aggregation exclusion test) — CI red. Commit 2 lands the authority, the boundary protocol, the classifier split, and their tests — CI green.

## Relationship to other PRs

- Supersedes #9263 (same fixes, written pre-connectivity-v2, now conflicting; will be closed).
- Overlaps #9259 at the same seam (`AuthCoordinator+Tokens`, broker token source): 9259 classifies the transition-owned token store as retryable; this PR is complementary but will conflict textually — whichever merges second needs a small rebase.
- The backoff-hygiene bounds (`CmxIrohRetrySchedule.foregroundClient`, `CmxIrohReconnectBackoff`) already landed with the connectivity-v2 closeout and are untouched here.

## Test plan

- `swift test --package-path Packages/Shared/CmuxAuthRuntime` — 182 tests green, including the new `AuthCoordinatorCredentialAuthorityTests` (concurrent rejections coalesce onto one mint; already-rotated pair recovers with zero mints; concurrent force refreshes coalesce; cross-account recovery fails closed).
- `swift test --package-path Packages/Shared/CmuxIrohTransport --filter "AuthClassifier|AuthRecovery|CmxIrohClientRuntimeTests|CmxIrohHostRuntime"` — 92 tests green (401 retry semantics, preserved-state fixtures, availability boundary).
- `MobileMacConnectionPoolTests` — new exclusion test green; three unrelated wall-clock-race tests flake identically on unmodified baseline under machine load (verified by stash-and-rerun both ways).
- Tagged cloud builds (macOS + iOS, tag `wkauth`) + iPhone dogfood: wake/foreground cycles with cmuxdiag ring pulled from the device.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/9344"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788151336&installation_model_id=21920&pr_number=9344&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F9344&signature=7c353b9d831d0eb25a7683ff506d91745e88b8e9e3078c9b30596397e92a70e9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Introduces a single credential authority with rejection-fenced recovery to stop wake-time 401 storms and long reconnects. Also adds an exactly-once 401 retry in the broker client and tightens cached-policy fallbacks to availability-only.

- **New Features**
  - Single-flight refresh in `AuthCoordinator`; adds `credentialsAfterRejection(accountID:rejectedRefreshToken:)` and coalesces all callers onto one mint.
  - `CmxIrohTrustBrokerClient` retries a 401 exactly once using a recovered pair via `CmxIrohBrokerTokenSource.recoveredCredentialPair`; wired on iOS and Mac.
  - Added targeted tests and docs (`docs/auth-credential-authority.md`), including auth classifier and recovery coverage.

- **Bug Fixes**
  - 401/403 no longer tear down verified state; 401 now retries initial activation.
  - Cached grants/offline policy only on availability failures via `isAvailabilityFailure`; 401/403 excluded to preserve the security boundary.
  - Prevent duplicate background-control dial by excluding the in-flight recovery target Mac from secondary aggregation.

<sup>Written for commit 41ca640b8a0c27eddf880a1061ffa3a2e66e16f5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/9344?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved recovery from expired or rejected credentials with coordinated refresh attempts and a single retry.
  * Prevented authentication failures from incorrectly enabling cached offline access or deactivating verified connections.
  * Preserved active endpoints during temporary broker failures, while still handling invalid requests appropriately.
  * Prevented duplicate Mac recovery connections while a device is reconnecting.
* **Documentation**
  * Added guidance describing credential recovery, refresh coordination, retry behavior, and offline-policy safeguards.
* **Tests**
  * Expanded coverage for credential recovery, broker rejection handling, connection preservation, and Mac reconnection scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->