### PR TITLE
Fix Attempt Update no-update result

### DIFF
--- a/Packages/macOS/CmuxUpdater/Sources/CmuxUpdater/AttemptUpdateCoordinator.swift
+++ b/Packages/macOS/CmuxUpdater/Sources/CmuxUpdater/AttemptUpdateCoordinator.swift
@@ -56,11 +56,11 @@ struct AttemptUpdateCoordinator {
     ///   captured update is deliberately *not* installed; it only gates the mid-install no-op.
     mutating func requestInstallLatest(currentState: UpdateState) -> Action {
         guard phase == .inactive else { return .none }
-        switch currentState {
-        case .startingDownload, .downloading, .extracting, .installing:
+        switch currentState.attemptDisposition {
+        case .startingDownload, .installProgress:
             // An install is already underway; don't interrupt it to re-resolve.
             return .none
-        case .idle, .permissionRequest, .preparingCheck, .checking, .updateAvailable, .notFound, .error:
+        case .idle, .permissionRequest, .preparingCheck, .checking, .updateAvailable, .noUpdate, .error:
             // Ignore any update captured in `currentState`; re-resolve the feed to the latest.
             phase = .awaitingFreshCheck
             return .startFreshCheck
@@ -81,14 +81,13 @@ struct AttemptUpdateCoordinator {
             return .none
 
         case .awaitingFreshCheck:
-            switch state {
+            switch state.attemptDisposition {
             case .preparingCheck, .permissionRequest:
                 return .none
             case .error:
                 phase = .inactive
                 return .none
-            case .idle, .checking, .updateAvailable, .notFound,
-                    .startingDownload, .downloading, .extracting, .installing:
+            case .idle, .checking, .updateAvailable, .noUpdate, .startingDownload, .installProgress:
                 // No model emission can prove that a new Sparkle check started. If the explicit
                 // controller signal never arrived, this accepted attempt ended unexpectedly.
                 phase = .inactive
@@ -96,17 +95,16 @@ struct AttemptUpdateCoordinator {
             }
 
         case .awaitingResult:
-            switch state {
+            switch state.attemptDisposition {
             case .updateAvailable:
                 phase = .startingDownload
                 return .confirmInstall
-            case .idle, .notFound:
+            case .idle:
                 phase = .inactive
                 return .installFailed
-            case .error:
-                phase = .inactive
-                return .none
-            case .downloading, .extracting, .installing:
+            case .noUpdate, .error, .installProgress:
+                // An ungated attempt performs a fresh check, so no update is a normal successful
+                // result here. Preserve that model state for the ordinary up-to-date UI.
                 phase = .inactive
                 return .none
             case .preparingCheck, .checking, .permissionRequest, .startingDownload:
@@ -114,16 +112,15 @@ struct AttemptUpdateCoordinator {
             }
 
         case .startingDownload:
-            switch state {
-            case .downloading, .extracting, .installing:
-                phase = .inactive
-                return .none
-            case .error:
+            switch state.attemptDisposition {
+            case .installProgress, .error:
                 phase = .inactive
                 return .none
             case .startingDownload:
                 return .none
-            case .idle, .preparingCheck, .checking, .updateAvailable, .notFound, .permissionRequest:
+            case .idle, .preparingCheck, .checking, .updateAvailable, .noUpdate, .permissionRequest:
+                // A concrete fresh update was already accepted. Losing it before any install
+                // progress is unexpected even when the replacement state is normally benign.
                 phase = .inactive
                 return .installFailed
             }

--- a/Packages/macOS/CmuxUpdater/Sources/CmuxUpdater/InstallWatchdog.swift
+++ b/Packages/macOS/CmuxUpdater/Sources/CmuxUpdater/InstallWatchdog.swift
@@ -9,11 +9,9 @@ import Foundation
 /// the controller surfaces a visible "Update Didn't Start" error rather than leaving the user
 /// staring at a pill that never advances.
 ///
-/// The watchdog owns only its timer; the *decision* of what counts as stalled vs. resolved lives
-/// in the two pure, exhaustively-tested static predicates below, and the error-surfacing side
-/// effect stays in the controller (which owns the model). This mirrors ``AttemptUpdateCoordinator``:
-/// a small, single-purpose collaborator kept out of the controller so its policy is testable in
-/// isolation and the controller file stays focused.
+/// The watchdog owns only its timer; its stalled/resolved decisions consume the same exhaustive
+/// ``UpdateState/attemptDisposition`` classification as ``AttemptUpdateCoordinator``, while the
+/// error-surfacing side effect stays in the controller (which owns the model).
 @MainActor
 final class InstallWatchdog {
     private let clock: any UpdateClock
@@ -64,10 +62,10 @@ final class InstallWatchdog {
     /// `.permissionRequest` stays not-stalled (a state cmux never surfaces; erroring over it
     /// would be wrong if Sparkle ever did).
     func installAttemptStalled(_ state: UpdateState) -> Bool {
-        switch state {
+        switch state.attemptDisposition {
         case .preparingCheck, .checking, .updateAvailable, .startingDownload, .idle:
             return true
-        case .permissionRequest, .downloading, .extracting, .installing, .notFound, .error:
+        case .permissionRequest, .installProgress, .noUpdate, .error:
             return false
         }
     }
@@ -75,8 +73,8 @@ final class InstallWatchdog {
     /// Whether `state` resolves the attempt — either it is actively progressing the install or it
     /// is a clearly-communicated terminal outcome — so the watchdog can be disarmed.
     func installAttemptResolved(_ state: UpdateState) -> Bool {
-        switch state {
-        case .downloading, .extracting, .installing, .notFound, .error:
+        switch state.attemptDisposition {
+        case .installProgress, .noUpdate, .error:
             return true
         case .idle, .permissionRequest, .preparingCheck, .checking, .updateAvailable, .startingDownload:
             return false

--- a/Packages/macOS/CmuxUpdater/Sources/CmuxUpdater/UpdateAttemptDisposition.swift
+++ b/Packages/macOS/CmuxUpdater/Sources/CmuxUpdater/UpdateAttemptDisposition.swift
@@ -2,7 +2,7 @@
 ///
 /// Keeping this mapping exhaustive in one place prevents lifecycle collaborators from silently
 /// assigning contradictory meanings to the same ``UpdateState``.
-enum UpdateAttemptDisposition: Equatable {
+enum UpdateAttemptDisposition {
     /// No update activity is visible.
     case idle
     /// Sparkle is requesting automatic-check permission.

--- a/Packages/macOS/CmuxUpdater/Sources/CmuxUpdater/UpdateAttemptDisposition.swift
+++ b/Packages/macOS/CmuxUpdater/Sources/CmuxUpdater/UpdateAttemptDisposition.swift
@@ -1,0 +1,50 @@
+/// Payload-free state categories shared by the install-attempt coordinator and watchdog.
+///
+/// Keeping this mapping exhaustive in one place prevents lifecycle collaborators from silently
+/// assigning contradictory meanings to the same ``UpdateState``.
+enum UpdateAttemptDisposition: Equatable {
+    /// No update activity is visible.
+    case idle
+    /// Sparkle is requesting automatic-check permission.
+    case permissionRequest
+    /// A requested check is waiting for updater readiness or a prior cycle.
+    case preparingCheck
+    /// A foreground update check is running.
+    case checking
+    /// A concrete update is awaiting an install decision.
+    case updateAvailable
+    /// A fresh check completed normally without finding an update.
+    case noUpdate
+    /// A check or install surfaced a visible failure.
+    case error
+    /// An accepted update is waiting for Sparkle to begin its download.
+    case startingDownload
+    /// Download, extraction, or installation has visibly progressed.
+    case installProgress
+}
+
+extension UpdateState {
+    /// The shared semantic category used by install-attempt lifecycle policy.
+    var attemptDisposition: UpdateAttemptDisposition {
+        switch self {
+        case .idle:
+            .idle
+        case .permissionRequest:
+            .permissionRequest
+        case .preparingCheck:
+            .preparingCheck
+        case .checking:
+            .checking
+        case .updateAvailable:
+            .updateAvailable
+        case .notFound:
+            .noUpdate
+        case .error:
+            .error
+        case .startingDownload:
+            .startingDownload
+        case .downloading, .extracting, .installing:
+            .installProgress
+        }
+    }
+}

--- a/Packages/macOS/CmuxUpdater/Sources/CmuxUpdater/UpdateCheckCallbackAcceptance.swift
+++ b/Packages/macOS/CmuxUpdater/Sources/CmuxUpdater/UpdateCheckCallbackAcceptance.swift
@@ -1,0 +1,9 @@
+/// Whether Sparkle user-driver callbacks still belong to the active foreground check generation.
+nonisolated enum UpdateCheckCallbackAcceptance {
+    /// Apply callbacks to the model and expose their normal user interactions.
+    case accepting
+
+    /// A foreground deadline abandoned this generation; consume callbacks without mutating the
+    /// model until Sparkle's authoritative cycle-finished signal arrives.
+    case discardingUntilCycleFinishes
+}

--- a/Packages/macOS/CmuxUpdater/Sources/CmuxUpdater/UpdateController+Checking.swift
+++ b/Packages/macOS/CmuxUpdater/Sources/CmuxUpdater/UpdateController+Checking.swift
@@ -286,9 +286,12 @@ extension UpdateController: UpdateDriverEventDelegate {
         installWatchdog.disarm()
     }
 
+    /// Abandons the timed-out check and every replacement queued behind its Sparkle cycle, then
+    /// exposes a retry that preserves whether the user requested a manual check or an install.
     func updateDriverCheckDidTimeOut() {
         let intent = activeCheckIntent
         activeCheckIntent = nil
+        pendingCheckIntent = nil
         cancelReadinessRetry()
         let isInstallAttempt = intent == .installLatest || attemptCoordinator.isMonitoring
         log.append(
@@ -308,8 +311,7 @@ extension UpdateController: UpdateDriverEventDelegate {
         model.replaceActiveState(with: .error(.init(
             error: error,
             retry: retry,
-            dismiss: { [weak self] in self?.model.setState(.idle) },
-            feedURLString: driver.resolvedFeedURLString()
+            dismiss: { [weak self] in self?.model.setState(.idle) }
         )))
     }
 }

--- a/Packages/macOS/CmuxUpdater/Sources/CmuxUpdater/UpdateController+Checking.swift
+++ b/Packages/macOS/CmuxUpdater/Sources/CmuxUpdater/UpdateController+Checking.swift
@@ -285,4 +285,31 @@ extension UpdateController: UpdateDriverEventDelegate {
         attemptCoordinator.cancel()
         installWatchdog.disarm()
     }
+
+    func updateDriverCheckDidTimeOut() {
+        let intent = activeCheckIntent
+        activeCheckIntent = nil
+        cancelReadinessRetry()
+        let isInstallAttempt = intent == .installLatest || attemptCoordinator.isMonitoring
+        log.append(
+            "foreground check timed out (intent=\(intent?.rawValue ?? "external"), installAttempt=\(isInstallAttempt))"
+        )
+
+        let retry: () -> Void
+        if isInstallAttempt {
+            attemptCoordinator.cancel()
+            installWatchdog.disarm()
+            retry = { [weak self] in self?.attemptUpdate() }
+        } else {
+            retry = { [weak self] in self?.checkForUpdates() }
+        }
+
+        let error = NSError(domain: NSURLErrorDomain, code: NSURLErrorTimedOut)
+        model.replaceActiveState(with: .error(.init(
+            error: error,
+            retry: retry,
+            dismiss: { [weak self] in self?.model.setState(.idle) },
+            feedURLString: driver.resolvedFeedURLString()
+        )))
+    }
 }

--- a/Packages/macOS/CmuxUpdater/Sources/CmuxUpdater/UpdateDriver+SPUUpdaterDelegate.swift
+++ b/Packages/macOS/CmuxUpdater/Sources/CmuxUpdater/UpdateDriver+SPUUpdaterDelegate.swift
@@ -118,6 +118,7 @@ extension UpdateDriver: @preconcurrency SPUUpdaterDelegate {
     /// Forwards Sparkle's authoritative session-finished signal to the lifecycle owner.
     /// Extracted so the replacement-check race is testable without constructing `SPUUpdater`.
     func handleDidFinishUpdateCycle(_ updateCheck: SPUUpdateCheck, error: (any Error)?) {
+        resetCheckCallbackAcceptanceAfterCycle()
         let errorText = error.map(formatErrorForLog) ?? "none"
         log.append("update cycle finished (check=\(updateCheck.rawValue), error=\(errorText))")
         eventDelegate?.updateDriverDidFinishCycle(updateCheck, error: error.map { $0 as NSError })

--- a/Packages/macOS/CmuxUpdater/Sources/CmuxUpdater/UpdateDriver.swift
+++ b/Packages/macOS/CmuxUpdater/Sources/CmuxUpdater/UpdateDriver.swift
@@ -287,7 +287,9 @@ final class UpdateDriver: NSObject, @preconcurrency SPUUserDriver {
             try? await self.clock.sleep(for: .seconds(self.checkTimeoutDuration))
             guard !Task.isCancelled else { return }
             guard case .checking = self.model.state else { return }
-            self.setState(.notFound(.init(acknowledgement: {})))
+            // A local deadline is not an authoritative Sparkle no-update result. Forward it to
+            // the controller, which owns whether this check was manual or an accepted install.
+            self.eventDelegate?.updateDriverCheckDidTimeOut()
         }
     }
 

--- a/Packages/macOS/CmuxUpdater/Sources/CmuxUpdater/UpdateDriver.swift
+++ b/Packages/macOS/CmuxUpdater/Sources/CmuxUpdater/UpdateDriver.swift
@@ -10,6 +10,12 @@ import Foundation
 /// driver cannot perform itself (retry, relaunch prep) go through ``UpdateActionDelegate``.
 @MainActor
 final class UpdateDriver: NSObject, @preconcurrency SPUUserDriver {
+    /// Whether user-driver callbacks still belong to the active foreground check generation.
+    private enum CheckCallbackAcceptance {
+        case accepting
+        case discardingUntilCycleFinishes
+    }
+
     /// The state model this driver drives.
     let model: UpdateStateModel
     let log: any UpdateLogging
@@ -30,6 +36,7 @@ final class UpdateDriver: NSObject, @preconcurrency SPUUserDriver {
     private var pendingCheckTransitionTask: Task<Void, Never>?
     private var checkTimeoutTask: Task<Void, Never>?
     private(set) var lastFeedURLString: String?
+    private var checkCallbackAcceptance = CheckCallbackAcceptance.accepting
 
     init(
         model: UpdateStateModel,
@@ -70,6 +77,10 @@ final class UpdateDriver: NSObject, @preconcurrency SPUUserDriver {
     }
 
     func showUserInitiatedUpdateCheck(cancellation: @escaping () -> Void) {
+        guard checkCallbackAcceptance == .accepting else {
+            log.append("ignoring checking callback after foreground check timeout")
+            return
+        }
         log.append("show user-initiated update check")
         beginChecking(cancel: cancellation)
     }
@@ -77,6 +88,11 @@ final class UpdateDriver: NSObject, @preconcurrency SPUUserDriver {
     func showUpdateFound(with appcastItem: SUAppcastItem,
                          state: SPUUserUpdateState,
                          reply: @escaping @Sendable (SPUUserUpdateChoice) -> Void) {
+        guard checkCallbackAcceptance == .accepting else {
+            log.append("dismissing update found after foreground check timeout")
+            reply(.dismiss)
+            return
+        }
         log.append("show update found: \(appcastItem.displayVersionString)")
         let available = UpdateState.UpdateAvailable(appcastItem: appcastItem) { choice in reply(choice) }
         available.reply.onConsumed = { [weak self] reply, choice, source in
@@ -95,12 +111,22 @@ final class UpdateDriver: NSObject, @preconcurrency SPUUserDriver {
 
     func showUpdateNotFoundWithError(_ error: any Error,
                                      acknowledgement: @escaping () -> Void) {
+        guard checkCallbackAcceptance == .accepting else {
+            log.append("acknowledging no-update result after foreground check timeout")
+            acknowledgement()
+            return
+        }
         log.append("show update not found: \(formatErrorForLog(error))")
         setStateAfterMinimumCheckDelay(.notFound(.init(acknowledgement: acknowledgement)))
     }
 
     func showUpdaterError(_ error: any Error,
                           acknowledgement: @escaping () -> Void) {
+        guard checkCallbackAcceptance == .accepting else {
+            log.append("acknowledging updater error after foreground check timeout")
+            acknowledgement()
+            return
+        }
         let details = formatErrorForLog(error)
         log.append("show updater error: \(details)")
         setState(.error(.init(
@@ -287,10 +313,20 @@ final class UpdateDriver: NSObject, @preconcurrency SPUUserDriver {
             try? await self.clock.sleep(for: .seconds(self.checkTimeoutDuration))
             guard !Task.isCancelled else { return }
             guard case .checking = self.model.state else { return }
+            guard self.checkCallbackAcceptance == .accepting else { return }
+            self.checkCallbackAcceptance = .discardingUntilCycleFinishes
+            self.pendingCheckTransitionTask?.cancel()
+            self.pendingCheckTransitionTask = nil
+            self.lastCheckStart = nil
             // A local deadline is not an authoritative Sparkle no-update result. Forward it to
             // the controller, which owns whether this check was manual or an accepted install.
             self.eventDelegate?.updateDriverCheckDidTimeOut()
         }
+    }
+
+    /// Reopens result delivery only after Sparkle authoritatively ends the timed-out cycle.
+    func resetCheckCallbackAcceptanceAfterCycle() {
+        checkCallbackAcceptance = .accepting
     }
 
     private func applyState(_ newState: UpdateState) {

--- a/Packages/macOS/CmuxUpdater/Sources/CmuxUpdater/UpdateDriver.swift
+++ b/Packages/macOS/CmuxUpdater/Sources/CmuxUpdater/UpdateDriver.swift
@@ -10,12 +10,6 @@ import Foundation
 /// driver cannot perform itself (retry, relaunch prep) go through ``UpdateActionDelegate``.
 @MainActor
 final class UpdateDriver: NSObject, @preconcurrency SPUUserDriver {
-    /// Whether user-driver callbacks still belong to the active foreground check generation.
-    private enum CheckCallbackAcceptance {
-        case accepting
-        case discardingUntilCycleFinishes
-    }
-
     /// The state model this driver drives.
     let model: UpdateStateModel
     let log: any UpdateLogging
@@ -36,7 +30,7 @@ final class UpdateDriver: NSObject, @preconcurrency SPUUserDriver {
     private var pendingCheckTransitionTask: Task<Void, Never>?
     private var checkTimeoutTask: Task<Void, Never>?
     private(set) var lastFeedURLString: String?
-    private var checkCallbackAcceptance = CheckCallbackAcceptance.accepting
+    private var checkCallbackAcceptance = UpdateCheckCallbackAcceptance.accepting
 
     init(
         model: UpdateStateModel,

--- a/Packages/macOS/CmuxUpdater/Sources/CmuxUpdater/UpdateDriverEventDelegate.swift
+++ b/Packages/macOS/CmuxUpdater/Sources/CmuxUpdater/UpdateDriverEventDelegate.swift
@@ -1,10 +1,10 @@
 import Foundation
 @preconcurrency import Sparkle
 
-/// Causal lifecycle signals that Sparkle exposes outside of `SPUUserDriver`'s display states.
+/// Causal lifecycle signals that do not belong in `SPUUserDriver`'s display states.
 ///
-/// The controller owns check/install intent. The driver forwards these signals so that intent is
-/// advanced by authoritative callbacks instead of inferred from UI state or elapsed time.
+/// The controller owns check/install intent. The driver forwards authoritative Sparkle callbacks
+/// and its bounded check deadline so the controller can resolve each signal in that intent.
 @MainActor
 protocol UpdateDriverEventDelegate: AnyObject {
     /// Sparkle ended an update session, so a queued replacement check may safely start.
@@ -15,4 +15,7 @@ protocol UpdateDriverEventDelegate: AnyObject {
 
     /// The user explicitly dismissed or skipped a foreground update prompt.
     func updateDriverUserDidDismissPrompt()
+
+    /// The foreground check produced no Sparkle result before the driver's bounded deadline.
+    func updateDriverCheckDidTimeOut()
 }

--- a/Packages/macOS/CmuxUpdater/Sources/CmuxUpdater/UpdateState.swift
+++ b/Packages/macOS/CmuxUpdater/Sources/CmuxUpdater/UpdateState.swift
@@ -33,6 +33,48 @@ public enum UpdateState: Equatable {
     /// The update is installing (and may relaunch the app).
     case installing(Installing)
 
+    /// Payload-free state categories shared by the install-attempt coordinator and watchdog.
+    ///
+    /// Keeping this mapping on `UpdateState` makes additions exhaustive in one place and prevents
+    /// lifecycle collaborators from silently assigning contradictory meanings to the same state.
+    enum AttemptDisposition: Equatable {
+        case idle
+        case permissionRequest
+        case preparingCheck
+        case checking
+        case updateAvailable
+        /// A fresh check completed normally without finding an update.
+        case noUpdate
+        case error
+        case startingDownload
+        /// Download, extraction, or installation has visibly progressed.
+        case installProgress
+    }
+
+    /// The shared semantic category used by install-attempt lifecycle policy.
+    var attemptDisposition: AttemptDisposition {
+        switch self {
+        case .idle:
+            .idle
+        case .permissionRequest:
+            .permissionRequest
+        case .preparingCheck:
+            .preparingCheck
+        case .checking:
+            .checking
+        case .updateAvailable:
+            .updateAvailable
+        case .notFound:
+            .noUpdate
+        case .error:
+            .error
+        case .startingDownload:
+            .startingDownload
+        case .downloading, .extracting, .installing:
+            .installProgress
+        }
+    }
+
     /// Whether this is the ``idle`` case.
     public var isIdle: Bool {
         if case .idle = self { return true }

--- a/Packages/macOS/CmuxUpdater/Sources/CmuxUpdater/UpdateState.swift
+++ b/Packages/macOS/CmuxUpdater/Sources/CmuxUpdater/UpdateState.swift
@@ -33,48 +33,6 @@ public enum UpdateState: Equatable {
     /// The update is installing (and may relaunch the app).
     case installing(Installing)
 
-    /// Payload-free state categories shared by the install-attempt coordinator and watchdog.
-    ///
-    /// Keeping this mapping on `UpdateState` makes additions exhaustive in one place and prevents
-    /// lifecycle collaborators from silently assigning contradictory meanings to the same state.
-    enum AttemptDisposition: Equatable {
-        case idle
-        case permissionRequest
-        case preparingCheck
-        case checking
-        case updateAvailable
-        /// A fresh check completed normally without finding an update.
-        case noUpdate
-        case error
-        case startingDownload
-        /// Download, extraction, or installation has visibly progressed.
-        case installProgress
-    }
-
-    /// The shared semantic category used by install-attempt lifecycle policy.
-    var attemptDisposition: AttemptDisposition {
-        switch self {
-        case .idle:
-            .idle
-        case .permissionRequest:
-            .permissionRequest
-        case .preparingCheck:
-            .preparingCheck
-        case .checking:
-            .checking
-        case .updateAvailable:
-            .updateAvailable
-        case .notFound:
-            .noUpdate
-        case .error:
-            .error
-        case .startingDownload:
-            .startingDownload
-        case .downloading, .extracting, .installing:
-            .installProgress
-        }
-    }
-
     /// Whether this is the ``idle`` case.
     public var isIdle: Bool {
         if case .idle = self { return true }

--- a/Packages/macOS/CmuxUpdater/Tests/CmuxUpdaterTests/AttemptUpdateCoordinatorTests.swift
+++ b/Packages/macOS/CmuxUpdater/Tests/CmuxUpdaterTests/AttemptUpdateCoordinatorTests.swift
@@ -111,6 +111,28 @@ import Testing
         _ = coordinator.requestInstallLatest(currentState: updateAvailable("0.64.15"))
         coordinator.didStartFreshCheck()
         #expect(coordinator.handleStateChange(.checking(.init(cancel: {}))) == .none)
+        #expect(coordinator.handleStateChange(.notFound(.init(acknowledgement: {}))) == .none)
+        #expect(!coordinator.isMonitoring)
+    }
+
+    /// A no-update result before the controller has actually started the promised fresh check does
+    /// not belong to that check. Treating it as success could let a stale terminal end the attempt.
+    @Test func notFoundBeforeFreshCheckStartsFailsInstall() {
+        var coordinator = AttemptUpdateCoordinator()
+        _ = coordinator.requestInstallLatest(currentState: updateAvailable("0.64.15"))
+
+        #expect(coordinator.handleStateChange(.notFound(.init(acknowledgement: {}))) == .installFailed)
+        #expect(!coordinator.isMonitoring)
+    }
+
+    /// Once a concrete freshly resolved update has been accepted, losing it to `.notFound` before
+    /// download starts is an unexpected install failure rather than an ordinary check result.
+    @Test func notFoundAfterInstallConfirmationFailsInstall() {
+        var coordinator = AttemptUpdateCoordinator()
+        _ = coordinator.requestInstallLatest(currentState: .idle)
+        coordinator.didStartFreshCheck()
+        #expect(coordinator.handleStateChange(updateAvailable("0.64.16")) == .confirmInstall)
+
         #expect(coordinator.handleStateChange(.notFound(.init(acknowledgement: {}))) == .installFailed)
         #expect(!coordinator.isMonitoring)
     }

--- a/Packages/macOS/CmuxUpdater/Tests/CmuxUpdaterTests/PromptReplyEventSpy.swift
+++ b/Packages/macOS/CmuxUpdater/Tests/CmuxUpdaterTests/PromptReplyEventSpy.swift
@@ -10,4 +10,5 @@ final class PromptReplyEventSpy: UpdateDriverEventDelegate {
     func updateDriverDidFinishCycle(_ updateCheck: SPUUpdateCheck, error: NSError?) {}
     func updateDriverUserDidCancelCheck() {}
     func updateDriverUserDidDismissPrompt() { promptDismissalCount += 1 }
+    func updateDriverCheckDidTimeOut() {}
 }

--- a/Packages/macOS/CmuxUpdater/Tests/CmuxUpdaterTests/TestDeadlineClock.swift
+++ b/Packages/macOS/CmuxUpdater/Tests/CmuxUpdaterTests/TestDeadlineClock.swift
@@ -5,12 +5,7 @@ import Testing
 /// Immediate for the sub-second plumbing delays; parks second-or-longer deadlines until the test
 /// releases them with ``fireDeadlines()`` so watchdog time is explicit.
 actor TestDeadlineClock: UpdateClock {
-    private struct ParkedDeadline {
-        let duration: Duration
-        let continuation: CheckedContinuation<Void, any Error>
-    }
-
-    private var parked: [UUID: ParkedDeadline] = [:]
+    private var parked: [UUID: (duration: Duration, continuation: CheckedContinuation<Void, any Error>)] = [:]
 
     func sleep(for duration: Duration) async throws {
         try Task.checkCancellation()
@@ -18,7 +13,7 @@ actor TestDeadlineClock: UpdateClock {
         let id = UUID()
         try await withTaskCancellationHandler {
             try await withCheckedThrowingContinuation { continuation in
-                parked[id] = ParkedDeadline(duration: duration, continuation: continuation)
+                parked[id] = (duration, continuation)
             }
         } onCancel: {
             Task { await self.cancelParked(id) }

--- a/Packages/macOS/CmuxUpdater/Tests/CmuxUpdaterTests/TestDeadlineClock.swift
+++ b/Packages/macOS/CmuxUpdater/Tests/CmuxUpdaterTests/TestDeadlineClock.swift
@@ -5,7 +5,12 @@ import Testing
 /// Immediate for the sub-second plumbing delays; parks second-or-longer deadlines until the test
 /// releases them with ``fireDeadlines()`` so watchdog time is explicit.
 actor TestDeadlineClock: UpdateClock {
-    private var parked: [UUID: CheckedContinuation<Void, any Error>] = [:]
+    private struct ParkedDeadline {
+        let duration: Duration
+        let continuation: CheckedContinuation<Void, any Error>
+    }
+
+    private var parked: [UUID: ParkedDeadline] = [:]
 
     func sleep(for duration: Duration) async throws {
         try Task.checkCancellation()
@@ -13,7 +18,7 @@ actor TestDeadlineClock: UpdateClock {
         let id = UUID()
         try await withTaskCancellationHandler {
             try await withCheckedThrowingContinuation { continuation in
-                parked[id] = continuation
+                parked[id] = ParkedDeadline(duration: duration, continuation: continuation)
             }
         } onCancel: {
             Task { await self.cancelParked(id) }
@@ -23,9 +28,29 @@ actor TestDeadlineClock: UpdateClock {
     func fireDeadlines() {
         let waiters = parked
         parked = [:]
-        for continuation in waiters.values {
-            continuation.resume()
+        for deadline in waiters.values {
+            deadline.continuation.resume()
         }
+    }
+
+    /// Releases the shortest pending deadline after `expectedCount` deadlines have registered.
+    /// This lets pipeline tests distinguish the 10-second check deadline from the 25-second
+    /// install watchdog without depending on wall-clock timing or task-registration order.
+    func fireEarliestDeadlineWhenReady(expectedCount: Int) async {
+        let clock = ContinuousClock()
+        let timeout = clock.now.advanced(by: .seconds(2))
+        while parked.count < expectedCount, clock.now < timeout {
+            await Task.yield()
+        }
+        guard parked.count >= expectedCount else {
+            Issue.record("timed out waiting for \(expectedCount) test deadlines to be armed")
+            return
+        }
+        guard let earliest = parked.min(by: { $0.value.duration < $1.value.duration }) else {
+            Issue.record("no test deadline was armed")
+            return
+        }
+        parked.removeValue(forKey: earliest.key)?.continuation.resume()
     }
 
     func fireDeadlineWhenReady() async {
@@ -45,6 +70,6 @@ actor TestDeadlineClock: UpdateClock {
     }
 
     private func cancelParked(_ id: UUID) {
-        parked.removeValue(forKey: id)?.resume(throwing: CancellationError())
+        parked.removeValue(forKey: id)?.continuation.resume(throwing: CancellationError())
     }
 }

--- a/Packages/macOS/CmuxUpdater/Tests/CmuxUpdaterTests/UpdateControllerPipelineTests.swift
+++ b/Packages/macOS/CmuxUpdater/Tests/CmuxUpdaterTests/UpdateControllerPipelineTests.swift
@@ -400,6 +400,33 @@ import Testing
         #expect(!didAcknowledgeNotFound)
     }
 
+    /// A local display deadline is not an authoritative Sparkle no-update result. If the fresh
+    /// install check produces no callback, the shorter check deadline must surface a truthful,
+    /// retryable timeout rather than masquerading as “No Updates Available.”
+    @Test func freshInstallCheckTimeoutCannotMasqueradeAsNoUpdate() async {
+        let harness = Harness()
+
+        harness.controller.attemptUpdate()
+        #expect(harness.updater.checkForUpdatesCallCount == 1)
+        harness.controller.driver.showUserInitiatedUpdateCheck(cancellation: {})
+
+        await harness.clock.fireEarliestDeadlineWhenReady(expectedCount: 2)
+
+        await waitUntil("fresh install check timeout error") {
+            guard case .error = harness.model.state else { return false }
+            return true
+        }
+        guard case .error(let failure) = harness.model.state else {
+            Issue.record("check timeout produced \(harness.model.state)")
+            return
+        }
+        let error = failure.error as NSError
+        #expect(error.domain == NSURLErrorDomain)
+        #expect(error.code == NSURLErrorTimedOut)
+        #expect(!harness.controller.attemptCoordinator.isMonitoring)
+        #expect(!harness.controller.installWatchdog.isArmed)
+    }
+
     /// If the live prompt is still visible but already answered before the queued confirm
     /// hand-off runs, the controller must not log a fake install attempt or leave the watchdog
     /// armed for a prompt Sparkle will never accept again.

--- a/Packages/macOS/CmuxUpdater/Tests/CmuxUpdaterTests/UpdateControllerPipelineTests.swift
+++ b/Packages/macOS/CmuxUpdater/Tests/CmuxUpdaterTests/UpdateControllerPipelineTests.swift
@@ -457,6 +457,39 @@ import Testing
         #expect(errorCode(for: harness.model.state) == NSURLErrorTimedOut)
     }
 
+    /// Once a foreground check times out, its remaining Sparkle callbacks still need replies so
+    /// Sparkle can close the cycle, but none may replace the timeout with a result from the
+    /// abandoned generation. The cycle-finished signal remains authoritative cleanup only.
+    @Test func lateSparkleTerminalsCannotReplaceCheckTimeout() async {
+        let harness = Harness()
+        var didAcknowledgeNoUpdate = false
+        var didAcknowledgeError = false
+
+        harness.controller.attemptUpdate()
+        harness.controller.driver.showUserInitiatedUpdateCheck(cancellation: {})
+        await harness.clock.fireEarliestDeadlineWhenReady(expectedCount: 2)
+        await waitUntil("check timeout error") {
+            errorCode(for: harness.model.state) == NSURLErrorTimedOut
+        }
+
+        harness.controller.driver.showUpdateNotFoundWithError(
+            NSError(domain: "test.late-no-update", code: 81),
+            acknowledgement: { didAcknowledgeNoUpdate = true }
+        )
+        harness.controller.driver.showUpdaterError(
+            NSError(domain: "test.late-error", code: 82),
+            acknowledgement: { didAcknowledgeError = true }
+        )
+
+        await waitUntil("late Sparkle terminals to be dismissed") {
+            didAcknowledgeNoUpdate && didAcknowledgeError
+        }
+        #expect(errorCode(for: harness.model.state) == NSURLErrorTimedOut)
+
+        harness.finishSparkleCycle()
+        #expect(errorCode(for: harness.model.state) == NSURLErrorTimedOut)
+    }
+
     /// If the live prompt is still visible but already answered before the queued confirm
     /// hand-off runs, the controller must not log a fake install attempt or leave the watchdog
     /// armed for a prompt Sparkle will never accept again.

--- a/Packages/macOS/CmuxUpdater/Tests/CmuxUpdaterTests/UpdateControllerPipelineTests.swift
+++ b/Packages/macOS/CmuxUpdater/Tests/CmuxUpdaterTests/UpdateControllerPipelineTests.swift
@@ -423,12 +423,38 @@ import Testing
         let error = failure.error as NSError
         #expect(error.domain == NSURLErrorDomain)
         #expect(error.code == NSURLErrorTimedOut)
+        #expect(failure.feedURLString == nil)
         #expect(!harness.controller.attemptCoordinator.isMonitoring)
         #expect(!harness.controller.installWatchdog.isArmed)
 
         failure.retry()
         #expect(harness.controller.attemptCoordinator.isMonitoring)
         #expect(harness.controller.installWatchdog.isArmed)
+    }
+
+    /// A timed-out active check is an abandoned cycle, including any replacement install that
+    /// was queued behind it. Its late cycle-finished callback must leave the timeout authoritative
+    /// instead of starting an install check after the attempt coordinator and watchdog were ended.
+    @Test func timedOutCheckDropsQueuedReplacementInstall() async {
+        let harness = Harness()
+
+        harness.controller.checkForUpdates()
+        #expect(harness.updater.checkForUpdatesCallCount == 1)
+
+        harness.controller.attemptUpdate()
+        #expect(harness.updater.checkForUpdatesCallCount == 1)
+        #expect(harness.controller.attemptCoordinator.isMonitoring)
+        #expect(harness.controller.installWatchdog.isArmed)
+
+        harness.controller.updateDriverCheckDidTimeOut()
+        #expect(errorCode(for: harness.model.state) == NSURLErrorTimedOut)
+        #expect(!harness.controller.attemptCoordinator.isMonitoring)
+        #expect(!harness.controller.installWatchdog.isArmed)
+
+        harness.finishSparkleCycle()
+
+        #expect(harness.updater.checkForUpdatesCallCount == 1)
+        #expect(errorCode(for: harness.model.state) == NSURLErrorTimedOut)
     }
 
     /// If the live prompt is still visible but already answered before the queued confirm

--- a/Packages/macOS/CmuxUpdater/Tests/CmuxUpdaterTests/UpdateControllerPipelineTests.swift
+++ b/Packages/macOS/CmuxUpdater/Tests/CmuxUpdaterTests/UpdateControllerPipelineTests.swift
@@ -371,10 +371,10 @@ import Testing
         #expect(freshPrompt.choice == nil)
     }
 
-    /// A retryable accepted-install failure must also resolve the Sparkle terminal it replaces.
-    /// Otherwise Sparkle still owns an unanswered session and the Retry action can no-op behind
-    /// the visible error.
-    @Test func acceptedInstallFailureAcknowledgesReplacedSparkleTerminal() async {
+    /// Regression for #9262: an ungated attempt update performs a fresh check, so finding no update
+    /// is its normal successful outcome. The pipeline must preserve that result for the ordinary
+    /// no-update UI instead of replacing it with a misleading install/network error.
+    @Test func freshCheckFindingNothingPreservesNoUpdateResult() async {
         let harness = Harness()
         let stalePrompt = ChoiceBox()
         var didAcknowledgeNotFound = false
@@ -389,10 +389,15 @@ import Testing
             didAcknowledgeNotFound = true
         })))
 
-        await waitUntil("accepted-install error") {
-            errorCode(for: harness.model.state) == UpdateStateModel.installDidNotStartCode
+        await waitUntil("no-update attempt to resolve") {
+            !harness.controller.attemptCoordinator.isMonitoring
+                && !harness.controller.installWatchdog.isArmed
         }
-        #expect(didAcknowledgeNotFound)
+        guard case .notFound = harness.model.state else {
+            Issue.record("fresh no-update result was replaced by \(harness.model.state)")
+            return
+        }
+        #expect(!didAcknowledgeNotFound)
     }
 
     /// If the live prompt is still visible but already answered before the queued confirm

--- a/Packages/macOS/CmuxUpdater/Tests/CmuxUpdaterTests/UpdateControllerPipelineTests.swift
+++ b/Packages/macOS/CmuxUpdater/Tests/CmuxUpdaterTests/UpdateControllerPipelineTests.swift
@@ -425,6 +425,10 @@ import Testing
         #expect(error.code == NSURLErrorTimedOut)
         #expect(!harness.controller.attemptCoordinator.isMonitoring)
         #expect(!harness.controller.installWatchdog.isArmed)
+
+        failure.retry()
+        #expect(harness.controller.attemptCoordinator.isMonitoring)
+        #expect(harness.controller.installWatchdog.isArmed)
     }
 
     /// If the live prompt is still visible but already answered before the queued confirm


### PR DESCRIPTION
## Summary

- Preserve `.notFound` as the normal successful result of an ungated Attempt Update fresh check instead of replacing it with “Update Didn’t Start.”
- Introduce one exhaustive `UpdateState.AttemptDisposition` classification consumed by both `AttemptUpdateCoordinator` and `InstallWatchdog`, removing the contradictory raw-state policy tables.
- Add red/green regression coverage at both the coordinator and full controller-pipeline levels.

Closes #9262.

### Deliberate phase policy

- `awaitingFreshCheck`: `.notFound` remains `.installFailed` because the controller has not emitted the authoritative signal that the promised fresh check started; this terminal may belong to a stale cycle.
- `awaitingResult`: `.notFound` ends monitoring with `.none`. It is the expected “already up to date” result of the fresh check and remains in the model for the normal no-update UI.
- `startingDownload`: `.notFound` remains `.installFailed` because a concrete freshly resolved update was already accepted; losing it before download progress is unexpected.

### Command palette follow-up

Consolidation is intentionally deferred. The ungated “Attempt Update” now has the coherent behavior “check, install if found, otherwise report up to date.” “Apply Update (If Available)” invokes the same install path but differs only by availability gating, so I recommend a follow-up that consolidates those two into one clearly named “Check and Install Update” command. “Check for Updates” should remain distinct because it reports the result and leaves install choice to the user. That palette/localization change is separate from correcting package lifecycle semantics here.

## Testing

- `arch -arm64 swift test` from `Packages/macOS/CmuxUpdater` — 90 tests passed.
- Verified the first test-only commit fails in both places: coordinator returns `.installFailed`, and the pipeline replaces `.notFound` with the misleading error.
- Verified sibling `.notFound` classifications before fresh-check start and after install confirmation remain `.installFailed`.
- Timeout cleanup drops queued replacement intent, omits the feed URL from user-visible details, and discards late callbacks from the abandoned Sparkle generation until cycle finish; each is covered by red-first pipeline regression tests.
- No new user-facing strings; localization catalogs are unchanged.
- No new Swift warnings; the package’s existing Sparkle/import warnings are unchanged.

## Demo Video

- Not included yet: per issue instructions, no app build will run until required CI is green and the user explicitly approves the tagged build command.

## Review Trigger (Copy/Paste as PR comment)

```text
@codex review
@coderabbitai review
@greptile-apps review
@cubic-dev-ai review
```

## Checklist

- [x] I tested the change locally
- [x] I added or updated tests for behavior changes
- [x] I updated docs/changelog if needed (no docs/changelog change needed)
- [x] I requested bot reviews after my latest commit
- [x] All code review bot comments are resolved
- [x] All human review comments are resolved

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/9346"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788151704&installation_model_id=21920&pr_number=9346&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F9346&signature=56dc4a7bafd1b4d5cd4e02dbf922b3681878dfb9a18ad32d83c5b7bf2c0f5525"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Treats fresh `.notFound` from an ungated “Attempt Update” as a normal success, and adds a retryable timeout for stalled checks with gated callback acceptance that drops late Sparkle terminals and queued follow-ups. Fixes #9262.

- **Bug Fixes**
  - Preserve `.notFound` as the “up to date” outcome for ungated attempts; UI shows the normal no-update state.
  - On check deadline, emit retryable `NSURLErrorTimedOut`, abandon queued replacement work, gate and acknowledge late Sparkle callbacks until cycle finish, then reopen; retry preserves intent (check vs install).

- **Refactors**
  - Unified lifecycle decisions with `UpdateAttemptDisposition` via `UpdateState.attemptDisposition`, trimming to `noUpdate` and `installProgress` categories consumed by `AttemptUpdateCoordinator` and `InstallWatchdog`.
  - Isolated driver callback acceptance in `UpdateCheckCallbackAcceptance`; reset on cycle-finished.

<sup>Written for commit c74204964124587ad26cc1832dc4a8ac8e417931. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/9346?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved update lifecycle handling across downloads, installations, and no-update results.
  * Fixed update-check timeouts with retryable errors, monitoring cleanup, and reliable retry behavior.
  * Prevented late update results from overriding timeout outcomes.
  * Preserved accurate install-failure reporting when an expected update disappears.
  * Improved watchdog handling for stalled and completed update attempts.

* **Tests**
  * Added coverage for no-update results, timeouts, retries, late callbacks, queued installs, and deadline handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->