### PR TITLE
Port reconnect residuals onto connectivity v2

### DIFF
--- a/Packages/Shared/CMUXMobileCore/Sources/CMUXMobileCore/DiagnosticTaxonomy.swift
+++ b/Packages/Shared/CMUXMobileCore/Sources/CMUXMobileCore/DiagnosticTaxonomy.swift
@@ -71,6 +71,11 @@ public enum DiagnosticFailureKind: Int, Sendable, Codable, CaseIterable {
     /// event queue overflowed while the transport stopped draining (for
     /// example the peer's network path died mid-write).
     case sendQueueOverflow = 24
+    /// The connect-attempt registry refused a dial because the exact route is
+    /// held by an in-flight connect attempt. Distinguishes gate refusals from
+    /// genuine dial timeouts in exports; a gated attempt never reached the
+    /// network.
+    case routeGated = 25
     case unknown = 255
 
     /// Reduces a typed or system error to the bounded diagnostic vocabulary.

--- a/Packages/Shared/CMUXMobileCore/Tests/CMUXMobileCoreTests/DiagnosticLogTests.swift
+++ b/Packages/Shared/CMUXMobileCore/Tests/CMUXMobileCoreTests/DiagnosticLogTests.swift
@@ -272,6 +272,7 @@ import os
         #expect(DiagnosticFailureKind.admissionLeaseExpired.rawValue == 22)
         #expect(DiagnosticFailureKind.admissionRevalidationFailed.rawValue == 23)
         #expect(DiagnosticFailureKind.sendQueueOverflow.rawValue == 24)
+        #expect(DiagnosticFailureKind.routeGated.rawValue == 25)
         #expect(
             Set(DiagnosticFailureKind.allCases.map(\.rawValue)).count
                 == DiagnosticFailureKind.allCases.count
@@ -439,6 +440,27 @@ import os
             #expect(report.lastFailureKind == .protocolViolation)
             #expect(report.lastFailureDate != nil)
         }
+    }
+
+    @Test func gatedDialRefusalsReportRouteGatedNotTimedOut() {
+        // A connect-registry gate refusal is instantaneous and never touched
+        // the network. It used to be classified as `.timedOut`, fabricating
+        // sub-30ms timeout failures that poisoned `lastFailureEvent`.
+        let gatedRefusal = DiagnosticEvent(
+            code: .transportDialFailed,
+            tNanos: 2,
+            a: DiagnosticTransportKind.iroh.rawValue,
+            b: DiagnosticFailureKind.routeGated.rawValue,
+            c: 7
+        )
+        let report = DiagnosticReport(
+            anchorWallNanos: 1_000_000_000,
+            anchorMonotonicNanos: 1,
+            events: [gatedRefusal]
+        )
+        #expect(report.lastFailureKind == .routeGated)
+        #expect(report.lastFailureKind != .timedOut)
+        #expect(report.lastFailureEvent == gatedRefusal)
     }
 
     @Test func clearStartsFreshBoundedSessionAndResetsAnchors() async {

--- a/Packages/iOS/CmuxMobileRPC/Sources/CmuxMobileRPC/MobileCoreRPCSession+RequestSettlement.swift
+++ b/Packages/iOS/CmuxMobileRPC/Sources/CmuxMobileRPC/MobileCoreRPCSession+RequestSettlement.swift
@@ -33,7 +33,7 @@ private extension MobileShellConnectionError {
         case .authorizationFailed, .accountMismatch, .rpcError:
             true
         case .invalidResponse, .connectionClosed, .requestTimedOut, .transportWriteTimedOut,
-             .routeCleanupBlocked, .insecureManualRoute, .attachTicketExpired:
+             .routeCleanupBlocked, .connectAttemptGated, .insecureManualRoute, .attachTicketExpired:
             false
         }
     }

--- a/Packages/iOS/CmuxMobileRPC/Sources/CmuxMobileRPC/MobileCoreRPCSession.swift
+++ b/Packages/iOS/CmuxMobileRPC/Sources/CmuxMobileRPC/MobileCoreRPCSession.swift
@@ -490,7 +490,10 @@ actor MobileCoreRPCSession {
             case .granted(let lease):
                 connectLease = lease
             case .busy:
-                throw MobileShellConnectionError.requestTimedOut
+                // A gate refusal is instantaneous and never touched the
+                // network; reporting it as a timeout fabricated sub-30ms
+                // "timedOut" failures that poisoned lastFailureEvent.
+                throw MobileShellConnectionError.connectAttemptGated
             case .cleanupBlocked:
                 throw MobileShellConnectionError.routeCleanupBlocked
             }

--- a/Packages/iOS/CmuxMobileRPC/Sources/CmuxMobileRPC/MobileShellConnectionError.swift
+++ b/Packages/iOS/CmuxMobileRPC/Sources/CmuxMobileRPC/MobileShellConnectionError.swift
@@ -17,6 +17,10 @@ public enum MobileShellConnectionError: LocalizedError, DiagnosticFailureProvidi
     /// remain blocked to cap retained transports until cleanup finishes or the
     /// app process restarts.
     case routeCleanupBlocked
+    /// The connect-attempt registry refused the dial because this exact route
+    /// already has a connect attempt in flight. The refusal is instantaneous
+    /// and never reached the network, so it must not masquerade as a timeout.
+    case connectAttemptGated
     /// A manual host did not advertise a secure route.
     case insecureManualRoute
     /// The attach ticket expired and no fallback was available.
@@ -46,6 +50,11 @@ public enum MobileShellConnectionError: LocalizedError, DiagnosticFailureProvidi
                 "mobile.connection.routeCleanupBlocked",
                 defaultValue: "Connection cleanup is stuck. Restart cmux on this device before reconnecting."
             )
+        case .connectAttemptGated:
+            return L10n.string(
+                "mobile.connection.connectAttemptGated",
+                defaultValue: "Mobile sync connection is retrying"
+            )
         case .insecureManualRoute:
             return "Manual host did not advertise a secure mobile sync route"
         case .attachTicketExpired:
@@ -67,6 +76,8 @@ public enum MobileShellConnectionError: LocalizedError, DiagnosticFailureProvidi
             .connectionClosed
         case .requestTimedOut, .transportWriteTimedOut:
             .timedOut
+        case .connectAttemptGated:
+            .routeGated
         case .routeCleanupBlocked:
             .admissionDenied
         case .insecureManualRoute:

--- a/Packages/iOS/CmuxMobileRPC/Tests/CmuxMobileRPCTests/MobileCoreRPCAbandonedConnectTests.swift
+++ b/Packages/iOS/CmuxMobileRPC/Tests/CmuxMobileRPCTests/MobileCoreRPCAbandonedConnectTests.swift
@@ -523,6 +523,60 @@ import Testing
         await registry.finishConnect(lease: nextLease)
     }
 
+    @Test func activeRouteAdmissionReportsRouteGatedInsteadOfTimedOut()
+        async throws {
+        let registry = MobileRPCConnectAttemptRegistry()
+        let key = debugConnectAttemptKey(port: 59_134)
+        let firstTransport = ReleasableConnectTransport()
+        let firstSession = MobileCoreRPCSession(
+            connectAttemptKey: key,
+            connectAttemptRegistry: registry,
+            makeTransport: { firstTransport }
+        )
+        let secondSession = MobileCoreRPCSession(
+            connectAttemptKey: key,
+            connectAttemptRegistry: registry,
+            makeTransport: {
+                Issue.record("Gated route must not allocate transport")
+                return ReleasableConnectTransport()
+            }
+        )
+        let firstTask = Task {
+            try await firstSession.send(
+                payload: MobileCoreRPCClient.requestData(
+                    method: "mobile.host.status",
+                    id: "active-route-owner"
+                ),
+                requestID: "active-route-owner",
+                deadlineUptimeNanoseconds:
+                    DispatchTime.now().uptimeNanoseconds
+                    + 60_000_000_000
+            )
+        }
+        #expect(await firstTransport.waitUntilConnectStarted())
+
+        do {
+            _ = try await secondSession.send(
+                payload: MobileCoreRPCClient.requestData(
+                    method: "mobile.host.status",
+                    id: "active-route-contender"
+                ),
+                requestID: "active-route-contender",
+                deadlineUptimeNanoseconds:
+                    DispatchTime.now().uptimeNanoseconds
+                    + 60_000_000_000
+            )
+            Issue.record("Expected route gate to reject concurrent admission")
+        } catch MobileShellConnectionError.connectAttemptGated {
+        } catch {
+            Issue.record("Expected connectAttemptGated, got \(error)")
+        }
+
+        await firstTransport.releaseConnect()
+        _ = try await firstTask.value
+        await firstSession.tearDown(error: .connectionClosed)
+    }
+
     @Test func connectAttemptKeySeparatesPeersAndIgnoresIrohHintChurn()
         async throws {
         let identityA = try CmxIrohPeerIdentity(

--- a/Packages/iOS/CmuxMobileRPC/Tests/CmuxMobileRPCTests/MobileRPCTransportConnectEventTests.swift
+++ b/Packages/iOS/CmuxMobileRPC/Tests/CmuxMobileRPCTests/MobileRPCTransportConnectEventTests.swift
@@ -128,6 +128,7 @@ import Testing
         #expect(MobileShellConnectionError.connectionClosed.diagnosticFailureKind == .connectionClosed)
         #expect(MobileShellConnectionError.requestTimedOut.diagnosticFailureKind == .timedOut)
         #expect(MobileShellConnectionError.transportWriteTimedOut.diagnosticFailureKind == .timedOut)
+        #expect(MobileShellConnectionError.connectAttemptGated.diagnosticFailureKind == .routeGated)
         #expect(
             MobileShellConnectionError.routeCleanupBlocked.diagnosticFailureKind
                 == .admissionDenied

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileChatEventSource.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileChatEventSource.swift
@@ -460,7 +460,7 @@ public actor MobileChatEventSource: ChatEventSource {
         }
         switch connectionError {
         case .invalidResponse, .connectionClosed, .requestTimedOut,
-             .transportWriteTimedOut,
+             .transportWriteTimedOut, .connectAttemptGated,
              .insecureManualRoute, .attachTicketExpired,
              .authorizationFailed, .accountMismatch, .routeCleanupBlocked:
             return .macUnreachable

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobilePairingFailure.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobilePairingFailure.swift
@@ -413,7 +413,7 @@ extension MobilePairingFailureCategory {
 
         if let connectionError = error as? MobileShellConnectionError {
             switch connectionError {
-            case .requestTimedOut:
+            case .requestTimedOut, .connectAttemptGated:
                 return .handshakeTimedOut(host: host, port: port)
             case .insecureManualRoute:
                 return .unsupportedRoute

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobilePresencePushRecoveryThrottle.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobilePresencePushRecoveryThrottle.swift
@@ -1,0 +1,49 @@
+import Foundation
+
+/// Decides whether one presence delivery may start another recovery pass.
+///
+/// Presence heartbeats about an online Mac arrive roughly every 15 seconds.
+/// While the phone is disconnected, each heartbeat used to restart connection
+/// recovery, so during a persistent outage the phone kept abandoning its own
+/// in-flight dials on the heartbeat cadence and each abandoned dial fed the
+/// connect-registry gate
+/// (https://github.com/manaflow-ai/cmux/issues/9177).
+///
+/// Changed evidence (new routes, a Mac coming online) always passes: that is
+/// the wake-up signal presence exists for. Unchanged heartbeats pass at most
+/// once per ``minimumUnchangedEvidenceInterval`` so an already-failing
+/// recovery loop gets its full dial budget between presence-triggered
+/// restarts.
+struct MobilePresencePushRecoveryThrottle {
+    /// Chosen above the ~15s presence heartbeat cadence and the dial budget a
+    /// recovery pass needs, below the point where a stalled recovery would be
+    /// user-visible next to the 30-60s automatic backoff ladder.
+    static let minimumUnchangedEvidenceInterval: TimeInterval = 45
+
+    private var lastRecoveryAt: Date?
+
+    /// Records and reports whether a presence-triggered recovery may start.
+    mutating func shouldRecover(evidenceChanged: Bool, now: Date) -> Bool {
+        if evidenceChanged {
+            lastRecoveryAt = now
+            return true
+        }
+        guard let lastRecoveryAt else {
+            self.lastRecoveryAt = now
+            return true
+        }
+        let elapsed = now.timeIntervalSince(lastRecoveryAt)
+        // A rewound wall clock (negative elapsed) must not freeze the
+        // throttle until the clock catches back up; treat it as expired.
+        guard elapsed >= 0, elapsed < Self.minimumUnchangedEvidenceInterval else {
+            self.lastRecoveryAt = now
+            return true
+        }
+        return false
+    }
+
+    /// Forgets throttle history at an account or session boundary.
+    mutating func reset() {
+        lastRecoveryAt = nil
+    }
+}

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+ConnectionRecovery.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+ConnectionRecovery.swift
@@ -52,6 +52,10 @@ extension MobileShellComposite {
         guard connectionState == .connected,
               let client = remoteClient,
               pairedMacStore != nil else { return }
+        guard foregroundRefreshIsActive else {
+            pendingInactiveRecoveryTrigger = .foreground
+            return
+        }
         beginConnectionRecovery(
             trigger: .foreground,
             expectedClient: client,
@@ -68,6 +72,12 @@ extension MobileShellComposite {
     /// shows Retry and the next network change re-attempts automatically.
     func recoverMobileConnection(trigger: RecoveryTrigger) {
         guard remoteClient != nil || pairedMacStore != nil else { return }
+        // A dial launched while the scene is inactive suspends with the
+        // process; park the trigger and replay it once on foreground.
+        guard foregroundRefreshIsActive else {
+            pendingInactiveRecoveryTrigger = trigger
+            return
+        }
         if let accountID = identityProvider?.currentUserID {
             switch trigger {
             case .manual, .networkChange, .foreground:
@@ -102,6 +112,10 @@ extension MobileShellComposite {
         expectedClient: MobileCoreRPCClient
     ) {
         guard remoteClient === expectedClient, connectionState == .connected else { return }
+        guard foregroundRefreshIsActive else {
+            pendingInactiveRecoveryTrigger = trigger
+            return
+        }
 
         if connectionRecoveryOwner.isRedialingOrValidating {
             let replacementIsInstalled = connectionRecoveryOwner.isValidatingReplacement
@@ -126,6 +140,17 @@ extension MobileShellComposite {
             resyncAfterHealthy: false,
             preclaimedAttempt: superseding
         )
+    }
+
+    /// Replays the most recent recovery trigger that was parked while the
+    /// scene was inactive. Called from `resumeForegroundRefresh()` after the
+    /// foreground recovery passes, so a replay coalesces into any attempt
+    /// they already started instead of stacking a second dial.
+    func recoverPendingInactiveRecoveryIfNeeded() {
+        guard foregroundRefreshIsActive,
+              let trigger = pendingInactiveRecoveryTrigger else { return }
+        pendingInactiveRecoveryTrigger = nil
+        recoverMobileConnection(trigger: trigger)
     }
 
     private func beginConnectionRecovery(

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+PresenceRouteSync.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+PresenceRouteSync.swift
@@ -216,6 +216,14 @@ extension MobileShellComposite {
         }
         // Presence is only a wake-up signal. The recovery pass still obtains
         // first-pair candidates from the authenticated personal broker.
+        // Unchanged heartbeats are throttled so a persistent outage cannot
+        // restart an in-flight recovery on the presence cadence.
+        guard presencePushRecoveryThrottle.shouldRecover(
+            evidenceChanged: evidenceChanged,
+            now: runtime?.now() ?? Date()
+        ) else {
+            return
+        }
         recoverMobileConnection(trigger: .presencePush)
     }
 

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+ReconnectRoutes.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+ReconnectRoutes.swift
@@ -301,6 +301,7 @@ extension MobileShellComposite {
 
     /// Resume foreground-only refresh loops after the app becomes active.
     public func resumeForegroundRefresh() {
+        foregroundRefreshIsActive = true
         foregroundResumeEpoch &+= 1
         startObservingNetworkPathChanges()
         // Covers stores constructed already-signed-in (no isSignedIn edge) and
@@ -319,6 +320,7 @@ extension MobileShellComposite {
         restartActiveMobileBrowserStreams()
         recoverForegroundConnectionIfNeeded(resyncAfterHealthy: shouldResync)
         recoverDisconnectedOnForegroundIfNeeded()
+        recoverPendingInactiveRecoveryIfNeeded()
         // The foreground Mac's workspace list updates live over the sync stream,
         // but the other Macs are a read-only snapshot. Re-aggregate them on
         // foreground so workspaces created on another Mac while backgrounded
@@ -330,6 +332,7 @@ extension MobileShellComposite {
 
     /// Record that the app left the active scene phase.
     public func suspendForegroundRefresh() {
+        foregroundRefreshIsActive = false
         if connectionRecoveryOwner.cancelProbing() {
             applyConnectionRecoveryOwnerState()
         }

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+TaskComposer.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+TaskComposer.swift
@@ -77,6 +77,7 @@ extension MobileShellComposite {
             ].contains(code?.lowercased() ?? ""):
                 return .failure(.unsupported)
             case .requestTimedOut,
+                 .connectAttemptGated,
                  .rpcError("request_timeout", _):
                 return .failure(.timedOut)
             case .authorizationFailed,

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+TaskDirectoryList.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+TaskDirectoryList.swift
@@ -77,6 +77,7 @@ extension MobileShellComposite {
             ].contains(code?.lowercased() ?? ""):
                 return .failure(.unsupported)
             case .requestTimedOut,
+                 .connectAttemptGated,
                  .rpcError("request_timeout", _):
                 return .failure(.timedOut)
             case .authorizationFailed,

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+WorkspaceActions.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+WorkspaceActions.swift
@@ -519,7 +519,7 @@ extension MobileShellComposite {
         case .connectionClosed, .transportWriteTimedOut,
              .routeCleanupBlocked:
             return .notConnected(hostDisplayName: hostDisplayName)
-        case .requestTimedOut:
+        case .requestTimedOut, .connectAttemptGated:
             return .requestTimedOut(hostDisplayName: hostDisplayName)
         case .attachTicketExpired, .authorizationFailed, .accountMismatch, .insecureManualRoute:
             return .authorizationFailed(hostDisplayName: hostDisplayName)

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
@@ -11989,7 +11989,7 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
                 || normalizedMessage.contains("expired token")
                 || normalizedMessage.contains("token expired")
         case .invalidResponse, .connectionClosed, .requestTimedOut,
-             .transportWriteTimedOut, .routeCleanupBlocked,
+             .transportWriteTimedOut, .routeCleanupBlocked, .connectAttemptGated,
              .insecureManualRoute:
             return false
         }

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
@@ -302,6 +302,7 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         scope: MobileShellScopeSnapshot,
         instances: [MobilePresenceReconnectEvidence]
     )?
+    var presencePushRecoveryThrottle = MobilePresencePushRecoveryThrottle()
     /// Whether the current attach ticket has a non-empty auth token and has not expired.
     public var hasActiveUnexpiredAttachTicket: Bool {
         guard let activeTicket,
@@ -1589,6 +1590,7 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         // projections.
         resetStateSyncForAccountBoundary()
         lastPresenceReconnectEvidence = nil
+        presencePushRecoveryThrottle.reset()
         pendingInactiveRecoveryTrigger = nil
         connectionRecoveryOwner.cancel()
         applyConnectionRecoveryOwnerState()

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
@@ -1589,6 +1589,7 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         // projections.
         resetStateSyncForAccountBoundary()
         lastPresenceReconnectEvidence = nil
+        pendingInactiveRecoveryTrigger = nil
         connectionRecoveryOwner.cancel()
         applyConnectionRecoveryOwnerState()
         invalidatePairingAttempt()
@@ -1972,6 +1973,17 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
     var networkPathObservationTask: Task<Void, Never>?
     let connectionRecoveryOwner = MobileConnectionRecoveryOwner()
     var lastReconnectStackUserID: String?
+    /// Whether the scene is in the active phase. Set by
+    /// `resumeForegroundRefresh()` / `suspendForegroundRefresh()`. Recovery
+    /// triggers that arrive while false park in
+    /// `pendingInactiveRecoveryTrigger` instead of dialing: a dial launched
+    /// during the backgrounding bounce suspends with the process (field
+    /// traces showed ~9.5s stalls) and then competes with the foreground
+    /// recovery pass.
+    var foregroundRefreshIsActive = true
+    /// The most recent recovery trigger parked while inactive, replayed once
+    /// by `recoverPendingInactiveRecoveryIfNeeded()` on foreground.
+    var pendingInactiveRecoveryTrigger: RecoveryTrigger?
 
     enum RecoveryTrigger: CustomStringConvertible {
         case networkChange
@@ -8957,7 +8969,8 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
     /// ticket probe has succeeded and a foreground replacement can proceed.
     private func preparePairingConnectionAttempt() {
         // Any explicit connect supersedes launch/network recovery, including a
-        // recovery suspended in a registry refresh for the same device id.
+        // recovery parked while the scene was inactive.
+        pendingInactiveRecoveryTrigger = nil
         connectionRecoveryOwner.cancel()
         applyConnectionRecoveryOwnerState()
         invalidateStoredMacReconnectAttempt()

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellMacAvailabilityFailureClassifier.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellMacAvailabilityFailureClassifier.swift
@@ -13,9 +13,9 @@ struct MobileShellMacAvailabilityFailureClassifier {
         case .connectionClosed, .transportWriteTimedOut,
              .routeCleanupBlocked:
             return true
-        case .invalidResponse, .requestTimedOut, .insecureManualRoute,
-             .attachTicketExpired, .authorizationFailed, .accountMismatch,
-             .rpcError:
+        case .invalidResponse, .requestTimedOut, .connectAttemptGated,
+             .insecureManualRoute, .attachTicketExpired, .authorizationFailed,
+             .accountMismatch, .rpcError:
             // .accountMismatch means the Mac is reachable but signed in to a
             // different account; that is an auth problem, not a Mac-availability one.
             return false

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/SecondaryControlAttemptPolicy.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/SecondaryControlAttemptPolicy.swift
@@ -35,8 +35,8 @@ func secondaryControlAttemptIsTransient(_ error: any Error) -> Bool {
     case .connectionClosed, .requestTimedOut, .transportWriteTimedOut,
          .routeCleanupBlocked:
         return true
-    case .invalidResponse, .insecureManualRoute, .attachTicketExpired,
-         .authorizationFailed, .accountMismatch:
+    case .invalidResponse, .connectAttemptGated, .insecureManualRoute,
+         .attachTicketExpired, .authorizationFailed, .accountMismatch:
         return false
     case let .rpcError(code, _):
         let permanentCodes: Set<String> = [

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/WorkspaceCreatePinnedContext.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/WorkspaceCreatePinnedContext.swift
@@ -58,6 +58,7 @@ extension MobileShellComposite {
             case is CancellationError,
                  MobileShellConnectionError.connectionClosed,
                  MobileShellConnectionError.requestTimedOut,
+                 MobileShellConnectionError.connectAttemptGated,
                  MobileShellConnectionError.transportWriteTimedOut,
                  MobileShellConnectionError.invalidResponse:
                 isAmbiguous = true

--- a/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/MobilePresencePushRecoveryThrottleTests.swift
+++ b/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/MobilePresencePushRecoveryThrottleTests.swift
@@ -1,0 +1,94 @@
+import Foundation
+import Testing
+@testable import CmuxMobileShell
+
+@Suite
+struct MobilePresencePushRecoveryThrottleTests {
+    private let now = Date(timeIntervalSince1970: 1_700_000_000)
+    private let interval = MobilePresencePushRecoveryThrottle.minimumUnchangedEvidenceInterval
+
+    @Test
+    func firstUnchangedHeartbeatRecoversThenHeartbeatCadenceIsThrottled() {
+        var throttle = MobilePresencePushRecoveryThrottle()
+
+        let first = throttle.shouldRecover(evidenceChanged: false, now: now)
+        // ~15s presence heartbeats inside the interval must not restart
+        // recovery; this cadence starved in-flight dials during the outage.
+        let heartbeat15 = throttle.shouldRecover(
+            evidenceChanged: false,
+            now: now.addingTimeInterval(15)
+        )
+        let heartbeat30 = throttle.shouldRecover(
+            evidenceChanged: false,
+            now: now.addingTimeInterval(30)
+        )
+        let afterInterval = throttle.shouldRecover(
+            evidenceChanged: false,
+            now: now.addingTimeInterval(interval)
+        )
+
+        #expect(first)
+        #expect(!heartbeat15)
+        #expect(!heartbeat30)
+        #expect(afterInterval)
+    }
+
+    @Test
+    func changedEvidenceAlwaysRecoversAndReArmsTheThrottle() {
+        var throttle = MobilePresencePushRecoveryThrottle()
+
+        let first = throttle.shouldRecover(evidenceChanged: false, now: now)
+        let changed = throttle.shouldRecover(
+            evidenceChanged: true,
+            now: now.addingTimeInterval(5)
+        )
+        // The changed-evidence pass restarts the unchanged-heartbeat window.
+        let unchangedAfterChanged = throttle.shouldRecover(
+            evidenceChanged: false,
+            now: now.addingTimeInterval(6)
+        )
+        let afterReArmedInterval = throttle.shouldRecover(
+            evidenceChanged: false,
+            now: now.addingTimeInterval(5 + interval)
+        )
+
+        #expect(first)
+        #expect(changed)
+        #expect(!unchangedAfterChanged)
+        #expect(afterReArmedInterval)
+    }
+
+    @Test
+    func rewoundWallClockDoesNotFreezeTheThrottle() {
+        var throttle = MobilePresencePushRecoveryThrottle()
+
+        let first = throttle.shouldRecover(evidenceChanged: false, now: now)
+        let afterRewind = throttle.shouldRecover(
+            evidenceChanged: false,
+            now: now.addingTimeInterval(-3600)
+        )
+
+        #expect(first)
+        #expect(afterRewind)
+    }
+
+    @Test
+    func resetForgetsHistorySoTheNextHeartbeatRecoversImmediately() {
+        var throttle = MobilePresencePushRecoveryThrottle()
+
+        let first = throttle.shouldRecover(evidenceChanged: false, now: now)
+        let throttled = throttle.shouldRecover(
+            evidenceChanged: false,
+            now: now.addingTimeInterval(1)
+        )
+        throttle.reset()
+        let afterReset = throttle.shouldRecover(
+            evidenceChanged: false,
+            now: now.addingTimeInterval(2)
+        )
+
+        #expect(first)
+        #expect(!throttled)
+        #expect(afterReset)
+    }
+}

--- a/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/MobileShellForegroundResumeTests.swift
+++ b/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/MobileShellForegroundResumeTests.swift
@@ -199,7 +199,7 @@ struct MobileShellForegroundConnectionRecoveryTests {
 }
 
 @MainActor
-@Test func foregroundResumeAbandonsProbeStartedDuringBackgroundAndProbesAgain() async throws {
+@Test func foregroundRecoveryRequestedDuringBackgroundWaitsForForegroundProbe() async throws {
     let router = LivenessHostRouter()
     let box = TransportBox()
     let clock = TestClock()
@@ -207,7 +207,7 @@ struct MobileShellForegroundConnectionRecoveryTests {
         router: router,
         box: box,
         clock: clock,
-        probeTimeoutNanoseconds: 50_000_000
+        probeTimeoutNanoseconds: 1_000_000_000
     )
     defer {
         Task { await router.releaseAllHeld() }
@@ -219,16 +219,32 @@ struct MobileShellForegroundConnectionRecoveryTests {
 
     store.suspendForegroundRefresh()
     store.recoverForegroundConnectionIfNeeded(resyncAfterHealthy: false)
-    #expect(await router.waitForCount(
+    // A dial launched mid-backgrounding suspends with the process (field
+    // traces showed ~9.5s stalls), so the trigger must park until foreground
+    // instead of dialing while inactive.
+    let probedWhileInactive = await router.waitForCount(
         of: "mobile.workspace.list",
-        atLeast: probeCount + 1
-    ))
+        atLeast: probeCount + 1,
+        timeoutNanoseconds: 200_000_000,
+        recordIssueOnTimeout: false
+    )
+    #expect(!probedWhileInactive)
     store.resumeForegroundRefresh()
 
     #expect(await router.waitForCount(
         of: "mobile.workspace.list",
-        atLeast: probeCount + 2
+        atLeast: probeCount + 1
     ))
+    // Exactly one probe: the parked trigger's replay coalesces into the
+    // foreground recovery pass instead of stacking a second dial.
+    let doubleProbed = await router.waitForCount(
+        of: "mobile.workspace.list",
+        atLeast: probeCount + 2,
+        timeoutNanoseconds: 200_000_000,
+        recordIssueOnTimeout: false
+    )
+    #expect(!doubleProbed)
+    await router.releaseAllHeld()
     #expect(try await pollUntil {
         store.connectionRecoveryOwner.phase == .idle
     })

--- a/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/MobileShellWorkspaceCreateTests.swift
+++ b/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/MobileShellWorkspaceCreateTests.swift
@@ -165,6 +165,7 @@ import Testing
         for error in [
             MobileShellConnectionError.connectionClosed,
             MobileShellConnectionError.requestTimedOut,
+            MobileShellConnectionError.connectAttemptGated,
             MobileShellConnectionError.invalidResponse,
         ] {
             #expect(

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MobileIrohSettingsView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MobileIrohSettingsView.swift
@@ -415,6 +415,8 @@ private extension MobileIrohSettingsView {
                 "mobile.iroh.diagnostics.failure.sendQueueOverflow",
                 defaultValue: "Send Queue Overflow"
             )
+        case .some(.routeGated):
+            L10n.string("mobile.iroh.diagnostics.failure.routeGated", defaultValue: "Route Gated")
         case .some(.superseded):
             L10n.string(
                 "mobile.iroh.diagnostics.failure.superseded",

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/Resources/Localizable.xcstrings
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/Resources/Localizable.xcstrings
@@ -1105,6 +1105,13 @@
         "ja" : { "stringUnit" : { "state" : "translated", "value" : "安全なチャネルの確立に失敗" } }
       }
     },
+    "mobile.iroh.diagnostics.failure.routeGated" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Route Gated" } },
+        "ja" : { "stringUnit" : { "state" : "translated", "value" : "経路が一時的に制限されています" } }
+      }
+    },
     "mobile.iroh.diagnostics.failure.sendQueueOverflow" : {
       "extractionState" : "manual",
       "localizations" : {

--- a/Packages/macOS/CmuxSettingsUI/Sources/CmuxSettingsUI/Sections/IrohNetworkingSection.swift
+++ b/Packages/macOS/CmuxSettingsUI/Sources/CmuxSettingsUI/Sections/IrohNetworkingSection.swift
@@ -593,6 +593,11 @@ private struct IrohDiagnosticsReportRows: View {
                 localized: "settings.networking.diagnostics.failure.sendQueueOverflow",
                 defaultValue: "Send Queue Overflow"
             )
+        case .some(.routeGated):
+            String(
+                localized: "settings.networking.diagnostics.failure.routeGated",
+                defaultValue: "Connection Attempt Held"
+            )
         case .some(.superseded):
             String(
                 localized: "settings.networking.diagnostics.failure.superseded",

--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -259794,6 +259794,23 @@
         }
       }
     },
+    "settings.networking.diagnostics.failure.routeGated": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Connection Attempt Held"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "接続試行が一時的に保留されました"
+          }
+        }
+      }
+    },
     "settings.networking.diagnostics.failure.secureChannelFailed": {
       "extractionState": "manual",
       "localizations": {

--- a/ios/cmux/Resources/Localizable.xcstrings
+++ b/ios/cmux/Resources/Localizable.xcstrings
@@ -2398,6 +2398,23 @@
         }
       }
     },
+    "mobile.connection.connectAttemptGated": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mobile sync connection is retrying"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "モバイル同期接続を再試行しています"
+          }
+        }
+      }
+    },
     "mobile.connection.connected": {
       "extractionState": "manual",
       "localizations": {


### PR DESCRIPTION
Ports the three pieces of https://github.com/manaflow-ai/cmux/pull/9256 (the field-incident fix on the pre-v2 architecture) that connectivity v2 (9eb240f262, `CmxIrohClientRuntime` + `CmxConnectivityEngine` + `CmxConnectivityPeerSession`) did not absorb. v2 already covers wake-time dead-session eviction (`deadOnArrivalSessionIsClosedAndRedialedOnce`, `unavailableSelectedPathEvictsTheSessionAndTheNextOperationRedials`, `backgroundPreservesEndpointAndForegroundReusesHealthyGeneration`), so only these three client-shell residuals are ported, re-implemented against current main rather than cherry-picked.

**1. Park inactive-phase recovery triggers** (red/green: 506dc59408 test, b8b4c5fc21 fix). Field traces showed a dial launched during the backgrounding bounce sitting suspended ~9.5s with the process, then competing with the foreground recovery pass. Recovery triggers arriving while the scene is inactive now park in `pendingInactiveRecoveryTrigger` and replay exactly once in `resumeForegroundRefresh()`, after the foreground passes, so the replay coalesces into any attempt they already started. Explicit pairing connects and the account boundary clear the parked trigger. Regression: `foregroundRecoveryRequestedDuringBackgroundWaitsForForegroundProbe` (no dial while inactive, exactly one on foreground; red on main at the tests-first commit).

**2. `connectAttemptGated` truth-telling** (78cd19d8f2, single commit — the tests reference the new enum cases so a tests-first commit cannot compile on main). A connect-registry `.busy` refusal threw `requestTimedOut`, fabricating instant sub-30ms "timedOut" failures that poisoned `lastFailureEvent` during recovery storms. New `MobileShellConnectionError.connectAttemptGated` maps to new `DiagnosticFailureKind.routeGated` (raw 25, append-only). Caller-facing categories stay retryable-timeout; only diagnostics and the iOS/macOS diagnostics rows distinguish the gate (localized en/ja). Regression: `activeRouteAdmissionReportsRouteGatedInsteadOfTimedOut` (gated attempt reports the gated outcome, allocates no transport) and `gatedDialRefusalsReportRouteGatedNotTimedOut` (`lastFailureKind == .routeGated`, never `.timedOut`).

**3. Presence-push recovery throttle** (c5f70e5553, single commit — tests reference the new type). Checked for v2 obsolescence first: `CmxConnectivityInvalidationSubscriber` / `ConnectivityInvalidationSubscriberCoordinator` replaced the Mac-side `PresenceNudgeSubscriber`, but the phone-side path (`PresenceClient` ~15s heartbeats → `syncPushedRoutes` → `recoverFromPushedRouteBatch` → `recoverMobileConnection(.presencePush)`) survives unthrottled on main, so during a persistent outage each heartbeat abandoned the in-flight dial and fed the connect gate (https://github.com/manaflow-ai/cmux/issues/9177). `MobilePresencePushRecoveryThrottle` passes changed evidence unconditionally and unchanged heartbeats at most once per 45s, injected clock per call, rewound-clock safe, reset at the account boundary.

Not ported (explicitly out of scope, still absent on main): 9256's abandoned-dial `.cancelled` connect-event reporting with the `lastFailureEvent` cancelled filter, the session-level abandoned-cleanup `requestTimedOut`→`routeCleanupBlocked` reclassification, and `resetRouteHealthForNetworkChange` (v2 keeps no route strikes to reset).

Local runs (M-series, heavily loaded box): `swift test --package-path Packages/Shared/CMUXMobileCore` 346/346 pass; `swift test --package-path Packages/iOS/CmuxMobileRPC` 171/171 pass; CmuxMobileShell focused suites (foreground recovery, throttle, workspace create, pairing failure, availability classifier, route race) pass except pre-existing load flake `foregroundResumeRedialsFinishedDisconnectedRecovery`, which also fails intermittently on unmodified main under the same load (parking guards instrumented and proven not to fire on its path). `Packages/Shared/CmuxIrohTransport` untouched by this PR. Hosted merge-gate run linked below.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/9347"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788151887&installation_model_id=21920&pr_number=9347&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F9347&signature=d85faacc1124936d3a8d449f79b948e9a61fdcbd1206c74205cc5f11d6591ee3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ports three reconnect fixes into connectivity v2 to prevent stalled background dials, reduce presence-driven dial churn, and make diagnostics honest during recovery storms. Improves reconnection stability and accuracy of failure reporting.

- **Bug Fixes**
  - Park recovery triggers while the app is inactive and replay once on foreground; no dialing while inactive, explicit pairing/account reset clears the parked trigger.
  - Classify connect-registry “busy” as `connectAttemptGated` mapped to `DiagnosticFailureKind.routeGated`; no transport allocation; user-facing stays a retryable timeout; added en/ja strings for settings and mobile surfaces.
  - Throttle unchanged presence-push recoveries to once per 45s; changed evidence always passes; clock-safe and reset at account boundary.

<sup>Written for commit c5f70e55534cf15009113ebfef7be1caa2545b93. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/9347?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

