### PR TITLE
Fix recovered remote daemon sidebar errors

### DIFF
--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -2543,6 +2543,7 @@ final class Workspace: Identifiable, ObservableObject {
 
     private static let remoteErrorStatusKey = "remote.error"
     private static let remotePortConflictStatusKey = "remote.port_conflicts"
+    private static let remoteDaemonLogSource = "remote-daemon"
     private static let remoteNotificationCooldown: TimeInterval = 5 * 60
     private static let remoteHeartbeatDateFormatter: ISO8601DateFormatter = {
         let formatter = ISO8601DateFormatter()
@@ -6852,6 +6853,9 @@ final class Workspace: Identifiable, ObservableObject {
         applyBrowserRemoteWorkspaceStatusToPanels()
         guard status.state == .error else {
             remoteLastDaemonErrorFingerprint = nil
+            if status.state == .ready {
+                logEntries.removeAll { $0.source == Self.remoteDaemonLogSource }
+            }
             return
         }
         let trimmedDetail = status.detail?.trimmingCharacters(in: .whitespacesAndNewlines) ?? "remote daemon error"
@@ -6861,7 +6865,7 @@ final class Workspace: Identifiable, ObservableObject {
         appendSidebarLog(
             message: "Remote daemon error (\(target)): \(trimmedDetail)",
             level: .error,
-            source: "remote-daemon"
+            source: Self.remoteDaemonLogSource
         )
     }
 

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -2517,6 +2517,7 @@ C0DE71B10000000000000001 /* AppDelegate+AgentChatNotifications.swift in Sources 
 		CB612C41C989F98979226B7C /* WorkspaceRecoveryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9D9924AC89D7C3408DBC56A /* WorkspaceRecoveryTests.swift */; };
 		C73660030000000000000001 /* WorkspaceRemoteBadgeTruthTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C73660030000000000000002 /* WorkspaceRemoteBadgeTruthTests.swift */; };
 		F6100000A1B2C3D4E5F60718 /* WorkspaceRemoteConnectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6100001A1B2C3D4E5F60718 /* WorkspaceRemoteConnectionTests.swift */; };
+		A89170010000000000000001 /* WorkspaceRemoteDaemonStatusTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A89170010000000000000002 /* WorkspaceRemoteDaemonStatusTests.swift */; };
 		7277A0017277A0017277A001 /* WorkspaceRemoteDirectoryProvenanceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7277B0017277B0017277B001 /* WorkspaceRemoteDirectoryProvenanceTests.swift */; };
 		E307B0000000000000000002 /* WorkspaceRemoteHostProbeOutcome.swift in Sources */ = {isa = PBXBuildFile; fileRef = E307B0000000000000000001 /* WorkspaceRemoteHostProbeOutcome.swift */; };
 		E30790000000000000000002 /* WorkspaceRemoteReconnectPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = E30790000000000000000001 /* WorkspaceRemoteReconnectPolicy.swift */; };
@@ -5086,6 +5087,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 		C9D9924AC89D7C3408DBC56A /* WorkspaceRecoveryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceRecoveryTests.swift; sourceTree = "<group>"; };
 		C73660030000000000000002 /* WorkspaceRemoteBadgeTruthTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceRemoteBadgeTruthTests.swift; sourceTree = "<group>"; };
 		F6100001A1B2C3D4E5F60718 /* WorkspaceRemoteConnectionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceRemoteConnectionTests.swift; sourceTree = "<group>"; };
+		A89170010000000000000002 /* WorkspaceRemoteDaemonStatusTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceRemoteDaemonStatusTests.swift; sourceTree = "<group>"; };
 		7277B0017277B0017277B001 /* WorkspaceRemoteDirectoryProvenanceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceRemoteDirectoryProvenanceTests.swift; sourceTree = "<group>"; };
 		E307B0000000000000000001 /* WorkspaceRemoteHostProbeOutcome.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceRemoteHostProbeOutcome.swift; sourceTree = "<group>"; };
 		E30790000000000000000001 /* WorkspaceRemoteReconnectPolicy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceRemoteReconnectPolicy.swift; sourceTree = "<group>"; };
@@ -7382,6 +7384,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				F6001001A1B2C3D4E5F60718 /* ShortcutUnbindingTests.swift */,
 				C73660030000000000000002 /* WorkspaceRemoteBadgeTruthTests.swift */,
 				F6100001A1B2C3D4E5F60718 /* WorkspaceRemoteConnectionTests.swift */,
+				A89170010000000000000002 /* WorkspaceRemoteDaemonStatusTests.swift */,
 				C0DE7101C0DE7101C0DE7101 /* CodexTerminalErrorNotificationTests.swift */,
 				7277B0017277B0017277B001 /* WorkspaceRemoteDirectoryProvenanceTests.swift */,
 				F6357301A1B2C3D4E5F60718 /* WorkspaceRemoteReconnectPolicyTests.swift */,
@@ -10869,6 +10872,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				CB612C41C989F98979226B7C /* WorkspaceRecoveryTests.swift in Sources */,
 				C73660030000000000000001 /* WorkspaceRemoteBadgeTruthTests.swift in Sources */,
 				F6100000A1B2C3D4E5F60718 /* WorkspaceRemoteConnectionTests.swift in Sources */,
+				A89170010000000000000001 /* WorkspaceRemoteDaemonStatusTests.swift in Sources */,
 				7277A0017277A0017277A001 /* WorkspaceRemoteDirectoryProvenanceTests.swift in Sources */,
 				F6357300A1B2C3D4E5F60718 /* WorkspaceRemoteReconnectPolicyTests.swift in Sources */,
 				5659A0035659A0035659A003 /* WorkspaceSidebarObservationTests.swift in Sources */,

--- a/cmuxTests/WorkspaceRemoteDaemonStatusTests.swift
+++ b/cmuxTests/WorkspaceRemoteDaemonStatusTests.swift
@@ -1,0 +1,57 @@
+import CmuxCore
+import CmuxSidebar
+import Foundation
+import Testing
+
+#if canImport(cmux_DEV)
+@testable import cmux_DEV
+#elseif canImport(cmux)
+@testable import cmux
+#endif
+
+@MainActor
+@Suite("Workspace remote daemon status")
+struct WorkspaceRemoteDaemonStatusTests {
+    @Test(
+        "Ready retracts the recovered daemon error from the sidebar",
+        arguments: [
+            "Remote daemon transport needs re-bootstrap after proxy failure (retry 1 in 2s)",
+            "Remote daemon bootstrap failed: incompatible daemon",
+            "Remote reverse relay unavailable; retrying",
+        ]
+    )
+    func readyRetractsRecoveredDaemonError(errorDetail: String) {
+        let workspace = Workspace()
+        let unrelatedLog = SidebarLogEntry(
+            message: "Unrelated workspace log",
+            level: .info,
+            source: "test",
+            timestamp: Date(timeIntervalSince1970: 1)
+        )
+        workspace.logEntries = [unrelatedLog]
+
+        workspace.applyRemoteDaemonStatusUpdate(
+            WorkspaceRemoteDaemonStatus(state: .error, detail: errorDetail),
+            target: "example-host"
+        )
+
+        #expect(workspace.remoteDaemonStatus.state == .error)
+        #expect(workspace.logEntries.last?.source == "remote-daemon")
+        #expect(
+            workspace.sessionSnapshot(includeScrollback: false).logEntries
+                .contains(where: { $0.source == "remote-daemon" })
+        )
+
+        workspace.applyRemoteDaemonStatusUpdate(
+            WorkspaceRemoteDaemonStatus(state: .ready, detail: "Remote daemon ready"),
+            target: "example-host"
+        )
+
+        #expect(workspace.remoteDaemonStatus.state == .ready)
+        #expect(workspace.logEntries == [unrelatedLog])
+        #expect(
+            !workspace.sessionSnapshot(includeScrollback: false).logEntries
+                .contains(where: { $0.source == "remote-daemon" })
+        )
+    }
+}

--- a/docs/cli-contract.md
+++ b/docs/cli-contract.md
@@ -560,7 +560,7 @@ the expected text without connecting to a cmux socket.
 - `cmux enable-browser --help` -> `Usage: cmux enable-browser [--json]`
 - `cmux browser-status --help` -> `Usage: cmux browser-status [--json]`
 - `cmux agent-hibernation --help` -> `Usage: cmux agent-hibernation <on|off> [--json]`
-- `cmux restore --help` -> `Usage: cmux restore <kind> <checkpoint-id>`; `--surface [id|ref]` uses the caller when omitted.
+- `cmux restore --help` -> `Usage: cmux restore <kind> <checkpoint-id>`
 - `cmux restore-session --help` -> `Usage: cmux restore-session`
 - `cmux open --help` -> `Usage: cmux open <path-or-url>...`
 - `cmux feedback --help` -> `Usage: cmux feedback`
@@ -680,6 +680,8 @@ the expected text without connecting to a cmux socket.
 - `cmux is-webview-focused --help` -> `Legacy alias for 'cmux browser is-webview-focused'`
 - `cmux markdown --help` -> `Usage: cmux markdown open <path>`
 <!-- cli-contract-help-probes:end -->
+
+For `cmux restore`, `--surface [id|ref]` uses the caller when omitted.
 
 ## No-Socket Negative Help Probes
 


### PR DESCRIPTION
## Summary

- Reconcile daemon-owned sidebar error logs with the authoritative daemon lifecycle.
- Retract recovered daemon errors without deleting unrelated workspace history.
- Cover transport, bootstrap, and relay failures through the shared status handler.

Closes #8917

## Testing

- Test-only commit 721545488 intentionally demonstrates the regression before the fix.
- scripts/lint-pbxproj-test-wiring.sh
- scripts/check-pbxproj.sh
- Local xcodebuild tests intentionally not run per task constraints; CI owns the red/green proof.

## Demo Video

- Not applicable: this is state-reconciliation behavior covered at the handler and persistence boundary. Tagged dogfood is deferred until CI is green and the requested reload command is approved.

## Checklist

- [ ] I tested the change locally
- [x] I added or updated tests for behavior changes
- [x] I updated docs/changelog if needed (not applicable)
- [ ] I requested bot reviews after my latest commit
- [ ] All code review bot comments are resolved
- [ ] All human review comments are resolved

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/9351"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788152382&installation_model_id=21920&pr_number=9351&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F9351&signature=96998dceecc62678a16f640ab99dce678ef98c528e94af897826c545d684ba2b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Retracts stale remote daemon errors from the sidebar when the daemon returns to ready by removing only remote-daemon log entries, leaving unrelated workspace logs untouched. Adds tests for transport/bootstrap/relay recovery and fixes `cmux restore` help probe formatting in docs. Closes #8917.

<sup>Written for commit 382582f3f576caddc6a88fbef7c07e8227732cf7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/9351?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Remote daemon error messages in the workspace sidebar are now cleared when the daemon becomes ready.
  * Unrelated workspace log entries remain preserved during status updates.

* **Tests**
  * Added coverage for remote daemon error and recovery status behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->