### PR TITLE
Prefer live agent sessions during stable-panel restore

### DIFF
--- a/Sources/RestorableAgentSession.swift
+++ b/Sources/RestorableAgentSession.swift
@@ -2285,8 +2285,10 @@ struct RestorableAgentSessionIndex: Sendable {
         self.entriesByPanel = entriesByPanel
         var entriesByPanelId: [UUID: Entry] = [:]
         for (key, entry) in entriesByPanel {
-            let existing = entriesByPanelId[key.panelId]
-            if existing == nil || entry.updatedAt >= (existing?.updatedAt ?? 0) {
+            if Self.shouldReplaceHookEntry(
+                existing: entriesByPanelId[key.panelId],
+                incoming: entry
+            ) {
                 entriesByPanelId[key.panelId] = entry
             }
         }

--- a/cmuxTests/RestorableAgentSessionIndexTests.swift
+++ b/cmuxTests/RestorableAgentSessionIndexTests.swift
@@ -448,6 +448,71 @@ struct RestorableAgentSessionIndexTests {
         )
     }
 
+    @Test
+    func testPanelFallbackPrefersLiveDetectedSessionAcrossOwnerRotation() throws {
+        let fm = FileManager.default
+        let root = fm.temporaryDirectory
+            .appendingPathComponent("cmux-live-panel-fallback-\(UUID().uuidString)", isDirectory: true)
+        defer { try? fm.removeItem(at: root) }
+
+        let cwd = root.appendingPathComponent("repo", isDirectory: true)
+        try fm.createDirectory(at: cwd, withIntermediateDirectories: true)
+
+        let panelId = UUID()
+        let staleWorkspaceId = UUID()
+        let liveWorkspaceId = UUID()
+        let restoredWorkspaceId = UUID()
+        let staleSessionId = "stale-exited-session"
+        let liveSessionId = "live-detected-session"
+        let liveProcessId = 4_242
+
+        try writeHookStore(
+            root: root,
+            storeFilename: "codex-hook-sessions.json",
+            sessions: [
+                staleSessionId: driftedAgentHookRecord(
+                    launcher: "codex",
+                    sessionId: staleSessionId,
+                    workspaceId: staleWorkspaceId,
+                    panelId: panelId,
+                    recordedCwd: cwd.path,
+                    launchCwd: cwd.path,
+                    updatedAt: 100
+                ),
+            ]
+        )
+
+        let liveKey = RestorableAgentSessionIndex.PanelKey(
+            workspaceId: liveWorkspaceId,
+            panelId: panelId
+        )
+        let index = RestorableAgentSessionIndex.load(
+            homeDirectory: root.path,
+            fileManager: fm,
+            registry: CmuxVaultAgentRegistry(registrations: []),
+            detectedSnapshots: [
+                liveKey: (
+                    snapshot: SessionRestorableAgentSnapshot(
+                        kind: .codex,
+                        sessionId: liveSessionId,
+                        workingDirectory: cwd.path
+                    ),
+                    updatedAt: 0,
+                    processIDs: [liveProcessId],
+                    agentProcessIDs: [liveProcessId],
+                    sessionIDSource: .explicit
+                ),
+            ],
+            processArgumentsProvider: { _ in nil }
+        )
+
+        let restoredEntry = try XCTUnwrap(
+            index.entry(workspaceId: restoredWorkspaceId, panelId: panelId)
+        )
+        XCTAssertEqual(restoredEntry.snapshot.sessionId, liveSessionId)
+        XCTAssertEqual(restoredEntry.processIDs, [liveProcessId])
+    }
+
     // A Claude session can start in one directory and `cd` into another (e.g. a repo root then a
     // worktree); the hook-reported `cwd` drifts to the latter, but Claude keeps the transcript in
     // the start directory's project folder. Fork/resume must cd into the directory that actually


### PR DESCRIPTION
## Summary

- add a regression for stable-panel lookup across rotating owner UUIDs when records disagree on liveness
- reuse the existing live-first session ordering for the panel-only restore index
- follow-up to #9266 after canonical autoreview identified the stale-record selection edge case

## Two-commit proof

1. `8f6443c458` — failing regression only
2. `aaaee6cdfa` — production fix

Focused class runs (the class also contains known upstream failures; the relevant assertion is called out in the logs):

- red test-only SHA: https://github.com/manaflow-ai/cmux/actions/runs/30685586489
- green fixed SHA: https://github.com/manaflow-ai/cmux/actions/runs/30685554730

The earlier completed red run shows the new test failing on both the chosen session ID and process IDs: https://github.com/manaflow-ai/cmux/actions/runs/30685013252.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/9354"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788153575&installation_model_id=21920&pr_number=9354&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F9354&signature=b497fab52b9c91ffc03cdea0f7cf79169ff33f752ea549952f7cf7670d66389b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prefer live agent sessions when restoring a panel so we don’t pick a stale session after owner/workspace rotation. Fixes cases where an old hook record could override a live detected session, ensuring the correct session and PIDs are restored.

- **Bug Fixes**
  - Panel-only restore now selects the live detected session over older hook entries for the same panel ID across owner rotations.
  - Reused the live-first ordering via shouldReplaceHookEntry when building the panel index.
  - Added a regression test that verifies the live session and process IDs are chosen correctly.

<sup>Written for commit aaaee6cdfa46a8286b0d53bee198fc0d9693da7a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/9354?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved session restoration when multiple candidates exist.
  * Live detected sessions are now preferred over stale sessions, including after workspace ownership changes.
  * Preserved the active process identity during restoration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->