### PR TITLE
Update Bonsplit for tab icon and color customization

### DIFF
--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -3197,6 +3197,14 @@ final class Workspace: Identifiable, ObservableObject {
             appearance: appearance
         )
         self.bonsplitController = BonsplitController(configuration: config)
+        bonsplitController.tabColorPaletteProvider = {
+            WorkspaceTabColorSettings.palette().map {
+                TabColorPaletteEntry(name: $0.name, hex: $0.hex)
+            }
+        }
+        bonsplitController.tabColorCustomColorRegistrationHandler = {
+            WorkspaceTabColorSettings.addCustomColor($0)
+        }
         paneTree.attach(host: self)
         surfaceList.attach(tree: self)
         bonsplitController.contextMenuShortcuts = Self.buildContextMenuShortcuts()


### PR DESCRIPTION
## Summary

- update Bonsplit for separate **Tab Icon…** and **Tab Color** right-click actions
- bridge the tab palette to the live workspace color palette, including registered custom colors
- render a selected tab color as the workspace-style leading rail while preserving host backgrounds
- provide a searchable broad SF Symbol picker with custom symbol entry
- persist tab customization through reloads, splits, and drag previews

## Dependency

- https://github.com/manaflow-ai/bonsplit/pull/196

## Validation

- Bonsplit `swift test` (218 tests, 0 failures)
- Bonsplit warning-free `swift build`
- English and Japanese localization parse, key-parity, and bare-string audit
- integrated tagged build: https://github.com/manaflow-ai/cmux/actions/runs/30695871978