### PR TITLE
Fix restore CLI help probe format

### DIFF
--- a/docs/cli-contract.md
+++ b/docs/cli-contract.md
@@ -560,7 +560,7 @@ the expected text without connecting to a cmux socket.
 - `cmux enable-browser --help` -> `Usage: cmux enable-browser [--json]`
 - `cmux browser-status --help` -> `Usage: cmux browser-status [--json]`
 - `cmux agent-hibernation --help` -> `Usage: cmux agent-hibernation <on|off> [--json]`
-- `cmux restore --help` -> `Usage: cmux restore <kind> <checkpoint-id>`; `--surface [id|ref]` uses the caller when omitted.
+- `cmux restore --help` -> `Usage: cmux restore <kind> <checkpoint-id>`
 - `cmux restore-session --help` -> `Usage: cmux restore-session`
 - `cmux open --help` -> `Usage: cmux open <path-or-url>...`
 - `cmux feedback --help` -> `Usage: cmux feedback`
@@ -680,6 +680,8 @@ the expected text without connecting to a cmux socket.
 - `cmux is-webview-focused --help` -> `Legacy alias for 'cmux browser is-webview-focused'`
 - `cmux markdown --help` -> `Usage: cmux markdown open <path>`
 <!-- cli-contract-help-probes:end -->
+
+For `cmux restore`, `--surface [id|ref]` uses the caller when omitted.
 
 ## No-Socket Negative Help Probes
 


### PR DESCRIPTION
The restore help probe included prose after its expected-output token, so `tests/test_cli_contract_help.py` rejected the line before running CLI checks. This broke app-host shard 4 on current main.

- Keep the executable probe in the parser-supported `command -> expected` form.
- Move the existing `--surface` explanation outside the executable marker block.

Failure: https://github.com/manaflow-ai/cmux/actions/runs/30683406881/job/91324950758

Verification:
- Parsed 150 help probes and 1 negative probe through `load_help_probes`.
- `python3 -m py_compile tests/test_cli_contract_help.py`
- `git diff --check`

Localization audit: no user-facing copy changed; the existing English explanation only moved outside the executable block, so no locale files changed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/9365"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788157187&installation_model_id=21920&pr_number=9365&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F9365&signature=1ddb445f44c6f9976386d18c047a771235e733f2dd462f8de6f93456f0eaa604"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix the `cmux restore --help` probe to use the parser-supported “command -> expected” format. Moved the `--surface` note outside the executable block to stop the contract help test from rejecting the probe and to unblock CI.

<sup>Written for commit 80f93181481e6db89ddfb281de23e8b749f792a4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/9365?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified the restore command’s help output contract.
  - Documented the default behavior for the `--surface [id|ref]` option separately.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->