### PR TITLE
Fix restoring Codex sessions across relaunch generations

### DIFF
--- a/Sources/RestoredAgentLifecycleCoordinator.swift
+++ b/Sources/RestoredAgentLifecycleCoordinator.swift
@@ -100,6 +100,28 @@ final class RestoredAgentLifecycleCoordinator {
         completedGenerationsByPanelId[panelId]
     }
 
+    /// Shell integration has observed the restored launch enter its command
+    /// phase and has not subsequently reported the prompt returning.
+    func confirmsRunningRestoredCommand(panelId: UUID) -> Bool {
+        switch resumeStatesByPanelId[panelId] {
+        case .autoResumeCommandRunning, .observedAgentCommandRunning:
+            true
+        case .manualResumeAvailable, .awaitingAutoResumeCommand, .completedAgentExit, nil:
+            false
+        }
+    }
+
+    /// The restored launch still owns its binding while startup input is
+    /// queued, even though only a later shell callback can prove it is running.
+    func ownsInFlightRestoredCommand(panelId: UUID) -> Bool {
+        switch resumeStatesByPanelId[panelId] {
+        case .awaitingAutoResumeCommand, .autoResumeCommandRunning, .observedAgentCommandRunning:
+            true
+        case .manualResumeAvailable, .completedAgentExit, nil:
+            false
+        }
+    }
+
     func seedTransferredState(
         panelId: UUID,
         snapshot: SessionRestorableAgentSnapshot?,

--- a/Sources/Workspace+AgentLifecycle.swift
+++ b/Sources/Workspace+AgentLifecycle.swift
@@ -134,6 +134,65 @@ extension Workspace {
         surfaceResumeBindingsByPanelId.removeValue(forKey: panelId)
     }
 
+    /// Keep an in-flight restored launch tied to the same structured binding
+    /// so a later, unrelated binding cannot inherit its lifecycle evidence.
+    func restoredAgentLifecycleOwns(
+        _ binding: SurfaceResumeBindingSnapshot,
+        panelId: UUID
+    ) -> Bool {
+        guard binding.isAgentHookBinding,
+              restoredAgentLifecycle.ownsInFlightRestoredCommand(panelId: panelId) else {
+            return false
+        }
+        if let storedBinding = surfaceResumeBindingsByPanelId[panelId] {
+            return storedBinding.isSameManagedSession(as: binding)
+        }
+        guard let restoredAgent = restoredAgentSnapshotsByPanelId[panelId] else {
+            return false
+        }
+        return Self.restorableAgentForSessionRestore(
+            restoredAgent,
+            resumeBinding: binding
+        ) != nil
+    }
+
+    /// A real shell callback has advanced this binding's restored launch from
+    /// queued input to a running command.
+    func restoredAgentLifecycleConfirmsRunning(
+        _ binding: SurfaceResumeBindingSnapshot,
+        panelId: UUID
+    ) -> Bool {
+        restoredAgentLifecycle.confirmsRunningRestoredCommand(panelId: panelId) &&
+            restoredAgentLifecycleOwns(binding, panelId: panelId)
+    }
+
+    /// Preserve restore lifecycle state across a same-session hook refresh,
+    /// but never let a replacement binding reuse the prior session's observed
+    /// command-running phase.
+    func invalidateRestoredAgentLifecycleIfBindingIsReplaced(
+        by binding: SurfaceResumeBindingSnapshot,
+        panelId: UUID
+    ) {
+        guard restoredAgentLifecycle.ownsInFlightRestoredCommand(panelId: panelId) else {
+            return
+        }
+        let continuesRestoredSession: Bool
+        if let storedBinding = surfaceResumeBindingsByPanelId[panelId] {
+            continuesRestoredSession = storedBinding == binding ||
+                storedBinding.isSameManagedSession(as: binding)
+        } else if let restoredAgent = restoredAgentSnapshotsByPanelId[panelId] {
+            continuesRestoredSession = Self.restorableAgentForSessionRestore(
+                restoredAgent,
+                resumeBinding: binding
+            ) != nil
+        } else {
+            continuesRestoredSession = false
+        }
+        guard !continuesRestoredSession else { return }
+        clearRestoredAgentSnapshot(panelId: panelId)
+        invalidatedRestoredAgentFingerprintsByPanelId.removeValue(forKey: panelId)
+    }
+
     /// True when `binding` is a plain (non-tmux) agent-hook resume binding
     /// whose session no longer shows up as a live process. Generalizes the
     /// tmux-only `isProcessDetected` staleness signal in
@@ -165,6 +224,9 @@ extension Workspace {
               !checkpointId.isEmpty,
               let kind = binding.kind?.trimmingCharacters(in: .whitespacesAndNewlines),
               !kind.isEmpty else {
+            return false
+        }
+        if restoredAgentLifecycleOwns(binding, panelId: panelId) {
             return false
         }
         let liveIndex = restorableAgentIndex ?? SharedLiveAgentIndex.shared.index

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -471,11 +471,14 @@ extension Workspace {
                 ? sessionRestorePolicy.restorableTmuxStartCommand(terminalPanel.surface.debugTmuxStartCommand())
                 : nil
             let agentWasRunning: Bool? = {
-                if resumeBinding?.isAgentHookBinding == true {
-                    guard let bindingKindValue = Self.normalizedResumeBindingValue(resumeBinding?.kind),
+                if let resumeBinding, resumeBinding.isAgentHookBinding {
+                    guard let bindingKindValue = Self.normalizedResumeBindingValue(resumeBinding.kind),
                           let bindingKind = RestorableAgentKind(rawValue: bindingKindValue),
-                          let bindingSessionId = Self.normalizedResumeBindingValue(resumeBinding?.checkpointId) else {
+                          let bindingSessionId = Self.normalizedResumeBindingValue(resumeBinding.checkpointId) else {
                         return false
+                    }
+                    if restoredAgentLifecycleConfirmsRunning(resumeBinding, panelId: panelId) {
+                        return true
                     }
                     let confirmedRuntimeProcessIdentities = confirmedRuntimeAgentProcessIdentities(
                         kind: bindingKind,
@@ -1252,6 +1255,10 @@ extension Workspace {
                 continue
             }
             if storedBinding.shouldYieldToDetectedSurfaceResumeBinding(detectedBinding) {
+                invalidateRestoredAgentLifecycleIfBindingIsReplaced(
+                    by: detectedBinding,
+                    panelId: panelId
+                )
                 surfaceResumeBindingsByPanelId[panelId] = detectedBinding
             } else if storedBinding.isProcessDetected {
                 surfaceResumeBindingsByPanelId.removeValue(forKey: panelId)
@@ -5062,6 +5069,10 @@ final class Workspace: Identifiable, ObservableObject {
               !startupInput.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
             return false
         }
+        invalidateRestoredAgentLifecycleIfBindingIsReplaced(
+            by: binding,
+            panelId: panelId
+        )
         // This transient cwd belongs to the binding restored at launch. Let a
         // same-session hook refresh keep its cwd rescue, but never let it
         // override a replacement session's structured restore record.

--- a/cmuxTests/SurfaceResumeAgentBindingGenerationTests.swift
+++ b/cmuxTests/SurfaceResumeAgentBindingGenerationTests.swift
@@ -1,3 +1,4 @@
+import CMUXAgentLaunch
 import Foundation
 import Testing
 
@@ -85,6 +86,95 @@ struct SurfaceResumeAgentBindingGenerationTests {
 
         #expect(snapshot.panels.first?.terminal?.wasAgentRunning == false)
         try expectNoResumeLaunch(snapshot: snapshot, defaults: defaults)
+    }
+
+    @Test("A restored Codex binding remains restorable across generations")
+    func restoredCodexBindingRemainsRestorableAcrossGenerations() throws {
+        try withFixture { source, defaults, index in
+            let sourcePanelID = try #require(source.focusedPanelId)
+            let sessionID = "a22293b7-bcef-4707-8439-2f538c8517a4"
+            let expectedRestoreInput =
+                " \(AgentRestoreLaunch.cliStartupExecutableToken) restore codex \(sessionID)\n"
+            source.updatePanelShellActivityState(panelId: sourcePanelID, state: .commandRunning)
+            source.recordAgentPID(
+                key: "codex.\(sessionID)",
+                pid: getpid(),
+                panelId: sourcePanelID,
+                refreshPorts: false
+            )
+
+            let sourceSnapshot = source.sessionSnapshot(
+                includeScrollback: false,
+                restorableAgentIndex: index,
+                surfaceResumeBindingIndex: codexBindingIndex(
+                    sessionID: sessionID,
+                    workspaceID: source.id,
+                    panelID: sourcePanelID
+                )
+            )
+            let sourceTerminal = try #require(sourceSnapshot.panels.first?.terminal)
+            #expect(sourceTerminal.wasAgentRunning == true)
+            #expect(sourceTerminal.resumeBinding?.restoreStartupInput() == expectedRestoreInput)
+
+            let firstRestore = Workspace(agentSessionAutoResumeDefaults: defaults)
+            defer { firstRestore.teardownAllPanels() }
+            firstRestore.restoreSessionSnapshot(sourceSnapshot)
+            let firstPanelID = try #require(firstRestore.focusedPanelId)
+            #expect(
+                firstRestore.restoredAgentResumeStatesByPanelId[firstPanelID]
+                    == .awaitingAutoResumeCommand
+            )
+            firstRestore.updatePanelShellActivityState(panelId: firstPanelID, state: .commandRunning)
+            #expect(
+                firstRestore.restoredAgentResumeStatesByPanelId[firstPanelID]
+                    == .autoResumeCommandRunning
+            )
+
+            // Codex does not publish a fresh hook record after this restore-verb
+            // launch. The shell callback is the only fresh evidence that the
+            // restored command is running when the next autosave reconciles.
+            let secondGenerationSnapshot = firstRestore.sessionSnapshot(
+                includeScrollback: false,
+                restorableAgentIndex: .empty,
+                surfaceResumeBindingIndex: SurfaceResumeBindingIndex(bindingsByPanel: [:])
+            )
+            let secondGenerationTerminal = try #require(
+                secondGenerationSnapshot.panels.first?.terminal
+            )
+            #expect(secondGenerationTerminal.wasAgentRunning == true)
+            #expect(
+                secondGenerationTerminal.resumeBinding?.checkpointId == sessionID
+            )
+            #expect(
+                secondGenerationTerminal.resumeBinding?.restoreStartupInput()
+                    == expectedRestoreInput
+            )
+
+            let secondRestore = Workspace(agentSessionAutoResumeDefaults: defaults)
+            defer { secondRestore.teardownAllPanels() }
+            secondRestore.restoreSessionSnapshot(secondGenerationSnapshot)
+            let secondPanelID = try #require(secondRestore.focusedPanelId)
+            #expect(
+                secondRestore.restoredAgentResumeStatesByPanelId[secondPanelID]
+                    == .awaitingAutoResumeCommand
+            )
+            secondRestore.updatePanelShellActivityState(panelId: secondPanelID, state: .commandRunning)
+
+            let thirdGenerationSnapshot = secondRestore.sessionSnapshot(
+                includeScrollback: false,
+                restorableAgentIndex: .empty,
+                surfaceResumeBindingIndex: SurfaceResumeBindingIndex(bindingsByPanel: [:])
+            )
+            let thirdGenerationTerminal = try #require(
+                thirdGenerationSnapshot.panels.first?.terminal
+            )
+            #expect(thirdGenerationTerminal.wasAgentRunning == true)
+            #expect(thirdGenerationTerminal.resumeBinding?.checkpointId == sessionID)
+            #expect(
+                thirdGenerationTerminal.resumeBinding?.restoreStartupInput()
+                    == expectedRestoreInput
+            )
+        }
     }
 
     private func withFixture(

--- a/cmuxTests/SurfaceResumeAgentBindingGenerationTests.swift
+++ b/cmuxTests/SurfaceResumeAgentBindingGenerationTests.swift
@@ -124,6 +124,16 @@ struct SurfaceResumeAgentBindingGenerationTests {
                 firstRestore.restoredAgentResumeStatesByPanelId[firstPanelID]
                     == .awaitingAutoResumeCommand
             )
+            let queuedLaunchSnapshot = firstRestore.sessionSnapshot(
+                includeScrollback: false,
+                restorableAgentIndex: .empty,
+                surfaceResumeBindingIndex: SurfaceResumeBindingIndex(bindingsByPanel: [:])
+            )
+            #expect(queuedLaunchSnapshot.panels.first?.terminal?.wasAgentRunning == false)
+            #expect(
+                queuedLaunchSnapshot.panels.first?.terminal?.resumeBinding?.checkpointId
+                    == sessionID
+            )
             firstRestore.updatePanelShellActivityState(panelId: firstPanelID, state: .commandRunning)
             #expect(
                 firstRestore.restoredAgentResumeStatesByPanelId[firstPanelID]
@@ -175,6 +185,49 @@ struct SurfaceResumeAgentBindingGenerationTests {
                     == expectedRestoreInput
             )
         }
+    }
+
+    @Test("A replacement binding cannot inherit restored-command liveness")
+    func replacementBindingCannotInheritRestoredCommandLiveness() throws {
+        let workspace = Workspace()
+        defer { workspace.teardownAllPanels() }
+        let panelID = try #require(workspace.focusedPanelId)
+        let restoredSessionID = "a22293b7-bcef-4707-8439-2f538c8517a4"
+        let restoredBinding = codexBinding(sessionID: restoredSessionID)
+
+        #expect(workspace.setSurfaceResumeBinding(restoredBinding, panelId: panelID))
+        workspace.restoredAgentSnapshotsByPanelId[panelID] = SessionRestorableAgentSnapshot(
+            kind: .codex,
+            sessionId: restoredSessionID,
+            workingDirectory: "/tmp/repo",
+            launchCommand: nil
+        )
+        workspace.restoredAgentResumeStatesByPanelId[panelID] = .autoResumeCommandRunning
+
+        let sameSessionRefresh = SurfaceResumeBindingSnapshot(
+            name: "Codex",
+            kind: "codex",
+            command: "/opt/codex/bin/codex resume \(restoredSessionID)",
+            cwd: "/tmp/refreshed-repo",
+            checkpointId: restoredSessionID,
+            source: "agent-hook",
+            autoResume: true,
+            updatedAt: 1_777_777_779
+        )
+        #expect(workspace.setSurfaceResumeBinding(sameSessionRefresh, panelId: panelID))
+        #expect(
+            workspace.restoredAgentResumeStatesByPanelId[panelID]
+                == .autoResumeCommandRunning
+        )
+        #expect(workspace.restoredAgentSnapshotsByPanelId[panelID]?.sessionId == restoredSessionID)
+
+        let replacementSessionID = "13a40ce0-f096-4c56-885b-592af90407c4"
+        #expect(workspace.setSurfaceResumeBinding(
+            codexBinding(sessionID: replacementSessionID),
+            panelId: panelID
+        ))
+        #expect(workspace.restoredAgentResumeStatesByPanelId[panelID] == nil)
+        #expect(workspace.restoredAgentSnapshotsByPanelId[panelID] == nil)
     }
 
     private func withFixture(
@@ -245,17 +298,21 @@ struct SurfaceResumeAgentBindingGenerationTests {
     ) -> SurfaceResumeBindingIndex {
         SurfaceResumeBindingIndex(bindingsByPanel: [
             SurfaceResumeBindingIndex.PanelKey(workspaceId: workspaceID, panelId: panelID):
-                SurfaceResumeBindingSnapshot(
-                    name: "Codex",
-                    kind: "codex",
-                    command: "codex resume \(sessionID)",
-                    cwd: "/tmp/repo",
-                    checkpointId: sessionID,
-                    source: "agent-hook",
-                    autoResume: true,
-                    updatedAt: 1_777_777_778
-                ),
+                codexBinding(sessionID: sessionID),
         ])
+    }
+
+    private func codexBinding(sessionID: String) -> SurfaceResumeBindingSnapshot {
+        SurfaceResumeBindingSnapshot(
+            name: "Codex",
+            kind: "codex",
+            command: "codex resume \(sessionID)",
+            cwd: "/tmp/repo",
+            checkpointId: sessionID,
+            source: "agent-hook",
+            autoResume: true,
+            updatedAt: 1_777_777_778
+        )
     }
 
     private func writeCodexHookRecord(


### PR DESCRIPTION
## Summary

- Treat the restored-agent lifecycle as authoritative continuation evidence once shell integration observes the restore command running.
- Keep queued and running restore bindings through process-index reconciliation, while persisting wasAgentRunning only after the real command-running callback.
- Scope lifecycle evidence to the same managed agent kind and checkpoint so replacement bindings cannot inherit it.
- Add a two-generation Codex restore-verb regression in a test-only commit, followed by the fix commit.

Fixes #9367.

## Testing

- swiftc -parse Sources/RestoredAgentLifecycleCoordinator.swift Sources/Workspace+AgentLifecycle.swift Sources/Workspace.swift cmuxTests/SurfaceResumeAgentBindingGenerationTests.swift
- ./scripts/lint-pbxproj-test-wiring.sh
- git diff --check origin/main...HEAD
- Confirmed .github/swift-warning-budget.tsv is unchanged.
- Per task instructions, no local xcodebuild or XCUITest was run; app test execution is delegated to GitHub Actions.

## Demo Video

Not applicable: this is session-persistence lifecycle behavior with behavior-level regression coverage.

## Checklist

- [ ] I tested the change locally (local Xcode builds were explicitly prohibited)
- [x] I added or updated tests for behavior changes
- [x] I updated docs/changelog if needed (not needed)
- [ ] I requested bot reviews after my latest commit (automatic review checks pending)
- [ ] All code review bot comments are resolved
- [x] All human review comments are resolved (none yet)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/9370"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788158794&installation_model_id=21920&pr_number=9370&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F9370&signature=b6b9fc383d3b04c65e2ddb9e1d01bbf2c8af6c904ec8790cf7c435d9f7feac18"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes restoring Codex sessions across relaunch generations by preserving lifecycle evidence for the same session and only marking the agent running after a real shell callback. Prevents replacement bindings from inheriting restored-command liveness. Fixes #9367.

- **Bug Fixes**
  - Treat shell-observed restored command as authoritative; set wasAgentRunning only after the command-running callback.
  - Keep queued/running restore bindings during process-index reconciliation so Codex restores remain valid across generations.
  - Scope lifecycle evidence to the same agent kind and checkpoint; invalidate it when a binding is replaced to avoid liveness leaks.
  - Added regression tests for two-generation Codex restore and for blocking liveness inheritance by replacement bindings.

<sup>Written for commit c64b59963c1a56c4b8d074b565355669182c7279. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/9370?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

