### PR TITLE
Preserve Claude executable selection across session restore

### DIFF
--- a/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/AgentLaunchEnvironmentPolicy.swift
+++ b/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/AgentLaunchEnvironmentPolicy.swift
@@ -69,6 +69,7 @@ public struct AgentLaunchEnvironmentPolicy: Sendable {
         "CAMPFIRE_RELAY_URL",
         "CLAUDE_CONFIG_DIR",
         "CMUX_CUSTOM_CLAUDE_PATH",
+        "CMUX_RESOLVED_CLAUDE_PATH",
         "CMUX_ROVODEV_SESSIONS_DIR",
         "CODEX_HOME",
         "CODEBUDDY_BASE_URL",

--- a/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/AgentRestorePlanner.swift
+++ b/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/AgentRestorePlanner.swift
@@ -216,7 +216,14 @@ public struct AgentRestorePlanner: Sendable {
             return arguments
         }
 
-        if first != restoreLaunch.executableName {
+        if kind == "claude" {
+            let replayKey = "CMUX_RESOLVED_CLAUDE_PATH"
+            if environment[replayKey] == nil,
+               let executablePath = normalized(request.launchCommand?.executablePath),
+               isExecutableFile(executablePath) {
+                environment[replayKey] = executablePath
+            }
+        } else if first != restoreLaunch.executableName {
             environment[restoreLaunch.customExecutablePathEnvironmentKey] = first
         }
         environment["CMUX_AGENT_RESTORE_LAUNCH"] = restoreLaunch.authorizationEnvironmentValue

--- a/Packages/macOS/CMUXAgentLaunch/Tests/CMUXAgentLaunchTests/AgentLaunchEnvironmentPolicyTests.swift
+++ b/Packages/macOS/CMUXAgentLaunch/Tests/CMUXAgentLaunchTests/AgentLaunchEnvironmentPolicyTests.swift
@@ -37,6 +37,18 @@ struct AgentLaunchEnvironmentPolicyTests {
         ])
     }
 
+    @Test("Claude restore transport keeps the resolved executable replay path")
+    func claudeRestoreTransportKeepsResolvedExecutablePath() {
+        let selected = AgentLaunchEnvironmentPolicy().selectedRestoreEnvironment(
+            from: ["CMUX_RESOLVED_CLAUDE_PATH": "/opt/Claude Code/bin/claude"],
+            kind: "claude"
+        )
+
+        #expect(selected == [
+            "CMUX_RESOLVED_CLAUDE_PATH": "/opt/Claude Code/bin/claude",
+        ])
+    }
+
     @Test("Preserves Campfire config roots and drops Pi-managed env")
     func preservesCampfireConfigRootsAndDropsManagedPackageDir() {
         let selected = AgentLaunchEnvironmentPolicy().selectedEnvironment(

--- a/Packages/macOS/CMUXAgentLaunch/Tests/CMUXAgentLaunchTests/AgentRestoreLaunchTests.swift
+++ b/Packages/macOS/CMUXAgentLaunch/Tests/CMUXAgentLaunchTests/AgentRestoreLaunchTests.swift
@@ -128,7 +128,7 @@ import Testing
             observedPermissionMode: "bypassPermissions"
         )
         let invocation = try #require(AgentRestorePlanner(
-            isExecutableFile: { $0 == "/shim/claude" }
+            isExecutableFile: { $0 == "/shim/claude" || $0 == "/opt/claude" }
         ).invocation(
             for: request,
             ambientEnvironment: ["CMUX_CLAUDE_WRAPPER_SHIM": "/shim/claude"]
@@ -139,6 +139,8 @@ import Testing
         #expect(invocation.arguments.contains(sessionID))
         #expect(invocation.arguments.contains("--permission-mode"))
         #expect(invocation.arguments.contains("bypassPermissions"))
+        #expect(invocation.environment["CMUX_RESOLVED_CLAUDE_PATH"] == "/opt/claude")
+        #expect(invocation.environment["CMUX_CUSTOM_CLAUDE_PATH"] == nil)
         #expect(
             invocation.environment["CMUX_AGENT_RESTORE_LAUNCH"]
                 == "claude:\(sessionID)"

--- a/Resources/bin/cmux-claude-wrapper
+++ b/Resources/bin/cmux-claude-wrapper
@@ -154,6 +154,15 @@ cmux_claude_wrapper_exec_resolved_claude() {
 
     if ! cmux_claude_wrapper_target_looks_like_reexec_shim "$target"; then
         # A non-shim target is the boundary where a real Claude process starts.
+        # Hook-integrated launches publish the final executable so restore hooks
+        # can replay it. Passthrough launches must not leak an inherited replay
+        # hint into updater/doctor/install/version subprocesses.
+        if [[ "${cmux_claude_wrapper_publish_resolved_path:-0}" == "1" ]]; then
+            export CMUX_RESOLVED_CLAUDE_PATH="$target"
+        else
+            unset CMUX_RESOLVED_CLAUDE_PATH
+        fi
+        unset cmux_claude_wrapper_publish_resolved_path
         # Clear the shim-bounce guard so real Claude children that invoke
         # `claude` later begin a fresh wrapper resolution.
         unset CMUX_AGENT_RESTORE_LAUNCH
@@ -191,18 +200,20 @@ cmux_claude_wrapper_init_reexec_guard
 
 # Find the real claude binary, skipping cmux's wrapper and temp shell shims.
 find_real_claude() {
-    # Honor custom path from Settings > Automation > Claude Code > Claude Binary Path.
-    # Guard against self-reference (user pointing back to this wrapper).
-    local custom="${CMUX_CUSTOM_CLAUDE_PATH:-}"
-    custom="${custom#"${custom%%[![:space:]]*}"}"  # trim leading whitespace
-    custom="${custom%"${custom##*[![:space:]]}"}"  # trim trailing whitespace
-    if [[ -n "$custom" && -f "$custom" && -x "$custom" ]]; then
-        # Use -ef to detect same underlying file even through symlinks.
-        if ! cmux_claude_wrapper_is_self_or_shim "$custom"; then
-            printf '%s' "$custom"
-            return 0
+    # Settings override restore replay, which overrides the current PATH. Invalid
+    # or self-referential configured paths fall through to the next candidate.
+    local configured
+    for configured in "${CMUX_CUSTOM_CLAUDE_PATH:-}" "${CMUX_RESOLVED_CLAUDE_PATH:-}"; do
+        configured="${configured#"${configured%%[![:space:]]*}"}"  # trim leading whitespace
+        configured="${configured%"${configured##*[![:space:]]}"}"  # trim trailing whitespace
+        if [[ -n "$configured" && -f "$configured" && -x "$configured" ]]; then
+            # Use -ef to detect the same underlying file even through symlinks.
+            if ! cmux_claude_wrapper_is_self_or_shim "$configured"; then
+                printf '%s' "$configured"
+                return 0
+            fi
         fi
-    fi
+    done
     local self_dir
     self_dir="$(cd "$(dirname "$0")" && pwd)"
     local IFS=:
@@ -210,7 +221,10 @@ find_real_claude() {
         [[ "$d" == "$self_dir" ]] && continue
         local candidate="$d/claude"
         cmux_claude_wrapper_is_self_or_shim "$candidate" && continue
-        [[ -x "$candidate" ]] && printf '%s' "$candidate" && return 0
+        if [[ -f "$candidate" && -x "$candidate" ]]; then
+            printf '%s' "$candidate"
+            return 0
+        fi
     done
     return 1
 }
@@ -1052,8 +1066,10 @@ process.stdout.write(JSON.stringify(acc));
 fi
 
 if [[ "$SKIP_SESSION_ID" == true ]]; then
+    export cmux_claude_wrapper_publish_resolved_path=1
     cmux_claude_wrapper_exec_resolved_claude "$REAL_CLAUDE" --settings "$HOOKS_JSON" "$@"
 else
     SESSION_ID="$(uuidgen | tr '[:upper:]' '[:lower:]')"
+    export cmux_claude_wrapper_publish_resolved_path=1
     cmux_claude_wrapper_exec_resolved_claude "$REAL_CLAUDE" --session-id "$SESSION_ID" --settings "$HOOKS_JSON" "$@"
 fi

--- a/tests/test_claude_wrapper_user_binary_resolution.py
+++ b/tests/test_claude_wrapper_user_binary_resolution.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import os
+import socket
 import subprocess
 import tempfile
 from pathlib import Path
@@ -134,6 +135,143 @@ echo real-claude "$@"
             failures.append(f"expected inherited cmux shim roots to be skipped, got {output!r}")
 
 
+def test_replay_path_beats_path_claude(failures: list[str]) -> None:
+    with tempfile.TemporaryDirectory(prefix="cmux-claude-wrapper-replay-") as td:
+        root = Path(td)
+        replay_bin = root / "captured-bin"
+        path_bin = root / "older-path-bin"
+        replay_bin.mkdir()
+        path_bin.mkdir()
+
+        replay_claude = replay_bin / "claude"
+        write_executable(
+            replay_claude,
+            """#!/bin/sh
+echo captured-claude "$@"
+""",
+        )
+        write_executable(
+            path_bin / "claude",
+            """#!/bin/sh
+echo older-path-claude "$@"
+""",
+        )
+
+        env = minimal_env(f"{path_bin}:/usr/bin:/bin")
+        env["CMUX_RESOLVED_CLAUDE_PATH"] = str(replay_claude)
+        result = run_wrapper([str(WRAPPER), "--version"], env)
+        output = (result.stdout + result.stderr).strip()
+        if result.returncode != 0:
+            failures.append(f"replay-path wrapper exited {result.returncode}: {output}")
+        if output != "captured-claude --version":
+            failures.append(f"expected captured Claude to beat PATH, got {output!r}")
+
+
+def test_stale_replay_path_falls_back_to_path(failures: list[str]) -> None:
+    with tempfile.TemporaryDirectory(prefix="cmux-claude-wrapper-stale-replay-") as td:
+        root = Path(td)
+        path_bin = root / "current-path-bin"
+        path_bin.mkdir()
+        write_executable(
+            path_bin / "claude",
+            """#!/bin/sh
+echo current-path-claude "$@"
+""",
+        )
+
+        env = minimal_env(f"{path_bin}:/usr/bin:/bin")
+        env["CMUX_RESOLVED_CLAUDE_PATH"] = str(root / "removed-bin" / "claude")
+        result = run_wrapper([str(WRAPPER), "--version"], env)
+        output = (result.stdout + result.stderr).strip()
+        if result.returncode != 0:
+            failures.append(f"stale-replay wrapper exited {result.returncode}: {output}")
+        if output != "current-path-claude --version":
+            failures.append(f"expected stale replay path to fall back to PATH, got {output!r}")
+
+
+def test_interactive_launch_exposes_resolved_path_without_passthrough_leak(
+    failures: list[str],
+) -> None:
+    with tempfile.TemporaryDirectory(prefix="cmux-claude-wrapper-capture-") as td:
+        root = Path(td)
+        bin_dir = root / "bin"
+        home_dir = root / "home"
+        tmp_dir = root / "tmp"
+        for directory in (bin_dir, home_dir, tmp_dir):
+            directory.mkdir()
+
+        selected_claude = bin_dir / "claude"
+        write_executable(
+            selected_claude,
+            """#!/bin/sh
+printf 'resolved=%s\\n' "${CMUX_RESOLVED_CLAUDE_PATH-__UNSET__}"
+printf 'executable=%s\\n' "${CMUX_AGENT_LAUNCH_EXECUTABLE-__UNSET__}"
+printf 'argv='
+printf '<%s>' "$@"
+printf '\\n'
+""",
+        )
+        fake_cmux = bin_dir / "cmux"
+        write_executable(
+            fake_cmux,
+            """#!/bin/sh
+if [ "${1:-}" = "--socket" ] && [ "${3:-}" = "ping" ]; then
+  exit 0
+fi
+exit 1
+""",
+        )
+
+        socket_path = root / "cmux.sock"
+        with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as listener:
+            listener.bind(str(socket_path))
+            listener.listen(1)
+            env = minimal_env(f"{bin_dir}:/usr/bin:/bin", tmp_dir)
+            env.update(
+                {
+                    "HOME": str(home_dir),
+                    "CMUX_SURFACE_ID": "surface-replay-capture",
+                    "CMUX_SOCKET_PATH": str(socket_path),
+                    "CMUX_BUNDLED_CLI_PATH": str(fake_cmux),
+                }
+            )
+
+            interactive = run_wrapper([str(WRAPPER), "--model", "sonnet"], env)
+            interactive_output = (interactive.stdout + interactive.stderr).strip()
+            if interactive.returncode != 0:
+                failures.append(
+                    f"interactive capture wrapper exited {interactive.returncode}: {interactive_output}"
+                )
+            if f"resolved={selected_claude}" not in interactive_output:
+                failures.append(
+                    f"expected hook launch to expose selected resolved path, got {interactive_output!r}"
+                )
+            if f"executable={selected_claude}" not in interactive_output:
+                failures.append(
+                    f"expected hook launch executable capture to use selected path, got {interactive_output!r}"
+                )
+
+            replay_env = dict(env)
+            replay_env["CMUX_RESOLVED_CLAUDE_PATH"] = str(selected_claude)
+            passthrough = run_wrapper(
+                [str(WRAPPER), "doctor", "--flag", "space arg"],
+                replay_env,
+            )
+            passthrough_output = (passthrough.stdout + passthrough.stderr).strip()
+            if passthrough.returncode != 0:
+                failures.append(
+                    f"doctor passthrough wrapper exited {passthrough.returncode}: {passthrough_output}"
+                )
+            if "resolved=__UNSET__" not in passthrough_output:
+                failures.append(
+                    f"expected doctor passthrough to scrub replay key, got {passthrough_output!r}"
+                )
+            if "argv=<doctor><--flag><space arg>" not in passthrough_output:
+                failures.append(
+                    f"expected doctor passthrough argv to remain exact, got {passthrough_output!r}"
+                )
+
+
 def test_shell_integration_does_not_shim_grok(failures: list[str]) -> None:
     with tempfile.TemporaryDirectory(prefix="cmux-grok-wrapper-resolution-") as td:
         root = Path(td)
@@ -229,6 +367,9 @@ def main() -> int:
     failures: list[str] = []
     test_wrapper_skips_cmux_shims_and_bundled_claude(failures)
     test_wrapper_skips_inherited_cmux_cli_shim_roots(failures)
+    test_replay_path_beats_path_claude(failures)
+    test_stale_replay_path_falls_back_to_path(failures)
+    test_interactive_launch_exposes_resolved_path_without_passthrough_leak(failures)
     test_shell_integration_does_not_shim_grok(failures)
     test_shell_integration_preserves_empty_path_components(failures)
     if failures:


### PR DESCRIPTION
Fixes https://github.com/manaflow-ai/cmux/issues/8317

## Change

Claude restore keeps cmux's wrapper for hooks while replaying the executable captured at the original launch. Resolution order is the configured Claude path, the captured executable, then the current `PATH`. Missing, non-executable, self-referential, and shim paths fall through safely.

Interactive launches publish the final resolved executable only after shim resolution. Updater, doctor, install, help, and version passthrough commands scrub that internal value and keep their exact arguments.

https://github.com/manaflow-ai/cmux/issues/3990 described the old argument-injection bug, which was fixed in v0.64.5. cmux ships a wrapper, not a Claude binary. The exact `Auto-update failed` record investigated here occurred during macOS DarkWake network loss and remains an upstream Claude Code updater failure, consistent with https://github.com/anthropics/claude-code/issues/81898.

## Verification

The first commit adds failing wrapper and restore-policy regressions. The second commit makes them pass.

- `python3 tests/test_claude_wrapper_user_binary_resolution.py`
- `python3 tests/test_claude_wrapper_hooks.py`
- `python3 tests/test_claude_wrapper_shim_root_survives_tmpdir_change.py`
- `python3 tests/test_issue_2448_shell_claude_wrapper_dispatch.py`
- `swift test --package-path Packages/macOS/CMUXAgentLaunch`, 280 tests in 39 suites
- tagged `clpath` app: hook-captured Claude restore selected the captured executable over a stale executable earlier on `PATH`, preserved the session ID, and reinstalled cmux hook metadata

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/9372"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788161631&installation_model_id=21920&pr_number=9372&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F9372&signature=04dbe117ef036587e2dc31157b716f2dafe9039fe65e92d7fbaafb809da28459"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keep the selected Claude executable across session restore and avoid PATH drift. The wrapper replays the captured binary with cmux hooks intact and scrubs replay hints for passthrough commands.

- **Bug Fixes**
  - Introduced CMUX_RESOLVED_CLAUDE_PATH; restore planner captures the resolved executable and transport policy preserves it for Claude restores.
  - Resolution order: user-configured CMUX_CUSTOM_CLAUDE_PATH → captured CMUX_RESOLVED_CLAUDE_PATH → current PATH; skip missing, non-executable, self, and shim paths.
  - Interactive launches publish the resolved path only after shim resolution; passthrough commands (updater, doctor, install, help, version) clear it and keep arguments exact.
  - Added tests covering replay beats PATH, stale replay falls back to PATH, interactive exposure without passthrough leakage, and env transport.

<sup>Written for commit ddbe45bf55e671641b8f2b37098670a5eedf6447. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/9372?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Claude session restoration by preserving and reusing the correct executable path.
  * Added support for executable paths containing spaces.
  * Prevented stale path information from affecting passthrough launches.
  * Ensured custom Claude executable settings and wrapper behavior continue to work correctly.

* **Tests**
  * Added coverage for restored executable paths, fallback behavior, interactive launches, and passthrough argument handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->