### PR TITLE
Fix Grok session discovery for fresh launches

### DIFF
--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -1186,6 +1186,7 @@ C0DE71B10000000000000001 /* AppDelegate+AgentChatNotifications.swift in Sources 
 		A6AC72010000000000000001 /* GPUSpinnerNSView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6AC72010000000000000002 /* GPUSpinnerNSView.swift */; };
 		A6AC72020000000000000001 /* GPUSpinnerStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6AC72020000000000000002 /* GPUSpinnerStyle.swift */; };
 		C1ADE10002A1B2C3D4E5F719 /* grok in Copy CLI */ = {isa = PBXBuildFile; fileRef = C1ADE10001A1B2C3D4E5F719 /* grok */; };
+		937700020000000000000001 /* GrokVaultAgentPersistenceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 937700010000000000000001 /* GrokVaultAgentPersistenceTests.swift */; };
 		C0DE34020000000000000005 /* HelpMenuUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE34020000000000000006 /* HelpMenuUITests.swift */; };
 		F5320000A1B2C3D4E5F60718 /* HermesAgentIndex.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5320001A1B2C3D4E5F60718 /* HermesAgentIndex.swift */; };
 		4931A11B0000000000000002 /* HiddenRightSidebarContentMountingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4931A11B0000000000000001 /* HiddenRightSidebarContentMountingTests.swift */; };
@@ -3775,6 +3776,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 		A6AC72010000000000000002 /* GPUSpinnerNSView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sidebar/GPUSpinnerNSView.swift; sourceTree = "<group>"; };
 		A6AC72020000000000000002 /* GPUSpinnerStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sidebar/GPUSpinnerStyle.swift; sourceTree = "<group>"; };
 		C1ADE10001A1B2C3D4E5F719 /* grok */ = {isa = PBXFileReference; lastKnownFileType = text.script.sh; path = Resources/bin/grok; sourceTree = SOURCE_ROOT; };
+		937700010000000000000001 /* GrokVaultAgentPersistenceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GrokVaultAgentPersistenceTests.swift; sourceTree = "<group>"; };
 		C0DE34020000000000000006 /* HelpMenuUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HelpMenuUITests.swift; sourceTree = "<group>"; };
 		F5320001A1B2C3D4E5F60718 /* HermesAgentIndex.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HermesAgentIndex.swift; sourceTree = "<group>"; };
 		4931A11B0000000000000001 /* HiddenRightSidebarContentMountingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HiddenRightSidebarContentMountingTests.swift; sourceTree = "<group>"; };
@@ -7285,6 +7287,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 					A1B2C3D4E5F600000000CF02 /* AppDelegateDisplayConfigRestoreTests.swift */,
 					793800000000000000000009 /* AppDelegateOversizedFrameRestoreTests.swift */,
 				B35750000000000000000009 /* PiVaultAgentPersistenceTests.swift */,
+				937700010000000000000001 /* GrokVaultAgentPersistenceTests.swift */,
 				C7A540000000000000000001 /* AgentChatFallbackTranscriptResolutionCoordinatorTests.swift */,
 				C7A51F000000000000000001 /* AgentChatSessionRegistryClaudeObservationTests.swift */,
 				C7A51C000000000000000001 /* AgentChatSessionRegistryHookStoreTests.swift */,
@@ -10537,6 +10540,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				8561A0048561A0048561A004 /* GlobalSearchShortcutSettingsModelTests.swift in Sources */,
 				3865A0053865A0053865A005 /* GlobalSearchShortcutSettingsTests.swift in Sources */,
 				8561A0038561A0038561A003 /* GlobalSearchVisiblePopoverShortcutTests.swift in Sources */,
+					937700020000000000000001 /* GrokVaultAgentPersistenceTests.swift in Sources */,
 				4931A11B0000000000000002 /* HiddenRightSidebarContentMountingTests.swift in Sources */,
 				B1F0C0040000000000000001 /* HostedInspectorDockControlScriptTests.swift in Sources */,
 				809100000000000000000001 /* HostSettingsShortcutNotificationTests.swift in Sources */,

--- a/cmuxTests/GrokVaultAgentPersistenceTests.swift
+++ b/cmuxTests/GrokVaultAgentPersistenceTests.swift
@@ -54,6 +54,59 @@ struct GrokVaultAgentPersistenceTests {
         #expect(detected?.snapshot.sessionId == "019ebaf3-8860-7f53-b31b-70e8b426016d")
     }
 
+    @Test func updatedAtRanksSessionWhenLastActiveAtIsMissing() throws {
+        let fixture = try Fixture.make()
+        defer { fixture.cleanup() }
+
+        try fixture.writeSession(
+            id: "updated-at-fallback",
+            createdAt: "2026-07-01T00:00:00Z",
+            updatedAt: "2026-07-10T00:00:00Z",
+            summaryModifiedAt: Date(timeIntervalSince1970: 1_000),
+            directoryModifiedAt: Date(timeIntervalSince1970: 1_000),
+            lockModifiedAt: Date(timeIntervalSince1970: 1_000)
+        )
+        try fixture.writeSession(
+            id: "older-last-active",
+            createdAt: "2026-07-01T00:00:00Z",
+            updatedAt: "2026-07-09T00:00:00Z",
+            lastActiveAt: "2026-07-09T00:00:00Z",
+            summaryModifiedAt: Date(timeIntervalSince1970: 2_000_000_000),
+            directoryModifiedAt: Date(timeIntervalSince1970: 2_000_000_000),
+            lockModifiedAt: Date(timeIntervalSince1970: 2_000_000_000)
+        )
+
+        let detected = fixture.detectedEntry(arguments: ["/usr/local/bin/grok"])
+
+        #expect(detected?.snapshot.sessionId == "updated-at-fallback")
+    }
+
+    @Test func createdAtRanksSessionWhenLaterActivityTimestampsAreMissing() throws {
+        let fixture = try Fixture.make()
+        defer { fixture.cleanup() }
+
+        try fixture.writeSession(
+            id: "created-at-fallback",
+            createdAt: "2026-07-10T00:00:00Z",
+            summaryModifiedAt: Date(timeIntervalSince1970: 1_000),
+            directoryModifiedAt: Date(timeIntervalSince1970: 1_000),
+            lockModifiedAt: Date(timeIntervalSince1970: 1_000)
+        )
+        try fixture.writeSession(
+            id: "older-last-active",
+            createdAt: "2026-07-01T00:00:00Z",
+            updatedAt: "2026-07-09T00:00:00Z",
+            lastActiveAt: "2026-07-09T00:00:00Z",
+            summaryModifiedAt: Date(timeIntervalSince1970: 2_000_000_000),
+            directoryModifiedAt: Date(timeIntervalSince1970: 2_000_000_000),
+            lockModifiedAt: Date(timeIntervalSince1970: 2_000_000_000)
+        )
+
+        let detected = fixture.detectedEntry(arguments: ["/usr/local/bin/grok"])
+
+        #expect(detected?.snapshot.sessionId == "created-at-fallback")
+    }
+
     @Test(arguments: ["-r", "--resume"])
     func explicitResumeArgumentTakesPriority(_ option: String) throws {
         let fixture = try Fixture.make()

--- a/cmuxTests/GrokVaultAgentPersistenceTests.swift
+++ b/cmuxTests/GrokVaultAgentPersistenceTests.swift
@@ -1,0 +1,243 @@
+import Foundation
+import Testing
+
+#if canImport(cmux_DEV)
+@testable import cmux_DEV
+#elseif canImport(cmux)
+@testable import cmux
+#endif
+
+@Suite
+struct GrokVaultAgentPersistenceTests {
+    @Test func freshLaunchDiscoversSessionFromConfiguredDirectory() throws {
+        let fixture = try Fixture.make()
+        defer { fixture.cleanup() }
+
+        try fixture.writeSession(
+            id: "019fbcbd-cdbe-74d2-9395-411d6f1dcdc1",
+            createdAt: "2026-08-01T09:53:03.549632Z",
+            updatedAt: "2026-08-01T09:53:16.673393Z",
+            lastActiveAt: "2026-08-01T09:53:16.673393Z"
+        )
+
+        let detected = fixture.detectedEntry(arguments: ["/usr/local/bin/grok"])
+
+        #expect(detected?.snapshot.sessionId == "019fbcbd-cdbe-74d2-9395-411d6f1dcdc1")
+        #expect(detected?.sessionIDSource == .inferredLatestSessionFile)
+    }
+
+    @Test func latestSessionUsesContentActivityInsteadOfIncidentalModificationDates() throws {
+        let fixture = try Fixture.make()
+        defer { fixture.cleanup() }
+
+        try fixture.writeSession(
+            id: "019f430d-7c57-70b2-a789-b643c0e148ee",
+            createdAt: "2026-07-08T18:46:25.247868Z",
+            updatedAt: "2026-07-20T02:23:23.521216Z",
+            lastActiveAt: "2026-07-08T18:58:26.470913Z",
+            summaryModifiedAt: Date(timeIntervalSince1970: 2_000_000_000),
+            directoryModifiedAt: Date(timeIntervalSince1970: 2_000_000_000),
+            lockModifiedAt: Date(timeIntervalSince1970: 2_000_000_000)
+        )
+        try fixture.writeSession(
+            id: "019ebaf3-8860-7f53-b31b-70e8b426016d",
+            createdAt: "2026-06-12T08:29:43.018254Z",
+            updatedAt: "2026-07-11T19:41:04.119069Z",
+            lastActiveAt: "2026-07-11T19:41:04.109119Z",
+            summaryModifiedAt: Date(timeIntervalSince1970: 1_000),
+            directoryModifiedAt: Date(timeIntervalSince1970: 1_000),
+            lockModifiedAt: Date(timeIntervalSince1970: 1_000)
+        )
+
+        let detected = fixture.detectedEntry(arguments: ["/usr/local/bin/grok"])
+
+        #expect(detected?.snapshot.sessionId == "019ebaf3-8860-7f53-b31b-70e8b426016d")
+    }
+
+    @Test(arguments: ["-r", "--resume"])
+    func explicitResumeArgumentTakesPriority(_ option: String) throws {
+        let fixture = try Fixture.make()
+        defer { fixture.cleanup() }
+
+        try fixture.writeSession(
+            id: "disk-session",
+            createdAt: "2026-08-01T09:53:03.549632Z",
+            updatedAt: "2026-08-01T09:53:16.673393Z",
+            lastActiveAt: "2026-08-01T09:53:16.673393Z"
+        )
+
+        let detected = fixture.detectedEntry(
+            arguments: ["/usr/local/bin/grok", option, "explicit-session"]
+        )
+
+        #expect(detected?.snapshot.sessionId == "explicit-session")
+        #expect(detected?.sessionIDSource == .explicit)
+    }
+
+    @Test func cwdWithoutMatchingSessionDirectoryReturnsNil() throws {
+        let fixture = try Fixture.make()
+        defer { fixture.cleanup() }
+        let otherCWD = fixture.root.appendingPathComponent("other-repo", isDirectory: true)
+        try fixture.fileManager.createDirectory(at: otherCWD, withIntermediateDirectories: true)
+        try fixture.writeSession(
+            id: "other-cwd-session",
+            cwd: otherCWD,
+            createdAt: "2026-08-01T09:53:03.549632Z",
+            updatedAt: "2026-08-01T09:53:16.673393Z",
+            lastActiveAt: "2026-08-01T09:53:16.673393Z"
+        )
+
+        #expect(fixture.detectedEntry(arguments: ["/usr/local/bin/grok"]) == nil)
+    }
+
+    @Test func summaryFileModificationDateIsLastResortWhenContentHasNoTimestamp() throws {
+        let fixture = try Fixture.make()
+        defer { fixture.cleanup() }
+
+        try fixture.writeSession(
+            id: "older-summary",
+            summaryModifiedAt: Date(timeIntervalSince1970: 1_000),
+            directoryModifiedAt: Date(timeIntervalSince1970: 3_000)
+        )
+        try fixture.writeSession(
+            id: "newer-summary",
+            summaryModifiedAt: Date(timeIntervalSince1970: 2_000),
+            directoryModifiedAt: Date(timeIntervalSince1970: 500)
+        )
+
+        let detected = fixture.detectedEntry(arguments: ["/usr/local/bin/grok"])
+
+        #expect(detected?.snapshot.sessionId == "newer-summary")
+    }
+}
+
+private extension GrokVaultAgentPersistenceTests {
+    struct Fixture {
+        let fileManager: FileManager
+        let root: URL
+        let cwd: URL
+        let sessionsRoot: URL
+        let workspaceID: UUID
+        let panelID: UUID
+
+        static func make() throws -> Self {
+            let fileManager = FileManager.default
+            let root = fileManager.temporaryDirectory
+                .appendingPathComponent("cmux-grok-process-discovery-\(UUID().uuidString)", isDirectory: true)
+            let cwd = root.appendingPathComponent("repo with spaces", isDirectory: true)
+            let sessionsRoot = root.appendingPathComponent("sessions", isDirectory: true)
+            try fileManager.createDirectory(at: cwd, withIntermediateDirectories: true)
+            try fileManager.createDirectory(at: sessionsRoot, withIntermediateDirectories: true)
+            return Self(
+                fileManager: fileManager,
+                root: root,
+                cwd: cwd,
+                sessionsRoot: sessionsRoot,
+                workspaceID: UUID(),
+                panelID: UUID()
+            )
+        }
+
+        func cleanup() {
+            try? fileManager.removeItem(at: root)
+        }
+
+        func detectedEntry(
+            arguments: [String],
+            cwd detectedCWD: URL? = nil
+        ) -> RestorableAgentSessionIndex.ProcessDetectedSnapshotEntry? {
+            let processID = 9_377
+            let process = CmuxTopProcessInfo(
+                pid: processID,
+                parentPID: 1,
+                name: "grok",
+                path: "/usr/local/bin/grok",
+                ttyDevice: nil,
+                cmuxWorkspaceID: workspaceID,
+                cmuxSurfaceID: panelID,
+                cmuxAttributionReason: "cmux-test",
+                processGroupID: nil,
+                terminalProcessGroupID: nil,
+                cpuPercent: 0,
+                residentBytes: 0,
+                virtualBytes: 0,
+                threadCount: 1
+            )
+            let processSnapshot = CmuxTopProcessSnapshot(
+                processes: [process],
+                sampledAt: Date(timeIntervalSince1970: 0),
+                includesProcessDetails: true
+            )
+            var registration = CmuxVaultAgentRegistration.builtInGrok
+            registration.sessionDirectory = sessionsRoot.path
+            let key = RestorableAgentSessionIndex.PanelKey(
+                workspaceId: workspaceID,
+                panelId: panelID
+            )
+
+            return RestorableAgentSessionIndex.processDetectedSnapshots(
+                registry: CmuxVaultAgentRegistry(registrations: [registration]),
+                fileManager: fileManager,
+                processSnapshot: processSnapshot,
+                capturedAt: 42,
+                processArgumentsProvider: { requestedProcessID in
+                    guard requestedProcessID == processID else { return nil }
+                    return CmuxTopProcessArguments(
+                        arguments: arguments,
+                        environment: [
+                            "HOME": root.path,
+                            "PWD": (detectedCWD ?? cwd).path,
+                        ]
+                    )
+                }
+            )[key]
+        }
+
+        func writeSession(
+            id: String,
+            cwd sessionCWD: URL? = nil,
+            createdAt: String? = nil,
+            updatedAt: String? = nil,
+            lastActiveAt: String? = nil,
+            summaryModifiedAt: Date? = nil,
+            directoryModifiedAt: Date? = nil,
+            lockModifiedAt: Date? = nil
+        ) throws {
+            let projectDirectory = sessionsRoot.appendingPathComponent(
+                GrokSessionLocator.encodedSessionCWD((sessionCWD ?? cwd).path),
+                isDirectory: true
+            )
+            let sessionDirectory = projectDirectory.appendingPathComponent(id, isDirectory: true)
+            try fileManager.createDirectory(at: sessionDirectory, withIntermediateDirectories: true)
+
+            var summary: [String: String] = [:]
+            summary["created_at"] = createdAt
+            summary["updated_at"] = updatedAt
+            summary["last_active_at"] = lastActiveAt
+            let summaryURL = sessionDirectory.appendingPathComponent("summary.json", isDirectory: false)
+            let summaryData = try JSONSerialization.data(withJSONObject: summary, options: [.sortedKeys])
+            try summaryData.write(to: summaryURL)
+            if let summaryModifiedAt {
+                try fileManager.setAttributes(
+                    [.modificationDate: summaryModifiedAt],
+                    ofItemAtPath: summaryURL.path
+                )
+            }
+
+            if let lockModifiedAt {
+                let lockURL = sessionDirectory.appendingPathComponent("summary.json.lock", isDirectory: false)
+                try Data().write(to: lockURL)
+                try fileManager.setAttributes(
+                    [.modificationDate: lockModifiedAt],
+                    ofItemAtPath: lockURL.path
+                )
+            }
+            if let directoryModifiedAt {
+                try fileManager.setAttributes(
+                    [.modificationDate: directoryModifiedAt],
+                    ofItemAtPath: sessionDirectory.path
+                )
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- discover a fresh Grok session from its cwd-scoped session directory when argv has no resume id
- preserve explicit `-r` and `--resume` priority
- rank sessions from Grok content timestamps instead of directory or lock-file mtimes

## Root cause

This is a discovery-time failure, not a restore lookup failure. The `.grokSessionDirectory` scanner branch only read an id already present on the running process argv. A fresh `grok` process has no resume argument, so cmux never produced the process-detected snapshot that writes the surface resume record. The later restore lookup correctly found that no record had been written.

## Latest session ranking

I inspected the real session directory from #9377 and its `summary.json`. Grok records ISO-8601 `last_active_at`, `updated_at`, and `created_at` fields with microsecond precision. `last_active_at` represents conversation activity and is the primary ranking field. The real data also contains a session whose `updated_at` moved days beyond `last_active_at`, so `updated_at` is only a fallback when activity is absent. If all content timestamps are absent, discovery falls back only to the direct `summary.json` file mtime, never a session-directory or tree mtime that lock files can perturb.

## Tests

The first commit adds the failing regression suite for fresh launch discovery, content timestamp ordering, explicit resume priority, cwd isolation, and the last-resort summary mtime path. The implementation follows in a separate commit.

Closes #9377

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/9379"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788171395&installation_model_id=21920&pr_number=9379&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F9379&signature=2c8e8d642fb9c679422a8330eb6f9d5163f5767dad8bb31df8ad69c25d8168c7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `grok` session discovery on fresh launches so the latest session is inferred from the cwd-scoped session directory when no resume id is provided. Keeps explicit `-r`/`--resume` precedence and uses Grok content timestamps for accurate ordering.

- **Bug Fixes**
  - Infer latest session from `summary.json`: prefer `last_active_at`, fallback to `updated_at`, then `created_at`; last resort is `summary.json` mtime.
  - Ignore directory and lock-file mtimes to avoid incidental updates influencing ranking.
  - Scope discovery to detected `PWD`; do not cross projects if no matching session directory.
  - Added regression tests for fresh launch discovery, content timestamp ordering (including `created_at` fallback), explicit resume priority, cwd isolation, and mtime fallback.

<sup>Written for commit ac7d0cccdb4160ff2ed67dc5e516fa1d52df4896. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/9379?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added coverage for session discovery across fresh launches, activity-based selection, explicit resume arguments, working-directory filtering, and summary-file date fallback.
  * Added temporary filesystem fixtures to simulate Grok session data and process metadata while ensuring test artifacts are cleaned up.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->