### PR TITLE
Keep sidebar icon until avatar URL exists

### DIFF
--- a/Sources/Auth/HostAccountFlow.swift
+++ b/Sources/Auth/HostAccountFlow.swift
@@ -69,10 +69,6 @@ final class HostAccountFlow: AccountFlow, AccountSignInFlow {
         coordinator.isAuthenticated
     }
 
-    var isRestoringSession: Bool {
-        coordinator.isRestoringSession
-    }
-
     var isPresentingSignIn: Bool {
         browserSignIn.isPresentingSignIn
     }

--- a/Sources/VerticalTabsSidebar+EmptyAreasAndFooter.swift
+++ b/Sources/VerticalTabsSidebar+EmptyAreasAndFooter.swift
@@ -52,9 +52,9 @@ struct SidebarAccountButtonPresentation: Equatable {
     static func resolve(
         isSignedIn: Bool,
         prefersProfileIcon: Bool,
-        isRestoringSession: Bool = false
+        hasProfilePicture: Bool = false
     ) -> SidebarAccountButtonPresentation {
-        if isSignedIn, !prefersProfileIcon, !isRestoringSession {
+        if isSignedIn, hasProfilePicture, !prefersProfileIcon {
             return SidebarAccountButtonPresentation(
                 visual: .profilePicture,
                 size: SidebarFooterButtonMetrics.profilePictureSize
@@ -260,12 +260,12 @@ struct SidebarAccountMenuButton: View {
 
     private func presentation(
         isSignedIn: Bool,
-        isRestoringSession: Bool
+        hasProfilePicture: Bool
     ) -> SidebarAccountButtonPresentation {
         let presentation = SidebarAccountButtonPresentation.resolve(
             isSignedIn: isSignedIn,
             prefersProfileIcon: prefersProfileIcon,
-            isRestoringSession: isRestoringSession
+            hasProfilePicture: hasProfilePicture
         )
 #if DEBUG
         if !presentation.showsProfilePicture {
@@ -284,7 +284,7 @@ struct SidebarAccountMenuButton: View {
         let buttonTitle = isSignedIn ? title : signInTitle
         let presentation = presentation(
             isSignedIn: isSignedIn,
-            isRestoringSession: accountFlow?.isRestoringSession == true
+            hasProfilePicture: identity?.avatarURL != nil
         )
         Button {
             if isSignedIn {

--- a/cmuxTests/WorkspaceContentViewVisibilityTests.swift
+++ b/cmuxTests/WorkspaceContentViewVisibilityTests.swift
@@ -450,7 +450,8 @@ final class WorkspaceContentViewVisibilityTests {
     func sidebarAccountPictureAndIconPresentationsStayDistinct() {
         let picture = SidebarAccountButtonPresentation.resolve(
             isSignedIn: true,
-            prefersProfileIcon: false
+            prefersProfileIcon: false,
+            hasProfilePicture: true
         )
         let toggledIcon = SidebarAccountButtonPresentation.resolve(
             isSignedIn: true,
@@ -460,10 +461,10 @@ final class WorkspaceContentViewVisibilityTests {
             isSignedIn: false,
             prefersProfileIcon: false
         )
-        let restoringSignedInIcon = SidebarAccountButtonPresentation.resolve(
+        let missingPictureIcon = SidebarAccountButtonPresentation.resolve(
             isSignedIn: true,
             prefersProfileIcon: false,
-            isRestoringSession: true
+            hasProfilePicture: false
         )
 
         #expect(picture.visual == .profilePicture)
@@ -479,7 +480,7 @@ final class WorkspaceContentViewVisibilityTests {
         )
         #expect(toggledIcon.size == SidebarFooterButtonMetrics.accountAndHelpVisualSize)
         #expect(signedOutIcon == toggledIcon)
-        #expect(restoringSignedInIcon == toggledIcon)
+        #expect(missingPictureIcon == toggledIcon)
         #expect(
             SidebarFooterButtonMetrics.profilePictureSize
                 == SidebarFooterButtonMetrics.helpIconSize


### PR DESCRIPTION
Follow-up to https://github.com/manaflow-ai/cmux/pull/9375.

The sidebar now stays on the person icon while a signed-in identity has no avatar URL. Once the URL exists, image loading keeps that same icon until the photo renders. Failed image URLs retain the neutral-gray letter fallback.

Verification:
- Focused WorkspaceContentViewVisibilityTests policy test passed, 1 test.
- Tagged avload cloud build succeeded.
- Controlled launch replay held the URL absent and delayed image loading; both states stayed on the person icon with no initial letter.

No user-facing strings changed.