### PR TITLE
Gate mobile notification sync on host capabilities

### DIFF
--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+NotificationDismissSync.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+NotificationDismissSync.swift
@@ -47,7 +47,9 @@ extension MobileShellComposite {
         macDeviceID: String?
     ) async {
         let ids = dismisses.map(\.id)
-        guard let client = notificationDismissClient(for: macDeviceID) else { return }
+        guard let target = notificationDismissTarget(for: macDeviceID),
+              target.capabilities.contains(Self.notificationDismissCapability)
+        else { return }
         do {
             let request = try MobileCoreRPCClient.requestData(
                 method: "notification.dismiss",
@@ -56,15 +58,20 @@ extension MobileShellComposite {
                     "client_id": clientID,
                 ]
             )
-            _ = try await client.sendRequest(request)
+            _ = try await target.client.sendRequest(request)
             pendingDismissQueue.remove(dismisses)
         } catch {
             mobileShellLog.error("notification dismiss sync failed count=\(ids.count, privacy: .public) error=\(String(describing: error), privacy: .public)")
         }
     }
 
-    private func notificationDismissClient(for macDeviceID: String?) -> MobileCoreRPCClient? {
-        guard let macDeviceID, !macDeviceID.isEmpty else { return remoteClient }
+    private func notificationDismissTarget(
+        for macDeviceID: String?
+    ) -> (client: MobileCoreRPCClient, capabilities: Set<String>)? {
+        guard let macDeviceID, !macDeviceID.isEmpty else {
+            guard let remoteClient else { return nil }
+            return (remoteClient, supportedHostCapabilities)
+        }
         // Dismiss records are device-scoped (push payloads carry no instance
         // tag). Route only when the owning build is unambiguous ACROSS STORED
         // pairings: the emitting build may be offline while a sibling is the
@@ -74,11 +81,12 @@ extension MobileShellComposite {
         }
         guard storedSiblings.count <= 1 else { return nil }
         if foregroundMacDeviceID == macDeviceID, let remoteClient {
-            return remoteClient
+            return (remoteClient, supportedHostCapabilities)
         }
-        return secondaryMacSubscriptions
-            .first { $0.value.macDeviceID == macDeviceID }?
-            .value.client
+        guard let subscription = secondaryMacSubscriptions
+            .first(where: { $0.value.macDeviceID == macDeviceID })?
+            .value else { return nil }
+        return (subscription.client, subscription.supportedHostCapabilities)
     }
 
     func flushPendingNotificationDismisses(macDeviceID: String? = nil) async {
@@ -126,10 +134,15 @@ extension MobileShellComposite {
     }
 
     func reconcileNotificationsWithMac(client: MobileCoreRPCClient) async {
+        guard supportedHostCapabilities.contains(Self.notificationReconcileCapability),
+              remoteClient === client,
+              connectionState == .connected else { return }
         let deliveredIDs = await deliveredNotificationClearer.deliveredIdentifiers()
         guard !Task.isCancelled,
               remoteClient === client,
-              connectionState == .connected else { return }
+              connectionState == .connected,
+              supportedHostCapabilities.contains(Self.notificationReconcileCapability)
+        else { return }
         do {
             let request = try MobileCoreRPCClient.requestData(
                 method: "notification.reconcile",

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
@@ -128,6 +128,8 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
     static let dogfoodFeedbackCapability = "dogfood.v1"
     static let workspaceGroupsCapability = "workspace.groups.v1"
     static let notificationFeedCapability = "notification.feed.v1"
+    static let notificationDismissCapability = "notification.dismiss.v1"
+    static let notificationReconcileCapability = "notification.reconcile.v1"
     private static let terminalOutputCapabilityTimeoutNanoseconds: UInt64 = 750_000_000
     /// How long the render-grid stream may stay silent (no event of any topic)
     /// before the liveness watchdog suspects the push subscription is dead and

--- a/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/ComposerSubmitRoutingTestSupport.swift
+++ b/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/ComposerSubmitRoutingTestSupport.swift
@@ -54,6 +54,7 @@ actor RoutingHostRouter {
     let terminalInputRecorder = RoutingTerminalInputRecorder()
     private(set) var directorySearchQueries: [String] = []
     private(set) var dismisses: [(notificationIDs: [String], clientID: String?)] = []
+    private(set) var requestedMethods: [String] = []
     private var notificationFeedMarkAllReadCount = 0
     private var workspaceCreates: [WorkspaceCreateRecord] = []
     /// Reject the Nth (0-based) and later paste_image requests; `nil` accepts all.
@@ -167,6 +168,7 @@ actor RoutingHostRouter {
         directoryListRequests
     }
     func recordedDismisses() -> [(notificationIDs: [String], clientID: String?)] { dismisses }
+    func recordedMethods() -> [String] { requestedMethods }
     func recordedNotificationFeedMarkAllReadCount() -> Int { notificationFeedMarkAllReadCount }
 
     /// Sendable extract of the request fields the router needs, pulled off the
@@ -195,6 +197,9 @@ actor RoutingHostRouter {
     func response(_ info: RequestInfo) async -> Data? {
         let method = info.method
         let id = info.id
+        if let method {
+            requestedMethods.append(method)
+        }
         switch method {
         case "workspace.list", "mobile.workspace.list":
             return try? Self.resultFrame(id: id, result: [
@@ -378,6 +383,11 @@ actor RoutingHostRouter {
                 clientID: info.clientID
             ))
             return try? Self.resultFrame(id: id, result: [:])
+        case "notification.reconcile":
+            return try? Self.resultFrame(id: id, result: [
+                "handled_ids": [],
+                "unread_count": 0,
+            ])
         case "notification.feed.mark_all_read":
             notificationFeedMarkAllReadCount += 1
             return try? Self.resultFrame(id: id, result: [

--- a/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/MobileShellDismissSyncTests.swift
+++ b/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/MobileShellDismissSyncTests.swift
@@ -81,7 +81,12 @@ import UserNotifications
         let foregroundRouter = RoutingHostRouter()
         let secondaryRouter = RoutingHostRouter()
         let store = try await makeRoutingConnectedStore(router: foregroundRouter)
-        try installSecondaryClient(on: store, macDeviceID: "mac-secondary", router: secondaryRouter)
+        try installSecondaryClient(
+            on: store,
+            macDeviceID: "mac-secondary",
+            router: secondaryRouter,
+            supportedHostCapabilities: ["notification.dismiss.v1"]
+        )
 
         await store.dismissNotification(ids: [" n-secondary "], macDeviceID: "mac-secondary")
 
@@ -106,7 +111,12 @@ import UserNotifications
             (id: "n-secondary", macDeviceID: "mac-secondary"),
             (id: "n-other", macDeviceID: "mac-other"),
         ])
-        try installSecondaryClient(on: store, macDeviceID: "mac-secondary", router: secondaryRouter)
+        try installSecondaryClient(
+            on: store,
+            macDeviceID: "mac-secondary",
+            router: secondaryRouter,
+            supportedHostCapabilities: ["notification.dismiss.v1"]
+        )
 
         await store.flushPendingNotificationDismisses(macDeviceID: "mac-secondary")
 
@@ -128,6 +138,75 @@ import UserNotifications
         #expect(foregroundDismisses.isEmpty)
         #expect(store.pendingDismissQueue.pendingDismisses.map(\.id) == ["n-missing"])
         #expect(store.pendingDismissQueue.pendingDismisses.map(\.macDeviceID) == ["mac-missing"])
+    }
+
+    @Test func syncSkipsNotificationMethodsMissingFromForegroundCapabilities() async throws {
+        let router = RoutingHostRouter()
+        let queue = PendingNotificationDismissQueue(
+            defaults: UserDefaults(suiteName: "dismiss-queue-\(UUID().uuidString)")!
+        )
+        queue.enqueue([(id: "n-old-host", macDeviceID: nil)])
+        let store = try await makeRoutingConnectedStore(
+            router: router,
+            pendingDismissQueue: queue,
+            hostCapabilities: []
+        )
+        let client = try #require(store.remoteClient)
+
+        store.scheduleNotificationReconcile(client: client)
+        await store.notificationReconcileTask?.value
+
+        let notificationMethods = await router.recordedMethods().filter {
+            $0.hasPrefix("notification.")
+        }
+        #expect(notificationMethods.isEmpty)
+        #expect(queue.pendingIDs == ["n-old-host"])
+    }
+
+    @Test func syncUsesNotificationMethodsAdvertisedByForegroundHost() async throws {
+        let router = RoutingHostRouter()
+        let queue = PendingNotificationDismissQueue(
+            defaults: UserDefaults(suiteName: "dismiss-queue-\(UUID().uuidString)")!
+        )
+        queue.enqueue([(id: "n-current-host", macDeviceID: nil)])
+        let store = try await makeRoutingConnectedStore(
+            router: router,
+            pendingDismissQueue: queue,
+            hostCapabilities: [
+                "notification.dismiss.v1",
+                "notification.reconcile.v1",
+            ]
+        )
+        let client = try #require(store.remoteClient)
+
+        store.scheduleNotificationReconcile(client: client)
+        await store.notificationReconcileTask?.value
+
+        let notificationMethods = await router.recordedMethods().filter {
+            $0.hasPrefix("notification.")
+        }
+        #expect(notificationMethods == ["notification.dismiss", "notification.reconcile"])
+        #expect(queue.pendingIDs.isEmpty)
+    }
+
+    @Test func dismissForSecondaryWithoutCapabilityStaysQueued() async throws {
+        let foregroundRouter = RoutingHostRouter()
+        let secondaryRouter = RoutingHostRouter()
+        let store = try await makeRoutingConnectedStore(router: foregroundRouter)
+        try installSecondaryClient(
+            on: store,
+            macDeviceID: "mac-secondary",
+            router: secondaryRouter,
+            supportedHostCapabilities: []
+        )
+
+        await store.dismissNotification(ids: ["n-legacy"], macDeviceID: "mac-secondary")
+
+        let notificationMethods = await secondaryRouter.recordedMethods().filter {
+            $0.hasPrefix("notification.")
+        }
+        #expect(notificationMethods.isEmpty)
+        #expect(store.pendingDismissQueue.pendingIDs == ["n-legacy"])
     }
 
     @Test func setsBadgeToAuthoritativeTotal() {


### PR DESCRIPTION
## Summary
- send notification dismissals only to hosts advertising `notification.dismiss.v1`
- run foreground reconciliation only when the host advertises `notification.reconcile.v1`
- keep dismissals queued when an older host cannot consume them

## Verification
- red proof: https://github.com/manaflow-ai/cmux/actions/runs/30705777284
- focused green proof: https://github.com/manaflow-ai/cmux/actions/runs/30706415594 (`MobileShellDismissSyncTests` passed; unrelated pre-existing timing tests later failed the job)
- tagged macOS cloud build: https://github.com/manaflow-ai/cmux/actions/runs/30706341569
- tagged web routes returned HTTP 200 on port 4012

Simulator, signed iPhone artifact, and speculative merge evidence will be added after the current tagged reload completes.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/9389"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788193167&installation_model_id=21920&pr_number=9389&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F9389&signature=ed67fa33b9b63c841503527e23b0a4d3bc3d5fde00f9a55fcd97ec58d121e9d4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Gate mobile notification sync on host capabilities. Dismiss and reconcile calls only run when the host advertises support; dismissals stay queued on legacy hosts.

- **Bug Fixes**
  - Send dismisses only if `notification.dismiss.v1` is advertised; route to the correct host using the device ID.
  - Run foreground reconcile only if `notification.reconcile.v1` is advertised.
  - Keep pending dismissals queued when the target host lacks capability.
  - Added capability constants and tests to verify routing and queuing behavior.

<sup>Written for commit 9f031ac4c201d56aba802b70854f4f0ac4910c37. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/9389?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved notification dismissal synchronization across paired and secondary devices.
  * Prevented unsupported notification operations from being sent to devices without the required capabilities.
  * Improved notification reconciliation to validate support before processing delivered notifications.

* **Tests**
  * Added coverage for capability-aware notification reconciliation and queued secondary-device dismissals.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->