### PR TITLE
Fix Kimi restore-of-restore binding kind decoding

### DIFF
--- a/Sources/DockSplitStore+SessionSnapshot.swift
+++ b/Sources/DockSplitStore+SessionSnapshot.swift
@@ -398,7 +398,12 @@ extension DockSplitStore {
             ?? resumeBinding.flatMap { $0.isAgentHookBinding ? $0 : nil }
         guard restorableAgent != nil || managedBinding != nil else { return nil }
         let expectedKind = managedBinding != nil
-            ? managedBinding?.kind.flatMap(RestorableAgentKind.init(rawValue:))
+            ? managedBinding?.kind.flatMap {
+                RestorableAgentKind(
+                    persistedRawValue: $0,
+                    registration: restorableAgent?.registration ?? observation?.snapshot.registration
+                )
+            }
             : restorableAgent?.kind
         let expectedSessionId = managedBinding != nil
             ? managedBinding?.checkpointId

--- a/Sources/RestorableAgentTypes.swift
+++ b/Sources/RestorableAgentTypes.swift
@@ -72,6 +72,17 @@ enum RestorableAgentKind: Codable, Hashable, Sendable {
         }
     }
 
+    init?(persistedRawValue rawValue: String, registration: CmuxVaultAgentRegistration?) {
+        guard let kind = RestorableAgentKind(rawValue: rawValue) else { return nil }
+        guard let registration,
+              registration.id == kind.rawValue,
+              !Self.allCases.contains(where: { $0.rawValue == kind.rawValue }) else {
+            self = kind
+            return
+        }
+        self = .custom(registration.id)
+    }
+
     var rawValue: String {
         switch self {
         case .claude: return "claude"

--- a/Sources/SessionRestorableAgentSnapshot+Commands.swift
+++ b/Sources/SessionRestorableAgentSnapshot+Commands.swift
@@ -12,21 +12,20 @@ extension SessionRestorableAgentSnapshot {
 
     init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: SnapshotCodingKeys.self)
-        var kind = try container.decode(RestorableAgentKind.self, forKey: .kind)
+        let persistedKind = try container.decode(String.self, forKey: .kind)
         let registration = try container.decodeIfPresent(
             CmuxVaultAgentRegistration.self,
             forKey: .registration
         )?.migratedPersistedBuiltInRegistration
-        // Registry-detected snapshots persist `.custom(id)`, whose raw string
-        // collapses to the native case on decode when the id matches a
-        // built-in raw value. Restore the write-side identity whenever that
-        // collapse would change command semantics (registry-owned Pi/Kimi or
-        // relaunch-only natives such as Ollama), so the stored registration
-        // keeps owning resume and fork behavior.
-        if (kind.restoreMode == .relaunchCommand || kind == .pi || kind == .kimi),
-           let registration,
-           registration.id == kind.rawValue {
-            kind = .custom(registration.id)
+        guard let kind = RestorableAgentKind(
+            persistedRawValue: persistedKind,
+            registration: registration
+        ) else {
+            throw DecodingError.dataCorruptedError(
+                forKey: .kind,
+                in: container,
+                debugDescription: "Invalid restorable agent kind '\(persistedKind)'"
+            )
         }
         self.init(
             kind: kind,

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -473,7 +473,11 @@ extension Workspace {
             let agentWasRunning: Bool? = {
                 if let resumeBinding, resumeBinding.isAgentHookBinding {
                     guard let bindingKindValue = Self.normalizedResumeBindingValue(resumeBinding.kind),
-                          let bindingKind = RestorableAgentKind(rawValue: bindingKindValue),
+                          let bindingKind = RestorableAgentKind(
+                              persistedRawValue: bindingKindValue,
+                              registration: effectiveRestorableAgent?.registration
+                                  ?? restorableAgentObservation?.snapshot.registration
+                          ),
                           let bindingSessionId = Self.normalizedResumeBindingValue(resumeBinding.checkpointId) else {
                         return false
                     }
@@ -987,7 +991,10 @@ extension Workspace {
         }
         if let bindingKind = binding.kind?.trimmingCharacters(in: .whitespacesAndNewlines),
            !bindingKind.isEmpty,
-           RestorableAgentKind(rawValue: bindingKind) != restorableAgent.kind {
+           RestorableAgentKind(
+               persistedRawValue: bindingKind,
+               registration: restorableAgent.registration
+           ) != restorableAgent.kind {
             return binding
         }
 
@@ -1020,7 +1027,10 @@ extension Workspace {
             return nil
         }
         if let kindValue = normalizedResumeBindingValue(resumeBinding.kind) {
-            guard let bindingKind = RestorableAgentKind(rawValue: kindValue),
+            guard let bindingKind = RestorableAgentKind(
+                persistedRawValue: kindValue,
+                registration: restorableAgent.registration
+            ),
                   bindingKind == restorableAgent.kind else {
                 return nil
             }

--- a/cmuxTests/KimiRestorableAgentTests.swift
+++ b/cmuxTests/KimiRestorableAgentTests.swift
@@ -279,3 +279,185 @@ struct KimiRestorableAgentTests {
         #expect(resumeCommand.hasPrefix("cd -- '\(runtimeWorkingDirectory.path)'"))
     }
 }
+
+@Suite("Restorable agent persisted kind decoding")
+struct RestorableAgentPersistedKindDecodingTests {
+    @Test("Registry-owned persisted binding kinds match live custom snapshots", arguments: registryOwnedCases)
+    func registryOwnedPersistedBindingKindMatchesLiveCustomSnapshot(_ testCase: KindCase) throws {
+        let sessionId = "session-\(testCase.id)"
+        let launchDirectory = "/tmp/cmux-\(testCase.id)-launch"
+        let runtimeDirectory = "/tmp/cmux-\(testCase.id)-runtime"
+        let liveSnapshot = SessionRestorableAgentSnapshot(
+            kind: .custom(testCase.id),
+            sessionId: sessionId,
+            workingDirectory: launchDirectory,
+            launchCommand: nil,
+            registration: testCase.registration
+        )
+        let persistedBinding = try Self.decodedBinding(
+            kind: testCase.id,
+            sessionId: sessionId,
+            cwd: runtimeDirectory
+        )
+
+        let compatible = Workspace.restorableAgentForSessionRestore(
+            liveSnapshot,
+            resumeBinding: persistedBinding
+        )
+        #expect(compatible?.kind == liveSnapshot.kind)
+        #expect(compatible?.kind == .custom(testCase.id))
+
+        let retargeted = Workspace.resumeBindingForSessionRestore(
+            persistedBinding,
+            restorableAgent: liveSnapshot
+        )
+        #expect(retargeted?.cwd == launchDirectory)
+    }
+
+    @Test("Native persisted binding kinds still match native snapshots", arguments: nativeCases)
+    func nativePersistedBindingKindMatchesNativeSnapshot(_ testCase: KindCase) throws {
+        let sessionId = "session-\(testCase.id)"
+        let launchDirectory = "/tmp/cmux-\(testCase.id)-launch"
+        let runtimeDirectory = "/tmp/cmux-\(testCase.id)-runtime"
+        let liveSnapshot = SessionRestorableAgentSnapshot(
+            kind: testCase.kind,
+            sessionId: sessionId,
+            workingDirectory: launchDirectory,
+            launchCommand: nil,
+            registration: testCase.registration
+        )
+        let persistedBinding = try Self.decodedBinding(
+            kind: testCase.id,
+            sessionId: sessionId,
+            cwd: runtimeDirectory
+        )
+
+        let compatible = Workspace.restorableAgentForSessionRestore(
+            liveSnapshot,
+            resumeBinding: persistedBinding
+        )
+        #expect(compatible?.kind == liveSnapshot.kind)
+
+        let retargeted = Workspace.resumeBindingForSessionRestore(
+            persistedBinding,
+            restorableAgent: liveSnapshot
+        )
+        #expect(retargeted?.cwd == launchDirectory)
+    }
+
+    @Test("Kimi hook-store snapshots match persisted Kimi resume bindings")
+    func kimiHookStoreSnapshotMatchesPersistedBindingKind() throws {
+        let fileManager = FileManager.default
+        let root = fileManager.temporaryDirectory
+            .appendingPathComponent("cmux-kimi-restore-of-restore-\(UUID().uuidString)", isDirectory: true)
+        defer { try? fileManager.removeItem(at: root) }
+
+        let launchDirectory = root.appendingPathComponent("launch-repo", isDirectory: true)
+        let runtimeDirectory = root.appendingPathComponent("runtime-worktree", isDirectory: true)
+        let stateDirectory = root.appendingPathComponent(".cmuxterm", isDirectory: true)
+        try fileManager.createDirectory(at: launchDirectory, withIntermediateDirectories: true)
+        try fileManager.createDirectory(at: runtimeDirectory, withIntermediateDirectories: true)
+        try fileManager.createDirectory(at: stateDirectory, withIntermediateDirectories: true)
+
+        let workspaceId = UUID()
+        let panelId = UUID()
+        let sessionId = "72124c21-7b09-40a1-a98f-718164c46431"
+        let store = try JSONSerialization.data(
+            withJSONObject: [
+                "version": 1,
+                "sessions": [
+                    sessionId: [
+                        "sessionId": sessionId,
+                        "workspaceId": workspaceId.uuidString,
+                        "surfaceId": panelId.uuidString,
+                        "cwd": runtimeDirectory.path,
+                        "launchCommand": [
+                            "launcher": "kimi",
+                            "executablePath": "/Users/example/.local/bin/kimi",
+                            "arguments": ["/Users/example/.local/bin/kimi"],
+                            "workingDirectory": launchDirectory.path,
+                            "capturedAt": 1_750_000_000.0,
+                            "source": "test",
+                        ],
+                        "isRestorable": true,
+                        "updatedAt": 1_750_000_000.0,
+                    ],
+                ],
+            ],
+            options: [.prettyPrinted, .sortedKeys]
+        )
+        try store.write(
+            to: stateDirectory.appendingPathComponent("kimi-hook-sessions.json", isDirectory: false),
+            options: .atomic
+        )
+
+        let liveSnapshot = try #require(
+            RestorableAgentSessionIndex.load(homeDirectory: root.path, fileManager: fileManager)
+                .snapshot(workspaceId: workspaceId, panelId: panelId)
+        )
+        #expect(liveSnapshot.kind == .custom("kimi"))
+        #expect(liveSnapshot.registration?.id == "kimi")
+
+        let persistedBinding = try Self.decodedBinding(
+            kind: "kimi",
+            sessionId: sessionId,
+            cwd: runtimeDirectory.path
+        )
+        let compatible = Workspace.restorableAgentForSessionRestore(
+            liveSnapshot,
+            resumeBinding: persistedBinding
+        )
+
+        #expect(compatible?.kind == liveSnapshot.kind)
+    }
+
+    private static func decodedBinding(
+        kind: String,
+        sessionId: String,
+        cwd: String
+    ) throws -> SurfaceResumeBindingSnapshot {
+        let persisted = SurfaceResumeBindingSnapshot(
+            kind: kind,
+            command: "'\(kind)' '--resume' '\(sessionId)'",
+            cwd: cwd,
+            checkpointId: sessionId,
+            source: "agent-hook",
+            autoResume: true
+        )
+        return try JSONDecoder().decode(
+            SurfaceResumeBindingSnapshot.self,
+            from: JSONEncoder().encode(persisted)
+        )
+    }
+
+    struct KindCase: Sendable, CustomTestStringConvertible {
+        let id: String
+        let kind: RestorableAgentKind
+        let registration: CmuxVaultAgentRegistration?
+
+        var testDescription: String { id }
+    }
+
+    private static let registryOwnedCases: [KindCase] = [
+        KindCase(id: "pi", kind: .custom("pi"), registration: .builtInPi),
+        KindCase(id: "grok", kind: .custom("grok"), registration: .builtInGrok),
+        KindCase(id: "antigravity", kind: .custom("antigravity"), registration: .builtInAntigravity),
+        KindCase(id: "kimi", kind: .custom("kimi"), registration: .builtInKimi),
+        KindCase(
+            id: "ollama",
+            kind: .custom("ollama"),
+            registration: CmuxVaultAgentRegistration(
+                id: "ollama",
+                name: "Custom Ollama",
+                sessionIdSource: .argvOption("--session"),
+                resumeCommand: "custom-ollama --resume {{sessionId}}"
+            )
+        ),
+    ]
+
+    private static let nativeCases: [KindCase] = [
+        KindCase(id: "claude", kind: .claude, registration: nil),
+        KindCase(id: "codex", kind: .codex, registration: nil),
+        KindCase(id: "opencode", kind: .opencode, registration: nil),
+    ]
+}


### PR DESCRIPTION
## Summary
- add regression coverage for persisted resume bindings matching registry-owned live snapshots
- decode persisted restorable agent kinds with registration context so registry-owned ids stay `.custom(id)`
- apply the shared decode path in Workspace and dock session restore/liveness comparisons

Fixes #9396

## Testing
- In progress: tagged dev build for dogfood

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/9397"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788223196&installation_model_id=21920&pr_number=9397&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F9397&signature=9d17e05166b214e6ab4eae9ff46391f7907eb527d76a322cd4c155af9df2a3a6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix restore binding kind decoding so registry-owned agents (e.g., Kimi, Pi, Grok, Ollama) persist and restore as .custom(id) and correctly match live snapshots. Applies registration-aware decoding across snapshot decode and restore checks, with regression tests to prevent regressions. Fixes #9396.

- **Bug Fixes**
  - Added RestorableAgentKind.init(persistedRawValue:registration:) to keep registry-owned ids as `.custom(id)`.
  - Applied the shared decode in Workspace restore checks and Dock session liveness/retargeting.
  - Added regression tests for registry-owned bindings and Kimi hook-store resume matching.

<sup>Written for commit 611d8f18013c066fa8fb758ae98a19f6a8dda26c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/9397?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved session restoration for built-in and custom agents by correctly matching persisted agent information with current registrations.
  * Added clearer handling for invalid persisted agent types during session decoding.
  * Preserved compatibility when restoring resume bindings and snapshots across registered agents.

* **Tests**
  * Added coverage for native agents, custom registered agents, and Kimi hook-store session restoration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->