### PR TITLE
Fix tab drag reorder to middle positions

### DIFF
--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -10929,6 +10929,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         guard tabManager != nil else { return }
         let startWithHiddenSidebar = env["CMUX_UI_TEST_BONSPLIT_START_WITH_HIDDEN_SIDEBAR"] == "1"
         let showRightSidebar = env["CMUX_UI_TEST_BONSPLIT_SHOW_RIGHT_SIDEBAR"] == "1"
+        let fourTabSetup = env["CMUX_UI_TEST_BONSPLIT_FOUR_TAB_SETUP"] == "1"
 
         let deadline = Date().addingTimeInterval(20.0)
         func mainWindowContextForUITest() -> (window: NSWindow, context: MainWindowContext)? {
@@ -10993,6 +10994,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
             let workspaceTitle = "UITest Workspace"
             let alphaTitle = "UITest Alpha"
             let betaTitle = "UITest Beta"
+            let gammaTitle = "UITest Gamma"
+            let deltaTitle = "UITest Delta"
             tabManager.setCustomTitle(tabId: workspace.id, title: workspaceTitle)
             workspace.setPanelCustomTitle(panelId: alphaPanelId, title: alphaTitle)
             tabManager.newSurface()
@@ -11003,6 +11006,30 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
             }
 
             workspace.setPanelCustomTitle(panelId: betaPanelId, title: betaTitle)
+            var gammaPanelId: UUID?
+            var deltaPanelId: UUID?
+            if fourTabSetup {
+                tabManager.newSurface()
+                guard let createdGammaPanelId = workspace.focusedPanelId,
+                      createdGammaPanelId != alphaPanelId,
+                      createdGammaPanelId != betaPanelId else {
+                    self.writeBonsplitTabDragUITestData(["setupError": "Failed to create third surface"])
+                    return
+                }
+                gammaPanelId = createdGammaPanelId
+                workspace.setPanelCustomTitle(panelId: createdGammaPanelId, title: gammaTitle)
+
+                tabManager.newSurface()
+                guard let createdDeltaPanelId = workspace.focusedPanelId,
+                      createdDeltaPanelId != alphaPanelId,
+                      createdDeltaPanelId != betaPanelId,
+                      createdDeltaPanelId != createdGammaPanelId else {
+                    self.writeBonsplitTabDragUITestData(["setupError": "Failed to create fourth surface"])
+                    return
+                }
+                deltaPanelId = createdDeltaPanelId
+                workspace.setPanelCustomTitle(panelId: createdDeltaPanelId, title: deltaTitle)
+            }
             if let rawActionButtonCount = env["CMUX_UI_TEST_BONSPLIT_ACTION_BUTTON_COUNT"],
                let requestedActionButtonCount = Int(rawActionButtonCount),
                requestedActionButtonCount > 0 {
@@ -11053,8 +11080,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
                 "workspaceTitle": workspaceTitle,
                 "alphaTitle": alphaTitle,
                 "betaTitle": betaTitle,
+                "gammaTitle": fourTabSetup ? gammaTitle : "",
+                "deltaTitle": fourTabSetup ? deltaTitle : "",
                 "alphaPanelId": alphaPanelId.uuidString,
                 "betaPanelId": betaPanelId.uuidString,
+                "gammaPanelId": gammaPanelId?.uuidString ?? "",
+                "deltaPanelId": deltaPanelId?.uuidString ?? "",
             ])
             self.startBonsplitTabDragUITestRecorder(
                 workspaceId: workspace.id,

--- a/cmuxUITests/BonsplitTabDragUITests.swift
+++ b/cmuxUITests/BonsplitTabDragUITests.swift
@@ -65,6 +65,102 @@ final class BonsplitTabDragUITests: XCTestCase {
         XCTAssertEqual(window.frame.origin.y, windowFrameBeforeDrag.origin.y, accuracy: 2.0, "Expected tab drag not to move the window vertically")
     }
 
+    func testMinimalModeReordersLaterTabToMiddleIndex() {
+        let (app, dataPath) = launchConfiguredApp(fourTabSetup: true)
+
+        XCTAssertTrue(
+            ensureAppRunningAfterLaunch(app, timeout: launchTimeout),
+            "Expected app to launch for later-to-middle Bonsplit tab drag UI test. state=\(app.state.rawValue)"
+        )
+        XCTAssertTrue(waitForAnyJSON(atPath: dataPath, timeout: setupTimeout), "Expected tab-drag setup data at \(dataPath)")
+        guard let ready = waitForJSONKey("ready", equals: "1", atPath: dataPath, timeout: setupTimeout) else {
+            XCTFail("Timed out waiting for ready=1. data=\(loadJSON(atPath: dataPath) ?? [:])")
+            return
+        }
+
+        if let setupError = ready["setupError"], !setupError.isEmpty {
+            XCTFail("Setup failed: \(setupError)")
+            return
+        }
+
+        let alphaTitle = ready["alphaTitle"] ?? "UITest Alpha"
+        let betaTitle = ready["betaTitle"] ?? "UITest Beta"
+        let gammaTitle = ready["gammaTitle"] ?? "UITest Gamma"
+        let deltaTitle = ready["deltaTitle"] ?? "UITest Delta"
+        let initialOrder = "\(alphaTitle)|\(betaTitle)|\(gammaTitle)|\(deltaTitle)"
+        let expectedOrder = "\(alphaTitle)|\(deltaTitle)|\(betaTitle)|\(gammaTitle)"
+        let window = app.windows.element(boundBy: 0)
+        let betaTab = app.buttons[betaTitle]
+        let deltaTab = app.buttons[deltaTitle]
+
+        XCTAssertTrue(window.waitForExistence(timeout: 5.0), "Expected main window to exist")
+        XCTAssertTrue(betaTab.waitForExistence(timeout: 5.0), "Expected beta tab to exist")
+        XCTAssertTrue(deltaTab.waitForExistence(timeout: 5.0), "Expected delta tab to exist")
+        XCTAssertTrue(
+            waitForJSONKey("trackedPaneTabTitles", equals: initialOrder, atPath: dataPath, timeout: 5.0) != nil,
+            "Expected initial tracked tab order to be \(initialOrder). data=\(loadJSON(atPath: dataPath) ?? [:])"
+        )
+
+        dragTab(deltaTab, before: betaTab)
+
+        XCTAssertTrue(
+            waitForJSONKey("trackedPaneTabTitles", equals: expectedOrder, atPath: dataPath, timeout: 5.0) != nil,
+            "Expected dragging the later tab into the middle to produce \(expectedOrder). data=\(loadJSON(atPath: dataPath) ?? [:])"
+        )
+        XCTAssertTrue(
+            waitForCondition(timeout: 5.0) { deltaTab.frame.minX < betaTab.frame.minX },
+            "Expected delta tab to settle before beta without appending to the end. beta=\(betaTab.frame) delta=\(deltaTab.frame)"
+        )
+    }
+
+    func testMinimalModeReordersEarlierTabToMiddleIndex() {
+        let (app, dataPath) = launchConfiguredApp(fourTabSetup: true)
+
+        XCTAssertTrue(
+            ensureAppRunningAfterLaunch(app, timeout: launchTimeout),
+            "Expected app to launch for earlier-to-middle Bonsplit tab drag UI test. state=\(app.state.rawValue)"
+        )
+        XCTAssertTrue(waitForAnyJSON(atPath: dataPath, timeout: setupTimeout), "Expected tab-drag setup data at \(dataPath)")
+        guard let ready = waitForJSONKey("ready", equals: "1", atPath: dataPath, timeout: setupTimeout) else {
+            XCTFail("Timed out waiting for ready=1. data=\(loadJSON(atPath: dataPath) ?? [:])")
+            return
+        }
+
+        if let setupError = ready["setupError"], !setupError.isEmpty {
+            XCTFail("Setup failed: \(setupError)")
+            return
+        }
+
+        let alphaTitle = ready["alphaTitle"] ?? "UITest Alpha"
+        let betaTitle = ready["betaTitle"] ?? "UITest Beta"
+        let gammaTitle = ready["gammaTitle"] ?? "UITest Gamma"
+        let deltaTitle = ready["deltaTitle"] ?? "UITest Delta"
+        let initialOrder = "\(alphaTitle)|\(betaTitle)|\(gammaTitle)|\(deltaTitle)"
+        let expectedOrder = "\(betaTitle)|\(gammaTitle)|\(alphaTitle)|\(deltaTitle)"
+        let window = app.windows.element(boundBy: 0)
+        let alphaTab = app.buttons[alphaTitle]
+        let deltaTab = app.buttons[deltaTitle]
+
+        XCTAssertTrue(window.waitForExistence(timeout: 5.0), "Expected main window to exist")
+        XCTAssertTrue(alphaTab.waitForExistence(timeout: 5.0), "Expected alpha tab to exist")
+        XCTAssertTrue(deltaTab.waitForExistence(timeout: 5.0), "Expected delta tab to exist")
+        XCTAssertTrue(
+            waitForJSONKey("trackedPaneTabTitles", equals: initialOrder, atPath: dataPath, timeout: 5.0) != nil,
+            "Expected initial tracked tab order to be \(initialOrder). data=\(loadJSON(atPath: dataPath) ?? [:])"
+        )
+
+        dragTab(alphaTab, before: deltaTab)
+
+        XCTAssertTrue(
+            waitForJSONKey("trackedPaneTabTitles", equals: expectedOrder, atPath: dataPath, timeout: 5.0) != nil,
+            "Expected dragging the earlier tab into the middle to produce \(expectedOrder). data=\(loadJSON(atPath: dataPath) ?? [:])"
+        )
+        XCTAssertTrue(
+            waitForCondition(timeout: 5.0) { alphaTab.frame.minX < deltaTab.frame.minX },
+            "Expected alpha tab to settle before delta without appending to the end. alpha=\(alphaTab.frame) delta=\(deltaTab.frame)"
+        )
+    }
+
     func testMinimalModePlacesPaneTabBarAtTopEdge() {
         let (app, dataPath) = launchConfiguredApp()
 
@@ -876,7 +972,8 @@ final class BonsplitTabDragUITests: XCTestCase {
         showRightSidebar: Bool = false,
         alwaysShowShortcutHints: Bool = false,
         windowSize: String? = nil,
-        actionButtonCount: Int? = nil
+        actionButtonCount: Int? = nil,
+        fourTabSetup: Bool = false
     ) -> (XCUIApplication, String) {
         let app = XCUIApplication.cmuxTestApplication()
         let dataPath = "/tmp/cmux-ui-test-bonsplit-tab-drag-\(UUID().uuidString).json"
@@ -893,6 +990,9 @@ final class BonsplitTabDragUITests: XCTestCase {
         }
         if let actionButtonCount {
             app.launchEnvironment["CMUX_UI_TEST_BONSPLIT_ACTION_BUTTON_COUNT"] = String(actionButtonCount)
+        }
+        if fourTabSetup {
+            app.launchEnvironment["CMUX_UI_TEST_BONSPLIT_FOUR_TAB_SETUP"] = "1"
         }
         if showRightSidebar {
             app.launchEnvironment["CMUX_UI_TEST_BONSPLIT_SHOW_RIGHT_SIDEBAR"] = "1"


### PR DESCRIPTION
## Summary
- Bump vendor/bonsplit to https://github.com/manaflow-ai/bonsplit/pull/197.
- Fix stale same-pane native drop fallback from overriding the manual tab reorder result and appending tabs after middle drops.
- Preserve cross-pane same-process fallback handling.

## Testing
- Remote aws-m4pro-4: swift test --filter TabDropDelegateSamePaneFallbackTests, 2 tests passed.

## Dependency
- Do not merge this cmux pointer until https://github.com/manaflow-ai/bonsplit/pull/197 is merged into manaflow-ai/bonsplit main.

## Issues
- Related: cmux tab drag reorder middle-index bug reported in chat.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/9398"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788223976&installation_model_id=21920&pr_number=9398&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F9398&signature=ff43c31df2f9d589f7c5b82c566aa503ee30a324a4a6914fac465b4cec61e2a2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes tab drag reorder for middle drops by using `bonsplit`’s manual drop target so tabs insert at the intended index. Updates `vendor/bonsplit` to the latest merge fixes and adds UI tests that verify both later-to-middle and earlier-to-middle reorders.

- **Bug Fixes**
  - Use `bonsplit` manual drop target for same-pane drops so middle drops go to the correct index.
  - Preserve cross-pane same-process fallback and prevent stale native drop from overriding manual reorder.

- **Tests**
  - Add UI tests for later-to-middle and earlier-to-middle reorders in a four-tab setup.
  - Add `CMUX_UI_TEST_BONSPLIT_FOUR_TAB_SETUP` and expose all tab titles and panel IDs for assertions.

<sup>Written for commit a9f9e2a5d655f62c3ef13be4779a95bf84493fe5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/9398?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated an underlying component to a newer revision.
  * No user-facing features, behavior, or interface changes are expected.
  * Existing application functionality remains unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->