### PR TITLE
Preserve Pi resume identity across repeated restores

### DIFF
--- a/Sources/AgentResumeLiveness.swift
+++ b/Sources/AgentResumeLiveness.swift
@@ -16,6 +16,11 @@ enum AgentResumeLiveness {
         sessionId: String
     ) -> Bool {
         guard let entry, !entry.processIDs.isEmpty else { return false }
-        return entry.snapshot.kind.rawValue == kind && entry.snapshot.sessionId == sessionId
+        return entry.snapshot.kind.rawValue == kind &&
+            ManagedAgentSessionIdentity.sessionIDsMatch(
+                kind: kind,
+                lhs: entry.snapshot.sessionId,
+                rhs: sessionId
+            )
     }
 }

--- a/Sources/DockSplitStore+SessionSnapshot.swift
+++ b/Sources/DockSplitStore+SessionSnapshot.swift
@@ -409,7 +409,14 @@ extension DockSplitStore {
             ? managedBinding?.checkpointId
             : restorableAgent?.sessionId
         let relevantObservation = observation.flatMap { entry -> RestorableAgentSessionIndex.Entry? in
-            guard entry.snapshot.kind == expectedKind, entry.snapshot.sessionId == expectedSessionId else {
+            guard let expectedKind,
+                  let expectedSessionId,
+                  entry.snapshot.kind.rawValue == expectedKind.rawValue,
+                  ManagedAgentSessionIdentity.sessionIDsMatch(
+                      kind: expectedKind.rawValue,
+                      lhs: entry.snapshot.sessionId,
+                      rhs: expectedSessionId
+                  ) else {
                 return nil
             }
             return entry

--- a/Sources/RestorableAgentSession.swift
+++ b/Sources/RestorableAgentSession.swift
@@ -924,6 +924,14 @@ struct RestorableAgentSessionIndex: Sendable {
     private struct SessionKey: Hashable {
         let kind: RestorableAgentKind
         let sessionId: String
+
+        init(kind: RestorableAgentKind, sessionId: String) {
+            self.kind = kind
+            self.sessionId = ManagedAgentSessionIdentity.canonicalSessionID(
+                kind: kind.rawValue,
+                sessionID: sessionId
+            )
+        }
     }
 
     private struct PanelKindKey: Hashable {
@@ -1243,7 +1251,11 @@ struct RestorableAgentSessionIndex: Sendable {
                         entry: shouldReplace ? entry : existingPanelIDCandidate.entry,
                         isAmbiguous: existingPanelIDCandidate.isAmbiguous ||
                             existingPanelIDCandidate.panelKey != key ||
-                            existingPanelIDCandidate.entry.snapshot.sessionId != entry.snapshot.sessionId
+                            !ManagedAgentSessionIdentity.sessionIDsMatch(
+                                kind: kind.rawValue,
+                                lhs: existingPanelIDCandidate.entry.snapshot.sessionId,
+                                rhs: entry.snapshot.sessionId
+                            )
                     )
                 } else {
                     hookCandidatesByPanelIdAndKind[panelIDKindKey] = PanelIDKindCandidate(
@@ -1384,7 +1396,11 @@ struct RestorableAgentSessionIndex: Sendable {
         [resolved, panelCandidate, sessionCandidate].compactMap { $0 }
             .filter {
                 $0.snapshot.kind == snapshot.kind &&
-                    $0.snapshot.sessionId == snapshot.sessionId
+                    ManagedAgentSessionIdentity.sessionIDsMatch(
+                        kind: snapshot.kind.rawValue,
+                        lhs: $0.snapshot.sessionId,
+                        rhs: snapshot.sessionId
+                    )
             }
             .max { $0.updatedAt < $1.updatedAt }
     }

--- a/Sources/SurfaceResumeBindingSnapshot+ManagedSessionIdentity.swift
+++ b/Sources/SurfaceResumeBindingSnapshot+ManagedSessionIdentity.swift
@@ -1,5 +1,56 @@
 import Foundation
 
+/// Compares the stable session identity published by agent hooks with the
+/// representation produced by process discovery.
+enum ManagedAgentSessionIdentity {
+    /// Pi-compatible hooks publish a UUID, while `.piSessionFile` discovery
+    /// resolves that UUID to the matching JSONL path. OMP uses the same store.
+    private static let piSessionFileKinds: Set<String> = ["pi", "omp"]
+
+    static func sessionIDsMatch(
+        kind: String,
+        lhs: String,
+        rhs: String
+    ) -> Bool {
+        let normalizedLHS = normalized(lhs)
+        let normalizedRHS = normalized(rhs)
+        guard normalizedLHS != normalizedRHS else { return true }
+        guard piSessionFileKinds.contains(normalized(kind)),
+              let lhsUUID = piSessionUUID(from: normalizedLHS),
+              let rhsUUID = piSessionUUID(from: normalizedRHS) else {
+            return false
+        }
+        return lhsUUID == rhsUUID
+    }
+
+    static func canonicalSessionID(kind: String, sessionID: String) -> String {
+        let normalizedSessionID = normalized(sessionID)
+        guard piSessionFileKinds.contains(normalized(kind)),
+              let uuid = piSessionUUID(from: normalizedSessionID) else {
+            return normalizedSessionID
+        }
+        return uuid.uuidString.lowercased()
+    }
+
+    private static func piSessionUUID(from value: String) -> UUID? {
+        if let uuid = UUID(uuidString: value) {
+            return uuid
+        }
+        let filename = (value as NSString).lastPathComponent
+        guard filename.hasSuffix(".jsonl") else { return nil }
+        let stem = String(filename.dropLast(".jsonl".count))
+        if let uuid = UUID(uuidString: stem) {
+            return uuid
+        }
+        guard let separator = stem.lastIndex(of: "_") else { return nil }
+        return UUID(uuidString: String(stem[stem.index(after: separator)...]))
+    }
+
+    private static func normalized(_ value: String) -> String {
+        value.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+}
+
 extension SurfaceResumeBindingSnapshot {
     var hasCompleteManagedSessionIdentity: Bool {
         managedSessionIdentity != nil
@@ -11,7 +62,11 @@ extension SurfaceResumeBindingSnapshot {
             return false
         }
         return identity.kind == otherIdentity.kind &&
-            identity.checkpointId == otherIdentity.checkpointId
+            ManagedAgentSessionIdentity.sessionIDsMatch(
+                kind: identity.kind,
+                lhs: identity.checkpointId,
+                rhs: otherIdentity.checkpointId
+            )
     }
 
     private var managedSessionIdentity: (kind: String, checkpointId: String)? {

--- a/Sources/Workspace+AgentLifecycle.swift
+++ b/Sources/Workspace+AgentLifecycle.swift
@@ -127,11 +127,14 @@ extension Workspace {
               binding.isAgentHookBinding else {
             return
         }
-        if let restoredAgent {
-            let checkpointId = binding.checkpointId?.trimmingCharacters(in: .whitespacesAndNewlines)
-            guard checkpointId == nil || checkpointId == restoredAgent.sessionId else {
-                return
-            }
+        if let restoredAgent,
+           let checkpointId = binding.checkpointId?.trimmingCharacters(in: .whitespacesAndNewlines),
+           !ManagedAgentSessionIdentity.sessionIDsMatch(
+               kind: restoredAgent.kind.rawValue,
+               lhs: checkpointId,
+               rhs: restoredAgent.sessionId
+           ) {
+            return
         }
         binding.autoResume = false
         surfaceResumeBindingsByPanelId[panelId] = binding

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -494,11 +494,19 @@ extension Workspace {
                         return true
                     }
                     guard let effectiveRestorableAgent,
-                          effectiveRestorableAgent.kind == bindingKind,
-                          effectiveRestorableAgent.sessionId == bindingSessionId,
+                          effectiveRestorableAgent.kind.rawValue == bindingKind.rawValue,
+                          ManagedAgentSessionIdentity.sessionIDsMatch(
+                              kind: bindingKind.rawValue,
+                              lhs: effectiveRestorableAgent.sessionId,
+                              rhs: bindingSessionId
+                          ),
                           let restorableAgentObservation,
-                          restorableAgentObservation.snapshot.kind == bindingKind,
-                          restorableAgentObservation.snapshot.sessionId == bindingSessionId else {
+                          restorableAgentObservation.snapshot.kind.rawValue == bindingKind.rawValue,
+                          ManagedAgentSessionIdentity.sessionIDsMatch(
+                              kind: bindingKind.rawValue,
+                              lhs: restorableAgentObservation.snapshot.sessionId,
+                              rhs: bindingSessionId
+                          ) else {
                         return false
                     }
                     return restorableAgentObservation.processLiveness
@@ -986,7 +994,12 @@ extension Workspace {
         guard let binding, binding.isAgentHookBinding, let restorableAgent else {
             return binding
         }
-        guard binding.checkpointId?.trimmingCharacters(in: .whitespacesAndNewlines) == restorableAgent.sessionId else {
+        guard let checkpointId = normalizedResumeBindingValue(binding.checkpointId),
+              ManagedAgentSessionIdentity.sessionIDsMatch(
+                  kind: restorableAgent.kind.rawValue,
+                  lhs: checkpointId,
+                  rhs: restorableAgent.sessionId
+              ) else {
             return binding
         }
         if let bindingKind = binding.kind?.trimmingCharacters(in: .whitespacesAndNewlines),
@@ -994,7 +1007,7 @@ extension Workspace {
            RestorableAgentKind(
                persistedRawValue: bindingKind,
                registration: restorableAgent.registration
-           ) != restorableAgent.kind {
+           )?.rawValue != restorableAgent.kind.rawValue {
             return binding
         }
 
@@ -1023,7 +1036,11 @@ extension Workspace {
         }
 
         if let checkpointId = normalizedResumeBindingValue(resumeBinding.checkpointId),
-           checkpointId != restorableAgent.sessionId {
+           !ManagedAgentSessionIdentity.sessionIDsMatch(
+               kind: restorableAgent.kind.rawValue,
+               lhs: checkpointId,
+               rhs: restorableAgent.sessionId
+           ) {
             return nil
         }
         if let kindValue = normalizedResumeBindingValue(resumeBinding.kind) {
@@ -1031,7 +1048,7 @@ extension Workspace {
                 persistedRawValue: kindValue,
                 registration: restorableAgent.registration
             ),
-                  bindingKind == restorableAgent.kind else {
+                  bindingKind.rawValue == restorableAgent.kind.rawValue else {
                 return nil
             }
         }

--- a/cmuxTests/WorkspaceIsStaleAgentHookBindingTests.swift
+++ b/cmuxTests/WorkspaceIsStaleAgentHookBindingTests.swift
@@ -16,6 +16,11 @@ import Testing
 @MainActor
 @Suite
 struct WorkspaceIsStaleAgentHookBindingTests {
+    private static let piSessionID = "019fbf0f-7fcd-70aa-9388-f44c4e27fa0c"
+    private static let piSessionPath =
+        "/Users/test/.pi/agent/sessions/--Users-test-project--/" +
+        "2026-08-01T18-39-09-000Z_\(piSessionID).jsonl"
+
     private static func agentHookBinding(
         launchFlavor: SurfaceResumeLaunchFlavor
     ) -> SurfaceResumeBindingSnapshot {
@@ -25,6 +30,43 @@ struct WorkspaceIsStaleAgentHookBindingTests {
             checkpointId: "session-1",
             source: "agent-hook",
             launchFlavor: launchFlavor
+        )
+    }
+
+    private static func piAgentHookBinding() -> SurfaceResumeBindingSnapshot {
+        SurfaceResumeBindingSnapshot(
+            kind: "pi",
+            command: "pi --session \(piSessionID)",
+            checkpointId: piSessionID,
+            source: "agent-hook"
+        )
+    }
+
+    private static func livePiIndex(
+        workspaceId: UUID,
+        panelId: UUID
+    ) -> RestorableAgentSessionIndex {
+        let key = RestorableAgentSessionIndex.PanelKey(
+            workspaceId: workspaceId,
+            panelId: panelId
+        )
+        return RestorableAgentSessionIndex.load(
+            homeDirectory: "/tmp/cmux-pi-repeat-restore-empty-home",
+            fileManager: .default,
+            registry: CmuxVaultAgentRegistry(registrations: []),
+            detectedSnapshots: [
+                key: (
+                    snapshot: SessionRestorableAgentSnapshot(
+                        kind: .custom("pi"),
+                        sessionId: piSessionPath
+                    ),
+                    updatedAt: 1,
+                    processIDs: [31_398],
+                    agentProcessIDs: [31_398],
+                    sessionIDSource: .explicit
+                ),
+            ],
+            processIdentityProvider: { _ in nil }
         )
     }
 
@@ -70,5 +112,39 @@ struct WorkspaceIsStaleAgentHookBindingTests {
         let retainedBinding = try #require(workspace.surfaceResumeBinding(panelId: panelId))
         #expect(retainedBinding.checkpointId == binding.checkpointId)
         #expect(retainedBinding.autoResume == false)
+    }
+
+    @Test
+    func reconciliationKeepsPiBindingAfterResumeScannerResolvesUUIDToSessionPath() throws {
+        let workspace = Workspace()
+        let panelId = try #require(workspace.focusedPanelId)
+        let binding = Self.piAgentHookBinding()
+        let index = Self.livePiIndex(workspaceId: workspace.id, panelId: panelId)
+        try #require(workspace.setSurfaceResumeBinding(binding, panelId: panelId))
+
+        workspace.reconcileSurfaceResumeBindings(
+            using: .empty,
+            restorableAgentIndex: index
+        )
+
+        #expect(workspace.surfaceResumeBinding(panelId: panelId) == binding)
+    }
+
+    @Test
+    func sessionRestoreMatchesPiBindingUUIDToDetectedSessionPath() throws {
+        let workspace = Workspace()
+        let panelId = try #require(workspace.focusedPanelId)
+        let binding = Self.piAgentHookBinding()
+        let index = Self.livePiIndex(workspaceId: workspace.id, panelId: panelId)
+        let detectedSnapshot = try #require(
+            index.snapshot(workspaceId: workspace.id, panelId: panelId)
+        )
+
+        let restoredSnapshot = Workspace.restorableAgentForSessionRestore(
+            detectedSnapshot,
+            resumeBinding: binding
+        )
+
+        #expect(restoredSnapshot?.sessionId == Self.piSessionPath)
     }
 }


### PR DESCRIPTION
## Summary

- Preserve Pi managed-session identity when hooks publish UUIDs and process discovery resolves timestamp-prefixed JSONL paths.
- Match registry-owned agent kinds by raw value, covering `.pi` and `.custom("pi")`.
- Use shared identity matching in liveness reconciliation, session restore, lifecycle cleanup, Dock and workspace snapshots, and restorable-session indexing.

## Confirmed cause

This is a third cause, not the fresh-discovery race or stale `CMUX_SURFACE_ID`.

After a Pi restore, the Pi hook publishes a UUID while `PiSessionLocator` resolves that same running session as its timestamp-prefixed JSONL path. Hook parsing also represents the kind as `.pi`, while registry scanning produces `.custom("pi")`. Exact ID and enum comparisons caused reconciliation to treat the live restored Pi process as a different session and discard its binding.

Tagged polling observed the binding disappear after about 7 seconds while Pi remained alive, matching the reconciliation cadence. Claude, Codex, and Grok retain stable native session IDs and did not show this conversion.

## Regression coverage

- The test-only commit proves reconciliation deleted a live Pi binding after UUID-to-path resolution.
- It also proves session restore rejected the same Pi session across UUID and JSONL path representations.
- Both new tests failed at the test-only commit and passed after the fix.

## Validation

- The focused `cmux-unit` suite passed 5 tests with 0 failures on the final PR HEAD.
- The tagged Debug build succeeded and its isolated socket returned the selected workspace.
- No local XCUITests were run.

Closes #9380

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved agent session restoration and resume behavior when session identifiers appear in different formats.
  - Better recognizes sessions represented by detected file paths, including Pi and OMP sessions.
  - Prevents valid resume bindings from being discarded unnecessarily.
  - Adds safeguards to avoid applying restored sessions or bindings to the wrong agent type or session.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->