### PR TITLE
Fix iOS discovery of sibling Mac builds

### DIFF
--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+PairedMacPersistence.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+PairedMacPersistence.swift
@@ -27,6 +27,7 @@ extension MobileShellComposite {
         instanceTagUpdate: PairedMacInstanceTagUpdate = .preserve,
         displayNameOverride: String? = nil,
         userAuthorizedTailscaleRoutes: [CmxAttachRoute] = [],
+        markActive: Bool = true,
         ifStillCurrent: (() -> Bool)? = nil
     ) async -> Bool {
         guard let pairedMacStore,
@@ -102,6 +103,7 @@ extension MobileShellComposite {
                     ticketRoutes: ticket.routes, storedRoutes: storedRoutes
                 )
                 : ticket.routes
+            let shouldMarkActive = markActive || existing?.isActive == true
             do {
                 if case .preserveOnlyIfUnclaimed = instanceTagUpdate {
                     accepted = try await pairedMacStore.upsertRoutesIfAuthorized(
@@ -109,7 +111,7 @@ extension MobileShellComposite {
                         displayName: displayName,
                         routes: routes,
                         condition: .unclaimed,
-                        markActive: true,
+                        markActive: shouldMarkActive,
                         stackUserID: stackUserID,
                         teamID: scope?.teamID,
                         now: Date()
@@ -121,7 +123,7 @@ extension MobileShellComposite {
                         displayName: displayName,
                         routes: routes,
                         instanceTag: instanceTag,
-                        markActive: true,
+                        markActive: shouldMarkActive,
                         stackUserID: stackUserID,
                         teamID: scope?.teamID,
                         now: Date()

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+ZeroTouchIroh.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+ZeroTouchIroh.swift
@@ -122,8 +122,10 @@ extension MobileShellComposite {
                 }
                 return $0.id < $1.id
             }
-        for candidate in candidates {
-            guard !Task.isCancelled, await isScopeCurrent(scope) else { return }
+        candidateLoop: for candidate in candidates {
+            guard !Task.isCancelled, await isScopeCurrent(scope) else {
+                break candidateLoop
+            }
             guard pendingZeroTouchIrohCandidatesByPairingID[candidate.id]
                     == candidate else {
                 continue
@@ -144,7 +146,7 @@ extension MobileShellComposite {
                     candidate.macDeviceID
                 )
             case .superseded:
-                return
+                break candidateLoop
             }
         }
         if pendingZeroTouchIrohCandidatesByPairingID.isEmpty {

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+ZeroTouchIroh.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+ZeroTouchIroh.swift
@@ -1,6 +1,13 @@
 import CmuxMobilePairedMac
 import Foundation
 
+private enum ZeroTouchSecondaryAuthenticationOutcome {
+    case persisted
+    case transientFailure
+    case discarded
+    case superseded
+}
+
 @MainActor
 extension MobileShellComposite {
     /// Limits one automatic launch pass so stale live registrations cannot make
@@ -53,5 +60,159 @@ extension MobileShellComposite {
             }
         }
         return candidates
+    }
+
+    /// Retains every discovered app instance except the foreground winner.
+    /// Broker data is only a dial hint; each row still has to prove its device
+    /// and build identity over an authenticated RPC before it is persisted.
+    func stageZeroTouchIrohCandidatesForSecondaryAuthentication(
+        _ candidates: [MobilePairedMac],
+        scope: MobileShellScopeSnapshot
+    ) {
+        guard multiMacAggregationEnabled else { return }
+        if pendingZeroTouchIrohCandidateScope != scope {
+            pendingZeroTouchIrohCandidatesByPairingID = [:]
+            pendingZeroTouchIrohCandidateScope = scope
+        }
+        let foregroundPairingID = foregroundMacDeviceID.map {
+            MobilePairedMac.pairingID(
+                macDeviceID: $0,
+                instanceTag: activeMacInstanceTag
+            )
+        }
+        for candidate in candidates where candidate.id != foregroundPairingID {
+            pendingZeroTouchIrohCandidatesByPairingID[candidate.id] = candidate
+        }
+        if pendingZeroTouchIrohCandidatesByPairingID.isEmpty {
+            pendingZeroTouchIrohCandidateScope = nil
+        }
+    }
+
+    /// Authenticates and saves sibling zero-touch candidates without replacing
+    /// the foreground connection. Successful rows become ordinary secondary
+    /// aggregation targets on the same pass.
+    func authenticatePendingZeroTouchIrohCandidates(
+        scope: MobileShellScopeSnapshot
+    ) async {
+        guard let pairedMacStore,
+              pendingZeroTouchIrohCandidateScope == scope,
+              !pendingZeroTouchIrohCandidatesByPairingID.isEmpty else {
+            return
+        }
+        let storedPairingIDs = Set(
+            (try? await pairedMacStore.loadAll(
+                stackUserID: scope.userID,
+                teamID: scope.teamID
+            ))?.map(\.id) ?? []
+        )
+        guard !Task.isCancelled, await isScopeCurrent(scope) else { return }
+
+        var didPersistCandidate = false
+        var transientFailureMacIDs: Set<String> = []
+        let foregroundPairingID = foregroundMacDeviceID.map {
+            MobilePairedMac.pairingID(
+                macDeviceID: $0,
+                instanceTag: activeMacInstanceTag
+            )
+        }
+        let candidates = pendingZeroTouchIrohCandidatesByPairingID.values
+            .sorted {
+                if $0.lastSeenAt != $1.lastSeenAt {
+                    return $0.lastSeenAt > $1.lastSeenAt
+                }
+                return $0.id < $1.id
+            }
+        for candidate in candidates {
+            guard !Task.isCancelled, await isScopeCurrent(scope) else { return }
+            guard pendingZeroTouchIrohCandidatesByPairingID[candidate.id]
+                    == candidate else {
+                continue
+            }
+            switch await authenticateZeroTouchIrohCandidate(
+                candidate,
+                storedPairingIDs: storedPairingIDs,
+                foregroundPairingID: foregroundPairingID,
+                scope: scope
+            ) {
+            case .persisted:
+                didPersistCandidate = true
+                pendingZeroTouchIrohCandidatesByPairingID[candidate.id] = nil
+            case .discarded:
+                pendingZeroTouchIrohCandidatesByPairingID[candidate.id] = nil
+            case .transientFailure:
+                transientFailureMacIDs.insert(
+                    candidate.macDeviceID
+                )
+            case .superseded:
+                return
+            }
+        }
+        if pendingZeroTouchIrohCandidatesByPairingID.isEmpty {
+            pendingZeroTouchIrohCandidateScope = nil
+        }
+        if didPersistCandidate {
+            await loadPairedMacs()
+        }
+        if !transientFailureMacIDs.isEmpty {
+            scheduleSecondaryAggregationRetry(
+                macDeviceIDs: transientFailureMacIDs
+            )
+        }
+    }
+
+    private func authenticateZeroTouchIrohCandidate(
+        _ candidate: MobilePairedMac,
+        storedPairingIDs: Set<String>,
+        foregroundPairingID: String?,
+        scope: MobileShellScopeSnapshot
+    ) async -> ZeroTouchSecondaryAuthenticationOutcome {
+        guard !storedPairingIDs.contains(candidate.id),
+              candidate.id != foregroundPairingID,
+              await !isHiddenMacDeviceID(
+                  candidate.macDeviceID,
+                  instanceTag: candidate.instanceTag,
+                  scope: scope
+              ) else {
+            return .discarded
+        }
+        let handle: SecondaryClientHandle
+        switch await makeSecondaryClient(for: candidate) {
+        case let .connected(connectedHandle):
+            handle = connectedHandle
+        case .transientFailure:
+            return .transientFailure
+        case .permanentFailure:
+            return .discarded
+        }
+        let client = handle.client
+        guard !Task.isCancelled, await isScopeCurrent(scope) else {
+            await client.disconnect()
+            return .superseded
+        }
+        guard macBuildIsCompatible(
+            instanceTag: handle.authenticatedInstanceTag
+        ),
+              await !isHiddenMacDeviceID(
+                  candidate.macDeviceID,
+                  instanceTag: candidate.instanceTag,
+                  scope: scope
+              ) else {
+            await client.disconnect()
+            return .discarded
+        }
+        let accepted = await persistPairedMacFromTicket(
+            handle.ticket,
+            instanceTagUpdate: .replace(handle.authenticatedInstanceTag),
+            displayNameOverride: handle.authenticatedDisplayName,
+            markActive: false,
+            ifStillCurrent: { [weak self] in
+                self?.pendingZeroTouchIrohCandidateScope == scope
+            }
+        )
+        await client.disconnect()
+        guard !Task.isCancelled, await isScopeCurrent(scope) else {
+            return .superseded
+        }
+        return accepted ? .persisted : .transientFailure
     }
 }

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
@@ -1049,6 +1049,14 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
     private var secondaryAggregationTask: Task<Void, Never>?
     private var secondaryAggregationTaskGeneration = UUID()
     private var secondaryAggregationPending = false
+    /// Live zero-touch rows that still need endpoint authentication before
+    /// they can enter the paired store. The existing aggregation task owns
+    /// these dials so sign-out and account changes cancel the whole operation.
+    @ObservationIgnored
+    var pendingZeroTouchIrohCandidatesByPairingID:
+        [String: MobilePairedMac] = [:]
+    @ObservationIgnored
+    var pendingZeroTouchIrohCandidateScope: MobileShellScopeSnapshot?
     /// Incremental presence edges are reconciled only for their affected Macs.
     /// One coalesced task drains the pending id set without widening each edge
     /// into a pool-wide workspace refresh.
@@ -2609,6 +2617,12 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
            !connectionRequiresReauth,
            attemptedAutomaticIroh {
             recordTransientAutomaticReconnectBackoff(accountID: scope.userID)
+        }
+        if connectionState == .connected {
+            stageZeroTouchIrohCandidatesForSecondaryAuthentication(
+                zeroTouchCandidates,
+                scope: scope
+            )
         }
         return connectionState == .connected ? .connected : lastDialOutcome
     }
@@ -4330,6 +4344,7 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
             authenticatedInstanceTag: macInstanceTagAuthority.normalize(
                 status.macInstanceTag
             ),
+            authenticatedDisplayName: status.macDisplayName,
             supportedHostCapabilities: capabilities,
             actionCapabilities: Self.workspaceActionCapabilities(
                 from: capabilities,
@@ -4530,6 +4545,10 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         if onlyMacDeviceIDs == nil,
            let refresher = pairedMacStore as? any PairedMacBackupRefreshing {
             await refresher.refreshFromBackup(stackUserID: scope.userID)
+        }
+        guard await isAggregationScopeValid(scope) else { return }
+        if allowsNewConnections {
+            await authenticatePendingZeroTouchIrohCandidates(scope: scope)
         }
         guard await isAggregationScopeValid(scope) else { return }
         let rawRequestedCanonicalIDs = onlyMacDeviceIDs.map {
@@ -6296,6 +6315,8 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         secondaryAggregationTask = nil
         secondaryAggregationTaskGeneration = UUID()
         secondaryAggregationPending = false
+        pendingZeroTouchIrohCandidatesByPairingID = [:]
+        pendingZeroTouchIrohCandidateScope = nil
         secondaryPresenceAggregationTask?.cancel()
         secondaryPresenceAggregationTask = nil
         secondaryPresenceAggregationTaskGeneration = UUID()

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/SecondaryClientHandle.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/SecondaryClientHandle.swift
@@ -11,6 +11,8 @@ struct SecondaryClientHandle {
     let storedInstanceTag: String?
     /// Instance identity proven by this client's authenticated host status.
     let authenticatedInstanceTag: String?
+    /// Display name proven by the same authenticated host status response.
+    let authenticatedDisplayName: String?
     let supportedHostCapabilities: Set<String>
     let actionCapabilities: MobileWorkspaceActionCapabilities
 }

--- a/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/IrohZeroTouchDiscoveryTests.swift
+++ b/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/IrohZeroTouchDiscoveryTests.swift
@@ -579,7 +579,9 @@ private struct ZeroTouchFixture {
     let directory: URL
 
     func cleanup() {
-        Task { await shell.remoteClient?.disconnect() }
+        let remoteClient = shell.remoteClient
+        shell.signOut()
+        Task { await remoteClient?.disconnect() }
         try? FileManager.default.removeItem(at: directory)
     }
 }

--- a/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/IrohZeroTouchDiscoveryTests.swift
+++ b/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/IrohZeroTouchDiscoveryTests.swift
@@ -102,6 +102,57 @@ struct IrohZeroTouchDiscoveryTests {
     }
 
     @Test
+    func cleanInstallPersistsEveryAuthenticatedSiblingBuild() async throws {
+        let nightlyRouteID = "iroh-mac-a-nightly"
+        let stableRouteID = "iroh-mac-a-default"
+        let fixture = try await makeFixture(
+            candidates: [
+                try candidate(
+                    deviceID: "mac-a",
+                    endpointByte: "a",
+                    instanceTag: "nightly",
+                    routeID: nightlyRouteID
+                ),
+                try candidate(
+                    deviceID: "mac-a",
+                    endpointByte: "b",
+                    instanceTag: "default",
+                    routeID: stableRouteID
+                ),
+            ],
+            reportedHostsByRouteID: [
+                nightlyRouteID: ZeroTouchReportedHost(
+                    deviceID: "mac-a",
+                    instanceTag: "nightly"
+                ),
+                stableRouteID: ZeroTouchReportedHost(
+                    deviceID: "mac-a",
+                    instanceTag: "default"
+                ),
+            ]
+        )
+        defer { fixture.cleanup() }
+
+        #expect(await fixture.shell.reconnectActiveMacIfAvailable(stackUserID: "user-1"))
+        #expect(try await pollUntil {
+            let rows = try? await fixture.store.loadAll(
+                stackUserID: "user-1",
+                teamID: nil
+            )
+            return Set(rows?.compactMap(\.instanceTag) ?? [])
+                == Set(["default", "nightly"])
+        })
+        #expect(Set(fixture.factory.attemptedRouteIDs()) == Set([
+            nightlyRouteID,
+            stableRouteID,
+        ]))
+
+        await fixture.shell.loadPairedMacs()
+        #expect(Set(fixture.shell.displayPairedMacs.compactMap(\.instanceTag))
+            == Set(["default", "nightly"]))
+    }
+
+    @Test
     func malformedDuplicateCannotHideLaterAuthenticatedCandidate() async throws {
         let valid = try candidate(deviceID: "mac-a", endpointByte: "a")
         let malformed = MobileDiscoveredIrohMac(
@@ -330,10 +381,64 @@ struct IrohZeroTouchDiscoveryTests {
         )
     }
 
+    private func makeFixture(
+        candidates: [MobileDiscoveredIrohMac],
+        reportedHostsByRouteID: [String: ZeroTouchReportedHost]
+    ) async throws -> ZeroTouchFixture {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        let store = try MobilePairedMacStore(
+            databaseURL: directory.appendingPathComponent("paired-macs.sqlite3")
+        )
+        var routersByRouteID: [String: LivenessHostRouter] = [:]
+        for (routeID, host) in reportedHostsByRouteID {
+            let router = LivenessHostRouter()
+            await router.setHostIdentity(
+                deviceID: host.deviceID,
+                instanceTag: host.instanceTag,
+                displayName: host.displayName
+            )
+            routersByRouteID[routeID] = router
+        }
+        let fallbackRouter = LivenessHostRouter()
+        let factory = ZeroTouchRouteFactory(
+            router: fallbackRouter,
+            routersByRouteID: routersByRouteID,
+            failingRouteIDs: [],
+            rateLimitedRouteIDs: []
+        )
+        let shell = MobileShellComposite(
+            runtime: LivenessTestRuntime(
+                transportFactory: factory,
+                now: { Self.fixedNow },
+                supportedRouteKinds: [.iroh]
+            ),
+            isSignedIn: true,
+            pairedMacStore: store,
+            personalIrohDiscovery: ScriptedIrohDiscovery(
+                snapshots: [candidates]
+            ),
+            identityProvider: StaticIdentityProvider(userID: "user-1"),
+            reachability: AlwaysOnlineReachability(),
+            pairingHintDefaults: UserDefaults(
+                suiteName: "iroh-zero-touch-\(UUID().uuidString)"
+            )!
+        )
+        return ZeroTouchFixture(
+            shell: shell,
+            store: store,
+            factory: factory,
+            router: fallbackRouter,
+            directory: directory
+        )
+    }
+
     private func candidate(
         deviceID: String,
         endpointByte: Character,
         instanceTag: String = "stable",
+        routeID: String? = nil,
         extraRoutes: [CmxAttachRoute] = []
     ) throws -> MobileDiscoveredIrohMac {
         let endpointID = String(repeating: String(endpointByte), count: 64)
@@ -342,7 +447,7 @@ struct IrohZeroTouchDiscoveryTests {
             displayName: "Test \(deviceID)",
             instanceTag: instanceTag,
             routes: [try CmxAttachRoute(
-                id: "iroh-\(deviceID)",
+                id: routeID ?? "iroh-\(deviceID)",
                 kind: .iroh,
                 endpoint: .peer(
                     identity: CmxIrohPeerIdentity(endpointID: endpointID),
@@ -353,6 +458,12 @@ struct IrohZeroTouchDiscoveryTests {
             lastSeenAt: Self.fixedNow
         )
     }
+}
+
+private struct ZeroTouchReportedHost {
+    let deviceID: String
+    let instanceTag: String
+    var displayName = "Test Mac"
 }
 
 @MainActor
@@ -414,6 +525,7 @@ private final class SuspendedIrohDiscovery: MobileIrohMacDiscovering {
 
 private final class ZeroTouchRouteFactory: CmxByteTransportFactory, @unchecked Sendable {
     private let router: LivenessHostRouter
+    private let routersByRouteID: [String: LivenessHostRouter]
     private let failingRouteIDs: Set<String>
     private let rateLimitedRouteIDs: Set<String>
     private let lock = NSLock()
@@ -421,10 +533,12 @@ private final class ZeroTouchRouteFactory: CmxByteTransportFactory, @unchecked S
 
     init(
         router: LivenessHostRouter,
+        routersByRouteID: [String: LivenessHostRouter] = [:],
         failingRouteIDs: Set<String>,
         rateLimitedRouteIDs: Set<String>
     ) {
         self.router = router
+        self.routersByRouteID = routersByRouteID
         self.failingRouteIDs = failingRouteIDs
         self.rateLimitedRouteIDs = rateLimitedRouteIDs
     }
@@ -437,7 +551,9 @@ private final class ZeroTouchRouteFactory: CmxByteTransportFactory, @unchecked S
         if rateLimitedRouteIDs.contains(route.id) {
             throw ZeroTouchRouteError.rateLimited
         }
-        return LivenessTransport(router: router)
+        return LivenessTransport(
+            router: routersByRouteID[route.id] ?? router
+        )
     }
 
     func attemptedRouteIDs() -> [String] {


### PR DESCRIPTION
Summary:
- retain every zero-touch Iroh candidate after the foreground build connects
- authenticate sibling build identity before persisting it as an inactive pairing
- preserve the selected foreground build while secondary aggregation connects siblings

Tests:
- regression test fails on the test-only commit and passes with the fix
- swift test --package-path Packages/iOS/CmuxMobileShell --filter IrohZeroTouchDiscoveryTests
- swift build --package-path Packages/iOS/CmuxMobileShell

Hosted evidence:
- red regression: https://github.com/manaflow-ai/cmux/actions/runs/30726329473
- fixed run: https://github.com/manaflow-ai/cmux/actions/runs/30726541187
- focused hosted test: https://github.com/manaflow-ai/cmux/actions/runs/30727825466

The fixed hosted run reaches unrelated current-main failures in package-conventions-lint and WorkspaceListTableCoordinatorDropTests. The full shell-package process also hits existing concurrent timing failures and does not exit before the job limit; the isolated changed suite passes.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/9403"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788225830&installation_model_id=21920&pr_number=9403&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F9403&signature=433c23341295642f8975a5941b6756545977363bdd4adb25101cd2ac22056f12"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes iOS zero-touch discovery so sibling Mac builds (e.g., stable + nightly) are authenticated and saved as secondary pairings without taking over the active connection. This stabilizes multi-Mac aggregation and prevents missing siblings.

- Bug Fixes
  - Retain all zero-touch Iroh candidates except the foreground winner; track by pairing ID within `CmuxMobileShell`.
  - Authenticate each candidate via RPC; verify device/build and use the authenticated instance tag and display name before persisting.
  - Persist siblings as inactive (`markActive: false`) and preserve already-active pairings on upsert so the foreground build stays active.
  - Retry on transient failures; discard incompatible, hidden, or permanent failures; clear staged candidates on sign-out, scope change, or after aggregation completes.
  - Run authentication during secondary aggregation when new connections are allowed; reload paired Macs after successful persists.
  - Add `markActive` to paired-mac persistence and `authenticatedDisplayName` to `SecondaryClientHandle`.
  - Add tests, including clean-install coverage that persists multiple authenticated sibling builds.

<sup>Written for commit ce91b32a1ff32b034db18d605f3d8bf9721a1f50. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/9403?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added zero-touch authentication for eligible secondary connections discovered during reconnection.
  * Preserves authenticated display names for secondary connections.
  * Supports retaining multiple authenticated sibling connections.

* **Bug Fixes**
  * Prevents already-active connections from being incorrectly deactivated during persistence.
  * Defers saving discovered connections until authentication and compatibility checks succeed.
  * Keeps temporary authentication failures eligible for retry.

* **Tests**
  * Added coverage for multiple authenticated connections and route-specific discovery scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->