### PR TITLE
Fail iOS workflow when selected filter runs zero tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -175,6 +175,9 @@ jobs:
       - name: Validate cmux scheme test configuration
         run: ./tests/test_ci_scheme_testaction_debug.sh
 
+      - name: Validate selected iOS test execution guard
+        run: python3 tests/test_ios_selected_test_execution.py
+
       - name: Validate cmuxTests sharding
         run: |
           python3 scripts/ci/cmux_unit_test_shard.py --validate

--- a/.github/workflows/test-ios.yml
+++ b/.github/workflows/test-ios.yml
@@ -401,6 +401,9 @@ jobs:
             xcrun simctl boot "$SIMULATOR_ID" >/dev/null 2>&1 || true
             xcrun simctl bootstatus "$SIMULATOR_ID" -b
             if xcodebuild "${XCODEBUILD_ARGS[@]}" 2>&1 | tee "$LOG_PATH"; then
+              ./scripts/ci/require_selected_test_execution.sh \
+                "$LOG_PATH" \
+                "${TEST_FILTER:-}"
               exit 0
             fi
             status="${PIPESTATUS[0]}"

--- a/scripts/ci/require_selected_test_execution.sh
+++ b/scripts/ci/require_selected_test_execution.sh
@@ -14,7 +14,7 @@ if [[ -z "$test_filter" ]]; then
 fi
 
 if [[ ! -f "$log_path" ]]; then
-  echo "selected iOS test execution log not found: $log_path" >&2
+  echo "selected iOS test execution log is unavailable" >&2
   exit 2
 fi
 
@@ -24,5 +24,12 @@ if grep -Eq \
   exit 0
 fi
 
-echo "selected iOS test filter '$test_filter' executed zero tests; use target/class or target/class/method syntax" >&2
+if grep -Eq \
+  "Executed 0 tests?,|Test run with 0 tests? (passed|failed)" \
+  "$log_path"; then
+  echo "selected iOS test filter matched zero tests; use target/class or target/class/method syntax" >&2
+  exit 1
+fi
+
+echo "selected iOS test execution summary was not found; verify the test log format" >&2
 exit 1

--- a/scripts/ci/require_selected_test_execution.sh
+++ b/scripts/ci/require_selected_test_execution.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ $# -ne 2 ]]; then
+  echo "usage: $0 <xcodebuild-log> <test-filter>" >&2
+  exit 2
+fi
+
+log_path="$1"
+test_filter="$2"
+
+if [[ -z "$test_filter" ]]; then
+  exit 0
+fi
+
+if [[ ! -f "$log_path" ]]; then
+  echo "selected iOS test execution log not found: $log_path" >&2
+  exit 2
+fi
+
+if grep -Eq \
+  "Executed [1-9][0-9]* tests?,|Test run with [1-9][0-9]* tests? (passed|failed)" \
+  "$log_path"; then
+  exit 0
+fi
+
+echo "selected iOS test filter '$test_filter' executed zero tests; use target/class or target/class/method syntax" >&2
+exit 1

--- a/scripts/ci/require_selected_test_execution.sh
+++ b/scripts/ci/require_selected_test_execution.sh
@@ -18,18 +18,33 @@ if [[ ! -f "$log_path" ]]; then
   exit 2
 fi
 
-if grep -Eq \
-  "Executed [1-9][0-9]* tests?,|Test run with [1-9][0-9]* tests? (passed|failed)" \
-  "$log_path"; then
-  exit 0
-fi
+summary_kind="$(
+  awk '
+    /Executed [0-9]+ tests?,/ || /Test run with [0-9]+ tests? (passed|failed)/ {
+      if ($0 ~ /Executed 0 tests?,/ || $0 ~ /Test run with 0 tests? (passed|failed)/) {
+        zero = 1
+      } else {
+        positive = 1
+      }
+    }
+    END {
+      if (positive) print "positive"
+      else if (zero) print "zero"
+      else print "missing"
+    }
+  ' "$log_path"
+)"
 
-if grep -Eq \
-  "Executed 0 tests?,|Test run with 0 tests? (passed|failed)" \
-  "$log_path"; then
-  echo "selected iOS test filter matched zero tests; use target/class or target/class/method syntax" >&2
-  exit 1
-fi
-
-echo "selected iOS test execution summary was not found; verify the test log format" >&2
-exit 1
+case "$summary_kind" in
+  positive)
+    exit 0
+    ;;
+  zero)
+    echo "selected iOS test filter matched zero tests; use target/class or target/class/method syntax" >&2
+    exit 1
+    ;;
+  *)
+    echo "selected iOS test execution summary was not found; verify the test log format" >&2
+    exit 1
+    ;;
+esac

--- a/tests/test_ios_selected_test_execution.py
+++ b/tests/test_ios_selected_test_execution.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+GUARD = REPO_ROOT / "scripts" / "ci" / "require_selected_test_execution.sh"
+
+
+class SelectedIOSTestExecutionGuardTests(unittest.TestCase):
+    def run_guard(self, log: str, test_filter: str) -> subprocess.CompletedProcess[str]:
+        with tempfile.NamedTemporaryFile(mode="w", encoding="utf-8") as log_file:
+            log_file.write(log)
+            log_file.flush()
+            return subprocess.run(
+                ["bash", str(GUARD), log_file.name, test_filter],
+                cwd=REPO_ROOT,
+                text=True,
+                capture_output=True,
+                check=False,
+            )
+
+    def test_accepts_xctest_singular_and_plural_nonzero_counts(self) -> None:
+        for summary in (
+            "Executed 1 test, with 0 failures (0 unexpected)",
+            "Executed 17 tests, with 0 failures (0 unexpected)",
+        ):
+            with self.subTest(summary=summary):
+                result = self.run_guard(summary, "cmuxUITests/cmuxUITests/testExample")
+                self.assertEqual(result.returncode, 0, result.stderr)
+
+    def test_accepts_swift_testing_nonzero_count(self) -> None:
+        result = self.run_guard(
+            "Test run with 2 tests passed after 0.012 seconds.",
+            "cmuxFeatureTests/ExampleSuite",
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+
+    def test_rejects_zero_tests_for_requested_filter(self) -> None:
+        test_filter = "cmuxUITests/testMissingMethod"
+        result = self.run_guard(
+            "Executed 0 tests, with 0 failures (0 unexpected)",
+            test_filter,
+        )
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn(test_filter, result.stderr)
+        self.assertIn("zero tests", result.stderr)
+
+    def test_rejects_missing_execution_summary_for_requested_filter(self) -> None:
+        result = self.run_guard("** TEST SUCCEEDED **", "cmuxUITests/testMissingMethod")
+        self.assertNotEqual(result.returncode, 0)
+
+    def test_allows_empty_filter_without_an_execution_summary(self) -> None:
+        result = self.run_guard("** TEST SUCCEEDED **", "")
+        self.assertEqual(result.returncode, 0, result.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_ios_selected_test_execution.py
+++ b/tests/test_ios_selected_test_execution.py
@@ -63,14 +63,15 @@ class SelectedIOSTestExecutionGuardTests(unittest.TestCase):
         )
 
     def test_missing_log_does_not_echo_its_path(self) -> None:
-        missing_log = "/tmp/private-selected-test-output.log"
-        result = subprocess.run(
-            ["bash", str(GUARD), missing_log, "cmuxUITests/testExample"],
-            cwd=REPO_ROOT,
-            text=True,
-            capture_output=True,
-            check=False,
-        )
+        with tempfile.TemporaryDirectory() as temp_dir:
+            missing_log = str(Path(temp_dir) / "missing.log")
+            result = subprocess.run(
+                ["bash", str(GUARD), missing_log, "cmuxUITests/testExample"],
+                cwd=REPO_ROOT,
+                text=True,
+                capture_output=True,
+                check=False,
+            )
         self.assertEqual(result.returncode, 2)
         self.assertEqual(
             result.stderr,

--- a/tests/test_ios_selected_test_execution.py
+++ b/tests/test_ios_selected_test_execution.py
@@ -40,18 +40,55 @@ class SelectedIOSTestExecutionGuardTests(unittest.TestCase):
         self.assertEqual(result.returncode, 0, result.stderr)
 
     def test_rejects_zero_tests_for_requested_filter(self) -> None:
-        test_filter = "cmuxUITests/testMissingMethod"
+        test_filter = "cmuxUITests/testMissingMethod\n::error::injected"
         result = self.run_guard(
             "Executed 0 tests, with 0 failures (0 unexpected)",
             test_filter,
         )
         self.assertNotEqual(result.returncode, 0)
-        self.assertIn(test_filter, result.stderr)
-        self.assertIn("zero tests", result.stderr)
+        self.assertEqual(
+            result.stderr,
+            "selected iOS test filter matched zero tests; "
+            "use target/class or target/class/method syntax\n",
+        )
+        self.assertNotIn(test_filter, result.stderr)
 
     def test_rejects_missing_execution_summary_for_requested_filter(self) -> None:
         result = self.run_guard("** TEST SUCCEEDED **", "cmuxUITests/testMissingMethod")
         self.assertNotEqual(result.returncode, 0)
+        self.assertEqual(
+            result.stderr,
+            "selected iOS test execution summary was not found; "
+            "verify the test log format\n",
+        )
+
+    def test_missing_log_does_not_echo_its_path(self) -> None:
+        missing_log = "/tmp/private-selected-test-output.log"
+        result = subprocess.run(
+            ["bash", str(GUARD), missing_log, "cmuxUITests/testExample"],
+            cwd=REPO_ROOT,
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+        self.assertEqual(result.returncode, 2)
+        self.assertEqual(
+            result.stderr,
+            "selected iOS test execution log is unavailable\n",
+        )
+        self.assertNotIn(missing_log, result.stderr)
+
+    def test_accepts_mixed_nested_summaries_when_tests_executed(self) -> None:
+        result = self.run_guard(
+            "\n".join(
+                (
+                    "Executed 0 tests, with 0 failures (0 unexpected)",
+                    "Executed 1 test, with 0 failures (0 unexpected)",
+                )
+            ),
+            "cmuxUITests/cmuxUITests/testExample",
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
 
     def test_allows_empty_filter_without_an_execution_summary(self) -> None:
         result = self.run_guard("** TEST SUCCEEDED **", "")


### PR DESCRIPTION
A malformed test-ios.yml filter can return xcodebuild 0 after executing zero tests, producing a false green result.

The first commit adds executable regression coverage and is intentionally red. The next commit adds the shared guard and workflow integration.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/9404"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788234090&installation_model_id=21920&pr_number=9404&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F9404&signature=029e7d871e3a4b6af4251e2f1851eae5349bd7a8ae91b0cad366bc608213112f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fail the iOS CI workflow when a selected test filter runs zero tests, preventing false green results from malformed `test-ios.yml` filters.

- **Bug Fixes**
  - Added a post-xcodebuild guard that parses XCTest/Swift Testing logs and exits non-zero when 0 tests run or the execution summary is missing; tightened classification to accept mixed nested summaries when tests did run; integrated into `test-ios.yml` and validated in `ci.yml`.
  - Sanitized diagnostics to avoid echoing user-provided filters or log paths, preventing GitHub command injection and noisy output.

<sup>Written for commit e69db7dc2ad5c88819a80dacfac218d6e614a3ef. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/9404?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved iOS test validation to ensure selected tests actually execute before a simulator job is marked successful.
  * Failed runs are now detected when filtered tests execute zero tests or produce no execution summary, while unfiltered runs continue to support empty filters.

* **Tests**
  * Added automated coverage for XCTest and Swift Testing results, including successful, zero-test, missing-summary, and empty-filter scenarios.
  * Integrated these checks into the workflow guard process.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->