### PR TITLE
Restore Markdown scroll per generated projection

### DIFF
--- a/Resources/markdown-viewer/shell.html
+++ b/Resources/markdown-viewer/shell.html
@@ -1259,6 +1259,58 @@ html { scroll-behavior: smooth; }
     });
   }
 
+  var activeMarkdownScrollKey = null;
+  var markdownScrollStatesByKey = new Map();
+  var maxRememberedMarkdownScrollKeys = 32;
+
+  function scrollKeyForMarkdown(md) {
+    var match = String(md || '').match(/^\s*<!--\s*cmux-scroll-key:\s*([^\r\n]*?)\s*-->/i);
+    if (!match) { return null; }
+    var key = String(match[1] || '').trim();
+    return /^[A-Za-z0-9._:/-]{1,256}$/.test(key) ? key : null;
+  }
+
+  function rememberMarkdownScrollState(key, state) {
+    if (!key || !state) { return; }
+    markdownScrollStatesByKey.delete(key);
+    markdownScrollStatesByKey.set(key, state);
+    if (markdownScrollStatesByKey.size > maxRememberedMarkdownScrollKeys) {
+      markdownScrollStatesByKey.delete(markdownScrollStatesByKey.keys().next().value);
+    }
+  }
+
+  function recalledMarkdownScrollState(key) {
+    if (!key || !markdownScrollStatesByKey.has(key)) { return null; }
+    var state = markdownScrollStatesByKey.get(key);
+    markdownScrollStatesByKey.delete(key);
+    markdownScrollStatesByKey.set(key, state);
+    return state;
+  }
+
+  function topMarkdownScrollState() {
+    return {
+      anchor: null,
+      nearTop: true,
+      nearBottom: false,
+      ratio: 0
+    };
+  }
+
+  function scrollStateForMarkdown(nextKey, currentState) {
+    if (nextKey === activeMarkdownScrollKey) { return currentState; }
+
+    var previousKey = activeMarkdownScrollKey;
+    rememberMarkdownScrollState(previousKey, currentState);
+    activeMarkdownScrollKey = nextKey;
+
+    var recalledState = recalledMarkdownScrollState(nextKey);
+    if (recalledState) { return recalledState; }
+    // An unkeyed document adopting its first key is still the same visible
+    // document. Only a transition between two explicit projection identities
+    // starts a new viewport at the top.
+    return previousKey && nextKey ? topMarkdownScrollState() : currentState;
+  }
+
   var mermaidInitialized = false;
   var cmuxMarkdownZoom = 1;
   // Whether this engine's pageZoom scales the whole CSS viewport (newer WebKit,
@@ -1782,14 +1834,18 @@ html { scroll-behavior: smooth; }
       var html = renderFrontmatter(documentParts.frontmatter)
         + sanitizeRenderedHTML(marked.parse(documentParts.body || ''));
       var didReplaceContent = contentEl.innerHTML !== html;
-      var scrollState = didReplaceContent ? captureMarkdownScrollState() : null;
+      var nextScrollKey = scrollKeyForMarkdown(md);
+      var didChangeScrollKey = nextScrollKey !== activeMarkdownScrollKey;
+      var scrollState = didReplaceContent || didChangeScrollKey
+        ? scrollStateForMarkdown(nextScrollKey, captureMarkdownScrollState())
+        : null;
       if (didReplaceContent) {
         contentEl.innerHTML = html;
       }
       rewriteLocalImageSources();
       rewriteRemoteImageSources();
       postProcessSpecialBlocks();
-      if (didReplaceContent) {
+      if (didReplaceContent || didChangeScrollKey) {
         restoreMarkdownScrollState(scrollState);
       }
     } catch (e) {

--- a/cmuxTests/ViewerNavigationTests.swift
+++ b/cmuxTests/ViewerNavigationTests.swift
@@ -324,6 +324,45 @@ struct ViewerNavigationTests {
     }
 
     @Test
+    func markdownViewerRestoresScrollPerProjectionIdentity() async throws {
+        let frame = NSRect(x: 0, y: 0, width: 720, height: 360)
+        let webView = MarkdownWebView(frame: frame, configuration: WKWebViewConfiguration())
+        let window = NSWindow(contentRect: frame, styleMask: [.borderless], backing: .buffered, defer: false)
+        window.contentView = webView
+        window.orderFrontRegardless()
+        defer {
+            webView.navigationDelegate = nil
+            window.close()
+        }
+
+        let loadDelegate = ViewerNavigationShellLoadDelegate()
+        webView.navigationDelegate = loadDelegate
+        try await loadDelegate.load(
+            MarkdownViewerAssets.shared.shellHTML(isDark: true),
+            in: webView,
+            baseURL: FileManager.default.temporaryDirectory.appendingPathComponent("projection.md")
+        )
+
+        try await renderMarkdown(projectionMarkdown(key: "surface-a", label: "A"), in: webView)
+        let surfaceAScrollY = try await scrollToHeading("a-section-20", in: webView)
+        #expect(surfaceAScrollY > 500)
+
+        try await renderMarkdown(projectionMarkdown(key: "surface-b", label: "B"), in: webView)
+        let firstSurfaceBScrollY = try await currentScrollY(in: webView)
+        #expect(firstSurfaceBScrollY <= 2, "a newly selected projection should start at the top")
+
+        let surfaceBScrollY = try await scrollToHeading("b-section-30", in: webView)
+        #expect(surfaceBScrollY > surfaceAScrollY + 100)
+
+        try await renderMarkdown(projectionMarkdown(key: "surface-a", label: "A"), in: webView)
+        let restoredSurfaceAScrollY = try await currentScrollY(in: webView)
+        #expect(
+            abs(restoredSurfaceAScrollY - surfaceAScrollY) <= 8,
+            "returning to a projection should restore that projection's own scroll position"
+        )
+    }
+
+    @Test
     func markdownViewerHonorsConfiguredWhenClause() throws {
         let appDelegate = try #require(AppDelegate.shared)
         let originalStore = KeyboardShortcutSettings.settingsFileStore
@@ -387,6 +426,39 @@ struct ViewerNavigationTests {
         let data = try JSONSerialization.data(withJSONObject: [markdown])
         let literal = try #require(String(data: data, encoding: .utf8))
         _ = try await webView.evaluateJavaScript("window.__cmuxRenderMarkdown(\(literal)[0]);")
+    }
+
+    private func currentScrollY(in webView: WKWebView) async throws -> Double {
+        let value = try await webView.evaluateJavaScript(
+            "window.scrollY || (document.scrollingElement && document.scrollingElement.scrollTop) || 0"
+        )
+        return try #require((value as? NSNumber)?.doubleValue)
+    }
+
+    private func scrollToHeading(_ id: String, in webView: WKWebView) async throws -> Double {
+        let data = try JSONSerialization.data(withJSONObject: [id])
+        let literal = try #require(String(data: data, encoding: .utf8))
+        let value = try await webView.evaluateJavaScript(
+            """
+            (function(ids) {
+              var heading = document.getElementById(ids[0]);
+              if (!heading) { return -1; }
+              document.documentElement.style.scrollBehavior = 'auto';
+              window.scrollTo(0, heading.offsetTop - 48);
+              return window.scrollY || (document.scrollingElement && document.scrollingElement.scrollTop) || 0;
+            })(\(literal));
+            """
+        )
+        return try #require((value as? NSNumber)?.doubleValue)
+    }
+
+    private func projectionMarkdown(key: String, label: String) -> String {
+        let sections = (1...36).map { section in
+            "## \(label) Section \(section)\n\n" + (1...5).map { paragraph in
+                "Paragraph \(paragraph) for \(label) section \(section). This keeps each generated projection tall enough to have an independent viewport."
+            }.joined(separator: "\n\n")
+        }.joined(separator: "\n\n")
+        return "<!-- cmux-scroll-key: \(key) -->\n\n\(sections)"
     }
 
     private func scrollSmokeMarkdown() -> String {


### PR DESCRIPTION
## Problem

A live Markdown panel can display multiple logical documents through one watched file path. cmux currently carries the outgoing document's scroll state into the incoming document, so returning to a tab can show a later section instead of that tab's prior viewport.

## Fix

- accept an invisible `cmux-scroll-key` on generated Markdown projections
- retain a bounded LRU of viewport snapshots by key
- keep existing scroll preservation for ordinary edits and unkeyed Markdown
- start a never-seen keyed projection at the top and restore its own viewport when revisited

`agent-state` emits a stable key from the selected surface and task in dotfiles commit `e99e546`.

## Red / green proof

The commits intentionally follow the regression policy:

1. `28353f6f96` adds the WebKit behavior test only.
2. `f97da3f109` adds the fix.

On the same Mac and viewer assets, an off-screen WebKit harness produced:

```text
RED: surface B inherited surface A scroll (6805.0)
GREEN: surface A restored 6805.0 after A -> B -> A
```

Additional verification:

- Markdown shell JavaScript syntax check passed.
- Dotfiles adapter frozen suite passed 51/51 tests.
- Independent cross-repo review was clean.
- `git diff --check` passed.

Full `cmux-unit` compilation and the required tagged `reload.sh` build are not available on this Mac because it currently has Command Line Tools but no full Xcode installation. The PR remains draft until a tagged build can be produced and dogfooded.

## Localization

No user-facing strings were added or changed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Markdown documents can now preserve scroll positions independently across different views or projection keys.
  * Returning to a previously viewed key restores its saved position, while new keys begin at the top.
  * Up to 32 recent scroll positions are retained automatically.

* **Bug Fixes**
  * Improved scroll-position handling when document content or the active view changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->