### PR TITLE
fix: Cmd+A in the TextBox selects the draft, not the terminal scrollback

### DIFF
--- a/Sources/TextBoxInput.swift
+++ b/Sources/TextBoxInput.swift
@@ -1026,6 +1026,36 @@ func textBoxCommandShortcutKey(
     return normalizedCharacters(event).lowercased()
 }
 
+/// Standard macOS editing commands the TextBox input owns while focused.
+///
+/// `selectAll` is here because cmux has no Edit > Select All menu item, so an
+/// unhandled Cmd+A falls through to the focused terminal and selects the whole
+/// Ghostty scrollback instead of the text the user is composing (issue: Cmd+A
+/// in the TextBox selects the page).
+enum TextBoxStandardEditCommand: Equatable {
+    case copy
+    case cut
+    case paste
+    case selectAll
+}
+
+func textBoxStandardEditCommand(
+    for event: NSEvent,
+    shortcutKey: (NSEvent) -> String = { textBoxCommandShortcutKey(for: $0) }
+) -> TextBoxStandardEditCommand? {
+    guard event.modifierFlags.intersection(.deviceIndependentFlagsMask) == .command else {
+        return nil
+    }
+
+    switch shortcutKey(event) {
+    case "c": return .copy
+    case "x": return .cut
+    case "v": return .paste
+    case "a": return .selectAll
+    default: return nil
+    }
+}
+
 private struct TextBoxMentionCompletionPopoverView: View {
     let suggestions: [TextBoxMentionSuggestion]
     let selectionIndex: Int
@@ -4816,22 +4846,19 @@ final class TextBoxInputTextView: NSTextView {
     }
 
     private func handleStandardEditShortcut(_ event: NSEvent) -> Bool {
-        let flags = event.modifierFlags.intersection(.deviceIndependentFlagsMask)
-        guard flags == .command else { return false }
+        guard let command = textBoxStandardEditCommand(for: event) else { return false }
 
-        switch textBoxCommandShortcutKey(for: event) {
-        case "c":
+        switch command {
+        case .copy:
             copy(nil)
-            return true
-        case "x":
+        case .cut:
             cut(nil)
-            return true
-        case "v":
+        case .paste:
             paste(nil)
-            return true
-        default:
-            return false
+        case .selectAll:
+            selectAll(nil)
         }
+        return true
     }
 
     func deleteAttachment(at characterIndex: Int) {

--- a/cmuxTests/TextBoxSelectionReplacementTests.swift
+++ b/cmuxTests/TextBoxSelectionReplacementTests.swift
@@ -1,4 +1,5 @@
 import AppKit
+import Carbon.HIToolbox
 import SwiftUI
 import Testing
 
@@ -59,6 +60,60 @@ struct TextBoxSelectionReplacementTests {
         #expect(createdTextView === textView)
         #expect(textView.string == "hello x")
         #expect(textView.selectedRange() == NSRange(location: 7, length: 0))
+    }
+
+    @Test("Cmd+A selects the TextBox draft instead of falling through to the terminal")
+    func commandASelectsAllTextBoxText() throws {
+        let draft = "select this draft, not the scrollback"
+        var createdTextView: TextBoxInputTextView?
+
+        let hostingView = NSHostingView(
+            rootView: TextBoxSelectionReplacementHarness(
+                externalText: draft,
+                refreshToken: 0,
+                onPublishedText: { _ in },
+                onTextViewCreated: { textView in
+                    createdTextView = textView
+                    textView.string = draft
+                }
+            )
+        )
+        hostingView.frame = NSRect(x: 0, y: 0, width: 360, height: 60)
+        let window = NSWindow(
+            contentRect: hostingView.frame,
+            styleMask: [.borderless],
+            backing: .buffered,
+            defer: false
+        )
+        window.isReleasedWhenClosed = false
+        window.contentView = hostingView
+        defer {
+            window.contentView = nil
+            window.close()
+        }
+
+        hostingView.layoutSubtreeIfNeeded()
+        let textView = try #require(createdTextView)
+        #expect(window.makeFirstResponder(textView))
+        textView.setSelectedRange(NSRange(location: 0, length: 0))
+
+        let commandA = try #require(
+            NSEvent.keyEvent(
+                with: .keyDown,
+                location: .zero,
+                modifierFlags: .command,
+                timestamp: 0,
+                windowNumber: window.windowNumber,
+                context: nil,
+                characters: "a",
+                charactersIgnoringModifiers: "a",
+                isARepeat: false,
+                keyCode: UInt16(kVK_ANSI_A)
+            )
+        )
+
+        #expect(textView.performKeyEquivalent(with: commandA))
+        #expect(textView.selectedRange() == NSRange(location: 0, length: (draft as NSString).length))
     }
 }
 


### PR DESCRIPTION
## Problem

With focus in the TextBox composer, Cmd+A selects the entire Ghostty scrollback instead of the text being composed.

cmux ships no **Edit → Select All** menu item, so AppKit never delivers `selectAll:` to `TextBoxInputTextView`. `handleStandardEditShortcut` claimed Cmd+C/X/V but not Cmd+A, so the event fell out of the TextBox and reached the focused terminal surface, which ran Ghostty's `select_all` binding.

## Fix

Route Cmd+A through the handler that already owns copy/cut/paste while the TextBox is first responder. The key→command mapping is extracted into a pure `textBoxStandardEditCommand(for:)` lookup so it can be exercised directly.

Terminal-focused Cmd+A is untouched — `GhosttyNSView.performKeyEquivalent` already guards on the first responder being itself or a descendant, so page select-all still works when the terminal has focus.

## Tests

Per `AGENTS.md`, two commits so CI shows the test catching the bug:

1. `test: Cmd+A in the TextBox should select the draft` — presses Cmd+A on a hosted `TextBoxInputTextView` and asserts the full draft is selected (red).
2. `fix: handle Cmd+A in the TextBox input` (green).

Note: I could not run the suite locally — this machine is under Santa lockdown, which SIGKILLs the unsigned cargo build-script binaries in the `CommandPaletteNucleoFFI` phase. Relying on CI for the red/green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/9411"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788288982&installation_model_id=21920&pr_number=9411&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F9411&signature=24a0276dbcbfabeecc5d08c3595293bf9dba26e80d9694c941fd1c64a887f94a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Cmd+A in the TextBox so it selects the draft, not the terminal scrollback. Routes Cmd+A through the TextBox’s standard edit handler while focused; terminal Cmd+A is unchanged.

- **Bug Fixes**
  - Added `TextBoxStandardEditCommand` and `textBoxStandardEditCommand(for:)` to handle Cmd+C/X/V/A in `TextBoxInputTextView`.
  - Cmd+A now calls `selectAll(nil)` when the TextBox is first responder; terminal still handles Cmd+A when it has focus.
  - Added a test that simulates Cmd+A and asserts the draft is fully selected.

<sup>Written for commit 44c072d6a48510679e60b19c952bbc5d3e563602. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/9411?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added standard keyboard shortcuts for focused text fields: Copy, Cut, Paste, and Select All.
  * Cmd+A now selects all text in the active text field.

* **Bug Fixes**
  * Prevented Select All from affecting terminal scrollback when editing text.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->