### PR TITLE
Fix registry kind test fixture compilation

### DIFF
--- a/cmuxTests/KimiRestorableAgentTests.swift
+++ b/cmuxTests/KimiRestorableAgentTests.swift
@@ -311,7 +311,8 @@ struct RestorableAgentPersistedKindDecodingTests {
             persistedBinding,
             restorableAgent: liveSnapshot
         )
-        #expect(retargeted?.cwd == launchDirectory)
+        let expectedDirectory = testCase.kind.cwdNamespacing == .byDirectory ? launchDirectory : runtimeDirectory
+        #expect(retargeted?.cwd == expectedDirectory)
     }
 
     @Test("Native persisted binding kinds still match native snapshots", arguments: nativeCases)
@@ -342,7 +343,8 @@ struct RestorableAgentPersistedKindDecodingTests {
             persistedBinding,
             restorableAgent: liveSnapshot
         )
-        #expect(retargeted?.cwd == launchDirectory)
+        let expectedDirectory = testCase.kind.cwdNamespacing == .byDirectory ? launchDirectory : runtimeDirectory
+        #expect(retargeted?.cwd == expectedDirectory)
     }
 
     @Test("Kimi hook-store snapshots match persisted Kimi resume bindings")

--- a/cmuxTests/KimiRestorableAgentTests.swift
+++ b/cmuxTests/KimiRestorableAgentTests.swift
@@ -449,6 +449,7 @@ struct RestorableAgentPersistedKindDecodingTests {
             registration: CmuxVaultAgentRegistration(
                 id: "ollama",
                 name: "Custom Ollama",
+                detect: CmuxVaultAgentDetectRule(processName: "ollama"),
                 sessionIdSource: .argvOption("--session"),
                 resumeCommand: "custom-ollama --resume {{sessionId}}"
             )


### PR DESCRIPTION
## Summary

- Supply the required Ollama process detection rule in the registry-owned kind fixture.
- Align the persisted-kind matrix with the shared working-directory policy for Codex, OpenCode, and Antigravity.
- Keep this follow-on test-only with no runtime behavior change.

## Evidence

Current `main` cannot compile the `cmux-unit` target because `KimiRestorableAgentTests.swift` omits the required `detect` argument when constructing its custom Ollama registration.

After adding that argument, the focused suite exposed three overbroad assertions. Existing `AgentResumeWorkingDirectory` policy and package tests confirm that Codex, OpenCode, and Antigravity are id-keyed agents and preserve the runtime working directory. The corrected matrix derives its expectation from that shared policy.

## Testing

- Focused `cmux-unit` verification passed 8 top-level tests and 14 parameterized invocations across `WorkspaceIsStaleAgentHookBindingTests` and `RestorableAgentPersistedKindDecodingTests`.
- Tagged Debug build `fix-9399-kimi-test-detect-fixture` succeeded on pushed commit `5dec69192a`.
- No local XCUITests were run.

Follow-up to #9399 and #9397.

Closes #9380