### PR TITLE
Preserve Claude secure storage config dir on restore

### DIFF
--- a/CLI/CMUXCLI+SessionsListForkStartupInput.swift
+++ b/CLI/CMUXCLI+SessionsListForkStartupInput.swift
@@ -89,7 +89,8 @@ extension CMUXCLI {
         for key in selectedEnvironment.keys.sorted() {
             guard let value = selectedEnvironment[key] else { continue }
             environmentParts.append("\(key)=\(value)")
-            if agent == "claude", sessionsListClaudeAuthSelectionEnvironmentKeys.contains(key) {
+            if AgentLaunchEnvironmentPolicy.isClaudeEnvironmentKind(agent),
+               sessionsListClaudeAuthSelectionEnvironmentKeys.contains(key) {
                 preservedClaudeKeys.append(key)
             }
         }
@@ -101,16 +102,7 @@ extension CMUXCLI {
     }
 
     private var sessionsListClaudeAuthSelectionEnvironmentKeys: Set<String> {
-        [
-            "ANTHROPIC_API_KEY",
-            "ANTHROPIC_AUTH_TOKEN",
-            "ANTHROPIC_BASE_URL",
-            "ANTHROPIC_MODEL",
-            "ANTHROPIC_SMALL_FAST_MODEL",
-            "CLAUDE_CODE_USE_BEDROCK",
-            "CLAUDE_CODE_USE_VERTEX",
-            "CLAUDE_CONFIG_DIR",
-        ]
+        AgentLaunchEnvironmentPolicy.claudeAuthSelectionEnvironmentKeys
     }
 
     private func sessionsListASCIIPrintfCommandSubstitution(for value: String) -> String {

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -28215,7 +28215,11 @@ struct CMUXCLI {
         let workingDirectory = (envCaptureIsTrusted ? normalizedHookValue(env["CMUX_AGENT_LAUNCH_CWD"]) : nil)
             ?? normalizedHookValue(cwd)
             ?? normalizedHookValue(env["PWD"])
-        let environment = selectedAgentLaunchEnvironment(from: env, kind: launcher)
+        let environment = selectedAgentLaunchEnvironment(
+            from: env,
+            kind: launcher,
+            includeClaudeCaptureMetadata: true
+        )
 
         // Fallback when the launch argv is genuinely UNAVAILABLE: plain `codex` with no cmux launcher
         // (no CMUX_AGENT_LAUNCH_ARGV_B64) and an unresolved/exited PID, so processArguments returns nil.
@@ -28520,19 +28524,11 @@ struct CMUXCLI {
         let selected = selectedAgentLaunchEnvironment(from: environment, kind: kind)
         guard !selected.isEmpty else { return nil }
 
-        let claudeAuthKeys: Set<String> = [
-            "ANTHROPIC_API_KEY",
-            "ANTHROPIC_AUTH_TOKEN",
-            "ANTHROPIC_BASE_URL",
-            "ANTHROPIC_MODEL",
-            "ANTHROPIC_SMALL_FAST_MODEL",
-            "CLAUDE_CODE_USE_BEDROCK",
-            "CLAUDE_CODE_USE_VERTEX",
-            "CLAUDE_CONFIG_DIR"
-        ]
         var resolved = selected
-        if kind == "claude" {
-            let preservedClaudeKeys = selected.keys.sorted().filter { claudeAuthKeys.contains($0) }
+        if AgentLaunchEnvironmentPolicy.isClaudeEnvironmentKind(kind) {
+            let preservedClaudeKeys = selected.keys.sorted().filter {
+                AgentLaunchEnvironmentPolicy.claudeAuthSelectionEnvironmentKeys.contains($0)
+            }
             if !preservedClaudeKeys.isEmpty {
                 resolved["CMUX_PRESERVE_CLAUDE_AUTH_SELECTION_ENV"] = "1"
                 resolved["CMUX_PRESERVE_CLAUDE_AUTH_SELECTION_ENV_KEYS"] = preservedClaudeKeys.joined(separator: ",")
@@ -28568,8 +28564,15 @@ struct CMUXCLI {
         return parts.isEmpty ? nil : parts
     }
 
-    private func selectedAgentLaunchEnvironment(from env: [String: String], kind: String? = nil) -> [String: String] {
-        var selected = AgentLaunchEnvironmentPolicy().selectedEnvironment(from: env, kind: kind)
+    private func selectedAgentLaunchEnvironment(
+        from env: [String: String],
+        kind: String? = nil,
+        includeClaudeCaptureMetadata: Bool = false
+    ) -> [String: String] {
+        let policy = AgentLaunchEnvironmentPolicy()
+        var selected = includeClaudeCaptureMetadata
+            ? policy.selectedLaunchEnvironment(from: env, kind: kind)
+            : policy.selectedEnvironment(from: env, kind: kind)
         if kind == "hermes-agent" {
             selected = HermesAgentCodexEnvironment.applyingDefaultCodexBaseURL(
                 to: selected,

--- a/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/AgentLaunchEnvironmentPolicy.swift
+++ b/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/AgentLaunchEnvironmentPolicy.swift
@@ -35,9 +35,45 @@ public struct AgentLaunchEnvironmentPolicy: Sendable {
     /// Creates a launch environment policy.
     public init() {}
 
+    /// Claude environment names that select which account or auth backend a restore should use.
+    ///
+    /// This is not a replay allowlist. Callers intersect it with values already filtered by
+    /// ``selectedEnvironment(from:kind:)`` so secret names here do not become persisted values.
+    public static let claudeAuthSelectionEnvironmentKeys: Set<String> = [
+        "ANTHROPIC_API_KEY",
+        "ANTHROPIC_AUTH_TOKEN",
+        "ANTHROPIC_BASE_URL",
+        "ANTHROPIC_MODEL",
+        "ANTHROPIC_SMALL_FAST_MODEL",
+        "CLAUDE_CODE_USE_BEDROCK",
+        "CLAUDE_CODE_USE_VERTEX",
+        "CLAUDE_CONFIG_DIR",
+        "CLAUDE_SECURESTORAGE_CONFIG_DIR",
+    ]
+
+    /// Environment key listing Claude auth-selection keys that were absent at capture time
+    /// and must be cleared from ambient restore environments before launching Claude.
+    public static let claudeAuthSelectionClearEnvironmentKeysKey =
+        "CMUX_CLEAR_CLAUDE_AUTH_SELECTION_ENV_KEYS"
+
     private static let hermesAgentEnvironmentKeys: Set<String> = [
         "CUSTOM_BASE_URL",
         "HERMES_CODEX_BASE_URL",
+    ]
+
+    private static let claudeOnlyEnvironmentKeys: Set<String> = [
+        claudeAuthSelectionClearEnvironmentKeysKey,
+        "CLAUDE_SECURESTORAGE_CONFIG_DIR",
+    ]
+
+    private static let claudeAuthSelectionClearWhenAbsentEnvironmentKeys: Set<String> = [
+        "CLAUDE_SECURESTORAGE_CONFIG_DIR",
+    ]
+
+    private static let claudeEnvironmentKinds: Set<String> = [
+        "claude",
+        "claudeteams",
+        "claude-teams",
     ]
 
     /// Keys campfire manages itself and must not inherit from a captured Pi
@@ -71,6 +107,7 @@ public struct AgentLaunchEnvironmentPolicy: Sendable {
         // Selects the directory holding Claude Code's .credentials.json. A path, not a secret,
         // so restoring it keeps a restored agent on the account it launched with.
         "CLAUDE_SECURESTORAGE_CONFIG_DIR",
+        "CMUX_CLEAR_CLAUDE_AUTH_SELECTION_ENV_KEYS",
         "CMUX_CUSTOM_CLAUDE_PATH",
         "CMUX_ROVODEV_SESSIONS_DIR",
         "CODEX_HOME",
@@ -141,12 +178,34 @@ public struct AgentLaunchEnvironmentPolicy: Sendable {
                 result.removeValue(forKey: key)
             }
         }
+        if !Self.isNormalizedClaudeEnvironmentKind(normalizedKind) {
+            for key in Self.claudeOnlyEnvironmentKeys {
+                result.removeValue(forKey: key)
+            }
+        }
         if normalizedKind == "campfire" {
             for key in Self.campfireManagedEnvironmentKeys {
                 result.removeValue(forKey: key)
             }
         }
         return result
+    }
+
+    /// Returns safe launch environment values plus cmux-owned metadata needed to preserve
+    /// meaningful absence for Claude auth-selection variables.
+    public func selectedLaunchEnvironment(from env: [String: String], kind: String? = nil) -> [String: String] {
+        var selected = selectedEnvironment(from: env, kind: kind)
+        selected.removeValue(forKey: Self.claudeAuthSelectionClearEnvironmentKeysKey)
+        guard Self.isClaudeEnvironmentKind(kind) else { return selected }
+
+        let clearKeys = Self.claudeAuthSelectionClearWhenAbsentEnvironmentKeys
+            .filter { env[$0] == nil && selected[$0] == nil }
+            .sorted()
+        if !clearKeys.isEmpty {
+            selected[Self.claudeAuthSelectionClearEnvironmentKeysKey] =
+                clearKeys.joined(separator: ",")
+        }
+        return selected
     }
 
     /// Returns the captured environment that may cross the restore transport boundary.
@@ -173,12 +232,27 @@ public struct AgentLaunchEnvironmentPolicy: Sendable {
         return selected
     }
 
+    /// Returns the Claude auth-selection keys represented by the clear marker, constrained
+    /// to keys this policy owns clearing for.
+    public func claudeAuthSelectionEnvironmentKeysToClear(from env: [String: String]) -> Set<String> {
+        guard let rawValue = env[Self.claudeAuthSelectionClearEnvironmentKeysKey] else {
+            return []
+        }
+        let requested = rawValue
+            .split(separator: ",")
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty }
+        return Set(requested).intersection(Self.claudeAuthSelectionClearWhenAbsentEnvironmentKeys)
+    }
+
     /// Returns a replay-safe value for a single environment variable, or `nil` when it should drop.
     public func sanitizedValue(key: String, value: String?) -> String? {
         guard Self.safeEnvironmentKeys.contains(key) else { return nil }
         switch key {
         case "CLAUDE_CONFIG_DIR":
             return value.map { ClaudeConfigDirectoryPath.preferredPath($0) }
+        case "CMUX_CLEAR_CLAUDE_AUTH_SELECTION_ENV_KEYS":
+            return sanitizedClaudeAuthSelectionClearKeys(value)
         case "NODE_OPTIONS":
             return sanitizedNodeOptions(value)
         default:
@@ -236,6 +310,26 @@ public struct AgentLaunchEnvironmentPolicy: Sendable {
         let joined = sanitized.joined(separator: " ")
             .trimmingCharacters(in: .whitespacesAndNewlines)
         return joined.isEmpty ? nil : joined
+    }
+
+    private func sanitizedClaudeAuthSelectionClearKeys(_ rawValue: String?) -> String? {
+        let keys = claudeAuthSelectionEnvironmentKeysToClear(
+            from: [Self.claudeAuthSelectionClearEnvironmentKeysKey: rawValue ?? ""]
+        )
+        let joined = keys.sorted().joined(separator: ",")
+        return joined.isEmpty ? nil : joined
+    }
+
+    private static func isNormalizedClaudeEnvironmentKind(_ normalizedKind: String?) -> Bool {
+        guard let normalizedKind else { return false }
+        return claudeEnvironmentKinds.contains(normalizedKind)
+    }
+
+    /// Returns true when an agent or launcher kind belongs to the Claude family.
+    public static func isClaudeEnvironmentKind(_ kind: String?) -> Bool {
+        isNormalizedClaudeEnvironmentKind(kind?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .lowercased())
     }
 
     private func normalizedValue(_ value: String?) -> String? {

--- a/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/AgentRestorePlanner.swift
+++ b/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/AgentRestorePlanner.swift
@@ -2,17 +2,6 @@ import Foundation
 
 /// Builds shell-free restore invocations from structured persisted records.
 public struct AgentRestorePlanner: Sendable {
-    private static let claudeAuthSelectionEnvironmentKeys: Set<String> = [
-        "ANTHROPIC_API_KEY",
-        "ANTHROPIC_AUTH_TOKEN",
-        "ANTHROPIC_BASE_URL",
-        "ANTHROPIC_MODEL",
-        "ANTHROPIC_SMALL_FAST_MODEL",
-        "CLAUDE_CODE_USE_BEDROCK",
-        "CLAUDE_CODE_USE_VERTEX",
-        "CLAUDE_CONFIG_DIR",
-    ]
-
     private let isExecutableFile: @Sendable (String) -> Bool
 
     /// Creates a restore planner.
@@ -72,6 +61,12 @@ public struct AgentRestorePlanner: Sendable {
         var environment = ambientEnvironment
         let restoredEnvironment = restoredEnvironment(for: request, kind: kind)
         environment.merge(restoredEnvironment) { _, restored in restored }
+        if AgentLaunchEnvironmentPolicy.isClaudeEnvironmentKind(kind) {
+            for key in AgentLaunchEnvironmentPolicy()
+                .claudeAuthSelectionEnvironmentKeysToClear(from: restoredEnvironment) {
+                environment.removeValue(forKey: key)
+            }
+        }
 
         var routedArguments = sanitizedArguments
         if request.mode != .direct {
@@ -162,9 +157,9 @@ public struct AgentRestorePlanner: Sendable {
             from: captured,
             kind: kind
         )
-        if kind == "claude" {
+        if AgentLaunchEnvironmentPolicy.isClaudeEnvironmentKind(kind) {
             let keys = selected.keys.sorted().filter {
-                Self.claudeAuthSelectionEnvironmentKeys.contains($0)
+                AgentLaunchEnvironmentPolicy.claudeAuthSelectionEnvironmentKeys.contains($0)
             }
             if !keys.isEmpty {
                 selected["CMUX_PRESERVE_CLAUDE_AUTH_SELECTION_ENV"] = "1"

--- a/Packages/macOS/CMUXAgentLaunch/Tests/CMUXAgentLaunchTests/AgentLaunchEnvironmentPolicyTests.swift
+++ b/Packages/macOS/CMUXAgentLaunch/Tests/CMUXAgentLaunchTests/AgentLaunchEnvironmentPolicyTests.swift
@@ -20,6 +20,30 @@ struct AgentLaunchEnvironmentPolicyTests {
         ])
     }
 
+    @Test("Preserves Claude secure storage config dir for Claude without persisting secrets")
+    func preservesClaudeSecureStorageConfigDirForClaudeWithoutPersistingSecrets() {
+        let selected = AgentLaunchEnvironmentPolicy().selectedEnvironment(
+            from: [
+                "AMP_API_KEY": "amp-secret-should-not-persist",
+                "ANTHROPIC_AUTH_TOKEN": "anthropic-secret-should-not-persist",
+                "CLAUDE_CONFIG_DIR": "/tmp/claude-config",
+                "CLAUDE_SECURESTORAGE_CONFIG_DIR": "/tmp/claude-secure-storage",
+            ],
+            kind: "claude"
+        )
+
+        #expect(selected["CLAUDE_CONFIG_DIR"] == "/tmp/claude-config")
+        #expect(selected["CLAUDE_SECURESTORAGE_CONFIG_DIR"] == "/tmp/claude-secure-storage")
+        #expect(selected["AMP_API_KEY"] == nil)
+        #expect(selected["ANTHROPIC_AUTH_TOKEN"] == nil)
+
+        let codexSelected = AgentLaunchEnvironmentPolicy().selectedEnvironment(
+            from: ["CLAUDE_SECURESTORAGE_CONFIG_DIR": "/tmp/claude-secure-storage"],
+            kind: "codex"
+        )
+        #expect(codexSelected["CLAUDE_SECURESTORAGE_CONFIG_DIR"] == nil)
+    }
+
     @Test("Restore transport keeps Pi PATH without crossing secrets")
     func restoreTransportKeepsPiPathWithoutSecrets() {
         let selected = AgentLaunchEnvironmentPolicy().selectedRestoreEnvironment(

--- a/Packages/macOS/CMUXAgentLaunch/Tests/CMUXAgentLaunchTests/AgentLaunchEnvironmentPolicyTests.swift
+++ b/Packages/macOS/CMUXAgentLaunch/Tests/CMUXAgentLaunchTests/AgentLaunchEnvironmentPolicyTests.swift
@@ -20,8 +20,8 @@ struct AgentLaunchEnvironmentPolicyTests {
         ])
     }
 
-    @Test("Preserves Claude secure storage config dir for Claude without persisting secrets")
-    func preservesClaudeSecureStorageConfigDirForClaudeWithoutPersistingSecrets() {
+    @Test("Preserves Claude secure storage config dir for Claude launchers without persisting secrets")
+    func preservesClaudeSecureStorageConfigDirForClaudeLaunchersWithoutPersistingSecrets() {
         let selected = AgentLaunchEnvironmentPolicy().selectedEnvironment(
             from: [
                 "AMP_API_KEY": "amp-secret-should-not-persist",
@@ -37,11 +37,58 @@ struct AgentLaunchEnvironmentPolicyTests {
         #expect(selected["AMP_API_KEY"] == nil)
         #expect(selected["ANTHROPIC_AUTH_TOKEN"] == nil)
 
+        let claudeTeamsSelected = AgentLaunchEnvironmentPolicy().selectedEnvironment(
+            from: ["CLAUDE_SECURESTORAGE_CONFIG_DIR": "/tmp/claude-teams-secure-storage"],
+            kind: "claudeTeams"
+        )
+        #expect(claudeTeamsSelected["CLAUDE_SECURESTORAGE_CONFIG_DIR"] == "/tmp/claude-teams-secure-storage")
+
         let codexSelected = AgentLaunchEnvironmentPolicy().selectedEnvironment(
             from: ["CLAUDE_SECURESTORAGE_CONFIG_DIR": "/tmp/claude-secure-storage"],
             kind: "codex"
         )
         #expect(codexSelected["CLAUDE_SECURESTORAGE_CONFIG_DIR"] == nil)
+    }
+
+    @Test("Records absent Claude secure storage config dir for Claude launch capture")
+    func recordsAbsentClaudeSecureStorageConfigDirForClaudeLaunchCapture() {
+        let policy = AgentLaunchEnvironmentPolicy()
+        let clearKeysKey = AgentLaunchEnvironmentPolicy.claudeAuthSelectionClearEnvironmentKeysKey
+
+        let present = policy.selectedLaunchEnvironment(
+            from: [
+                clearKeysKey: "CLAUDE_SECURESTORAGE_CONFIG_DIR",
+                "CLAUDE_SECURESTORAGE_CONFIG_DIR": "/tmp/claude-secure-storage",
+            ],
+            kind: "claude"
+        )
+        #expect(present["CLAUDE_SECURESTORAGE_CONFIG_DIR"] == "/tmp/claude-secure-storage")
+        #expect(present[clearKeysKey] == nil)
+
+        let absent = policy.selectedLaunchEnvironment(
+            from: [
+                clearKeysKey: "UNSUPPORTED_KEY,CLAUDE_SECURESTORAGE_CONFIG_DIR",
+                "CLAUDE_CONFIG_DIR": "/tmp/claude-config",
+            ],
+            kind: "claude"
+        )
+        #expect(absent["CLAUDE_SECURESTORAGE_CONFIG_DIR"] == nil)
+        #expect(absent[clearKeysKey] == "CLAUDE_SECURESTORAGE_CONFIG_DIR")
+
+        let claudeTeamsAbsent = policy.selectedLaunchEnvironment(from: [:], kind: "claudeTeams")
+        #expect(claudeTeamsAbsent[clearKeysKey] == "CLAUDE_SECURESTORAGE_CONFIG_DIR")
+
+        let codexAbsent = policy.selectedLaunchEnvironment(from: [:], kind: "codex")
+        #expect(codexAbsent[clearKeysKey] == nil)
+
+        let genericSelected = policy.selectedEnvironment(
+            from: [
+                clearKeysKey: "CLAUDE_SECURESTORAGE_CONFIG_DIR",
+                "CLAUDE_SECURESTORAGE_CONFIG_DIR": "/tmp/claude-secure-storage",
+            ]
+        )
+        #expect(genericSelected[clearKeysKey] == nil)
+        #expect(genericSelected["CLAUDE_SECURESTORAGE_CONFIG_DIR"] == nil)
     }
 
     @Test("Restore transport keeps Pi PATH without crossing secrets")

--- a/Packages/macOS/CMUXAgentLaunch/Tests/CMUXAgentLaunchTests/AgentRestoreLaunchTests.swift
+++ b/Packages/macOS/CMUXAgentLaunch/Tests/CMUXAgentLaunchTests/AgentRestoreLaunchTests.swift
@@ -184,6 +184,91 @@ import Testing
         )
     }
 
+    @Test func structuredClaudeTeamsRestoreMarksSecureStorageConfigDirAsAuthSelection() throws {
+        let request = AgentRestoreRequest(
+            mode: .resumeAgent,
+            kind: "claudeTeams",
+            checkpointID: sessionID,
+            source: "agent-hook",
+            workingDirectory: "/tmp/work",
+            environment: [:],
+            launchCommand: AgentLaunchCommand(
+                launcher: "claudeTeams",
+                executablePath: "/usr/local/bin/cmux",
+                arguments: ["/usr/local/bin/cmux", "claude-teams"],
+                workingDirectory: "/tmp/work",
+                environment: [
+                    "CLAUDE_CONFIG_DIR": "/tmp/claude-config",
+                    "CLAUDE_SECURESTORAGE_CONFIG_DIR": "/tmp/claude-secure-storage",
+                ]
+            ),
+            preparedArguments: nil,
+            observedPermissionMode: nil
+        )
+        let invocation = try #require(AgentRestorePlanner(
+            isExecutableFile: { _ in false }
+        ).invocation(
+            for: request,
+            ambientEnvironment: [:]
+        ))
+
+        #expect(invocation.arguments == [
+            "/usr/local/bin/cmux",
+            "claude-teams",
+            "--resume",
+            sessionID,
+        ])
+        #expect(invocation.environment["CLAUDE_CONFIG_DIR"] == "/tmp/claude-config")
+        #expect(invocation.environment["CLAUDE_SECURESTORAGE_CONFIG_DIR"] == "/tmp/claude-secure-storage")
+        #expect(invocation.environment["CMUX_PRESERVE_CLAUDE_AUTH_SELECTION_ENV"] == "1")
+        #expect(
+            invocation.environment["CMUX_PRESERVE_CLAUDE_AUTH_SELECTION_ENV_KEYS"]
+                == "CLAUDE_CONFIG_DIR,CLAUDE_SECURESTORAGE_CONFIG_DIR"
+        )
+    }
+
+    @Test func structuredClaudeRestoreClearsAmbientSecureStorageConfigDirWhenCaptureMarkedAbsent() throws {
+        let clearKeysKey = AgentLaunchEnvironmentPolicy.claudeAuthSelectionClearEnvironmentKeysKey
+        let request = AgentRestoreRequest(
+            mode: .resumeAgent,
+            kind: "claude",
+            checkpointID: sessionID,
+            source: "agent-hook",
+            workingDirectory: "/tmp/work",
+            environment: [:],
+            launchCommand: AgentLaunchCommand(
+                launcher: "claude",
+                executablePath: "/opt/claude",
+                arguments: ["/opt/claude"],
+                workingDirectory: "/tmp/work",
+                environment: [
+                    clearKeysKey: "CLAUDE_SECURESTORAGE_CONFIG_DIR",
+                    "CLAUDE_CONFIG_DIR": "/tmp/claude-config",
+                ]
+            ),
+            preparedArguments: nil,
+            observedPermissionMode: nil
+        )
+        let invocation = try #require(AgentRestorePlanner(
+            isExecutableFile: { $0 == "/shim/claude" }
+        ).invocation(
+            for: request,
+            ambientEnvironment: [
+                "CLAUDE_SECURESTORAGE_CONFIG_DIR": "/tmp/ambient-secure-storage",
+                "CMUX_CLAUDE_WRAPPER_SHIM": "/shim/claude",
+            ]
+        ))
+
+        #expect(invocation.environment["CLAUDE_CONFIG_DIR"] == "/tmp/claude-config")
+        #expect(invocation.environment["CLAUDE_SECURESTORAGE_CONFIG_DIR"] == nil)
+        #expect(invocation.environment[clearKeysKey] == "CLAUDE_SECURESTORAGE_CONFIG_DIR")
+        #expect(invocation.environment["CMUX_PRESERVE_CLAUDE_AUTH_SELECTION_ENV"] == "1")
+        #expect(
+            invocation.environment["CMUX_PRESERVE_CLAUDE_AUTH_SELECTION_ENV_KEYS"]
+                == "CLAUDE_CONFIG_DIR"
+        )
+    }
+
     @Test func managedRestoreUsesCapturedExecutableWhenWrapperShimIsUnavailable() throws {
         let executable = "/opt/custom tools/codex"
         let request = AgentRestoreRequest(

--- a/Packages/macOS/CMUXAgentLaunch/Tests/CMUXAgentLaunchTests/AgentRestoreLaunchTests.swift
+++ b/Packages/macOS/CMUXAgentLaunch/Tests/CMUXAgentLaunchTests/AgentRestoreLaunchTests.swift
@@ -145,6 +145,45 @@ import Testing
         )
     }
 
+    @Test func structuredClaudeRestoreMarksSecureStorageConfigDirAsAuthSelection() throws {
+        let request = AgentRestoreRequest(
+            mode: .resumeAgent,
+            kind: "claude",
+            checkpointID: sessionID,
+            source: "agent-hook",
+            workingDirectory: "/tmp/work",
+            environment: [:],
+            launchCommand: AgentLaunchCommand(
+                launcher: "claude",
+                executablePath: "/opt/claude",
+                arguments: ["/opt/claude"],
+                workingDirectory: "/tmp/work",
+                environment: [
+                    "ANTHROPIC_AUTH_TOKEN": "token-should-not-persist",
+                    "CLAUDE_CONFIG_DIR": "/tmp/claude-config",
+                    "CLAUDE_SECURESTORAGE_CONFIG_DIR": "/tmp/claude-secure-storage",
+                ]
+            ),
+            preparedArguments: nil,
+            observedPermissionMode: nil
+        )
+        let invocation = try #require(AgentRestorePlanner(
+            isExecutableFile: { $0 == "/shim/claude" }
+        ).invocation(
+            for: request,
+            ambientEnvironment: ["CMUX_CLAUDE_WRAPPER_SHIM": "/shim/claude"]
+        ))
+
+        #expect(invocation.environment["CLAUDE_CONFIG_DIR"] == "/tmp/claude-config")
+        #expect(invocation.environment["CLAUDE_SECURESTORAGE_CONFIG_DIR"] == "/tmp/claude-secure-storage")
+        #expect(invocation.environment["ANTHROPIC_AUTH_TOKEN"] == nil)
+        #expect(invocation.environment["CMUX_PRESERVE_CLAUDE_AUTH_SELECTION_ENV"] == "1")
+        #expect(
+            invocation.environment["CMUX_PRESERVE_CLAUDE_AUTH_SELECTION_ENV_KEYS"]
+                == "CLAUDE_CONFIG_DIR,CLAUDE_SECURESTORAGE_CONFIG_DIR"
+        )
+    }
+
     @Test func managedRestoreUsesCapturedExecutableWhenWrapperShimIsUnavailable() throws {
         let executable = "/opt/custom tools/codex"
         let request = AgentRestoreRequest(

--- a/Resources/bin/cmux-claude-wrapper
+++ b/Resources/bin/cmux-claude-wrapper
@@ -555,6 +555,20 @@ reconcile_claude_config_dir_for_resume() {
 }
 
 clear_inherited_claude_auth_selection_env() {
+    local clear_keys="${CMUX_CLEAR_CLAUDE_AUTH_SELECTION_ENV_KEYS:-}"
+    if [[ -n "$clear_keys" ]]; then
+        clear_keys="${clear_keys//,/ }"
+        local clear_key
+        for clear_key in $clear_keys; do
+            case "$clear_key" in
+                CLAUDE_SECURESTORAGE_CONFIG_DIR)
+                    unset "$clear_key"
+                    ;;
+            esac
+        done
+        unset CMUX_CLEAR_CLAUDE_AUTH_SELECTION_ENV_KEYS
+    fi
+
     if [[ "${IN_CMUX:-0}" == "1" ]]; then
         local key
         for key in "${CLAUDE_AUTH_SELECTION_ENV_KEYS[@]}"; do

--- a/Sources/RestorableAgentSession.swift
+++ b/Sources/RestorableAgentSession.swift
@@ -310,16 +310,6 @@ enum TerminalStartupWorkingDirectoryPrefix {
 }
 
 enum AgentResumeCommandBuilder {
-    private static let claudeAuthSelectionEnvironmentKeys: Set<String> = [
-        "ANTHROPIC_API_KEY",
-        "ANTHROPIC_AUTH_TOKEN",
-        "ANTHROPIC_BASE_URL",
-        "ANTHROPIC_MODEL",
-        "ANTHROPIC_SMALL_FAST_MODEL",
-        "CLAUDE_CODE_USE_BEDROCK",
-        "CLAUDE_CODE_USE_VERTEX",
-        "CLAUDE_CONFIG_DIR"
-    ]
     static func resumeShellCommand(
         kind: RestorableAgentKind,
         sessionId: String,
@@ -495,8 +485,8 @@ enum AgentResumeCommandBuilder {
         for key in selectedEnvironment.keys.sorted() {
             guard let value = selectedEnvironment[key] else { continue }
             environmentParts.append("\(key)=\(value)")
-            if kind == .claude,
-               claudeAuthSelectionEnvironmentKeys.contains(key) {
+            if AgentLaunchEnvironmentPolicy.isClaudeEnvironmentKind(kind.rawValue),
+               AgentLaunchEnvironmentPolicy.claudeAuthSelectionEnvironmentKeys.contains(key) {
                 preservedClaudeAuthSelectionEnvironmentKeys.append(key)
             }
         }

--- a/Sources/VaultAgentProcessScanner.swift
+++ b/Sources/VaultAgentProcessScanner.swift
@@ -10,7 +10,7 @@ extension AgentLaunchCommandSnapshot {
         workingDirectory: String?,
         environment: [String: String]
     ) {
-        var selectedEnvironment = AgentLaunchEnvironmentPolicy().selectedEnvironment(from: environment, kind: launcher)
+        var selectedEnvironment = AgentLaunchEnvironmentPolicy().selectedLaunchEnvironment(from: environment, kind: launcher)
         if ["opencode", "pi", "omp"].contains(launcher),
            let path = environment["PATH"]?.trimmingCharacters(in: .whitespacesAndNewlines),
            !path.isEmpty {

--- a/cmuxTests/CLINotifyProcessIntegrationRegressionTests.swift
+++ b/cmuxTests/CLINotifyProcessIntegrationRegressionTests.swift
@@ -1,5 +1,6 @@
 import XCTest
 import Darwin
+import CMUXAgentLaunch
 #if canImport(cmux_DEV)
 @testable import cmux_DEV
 #elseif canImport(cmux)
@@ -1470,6 +1471,7 @@ final class CLINotifyProcessIntegrationRegressionTests: XCTestCase {
             "ANTHROPIC_BASE_URL": "https://api.example.test",
             "ANTHROPIC_MODEL": "claude-sonnet-test",
             "CLAUDE_CONFIG_DIR": context.root.appendingPathComponent("claude-config", isDirectory: true).path,
+            "CLAUDE_SECURESTORAGE_CONFIG_DIR": context.root.appendingPathComponent("claude-securestorage", isDirectory: true).path,
         ]
         startClaudeHookMockServerAccepting(
             context: context,
@@ -1511,7 +1513,7 @@ final class CLINotifyProcessIntegrationRegressionTests: XCTestCase {
         XCTAssertEqual(environment["CMUX_PRESERVE_CLAUDE_AUTH_SELECTION_ENV"] as? String, "1")
         XCTAssertEqual(
             environment["CMUX_PRESERVE_CLAUDE_AUTH_SELECTION_ENV_KEYS"] as? String,
-            "ANTHROPIC_BASE_URL,ANTHROPIC_MODEL,CLAUDE_CONFIG_DIR"
+            "ANTHROPIC_BASE_URL,ANTHROPIC_MODEL,CLAUDE_CONFIG_DIR,CLAUDE_SECURESTORAGE_CONFIG_DIR"
         )
         XCTAssertNil(environment["ANTHROPIC_API_KEY"])
         XCTAssertEqual(environment["ANTHROPIC_BASE_URL"] as? String, "https://api.example.test")
@@ -1520,6 +1522,81 @@ final class CLINotifyProcessIntegrationRegressionTests: XCTestCase {
             environment["CLAUDE_CONFIG_DIR"] as? String,
             context.root.appendingPathComponent("claude-config", isDirectory: true).path
         )
+        XCTAssertEqual(
+            environment["CLAUDE_SECURESTORAGE_CONFIG_DIR"] as? String,
+            context.root.appendingPathComponent("claude-securestorage", isDirectory: true).path
+        )
+    }
+
+    func testClaudePromptSubmitResumeBindingMarksAbsentSecureStorageConfigDirForClearing() throws {
+        let context = try makeClaudeHookContext(name: "claude-resume-env-absent-securestorage")
+        defer { context.cleanup() }
+
+        let sessionId = "claude-absent-securestorage-session"
+        let clearKeysKey = AgentLaunchEnvironmentPolicy.claudeAuthSelectionClearEnvironmentKeysKey
+        let launchEnvironment = [
+            "CMUX_AGENT_LAUNCH_KIND": "claude",
+            "CMUX_AGENT_LAUNCH_EXECUTABLE": "/usr/local/bin/claude",
+            "CMUX_AGENT_LAUNCH_CWD": context.root.path,
+            "CMUX_AGENT_LAUNCH_ARGV_B64": base64NULSeparated([
+                "/usr/local/bin/claude",
+                "--model",
+                "sonnet",
+            ]),
+            "ANTHROPIC_AUTH_TOKEN": "should-not-persist",
+            "ANTHROPIC_MODEL": "claude-sonnet-test",
+            "CLAUDE_CONFIG_DIR": context.root.appendingPathComponent("claude-config", isDirectory: true).path,
+        ]
+        startClaudeHookMockServerAccepting(
+            context: context,
+            surfaceIds: [context.surfaceId],
+            connectionLimit: 5
+        )
+
+        let start = runClaudeHookWithoutServer(
+            context: context,
+            arguments: ["hooks", "claude", "session-start"],
+            standardInput: #"{"session_id":"\#(sessionId)","source":"startup","cwd":"\#(context.root.path)","hook_event_name":"SessionStart"}"#,
+            extraEnvironment: launchEnvironment
+        )
+        XCTAssertFalse(start.timedOut, start.stderr)
+        XCTAssertEqual(start.status, 0, start.stderr)
+
+        let commandStart = context.state.commands.count
+        let prompt = runClaudeHookWithoutServer(
+            context: context,
+            arguments: ["hooks", "claude", "prompt-submit"],
+            standardInput: #"{"session_id":"\#(sessionId)","turn_id":"turn-1","cwd":"\#(context.root.path)","hook_event_name":"UserPromptSubmit"}"#,
+            extraEnvironment: launchEnvironment
+        )
+        XCTAssertFalse(prompt.timedOut, prompt.stderr)
+        XCTAssertEqual(prompt.status, 0, prompt.stderr)
+
+        let promptCommands = Array(context.state.commands.dropFirst(commandStart))
+        let resumeBindingRequests = promptCommands.compactMap { command -> [String: Any]? in
+            guard let payload = jsonObject(command),
+                  payload["method"] as? String == "surface.resume.set" else {
+                return nil
+            }
+            return payload["params"] as? [String: Any]
+        }
+        XCTAssertEqual(resumeBindingRequests.count, 1, promptCommands.joined(separator: "\n"))
+        let request = try XCTUnwrap(resumeBindingRequests.first)
+        XCTAssertEqual(request["auto_resume"] as? Bool, true)
+        let environment = try XCTUnwrap(request["environment"] as? [String: Any])
+        XCTAssertEqual(environment["CMUX_PRESERVE_CLAUDE_AUTH_SELECTION_ENV"] as? String, "1")
+        XCTAssertEqual(
+            environment["CMUX_PRESERVE_CLAUDE_AUTH_SELECTION_ENV_KEYS"] as? String,
+            "ANTHROPIC_MODEL,CLAUDE_CONFIG_DIR"
+        )
+        XCTAssertEqual(environment[clearKeysKey] as? String, "CLAUDE_SECURESTORAGE_CONFIG_DIR")
+        XCTAssertNil(environment["ANTHROPIC_AUTH_TOKEN"])
+        XCTAssertEqual(environment["ANTHROPIC_MODEL"] as? String, "claude-sonnet-test")
+        XCTAssertEqual(
+            environment["CLAUDE_CONFIG_DIR"] as? String,
+            context.root.appendingPathComponent("claude-config", isDirectory: true).path
+        )
+        XCTAssertNil(environment["CLAUDE_SECURESTORAGE_CONFIG_DIR"])
     }
 
     func testClaudeSessionEndChecksConsumedWorkspaceBeforeClearingVisibleState() throws {

--- a/tests/test_claude_wrapper_hooks.py
+++ b/tests/test_claude_wrapper_hooks.py
@@ -397,6 +397,7 @@ keys=(
   CLAUDE_CODE_USE_BEDROCK
   CLAUDE_CODE_USE_VERTEX
   CLAUDE_CONFIG_DIR
+  CLAUDE_SECURESTORAGE_CONFIG_DIR
   CLOUD_ML_REGION
 )
 for key in "${keys[@]}"; do
@@ -453,6 +454,7 @@ exit 0
                 "CLAUDE_CODE_USE_BEDROCK",
                 "CLAUDE_CODE_USE_VERTEX",
                 "CLAUDE_CONFIG_DIR",
+                "CLAUDE_SECURESTORAGE_CONFIG_DIR",
                 "CLOUD_ML_REGION",
             ):
                 env.pop(ambient_key, None)
@@ -964,6 +966,7 @@ def test_live_socket_preserves_third_party_claude_auth_for_fresh_launch(failures
     # test_live_socket_preserves_plain_anthropic_model_on_default_path (#7047).
     inherited = {
         "CLAUDE_CONFIG_DIR": "/tmp/claude-config",
+        "CLAUDE_SECURESTORAGE_CONFIG_DIR": "/tmp/claude-securestorage",
         "ANTHROPIC_API_KEY": "stale-api-key",
         "ANTHROPIC_AUTH_TOKEN": "third-party-auth-token",
         "ANTHROPIC_BASE_URL": "https://api.example.test",
@@ -976,6 +979,7 @@ def test_live_socket_preserves_third_party_claude_auth_for_fresh_launch(failures
     )
     expect(code == 0, f"fresh auth env: wrapper exited {code}: {stderr}", failures)
     expect(auth_env.get("CLAUDE_CONFIG_DIR") == "/tmp/claude-config", f"fresh auth env: expected CLAUDE_CONFIG_DIR preserved, got {auth_env.get('CLAUDE_CONFIG_DIR')!r}", failures)
+    expect(auth_env.get("CLAUDE_SECURESTORAGE_CONFIG_DIR") == "/tmp/claude-securestorage", f"fresh auth env: expected CLAUDE_SECURESTORAGE_CONFIG_DIR preserved, got {auth_env.get('CLAUDE_SECURESTORAGE_CONFIG_DIR')!r}", failures)
     expect(auth_env.get("ANTHROPIC_AUTH_TOKEN") == "third-party-auth-token", f"fresh auth env: expected ANTHROPIC_AUTH_TOKEN preserved, got {auth_env.get('ANTHROPIC_AUTH_TOKEN')!r}", failures)
     expect(auth_env.get("ANTHROPIC_BASE_URL") == "https://api.example.test", f"fresh auth env: expected ANTHROPIC_BASE_URL preserved, got {auth_env.get('ANTHROPIC_BASE_URL')!r}", failures)
     for key in [
@@ -1424,12 +1428,13 @@ def test_live_socket_resume_self_heal_ignores_prompt_text_after_double_dash(fail
 def test_live_socket_preserves_claude_auth_for_resume_launch(failures: list[str]) -> None:
     expected_auth_env = {
         "CLAUDE_CONFIG_DIR": "/tmp/resume-claude-config",
+        "CLAUDE_SECURESTORAGE_CONFIG_DIR": "/tmp/resume-claude-securestorage",
         "ANTHROPIC_MODEL": "resume-model",
     }
     inherited = {
         **expected_auth_env,
         "CMUX_PRESERVE_CLAUDE_AUTH_SELECTION_ENV": "1",
-        "CMUX_PRESERVE_CLAUDE_AUTH_SELECTION_ENV_KEYS": "CLAUDE_CONFIG_DIR,ANTHROPIC_MODEL",
+        "CMUX_PRESERVE_CLAUDE_AUTH_SELECTION_ENV_KEYS": "CLAUDE_CONFIG_DIR,CLAUDE_SECURESTORAGE_CONFIG_DIR,ANTHROPIC_MODEL",
     }
     code, auth_env, real_argv, stderr = run_wrapper_auth_env(
         argv=["--resume", "claude-session-123"],
@@ -1439,6 +1444,25 @@ def test_live_socket_preserves_claude_auth_for_resume_launch(failures: list[str]
     for key, value in expected_auth_env.items():
         expect(auth_env.get(key) == value, f"resume auth env: expected {key}={value!r}, got {auth_env.get(key)!r}", failures)
     expect("--session-id" not in real_argv, f"resume auth env: expected no injected session id, got {real_argv}", failures)
+
+
+def test_live_socket_clears_marked_absent_claude_securestorage_for_resume_launch(failures: list[str]) -> None:
+    inherited = {
+        "CLAUDE_SECURESTORAGE_CONFIG_DIR": "/tmp/ambient-claude-securestorage",
+        "CMUX_CLEAR_CLAUDE_AUTH_SELECTION_ENV_KEYS": "UNSUPPORTED_KEY,CLAUDE_SECURESTORAGE_CONFIG_DIR",
+    }
+    code, auth_env, real_argv, stderr = run_wrapper_auth_env(
+        argv=["--resume", "claude-session-123"],
+        inherited_env=inherited,
+    )
+    expect(code == 0, f"clear absent securestorage auth env: wrapper exited {code}: {stderr}", failures)
+    expect(
+        auth_env.get("CLAUDE_SECURESTORAGE_CONFIG_DIR") == "__UNSET__",
+        "clear absent securestorage auth env: expected CLAUDE_SECURESTORAGE_CONFIG_DIR unset, "
+        f"got {auth_env.get('CLAUDE_SECURESTORAGE_CONFIG_DIR')!r}",
+        failures,
+    )
+    expect("--session-id" not in real_argv, f"clear absent securestorage auth env: expected no injected session id, got {real_argv}", failures)
 
 
 def test_live_socket_preserves_only_listed_claude_auth_keys(failures: list[str]) -> None:
@@ -1969,6 +1993,7 @@ def main() -> int:
     test_live_socket_resume_keeps_correct_claude_config_dir(failures)
     test_live_socket_resume_self_heal_ignores_prompt_text_after_double_dash(failures)
     test_live_socket_preserves_claude_auth_for_resume_launch(failures)
+    test_live_socket_clears_marked_absent_claude_securestorage_for_resume_launch(failures)
     test_live_socket_preserves_only_listed_claude_auth_keys(failures)
     test_live_socket_auto_preserves_vertex_auth_when_truthy(failures)
     test_live_socket_auto_preserves_bedrock_auth_when_truthy(failures)


### PR DESCRIPTION
Fixes #9412

## Summary
- Rebased on `origin/main`, which now contains PR #9419's minimal `CLAUDE_SECURESTORAGE_CONFIG_DIR` allowlist change.
- Add a regression-first test commit for Claude secure-storage restore behavior, including the non-Claude exclusion case and secret exclusion checks.
- Centralize Claude auth-selection keys in `AgentLaunchEnvironmentPolicy` so app restore, CLI resume binding, and session-list startup input mark the same replayed keys in `CMUX_PRESERVE_CLAUDE_AUTH_SELECTION_ENV_KEYS`.
- Add launch-capture metadata for the meaningful absent case: new Claude captures that did not have `CLAUDE_SECURESTORAGE_CONFIG_DIR` record `CMUX_CLEAR_CLAUDE_AUTH_SELECTION_ENV_KEYS=CLAUDE_SECURESTORAGE_CONFIG_DIR`, and restore/wrapper paths clear inherited ambient secure-storage only for that explicit marker.

## Claude auth-selection marker decision
`CLAUDE_SECURESTORAGE_CONFIG_DIR` belongs in the narrower Claude auth-selection marker list because it selects which Claude credential store is read, in the same account-selecting class as `CLAUDE_CONFIG_DIR`.

I did not add it to the wrapper's broad stale-auth scrub list for fresh launches. Fresh `cmux claude` or third-party Claude launches should be allowed to inherit an intentional secure-storage selector. The wrapper now clears it only when cmux captured an explicit absence marker for a restore. Existing records without the marker cannot distinguish “absent at launch” from “dropped by the old allowlist bug,” so this PR avoids inventing that state retroactively.

## Tests
- Red test commit: `edb1166406 Add Claude secure storage env regression tests`
- Green fix commit: `2725164917 Preserve Claude secure storage config dir`
- `swift test --package-path Packages/macOS/CMUXAgentLaunch --filter 'AgentLaunchEnvironmentPolicyTests|AgentRestoreLaunchTests/structuredClaude'`
- `swift test --package-path Packages/macOS/CMUXAgentLaunch`
- `python3 tests/test_claude_wrapper_hooks.py`
- `xcodebuild -project cmux.xcodeproj -scheme cmux-unit -configuration Debug -destination 'platform=macOS' -derivedDataPath /tmp/cmux-claude-securestorage test -only-testing:cmuxTests/CLINotifyProcessIntegrationRegressionTests/testClaudePromptSubmitResumeBindingPersistsSafeAuthSelectionValues -only-testing:cmuxTests/CLINotifyProcessIntegrationRegressionTests/testClaudePromptSubmitResumeBindingMarksAbsentSecureStorageConfigDirForClearing`
- `git diff --check origin/main...HEAD`
- `./scripts/reload.sh --tag claude-securestorage`

Tagged build: http://127.0.0.1:17320/claude-securestorage

Localization audit: no user-facing strings changed.
