### PR TITLE
Clear Dock notifications when focused

### DIFF
--- a/Packages/macOS/CmuxNotifications/Sources/CmuxNotifications/NotificationDismissalHosting.swift
+++ b/Packages/macOS/CmuxNotifications/Sources/CmuxNotifications/NotificationDismissalHosting.swift
@@ -20,8 +20,17 @@ public import Foundation
 public protocol NotificationDismissalHosting: AnyObject {
     // MARK: Selection / environment reads
 
-    /// The window's selected workspace id, if any.
-    var selectedWorkspaceId: UUID? { get }
+    /// Whether a notification namespace and optional surface identify the
+    /// host's currently selected interaction target.
+    ///
+    /// The host owns container resolution so the dismissal model can apply one
+    /// policy to workspace panels and panels hosted by other containers.
+    ///
+    /// - Parameters:
+    ///   - workspaceId: The notification namespace that owns the target.
+    ///   - surfaceId: The target surface, or `nil` for a namespace-wide action.
+    /// - Returns: `true` when the target is selected for interaction.
+    func isNotificationTargetSelected(workspaceId: UUID, surfaceId: UUID?) -> Bool
     /// Whether the app is active (legacy `AppFocusState.isAppActive()`).
     var isAppActive: Bool { get }
     /// Whether the notification store exists yet (legacy

--- a/Packages/macOS/CmuxNotifications/Sources/CmuxNotifications/NotificationDismissalModel.swift
+++ b/Packages/macOS/CmuxNotifications/Sources/CmuxNotifications/NotificationDismissalModel.swift
@@ -76,7 +76,6 @@ public final class NotificationDismissalModel: NotificationDismissing {
         panelId: UUID,
         context: NotificationDismissalContext
     ) {
-        guard host?.selectedWorkspaceId == workspaceId else { return }
         guard !suppressFocusFlash else { return }
         _ = dismissNotification(
             workspaceId: workspaceId,
@@ -102,7 +101,10 @@ public final class NotificationDismissalModel: NotificationDismissing {
         context: NotificationDismissalContext
     ) -> Bool {
         guard let host else { return false }
-        guard host.selectedWorkspaceId == workspaceId else { return false }
+        guard host.isNotificationTargetSelected(
+            workspaceId: workspaceId,
+            surfaceId: surfaceId
+        ) else { return false }
         if context.requiresActiveApp {
             guard host.isAppActive else { return false }
             // Opt-in (`notifications.suppressOnlyFocusedSurface`): narrow the

--- a/Packages/macOS/CmuxNotifications/Tests/CmuxNotificationsTests/NotificationDismissalModelTests.swift
+++ b/Packages/macOS/CmuxNotifications/Tests/CmuxNotificationsTests/NotificationDismissalModelTests.swift
@@ -37,6 +37,10 @@ private final class FakeHost: NotificationDismissalHosting {
         focusedPanelIds[workspaceId]
     }
 
+    func isNotificationTargetSelected(workspaceId: UUID, surfaceId: UUID?) -> Bool {
+        selectedWorkspaceId == workspaceId
+    }
+
     func focusedSurfaceId(in workspaceId: UUID) -> UUID? {
         focusedSurfaceIds[workspaceId]
     }

--- a/Sources/DockSplitStore+PaneFocus.swift
+++ b/Sources/DockSplitStore+PaneFocus.swift
@@ -51,11 +51,20 @@ extension DockSplitStore {
     }
 
     /// Applies the complete user-interaction focus transaction for a Dock panel.
-    /// Model selection and window-scoped shortcut intent move together so AppKit
-    /// focus cannot point at one panel while Dock selection points at another.
+    /// Model selection, window-scoped shortcut intent, and notification
+    /// dismissal move together so AppKit focus, Dock selection, and read state
+    /// converge on the same panel.
     func focusPanelFromDockInteraction(_ panelId: UUID, window: NSWindow?) {
         noteKeyboardFocusIntent(window: window)
         focusPanel(panelId)
+        guard let appDelegate = AppDelegate.shared,
+              let tabManager = appDelegate.dockReferenceTabManager(for: self) else {
+            return
+        }
+        _ = tabManager.dismissNotificationOnDirectInteraction(
+            tabId: workspaceId,
+            surfaceId: panelId
+        )
     }
 
     /// Resolves both workspace and per-window Docks through their shared live

--- a/Sources/DockSplitStore+ShortcutCommands.swift
+++ b/Sources/DockSplitStore+ShortcutCommands.swift
@@ -62,8 +62,9 @@ extension DockSplitStore {
 
     private func applyFocusedShortcutSelection() {
         guard let pane = bonsplitController.focusedPaneId,
-              let tab = bonsplitController.selectedTab(inPane: pane) else { return }
-        applyDockSelection(tabId: tab.id, inPane: pane)
+              let tab = bonsplitController.selectedTab(inPane: pane),
+              let panelId = surfaceIdToPanelId[tab.id] else { return }
+        focusPanelFromDockInteraction(panelId, window: nil)
     }
 
     private func selectDockSurface(number: Int) -> Bool {
@@ -79,7 +80,7 @@ extension DockSplitStore {
         }
         guard let tab else { return true }
         bonsplitController.selectTab(tab.id)
-        applyDockSelection(tabId: tab.id, inPane: pane)
+        applyFocusedShortcutSelection()
         return true
     }
 
@@ -136,7 +137,7 @@ extension DockSplitStore: FocusHistoryHosting {
 
     func focusPanel(workspaceId: UUID, panelId: UUID) {
         guard self.workspaceId == workspaceId else { return }
-        focusPanel(panelId)
+        focusPanelFromDockInteraction(panelId, window: nil)
     }
 
     func triggerFocusFlash(workspaceId: UUID, panelId: UUID) {
@@ -146,7 +147,7 @@ extension DockSplitStore: FocusHistoryHosting {
 
     func focusSelectedWorkspacePanel() {
         guard let focusedPanelId else { return }
-        focusPanel(focusedPanelId)
+        focusPanelFromDockInteraction(focusedPanelId, window: nil)
     }
 
     func focusHistoryRevisionDidChange() {}

--- a/Sources/TabManager+FocusHistoryHosting.swift
+++ b/Sources/TabManager+FocusHistoryHosting.swift
@@ -8,14 +8,17 @@ import Foundation
 /// `tabs.first(where:)` reads, so a gone workspace/panel makes every read
 /// `false`/`nil` and every mutation a no-op.
 ///
-/// `selectedWorkspaceId`, `workspaceExists(_:)`, and
-/// `panelExists(workspaceId:panelId:)` are already witnessed by the
-/// NotificationDismissalHosting/SidebarGitHosting conformances; one
-/// declaration satisfies all seams. `focusSelectedWorkspacePanel()` and
+/// `workspaceExists(_:)` and `panelExists(workspaceId:panelId:)` are already
+/// witnessed by the SidebarGitHosting conformance; one declaration satisfies
+/// both seams. `focusSelectedWorkspacePanel()` and
 /// `focusHistoryRevisionDidChange()` live in `TabManager.swift` because
 /// they touch `private` members (`focusSelectedTabPanel`,
 /// `focusHistoryRevision`).
 extension TabManager: FocusHistoryHosting {
+    var selectedWorkspaceId: UUID? {
+        selectedTabId
+    }
+
     func workspaceTitle(_ workspaceId: UUID) -> String? {
         tabs.first(where: { $0.id == workspaceId })?.title
     }

--- a/Sources/TabManager+NotificationDismissalHosting.swift
+++ b/Sources/TabManager+NotificationDismissalHosting.swift
@@ -9,8 +9,17 @@ import Foundation
 /// so a gone workspace/panel makes every read `false`/`nil` and every
 /// mutation a no-op.
 extension TabManager: NotificationDismissalHosting {
-    var selectedWorkspaceId: UUID? {
-        selectedTabId
+    func isNotificationTargetSelected(workspaceId: UUID, surfaceId: UUID?) -> Bool {
+        guard let surfaceId,
+              let dock = DockSplitStore.liveStore(containingPanel: surfaceId) else {
+            return selectedTabId == workspaceId
+        }
+        guard dock.workspaceId == workspaceId,
+              dock.focusedPanelId == surfaceId,
+              let appDelegate = AppDelegate.shared else {
+            return false
+        }
+        return appDelegate.dockReferenceTabManager(for: dock) === self
     }
 
     var isAppActive: Bool {
@@ -35,7 +44,14 @@ extension TabManager: NotificationDismissalHosting {
     // satisfies both seams.
 
     func focusedSurfaceId(in workspaceId: UUID) -> UUID? {
-        focusedSurfaceId(for: workspaceId)
+        if workspacesById[workspaceId] != nil {
+            return focusedSurfaceId(for: workspaceId)
+        }
+        guard let appDelegate = AppDelegate.shared else { return nil }
+        return DockSplitStore.liveStores.first(where: {
+            $0.workspaceId == workspaceId &&
+                appDelegate.dockReferenceTabManager(for: $0) === self
+        })?.focusedPanelId
     }
 
     // Cache the catalog section so reading the flag does not re-init every
@@ -50,6 +66,11 @@ extension TabManager: NotificationDismissalHosting {
     }
 
     func panelId(forSurfaceOrPanelId surfaceId: UUID, in workspaceId: UUID) -> UUID? {
+        if let dock = DockSplitStore.liveStore(containingPanel: surfaceId),
+           dock.workspaceId == workspaceId,
+           AppDelegate.shared?.dockReferenceTabManager(for: dock) === self {
+            return surfaceId
+        }
         guard let workspace = tabs.first(where: { $0.id == workspaceId }) else { return nil }
         return workspace.surfaceOwnershipTarget(for: surfaceId)?.containerPanelID
     }

--- a/cmuxTests/DockRuntimeParityTests.swift
+++ b/cmuxTests/DockRuntimeParityTests.swift
@@ -250,6 +250,66 @@ struct DockRuntimeParityTests {
         }
     }
 
+    @Test("Focusing a window Dock panel dismisses its unread notification")
+    func focusingWindowDockPanelDismissesUnreadNotification() async throws {
+        try await withAppContext { appDelegate, _, _, windowID in
+            let notificationStore = TerminalNotificationStore.shared
+            let previousNotificationStore = appDelegate.notificationStore
+            notificationStore.replaceNotificationsForTesting([])
+            appDelegate.notificationStore = notificationStore
+            defer {
+                notificationStore.replaceNotificationsForTesting([])
+                appDelegate.notificationStore = previousNotificationStore
+            }
+
+            let dock = appDelegate.windowDock(forWindowId: windowID)
+            let panel = DockRuntimeParityPanel(title: "Window Dock")
+            try dock.seedRuntimeParityPanel(panel)
+            let unreadProjection = DockUnreadPanelProjection(
+                source: notificationStore.sidebarUnread,
+                workspaceID: dock.workspaceId,
+                panelIDs: [panel.id],
+                isActive: true
+            )
+            notificationStore.replaceNotificationsForTesting([
+                TerminalNotification(
+                    id: UUID(),
+                    tabId: dock.workspaceId,
+                    surfaceId: panel.id,
+                    title: "Dock",
+                    subtitle: "",
+                    body: "Unread",
+                    createdAt: .now,
+                    isRead: false
+                ),
+            ])
+
+            #expect(notificationStore.hasUnreadNotification(
+                forTabId: dock.workspaceId,
+                surfaceId: panel.id
+            ))
+            #expect(unreadProjection.unreadPanelIDs == [panel.id])
+            #expect(TerminalNotificationStore.dockBadgeLabel(
+                unreadCount: notificationStore.unreadCount,
+                isEnabled: true
+            ) == "1")
+
+            dock.focusPanelFromDockInteraction(panel.id, window: nil)
+
+            #expect(!notificationStore.hasUnreadNotification(
+                forTabId: dock.workspaceId,
+                surfaceId: panel.id
+            ))
+            #expect(unreadProjection.unreadPanelIDs.isEmpty)
+            #expect(notificationStore.unreadCount == 0)
+            #expect(TerminalNotificationStore.dockBadgeLabel(
+                unreadCount: notificationStore.unreadCount,
+                isEnabled: true
+            ) == nil)
+            #expect(panel.flashReasons == [.notificationDismiss])
+        }
+    }
+
     @Test("Explicit socket flashes route as user initiated in both Dock scopes")
     func explicitSocketFlashesRouteAsUserInitiatedInBothDockScopes() async throws {
         try await withAppContext { appDelegate, _, workspace, windowID in


### PR DESCRIPTION
## Summary\n\n- route Dock pointer, keyboard, and focus-history interactions through the shared notification dismissal model\n- generalize the dismissal host's selection check from workspace-only selection to the active notification target\n- resolve Dock panel identity and focus through the owning window's TabManager\n- verify the in-app Dock unread projection and macOS Dock badge derivation clear together\n\n## Root cause\n\nDock notifications are stored under the Dock's notification namespace. For a window Dock, that namespace is the window ID. The shared dismissal model only accepted the selected workspace ID, so it rejected a focused Dock surface before reaching the existing mark-read and dismissal logic.\n\n## Testing\n\n- Added the behavior test DockRuntimeParityTests.focusingWindowDockPanelDismissesUnreadNotification.\n- The test-only commit failed on the unread notification, in-app Dock projection, unread count, badge label, and dismissal flash: https://github.com/manaflow-ai/cmux/actions/runs/30777554587\n- Focused green run on the fix commit: https://github.com/manaflow-ai/cmux/actions/runs/30778855026\n\nCloses #9415

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/9418"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788314600&installation_model_id=21920&pr_number=9418&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F9418&signature=f9bce79e2cc09db0eecef3ae2d5bf5db91f8b1d7173b981b1335bfc3d98e7e91"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Dock notifications now clear as soon as you focus a panel (click, keyboard, or focus history). This keeps the in-app Dock unread state and the macOS Dock badge in sync.

- **Bug Fixes**
  - Route Dock interactions through the shared dismissal model so focus marks notifications read.
  - Replace workspace-only checks with `isNotificationTargetSelected(workspaceId:surfaceId:)` to handle Dock surfaces.
  - Resolve Dock panel identity via the owning window’s `TabManager` and `DockSplitStore` so only the selected Dock clears.
  - Align shortcuts and focus history via `focusPanelFromDockInteraction`; restore focus-history host conformance by exposing `selectedWorkspaceId` in `TabManager`.

- **Refactors**
  - `NotificationDismissalHosting`: remove `selectedWorkspaceId`; add `isNotificationTargetSelected(workspaceId:surfaceId:)`.

<sup>Written for commit b0f3144214f8f5f6b8431dba8b49f6b703bda232. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/9418?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved notification dismissal when focusing panels through the Dock, shortcuts, or focus history.
  * Notifications now dismiss correctly for specific workspace and panel targets, including Dock-only workspaces.
  * Focused-panel notifications are dismissed without requiring the workspace to be selected.
  * Unread indicators and badge counts now update consistently after dismissal.

* **Tests**
  * Added coverage confirming that focusing a Dock panel dismisses notifications and updates related indicators.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->