### PR TITLE
Preserve CLAUDE_SECURESTORAGE_CONFIG_DIR across agent restore

### DIFF
--- a/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/AgentLaunchEnvironmentPolicy.swift
+++ b/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/AgentLaunchEnvironmentPolicy.swift
@@ -68,6 +68,9 @@ public struct AgentLaunchEnvironmentPolicy: Sendable {
         "CAMPFIRE_CODING_AGENT_SESSION_DIR",
         "CAMPFIRE_RELAY_URL",
         "CLAUDE_CONFIG_DIR",
+        // Selects the directory holding Claude Code's .credentials.json. A path, not a secret,
+        // so restoring it keeps a restored agent on the account it launched with.
+        "CLAUDE_SECURESTORAGE_CONFIG_DIR",
         "CMUX_CUSTOM_CLAUDE_PATH",
         "CMUX_ROVODEV_SESSIONS_DIR",
         "CODEX_HOME",

--- a/Packages/macOS/CMUXAgentLaunch/Tests/CMUXAgentLaunchTests/AgentLaunchEnvironmentPolicyTests.swift
+++ b/Packages/macOS/CMUXAgentLaunch/Tests/CMUXAgentLaunchTests/AgentLaunchEnvironmentPolicyTests.swift
@@ -88,32 +88,3 @@ struct AgentLaunchEnvironmentPolicyTests {
         #expect(selectedOmp["PI_PACKAGE_DIR"] == "/nix/store/pi-package")
     }
 }
-
-@Suite("ClaudeSecureStorageConfigDirectoryPolicy")
-struct ClaudeSecureStorageConfigDirectoryPolicyTests {
-    @Test("Preserves Claude secure storage config dir on capture")
-    func preservesClaudeSecureStorageConfigDirectory() {
-        let selected = AgentLaunchEnvironmentPolicy().selectedEnvironment(
-            from: [
-                "CLAUDE_CONFIG_DIR": "/tmp/claude-work",
-                "CLAUDE_SECURESTORAGE_CONFIG_DIR": "/tmp/claude-work-credentials",
-                "ANTHROPIC_AUTH_TOKEN": "secret-should-not-persist",
-            ],
-            kind: "claude"
-        )
-
-        #expect(selected["CLAUDE_SECURESTORAGE_CONFIG_DIR"] == "/tmp/claude-work-credentials")
-        #expect(selected["ANTHROPIC_AUTH_TOKEN"] == nil)
-    }
-
-    @Test("Passes Claude secure storage config dir through sanitizedValue unchanged")
-    func sanitizesClaudeSecureStorageConfigDirectory() {
-        let policy = AgentLaunchEnvironmentPolicy()
-        #expect(
-            policy.sanitizedValue(
-                key: "CLAUDE_SECURESTORAGE_CONFIG_DIR",
-                value: "/tmp/claude-work-credentials"
-            ) == "/tmp/claude-work-credentials"
-        )
-    }
-}

--- a/Packages/macOS/CMUXAgentLaunch/Tests/CMUXAgentLaunchTests/AgentLaunchEnvironmentPolicyTests.swift
+++ b/Packages/macOS/CMUXAgentLaunch/Tests/CMUXAgentLaunchTests/AgentLaunchEnvironmentPolicyTests.swift
@@ -88,3 +88,32 @@ struct AgentLaunchEnvironmentPolicyTests {
         #expect(selectedOmp["PI_PACKAGE_DIR"] == "/nix/store/pi-package")
     }
 }
+
+@Suite("ClaudeSecureStorageConfigDirectoryPolicy")
+struct ClaudeSecureStorageConfigDirectoryPolicyTests {
+    @Test("Preserves Claude secure storage config dir on capture")
+    func preservesClaudeSecureStorageConfigDirectory() {
+        let selected = AgentLaunchEnvironmentPolicy().selectedEnvironment(
+            from: [
+                "CLAUDE_CONFIG_DIR": "/tmp/claude-work",
+                "CLAUDE_SECURESTORAGE_CONFIG_DIR": "/tmp/claude-work-credentials",
+                "ANTHROPIC_AUTH_TOKEN": "secret-should-not-persist",
+            ],
+            kind: "claude"
+        )
+
+        #expect(selected["CLAUDE_SECURESTORAGE_CONFIG_DIR"] == "/tmp/claude-work-credentials")
+        #expect(selected["ANTHROPIC_AUTH_TOKEN"] == nil)
+    }
+
+    @Test("Passes Claude secure storage config dir through sanitizedValue unchanged")
+    func sanitizesClaudeSecureStorageConfigDirectory() {
+        let policy = AgentLaunchEnvironmentPolicy()
+        #expect(
+            policy.sanitizedValue(
+                key: "CLAUDE_SECURESTORAGE_CONFIG_DIR",
+                value: "/tmp/claude-work-credentials"
+            ) == "/tmp/claude-work-credentials"
+        )
+    }
+}

--- a/Packages/macOS/CMUXAgentLaunch/Tests/CMUXAgentLaunchTests/ClaudeSecureStorageConfigDirectoryPolicyTests.swift
+++ b/Packages/macOS/CMUXAgentLaunch/Tests/CMUXAgentLaunchTests/ClaudeSecureStorageConfigDirectoryPolicyTests.swift
@@ -1,0 +1,31 @@
+import CMUXAgentLaunch
+import Testing
+
+@Suite("ClaudeSecureStorageConfigDirectoryPolicy")
+struct ClaudeSecureStorageConfigDirectoryPolicyTests {
+    @Test("Preserves Claude secure storage config dir on capture")
+    func preservesClaudeSecureStorageConfigDirectory() {
+        let selected = AgentLaunchEnvironmentPolicy().selectedEnvironment(
+            from: [
+                "CLAUDE_CONFIG_DIR": "/tmp/claude-work",
+                "CLAUDE_SECURESTORAGE_CONFIG_DIR": "/tmp/claude-work-credentials",
+                "ANTHROPIC_AUTH_TOKEN": "secret-should-not-persist",
+            ],
+            kind: "claude"
+        )
+
+        #expect(selected["CLAUDE_SECURESTORAGE_CONFIG_DIR"] == "/tmp/claude-work-credentials")
+        #expect(selected["ANTHROPIC_AUTH_TOKEN"] == nil)
+    }
+
+    @Test("Passes Claude secure storage config dir through sanitizedValue unchanged")
+    func sanitizesClaudeSecureStorageConfigDirectory() {
+        let policy = AgentLaunchEnvironmentPolicy()
+        #expect(
+            policy.sanitizedValue(
+                key: "CLAUDE_SECURESTORAGE_CONFIG_DIR",
+                value: "/tmp/claude-work-credentials"
+            ) == "/tmp/claude-work-credentials"
+        )
+    }
+}


### PR DESCRIPTION
Fixes #9412

Restored Claude agents fell back to the ambient account because `CLAUDE_SECURESTORAGE_CONFIG_DIR`, the variable that selects which directory holds `.credentials.json`, was not in `safeEnvironmentKeys`. `sanitizedValue` drops any key missing from that set, so the value was discarded at capture time and the replayed environment carried nothing. `CODEX_HOME` is allowlisted, which is why Codex sessions restored correctly and Claude ones did not.

## Mechanism

Added `"CLAUDE_SECURESTORAGE_CONFIG_DIR"` to `safeEnvironmentKeys` in `Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/AgentLaunchEnvironmentPolicy.swift`, beside `CLAUDE_CONFIG_DIR`. It falls through `sanitizedValue`'s `default` branch unmodified, which is right: it is a directory path, not a secret, and cmux has no reason to rewrite it. Principled fix, one line at the actual gate. Residual risk is that the variable is undocumented by Anthropic and could change name; an allowlist entry for an unset variable is inert, so the cost is bounded.

Deliberately not adding it to `claudeAuthKeys` in `CLI/cmux.swift`. That list exists to tell `Resources/bin/cmux-claude-wrapper` not to scrub keys it would otherwise strip, and the wrapper's `CLAUDE_AUTH_SELECTION_ENV_KEYS` never touches `CLAUDE_SECURESTORAGE_CONFIG_DIR`, so an entry there would be inert. This confirms the open question in the issue.

## Symphony verification

Regression test: `ClaudeSecureStorageConfigDirectoryPolicyTests` in `Packages/macOS/CMUXAgentLaunch/Tests/CMUXAgentLaunchTests/AgentLaunchEnvironmentPolicyTests.swift` (two cases: capture via `selectedEnvironment(from:kind:)` keeps the path while `ANTHROPIC_AUTH_TOKEN` is still dropped, and `sanitizedValue` returns it unchanged).

Two commits so CI shows red then green:
- commit 1, test only. `cd Packages/macOS/CMUXAgentLaunch && swift test --filter ClaudeSecureStorageConfigDirectoryPolicyTests` -> `Test run with 2 tests in 1 suite failed`, both expectations returning `nil`.
- commit 2, fix. `cd Packages/macOS/CMUXAgentLaunch && swift test` -> `Test run with 281 tests in 40 suites passed`.

Package-only change with no Swift app or UI surface, so no tagged reload or e2e workflow run.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/9419"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788314609&installation_model_id=21920&pr_number=9419&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F9419&signature=b19f96dc3f23bbece7f9101666d0ab535ee9b23e28bf7b8dd760257ea8c34835"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves Claude agent account on restore by keeping `CLAUDE_SECURESTORAGE_CONFIG_DIR` in the captured and replayed environment.

- **Bug Fixes**
  - Allowlist `CLAUDE_SECURESTORAGE_CONFIG_DIR` in `AgentLaunchEnvironmentPolicy` so restored agents don’t switch to the default account.
  - Add dedicated `ClaudeSecureStorageConfigDirectoryPolicyTests` verifying the path is preserved and `ANTHROPIC_AUTH_TOKEN` is still dropped.

<sup>Written for commit b024fefbb9561c540d6165d0c871d501161ff61b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/9419?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved Claude Code’s secure storage configuration directory when restoring agent sessions.
  * Continued excluding sensitive authentication tokens from captured environment data.

* **Tests**
  * Added coverage verifying directory preservation, value handling, and authentication token protection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->