### PR TITLE
Fix noclobber 'cannot overwrite existing file' error from bash shell integration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1062,6 +1062,7 @@ jobs:
           python3 tests/test_issue_2448_shell_claude_wrapper_dispatch.py
           python3 tests/test_issue_8093_ghostty_ssh_binary_path.py
           python3 tests/test_issue_6714_zsh_shim_noclobber.py
+          python3 tests/test_issue_9356_bash_shim_noclobber.py
           python3 tests/test_issue_8953_zsh_prompt_wrap_guard.py
           python3 tests/test_shell_git_branch_stale_cwd.py
           python3 tests/test_shell_git_config_remote_url_parsing.py

--- a/Resources/shell-integration/cmux-bash-integration.bash
+++ b/Resources/shell-integration/cmux-bash-integration.bash
@@ -76,7 +76,7 @@ _cmux_start_tracked_bg() {
     local __pid=""
     (
         "$@" >/dev/null 2>&1 &
-        printf '%s\n' "$!" > "$__pid_file"
+        printf '%s\n' "$!" >| "$__pid_file"
     )
     if [[ -r "$__pid_file" ]]; then
         IFS= read -r __pid < "$__pid_file" || __pid=""
@@ -361,7 +361,12 @@ _cmux_install_cli_command_shim() {
         else
             printf 'exec "%s" "$@"\n' "$escaped_wrapper"
         fi
-    } >"$shim_path" 2>/dev/null || return 0
+    # `>|` forces the truncate so cmux can always refresh its own generated
+    # shim, even when the user's interactive bash has `noclobber` set. A plain
+    # `>` is refused under noclobber and prints `cannot overwrite existing file`
+    # on every prompt (the redirect failure is reported by the shell, so the
+    # `2>/dev/null` on the compound command does not suppress it).
+    } >|"$shim_path" 2>/dev/null || return 0
     /bin/chmod 0700 "$shim_path" >/dev/null 2>&1 || return 0
 
     if [[ "$command_name" == "claude" ]]; then
@@ -790,7 +795,7 @@ _cmux_store_pr_command_hint() {
     target="${target//$'\n'/ }"
     target="${target//$'\r'/ }"
     target="${target//$'\t'/ }"
-    printf '%s\t%s\n' "$_CMUX_LAST_PR_ACTION" "$target" > "$_CMUX_PR_ACTION_HINT_FILE" 2>/dev/null || true
+    printf '%s\t%s\n' "$_CMUX_LAST_PR_ACTION" "$target" >| "$_CMUX_PR_ACTION_HINT_FILE" 2>/dev/null || true
 }
 
 _cmux_load_pr_command_hint() {
@@ -1284,7 +1289,7 @@ _cmux_report_pr_for_path() {
                 "${gh_repo_args[@]}" \
                 --json number,state,url \
                 --jq '[.number, .state, .url] | @tsv' \
-                2>"$err_file"
+                2>|"$err_file"
     )"
     gh_status=$?
     if [[ -f "$err_file" ]]; then
@@ -1565,7 +1570,7 @@ _cmux_bash_history_command() {
     local HISTTIMEFORMAT=
     local history_file="${TMPDIR:-/tmp}/cmux-history-$$-${RANDOM:-0}"
     local line="" history_number="" last_number=""
-    builtin history 1 > "$history_file" 2>/dev/null || {
+    builtin history 1 >| "$history_file" 2>/dev/null || {
         /bin/rm -f -- "$history_file" >/dev/null 2>&1 || true
         return 1
     }
@@ -1578,7 +1583,7 @@ _cmux_bash_history_command() {
         fi
         [[ "$history_number" == "$last_number" ]] && return 1
         if [[ -n "${_CMUX_BASH_HISTORY_LAST_FILE:-}" ]]; then
-            printf '%s\n' "$history_number" > "$_CMUX_BASH_HISTORY_LAST_FILE" 2>/dev/null || true
+            printf '%s\n' "$history_number" >| "$_CMUX_BASH_HISTORY_LAST_FILE" 2>/dev/null || true
         fi
         printf '%s\n' "${BASH_REMATCH[2]}"
         return 0

--- a/Resources/shell-integration/cmux-zsh-integration.zsh
+++ b/Resources/shell-integration/cmux-zsh-integration.zsh
@@ -1371,7 +1371,7 @@ _cmux_report_pr_for_path() {
                 "${gh_repo_args[@]}" \
                 --json number,state,url \
                 --jq '[.number, .state, .url] | @tsv' \
-                2>"$err_file"
+                2>|"$err_file"
     )"
     gh_status=$?
     if [[ -f "$err_file" ]]; then

--- a/tests/test_issue_9356_bash_shim_noclobber.py
+++ b/tests/test_issue_9356_bash_shim_noclobber.py
@@ -1,0 +1,135 @@
+#!/usr/bin/env python3
+"""
+Regression coverage for https://github.com/manaflow-ai/cmux/issues/9356.
+
+Same bug as #6714, but in the bash integration: with ``set -o noclobber`` in the
+user's interactive bash, every prompt prints
+
+    bash: /var/folders/.../T/cmux-cli-shims/<surface-id>/claude: cannot overwrite existing file
+
+``Resources/shell-integration/cmux-bash-integration.bash`` writes its per-surface
+CLI shim with a plain ``>`` redirection::
+
+    } >"$shim_path" 2>/dev/null || return 0
+
+``_cmux_install_cli_command_shim`` runs more than once per shell (source time,
+then again from the prompt hook), so the second and later writes target an
+existing file. Under ``noclobber`` bash refuses the redirect and reports it; the
+``2>/dev/null`` does not suppress the message because the shell's redirection
+machinery reports the failure on the compound-command redirect itself. The
+``|| return 0`` then skips the write, so the shim is also left stale.
+
+Fix: bash's explicit clobber redirection ``>|`` for this cmux-owned generated
+file, matching the zsh integration.
+
+This test drives the real integration file through real bash with ``noclobber``
+enabled and asserts that a second shim write is silent **and** actually
+refreshes the shim contents. Deterministic (no PTY, no sleeps, no network) and
+locale-pinned so assertions do not depend on bash's message wording.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import tempfile
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+INTEGRATION = REPO_ROOT / "Resources/shell-integration/cmux-bash-integration.bash"
+
+# Two explicit shim writes under noclobber, with two different wrapper paths so
+# we can prove the second write refreshed the file rather than silently
+# no-op'ing. Sourcing without CMUX_SHELL_INTEGRATION_DIR keeps the top-level
+# wrapper install an early-return, and the prompt hooks never fire under
+# `bash -c`, so these are the only writes.
+DRIVER = r"""
+set -o noclobber
+source "$CMUX_BASH_INTEGRATION" 2>/dev/null
+export TMPDIR="$CMUX_TEST_TMPDIR"
+export CMUX_SURFACE_ID="$CMUX_TEST_SURFACE_ID"
+_cmux_install_cli_command_shim claude "$CMUX_TEST_WRAPPER_A"
+_cmux_install_cli_command_shim claude "$CMUX_TEST_WRAPPER_B"
+"""
+
+
+def _run_driver(tmp: Path) -> subprocess.CompletedProcess[str]:
+    wrapper_a = tmp / "wrapper-a"
+    wrapper_b = tmp / "wrapper-b"
+    wrapper_a.write_text("#!/usr/bin/env bash\nexit 0\n", encoding="utf-8")
+    wrapper_b.write_text("#!/usr/bin/env bash\nexit 0\n", encoding="utf-8")
+    wrapper_a.chmod(0o755)
+    wrapper_b.chmod(0o755)
+
+    env = {key: value for key, value in os.environ.items() if not key.startswith("CMUX")}
+    env.update(
+        {
+            "LC_ALL": "C",
+            "LANG": "C",
+            "CMUX_BASH_INTEGRATION": str(INTEGRATION),
+            "CMUX_TEST_TMPDIR": str(tmp),
+            "CMUX_TEST_SURFACE_ID": "issue-9356-shim",
+            "CMUX_TEST_WRAPPER_A": str(wrapper_a),
+            "CMUX_TEST_WRAPPER_B": str(wrapper_b),
+            "CMUX_SOCKET_PATH": "",
+            "CMUX_LOAD_GHOSTTY_BASH_INTEGRATION": "0",
+            "GHOSTTY_RESOURCES_DIR": "",
+        }
+    )
+
+    return subprocess.run(
+        ["bash", "--norc", "--noprofile", "-c", DRIVER],
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=False,
+    )
+
+
+def test_bash_shim_refresh_is_silent_and_refreshes_under_noclobber() -> None:
+    assert INTEGRATION.exists(), f"missing integration file: {INTEGRATION}"
+
+    with tempfile.TemporaryDirectory(prefix="cmux-9356-") as td:
+        tmp = Path(td)
+        proc = _run_driver(tmp)
+        debug = (
+            f"\nexit={proc.returncode}"
+            f"\n--- driver stdout ---\n{proc.stdout}"
+            f"\n--- driver stderr ---\n{proc.stderr}"
+        )
+
+        assert "cannot overwrite existing file" not in proc.stderr.lower(), (
+            "cmux printed a noclobber 'cannot overwrite existing file' error while "
+            "refreshing its own generated shim" + debug
+        )
+        # Locale-independent guard: the failing redirect names the shim path.
+        assert "cmux-cli-shims" not in proc.stderr, (
+            "the shim writer reported an error to stderr while refreshing the shim"
+            + debug
+        )
+
+        shim_path = tmp / "cmux-cli-shims" / "issue-9356-shim" / "claude"
+        assert shim_path.exists(), f"shim was not created at {shim_path}" + debug
+        assert os.access(shim_path, os.X_OK), (
+            f"shim is not executable: {shim_path}" + debug
+        )
+
+        contents = shim_path.read_text(encoding="utf-8")
+        wrapper_b = str(tmp / "wrapper-b")
+        wrapper_a = str(tmp / "wrapper-a")
+        assert f'cmux_wrapper="{wrapper_b}"' in contents, (
+            "cmux did not refresh its generated shim on the second write under "
+            f"noclobber (expected wrapper {wrapper_b!r}).\n--- shim ---\n{contents}"
+            + debug
+        )
+        assert f'cmux_wrapper="{wrapper_a}"' not in contents, (
+            "stale wrapper path from the first write survived the refresh.\n"
+            f"--- shim ---\n{contents}" + debug
+        )
+
+
+if __name__ == "__main__":
+    test_bash_shim_refresh_is_silent_and_refreshes_under_noclobber()
+    print("PASS: cmux refreshes its bash CLI shim silently under noclobber")


### PR DESCRIPTION
With `set -o noclobber` in an interactive bash, cmux printed

```
bash: .../T/cmux-cli-shims/<surface-id>/claude: cannot overwrite existing file
```

on every prompt.

## Mechanism

`_cmux_install_cli_command_shim` in `Resources/shell-integration/cmux-bash-integration.bash` wrote the per-surface CLI shim with a plain `} >"$shim_path" 2>/dev/null || return 0`. The function runs more than once per shell (source time, then again from the prompt hook), so every write after the first targets an existing file. Under `noclobber` bash refuses the redirect and reports it itself, before the compound command's `2>/dev/null` applies, so the message leaks to the terminal. The `|| return 0` then skips the write entirely, leaving the shim stale at the first wrapper path.

The fix is bash's explicit clobber operator `>|`, which truncates regardless of the user's global `noclobber` setting. This is the same operator the zsh integration already uses after the identical fix for #6714, and the same operator the rest of both integrations already use for their generated marker/cache files.

Same-class sites fixed in one pass: the bash bg-pid file, gh stderr capture, history temp file, and history-last marker, plus the zsh gh stderr capture. Fish has no `noclobber` option, so `fish/config.fish` is unaffected.

Fixes #9356

## Symphony verification

Regression test: `tests/test_issue_9356_bash_shim_noclobber.py::test_bash_shim_refresh_is_silent_and_refreshes_under_noclobber`. It sources the real integration file in `bash --norc --noprofile` with `set -o noclobber`, calls the shim writer twice with two different wrapper paths, and asserts stderr is clean and the shim content was actually refreshed to the second wrapper (catching both the visible error and the silent staleness).

Red then green is visible in the Commits tab: commit 1 is the test only, commit 2 is the fix.

```
$ python3 tests/test_issue_9356_bash_shim_noclobber.py    # at commit 1 (test only)
AssertionError: cmux printed a noclobber 'cannot overwrite existing file' error
  while refreshing its own generated shim
--- driver stderr ---
cmux-bash-integration.bash: line 303: /var/folders/.../T/cmux-9356-70ppyg26/cmux-cli-shims/issue-9356-shim/claude: cannot overwrite existing file

$ python3 tests/test_issue_9356_bash_shim_noclobber.py    # at commit 2 (fix)
PASS: cmux refreshes its bash CLI shim silently under noclobber
```

Also run locally on the fix commit: `bash -n cmux-bash-integration.bash`, `zsh -n cmux-zsh-integration.zsh`, and the neighboring shell-integration tests `test_issue_6714_zsh_shim_noclobber.py`, `test_issue_2448_shell_claude_wrapper_dispatch.py`, `test_shell_git_branch_stale_cwd.py`, `test_shell_git_config_remote_url_parsing.py`, all pass. `test_issue_8953_zsh_prompt_wrap_guard.py` fails identically on the unmodified base, so it is pre-existing and unrelated.

The new test is wired into `.github/workflows/ci.yml` next to the #6714 test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/9420"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788314686&installation_model_id=21920&pr_number=9420&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F9420&signature=5db388aa1654477ff3563112a47fe11b19d39d2e4cee9b4380414de0aa80850d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the bash shell integration error under `set -o noclobber` that printed “cannot overwrite existing file” and left the CLI shim stale by force-clobbering cmux-generated files with `>|`. Also applies the same fix to a zsh stderr capture and adds a regression test to CI, fixing #9356.

- **Bug Fixes**
  - Bash: write the per-surface CLI shim with `>|` so refreshes are silent and correct under `noclobber`.
  - Bash: use `>|` for bg PID file, `gh` stderr capture, history temp, and history-last marker; zsh: `gh` stderr capture.
  - CI: add `test_issue_9356_bash_shim_noclobber.py` to verify no stderr noise and that the shim updates to the latest wrapper.

<sup>Written for commit f8dd3b28368fd1a4145bfd6fa1367f5f22f71bbc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/9420?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed shell integration file updates when Bash or Zsh `noclobber` mode is enabled.
  - Ensured refreshed command-line shims overwrite stale content correctly and continue to run silently.

- **Tests**
  - Added regression coverage for Bash shim refreshes under `noclobber`.
  - Included the regression test in the macOS CI suite.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->