### PR TITLE
Reject stale kind:N handle refs instead of closing the focused surface

### DIFF
--- a/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Coordinator/ControlCommandContext.swift
+++ b/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Coordinator/ControlCommandContext.swift
@@ -55,4 +55,17 @@ public protocol ControlCommandContext:
     nonisolated func controlResolveOnMain<T: Sendable>(
         _ body: @MainActor (any ControlCommandContext) -> T
     ) -> T
+
+    /// Runs a short closure synchronously on the main actor WITHOUT the
+    /// known-ref refresh — the hop the dispatch preflight takes to read the
+    /// handle registry (issue #9410).
+    ///
+    /// The preflight only resolves refs the caller already holds, and a ref
+    /// can only have reached a caller by being minted, so the refresh would
+    /// add a full window/workspace/pane/surface sweep to every ref-carrying
+    /// worker-lane request without changing the answer. Command bodies keep
+    /// using ``controlResolveOnMain``, whose refresh their ref minting needs.
+    nonisolated func controlMainSyncWithoutRefreshingRefs<T: Sendable>(
+        _ body: @MainActor (any ControlCommandContext) -> T
+    ) -> T
 }

--- a/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Coordinator/ControlCommandCoordinator+HandleRefPreflight.swift
+++ b/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Coordinator/ControlCommandCoordinator+HandleRefPreflight.swift
@@ -126,12 +126,13 @@ extension ControlCommandCoordinator {
     /// takes the same `controlResolveOnMain` hop (and known-ref refresh) the
     /// worker-lane bodies use — only when a target actually needs it.
     ///
-    /// A ref-carrying worker request therefore costs one hop more than the
-    /// body's documented single hop. That is deliberate: the alternative is
-    /// threading validation through every worker-lane body's own hop, and the
-    /// typing-latency paths (`surface.send_text` / `send_key` from shell
-    /// integration and hooks) carry UUID targets, which skip the hop
-    /// entirely.
+    /// A ref-carrying worker request therefore costs one extra main hop, but
+    /// not an extra topology sweep: it uses the refresh-free
+    /// `controlMainSyncWithoutRefreshingRefs` seam, since a ref the caller
+    /// holds was necessarily minted before. A UUID target skips the hop
+    /// altogether, so the typing-latency paths (`surface.send_text` /
+    /// `send_key` from shell integration and hooks, which carry UUIDs) are
+    /// untouched.
     ///
     /// - Parameters:
     ///   - request: The decoded request envelope.
@@ -143,7 +144,7 @@ extension ControlCommandCoordinator {
     ) -> ControlCallResult? {
         if let malformed = malformedTargetError(request) { return malformed }
         guard targetsNeedHandleRegistry(request), let context else { return nil }
-        return context.controlResolveOnMain { _ in
+        return context.controlMainSyncWithoutRefreshingRefs { _ in
             self.unresolvedTargetError(request)
         }
     }

--- a/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Coordinator/ControlCommandCoordinator+HandleRefPreflight.swift
+++ b/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Coordinator/ControlCommandCoordinator+HandleRefPreflight.swift
@@ -1,0 +1,67 @@
+internal import Foundation
+
+/// Dispatch preflight that rejects stale `kind:N` handle refs (issue #9410).
+///
+/// Every routing/target param (`window_id`, `workspace_id`, `surface_id`, …)
+/// accepts either a UUID or a `kind:N` ref minted by ``ControlHandleRegistry``.
+/// A ref that the registry does not know used to resolve to `nil`, which is
+/// indistinguishable from "the caller passed no target": commands then fell
+/// back to the focused/selected object. For a destructive op such as
+/// `surface.close` or `surface.respawn` that turned a stale or typo'd ref into
+/// a roulette close of whatever happened to be selected.
+///
+/// An explicit target that cannot be found means the caller's model of the
+/// world is wrong, which is exactly when acting on some other object is most
+/// dangerous, so the request fails with `not_found` and no side effect.
+///
+/// The preflight runs after the dispatch preamble's known-ref refresh, so the
+/// registry already holds a ref for every live window, workspace, pane, and
+/// surface: an unresolvable ref is definitively stale. It only inspects
+/// strings shaped like a ref (`<known kind>:<digits>`, plus the `tab:N` alias
+/// for `surface:N`); UUID targets keep their existing per-command not-found
+/// handling, and non-ref strings are left to their command.
+extension ControlCommandCoordinator {
+    /// The id params that select an object to act on, with the noun used in
+    /// the error message.
+    private static let handleRefParamNouns: [(key: String, noun: String)] = [
+        ("window_id", "Window"),
+        ("group_id", "Workspace group"),
+        ("workspace_id", "Workspace"),
+        ("surface_id", "Surface"),
+        ("terminal_id", "Surface"),
+        ("tab_id", "Surface"),
+        ("pane_id", "Pane"),
+    ]
+
+    /// Whether a string is shaped like a handle ref this registry mints.
+    private static func isHandleRefShaped(_ raw: String) -> Bool {
+        let lowered = raw.lowercased()
+        guard let separator = lowered.lastIndex(of: ":") else { return false }
+        let kind = String(lowered[lowered.startIndex..<separator])
+        let ordinal = lowered[lowered.index(after: separator)...]
+        guard !ordinal.isEmpty, ordinal.allSatisfy({ $0.isNumber }) else { return false }
+        if kind == "tab" { return true }
+        return ControlHandleKind(rawValue: kind) != nil
+    }
+
+    /// Returns a `not_found` error when a request names a target through a
+    /// handle ref that no longer exists, or `nil` when every ref-shaped target
+    /// resolves.
+    ///
+    /// - Parameter params: The decoded request params.
+    /// - Returns: The error result to return instead of running the command.
+    func staleHandleRefError(_ params: [String: JSONValue]) -> ControlCallResult? {
+        for (key, noun) in Self.handleRefParamNouns {
+            guard let raw = string(params, key) else { continue }
+            guard UUID(uuidString: raw) == nil else { continue }
+            guard Self.isHandleRefShaped(raw) else { continue }
+            guard handles.uuid(forRef: raw) == nil else { continue }
+            return .err(
+                code: "not_found",
+                message: "\(noun) not found",
+                data: .object([key: .string(raw)])
+            )
+        }
+        return nil
+    }
+}

--- a/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Coordinator/ControlCommandCoordinator+HandleRefPreflight.swift
+++ b/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Coordinator/ControlCommandCoordinator+HandleRefPreflight.swift
@@ -10,6 +10,18 @@ private let handleTargetParamNouns: [(key: String, noun: String)] = [
     ("terminal_id", "Surface"),
     ("tab_id", "Surface"),
     ("pane_id", "Pane"),
+    ("target_surface_id", "Surface"),
+    ("target_pane_id", "Pane"),
+    // Relative selectors: a stale one here is silently dropped and the
+    // mutation (reorder, move) still runs, at a position the caller did not
+    // ask for.
+    ("before_surface_id", "Surface"),
+    ("after_surface_id", "Surface"),
+    ("before_workspace_id", "Workspace"),
+    ("after_workspace_id", "Workspace"),
+    ("reference_workspace_id", "Workspace"),
+    ("before_group_id", "Workspace group"),
+    ("after_group_id", "Workspace group"),
 ]
 
 /// Whether a method resolves its own target instead of going through the
@@ -113,6 +125,13 @@ extension ControlCommandCoordinator {
     /// checks run on the calling socket-worker thread, and the registry lookup
     /// takes the same `controlResolveOnMain` hop (and known-ref refresh) the
     /// worker-lane bodies use — only when a target actually needs it.
+    ///
+    /// A ref-carrying worker request therefore costs one hop more than the
+    /// body's documented single hop. That is deliberate: the alternative is
+    /// threading validation through every worker-lane body's own hop, and the
+    /// typing-latency paths (`surface.send_text` / `send_key` from shell
+    /// integration and hooks) carry UUID targets, which skip the hop
+    /// entirely.
     ///
     /// - Parameters:
     ///   - request: The decoded request envelope.

--- a/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Coordinator/ControlCommandCoordinator+HandleRefPreflight.swift
+++ b/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Coordinator/ControlCommandCoordinator+HandleRefPreflight.swift
@@ -1,10 +1,39 @@
 internal import Foundation
 
-/// Dispatch preflight that rejects stale `kind:N` handle refs (issue #9410).
+/// The id params that select an object to act on, with the noun used in the
+/// error message.
+private let handleTargetParamNouns: [(key: String, noun: String)] = [
+    ("window_id", "Window"),
+    ("group_id", "Workspace group"),
+    ("workspace_id", "Workspace"),
+    ("surface_id", "Surface"),
+    ("terminal_id", "Surface"),
+    ("tab_id", "Surface"),
+    ("pane_id", "Pane"),
+]
+
+/// Whether a method resolves its own target instead of going through the
+/// handle registry, so the preflight must leave its params alone.
+///
+/// `debug.*` verbs take the legacy v1 `<id|idx>` argument form
+/// (`debug.terminal.read_text 0`) and hand the raw string to the app-side v1
+/// resolver. The mobile-host verbs (`mobile.*` / `terminal.*` /
+/// `chat.sessions.dump`) are pass-throughs whose seam runs the legacy body
+/// app-side; none of them mint or read `kind:N` refs.
+private func resolvesTargetOutsideTheHandleRegistry(method: String) -> Bool {
+    method.hasPrefix("debug.")
+        || method.hasPrefix("mobile.")
+        || method.hasPrefix("terminal.")
+        || method.hasPrefix("chat.")
+}
+
+/// Dispatch preflight that rejects explicit targets that resolve to nothing
+/// (issue #9410).
 ///
 /// Every routing/target param (`window_id`, `workspace_id`, `surface_id`, …)
 /// accepts either a UUID or a `kind:N` ref minted by ``ControlHandleRegistry``.
-/// A ref that the registry does not know used to resolve to `nil`, which is
+/// Anything else — a stale ref, a mistyped kind (`surafce:12`), a malformed
+/// ordinal (`surface:not-a-number`) — used to parse to `nil`, which is
 /// indistinguishable from "the caller passed no target": commands then fell
 /// back to the focused/selected object. For a destructive op such as
 /// `surface.close` or `surface.respawn` that turned a stale or typo'd ref into
@@ -12,49 +41,25 @@ internal import Foundation
 ///
 /// An explicit target that cannot be found means the caller's model of the
 /// world is wrong, which is exactly when acting on some other object is most
-/// dangerous, so the request fails with `not_found` and no side effect.
+/// dangerous, so the request fails closed with `not_found` and no side effect.
 ///
 /// The preflight runs after the dispatch preamble's known-ref refresh, so the
 /// registry already holds a ref for every live window, workspace, pane, and
-/// surface: an unresolvable ref is definitively stale. It only inspects
-/// strings shaped like a ref (`<known kind>:<digits>`, plus the `tab:N` alias
-/// for `surface:N`); UUID targets keep their existing per-command not-found
-/// handling, and non-ref strings are left to their command.
+/// surface: a ref it cannot resolve is definitively stale. A UUID target is
+/// accepted here and keeps its existing per-command not-found handling, which
+/// reports the id the caller passed.
 extension ControlCommandCoordinator {
-    /// The id params that select an object to act on, with the noun used in
-    /// the error message.
-    private static let handleRefParamNouns: [(key: String, noun: String)] = [
-        ("window_id", "Window"),
-        ("group_id", "Workspace group"),
-        ("workspace_id", "Workspace"),
-        ("surface_id", "Surface"),
-        ("terminal_id", "Surface"),
-        ("tab_id", "Surface"),
-        ("pane_id", "Pane"),
-    ]
-
-    /// Whether a string is shaped like a handle ref this registry mints.
-    private static func isHandleRefShaped(_ raw: String) -> Bool {
-        let lowered = raw.lowercased()
-        guard let separator = lowered.lastIndex(of: ":") else { return false }
-        let kind = String(lowered[lowered.startIndex..<separator])
-        let ordinal = lowered[lowered.index(after: separator)...]
-        guard !ordinal.isEmpty, ordinal.allSatisfy({ $0.isNumber }) else { return false }
-        if kind == "tab" { return true }
-        return ControlHandleKind(rawValue: kind) != nil
-    }
-
-    /// Returns a `not_found` error when a request names a target through a
-    /// handle ref that no longer exists, or `nil` when every ref-shaped target
+    /// Returns a `not_found` error when a request names a target this
+    /// coordinator cannot resolve, or `nil` when every explicit target
     /// resolves.
     ///
-    /// - Parameter params: The decoded request params.
+    /// - Parameter request: The decoded request envelope.
     /// - Returns: The error result to return instead of running the command.
-    func staleHandleRefError(_ params: [String: JSONValue]) -> ControlCallResult? {
-        for (key, noun) in Self.handleRefParamNouns {
-            guard let raw = string(params, key) else { continue }
+    func unresolvedTargetError(_ request: ControlRequest) -> ControlCallResult? {
+        if resolvesTargetOutsideTheHandleRegistry(method: request.method) { return nil }
+        for (key, noun) in handleTargetParamNouns {
+            guard let raw = string(request.params, key) else { continue }
             guard UUID(uuidString: raw) == nil else { continue }
-            guard Self.isHandleRefShaped(raw) else { continue }
             guard handles.uuid(forRef: raw) == nil else { continue }
             return .err(
                 code: "not_found",

--- a/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Coordinator/ControlCommandCoordinator+HandleRefPreflight.swift
+++ b/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Coordinator/ControlCommandCoordinator+HandleRefPreflight.swift
@@ -49,13 +49,52 @@ private func resolvesTargetOutsideTheHandleRegistry(method: String) -> Bool {
 /// accepted here and keeps its existing per-command not-found handling, which
 /// reports the id the caller passed.
 extension ControlCommandCoordinator {
-    /// Returns a `not_found` error when a request names a target this
-    /// coordinator cannot resolve, or `nil` when every explicit target
-    /// resolves.
+    /// Returns an error when a request names a target that is not a usable
+    /// identifier at all: present and non-null, but not a non-empty string.
+    /// A number, an object, or `"   "` would otherwise read as "no target"
+    /// and hand the command its focused-object fallback.
+    ///
+    /// `nonisolated` and registry-free, so both dispatch lanes can run it
+    /// without a main-actor hop.
+    ///
+    /// - Parameter request: The decoded request envelope.
+    /// - Returns: The error result to return instead of running the command.
+    nonisolated func malformedTargetError(_ request: ControlRequest) -> ControlCallResult? {
+        if resolvesTargetOutsideTheHandleRegistry(method: request.method) { return nil }
+        for (key, noun) in handleTargetParamNouns {
+            guard hasNonNull(request.params, key) else { continue }
+            guard string(request.params, key) == nil else { continue }
+            return .err(
+                code: "invalid_params",
+                message: "\(noun) target \(key) must be a non-empty id or handle ref",
+                data: nil
+            )
+        }
+        return nil
+    }
+
+    /// Whether any explicit target needs the handle registry to resolve, i.e.
+    /// is a string that is not already a UUID. Lets the worker lane skip its
+    /// main-actor preflight hop for the common all-UUID request.
+    ///
+    /// - Parameter request: The decoded request envelope.
+    /// - Returns: `true` when a registry lookup is required.
+    nonisolated func targetsNeedHandleRegistry(_ request: ControlRequest) -> Bool {
+        if resolvesTargetOutsideTheHandleRegistry(method: request.method) { return false }
+        return handleTargetParamNouns.contains { key, _ in
+            guard let raw = string(request.params, key) else { return false }
+            return UUID(uuidString: raw) == nil
+        }
+    }
+
+    /// Returns a `not_found` error when a request names a target through a
+    /// handle ref this coordinator cannot resolve, or `nil` when every
+    /// explicit target resolves.
     ///
     /// - Parameter request: The decoded request envelope.
     /// - Returns: The error result to return instead of running the command.
     func unresolvedTargetError(_ request: ControlRequest) -> ControlCallResult? {
+        if let malformed = malformedTargetError(request) { return malformed }
         if resolvesTargetOutsideTheHandleRegistry(method: request.method) { return nil }
         for (key, noun) in handleTargetParamNouns {
             guard let raw = string(request.params, key) else { continue }
@@ -68,5 +107,25 @@ extension ControlCommandCoordinator {
             )
         }
         return nil
+    }
+
+    /// The worker lane's twin of ``unresolvedTargetError(_:)``: the pure
+    /// checks run on the calling socket-worker thread, and the registry lookup
+    /// takes the same `controlResolveOnMain` hop (and known-ref refresh) the
+    /// worker-lane bodies use — only when a target actually needs it.
+    ///
+    /// - Parameters:
+    ///   - request: The decoded request envelope.
+    ///   - context: The live app seam.
+    /// - Returns: The error result to return instead of running the command.
+    nonisolated func unresolvedTargetErrorOnWorkerLane(
+        _ request: ControlRequest,
+        context: (any ControlCommandContext)?
+    ) -> ControlCallResult? {
+        if let malformed = malformedTargetError(request) { return malformed }
+        guard targetsNeedHandleRegistry(request), let context else { return nil }
+        return context.controlResolveOnMain { _ in
+            self.unresolvedTargetError(request)
+        }
     }
 }

--- a/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Coordinator/ControlCommandCoordinator.swift
+++ b/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Coordinator/ControlCommandCoordinator.swift
@@ -68,12 +68,12 @@ public final class ControlCommandCoordinator {
     /// - Parameter request: The decoded request envelope.
     /// - Returns: The command result, or `nil` if not owned here.
     public func handle(_ request: ControlRequest) -> ControlCallResult? {
-        // An explicit `kind:N` target that the registry cannot resolve is a
-        // stale ref, not "no target": fail before any command can fall back to
-        // the focused/selected object and act on it (issue #9410). Runs after
-        // the caller's known-ref refresh, so every live object already has a
-        // ref.
-        if let staleRef = staleHandleRefError(request.params) { return staleRef }
+        // An explicit target the registry cannot resolve is a stale or
+        // malformed ref, not "no target": fail before any command can fall
+        // back to the focused/selected object and act on it (issue #9410).
+        // Runs after the caller's known-ref refresh, so every live object
+        // already has a ref.
+        if let unresolved = unresolvedTargetError(request) { return unresolved }
 
         // Each domain's handler (in its own `+<Domain>.swift` extension) owns its
         // methods and returns `nil` for anything else, so the chain falls through

--- a/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Coordinator/ControlCommandCoordinator.swift
+++ b/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Coordinator/ControlCommandCoordinator.swift
@@ -127,6 +127,12 @@ public final class ControlCommandCoordinator {
         _ request: ControlRequest,
         context: (any ControlCommandContext)?
     ) -> ControlCallResult? {
+        // The worker lane's twin of the main-lane preflight: an explicit
+        // target that cannot be resolved must not degrade into the focused
+        // fallback here either (issue #9410).
+        if let unresolved = unresolvedTargetErrorOnWorkerLane(request, context: context) {
+            return unresolved
+        }
         switch request.method {
         case "surface.list":
             return surfaceList(request.params, context: context)
@@ -259,7 +265,7 @@ public final class ControlCommandCoordinator {
 
     /// Whether a param is present and not JSON `null` (matches legacy
     /// `v2HasNonNullParam`).
-    func hasNonNull(_ params: [String: JSONValue], _ key: String) -> Bool {
+    nonisolated func hasNonNull(_ params: [String: JSONValue], _ key: String) -> Bool {
         guard let value = params[key] else { return false }
         if case .null = value { return false }
         return true

--- a/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Coordinator/ControlCommandCoordinator.swift
+++ b/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Coordinator/ControlCommandCoordinator.swift
@@ -68,6 +68,13 @@ public final class ControlCommandCoordinator {
     /// - Parameter request: The decoded request envelope.
     /// - Returns: The command result, or `nil` if not owned here.
     public func handle(_ request: ControlRequest) -> ControlCallResult? {
+        // An explicit `kind:N` target that the registry cannot resolve is a
+        // stale ref, not "no target": fail before any command can fall back to
+        // the focused/selected object and act on it (issue #9410). Runs after
+        // the caller's known-ref refresh, so every live object already has a
+        // ref.
+        if let staleRef = staleHandleRefError(request.params) { return staleRef }
+
         // Each domain's handler (in its own `+<Domain>.swift` extension) owns its
         // methods and returns `nil` for anything else, so the chain falls through
         // to the next domain and finally to the legacy app-side dispatcher.

--- a/Packages/macOS/CmuxControlSocket/Tests/CmuxControlSocketTests/ControlCommandContextTestStubs.swift
+++ b/Packages/macOS/CmuxControlSocket/Tests/CmuxControlSocketTests/ControlCommandContextTestStubs.swift
@@ -29,6 +29,14 @@ extension ControlCommandContext {
             MainActor.assumeIsolated { body(seam) }
         }
     }
+
+    /// Test default for the preflight hop: the fakes have no known-ref
+    /// refresh, so it is the same synchronous main hop.
+    nonisolated func controlMainSyncWithoutRefreshingRefs<T: Sendable>(
+        _ body: @MainActor (any ControlCommandContext) -> T
+    ) -> T {
+        controlResolveOnMain(body)
+    }
 }
 
 extension ControlAppFocusContext {

--- a/Packages/macOS/CmuxControlSocket/Tests/CmuxControlSocketTests/ControlCommandCoordinatorStaleHandleRefTests.swift
+++ b/Packages/macOS/CmuxControlSocket/Tests/CmuxControlSocketTests/ControlCommandCoordinatorStaleHandleRefTests.swift
@@ -36,8 +36,16 @@ struct ControlCommandCoordinatorStaleHandleRefTests {
         #expect(context.closeCalls.isEmpty)
     }
 
-    @Test(arguments: ["surface:not-a-number", "surafce:12", "surface-3", "", "  "])
-    func closeSurfaceWithMalformedSurfaceTargetClosesNothing(target: String) {
+    @Test(arguments: [
+        JSONValue.string("surface:not-a-number"),
+        .string("surafce:12"),
+        .string("surface-3"),
+        .string(""),
+        .string("   "),
+        .int(1),
+        .bool(false),
+    ])
+    func closeSurfaceWithMalformedSurfaceTargetClosesNothing(target: JSONValue) {
         let context = RecordingDestructiveSurfaceContext()
         let coordinator = ControlCommandCoordinator(context: context)
         coordinator.ensureRef(kind: .surface, uuid: UUID())
@@ -50,21 +58,17 @@ struct ControlCommandCoordinatorStaleHandleRefTests {
         let result = coordinator.handle(ControlRequest(
             id: .int(1),
             method: "surface.close",
-            params: ["surface_id": .string(target)]
+            params: ["surface_id": target]
         ))
 
-        // A whitespace-only value reads as absent (legacy `v2String`), so the
-        // focused-surface close stays legal there; anything else names a
-        // target that cannot be resolved and must not close a bystander.
-        if target.trimmingCharacters(in: .whitespaces).isEmpty {
-            #expect(context.closeCalls == [nil])
-            return
-        }
+        // Present-but-unusable is never "no target": an empty string, a
+        // whitespace-only string, a non-string JSON value, and a mistyped ref
+        // must all fail closed rather than close the focused surface.
         guard case .err(let code, _, _) = result else {
-            Issue.record("expected an error for target '\(target)', got \(String(describing: result))")
+            Issue.record("expected an error for target \(target), got \(String(describing: result))")
             return
         }
-        #expect(code == "not_found")
+        #expect(code == "not_found" || code == "invalid_params")
         #expect(context.closeCalls.isEmpty)
     }
 
@@ -148,6 +152,30 @@ struct ControlCommandCoordinatorStaleHandleRefTests {
         }
         #expect(code == "not_found")
         #expect(context.closeCalls == [requested])
+    }
+
+    @Test func workerLaneSendTextWithUnknownSurfaceRefFailsClosed() {
+        let context = RecordingDestructiveSurfaceContext()
+        let coordinator = ControlCommandCoordinator(context: context)
+        coordinator.ensureRef(kind: .surface, uuid: UUID())
+
+        let result = coordinator.handleSocketWorkerV2(
+            ControlRequest(
+                id: .int(1),
+                method: "surface.send_text",
+                params: [
+                    "surface_id": .string("surface:77777"),
+                    "text": .string("rm -rf /"),
+                ]
+            ),
+            context: context
+        )
+
+        guard case .err(let code, _, _) = result else {
+            Issue.record("expected an error for an unknown surface ref, got \(String(describing: result))")
+            return
+        }
+        #expect(code == "not_found")
     }
 
     @Test func closeSurfaceWithNoTargetStillUsesFocusedSurface() {

--- a/Packages/macOS/CmuxControlSocket/Tests/CmuxControlSocketTests/ControlCommandCoordinatorStaleHandleRefTests.swift
+++ b/Packages/macOS/CmuxControlSocket/Tests/CmuxControlSocketTests/ControlCommandCoordinatorStaleHandleRefTests.swift
@@ -1,0 +1,149 @@
+import Foundation
+import Testing
+@testable import CmuxControlSocket
+
+/// Regression coverage for https://github.com/manaflow-ai/cmux/issues/9410:
+/// a `kind:N` handle ref that resolves to nothing must be a hard error, never
+/// a silent fall-through to the focused/selected target. For destructive ops
+/// (`surface.close`, `surface.respawn`) the fall-through destroys live state.
+@MainActor
+@Suite("ControlCommandCoordinator stale handle refs")
+struct ControlCommandCoordinatorStaleHandleRefTests {
+    /// Records the destructive seam calls so a test can assert that a stale
+    /// ref never reaches them.
+    @MainActor
+    private final class RecordingContext: ControlCommandContext {
+        var closeCalls: [UUID?] = []
+        var respawnCalls: [UUID?] = []
+        var closeResolution: ControlSurfaceCloseResolution = .tabManagerUnavailable
+
+        func controlSurfaceRoutingResolvesTabManager(routing: ControlRoutingSelectors) -> Bool { true }
+
+        func controlSurfaceClose(
+            routing: ControlRoutingSelectors,
+            surfaceID: UUID?
+        ) -> ControlSurfaceCloseResolution {
+            closeCalls.append(surfaceID)
+            return closeResolution
+        }
+
+        func controlSurfaceRespawn(
+            routing: ControlRoutingSelectors,
+            inputs: ControlSurfaceRespawnInputs
+        ) -> ControlSurfaceRespawnResolution {
+            respawnCalls.append(inputs.requestedSurfaceID)
+            return .tabManagerUnavailable
+        }
+    }
+
+    @Test func closeSurfaceWithUnknownSurfaceRefErrorsWithoutClosingAnything() {
+        let context = RecordingContext()
+        let coordinator = ControlCommandCoordinator(context: context)
+        // A live surface exists and holds a ref, so the registry is populated;
+        // `surface:99999` still matches nothing.
+        let liveSurface = UUID()
+        coordinator.ensureRef(kind: .surface, uuid: liveSurface)
+        context.closeResolution = .closed(
+            windowID: UUID(),
+            workspaceID: UUID(),
+            surfaceID: liveSurface
+        )
+
+        let result = coordinator.handle(ControlRequest(
+            id: .int(1),
+            method: "surface.close",
+            params: ["surface_id": .string("surface:99999")]
+        ))
+
+        guard case .err(let code, _, _) = result else {
+            Issue.record("expected an error for an unknown surface ref, got \(String(describing: result))")
+            return
+        }
+        #expect(code == "not_found")
+        #expect(context.closeCalls.isEmpty)
+    }
+
+    @Test func closeSurfaceWithUnknownWorkspaceRefErrorsWithoutClosingAnything() {
+        let context = RecordingContext()
+        let coordinator = ControlCommandCoordinator(context: context)
+        coordinator.ensureRef(kind: .workspace, uuid: UUID())
+
+        let result = coordinator.handle(ControlRequest(
+            id: .int(1),
+            method: "surface.close",
+            params: ["workspace_id": .string("workspace:99")]
+        ))
+
+        guard case .err(let code, _, _) = result else {
+            Issue.record("expected an error for an unknown workspace ref, got \(String(describing: result))")
+            return
+        }
+        #expect(code == "not_found")
+        #expect(context.closeCalls.isEmpty)
+    }
+
+    @Test func respawnWithUnknownSurfaceRefErrorsWithoutRespawningAnything() {
+        let context = RecordingContext()
+        let coordinator = ControlCommandCoordinator(context: context)
+        coordinator.ensureRef(kind: .surface, uuid: UUID())
+
+        let result = coordinator.handle(ControlRequest(
+            id: .int(1),
+            method: "surface.respawn",
+            params: ["surface_id": .string("surface:4242")]
+        ))
+
+        guard case .err(let code, _, _) = result else {
+            Issue.record("expected an error for an unknown surface ref, got \(String(describing: result))")
+            return
+        }
+        #expect(code == "not_found")
+        #expect(context.respawnCalls.isEmpty)
+    }
+
+    @Test func closeSurfaceWithKnownRefStillCloses() {
+        let context = RecordingContext()
+        let coordinator = ControlCommandCoordinator(context: context)
+        let surfaceID = UUID()
+        let ref = coordinator.ensureRef(kind: .surface, uuid: surfaceID)
+        context.closeResolution = .closed(
+            windowID: UUID(),
+            workspaceID: UUID(),
+            surfaceID: surfaceID
+        )
+
+        let result = coordinator.handle(ControlRequest(
+            id: .int(1),
+            method: "surface.close",
+            params: ["surface_id": .string(ref)]
+        ))
+
+        guard case .ok = result else {
+            Issue.record("expected a successful close, got \(String(describing: result))")
+            return
+        }
+        #expect(context.closeCalls == [surfaceID])
+    }
+
+    @Test func closeSurfaceWithNoTargetStillUsesFocusedSurface() {
+        let context = RecordingContext()
+        let coordinator = ControlCommandCoordinator(context: context)
+        context.closeResolution = .closed(
+            windowID: UUID(),
+            workspaceID: UUID(),
+            surfaceID: UUID()
+        )
+
+        let result = coordinator.handle(ControlRequest(
+            id: .int(1),
+            method: "surface.close",
+            params: [:]
+        ))
+
+        guard case .ok = result else {
+            Issue.record("expected a successful close, got \(String(describing: result))")
+            return
+        }
+        #expect(context.closeCalls == [nil])
+    }
+}

--- a/Packages/macOS/CmuxControlSocket/Tests/CmuxControlSocketTests/ControlCommandCoordinatorStaleHandleRefTests.swift
+++ b/Packages/macOS/CmuxControlSocket/Tests/CmuxControlSocketTests/ControlCommandCoordinatorStaleHandleRefTests.swift
@@ -3,41 +3,14 @@ import Testing
 @testable import CmuxControlSocket
 
 /// Regression coverage for https://github.com/manaflow-ai/cmux/issues/9410:
-/// a `kind:N` handle ref that resolves to nothing must be a hard error, never
-/// a silent fall-through to the focused/selected target. For destructive ops
+/// an explicit target that resolves to nothing must be a hard error, never a
+/// silent fall-through to the focused/selected target. For destructive ops
 /// (`surface.close`, `surface.respawn`) the fall-through destroys live state.
 @MainActor
-@Suite("ControlCommandCoordinator stale handle refs")
+@Suite("ControlCommandCoordinator unresolvable targets")
 struct ControlCommandCoordinatorStaleHandleRefTests {
-    /// Records the destructive seam calls so a test can assert that a stale
-    /// ref never reaches them.
-    @MainActor
-    private final class RecordingContext: ControlCommandContext {
-        var closeCalls: [UUID?] = []
-        var respawnCalls: [UUID?] = []
-        var closeResolution: ControlSurfaceCloseResolution = .tabManagerUnavailable
-
-        func controlSurfaceRoutingResolvesTabManager(routing: ControlRoutingSelectors) -> Bool { true }
-
-        func controlSurfaceClose(
-            routing: ControlRoutingSelectors,
-            surfaceID: UUID?
-        ) -> ControlSurfaceCloseResolution {
-            closeCalls.append(surfaceID)
-            return closeResolution
-        }
-
-        func controlSurfaceRespawn(
-            routing: ControlRoutingSelectors,
-            inputs: ControlSurfaceRespawnInputs
-        ) -> ControlSurfaceRespawnResolution {
-            respawnCalls.append(inputs.requestedSurfaceID)
-            return .tabManagerUnavailable
-        }
-    }
-
     @Test func closeSurfaceWithUnknownSurfaceRefErrorsWithoutClosingAnything() {
-        let context = RecordingContext()
+        let context = RecordingDestructiveSurfaceContext()
         let coordinator = ControlCommandCoordinator(context: context)
         // A live surface exists and holds a ref, so the registry is populated;
         // `surface:99999` still matches nothing.
@@ -63,8 +36,40 @@ struct ControlCommandCoordinatorStaleHandleRefTests {
         #expect(context.closeCalls.isEmpty)
     }
 
+    @Test(arguments: ["surface:not-a-number", "surafce:12", "surface-3", "", "  "])
+    func closeSurfaceWithMalformedSurfaceTargetClosesNothing(target: String) {
+        let context = RecordingDestructiveSurfaceContext()
+        let coordinator = ControlCommandCoordinator(context: context)
+        coordinator.ensureRef(kind: .surface, uuid: UUID())
+        context.closeResolution = .closed(
+            windowID: UUID(),
+            workspaceID: UUID(),
+            surfaceID: UUID()
+        )
+
+        let result = coordinator.handle(ControlRequest(
+            id: .int(1),
+            method: "surface.close",
+            params: ["surface_id": .string(target)]
+        ))
+
+        // A whitespace-only value reads as absent (legacy `v2String`), so the
+        // focused-surface close stays legal there; anything else names a
+        // target that cannot be resolved and must not close a bystander.
+        if target.trimmingCharacters(in: .whitespaces).isEmpty {
+            #expect(context.closeCalls == [nil])
+            return
+        }
+        guard case .err(let code, _, _) = result else {
+            Issue.record("expected an error for target '\(target)', got \(String(describing: result))")
+            return
+        }
+        #expect(code == "not_found")
+        #expect(context.closeCalls.isEmpty)
+    }
+
     @Test func closeSurfaceWithUnknownWorkspaceRefErrorsWithoutClosingAnything() {
-        let context = RecordingContext()
+        let context = RecordingDestructiveSurfaceContext()
         let coordinator = ControlCommandCoordinator(context: context)
         coordinator.ensureRef(kind: .workspace, uuid: UUID())
 
@@ -83,7 +88,7 @@ struct ControlCommandCoordinatorStaleHandleRefTests {
     }
 
     @Test func respawnWithUnknownSurfaceRefErrorsWithoutRespawningAnything() {
-        let context = RecordingContext()
+        let context = RecordingDestructiveSurfaceContext()
         let coordinator = ControlCommandCoordinator(context: context)
         coordinator.ensureRef(kind: .surface, uuid: UUID())
 
@@ -102,7 +107,7 @@ struct ControlCommandCoordinatorStaleHandleRefTests {
     }
 
     @Test func closeSurfaceWithKnownRefStillCloses() {
-        let context = RecordingContext()
+        let context = RecordingDestructiveSurfaceContext()
         let coordinator = ControlCommandCoordinator(context: context)
         let surfaceID = UUID()
         let ref = coordinator.ensureRef(kind: .surface, uuid: surfaceID)
@@ -125,8 +130,28 @@ struct ControlCommandCoordinatorStaleHandleRefTests {
         #expect(context.closeCalls == [surfaceID])
     }
 
+    @Test func closeSurfaceWithUnknownUUIDStillReachesTheCommandsOwnNotFound() {
+        let context = RecordingDestructiveSurfaceContext()
+        let coordinator = ControlCommandCoordinator(context: context)
+        let requested = UUID()
+        context.closeResolution = .surfaceNotFound(requested)
+
+        let result = coordinator.handle(ControlRequest(
+            id: .int(1),
+            method: "surface.close",
+            params: ["surface_id": .string(requested.uuidString)]
+        ))
+
+        guard case .err(let code, _, _) = result else {
+            Issue.record("expected a not_found error, got \(String(describing: result))")
+            return
+        }
+        #expect(code == "not_found")
+        #expect(context.closeCalls == [requested])
+    }
+
     @Test func closeSurfaceWithNoTargetStillUsesFocusedSurface() {
-        let context = RecordingContext()
+        let context = RecordingDestructiveSurfaceContext()
         let coordinator = ControlCommandCoordinator(context: context)
         context.closeResolution = .closed(
             windowID: UUID(),

--- a/Packages/macOS/CmuxControlSocket/Tests/CmuxControlSocketTests/RecordingDestructiveSurfaceContext.swift
+++ b/Packages/macOS/CmuxControlSocket/Tests/CmuxControlSocketTests/RecordingDestructiveSurfaceContext.swift
@@ -1,0 +1,29 @@
+import Foundation
+@testable import CmuxControlSocket
+
+/// Records the destructive surface seam calls so a test can assert that an
+/// unresolvable target never reaches them (issue #9410).
+@MainActor
+final class RecordingDestructiveSurfaceContext: ControlCommandContext {
+    var closeCalls: [UUID?] = []
+    var respawnCalls: [UUID?] = []
+    var closeResolution: ControlSurfaceCloseResolution = .tabManagerUnavailable
+
+    func controlSurfaceRoutingResolvesTabManager(routing: ControlRoutingSelectors) -> Bool { true }
+
+    func controlSurfaceClose(
+        routing: ControlRoutingSelectors,
+        surfaceID: UUID?
+    ) -> ControlSurfaceCloseResolution {
+        closeCalls.append(surfaceID)
+        return closeResolution
+    }
+
+    func controlSurfaceRespawn(
+        routing: ControlRoutingSelectors,
+        inputs: ControlSurfaceRespawnInputs
+    ) -> ControlSurfaceRespawnResolution {
+        respawnCalls.append(inputs.requestedSurfaceID)
+        return .tabManagerUnavailable
+    }
+}

--- a/Sources/TerminalControllerControlCommandContext.swift
+++ b/Sources/TerminalControllerControlCommandContext.swift
@@ -32,6 +32,15 @@ extension TerminalController: ControlCommandContext {
             return body(self)
         }
     }
+
+    /// The refresh-free twin used by the dispatch preflight: the same
+    /// `v2MainSync` hop, without the topology sweep the preflight does not
+    /// need (see the protocol requirement's doc).
+    nonisolated func controlMainSyncWithoutRefreshingRefs<T: Sendable>(
+        _ body: @MainActor (any ControlCommandContext) -> T
+    ) -> T {
+        v2MainSync { body(self) }
+    }
 }
 
 /// The window-domain witnesses are the byte-faithful bodies of the former

--- a/cmuxTests/AppDelegateIssue2907RoutingTests.swift
+++ b/cmuxTests/AppDelegateIssue2907RoutingTests.swift
@@ -354,7 +354,9 @@ final class AppDelegateIssue2907RoutingTests: XCTestCase {
             method: "workspace.current",
             params: ["window_id": "window:999"]
         )
-        XCTAssertEqual(error["code"] as? String, "unavailable")
+        // The dispatch preflight now names the stale ref explicitly instead of
+        // letting routing report a missing window (issue #9410).
+        XCTAssertEqual(error["code"] as? String, "not_found")
     }
 
     func testWorkspaceListRejectsWindowAliasInsteadOfDefaultWindowFallback() throws {


### PR DESCRIPTION
Fixes #9410

`cmux close-surface --surface surface:99999` exited 0 and closed the workspace's *selected* surface. Every routing/target param (`surface_id`, `workspace_id`, `pane_id`, …) accepts a UUID or a `kind:N` handle ref, and a target the registry could not resolve became `nil` — indistinguishable from "no explicit target passed" — so the command fell back to the focused/selected object and destroyed it. `surface.respawn` had the same fall-through.

## Mechanism

Both v2 dispatch lanes now run a preflight before any command:

- `ControlCommandCoordinator.handle` (main lane) and `handleSocketWorkerV2` (socket-worker lane) reject a request whose explicit target cannot be resolved: an unknown `kind:N` ref, a mistyped one (`surafce:12`, `surface:not-a-number`), an empty or whitespace-only string, or a non-string JSON value. `not_found` / `invalid_params`, no side effect.
- Targets covered: `window_id`, `group_id`, `workspace_id`, `surface_id`, `terminal_id`, `tab_id`, `pane_id`, plus the relative selectors (`before_/after_surface_id`, `before_/after_workspace_id`, `before_/after_group_id`, `reference_workspace_id`, `target_pane_id`, `target_surface_id`) — a stale one there was dropped silently while the reorder or move still ran.
- Exempt: `debug.*` (legacy v1 `<id|idx>` arguments) and the mobile-host pass-throughs (`mobile.*` / `terminal.*` / `chat.*`), which resolve their own target strings and never read the handle registry.
- The main lane sits after the dispatch preamble's `v2RefreshKnownRefs()`. The worker lane hops through a new refresh-free seam (`controlMainSyncWithoutRefreshingRefs`), because a ref the caller holds was necessarily minted earlier, so it costs one cheap main hop and no second topology sweep — and only for requests that actually carry a ref. UUID targets skip the hop, so the typing-latency paths (`surface.send_text` / `send_key` from shell integration and hooks) are untouched.

UUID targets keep their existing per-command not-found handling, and a request with no target still resolves to the focused surface.

Principled: one dispatch-level rule for both lanes rather than patching `surface.close` alone.

## Known residual gap (filed as #9424)

Routing selectors whose id is well-formed but matches nothing — an unknown *UUID* in `group_id`/`pane_id`, or a live ref of the wrong kind (`group_id: "surface:1"`) — still fall through `v2ResolveTabManager` to the active window. Closing that needs a product call rather than a mechanical fix: the CLI injects the caller's `CMUX_WORKSPACE_ID`/`CMUX_SURFACE_ID` into most commands, so the RPC layer cannot distinguish a user-specified target from caller context, and hard-failing unknown UUIDs would also break ordinary commands run from a terminal whose workspace has since closed. Kind enforcement likewise needs an alias table (the Window Dock legitimately passes a *window* UUID as `workspace_id`; `tab:N` aliases `surface:N`). Both are written up in #9424. The reported bug — an explicit ref that resolves to nothing closing a bystander — is fixed here.

`surface_id` itself is safe in the UUID case: close/respawn report `surfaceNotFound` for an unknown surface UUID.

## Symphony verification

Regression test: `ControlCommandCoordinatorStaleHandleRefTests` in `Packages/macOS/CmuxControlSocket/Tests/CmuxControlSocketTests/` — unknown `surface_id` ref, unknown `workspace_id` ref, unknown ref on `surface.respawn`, a parameterized malformed-target case (`surface:not-a-number`, `surafce:12`, `surface-3`, `""`, `"   "`, `1`, `false`), worker-lane `surface.send_text` with a stale ref, plus the behaviors that must not change (a known ref still closes, an unknown UUID still reaches the command's own not-found, no target still closes the focused surface).

Commit 1 adds the test only, commit 2 the fix; later commits are review follow-ups.

```
cd Packages/macOS/CmuxControlSocket && swift test
```

- At commit 1 (test only): 3 of the then-5 tests fail. `closeSurfaceWithUnknownSurfaceRefErrorsWithoutClosingAnything` returned `ok` with a freshly minted `surface_ref` while `controlSurfaceClose` was invoked with `nil` (the focused-surface fall-through); the workspace-ref and respawn cases likewise reached their seam with `nil`.
- At HEAD: `Test run with 345 tests in 45 suites passed`.
- App compile check at HEAD: `xcodebuild -project cmux.xcodeproj -scheme cmux -configuration Debug -destination 'platform=macOS' -derivedDataPath /tmp/cmux-i9410 build` → `** BUILD SUCCEEDED **`.
- One existing expectation changed: `AppDelegateIssue2907RoutingTests.testUnresolvedWindowRefDoesNotFallBackToActiveWindow` asserted `unavailable` for `window_id: "window:999"`; the preflight now names the stale ref with `not_found`. The test's invariant (no fallback to the active window) is unchanged. That file is pre-existing XCTest and the touch is the single assertion, so it was not migrated to Swift Testing.

CI on this branch reproduces red-then-green across the first two commits.