### PR TITLE
Fail closed for stale destructive surface targets

### DIFF
--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -4947,15 +4947,25 @@ struct CMUXCLI {
             let csWsFlag = optionValue(commandArgs, name: "--workspace")
             let windowRaw = windowFromArgsOrOverride(commandArgs, windowOverride: windowId)
             let workspaceArg = csWsFlag ?? (windowRaw == nil ? ProcessInfo.processInfo.environment["CMUX_WORKSPACE_ID"] : nil)
-            let surfaceRaw = optionValue(commandArgs, name: "--surface") ?? optionValue(commandArgs, name: "--panel") ?? (csWsFlag == nil && windowRaw == nil ? ProcessInfo.processInfo.environment["CMUX_SURFACE_ID"] : nil)
+            let explicitSurfaceRaw = optionValue(commandArgs, name: "--surface") ?? optionValue(commandArgs, name: "--panel")
+            let surfaceRaw = explicitSurfaceRaw ?? (csWsFlag == nil && windowRaw == nil ? ProcessInfo.processInfo.environment["CMUX_SURFACE_ID"] : nil)
             var params: [String: Any] = [:]
             let winId = try normalizeWindowHandle(windowRaw, client: client)
             if let winId { params["window_id"] = winId }
             let wsId = try normalizeWorkspaceHandle(workspaceArg, client: client, windowHandle: winId)
             if let wsId { params["workspace_id"] = wsId }
             let sfId: String?
-            if let surfaceRaw, let wsId {
-                sfId = try resolveSurfaceId(surfaceRaw, workspaceId: wsId, client: client)
+            if let explicitSurfaceRaw {
+                if let wsId {
+                    sfId = try resolveSurfaceId(explicitSurfaceRaw, workspaceId: wsId, client: client)
+                } else if let winId {
+                    sfId = try normalizeSurfaceHandle(explicitSurfaceRaw, client: client, workspaceHandle: nil, windowHandle: winId)
+                } else {
+                    throw CLIError(message: String(
+                        localized: "cli.closeSurface.error.explicitSurfaceRequiresWorkspaceOrWindow",
+                        defaultValue: "close-surface requires --workspace or --window with explicit --surface"
+                    ))
+                }
             } else {
                 sfId = try normalizeSurfaceHandle(surfaceRaw, client: client, workspaceHandle: wsId, windowHandle: winId)
             }
@@ -15381,27 +15391,45 @@ struct CMUXCLI {
         if let raw {
             let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
             guard !trimmed.isEmpty else {
-                throw CLIError(message: "Surface handle is blank")
+                throw CLIError(message: String(
+                    localized: "cli.surface.error.handleBlank",
+                    defaultValue: "Surface handle is blank"
+                ))
             }
             if isUUID(trimmed) {
                 for item in items where surfaceHandleMatches(trimmed, item: item) {
                     if let id = item["id"] as? String { return id }
                 }
-                throw CLIError(message: "Surface not found: \(trimmed)")
+                throw CLIError(message: localizedFormat(
+                    "cli.surface.error.notFound",
+                    defaultValue: "Surface not found: %@",
+                    trimmed
+                ))
             }
             if isHandleRef(trimmed) {
                 for item in items where surfaceHandleMatches(trimmed, item: item) {
                     if let id = item["id"] as? String { return id }
                 }
-                throw CLIError(message: "Surface ref not found: \(trimmed)")
+                throw CLIError(message: localizedFormat(
+                    "cli.surface.error.refNotFound",
+                    defaultValue: "Surface ref not found: %@",
+                    trimmed
+                ))
             }
             guard let index = Int(trimmed) else {
-                throw CLIError(message: "Invalid surface handle: \(trimmed) (expected UUID, ref like surface:1, or index)")
+                throw CLIError(message: localizedFormat(
+                    "cli.surface.error.invalidHandle",
+                    defaultValue: "Invalid surface handle: %@ (expected UUID, ref like surface:1, or index)",
+                    trimmed
+                ))
             }
             for item in items where intFromAny(item["index"]) == index {
                 if let id = item["id"] as? String { return id }
             }
-            throw CLIError(message: "Surface index not found")
+            throw CLIError(message: String(
+                localized: "cli.surface.error.indexNotFound",
+                defaultValue: "Surface index not found"
+            ))
         }
 
         if let focused = items.first(where: { ($0["focused"] as? Bool) == true }) {

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -4956,10 +4956,17 @@ struct CMUXCLI {
             if let wsId { params["workspace_id"] = wsId }
             let sfId: String?
             if let explicitSurfaceRaw {
+                let explicitSurfaceHandle = explicitSurfaceRaw.trimmingCharacters(in: .whitespacesAndNewlines)
+                guard !explicitSurfaceHandle.isEmpty else {
+                    throw CLIError(message: String(
+                        localized: "cli.surface.error.handleBlank",
+                        defaultValue: "Surface handle is blank"
+                    ))
+                }
                 if let wsId {
-                    sfId = try resolveSurfaceId(explicitSurfaceRaw, workspaceId: wsId, client: client)
+                    sfId = try resolveSurfaceId(explicitSurfaceHandle, workspaceId: wsId, client: client)
                 } else if let winId {
-                    sfId = try normalizeSurfaceHandle(explicitSurfaceRaw, client: client, workspaceHandle: nil, windowHandle: winId)
+                    sfId = try normalizeSurfaceHandle(explicitSurfaceHandle, client: client, workspaceHandle: nil, windowHandle: winId)
                 } else {
                     throw CLIError(message: String(
                         localized: "cli.closeSurface.error.explicitSurfaceRequiresWorkspaceOrWindow",

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -4953,7 +4953,12 @@ struct CMUXCLI {
             if let winId { params["window_id"] = winId }
             let wsId = try normalizeWorkspaceHandle(workspaceArg, client: client, windowHandle: winId)
             if let wsId { params["workspace_id"] = wsId }
-            let sfId = try normalizeSurfaceHandle(surfaceRaw, client: client, workspaceHandle: wsId, windowHandle: winId)
+            let sfId: String?
+            if let surfaceRaw, let wsId {
+                sfId = try resolveSurfaceId(surfaceRaw, workspaceId: wsId, client: client)
+            } else {
+                sfId = try normalizeSurfaceHandle(surfaceRaw, client: client, workspaceHandle: wsId, windowHandle: winId)
+            }
             if let sfId { params["surface_id"] = sfId }
             let payload = try client.sendV2(method: "surface.close", params: params)
             if let closedWorkspaceId = (payload["workspace_id"] as? String) ?? wsId,
@@ -15370,22 +15375,29 @@ struct CMUXCLI {
     }
 
     private func resolveSurfaceId(_ raw: String?, workspaceId: String, client: SocketClient) throws -> String {
-        if let raw, isUUID(raw) {
-            return raw
-        }
-        if let raw, isHandleRef(raw) {
-            let listed = try client.sendV2(method: "surface.list", params: ["workspace_id": workspaceId])
-            let items = listed["surfaces"] as? [[String: Any]] ?? []
-            for item in items where (item["ref"] as? String) == raw {
-                if let id = item["id"] as? String { return id }
-            }
-            throw CLIError(message: "Surface ref not found: \(raw)")
-        }
-
         let listed = try client.sendV2(method: "surface.list", params: ["workspace_id": workspaceId])
         let items = listed["surfaces"] as? [[String: Any]] ?? []
 
-        if let raw, let index = Int(raw) {
+        if let raw {
+            let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !trimmed.isEmpty else {
+                throw CLIError(message: "Surface handle is blank")
+            }
+            if isUUID(trimmed) {
+                for item in items where surfaceHandleMatches(trimmed, item: item) {
+                    if let id = item["id"] as? String { return id }
+                }
+                throw CLIError(message: "Surface not found: \(trimmed)")
+            }
+            if isHandleRef(trimmed) {
+                for item in items where surfaceHandleMatches(trimmed, item: item) {
+                    if let id = item["id"] as? String { return id }
+                }
+                throw CLIError(message: "Surface ref not found: \(trimmed)")
+            }
+            guard let index = Int(trimmed) else {
+                throw CLIError(message: "Invalid surface handle: \(trimmed) (expected UUID, ref like surface:1, or index)")
+            }
             for item in items where intFromAny(item["index"]) == index {
                 if let id = item["id"] as? String { return id }
             }

--- a/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Coordinator/Pane/ControlCommandCoordinator+Pane.swift
+++ b/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Coordinator/Pane/ControlCommandCoordinator+Pane.swift
@@ -506,10 +506,14 @@ extension ControlCommandCoordinator {
         guard context?.controlPaneRoutingResolvesTabManager(routing: routing) ?? false else {
             return .err(code: "unavailable", message: "TabManager not available", data: nil)
         }
+        let surfaceID = uuid(params, "surface_id")
+        if hasNonNull(params, "surface_id"), surfaceID == nil {
+            return .err(code: "not_found", message: "Surface not found", data: nil)
+        }
         let resolution = context?.controlPaneBreak(
             routing: routing,
             paneID: uuid(params, "pane_id"),
-            surfaceID: uuid(params, "surface_id"),
+            surfaceID: surfaceID,
             requestedFocus: bool(params, "focus") ?? false
         ) ?? .tabManagerUnavailable
         switch resolution {
@@ -555,10 +559,14 @@ extension ControlCommandCoordinator {
         guard let targetPaneID = uuid(params, "target_pane_id") else {
             return .err(code: "invalid_params", message: "Missing or invalid target_pane_id", data: nil)
         }
+        let surfaceID = uuid(params, "surface_id")
+        if hasNonNull(params, "surface_id"), surfaceID == nil {
+            return .err(code: "not_found", message: "Surface not found", data: nil)
+        }
         let hasFocusParam = bool(params, "focus") != nil
         let resolution = context?.controlPaneJoin(
             targetPaneID: targetPaneID,
-            surfaceID: uuid(params, "surface_id"),
+            surfaceID: surfaceID,
             sourcePaneID: uuid(params, "pane_id"),
             hasFocusParam: hasFocusParam,
             focus: bool(params, "focus") ?? false

--- a/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Coordinator/Pane/ControlCommandCoordinator+Pane.swift
+++ b/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Coordinator/Pane/ControlCommandCoordinator+Pane.swift
@@ -503,19 +503,19 @@ extension ControlCommandCoordinator {
     /// `pane.break` — detach a surface into a new workspace.
     func paneBreak(_ params: [String: JSONValue]) -> ControlCallResult {
         let routing = routingSelectors(params)
-        guard context?.controlPaneRoutingResolvesTabManager(routing: routing) ?? false else {
+        guard let context, context.controlPaneRoutingResolvesTabManager(routing: routing) else {
             return .err(code: "unavailable", message: "TabManager not available", data: nil)
         }
         let surfaceID = uuid(params, "surface_id")
-        if hasNonNull(params, "surface_id"), surfaceID == nil {
-            return .err(code: "not_found", message: "Surface not found", data: nil)
+        if params["surface_id"] != nil, surfaceID == nil {
+            return .err(code: "not_found", message: context.controlPaneSurfaceNotFoundMessage(), data: nil)
         }
-        let resolution = context?.controlPaneBreak(
+        let resolution = context.controlPaneBreak(
             routing: routing,
             paneID: uuid(params, "pane_id"),
             surfaceID: surfaceID,
             requestedFocus: bool(params, "focus") ?? false
-        ) ?? .tabManagerUnavailable
+        )
         switch resolution {
         case .tabManagerUnavailable:
             return .err(code: "unavailable", message: "TabManager not available", data: nil)
@@ -524,7 +524,7 @@ extension ControlCommandCoordinator {
         case .noSourceSurface:
             return .err(code: "not_found", message: "No source surface to break", data: nil)
         case .surfaceNotFound(let id):
-            return .err(code: "not_found", message: "Surface not found", data: .object(["surface_id": .string(id.uuidString)]))
+            return .err(code: "not_found", message: context.controlPaneSurfaceNotFoundMessage(), data: .object(["surface_id": .string(id.uuidString)]))
         case .detachFailed:
             return .err(code: "internal_error", message: "Failed to detach source surface", data: nil)
         case .createWorkspaceFailed:
@@ -559,21 +559,21 @@ extension ControlCommandCoordinator {
         guard let targetPaneID = uuid(params, "target_pane_id") else {
             return .err(code: "invalid_params", message: "Missing or invalid target_pane_id", data: nil)
         }
+        guard let context else {
+            return .err(code: "unavailable", message: "TabManager not available", data: nil)
+        }
         let surfaceID = uuid(params, "surface_id")
-        if hasNonNull(params, "surface_id"), surfaceID == nil {
-            return .err(code: "not_found", message: "Surface not found", data: nil)
+        if params["surface_id"] != nil, surfaceID == nil {
+            return .err(code: "not_found", message: context.controlPaneSurfaceNotFoundMessage(), data: nil)
         }
         let hasFocusParam = bool(params, "focus") != nil
-        let resolution = context?.controlPaneJoin(
+        let resolution = context.controlPaneJoin(
             targetPaneID: targetPaneID,
             surfaceID: surfaceID,
             sourcePaneID: uuid(params, "pane_id"),
             hasFocusParam: hasFocusParam,
             focus: bool(params, "focus") ?? false
         )
-        guard let resolution else {
-            return .err(code: "invalid_params", message: "Missing surface_id (or pane_id with selected surface)", data: nil)
-        }
         switch resolution {
         case .sourceSurfaceUnresolved(let sourcePaneID):
             return .err(

--- a/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Coordinator/Pane/ControlPaneContext.swift
+++ b/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Coordinator/Pane/ControlPaneContext.swift
@@ -36,6 +36,12 @@ public protocol ControlPaneContext: AnyObject {
     /// - Returns: The localized invalid-parameters message.
     func controlPaneResizeInvalidParametersMessage() -> String
 
+    /// Returns the app-localized generic surface-not-found message for pane
+    /// mutations whose explicit `surface_id` cannot be parsed or resolved.
+    ///
+    /// - Returns: The localized surface-not-found message.
+    func controlPaneSurfaceNotFoundMessage() -> String
+
     /// Focuses the pane `paneID` in the resolved workspace for `pane.focus`.
     ///
     /// - Parameters:

--- a/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Coordinator/Surface/ControlCommandCoordinator+Surface.swift
+++ b/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Coordinator/Surface/ControlCommandCoordinator+Surface.swift
@@ -444,7 +444,7 @@ extension ControlCommandCoordinator {
             return .err(code: "invalid_params", message: strings.invalidFocus, data: nil)
         }
 
-        let hasSurfaceIDParam = hasNonNull(params, "surface_id")
+        let hasSurfaceIDParam = params["surface_id"] != nil
         let requestedSurfaceID = uuid(params, "surface_id")
         if hasSurfaceIDParam, requestedSurfaceID == nil {
             return .err(code: "not_found", message: strings.surfaceNotFoundForID, data: nil)
@@ -611,20 +611,19 @@ extension ControlCommandCoordinator {
     /// `surface.close` — force-close a surface.
     func surfaceClose(_ params: [String: JSONValue]) -> ControlCallResult {
         let routing = routingSelectors(params)
-        guard context?.controlSurfaceRoutingResolvesTabManager(routing: routing) ?? false else {
+        guard let context, context.controlSurfaceRoutingResolvesTabManager(routing: routing) else {
             return .err(code: "unavailable", message: "TabManager not available", data: nil)
         }
         let surfaceID = uuid(params, "surface_id")
-        let hasSurfaceIDParam = hasNonNull(params, "surface_id")
+        let hasSurfaceIDParam = params["surface_id"] != nil
         if hasSurfaceIDParam, surfaceID == nil {
-            return .err(code: "not_found", message: "Surface not found", data: nil)
+            return .err(code: "not_found", message: context.controlSurfaceNotFoundMessage(), data: nil)
         }
-        let resolution = context?.controlSurfaceClose(
+        let resolution = context.controlSurfaceClose(
             routing: routing,
             surfaceID: surfaceID,
             hasSurfaceIDParam: hasSurfaceIDParam
         )
-            ?? .tabManagerUnavailable
         switch resolution {
         case .tabManagerUnavailable:
             return .err(code: "unavailable", message: "TabManager not available", data: nil)
@@ -633,11 +632,11 @@ extension ControlCommandCoordinator {
         case .noFocusedSurface:
             return .err(code: "not_found", message: "No focused surface", data: nil)
         case .invalidSurfaceID:
-            return .err(code: "not_found", message: "Surface not found", data: nil)
+            return .err(code: "not_found", message: context.controlSurfaceNotFoundMessage(), data: nil)
         case .surfaceNotFound(let id):
             return .err(
                 code: "not_found",
-                message: "Surface not found",
+                message: context.controlSurfaceNotFoundMessage(),
                 data: .object(["surface_id": .string(id.uuidString)])
             )
         case .lastSurface:

--- a/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Coordinator/Surface/ControlCommandCoordinator+Surface.swift
+++ b/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Coordinator/Surface/ControlCommandCoordinator+Surface.swift
@@ -444,12 +444,18 @@ extension ControlCommandCoordinator {
             return .err(code: "invalid_params", message: strings.invalidFocus, data: nil)
         }
 
+        let hasSurfaceIDParam = hasNonNull(params, "surface_id")
+        let requestedSurfaceID = uuid(params, "surface_id")
+        if hasSurfaceIDParam, requestedSurfaceID == nil {
+            return .err(code: "not_found", message: strings.surfaceNotFoundForID, data: nil)
+        }
+
         let inputs = ControlSurfaceRespawnInputs(
             command: command,
             tmuxStartCommand: tmuxStartCommand,
             workingDirectory: workingDirectory,
-            hasSurfaceIDParam: hasNonNull(params, "surface_id"),
-            requestedSurfaceID: uuid(params, "surface_id"),
+            hasSurfaceIDParam: hasSurfaceIDParam,
+            requestedSurfaceID: requestedSurfaceID,
             hasFocusParam: hasFocusParam,
             requestedFocus: bool(params, "focus") ?? false
         )
@@ -608,7 +614,16 @@ extension ControlCommandCoordinator {
         guard context?.controlSurfaceRoutingResolvesTabManager(routing: routing) ?? false else {
             return .err(code: "unavailable", message: "TabManager not available", data: nil)
         }
-        let resolution = context?.controlSurfaceClose(routing: routing, surfaceID: uuid(params, "surface_id"))
+        let surfaceID = uuid(params, "surface_id")
+        let hasSurfaceIDParam = hasNonNull(params, "surface_id")
+        if hasSurfaceIDParam, surfaceID == nil {
+            return .err(code: "not_found", message: "Surface not found", data: nil)
+        }
+        let resolution = context?.controlSurfaceClose(
+            routing: routing,
+            surfaceID: surfaceID,
+            hasSurfaceIDParam: hasSurfaceIDParam
+        )
             ?? .tabManagerUnavailable
         switch resolution {
         case .tabManagerUnavailable:
@@ -617,6 +632,8 @@ extension ControlCommandCoordinator {
             return .err(code: "not_found", message: "Workspace not found", data: nil)
         case .noFocusedSurface:
             return .err(code: "not_found", message: "No focused surface", data: nil)
+        case .invalidSurfaceID:
+            return .err(code: "not_found", message: "Surface not found", data: nil)
         case .surfaceNotFound(let id):
             return .err(
                 code: "not_found",

--- a/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Coordinator/Surface/ControlSurfaceCloseResolution.swift
+++ b/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Coordinator/Surface/ControlSurfaceCloseResolution.swift
@@ -13,6 +13,9 @@ public enum ControlSurfaceCloseResolution: Sendable, Equatable {
     /// No surface resolved and none focused (legacy `not_found` / "No focused
     /// surface").
     case noFocusedSurface
+    /// A `surface_id` param was present but did not resolve to a UUID/ref. This
+    /// must fail closed instead of falling back to the focused surface.
+    case invalidSurfaceID
     /// The surface id did not exist (legacy `not_found` / "Surface not found",
     /// `data: {"surface_id": …}`). Carries the surface id.
     case surfaceNotFound(UUID)

--- a/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Coordinator/Surface/ControlSurfaceContext.swift
+++ b/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Coordinator/Surface/ControlSurfaceContext.swift
@@ -54,6 +54,12 @@ public protocol ControlSurfaceContext: AnyObject {
     /// - Returns: The respawn strings.
     func controlSurfaceRespawnStrings() -> ControlSurfaceRespawnStrings
 
+    /// Returns the app-localized generic surface-not-found message for close
+    /// failures whose explicit `surface_id` cannot be parsed or resolved.
+    ///
+    /// - Returns: The localized surface-not-found message.
+    func controlSurfaceNotFoundMessage() -> String
+
     // MARK: - focus / split / respawn / create / close
 
     /// Focuses a surface for `surface.focus`.

--- a/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Coordinator/Surface/ControlSurfaceContext.swift
+++ b/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Coordinator/Surface/ControlSurfaceContext.swift
@@ -108,10 +108,13 @@ public protocol ControlSurfaceContext: AnyObject {
     /// - Parameters:
     ///   - routing: The routing selectors.
     ///   - surfaceID: The explicit `surface_id`, or `nil` for the focused surface.
+    ///   - hasSurfaceIDParam: Whether a `surface_id` param was present at all, so
+    ///     an unresolvable explicit ref cannot fall back to the focused surface.
     /// - Returns: The close resolution.
     func controlSurfaceClose(
         routing: ControlRoutingSelectors,
-        surfaceID: UUID?
+        surfaceID: UUID?,
+        hasSurfaceIDParam: Bool
     ) -> ControlSurfaceCloseResolution
 
     // MARK: - move / reorder

--- a/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Coordinator/System/ControlCommandCoordinator+SystemTabAction.swift
+++ b/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Coordinator/System/ControlCommandCoordinator+SystemTabAction.swift
@@ -15,16 +15,19 @@ extension ControlCommandCoordinator {
 
     /// `surface.action` / `tab.action` — run one surface-tab mutation.
     func tabAction(_ params: [String: JSONValue]) -> ControlCallResult {
+        guard let systemContext else {
+            return .err(code: "unavailable", message: "TabManager not available", data: nil)
+        }
         let action = actionKey(params)
         let surfaceID = uuid(params, "surface_id")
         let tabID = uuid(params, "tab_id")
-        if hasNonNull(params, "surface_id"), surfaceID == nil {
-            return .err(code: "not_found", message: "Surface not found", data: nil)
+        if params["surface_id"] != nil, surfaceID == nil {
+            return .err(code: "not_found", message: systemContext.controlSystemSurfaceNotFoundMessage(), data: nil)
         }
-        if hasNonNull(params, "tab_id"), tabID == nil {
-            return .err(code: "not_found", message: "Tab not found", data: nil)
+        if params["tab_id"] != nil, tabID == nil {
+            return .err(code: "not_found", message: systemContext.controlSystemTabNotFoundMessage(), data: nil)
         }
-        let resolution = systemContext?.controlTabAction(
+        let resolution = systemContext.controlTabAction(
             routing: routingSelectors(params),
             actionKey: action,
             title: string(params, "title"),
@@ -32,7 +35,7 @@ extension ControlCommandCoordinator {
             surfaceID: surfaceID ?? tabID,
             requestedFocus: bool(params, "focus") ?? false,
             moveParams: params
-        ) ?? .tabManagerUnavailable
+        )
 
         switch resolution {
         case .tabManagerUnavailable:
@@ -46,7 +49,7 @@ extension ControlCommandCoordinator {
         case .tabNotFound(let surfaceID):
             return .err(
                 code: "not_found",
-                message: "Tab not found",
+                message: systemContext.controlSystemTabNotFoundMessage(),
                 data: .object([
                     "surface_id": .string(surfaceID.uuidString),
                     "surface_ref": ref(.surface, surfaceID),

--- a/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Coordinator/System/ControlCommandCoordinator+SystemTabAction.swift
+++ b/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Coordinator/System/ControlCommandCoordinator+SystemTabAction.swift
@@ -16,12 +16,20 @@ extension ControlCommandCoordinator {
     /// `surface.action` / `tab.action` — run one surface-tab mutation.
     func tabAction(_ params: [String: JSONValue]) -> ControlCallResult {
         let action = actionKey(params)
+        let surfaceID = uuid(params, "surface_id")
+        let tabID = uuid(params, "tab_id")
+        if hasNonNull(params, "surface_id"), surfaceID == nil {
+            return .err(code: "not_found", message: "Surface not found", data: nil)
+        }
+        if hasNonNull(params, "tab_id"), tabID == nil {
+            return .err(code: "not_found", message: "Tab not found", data: nil)
+        }
         let resolution = systemContext?.controlTabAction(
             routing: routingSelectors(params),
             actionKey: action,
             title: string(params, "title"),
             rawURL: string(params, "url"),
-            surfaceID: uuid(params, "surface_id") ?? uuid(params, "tab_id"),
+            surfaceID: surfaceID ?? tabID,
             requestedFocus: bool(params, "focus") ?? false,
             moveParams: params
         ) ?? .tabManagerUnavailable

--- a/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Coordinator/System/ControlSystemContext.swift
+++ b/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Coordinator/System/ControlSystemContext.swift
@@ -104,6 +104,18 @@ public protocol ControlSystemContext: AnyObject {
         moveParams: [String: JSONValue]
     ) -> ControlTabActionResolution
 
+    /// Returns the app-localized generic surface-not-found message for tab-action
+    /// routing failures.
+    ///
+    /// - Returns: The localized surface-not-found message.
+    func controlSystemSurfaceNotFoundMessage() -> String
+
+    /// Returns the app-localized generic tab-not-found message for tab-action
+    /// routing failures.
+    ///
+    /// - Returns: The localized tab-not-found message.
+    func controlSystemTabNotFoundMessage() -> String
+
     /// Splits a surface off into its own pane for `surface.split_off` /
     /// `surface.drag_to_split`, delegating to the shared app-side
     /// `v2SurfaceSplitOff` (also driven by the v1 `drag_surface_to_split`

--- a/Packages/macOS/CmuxControlSocket/Tests/CmuxControlSocketTests/ControlCommandContextTestStubs+System.swift
+++ b/Packages/macOS/CmuxControlSocket/Tests/CmuxControlSocketTests/ControlCommandContextTestStubs+System.swift
@@ -42,6 +42,8 @@ extension ControlSystemContext {
         requestedFocus: Bool,
         moveParams: [String: JSONValue]
     ) -> ControlTabActionResolution { .tabManagerUnavailable }
+    func controlSystemSurfaceNotFoundMessage() -> String { "Surface not found" }
+    func controlSystemTabNotFoundMessage() -> String { "Tab not found" }
     func controlSurfaceSplitOff(params: [String: JSONValue]) -> ControlCallResult {
         .err(code: "unavailable", message: "AppDelegate not available", data: nil)
     }

--- a/Packages/macOS/CmuxControlSocket/Tests/CmuxControlSocketTests/ControlCommandContextTestStubs.swift
+++ b/Packages/macOS/CmuxControlSocket/Tests/CmuxControlSocketTests/ControlCommandContextTestStubs.swift
@@ -45,6 +45,7 @@ extension ControlPaneContext {
     func controlPaneList(routing: ControlRoutingSelectors) -> ControlPaneListSnapshot? { nil }
     func controlPaneRoutingResolvesTabManager(routing: ControlRoutingSelectors) -> Bool { false }
     func controlPaneResizeInvalidParametersMessage() -> String { "Invalid pane resize parameters" }
+    func controlPaneSurfaceNotFoundMessage() -> String { "Surface not found" }
     func controlPaneFocus(
         routing: ControlRoutingSelectors,
         paneID: UUID
@@ -419,6 +420,7 @@ extension ControlSurfaceContext {
             surfaceNotTerminal: ""
         )
     }
+    func controlSurfaceNotFoundMessage() -> String { "Surface not found" }
 
     func controlSurfaceSplit(
         routing: ControlRoutingSelectors,

--- a/Packages/macOS/CmuxControlSocket/Tests/CmuxControlSocketTests/ControlCommandContextTestStubs.swift
+++ b/Packages/macOS/CmuxControlSocket/Tests/CmuxControlSocketTests/ControlCommandContextTestStubs.swift
@@ -437,7 +437,8 @@ extension ControlSurfaceContext {
 
     func controlSurfaceClose(
         routing: ControlRoutingSelectors,
-        surfaceID: UUID?
+        surfaceID: UUID?,
+        hasSurfaceIDParam: Bool
     ) -> ControlSurfaceCloseResolution { .tabManagerUnavailable }
 
     func controlSurfaceMove(params: [String: JSONValue]) -> ControlCallResult {

--- a/Packages/macOS/CmuxControlSocket/Tests/CmuxControlSocketTests/ControlCommandCoordinatorSurfaceTests.swift
+++ b/Packages/macOS/CmuxControlSocket/Tests/CmuxControlSocketTests/ControlCommandCoordinatorSurfaceTests.swift
@@ -145,6 +145,44 @@ struct ControlCommandCoordinatorSurfaceTests {
         #expect(data == .object(["type": .string("agentSession")]))
     }
 
+    @Test func surfaceCloseRejectsUnresolvedExplicitSurfaceRef() {
+        let context = FakeSurfaceControlCommandContext()
+        let coordinator = ControlCommandCoordinator(context: context)
+
+        let result = coordinator.handle(ControlRequest(
+            id: .int(1),
+            method: "surface.close",
+            params: [
+                "workspace_id": .string(UUID().uuidString),
+                "surface_id": .string("surface:99999"),
+            ]
+        ))
+
+        #expect(result == .err(code: "not_found", message: "Surface not found", data: nil))
+    }
+
+    @Test func surfaceRespawnRejectsUnresolvedExplicitSurfaceRef() {
+        let context = FakeSurfaceControlCommandContext()
+        let coordinator = ControlCommandCoordinator(context: context)
+
+        let result = coordinator.handle(ControlRequest(
+            id: .int(1),
+            method: "surface.respawn",
+            params: [
+                "workspace_id": .string(UUID().uuidString),
+                "surface_id": .string("surface:99999"),
+                "command": .string("echo nope"),
+            ]
+        ))
+
+        guard case .err(let code, _, let data) = result else {
+            Issue.record("expected not_found error")
+            return
+        }
+        #expect(code == "not_found")
+        #expect(data == nil)
+    }
+
     @Test func surfaceListIncludesLiveSimulatorIdentity() throws {
         let context = FakeSurfaceControlCommandContext()
         let workspaceID = UUID()

--- a/Packages/macOS/CmuxControlSocket/Tests/CmuxControlSocketTests/ControlCommandCoordinatorSurfaceTests.swift
+++ b/Packages/macOS/CmuxControlSocket/Tests/CmuxControlSocketTests/ControlCommandCoordinatorSurfaceTests.swift
@@ -94,6 +94,35 @@ struct ControlCommandCoordinatorSurfaceTests {
         #expect(payload["type"] == .string("terminal"))
     }
 
+    @Test func paneBreakRejectsExplicitNullSurfaceID() {
+        let context = FakeSurfaceControlCommandContext()
+        let coordinator = ControlCommandCoordinator(context: context)
+
+        let result = coordinator.handle(ControlRequest(
+            id: .int(1),
+            method: "pane.break",
+            params: ["surface_id": .null]
+        ))
+
+        #expect(result == .err(code: "not_found", message: "Surface not found", data: nil))
+    }
+
+    @Test func paneJoinRejectsExplicitNullSurfaceID() {
+        let context = FakeSurfaceControlCommandContext()
+        let coordinator = ControlCommandCoordinator(context: context)
+
+        let result = coordinator.handle(ControlRequest(
+            id: .int(1),
+            method: "pane.join",
+            params: [
+                "target_pane_id": .string(UUID().uuidString),
+                "surface_id": .null,
+            ]
+        ))
+
+        #expect(result == .err(code: "not_found", message: "Surface not found", data: nil))
+    }
+
     @Test func surfaceCreateRemotePayloadIdentifiesTmuxNewWindow() throws {
         let workspaceID = UUID()
         let (coordinator, context) = coordinator(createResolution: .routedToRemote(
@@ -161,6 +190,22 @@ struct ControlCommandCoordinatorSurfaceTests {
         #expect(result == .err(code: "not_found", message: "Surface not found", data: nil))
     }
 
+    @Test func surfaceCloseRejectsExplicitNullSurfaceID() {
+        let context = FakeSurfaceControlCommandContext()
+        let coordinator = ControlCommandCoordinator(context: context)
+
+        let result = coordinator.handle(ControlRequest(
+            id: .int(1),
+            method: "surface.close",
+            params: [
+                "workspace_id": .string(UUID().uuidString),
+                "surface_id": .null,
+            ]
+        ))
+
+        #expect(result == .err(code: "not_found", message: "Surface not found", data: nil))
+    }
+
     @Test func surfaceRespawnRejectsUnresolvedExplicitSurfaceRef() {
         let context = FakeSurfaceControlCommandContext()
         let coordinator = ControlCommandCoordinator(context: context)
@@ -171,6 +216,28 @@ struct ControlCommandCoordinatorSurfaceTests {
             params: [
                 "workspace_id": .string(UUID().uuidString),
                 "surface_id": .string("surface:99999"),
+                "command": .string("echo nope"),
+            ]
+        ))
+
+        guard case .err(let code, _, let data) = result else {
+            Issue.record("expected not_found error")
+            return
+        }
+        #expect(code == "not_found")
+        #expect(data == nil)
+    }
+
+    @Test func surfaceRespawnRejectsExplicitNullSurfaceID() {
+        let context = FakeSurfaceControlCommandContext()
+        let coordinator = ControlCommandCoordinator(context: context)
+
+        let result = coordinator.handle(ControlRequest(
+            id: .int(1),
+            method: "surface.respawn",
+            params: [
+                "workspace_id": .string(UUID().uuidString),
+                "surface_id": .null,
                 "command": .string("echo nope"),
             ]
         ))

--- a/Packages/macOS/CmuxControlSocket/Tests/CmuxControlSocketTests/ControlCommandCoordinatorTabActionTests.swift
+++ b/Packages/macOS/CmuxControlSocket/Tests/CmuxControlSocketTests/ControlCommandCoordinatorTabActionTests.swift
@@ -71,6 +71,42 @@ struct ControlCommandCoordinatorTabActionTests {
         #expect(supportedActions.contains(.string("toggle_full_width_tab")))
     }
 
+    @Test func tabActionRejectsExplicitNullSurfaceIDBeforeContextMutation() {
+        let context = FakeTabActionControlCommandContext()
+        let coordinator = ControlCommandCoordinator(context: context)
+
+        let result = coordinator.handle(ControlRequest(
+            id: .int(1),
+            method: "tab.action",
+            params: [
+                "action": .string("close_right"),
+                "surface_id": .null,
+            ]
+        ))
+
+        #expect(result == .err(code: "not_found", message: "Surface not found", data: nil))
+        #expect(context.actionKey == nil)
+        #expect(context.surfaceID == nil)
+    }
+
+    @Test func tabActionRejectsExplicitNullTabIDBeforeContextMutation() {
+        let context = FakeTabActionControlCommandContext()
+        let coordinator = ControlCommandCoordinator(context: context)
+
+        let result = coordinator.handle(ControlRequest(
+            id: .int(1),
+            method: "tab.action",
+            params: [
+                "action": .string("close_right"),
+                "tab_id": .null,
+            ]
+        ))
+
+        #expect(result == .err(code: "not_found", message: "Tab not found", data: nil))
+        #expect(context.actionKey == nil)
+        #expect(context.surfaceID == nil)
+    }
+
     @Test func failedFullWidthTabToggleReturnsInvalidState() throws {
         let surfaceID = UUID()
         let context = FakeTabActionControlCommandContext()

--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -35061,6 +35061,108 @@
         }
       }
     },
+    "cli.closeSurface.error.explicitSurfaceRequiresWorkspaceOrWindow": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "close-surface requires --workspace or --window with explicit --surface"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "明示的に --surface を指定する場合、close-surface には --workspace または --window が必要です"
+          }
+        }
+      }
+    },
+    "cli.surface.error.handleBlank": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Surface handle is blank"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "サーフェスハンドルが空です"
+          }
+        }
+      }
+    },
+    "cli.surface.error.indexNotFound": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Surface index not found"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "サーフェスインデックスが見つかりません"
+          }
+        }
+      }
+    },
+    "cli.surface.error.invalidHandle": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Invalid surface handle: %@ (expected UUID, ref like surface:1, or index)"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "無効なサーフェスハンドル: %@ (UUID、surface:1 のような参照、またはインデックスを指定してください)"
+          }
+        }
+      }
+    },
+    "cli.surface.error.notFound": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Surface not found: %@"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "サーフェスが見つかりません: %@"
+          }
+        }
+      }
+    },
+    "cli.surface.error.refNotFound": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Surface ref not found: %@"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "サーフェス参照が見つかりません: %@"
+          }
+        }
+      }
+    },
     "cli.claude-hook.notification.title": {
       "extractionState": "manual",
       "localizations": {
@@ -228799,6 +228901,23 @@
         }
       }
     },
+    "socket.pane.error.surfaceNotFound": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Surface not found"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "サーフェスが見つかりません"
+          }
+        }
+      }
+    },
     "socket.pane.resize.invalidParameters": {
       "extractionState": "manual",
       "localizations": {
@@ -229122,6 +229241,23 @@
         }
       }
     },
+    "socket.surface.error.surfaceNotFound": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Surface not found"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "サーフェスが見つかりません"
+          }
+        }
+      }
+    },
     "socket.surfaceSplitOff.error.appDelegateUnavailable": {
       "extractionState": "manual",
       "localizations": {
@@ -229322,6 +229458,40 @@
           "stringUnit": {
             "state": "translated",
             "value": "分割して移動すると移動元ペインが空になります"
+          }
+        }
+      }
+    },
+    "socket.tabAction.error.surfaceNotFound": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Surface not found"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "サーフェスが見つかりません"
+          }
+        }
+      }
+    },
+    "socket.tabAction.error.tabNotFound": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tab not found"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "タブが見つかりません"
           }
         }
       }

--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -35064,10 +35064,52 @@
     "cli.closeSurface.error.explicitSurfaceRequiresWorkspaceOrWindow": {
       "extractionState": "manual",
       "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "يتطلب close-surface الخيار --workspace أو --window عند تحديد --surface صراحةً"
+          }
+        },
+        "bs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "close-surface zahtijeva --workspace ili --window uz eksplicitni --surface"
+          }
+        },
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "close-surface kræver --workspace eller --window med eksplicit --surface"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "close-surface erfordert --workspace oder --window mit explizitem --surface"
+          }
+        },
         "en": {
           "stringUnit": {
             "state": "translated",
             "value": "close-surface requires --workspace or --window with explicit --surface"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "close-surface requiere --workspace o --window con --surface explícito"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "close-surface requiert --workspace ou --window avec --surface explicite"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "close-surface richiede --workspace o --window con --surface esplicito"
           }
         },
         "ja": {
@@ -35075,16 +35117,124 @@
             "state": "translated",
             "value": "明示的に --surface を指定する場合、close-surface には --workspace または --window が必要です"
           }
+        },
+        "km": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "close-surface ត្រូវការ --workspace ឬ --window ជាមួយ --surface ដែលបានបញ្ជាក់ច្បាស់"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "명시적 --surface에는 close-surface에 --workspace 또는 --window가 필요합니다"
+          }
+        },
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "close-surface krever --workspace eller --window med eksplisitt --surface"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "close-surface wymaga --workspace albo --window przy jawnym --surface"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "close-surface requer --workspace ou --window com --surface explícito"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "close-surface требует --workspace или --window при явном --surface"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "close-surface ต้องใช้ --workspace หรือ --window เมื่อระบุ --surface อย่างชัดเจน"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Açık --surface ile close-surface için --workspace veya --window gerekir"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "close-surface потребує --workspace або --window з явним --surface"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "显式指定 --surface 时，close-surface 需要 --workspace 或 --window"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "明確指定 --surface 時，close-surface 需要 --workspace 或 --window"
+          }
         }
       }
     },
     "cli.surface.error.handleBlank": {
       "extractionState": "manual",
       "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "معرّف السطح فارغ"
+          }
+        },
+        "bs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ručka površine je prazna"
+          }
+        },
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Overfladehåndtaget er tomt"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Oberflächen-Handle ist leer"
+          }
+        },
         "en": {
           "stringUnit": {
             "state": "translated",
             "value": "Surface handle is blank"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "El identificador de superficie está vacío"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "L’identifiant de surface est vide"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "L'handle della superficie è vuoto"
           }
         },
         "ja": {
@@ -35092,16 +35242,124 @@
             "state": "translated",
             "value": "サーフェスハンドルが空です"
           }
+        },
+        "km": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ហែនឌែលផ្ទៃទទេ"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "서피스 핸들이 비어 있습니다"
+          }
+        },
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Overflatehåndtaket er tomt"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Uchwyt powierzchni jest pusty"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "O identificador da superfície está vazio"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Дескриптор поверхности пуст"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "แฮนเดิลพื้นผิวว่างเปล่า"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Yüzey tanıtıcısı boş"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Дескриптор поверхні порожній"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "表面句柄为空"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "表面控制代碼為空"
+          }
         }
       }
     },
     "cli.surface.error.indexNotFound": {
       "extractionState": "manual",
       "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "لم يتم العثور على فهرس السطح"
+          }
+        },
+        "bs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Indeks površine nije pronađen"
+          }
+        },
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Overfladeindeks blev ikke fundet"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Oberflächenindex nicht gefunden"
+          }
+        },
         "en": {
           "stringUnit": {
             "state": "translated",
             "value": "Surface index not found"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No se encontró el índice de superficie"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Index de surface introuvable"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Indice superficie non trovato"
           }
         },
         "ja": {
@@ -35109,16 +35367,124 @@
             "state": "translated",
             "value": "サーフェスインデックスが見つかりません"
           }
+        },
+        "km": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "រកមិនឃើញលិបិក្រមផ្ទៃ"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "서피스 인덱스를 찾을 수 없습니다"
+          }
+        },
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fant ikke overflateindeks"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nie znaleziono indeksu powierzchni"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Índice de superfície não encontrado"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Индекс поверхности не найден"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ไม่พบดัชนีพื้นผิว"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Yüzey dizini bulunamadı"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Індекс поверхні не знайдено"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "未找到表面索引"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "找不到表面索引"
+          }
         }
       }
     },
     "cli.surface.error.invalidHandle": {
       "extractionState": "manual",
       "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "معرّف سطح غير صالح: %@ (المتوقع UUID أو مرجع مثل surface:1 أو فهرس)"
+          }
+        },
+        "bs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nevažeća ručka površine: %@ (očekuje se UUID, referenca poput surface:1 ili indeks)"
+          }
+        },
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ugyldigt overfladehåndtag: %@ (forventede UUID, reference som surface:1 eller indeks)"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ungültiges Oberflächen-Handle: %@ (UUID, Referenz wie surface:1 oder Index erwartet)"
+          }
+        },
         "en": {
           "stringUnit": {
             "state": "translated",
             "value": "Invalid surface handle: %@ (expected UUID, ref like surface:1, or index)"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Identificador de superficie no válido: %@ (se esperaba UUID, referencia como surface:1 o índice)"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Identifiant de surface invalide: %@ (UUID, référence comme surface:1 ou index attendu)"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Handle superficie non valido: %@ (previsto UUID, riferimento come surface:1 o indice)"
           }
         },
         "ja": {
@@ -35126,16 +35492,124 @@
             "state": "translated",
             "value": "無効なサーフェスハンドル: %@ (UUID、surface:1 のような参照、またはインデックスを指定してください)"
           }
+        },
+        "km": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ហែនឌែលផ្ទៃមិនត្រឹមត្រូវ: %@ (រំពឹង UUID សេចក្តីយោងដូចជា surface:1 ឬលិបិក្រម)"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "잘못된 서피스 핸들: %@ (UUID, surface:1 같은 참조 또는 인덱스 필요)"
+          }
+        },
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ugyldig overflatehåndtak: %@ (forventet UUID, referanse som surface:1 eller indeks)"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nieprawidłowy uchwyt powierzchni: %@ (oczekiwano UUID, odwołania jak surface:1 albo indeksu)"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Identificador de superfície inválido: %@ (esperado UUID, referência como surface:1 ou índice)"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Недопустимый дескриптор поверхности: %@ (ожидается UUID, ссылка вида surface:1 или индекс)"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "แฮนเดิลพื้นผิวไม่ถูกต้อง: %@ (ต้องเป็น UUID การอ้างอิงเช่น surface:1 หรือดัชนี)"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Geçersiz yüzey tanıtıcısı: %@ (UUID, surface:1 gibi başvuru veya dizin beklenir)"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Недійсний дескриптор поверхні: %@ (очікується UUID, посилання на кшталт surface:1 або індекс)"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "无效的表面句柄: %@ (应为 UUID、类似 surface:1 的引用或索引)"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "無效的表面控制代碼: %@ (預期 UUID、類似 surface:1 的參照或索引)"
+          }
         }
       }
     },
     "cli.surface.error.notFound": {
       "extractionState": "manual",
       "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "لم يتم العثور على السطح: %@"
+          }
+        },
+        "bs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Površina nije pronađena: %@"
+          }
+        },
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Overflade blev ikke fundet: %@"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Oberfläche nicht gefunden: %@"
+          }
+        },
         "en": {
           "stringUnit": {
             "state": "translated",
             "value": "Surface not found: %@"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No se encontró la superficie: %@"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Surface introuvable: %@"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Superficie non trovata: %@"
           }
         },
         "ja": {
@@ -35143,22 +35617,196 @@
             "state": "translated",
             "value": "サーフェスが見つかりません: %@"
           }
+        },
+        "km": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "រកមិនឃើញផ្ទៃ: %@"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "서피스를 찾을 수 없습니다: %@"
+          }
+        },
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fant ikke overflate: %@"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nie znaleziono powierzchni: %@"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Superfície não encontrada: %@"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Поверхность не найдена: %@"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ไม่พบพื้นผิว: %@"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Yüzey bulunamadı: %@"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Поверхню не знайдено: %@"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "未找到表面: %@"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "找不到表面: %@"
+          }
         }
       }
     },
     "cli.surface.error.refNotFound": {
       "extractionState": "manual",
       "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "لم يتم العثور على مرجع السطح: %@"
+          }
+        },
+        "bs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Referenca površine nije pronađena: %@"
+          }
+        },
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Overfladereference blev ikke fundet: %@"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Oberflächenreferenz nicht gefunden: %@"
+          }
+        },
         "en": {
           "stringUnit": {
             "state": "translated",
             "value": "Surface ref not found: %@"
           }
         },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No se encontró la referencia de superficie: %@"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Référence de surface introuvable: %@"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Riferimento superficie non trovato: %@"
+          }
+        },
         "ja": {
           "stringUnit": {
             "state": "translated",
             "value": "サーフェス参照が見つかりません: %@"
+          }
+        },
+        "km": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "រកមិនឃើញសេចក្តីយោងផ្ទៃ: %@"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "서피스 참조를 찾을 수 없습니다: %@"
+          }
+        },
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fant ikke overflatereferanse: %@"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nie znaleziono odwołania do powierzchni: %@"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Referência de superfície não encontrada: %@"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ссылка на поверхность не найдена: %@"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ไม่พบการอ้างอิงพื้นผิว: %@"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Yüzey referansı bulunamadı: %@"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Посилання на поверхню не знайдено: %@"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "未找到表面引用: %@"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "找不到表面參照: %@"
           }
         }
       }
@@ -228904,16 +229552,124 @@
     "socket.pane.error.surfaceNotFound": {
       "extractionState": "manual",
       "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "لم يتم العثور على السطح"
+          }
+        },
+        "bs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Površina nije pronađena"
+          }
+        },
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Overflade blev ikke fundet"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Oberfläche nicht gefunden"
+          }
+        },
         "en": {
           "stringUnit": {
             "state": "translated",
             "value": "Surface not found"
           }
         },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No se encontró la superficie"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Surface introuvable"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Superficie non trovata"
+          }
+        },
         "ja": {
           "stringUnit": {
             "state": "translated",
             "value": "サーフェスが見つかりません"
+          }
+        },
+        "km": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "រកមិនឃើញផ្ទៃ"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "서피스를 찾을 수 없습니다"
+          }
+        },
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fant ikke overflate"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nie znaleziono powierzchni"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Superfície não encontrada"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Поверхность не найдена"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ไม่พบพื้นผิว"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Yüzey bulunamadı"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Поверхню не знайдено"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "未找到表面"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "找不到表面"
           }
         }
       }
@@ -229244,16 +230000,124 @@
     "socket.surface.error.surfaceNotFound": {
       "extractionState": "manual",
       "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "لم يتم العثور على السطح"
+          }
+        },
+        "bs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Površina nije pronađena"
+          }
+        },
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Overflade blev ikke fundet"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Oberfläche nicht gefunden"
+          }
+        },
         "en": {
           "stringUnit": {
             "state": "translated",
             "value": "Surface not found"
           }
         },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No se encontró la superficie"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Surface introuvable"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Superficie non trovata"
+          }
+        },
         "ja": {
           "stringUnit": {
             "state": "translated",
             "value": "サーフェスが見つかりません"
+          }
+        },
+        "km": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "រកមិនឃើញផ្ទៃ"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "서피스를 찾을 수 없습니다"
+          }
+        },
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fant ikke overflate"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nie znaleziono powierzchni"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Superfície não encontrada"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Поверхность не найдена"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ไม่พบพื้นผิว"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Yüzey bulunamadı"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Поверхню не знайдено"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "未找到表面"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "找不到表面"
           }
         }
       }
@@ -229465,10 +230329,52 @@
     "socket.tabAction.error.surfaceNotFound": {
       "extractionState": "manual",
       "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "لم يتم العثور على السطح"
+          }
+        },
+        "bs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Površina nije pronađena"
+          }
+        },
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Overflade blev ikke fundet"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Oberfläche nicht gefunden"
+          }
+        },
         "en": {
           "stringUnit": {
             "state": "translated",
             "value": "Surface not found"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No se encontró la superficie"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Surface introuvable"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Superficie non trovata"
           }
         },
         "ja": {
@@ -229476,22 +230382,196 @@
             "state": "translated",
             "value": "サーフェスが見つかりません"
           }
+        },
+        "km": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "រកមិនឃើញផ្ទៃ"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "서피스를 찾을 수 없습니다"
+          }
+        },
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fant ikke overflate"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nie znaleziono powierzchni"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Superfície não encontrada"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Поверхность не найдена"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ไม่พบพื้นผิว"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Yüzey bulunamadı"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Поверхню не знайдено"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "未找到表面"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "找不到表面"
+          }
         }
       }
     },
     "socket.tabAction.error.tabNotFound": {
       "extractionState": "manual",
       "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "لم يتم العثور على علامة التبويب"
+          }
+        },
+        "bs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kartica nije pronađena"
+          }
+        },
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fane blev ikke fundet"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tab nicht gefunden"
+          }
+        },
         "en": {
           "stringUnit": {
             "state": "translated",
             "value": "Tab not found"
           }
         },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No se encontró la pestaña"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Onglet introuvable"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Scheda non trovata"
+          }
+        },
         "ja": {
           "stringUnit": {
             "state": "translated",
             "value": "タブが見つかりません"
+          }
+        },
+        "km": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "រកមិនឃើញផ្ទាំង"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "탭을 찾을 수 없습니다"
+          }
+        },
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fant ikke fane"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nie znaleziono karty"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aba não encontrada"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Вкладка не найдена"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ไม่พบแท็บ"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sekme bulunamadı"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Вкладку не знайдено"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "未找到标签页"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "找不到分頁"
           }
         }
       }

--- a/Sources/TerminalController+ControlPaneContext.swift
+++ b/Sources/TerminalController+ControlPaneContext.swift
@@ -15,6 +15,10 @@ extension TerminalController: ControlPaneContext {
         String(localized: "socket.pane.resize.invalidParameters", defaultValue: "Invalid pane resize parameters")
     }
 
+    func controlPaneSurfaceNotFoundMessage() -> String {
+        String(localized: "socket.pane.error.surfaceNotFound", defaultValue: "Surface not found")
+    }
+
     // MARK: - Routing helpers
 
     /// The routing twin of the legacy `v2ResolveWorkspace(params:tabManager:)`,

--- a/Sources/TerminalController+ControlSurfaceContext2.swift
+++ b/Sources/TerminalController+ControlSurfaceContext2.swift
@@ -41,6 +41,10 @@ extension TerminalController {
         )
     }
 
+    func controlSurfaceNotFoundMessage() -> String {
+        String(localized: "socket.surface.error.surfaceNotFound", defaultValue: "Surface not found")
+    }
+
     /// The byte-faithful twin of `v2BrowserDisabledExternalOpenResult`, mapped onto
     /// the shared ``ControlSurfaceBrowserDisabledOutcome``.
     private func surfaceBrowserDisabledOutcome(

--- a/Sources/TerminalController+ControlSurfaceContext2.swift
+++ b/Sources/TerminalController+ControlSurfaceContext2.swift
@@ -435,12 +435,21 @@ extension TerminalController {
 
     func controlSurfaceClose(
         routing: ControlRoutingSelectors,
-        surfaceID: UUID?
+        surfaceID: UUID?,
+        hasSurfaceIDParam: Bool
     ) -> ControlSurfaceCloseResolution {
         guard let tabManager = resolveTabManager(routing: routing) else {
             return .tabManagerUnavailable
         }
-        if let resolution = controlWindowDockSurfaceClose(routing: routing, surfaceID: surfaceID, tabManager: tabManager) {
+        if hasSurfaceIDParam, surfaceID == nil {
+            return .invalidSurfaceID
+        }
+        if let resolution = controlWindowDockSurfaceClose(
+            routing: routing,
+            surfaceID: surfaceID,
+            hasSurfaceIDParam: hasSurfaceIDParam,
+            tabManager: tabManager
+        ) {
             return resolution
         }
         guard let ws = resolveSurfaceWorkspace(routing: routing, tabManager: tabManager) else {
@@ -448,6 +457,7 @@ extension TerminalController {
         }
         guard let surfaceId = resolvedSurfaceIdForClose(
             explicitSurfaceID: surfaceID,
+            hasSurfaceIDParam: hasSurfaceIDParam,
             routing: routing,
             fallbackWorkspace: ws
         ) else {

--- a/Sources/TerminalController+ControlSurfaceDock.swift
+++ b/Sources/TerminalController+ControlSurfaceDock.swift
@@ -317,15 +317,19 @@ extension TerminalController {
     func controlWindowDockSurfaceClose(
         routing: ControlRoutingSelectors,
         surfaceID: UUID?,
+        hasSurfaceIDParam: Bool,
         tabManager: TabManager
     ) -> ControlSurfaceCloseResolution? {
         guard let windowDock = windowDockForRouting(routing, tabManager: tabManager) else { return nil }
         let resolved = resolvedWindowDockSurfaceId(
             explicitSurfaceID: surfaceID,
-            hasSurfaceIDParam: false,
+            hasSurfaceIDParam: hasSurfaceIDParam,
             routing: routing,
             dock: windowDock
         )
+        if resolved.invalidSurfaceID {
+            return .invalidSurfaceID
+        }
         guard let surfaceId = resolved.surfaceID else {
             return .noFocusedSurface
         }
@@ -385,9 +389,13 @@ extension TerminalController {
 
     func resolvedSurfaceIdForClose(
         explicitSurfaceID: UUID?,
+        hasSurfaceIDParam: Bool,
         routing: ControlRoutingSelectors,
         fallbackWorkspace: Workspace
     ) -> UUID? {
+        if hasSurfaceIDParam && explicitSurfaceID == nil {
+            return nil
+        }
         if let explicitSurfaceID {
             return explicitSurfaceID
         }

--- a/Sources/TerminalController+ControlSystemContext.swift
+++ b/Sources/TerminalController+ControlSystemContext.swift
@@ -16,6 +16,14 @@ import Foundation
 /// `drag_surface_to_split`), so their witnesses bridge.
 extension TerminalController: ControlSystemContext {
 
+    func controlSystemSurfaceNotFoundMessage() -> String {
+        String(localized: "socket.tabAction.error.surfaceNotFound", defaultValue: "Surface not found")
+    }
+
+    func controlSystemTabNotFoundMessage() -> String {
+        String(localized: "socket.tabAction.error.tabNotFound", defaultValue: "Tab not found")
+    }
+
     // MARK: - identify (bridge to the still-shared v2Identify)
 
     func controlSystemIdentify(params: [String: JSONValue]) -> JSONValue {

--- a/cmuxTests/CLIExplicitSurfaceRoutingTests.swift
+++ b/cmuxTests/CLIExplicitSurfaceRoutingTests.swift
@@ -203,6 +203,56 @@ struct CLIExplicitSurfaceRoutingTests {
         #expect(requests.isEmpty, Comment(rawValue: String(describing: requests)))
     }
 
+    @Test func closeSurfaceRejectsBlankExplicitTargetWithWindowWithoutMutation() throws {
+        let socketPath = Self.makeSocketPath("close-blank")
+        let listenerFD = try Self.bindUnixSocket(at: socketPath)
+        defer {
+            Darwin.close(listenerFD)
+            unlink(socketPath)
+        }
+
+        var environment = cliEnvironment(socketPath: socketPath)
+        environment.removeValue(forKey: "CMUX_WORKSPACE_ID")
+        environment.removeValue(forKey: "CMUX_SURFACE_ID")
+
+        let state = ServerState()
+        let handled = Self.startMockServer(listenerFD: listenerFD, state: state) { line in
+            guard let payload = Self.jsonObject(line),
+                  let id = payload["id"] as? String,
+                  let method = payload["method"] as? String else {
+                return Self.malformedRequestResponse(raw: line)
+            }
+            if method == "surface.close" {
+                state.recordMutation()
+            }
+            return Self.v2Response(
+                id: id,
+                ok: false,
+                error: ["code": "unexpected_method", "message": method]
+            )
+        }
+
+        let result = Self.runProcess(
+            executablePath: try Self.bundledCLIPath(),
+            arguments: [
+                "close-surface",
+                "--window", Self.reproWindowId,
+                "--surface", "   ",
+            ],
+            environment: environment,
+            timeout: 5
+        )
+
+        #expect(handled.wait(timeout: .now() + 5) == .success)
+        #expect(state.errorsSnapshot().isEmpty, Comment(rawValue: state.errorsSnapshot().joined(separator: "\n")))
+        #expect(!result.timedOut, Comment(rawValue: result.stderr))
+        #expect(result.status != 0, Comment(rawValue: result.stderr + result.stdout))
+        #expect((result.stderr + result.stdout).contains("Surface handle is blank"))
+        #expect(state.mutationCountSnapshot() == 0)
+        let requests = try state.requestObjects()
+        #expect(requests.isEmpty, Comment(rawValue: String(describing: requests)))
+    }
+
     @Test func respawnPaneRejectsMissingExplicitUUIDWithoutMutation() throws {
         let socketPath = Self.makeSocketPath("respawn")
         let listenerFD = try Self.bindUnixSocket(at: socketPath)

--- a/cmuxTests/CLIExplicitSurfaceRoutingTests.swift
+++ b/cmuxTests/CLIExplicitSurfaceRoutingTests.swift
@@ -96,6 +96,131 @@ struct CLIExplicitSurfaceRoutingTests {
         #expect(readParams["surface_id"] as? String == Self.numericSurfaceId)
     }
 
+    @Test func closeSurfaceRejectsMissingExplicitRefWithoutMutation() throws {
+        let socketPath = Self.makeSocketPath("close")
+        let listenerFD = try Self.bindUnixSocket(at: socketPath)
+        defer {
+            Darwin.close(listenerFD)
+            unlink(socketPath)
+        }
+
+        let state = ServerState()
+        let handled = Self.startMockServer(listenerFD: listenerFD, state: state) { line in
+            guard let payload = Self.jsonObject(line),
+                  let id = payload["id"] as? String,
+                  let method = payload["method"] as? String else {
+                return Self.malformedRequestResponse(raw: line)
+            }
+            switch method {
+            case "surface.list":
+                return Self.v2Response(id: id, ok: true, result: ["surfaces": Self.reproSurfaceRows])
+            case "surface.close":
+                state.recordMutation()
+                return Self.v2Response(
+                    id: id,
+                    ok: true,
+                    result: ["workspace_id": Self.reproWorkspaceRef, "surface_id": Self.reproSelectedSurfaceId]
+                )
+            default:
+                return Self.v2Response(
+                    id: id,
+                    ok: false,
+                    error: ["code": "unexpected_method", "message": method]
+                )
+            }
+        }
+
+        let result = Self.runProcess(
+            executablePath: try Self.bundledCLIPath(),
+            arguments: [
+                "close-surface",
+                "--surface", "surface:99999",
+                "--workspace", Self.reproWorkspaceRef,
+            ],
+            environment: cliEnvironment(socketPath: socketPath),
+            timeout: 5
+        )
+
+        #expect(handled.wait(timeout: .now() + 5) == .success)
+        #expect(state.errorsSnapshot().isEmpty, Comment(rawValue: state.errorsSnapshot().joined(separator: "\n")))
+        #expect(!result.timedOut, Comment(rawValue: result.stderr))
+        #expect(result.status != 0, Comment(rawValue: result.stderr + result.stdout))
+        #expect((result.stderr + result.stdout).contains("Surface ref not found: surface:99999"))
+        #expect(state.mutationCountSnapshot() == 0)
+
+        let requests = try state.requestObjects()
+        #expect(requests.compactMap { $0["method"] as? String } == ["surface.list"])
+        let listParams = try #require(requests.first?["params"] as? [String: Any])
+        #expect(listParams["workspace_id"] as? String == Self.reproWorkspaceRef)
+    }
+
+    @Test func respawnPaneRejectsMissingExplicitUUIDWithoutMutation() throws {
+        let socketPath = Self.makeSocketPath("respawn")
+        let listenerFD = try Self.bindUnixSocket(at: socketPath)
+        defer {
+            Darwin.close(listenerFD)
+            unlink(socketPath)
+        }
+
+        let state = ServerState()
+        let handled = Self.startMockServer(listenerFD: listenerFD, state: state) { line in
+            guard let payload = Self.jsonObject(line),
+                  let id = payload["id"] as? String,
+                  let method = payload["method"] as? String else {
+                return Self.malformedRequestResponse(raw: line)
+            }
+            switch method {
+            case "window.list":
+                return Self.v2Response(
+                    id: id,
+                    ok: true,
+                    result: ["windows": [["id": Self.reproWindowId, "ref": "window:1", "index": 0]]]
+                )
+            case "workspace.list":
+                return Self.v2Response(
+                    id: id,
+                    ok: true,
+                    result: ["workspaces": [["id": Self.reproWorkspaceId, "ref": Self.reproWorkspaceRef, "index": 0]]]
+                )
+            case "surface.list":
+                return Self.v2Response(id: id, ok: true, result: ["surfaces": Self.reproSurfaceRows])
+            case "surface.respawn":
+                state.recordMutation()
+                return Self.v2Response(id: id, ok: true, result: ["surface_id": Self.reproSelectedSurfaceId])
+            default:
+                return Self.v2Response(
+                    id: id,
+                    ok: false,
+                    error: ["code": "unexpected_method", "message": method]
+                )
+            }
+        }
+
+        let result = Self.runProcess(
+            executablePath: try Self.bundledCLIPath(),
+            arguments: [
+                "respawn-pane",
+                "--workspace", Self.reproWorkspaceRef,
+                "--surface", Self.missingSurfaceUUID,
+                "--command", "echo nope",
+            ],
+            environment: cliEnvironment(socketPath: socketPath),
+            timeout: 5
+        )
+
+        #expect(handled.wait(timeout: .now() + 5) == .success)
+        #expect(state.errorsSnapshot().isEmpty, Comment(rawValue: state.errorsSnapshot().joined(separator: "\n")))
+        #expect(!result.timedOut, Comment(rawValue: result.stderr))
+        #expect(result.status != 0, Comment(rawValue: result.stderr + result.stdout))
+        #expect((result.stderr + result.stdout).contains("Surface not found: \(Self.missingSurfaceUUID)"))
+        #expect(state.mutationCountSnapshot() == 0)
+
+        let requests = try state.requestObjects()
+        #expect(requests.compactMap { $0["method"] as? String } == ["window.list", "workspace.list", "surface.list"])
+        let listParams = try #require(requests.last?["params"] as? [String: Any])
+        #expect(listParams["workspace_id"] as? String == Self.reproWorkspaceId)
+    }
+
     private func assertExplicitSurfaceCommand(
         arguments: [String],
         expectedMethod: String,
@@ -171,6 +296,20 @@ struct CLIExplicitSurfaceRoutingTests {
     private static let callerSurfaceId = "22222222-2222-2222-2222-222222222222"
     private static let targetSurfaceRef = "surface:11"
     private static let numericSurfaceId = "33333333-3333-3333-3333-333333333333"
+    private static let reproWindowId = "44444444-4444-4444-4444-444444443001"
+    private static let reproWorkspaceId = "44444444-4444-4444-4444-444444443071"
+    private static let reproWorkspaceRef = "workspace:71"
+    private static let reproSelectedSurfaceId = "44444444-4444-4444-4444-444444443222"
+    private static let reproSecondSurfaceId = "44444444-4444-4444-4444-444444443223"
+    private static let reproThirdSurfaceId = "44444444-4444-4444-4444-444444443224"
+    private static let missingSurfaceUUID = "99999999-9999-9999-9999-999999999999"
+    private static var reproSurfaceRows: [[String: Any]] {
+        [
+            ["id": reproSelectedSurfaceId, "ref": "surface:3222", "index": 0, "focused": true],
+            ["id": reproSecondSurfaceId, "ref": "surface:3223", "index": 1, "focused": false],
+            ["id": reproThirdSurfaceId, "ref": "surface:3224", "index": 2, "focused": false],
+        ]
+    }
 
     private final class CLIExplicitSurfaceRoutingBundleToken {}
 
@@ -179,6 +318,7 @@ struct CLIExplicitSurfaceRoutingTests {
         private let lock = NSLock()
         private var requestLines: [String] = []
         private var errors: [String] = []
+        private var mutationCount = 0
 
         func record(_ line: String) {
             lock.lock()
@@ -196,6 +336,18 @@ struct CLIExplicitSurfaceRoutingTests {
             lock.lock()
             defer { lock.unlock() }
             return errors
+        }
+
+        func recordMutation() {
+            lock.lock()
+            mutationCount += 1
+            lock.unlock()
+        }
+
+        func mutationCountSnapshot() -> Int {
+            lock.lock()
+            defer { lock.unlock() }
+            return mutationCount
         }
 
         func requestObjects() throws -> [[String: Any]] {

--- a/cmuxTests/CLIExplicitSurfaceRoutingTests.swift
+++ b/cmuxTests/CLIExplicitSurfaceRoutingTests.swift
@@ -154,6 +154,55 @@ struct CLIExplicitSurfaceRoutingTests {
         #expect(listParams["workspace_id"] as? String == Self.reproWorkspaceRef)
     }
 
+    @Test func closeSurfaceRejectsExplicitTargetWithoutWorkspaceOrWindowWithoutMutation() throws {
+        let socketPath = Self.makeSocketPath("close-noworkspace")
+        let listenerFD = try Self.bindUnixSocket(at: socketPath)
+        defer {
+            Darwin.close(listenerFD)
+            unlink(socketPath)
+        }
+
+        var environment = cliEnvironment(socketPath: socketPath)
+        environment.removeValue(forKey: "CMUX_WORKSPACE_ID")
+        environment.removeValue(forKey: "CMUX_SURFACE_ID")
+
+        let state = ServerState()
+        let handled = Self.startMockServer(listenerFD: listenerFD, state: state) { line in
+            guard let payload = Self.jsonObject(line),
+                  let id = payload["id"] as? String,
+                  let method = payload["method"] as? String else {
+                return Self.malformedRequestResponse(raw: line)
+            }
+            if method == "surface.close" {
+                state.recordMutation()
+            }
+            return Self.v2Response(
+                id: id,
+                ok: false,
+                error: ["code": "unexpected_method", "message": method]
+            )
+        }
+
+        let result = Self.runProcess(
+            executablePath: try Self.bundledCLIPath(),
+            arguments: [
+                "close-surface",
+                "--surface", Self.missingSurfaceUUID,
+            ],
+            environment: environment,
+            timeout: 5
+        )
+
+        #expect(handled.wait(timeout: .now() + 5) == .success)
+        #expect(state.errorsSnapshot().isEmpty, Comment(rawValue: state.errorsSnapshot().joined(separator: "\n")))
+        #expect(!result.timedOut, Comment(rawValue: result.stderr))
+        #expect(result.status != 0, Comment(rawValue: result.stderr + result.stdout))
+        #expect((result.stderr + result.stdout).contains("close-surface requires --workspace or --window with explicit --surface"))
+        #expect(state.mutationCountSnapshot() == 0)
+        let requests = try state.requestObjects()
+        #expect(requests.isEmpty, Comment(rawValue: String(describing: requests)))
+    }
+
     @Test func respawnPaneRejectsMissingExplicitUUIDWithoutMutation() throws {
         let socketPath = Self.makeSocketPath("respawn")
         let listenerFD = try Self.bindUnixSocket(at: socketPath)

--- a/cmuxTests/RemoteTmuxMirrorCLIFailClosedTests.swift
+++ b/cmuxTests/RemoteTmuxMirrorCLIFailClosedTests.swift
@@ -30,7 +30,8 @@ extension RemoteTmuxMirrorCLIObservabilityTests {
 
             let result = TerminalController.shared.controlSurfaceClose(
                 routing: harness.routing(),
-                surfaceID: nil
+                surfaceID: nil,
+                hasSurfaceIDParam: false
             )
 
             #expect(result == .noFocusedSurface)
@@ -93,7 +94,8 @@ extension RemoteTmuxMirrorCLIObservabilityTests {
             defer { harness.tearDown() }
             let result = TerminalController.shared.controlSurfaceClose(
                 routing: harness.routing(),
-                surfaceID: harness.outerPanelID
+                surfaceID: harness.outerPanelID,
+                hasSurfaceIDParam: true
             )
 
             #expect(result == .surfaceNotFound(harness.outerPanelID))
@@ -253,7 +255,8 @@ extension RemoteTmuxMirrorCLIObservabilityTests {
 
             let result = TerminalController.shared.controlSurfaceClose(
                 routing: harness.routing(paneID: firstPaneID),
-                surfaceID: nil
+                surfaceID: nil,
+                hasSurfaceIDParam: false
             )
 
             #expect(result == .closeFailed(firstSurfaceID))

--- a/cmuxTests/RemoteTmuxMirrorCLIObservabilityTests.swift
+++ b/cmuxTests/RemoteTmuxMirrorCLIObservabilityTests.swift
@@ -302,7 +302,8 @@ struct RemoteTmuxMirrorCLIObservabilityTests {
         #expect(respawn == .respawnFailed(surfaceID))
         #expect(TerminalController.shared.controlSurfaceClose(
             routing: routing,
-            surfaceID: surfaceID
+            surfaceID: surfaceID,
+            hasSurfaceIDParam: true
         ) == .closeFailed(surfaceID))
     }
 


### PR DESCRIPTION
## Summary
- validate explicit close-surface targets against the workspace surface list before sending the destructive RPC
- make respawn-pane UUID/ref resolution fail closed when the target surface is not present
- add socket-side guards for destructive surface-taking operations so direct ref/invalid surface_id values cannot fall back to focused state

Fixes #9410

## Verification
- xcodebuild test -project cmux.xcodeproj -scheme cmux-unit -configuration Debug -destination "platform=macOS" -derivedDataPath /tmp/cmux-fix-close-surface-ref -only-testing:cmuxTests/CLIExplicitSurfaceRoutingTests
- swift test --package-path Packages/macOS/CmuxControlSocket --filter ControlCommandCoordinatorSurfaceTests
- ./scripts/lint-pbxproj-test-wiring.sh
- ./scripts/reload.sh --tag fix-close-surface-ref

## Red/green shape
- 786a077bc3 adds the CLI regression only; on main it fails because stale explicit surface targets still reach surface.close/surface.respawn.
- bd89d1c16c adds the fail-closed fix and supporting package tests.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/9422"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788315022&installation_model_id=21920&pr_number=9422&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F9422&signature=f01428ec5e9eefb63ff97fee0abadd771c1423ff1e194d1878bbf9fb64a706e7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents destructive surface, pane, and tab actions from falling back to the focused target when an explicit ID is stale, blank, or invalid. Adds strict CLI resolution and localized errors. Fixes #9410.

- **Bug Fixes**
  - CLI: For `close-surface`, require `--workspace` or `--window` when `--surface` is provided; validate UUID/ref/index against `surface.list` in the selected scope; reject blank/unknown/invalid handles; do not send `surface.close`/`surface.respawn` when unresolved.
  - Control socket: For `surface.close`, `surface.respawn`, `pane.break`/`pane.join`, and `surface.action`/`tab.action`, if `surface_id`/`tab_id` is present but null/invalid/unresolved, return `not_found` with localized messages; never fall back to focused. Add `invalidSurfaceID` close resolution and plumb `hasSurfaceIDParam` through `ControlSurfaceContext`, `ControlPaneContext`, `ControlSystemContext`, and `TerminalController`.
  - Localization: Added localized CLI and socket messages for surface/tab not found and invalid surface handles.
  - Tests: Added coverage for explicit null IDs, missing `--workspace`/`--window` with `--surface`, and stale refs; verify no mutation RPCs occur when resolution fails.

<sup>Written for commit 63c8c28288668efa9b3bb81022a9d6c49cd9c445. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/9422?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation for surface and tab references across close, respawn, break, join, and tab actions.
  * Invalid, unresolved, or explicitly null IDs now return clear localized errors without affecting the focused surface.
  * Explicit surface handles resolve within the selected workspace when applicable.
  * CLI commands fail safely without sending unintended mutations.

* **Tests**
  * Added regression coverage for invalid references, error handling, and routing behavior.

* **Localization**
  * Added localized messages for missing surfaces and tabs across supported languages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->