### PR TITLE
Fix compound SSH PTY attach startup scripts

### DIFF
--- a/Packages/macOS/CmuxFoundation/Sources/CmuxFoundation/SSHPTYAttachExitCode.swift
+++ b/Packages/macOS/CmuxFoundation/Sources/CmuxFoundation/SSHPTYAttachExitCode.swift
@@ -126,7 +126,7 @@ public enum SSHPTYAttachExitCode: Int32 {
     /// wrapper so its existing reconnect and reauthentication behavior remains
     /// the single owner of those transitions.
     ///
-    /// - Parameter command: The shell command that performs one attach attempt.
+    /// - Parameter command: Shell source that performs one attach attempt.
     /// - Returns: Shell source lines implementing the no-progress budget.
     public static func noProgressRetryLoopLines(command: String) -> [String] {
         let policy = noProgressShellPolicy()
@@ -134,7 +134,9 @@ public enum SSHPTYAttachExitCode: Int32 {
         return policy.configurationLines + [
             "cmux_ssh_attach_no_progress_retry=0",
             "while :; do",
-            "  CMUX_SSH_PTY_ATTACH_NO_PROGRESS_RETRY=\"$cmux_ssh_attach_no_progress_retry\" CMUX_SSH_PTY_ATTACH_NO_PROGRESS_LIMIT=\"$cmux_ssh_attach_no_progress_limit\" \(command)",
+            "  export CMUX_SSH_PTY_ATTACH_NO_PROGRESS_RETRY=\"$cmux_ssh_attach_no_progress_retry\"",
+            "  export CMUX_SSH_PTY_ATTACH_NO_PROGRESS_LIMIT=\"$cmux_ssh_attach_no_progress_limit\"",
+            "  \(command)",
             "  cmux_ssh_attach_status=$?",
             "  if [ \"$cmux_ssh_attach_status\" -ne \(policy.status) ]; then exit \"$cmux_ssh_attach_status\"; fi",
             "  cmux_ssh_attach_no_progress_retry=$((cmux_ssh_attach_no_progress_retry + 1))",

--- a/cmuxTests/SSHPTYAttachNoProgressRetryTests.swift
+++ b/cmuxTests/SSHPTYAttachNoProgressRetryTests.swift
@@ -29,6 +29,29 @@ struct SSHPTYAttachNoProgressRetryTests {
         #expect(!SSHPTYAttachExitCode.hasNoProgressRetryRemaining(currentRetry: 2, limit: 3))
     }
 
+    @Test("Compound attach attempts parse and receive the retry policy environment")
+    func compoundAttachAttemptReceivesRetryEnvironment() {
+        let script = SSHPTYAttachExitCode.noProgressRetryLoopLines(
+            command: """
+            if [ "$cmux_ssh_attach_no_progress_retry" -gt 0 ]; then exit 9; fi
+            if [ "$CMUX_SSH_PTY_ATTACH_NO_PROGRESS_RETRY" != "$cmux_ssh_attach_no_progress_retry" ]; then exit 10; fi
+            if [ "$CMUX_SSH_PTY_ATTACH_NO_PROGRESS_LIMIT" != "$cmux_ssh_attach_no_progress_limit" ]; then exit 11; fi
+            exit 0
+            """
+        ).joined(separator: "\n")
+
+        let result = Self.run(
+            command: script,
+            environment: [
+                "PATH": "/usr/bin:/bin",
+                "CMUX_SSH_PTY_NO_PROGRESS_RETRY_LIMIT": "3",
+            ]
+        )
+
+        #expect(!result.timedOut, Comment(rawValue: result.stderr))
+        #expect(result.status == 0, Comment(rawValue: result.stderr))
+    }
+
     @Test("Output or a sustained connection proves bridge progress")
     func bridgeProgressClassification() {
         #expect(


### PR DESCRIPTION
## Summary

- Export the no-progress retry environment on standalone shell lines before executing attach source.
- Keep `noProgressRetryLoopLines(command:)` valid for simple, compound, and multi-line POSIX shell commands.
- Add a behavior regression that executes a generated compound attach script under `/bin/sh`.

Closes #9423

## Root cause

`noProgressRetryLoopLines(command:)` accepted arbitrary shell source but interpolated it after `NAME=value` prefixes. The foreground-auth CLI path passed a command beginning with `if`, and POSIX shells only permit assignment prefixes before a simple command. The generated startup script therefore failed during parsing before SSH could start.

Moving the two per-attempt values into standalone `export` commands removes that hidden command-shape restriction. Future callers cannot recreate the same syntax error by supplying compound or multi-line shell source.

## Testing

- Red baseline: https://github.com/manaflow-ai/cmux/actions/runs/30783465527
  - 8 tests executed on test-only commit `b0b5270cbe`.
  - The new regression failed alone with status 2 and the expected `unexpected token then` parse error.
- Local `/bin/sh -n` syntax check passed with the fixed shape.
- Local `/bin/sh` execution verified both retry values are exported to child processes.
- Swift parser checks passed for the changed source and test files.
- `git diff --check origin/main...HEAD` passed.

## Demo Video

Not applicable. This changes generated CLI shell source and has no visual UI.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/9429"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788323026&installation_model_id=21920&pr_number=9429&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F9429&signature=6bfed1034c19a8122a08a18ca5a959c5302d31fa226c908a4fb56314c08c2c74"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes SSH PTY attach startup scripts so compound or multi-line POSIX shell commands don’t fail to parse. Exports retry env vars on their own lines to avoid `if`-prefix syntax errors and preserve the retry policy (addresses #9423).

- **Bug Fixes**
  - Export `CMUX_SSH_PTY_ATTACH_NO_PROGRESS_RETRY` and `CMUX_SSH_PTY_ATTACH_NO_PROGRESS_LIMIT` before running the attach command; no assignment prefixes.
  - Keep `noProgressRetryLoopLines(command:)` valid for simple, compound, and multi-line commands.
  - Add a regression test that runs a compound `if`-based attach under `/bin/sh` and verifies env propagation.

<sup>Written for commit 1c4e8ac2217f6a9c05da466aaa7b34c3f044f744. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/9429?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved SSH terminal attachment reliability by ensuring no-progress retry settings are preserved through nested shell commands.
  - Reduced the risk of attachment timeouts and incorrect exit statuses during stalled or slow connections.

- **Tests**
  - Added coverage for nested-shell attachment scenarios, including retry configuration propagation and successful completion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->