### PR TITLE
Return the created workspace's UUID from `workspace create`

### DIFF
--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -7822,17 +7822,32 @@ struct CMUXCLI {
         }
         try applyFocusOption(focusOpt, defaultValue: false, to: &params)
         let response = try client.sendV2(method: "workspace.create", params: params)
-        let wsId = (response["workspace_ref"] as? String) ?? (response["workspace_id"] as? String) ?? ""
+        let wsRef = response["workspace_ref"] as? String
+        let wsUUID = response["workspace_id"] as? String
+        let wsDisplayId = wsRef ?? wsUUID ?? ""
         if jsonOutput && honorJSONOutput {
-            print(jsonString(formatIDs(response, mode: idFormat)))
+            // Refs are per-connection handles that can be recycled, while the
+            // input RPCs (`surface.send_text`, `surface.send_key`,
+            // `workspace.prompt_submit`) key off UUIDs. `create` is the only
+            // place a caller can learn the new workspace's UUID, so keep the
+            // created object's UUIDs in the payload even in `refs` mode.
+            print(jsonString(formatIDs(
+                response,
+                mode: idFormat,
+                preservingIDKinds: ["workspace", "surface", "pane"]
+            )))
         } else {
-            print("OK \(wsId)")
+            print("OK \(wsDisplayId)")
         }
-        if layoutOpt == nil, let commandText = commandOpt, !wsId.isEmpty {
+        // Route the initial command by UUID, not by the ref: a ref that another
+        // connection has since recycled would silently deliver to the focused
+        // surface instead.
+        let sendTarget = wsUUID ?? wsRef
+        if layoutOpt == nil, let commandText = commandOpt, let sendTarget, !sendTarget.isEmpty {
             let text = unescapeSendText(commandText + "\\n")
             let sendParams: [String: Any] = [
                 "text": text,
-                "workspace_id": wsId
+                "workspace_id": sendTarget
             ]
             _ = try client.sendV2(method: "surface.send_text", params: sendParams)
         }

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -7755,7 +7755,8 @@ struct CMUXCLI {
         jsonOutput: Bool,
         idFormat: CLIIDFormat,
         windowOverride: String?,
-        honorJSONOutput: Bool
+        honorJSONOutput: Bool,
+        preserveStableIDs: Bool = false
     ) throws {
         let (commandOpt, rem0) = parseOption(commandArgs, name: "--command")
         let (cwdOpt, rem1) = parseOption(rem0, name: "--cwd")
@@ -7837,7 +7838,7 @@ struct CMUXCLI {
             print(jsonString(formatIDs(
                 response,
                 mode: idFormat,
-                preservingIDKinds: ["workspace", "surface", "pane"]
+                preservingIDKinds: preserveStableIDs ? ["workspace", "surface", "pane"] : []
             )))
         } else {
             print("OK \(wsDisplayId)")
@@ -8526,7 +8527,8 @@ struct CMUXCLI {
                 jsonOutput: jsonOutput,
                 idFormat: idFormat,
                 windowOverride: windowOverride,
-                honorJSONOutput: true
+                honorJSONOutput: true,
+                preserveStableIDs: preserveStableListIDs
             )
         case "env":
             try runWorkspaceEnvCommand(

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -7824,7 +7824,10 @@ struct CMUXCLI {
         let response = try client.sendV2(method: "workspace.create", params: params)
         let wsRef = response["workspace_ref"] as? String
         let wsUUID = response["workspace_id"] as? String
-        let wsDisplayId = wsRef ?? wsUUID ?? ""
+        // The ref stays first so existing `OK <ref>` parsers keep working; the
+        // UUID follows because it is the only identity that survives this
+        // process exiting and is the one the input RPCs accept.
+        let wsDisplayId = [wsRef, wsUUID].compactMap { $0 }.joined(separator: " ")
         if jsonOutput && honorJSONOutput {
             // Refs are per-connection handles that can be recycled, while the
             // input RPCs (`surface.send_text`, `surface.send_key`,
@@ -7839,15 +7842,25 @@ struct CMUXCLI {
         } else {
             print("OK \(wsDisplayId)")
         }
-        // Route the initial command by UUID, not by the ref: a ref that another
-        // connection has since recycled would silently deliver to the focused
-        // surface instead.
-        let sendTarget = wsUUID ?? wsRef
-        if layoutOpt == nil, let commandText = commandOpt, let sendTarget, !sendTarget.isEmpty {
+        // Route the initial command by UUID only. Falling back to the ref would
+        // reintroduce the wrong-session delivery this command exists to avoid:
+        // a recycled ref resolves to a different workspace, and against a
+        // server without the fail-closed routing it lands in the focused one.
+        if layoutOpt == nil, let commandText = commandOpt {
+            guard let wsUUID, !wsUUID.isEmpty else {
+                throw CLIError(message: String(
+                    format: String(
+                        localized: "cli.workspace.create.error.commandMissingWorkspaceUUID",
+                        defaultValue: "%@: the workspace was created, but the app did not return its UUID, so --command was not delivered. Update the cmux app, then send the command with 'cmux send --workspace <uuid>'."
+                    ),
+                    locale: .current,
+                    commandName
+                ))
+            }
             let text = unescapeSendText(commandText + "\\n")
             let sendParams: [String: Any] = [
                 "text": text,
-                "workspace_id": sendTarget
+                "workspace_id": wsUUID
             ]
             _ = try client.sendV2(method: "surface.send_text", params: sendParams)
         }

--- a/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Coordinator/ControlCommandCoordinator.swift
+++ b/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Coordinator/ControlCommandCoordinator.swift
@@ -270,7 +270,8 @@ public final class ControlCommandCoordinator {
             surfaceID: uuid(params, "surface_id")
                 ?? uuid(params, "terminal_id")
                 ?? uuid(params, "tab_id"),
-            paneID: uuid(params, "pane_id")
+            paneID: uuid(params, "pane_id"),
+            hasWorkspaceIDParam: hasNonNull(params, "workspace_id")
         )
     }
 }

--- a/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Coordinator/ControlRoutingSelectors.swift
+++ b/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Coordinator/ControlRoutingSelectors.swift
@@ -24,6 +24,12 @@ public struct ControlRoutingSelectors: Sendable, Equatable {
     public let groupID: UUID?
     /// The resolved `workspace_id` target, if any.
     public let workspaceID: UUID?
+    /// Whether the request carried a non-null `workspace_id` param at all. A
+    /// present-but-unresolvable `workspace_id` (a recycled or foreign
+    /// `workspace:N` ref, or a typo) must resolve to no target rather than
+    /// falling through to the caller's focused workspace, which would deliver
+    /// input to the wrong session with no error (issue #9191).
+    public let hasWorkspaceIDParam: Bool
     /// The resolved surface target (`surface_id`, then `terminal_id`, then
     /// `tab_id`), if any.
     public let surfaceID: UUID?
@@ -39,18 +45,23 @@ public struct ControlRoutingSelectors: Sendable, Equatable {
     ///   - workspaceID: The resolved `workspace_id` target.
     ///   - surfaceID: The resolved surface target.
     ///   - paneID: The resolved `pane_id` target.
+    ///   - hasWorkspaceIDParam: Whether a non-null `workspace_id` param was
+    ///     present. Defaults to `false` for in-app callers that synthesize
+    ///     routing rather than decoding it from request params.
     public init(
         hasWindowIDParam: Bool,
         windowID: UUID?,
         groupID: UUID?,
         workspaceID: UUID?,
         surfaceID: UUID?,
-        paneID: UUID?
+        paneID: UUID?,
+        hasWorkspaceIDParam: Bool = false
     ) {
         self.hasWindowIDParam = hasWindowIDParam
         self.windowID = windowID
         self.groupID = groupID
         self.workspaceID = workspaceID
+        self.hasWorkspaceIDParam = hasWorkspaceIDParam
         self.surfaceID = surfaceID
         self.paneID = paneID
     }

--- a/Packages/macOS/CmuxControlSocket/Tests/CmuxControlSocketTests/ControlCommandCoordinatorParamsTests.swift
+++ b/Packages/macOS/CmuxControlSocket/Tests/CmuxControlSocketTests/ControlCommandCoordinatorParamsTests.swift
@@ -52,4 +52,24 @@ struct ControlCommandCoordinatorParamsTests {
         #expect(c.int(["x": .null], "x") == nil)
         #expect(c.double(["x": .array([])], "x") == nil)
     }
+
+    /// Issue #9191: a `workspace_id` that is present but resolves to nothing
+    /// (a recycled or foreign `workspace:N` ref) must be distinguishable from
+    /// an omitted one, so the app target can fail closed instead of falling
+    /// back to the caller's focused workspace.
+    @Test func routingFlagsPresentButUnresolvableWorkspaceID() {
+        let c = coordinator()
+
+        let unresolvable = c.routingSelectors(["workspace_id": .string("workspace:999")])
+        #expect(unresolvable.workspaceID == nil)
+        #expect(unresolvable.hasWorkspaceIDParam)
+
+        #expect(!c.routingSelectors([:]).hasWorkspaceIDParam)
+        #expect(!c.routingSelectors(["workspace_id": .null]).hasWorkspaceIDParam)
+
+        let uuid = UUID()
+        let resolved = c.routingSelectors(["workspace_id": .string(uuid.uuidString)])
+        #expect(resolved.workspaceID == uuid)
+        #expect(resolved.hasWorkspaceIDParam)
+    }
 }

--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -52615,6 +52615,35 @@
         }
       }
     },
+    "cli.workspace.create.error.commandMissingWorkspaceUUID": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@: the workspace was created, but the app did not return its UUID, so --command was not delivered. Update the cmux app, then send the command with 'cmux send --workspace <uuid>'."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@: ワークスペースは作成されましたが、アプリが UUID を返さなかったため --command は配信されませんでした。cmux アプリを更新してから、'cmux send --workspace <uuid>' でコマンドを送信してください。"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@: 작업 공간은 생성되었지만 앱이 UUID를 반환하지 않아 --command가 전달되지 않았습니다. cmux 앱을 업데이트한 뒤 'cmux send --workspace <uuid>'로 명령을 보내세요."
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@: робочий простір створено, але застосунок не повернув його UUID, тому --command не було доставлено. Оновіть застосунок cmux, а потім надішліть команду через 'cmux send --workspace <uuid>'."
+          }
+        }
+      }
+    },
     "cli.workspace.create.error.envFileRequiresValue": {
       "extractionState": "manual",
       "localizations": {

--- a/Sources/RemoteTmuxAttachWindowTarget.swift
+++ b/Sources/RemoteTmuxAttachWindowTarget.swift
@@ -6,8 +6,9 @@ enum RemoteTmuxAttachWindowTarget: Sendable, Equatable {
     case dedicatedNewWindow
     /// A non-null `window_id` that resolved when the request was parsed.
     case explicitWindow(UUID)
-    /// A non-null `window_id` that did not resolve; never falls back to active.
-    case unresolvedExplicitWindow
+    /// An explicit `window_id` or `workspace_id` that did not resolve; never
+    /// falls back to the active window (issue #9191).
+    case unresolvedExplicitTarget
     /// Contextual routing (group/workspace/surface/pane/caller), which may fall
     /// back to the active window if its preferred window disappears.
     case contextualWindow(UUID?)
@@ -26,7 +27,7 @@ enum RemoteTmuxAttachWindowTarget: Sendable, Equatable {
             return nil
         case .explicitWindow(let windowID):
             return isLive(windowID) ? windowID : nil
-        case .unresolvedExplicitWindow:
+        case .unresolvedExplicitTarget:
             return nil
         case .contextualWindow(let preferredWindowID):
             if let preferredWindowID, isLive(preferredWindowID) {

--- a/Sources/TerminalController+ControlSurfaceContext.swift
+++ b/Sources/TerminalController+ControlSurfaceContext.swift
@@ -40,6 +40,11 @@ extension TerminalController: ControlSurfaceContext {
             guard !AppDelegate.isWindowDockRoutingId(wsId) else { return nil }
             return tabManager.tabs.first(where: { $0.id == wsId })
         }
+        // A present-but-unresolvable workspace_id (a recycled or foreign
+        // `workspace:N` ref, or a typo) must resolve to no workspace. Falling
+        // through would target the caller's focused workspace and silently
+        // deliver input to the wrong session (issue #9191).
+        if routing.hasWorkspaceIDParam { return nil }
         if let surfaceId = routing.surfaceID {
             if let workspace = tabManager.tabs.first(where: { $0.panels[surfaceId] != nil }) {
                 return workspace

--- a/Sources/TerminalController+ControlSurfaceContext.swift
+++ b/Sources/TerminalController+ControlSurfaceContext.swift
@@ -43,7 +43,9 @@ extension TerminalController: ControlSurfaceContext {
         // A present-but-unresolvable workspace_id (a recycled or foreign
         // `workspace:N` ref, or a typo) must resolve to no workspace. Falling
         // through would target the caller's focused workspace and silently
-        // deliver input to the wrong session (issue #9191).
+        // deliver input to the wrong session (issue #9191). `resolveTabManager`
+        // already refuses such a request; this keeps the invariant local for
+        // callers that pass a TabManager in directly.
         if routing.hasWorkspaceIDParam { return nil }
         if let surfaceId = routing.surfaceID {
             if let workspace = tabManager.tabs.first(where: { $0.panels[surfaceId] != nil }) {

--- a/Sources/TerminalController+RemoteTmux.swift
+++ b/Sources/TerminalController+RemoteTmux.swift
@@ -202,16 +202,7 @@ extension TerminalController {
     }
 
     nonisolated func remoteTmuxRouting(from params: [String: Any]) -> ControlRoutingSelectors {
-        ControlRoutingSelectors(
-            hasWindowIDParam: v2HasNonNullParam(params, "window_id"),
-            windowID: v2UUID(params, "window_id"),
-            groupID: v2UUID(params, "group_id"),
-            workspaceID: v2UUID(params, "workspace_id"),
-            surfaceID: v2UUID(params, "surface_id")
-                ?? v2UUID(params, "terminal_id")
-                ?? v2UUID(params, "tab_id"),
-            paneID: v2UUID(params, "pane_id")
-        )
+        v2RoutingSelectors(params)
     }
 
     private nonisolated static func remoteTmuxActivate(from params: [String: Any]) -> Bool {

--- a/Sources/TerminalController+RemoteTmux.swift
+++ b/Sources/TerminalController+RemoteTmux.swift
@@ -215,11 +215,14 @@ extension TerminalController {
     ) -> RemoteTmuxAttachWindowTarget {
         if routing.hasWindowIDParam {
             return routing.windowID.map(RemoteTmuxAttachWindowTarget.explicitWindow)
-                ?? .unresolvedExplicitWindow
+                ?? .unresolvedExplicitTarget
         }
-        let preferredWindowID = resolveTabManager(routing: routing)
-            .flatMap { AppDelegate.shared?.windowId(for: $0) }
-        return .contextualWindow(preferredWindowID)
+        guard let tabManager = resolveTabManager(routing: routing) else {
+            // An explicit workspace that resolved to no window must not mirror
+            // into the active window; a purely contextual request still may.
+            return routing.hasWorkspaceIDParam ? .unresolvedExplicitTarget : .contextualWindow(nil)
+        }
+        return .contextualWindow(AppDelegate.shared?.windowId(for: tabManager))
     }
 
     /// `remote.tmux.detach` — detach a control client and remove its mirror workspace;

--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -5419,16 +5419,7 @@ class TerminalController {
             // resolve, exactly as the former main-actor dispatch did before
             // handing off to the coordinator.
             self.v2RefreshKnownRefs()
-            let routing = ControlRoutingSelectors(
-                hasWindowIDParam: self.v2HasNonNullParam(params, "window_id"),
-                windowID: self.v2UUID(params, "window_id"),
-                groupID: self.v2UUID(params, "group_id"),
-                workspaceID: self.v2UUID(params, "workspace_id"),
-                surfaceID: self.v2UUID(params, "surface_id")
-                    ?? self.v2UUID(params, "terminal_id")
-                    ?? self.v2UUID(params, "tab_id"),
-                paneID: self.v2UUID(params, "pane_id")
-            )
+            let routing = self.v2RoutingSelectors(params)
             guard let tabManager = self.resolveTabManager(routing: routing) else {
                 return .finished(.err(code: "unavailable", message: "TabManager not available", data: nil))
             }

--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -3658,45 +3658,15 @@ class TerminalController {
 
     // MARK: - V2 Context Resolution
 
+    /// The params-shaped entry to the shared routing resolution.
+    ///
+    /// Decodes the selectors once and defers to
+    /// ``resolveTabManager(routing:)``, so the legacy params path and the
+    /// coordinator path cannot drift — including the fail-closed handling of a
+    /// named-but-unresolvable workspace (issue #9191).
     nonisolated func v2ResolveTabManager(params: [String: Any]) -> TabManager? {
-        // Prefer explicit window_id routing. Otherwise prefer group_id (group
-        // methods are the only routing key for cross-window group ops, and
-        // CLI helpers always inject caller workspace_id/surface_id, which
-        // would otherwise win even when the group belongs to a different
-        // window). Then use workspace/surface/pane lookup and the active window.
-        if v2HasNonNullParam(params, "window_id") {
-            guard let windowId = v2UUID(params, "window_id") else { return nil }
-            return v2MainSync { AppDelegate.shared?.tabManagerFor(windowId: windowId) }
-        }
-        if let groupId = v2UUID(params, "group_id") {
-            if let tm = v2MainSync({ v2LocateTabManager(forGroupId: groupId) }) {
-                return tm
-            }
-        }
-        if let wsId = v2UUID(params, "workspace_id") {
-            if wsId == AppDelegate.windowDockAliasWorkspaceId {
-                return v2MainSync { tabManager ?? AppDelegate.shared?.currentScriptableMainWindow()?.tabManager }
-            }
-            if let tm = v2MainSync({ AppDelegate.shared?.tabManagerFor(tabId: wsId) }) {
-                return tm
-            }
-            // A window-Dock owner id IS its owning window's id, so a Dock-scoped
-            // workspace_id routes to that window rather than the caller's.
-            if let tm = v2MainSync({ AppDelegate.shared?.tabManagerForWindowDockOwner(wsId) }) {
-                return tm
-            }
-        }
-        if let surfaceId = v2UUID(params, "surface_id")
-            ?? v2UUID(params, "terminal_id")
-            ?? v2UUID(params, "tab_id") {
-            if let manager = v2MainSync({ controlTabManager(surfaceID: surfaceId) }) { return manager }
-        }
-        if let paneId = v2UUID(params, "pane_id") {
-            if let tm = v2MainSync({ controlTabManager(paneID: paneId) }) {
-                return tm
-            }
-        }
-        return v2MainSync { tabManager ?? AppDelegate.shared?.currentScriptableMainWindow()?.tabManager }
+        let routing = v2RoutingSelectors(params)
+        return v2MainSync { resolveTabManager(routing: routing) }
     }
 
     @MainActor
@@ -3745,6 +3715,12 @@ class TerminalController {
             if let tm = AppDelegate.shared?.tabManagerForWindowDockOwner(workspaceId) {
                 return tm
             }
+            // The request named a workspace that no window owns — a closed one,
+            // or an id from another app instance. Falling through to the
+            // surface/pane/caller selectors would act on the caller's own
+            // window, which is the wrong-session failure this guard exists to
+            // prevent (issue #9191).
+            return nil
         }
         if let surfaceId = routing.surfaceID {
             if let manager = controlTabManager(surfaceID: surfaceId) { return manager }

--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -3719,6 +3719,12 @@ class TerminalController {
     /// active scriptable window. Lives here so it can read the controller's
     /// `private` `tabManager` / `v2LocateTabManager`.
     func resolveTabManager(routing: ControlRoutingSelectors) -> TabManager? {
+        // A named-but-unresolvable workspace yields no target, the same way an
+        // unresolvable `window_id` does. This is the choke point every routed
+        // command reaches, so no consumer with an optional workspace (todos,
+        // status, remote-tmux host selection) can quietly read the flag as
+        // "workspace omitted" and act on the caller's own window (issue #9191).
+        if routing.hasWorkspaceIDParam, routing.workspaceID == nil { return nil }
         if routing.hasWindowIDParam {
             guard let windowId = routing.windowID else { return nil }
             return AppDelegate.shared?.tabManagerFor(windowId: windowId)

--- a/Sources/TerminalControllerV2ParamParsingSupport.swift
+++ b/Sources/TerminalControllerV2ParamParsingSupport.swift
@@ -1,5 +1,6 @@
 import Foundation
 import Bonsplit
+import CmuxControlSocket
 
 extension TerminalController {
     nonisolated func v2String(_ params: [String: Any], _ key: String) -> String? {
@@ -82,6 +83,26 @@ extension TerminalController {
             )
         }
         return (min(max(rawPosition, 0.1), 0.9), nil)
+    }
+
+    /// Decodes the routing selectors carried by a v2 request's params.
+    ///
+    /// The single decoder for every app-side request path, so a selector's
+    /// present-but-unresolvable flag cannot be set on one entrypoint and
+    /// silently omitted on another (issue #9191). The package-side dispatch
+    /// has its own equivalent in `ControlCommandCoordinator.routingSelectors`.
+    nonisolated func v2RoutingSelectors(_ params: [String: Any]) -> ControlRoutingSelectors {
+        ControlRoutingSelectors(
+            hasWindowIDParam: v2HasNonNullParam(params, "window_id"),
+            windowID: v2UUID(params, "window_id"),
+            groupID: v2UUID(params, "group_id"),
+            workspaceID: v2UUID(params, "workspace_id"),
+            surfaceID: v2UUID(params, "surface_id")
+                ?? v2UUID(params, "terminal_id")
+                ?? v2UUID(params, "tab_id"),
+            paneID: v2UUID(params, "pane_id"),
+            hasWorkspaceIDParam: v2HasNonNullParam(params, "workspace_id")
+        )
     }
 
     nonisolated func v2UUID(_ params: [String: Any], _ key: String) -> UUID? {

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -2100,6 +2100,7 @@ C0DE71B10000000000000001 /* AppDelegate+AgentChatNotifications.swift in Sources 
 		7989B0027989B0027989B002 /* SurfaceResumeLaunchFlavor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7989B1027989B1027989B102 /* SurfaceResumeLaunchFlavor.swift */; };
 		7989B0037989B0037989B003 /* SurfaceResumeRemoteContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7989B1037989B1037989B103 /* SurfaceResumeRemoteContext.swift */; };
 		F27B00000000000000000001 /* SurfaceResumeRunPromptBatch.swift in Sources */ = {isa = PBXBuildFile; fileRef = F27B00000000000000000002 /* SurfaceResumeRunPromptBatch.swift */; };
+		91910000000000000000000E /* SurfaceRoutingUnresolvableWorkspaceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91910000000000000000000F /* SurfaceRoutingUnresolvableWorkspaceTests.swift */; };
 		A5001303 /* SurfaceSearchOverlay.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001301 /* SurfaceSearchOverlay.swift */; };
 		C51A73B40000000000000002 /* SurfaceTabBarButtonConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = C51A73B40000000000000001 /* SurfaceTabBarButtonConfiguration.swift */; };
 		F2100000000000000000000F /* SyntheticKeyEventFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1100000000000000000000F /* SyntheticKeyEventFactory.swift */; };
@@ -4684,6 +4685,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 		7989B1027989B1027989B102 /* SurfaceResumeLaunchFlavor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SurfaceResumeLaunchFlavor.swift; sourceTree = "<group>"; };
 		7989B1037989B1037989B103 /* SurfaceResumeRemoteContext.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SurfaceResumeRemoteContext.swift; sourceTree = "<group>"; };
 		F27B00000000000000000002 /* SurfaceResumeRunPromptBatch.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SurfaceResumeRunPromptBatch.swift; sourceTree = "<group>"; };
+		91910000000000000000000F /* SurfaceRoutingUnresolvableWorkspaceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SurfaceRoutingUnresolvableWorkspaceTests.swift; sourceTree = "<group>"; };
 		A5001301 /* SurfaceSearchOverlay.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Find/SurfaceSearchOverlay.swift; sourceTree = "<group>"; };
 		C51A73B40000000000000001 /* SurfaceTabBarButtonConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SurfaceTabBarButtonConfiguration.swift; sourceTree = "<group>"; };
 		F1100000000000000000000F /* SyntheticKeyEventFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SyntheticKeyEventFactory.swift; sourceTree = "<group>"; };
@@ -7603,6 +7605,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				773600000000000000000004 /* CLIWindowHandleRoutingTests.swift */,
 				846600000000000000000002 /* CLIWorkspaceGroupSafetyMockServer.swift */,
 				846600000000000000000004 /* CLIWorkspaceGroupSafetyTests.swift */,
+				91910000000000000000000F /* SurfaceRoutingUnresolvableWorkspaceTests.swift */,
 				91910000000000000000000B /* CLIWorkspaceCreateIdentityMockServer.swift */,
 				91910000000000000000000D /* CLIWorkspaceCreateIdentityTests.swift */,
 				799100000000000000000002 /* CLIWorkspaceStableIDMockServer.swift */,
@@ -10447,7 +10450,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				7837E0057837E0057837E005 /* CLITmuxCompatResizePaneTests.swift in Sources */,
 					773600000000000000000001 /* CLIWindowCommandMockServer.swift in Sources */,
 					773600000000000000000003 /* CLIWindowHandleRoutingTests.swift in Sources */,
-					91910000000000000000000A /* CLIWorkspaceCreateIdentityMockServer.swift in Sources */,
+				91910000000000000000000A /* CLIWorkspaceCreateIdentityMockServer.swift in Sources */,
 					91910000000000000000000C /* CLIWorkspaceCreateIdentityTests.swift in Sources */,
 					846600000000000000000001 /* CLIWorkspaceGroupSafetyMockServer.swift in Sources */,
 					846600000000000000000003 /* CLIWorkspaceGroupSafetyTests.swift in Sources */,
@@ -10839,6 +10842,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				842300000000000000000007 /* SurfaceResumeAgentBindingGenerationTests.swift in Sources */,
 				F6572012A1B2C3D4E5F60718 /* SurfaceResumeBindingCodexUpdateCheckTests.swift in Sources */,
 				842300000000000000000001 /* SurfaceResumeExitedAgentLivenessTests.swift in Sources */,
+					91910000000000000000000E /* SurfaceRoutingUnresolvableWorkspaceTests.swift in Sources */,
 				A7206B010000000000000001 /* SystemAppearanceObserverTests.swift in Sources */,
 				FBE660ABA1854983B84368C6 /* SystemWideHotkeyShortcutPolicyTests.swift in Sources */,
 				F8120F5386FBE726864D340B /* TabManagerBackgroundWorkspaceMountBoundTests.swift in Sources */,

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -558,6 +558,8 @@ C0DE71B10000000000000001 /* AppDelegate+AgentChatNotifications.swift in Sources 
 		7837E0057837E0057837E005 /* CLITmuxCompatResizePaneTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7837E0067837E0067837E006 /* CLITmuxCompatResizePaneTests.swift */; };
 		773600000000000000000001 /* CLIWindowCommandMockServer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 773600000000000000000002 /* CLIWindowCommandMockServer.swift */; };
 		773600000000000000000003 /* CLIWindowHandleRoutingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 773600000000000000000004 /* CLIWindowHandleRoutingTests.swift */; };
+		91910000000000000000000A /* CLIWorkspaceCreateIdentityMockServer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91910000000000000000000B /* CLIWorkspaceCreateIdentityMockServer.swift */; };
+		91910000000000000000000C /* CLIWorkspaceCreateIdentityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91910000000000000000000D /* CLIWorkspaceCreateIdentityTests.swift */; };
 		846600000000000000000001 /* CLIWorkspaceGroupSafetyMockServer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 846600000000000000000002 /* CLIWorkspaceGroupSafetyMockServer.swift */; };
 		846600000000000000000003 /* CLIWorkspaceGroupSafetyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 846600000000000000000004 /* CLIWorkspaceGroupSafetyTests.swift */; };
 		799100000000000000000001 /* CLIWorkspaceStableIDMockServer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 799100000000000000000002 /* CLIWorkspaceStableIDMockServer.swift */; };
@@ -3230,6 +3232,8 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 		7837E0067837E0067837E006 /* CLITmuxCompatResizePaneTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CLITmuxCompatResizePaneTests.swift; sourceTree = "<group>"; };
 		773600000000000000000002 /* CLIWindowCommandMockServer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CLIWindowCommandMockServer.swift; sourceTree = "<group>"; };
 		773600000000000000000004 /* CLIWindowHandleRoutingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CLIWindowHandleRoutingTests.swift; sourceTree = "<group>"; };
+		91910000000000000000000B /* CLIWorkspaceCreateIdentityMockServer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CLIWorkspaceCreateIdentityMockServer.swift; sourceTree = "<group>"; };
+		91910000000000000000000D /* CLIWorkspaceCreateIdentityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CLIWorkspaceCreateIdentityTests.swift; sourceTree = "<group>"; };
 		846600000000000000000002 /* CLIWorkspaceGroupSafetyMockServer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CLIWorkspaceGroupSafetyMockServer.swift; sourceTree = "<group>"; };
 		846600000000000000000004 /* CLIWorkspaceGroupSafetyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CLIWorkspaceGroupSafetyTests.swift; sourceTree = "<group>"; };
 		799100000000000000000002 /* CLIWorkspaceStableIDMockServer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CLIWorkspaceStableIDMockServer.swift; sourceTree = "<group>"; };
@@ -7599,6 +7603,8 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				773600000000000000000004 /* CLIWindowHandleRoutingTests.swift */,
 				846600000000000000000002 /* CLIWorkspaceGroupSafetyMockServer.swift */,
 				846600000000000000000004 /* CLIWorkspaceGroupSafetyTests.swift */,
+				91910000000000000000000B /* CLIWorkspaceCreateIdentityMockServer.swift */,
+				91910000000000000000000D /* CLIWorkspaceCreateIdentityTests.swift */,
 				799100000000000000000002 /* CLIWorkspaceStableIDMockServer.swift */,
 				799100000000000000000004 /* CLIWorkspaceStableIDTests.swift */,
 				805500000000000000000002 /* CLIBrowserEvalOutputTests.swift */,
@@ -10441,6 +10447,8 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				7837E0057837E0057837E005 /* CLITmuxCompatResizePaneTests.swift in Sources */,
 					773600000000000000000001 /* CLIWindowCommandMockServer.swift in Sources */,
 					773600000000000000000003 /* CLIWindowHandleRoutingTests.swift in Sources */,
+					91910000000000000000000A /* CLIWorkspaceCreateIdentityMockServer.swift in Sources */,
+					91910000000000000000000C /* CLIWorkspaceCreateIdentityTests.swift in Sources */,
 					846600000000000000000001 /* CLIWorkspaceGroupSafetyMockServer.swift in Sources */,
 					846600000000000000000003 /* CLIWorkspaceGroupSafetyTests.swift in Sources */,
 					799100000000000000000001 /* CLIWorkspaceStableIDMockServer.swift in Sources */,

--- a/cmuxTests/CLIWorkspaceCreateIdentityMockServer.swift
+++ b/cmuxTests/CLIWorkspaceCreateIdentityMockServer.swift
@@ -1,0 +1,178 @@
+import Darwin
+import Foundation
+
+/// One-connection control-socket fixture that answers `workspace.create` with a
+/// full identity payload (UUIDs plus refs) and records every request the CLI
+/// sends, so tests can assert both the printed output and the follow-up
+/// `surface.send_text` routing.
+struct CLIWorkspaceCreateIdentityMockServer: Sendable {
+    private let socketPath: String
+    private let listenerDescriptor: Int32
+    private let expectedRequestCount: Int
+
+    static let windowID = "11111111-1111-1111-1111-111111111111"
+    static let workspaceID = "4B74B022-13FA-4566-84E5-D50E4B7414FE"
+    static let surfaceID = "03DF72BC-0608-4ED1-8548-CFDC0D3B7ACA"
+    static let workspaceRef = "workspace:39"
+    static let surfaceRef = "surface:12"
+
+    init(socketPath: String, expectedRequestCount: Int) throws {
+        self.socketPath = socketPath
+        self.expectedRequestCount = expectedRequestCount
+
+        unlink(socketPath)
+        let descriptor = Darwin.socket(AF_UNIX, SOCK_STREAM, 0)
+        guard descriptor >= 0 else { throw Self.posixError("socket") }
+
+        var address = sockaddr_un()
+        address.sun_family = sa_family_t(AF_UNIX)
+        let pathCapacity = MemoryLayout.size(ofValue: address.sun_path)
+        guard socketPath.utf8.count < pathCapacity else {
+            Darwin.close(descriptor)
+            throw NSError(
+                domain: NSPOSIXErrorDomain,
+                code: Int(ENAMETOOLONG),
+                userInfo: [NSLocalizedDescriptionKey: "Unix socket path is too long"]
+            )
+        }
+        socketPath.withCString { source in
+            withUnsafeMutablePointer(to: &address.sun_path) { destination in
+                let buffer = UnsafeMutableRawPointer(destination).assumingMemoryBound(to: CChar.self)
+                strncpy(buffer, source, pathCapacity - 1)
+            }
+        }
+
+        let bindResult = withUnsafePointer(to: &address) { pointer in
+            pointer.withMemoryRebound(to: sockaddr.self, capacity: 1) { socketPointer in
+                Darwin.bind(descriptor, socketPointer, socklen_t(MemoryLayout<sockaddr_un>.size))
+            }
+        }
+        guard bindResult == 0, Darwin.listen(descriptor, 1) == 0 else {
+            let error = Self.posixError("bind/listen")
+            Darwin.close(descriptor)
+            unlink(socketPath)
+            throw error
+        }
+
+        listenerDescriptor = descriptor
+    }
+
+    /// Serves one CLI process and returns the socket request lines it sent.
+    func start() -> Task<[String], Never> {
+        Task.detached(priority: .userInitiated) { [self] in
+            defer {
+                Darwin.close(listenerDescriptor)
+                unlink(socketPath)
+            }
+
+            var readiness = pollfd(fd: listenerDescriptor, events: Int16(POLLIN), revents: 0)
+            guard Darwin.poll(&readiness, 1, 5_000) > 0 else { return [] }
+
+            var clientAddress = sockaddr_un()
+            var clientAddressLength = socklen_t(MemoryLayout<sockaddr_un>.size)
+            let clientDescriptor = withUnsafeMutablePointer(to: &clientAddress) { pointer in
+                pointer.withMemoryRebound(to: sockaddr.self, capacity: 1) { socketPointer in
+                    Darwin.accept(listenerDescriptor, socketPointer, &clientAddressLength)
+                }
+            }
+            guard clientDescriptor >= 0 else { return [] }
+            defer { Darwin.close(clientDescriptor) }
+
+            var requests: [String] = []
+            var pending = Data()
+            var buffer = [UInt8](repeating: 0, count: 4_096)
+            while requests.count < expectedRequestCount {
+                let count = Darwin.read(clientDescriptor, &buffer, buffer.count)
+                if count < 0 {
+                    if errno == EINTR { continue }
+                    return requests
+                }
+                if count == 0 { return requests }
+                pending.append(buffer, count: count)
+
+                while let newline = pending.firstRange(of: Data([0x0A])) {
+                    let lineData = pending.subdata(in: 0..<newline.lowerBound)
+                    pending.removeSubrange(0...newline.lowerBound)
+                    guard let line = String(data: lineData, encoding: .utf8) else { continue }
+                    requests.append(line)
+                    guard writeResponse(response(for: line), to: clientDescriptor) else {
+                        return requests
+                    }
+                }
+            }
+            return requests
+        }
+    }
+
+    private func response(for line: String) -> String {
+        guard let data = line.data(using: .utf8),
+              let request = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let requestID = request["id"] as? String,
+              let method = request["method"] as? String else {
+            return "ERROR: malformed request"
+        }
+
+        switch method {
+        case "workspace.create":
+            return encodedResponse(id: requestID, result: [
+                "window_id": Self.windowID,
+                "window_ref": "window:1",
+                "workspace_id": Self.workspaceID,
+                "workspace_ref": Self.workspaceRef,
+                "group_id": NSNull(),
+                "group_ref": NSNull(),
+                "surface_id": Self.surfaceID,
+                "surface_ref": Self.surfaceRef,
+            ])
+        case "surface.send_text":
+            return encodedResponse(id: requestID, result: [
+                "workspace_id": Self.workspaceID,
+                "workspace_ref": Self.workspaceRef,
+                "surface_id": Self.surfaceID,
+                "surface_ref": Self.surfaceRef,
+                "queued": false,
+            ])
+        default:
+            return encodedResponse(id: requestID, error: ["code": "unexpected_method", "message": method])
+        }
+    }
+
+    private func encodedResponse(
+        id: String,
+        result: [String: Any]? = nil,
+        error: [String: Any]? = nil
+    ) -> String {
+        var payload: [String: Any] = ["id": id, "ok": error == nil]
+        if let result { payload["result"] = result }
+        if let error { payload["error"] = error }
+        guard let data = try? JSONSerialization.data(withJSONObject: payload) else { return "{}" }
+        return String(decoding: data, as: UTF8.self)
+    }
+
+    private func writeResponse(_ response: String, to descriptor: Int32) -> Bool {
+        let data = Data((response + "\n").utf8)
+        return data.withUnsafeBytes { bytes in
+            guard let base = bytes.bindMemory(to: UInt8.self).baseAddress else { return true }
+            var offset = 0
+            while offset < bytes.count {
+                let written = Darwin.write(descriptor, base.advanced(by: offset), bytes.count - offset)
+                if written > 0 {
+                    offset += written
+                } else if written < 0, errno == EINTR {
+                    continue
+                } else {
+                    return false
+                }
+            }
+            return true
+        }
+    }
+
+    private static func posixError(_ operation: String) -> NSError {
+        NSError(
+            domain: NSPOSIXErrorDomain,
+            code: Int(errno),
+            userInfo: [NSLocalizedDescriptionKey: "\(operation) failed: \(String(cString: strerror(errno)))"]
+        )
+    }
+}

--- a/cmuxTests/CLIWorkspaceCreateIdentityMockServer.swift
+++ b/cmuxTests/CLIWorkspaceCreateIdentityMockServer.swift
@@ -9,6 +9,8 @@ struct CLIWorkspaceCreateIdentityMockServer: Sendable {
     private let socketPath: String
     private let listenerDescriptor: Int32
     private let expectedRequestCount: Int
+    /// Simulates an older app that answers `workspace.create` with a ref only.
+    private let omitsWorkspaceUUID: Bool
 
     static let windowID = "11111111-1111-1111-1111-111111111111"
     static let workspaceID = "4B74B022-13FA-4566-84E5-D50E4B7414FE"
@@ -16,9 +18,14 @@ struct CLIWorkspaceCreateIdentityMockServer: Sendable {
     static let workspaceRef = "workspace:39"
     static let surfaceRef = "surface:12"
 
-    init(socketPath: String, expectedRequestCount: Int) throws {
+    init(
+        socketPath: String,
+        expectedRequestCount: Int,
+        omitsWorkspaceUUID: Bool = false
+    ) throws {
         self.socketPath = socketPath
         self.expectedRequestCount = expectedRequestCount
+        self.omitsWorkspaceUUID = omitsWorkspaceUUID
 
         unlink(socketPath)
         let descriptor = Darwin.socket(AF_UNIX, SOCK_STREAM, 0)
@@ -114,16 +121,19 @@ struct CLIWorkspaceCreateIdentityMockServer: Sendable {
 
         switch method {
         case "workspace.create":
-            return encodedResponse(id: requestID, result: [
+            var result: [String: Any] = [
                 "window_id": Self.windowID,
                 "window_ref": "window:1",
-                "workspace_id": Self.workspaceID,
                 "workspace_ref": Self.workspaceRef,
                 "group_id": NSNull(),
                 "group_ref": NSNull(),
                 "surface_id": Self.surfaceID,
                 "surface_ref": Self.surfaceRef,
-            ])
+            ]
+            if !omitsWorkspaceUUID {
+                result["workspace_id"] = Self.workspaceID
+            }
+            return encodedResponse(id: requestID, result: result)
         case "surface.send_text":
             return encodedResponse(id: requestID, result: [
                 "workspace_id": Self.workspaceID,

--- a/cmuxTests/CLIWorkspaceCreateIdentityTests.swift
+++ b/cmuxTests/CLIWorkspaceCreateIdentityTests.swift
@@ -68,6 +68,54 @@ struct CLIWorkspaceCreateIdentityTests {
         )
     }
 
+    @Test("workspace create prints the UUID alongside the ref in plain output")
+    func createPlainOutputIncludesUUID() async throws {
+        let cliPath = try BundledCLITestSupport.bundledCLIPath(for: BundledCLILinkageTests.self)
+        let result = try await run(
+            command: [
+                "workspace", "create",
+                "--window", CLIWorkspaceCreateIdentityMockServer.windowID,
+                "--name", "issue-repro",
+            ],
+            cliPath: cliPath,
+            expectedRequestCount: 1
+        )
+        #expect(!result.process.timedOut, Comment(rawValue: result.process.stderr))
+        #expect(result.process.status == 0, Comment(rawValue: result.process.stderr))
+        #expect(
+            result.process.stdout.trimmingCharacters(in: .whitespacesAndNewlines)
+                == "OK \(CLIWorkspaceCreateIdentityMockServer.workspaceRef) "
+                + CLIWorkspaceCreateIdentityMockServer.workspaceID,
+            Comment(rawValue: "stdout=\(result.process.stdout)")
+        )
+    }
+
+    @Test("workspace create --command fails closed when the app returns no UUID")
+    func createCommandFailsClosedWithoutUUID() async throws {
+        let cliPath = try BundledCLITestSupport.bundledCLIPath(for: BundledCLILinkageTests.self)
+        let result = try await run(
+            command: [
+                "workspace", "create",
+                "--window", CLIWorkspaceCreateIdentityMockServer.windowID,
+                "--name", "issue-repro",
+                "--command", "echo hi",
+            ],
+            cliPath: cliPath,
+            // Two, so the fixture keeps reading past the create and would
+            // capture a follow-up send instead of leaving it unread.
+            expectedRequestCount: 2,
+            omitsWorkspaceUUID: true
+        )
+        #expect(!result.process.timedOut, Comment(rawValue: result.process.stderr))
+        #expect(result.process.status != 0, Comment(rawValue: result.process.stdout))
+        // The ref must never be used as a send target: it can resolve to a
+        // different workspace, or to the focused one.
+        #expect(
+            !result.requests.contains { $0.contains("surface.send_text") },
+            Comment(rawValue: "requests=\(result.requests)")
+        )
+    }
+
     private struct RunResult {
         let process: (status: Int32, stdout: String, stderr: String, timedOut: Bool)
         let requests: [String]
@@ -76,12 +124,14 @@ struct CLIWorkspaceCreateIdentityTests {
     private func run(
         command: [String],
         cliPath: String,
-        expectedRequestCount: Int
+        expectedRequestCount: Int,
+        omitsWorkspaceUUID: Bool = false
     ) async throws -> RunResult {
         let socketPath = Self.socketPath()
         let server = try CLIWorkspaceCreateIdentityMockServer(
             socketPath: socketPath,
-            expectedRequestCount: expectedRequestCount
+            expectedRequestCount: expectedRequestCount,
+            omitsWorkspaceUUID: omitsWorkspaceUUID
         )
         let requests = server.start()
 

--- a/cmuxTests/CLIWorkspaceCreateIdentityTests.swift
+++ b/cmuxTests/CLIWorkspaceCreateIdentityTests.swift
@@ -68,6 +68,46 @@ struct CLIWorkspaceCreateIdentityTests {
         )
     }
 
+    @Test("An explicit --id-format still shapes workspace create JSON")
+    func explicitIDFormatsShapeCreateJSON() async throws {
+        let cliPath = try BundledCLITestSupport.bundledCLIPath(for: BundledCLILinkageTests.self)
+        let expectations: [(mode: String, hasIDs: Bool, hasRefs: Bool)] = [
+            ("refs", false, true),
+            ("uuids", true, false),
+            ("both", true, true),
+        ]
+
+        for expectation in expectations {
+            let result = try await run(
+                command: [
+                    "workspace", "create",
+                    "--window", CLIWorkspaceCreateIdentityMockServer.windowID,
+                    "--name", "issue-repro",
+                    "--json", "--id-format", expectation.mode,
+                ],
+                cliPath: cliPath,
+                expectedRequestCount: 1
+            )
+            #expect(!result.process.timedOut, Comment(rawValue: result.process.stderr))
+            #expect(result.process.status == 0, Comment(rawValue: result.process.stderr))
+
+            let payload = try #require(
+                JSONSerialization.jsonObject(with: Data(result.process.stdout.utf8)) as? [String: Any],
+                "Expected JSON object, got: \(result.process.stdout)"
+            )
+            for kind in ["workspace", "surface"] {
+                #expect(
+                    (payload["\(kind)_id"] != nil) == expectation.hasIDs,
+                    Comment(rawValue: "mode=\(expectation.mode) payload=\(payload)")
+                )
+                #expect(
+                    (payload["\(kind)_ref"] != nil) == expectation.hasRefs,
+                    Comment(rawValue: "mode=\(expectation.mode) payload=\(payload)")
+                )
+            }
+        }
+    }
+
     @Test("workspace create prints the UUID alongside the ref in plain output")
     func createPlainOutputIncludesUUID() async throws {
         let cliPath = try BundledCLITestSupport.bundledCLIPath(for: BundledCLILinkageTests.self)

--- a/cmuxTests/CLIWorkspaceCreateIdentityTests.swift
+++ b/cmuxTests/CLIWorkspaceCreateIdentityTests.swift
@@ -1,0 +1,150 @@
+import Darwin
+import Foundation
+import Testing
+
+/// Regression coverage for GitHub issue #9191: `workspace create` has to hand
+/// back the new workspace's UUID, because the input RPCs
+/// (`surface.send_text`, `surface.send_key`, `workspace.prompt_submit`) key off
+/// UUIDs and a short `workspace:N` ref is recyclable.
+@Suite(.serialized)
+struct CLIWorkspaceCreateIdentityTests {
+    @Test("workspace create --json exposes the created workspace and surface UUIDs")
+    func createJSONExposesUUIDs() async throws {
+        let cliPath = try BundledCLITestSupport.bundledCLIPath(for: BundledCLILinkageTests.self)
+        let result = try await run(
+            command: [
+                "workspace", "create",
+                "--window", CLIWorkspaceCreateIdentityMockServer.windowID,
+                "--name", "issue-repro",
+                "--json",
+            ],
+            cliPath: cliPath,
+            expectedRequestCount: 1
+        )
+        #expect(!result.process.timedOut, Comment(rawValue: result.process.stderr))
+        #expect(result.process.status == 0, Comment(rawValue: result.process.stderr))
+
+        let payload = try #require(
+            JSONSerialization.jsonObject(with: Data(result.process.stdout.utf8)) as? [String: Any],
+            "Expected JSON object, got: \(result.process.stdout)"
+        )
+        #expect(
+            payload["workspace_id"] as? String == CLIWorkspaceCreateIdentityMockServer.workspaceID,
+            Comment(rawValue: "payload=\(payload)")
+        )
+        #expect(
+            payload["surface_id"] as? String == CLIWorkspaceCreateIdentityMockServer.surfaceID,
+            Comment(rawValue: "payload=\(payload)")
+        )
+        #expect(payload["workspace_ref"] as? String == CLIWorkspaceCreateIdentityMockServer.workspaceRef)
+        #expect(payload["surface_ref"] as? String == CLIWorkspaceCreateIdentityMockServer.surfaceRef)
+    }
+
+    @Test("workspace create --command routes the initial command by UUID")
+    func createCommandRoutesByUUID() async throws {
+        let cliPath = try BundledCLITestSupport.bundledCLIPath(for: BundledCLILinkageTests.self)
+        let result = try await run(
+            command: [
+                "workspace", "create",
+                "--window", CLIWorkspaceCreateIdentityMockServer.windowID,
+                "--name", "issue-repro",
+                "--command", "echo hi",
+            ],
+            cliPath: cliPath,
+            expectedRequestCount: 2
+        )
+        #expect(!result.process.timedOut, Comment(rawValue: result.process.stderr))
+        #expect(result.process.status == 0, Comment(rawValue: result.process.stderr))
+
+        #expect(result.requests.count == 2, Comment(rawValue: "requests=\(result.requests)"))
+        let sendRequest = try #require(result.requests.last.flatMap {
+            try? JSONSerialization.jsonObject(with: Data($0.utf8)) as? [String: Any]
+        })
+        #expect(sendRequest["method"] as? String == "surface.send_text")
+        let params = try #require(sendRequest["params"] as? [String: Any])
+        #expect(
+            params["workspace_id"] as? String == CLIWorkspaceCreateIdentityMockServer.workspaceID,
+            Comment(rawValue: "params=\(params)")
+        )
+    }
+
+    private struct RunResult {
+        let process: (status: Int32, stdout: String, stderr: String, timedOut: Bool)
+        let requests: [String]
+    }
+
+    private func run(
+        command: [String],
+        cliPath: String,
+        expectedRequestCount: Int
+    ) async throws -> RunResult {
+        let socketPath = Self.socketPath()
+        let server = try CLIWorkspaceCreateIdentityMockServer(
+            socketPath: socketPath,
+            expectedRequestCount: expectedRequestCount
+        )
+        let requests = server.start()
+
+        var environment = ProcessInfo.processInfo.environment
+        for key in Array(environment.keys) where key.hasPrefix("CMUX_") {
+            environment.removeValue(forKey: key)
+        }
+        environment["CMUX_SOCKET_PATH"] = socketPath
+        environment["CMUX_CLI_SENTRY_DISABLED"] = "1"
+        environment["CMUXTERM_CLI_RESPONSE_TIMEOUT_SEC"] = "2"
+        let process = Self.runProcess(
+            executablePath: cliPath,
+            arguments: command,
+            environment: environment
+        )
+        return RunResult(process: process, requests: await requests.value)
+    }
+
+    private static func runProcess(
+        executablePath: String,
+        arguments: [String],
+        environment: [String: String]
+    ) -> (status: Int32, stdout: String, stderr: String, timedOut: Bool) {
+        let process = Process()
+        let stdoutPipe = Pipe()
+        let stderrPipe = Pipe()
+        process.executableURL = URL(fileURLWithPath: executablePath)
+        process.arguments = arguments
+        process.environment = environment
+        process.standardInput = FileHandle.nullDevice
+        process.standardOutput = stdoutPipe
+        process.standardError = stderrPipe
+
+        // One-shot process completion signal; it does not guard mutable state.
+        let exited = DispatchSemaphore(value: 0)
+        process.terminationHandler = { _ in exited.signal() }
+        do {
+            try process.run()
+        } catch {
+            return (-1, "", String(describing: error), false)
+        }
+
+        let timedOut = exited.wait(timeout: .now() + 5) == .timedOut
+        if timedOut {
+            process.terminate()
+            if exited.wait(timeout: .now() + 1) == .timedOut, process.isRunning {
+                Darwin.kill(process.processIdentifier, SIGKILL)
+                _ = exited.wait(timeout: .now() + 1)
+            }
+        }
+
+        return (
+            timedOut ? 124 : process.terminationStatus,
+            String(decoding: stdoutPipe.fileHandleForReading.readDataToEndOfFile(), as: UTF8.self),
+            String(decoding: stderrPipe.fileHandleForReading.readDataToEndOfFile(), as: UTF8.self),
+            timedOut
+        )
+    }
+
+    private static func socketPath() -> String {
+        let suffix = UUID().uuidString.replacingOccurrences(of: "-", with: "").prefix(8)
+        return URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("cli-wscreate-\(suffix).sock")
+            .path
+    }
+}

--- a/cmuxTests/RemoteTmuxMirrorPlacementTests.swift
+++ b/cmuxTests/RemoteTmuxMirrorPlacementTests.swift
@@ -14,7 +14,7 @@ import Testing
         let explicit = UUID()
         let active = UUID()
 
-        #expect(RemoteTmuxAttachWindowTarget.unresolvedExplicitWindow.resolve(
+        #expect(RemoteTmuxAttachWindowTarget.unresolvedExplicitTarget.resolve(
             existingMirrorWindowID: nil,
             activeWindowID: active,
             isLive: { $0 == active }
@@ -24,11 +24,33 @@ import Testing
             activeWindowID: active,
             isLive: { $0 == active }
         ) == nil)
-        #expect(RemoteTmuxAttachWindowTarget.unresolvedExplicitWindow.resolve(
+        #expect(RemoteTmuxAttachWindowTarget.unresolvedExplicitTarget.resolve(
             existingMirrorWindowID: existing,
             activeWindowID: active,
             isLive: { $0 == existing || $0 == active }
         ) == existing)
+    }
+
+    /// Issue #9191: an explicit but unresolvable `workspace_id` must not let
+    /// the mirror land in the active window.
+    @Test func explicitUnresolvableWorkspaceRoutingFailsClosed() {
+        let controller = TerminalController.shared
+        let active = UUID()
+
+        for params in [
+            ["workspace_id": "workspace:999"],
+            ["workspace_id": UUID().uuidString],
+        ] {
+            let target = controller.remoteTmuxAttachWindowTarget(
+                routing: controller.v2RoutingSelectors(params)
+            )
+            #expect(target == .unresolvedExplicitTarget, Comment(rawValue: "params=\(params)"))
+            #expect(target.resolve(
+                existingMirrorWindowID: nil,
+                activeWindowID: active,
+                isLive: { $0 == active }
+            ) == nil)
+        }
     }
 
     @Test func contextualRoutingRecoversFromAClosedPreferredWindow() {

--- a/cmuxTests/SurfaceRoutingUnresolvableWorkspaceTests.swift
+++ b/cmuxTests/SurfaceRoutingUnresolvableWorkspaceTests.swift
@@ -45,6 +45,31 @@ struct SurfaceRoutingUnresolvableWorkspaceTests {
         #expect(resolved?.id == selected.id)
     }
 
+    /// The app-side request decoder is the single place every non-coordinator
+    /// entrypoint (`surface.read_text` on the socket-worker lane, the
+    /// remote-tmux paths) gets its selectors from, so the presence flag cannot
+    /// be wired into one command and forgotten in another.
+    @Test
+    func appSideDecoderFlagsPresentButUnresolvableWorkspaceID() {
+        let controller = TerminalController.shared
+
+        let unresolvable = controller.v2RoutingSelectors(["workspace_id": "workspace:999"])
+        #expect(unresolvable.workspaceID == nil)
+        #expect(unresolvable.hasWorkspaceIDParam)
+
+        #expect(!controller.v2RoutingSelectors([:]).hasWorkspaceIDParam)
+        #expect(!controller.v2RoutingSelectors(["workspace_id": NSNull()]).hasWorkspaceIDParam)
+
+        let uuid = UUID()
+        let resolved = controller.v2RoutingSelectors(["workspace_id": uuid.uuidString])
+        #expect(resolved.workspaceID == uuid)
+        #expect(resolved.hasWorkspaceIDParam)
+
+        #expect(
+            controller.remoteTmuxRouting(from: ["workspace_id": "workspace:999"]) == unresolvable
+        )
+    }
+
     private static func routing(
         workspaceID: UUID?,
         hasWorkspaceIDParam: Bool

--- a/cmuxTests/SurfaceRoutingUnresolvableWorkspaceTests.swift
+++ b/cmuxTests/SurfaceRoutingUnresolvableWorkspaceTests.swift
@@ -1,0 +1,62 @@
+import CmuxControlSocket
+import Foundation
+import Testing
+
+#if canImport(cmux_DEV)
+    @testable import cmux_DEV
+#elseif canImport(cmux)
+    @testable import cmux
+#endif
+
+/// Regression coverage for GitHub issue #9191: an input RPC that carries a
+/// `workspace_id` the app cannot resolve (a recycled or foreign `workspace:N`
+/// ref, or a typo) must fail closed instead of silently retargeting the
+/// caller's focused workspace.
+@Suite(.serialized)
+@MainActor
+struct SurfaceRoutingUnresolvableWorkspaceTests {
+    @Test
+    func unresolvableWorkspaceIDResolvesToNoWorkspace() throws {
+        let manager = TabManager()
+        let selected = try #require(manager.selectedWorkspace)
+
+        let omitted = TerminalController.shared.resolveSurfaceWorkspace(
+            routing: Self.routing(workspaceID: nil, hasWorkspaceIDParam: false),
+            tabManager: manager
+        )
+        #expect(omitted?.id == selected.id)
+
+        let unresolvable = TerminalController.shared.resolveSurfaceWorkspace(
+            routing: Self.routing(workspaceID: nil, hasWorkspaceIDParam: true),
+            tabManager: manager
+        )
+        #expect(unresolvable == nil)
+    }
+
+    @Test
+    func resolvedWorkspaceIDStillRoutesToItsWorkspace() throws {
+        let manager = TabManager()
+        let selected = try #require(manager.selectedWorkspace)
+
+        let resolved = TerminalController.shared.resolveSurfaceWorkspace(
+            routing: Self.routing(workspaceID: selected.id, hasWorkspaceIDParam: true),
+            tabManager: manager
+        )
+        #expect(resolved?.id == selected.id)
+    }
+
+    private static func routing(
+        workspaceID: UUID?,
+        hasWorkspaceIDParam: Bool
+    ) -> ControlRoutingSelectors {
+        ControlRoutingSelectors(
+            hasWindowIDParam: false,
+            windowID: nil,
+            groupID: nil,
+            workspaceID: workspaceID,
+            surfaceID: nil,
+            paneID: nil,
+            hasWorkspaceIDParam: hasWorkspaceIDParam
+        )
+    }
+}

--- a/cmuxTests/SurfaceRoutingUnresolvableWorkspaceTests.swift
+++ b/cmuxTests/SurfaceRoutingUnresolvableWorkspaceTests.swift
@@ -52,8 +52,14 @@ struct SurfaceRoutingUnresolvableWorkspaceTests {
     /// focused workspace instead.
     @Test
     func unresolvableWorkspaceIDResolvesToNoTabManager() {
+        // An unparseable/unknown ref, which decodes to no UUID at all...
         #expect(TerminalController.shared.resolveTabManager(
             routing: Self.routing(workspaceID: nil, hasWorkspaceIDParam: true)
+        ) == nil)
+        // ...and a well-formed UUID that no window owns (a closed workspace, or
+        // an id from another app instance), which parses but locates nothing.
+        #expect(TerminalController.shared.resolveTabManager(
+            routing: Self.routing(workspaceID: UUID(), hasWorkspaceIDParam: true)
         ) == nil)
     }
 
@@ -62,17 +68,21 @@ struct SurfaceRoutingUnresolvableWorkspaceTests {
     /// workspace and add the item there. It must refuse instead.
     @Test
     func unresolvableWorkspaceIDDoesNotMutateTheFocusedWorkspaceTodos() {
-        let result = TerminalController.shared.controlWorkspaceTodoAdd(
-            routing: Self.routing(workspaceID: nil, hasWorkspaceIDParam: true),
-            workspaceID: nil,
-            text: "must not land in the focused workspace",
-            stateRaw: nil,
-            originRaw: nil
-        )
+        for workspaceID in [nil, UUID()] as [UUID?] {
+            let result = TerminalController.shared.controlWorkspaceTodoAdd(
+                routing: Self.routing(workspaceID: workspaceID, hasWorkspaceIDParam: true),
+                workspaceID: workspaceID,
+                text: "must not land in the focused workspace",
+                stateRaw: nil,
+                originRaw: nil
+            )
 
-        guard case .tabManagerUnavailable = result else {
-            Issue.record("expected the add to be refused, got \(result)")
-            return
+            switch result {
+            case .tabManagerUnavailable, .notFound:
+                continue
+            default:
+                Issue.record("expected the add to be refused, got \(result)")
+            }
         }
     }
 

--- a/cmuxTests/SurfaceRoutingUnresolvableWorkspaceTests.swift
+++ b/cmuxTests/SurfaceRoutingUnresolvableWorkspaceTests.swift
@@ -45,6 +45,37 @@ struct SurfaceRoutingUnresolvableWorkspaceTests {
         #expect(resolved?.id == selected.id)
     }
 
+    /// `resolveTabManager` is the choke point every routed command reaches,
+    /// including the ones whose own workspace param is optional (todos,
+    /// status, remote-tmux host selection). It has to refuse a named-but-
+    /// unresolvable workspace there, or those commands mutate the caller's
+    /// focused workspace instead.
+    @Test
+    func unresolvableWorkspaceIDResolvesToNoTabManager() {
+        #expect(TerminalController.shared.resolveTabManager(
+            routing: Self.routing(workspaceID: nil, hasWorkspaceIDParam: true)
+        ) == nil)
+    }
+
+    /// A non-surface mutation: `workspace.todo.add` carries an optional
+    /// workspace param, so an unknown ref used to fall through to the selected
+    /// workspace and add the item there. It must refuse instead.
+    @Test
+    func unresolvableWorkspaceIDDoesNotMutateTheFocusedWorkspaceTodos() {
+        let result = TerminalController.shared.controlWorkspaceTodoAdd(
+            routing: Self.routing(workspaceID: nil, hasWorkspaceIDParam: true),
+            workspaceID: nil,
+            text: "must not land in the focused workspace",
+            stateRaw: nil,
+            originRaw: nil
+        )
+
+        guard case .tabManagerUnavailable = result else {
+            Issue.record("expected the add to be refused, got \(result)")
+            return
+        }
+    }
+
     /// The app-side request decoder is the single place every non-coordinator
     /// entrypoint (`surface.read_text` on the socket-worker lane, the
     /// remote-tmux paths) gets its selectors from, so the presence flag cannot

--- a/docs/cli-contract.md
+++ b/docs/cli-contract.md
@@ -43,6 +43,16 @@ Global options:
 | `--id-format <refs\|uuids\|both>` | Select handle format in JSON and supported text output. |
 | `--window <id\|ref\|index>` | Route the command through a specific window when supported. |
 
+Short `kind:N` refs are display handles: they are scoped to the app's current
+handle table and are reused after the object they named is closed. UUIDs are the
+stable identity, and the input RPCs (`surface.send_text`, `surface.send_key`,
+`workspace.prompt_submit`) accept UUIDs. Scripts that create an object and then
+talk to it must carry the UUID. `cmux workspace create` therefore reports both:
+plain output prints `OK <workspace_ref> <workspace_uuid>`, and `--json` keeps
+`workspace_id`, `surface_id`, and `pane_id` in the payload even in the default
+`refs` id-format. A `workspace_id` that the app cannot resolve is rejected with
+`not_found` rather than falling back to the focused workspace.
+
 Environment:
 
 | Variable | Contract |

--- a/docs/cli-contract.md
+++ b/docs/cli-contract.md
@@ -50,8 +50,8 @@ stable identity, and the input RPCs (`surface.send_text`, `surface.send_key`,
 talk to it must carry the UUID. `cmux workspace create` therefore reports both:
 plain output prints `OK <workspace_ref> <workspace_uuid>`, and `--json` keeps
 `workspace_id`, `surface_id`, and `pane_id` in the payload even in the default
-`refs` id-format. A `workspace_id` that the app cannot resolve is rejected with
-`not_found` rather than falling back to the focused workspace.
+`refs` id-format. A `workspace_id` the app cannot resolve is rejected, rather
+than falling back to the caller's focused workspace, for every routed command.
 
 Environment:
 


### PR DESCRIPTION
`cmux workspace create` printed only a short `workspace:N` ref. Refs are recyclable per-connection handles, while the input RPCs (`surface.send_text`, `surface.send_key`, `workspace.prompt_submit`) key off UUIDs, so the one identifier `create` handed back was the one that was unsafe to carry into them. Worse, a `workspace_id` that resolved to nothing fell through to the caller's focused workspace, so passing the ref along typed into whatever session happened to be in front of the user, with no error.

Two changes:

- `workspace create --json` keeps the created workspace/surface/pane UUIDs in the payload even in the default `refs` id-format (the same `preservingIDKinds` mechanism `workspace list` already uses for workspace ids), and the `--command` follow-up routes its `surface.send_text` by the returned UUID instead of the ref. `workspace.create` already returned both forms over the socket; only the CLI's id-format shaping was dropping them.
- The surface domain now fails closed on an unresolvable `workspace_id`. `ControlCommandCoordinator.routingSelectors` records `hasWorkspaceIDParam` alongside the resolved id, mirroring the existing `hasWindowIDParam` precedent, and `resolveSurfaceWorkspace` returns no workspace when the param was present but resolved to nothing. The call answers `not_found` instead of silently retargeting.

The related readability point in the issue (a workspace's terminal is unreadable until selected once) is untouched here and is worth its own issue.

## Testing

Regression tests, added in commit 1 so CI goes red before the fix in commit 2:

- `cmuxTests/CLIWorkspaceCreateIdentityTests.swift` runs the bundled CLI against a mock control socket and asserts `workspace create --json` emits the `workspace_id`/`surface_id` UUIDs, and that `--command` routes `surface.send_text` by UUID.
- `cmuxTests/SurfaceRoutingUnresolvableWorkspaceTests.swift` asserts `resolveSurfaceWorkspace` returns the selected workspace when `workspace_id` is omitted, and nothing when it is present but unresolvable.
- `ControlCommandCoordinatorParamsTests.routingFlagsPresentButUnresolvableWorkspaceID` covers the coordinator half. `swift test --filter routingFlagsPresentButUnresolvableWorkspaceID` passes in `Packages/macOS/CmuxControlSocket`.

Dev build `cmux DEV sym9191`, driven over `/tmp/cmux-debug-sym9191.sock`:

```console
$ cmux workspace create --name issue-repro --cwd /tmp --json
{ "surface_id": "FC99D1DC-...", "surface_ref": "surface:2",
  "workspace_id": "DB6D2265-...", "workspace_ref": "workspace:2", ... }

$ cmux rpc surface.send_text '{"workspace_id":"workspace:999","text":"MISDELIVERED\n"}'
Error: not_found: Workspace not found          # previously typed into the focused surface

$ cmux rpc surface.send_text '{"workspace_id":"DB6D2265-...","text":"echo DELIVERED_TO_NEW\n"}'
{ "surface_id": "FC99D1DC-...", "queued": true, ... }
```

Reading that surface afterwards shows `DELIVERED_TO_NEW`, in the new workspace.

Fixes #9191

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/9433"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788323150&installation_model_id=21920&pr_number=9433&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F9433&signature=834b608369627792db1748a7d54112ffc279a18e7c183bb6cf3b9a20f5a3f480"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Return the created workspace’s UUID from `cmux workspace create`, print it next to the ref, and route `--command` by UUID. Fail closed when a present `workspace_id`/`window_id` is invalid or not owned, across CLI and remote-tmux, to prevent misdelivery. Fixes #9191.

- **Bug Fixes**
  - `cmux workspace create --json` keeps the created `workspace_id`/`surface_id`/`pane_id` when the id-format isn’t explicitly set; an explicit `--id-format` (`refs`/`uuids`/`both`) shapes JSON strictly.
  - Plain output prints `OK <workspace_ref> <workspace_uuid>`.
  - `--command` sends by UUID only and exits non-zero if the app omits the UUID; no ref fallback.
  - An explicit `workspace_id`/`window_id` that can’t be resolved or names no live target is rejected in the shared resolver, so `workspace.todo.*`, `workspace.status.*`, `remote.tmux.host`, and `remote.tmux.mirror` no longer fall back to the focused/active window.

- **Migration**
  - Read the UUID from `workspace create` (JSON or plain) and use it for input RPCs.
  - If you set `--id-format`, expect JSON shaped exactly by it.
  - Handle `not_found` when a `workspace_id` is present but invalid/closed.
  - Expect a non-zero exit for `--command` on older apps that don’t return the UUID.

<sup>Written for commit 9923a1daef3862ec23f87e2b717d6cec3b6e7a46. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/9433?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Workspace creation can preserve stable identifiers and display both references and UUIDs in text or JSON output.
  * Added explicit identifier-format options for workspace, surface, and pane output.

* **Bug Fixes**
  * Commands now route using workspace UUIDs when available.
  * Invalid workspace IDs no longer fall back to the selected workspace.
  * Added a clear error when command delivery lacks a workspace UUID.

* **Documentation**
  * Clarified identifier formats and routing behavior in the CLI contract.

* **Tests**
  * Added coverage for identifier output, routing, and workspace resolution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->