### PR TITLE
Treat "no update available" as a success in Attempt Update

### DIFF
--- a/Packages/macOS/CmuxUpdater/Sources/CmuxUpdater/AttemptUpdateCoordinator.swift
+++ b/Packages/macOS/CmuxUpdater/Sources/CmuxUpdater/AttemptUpdateCoordinator.swift
@@ -100,7 +100,13 @@ struct AttemptUpdateCoordinator {
             case .updateAvailable:
                 phase = .startingDownload
                 return .confirmInstall
-            case .idle, .notFound:
+            case .notFound:
+                // Being already up to date is the expected outcome of this fresh check, not a
+                // failure (issue #9262). End the attempt quietly and let the model's `.notFound`
+                // state render as the normal up-to-date result.
+                phase = .inactive
+                return .none
+            case .idle:
                 phase = .inactive
                 return .installFailed
             case .error:

--- a/Packages/macOS/CmuxUpdater/Tests/CmuxUpdaterTests/AttemptUpdateCoordinatorTests.swift
+++ b/Packages/macOS/CmuxUpdater/Tests/CmuxUpdaterTests/AttemptUpdateCoordinatorTests.swift
@@ -106,12 +106,26 @@ import Testing
         }
     }
 
+    /// Regression (issue #9262): being already up to date is the most likely outcome of the fresh
+    /// check this coordinator performs. It must end the attempt quietly so the model's `.notFound`
+    /// state renders normally, instead of being replaced by a "check your internet connection"
+    /// install-failure error.
     @Test func stopsMonitoringWhenFreshCheckFindsNothing() {
         var coordinator = AttemptUpdateCoordinator()
         _ = coordinator.requestInstallLatest(currentState: updateAvailable("0.64.15"))
         coordinator.didStartFreshCheck()
         #expect(coordinator.handleStateChange(.checking(.init(cancel: {}))) == .none)
-        #expect(coordinator.handleStateChange(.notFound(.init(acknowledgement: {}))) == .installFailed)
+        #expect(coordinator.handleStateChange(.notFound(.init(acknowledgement: {}))) == .none)
+        #expect(!coordinator.isMonitoring)
+    }
+
+    /// `.idle` in the same phase is still a genuine failure: the accepted attempt ended with no
+    /// result at all, so it must keep reporting `.installFailed`.
+    @Test func reportsInstallFailedWhenFreshCheckEndsAtIdle() {
+        var coordinator = AttemptUpdateCoordinator()
+        _ = coordinator.requestInstallLatest(currentState: updateAvailable("0.64.15"))
+        coordinator.didStartFreshCheck()
+        #expect(coordinator.handleStateChange(.idle) == .installFailed)
         #expect(!coordinator.isMonitoring)
     }
 

--- a/Packages/macOS/CmuxUpdater/Tests/CmuxUpdaterTests/UpdateControllerPipelineTests.swift
+++ b/Packages/macOS/CmuxUpdater/Tests/CmuxUpdaterTests/UpdateControllerPipelineTests.swift
@@ -385,6 +385,11 @@ import Testing
         await waitUntil("fresh check to start") { harness.updater.checkForUpdatesCallCount == 1 }
 
         harness.model.setState(.checking(.init(cancel: {})))
+        let freshPrompt = ChoiceBox()
+        harness.model.setState(updateAvailable("0.64.16", replyingInto: freshPrompt))
+        await waitUntil("fresh prompt to be accepted") { freshPrompt.choice == .install }
+
+        // Sparkle answers the accepted install with a terminal that never starts a download.
         harness.model.setState(.notFound(.init(acknowledgement: {
             didAcknowledgeNotFound = true
         })))

--- a/Packages/macOS/CmuxUpdater/Tests/CmuxUpdaterTests/UpdateControllerPipelineTests.swift
+++ b/Packages/macOS/CmuxUpdater/Tests/CmuxUpdaterTests/UpdateControllerPipelineTests.swift
@@ -395,6 +395,29 @@ import Testing
         #expect(didAcknowledgeNotFound)
     }
 
+    /// Regression (issue #9262): "Attempt Update" while already on the latest version must show
+    /// the normal up-to-date result, not a red "check your internet connection" error.
+    @Test func upToDateAttemptShowsNoUpdateAvailableInsteadOfError() async {
+        let harness = Harness()
+        let stalePrompt = ChoiceBox()
+
+        harness.model.setState(updateAvailable("0.64.15", replyingInto: stalePrompt))
+        harness.controller.attemptUpdate()
+        harness.finishSparkleCycle()
+        await waitUntil("fresh check to start") { harness.updater.checkForUpdatesCallCount == 1 }
+
+        harness.model.setState(.checking(.init(cancel: {})))
+        harness.model.setState(.notFound(.init(acknowledgement: {})))
+
+        // Give any erroneous reaction a chance to replace the state.
+        for _ in 0..<2_000 { await Task.yield() }
+
+        guard case .notFound = harness.model.state else {
+            Issue.record("up-to-date attempt replaced notFound with: \(harness.model.state)")
+            return
+        }
+    }
+
     /// If the live prompt is still visible but already answered before the queued confirm
     /// hand-off runs, the controller must not log a fake install attempt or leave the watchdog
     /// armed for a prompt Sparkle will never accept again.

--- a/cmuxUITests/UpdatePillUITests.swift
+++ b/cmuxUITests/UpdatePillUITests.swift
@@ -183,6 +183,31 @@ final class UpdatePillUITests: XCTestCase {
         XCTAssertFalse(app.buttons["SidebarUpdateBannerAction"].exists)
     }
 
+    /// Regression for https://github.com/manaflow-ai/cmux/issues/9262: running "Attempt Update"
+    /// from the command palette while no update is available must report the normal up-to-date
+    /// result, not the red "Update Didn't Start / check your internet connection" error.
+    ///
+    /// A DEV build short-circuits its manual check to `.notFound`, which is the same terminal a
+    /// release build reaches when the feed publishes nothing newer, so this exercises the real
+    /// palette entry point end to end without a mock feed.
+    func testAttemptUpdateWithNoUpdateAvailableDoesNotShowError() {
+        let systemSettings = XCUIApplication(bundleIdentifier: "com.apple.systempreferences")
+        systemSettings.terminate()
+        let app = XCUIApplication.cmuxTestApplication()
+        app.launchEnvironment["CMUX_UI_TEST_MODE"] = "1"
+        launchAndActivate(app)
+        XCTAssertTrue(waitForWindowCount(atLeast: 1, app: app, timeout: 6.0))
+
+        app.typeKey("p", modifierFlags: [.command, .shift])
+        app.typeText("Attempt Update")
+        app.typeKey(.return, modifierFlags: [])
+
+        let upToDatePill = pillButton(app: app, expectedLabel: "No Updates Available")
+        XCTAssertTrue(upToDatePill.waitForExistence(timeout: 10.0))
+        attachScreenshot(name: "attempt-update-no-update")
+        XCTAssertFalse(pillButton(app: app, expectedLabel: "Update Didn’t Start").exists)
+    }
+
     func testNoSparklePermissionDialogIsShown() {
         let systemSettings = XCUIApplication(bundleIdentifier: "com.apple.systempreferences")
         systemSettings.terminate()


### PR DESCRIPTION
Fixes #9262

Running "Attempt Update" from the command palette while already on the latest version showed a red pill: "Update Didn't Start — cmux couldn't start the update. Check your internet connection and try again." The check had succeeded and the network was fine; there was simply nothing to install.

## Mechanism

`AttemptUpdateCoordinator.handleStateChange` classified `.notFound` as `.installFailed` in the `.awaitingResult` phase. The controller then ran `setInstallDidNotStartError`, whose final `model.replaceActiveState(with: errorState)` overwrote the model's correct `.notFound` state with the error, so the user never saw the true result of their own check.

`.notFound` in `.awaitingResult` now stops monitoring and returns `.none`, leaving the model's `.notFound` to render as the normal up-to-date result. This also makes the coordinator agree with `InstallWatchdog`, which already classified `.notFound` as resolved and non-stalled.

Deliberately unchanged: `.idle` in the same phase still returns `.installFailed` (the attempt ended with no result at all), and `.notFound` in `.awaitingFreshCheck` / `.startingDownload` still fails, since a `notFound` after the user accepted an install is genuinely unexpected. The issue's wider question about whether the three palette update commands should stay distinct is out of scope here.

## Testing

Regression tests, split so CI goes red then green:

- Commit 1 updates `stopsMonitoringWhenFreshCheckFindsNothing` to assert `.none` (it previously asserted `.installFailed`, locking the bug in) and adds `reportsInstallFailedWhenFreshCheckEndsAtIdle` to pin the `.idle` behavior that is intentionally kept.
- Commit 2 adds `UpdatePillUITests.testAttemptUpdateWithNoUpdateAvailableDoesNotShowError`, which drives the real command palette entry point and asserts the "No Updates Available" pill appears instead of the error.
- Commit 3 is the fix, plus a retarget of `acceptedInstallFailureAcknowledgesReplacedSparkleTerminal` so it exercises the accepted-install path (`.startingDownload`) that still fails, rather than the up-to-date path that no longer does.

Commands:

- `swift test` in `Packages/macOS/CmuxUpdater`: 87 tests pass at the fix commit. At the pre-fix source, `stopsMonitoringWhenFreshCheckFindsNothing` and a new pipeline-level replay (`upToDateAttemptShowsNoUpdateAvailableInsteadOfError`) both fail, confirming they capture the bug.
- Hosted `test-e2e.yml` run of `UpdatePillUITests/testAttemptUpdateWithNoUpdateAvailableDoesNotShowError`, dispatched at both the pre-fix commit and the fix head.

Dev build: `./scripts/reload.sh --tag sym9262` succeeded and the tagged app launched (the cloud builder failed on an unrelated stale zig toolchain). Driving the palette from the debug socket was not possible in this environment because the tagged window never became key, so the palette entry point is covered by the hosted XCUITest above rather than by a local socket transcript.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/9435"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788323671&installation_model_id=21920&pr_number=9435&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F9435&signature=6858e3efc45ecc38b95014749efb77973df28bd0fedd47ff37dba1b3f364d2d1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Treat “no update available” as a successful outcome for “Attempt Update,” so users see “No Updates Available” instead of the red “Update Didn’t Start” error. Fixes #9262.

- **Bug Fixes**
  - In the coordinator, `.notFound` during the fresh check now ends the attempt quietly (stop monitoring, return `.none`) and keeps the model’s `.notFound` state; `.idle` and unexpected `.notFound` in earlier phases still fail.
  - Added regression coverage with unit tests and a UI test to assert the up‑to‑date pill appears and no error pill is shown.

<sup>Written for commit ea628a847fb587620c92fdef0c0f314ffefd65f6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/9435?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved update checks when no newer version is available.
  * “No Updates Available” is now shown without incorrectly displaying an update failure message.
  * Update attempts that are already current now complete normally.
  * Preserved error handling when an update check ends unexpectedly while idle.

* **Tests**
  * Added regression coverage for update prompts, terminal responses, and the command-palette update flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->