### PR TITLE
Fix INTERNAL iOS Ghostty startup crash

### DIFF
--- a/docs/ghostty-fork.md
+++ b/docs/ghostty-fork.md
@@ -12,10 +12,11 @@ When we change the fork, update this document and the parent submodule SHA.
 
 ## Current fork changes
 
-The submodule pinned by this branch is `88357634c`, the fork-main merge of
-https://github.com/manaflow-ai/ghostty/pull/175. It combines the initial cmux
-theme-picker render fix at `5068b3a37` with terminal-owned semantic-prompt row
-lifecycle enforcement through `2d6e944e3` from
+The submodule pinned by this branch is `f0f8273b7`, adding the iOS startup
+locale/crash-reporting order fix on top of `88357634c`, the fork-main merge of
+https://github.com/manaflow-ai/ghostty/pull/175. That previous merge combines
+the initial cmux theme-picker render fix at `5068b3a37` with terminal-owned
+semantic-prompt row lifecycle enforcement through `2d6e944e3` from
 https://github.com/manaflow-ai/ghostty/pull/176.
 The earlier integration combines the hidden-renderer reclamation and
 retry-deadline line through `4d6f0014f` with the resolved font-binding action
@@ -42,6 +43,21 @@ The seven PRs landed in merge commits `1e86b46e2`, `4dab6fd6c`,
 `2fc66ed15`, `3c1b75d25`, `c467d389c`, `64d7fca66`, and `4d6f0014f`.
 The final font integration landed in merge commits `23003282d` and
 `36a46414a`.
+
+### iOS startup locale before crash reporting
+
+- Commit: `f0f8273b7` (Initialize locale before crash reporting)
+- File: `src/global.zig`
+- Summary:
+  - Moves `ensureLocale()` and `syncEnviron()` before Ghostty's crash reporting
+    init so Darwin `setlocale` completes before Sentry starts its background
+    initialization thread.
+  - Fixes the cmux INTERNAL TestFlight crash from August 2, 2026, where build
+    `20260801151612` crashed in `ghostty_init + 1388` while the main thread was
+    in `setlocale` from `GhosttyRuntime.init`.
+- Conflict note:
+  - Preserve this ordering during future `global.init` merges: process-wide
+    locale mutation must stay before any Ghostty-owned background thread starts.
 
 ### Initial cmux theme-picker render
 


### PR DESCRIPTION
Summary:
- pins the cmux Ghostty submodule to https://github.com/manaflow-ai/ghostty/pull/178, which initializes Darwin locale before crash reporting starts Sentry background initialization
- updates the Ghostty fork ledger so this startup ordering survives future fork merges

ASC evidence:
- evidence saved under out/perf-incident-20260802-211649
- app: cmux INTERNAL, App Store Connect app ID 6791408425, bundle dev.cmux.app.internal
- build: 1.0.4 (20260801151612), ASC build ID 70601b34-24c2-4cc2-badf-442e42b08fe1
- crashes: ABcW9SkjM5N2hVaFZE0YBsM at 2026-08-02 20:38:27 -0700, AIvdoBLmrBQfVpYrycr3lg8 at 2026-08-02 21:05:15 -0700
- signature: EXC_BAD_ACCESS in ghostty_init + 1388 while the main thread was in Darwin setlocale/loadlocale through GhosttyRuntime.swift:110

Root cause:
- Ghostty crash reporting could start its Sentry background thread before process-wide Darwin locale setup completed, racing setlocale during iOS terminal startup.

Testing:
- zig fmt ghostty/src/global.zig
- git diff --check in cmux parent and Ghostty submodule
- remote macOS reload-build succeeded for tag intcrs: https://github.com/manaflow-ai/cmux/actions/runs/30784363246
- local web warm for iOS support routes: / 200, /handler/sign-in 200, /handler/after-sign-in -L 200
- iOS cloud device archive succeeded for tag intcrs with CMUX_GIT_SHA=e2123c276b and Ghostty f0f8273b7; signing/export succeeded, Aziz iPhone was unreachable, so the signed build was queued for auto-install
- hosted iOS workflow run failed before crash-specific UI runtime proof: https://github.com/manaflow-ai/cmux/actions/runs/30785343877. package-conventions-lint reported pre-existing iOS convention debt, and ios-simulator (iphone) failed compiling unrelated CmuxMobileShellUI tests in WorkspaceListTableCoordinatorDropTests.swift before cmuxUITests/testTerminalReplayRendersGhosttyText could launch