### PR TITLE
Reject directories in provider executable PATH resolution

### DIFF
--- a/CLI/CMUXCLI+ExecutableResolution.swift
+++ b/CLI/CMUXCLI+ExecutableResolution.swift
@@ -85,7 +85,14 @@ extension CMUXCLI {
             let candidate = URL(fileURLWithPath: entry, isDirectory: true)
                 .appendingPathComponent(name, isDirectory: false)
                 .path
-            guard FileManager.default.isExecutableFile(atPath: candidate) else { continue }
+            // isExecutableFile(atPath:) returns true for directories, so a
+            // directory named like the binary earlier on PATH must not shadow
+            // the real executable (mirrors the configured-candidate guard in
+            // resolveClaudeExecutable(configuredCandidates:searchPath:)).
+            var isDirectory: ObjCBool = false
+            guard FileManager.default.fileExists(atPath: candidate, isDirectory: &isDirectory),
+                  !isDirectory.boolValue,
+                  FileManager.default.isExecutableFile(atPath: candidate) else { continue }
             guard !isBundledProviderExecutable(at: candidate) else { continue }
             if let skip, skip(candidate) { continue }
             return candidate

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -544,6 +544,7 @@ C0DE71B10000000000000001 /* AppDelegate+AgentChatNotifications.swift in Sources 
 		A5D41205A1B2C3D4E5F60718 /* CLINotifyProcessTestSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5D41206A1B2C3D4E5F60718 /* CLINotifyProcessTestSupport.swift */; };
 		89930001AABBCCDDEEFF0001 /* CLIOmpHookBindingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 89930001AABBCCDDEEFF0002 /* CLIOmpHookBindingTests.swift */; };
 		89930006AABBCCDDEEFF0001 /* CLIOmpSupersededCleanupTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 89930006AABBCCDDEEFF0002 /* CLIOmpSupersededCleanupTests.swift */; };
+		8743A00000000000000000A2 /* CLIProviderPathDirectoryShadowTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8743A00000000000000000A1 /* CLIProviderPathDirectoryShadowTests.swift */; };
 		C0F16B000000000000000001 /* CLIRemoteShellStartupPerformanceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0F16B000000000000000002 /* CLIRemoteShellStartupPerformanceTests.swift */; };
 		A5D41209A1B2C3D4E5F60718 /* CLIRovoDevHookPersistenceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5D4120AA1B2C3D4E5F60718 /* CLIRovoDevHookPersistenceTests.swift */; };
 		B900004AA1B2C3D4E5F60719 /* CLISocketPathResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = B900004BA1B2C3D4E5F60719 /* CLISocketPathResolver.swift */; };
@@ -3216,6 +3217,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 		A5D41206A1B2C3D4E5F60718 /* CLINotifyProcessTestSupport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CLINotifyProcessTestSupport.swift; sourceTree = "<group>"; };
 		89930001AABBCCDDEEFF0002 /* CLIOmpHookBindingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CLIOmpHookBindingTests.swift; sourceTree = "<group>"; };
 		89930006AABBCCDDEEFF0002 /* CLIOmpSupersededCleanupTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CLIOmpSupersededCleanupTests.swift; sourceTree = "<group>"; };
+		8743A00000000000000000A1 /* CLIProviderPathDirectoryShadowTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CLIProviderPathDirectoryShadowTests.swift; sourceTree = "<group>"; };
 		C0F16B000000000000000002 /* CLIRemoteShellStartupPerformanceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CLIRemoteShellStartupPerformanceTests.swift; sourceTree = "<group>"; };
 		A5D4120AA1B2C3D4E5F60718 /* CLIRovoDevHookPersistenceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CLIRovoDevHookPersistenceTests.swift; sourceTree = "<group>"; };
 		B900004BA1B2C3D4E5F60719 /* CLISocketPathResolver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CLISocketPathResolver.swift; sourceTree = "<group>"; };
@@ -7789,6 +7791,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				C7A50C000000000000000001 /* CmuxTopProcessCPUTests.swift */,
 				C7A50C000000000000000004 /* CmuxTopProcessArgumentsTests.swift */,
 				906900000000000000000003 /* CMUXCLIMemoryAttributionTests.swift */,
+				8743A00000000000000000A1 /* CLIProviderPathDirectoryShadowTests.swift */,
 				D7AB34300000000000000006 /* SidebarWorkspaceDropPlannerTests.swift */,
 				B804D0010000000000000001 /* SidebarWorkspaceTableTests.swift */,
 				B804D0020000000000000002 /* SidebarSelectionCoalescerTests.swift */,
@@ -10429,6 +10432,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				A5D41205A1B2C3D4E5F60718 /* CLINotifyProcessTestSupport.swift in Sources */,
 				89930001AABBCCDDEEFF0001 /* CLIOmpHookBindingTests.swift in Sources */,
 				89930006AABBCCDDEEFF0001 /* CLIOmpSupersededCleanupTests.swift in Sources */,
+					8743A00000000000000000A2 /* CLIProviderPathDirectoryShadowTests.swift in Sources */,
 				C0F16B000000000000000001 /* CLIRemoteShellStartupPerformanceTests.swift in Sources */,
 				A5D41209A1B2C3D4E5F60718 /* CLIRovoDevHookPersistenceTests.swift in Sources */,
 				A8D837B3AA85F4353C493DE1 /* CLISSHPTYAttachProbeReplyRegressionTests.swift in Sources */,

--- a/cmuxTests/CLIProviderPathDirectoryShadowTests.swift
+++ b/cmuxTests/CLIProviderPathDirectoryShadowTests.swift
@@ -1,0 +1,55 @@
+import Foundation
+import Testing
+
+// Regression coverage for https://github.com/manaflow-ai/cmux/issues/8743:
+// `resolveExecutableInSearchPath` accepted PATH candidates via
+// `FileManager.isExecutableFile(atPath:)` alone, which returns true for
+// directories on macOS. A directory named like a provider binary earlier on
+// PATH could shadow the real executable and break provider launch.
+extension CMUXCLIErrorOutputRegressionTests {
+    @Test func testProviderPathResolutionSkipsDirectoryNamedLikeProviderBinary() throws {
+        let cliPath = try bundledCLIPath()
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cmux-path-dir-shadow-\(UUID().uuidString)", isDirectory: true)
+        let shadowBin = root.appendingPathComponent("shadow-bin", isDirectory: true)
+        let shadowDirectory = shadowBin.appendingPathComponent("codex", isDirectory: true)
+        let realBin = root.appendingPathComponent("real-bin", isDirectory: true)
+        try FileManager.default.createDirectory(at: shadowDirectory, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: realBin, withIntermediateDirectories: true)
+        try FileManager.default.setAttributes(
+            [.posixPermissions: 0o755], ofItemAtPath: shadowDirectory.path)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let realCodex = realBin.appendingPathComponent("codex", isDirectory: false)
+        try "#!/bin/sh\necho fake-codex-resolved\nexit 0\n"
+            .write(to: realCodex, atomically: true, encoding: .utf8)
+        try FileManager.default.setAttributes(
+            [.posixPermissions: 0o755], ofItemAtPath: realCodex.path)
+
+        var environment = ProcessInfo.processInfo.environment
+        for key in Array(environment.keys) where key.hasPrefix("CMUX_") {
+            environment.removeValue(forKey: key)
+        }
+        environment["CMUX_CLI_SENTRY_DISABLED"] = "1"
+        // A throwaway HOME keeps the resolver's implicit home-relative search
+        // directories (~/.local/bin, ~/.bun/bin, ...) hermetic. The absolute
+        // fallback directories (/opt/homebrew/bin, ...) come after the PATH
+        // walk, so the fake codex in real-bin always wins once the shadow
+        // directory is rejected.
+        environment["HOME"] = root.path
+        environment["PATH"] = "\(shadowBin.path):\(realBin.path)"
+
+        // The fake codex exits immediately; the deadline only bounds a hung
+        // CLI process and never grades speed.
+        let result = runProcess(
+            executablePath: cliPath,
+            arguments: ["codex-teams", "--version"],
+            environment: environment,
+            timeout: 10
+        )
+
+        #expect(!result.timedOut, Comment(rawValue: result.stdout))
+        #expect(result.status == 0, Comment(rawValue: result.stdout))
+        #expect(result.stdout.contains("fake-codex-resolved"), Comment(rawValue: result.stdout))
+    }
+}


### PR DESCRIPTION
## Summary

- What changed? `resolveExecutableInSearchPath` now rejects directories during the provider PATH walk: a candidate must exist, not be a directory, and be executable - mirroring the configured-candidate guard already used by `resolveClaudeExecutable(configuredCandidates:searchPath:)`.
- Why? `FileManager.isExecutableFile(atPath:)` returns true for directories with search permission on macOS, so a directory named like a provider binary (e.g. `~/bin/codex/`) earlier on PATH shadowed the real executable. Provider launches then failed at exec time with a confusing `NSPOSIXErrorDomain Code=13 "Permission denied"` instead of resolving the real binary later on PATH. The bug is general to the shared resolver (`claude`, `codex`, `opencode`, `omx`, `omc`, and future consumers such as the Herdr compat path from #8736).

Fixes #8743

Per the regression test commit policy, this PR is two commits so CI shows the test catches the bug:

1. Failing regression test only: `cmuxTests/CLIProviderPathDirectoryShadowTests.swift` runs the bundled CLI with a hermetic `HOME`/`PATH` where a directory named `codex` precedes a fake `codex` executable, and expects the informational `codex-teams --version` launch to resolve the fake executable. Without the fix the CLI execs the directory and exits 1 with the EACCES error.
2. The fix.

The test stays hermetic on machines that have a real `codex` installed: PATH entries are walked before the absolute fallback directories (`/opt/homebrew/bin`, ...), so once the shadow directory is rejected the fake executable inside the injected PATH always wins. The 10-second `runProcess` deadline only bounds a hung CLI process (the fake codex exits immediately); it never grades speed.

## Testing

- Built the `cmux-cli` target before and after the fix and drove the exact repro:
  - pre-fix: `PATH="<shadow-dir-bin>:<real-bin>" cmux codex-teams --version` -> exit 1, `Error Domain=NSPOSIXErrorDomain Code=13 "Permission denied"`
  - post-fix: same invocation -> exit 0, resolves and runs the real executable from the next PATH entry
- `xcodebuild -scheme cmux-unit build-for-testing` -> TEST BUILD SUCCEEDED, then `test-without-building -only-testing:'cmuxTests/CMUXCLIErrorOutputRegressionTests/testProviderPathResolutionSkipsDirectoryNamedLikeProviderBinary()'` -> 1 test passed (0.45s) against the bundled CLI.
- Verified missing-binary handling is unchanged: with no shadow and no real executable on the injected PATH, resolution still falls through to the absolute fallback directories / the "Codex was not found" error.
- `./scripts/lint-pbxproj-test-wiring.sh` -> ok (new test file is wired); `python3 scripts/normalize-pbxproj.py` -> no further changes.

Localization audit: no user-facing strings added or changed (the fix is a resolver guard plus code comments), so no `Localizable.xcstrings` or web locale changes.

## Demo Video

N/A - CLI resolver fix, no UI change. Terminal repro transcript is in Testing above.

## Checklist

- [x] I tested the change locally
- [x] I added or updated tests for behavior changes
- [x] I updated docs/changelog if needed (N/A - no user-facing behavior contract change)
- [ ] I requested bot reviews after my latest commit
- [ ] All code review bot comments are resolved
- [ ] All human review comments are resolved

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/9439"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788328933&installation_model_id=21920&pr_number=9439&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F9439&signature=303e8590c97b03db2b9a3311a1b5062185b0fe79dc47e36608aa512ad4966e77"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Skip directories during PATH resolution of provider executables to prevent shadowing real binaries and “Permission denied” failures on macOS. Fixes #8743.

- **Bug Fixes**
  - Hardened `resolveExecutableInSearchPath` to require the candidate exists, is not a directory, and is executable; mirrors `resolveClaudeExecutable(...)`.
  - Added `CLIProviderPathDirectoryShadowTests.swift` to verify a `codex` directory on PATH is skipped and the next real/executable binary is chosen.

<sup>Written for commit 4f3d2b71b5630d1c59390a1d7ac5e6a322b29bae. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/9439?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved command-line provider detection so directories with executable-like names no longer shadow valid commands earlier in the system path.
  - Ensured commands such as `codex-teams --version` resolve and run the correct executable.

- **Tests**
  - Added regression coverage for executable resolution when similarly named directories appear earlier in the path.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->