### PR TITLE
Require Package.resolved diffs only when remote reachability changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -258,7 +258,9 @@ jobs:
         run: python3 scripts/check-workspace-package-groups.py --check
 
       - name: Validate SwiftPM lockfile policy
-        run: python3 scripts/check-package-resolved-policy.py
+        run: |
+          python3 tests/test_check_package_resolved_policy.py
+          python3 scripts/check-package-resolved-policy.py
 
       - name: Validate bash shell integration job control
         run: python3 tests/test_bash_integration_no_done_notifications.py

--- a/scripts/check-package-resolved-policy.py
+++ b/scripts/check-package-resolved-policy.py
@@ -9,6 +9,7 @@ from pathlib import Path
 import re
 import subprocess
 import sys
+from typing import NamedTuple
 
 
 ALLOWED_IGNORED_PREFIXES = (
@@ -105,15 +106,24 @@ def tracked_package_manifests_at_ref(
     return manifests
 
 
+class PackageNode(NamedTuple):
+    has_url_dependency: bool
+    path_dependencies: list[str]
+    url_dependency_calls: list[str]
+
+
+EMPTY_PACKAGE_NODE = PackageNode(False, [], [])
+
+
 def package_graph(
     manifests: dict[str, Path],
     *,
     ref: str | None = None,
-) -> dict[str, tuple[bool, list[str]]]:
+) -> dict[str, PackageNode]:
     root_by_resolved_path = {
         manifest.parent.resolve(): root for root, manifest in manifests.items()
     }
-    graph: dict[str, tuple[bool, list[str]]] = {}
+    graph: dict[str, PackageNode] = {}
 
     for root, manifest in manifests.items():
         text = (
@@ -124,17 +134,21 @@ def package_graph(
         if not text:
             continue
         path_dependencies: list[str] = []
-        has_url_dependency = False
+        url_dependency_calls: list[str] = []
         for dependency in PACKAGE_DEPENDENCY_RE.findall(text):
             if PACKAGE_URL_ARGUMENT_RE.search(dependency):
-                has_url_dependency = True
+                url_dependency_calls.append(" ".join(dependency.split()))
             path_match = PACKAGE_PATH_ARGUMENT_RE.search(dependency)
             if path_match is None:
                 continue
             dependency_root = (manifest.parent / path_match.group(1)).resolve()
             if dependency_root in root_by_resolved_path:
                 path_dependencies.append(root_by_resolved_path[dependency_root])
-        graph[root] = (has_url_dependency, path_dependencies)
+        graph[root] = PackageNode(
+            bool(url_dependency_calls),
+            path_dependencies,
+            url_dependency_calls,
+        )
 
     return graph
 
@@ -143,13 +157,9 @@ def package_dependency_calls(text: str) -> list[str]:
     return [" ".join(dependency.split()) for dependency in PACKAGE_DEPENDENCY_RE.findall(text)]
 
 
-def dependency_calls_include_url(calls: list[str]) -> bool:
-    return any(PACKAGE_URL_ARGUMENT_RE.search(call) for call in calls)
-
-
 def has_remote_dependency(
     root: str,
-    graph: dict[str, tuple[bool, list[str]]],
+    graph: dict[str, PackageNode],
     memo: dict[str, bool],
     visiting: set[str],
 ) -> bool:
@@ -157,7 +167,7 @@ def has_remote_dependency(
         return memo[root]
     if root in visiting:
         return False
-    has_url_dependency, path_dependencies = graph.get(root, (False, []))
+    has_url_dependency, path_dependencies, _ = graph.get(root, EMPTY_PACKAGE_NODE)
     visiting.add(root)
     needs_lockfile = has_url_dependency or any(
         has_remote_dependency(dependency, graph, memo, visiting)
@@ -170,7 +180,7 @@ def has_remote_dependency(
 
 def package_dependency_closure(
     root: str,
-    graph: dict[str, tuple[bool, list[str]]],
+    graph: dict[str, PackageNode],
 ) -> set[str]:
     closure: set[str] = set()
 
@@ -178,12 +188,29 @@ def package_dependency_closure(
         if current in closure:
             return
         closure.add(current)
-        _has_url_dependency, path_dependencies = graph.get(current, (False, []))
+        path_dependencies = graph.get(current, EMPTY_PACKAGE_NODE).path_dependencies
         for dependency in path_dependencies:
             visit(dependency)
 
     visit(root)
     return closure
+
+
+def reachable_remote_dependency_calls(
+    root: str,
+    graph: dict[str, PackageNode],
+) -> frozenset[str]:
+    """The remote dependency declarations reachable from a package's closure.
+
+    These declarations are the resolve input that produces the external pins:
+    when the set is identical between two revisions, `swift package resolve`
+    is a no-op for the root and no Package.resolved diff can exist.
+    """
+    return frozenset(
+        call
+        for closure_root in package_dependency_closure(root, graph)
+        for call in graph.get(closure_root, EMPTY_PACKAGE_NODE).url_dependency_calls
+    )
 
 
 def workspace_package_roots(
@@ -211,7 +238,7 @@ def workspace_package_roots(
 
 def package_roots_requiring_lockfiles(
     cmux_manifests: dict[str, Path] | None = None,
-    graph: dict[str, tuple[bool, list[str]]] | None = None,
+    graph: dict[str, PackageNode] | None = None,
 ) -> set[str]:
     if cmux_manifests is None or graph is None:
         all_manifests = tracked_package_manifests(include_allowed_vendor=True)
@@ -327,16 +354,14 @@ def main() -> int:
     changed_files = changed_files_since(merge_base)
     changed_dependency_roots: set[str] = set()
     previous_manifests: dict[str, Path] = {}
-    previous_graph: dict[str, tuple[bool, list[str]]] = {}
+    previous_graph: dict[str, PackageNode] = {}
 
     if merge_base is not None:
-        current_remote_memo: dict[str, bool] = {}
         previous_manifests = tracked_package_manifests_at_ref(
             merge_base,
             include_allowed_vendor=True,
         )
         previous_graph = package_graph(previous_manifests, ref=merge_base)
-        previous_remote_memo: dict[str, bool] = {}
         for root, manifest in all_manifests.items():
             if manifest.as_posix() not in changed_files:
                 continue
@@ -350,18 +375,13 @@ def main() -> int:
                 continue
             # Local path-only dependency edits do not always change the resolved
             # external pins. Require a matching Package.resolved diff only when
-            # the edited manifest's graph currently has, previously had, or
-            # directly changes a remote dependency.
-            if (
-                dependency_calls_include_url(current_calls + previous_calls)
-                or has_remote_dependency(root, graph, current_remote_memo, set())
-                or has_remote_dependency(
-                    root,
-                    previous_graph,
-                    previous_remote_memo,
-                    set(),
-                )
-            ):
+            # the edit changes which remote dependency declarations are reachable
+            # from the manifest's closure; adding or removing a leaf local-path
+            # package with a remote-free closure leaves the resolve input
+            # untouched, so the demanded diff could never exist (issue #8871).
+            if reachable_remote_dependency_calls(
+                root, graph
+            ) != reachable_remote_dependency_calls(root, previous_graph):
                 changed_dependency_roots.add(root)
 
     if (

--- a/tests/test_check_package_resolved_policy.py
+++ b/tests/test_check_package_resolved_policy.py
@@ -1,0 +1,226 @@
+#!/usr/bin/env python3
+"""Behavioral guards for scripts/check-package-resolved-policy.py.
+
+Regression coverage for https://github.com/manaflow-ai/cmux/issues/8871: adding
+a leaf local-path package (no remote dependency anywhere in the added closure)
+must not demand a Package.resolved diff, because `swift package resolve` is a
+byte-identical no-op for that edit and the demanded diff cannot exist. Remote
+reachability changes must still require the lockfile diff.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+POLICY_SCRIPT = ROOT / "scripts" / "check-package-resolved-policy.py"
+BASE_BRANCH = "policy-test-base"
+
+REMOTE_DEP_CALL = '.package(url: "https://example.invalid/dep.git", from: "1.0.0")'
+BUMPED_REMOTE_DEP_CALL = '.package(url: "https://example.invalid/dep.git", from: "2.0.0")'
+LIB_REMOTE_DEP_CALL = '.package(url: "https://example.invalid/lib.git", from: "1.0.0")'
+
+MINIMAL_RESOLVED = '{"pins": [], "version": 2}\n'
+MINIMAL_IOS_WORKSPACE = (
+    '<?xml version="1.0" encoding="UTF-8"?>\n'
+    '<Workspace version = "1.0">\n'
+    "</Workspace>\n"
+)
+
+
+def run_git(repo: Path, *args: str) -> None:
+    subprocess.run(
+        [
+            "git",
+            "-c", "user.name=policy-test",
+            "-c", "user.email=policy-test@example.invalid",
+            *args,
+        ],
+        check=True,
+        cwd=repo,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+    )
+
+
+def write_manifest(repo: Path, root: str, name: str, dependency_calls: list[str]) -> None:
+    dependencies = "".join(f"        {call},\n" for call in dependency_calls)
+    manifest = (
+        "// swift-tools-version: 5.9\n"
+        "import PackageDescription\n"
+        "\n"
+        "let package = Package(\n"
+        f'    name: "{name}",\n'
+        "    dependencies: [\n"
+        f"{dependencies}"
+        "    ]\n"
+        ")\n"
+    )
+    directory = repo / root
+    directory.mkdir(parents=True, exist_ok=True)
+    (directory / "Package.swift").write_text(manifest, encoding="utf-8")
+
+
+def make_base_repo(repo: Path) -> None:
+    """Commit a minimal repo shape the policy script can walk.
+
+    Packages/RemoteApp has a remote pin (and a tracked lockfile); Packages/RemoteLib
+    is a second remote-bearing package available for reachability-change cases.
+    """
+    run_git(repo, "init", "-q", "-b", "main")
+    write_manifest(repo, "Packages/RemoteApp", "RemoteApp", [REMOTE_DEP_CALL])
+    (repo / "Packages/RemoteApp/Package.resolved").write_text(
+        MINIMAL_RESOLVED, encoding="utf-8"
+    )
+    write_manifest(repo, "Packages/RemoteLib", "RemoteLib", [LIB_REMOTE_DEP_CALL])
+    (repo / "Packages/RemoteLib/Package.resolved").write_text(
+        MINIMAL_RESOLVED, encoding="utf-8"
+    )
+    ios_workspace = repo / "ios/cmux.xcworkspace"
+    ios_workspace.mkdir(parents=True)
+    (ios_workspace / "contents.xcworkspacedata").write_text(
+        MINIMAL_IOS_WORKSPACE, encoding="utf-8"
+    )
+    run_git(repo, "add", "-A")
+    run_git(repo, "commit", "-q", "-m", "base")
+    run_git(repo, "branch", BASE_BRANCH)
+
+
+def run_policy(repo: Path) -> subprocess.CompletedProcess[str]:
+    environment = dict(os.environ)
+    environment["PACKAGE_RESOLVED_POLICY_BASE_REF"] = BASE_BRANCH
+    return subprocess.run(
+        [sys.executable, str(POLICY_SCRIPT)],
+        cwd=repo,
+        env=environment,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+    )
+
+
+def check_leaf_local_dependency_needs_no_lockfile_diff() -> int:
+    """Adding a remote-free leaf package must not demand an impossible diff."""
+    with tempfile.TemporaryDirectory() as tmp:
+        repo = Path(tmp)
+        make_base_repo(repo)
+        write_manifest(repo, "Packages/Leaf", "Leaf", [])
+        write_manifest(
+            repo,
+            "Packages/RemoteApp",
+            "RemoteApp",
+            [REMOTE_DEP_CALL, '.package(path: "../Leaf")'],
+        )
+        run_git(repo, "add", "-A")
+        run_git(repo, "commit", "-q", "-m", "add leaf local dependency")
+
+        result = run_policy(repo)
+        if result.returncode != 0:
+            print(result.stdout, end="")
+            print(
+                "FAIL: leaf local-path dependency (remote-free closure) demanded "
+                f"a Package.resolved diff; policy exited {result.returncode}"
+            )
+            return 1
+    print("PASS: leaf local-path dependency needs no lockfile diff")
+    return 0
+
+
+def check_remote_version_bump_still_requires_lockfile_diff() -> int:
+    with tempfile.TemporaryDirectory() as tmp:
+        repo = Path(tmp)
+        make_base_repo(repo)
+        write_manifest(repo, "Packages/RemoteApp", "RemoteApp", [BUMPED_REMOTE_DEP_CALL])
+        run_git(repo, "add", "-A")
+        run_git(repo, "commit", "-q", "-m", "bump remote dependency")
+
+        result = run_policy(repo)
+        if result.returncode == 0:
+            print(result.stdout, end="")
+            print("FAIL: remote version bump without lockfile diff passed the policy")
+            return 1
+        if "Packages/RemoteApp/Package.resolved" not in result.stdout:
+            print(result.stdout, end="")
+            print("FAIL: remote version bump violation does not name the lockfile")
+            return 1
+    print("PASS: remote version bump still requires a lockfile diff")
+    return 0
+
+
+def check_local_dependency_reaching_remote_still_requires_lockfile_diff() -> int:
+    with tempfile.TemporaryDirectory() as tmp:
+        repo = Path(tmp)
+        make_base_repo(repo)
+        write_manifest(
+            repo,
+            "Packages/RemoteApp",
+            "RemoteApp",
+            [REMOTE_DEP_CALL, '.package(path: "../RemoteLib")'],
+        )
+        run_git(repo, "add", "-A")
+        run_git(repo, "commit", "-q", "-m", "add local dependency with remote closure")
+
+        result = run_policy(repo)
+        if result.returncode == 0:
+            print(result.stdout, end="")
+            print(
+                "FAIL: local dependency that adds remote reachability passed "
+                "without a lockfile diff"
+            )
+            return 1
+    print("PASS: local dependency adding remote reachability still requires a diff")
+    return 0
+
+
+def check_leaf_removal_needs_no_lockfile_diff() -> int:
+    with tempfile.TemporaryDirectory() as tmp:
+        repo = Path(tmp)
+        make_base_repo(repo)
+        write_manifest(repo, "Packages/Leaf", "Leaf", [])
+        write_manifest(
+            repo,
+            "Packages/RemoteApp",
+            "RemoteApp",
+            [REMOTE_DEP_CALL, '.package(path: "../Leaf")'],
+        )
+        run_git(repo, "add", "-A")
+        run_git(repo, "commit", "-q", "-m", "base with leaf dependency")
+        run_git(repo, "branch", "-f", BASE_BRANCH)
+        write_manifest(repo, "Packages/RemoteApp", "RemoteApp", [REMOTE_DEP_CALL])
+        run_git(repo, "add", "-A")
+        run_git(repo, "commit", "-q", "-m", "drop leaf local dependency")
+
+        result = run_policy(repo)
+        if result.returncode != 0:
+            print(result.stdout, end="")
+            print(
+                "FAIL: removing a remote-free leaf dependency demanded a "
+                f"Package.resolved diff; policy exited {result.returncode}"
+            )
+            return 1
+    print("PASS: removing a leaf local-path dependency needs no lockfile diff")
+    return 0
+
+
+def main() -> int:
+    checks = (
+        check_leaf_local_dependency_needs_no_lockfile_diff,
+        check_remote_version_bump_still_requires_lockfile_diff,
+        check_local_dependency_reaching_remote_still_requires_lockfile_diff,
+        check_leaf_removal_needs_no_lockfile_diff,
+    )
+    for check in checks:
+        if (return_code := check()) != 0:
+            return return_code
+    print("PASS: Package.resolved policy matches remote reachability")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

- What changed? `scripts/check-package-resolved-policy.py` now tracks the set of remote dependency declarations reachable from each package's closure, and requires a `Package.resolved` diff for a manifest dependency edit only when that set differs between the merge base and HEAD.
- Why? The policy previously flagged any dependency-call edit on a manifest whose graph has any remote dependency - including edits that only add or remove a leaf local-path package with a remote-free closure. For those edits the resolved pins and `originHash` are unchanged, `swift package resolve` is a byte-identical no-op, and the demanded lockfile diff cannot exist. #8221 hit exactly this (three impossible violations for adding dependency-free `CmuxMobileChanges`), and #8376 merged the identical pattern with no lockfile diffs.

Fixes #8871

Per the regression test commit policy, this PR is two commits so CI shows the guards catch the bug:

1. Failing behavioral guards only: `tests/test_check_package_resolved_policy.py` builds throwaway git repos and drives the policy script end-to-end over four shapes - add a remote-free leaf local dependency (must pass, previously an impossible-diff violation), remote version bump without a lockfile diff (must keep failing), local-path dependency whose closure adds remote reachability without a lockfile diff (must keep failing), and remove a remote-free leaf local dependency (must pass). The guards run in CI in the same step as the policy script, matching the existing lint-test pairing pattern.
2. The fix.

Remote version bumps still require the diff (the changed `.package(url:)` call text changes the reachable set), and so do local-path dependency edits that add or drop remote reachability. Only the previously impossible leaf-local cases stop being flagged.

## Testing

- `python3 tests/test_check_package_resolved_policy.py` at commit 1 (guards only): exits 1 - the leaf local-path case reproduces the impossible-diff violation. At commit 2: all four guards pass.
- `python3 scripts/check-package-resolved-policy.py` on this branch: `Package.resolved policy OK` (repo-wide behavior unchanged).
- Replayed the #8221 repro against this repo: added a dependency-free `Packages/iOS/CmuxMobileChanges` package plus `.package(path: "../CmuxMobileChanges")` in `Packages/iOS/CmuxMobileShellUI/Package.swift` on a throwaway commit - the fixed policy reports `Package.resolved policy OK` instead of three impossible violations.
- `python3 -m py_compile scripts/check-package-resolved-policy.py`.

Localization audit: no user-facing strings changed (CI policy script and test only), so no `Localizable.xcstrings` or web locale changes.

## Demo Video

N/A - CI policy script fix, no UI change.

## Checklist

- [x] I tested the change locally
- [x] I added or updated tests for behavior changes
- [x] I updated docs/changelog if needed (N/A - internal CI policy behavior)
- [ ] I requested bot reviews after my latest commit
- [ ] All code review bot comments are resolved
- [ ] All human review comments are resolved

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/9440"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788331500&installation_model_id=21920&pr_number=9440&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F9440&signature=23f6bd6c5e885c7807adc488f0bf5a7a121a1d14414cf1ff5466c2c94c31018e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update `scripts/check-package-resolved-policy.py` to require `Package.resolved` diffs only when a manifest edit changes which remote dependency declarations are reachable from its closure, fixing false positives for leaf local-path packages. Fixes #8871.

- **Bug Fixes**
  - Compare the set of reachable remote dependency calls between merge base and HEAD; only require a lockfile diff when that set changes.
  - Remote version bumps and local-path edits that add remote reachability still require diffs; adding/removing remote-free leaf packages no longer does.
  - Added regression tests in `tests/test_check_package_resolved_policy.py` and run them in CI via `.github/workflows/ci.yml`.

<sup>Written for commit b5de24ae798e200cc54626c1504dd09844e4c770. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/9440?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved package lockfile policy checks to distinguish local-only dependency changes from changes that affect reachable remote dependencies.
  * Prevented unnecessary lockfile updates for dependency changes that do not alter remote package resolution.
  * Continued requiring lockfile updates when remote versions or remote dependency reachability changes.

* **Tests**
  * Added coverage for local dependency additions, removals, remote version changes, and mixed dependency graphs.
  * CI now runs both policy validation and its dedicated test suite.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->