### PR TITLE
Mark stable releases as latest so the appcast picks them up

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -538,6 +538,11 @@ jobs:
             remote-daemon-assets/cmuxd-remote-checksums.txt
             remote-daemon-assets/cmuxd-remote-manifest.json
           generate_release_notes: true
+          # Explicitly claim the releases/latest pointer. Without this GitHub
+          # can leave "latest" on an older release, and the stable Sparkle feed
+          # (releases/latest/download/appcast.xml) keeps serving the previous
+          # version (https://github.com/manaflow-ai/cmux/issues/9441).
+          make_latest: true
           overwrite_files: false
 
       - name: Upload release appcast to R2


### PR DESCRIPTION
The stable Sparkle feed is served from `releases/latest/download/appcast.xml`, but GitHub does not always move the `latest` pointer to a newly published release — v0.64.21 was published without becoming "latest", so the feed kept serving the 0.64.20 appcast and stable users never saw the update.

Set `make_latest: true` on the release step so every stable release explicitly claims the `releases/latest` pointer.

Fixes #9441