### PR TITLE
Present resume approval as a sheet instead of blocking the socket

### DIFF
--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -235505,6 +235505,23 @@
         }
       }
     },
+    "surfaceResumeApproval.awaitingDecision.message": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Resume approval is waiting for a response in the cmux window. Retry the request."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "復元の承認は cmux ウィンドウでの応答を待っています。リクエストを再試行してください。"
+          }
+        }
+      }
+    },
     "surfaceResumeApproval.cwd.none": {
       "extractionState": "manual",
       "localizations": {

--- a/Sources/ControlSurfaceResumeTarget.swift
+++ b/Sources/ControlSurfaceResumeTarget.swift
@@ -378,9 +378,19 @@ extension TerminalController {
         )
     }
 
+    /// The outcome of the `surface.resume.set` approval flow: the two retryable
+    /// waits (signing secret still loading, approval prompt still open) or the
+    /// resolved binding (issue #9369).
+    private enum SurfaceResumeApprovalFlowLookup {
+        case pendingSigningSecret
+        case approvalPromptPending
+        case resolved(SurfaceResumeBindingSnapshot)
+    }
+
     private func surfaceResumeBindingWithApproval(
-        _ binding: SurfaceResumeBindingSnapshot
-    ) -> SurfaceResumeApprovalLookup<SurfaceResumeBindingSnapshot> {
+        _ binding: SurfaceResumeBindingSnapshot,
+        target: ControlSurfaceResumeTarget
+    ) -> SurfaceResumeApprovalFlowLookup {
         let context: (
             effectiveBinding: SurfaceResumeBindingSnapshot,
             existingRecord: SurfaceResumeApprovalRecord?
@@ -391,7 +401,7 @@ extension TerminalController {
         case let .resolved(resolvedContext):
             context = resolvedContext
         }
-        var effectiveBinding = context.effectiveBinding
+        let effectiveBinding = context.effectiveBinding
         if let promptlessCLIManualBinding = SurfaceResumeApprovalStore.applyingPromptlessCLIManualApprovalIfNeeded(
             to: binding,
             existingRecord: context.existingRecord
@@ -406,18 +416,68 @@ extension TerminalController {
         ) else {
             return .resolved(effectiveBinding)
         }
-        let approval = surfacePromptForResumeApproval(binding: effectiveBinding)
-        guard let record = SurfaceResumeApprovalStore.approve(
-            binding: binding,
-            policy: approval.policy,
-            commandPrefix: approval.commandPrefix
-        ) else {
+        // issue #9369: the prompt must never run modally inside this socket
+        // main hop — that held the main actor and blocked unrelated
+        // resume.get/.clear requests until they timed out. It presents as a
+        // sheet instead; this set answers a retryable `approvalPending` until
+        // the user decides (or a clear cancels the prompt).
+        guard let window = surfaceResumeApprovalPromptWindow(for: target) else {
+            // No window can host the sheet, so nobody can be asked; keep the
+            // binding without an approval record (the same shape as a failed
+            // `approve`).
             return .resolved(effectiveBinding)
         }
-        effectiveBinding.approvalPolicy = record.policy
-        effectiveBinding.approvalRecordId = record.id
-        effectiveBinding.autoResume = record.policy == .auto
-        return .resolved(effectiveBinding)
+        let outcome = surfaceResumeApprovalPrompts.begin(
+            key: SurfaceResumeApprovalPromptCoordinator.RequestKey(
+                surfaceID: target.surfaceID,
+                binding: binding
+            ),
+            presenter: { [weak self] completion in
+                self?.presentSurfaceResumeApprovalPrompt(
+                    binding: effectiveBinding,
+                    window: window,
+                    completion: completion
+                ) ?? {}
+            },
+            onDecision: { decision in
+                // Complete the pending set when the user answers, so the
+                // binding sticks even if the caller never retries.
+                _ = target.setBinding(Self.surfaceResumeBindingApplyingApprovalDecision(
+                    decision,
+                    original: binding,
+                    effective: effectiveBinding
+                ))
+            }
+        )
+        switch outcome {
+        case .pending:
+            return .approvalPromptPending
+        case let .decided(decision):
+            return .resolved(Self.surfaceResumeBindingApplyingApprovalDecision(
+                decision,
+                original: binding,
+                effective: effectiveBinding
+            ))
+        }
+    }
+
+    private static func surfaceResumeBindingApplyingApprovalDecision(
+        _ decision: SurfaceResumeApprovalPromptCoordinator.Decision,
+        original: SurfaceResumeBindingSnapshot,
+        effective: SurfaceResumeBindingSnapshot
+    ) -> SurfaceResumeBindingSnapshot {
+        guard let record = SurfaceResumeApprovalStore.approve(
+            binding: original,
+            policy: decision.policy,
+            commandPrefix: decision.commandPrefix
+        ) else {
+            return effective
+        }
+        var approved = effective
+        approved.approvalPolicy = record.policy
+        approved.approvalRecordId = record.id
+        approved.autoResume = record.policy == .auto
+        return approved
     }
 
     private var surfaceResumeApprovalPendingMessage: String {
@@ -427,9 +487,30 @@ extension TerminalController {
         )
     }
 
-    private func surfacePromptForResumeApproval(
-        binding: SurfaceResumeBindingSnapshot
-    ) -> (policy: SurfaceResumeApprovalPolicy, commandPrefix: [String]?) {
+    private var surfaceResumeApprovalAwaitingDecisionMessage: String {
+        String(
+            localized: "surfaceResumeApproval.awaitingDecision.message",
+            defaultValue: "Resume approval is waiting for a response in the cmux window. Retry the request."
+        )
+    }
+
+    private func surfaceResumeApprovalPromptWindow(
+        for target: ControlSurfaceResumeTarget
+    ) -> NSWindow? {
+        AppDelegate.shared?.mainWindowContainingWorkspace(target.workspaceID)
+            ?? NSApp.keyWindow
+            ?? NSApp.mainWindow
+    }
+
+    /// Builds the resume-approval alert and presents it as a sheet on `window`
+    /// without blocking the main actor (issue #9369). Reports the decision (or
+    /// `nil` on programmatic dismissal) through `completion` and returns the
+    /// closure that cancels the prompt.
+    private func presentSurfaceResumeApprovalPrompt(
+        binding: SurfaceResumeBindingSnapshot,
+        window: NSWindow,
+        completion: @escaping @MainActor (SurfaceResumeApprovalPromptCoordinator.Decision?) -> Void
+    ) -> @MainActor () -> Void {
         let alert = NSAlert()
         alert.alertStyle = .informational
         alert.messageText = String(
@@ -472,16 +553,27 @@ extension TerminalController {
             flattenedText: informativeText,
             separatingScrollableDetails: binding.command
         )
-        content.apply(to: alert, presentingWindow: nil)
+        content.apply(to: alert, presentingWindow: window)
 
-        let response = alert.runModal()
-        let commandPrefix = alert.suppressionButton?.state == .on
-            ? folderScopedGeneralizedPrefix
-            : nil
-        return switch response {
-        case .alertFirstButtonReturn: (.auto, commandPrefix)
-        case .alertSecondButtonReturn: (.prompt, commandPrefix)
-        default: (.manual, commandPrefix)
+        alert.beginSheetModal(for: window) { response in
+            let commandPrefix = alert.suppressionButton?.state == .on
+                ? folderScopedGeneralizedPrefix
+                : nil
+            switch response {
+            case .alertFirstButtonReturn:
+                completion(.init(policy: .auto, commandPrefix: commandPrefix))
+            case .alertSecondButtonReturn:
+                completion(.init(policy: .prompt, commandPrefix: commandPrefix))
+            case .alertThirdButtonReturn:
+                completion(.init(policy: .manual, commandPrefix: commandPrefix))
+            default:
+                // Programmatic dismissal (a resume.clear cancelling the
+                // pending approval): no decision, nothing recorded.
+                completion(nil)
+            }
+        }
+        return { [weak window] in
+            window?.endSheet(alert.window, returnCode: .abort)
         }
     }
 
@@ -529,9 +621,11 @@ extension TerminalController {
             return .setFailed
         }
         let effectiveBinding: SurfaceResumeBindingSnapshot
-        switch surfaceResumeBindingWithApproval(locatedBinding) {
+        switch surfaceResumeBindingWithApproval(locatedBinding, target: target) {
         case .pendingSigningSecret:
             return .approvalPending(message: surfaceResumeApprovalPendingMessage)
+        case .approvalPromptPending:
+            return .approvalPending(message: surfaceResumeApprovalAwaitingDecisionMessage)
         case let .resolved(binding):
             effectiveBinding = binding
         }
@@ -593,6 +687,10 @@ extension TerminalController {
         if let expectedSource, bindingForClear?.source != expectedSource {
             return .result(surfaceResumeSnapshot(target: target, binding: target.binding, cleared: false))
         }
+        // A clear wins over an in-flight approval prompt for this surface:
+        // dismiss it without a decision so the pending set never lands after
+        // the clear (issue #9369).
+        surfaceResumeApprovalPrompts.cancelPending(surfaceID: target.surfaceID)
         target.clearBinding(bindingForClear, agentSessionEnded: agentSessionEnded)
         return .result(surfaceResumeSnapshot(target: target, binding: target.binding, cleared: true))
     }

--- a/Sources/SurfaceResumeApprovalPromptCoordinator.swift
+++ b/Sources/SurfaceResumeApprovalPromptCoordinator.swift
@@ -1,0 +1,125 @@
+import Foundation
+
+/// The single owner of the one in-flight `surface.resume.set` approval prompt
+/// (issue #9369).
+///
+/// The legacy flow ran `NSAlert.runModal()` synchronously inside the socket
+/// main-actor hop, so while the approval alert was open every unrelated
+/// main-lane request — including `surface.resume.get` and `.clear` — queued
+/// behind it until the socket timeout. The prompt now presents asynchronously;
+/// while it is open this coordinator tracks the pending set so:
+/// - the initiating (and any duplicate) set answers a retryable
+///   `approvalPending` result instead of blocking,
+/// - the user's decision applies the binding when it arrives and is handed to
+///   the next retried set for the same request,
+/// - `surface.resume.clear` can cancel the prompt outright.
+@MainActor
+final class SurfaceResumeApprovalPromptCoordinator {
+    /// The user's answer to the approval prompt.
+    struct Decision: Equatable, Sendable {
+        let policy: SurfaceResumeApprovalPolicy
+        let commandPrefix: [String]?
+    }
+
+    /// The identity of one requested approval: the same surface proposing the
+    /// same command in the same folder is the same logical set request.
+    struct RequestKey: Equatable, Sendable {
+        let surfaceID: UUID
+        let command: String
+        let cwd: String?
+
+        init(surfaceID: UUID, binding: SurfaceResumeBindingSnapshot) {
+            self.surfaceID = surfaceID
+            command = binding.command
+            cwd = binding.cwd
+        }
+    }
+
+    /// Presents the prompt without blocking the main actor, reports the user's
+    /// decision (or `nil` when cancelled) exactly once, and returns the closure
+    /// that dismisses the prompt programmatically.
+    typealias Presenter = @MainActor (
+        _ completion: @escaping @MainActor (Decision?) -> Void
+    ) -> @MainActor () -> Void
+
+    enum BeginOutcome: Equatable {
+        /// A prompt is open (this request's, or another one keeping the single
+        /// prompt slot busy); the set should answer `approvalPending` so the
+        /// caller retries.
+        case pending
+        /// A finished prompt for this request left a decision; the retried set
+        /// consumes it and completes synchronously without prompting again.
+        case decided(Decision)
+    }
+
+    private final class PendingPrompt {
+        let key: RequestKey
+        let onDecision: @MainActor (Decision) -> Void
+        var cancel: @MainActor () -> Void = {}
+
+        init(key: RequestKey, onDecision: @escaping @MainActor (Decision) -> Void) {
+            self.key = key
+            self.onDecision = onDecision
+        }
+    }
+
+    private var pendingPrompt: PendingPrompt?
+    private var completedDecision: (key: RequestKey, decision: Decision)?
+
+    /// Consumes a completed decision for `key`, joins the already-open prompt,
+    /// or opens a new one. `onDecision` runs when the user answers, so the set
+    /// completes (approval record + binding) even if the caller never retries.
+    func begin(
+        key: RequestKey,
+        presenter: Presenter,
+        onDecision: @escaping @MainActor (Decision) -> Void
+    ) -> BeginOutcome {
+        if let completed = takeCompletedDecision(key: key) {
+            return .decided(completed)
+        }
+        guard pendingPrompt == nil else { return .pending }
+        let prompt = PendingPrompt(key: key, onDecision: onDecision)
+        pendingPrompt = prompt
+        prompt.cancel = presenter { [weak self] decision in
+            self?.finish(prompt: prompt, decision: decision)
+        }
+        // A synchronous presenter (tests) may have decided before returning.
+        if let completed = takeCompletedDecision(key: key) {
+            return .decided(completed)
+        }
+        return .pending
+    }
+
+    /// Whether a prompt is currently open for `surfaceID`.
+    func hasPendingPrompt(surfaceID: UUID) -> Bool {
+        pendingPrompt?.key.surfaceID == surfaceID
+    }
+
+    /// Dismisses the open prompt for `surfaceID` (if any) without a decision
+    /// and drops any unconsumed decision for it, so `surface.resume.clear`
+    /// wins over the in-flight approval.
+    func cancelPending(surfaceID: UUID) {
+        if completedDecision?.key.surfaceID == surfaceID {
+            completedDecision = nil
+        }
+        guard let prompt = pendingPrompt, prompt.key.surfaceID == surfaceID else { return }
+        pendingPrompt = nil
+        prompt.cancel()
+    }
+
+    private func takeCompletedDecision(key: RequestKey) -> Decision? {
+        guard let completed = completedDecision, completed.key == key else { return nil }
+        completedDecision = nil
+        return completed.decision
+    }
+
+    private func finish(prompt: PendingPrompt, decision: Decision?) {
+        // A cancelled prompt (or a stale sheet callback after cancelPending
+        // already released the slot) must not apply anything.
+        guard pendingPrompt === prompt else { return }
+        pendingPrompt = nil
+        guard let decision else { return }
+        completedDecision = (prompt.key, decision)
+        prompt.onDecision(decision)
+    }
+}

--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -305,6 +305,11 @@ class TerminalController {
     /// `init`; its `context` is wired to `self` once `self` is available.
     let controlCommandCoordinator = ControlCommandCoordinator()
 
+    /// The single owner of the one in-flight `surface.resume.set` approval
+    /// prompt, so approval never blocks the main actor inside a socket hop
+    /// (issue #9369).
+    let surfaceResumeApprovalPrompts = SurfaceResumeApprovalPromptCoordinator()
+
     private struct V2BrowserElementRefEntry {
         let surfaceId: UUID
         let selector: String

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -1210,6 +1210,7 @@ C0DE71B10000000000000001 /* AppDelegate+AgentChatNotifications.swift in Sources 
 		C51A73B20000000000000002 /* IOSScreenshotCommandResultBox.swift in Sources */ = {isa = PBXBuildFile; fileRef = C51A73B20000000000000001 /* IOSScreenshotCommandResultBox.swift */; };
 		E7B200000000000000000001 /* IrohTransportDebugMenuButtons.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7B100000000000000000001 /* IrohTransportDebugMenuButtons.swift */; };
 		875900000000000000000001 /* Issue8759FreezeRegressionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 875900000000000000000002 /* Issue8759FreezeRegressionTests.swift */; };
+		936900000000000000000001 /* Issue9369ResumeApprovalPromptTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 936900000000000000000002 /* Issue9369ResumeApprovalPromptTests.swift */; };
 		A5FB1307 /* JSONCObjectEditor+Remove.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5FB1309 /* JSONCObjectEditor+Remove.swift */; };
 		A5FB1308 /* JSONCObjectEditor+Remove.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5FB1309 /* JSONCObjectEditor+Remove.swift */; };
 		A5FB1311 /* JSONCObjectEditor+Set.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5FB1310 /* JSONCObjectEditor+Set.swift */; };
@@ -2087,6 +2088,7 @@ C0DE71B10000000000000001 /* AppDelegate+AgentChatNotifications.swift in Sources 
 		875200000000000000000014 /* SurfacePaneMovement.swift in Sources */ = {isa = PBXBuildFile; fileRef = 875200000000000000000004 /* SurfacePaneMovement.swift */; };
 		842300000000000000000007 /* SurfaceResumeAgentBindingGenerationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 842300000000000000000008 /* SurfaceResumeAgentBindingGenerationTests.swift */; };
 		883700000000000000000003 /* SurfaceResumeApprovalLookup.swift in Sources */ = {isa = PBXBuildFile; fileRef = 883700000000000000000004 /* SurfaceResumeApprovalLookup.swift */; };
+		936900000000000000000003 /* SurfaceResumeApprovalPromptCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 936900000000000000000004 /* SurfaceResumeApprovalPromptCoordinator.swift */; };
 		875900000000000000000005 /* SurfaceResumeApprovalSigningSecretCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 875900000000000000000006 /* SurfaceResumeApprovalSigningSecretCache.swift */; };
 		883700000000000000000001 /* SurfaceResumeApprovalSigningSecretResolution.swift in Sources */ = {isa = PBXBuildFile; fileRef = 883700000000000000000002 /* SurfaceResumeApprovalSigningSecretResolution.swift */; };
 		F6572012A1B2C3D4E5F60718 /* SurfaceResumeBindingCodexUpdateCheckTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6572013A1B2C3D4E5F60718 /* SurfaceResumeBindingCodexUpdateCheckTests.swift */; };
@@ -3811,6 +3813,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 		C51A73B20000000000000001 /* IOSScreenshotCommandResultBox.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IOSScreenshotCommandResultBox.swift; sourceTree = "<group>"; };
 		E7B100000000000000000001 /* IrohTransportDebugMenuButtons.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IrohTransportDebugMenuButtons.swift; sourceTree = "<group>"; };
 		875900000000000000000002 /* Issue8759FreezeRegressionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Issue8759FreezeRegressionTests.swift; sourceTree = "<group>"; };
+		936900000000000000000002 /* Issue9369ResumeApprovalPromptTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Issue9369ResumeApprovalPromptTests.swift; sourceTree = "<group>"; };
 		A5FB1309 /* JSONCObjectEditor+Remove.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "JSONCObjectEditor+Remove.swift"; sourceTree = "<group>"; };
 		A5FB1310 /* JSONCObjectEditor+Set.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "JSONCObjectEditor+Set.swift"; sourceTree = "<group>"; };
 		C0DEF0B10000000000000002 /* JSONCParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JSONCParser.swift; sourceTree = "<group>"; };
@@ -4670,6 +4673,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 		875200000000000000000004 /* SurfacePaneMovement.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SurfacePaneMovement.swift; sourceTree = "<group>"; };
 		842300000000000000000008 /* SurfaceResumeAgentBindingGenerationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SurfaceResumeAgentBindingGenerationTests.swift; sourceTree = "<group>"; };
 		883700000000000000000004 /* SurfaceResumeApprovalLookup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SurfaceResumeApprovalLookup.swift; sourceTree = "<group>"; };
+		936900000000000000000004 /* SurfaceResumeApprovalPromptCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SurfaceResumeApprovalPromptCoordinator.swift; sourceTree = "<group>"; };
 		875900000000000000000006 /* SurfaceResumeApprovalSigningSecretCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SurfaceResumeApprovalSigningSecretCache.swift; sourceTree = "<group>"; };
 		883700000000000000000002 /* SurfaceResumeApprovalSigningSecretResolution.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SurfaceResumeApprovalSigningSecretResolution.swift; sourceTree = "<group>"; };
 		F6572013A1B2C3D4E5F60718 /* SurfaceResumeBindingCodexUpdateCheckTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SurfaceResumeBindingCodexUpdateCheckTests.swift; sourceTree = "<group>"; };
@@ -6833,6 +6837,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				875900000000000000000004 /* MainThreadHangWatchdog.swift */,
 				875900000000000000000008 /* MainThreadHangWatchdogState.swift */,
 				883700000000000000000004 /* SurfaceResumeApprovalLookup.swift */,
+				936900000000000000000004 /* SurfaceResumeApprovalPromptCoordinator.swift */,
 				875900000000000000000006 /* SurfaceResumeApprovalSigningSecretCache.swift */,
 				883700000000000000000002 /* SurfaceResumeApprovalSigningSecretResolution.swift */,
 				F27B00000000000000000002 /* SurfaceResumeRunPromptBatch.swift */,
@@ -7624,6 +7629,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				D0B10019A1B2C3D4E5F60001 /* FileDropOverlayViewTests.swift */,
 				2907A0042907A0042907A004 /* AppDelegateIssue2907RoutingTests.swift */,
 				875900000000000000000002 /* Issue8759FreezeRegressionTests.swift */,
+				936900000000000000000002 /* Issue9369ResumeApprovalPromptTests.swift */,
 				C6711B030000000000000001 /* AppDelegateSurfaceResumeTerminalIdTests.swift */,
 				7375A0047375A0047375A004 /* ClosedMainWindowRoutingTests.swift */,
 				E50320010000000000000002 /* ExtensionWorktreeSpawnArgsTests.swift */,
@@ -9668,6 +9674,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				D7AB00000000000000B041 /* SupersededPhoneDismissBuffer.swift in Sources */,
 				875200000000000000000014 /* SurfacePaneMovement.swift in Sources */,
 				883700000000000000000003 /* SurfaceResumeApprovalLookup.swift in Sources */,
+				936900000000000000000003 /* SurfaceResumeApprovalPromptCoordinator.swift in Sources */,
 				875900000000000000000005 /* SurfaceResumeApprovalSigningSecretCache.swift in Sources */,
 				883700000000000000000001 /* SurfaceResumeApprovalSigningSecretResolution.swift in Sources */,
 				F0ACC0DE000000000000000F /* SurfaceResumeBindingIndex.swift in Sources */,
@@ -10591,6 +10598,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				F1C1AA21B7E84D10A1C10001 /* InactivePaneFirstClickFocusTests.swift in Sources */,
 				C0DE71450000000000000003 /* InMemoryWorkspaceCreateIdempotencyStore.swift in Sources */,
 				875900000000000000000001 /* Issue8759FreezeRegressionTests.swift in Sources */,
+				936900000000000000000001 /* Issue9369ResumeApprovalPromptTests.swift in Sources */,
 				C34670050000000000000001 /* KeyboardShortcutContextSwiftTests.swift in Sources */,
 				C34670020000000000000001 /* KeyboardShortcutContextTests.swift in Sources */,
 				6042A0026042A0026042A002 /* KeyboardShortcutModifierHoldHintsSettingsFileTests.swift in Sources */,

--- a/cmuxTests/Issue9369ResumeApprovalPromptTests.swift
+++ b/cmuxTests/Issue9369ResumeApprovalPromptTests.swift
@@ -1,0 +1,184 @@
+import Foundation
+import Testing
+
+#if canImport(cmux_DEV)
+@testable import cmux_DEV
+#elseif canImport(cmux)
+@testable import cmux
+#endif
+
+/// Issue #9369: the `surface.resume.set` approval prompt used to run
+/// `NSAlert.runModal()` inside the socket main-actor hop, so unrelated
+/// `surface.resume.get` / `.clear` requests queued behind the alert until they
+/// timed out. These tests drive the pending-approval lifecycle synchronously
+/// on the main actor (no run loop, no sleeps): while a prompt is open, every
+/// coordinator call returns immediately, duplicate sets stay pending instead
+/// of stacking a second modal, a clear cancels the prompt, and the decision is
+/// handed to the retried set exactly once.
+@MainActor
+@Suite struct Issue9369ResumeApprovalPromptTests {
+    private typealias Coordinator = SurfaceResumeApprovalPromptCoordinator
+
+    private final class PromptRecorder {
+        private(set) var presentedCount = 0
+        private(set) var cancelledCount = 0
+        private(set) var decisions: [Coordinator.Decision] = []
+        private var completion: (@MainActor (Coordinator.Decision?) -> Void)?
+
+        @MainActor
+        func presenter(_ completion: @escaping @MainActor (Coordinator.Decision?) -> Void) -> @MainActor () -> Void {
+            presentedCount += 1
+            self.completion = completion
+            return { self.cancelledCount += 1 }
+        }
+
+        @MainActor
+        func answer(_ decision: Coordinator.Decision?) {
+            let completion = self.completion
+            self.completion = nil
+            completion?(decision)
+        }
+
+        @MainActor
+        func recordDecision(_ decision: Coordinator.Decision) {
+            decisions.append(decision)
+        }
+    }
+
+    private func makeKey(
+        surfaceID: UUID = UUID(),
+        command: String = "tmux attach -t work"
+    ) -> Coordinator.RequestKey {
+        Coordinator.RequestKey(
+            surfaceID: surfaceID,
+            binding: SurfaceResumeBindingSnapshot(command: command, cwd: "/tmp/project")
+        )
+    }
+
+    @Test func openPromptNeverBlocksAndDuplicateSetsShareIt() {
+        let coordinator = Coordinator()
+        let recorder = PromptRecorder()
+        let key = makeKey()
+
+        let first = coordinator.begin(key: key, presenter: recorder.presenter) {
+            recorder.recordDecision($0)
+        }
+        #expect(first == .pending)
+        #expect(recorder.presentedCount == 1)
+        #expect(coordinator.hasPendingPrompt(surfaceID: key.surfaceID))
+
+        // A duplicate set (retry) while the prompt is open joins it instead of
+        // presenting a second modal; a set for another surface is rejected as
+        // pending too — the single slot stays owned by the open prompt.
+        let retry = coordinator.begin(key: key, presenter: recorder.presenter) {
+            recorder.recordDecision($0)
+        }
+        let otherSurface = coordinator.begin(key: makeKey(), presenter: recorder.presenter) {
+            recorder.recordDecision($0)
+        }
+        #expect(retry == .pending)
+        #expect(otherSurface == .pending)
+        #expect(recorder.presentedCount == 1)
+
+        // get/clear-style reads run on their own synchronous path; the only
+        // coordinator touchpoint while a prompt is open completes inline.
+        #expect(!coordinator.hasPendingPrompt(surfaceID: UUID()))
+    }
+
+    @Test func decisionCompletesPendingSetAndHandsOffToOneRetry() {
+        let coordinator = Coordinator()
+        let recorder = PromptRecorder()
+        let key = makeKey()
+        let decision = Coordinator.Decision(policy: .auto, commandPrefix: ["tmux"])
+
+        #expect(coordinator.begin(key: key, presenter: recorder.presenter) {
+            recorder.recordDecision($0)
+        } == .pending)
+
+        recorder.answer(decision)
+        #expect(recorder.decisions == [decision], "the pending set completes when the user answers")
+        #expect(!coordinator.hasPendingPrompt(surfaceID: key.surfaceID))
+
+        // The retried set consumes the decision exactly once and never
+        // re-presents the prompt for it.
+        let retry = coordinator.begin(key: key, presenter: recorder.presenter) {
+            recorder.recordDecision($0)
+        }
+        #expect(retry == .decided(decision))
+        #expect(recorder.presentedCount == 1)
+
+        // With the decision consumed, the same request prompts afresh.
+        #expect(coordinator.begin(key: key, presenter: recorder.presenter) {
+            recorder.recordDecision($0)
+        } == .pending)
+        #expect(recorder.presentedCount == 2)
+    }
+
+    @Test func clearCancelsPendingApprovalWithoutApplyingIt() {
+        let coordinator = Coordinator()
+        let recorder = PromptRecorder()
+        let key = makeKey()
+
+        #expect(coordinator.begin(key: key, presenter: recorder.presenter) {
+            recorder.recordDecision($0)
+        } == .pending)
+
+        // resume.clear for an unrelated surface leaves the prompt alone.
+        coordinator.cancelPending(surfaceID: UUID())
+        #expect(recorder.cancelledCount == 0)
+        #expect(coordinator.hasPendingPrompt(surfaceID: key.surfaceID))
+
+        // resume.clear for the prompting surface dismisses it; the sheet's
+        // late no-decision callback is a no-op, and nothing was applied.
+        coordinator.cancelPending(surfaceID: key.surfaceID)
+        #expect(recorder.cancelledCount == 1)
+        #expect(!coordinator.hasPendingPrompt(surfaceID: key.surfaceID))
+        recorder.answer(nil)
+        #expect(recorder.decisions.isEmpty)
+
+        // The slot is free again for the next set.
+        #expect(coordinator.begin(key: key, presenter: recorder.presenter) {
+            recorder.recordDecision($0)
+        } == .pending)
+        #expect(recorder.presentedCount == 2)
+    }
+
+    @Test func clearDropsAnUnconsumedDecisionForItsSurface() {
+        let coordinator = Coordinator()
+        let recorder = PromptRecorder()
+        let key = makeKey()
+        let decision = Coordinator.Decision(policy: .prompt, commandPrefix: nil)
+
+        #expect(coordinator.begin(key: key, presenter: recorder.presenter) {
+            recorder.recordDecision($0)
+        } == .pending)
+        recorder.answer(decision)
+
+        coordinator.cancelPending(surfaceID: key.surfaceID)
+
+        // The cleared surface's stale decision must not complete a later set.
+        #expect(coordinator.begin(key: key, presenter: recorder.presenter) {
+            recorder.recordDecision($0)
+        } == .pending)
+        #expect(recorder.presentedCount == 2)
+    }
+
+    @Test func synchronousDecisionResolvesTheInitiatingSet() {
+        let coordinator = Coordinator()
+        let decision = Coordinator.Decision(policy: .manual, commandPrefix: nil)
+        var applied: [Coordinator.Decision] = []
+
+        // A presenter that answers before returning (no run loop involved)
+        // resolves the initiating set in the same call.
+        let outcome = coordinator.begin(
+            key: makeKey(),
+            presenter: { completion in
+                completion(decision)
+                return {}
+            },
+            onDecision: { applied.append($0) }
+        )
+        #expect(outcome == .decided(decision))
+        #expect(applied == [decision])
+    }
+}


### PR DESCRIPTION
`surface.resume.set` prompted for approval with `NSAlert.runModal()` inside the control-socket main-actor hop. While the alert was up, every unrelated `resume.get`/`resume.clear` request was blocked behind it until the socket timeout fired.

This reworks the flow so the socket path never blocks:

- The prompt is presented as a window sheet by a coordinator keyed on the binding, so repeated `set` requests reuse the pending prompt instead of stacking alerts.
- While the sheet is up, `set` answers with the retryable `approvalPending` status (same shape callers already handle for the signing-secret wait); `clear` cancels the pending prompt.
- If no window can host the sheet, the binding resolves without an approval record, matching the existing failed-approve shape.

Fixes #9369