### PR TITLE
Suppress Pi notifications after interrupted turns

### DIFF
--- a/CLI/CMUXCLI+PiExtensionSourcePart1.swift
+++ b/CLI/CMUXCLI+PiExtensionSourcePart1.swift
@@ -376,37 +376,38 @@ function textFromContent(content: unknown): string | null {
   return parts.join("\n") || null;
 }
 
-function lastAssistantMessage(event: unknown): string | undefined {
-  const messagesValue = objectValue(event, ["messages"]);
-  const messages = Array.isArray(messagesValue) ? messagesValue : [];
-  for (let index = messages.length - 1; index >= 0; index -= 1) {
-    const message = messages[index];
-    if (!message || typeof message !== "object") continue;
-    const typed = message as { role?: unknown; content?: unknown };
-    if (typed.role !== "assistant") continue;
-    const text = firstString(textFromContent(typed.content));
-    if (text) return text;
-  }
-  return undefined;
+interface AssistantCompletion {
+  lastAssistantMessage?: string;
+  suppressNotification: boolean;
 }
 
-function completionSuppressesNotification(event: unknown): boolean {
+function assistantCompletionFrom(event: unknown): AssistantCompletion {
   const messagesValue = objectValue(event, ["messages"]);
   const messages = Array.isArray(messagesValue) ? messagesValue : [];
+  let suppressNotification = false;
+  let inspectedLatestAssistant = false;
+  // Resolve text and interruption metadata in one reverse pass. agent_end may
+  // carry a large message array, so notification support must not rescan it.
   for (let index = messages.length - 1; index >= 0; index -= 1) {
     const message = messages[index];
     if (!message || typeof message !== "object") continue;
     const typed = message as {
       role?: unknown;
+      content?: unknown;
       stopReason?: unknown;
       cmuxSuppressNotification?: unknown;
     };
     if (typed.role !== "assistant") continue;
-    // Input extensions may normalize an abort to `stop` to keep Pi's UI quiet;
-    // the marker preserves the interruption intent across that normalization.
-    return typed.stopReason === "aborted" || typed.cmuxSuppressNotification === true;
+    if (!inspectedLatestAssistant) {
+      // Input extensions may normalize an abort to `stop` to keep Pi's UI quiet;
+      // the marker preserves the interruption intent across that normalization.
+      suppressNotification = typed.stopReason === "aborted" || typed.cmuxSuppressNotification === true;
+      inspectedLatestAssistant = true;
+    }
+    const text = firstString(textFromContent(typed.content));
+    if (text) return { lastAssistantMessage: text, suppressNotification };
   }
-  return false;
+  return { suppressNotification };
 }
 
 function sessionIdFrom(ctx: ExtensionContext): string | null {

--- a/CLI/CMUXCLI+PiExtensionSourcePart1.swift
+++ b/CLI/CMUXCLI+PiExtensionSourcePart1.swift
@@ -17,6 +17,7 @@ interface PendingCompletion {
   lastAssistantMessage?: string;
   notificationType: string;
   turnId: string;
+  suppressNotification: boolean;
 }
 
 interface SessionState {
@@ -387,6 +388,25 @@ function lastAssistantMessage(event: unknown): string | undefined {
     if (text) return text;
   }
   return undefined;
+}
+
+function completionSuppressesNotification(event: unknown): boolean {
+  const messagesValue = objectValue(event, ["messages"]);
+  const messages = Array.isArray(messagesValue) ? messagesValue : [];
+  for (let index = messages.length - 1; index >= 0; index -= 1) {
+    const message = messages[index];
+    if (!message || typeof message !== "object") continue;
+    const typed = message as {
+      role?: unknown;
+      stopReason?: unknown;
+      cmuxSuppressNotification?: unknown;
+    };
+    if (typed.role !== "assistant") continue;
+    // Input extensions may normalize an abort to `stop` to keep Pi's UI quiet;
+    // the marker preserves the interruption intent across that normalization.
+    return typed.stopReason === "aborted" || typed.cmuxSuppressNotification === true;
+  }
+  return false;
 }
 
 function sessionIdFrom(ctx: ExtensionContext): string | null {

--- a/CLI/CMUXCLI+PiExtensionSourcePart2.swift
+++ b/CLI/CMUXCLI+PiExtensionSourcePart2.swift
@@ -353,7 +353,11 @@ async function publishPendingCompletion(
     last_assistant_message: completion.lastAssistantMessage,
     turn_id: completion.turnId,
   };
-  if (feedDelivered) {
+  if (completion.suppressNotification) {
+    // Stop normally creates cmux's native fallback notification when no explicit
+    // notification was routed. Mark intentional interruption as already handled.
+    stopPayload.cmux_notification_routed = true;
+  } else if (feedDelivered) {
     const notificationRouted = await sendHook(dispatcher, "notification", context, {
       message: completion.lastAssistantMessage || "Task completed",
       turn_id: completion.turnId,
@@ -459,6 +463,7 @@ export default function cmuxPiSessionExtension(pi: ExtensionAPI) {
       lastAssistantMessage: message || state.pendingCompletion?.lastAssistantMessage,
       notificationType: firstString(objectValue(event, ["stopReason", "reason", "terminationReason"])) || "completed",
       turnId: currentTurnId(sessionStates, sessionId, event),
+      suppressNotification: completionSuppressesNotification(event),
     };
     // Older Pi versions do not emit agent_settled, so retain their established completion behavior.
     if (!supportsAgentSettled()) {

--- a/CLI/CMUXCLI+PiExtensionSourcePart2.swift
+++ b/CLI/CMUXCLI+PiExtensionSourcePart2.swift
@@ -457,13 +457,13 @@ export default function cmuxPiSessionExtension(pi: ExtensionAPI) {
     const sessionId = context.sessionId;
     if (!sessionId) return;
     const state = stateFor(sessionStates, sessionId);
-    const message = lastAssistantMessage(event);
+    const assistantCompletion = assistantCompletionFrom(event);
     // Preserve the latest low-level result until Pi confirms no automatic work remains.
     state.pendingCompletion = {
-      lastAssistantMessage: message || state.pendingCompletion?.lastAssistantMessage,
+      lastAssistantMessage: assistantCompletion.lastAssistantMessage || state.pendingCompletion?.lastAssistantMessage,
       notificationType: firstString(objectValue(event, ["stopReason", "reason", "terminationReason"])) || "completed",
       turnId: currentTurnId(sessionStates, sessionId, event),
-      suppressNotification: completionSuppressesNotification(event),
+      suppressNotification: assistantCompletion.suppressNotification,
     };
     // Older Pi versions do not emit agent_settled, so retain their established completion behavior.
     if (!supportsAgentSettled()) {

--- a/tests/test_pi_extension_install.py
+++ b/tests/test_pi_extension_install.py
@@ -611,6 +611,57 @@ await handlers.get("agent_settled")({}, ctx);
 if (await completionHookCount() !== completionCount) throw new Error("duplicate agent_settled emitted completion twice");
 await handlers.get("session_shutdown")({ reason: "quit" }, ctx);
 if (await completionHookCount() !== completionCount) throw new Error("shutdown after settlement emitted a duplicate stop");
+const abortedCtx = {
+  cwd: "/tmp/pi-project",
+  isIdle() { return true; },
+  sessionManager: {
+    getSessionId() { return "pi-session-aborted"; }
+  }
+};
+await handlers.get("session_start")({}, abortedCtx);
+await handlers.get("before_agent_start")({ prompt: "abort me" }, abortedCtx);
+completionCount = await completionHookCount();
+await handlers.get("agent_end")({
+  messages: [
+    { role: "user", content: "abort me" },
+    { role: "assistant", content: "partial response", stopReason: "aborted" }
+  ]
+}, abortedCtx);
+await handlers.get("agent_settled")({}, abortedCtx);
+completionCount += 1;
+await waitForCompletionHookCount(completionCount);
+await handlers.get("agent_settled")({}, abortedCtx);
+if (await completionHookCount() !== completionCount) throw new Error("duplicate aborted settlement emitted completion twice");
+await handlers.get("session_shutdown")({ reason: "quit" }, abortedCtx);
+if (await completionHookCount() !== completionCount) throw new Error("aborted shutdown emitted a duplicate stop");
+const immediateSubmitCtx = {
+  cwd: "/tmp/pi-project",
+  isIdle() { return true; },
+  sessionManager: {
+    getSessionId() { return "pi-session-immediate-submit"; }
+  }
+};
+await handlers.get("session_start")({}, immediateSubmitCtx);
+await handlers.get("before_agent_start")({ prompt: "replace me" }, immediateSubmitCtx);
+completionCount = await completionHookCount();
+await handlers.get("agent_end")({
+  messages: [
+    { role: "user", content: "replace me" },
+    {
+      role: "assistant",
+      content: "partial response",
+      stopReason: "stop",
+      cmuxSuppressNotification: true
+    }
+  ]
+}, immediateSubmitCtx);
+await handlers.get("agent_settled")({}, immediateSubmitCtx);
+completionCount += 1;
+await waitForCompletionHookCount(completionCount);
+await handlers.get("agent_settled")({}, immediateSubmitCtx);
+if (await completionHookCount() !== completionCount) throw new Error("duplicate immediate-submit settlement emitted completion twice");
+await handlers.get("session_shutdown")({ reason: "quit" }, immediateSubmitCtx);
+if (await completionHookCount() !== completionCount) throw new Error("immediate-submit shutdown emitted a duplicate stop");
 const interruptedCtx = {
   cwd: "/tmp/pi-project",
   isIdle() { return true; },
@@ -752,17 +803,17 @@ await waitForCompletionHookCount(completionCount);
 
         args_log = wait_for_text(
             fake_args_log,
-            38,
+            50,
             timeout=20.0,
             expected_substrings=("hooks feed --source pi --event PostToolUse",),
         )
         stdin_log = wait_for_text(
             fake_stdin_log,
-            38,
+            50,
             timeout=20.0,
             expected_substrings=('"hook_event_name":"PostToolUse"',),
         )
-        env_log = wait_for_text(fake_env_log, 38 * 3, timeout=20.0)
+        env_log = wait_for_text(fake_env_log, 50 * 3, timeout=20.0)
         for expected in [
             "hooks pi session-start",
             "hooks pi prompt-submit",
@@ -799,6 +850,12 @@ await waitForCompletionHookCount(completionCount);
             "clear",
             "set",
             "get",
+            "clear",
+            "set",
+            "get",
+            "clear",
+            "set",
+            "get",
             "set",
             "get",
             "set",
@@ -826,6 +883,23 @@ await waitForCompletionHookCount(completionCount);
             ]
             if completion_events != ["Notification", "Stop"]:
                 print(f"FAIL: completion hooks were out of order for {session_id}: {completion_events!r}")
+                return 1
+        for session_id in ["pi-session-aborted", "pi-session-immediate-submit"]:
+            completion_payloads = [
+                payload
+                for payload in payloads
+                if payload.get("session_id") == session_id
+                and payload.get("hook_event_name") in {"Notification", "Stop"}
+            ]
+            completion_events = [payload.get("hook_event_name") for payload in completion_payloads]
+            if completion_events != ["Stop"]:
+                print(f"FAIL: interrupted Pi turn emitted a completion notification for {session_id}: {completion_events!r}")
+                return 1
+            if completion_payloads[0].get("cmux_notification_routed") is not True:
+                print(
+                    f"FAIL: interrupted Pi stop did not suppress the native notification fallback for {session_id}: "
+                    f"{completion_payloads[0]!r}"
+                )
                 return 1
         if not any(payload.get("session_id") == "pi-session-test" for payload in payloads):
             print(f"FAIL: extension did not pass session id, got {payloads!r}")


### PR DESCRIPTION
## Summary

- suppress Pi completion notifications for native aborted turns and extension-declared immediate-submit interruptions
- still emit `Stop` lifecycle bookkeeping while marking the native cmux fallback as already handled
- preserve normal completion notifications and fallback behavior when notification delivery genuinely fails
- keep `agent_end` inspection to one reverse pass and leave all subprocess work on the existing detached lifecycle queue

This is a narrow alternative to the broader unsuccessful-outcome work in #9021, and additionally covers input extensions that normalize an abort to `stop` to avoid Pi's aborted-message UI.

## Testing

- added generated-extension integration coverage for native Pi aborts and double-Enter/immediate-submit interruption markers
- test-only `ebac29cf20`: CI app-host shard 4 failed in the new interrupted-turn assertion, proving the regression
- fixed `0bac41fa56`: [full dispatched CI passed](https://github.com/manaflow-ai/cmux/actions/runs/30810176184), including `tests/test_pi_extension_install.py`, aggregate `tests`, and the universal Release build
- `git diff --check`
- existing `tests/test_pi_extension_dispatch.py` covers immediate lifecycle-handler return and serialized detached hook delivery
- `/autoreview`: local `codex review --base origin/main` found no actionable regressions; CodeRabbit found no actionable comments and passed its blocking-runtime and algorithmic-complexity checks
- installed-extension TypeScript check passed after mirroring the interruption detector locally
- tagged Debug build attempted with `./scripts/reload.sh --tag piintnotif`; package resolution hit a transient Sentry artifact HTTP 500, then the retry was blocked by the repository's non-bypassable 250 GiB free-space floor. CI's macOS test and universal Release-build lanes passed instead.

## Demo Video

- Video URL or attachment: N/A — hook integration behavior with no UI changes

## Review Trigger (Copy/Paste as PR comment)

```text
@codex review
@coderabbitai review
@greptile-apps review
@cubic-dev-ai review
```

## Checklist

- [ ] I tested the change locally
- [x] I added or updated tests for behavior changes
- [x] I updated docs/changelog if needed (not needed; no user-facing strings or documented API changed)
- [x] I requested bot reviews after my latest commit (copy/paste block above or equivalent)
- [x] All code review bot comments are resolved
- [x] All human review comments are resolved (none received)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of aborted and immediately submitted turns.
  * Prevented duplicate stop events, shutdown hooks, and completion handling.
  * Suppressed redundant notifications when stop events have already been routed.
  * Improved resume-operation event ordering and lifecycle consistency.
  * Added safeguards to ensure aborted completions do not trigger unwanted notifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
