### PR TITLE
Include Pi session titles in notifications

### DIFF
--- a/CLI/AgentHookNotificationPolicy.swift
+++ b/CLI/AgentHookNotificationPolicy.swift
@@ -200,7 +200,10 @@ enum AgentHookNotificationPolicy {
             return displayName
         }
         if surfaceTitle.caseInsensitiveCompare(displayName) == .orderedSame
-            || surfaceTitle.hasPrefix("\(displayName) · ") {
+            || surfaceTitle.range(
+                of: "\(displayName) · ",
+                options: [.anchored, .caseInsensitive]
+            ) != nil {
             return surfaceTitle
         }
         return "\(displayName) · \(surfaceTitle)"

--- a/CLI/AgentHookNotificationPolicy.swift
+++ b/CLI/AgentHookNotificationPolicy.swift
@@ -189,6 +189,23 @@ enum AgentHookNotificationClassifier {
 enum AgentHookNotificationPolicy {
     static let dedupeEligibleAgents: Set<String> = ["grok", "antigravity"]
 
+    static func notificationTitle(
+        agentName: String,
+        displayName: String,
+        surfaceTitle: String?
+    ) -> String {
+        guard agentName == "pi",
+              let surfaceTitle = surfaceTitle?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !surfaceTitle.isEmpty else {
+            return displayName
+        }
+        if surfaceTitle.caseInsensitiveCompare(displayName) == .orderedSame
+            || surfaceTitle.hasPrefix("\(displayName) · ") {
+            return surfaceTitle
+        }
+        return "\(displayName) · \(surfaceTitle)"
+    }
+
     /// Stable per-session fingerprint. Grok 0.2.91 emits an identical generic
     /// "Tool permission requested" Notification for every tool step, even in
     /// auto-approve mode where nothing awaits the user; those repeats dedupe by

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -31100,8 +31100,7 @@ export default CMUXSessionRestore;
                       ),
                       let surfaces = listed["surfaces"] as? [[String: Any]],
                       let surface = surfaces.first(where: {
-                          ($0["id"] as? String) == surfaceId
-                              || ($0["ref"] as? String) == surfaceId
+                          surfaceHandleMatches(surfaceId, item: $0)
                       }) else {
                     return nil
                 }

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -31091,6 +31091,28 @@ export default CMUXSessionRestore;
                 body: body
             )
         }
+        func notificationTitle(workspaceId: String, surfaceId: String) -> String {
+            let surfaceTitle: String? = {
+                guard def.name == "pi",
+                      let listed = try? client.sendV2(
+                          method: "surface.list",
+                          params: ["workspace_id": workspaceId]
+                      ),
+                      let surfaces = listed["surfaces"] as? [[String: Any]],
+                      let surface = surfaces.first(where: {
+                          ($0["id"] as? String) == surfaceId
+                              || ($0["ref"] as? String) == surfaceId
+                      }) else {
+                    return nil
+                }
+                return surface["title"] as? String
+            }()
+            return AgentHookNotificationPolicy.notificationTitle(
+                agentName: def.name,
+                displayName: def.displayName,
+                surfaceTitle: surfaceTitle
+            )
+        }
         func hasActiveAntigravityBackgroundWork() -> Bool {
             def.name == "antigravity" && (input.rawObject?["fullyIdle"] as? Bool) == false
         }
@@ -31971,7 +31993,12 @@ export default CMUXSessionRestore;
                 let stopMeta: String? = stopNotificationStatus == .idle
                     ? AgentHookNotifyCategory.turnComplete.metaSegment(pending: antigravityHasActiveBackgroundWork)
                     : nil
-                let payload = notificationPayload(title: def.displayName, subtitle: subtitle, body: body, meta: stopMeta)
+                let payload = notificationPayload(
+                    title: notificationTitle(workspaceId: workspaceId, surfaceId: surfaceId),
+                    subtitle: subtitle,
+                    body: body,
+                    meta: stopMeta
+                )
                 let notifyCommand = "notify_target_async \(workspaceId) \(surfaceId) \(payload)"
 #if DEBUG
                 agentHookDebugLog(
@@ -32370,7 +32397,12 @@ export default CMUXSessionRestore;
                     pending: (summary.notifyCategory == .turnComplete || summary.notifyCategory == .idleReminder)
                         && hasActiveAntigravityBackgroundWork()
                 )
-                let payload = notificationPayload(title: def.displayName, subtitle: summary.subtitle, body: summary.body, meta: notificationMeta)
+                let payload = notificationPayload(
+                    title: notificationTitle(workspaceId: workspaceId, surfaceId: surfaceId),
+                    subtitle: summary.subtitle,
+                    body: summary.body,
+                    meta: notificationMeta
+                )
                 let notifyCommand = "notify_target_async \(workspaceId) \(surfaceId) \(payload)"
 #if DEBUG
                 agentHookDebugLog(

--- a/cmuxTests/AgentHookNotificationPolicyTests.swift
+++ b/cmuxTests/AgentHookNotificationPolicyTests.swift
@@ -108,6 +108,30 @@ struct AgentHookNotificationPolicyTests {
         ) == false)
     }
 
+    @Test func piNotificationTitleIncludesSurfaceTitle() {
+        #expect(
+            AgentHookNotificationPolicy.notificationTitle(
+                agentName: "pi",
+                displayName: "Pi",
+                surfaceTitle: "Pi Notification Session Titles"
+            ) == "Pi · Pi Notification Session Titles"
+        )
+        #expect(
+            AgentHookNotificationPolicy.notificationTitle(
+                agentName: "pi",
+                displayName: "Pi",
+                surfaceTitle: nil
+            ) == "Pi"
+        )
+        #expect(
+            AgentHookNotificationPolicy.notificationTitle(
+                agentName: "codex",
+                displayName: "Codex",
+                surfaceTitle: "Unrelated surface title"
+            ) == "Codex"
+        )
+    }
+
     private func classify(_ message: String) -> AgentHookNotificationSummary {
         AgentHookNotificationClassifier.classify(
             displayName: "Grok",

--- a/cmuxTests/AgentHookNotificationPolicyTests.swift
+++ b/cmuxTests/AgentHookNotificationPolicyTests.swift
@@ -125,6 +125,13 @@ struct AgentHookNotificationPolicyTests {
         )
         #expect(
             AgentHookNotificationPolicy.notificationTitle(
+                agentName: "pi",
+                displayName: "Pi",
+                surfaceTitle: "pi · Build"
+            ) == "pi · Build"
+        )
+        #expect(
+            AgentHookNotificationPolicy.notificationTitle(
                 agentName: "codex",
                 displayName: "Codex",
                 surfaceTitle: "Unrelated surface title"


### PR DESCRIPTION
## Summary
- include the target Pi surface title in all Pi notification titles
- preserve the existing `Pi` fallback when the surface title is unavailable
- leave other agent notification titles unchanged

## Implementation
The hook handler resolves the already-validated target surface through `surface.list` only when a Pi notification is actually emitted, then formats `Pi · <surface title>`. The existing notification policy, dedupe, and app delivery path remain unchanged.

## Regression workflow
- Test-only commit: `644d5763ba`
- Expected red unit run: [30809118119](https://github.com/manaflow-ai/cmux/actions/runs/30809118119) — failed because the title formatter did not exist
- Fix commit: `7abfaf716c`
- Review follow-up: `e903b3b865`
- Targeted green run: [30812876736](https://github.com/manaflow-ai/cmux/actions/runs/30812876736) — `cmuxTests/AgentHookNotificationPolicyTests` passed

## Local dogfood
Confirmed against the installed Pi hook: macOS displayed `Pi · <surface title>` and the stop-hook dedupe marker prevented a duplicate `Pi` notification.

## Testing
- Targeted notification-policy tests passed remotely
- [Full unit workflow](https://github.com/manaflow-ai/cmux/actions/runs/30811391824) compiled successfully and ran until the workflow's hard 20-minute limit; no test failure surfaced
- Tagged Debug app Swift compilation completed; packaging then stopped at the Nucleo FFI script's local 250 GiB free-space floor
- No tests run locally, per repository policy

## Localization
No translatable copy is added; the title combines the existing agent brand and runtime surface title with a middle-dot separator.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Enhancements**
  * Pi notification titles now include the relevant surface title when available.
  * Titles fall back cleanly when no surface title is present and avoid duplicate display names.
  * Notification titles are now resolved consistently across supported notification types.

* **Tests**
  * Added coverage for matching, missing, and preformatted surface titles, as well as unrelated titles for Codex.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
