### PR TITLE
Add focused iOS MVP experience profile

### DIFF
--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileExperiencePolicy.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileExperiencePolicy.swift
@@ -1,0 +1,58 @@
+/// Product-level capability policy for the mobile client.
+public struct MobileExperiencePolicy: Equatable, Sendable {
+    /// The profile that drives this policy.
+    public let profile: MobileExperienceProfile
+
+    /// Creates a policy for a product profile.
+    public init(profile: MobileExperienceProfile = .full) {
+        self.profile = profile
+    }
+
+    /// The complete development and dogfood policy.
+    public static let full = Self(profile: .full)
+    /// The focused first-release policy.
+    public static let mvp = Self(profile: .mvp)
+
+    /// Whether the phone-local browser is available.
+    public var allowsLocalBrowser: Bool { profile == .full }
+    /// Whether Mac browser panes can be streamed to the phone.
+    public var allowsBrowserStream: Bool { profile == .full }
+    /// Whether workspace diffs and change summaries are available.
+    public var allowsWorkspaceChanges: Bool { profile == .full }
+    /// Whether artifact browsing and previews are available.
+    public var allowsArtifacts: Bool { profile == .full }
+    /// Whether workspace grouping, moving, and advanced mutations are available.
+    public var allowsAdvancedWorkspaceManagement: Bool { profile == .full }
+    /// Whether advanced relay and transport settings are available.
+    public var allowsAdvancedNetworking: Bool { profile == .full }
+    /// Whether the user can switch the active team from mobile settings.
+    public var allowsTeamSwitching: Bool { profile == .full }
+
+    /// Applies the profile to an authenticated host capability snapshot.
+    ///
+    /// Core terminal, task, notification, connection, and workspace lifecycle
+    /// capabilities are preserved in every profile.
+    public func filteredHostCapabilities(_ capabilities: Set<String>) -> Set<String> {
+        guard profile == .mvp else { return capabilities }
+        return capabilities.subtracting(Self.mvpDisabledHostCapabilities)
+    }
+
+    private static let mvpDisabledHostCapabilities: Set<String> = [
+        "browser.stream.v1",
+        "browser.stream.viewport.v1",
+        "browser.stream.dialog.v1",
+        "workspace.changes.v1",
+        "workspace.move.v1",
+        "workspace.group_actions.v1",
+        "workspace.create_in_group.v1",
+        "workspace.group_create.v1",
+        "workspace.groups.v1",
+        "chat.artifact.v1",
+        "chat.artifact.gallery.v1",
+        "chat.artifact.folders.v1",
+        "terminal.artifact.v1",
+        "terminal.artifact.list.v1",
+        "iroh.artifact_lane.v1",
+        "dogfood.v1",
+    ]
+}

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileExperienceProfile.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileExperienceProfile.swift
@@ -1,0 +1,20 @@
+import Foundation
+
+/// Selects the product surface exposed by the mobile client.
+public enum MobileExperienceProfile: String, Equatable, Sendable {
+    /// The complete development and dogfood experience.
+    case full
+    /// The focused first-release experience centered on remote agent control.
+    case mvp
+
+    /// Creates a profile from an Info.plist or build-setting value.
+    ///
+    /// Unknown and missing values resolve to ``full`` so local development
+    /// never loses tools because of a malformed optional setting.
+    public init(configurationValue: String?) {
+        let normalized = configurationValue?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .lowercased()
+        self = normalized == Self.mvp.rawValue ? .mvp : .full
+    }
+}

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+Capabilities.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+Capabilities.swift
@@ -1,4 +1,9 @@
 extension MobileShellComposite {
+    /// Publishes one profile-filtered capability snapshot to all shell feature gates.
+    func applySupportedHostCapabilities(_ capabilities: Set<String>) {
+        supportedHostCapabilities = experiencePolicy.filteredHostCapabilities(capabilities)
+    }
+
     /// Whether the connected Mac supports browser-pane streaming.
     public var supportsBrowserStream: Bool { supportedHostCapabilities.contains(Self.browserStreamCapability) }
     /// Whether the connected Mac can reflow a browser stream to the phone viewport.

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+MacUpdateHint.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+MacUpdateHint.swift
@@ -40,6 +40,10 @@ extension MobileShellComposite {
         statusMacAppVersion: String?,
         macDeviceID: String?
     ) {
+        guard experiencePolicy.profile == .full else {
+            clearMacUpdateHint()
+            return
+        }
         let version = statusMacAppVersion ?? activeTicket?.macAppVersion
         // Fail closed without a stable Mac identity: a shared fallback key
         // would let a dismissal on one anonymous Mac suppress the hint on

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+SecondaryPromotion.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+SecondaryPromotion.swift
@@ -638,7 +638,7 @@ extension MobileShellComposite {
             workspacesByMac[ownerKey] = nil
             workspacesByMac[foregroundMacKey] = promotedState
         }
-        supportedHostCapabilities = sub.supportedHostCapabilities
+        applySupportedHostCapabilities(sub.supportedHostCapabilities)
         // Promotion has already authenticated this capability snapshot on the
         // control connection. Publish its terminal mode synchronously so input
         // can use the warm connection immediately while the render listener

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
@@ -429,6 +429,8 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
     @ObservationIgnored var groupCollapseStore: MobileWorkspaceGroupCollapseStore
     /// Device-local task templates used by the iOS task composer.
     @ObservationIgnored public let taskTemplateStore: (any MobileTaskTemplateStoring)?
+    /// Product policy that narrows the complete shell into a release profile.
+    @ObservationIgnored public let experiencePolicy: MobileExperiencePolicy
     /// The connected Mac's `mobile.host.status` capabilities. Feature gates are
     /// computed from this set so version-skew checks cannot drift from the raw
     /// host payload.
@@ -1319,6 +1321,7 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
     /// - Parameter browserStreamEvents: App-lifetime browser stream state kept outside workspace previews.
     public init(
         runtime: (any MobileSyncRuntime)? = nil,
+        experiencePolicy: MobileExperiencePolicy = .full,
         isSignedIn: Bool = false,
         connectionState: MobileConnectionState = .disconnected,
         connectedHostName: String = "",
@@ -1358,6 +1361,7 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         storedMacReconnectRestoringDeadlineSeconds: Double = 15
     ) {
         self.runtime = runtime
+        self.experiencePolicy = experiencePolicy
         self.draftStore = draftStore
         self.groupCollapseStore = groupCollapseStore
         self.workspaceChangesHintDismissalStore = workspaceChangesHintDismissalStore
@@ -4316,7 +4320,7 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
             await client.disconnect()
             return .permanentFailure
         }
-        let capabilities = Set(status.capabilities)
+        let capabilities = experiencePolicy.filteredHostCapabilities(Set(status.capabilities))
         if !capabilities.contains("events.v1") {
             mobileShellLog.info(
                 "secondary client using refresh-only fallback mac=\(mac.macDeviceID, privacy: .private)"
@@ -8121,6 +8125,9 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
                         hint: pairedMacDeviceID
                     )
                     let authenticatedCapabilities = Set(status.capabilities)
+                    let effectiveCapabilities = experiencePolicy.filteredHostCapabilities(
+                        authenticatedCapabilities
+                    )
                     if let previousFocusedConnection {
                         let resolvesToSameMac = !resolvedForegroundMacID.isEmpty
                             && cmxCanonicalDeviceID(previousFocusedConnection.macDeviceID)
@@ -8219,7 +8226,7 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
                     } else {
                         foregroundMacDeviceID = resolvedForegroundMacID
                     }
-                    supportedHostCapabilities = authenticatedCapabilities
+                    applySupportedHostCapabilities(authenticatedCapabilities)
                     // Publish transport selection with the authenticated
                     // capability snapshot before exposing `.connected`.
                     // The listener reuses this same status below, but starts in
@@ -8286,9 +8293,9 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
                             generation: liveConnectionGeneration,
                             displayName: connectedHostName,
                             instanceTag: activeMacInstanceTag,
-                            supportedHostCapabilities: authenticatedCapabilities,
+                            supportedHostCapabilities: effectiveCapabilities,
                             actionCapabilities: Self.workspaceActionCapabilities(
-                                from: authenticatedCapabilities,
+                                from: effectiveCapabilities,
                                 allowsMacScopedMutations: allowsMacScopedWorkspaceMutations
                             )
                         ))
@@ -8949,7 +8956,7 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         terminalScrollbackPrefetchStatesBySurfaceID = [:]
         terminalOutputTransport = .rawBytes
         deactivateAllTerminalLanes()
-        supportedHostCapabilities = []
+        applySupportedHostCapabilities([])
         clearMacUpdateHint()
         terminalSubscriptionRefreshTask?.cancel()
         terminalSubscriptionRefreshTask = nil
@@ -10117,7 +10124,7 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
             ) else {
                 return .rawBytes
             }
-            supportedHostCapabilities = Set(payload.capabilities)
+            applySupportedHostCapabilities(Set(payload.capabilities))
             restartActiveMobileBrowserStreams()
             refreshVisibleMobileBrowserPanels()
             prepareTerminalThemeRevisionAuthority(

--- a/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/MobileExperiencePolicyTests.swift
+++ b/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/MobileExperiencePolicyTests.swift
@@ -1,0 +1,75 @@
+import Testing
+@testable import CmuxMobileShell
+
+@Suite struct MobileExperiencePolicyTests {
+    @Test func fullPolicyPreservesAuthenticatedHostCapabilities() {
+        let capabilities: Set<String> = [
+            "terminal.render_grid.v1",
+            "workspace.task_create.v1",
+            "browser.stream.v1",
+            "chat.artifact.v1",
+        ]
+
+        #expect(MobileExperiencePolicy.full.filteredHostCapabilities(capabilities) == capabilities)
+        #expect(MobileExperiencePolicy.full.allowsBrowserStream)
+        #expect(MobileExperiencePolicy.full.allowsArtifacts)
+    }
+
+    @Test func mvpPolicyPreservesCoreAgentLoopAndRemovesAdvancedSurfaces() {
+        let capabilities: Set<String> = [
+            "events.v1",
+            "terminal.render_grid.v1",
+            "terminal.input.ordered.v1",
+            "workspace.actions.v1",
+            "workspace.task_create.v1",
+            "notification.feed.v1",
+            "browser.stream.v1",
+            "browser.stream.viewport.v1",
+            "workspace.changes.v1",
+            "workspace.move.v1",
+            "workspace.group_actions.v1",
+            "workspace.groups.v1",
+            "chat.artifact.v1",
+            "terminal.artifact.v1",
+            "iroh.artifact_lane.v1",
+            "dogfood.v1",
+        ]
+
+        let filtered = MobileExperiencePolicy.mvp.filteredHostCapabilities(capabilities)
+
+        #expect(filtered == Set([
+            "events.v1",
+            "terminal.render_grid.v1",
+            "terminal.input.ordered.v1",
+            "workspace.actions.v1",
+            "workspace.task_create.v1",
+            "notification.feed.v1",
+        ]))
+        #expect(!MobileExperiencePolicy.mvp.allowsLocalBrowser)
+        #expect(!MobileExperiencePolicy.mvp.allowsBrowserStream)
+        #expect(!MobileExperiencePolicy.mvp.allowsWorkspaceChanges)
+        #expect(!MobileExperiencePolicy.mvp.allowsArtifacts)
+        #expect(!MobileExperiencePolicy.mvp.allowsAdvancedWorkspaceManagement)
+        #expect(!MobileExperiencePolicy.mvp.allowsAdvancedNetworking)
+        #expect(!MobileExperiencePolicy.mvp.allowsTeamSwitching)
+    }
+
+    @MainActor
+    @Test func shellPublishesOnlyEffectiveCapabilities() {
+        let store = MobileShellComposite(experiencePolicy: .mvp)
+
+        store.applySupportedHostCapabilities([
+            "terminal.render_grid.v1",
+            "workspace.task_create.v1",
+            "browser.stream.v1",
+            "workspace.changes.v1",
+        ])
+
+        #expect(store.supportedHostCapabilities == Set([
+            "terminal.render_grid.v1",
+            "workspace.task_create.v1",
+        ]))
+        #expect(!store.supportsBrowserStream)
+        #expect(!store.workspaceChangesCapable)
+    }
+}

--- a/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/MobileExperienceProfileTests.swift
+++ b/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/MobileExperienceProfileTests.swift
@@ -1,0 +1,15 @@
+import Testing
+@testable import CmuxMobileShell
+
+@Suite struct MobileExperienceProfileTests {
+    @Test func parsesMVPConfigurationValue() {
+        #expect(MobileExperienceProfile(configurationValue: "mvp") == .mvp)
+        #expect(MobileExperienceProfile(configurationValue: "  MVP  ") == .mvp)
+    }
+
+    @Test func missingOrUnknownConfigurationUsesFullExperience() {
+        #expect(MobileExperienceProfile(configurationValue: nil) == .full)
+        #expect(MobileExperienceProfile(configurationValue: "") == .full)
+        #expect(MobileExperienceProfile(configurationValue: "beta") == .full)
+    }
+}

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MobileSettingsView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MobileSettingsView.swift
@@ -66,7 +66,8 @@ struct MobileSettingsView: View {
                 // small set). Selecting a team writes `selectedTeamID`, which the root
                 // view observes to re-scope the team-bound surfaces (paired Macs,
                 // presence, backup) to that team without dropping the live terminal.
-                if authManager.availableTeams.count > 1 {
+                if experiencePolicy.allowsTeamSwitching,
+                   authManager.availableTeams.count > 1 {
                     Section {
                         Picker(selection: teamSelection) {
                             ForEach(authManager.availableTeams) { team in
@@ -162,7 +163,8 @@ struct MobileSettingsView: View {
                     )
                 }
 
-                if let irohSettingsController {
+                if experiencePolicy.allowsAdvancedNetworking,
+                   let irohSettingsController {
                     Section(L10n.string("mobile.settings.networking", defaultValue: "Networking")) {
                         NavigationLink {
                             MobileIrohSettingsView(controller: irohSettingsController)
@@ -185,13 +187,15 @@ struct MobileSettingsView: View {
                     }
                     .accessibilityIdentifier("MobileSettingsAltScreenNoticeToggle")
 
-                    Toggle(isOn: $displaySettings.terminalFolderTapEnabled) {
-                        Text(L10n.string(
-                            "mobile.settings.terminalFolderTap",
-                            defaultValue: "Open Folders on Tap"
-                        ))
+                    if experiencePolicy.allowsArtifacts {
+                        Toggle(isOn: $displaySettings.terminalFolderTapEnabled) {
+                            Text(L10n.string(
+                                "mobile.settings.terminalFolderTap",
+                                defaultValue: "Open Folders on Tap"
+                            ))
+                        }
+                        .accessibilityIdentifier("MobileSettingsTerminalFolderTapToggle")
                     }
-                    .accessibilityIdentifier("MobileSettingsTerminalFolderTapToggle")
 
                     Button {
                         showingShortcuts = true
@@ -230,13 +234,15 @@ struct MobileSettingsView: View {
                     }
                     .accessibilityIdentifier("MobileSettingsTaskComposer")
 
-                    Toggle(isOn: $displaySettings.terminalFilesChipEnabled) {
-                        Text(L10n.string(
-                            "mobile.settings.terminalFilesChip",
-                            defaultValue: "Terminal Files Chip"
-                        ))
+                    if experiencePolicy.allowsArtifacts {
+                        Toggle(isOn: $displaySettings.terminalFilesChipEnabled) {
+                            Text(L10n.string(
+                                "mobile.settings.terminalFilesChip",
+                                defaultValue: "Terminal Files Chip"
+                            ))
+                        }
+                        .accessibilityIdentifier("MobileSettingsTerminalFilesChip")
                     }
-                    .accessibilityIdentifier("MobileSettingsTerminalFilesChip")
 
                     Toggle(isOn: $toasts.isEnabled) {
                         Text(L10n.string(
@@ -511,6 +517,10 @@ struct MobileSettingsView: View {
         default:
             true
         }
+    }
+
+    private var experiencePolicy: MobileExperiencePolicy {
+        store?.experiencePolicy ?? .full
     }
 
     private func retryAutomaticConnection() {

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TerminalPickerMenu.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TerminalPickerMenu.swift
@@ -59,8 +59,8 @@ struct TerminalPickerMenu: View, Equatable {
             }
         }
 
-        if value.supportsBrowserStream {
-            if !value.browserStreamRows.isEmpty {
+        if value.showsBrowserStreamSection {
+            if value.supportsBrowserStream, !value.browserStreamRows.isEmpty {
                 Section(L10n.string("mobile.browserStream.menuTitle", defaultValue: "Mac Browsers")) {
                     ForEach(value.browserStreamRows) { panel in
                         Button { actions.selectBrowserStream(panel.id) } label: {
@@ -74,14 +74,14 @@ struct TerminalPickerMenu: View, Equatable {
                         .accessibilityIdentifier("BrowserStreamMenuItem-\(panel.id)")
                     }
                 }
-            }
-        } else {
-            Section(L10n.string("mobile.browserStream.menuTitle", defaultValue: "Mac Browsers")) {
-                Label(
-                    L10n.string("mobile.macUpdateHint.browserStream", defaultValue: "Update cmux on your Mac to stream browser panes"),
-                    systemImage: "arrow.down.circle"
-                )
-                .accessibilityIdentifier("BrowserStreamMacUpdateHint")
+            } else if !value.supportsBrowserStream {
+                Section(L10n.string("mobile.browserStream.menuTitle", defaultValue: "Mac Browsers")) {
+                    Label(
+                        L10n.string("mobile.macUpdateHint.browserStream", defaultValue: "Update cmux on your Mac to stream browser panes"),
+                        systemImage: "arrow.down.circle"
+                    )
+                    .accessibilityIdentifier("BrowserStreamMacUpdateHint")
+                }
             }
         }
 
@@ -100,13 +100,15 @@ struct TerminalPickerMenu: View, Equatable {
             }
             .accessibilityIdentifier("MobileNewTerminalMenuItem")
 
-            Button(action: actions.openBrowser) {
-                Label(
-                    L10n.string("mobile.browser.new", defaultValue: "New Browser"),
-                    systemImage: value.hasActiveBrowser ? "checkmark.circle.fill" : "globe"
-                )
+            if value.allowsLocalBrowser {
+                Button(action: actions.openBrowser) {
+                    Label(
+                        L10n.string("mobile.browser.new", defaultValue: "New Browser"),
+                        systemImage: value.hasActiveBrowser ? "checkmark.circle.fill" : "globe"
+                    )
+                }
+                .accessibilityIdentifier("MobileNewBrowserMenuItem")
             }
-            .accessibilityIdentifier("MobileNewBrowserMenuItem")
         }
 
         #if canImport(UIKit)

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TerminalPickerMenuValue.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TerminalPickerMenuValue.swift
@@ -11,6 +11,8 @@ struct TerminalPickerMenuValue: Equatable {
     let browserStreamRows: [BrowserStreamPickerRow]
     let supportsBrowserStream: Bool
     let activeBrowserStreamPanelID: String?
+    let showsBrowserStreamSection: Bool
+    let allowsLocalBrowser: Bool
 
     init(
         liveTerminals: [MobileTerminalPreview],
@@ -21,7 +23,9 @@ struct TerminalPickerMenuValue: Equatable {
         isChatMode: Bool,
         browserStreamRows: [BrowserStreamPickerRow] = [],
         supportsBrowserStream: Bool = false,
-        activeBrowserStreamPanelID: String? = nil
+        activeBrowserStreamPanelID: String? = nil,
+        showsBrowserStreamSection: Bool = true,
+        allowsLocalBrowser: Bool = true
     ) {
         rows = snapshotRows.isEmpty
             ? liveTerminals.map(TerminalPickerMenuRow.init)
@@ -35,5 +39,7 @@ struct TerminalPickerMenuValue: Equatable {
         self.browserStreamRows = browserStreamRows
         self.supportsBrowserStream = supportsBrowserStream
         self.activeBrowserStreamPanelID = activeBrowserStreamPanelID
+        self.showsBrowserStreamSection = showsBrowserStreamSection
+        self.allowsLocalBrowser = allowsLocalBrowser
     }
 }

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceDetailView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceDetailView.swift
@@ -590,7 +590,9 @@ struct WorkspaceDetailView: View {
                 isChatMode: isChatMode,
                 browserStreamRows: browserStreamStore.panels(in: workspace.rpcWorkspaceID.rawValue).map(BrowserStreamPickerRow.init),
                 supportsBrowserStream: store.supportsBrowserStream,
-                activeBrowserStreamPanelID: activeBrowserStream?.id
+                activeBrowserStreamPanelID: activeBrowserStream?.id,
+                showsBrowserStreamSection: store.experiencePolicy.allowsBrowserStream,
+                allowsLocalBrowser: store.experiencePolicy.allowsLocalBrowser
             ),
             actions: TerminalPickerMenuActions(
                 selectTerminal: selectTerminalFromPicker,

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceShellView+WorkspaceActions.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceShellView+WorkspaceActions.swift
@@ -415,6 +415,7 @@ extension WorkspaceShellView {
     /// Group collapse/expand closure. Present when the Mac advertises
     /// `workspace.groups.v1` or has actually emitted group sections.
     var toggleGroupCollapsedClosure: ((MobileWorkspaceGroupPreview.ID, Bool) -> Void)? {
+        guard store.experiencePolicy.allowsAdvancedWorkspaceManagement else { return nil }
         guard store.supportsWorkspaceGroups || !store.workspaceGroups.isEmpty else { return nil }
         let store = store
         return { id, collapsed in Task { await store.setWorkspaceGroupCollapsed(id: id, collapsed) } }

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceShellView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceShellView.swift
@@ -596,7 +596,9 @@ struct WorkspaceShellView: View {
         )
         return WorkspaceListView(
             workspaces: store.workspaces,
-            groups: store.workspaceGroups,
+            groups: store.experiencePolicy.allowsAdvancedWorkspaceManagement
+                ? store.workspaceGroups
+                : [],
             selectedWorkspaceID: store.selectedWorkspaceID,
             host: store.connectedHostName,
             connectionStatus: listConnectionStatus,

--- a/Packages/iOS/CmuxMobileShellUI/Tests/CmuxMobileShellUITests/TerminalPickerMenuValueTests.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Tests/CmuxMobileShellUITests/TerminalPickerMenuValueTests.swift
@@ -75,6 +75,22 @@ import Testing
         #expect(noTerminals.selectedName == nil)
     }
 
+    @Test func firstReleasePolicyCanHideBothBrowserEntryPoints() {
+        let value = TerminalPickerMenuValue(
+            liveTerminals: [],
+            snapshotRows: [],
+            selectedID: nil,
+            canCreateWorkspace: true,
+            hasActiveBrowser: false,
+            isChatMode: false,
+            showsBrowserStreamSection: false,
+            allowsLocalBrowser: false
+        )
+
+        #expect(!value.showsBrowserStreamSection)
+        #expect(!value.allowsLocalBrowser)
+    }
+
     private func menuValue(
         liveTerminals: [MobileTerminalPreview],
         snapshotRows: [TerminalPickerMenuRow],

--- a/ios/Config/Info.plist
+++ b/ios/Config/Info.plist
@@ -14,6 +14,8 @@
 	<string>6.0</string>
 	<key>CMUXAuthEnvironment</key>
 	<string>$(CMUX_IOS_AUTH_ENV)</string>
+	<key>CMUXExperienceProfile</key>
+	<string>$(CMUX_IOS_EXPERIENCE_PROFILE)</string>
 	<key>CMUXApiBaseURL</key>
 	<string>$(CMUX_API_BASE_URL)</string>
 	<key>CMUXIrohBrokerBaseURL</key>

--- a/ios/Config/Release.xcconfig
+++ b/ios/Config/Release.xcconfig
@@ -11,6 +11,11 @@ DEVELOPMENT_TEAM = 7WLXT3NR37
 // (overrides PRODUCT_DISPLAY_NAME = cmux from Shared.xcconfig). Debug stays "cmux".
 PRODUCT_DISPLAY_NAME = cmux BETA
 
+// First App Store/TestFlight release: keep pairing, remote terminal/task
+// control, notifications, and diagnostics while hiding advanced browser,
+// artifact, workspace-management, team, and relay surfaces.
+CMUX_IOS_EXPERIENCE_PROFILE = mvp
+
 // TestFlight/App Store builds use production APNs. Debug keeps
 // Config/cmux.entitlements from Shared.xcconfig.
 CODE_SIGN_ENTITLEMENTS = Config/cmux-release.entitlements

--- a/ios/Config/Shared.xcconfig
+++ b/ios/Config/Shared.xcconfig
@@ -27,6 +27,11 @@ CURRENT_PROJECT_VERSION = 1
 CMUX_GIT_SHA =
 CMUX_DEV_TAG =
 
+// Product surface compiled into CMUXExperienceProfile. `full` is the default
+// for tagged/local development; Release.xcconfig narrows distribution builds
+// to the first-release remote-agent-control experience.
+CMUX_IOS_EXPERIENCE_PROFILE = full
+
 // Per-developer presence/paired-Mac-backup worker override, baked into the
 // CMUXPresenceBaseURL Info.plist key so a normally-tapped dev device build (which
 // sees no shell env) talks to an isolated worker instead of the shared

--- a/ios/README.md
+++ b/ios/README.md
@@ -19,6 +19,25 @@ Build and reload the simulator:
 ios/scripts/reload.sh --tag iossh
 ```
 
+## First-release experience profile
+
+Release/TestFlight builds use the focused `mvp` profile. It keeps the complete
+remote-agent loop: sign in and pairing, computer/workspace selection, terminal
+view and input, task creation, push alerts, release information, and
+diagnostics. Browser surfaces, artifact/diff galleries, workspace groups and
+advanced mutations, team switching, and advanced Iroh/relay settings remain in
+the codebase but are hidden from this profile.
+
+Tagged Debug builds use `full` by default. Verify the distribution surface with:
+
+```bash
+ios/scripts/reload.sh --tag ios-mvp --mvp
+```
+
+The equivalent build setting is `CMUX_IOS_EXPERIENCE_PROFILE=full|mvp`; it is
+baked into the `CMUXExperienceProfile` Info.plist key. Unknown or missing values
+fall back to `full` so a local developer build cannot silently lose tools.
+
 Run package tests:
 
 ```bash

--- a/ios/cmux/cmuxApp.swift
+++ b/ios/cmux/cmuxApp.swift
@@ -19,6 +19,14 @@ struct cmuxApp: App {
     @UIApplicationDelegateAdaptor(CmuxAppDelegate.self) private var appDelegate
     @Environment(\.scenePhase) private var scenePhase
 
+    private static let experiencePolicy = MobileExperiencePolicy(
+        profile: MobileExperienceProfile(
+            configurationValue: Bundle.main.object(
+                forInfoDictionaryKey: "CMUXExperienceProfile"
+            ) as? String
+        )
+    )
+
     /// The de-singletonized composition root: built once, injected down.
     @MainActor
     private static let root: AppCompositionRoot = {
@@ -163,6 +171,7 @@ struct cmuxApp: App {
             auth: Self.root.auth,
             reachability: Self.root.reachability,
             analytics: Self.root.analytics.emitter,
+            experiencePolicy: Self.experiencePolicy,
             pushCoordinator: Self.root.pushCoordinator,
             displaySettings: Self.root.displaySettings,
             connectionMethodStore: Self.root.connectionMethodStore,

--- a/ios/cmuxPackage/Sources/cmuxFeature/CMUXMobileRootScene.swift
+++ b/ios/cmuxPackage/Sources/cmuxFeature/CMUXMobileRootScene.swift
@@ -36,6 +36,7 @@ public struct CMUXMobileRootScene: View {
     private let auth: MobileAuthComposition
     private let reachability: any ReachabilityProviding
     private let analytics: any AnalyticsEmitting
+    private let experiencePolicy: MobileExperiencePolicy
     package let signOutHook: MobileSignOutHook
     private let personalIrohRouteCatalog: MobileIrohRouteCatalog?
     private let personalIrohDiscovery: (any MobileIrohMacDiscovering)?
@@ -83,6 +84,7 @@ public struct CMUXMobileRootScene: View {
     ///   - reachability: The process-wide reachability monitor, injected into
     ///     the shell store (already used to build `auth`).
     ///   - analytics: The app-root analytics emitter, injected into the store.
+    ///   - experiencePolicy: Product-surface policy applied at the shell boundary.
     ///   - pushCoordinator: The app-root push coordinator (shared with the app
     ///     delegate) injected into the environment.
     ///   - displaySettings: The app-root mobile display settings injected into
@@ -104,6 +106,7 @@ public struct CMUXMobileRootScene: View {
         auth: MobileAuthComposition,
         reachability: any ReachabilityProviding,
         analytics: any AnalyticsEmitting,
+        experiencePolicy: MobileExperiencePolicy = .full,
         pushCoordinator: MobilePushCoordinator,
         displaySettings: MobileDisplaySettings,
         connectionMethodStore: MobileConnectionMethodStore,
@@ -119,6 +122,7 @@ public struct CMUXMobileRootScene: View {
         self.auth = auth
         self.reachability = reachability
         self.analytics = analytics
+        self.experiencePolicy = experiencePolicy
         self.pushCoordinator = pushCoordinator
         self.displaySettings = displaySettings
         self.connectionMethodStore = connectionMethodStore
@@ -139,12 +143,14 @@ public struct CMUXMobileRootScene: View {
         auth: MobileAuthComposition,
         reachability: any ReachabilityProviding,
         analytics: any AnalyticsEmitting,
+        experiencePolicy: MobileExperiencePolicy = .full,
         signOutHook: MobileSignOutHook = MobileSignOutHook()
     ) {
         self.runtime = runtime
         self.auth = auth
         self.reachability = reachability
         self.analytics = analytics
+        self.experiencePolicy = experiencePolicy
         self.signOutHook = signOutHook
         self.personalIrohRouteCatalog = nil
         self.personalIrohDiscovery = nil
@@ -392,6 +398,7 @@ public struct CMUXMobileRootScene: View {
         }
         return CMUXMobileShellStore(
             runtime: runtime,
+            experiencePolicy: experiencePolicy,
             pairedMacStore: backedUpPairedMacStore,
             connectionMethodStore: connectionMethodStore,
             buildCompatibilityPolicy: buildCompatibilityPolicy,

--- a/ios/scripts/reload.sh
+++ b/ios/scripts/reload.sh
@@ -10,6 +10,10 @@ Usage: ios/scripts/reload.sh --tag <tag> [--simulator <name>] [--simulator-id <i
 
 Build, install, and launch the cmux iOS app with an isolated tag.
 
+Pass --mvp to verify the focused first-release product surface. Tagged builds
+otherwise use the complete development surface. CMUX_IOS_EXPERIENCE_PROFILE may
+also be set to `full` or `mvp`.
+
 Verification default is simulator + iPhone: when a default iPhone is configured
 (CMUX_IPHONE_DEVICE_ID or ~/.config/cmux/iphone-device-id), the device leg is
 enabled automatically; --simulator-only opts out explicitly. Without a
@@ -91,6 +95,9 @@ SWIFT_FRONTEND_WORKAROUND="${CMUX_SWIFT_FRONTEND_WORKAROUND:-0}"
 # against the production Stack project. Build compatibility remains exact-tag
 # DEV to DEV.
 PROD_AUTH=0
+# Product surface baked into CMUXExperienceProfile. Tagged development defaults
+# to full; --mvp mirrors the Release/TestFlight experience.
+EXPERIENCE_PROFILE="${CMUX_IOS_EXPERIENCE_PROFILE:-full}"
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -173,6 +180,10 @@ while [[ $# -gt 0 ]]; do
       PROD_AUTH=1
       shift
       ;;
+    --mvp)
+      EXPERIENCE_PROFILE="mvp"
+      shift
+      ;;
     -h|--help)
       usage
       exit 0
@@ -188,6 +199,11 @@ done
 if [[ -z "$TAG" ]]; then
   echo "error: --tag is required" >&2
   usage >&2
+  exit 1
+fi
+
+if [[ "$EXPERIENCE_PROFILE" != "full" && "$EXPERIENCE_PROFILE" != "mvp" ]]; then
+  echo "error: CMUX_IOS_EXPERIENCE_PROFILE must be 'full' or 'mvp'" >&2
   exit 1
 fi
 
@@ -659,6 +675,7 @@ reload_simulator() {
     CMUX_DEV_TAG="$TAG" \
     CMUX_PRESENCE_BASE_URL="${CMUX_PRESENCE_BASE_URL:-}" \
     CMUX_IOS_AUTH_ENV="$CMUX_IOS_AUTH_ENV_VALUE" \
+    CMUX_IOS_EXPERIENCE_PROFILE="$EXPERIENCE_PROFILE" \
     CMUX_API_BASE_URL="$CMUX_IOS_SIMULATOR_API_BASE_URL_VALUE" \
     CMUX_IROH_BROKER_BASE_URL="$CMUX_IOS_IROH_BROKER_BASE_URL_VALUE" \
     EXCLUDED_SOURCE_FILE_NAMES=Info.plist \
@@ -866,6 +883,7 @@ reload_device() {
     CMUX_DEV_TAG="$TAG"
     CMUX_PRESENCE_BASE_URL="${CMUX_PRESENCE_BASE_URL:-}"
     CMUX_IOS_AUTH_ENV="$CMUX_IOS_AUTH_ENV_VALUE"
+    CMUX_IOS_EXPERIENCE_PROFILE="$EXPERIENCE_PROFILE"
     CMUX_API_BASE_URL="$CMUX_IOS_DEVICE_API_BASE_URL_VALUE"
     CMUX_IROH_BROKER_BASE_URL="$CMUX_IOS_IROH_BROKER_BASE_URL_VALUE"
     EXCLUDED_SOURCE_FILE_NAMES=Info.plist


### PR DESCRIPTION
## Summary

- What changed?
- Why?

## Testing

- How did you test this change?
- What did you verify manually?

## Demo Video

For UI or behavior changes, include a short demo video (GitHub upload, Loom, or other direct link).

- Video URL or attachment:

## Review Trigger (Copy/Paste as PR comment)

```text
@codex review
@coderabbitai review
@greptile-apps review
@cubic-dev-ai review
```

## Checklist

- [ ] I tested the change locally
- [ ] I added or updated tests for behavior changes
- [ ] I updated docs/changelog if needed
- [ ] I requested bot reviews after my latest commit (copy/paste block above or equivalent)
- [ ] All code review bot comments are resolved
- [ ] All human review comments are resolved

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/9454"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788348339&installation_model_id=21920&pr_number=9454&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F9454&signature=d8787577e52530c8af39ced07c4d94b351a70e404cfc625117a23e791dc2c585"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add an iOS experience profile system and ship the focused `mvp` profile for the first release. It filters host capabilities and hides advanced UI to center on remote agent control.

- **New Features**
  - Introduced `MobileExperienceProfile` (`full`, `mvp`) and `MobileExperiencePolicy` that filter authenticated host capabilities and gate UI.
  - Wired capability filtering across the shell (auth, promotion, refresh) via applySupportedHostCapabilities; feature gates now use the filtered set; Mac update hint is suppressed in `mvp`.
  - UI gated by policy: Terminal Picker can hide the Mac Browser section and New Browser; Settings hides Team switching, Advanced Networking, and artifact-related toggles; workspace groups and related actions are disabled under `mvp`.
  - Build/config: `CMUXExperienceProfile` read from Info.plist (`CMUX_IOS_EXPERIENCE_PROFILE`); `Release.xcconfig` sets `mvp`; `reload.sh` adds `--mvp`; README documents the profile.
  - Tests added for profile parsing, capability filtering, and picker visibility.

- **Migration**
  - No changes for local dev: default profile is `full`.
  - Release/TestFlight already use `mvp`. To verify locally: `ios/scripts/reload.sh --tag <tag> --mvp` or set `CMUX_IOS_EXPERIENCE_PROFILE=mvp`.

<sup>Written for commit ff5006c1aff996b0e7d3356a7030e27c326dd367. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/9454?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable Full and MVP experience profiles for iOS.
  * MVP mode focuses on core pairing, terminal control, notifications, and diagnostics while hiding advanced features.
  * Browser access, workspace management, artifacts, networking, and team switching now adapt to the selected profile.
  * Added support for selecting the MVP profile during release builds and reloads.

* **Documentation**
  * Documented profile behavior, configuration, and reload commands.

* **Bug Fixes**
  * Prevented unsupported capabilities and Mac update prompts from appearing in MVP mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->