### PR TITLE
Forward CMUX_SOCKET_CAPABILITY to Pi hook children

### DIFF
--- a/CLI/CMUXCLI+PiExtensionSourcePart1.swift
+++ b/CLI/CMUXCLI+PiExtensionSourcePart1.swift
@@ -333,10 +333,15 @@ function hookEnvironment(cwd: string, includeSocketPassword = false): NodeJS.Pro
     if (value === undefined) continue;
     if (shouldPreserveEnvKey(key)) env[key] = value;
   }
-  // Only cmux CLI children need the socket credential; keep it out of the generic allowlist.
+  // Only cmux CLI children need the socket credentials; keep them out of the generic allowlist.
+  // CMUX_SOCKET_CAPABILITY must reach cmux CLI children: the detached auto-name pass they spawn
+  // is orphaned (sh -c '... &'), so ancestry-based socket auth fails and the inherited capability
+  // is that process's only credential. Without it the naming pass exits silently at its first probe.
   if (includeSocketPassword) {
     const socketPassword = process.env.CMUX_SOCKET_PASSWORD;
     if (socketPassword) env.CMUX_SOCKET_PASSWORD = socketPassword;
+    const socketCapability = process.env.CMUX_SOCKET_CAPABILITY;
+    if (socketCapability) env.CMUX_SOCKET_CAPABILITY = socketCapability;
   }
   if (!env.CMUX_AGENT_LAUNCH_ARGV_B64) {
     const argv = normalizedLaunchArgv();


### PR DESCRIPTION
## Context
Workspace auto-naming never fires for Pi sessions, even with `automation.workspaceAutoNaming` enabled and healthy Stop hooks. The detached naming pass exits silently before its first socket call.

## Summary
- Forward `CMUX_SOCKET_CAPABILITY` to cmux CLI hook children in the Pi extension.
- The orphaned auto-name pass (`sh -c '... &'`) fails ancestry-based socket auth without it.
- Verified end-to-end: probe rejected without the capability, rename succeeds with it forwarded.

## Dependencies
None.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/9460"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788366218&installation_model_id=21920&pr_number=9460&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F9460&signature=fed55edf2e2e73ad9737ed49361c8a8b5fb1e8c2101dda4917ad5464a38b6d99"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Forward `CMUX_SOCKET_CAPABILITY` to Pi hook children of the cmux CLI so the detached auto-name pass can authenticate. Restores workspace auto-naming for Pi sessions that previously exited before the first probe due to missing credentials.

<sup>Written for commit 09559414ccd9f82637ab0f1143f13da1b2a54a39. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/9460?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved socket authentication for detached and automatically named command-line processes by forwarding the required socket capability information alongside existing credentials.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->