### PR TITLE
Fix dark-on-dark rendering in browser Downloads popover

### DIFF
--- a/Sources/Panels/BrowserDownloadsToolbarButton.swift
+++ b/Sources/Panels/BrowserDownloadsToolbarButton.swift
@@ -11,6 +11,12 @@ struct BrowserDownloadsToolbarButton: View {
     let isDownloading: Bool
     let iconPointSize: CGFloat
     let hitSize: CGFloat
+    /// Color scheme of the hosting window. The omnibar forces the browser
+    /// chrome scheme (derived from the web page's theme color) into its
+    /// environment, and popover content inherits it — but NSPopover draws its
+    /// translucent panel with the window's appearance. Re-injecting the window
+    /// scheme keeps labels/icons readable against the panel (#9341).
+    let hostColorScheme: ColorScheme
     let onOpen: (BrowserDownloadRecord) -> Void
     let onReveal: (BrowserDownloadRecord) -> Void
     let onClear: () -> Void
@@ -85,6 +91,7 @@ struct BrowserDownloadsToolbarButton: View {
                 onReveal: onReveal,
                 onClear: onClear
             )
+            .environment(\.colorScheme, hostColorScheme)
         }
     }
 }

--- a/Sources/Panels/BrowserPanelView.swift
+++ b/Sources/Panels/BrowserPanelView.swift
@@ -1238,6 +1238,11 @@ struct BrowserPanelView: View {
                     isDownloading: panel.isDownloading,
                     iconPointSize: chromeMetrics.navigationIconFontSize,
                     hitSize: addressBarButtonHitSize,
+                    // The window scheme (read outside the addressBar's
+                    // browserChromeColorScheme override) — the downloads
+                    // popover panel is drawn with the window appearance, not
+                    // the page-derived chrome scheme.
+                    hostColorScheme: colorScheme,
                     onOpen: { panel.openDownload($0) },
                     onReveal: { panel.revealDownloadInFinder($0) },
                     onClear: { panel.clearRecentDownloads() }


### PR DESCRIPTION
The omnibar overrides the environment color scheme with the page-derived browser chrome scheme, and the Downloads popover content inherited that override. NSPopover, however, draws its translucent panel using the window's appearance — so when the chrome scheme and window scheme disagreed (e.g. dark chrome on a light window), labels and icons became unreadable against the panel.

Pass the host window's color scheme into `BrowserDownloadsToolbarButton` (read in `BrowserPanelView` outside the chrome override) and re-inject it into the popover content's environment, so the content always matches the panel it's drawn on.

Fixes #9341

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/9461"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788368847&installation_model_id=21920&pr_number=9461&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F9461&signature=1dd01bc46196f5fc4cc57b21fed90afbcc320b1944a50a1f132d3aa1aeb4b180"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes unreadable dark-on-dark content in the Downloads popover by making its color scheme follow the window appearance, not the page-derived chrome. This keeps labels and icons readable against the NSPopover panel.

- **Bug Fixes**
  - Read the window `colorScheme` in `BrowserPanelView` and pass it to `BrowserDownloadsToolbarButton` as `hostColorScheme`.
  - Apply it to the popover content with `.environment(\.colorScheme, hostColorScheme)` so it matches the panel. Fixes #9341.

<sup>Written for commit 4ee297ca7503959c9d4a435939fe92cf5f7ed29c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/9461?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the Downloads popover so it consistently matches the browser window’s light or dark appearance.
  * Improved visual consistency when the webpage uses a different color scheme from the surrounding browser interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->