### PR TITLE
Extend Pi hook timeout

### DIFF
--- a/CLI/CMUXCLI+PiExtensionSourceDispatch.swift
+++ b/CLI/CMUXCLI+PiExtensionSourceDispatch.swift
@@ -27,9 +27,8 @@ class PiCmuxCommandDispatcher {
   private static readonly maxCompactedTerminalSummaries = 64;
   // Leave headroom for the feed.push envelope under the relay's 16 KiB frame limit.
   private static readonly maxFeedInputBytes = 12 * 1024;
-  // The app may spend three seconds committing acknowledged Feed ingress and the
-  // CLI owns a four-second end-to-end deadline. Observe that outcome before the
-  // extension classifies a terminal delivery as failed.
+  // Allow cmux to commit a slow session hook before the extension stops the CLI.
+  private static readonly commandDeadlineMs = 15000;
   private static readonly feedDrainDeadlineMs = 4500;
   private controlQueues = new Map<string | null, Promise<void>>();
   private pendingFeedCommands = new Map<string, PiFeedCommand>();
@@ -479,8 +478,8 @@ class PiCmuxCommandDispatcher {
           if (cancellation.cancelled) cancellation.cancel();
         }
         timeout = setTimeout(() => {
-          beginTermination(new Error("cmux command timed out after 5000ms"));
-        }, 5000);
+          beginTermination(new Error(`cmux command timed out after ${PiCmuxCommandDispatcher.commandDeadlineMs}ms`));
+        }, PiCmuxCommandDispatcher.commandDeadlineMs);
         child.stdin.end(input);
       } catch (error) {
         settle({ ok: false, status: null, stdout, stderr, error });

--- a/tests/test_pi_extension_dispatch.py
+++ b/tests/test_pi_extension_dispatch.py
@@ -444,6 +444,57 @@ await handlers.get("session_shutdown")({ reason: "session A complete" }, slow);
     return 0
 
 
+def check_session_start_allows_slow_cmux(bun: str, root: Path, extension_path: Path) -> int:
+    completed_marker = root / "slow-session-start-completed"
+    slow_cmux = root / "slow-session-start-cmux"
+    make_executable(
+        slow_cmux,
+        """#!/usr/bin/env python3
+import os
+import sys
+import time
+
+sys.stdin.read()
+# Model the observed session-start hook duration.
+time.sleep(6)
+with open(os.environ["CMUX_TEST_PI_SESSION_START_MARKER"], "w", encoding="utf-8") as stream:
+    stream.write("completed")
+print('{"workspace_id":"00000000-0000-0000-0000-000000008673","surface_id":"00000000-0000-0000-0000-000000008672"}')
+""",
+    )
+    source = """
+import { existsSync } from "node:fs";
+const extensionPath = process.env.CMUX_TEST_PI_EXTENSION_PATH;
+const mod = await import(extensionPath);
+const handlers = new Map();
+mod.default({ on(name, handler) { handlers.set(name, handler); } });
+const sessionStart = handlers.get("session_start");
+if (typeof sessionStart !== "function") throw new Error("missing session_start");
+sessionStart({}, {
+  cwd: "/tmp/pi-slow-session-start",
+  sessionManager: { getSessionId() { return "pi-slow-session-start"; } }
+});
+const deadline = Date.now() + 10_000;
+while (!existsSync(process.env.CMUX_TEST_PI_SESSION_START_MARKER)) {
+  if (Date.now() >= deadline) throw new Error("session-start hook did not complete");
+  await Bun.sleep(50);
+}
+"""
+    result = run_extension(
+        bun=bun,
+        root=root,
+        extension_path=extension_path,
+        fake_cmux=slow_cmux,
+        source=source,
+        extra_env={"CMUX_TEST_PI_SESSION_START_MARKER": str(completed_marker)},
+    )
+    if result.returncode != 0:
+        print(f"FAIL: session-start hook timed out before cmux completed: {result.stderr!r}")
+        return 1
+
+    return 0
+
+
 def check_panel_only_target_fails_closed(bun: str, root: Path, extension_path: Path) -> int:
     marker = root / "panel-only-cmux-called"
     fake_cmux = root / "panel-only-cmux"
@@ -2448,6 +2499,7 @@ def run_checks(bun: str, root: Path, extension_path: Path) -> int:
         check_ui_lifecycle_handlers_return_immediately,
         check_completion_precedes_next_prompt,
         check_cross_session_lifecycle_isolation,
+        check_session_start_allows_slow_cmux,
         check_panel_only_target_fails_closed,
         check_feed_backlog,
         check_terminal_feed_compaction,


### PR DESCRIPTION
## Context
Pi session-start hooks can exceed five seconds. The generated extension stops these commands early.

## Summary
- Extend the Pi hook command timeout to 15 seconds.
- Add regression coverage for a six-second session hook.

## Dependencies
None.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Extend Pi hook command deadline from 5s to 15s so slow session-start hooks can finish instead of being killed early. Add a regression test that simulates a 6s session-start and verifies it completes under the new cmux timeout.

<sup>Written for commit 543e21e8dd371f65cc51278110d108e94c819962. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/9464?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Increased the command timeout to 15 seconds, allowing longer-running commands to complete successfully.
  * Preserved the existing feed processing deadline.

* **Tests**
  * Added coverage to verify session startup remains responsive while a longer command is running.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->