### PR TITLE
Fix group header title flashing white in light mode (#9140)

### DIFF
--- a/Sources/Sidebar/AppKitList/Cells/SidebarGroupHeaderRowView.swift
+++ b/Sources/Sidebar/AppKitList/Cells/SidebarGroupHeaderRowView.swift
@@ -59,7 +59,9 @@ final class SidebarGroupHeaderTableCellView: NSTableCellView {
         addSubview(backgroundView)
 
         pinImageView.imageScaling = .scaleProportionallyDown
-        pinImageView.contentTintColor = NSColor.secondaryLabelColor.withAlphaComponent(0.8)
+        // Dynamic color + alphaValue, not withAlphaComponent: see applyModel.
+        pinImageView.contentTintColor = .secondaryLabelColor
+        pinImageView.alphaValue = 0.8
         addSubview(pinImageView)
 
         chevronButton.onClick = { [weak self] in self?.actions?.onToggleCollapsed() }
@@ -178,7 +180,13 @@ final class SidebarGroupHeaderTableCellView: NSTableCellView {
             ofSize: GlobalFontMagnification.scaledSize(metrics.nameFontSize, percent: percent),
             weight: .semibold
         )
-        nameField.textColor = model.isAnchorActive ? .labelColor : NSColor.labelColor.withAlphaComponent(0.9)
+        // Dim via alphaValue, never withAlphaComponent: resolving a dynamic
+        // color at configure time snapshots the ambient drawing appearance,
+        // and the synchronous selection commit can configure this cell inside
+        // the dark terminal's display pass — the title then rendered
+        // white-on-white in a light sidebar and vanished.
+        nameField.textColor = .labelColor
+        nameField.alphaValue = model.isAnchorActive ? 1 : 0.9
 
         let showsBadge = model.anchorUnreadCount > 0
         unreadBadgeView.isHidden = !showsBadge
@@ -213,10 +221,10 @@ final class SidebarGroupHeaderTableCellView: NSTableCellView {
         backgroundView.layer?.cornerRadius = model.isMultiSelected && !model.isAnchorActive
             ? 6
             : 4
-        backgroundView.layer?.backgroundColor = headerBackgroundColor(for: model).cgColor
+        backgroundView.layer?.backgroundColor = resolvedCGColor { self.headerBackgroundColor(for: model) }
 
-        topDropIndicator.layer?.backgroundColor = cmuxAccentNSColor().cgColor
-        bottomDropIndicator.layer?.backgroundColor = cmuxAccentNSColor().cgColor
+        topDropIndicator.layer?.backgroundColor = resolvedCGColor { cmuxAccentNSColor() }
+        bottomDropIndicator.layer?.backgroundColor = resolvedCGColor { cmuxAccentNSColor() }
         topDropIndicator.isHidden = !model.topDropIndicatorVisible
         bottomDropIndicator.isHidden = !model.bottomDropIndicatorVisible
 
@@ -236,8 +244,8 @@ final class SidebarGroupHeaderTableCellView: NSTableCellView {
     /// Live drop-line painting during native reorder drags; see
     /// `SidebarWorkspaceRowTableCellView.paintControllerDropIndicator`.
     func paintControllerDropIndicator(top: Bool, bottom: Bool) {
-        topDropIndicator.layer?.backgroundColor = cmuxAccentNSColor().cgColor
-        bottomDropIndicator.layer?.backgroundColor = cmuxAccentNSColor().cgColor
+        topDropIndicator.layer?.backgroundColor = resolvedCGColor { cmuxAccentNSColor() }
+        bottomDropIndicator.layer?.backgroundColor = resolvedCGColor { cmuxAccentNSColor() }
         topDropIndicator.isHidden = !top
         bottomDropIndicator.isHidden = !bottom
     }
@@ -270,9 +278,9 @@ final class SidebarGroupHeaderTableCellView: NSTableCellView {
         CATransaction.begin()
         CATransaction.setDisableActions(true)
         backgroundView.layer?.cornerRadius = 4
-        backgroundView.layer?.backgroundColor = NSColor.labelColor.withAlphaComponent(0.08).cgColor
+        backgroundView.layer?.backgroundColor = resolvedCGColor { NSColor.labelColor.withAlphaComponent(0.08) }
         CATransaction.commit()
-        nameField.textColor = .labelColor
+        nameField.alphaValue = 1
     }
 
     /// Modifier-click preview: paints the same dim membership tint as an
@@ -282,7 +290,7 @@ final class SidebarGroupHeaderTableCellView: NSTableCellView {
         CATransaction.begin()
         CATransaction.setDisableActions(true)
         backgroundView.layer?.cornerRadius = 6
-        backgroundView.layer?.backgroundColor = headerMultiSelectionBackgroundColor(for: model).cgColor
+        backgroundView.layer?.backgroundColor = resolvedCGColor { self.headerMultiSelectionBackgroundColor(for: model) }
         CATransaction.commit()
     }
 
@@ -295,7 +303,9 @@ final class SidebarGroupHeaderTableCellView: NSTableCellView {
         backgroundView.layer?.cornerRadius = 4
         backgroundView.layer?.backgroundColor = NSColor.clear.cgColor
         CATransaction.commit()
-        nameField.textColor = NSColor.labelColor.withAlphaComponent(0.9)
+        // The title color stays the dynamic label color; only the settled
+        // dim is previewed, so no appearance resolution happens mid-click.
+        nameField.alphaValue = 0.9
     }
 
     /// Inverse of the press treatment: previewing a different row must peel a
@@ -306,6 +316,26 @@ final class SidebarGroupHeaderTableCellView: NSTableCellView {
     func clearOptimisticAnchorActive() {
         guard let model, !model.isAnchorActive else { return }
         applyModel(model)
+    }
+
+    /// Resolves a dynamic color against this cell's own effective appearance.
+    /// Layer colors are CGColors and resolve at conversion time; converting
+    /// under the ambient drawing appearance (which can belong to another
+    /// view mid-click — see the title comment in `applyModel`) snapshots the
+    /// wrong variant.
+    private func resolvedCGColor(_ make: () -> NSColor) -> CGColor {
+        var resolved = CGColor(gray: 0, alpha: 0)
+        effectiveAppearance.performAsCurrentDrawingAppearance {
+            resolved = make().cgColor
+        }
+        return resolved
+    }
+
+    /// Layer colors were resolved through the appearance current at the last
+    /// configure; a theme flip must re-resolve them.
+    override func viewDidChangeEffectiveAppearance() {
+        super.viewDidChangeEffectiveAppearance()
+        if let model { applyModel(model) }
     }
 
     private func headerBackgroundColor(for model: SidebarGroupHeaderRowModel) -> NSColor {

--- a/Sources/Sidebar/AppKitList/Cells/SidebarGroupHeaderRowView.swift
+++ b/Sources/Sidebar/AppKitList/Cells/SidebarGroupHeaderRowView.swift
@@ -180,11 +180,8 @@ final class SidebarGroupHeaderTableCellView: NSTableCellView {
             ofSize: GlobalFontMagnification.scaledSize(metrics.nameFontSize, percent: percent),
             weight: .semibold
         )
-        // Dim via alphaValue, never withAlphaComponent: resolving a dynamic
-        // color at configure time snapshots the ambient drawing appearance,
-        // and the synchronous selection commit can configure this cell inside
-        // the dark terminal's display pass — the title then rendered
-        // white-on-white in a light sidebar and vanished.
+        // Dim via alphaValue, not withAlphaComponent: resolving a dynamic
+        // NSColor mid-click can snapshot the wrong appearance and flash white-on-white.
         nameField.textColor = .labelColor
         nameField.alphaValue = model.isAnchorActive ? 1 : 0.9
 
@@ -318,11 +315,8 @@ final class SidebarGroupHeaderTableCellView: NSTableCellView {
         applyModel(model)
     }
 
-    /// Resolves a dynamic color against this cell's own effective appearance.
-    /// Layer colors are CGColors and resolve at conversion time; converting
-    /// under the ambient drawing appearance (which can belong to another
-    /// view mid-click — see the title comment in `applyModel`) snapshots the
-    /// wrong variant.
+    /// Resolves against this cell's own effective appearance, not whatever
+    /// ambient appearance happens to be current (see `applyModel`).
     private func resolvedCGColor(_ make: () -> NSColor) -> CGColor {
         var resolved = CGColor(gray: 0, alpha: 0)
         effectiveAppearance.performAsCurrentDrawingAppearance {


### PR DESCRIPTION
## Summary

- Fixes #9140: the sidebar workspace group header title text could flip to unreadable white in light mode after clicking/focusing the sidebar.
- Root cause: `SidebarGroupHeaderTableCellView` resolved dynamic `NSColor`s (`.labelColor`, accent, background) to `CGColor` via `.cgColor` at configure time. That conversion snapshots whatever appearance happens to be the *ambient drawing appearance* at that moment (not necessarily the cell's own `effectiveAppearance`) — during a synchronous selection commit the ambient context could belong to the dark terminal view mid-draw, baking a dark-mode white title into a light sidebar.
- Fix, mirroring the existing pattern already used elsewhere in this file:
  - Resolve every dynamic color explicitly via `effectiveAppearance.performAsCurrentDrawingAppearance { ... }` before taking `.cgColor`.
  - For the title/pin dimming, stop calling `withAlphaComponent` on a dynamic color at configure time; use `alphaValue` on the view instead so no appearance resolution happens on the hot click path.
  - Add `viewDidChangeEffectiveAppearance()` override so a live theme flip re-resolves the cached layer colors from the model, instead of only reacting to explicit model diffs.
- This exact fix already existed as an orphaned commit (`a6e1cf9ccb`, "Resolve group header colors against the cell appearance") on an unrelated, unmerged upstream branch (`issue-9199-rename-shortcut-targets-group`) — cherry-picked here cleanly onto `main` and re-verified.

## Testing

- `xcodebuild build -scheme cmux -destination 'platform=macOS'` — succeeds.
- `xcodebuild test -scheme cmux-ci -only-testing:cmuxTests/SidebarAppKitRowCellTests` — passes except one pre-existing, unrelated flaky failure (`shortcutHintPillUsesExplicitOpacityAnimationInsideDisabledTransaction`, an animation-timing assertion in a different test, reproduces identically on `main` without this change).

## Demo Video

Not included — this is a targeted appearance-resolution fix in a single file with no visual/behavioral change outside of the color bug itself.

## Review Trigger (Copy/Paste as PR comment)

```text
@codex review
@coderabbitai review
@greptile-apps review
@cubic-dev-ai review
```

## Checklist

- [x] I tested the change locally
- [x] I added or updated tests for behavior changes (existing cell tests re-verified; no new observable behavior to add tests for)
- [ ] I updated docs/changelog if needed
- [ ] I requested bot reviews after my latest commit (copy/paste block above or equivalent)
- [ ] All code review bot comments are resolved
- [ ] All human review comments are resolved

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/9465"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788375469&installation_model_id=21920&pr_number=9465&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F9465&signature=d1fb58285e664acc5ea41e94305322a7067861a6220b9ac6213a4d06d356b407"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #9140: prevents the sidebar group header title from flashing white in light mode when the sidebar is clicked. Colors now resolve against the cell’s own appearance so text stays readable.

- **Bug Fixes**
  - Resolve dynamic colors under the cell’s `effectiveAppearance` via a `resolvedCGColor` helper (background and drop indicators); re-resolve on theme changes in `viewDidChangeEffectiveAppearance()`.
  - Use view `alphaValue` (not `withAlphaComponent`) for the title and pin tint to avoid appearance snapshots during clicks.
  - Trimmed in-file comments for clarity; no behavior change.

<sup>Written for commit 675221e916cf8ec7526fc2187be604b0449a6ee9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/9465?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

