### PR TITLE
Keep Mobile Connect available in the command palette

### DIFF
--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -110354,13 +110354,13 @@
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "Shows Mobile Connect entrypoints that open the iPhone pairing workspace."
+            "value": "Shows the Mobile Connect button in the sidebar footer."
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "iPhoneペアリングワークスペースを開くMobile Connectの入口を表示します。"
+            "value": "サイドバーのフッターにMobile Connectボタンを表示します。"
           }
         }
       }

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -7258,16 +7258,14 @@ struct ContentView: View {
                 keywords: ["open", "ghostty", "settings", "config", "configuration", "file", "textedit", "terminal"]
             )
         )
-        if CmuxFeatureFlags.shared.isMobileConnectButtonEnabled {
-            contributions.append(
-                CommandPaletteCommandContribution(
-                    commandId: "palette.mobileConnect",
-                    title: constant(String(localized: "command.mobileConnect.title", defaultValue: "Connect iPhone/iPad")),
-                    subtitle: constant(String(localized: "command.mobileConnect.subtitle", defaultValue: "Mobile")),
-                    keywords: Self.commandPaletteMobileConnectKeywords
-                )
+        contributions.append(
+            CommandPaletteCommandContribution(
+                commandId: "palette.mobileConnect",
+                title: constant(String(localized: "command.mobileConnect.title", defaultValue: "Connect iPhone/iPad")),
+                subtitle: constant(String(localized: "command.mobileConnect.subtitle", defaultValue: "Mobile")),
+                keywords: Self.commandPaletteMobileConnectKeywords
             )
-        }
+        )
         contributions.append(contentsOf: Self.commandPaletteAuthCommandContributions() + Self.commandPaletteProCommandContributions())
         contributions.append(
             CommandPaletteCommandContribution(
@@ -8402,6 +8400,7 @@ struct ContentView: View {
             _ = AppDelegate.shared?.performMobileConnectWorkspaceAction(
                 tabManager: tabManager,
                 preferredWindow: observedWindow,
+                enforceFeatureFlag: false,
                 debugSource: "palette.mobileConnect"
             )
         }

--- a/Sources/FeatureFlags.swift
+++ b/Sources/FeatureFlags.swift
@@ -139,7 +139,7 @@ final class CmuxFeatureFlags {
                 title: String(localized: "featureFlags.mobileConnect.title", defaultValue: "Mobile Connect button"),
                 flagDescription: String(
                     localized: "featureFlags.mobileConnect.description",
-                    defaultValue: "Shows Mobile Connect entrypoints that open the iPhone pairing workspace."
+                    defaultValue: "Shows the Mobile Connect button in the sidebar footer."
                 ),
                 defaultWhenUnavailable: CmuxFeatureFlags.mobileConnectButtonDefault
             ),

--- a/cmuxUITests/CommandPaletteIdentifierClipboardUITests.swift
+++ b/cmuxUITests/CommandPaletteIdentifierClipboardUITests.swift
@@ -110,6 +110,109 @@ final class CommandPaletteIdentifierClipboardUITests: XCTestCase {
         XCTAssertEqual(openedPath, expectedPath)
     }
 
+    func testConnectIPhoneCommandRemainsAvailableWhenMobileButtonFlagIsOff() throws {
+        let usageHistoryKey = "commandPalette.commandUsage.v1"
+        let usageDefaults = try XCTUnwrap(UserDefaults(suiteName: debugDefaultsDomain))
+        let previousUsageHistory = usageDefaults.object(forKey: usageHistoryKey)
+        let seededUsageHistory = try JSONSerialization.data(withJSONObject: [
+            "palette.mobileConnect": [
+                "useCount": 100,
+                "lastUsedAt": Date().timeIntervalSince1970,
+            ],
+        ])
+        usageDefaults.set(seededUsageHistory, forKey: usageHistoryKey)
+        usageDefaults.synchronize()
+        addTeardownBlock {
+            if let previousUsageHistory {
+                usageDefaults.set(previousUsageHistory, forKey: usageHistoryKey)
+            } else {
+                usageDefaults.removeObject(forKey: usageHistoryKey)
+            }
+            usageDefaults.synchronize()
+        }
+
+        let token = String(UUID().uuidString.prefix(8)).lowercased()
+        let temporaryDirectory = FileManager.default.temporaryDirectory
+        let socketPath = temporaryDirectory
+            .appendingPathComponent("cmux-mcp-\(token).sock")
+            .path
+        let logPath = temporaryDirectory
+            .appendingPathComponent("cmux-mcp-\(token).log")
+            .path
+        try? FileManager.default.removeItem(atPath: socketPath)
+        try? FileManager.default.removeItem(atPath: logPath)
+
+        let process = try launchSocketDrivenCommandPaletteApp(
+            socketPath: socketPath,
+            logPath: logPath
+        )
+        addTeardownBlock {
+            self.terminateAppProcess(process)
+            try? FileManager.default.removeItem(atPath: socketPath)
+            try? FileManager.default.removeItem(atPath: logPath)
+        }
+        let socket = ControlSocketClient(path: socketPath, responseTimeout: 2.0)
+
+        let socketReady = pollUntil(timeout: 15.0) {
+            socket.sendLine("ping") == "PONG"
+        }
+        XCTAssertTrue(
+            socketReady,
+            "Expected control socket at \(socketPath). app=\(appProcessDiagnostics(process)) log=\(tailOfFile(at: logPath))"
+        )
+        guard socketReady else { return }
+
+        var windowId: String?
+        XCTAssertTrue(
+            pollUntil(timeout: 8.0) {
+                guard let response = socket.sendLine("current_window"),
+                      UUID(uuidString: response) != nil else { return false }
+                windowId = response
+                return true
+            },
+            "Expected the socket to resolve a main window. log=\(tailOfFile(at: logPath))"
+        )
+        let resolvedWindowId = try XCTUnwrap(windowId)
+
+        let toggleResponse = try XCTUnwrap(
+            socket.sendJSON([
+                "id": UUID().uuidString,
+                "method": "debug.command_palette.toggle",
+                "params": ["window_id": resolvedWindowId],
+            ])
+        )
+        XCTAssertEqual(toggleResponse["ok"] as? Bool, true, "toggle failed: \(toggleResponse)")
+
+        XCTAssertTrue(
+            pollUntil(timeout: 5.0) {
+                guard let result = self.commandPaletteSnapshot(
+                    socket: socket,
+                    windowId: resolvedWindowId
+                ) else { return false }
+                return result["visible"] as? Bool == true
+            },
+            "Expected the command palette to become visible"
+        )
+
+        var matchingSnapshot: [String: Any]?
+        XCTAssertTrue(
+            pollUntil(timeout: 5.0) {
+                guard let result = self.commandPaletteSnapshot(
+                    socket: socket,
+                    windowId: resolvedWindowId
+                ) else { return false }
+                matchingSnapshot = result
+                guard result["query"] as? String == "",
+                let rows = result["results"] as? [[String: Any]],
+                rows.first?["command_id"] as? String == "palette.mobileConnect" else {
+                    return false
+                }
+                return true
+            },
+            "Expected Connect iPhone/iPad in the unfiltered palette while its sidebar flag is off. snapshot=\(matchingSnapshot ?? [:])"
+        )
+    }
+
     private func loginHomeDirectoryPath() -> String {
         if let passwd = getpwuid(getuid()), let home = passwd.pointee.pw_dir {
             return String(cString: home)
@@ -158,6 +261,227 @@ final class CommandPaletteIdentifierClipboardUITests: XCTestCase {
             )
         } catch {
             XCTFail("Failed to reset menuBarOnly default: \(error.localizedDescription)")
+        }
+    }
+
+    private func launchSocketDrivenCommandPaletteApp(
+        socketPath: String,
+        logPath: String
+    ) throws -> Process {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: try resolveAppBinaryPath())
+        process.arguments = [
+            "-AppleLanguages", "(en)",
+            "-AppleLocale", "en_US",
+            "-menuBarOnly", "<false/>",
+            "-socketControlMode", "allowAll",
+            "-cmux.flags.override.mobile-connect-button-enabled-release", "<false/>",
+        ]
+
+        var environment = ProcessInfo.processInfo.environment
+        environment["CMUX_UI_TEST_MODE"] = "1"
+        environment["CMUX_SOCKET_ENABLE"] = "1"
+        environment["CMUX_SOCKET_MODE"] = "allowAll"
+        environment["CMUX_SOCKET_PATH"] = socketPath
+        environment["CMUX_ALLOW_SOCKET_OVERRIDE"] = "1"
+        environment["CMUX_UI_TEST_SOCKET_SANITY"] = "1"
+        environment.removeValue(forKey: "CMUX_TAG")
+        process.environment = environment
+
+        _ = FileManager.default.createFile(atPath: logPath, contents: nil)
+        let logHandle = try FileHandle(forWritingTo: URL(fileURLWithPath: logPath))
+        process.standardOutput = logHandle
+        process.standardError = logHandle
+        try process.run()
+        return process
+    }
+
+    private func resolveAppBinaryPath() throws -> String {
+        let testBundle = Bundle(for: Self.self)
+        let productsDirectory = testBundle.bundleURL
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+        let configuration = productsDirectory.lastPathComponent.lowercased()
+        let productNames = configuration.contains("release")
+            ? ["cmux", "cmux DEV"]
+            : ["cmux DEV", "cmux"]
+        let binaryPaths = productNames.map { productName in
+            productsDirectory
+                .appendingPathComponent("\(productName).app")
+                .appendingPathComponent("Contents/MacOS/\(productName)")
+                .path
+        }
+        if let binaryPath = binaryPaths.first(where: FileManager.default.isExecutableFile(atPath:)) {
+            return binaryPath
+        }
+        throw NSError(
+            domain: "CommandPaletteIdentifierClipboardUITests",
+            code: 1,
+            userInfo: [
+                NSLocalizedDescriptionKey: "App binary not found at \(binaryPaths.joined(separator: " or ")). testBundle=\(testBundle.bundleURL.path)"
+            ]
+        )
+    }
+
+    private func terminateAppProcess(_ process: Process) {
+        guard process.isRunning else { return }
+        process.terminate()
+        _ = pollUntil(timeout: 5.0, pollInterval: 0.1) { !process.isRunning }
+        guard process.isRunning else { return }
+        _ = Darwin.kill(process.processIdentifier, SIGKILL)
+        _ = pollUntil(timeout: 2.0, pollInterval: 0.1) { !process.isRunning }
+    }
+
+    private func appProcessDiagnostics(_ process: Process) -> String {
+        let status = process.isRunning ? "running" : String(process.terminationStatus)
+        return "pid=\(process.processIdentifier) running=\(process.isRunning) status=\(status)"
+    }
+
+    private func tailOfFile(at path: String, maximumLength: Int = 2_000) -> String {
+        guard let contents = try? String(contentsOfFile: path, encoding: .utf8) else {
+            return "<missing>"
+        }
+        return String(contents.suffix(maximumLength))
+    }
+
+    private func commandPaletteSnapshot(
+        socket: ControlSocketClient,
+        windowId: String
+    ) -> [String: Any]? {
+        guard let envelope = socket.sendJSON([
+            "id": UUID().uuidString,
+            "method": "debug.command_palette.results",
+            "params": [
+                "window_id": windowId,
+                "limit": 20,
+            ],
+        ]),
+        envelope["ok"] as? Bool == true else {
+            return nil
+        }
+        return envelope["result"] as? [String: Any]
+    }
+
+    private final class ControlSocketClient {
+        private let path: String
+        private let responseTimeout: TimeInterval
+
+        init(path: String, responseTimeout: TimeInterval) {
+            self.path = path
+            self.responseTimeout = responseTimeout
+        }
+
+        func sendJSON(_ object: [String: Any]) -> [String: Any]? {
+            guard JSONSerialization.isValidJSONObject(object),
+                  let data = try? JSONSerialization.data(withJSONObject: object),
+                  let line = String(data: data, encoding: .utf8),
+                  let response = sendLine(line),
+                  let responseData = response.data(using: .utf8) else {
+                return nil
+            }
+            return (try? JSONSerialization.jsonObject(with: responseData)) as? [String: Any]
+        }
+
+        func sendLine(_ line: String) -> String? {
+            let fileDescriptor = socket(AF_UNIX, SOCK_STREAM, 0)
+            guard fileDescriptor >= 0 else { return nil }
+            defer { close(fileDescriptor) }
+
+            var timeout = timeval(
+                tv_sec: Int(responseTimeout),
+                tv_usec: Int32((responseTimeout - floor(responseTimeout)) * 1_000_000)
+            )
+            withUnsafePointer(to: &timeout) { pointer in
+                _ = setsockopt(
+                    fileDescriptor,
+                    SOL_SOCKET,
+                    SO_RCVTIMEO,
+                    pointer,
+                    socklen_t(MemoryLayout<timeval>.size)
+                )
+                _ = setsockopt(
+                    fileDescriptor,
+                    SOL_SOCKET,
+                    SO_SNDTIMEO,
+                    pointer,
+                    socklen_t(MemoryLayout<timeval>.size)
+                )
+            }
+
+            var address = sockaddr_un()
+            memset(&address, 0, MemoryLayout<sockaddr_un>.size)
+            address.sun_family = sa_family_t(AF_UNIX)
+
+            let pathBytes = Array(path.utf8CString)
+            let maximumPathLength = MemoryLayout.size(ofValue: address.sun_path)
+            guard pathBytes.count <= maximumPathLength else { return nil }
+            withUnsafeMutablePointer(to: &address.sun_path) { pointer in
+                let raw = UnsafeMutableRawPointer(pointer).assumingMemoryBound(to: CChar.self)
+                for index in 0..<pathBytes.count {
+                    raw[index] = pathBytes[index]
+                }
+            }
+
+            guard let pathOffset = MemoryLayout<sockaddr_un>.offset(of: \.sun_path) else {
+                return nil
+            }
+            let addressLength = socklen_t(pathOffset + pathBytes.count)
+            let connected = withUnsafePointer(to: &address) { pointer in
+                pointer.withMemoryRebound(to: sockaddr.self, capacity: 1) { sockaddrPointer in
+                    Darwin.connect(fileDescriptor, sockaddrPointer, addressLength)
+                }
+            }
+            guard connected == 0 else { return nil }
+
+            let payload = Array((line + "\n").utf8)
+            let wrotePayload = payload.withUnsafeBytes { rawBuffer in
+                guard let baseAddress = rawBuffer.baseAddress else { return true }
+                var offset = 0
+                while offset < rawBuffer.count {
+                    let written = Darwin.write(
+                        fileDescriptor,
+                        baseAddress.advanced(by: offset),
+                        rawBuffer.count - offset
+                    )
+                    if written < 0 {
+                        if errno == EINTR {
+                            continue
+                        }
+                        return false
+                    }
+                    if written == 0 {
+                        return false
+                    }
+                    offset += written
+                }
+                return true
+            }
+            guard wrotePayload else { return nil }
+
+            var buffer = [UInt8](repeating: 0, count: 4_096)
+            var accumulator: [UInt8] = []
+            let deadline = Date().addingTimeInterval(responseTimeout)
+            while Date() < deadline {
+                let count = Darwin.read(fileDescriptor, &buffer, buffer.count)
+                if count < 0 {
+                    if errno == EINTR || errno == EAGAIN || errno == EWOULDBLOCK {
+                        continue
+                    }
+                    break
+                }
+                if count == 0 {
+                    break
+                }
+                accumulator.append(contentsOf: buffer[0..<count])
+                if let newline = accumulator.firstIndex(of: 0x0A) {
+                    return String(decoding: accumulator[..<newline], as: UTF8.self)
+                }
+            }
+            let trimmed = String(decoding: accumulator, as: UTF8.self)
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+            return trimmed.isEmpty ? nil : trimmed
         }
     }
 


### PR DESCRIPTION
## Summary

- keep Connect iPhone/iPad in the command palette when the sidebar button flag is off
- invoke the existing shared Mobile Connect action with an explicit palette exemption
- clarify that the feature flag controls only the sidebar footer button
- add a UI regression test for command availability with the flag off

## Cause

https://github.com/manaflow-ai/cmux/pull/8354 wrapped the command-palette contribution in the sidebar button flag and left the registered action flag-gated. This accidentally broadened a button-only flag after https://github.com/manaflow-ai/cmux/pull/8821 made that flag off by default.

## Verification

- expected-red test-only run: https://github.com/manaflow-ai/cmux/actions/runs/30857090549
- fixed-head run: https://github.com/manaflow-ai/cmux/actions/runs/30857092654
- tagged cloud build: https://github.com/manaflow-ai/cmux/actions/runs/30852926855
- live palfix preflight: sidebar button hidden, palette command visible and searchable, command opened a mobilePairing surface
- python3 scripts/lint-feature-flags.py
- xcrun swiftc -parse cmuxUITests/CommandPaletteIdentifierClipboardUITests.swift Sources/ContentView.swift Sources/FeatureFlags.swift
- jq empty Resources/Localizable.xcstrings
