### PR TITLE
Emit a cancelled outcome for abandoned transport dials

### DIFF
--- a/Packages/Shared/CMUXMobileCore/Sources/CMUXMobileCore/DiagnosticReport.swift
+++ b/Packages/Shared/CMUXMobileCore/Sources/CMUXMobileCore/DiagnosticReport.swift
@@ -128,9 +128,16 @@ public struct DiagnosticReport: Sendable, Codable, Equatable {
     }
 
     /// The latest event that marks a failed connection/lifecycle milestone.
+    ///
+    /// A ``DiagnosticFailureKind/cancelled`` outcome records that an in-flight
+    /// attempt was abandoned by recovery supersession or a caller timeout. It
+    /// completes the started/outcome pairing an export needs, but it is
+    /// lifecycle churn rather than something that failed, so it never becomes
+    /// the reported last failure.
     public var lastFailureEvent: DiagnosticEvent? {
         events.last(where: { event in
-            event.code.isDiagnosticFailure
+            guard event.diagnosticFailureKind != .cancelled else { return false }
+            return event.code.isDiagnosticFailure
                 || event.diagnosticFailureKind.map { $0 != .none } == true
         })
     }

--- a/Packages/Shared/CMUXMobileCore/Tests/CMUXMobileCoreTests/DiagnosticLogTests.swift
+++ b/Packages/Shared/CMUXMobileCore/Tests/CMUXMobileCoreTests/DiagnosticLogTests.swift
@@ -463,6 +463,43 @@ import os
         #expect(report.lastFailureEvent == gatedRefusal)
     }
 
+    @Test func cancelledDialOutcomesAreNotTreatedAsFailures() {
+        // Abandoned dials now emit a `cancelled` outcome so every
+        // `transportDialStarted` has exactly one outcome event. Report readers
+        // must not mistake that lifecycle churn for a real failure.
+        let realFailure = DiagnosticEvent(
+            code: .transportDialFailed,
+            tNanos: 2,
+            a: DiagnosticTransportKind.iroh.rawValue,
+            b: DiagnosticFailureKind.timedOut.rawValue,
+            c: 7
+        )
+        let cancelled = DiagnosticEvent(
+            code: .transportDialFailed,
+            tNanos: 3,
+            ms: 12_000,
+            a: DiagnosticTransportKind.iroh.rawValue,
+            b: DiagnosticFailureKind.cancelled.rawValue,
+            c: 8
+        )
+        let mixed = DiagnosticReport(
+            anchorWallNanos: 1_000_000_000,
+            anchorMonotonicNanos: 1,
+            events: [realFailure, cancelled]
+        )
+        #expect(mixed.lastFailureEvent == realFailure)
+        #expect(mixed.lastFailureKind == .timedOut)
+
+        let cancelledOnly = DiagnosticReport(
+            anchorWallNanos: 1_000_000_000,
+            anchorMonotonicNanos: 1,
+            events: [cancelled]
+        )
+        #expect(cancelledOnly.lastFailureEvent == nil)
+        #expect(cancelledOnly.lastFailureKind == nil)
+        #expect(cancelledOnly.lastFailureDate == nil)
+    }
+
     @Test func clearStartsFreshBoundedSessionAndResetsAnchors() async {
         let log = DiagnosticLog(
             capacity: 2,

--- a/Packages/iOS/CmuxMobileRPC/Sources/CmuxMobileRPC/MobileCoreRPCSession.swift
+++ b/Packages/iOS/CmuxMobileRPC/Sources/CmuxMobileRPC/MobileCoreRPCSession.swift
@@ -502,6 +502,26 @@ actor MobileCoreRPCSession {
             let diagnosticTransport = diagnosticTransport
             let transportConnectObserver = transportConnectObserver
             let initialSessionPurpose = transportSessionPurpose
+            // Every `transportDialStarted` must get exactly one outcome, so a
+            // diagnostic export can say what happened to a dial instead of
+            // ending the timeline at the attempt. Abandoned dials report
+            // `cancelled`, which report readers treat as lifecycle churn rather
+            // than a failure.
+            let emitDialOutcome: @Sendable (DiagnosticFailureKind) -> Void = {
+                failure in
+                guard let diagnosticTransport, let transportConnectObserver
+                else { return }
+                transportConnectObserver(
+                    .failed(
+                        attemptID: connectAttemptID,
+                        transport: diagnosticTransport,
+                        failure: failure,
+                        elapsedMilliseconds: Self.elapsedMilliseconds(
+                            since: connectStartedAt
+                        )
+                    )
+                )
+            }
             if let diagnosticTransport, let transportConnectObserver {
                 transportConnectObserver(
                     .attempt(
@@ -520,40 +540,19 @@ actor MobileCoreRPCSession {
                     await rejected.task.value
                 }
                 if Task.isCancelled {
+                    emitDialOutcome(.cancelled)
                     throw CancellationError()
                 }
                 let error = MobileShellConnectionError.connectionClosed
-                if let diagnosticTransport,
-                   let transportConnectObserver {
-                    transportConnectObserver(
-                        .failed(
-                            attemptID: connectAttemptID,
-                            transport: diagnosticTransport,
-                            failure: DiagnosticFailureKind.classify(error),
-                            elapsedMilliseconds: Self.elapsedMilliseconds(
-                                since: connectStartedAt
-                            )
-                        )
-                    )
-                }
+                emitDialOutcome(DiagnosticFailureKind.classify(error))
                 throw error
             } catch {
                 await connectAttemptRegistry.finishConnect(lease: connectLease)
                 if error is CancellationError || Task.isCancelled {
+                    emitDialOutcome(.cancelled)
                     throw CancellationError()
                 }
-                if let diagnosticTransport, let transportConnectObserver {
-                    transportConnectObserver(
-                        .failed(
-                            attemptID: connectAttemptID,
-                            transport: diagnosticTransport,
-                            failure: DiagnosticFailureKind.classify(error),
-                            elapsedMilliseconds: Self.elapsedMilliseconds(
-                                since: connectStartedAt
-                            )
-                        )
-                    )
-                }
+                emitDialOutcome(DiagnosticFailureKind.classify(error))
                 throw error
             }
             connectionID = UUID()
@@ -583,11 +582,12 @@ actor MobileCoreRPCSession {
                     // A cancellation-ignoring transport must still return its
                     // late candidate to the existing abandoned-connect cleanup
                     // path so that path can close it again after completion.
-                    // Suppress the success event without replacing that result
-                    // with `CancellationError`.
-                    if !Task.isCancelled,
-                       let diagnosticTransport,
-                       let transportConnectObserver {
+                    // Report the abandonment instead of the success without
+                    // replacing that result with `CancellationError`.
+                    if Task.isCancelled {
+                        emitDialOutcome(.cancelled)
+                    } else if let diagnosticTransport,
+                              let transportConnectObserver {
                         transportConnectObserver(
                             .connected(
                                 attemptID: connectAttemptID,
@@ -605,29 +605,21 @@ actor MobileCoreRPCSession {
                     } else {
                         await cancellationClose.finishWithoutClose()
                     }
+                    emitDialOutcome(.cancelled)
                     throw CancellationError()
                 } catch {
                     // Some transports surface their close error instead of
                     // `CancellationError` after the cancellation handler closes
                     // them. Treat the task's cancellation bit as authoritative
-                    // so an abandoned dial never becomes a false failure event.
+                    // so an abandoned dial is reported as `cancelled` rather
+                    // than as a false failure of whatever the close raised.
                     if Task.isCancelled {
                         _ = await cancellationClose.task()
+                        emitDialOutcome(.cancelled)
                         throw CancellationError()
                     }
                     await cancellationClose.finishWithoutClose()
-                    if let diagnosticTransport, let transportConnectObserver {
-                        transportConnectObserver(
-                            .failed(
-                                attemptID: connectAttemptID,
-                                transport: diagnosticTransport,
-                                failure: DiagnosticFailureKind.classify(error),
-                                elapsedMilliseconds: Self.elapsedMilliseconds(
-                                    since: connectStartedAt
-                                )
-                            )
-                        )
-                    }
+                    emitDialOutcome(DiagnosticFailureKind.classify(error))
                     throw error
                 }
             }

--- a/Packages/iOS/CmuxMobileRPC/Tests/CmuxMobileRPCTests/MobileRPCTransportConnectEventTests.swift
+++ b/Packages/iOS/CmuxMobileRPC/Tests/CmuxMobileRPCTests/MobileRPCTransportConnectEventTests.swift
@@ -52,7 +52,74 @@ import Testing
         #expect(failure == .unsupportedRoute)
     }
 
-    @Test func callerCancellationSuppressesCloseInducedFailureAndRetryConnects() async throws {
+    @Test func cancelledHungDialEmitsCancelledOutcomeWithElapsedTime() async throws {
+        let transport = FirstConnectHangsThenSucceedsTransport()
+        let (events, continuation) = AsyncStream<MobileRPCTransportConnectEvent>.makeStream()
+        let session = MobileCoreRPCSession(
+            makeTransport: { transport },
+            diagnosticTransport: .iroh,
+            transportConnectObserver: { event in
+                _ = continuation.yield(event)
+            }
+        )
+        let request = try MobileCoreRPCClient.requestData(
+            method: "mobile.host.status",
+            id: "hung-dial"
+        )
+        let pending = Task {
+            try await session.send(
+                payload: request,
+                requestID: "hung-dial",
+                deadlineUptimeNanoseconds: DispatchTime.now().uptimeNanoseconds
+                    + 60 * 1_000_000_000
+            )
+        }
+
+        while await transport.connectCount() < 1 {
+            await Task.yield()
+        }
+        pending.cancel()
+        do {
+            _ = try await pending.value
+            Issue.record("Expected the hung dial to throw CancellationError")
+        } catch is CancellationError {
+        } catch {
+            Issue.record("Expected CancellationError, got \(error)")
+        }
+        #expect(await transport.waitUntilFirstAttemptClosed())
+
+        let recorded = await collect(events, atLeast: 2)
+        continuation.finish()
+        #expect(recorded.count == 2)
+        guard recorded.count == 2 else {
+            await session.tearDown(error: .connectionClosed)
+            return
+        }
+        guard case let .attempt(attemptID, attemptTransport) = recorded[0] else {
+            Issue.record("Expected attempt event first, got \(recorded[0])")
+            await session.tearDown(error: .connectionClosed)
+            return
+        }
+        guard case let .failed(
+            failedID,
+            failedTransport,
+            failure,
+            elapsedMilliseconds
+        ) = recorded[1] else {
+            Issue.record("Expected a cancelled outcome event, got \(recorded[1])")
+            await session.tearDown(error: .connectionClosed)
+            return
+        }
+        #expect(failedID == attemptID)
+        #expect(attemptTransport == .iroh)
+        #expect(failedTransport == .iroh)
+        #expect(failure == .cancelled)
+        #expect(elapsedMilliseconds >= 0)
+        #expect(Self.outcomeCountsPerAttempt(recorded) == [attemptID: 1])
+        await session.tearDown(error: .connectionClosed)
+    }
+
+    @Test func callerCancellationReportsCancelledOutcomeAndRetryConnects() async throws {
         let transport = FirstConnectClosedErrorThenSucceedsTransport()
         let (events, continuation) = AsyncStream<MobileRPCTransportConnectEvent>.makeStream()
         let session = MobileCoreRPCSession(
@@ -100,17 +167,40 @@ import Testing
         #expect(await transport.connectCount() == 2)
         #expect(try await transport.sentRequests().map(\.id) == ["retry-after-closed-connect"])
 
+        let recorded = await collect(events, atLeast: 4)
         continuation.finish()
-        let recorded = await collect(events)
-        #expect(recorded.count == 3)
-        guard recorded.count == 3 else {
+        #expect(recorded.count == 4)
+        guard recorded.count == 4 else {
             await session.tearDown(error: .connectionClosed)
             return
         }
-        guard case let .attempt(firstAttemptID, firstTransport) = recorded[0],
-              case let .attempt(secondAttemptID, secondTransport) = recorded[1],
-              case let .connected(connectedID, connectedTransport, _) = recorded[2] else {
-            Issue.record("Expected attempt, attempt, connected with no failure")
+        guard case let .attempt(firstAttemptID, firstTransport) = recorded[0] else {
+            Issue.record("Expected an attempt event first, got \(recorded[0])")
+            await session.tearDown(error: .connectionClosed)
+            return
+        }
+        // The transport surfaces its close error instead of `CancellationError`
+        // after the cancellation handler closes it. That is an abandoned dial,
+        // not a real failure, so it is classified `cancelled`.
+        guard let cancelled = recorded.dropFirst().first(where: {
+            if case .failed = $0 { return true }
+            return false
+        }), case let .failed(cancelledID, _, failure, _) = cancelled else {
+            Issue.record("Expected a cancelled outcome for the abandoned dial")
+            await session.tearDown(error: .connectionClosed)
+            return
+        }
+        #expect(cancelledID == firstAttemptID)
+        #expect(failure == .cancelled)
+        guard let secondAttempt = recorded.first(where: {
+            if case let .attempt(id, _) = $0 { return id != firstAttemptID }
+            return false
+        }), case let .attempt(secondAttemptID, secondTransport) = secondAttempt,
+            let connected = recorded.first(where: {
+                if case .connected = $0 { return true }
+                return false
+            }), case let .connected(connectedID, connectedTransport, _) = connected else {
+            Issue.record("Expected a second attempt that connected")
             await session.tearDown(error: .connectionClosed)
             return
         }
@@ -120,6 +210,11 @@ import Testing
         #expect(secondTransport == .debugLoopback)
         #expect(connectedID == secondAttemptID)
         #expect(connectedTransport == .debugLoopback)
+        // Every started dial has exactly one outcome event.
+        #expect(Self.outcomeCountsPerAttempt(recorded) == [
+            firstAttemptID: 1,
+            secondAttemptID: 1,
+        ])
         await session.tearDown(error: .connectionClosed)
     }
 
@@ -157,5 +252,62 @@ import Testing
             events.append(event)
         }
         return events
+    }
+
+    /// Drain `count` events, or everything that arrived within a bounded wait.
+    /// Outcome events are emitted by the detached dial task, so a caller that
+    /// already threw may observe them slightly later.
+    private func collect(
+        _ stream: AsyncStream<MobileRPCTransportConnectEvent>,
+        atLeast count: Int
+    ) async -> [MobileRPCTransportConnectEvent] {
+        let collected = Collected()
+        return await withTaskGroup(
+            of: Void.self,
+            returning: [MobileRPCTransportConnectEvent].self
+        ) { group in
+            group.addTask {
+                var iterator = stream.makeAsyncIterator()
+                while await collected.count() < count,
+                      let event = await iterator.next() {
+                    await collected.append(event)
+                }
+            }
+            group.addTask {
+                try? await Task.sleep(nanoseconds: 5 * 1_000_000_000)
+            }
+            await group.next()
+            group.cancelAll()
+            return await collected.events()
+        }
+    }
+
+    private actor Collected {
+        private var stored: [MobileRPCTransportConnectEvent] = []
+
+        func append(_ event: MobileRPCTransportConnectEvent) {
+            stored.append(event)
+        }
+
+        func count() -> Int { stored.count }
+        func events() -> [MobileRPCTransportConnectEvent] { stored }
+    }
+
+    /// Number of terminal outcome events per attempt ID. Exactly one outcome
+    /// per started dial is the invariant a diagnostic export depends on.
+    private static func outcomeCountsPerAttempt(
+        _ events: [MobileRPCTransportConnectEvent]
+    ) -> [Int: Int] {
+        var counts: [Int: Int] = [:]
+        for event in events {
+            switch event {
+            case .attempt:
+                continue
+            case let .connected(attemptID, _, _),
+                 let .failed(attemptID, _, _, _):
+                counts[attemptID, default: 0] += 1
+            }
+        }
+        return counts
     }
 }


### PR DESCRIPTION
Fixes #9167

A cmuxdiag export from a reconnect outage contained `transportDialStarted` events with no outcome after them. Those were hung dials cancelled by recovery supersession or a caller timeout, and `MobileCoreRPCSession.ensureConnected` deliberately suppressed the outcome event so an abandoned dial would not become a false failure. The result was an export that could not say what happened to the most important dials in the incident.

Mechanism: every cancellation path in the dial (transport construction cancelled, rejected-disposal cancelled, connect throwing `CancellationError`, connect surfacing its close error while the task's cancellation bit is set, and a late success on an already-cancelled task) now emits `transportDialFailed` with `DiagnosticFailureKind.cancelled` and elapsed ms through one shared `emitDialOutcome` closure, so each attempt ID has exactly one outcome. The original false-failure concern stays handled on the reader side: `DiagnosticReport.lastFailureEvent` skips `cancelled` outcomes, so `lastFailureEvent`, `lastFailureKind`, and `lastFailureDate` never report lifecycle churn as a failure. `TransportIncidentPolicy` already suppressed `cancelled`, so telemetry volume is unchanged.

## Testing

Regression tests, added in commit 1 so CI goes red before the fix in commit 2:

- `MobileRPCTransportConnectEventTests.cancelledHungDialEmitsCancelledOutcomeWithElapsedTime` cancels a hung dial and asserts an attempt plus one `cancelled` outcome with elapsed ms and a matching attempt ID.
- `MobileRPCTransportConnectEventTests.callerCancellationReportsCancelledOutcomeAndRetryConnects` (was `callerCancellationSuppressesCloseInducedFailureAndRetryConnects`) now asserts the abandoned dial reports `cancelled` and that every started dial has exactly one outcome.
- `DiagnosticLogTests.cancelledDialOutcomesAreNotTreatedAsFailures` asserts a `cancelled` outcome is excluded from `lastFailureEvent`/`lastFailureKind`/`lastFailureDate`.

Commands:

- `swift test --filter MobileRPCTransportConnectEventTests` in `Packages/iOS/CmuxMobileRPC`: both new/updated tests fail before the fix (`recorded.count -> 1) == 2`, `(recorded.count -> 3) == 4`) and pass after.
- `swift test` in `Packages/Shared/CMUXMobileCore`: 347 tests pass (the new report test fails with 5 issues before the fix).
- `swift build --build-tests` in `Packages/iOS/CmuxMobileShell` succeeds.

Dev build: `scripts/reload-cloud.sh --tag sym9167` compiled the full macOS app on the fleet builder, but the local install could not complete because this Mac's data volume is full (~260 MB free, occupied by other agents' DerivedData), so the tagged app was not launched. The changed dial path is iOS-only (`CmuxMobileRPC`) and is not reachable from the macOS app; the shared change is the `DiagnosticReport` reader, covered by the unit test above.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/9469"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788383346&installation_model_id=21920&pr_number=9469&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F9469&signature=c579c712b0620b402e3cda5a38ad668f7df608eeb096fd23fe5dfe65021595c1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Emit a `cancelled` outcome for abandoned transport dials so every `transportDialStarted` has exactly one outcome and diagnostics are complete without false failures. Report readers ignore these as failures to keep signal clean.

- **Bug Fixes**
  - In `CmuxMobileRPC` (`MobileCoreRPCSession`), all dial cancellation paths now emit `transportDialFailed` with `DiagnosticFailureKind.cancelled` and elapsed ms via a shared `emitDialOutcome`.
  - In `CMUXMobileCore` (`DiagnosticReport.lastFailureEvent`), `cancelled` outcomes are skipped so churn doesn’t read as a failure.
  - Added tests to ensure one terminal outcome per attempt and that `cancelled` outcomes aren’t treated as failures.

<sup>Written for commit 5c7392a39cdf283f6f020988fbaf6911b8e47609. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/9469?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Cancelled connection attempts are no longer reported as genuine diagnostic failures.
  * Connection diagnostics now consistently distinguish cancelled attempts from timeouts and other failures.
  * Retry scenarios accurately record one outcome per connection attempt, including cancellations before successful reconnection.

* **Tests**
  * Added coverage for cancellation during stalled connection attempts and subsequent retries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->