### PR TITLE
Fix Package.resolved policy false positive on leaf local-path packages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -258,7 +258,9 @@ jobs:
         run: python3 scripts/check-workspace-package-groups.py --check
 
       - name: Validate SwiftPM lockfile policy
-        run: python3 scripts/check-package-resolved-policy.py
+        run: |
+          python3 tests/test_check_package_resolved_policy.py
+          python3 scripts/check-package-resolved-policy.py
 
       - name: Validate bash shell integration job control
         run: python3 tests/test_bash_integration_no_done_notifications.py

--- a/scripts/check-package-resolved-policy.py
+++ b/scripts/check-package-resolved-policy.py
@@ -9,6 +9,7 @@ from pathlib import Path
 import re
 import subprocess
 import sys
+from typing import NamedTuple
 
 
 ALLOWED_IGNORED_PREFIXES = (
@@ -38,6 +39,20 @@ XCODE_PACKAGE_REFERENCE_TOKENS = (
     "branch",
     "requirement =",
 )
+
+
+class PackageNode(NamedTuple):
+    """Dependency edges declared by one Package.swift."""
+
+    has_url_dependency: bool
+    path_dependencies: list[str]
+    # Normalized text of every `.package(url:)` call, so a version-requirement
+    # bump on an unchanged URL still counts as a remote-resolution change.
+    url_calls: frozenset[str]
+
+
+EMPTY_PACKAGE_NODE = PackageNode(False, [], frozenset())
+
 PACKAGE_DEPENDENCY_RE = re.compile(r"\.package\(([^)]*)\)", re.DOTALL)
 PACKAGE_PATH_ARGUMENT_RE = re.compile(r'\bpath\s*:\s*"([^"]+)"')
 PACKAGE_URL_ARGUMENT_RE = re.compile(r'\burl\s*:\s*"[^"]+"')
@@ -109,11 +124,11 @@ def package_graph(
     manifests: dict[str, Path],
     *,
     ref: str | None = None,
-) -> dict[str, tuple[bool, list[str]]]:
+) -> dict[str, PackageNode]:
     root_by_resolved_path = {
         manifest.parent.resolve(): root for root, manifest in manifests.items()
     }
-    graph: dict[str, tuple[bool, list[str]]] = {}
+    graph: dict[str, PackageNode] = {}
 
     for root, manifest in manifests.items():
         text = (
@@ -124,17 +139,19 @@ def package_graph(
         if not text:
             continue
         path_dependencies: list[str] = []
-        has_url_dependency = False
+        url_calls: set[str] = set()
         for dependency in PACKAGE_DEPENDENCY_RE.findall(text):
             if PACKAGE_URL_ARGUMENT_RE.search(dependency):
-                has_url_dependency = True
+                url_calls.add(" ".join(dependency.split()))
             path_match = PACKAGE_PATH_ARGUMENT_RE.search(dependency)
             if path_match is None:
                 continue
             dependency_root = (manifest.parent / path_match.group(1)).resolve()
             if dependency_root in root_by_resolved_path:
                 path_dependencies.append(root_by_resolved_path[dependency_root])
-        graph[root] = (has_url_dependency, path_dependencies)
+        graph[root] = PackageNode(
+            bool(url_calls), path_dependencies, frozenset(url_calls)
+        )
 
     return graph
 
@@ -143,13 +160,24 @@ def package_dependency_calls(text: str) -> list[str]:
     return [" ".join(dependency.split()) for dependency in PACKAGE_DEPENDENCY_RE.findall(text)]
 
 
-def dependency_calls_include_url(calls: list[str]) -> bool:
-    return any(PACKAGE_URL_ARGUMENT_RE.search(call) for call in calls)
+def closure_remote_dependency_calls(
+    root: str,
+    graph: dict[str, PackageNode],
+) -> frozenset[str]:
+    """Every `.package(url:)` call reachable from ``root``.
+
+    This is what `swift package resolve` actually pins, so comparing it across
+    refs answers "can a Package.resolved diff exist for this change?".
+    """
+    calls: set[str] = set()
+    for member in package_dependency_closure(root, graph):
+        calls.update(graph.get(member, EMPTY_PACKAGE_NODE).url_calls)
+    return frozenset(calls)
 
 
 def has_remote_dependency(
     root: str,
-    graph: dict[str, tuple[bool, list[str]]],
+    graph: dict[str, PackageNode],
     memo: dict[str, bool],
     visiting: set[str],
 ) -> bool:
@@ -157,7 +185,9 @@ def has_remote_dependency(
         return memo[root]
     if root in visiting:
         return False
-    has_url_dependency, path_dependencies = graph.get(root, (False, []))
+    node = graph.get(root, EMPTY_PACKAGE_NODE)
+    has_url_dependency = node.has_url_dependency
+    path_dependencies = node.path_dependencies
     visiting.add(root)
     needs_lockfile = has_url_dependency or any(
         has_remote_dependency(dependency, graph, memo, visiting)
@@ -170,7 +200,7 @@ def has_remote_dependency(
 
 def package_dependency_closure(
     root: str,
-    graph: dict[str, tuple[bool, list[str]]],
+    graph: dict[str, PackageNode],
 ) -> set[str]:
     closure: set[str] = set()
 
@@ -178,8 +208,7 @@ def package_dependency_closure(
         if current in closure:
             return
         closure.add(current)
-        _has_url_dependency, path_dependencies = graph.get(current, (False, []))
-        for dependency in path_dependencies:
+        for dependency in graph.get(current, EMPTY_PACKAGE_NODE).path_dependencies:
             visit(dependency)
 
     visit(root)
@@ -211,7 +240,7 @@ def workspace_package_roots(
 
 def package_roots_requiring_lockfiles(
     cmux_manifests: dict[str, Path] | None = None,
-    graph: dict[str, tuple[bool, list[str]]] | None = None,
+    graph: dict[str, PackageNode] | None = None,
 ) -> set[str]:
     if cmux_manifests is None or graph is None:
         all_manifests = tracked_package_manifests(include_allowed_vendor=True)
@@ -327,16 +356,14 @@ def main() -> int:
     changed_files = changed_files_since(merge_base)
     changed_dependency_roots: set[str] = set()
     previous_manifests: dict[str, Path] = {}
-    previous_graph: dict[str, tuple[bool, list[str]]] = {}
+    previous_graph: dict[str, PackageNode] = {}
 
     if merge_base is not None:
-        current_remote_memo: dict[str, bool] = {}
         previous_manifests = tracked_package_manifests_at_ref(
             merge_base,
             include_allowed_vendor=True,
         )
         previous_graph = package_graph(previous_manifests, ref=merge_base)
-        previous_remote_memo: dict[str, bool] = {}
         for root, manifest in all_manifests.items():
             if manifest.as_posix() not in changed_files:
                 continue
@@ -350,18 +377,14 @@ def main() -> int:
                 continue
             # Local path-only dependency edits do not always change the resolved
             # external pins. Require a matching Package.resolved diff only when
-            # the edited manifest's graph currently has, previously had, or
-            # directly changes a remote dependency.
-            if (
-                dependency_calls_include_url(current_calls + previous_calls)
-                or has_remote_dependency(root, graph, current_remote_memo, set())
-                or has_remote_dependency(
-                    root,
-                    previous_graph,
-                    previous_remote_memo,
-                    set(),
-                )
-            ):
+            # the set of `.package(url:)` calls reachable from this manifest
+            # actually differs, since that set is what `swift package resolve`
+            # pins. Adding a leaf local-path package whose closure has no remote
+            # dependency leaves the lockfiles byte-identical, so demanding a
+            # diff there is unsatisfiable (issue #8871).
+            if closure_remote_dependency_calls(
+                root, graph
+            ) != closure_remote_dependency_calls(root, previous_graph):
                 changed_dependency_roots.add(root)
 
     if (

--- a/tests/test_check_package_resolved_policy.py
+++ b/tests/test_check_package_resolved_policy.py
@@ -1,0 +1,285 @@
+#!/usr/bin/env python3
+"""Regression tests for ./scripts/check-package-resolved-policy.py.
+
+The guard requires a Package.resolved diff whenever a manifest's dependency
+calls change. It must key that requirement off the *remote* dependency calls
+reachable from the manifest, not off "this manifest's graph has some remote
+dependency somewhere", otherwise adding a dependency-free local-path package
+demands a lockfile diff that `swift package resolve` cannot produce
+(https://github.com/manaflow-ai/cmux/issues/8871).
+
+Cases:
+  (a) Adding a leaf `.package(path:)` with no remote closure to a manifest that
+      already has remote pins passes (exit 0) with no lockfile diff.
+  (b) Adding a `.package(url:)` still fails (exit 1) — true positives intact.
+  (c) Removing a `.package(url:)` still fails (exit 1).
+  (d) Bumping an existing `.package(url:)` version requirement still fails
+      (exit 1), even though the URL set is unchanged.
+  (e) Adding a local-path package that itself carries remote pins still fails
+      (exit 1), because it changes the reachable remote set.
+  (f) Case (b) passes once the matching Package.resolved diffs are included.
+"""
+
+import os
+import subprocess
+import sys
+import tempfile
+
+ROOT_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+GUARD = os.path.join(ROOT_DIR, "scripts", "check-package-resolved-policy.py")
+
+REMOTE_DEPENDENCY = (
+    '.package(url: "https://github.com/apple/swift-collections.git", from: "1.1.0")'
+)
+
+RESOLVED_JSON = """{
+  "originHash" : "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "pins" : [
+    {
+      "identity" : "swift-collections",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-collections.git",
+      "state" : {
+        "revision" : "1111111111111111111111111111111111111111",
+        "version" : "1.1.0"
+      }
+    }
+  ],
+  "version" : 3
+}
+"""
+
+
+def write_text(path, contents):
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    with open(path, "w", encoding="utf-8") as handle:
+        handle.write(contents)
+
+
+def manifest(name, dependencies):
+    joined = "".join(f"        {dependency},\n" for dependency in dependencies)
+    return (
+        "// swift-tools-version: 6.0\n"
+        "import PackageDescription\n\n"
+        "let package = Package(\n"
+        f'    name: "{name}",\n'
+        "    dependencies: [\n"
+        f"{joined}"
+        "    ]\n"
+        ")\n"
+    )
+
+
+def git(repo, *args):
+    subprocess.run(["git", *args], cwd=repo, check=True, stdout=subprocess.DEVNULL)
+
+
+def workspace_data(locations):
+    entries = "".join(
+        f'   <FileRef location = "group:{location}"></FileRef>\n'
+        for location in locations
+    )
+    return (
+        '<?xml version="1.0" encoding="UTF-8"?>\n'
+        '<Workspace version = "1.0">\n'
+        f"{entries}"
+        "</Workspace>\n"
+    )
+
+
+def make_base_repo(repo):
+    """A minimal cmux-shaped repo: an iOS package with remote pins, plus the
+    iOS workspace the guard always reads."""
+    git(repo, "init", "-q", "-b", "main")
+    git(repo, "config", "user.email", "test@example.com")
+    git(repo, "config", "user.name", "test")
+
+    write_text(
+        os.path.join(repo, "Packages/iOS/CmuxMobileShellUI/Package.swift"),
+        manifest("CmuxMobileShellUI", [REMOTE_DEPENDENCY]),
+    )
+    write_text(
+        os.path.join(repo, "Packages/iOS/CmuxMobileShellUI/Package.resolved"),
+        RESOLVED_JSON,
+    )
+    write_text(
+        os.path.join(repo, "ios/cmuxPackage/Package.swift"),
+        manifest(
+            "cmuxPackage",
+            ['.package(path: "../../Packages/iOS/CmuxMobileShellUI")'],
+        ),
+    )
+    write_text(os.path.join(repo, "ios/cmuxPackage/Package.resolved"), RESOLVED_JSON)
+    write_text(
+        os.path.join(repo, "ios/cmux.xcworkspace/contents.xcworkspacedata"),
+        workspace_data(["cmuxPackage", "../Packages/iOS/CmuxMobileShellUI"]),
+    )
+    write_text(
+        os.path.join(
+            repo, "ios/cmux.xcworkspace/xcshareddata/swiftpm/Package.resolved"
+        ),
+        RESOLVED_JSON,
+    )
+    git(repo, "add", "-A")
+    git(repo, "commit", "-qm", "base")
+
+
+def run_guard(repo):
+    env = dict(os.environ)
+    env["PACKAGE_RESOLVED_POLICY_BASE_REF"] = "HEAD~1"
+    return subprocess.run(
+        [sys.executable, GUARD],
+        cwd=repo,
+        env=env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+    )
+
+
+def scenario(mutate):
+    with tempfile.TemporaryDirectory() as tmp:
+        repo = os.path.join(tmp, "repo")
+        os.makedirs(repo)
+        make_base_repo(repo)
+        mutate(repo)
+        git(repo, "add", "-A")
+        git(repo, "commit", "-qm", "change")
+        return run_guard(repo)
+
+
+def shell_ui_manifest(repo):
+    return os.path.join(repo, "Packages/iOS/CmuxMobileShellUI/Package.swift")
+
+
+def add_leaf_path_package(repo):
+    write_text(
+        os.path.join(repo, "Packages/iOS/CmuxMobileChanges/Package.swift"),
+        manifest("CmuxMobileChanges", []),
+    )
+    write_text(
+        shell_ui_manifest(repo),
+        manifest(
+            "CmuxMobileShellUI",
+            [REMOTE_DEPENDENCY, '.package(path: "../CmuxMobileChanges")'],
+        ),
+    )
+
+
+def add_remote_bearing_path_package(repo):
+    write_text(
+        os.path.join(repo, "Packages/iOS/CmuxMobileChanges/Package.swift"),
+        manifest(
+            "CmuxMobileChanges",
+            ['.package(url: "https://github.com/apple/swift-log.git", from: "1.0.0")'],
+        ),
+    )
+    write_text(
+        os.path.join(repo, "Packages/iOS/CmuxMobileChanges/Package.resolved"),
+        RESOLVED_JSON,
+    )
+    write_text(
+        shell_ui_manifest(repo),
+        manifest(
+            "CmuxMobileShellUI",
+            [REMOTE_DEPENDENCY, '.package(path: "../CmuxMobileChanges")'],
+        ),
+    )
+
+
+def add_remote_package(repo):
+    write_text(
+        shell_ui_manifest(repo),
+        manifest(
+            "CmuxMobileShellUI",
+            [
+                REMOTE_DEPENDENCY,
+                '.package(url: "https://github.com/apple/swift-log.git", from: "1.0.0")',
+            ],
+        ),
+    )
+
+
+def remove_remote_package(repo):
+    write_text(shell_ui_manifest(repo), manifest("CmuxMobileShellUI", []))
+
+
+def bump_remote_requirement(repo):
+    write_text(
+        shell_ui_manifest(repo),
+        manifest(
+            "CmuxMobileShellUI",
+            [
+                '.package(url: "https://github.com/apple/swift-collections.git", '
+                'from: "2.0.0")'
+            ],
+        ),
+    )
+
+
+def touch_all_lockfiles(repo):
+    bumped = RESOLVED_JSON.replace("1.1.0", "1.2.0")
+    for lockfile in (
+        "Packages/iOS/CmuxMobileShellUI/Package.resolved",
+        "ios/cmuxPackage/Package.resolved",
+        "ios/cmux.xcworkspace/xcshareddata/swiftpm/Package.resolved",
+    ):
+        write_text(os.path.join(repo, lockfile), bumped)
+
+
+def expect(label, result, expected_code):
+    if result.returncode == expected_code:
+        print(f"ok: {label}")
+        return True
+    print(f"FAIL: {label}: expected exit {expected_code}, got {result.returncode}")
+    print(result.stdout)
+    return False
+
+
+def main():
+    ok = True
+
+    ok &= expect(
+        "(a) leaf local-path package needs no lockfile diff",
+        scenario(add_leaf_path_package),
+        0,
+    )
+    ok &= expect(
+        "(b) added remote dependency still requires a lockfile diff",
+        scenario(add_remote_package),
+        1,
+    )
+    ok &= expect(
+        "(c) removed remote dependency still requires a lockfile diff",
+        scenario(remove_remote_package),
+        1,
+    )
+    ok &= expect(
+        "(d) bumped remote requirement still requires a lockfile diff",
+        scenario(bump_remote_requirement),
+        1,
+    )
+    ok &= expect(
+        "(e) local-path package with remote pins still requires a lockfile diff",
+        scenario(add_remote_bearing_path_package),
+        1,
+    )
+
+    def add_remote_package_with_lockfiles(repo):
+        add_remote_package(repo)
+        touch_all_lockfiles(repo)
+
+    ok &= expect(
+        "(f) added remote dependency passes with matching lockfile diffs",
+        scenario(add_remote_package_with_lockfiles),
+        0,
+    )
+
+    if not ok:
+        return 1
+    print("check-package-resolved-policy regression tests OK")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
`scripts/check-package-resolved-policy.py` required a `Package.resolved` diff whenever a manifest's dependency calls changed and that manifest's graph contained any remote dependency at all. Adding a dependency-free local-path package to such a manifest (the pattern in #8221 and #8376) reported violations for lockfiles that `swift package resolve` leaves byte-identical, so the demanded diff was impossible to produce.

Fixes #8871

## Mechanism

The package graph now records the normalized text of every `.package(url:)` call per manifest, alongside the existing local-path edges. A changed manifest is flagged only when the set of url calls reachable through its local-path closure differs between merge-base and HEAD. That set is what SwiftPM actually pins, so the check now answers "can a lockfile diff exist for this change?" rather than "does this package have remote pins somewhere?".

Storing the full normalized call text (not just the URL) keeps version-requirement bumps on an unchanged URL flagged. Comparing the closure, not just the edited manifest, keeps a newly added local-path package that itself carries remote pins flagged.

Principled: it replaces a proxy condition with the real quantity the policy is about. The one residual gap is regex-level manifest parsing, which the script already relied on; a computed or conditional `.package(url:)` would not be detected, same as before.

## Testing

- `tests/test_check_package_resolved_policy.py` (new, wired into the `Validate SwiftPM lockfile policy` CI step) builds throwaway git repos shaped like the iOS package layout and asserts the guard's exit code across six cases: leaf local-path package passes; added, removed, and version-bumped remote dependencies still fail; a local-path package carrying its own remote pins still fails; and the added-remote case passes once matching lockfile diffs are included.
- Red then green is visible in the Commits tab: commit 1 adds the test only (case (a) fails with the same three violations the issue reports), commit 2 adds the fix.
- `python3 tests/test_check_package_resolved_policy.py` → all six cases ok.
- `python3 scripts/check-package-resolved-policy.py` on this repo → `Package.resolved policy OK`.

No dev build: this changes a Python CI guard only, with no app or runtime code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/9470"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788383534&installation_model_id=21920&pr_number=9470&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F9470&signature=f1ea86a371113ece5142a9f7d958468926be2bcb38886cda8f1ea666fc7d2509"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #8871 by removing false positives in `scripts/check-package-resolved-policy.py` that demanded `Package.resolved` diffs when adding a dependency-free local-path package. The check now compares the set of reachable `.package(url:)` calls between merge-base and HEAD, and only requires lockfile diffs when that set changes.

- **Bug Fixes**
  - Store normalized `.package(url:)` calls per manifest and compare the closure through local-path edges across refs.
  - Still flags version bumps on the same URL and local-path additions that introduce remote pins.
  - Add `tests/test_check_package_resolved_policy.py` with six cases; CI runs it before the guard.

<sup>Written for commit 888b188ceac1ffb0579c825b13b4c6dd3d263914. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/9470?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved dependency policy checks to distinguish local-only package changes from changes that affect remote dependencies.
  - Lockfile updates are now required only when remote dependency references change.

- **Tests**
  - Added comprehensive regression coverage for local packages, remote dependency additions and removals, version updates, and matching lockfile changes.
  - CI now runs the dedicated policy test suite before validating the lockfile policy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->