### PR TITLE
Retract recovered daemon transport errors from the workspace sidebar

### DIFF
--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -2728,6 +2728,15 @@ final class Workspace: Identifiable, ObservableObject {
         }
     }
 
+    /// Removes proxy-only daemon log entries appended by
+    /// `applyRemoteDaemonStatusUpdate`, without touching the connection-state
+    /// artifacts owned by `applyRemoteConnectionStateUpdate`.
+    func clearProxyOnlyRemoteDaemonSidebarArtifacts() {
+        logEntries.removeAll { entry in
+            entry.source == "remote-daemon" && Self.isProxyOnlyRemoteError(entry.message)
+        }
+    }
+
     private func remoteNotificationCooldownKey(target: String) -> String? {
         let rawTarget = (remoteConfiguration?.destination ?? target)
             .trimmingCharacters(in: .whitespacesAndNewlines)
@@ -6910,6 +6919,12 @@ final class Workspace: Identifiable, ObservableObject {
         applyBrowserRemoteWorkspaceStatusToPanels()
         guard status.state == .error else {
             remoteLastDaemonErrorFingerprint = nil
+            if status.state == .ready {
+                // #8917: a transport bounce that re-bootstrapped successfully is
+                // not a workspace failure, so retract its sidebar error the same
+                // way the connection-state path retracts on `.connected`.
+                clearProxyOnlyRemoteDaemonSidebarArtifacts()
+            }
             return
         }
         let trimmedDetail = status.detail?.trimmingCharacters(in: .whitespacesAndNewlines) ?? "remote daemon error"

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -2531,6 +2531,7 @@ C0DE71B10000000000000001 /* AppDelegate+AgentChatNotifications.swift in Sources 
 		CB612C41C989F98979226B7C /* WorkspaceRecoveryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9D9924AC89D7C3408DBC56A /* WorkspaceRecoveryTests.swift */; };
 		C73660030000000000000001 /* WorkspaceRemoteBadgeTruthTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C73660030000000000000002 /* WorkspaceRemoteBadgeTruthTests.swift */; };
 		F6100000A1B2C3D4E5F60718 /* WorkspaceRemoteConnectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6100001A1B2C3D4E5F60718 /* WorkspaceRemoteConnectionTests.swift */; };
+		F6100000A1B2C3D4E5F60719 /* WorkspaceRemoteDaemonRecoveryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6100001A1B2C3D4E5F60719 /* WorkspaceRemoteDaemonRecoveryTests.swift */; };
 		7277A0017277A0017277A001 /* WorkspaceRemoteDirectoryProvenanceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7277B0017277B0017277B001 /* WorkspaceRemoteDirectoryProvenanceTests.swift */; };
 		E307B0000000000000000002 /* WorkspaceRemoteHostProbeOutcome.swift in Sources */ = {isa = PBXBuildFile; fileRef = E307B0000000000000000001 /* WorkspaceRemoteHostProbeOutcome.swift */; };
 		E30790000000000000000002 /* WorkspaceRemoteReconnectPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = E30790000000000000000001 /* WorkspaceRemoteReconnectPolicy.swift */; };
@@ -5114,6 +5115,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 		C9D9924AC89D7C3408DBC56A /* WorkspaceRecoveryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceRecoveryTests.swift; sourceTree = "<group>"; };
 		C73660030000000000000002 /* WorkspaceRemoteBadgeTruthTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceRemoteBadgeTruthTests.swift; sourceTree = "<group>"; };
 		F6100001A1B2C3D4E5F60718 /* WorkspaceRemoteConnectionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceRemoteConnectionTests.swift; sourceTree = "<group>"; };
+		F6100001A1B2C3D4E5F60719 /* WorkspaceRemoteDaemonRecoveryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceRemoteDaemonRecoveryTests.swift; sourceTree = "<group>"; };
 		7277B0017277B0017277B001 /* WorkspaceRemoteDirectoryProvenanceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceRemoteDirectoryProvenanceTests.swift; sourceTree = "<group>"; };
 		E307B0000000000000000001 /* WorkspaceRemoteHostProbeOutcome.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceRemoteHostProbeOutcome.swift; sourceTree = "<group>"; };
 		E30790000000000000000001 /* WorkspaceRemoteReconnectPolicy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceRemoteReconnectPolicy.swift; sourceTree = "<group>"; };
@@ -7422,6 +7424,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				F6001001A1B2C3D4E5F60718 /* ShortcutUnbindingTests.swift */,
 				C73660030000000000000002 /* WorkspaceRemoteBadgeTruthTests.swift */,
 				F6100001A1B2C3D4E5F60718 /* WorkspaceRemoteConnectionTests.swift */,
+				F6100001A1B2C3D4E5F60719 /* WorkspaceRemoteDaemonRecoveryTests.swift */,
 				C0DE7101C0DE7101C0DE7101 /* CodexTerminalErrorNotificationTests.swift */,
 				7277B0017277B0017277B001 /* WorkspaceRemoteDirectoryProvenanceTests.swift */,
 				F6357301A1B2C3D4E5F60718 /* WorkspaceRemoteReconnectPolicyTests.swift */,
@@ -10925,6 +10928,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				CB612C41C989F98979226B7C /* WorkspaceRecoveryTests.swift in Sources */,
 				C73660030000000000000001 /* WorkspaceRemoteBadgeTruthTests.swift in Sources */,
 				F6100000A1B2C3D4E5F60718 /* WorkspaceRemoteConnectionTests.swift in Sources */,
+				F6100000A1B2C3D4E5F60719 /* WorkspaceRemoteDaemonRecoveryTests.swift in Sources */,
 				7277A0017277A0017277A001 /* WorkspaceRemoteDirectoryProvenanceTests.swift in Sources */,
 				F6357300A1B2C3D4E5F60718 /* WorkspaceRemoteReconnectPolicyTests.swift in Sources */,
 				5659A0035659A0035659A003 /* WorkspaceSidebarObservationTests.swift in Sources */,

--- a/cmuxTests/WorkspaceRemoteConnectionTests.swift
+++ b/cmuxTests/WorkspaceRemoteConnectionTests.swift
@@ -3269,54 +3269,6 @@ final class WorkspaceRemoteConnectionTests: XCTestCase {
         )
     }
 
-    @MainActor
-    func testRecoveredDaemonTransportBounceClearsSidebarDaemonError() {
-        let workspace = Workspace()
-        let config = WorkspaceRemoteConfiguration(
-            destination: "dev@example.com",
-            port: 22,
-            identityFile: nil,
-            sshOptions: [],
-            localProxyPort: nil,
-            relayPort: 64_021,
-            relayID: String(repeating: "c", count: 16),
-            relayToken: String(repeating: "d", count: 64),
-            localSocketPath: "/tmp/cmux-debug-test.sock",
-            terminalStartupCommand: "ssh dev@example.com",
-            preserveAfterTerminalExit: true,
-            skipDaemonBootstrap: true
-        )
-        workspace.configureRemoteConnection(config, autoConnect: false)
-
-        workspace.applyRemoteDaemonStatusUpdate(
-            WorkspaceRemoteDaemonStatus(state: .ready),
-            target: "dev@example.com"
-        )
-        workspace.applyRemoteDaemonStatusUpdate(
-            WorkspaceRemoteDaemonStatus(
-                state: .error,
-                detail: "Remote daemon transport needs re-bootstrap after proxy failure (retry 1 in 2s)"
-            ),
-            target: "dev@example.com"
-        )
-
-        XCTAssertEqual(workspace.logEntries.last?.level, .error)
-
-        workspace.applyRemoteDaemonStatusUpdate(
-            WorkspaceRemoteDaemonStatus(state: .ready),
-            target: "dev@example.com"
-        )
-
-        XCTAssertNil(
-            workspace.logEntries.last(where: { $0.source == "remote-daemon" }),
-            "A recovered daemon transport bounce must retract its sidebar error"
-        )
-        XCTAssertNotEqual(
-            workspace.logEntries.last?.level,
-            .error,
-            "The workspace row must not keep rendering the recovered daemon error"
-        )
-    }
 }
 
 final class CLINotifyProcessIntegrationTests: XCTestCase {

--- a/cmuxTests/WorkspaceRemoteConnectionTests.swift
+++ b/cmuxTests/WorkspaceRemoteConnectionTests.swift
@@ -3268,7 +3268,6 @@ final class WorkspaceRemoteConnectionTests: XCTestCase {
             "error"
         )
     }
-
 }
 
 final class CLINotifyProcessIntegrationTests: XCTestCase {

--- a/cmuxTests/WorkspaceRemoteConnectionTests.swift
+++ b/cmuxTests/WorkspaceRemoteConnectionTests.swift
@@ -3268,6 +3268,55 @@ final class WorkspaceRemoteConnectionTests: XCTestCase {
             "error"
         )
     }
+
+    @MainActor
+    func testRecoveredDaemonTransportBounceClearsSidebarDaemonError() {
+        let workspace = Workspace()
+        let config = WorkspaceRemoteConfiguration(
+            destination: "dev@example.com",
+            port: 22,
+            identityFile: nil,
+            sshOptions: [],
+            localProxyPort: nil,
+            relayPort: 64_021,
+            relayID: String(repeating: "c", count: 16),
+            relayToken: String(repeating: "d", count: 64),
+            localSocketPath: "/tmp/cmux-debug-test.sock",
+            terminalStartupCommand: "ssh dev@example.com",
+            preserveAfterTerminalExit: true,
+            skipDaemonBootstrap: true
+        )
+        workspace.configureRemoteConnection(config, autoConnect: false)
+
+        workspace.applyRemoteDaemonStatusUpdate(
+            WorkspaceRemoteDaemonStatus(state: .ready),
+            target: "dev@example.com"
+        )
+        workspace.applyRemoteDaemonStatusUpdate(
+            WorkspaceRemoteDaemonStatus(
+                state: .error,
+                detail: "Remote daemon transport needs re-bootstrap after proxy failure (retry 1 in 2s)"
+            ),
+            target: "dev@example.com"
+        )
+
+        XCTAssertEqual(workspace.logEntries.last?.level, .error)
+
+        workspace.applyRemoteDaemonStatusUpdate(
+            WorkspaceRemoteDaemonStatus(state: .ready),
+            target: "dev@example.com"
+        )
+
+        XCTAssertNil(
+            workspace.logEntries.last(where: { $0.source == "remote-daemon" }),
+            "A recovered daemon transport bounce must retract its sidebar error"
+        )
+        XCTAssertNotEqual(
+            workspace.logEntries.last?.level,
+            .error,
+            "The workspace row must not keep rendering the recovered daemon error"
+        )
+    }
 }
 
 final class CLINotifyProcessIntegrationTests: XCTestCase {

--- a/cmuxTests/WorkspaceRemoteDaemonRecoveryTests.swift
+++ b/cmuxTests/WorkspaceRemoteDaemonRecoveryTests.swift
@@ -1,0 +1,63 @@
+import CmuxCore
+import Foundation
+import Testing
+
+#if canImport(cmux_DEV)
+@testable import cmux_DEV
+#elseif canImport(cmux)
+@testable import cmux
+#endif
+
+@MainActor
+struct WorkspaceRemoteDaemonRecoveryTests {
+    /// https://github.com/manaflow-ai/cmux/issues/8917: a daemon transport
+    /// bounce that re-bootstraps successfully must not leave a permanent error
+    /// on the workspace's sidebar row.
+    @Test
+    func recoveredDaemonTransportBounceClearsSidebarDaemonError() {
+        let workspace = Workspace()
+        let config = WorkspaceRemoteConfiguration(
+            destination: "dev@example.com",
+            port: 22,
+            identityFile: nil,
+            sshOptions: [],
+            localProxyPort: nil,
+            relayPort: 64_021,
+            relayID: String(repeating: "c", count: 16),
+            relayToken: String(repeating: "d", count: 64),
+            localSocketPath: "/tmp/cmux-debug-test.sock",
+            terminalStartupCommand: "ssh dev@example.com",
+            preserveAfterTerminalExit: true,
+            skipDaemonBootstrap: true
+        )
+        workspace.configureRemoteConnection(config, autoConnect: false)
+
+        workspace.applyRemoteDaemonStatusUpdate(
+            WorkspaceRemoteDaemonStatus(state: .ready),
+            target: "dev@example.com"
+        )
+        workspace.applyRemoteDaemonStatusUpdate(
+            WorkspaceRemoteDaemonStatus(
+                state: .error,
+                detail: "Remote daemon transport needs re-bootstrap after proxy failure (retry 1 in 2s)"
+            ),
+            target: "dev@example.com"
+        )
+
+        #expect(workspace.logEntries.last?.level == .error)
+
+        workspace.applyRemoteDaemonStatusUpdate(
+            WorkspaceRemoteDaemonStatus(state: .ready),
+            target: "dev@example.com"
+        )
+
+        #expect(
+            workspace.logEntries.last(where: { $0.source == "remote-daemon" }) == nil,
+            "A recovered daemon transport bounce must retract its sidebar error"
+        )
+        #expect(
+            workspace.logEntries.last?.level != .error,
+            "The workspace row must not keep rendering the recovered daemon error"
+        )
+    }
+}

--- a/cmuxTests/WorkspaceRemoteDaemonRecoveryTests.swift
+++ b/cmuxTests/WorkspaceRemoteDaemonRecoveryTests.swift
@@ -1,4 +1,5 @@
 import CmuxCore
+import CmuxSidebar
 import Foundation
 import Testing
 


### PR DESCRIPTION
A transient daemon-transport drop on an SSH remote workspace escalates to a `.error` daemon status, and `applyRemoteDaemonStatusUpdate` appends `Remote daemon error (<host>): Remote daemon transport needs re-bootstrap after proxy failure ...` to the sidebar log. When the transport re-bootstraps a few seconds later the handler only reset the dedup fingerprint, so that entry stayed the workspace's last log entry, which is exactly what the sidebar row renders (`SidebarWorkspaceSnapshotFactory` -> `latestLog`), and it persisted across restarts. The connection-state path already self-heals on `.connected`; the daemon path did not.

The daemon-status handler now retracts its own proxy-only artifacts when the daemon returns to `.ready`, via a new `clearProxyOnlyRemoteDaemonSidebarArtifacts()` that removes only `remote-daemon`-sourced entries matching `isProxyOnlyRemoteError`. It deliberately does not reuse `clearProxyOnlyRemoteSidebarArtifacts()`, which also drops the connection-state status entry and proxy notifications owned by `applyRemoteConnectionStateUpdate`; a healthy daemon does not imply a healthy connection.

Fixes #8917

## Testing

- New regression test `WorkspaceRemoteConnectionTests.testRecoveredDaemonTransportBounceClearsSidebarDaemonError` drives an ordinary SSH workspace with persistent PTY through `.ready` -> `.error` (proxy-only re-bootstrap message) -> `.ready` and asserts no `remote-daemon` entry remains and the last log entry is not an error.
- Two commits so CI shows red then green: the first adds the test only, the second adds the fix.
- Tagged Debug build of the branch head (`scripts/reload.sh --tag sym8917`) succeeded, launched, and answered on its debug socket; the app was then quit. A live end-to-end repro was not run because it needs a real SSH remote workspace plus a ~40s network interruption, which this machine has no sshd or remote host for. The state transition itself is covered deterministically by the unit test.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Cleared stale remote connection error messages after a successful reconnection.
  * Preserved relevant connection status information while removing outdated sidebar entries.
  * Improved workspace status updates when a remote connection recovers, ensuring the workspace no longer appears to be in an error state.

* **Tests**
  * Added coverage for remote daemon recovery, repeated status changes, and error removal after re-establishing a connection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->