### PR TITLE
Pass a valid empty MCP configuration to the auto-naming summarizer

### DIFF
--- a/CLI/CMUXCLI+AutoNaming.swift
+++ b/CLI/CMUXCLI+AutoNaming.swift
@@ -141,6 +141,23 @@ struct AutoNamingEnvironmentPolicy: Sendable {
             .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
         return override.isEmpty ? "haiku" : override
     }
+
+    /// Inline MCP configuration passed with `--strict-mcp-config` so the
+    /// summarizer starts no MCP servers.
+    static let emptyMCPConfigJSON = "{}"
+
+    /// Argument vector for the tool-disabled `claude -p` summarizer call.
+    func claudeSummarizerArguments(from env: [String: String]) -> [String] {
+        [
+            "-p",
+            "--model", claudeModel(from: env),
+            "--tools", "",
+            "--disable-slash-commands",
+            "--no-session-persistence",
+            "--strict-mcp-config",
+            "--mcp-config", Self.emptyMCPConfigJSON
+        ]
+    }
 }
 
 /// Pure auto-naming logic: throttle decisions, transcript extraction,

--- a/CLI/CMUXCLI+AutoNaming.swift
+++ b/CLI/CMUXCLI+AutoNaming.swift
@@ -143,8 +143,11 @@ struct AutoNamingEnvironmentPolicy: Sendable {
     }
 
     /// Inline MCP configuration passed with `--strict-mcp-config` so the
-    /// summarizer starts no MCP servers.
-    static let emptyMCPConfigJSON = "{}"
+    /// summarizer starts no MCP servers. Claude Code validates this JSON
+    /// against a schema requiring an `mcpServers` record, so a bare `{}` is
+    /// rejected during argument parsing and the subprocess exits before it
+    /// can produce a title (cmux#9457).
+    static let emptyMCPConfigJSON = #"{"mcpServers":{}}"#
 
     /// Argument vector for the tool-disabled `claude -p` summarizer call.
     func claudeSummarizerArguments(from env: [String: String]) -> [String] {

--- a/CLI/CMUXCLI+AutoNamingDispatch.swift
+++ b/CLI/CMUXCLI+AutoNamingDispatch.swift
@@ -123,15 +123,7 @@ extension CMUXCLI {
         guard let executable else { return nil }
         return runAutoNamingSummarizer(
             executable: executable,
-            arguments: [
-                "-p",
-                "--model", policy.claudeModel(from: env),
-                "--tools", "",
-                "--disable-slash-commands",
-                "--no-session-persistence",
-                "--strict-mcp-config",
-                "--mcp-config", "{}"
-            ],
+            arguments: policy.claudeSummarizerArguments(from: env),
             prompt: prompt,
             environment: policy.summarizerEnvironment(from: env),
             timeout: timeout

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -249,6 +249,7 @@ C0DE71B10000000000000001 /* AppDelegate+AgentChatNotifications.swift in Sources 
 		D9FEC58D5BACCF76459F1BBE /* AuthEnvironment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43430FA5929121E2EAAB3091 /* AuthEnvironment.swift */; };
 		A47E00010000000000000001 /* AuthEnvironmentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A47E00010000000000000002 /* AuthEnvironmentTests.swift */; };
 		B9000012A1B2C3D4E5F60719 /* AutomationSocketUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9000011A1B2C3D4E5F60719 /* AutomationSocketUITests.swift */; };
+		AA9457BF0000000000000001 /* AutoNamingClaudeArgumentsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA9457FR0000000000000001 /* AutoNamingClaudeArgumentsTests.swift */; };
 		FF068325E8A04E51A30AE9BA /* AutoNamingCodexAdapterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70034F4D644C4896B8B925F3 /* AutoNamingCodexAdapterTests.swift */; };
 		7C592156DCB3419BB95383E5 /* AutoNamingEngineTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7752D68A758642EFA282C208 /* AutoNamingEngineTests.swift */; };
 		A4ECF22C62724853A72D6BDE /* AutoNamingGrokAdapterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 07EC52007B2144C59C047774 /* AutoNamingGrokAdapterTests.swift */; };
@@ -2924,6 +2925,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 		43430FA5929121E2EAAB3091 /* AuthEnvironment.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AuthEnvironment.swift; sourceTree = "<group>"; };
 		A47E00010000000000000002 /* AuthEnvironmentTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthEnvironmentTests.swift; sourceTree = "<group>"; };
 		B9000011A1B2C3D4E5F60719 /* AutomationSocketUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutomationSocketUITests.swift; sourceTree = "<group>"; };
+		AA9457FR0000000000000001 /* AutoNamingClaudeArgumentsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutoNamingClaudeArgumentsTests.swift; sourceTree = "<group>"; };
 		70034F4D644C4896B8B925F3 /* AutoNamingCodexAdapterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutoNamingCodexAdapterTests.swift; sourceTree = "<group>"; };
 		7752D68A758642EFA282C208 /* AutoNamingEngineTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutoNamingEngineTests.swift; sourceTree = "<group>"; };
 		07EC52007B2144C59C047774 /* AutoNamingGrokAdapterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutoNamingGrokAdapterTests.swift; sourceTree = "<group>"; };
@@ -7554,6 +7556,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				F92AB6D1CB714189A8F167E5 /* SetAutoTitleSocketTests.swift */,
 				7752D68A758642EFA282C208 /* AutoNamingEngineTests.swift */,
 				70034F4D644C4896B8B925F3 /* AutoNamingCodexAdapterTests.swift */,
+				AA9457FR0000000000000001 /* AutoNamingClaudeArgumentsTests.swift */,
 				07EC52007B2144C59C047774 /* AutoNamingGrokAdapterTests.swift */,
 				46792DAA478444ED87B17B31 /* AutoNamingHookPayloadAdapterTests.swift */,
 				CE7000000000000000000002 /* ClaudeWrapperResumeEnvironmentTests.swift */,
@@ -10342,6 +10345,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				A11EAA000000000000000000 /* AppearanceSettingsTests.swift in Sources */,
 				A7206E010000000000000001 /* AppIconAppearanceObserverTests.swift in Sources */,
 				A47E00010000000000000001 /* AuthEnvironmentTests.swift in Sources */,
+				AA9457BF0000000000000001 /* AutoNamingClaudeArgumentsTests.swift in Sources */,
 				FF068325E8A04E51A30AE9BA /* AutoNamingCodexAdapterTests.swift in Sources */,
 				7C592156DCB3419BB95383E5 /* AutoNamingEngineTests.swift in Sources */,
 				A4ECF22C62724853A72D6BDE /* AutoNamingGrokAdapterTests.swift in Sources */,

--- a/cmuxTests/AutoNamingClaudeArgumentsTests.swift
+++ b/cmuxTests/AutoNamingClaudeArgumentsTests.swift
@@ -1,0 +1,54 @@
+import Foundation
+import Testing
+
+// `AutoNamingEnvironmentPolicy` lives in the shared auto-naming CLI file,
+// which is compiled directly into this test target (see AutoNamingEngineTests
+// for the same arrangement).
+
+/// Behavior tests for the argument vector cmux hands `claude -p` when it
+/// summarizes a transcript into a workspace title.
+@Suite struct AutoNamingClaudeArgumentsTests {
+    private let policy = AutoNamingEnvironmentPolicy()
+
+    private func value(of flag: String, in arguments: [String]) -> String? {
+        guard let index = arguments.firstIndex(of: flag), index + 1 < arguments.count else {
+            return nil
+        }
+        return arguments[index + 1]
+    }
+
+    /// Claude Code validates `--mcp-config` against a schema that requires an
+    /// `mcpServers` record. A bare `{}` fails argument validation and the
+    /// summarizer exits before producing a title (cmux#9457).
+    @Test func mcpConfigIsAValidEmptyServerConfiguration() throws {
+        let arguments = policy.claudeSummarizerArguments(from: [:])
+        let raw = try #require(value(of: "--mcp-config", in: arguments))
+        #expect(raw != "{}")
+
+        let parsed = try JSONSerialization.jsonObject(
+            with: Data(raw.utf8)
+        ) as? [String: Any]
+        let object = try #require(parsed)
+        #expect(object["mcpServers"] as? [String: Any] != nil)
+        #expect(object.count == 1)
+    }
+
+    @Test func keepsToolsAndSessionIsolationFlags() {
+        let arguments = policy.claudeSummarizerArguments(from: [:])
+        #expect(arguments.first == "-p")
+        #expect(arguments.contains("--strict-mcp-config"))
+        #expect(arguments.contains("--disable-slash-commands"))
+        #expect(arguments.contains("--no-session-persistence"))
+        #expect(value(of: "--tools", in: arguments) == "")
+    }
+
+    @Test func honorsSmallFastModelOverride() {
+        let arguments = policy.claudeSummarizerArguments(from: [:])
+        #expect(value(of: "--model", in: arguments) == "haiku")
+
+        let overridden = policy.claudeSummarizerArguments(
+            from: ["ANTHROPIC_SMALL_FAST_MODEL": "claude-haiku-4-5"]
+        )
+        #expect(value(of: "--model", in: overridden) == "claude-haiku-4-5")
+    }
+}


### PR DESCRIPTION
Workspace auto-naming failed on every attempt with a Claude Code session. cmux spawned the summarizer with `--strict-mcp-config --mcp-config {}`, and Claude Code 2.1.220 validates that JSON against a schema requiring an `mcpServers` record. The subprocess exited on argument validation in under a second (`mcpServers: Invalid input: expected record, received undefined`), so no title was ever produced and every attempt recorded `autoNamingLastStatus.category: "failed"`.

The fix emits `{"mcpServers":{}}` instead, which is the same semantics (no MCP servers) in a form the current schema accepts. The argv is now built by `AutoNamingEnvironmentPolicy.claudeSummarizerArguments(from:)` so it is covered by a test rather than living inline in the dispatch path.

Fixes #9457

Not addressed here: the reporter's secondary observations (the summarizer still loads the user's global `CLAUDE.md`, and the failure is invisible from outside because the subprocess stderr and exit code are discarded). Both are real but separate from the argument bug; leaving them out keeps this change minimal.

## Testing

Regression test: `cmuxTests/AutoNamingClaudeArgumentsTests.swift` asserts the `--mcp-config` value is not `{}` and parses to an object whose only key is an `mcpServers` record, plus the tool/session-isolation flags and the `ANTHROPIC_SMALL_FAST_MODEL` override. Two commits, `ad2dc5c` adds the test against the current `{}` argument and `5d7d7ea` applies the fix.

CI could not run that test on either commit. `ci.yml` is dispatch-only right now, and both dispatched runs ([30855956954](https://github.com/manaflow-ai/cmux/actions/runs/30855956954) on the test-only commit, [30855966921](https://github.com/manaflow-ai/cmux/actions/runs/30855966921) on the fix) failed before the macOS `tests` job at a preexisting gate on `main`: `workflow-guard-tests` reports `scripts/ghosttykit-checksums.txt is missing an entry for ghostty f0f8273b700e754b3f0052cea033789aab902fd1`, which is the SHA `main` pins. `linux-preflight` gates `tests` on that guard, so the same failure is hitting other branches. That pin is a separate fix.

Verified at runtime instead, on macOS 26 with Claude Code 2.1.220 installed locally:

1. Reproduced the bug against the real binary. `claude -p --model haiku --tools "" --disable-slash-commands --no-session-persistence --strict-mcp-config --mcp-config '{}'` prints `Error: Invalid MCP configuration: mcpServers: Invalid input: expected record, received undefined`. The same command with `'{"mcpServers":{}}'` returns a title.
2. Built a tagged dev app with `./scripts/reload.sh --tag sym9457` and confirmed the bundled CLI carries the new literal.
3. Drove the real path end to end in that app: enabled `workspaceAutoNamingEnabled` with `autoNamingAgent: claude`, ran an interactive Claude Code session in a workspace over `/tmp/cmux-debug-sym9457.sock`, and completed a turn so the `Stop` hook fired. The workspace was renamed to `custom_title: "OAuth Refresh Tokens"` with `has_custom_title: true`, and `autoNamingLastStatus` did not exist afterward, which is the success signature the reporter described. Before this change the same flow left `custom_title: null` and recorded `category: "failed"`.

The tagged app was quit and its temporary `defaults` were removed after verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
