### PR TITLE
Resolve kind:N routing refs only for the kind the param expects

### DIFF
--- a/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Coordinator/ControlCommandContext.swift
+++ b/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Coordinator/ControlCommandContext.swift
@@ -31,7 +31,8 @@ public protocol ControlCommandContext:
     ControlProjectContext,
     ControlDebugContext,
     ControlSidebarContext,
-    ControlBrowserPanelContext
+    ControlBrowserPanelContext,
+    ControlIdentityKindContext
 {
     // MARK: Worker-lane resolution hop
 

--- a/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Coordinator/ControlCommandCoordinator.swift
+++ b/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Coordinator/ControlCommandCoordinator.swift
@@ -242,13 +242,59 @@ public final class ControlCommandCoordinator {
 
     /// A UUID param, accepting either a UUID string or a `kind:N` ref resolved
     /// through the handle registry (matches legacy `v2UUID`).
+    ///
+    /// A `kind:N` ref only resolves when it was minted for one of the kinds the
+    /// param key expects, so `group_id: "surface:1"` no longer resolves to a
+    /// surface, misses its group lookup, and degrades to the active window
+    /// (https://github.com/manaflow-ai/cmux/issues/9424). Keys with no declared
+    /// expectation (`id`, notification/todo ids) keep the unrestricted search.
     func uuid(_ params: [String: JSONValue], _ key: String) -> UUID? {
         guard let raw = string(params, key) else { return nil }
         if let parsed = UUID(uuidString: raw) {
             return parsed
         }
-        return handles.uuid(forRef: raw)
+        return resolveRef(raw, forParamKey: key)
     }
+
+    /// Resolves a `kind:N` ref for a named param key, restricted to the handle
+    /// kinds that key accepts. Unknown keys keep the unrestricted search.
+    ///
+    /// - Parameters:
+    ///   - ref: The ref string.
+    ///   - key: The param key the ref arrived under.
+    /// - Returns: The identifier, or `nil` if unknown or of the wrong kind.
+    public func resolveRef(_ ref: String, forParamKey key: String) -> UUID? {
+        guard let kinds = Self.expectedHandleKinds[key] else {
+            return handles.uuid(forRef: ref)
+        }
+        return handles.uuid(forRef: ref, kinds: kinds)
+    }
+
+    /// The handle kinds each routing/target param key accepts as a `kind:N` ref.
+    ///
+    /// Only the two aliases the protocol really uses are widened: `tab:N` for
+    /// surfaces (handled inside the registry), and a *window* identity passed as
+    /// `workspace_id`, which the Window Dock does legitimately.
+    static let expectedHandleKinds: [String: [ControlHandleKind]] = [
+        "window_id": [.window],
+        "workspace_id": [.workspace, .window],
+        "reference_workspace_id": [.workspace, .window],
+        "before_workspace_id": [.workspace, .window],
+        "after_workspace_id": [.workspace, .window],
+        "_cmux_remote_workspace_id": [.workspace],
+        "group_id": [.workspaceGroup],
+        "before_group_id": [.workspaceGroup],
+        "after_group_id": [.workspaceGroup],
+        "pane_id": [.pane],
+        "target_pane_id": [.pane],
+        "surface_id": [.surface],
+        "target_surface_id": [.surface],
+        "before_surface_id": [.surface],
+        "after_surface_id": [.surface],
+        "terminal_id": [.surface],
+        "tab_id": [.surface],
+        "panel_id": [.surface],
+    ]
 
     /// Whether a param is present and not JSON `null` (matches legacy
     /// `v2HasNonNullParam`).

--- a/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Coordinator/ControlCommandCoordinator.swift
+++ b/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Coordinator/ControlCommandCoordinator.swift
@@ -277,8 +277,20 @@ public final class ControlCommandCoordinator {
             return resolveRef(raw, forParamKey: key)
         }
         guard let expected = Self.expectedHandleKinds[key] else { return parsed }
+        // The mint history is a sound kind oracle here rather than an accident
+        // of what the caller happens to have been handed: dispatch re-mints refs
+        // for live topology first (the conformer's `v2RefreshKnownRefs` walks
+        // every main window, workspace, workspace group, pane and surface), so
+        // anything routing can reach has a kind by the time params are parsed.
+        // The residual is dock-hosted surfaces, which are first-minted by the
+        // individual command bodies.
         let minted = handles.mintedKinds(for: parsed)
-        // Never minted → kind unknown, so it still passes through (issue gap 1).
+        // Never minted → kind unknown, so it still passes through. That is gap 1
+        // of the issue: the CLI injects the caller's own CMUX_WORKSPACE_ID /
+        // CMUX_SURFACE_ID into most commands, so failing closed here would also
+        // fail ordinary commands issued from a since-closed workspace. Telling
+        // those apart needs the wire-format change the issue defers to a
+        // product call.
         guard minted.isEmpty || !minted.isDisjoint(with: expected) else { return nil }
         return parsed
     }

--- a/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Coordinator/ControlCommandCoordinator.swift
+++ b/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Coordinator/ControlCommandCoordinator.swift
@@ -297,18 +297,27 @@ public final class ControlCommandCoordinator {
         return handles.uuid(forRef: ref, kinds: kinds)
     }
 
-    /// The handle kinds each routing/target param key accepts as a `kind:N` ref.
+    /// The handle kinds each routing/target param key accepts.
     ///
-    /// Only the two aliases the protocol really uses are widened: `tab:N` for
-    /// surfaces (handled inside the registry), and a *window* identity passed as
-    /// `workspace_id`, which the Window Dock does legitimately.
+    /// Only two aliases are widened, and only where the protocol really uses
+    /// them: `tab:N` for surfaces (handled inside the registry), and a *window*
+    /// identity passed as the routing `workspace_id`, which the Window Dock does
+    /// legitimately because a Dock owner id IS its owning window's id. The
+    /// ordering/reference workspace keys take part in no such aliasing, so they
+    /// stay `.workspace` only.
+    ///
+    /// `from_tab_id`/`to_tab_id` are workspaces despite the name: they are
+    /// matched against a window's workspace list, not against surfaces.
     static let expectedHandleKinds: [String: [ControlHandleKind]] = [
         "window_id": [.window],
         "workspace_id": [.workspace, .window],
-        "reference_workspace_id": [.workspace, .window],
-        "before_workspace_id": [.workspace, .window],
-        "after_workspace_id": [.workspace, .window],
+        "reference_workspace_id": [.workspace],
+        "group_reference_workspace_id": [.workspace],
+        "before_workspace_id": [.workspace],
+        "after_workspace_id": [.workspace],
         "_cmux_remote_workspace_id": [.workspace],
+        "from_tab_id": [.workspace],
+        "to_tab_id": [.workspace],
         "group_id": [.workspaceGroup],
         "before_group_id": [.workspaceGroup],
         "after_group_id": [.workspaceGroup],
@@ -321,6 +330,7 @@ public final class ControlCommandCoordinator {
         "terminal_id": [.surface],
         "tab_id": [.surface],
         "panel_id": [.surface],
+        "return_to": [.surface],
     ]
 
     /// Whether a param is present and not JSON `null` (matches legacy

--- a/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Coordinator/ControlCommandCoordinator.swift
+++ b/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Coordinator/ControlCommandCoordinator.swift
@@ -42,6 +42,10 @@ public final class ControlCommandCoordinator {
     @ObservationIgnored
     public var handles: ControlHandleRegistry
 
+    /// Per-request memo for ``identityKinds(for:)``, cleared by
+    /// ``resetIdentityKindCache()`` at each request boundary.
+    var identityKindCache: [UUID: (kinds: Set<ControlHandleKind>, authoritative: Bool)] = [:]
+
     @ObservationIgnored
     nonisolated let simulatorOperationAdmissionGate =
         ControlSimulatorOperationAdmissionGate(maximumConcurrentOperations: 4)
@@ -68,6 +72,9 @@ public final class ControlCommandCoordinator {
     /// - Parameter request: The decoded request envelope.
     /// - Returns: The command result, or `nil` if not owned here.
     public func handle(_ request: ControlRequest) -> ControlCallResult? {
+        // Identity classification is a per-request snapshot of live topology,
+        // exactly as the conformer's handle-ref refresh already is.
+        resetIdentityKindCache()
         // Each domain's handler (in its own `+<Domain>.swift` extension) owns its
         // methods and returns `nil` for anything else, so the chain falls through
         // to the next domain and finally to the legacy app-side dispatcher.
@@ -295,29 +302,66 @@ public final class ControlCommandCoordinator {
             return handles.uuid(forRef: raw, kinds: expected)
         }
         let known = identityKinds(for: parsed)
-        // Empty means no source can name a kind for this identity, which is gap
-        // 1 of the issue: the CLI injects the caller's own CMUX_WORKSPACE_ID /
-        // CMUX_SURFACE_ID into most commands, so failing closed here would also
-        // fail ordinary commands issued from a since-closed workspace. Telling
-        // those apart needs the wire-format change the issue defers to a
-        // product call.
-        guard known.isEmpty || !known.isDisjoint(with: expected) else { return nil }
+        if !known.kinds.isEmpty {
+            guard !known.kinds.isDisjoint(with: expected) else { return nil }
+            return parsed
+        }
+        // Live topology says this id names nothing. For a key the CLI never
+        // fills from caller context, that is unambiguously a user-specified
+        // target that does not exist, so it fails closed.
+        if known.authoritative, !Self.callerInjectableKeys.contains(key) {
+            return nil
+        }
+        // Otherwise it stays acceptable. That is gap 1 of the issue: the CLI
+        // injects the caller's own CMUX_WORKSPACE_ID / CMUX_SURFACE_ID into
+        // most commands, so failing closed on these keys would also fail
+        // ordinary commands issued from a since-closed workspace. Telling those
+        // apart needs the wire-format change the issue defers to a product
+        // call. Non-authoritative classification (no app attached) also stays
+        // permissive, since absence of evidence is not evidence of absence.
         return parsed
     }
 
+    /// The param keys the CLI fills from the caller's own environment
+    /// (`CMUX_WORKSPACE_ID` / `CMUX_SURFACE_ID`), where a stale id is ordinary
+    /// rather than a mistargeted command. Every other key is user-specified.
+    static let callerInjectableKeys: Set<String> = [
+        "workspace_id", "surface_id", "terminal_id", "tab_id", "panel_id",
+    ]
+
     /// The kinds an identity is known to have, preferring the app's live
-    /// topology over the handle registry's mint history.
+    /// topology over the handle registry's mint history, plus whether that
+    /// answer is authoritative.
     ///
     /// Mint history alone is not a sound oracle: dock-hosted objects may not be
     /// minted yet, and ``ControlHandleRegistry/removeRef(kind:uuid:)`` erases
     /// what the registry knew. The conformer answers from live topology when it
     /// can; the registry is the fallback for contexts with no app attached
-    /// (tests, and any conformer that does not implement the seam).
-    func identityKinds(for uuid: UUID) -> Set<ControlHandleKind> {
+    /// (tests, and any conformer that does not implement the seam), and that
+    /// fallback is never treated as authoritative.
+    ///
+    /// Memoized for the current request: classification sweeps live topology,
+    /// and one request resolves the same id repeatedly (rejection checking,
+    /// routing, then the command body).
+    func identityKinds(for uuid: UUID) -> (kinds: Set<ControlHandleKind>, authoritative: Bool) {
+        if let cached = identityKindCache[uuid] { return cached }
+        let resolved: (kinds: Set<ControlHandleKind>, authoritative: Bool)
         if let authoritative = context?.controlIdentityKinds(for: uuid) {
-            return authoritative
+            resolved = (authoritative, true)
+        } else {
+            resolved = (handles.mintedKinds(for: uuid), false)
         }
-        return handles.mintedKinds(for: uuid)
+        identityKindCache[uuid] = resolved
+        return resolved
+    }
+
+    /// Drops the memoized identity classifications.
+    ///
+    /// Called at each request boundary, alongside the conformer's ref refresh,
+    /// so classification is a per-request snapshot of topology exactly as the
+    /// handle refs already are.
+    public func resetIdentityKindCache() {
+        identityKindCache.removeAll(keepingCapacity: true)
     }
 
     /// Resolves a `kind:N` ref for a named param key, restricted to the handle
@@ -400,28 +444,34 @@ public final class ControlCommandCoordinator {
     /// selector through the handle registry exactly as the legacy
     /// `v2ResolveTabManager` did before walking its precedence.
     func routingSelectors(_ params: [String: JSONValue]) -> ControlRoutingSelectors {
-        ControlRoutingSelectors(
-            hasWindowIDParam: hasNonNull(params, "window_id"),
-            windowID: routingUUID(params, "window_id"),
-            groupID: routingUUID(params, "group_id"),
-            workspaceID: routingUUID(params, "workspace_id"),
-            surfaceID: routingUUID(params, "surface_id")
-                ?? routingUUID(params, "terminal_id")
-                ?? routingUUID(params, "tab_id"),
-            paneID: routingUUID(params, "pane_id"),
-            hasRejectedSelector: hasRejectedRoutingSelector(params)
-        )
-    }
-
-    /// Whether any routing selector was supplied but failed to resolve, which
-    /// must fail the routing walk rather than read as an absent selector.
-    ///
-    /// `window_id` is excluded: its presence is already carried separately by
-    /// ``ControlRoutingSelectors/hasWindowIDParam`` and handled by the walk.
-    func hasRejectedRoutingSelector(_ params: [String: JSONValue]) -> Bool {
-        Self.routingSelectorKeys.contains { key in
-            hasNonNull(params, key) && routingUUID(params, key) == nil
+        // Each key is resolved exactly once: classification sweeps live
+        // topology, so resolving a second time to compute the rejection flag
+        // would double the cost of every routed request.
+        var rejected = false
+        func selector(_ key: String) -> UUID? {
+            let resolved = routingUUID(params, key)
+            if resolved == nil, hasNonNull(params, key) { rejected = true }
+            return resolved
         }
+
+        // `window_id` is resolved without the rejection flag: its presence is
+        // carried separately by `hasWindowIDParam`, which the walk already
+        // fails closed on.
+        let windowID = routingUUID(params, "window_id")
+        let groupID = selector("group_id")
+        let workspaceID = selector("workspace_id")
+        let surfaceID = selector("surface_id") ?? selector("terminal_id") ?? selector("tab_id")
+        let paneID = selector("pane_id")
+
+        return ControlRoutingSelectors(
+            hasWindowIDParam: hasNonNull(params, "window_id"),
+            windowID: windowID,
+            groupID: groupID,
+            workspaceID: workspaceID,
+            surfaceID: surfaceID,
+            paneID: paneID,
+            hasRejectedSelector: rejected
+        )
     }
 
     /// The routing selector keys whose supplied-but-invalid state fails closed.

--- a/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Coordinator/ControlCommandCoordinator.swift
+++ b/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Coordinator/ControlCommandCoordinator.swift
@@ -263,6 +263,14 @@ public final class ControlCommandCoordinator {
         return resolveIdentifier(raw, forParamKey: key)
     }
 
+    /// The routing-lane twin of ``uuid(_:_:)``: identical, except the Window
+    /// Dock's window-as-`workspace_id` alias is accepted. Only the routing walk
+    /// may take that alias, so it is never granted by param name alone.
+    func routingUUID(_ params: [String: JSONValue], _ key: String) -> UUID? {
+        guard let raw = string(params, key) else { return nil }
+        return resolveIdentifier(raw, forParamKey: key, routing: true)
+    }
+
     /// Resolves either wire representation of an identifier — a raw UUID string
     /// or a `kind:N` ref — for a named param key, rejecting kinds that key does
     /// not accept. The single entrypoint both the typed params and the legacy
@@ -271,28 +279,45 @@ public final class ControlCommandCoordinator {
     /// - Parameters:
     ///   - raw: The trimmed, non-empty param value.
     ///   - key: The param key the value arrived under.
+    ///   - routing: Whether this resolution feeds the routing walk, which is the
+    ///     only caller allowed the window-as-`workspace_id` alias.
     /// - Returns: The identifier, or `nil` if unknown or of the wrong kind.
-    public func resolveIdentifier(_ raw: String, forParamKey key: String) -> UUID? {
-        guard let parsed = UUID(uuidString: raw) else {
-            return resolveRef(raw, forParamKey: key)
+    public func resolveIdentifier(
+        _ raw: String,
+        forParamKey key: String,
+        routing: Bool = false
+    ) -> UUID? {
+        guard let expected = acceptedKinds(forParamKey: key, routing: routing) else {
+            // No declared expectation (`id`, notification/todo ids): unrestricted.
+            return UUID(uuidString: raw) ?? handles.uuid(forRef: raw)
         }
-        guard let expected = Self.expectedHandleKinds[key] else { return parsed }
-        // The mint history is a sound kind oracle here rather than an accident
-        // of what the caller happens to have been handed: dispatch re-mints refs
-        // for live topology first (the conformer's `v2RefreshKnownRefs` walks
-        // every main window, workspace, workspace group, pane and surface), so
-        // anything routing can reach has a kind by the time params are parsed.
-        // The residual is dock-hosted surfaces, which are first-minted by the
-        // individual command bodies.
-        let minted = handles.mintedKinds(for: parsed)
-        // Never minted → kind unknown, so it still passes through. That is gap 1
-        // of the issue: the CLI injects the caller's own CMUX_WORKSPACE_ID /
+        guard let parsed = UUID(uuidString: raw) else {
+            return handles.uuid(forRef: raw, kinds: expected)
+        }
+        let known = identityKinds(for: parsed)
+        // Empty means no source can name a kind for this identity, which is gap
+        // 1 of the issue: the CLI injects the caller's own CMUX_WORKSPACE_ID /
         // CMUX_SURFACE_ID into most commands, so failing closed here would also
         // fail ordinary commands issued from a since-closed workspace. Telling
         // those apart needs the wire-format change the issue defers to a
         // product call.
-        guard minted.isEmpty || !minted.isDisjoint(with: expected) else { return nil }
+        guard known.isEmpty || !known.isDisjoint(with: expected) else { return nil }
         return parsed
+    }
+
+    /// The kinds an identity is known to have, preferring the app's live
+    /// topology over the handle registry's mint history.
+    ///
+    /// Mint history alone is not a sound oracle: dock-hosted objects may not be
+    /// minted yet, and ``ControlHandleRegistry/removeRef(kind:uuid:)`` erases
+    /// what the registry knew. The conformer answers from live topology when it
+    /// can; the registry is the fallback for contexts with no app attached
+    /// (tests, and any conformer that does not implement the seam).
+    func identityKinds(for uuid: UUID) -> Set<ControlHandleKind> {
+        if let authoritative = context?.controlIdentityKinds(for: uuid) {
+            return authoritative
+        }
+        return handles.mintedKinds(for: uuid)
     }
 
     /// Resolves a `kind:N` ref for a named param key, restricted to the handle
@@ -309,20 +334,38 @@ public final class ControlCommandCoordinator {
         return handles.uuid(forRef: ref, kinds: kinds)
     }
 
+    /// The kinds a param key accepts, widened only for the routing lane.
+    ///
+    /// - Parameters:
+    ///   - key: The param key.
+    ///   - routing: Whether the resolution feeds the routing walk.
+    /// - Returns: The accepted kinds, or `nil` when the key declares none.
+    func acceptedKinds(forParamKey key: String, routing: Bool) -> [ControlHandleKind]? {
+        if routing, let widened = Self.routingHandleKinds[key] { return widened }
+        return Self.expectedHandleKinds[key]
+    }
+
+    /// The extra kinds the routing walk alone accepts.
+    ///
+    /// The Window Dock legitimately routes by passing a *window* identity as
+    /// `workspace_id`, because a Dock owner id IS its owning window's id. That
+    /// is a property of the routing walk, not of the parameter: a command that
+    /// uses `workspace_id` as an actual workspace target must still reject a
+    /// window, so the alias is granted per call site rather than by name.
+    static let routingHandleKinds: [String: [ControlHandleKind]] = [
+        "workspace_id": [.workspace, .window],
+    ]
+
     /// The handle kinds each routing/target param key accepts.
     ///
-    /// Only two aliases are widened, and only where the protocol really uses
-    /// them: `tab:N` for surfaces (handled inside the registry), and a *window*
-    /// identity passed as the routing `workspace_id`, which the Window Dock does
-    /// legitimately because a Dock owner id IS its owning window's id. The
-    /// ordering/reference workspace keys take part in no such aliasing, so they
-    /// stay `.workspace` only.
+    /// `tab:N` for surfaces is the one alias handled inside the registry. The
+    /// window-as-`workspace_id` alias is NOT here: see ``routingHandleKinds``.
     ///
     /// `from_tab_id`/`to_tab_id` are workspaces despite the name: they are
     /// matched against a window's workspace list, not against surfaces.
     static let expectedHandleKinds: [String: [ControlHandleKind]] = [
         "window_id": [.window],
-        "workspace_id": [.workspace, .window],
+        "workspace_id": [.workspace],
         "reference_workspace_id": [.workspace],
         "group_reference_workspace_id": [.workspace],
         "before_workspace_id": [.workspace],
@@ -359,13 +402,13 @@ public final class ControlCommandCoordinator {
     func routingSelectors(_ params: [String: JSONValue]) -> ControlRoutingSelectors {
         ControlRoutingSelectors(
             hasWindowIDParam: hasNonNull(params, "window_id"),
-            windowID: uuid(params, "window_id"),
-            groupID: uuid(params, "group_id"),
-            workspaceID: uuid(params, "workspace_id"),
-            surfaceID: uuid(params, "surface_id")
-                ?? uuid(params, "terminal_id")
-                ?? uuid(params, "tab_id"),
-            paneID: uuid(params, "pane_id")
+            windowID: routingUUID(params, "window_id"),
+            groupID: routingUUID(params, "group_id"),
+            workspaceID: routingUUID(params, "workspace_id"),
+            surfaceID: routingUUID(params, "surface_id")
+                ?? routingUUID(params, "terminal_id")
+                ?? routingUUID(params, "tab_id"),
+            paneID: routingUUID(params, "pane_id")
         )
     }
 }

--- a/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Coordinator/ControlCommandCoordinator.swift
+++ b/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Coordinator/ControlCommandCoordinator.swift
@@ -243,17 +243,44 @@ public final class ControlCommandCoordinator {
     /// A UUID param, accepting either a UUID string or a `kind:N` ref resolved
     /// through the handle registry (matches legacy `v2UUID`).
     ///
-    /// A `kind:N` ref only resolves when it was minted for one of the kinds the
-    /// param key expects, so `group_id: "surface:1"` no longer resolves to a
-    /// surface, misses its group lookup, and degrades to the active window
-    /// (https://github.com/manaflow-ai/cmux/issues/9424). Keys with no declared
-    /// expectation (`id`, notification/todo ids) keep the unrestricted search.
+    /// An identifier only resolves when its kind is one the param key expects,
+    /// so `group_id: "surface:1"` no longer resolves to a surface, misses its
+    /// group lookup, and degrades to the active window
+    /// (https://github.com/manaflow-ai/cmux/issues/9424).
+    ///
+    /// This holds for both wire representations. A `kind:N` ref names its kind
+    /// outright. A raw UUID does not, but the registry knows the kinds it has
+    /// already minted refs for, so a surface UUID supplied as `group_id` is
+    /// rejected too. A UUID the registry has never seen has no known kind and
+    /// still passes through — that is gap 1 of the issue, which needs a product
+    /// call on distinguishing caller-injected context from user-specified
+    /// targets on the wire.
+    ///
+    /// Keys with no declared expectation (`id`, notification/todo ids) keep the
+    /// unrestricted lookup.
     func uuid(_ params: [String: JSONValue], _ key: String) -> UUID? {
         guard let raw = string(params, key) else { return nil }
-        if let parsed = UUID(uuidString: raw) {
-            return parsed
+        return resolveIdentifier(raw, forParamKey: key)
+    }
+
+    /// Resolves either wire representation of an identifier — a raw UUID string
+    /// or a `kind:N` ref — for a named param key, rejecting kinds that key does
+    /// not accept. The single entrypoint both the typed params and the legacy
+    /// `[String: Any]` `v2UUID` path go through.
+    ///
+    /// - Parameters:
+    ///   - raw: The trimmed, non-empty param value.
+    ///   - key: The param key the value arrived under.
+    /// - Returns: The identifier, or `nil` if unknown or of the wrong kind.
+    public func resolveIdentifier(_ raw: String, forParamKey key: String) -> UUID? {
+        guard let parsed = UUID(uuidString: raw) else {
+            return resolveRef(raw, forParamKey: key)
         }
-        return resolveRef(raw, forParamKey: key)
+        guard let expected = Self.expectedHandleKinds[key] else { return parsed }
+        let minted = handles.mintedKinds(for: parsed)
+        // Never minted → kind unknown, so it still passes through (issue gap 1).
+        guard minted.isEmpty || !minted.isDisjoint(with: expected) else { return nil }
+        return parsed
     }
 
     /// Resolves a `kind:N` ref for a named param key, restricted to the handle

--- a/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Coordinator/ControlCommandCoordinator.swift
+++ b/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Coordinator/ControlCommandCoordinator.swift
@@ -408,7 +408,25 @@ public final class ControlCommandCoordinator {
             surfaceID: routingUUID(params, "surface_id")
                 ?? routingUUID(params, "terminal_id")
                 ?? routingUUID(params, "tab_id"),
-            paneID: routingUUID(params, "pane_id")
+            paneID: routingUUID(params, "pane_id"),
+            hasRejectedSelector: hasRejectedRoutingSelector(params)
         )
     }
+
+    /// Whether any routing selector was supplied but failed to resolve, which
+    /// must fail the routing walk rather than read as an absent selector.
+    ///
+    /// `window_id` is excluded: its presence is already carried separately by
+    /// ``ControlRoutingSelectors/hasWindowIDParam`` and handled by the walk.
+    func hasRejectedRoutingSelector(_ params: [String: JSONValue]) -> Bool {
+        Self.routingSelectorKeys.contains { key in
+            hasNonNull(params, key) && routingUUID(params, key) == nil
+        }
+    }
+
+    /// The routing selector keys whose supplied-but-invalid state fails closed.
+    /// `public` so the legacy `[String: Any]` routing walk applies the same set.
+    public static let routingSelectorKeys = [
+        "group_id", "workspace_id", "surface_id", "terminal_id", "tab_id", "pane_id",
+    ]
 }

--- a/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Coordinator/ControlIdentityKindContext.swift
+++ b/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Coordinator/ControlIdentityKindContext.swift
@@ -1,0 +1,34 @@
+public import Foundation
+
+/// The seam through which ``ControlCommandCoordinator`` asks the app what kind
+/// of object a raw UUID names.
+///
+/// A `kind:N` ref states its own kind, but the protocol also accepts raw UUID
+/// strings, which carry none. Without an answer here the coordinator can only
+/// consult the handle registry's mint history, and that is not a sound oracle:
+/// dock-hosted objects may not be minted yet, and
+/// ``ControlHandleRegistry/removeRef(kind:uuid:)`` erases what it knew. Live
+/// topology is authoritative, so a surface UUID handed to `group_id` is
+/// rejected rather than routed
+/// (https://github.com/manaflow-ai/cmux/issues/9424).
+@MainActor
+public protocol ControlIdentityKindContext: AnyObject {
+    /// The kinds a raw identifier is known to name in live app topology.
+    ///
+    /// An identity may hold more than one kind: a Window Dock owner id IS its
+    /// owning window's id, so it answers as both.
+    ///
+    /// - Parameter uuid: The identifier to classify.
+    /// - Returns: Every kind the identity currently names — empty when it names
+    ///   nothing live — or `nil` when this conformer cannot classify at all, in
+    ///   which case the coordinator falls back to the handle registry.
+    func controlIdentityKinds(for uuid: UUID) -> Set<ControlHandleKind>?
+}
+
+extension ControlIdentityKindContext {
+    /// Conformers that cannot classify opt out; the coordinator then falls back
+    /// to the handle registry's mint history.
+    public func controlIdentityKinds(for uuid: UUID) -> Set<ControlHandleKind>? {
+        nil
+    }
+}

--- a/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Coordinator/ControlRoutingSelectors.swift
+++ b/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Coordinator/ControlRoutingSelectors.swift
@@ -29,6 +29,22 @@ public struct ControlRoutingSelectors: Sendable, Equatable {
     public let surfaceID: UUID?
     /// The resolved `pane_id` target, if any.
     public let paneID: UUID?
+    /// Whether any routing selector was supplied but could not be resolved —
+    /// a wrong-kind ref or id, an unknown `kind:N` ref, or a blank/non-string
+    /// value.
+    ///
+    /// A supplied-but-invalid selector is NOT the same as an absent one: a
+    /// `nil` id alone reads as "caller did not target this", so the walk would
+    /// slide past it to the active window and run the command against an
+    /// implicit target the caller never named
+    /// (https://github.com/manaflow-ai/cmux/issues/9424). The walk must fail
+    /// closed when this is set, exactly as it already does for a
+    /// present-but-unresolvable `window_id`.
+    ///
+    /// This deliberately does not cover a well-formed id that names nothing
+    /// live: that is the issue's gap 1, where the CLI's injected caller
+    /// context is indistinguishable on the wire from a user-specified target.
+    public let hasRejectedSelector: Bool
 
     /// Creates a routing-selectors value.
     ///
@@ -39,13 +55,15 @@ public struct ControlRoutingSelectors: Sendable, Equatable {
     ///   - workspaceID: The resolved `workspace_id` target.
     ///   - surfaceID: The resolved surface target.
     ///   - paneID: The resolved `pane_id` target.
+    ///   - hasRejectedSelector: Whether a supplied selector failed to resolve.
     public init(
         hasWindowIDParam: Bool,
         windowID: UUID?,
         groupID: UUID?,
         workspaceID: UUID?,
         surfaceID: UUID?,
-        paneID: UUID?
+        paneID: UUID?,
+        hasRejectedSelector: Bool = false
     ) {
         self.hasWindowIDParam = hasWindowIDParam
         self.windowID = windowID
@@ -53,5 +71,6 @@ public struct ControlRoutingSelectors: Sendable, Equatable {
         self.workspaceID = workspaceID
         self.surfaceID = surfaceID
         self.paneID = paneID
+        self.hasRejectedSelector = hasRejectedSelector
     }
 }

--- a/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Wire/ControlHandleRegistry.swift
+++ b/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Wire/ControlHandleRegistry.swift
@@ -61,6 +61,24 @@ public struct ControlHandleRegistry: Sendable {
         refByUUID[kind]?.removeValue(forKey: uuid)
     }
 
+    /// The kinds an identity has been minted a ref for.
+    ///
+    /// A raw UUID carries no kind on the wire, but once the registry has handed
+    /// out a ref for it, its kind is known: a UUID minted only as `.surface` and
+    /// then supplied as `group_id` is provably the wrong kind, not merely an
+    /// unrecognized one. Empty means the registry has never seen this identity,
+    /// so its kind is genuinely unknown.
+    ///
+    /// - Parameter uuid: The object identity.
+    /// - Returns: Every kind this identity has a minted ref for.
+    public func mintedKinds(for uuid: UUID) -> Set<ControlHandleKind> {
+        var kinds: Set<ControlHandleKind> = []
+        for kind in ControlHandleKind.allCases where refByUUID[kind]?[uuid] != nil {
+            kinds.insert(kind)
+        }
+        return kinds
+    }
+
     /// Resolves a ref back to the object identity it was minted for.
     ///
     /// `tab:N` refs are accepted as aliases for `surface:N` in tab-facing

--- a/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Wire/ControlHandleRegistry.swift
+++ b/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Wire/ControlHandleRegistry.swift
@@ -69,12 +69,33 @@ public struct ControlHandleRegistry: Sendable {
     /// - Parameter ref: The handle ref to resolve.
     /// - Returns: The object identity, or `nil` for an unknown ref.
     public func uuid(forRef ref: String) -> UUID? {
-        for kind in ControlHandleKind.allCases {
+        uuid(forRef: ref, kinds: ControlHandleKind.allCases)
+    }
+
+    /// Resolves a ref back to the object identity it was minted for, but only
+    /// when that identity was minted for one of `kinds`.
+    ///
+    /// Routing params carry an expected kind (`group_id` means a workspace
+    /// group, `pane_id` means a pane), and an unrestricted search lets a
+    /// wrong-kind ref resolve to some unrelated object, miss its lookup, and
+    /// degrade to the active window
+    /// (https://github.com/manaflow-ai/cmux/issues/9424).
+    ///
+    /// `tab:N` is still accepted as the wire alias for `surface:N` whenever
+    /// `.surface` is an accepted kind.
+    ///
+    /// - Parameters:
+    ///   - ref: The handle ref to resolve.
+    ///   - kinds: The kinds the caller will accept.
+    /// - Returns: The object identity, or `nil` for an unknown or wrong-kind ref.
+    public func uuid(forRef ref: String, kinds: [ControlHandleKind]) -> UUID? {
+        for kind in kinds {
             if let id = uuidByRef[kind]?[ref] {
                 return id
             }
         }
         // Tab refs are aliases for surface refs in tab-facing APIs.
+        guard kinds.contains(.surface) else { return nil }
         let trimmed = ref.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
         if trimmed.hasPrefix("tab:"),
            let ordinal = Int(trimmed.replacingOccurrences(of: "tab:", with: "")),

--- a/Packages/macOS/CmuxControlSocket/Tests/CmuxControlSocketTests/ControlCommandCoordinatorRoutingKindTests.swift
+++ b/Packages/macOS/CmuxControlSocket/Tests/CmuxControlSocketTests/ControlCommandCoordinatorRoutingKindTests.swift
@@ -1,0 +1,85 @@
+import Foundation
+import Testing
+@testable import CmuxControlSocket
+
+/// Regression coverage for https://github.com/manaflow-ai/cmux/issues/9424 (2):
+/// a `kind:N` ref must only resolve for the kind its param key expects.
+///
+/// `ControlHandleRegistry.uuid(forRef:)` searches every kind, so `group_id:
+/// "surface:1"` used to resolve to a surface UUID, fail the group lookup in the
+/// routing walk, and fall through to the active window — turning a
+/// wrong-kind explicit target into an implicit one.
+@MainActor
+@Suite("ControlCommandCoordinator routing ref kinds")
+struct ControlCommandCoordinatorRoutingKindTests {
+    private struct Handles {
+        var window = UUID()
+        var workspace = UUID()
+        var group = UUID()
+        var pane = UUID()
+        var surface = UUID()
+    }
+
+    /// A coordinator with one minted ref per kind (`window:1`, `workspace:1`,
+    /// `workspace_group:1`, `pane:1`, `surface:1`).
+    private func coordinatorWithOneRefPerKind() -> (ControlCommandCoordinator, Handles) {
+        let coordinator = ControlCommandCoordinator()
+        let handles = Handles()
+        coordinator.ensureRef(kind: .window, uuid: handles.window)
+        coordinator.ensureRef(kind: .workspace, uuid: handles.workspace)
+        coordinator.ensureRef(kind: .workspaceGroup, uuid: handles.group)
+        coordinator.ensureRef(kind: .pane, uuid: handles.pane)
+        coordinator.ensureRef(kind: .surface, uuid: handles.surface)
+        return (coordinator, handles)
+    }
+
+    @Test func wrongKindRefsDoNotResolveAsRoutingSelectors() {
+        let (coordinator, _) = coordinatorWithOneRefPerKind()
+
+        #expect(coordinator.routingSelectors(["group_id": .string("surface:1")]).groupID == nil)
+        #expect(coordinator.routingSelectors(["group_id": .string("workspace:1")]).groupID == nil)
+        #expect(coordinator.routingSelectors(["pane_id": .string("workspace:1")]).paneID == nil)
+        #expect(coordinator.routingSelectors(["workspace_id": .string("pane:1")]).workspaceID == nil)
+        #expect(coordinator.routingSelectors(["surface_id": .string("pane:1")]).surfaceID == nil)
+
+        // A present-but-wrong-kind window_id must stay "present, unresolvable"
+        // so the routing walk fails closed instead of falling through.
+        let windowRouting = coordinator.routingSelectors(["window_id": .string("surface:1")])
+        #expect(windowRouting.hasWindowIDParam)
+        #expect(windowRouting.windowID == nil)
+    }
+
+    @Test func rightKindRefsStillResolve() {
+        let (coordinator, handles) = coordinatorWithOneRefPerKind()
+
+        #expect(coordinator.routingSelectors(["window_id": .string("window:1")]).windowID == handles.window)
+        #expect(
+            coordinator.routingSelectors(["workspace_id": .string("workspace:1")]).workspaceID
+                == handles.workspace
+        )
+        #expect(
+            coordinator.routingSelectors(["group_id": .string("workspace_group:1")]).groupID
+                == handles.group
+        )
+        #expect(coordinator.routingSelectors(["pane_id": .string("pane:1")]).paneID == handles.pane)
+        #expect(
+            coordinator.routingSelectors(["surface_id": .string("surface:1")]).surfaceID
+                == handles.surface
+        )
+    }
+
+    @Test func protocolAliasesStayAccepted() {
+        let (coordinator, handles) = coordinatorWithOneRefPerKind()
+
+        // `tab:N` is the wire alias for `surface:N` in tab-facing APIs.
+        #expect(coordinator.routingSelectors(["surface_id": .string("tab:1")]).surfaceID == handles.surface)
+        #expect(coordinator.routingSelectors(["tab_id": .string("tab:1")]).surfaceID == handles.surface)
+        #expect(coordinator.routingSelectors(["terminal_id": .string("surface:1")]).surfaceID == handles.surface)
+
+        // The Window Dock passes a *window* identity as `workspace_id`.
+        #expect(
+            coordinator.routingSelectors(["workspace_id": .string("window:1")]).workspaceID
+                == handles.window
+        )
+    }
+}

--- a/Packages/macOS/CmuxControlSocket/Tests/CmuxControlSocketTests/ControlCommandCoordinatorRoutingKindTests.swift
+++ b/Packages/macOS/CmuxControlSocket/Tests/CmuxControlSocketTests/ControlCommandCoordinatorRoutingKindTests.swift
@@ -147,20 +147,76 @@ struct ControlCommandCoordinatorRoutingKindTests {
         }
     }
 
-    /// The Window Dock alias belongs to the routing `workspace_id` only. The
-    /// ordering/reference workspace keys take part in no aliasing, so a window
-    /// identity is wrong-kind there.
-    @Test func onlyRoutingWorkspaceIDTakesTheWindowAlias() {
+    /// The Window Dock alias belongs to the routing walk, not to the parameter
+    /// name: a command using `workspace_id` as an actual workspace target must
+    /// still reject a window identity.
+    @Test func theWindowAliasIsScopedToTheRoutingLane() {
         let (coordinator, handles) = coordinatorWithOneRefPerKind()
 
-        #expect(coordinator.resolveIdentifier("window:1", forParamKey: "workspace_id") == handles.window)
+        #expect(
+            coordinator.routingSelectors(["workspace_id": .string("window:1")]).workspaceID
+                == handles.window
+        )
+        #expect(coordinator.resolveIdentifier("window:1", forParamKey: "workspace_id") == nil)
+        #expect(
+            coordinator.resolveIdentifier("window:1", forParamKey: "workspace_id", routing: true)
+                == handles.window
+        )
+        // A real workspace is accepted on both lanes.
+        #expect(coordinator.resolveIdentifier("workspace:1", forParamKey: "workspace_id") == handles.workspace)
+
+        // The ordering/reference workspace keys take part in no aliasing at all.
         for key in [
             "reference_workspace_id", "group_reference_workspace_id",
             "before_workspace_id", "after_workspace_id",
         ] {
-            #expect(coordinator.resolveIdentifier("window:1", forParamKey: key) == nil)
+            #expect(coordinator.resolveIdentifier("window:1", forParamKey: key, routing: true) == nil)
             #expect(coordinator.resolveIdentifier("workspace:1", forParamKey: key) == handles.workspace)
         }
+    }
+
+    /// Live topology outranks mint history, so an identity the registry never
+    /// minted (a dock-hosted surface) or has since forgotten is still rejected
+    /// under a wrong-kind key.
+    @Test func authoritativeKindsOutrankMintHistory() {
+        let coordinator = ControlCommandCoordinator()
+        let context = FakeSurfaceControlCommandContext()
+        coordinator.context = context
+        let dockSurface = UUID()
+        context.identityKinds = [dockSurface: [.surface]]
+
+        // Never minted, so mint history alone would have let this through.
+        #expect(coordinator.handles.mintedKinds(for: dockSurface).isEmpty)
+        #expect(coordinator.routingSelectors(["group_id": .string(dockSurface.uuidString)]).groupID == nil)
+        #expect(coordinator.routingSelectors(["pane_id": .string(dockSurface.uuidString)]).paneID == nil)
+        #expect(
+            coordinator.routingSelectors(["surface_id": .string(dockSurface.uuidString)]).surfaceID
+                == dockSurface
+        )
+
+        // Forgetting the ref does not resurrect the wrong-kind acceptance.
+        let surface = UUID()
+        context.identityKinds?[surface] = [.surface]
+        coordinator.ensureRef(kind: .surface, uuid: surface)
+        coordinator.removeRef(kind: .surface, uuid: surface)
+        #expect(coordinator.routingSelectors(["group_id": .string(surface.uuidString)]).groupID == nil)
+    }
+
+    /// An identity live topology reports as multi-kind (a Window Dock owner id
+    /// IS its owning window's id) satisfies either expectation.
+    @Test func multiKindIdentitiesSatisfyEitherExpectation() {
+        let coordinator = ControlCommandCoordinator()
+        let context = FakeSurfaceControlCommandContext()
+        coordinator.context = context
+        let dockOwner = UUID()
+        context.identityKinds = [dockOwner: [.window, .workspace]]
+
+        #expect(coordinator.routingSelectors(["window_id": .string(dockOwner.uuidString)]).windowID == dockOwner)
+        #expect(
+            coordinator.routingSelectors(["workspace_id": .string(dockOwner.uuidString)]).workspaceID
+                == dockOwner
+        )
+        #expect(coordinator.routingSelectors(["group_id": .string(dockOwner.uuidString)]).groupID == nil)
     }
 
     @Test func registryRejectsRefsOutsideTheRequestedKinds() {

--- a/Packages/macOS/CmuxControlSocket/Tests/CmuxControlSocketTests/ControlCommandCoordinatorRoutingKindTests.swift
+++ b/Packages/macOS/CmuxControlSocket/Tests/CmuxControlSocketTests/ControlCommandCoordinatorRoutingKindTests.swift
@@ -219,6 +219,70 @@ struct ControlCommandCoordinatorRoutingKindTests {
         #expect(coordinator.routingSelectors(["group_id": .string(dockOwner.uuidString)]).groupID == nil)
     }
 
+    /// A supplied-but-invalid selector must not read as an absent one. Without
+    /// this the walk slides past the `nil` id to the active window and runs the
+    /// command against a target the caller never named — the original bug,
+    /// merely reached one step later.
+    @Test func suppliedButInvalidSelectorsAreMarkedRejected() {
+        let (coordinator, handles) = coordinatorWithOneRefPerKind()
+
+        for params: [String: JSONValue] in [
+            ["group_id": .string("surface:1")],
+            ["group_id": .string(handles.surface.uuidString)],
+            ["workspace_id": .string("pane:1")],
+            ["surface_id": .string("pane:1")],
+            ["pane_id": .string("surface:1")],
+            ["tab_id": .string("workspace:1")],
+            ["terminal_id": .string("pane:1")],
+            ["group_id": .string("workspace_group:99")],
+            ["group_id": .string("   ")],
+            ["group_id": .int(7)],
+        ] {
+            #expect(coordinator.routingSelectors(params).hasRejectedSelector)
+        }
+    }
+
+    @Test func validAndAbsentSelectorsAreNotMarkedRejected() {
+        let (coordinator, handles) = coordinatorWithOneRefPerKind()
+
+        for params: [String: JSONValue] in [
+            [:],
+            ["group_id": .null],
+            ["group_id": .string("workspace_group:1")],
+            ["workspace_id": .string("workspace:1")],
+            ["workspace_id": .string("window:1")],
+            ["surface_id": .string("tab:1")],
+            ["pane_id": .string(handles.pane.uuidString)],
+            // Unknown-but-well-formed ids stay acceptable: that is gap 1.
+            ["group_id": .string(UUID().uuidString)],
+        ] {
+            #expect(!coordinator.routingSelectors(params).hasRejectedSelector)
+        }
+    }
+
+    /// End-to-end: a wrong-kind `group_id` on a destructive command must be
+    /// refused, not routed to whatever window happens to be active.
+    @Test func wrongKindRoutingSelectorRefusesTheCommand() {
+        let coordinator = ControlCommandCoordinator()
+        let context = FakeSurfaceControlCommandContext()
+        // Mirror the app rule: a rejected selector resolves no tab manager.
+        context.routingResolvesTabManager = { !$0.hasRejectedSelector }
+        coordinator.context = context
+        coordinator.ensureRef(kind: .surface, uuid: UUID())
+
+        let result = coordinator.handle(ControlRequest(
+            id: .int(1),
+            method: "surface.close",
+            params: ["group_id": .string("surface:1")]
+        ))
+
+        guard case .err(let code, _, _) = result else {
+            Issue.record("expected a wrong-kind group_id to refuse surface.close, got \(result)")
+            return
+        }
+        #expect(code == "unavailable")
+    }
+
     @Test func registryRejectsRefsOutsideTheRequestedKinds() {
         var registry = ControlHandleRegistry()
         let surfaceID = UUID()

--- a/Packages/macOS/CmuxControlSocket/Tests/CmuxControlSocketTests/ControlCommandCoordinatorRoutingKindTests.swift
+++ b/Packages/macOS/CmuxControlSocket/Tests/CmuxControlSocketTests/ControlCommandCoordinatorRoutingKindTests.swift
@@ -283,6 +283,77 @@ struct ControlCommandCoordinatorRoutingKindTests {
         #expect(code == "unavailable")
     }
 
+    /// A user-specified selector naming nothing live fails closed. `group_id`
+    /// and `pane_id` are never filled from the caller's environment by the CLI,
+    /// so a stale or invented id there is a mistargeted command, not context.
+    @Test func unknownUserSpecifiedSelectorsFailClosed() {
+        let coordinator = ControlCommandCoordinator()
+        let context = FakeSurfaceControlCommandContext()
+        context.identityKinds = [:]
+        coordinator.context = context
+        let stranger = UUID()
+
+        let group = coordinator.routingSelectors(["group_id": .string(stranger.uuidString)])
+        #expect(group.groupID == nil)
+        #expect(group.hasRejectedSelector)
+
+        let pane = coordinator.routingSelectors(["pane_id": .string(stranger.uuidString)])
+        #expect(pane.paneID == nil)
+        #expect(pane.hasRejectedSelector)
+    }
+
+    /// The caller-injected keys keep falling back, because the CLI puts the
+    /// caller's own `CMUX_WORKSPACE_ID`/`CMUX_SURFACE_ID` there and a
+    /// since-closed workspace must not break ordinary commands. That is gap 1,
+    /// pending the wire-format change.
+    @Test func unknownCallerInjectableSelectorsStillPassThrough() {
+        let coordinator = ControlCommandCoordinator()
+        let context = FakeSurfaceControlCommandContext()
+        context.identityKinds = [:]
+        coordinator.context = context
+        let stale = UUID()
+
+        for key in ["workspace_id", "surface_id", "terminal_id", "tab_id"] {
+            let routing = coordinator.routingSelectors([key: .string(stale.uuidString)])
+            #expect(!routing.hasRejectedSelector)
+        }
+        #expect(
+            coordinator.routingSelectors(["workspace_id": .string(stale.uuidString)]).workspaceID == stale
+        )
+    }
+
+    /// With no app attached the classification is not authoritative, so absence
+    /// of evidence must not become evidence of absence.
+    @Test func nonAuthoritativeClassificationStaysPermissive() {
+        let (coordinator, _) = coordinatorWithOneRefPerKind()
+        let stranger = UUID()
+
+        let routing = coordinator.routingSelectors(["group_id": .string(stranger.uuidString)])
+        #expect(routing.groupID == stranger)
+        #expect(!routing.hasRejectedSelector)
+    }
+
+    /// Classification is memoized per request, so a routed command does not
+    /// sweep live topology once per selector occurrence.
+    @Test func identityClassificationIsMemoizedPerRequest() {
+        let coordinator = ControlCommandCoordinator()
+        let context = FakeSurfaceControlCommandContext()
+        let workspace = UUID()
+        context.identityKinds = [workspace: [.workspace]]
+        coordinator.context = context
+
+        _ = coordinator.routingSelectors([
+            "workspace_id": .string(workspace.uuidString),
+            "surface_id": .string(workspace.uuidString),
+        ])
+        #expect(context.identityKindQueries[workspace] == 1)
+
+        // A new request re-snapshots topology.
+        coordinator.resetIdentityKindCache()
+        _ = coordinator.routingSelectors(["workspace_id": .string(workspace.uuidString)])
+        #expect(context.identityKindQueries[workspace] == 2)
+    }
+
     @Test func registryRejectsRefsOutsideTheRequestedKinds() {
         var registry = ControlHandleRegistry()
         let surfaceID = UUID()

--- a/Packages/macOS/CmuxControlSocket/Tests/CmuxControlSocketTests/ControlCommandCoordinatorRoutingKindTests.swift
+++ b/Packages/macOS/CmuxControlSocket/Tests/CmuxControlSocketTests/ControlCommandCoordinatorRoutingKindTests.swift
@@ -82,4 +82,21 @@ struct ControlCommandCoordinatorRoutingKindTests {
                 == handles.window
         )
     }
+
+    @Test func registryRejectsRefsOutsideTheRequestedKinds() {
+        var registry = ControlHandleRegistry()
+        let surfaceID = UUID()
+        let paneID = UUID()
+        _ = registry.ensureRef(kind: .surface, uuid: surfaceID)
+        _ = registry.ensureRef(kind: .pane, uuid: paneID)
+
+        #expect(registry.uuid(forRef: "surface:1", kinds: [.surface]) == surfaceID)
+        #expect(registry.uuid(forRef: "tab:1", kinds: [.surface]) == surfaceID)
+        #expect(registry.uuid(forRef: "surface:1", kinds: [.pane]) == nil)
+        #expect(registry.uuid(forRef: "tab:1", kinds: [.pane]) == nil)
+        #expect(registry.uuid(forRef: "pane:1", kinds: [.pane, .surface]) == paneID)
+        #expect(registry.uuid(forRef: "pane:1", kinds: []) == nil)
+        // The unrestricted overload is unchanged for kind-agnostic callers.
+        #expect(registry.uuid(forRef: "pane:1") == paneID)
+    }
 }

--- a/Packages/macOS/CmuxControlSocket/Tests/CmuxControlSocketTests/ControlCommandCoordinatorRoutingKindTests.swift
+++ b/Packages/macOS/CmuxControlSocket/Tests/CmuxControlSocketTests/ControlCommandCoordinatorRoutingKindTests.swift
@@ -12,19 +12,19 @@ import Testing
 @MainActor
 @Suite("ControlCommandCoordinator routing ref kinds")
 struct ControlCommandCoordinatorRoutingKindTests {
-    private struct Handles {
-        var window = UUID()
-        var workspace = UUID()
-        var group = UUID()
-        var pane = UUID()
-        var surface = UUID()
-    }
+    /// The identities behind `window:1`, `workspace:1`, `workspace_group:1`,
+    /// `pane:1`, and `surface:1` in a freshly seeded coordinator.
+    private typealias Handles = (
+        window: UUID, workspace: UUID, group: UUID, pane: UUID, surface: UUID
+    )
 
     /// A coordinator with one minted ref per kind (`window:1`, `workspace:1`,
     /// `workspace_group:1`, `pane:1`, `surface:1`).
     private func coordinatorWithOneRefPerKind() -> (ControlCommandCoordinator, Handles) {
         let coordinator = ControlCommandCoordinator()
-        let handles = Handles()
+        let handles: Handles = (
+            window: UUID(), workspace: UUID(), group: UUID(), pane: UUID(), surface: UUID()
+        )
         coordinator.ensureRef(kind: .window, uuid: handles.window)
         coordinator.ensureRef(kind: .workspace, uuid: handles.workspace)
         coordinator.ensureRef(kind: .workspaceGroup, uuid: handles.group)
@@ -81,6 +81,54 @@ struct ControlCommandCoordinatorRoutingKindTests {
             coordinator.routingSelectors(["workspace_id": .string("window:1")]).workspaceID
                 == handles.window
         )
+    }
+
+    /// A raw UUID string bypasses `kind:N` parsing entirely, so kind checking
+    /// has to happen for it too whenever the registry already knows what that
+    /// identity is. A surface UUID handed to `group_id` is provably wrong-kind.
+    @Test func rawUUIDsOfAKnownWrongKindDoNotResolve() {
+        let (coordinator, handles) = coordinatorWithOneRefPerKind()
+
+        #expect(coordinator.routingSelectors(["group_id": .string(handles.surface.uuidString)]).groupID == nil)
+        #expect(coordinator.routingSelectors(["group_id": .string(handles.workspace.uuidString)]).groupID == nil)
+        #expect(coordinator.routingSelectors(["pane_id": .string(handles.surface.uuidString)]).paneID == nil)
+        #expect(coordinator.routingSelectors(["surface_id": .string(handles.pane.uuidString)]).surfaceID == nil)
+        #expect(coordinator.routingSelectors(["workspace_id": .string(handles.pane.uuidString)]).workspaceID == nil)
+
+        let windowRouting = coordinator.routingSelectors(["window_id": .string(handles.surface.uuidString)])
+        #expect(windowRouting.hasWindowIDParam)
+        #expect(windowRouting.windowID == nil)
+    }
+
+    @Test func rawUUIDsOfTheRightKindStillResolve() {
+        let (coordinator, handles) = coordinatorWithOneRefPerKind()
+
+        #expect(
+            coordinator.routingSelectors(["group_id": .string(handles.group.uuidString)]).groupID
+                == handles.group
+        )
+        #expect(
+            coordinator.routingSelectors(["surface_id": .string(handles.surface.uuidString)]).surfaceID
+                == handles.surface
+        )
+        #expect(coordinator.routingSelectors(["pane_id": .string(handles.pane.uuidString)]).paneID == handles.pane)
+        // The Window Dock passes a window identity as workspace_id.
+        #expect(
+            coordinator.routingSelectors(["workspace_id": .string(handles.window.uuidString)]).workspaceID
+                == handles.window
+        )
+    }
+
+    /// A UUID the registry has never minted has no known kind, so it still
+    /// passes through. That is gap 1 of the issue (the caller-injected
+    /// `CMUX_WORKSPACE_ID`/`CMUX_SURFACE_ID` context problem), which needs a
+    /// product call on the wire format before it can fail closed.
+    @Test func unmintedRawUUIDsStillPassThrough() {
+        let (coordinator, _) = coordinatorWithOneRefPerKind()
+        let stranger = UUID()
+
+        #expect(coordinator.routingSelectors(["group_id": .string(stranger.uuidString)]).groupID == stranger)
+        #expect(coordinator.routingSelectors(["surface_id": .string(stranger.uuidString)]).surfaceID == stranger)
     }
 
     @Test func registryRejectsRefsOutsideTheRequestedKinds() {

--- a/Packages/macOS/CmuxControlSocket/Tests/CmuxControlSocketTests/ControlCommandCoordinatorRoutingKindTests.swift
+++ b/Packages/macOS/CmuxControlSocket/Tests/CmuxControlSocketTests/ControlCommandCoordinatorRoutingKindTests.swift
@@ -131,6 +131,38 @@ struct ControlCommandCoordinatorRoutingKindTests {
         #expect(coordinator.routingSelectors(["surface_id": .string(stranger.uuidString)]).surfaceID == stranger)
     }
 
+    /// Non-routing target keys resolved through the same helper need the kind
+    /// they actually mean: `return_to` is a surface, while `from_tab_id` and
+    /// `to_tab_id` are workspaces despite the name (they are matched against a
+    /// window's workspace list).
+    @Test func secondaryTargetKeysUseTheKindTheyActuallyMean() {
+        let (coordinator, handles) = coordinatorWithOneRefPerKind()
+
+        #expect(coordinator.resolveIdentifier("surface:1", forParamKey: "return_to") == handles.surface)
+        #expect(coordinator.resolveIdentifier("workspace:1", forParamKey: "return_to") == nil)
+
+        for key in ["from_tab_id", "to_tab_id"] {
+            #expect(coordinator.resolveIdentifier("workspace:1", forParamKey: key) == handles.workspace)
+            #expect(coordinator.resolveIdentifier("surface:1", forParamKey: key) == nil)
+        }
+    }
+
+    /// The Window Dock alias belongs to the routing `workspace_id` only. The
+    /// ordering/reference workspace keys take part in no aliasing, so a window
+    /// identity is wrong-kind there.
+    @Test func onlyRoutingWorkspaceIDTakesTheWindowAlias() {
+        let (coordinator, handles) = coordinatorWithOneRefPerKind()
+
+        #expect(coordinator.resolveIdentifier("window:1", forParamKey: "workspace_id") == handles.window)
+        for key in [
+            "reference_workspace_id", "group_reference_workspace_id",
+            "before_workspace_id", "after_workspace_id",
+        ] {
+            #expect(coordinator.resolveIdentifier("window:1", forParamKey: key) == nil)
+            #expect(coordinator.resolveIdentifier("workspace:1", forParamKey: key) == handles.workspace)
+        }
+    }
+
     @Test func registryRejectsRefsOutsideTheRequestedKinds() {
         var registry = ControlHandleRegistry()
         let surfaceID = UUID()

--- a/Packages/macOS/CmuxControlSocket/Tests/CmuxControlSocketTests/FakeSurfaceControlCommandContext.swift
+++ b/Packages/macOS/CmuxControlSocket/Tests/CmuxControlSocketTests/FakeSurfaceControlCommandContext.swift
@@ -22,7 +22,11 @@ final class FakeSurfaceControlCommandContext: ControlCommandContext {
     /// classification so the coordinator falls back to the handle registry.
     var identityKinds: [UUID: Set<ControlHandleKind>]?
 
+    /// How many times each identity was classified, for memoization coverage.
+    var identityKindQueries: [UUID: Int] = [:]
+
     func controlIdentityKinds(for uuid: UUID) -> Set<ControlHandleKind>? {
+        identityKindQueries[uuid, default: 0] += 1
         guard let identityKinds else { return nil }
         return identityKinds[uuid] ?? []
     }

--- a/Packages/macOS/CmuxControlSocket/Tests/CmuxControlSocketTests/FakeSurfaceControlCommandContext.swift
+++ b/Packages/macOS/CmuxControlSocket/Tests/CmuxControlSocketTests/FakeSurfaceControlCommandContext.swift
@@ -38,7 +38,12 @@ final class FakeSurfaceControlCommandContext: ControlCommandContext {
     func controlWindowExists(id: UUID) -> Bool { false }
     func controlMoveWindow(id: UUID, toDisplayMatching query: String) -> String? { nil }
     func controlMoveAllWindows(toDisplayMatching query: String) -> ControlMoveAllWindowsResult? { nil }
-    func controlSurfaceRoutingResolvesTabManager(routing: ControlRoutingSelectors) -> Bool { true }
+    /// Overridable routing rule; defaults to the app's "always resolves".
+    var routingResolvesTabManager: (ControlRoutingSelectors) -> Bool = { _ in true }
+
+    func controlSurfaceRoutingResolvesTabManager(routing: ControlRoutingSelectors) -> Bool {
+        routingResolvesTabManager(routing)
+    }
     func controlSurfaceList(routing: ControlRoutingSelectors) -> ControlSurfaceListSnapshot? {
         surfaceListSnapshot
     }

--- a/Packages/macOS/CmuxControlSocket/Tests/CmuxControlSocketTests/FakeSurfaceControlCommandContext.swift
+++ b/Packages/macOS/CmuxControlSocket/Tests/CmuxControlSocketTests/FakeSurfaceControlCommandContext.swift
@@ -18,6 +18,14 @@ final class FakeSurfaceControlCommandContext: ControlCommandContext {
     var reportGitResolution: ControlSurfaceReportGitBranchResolution = .recorded(surfaceID: UUID())
     var reportedGit: (workspaceID: UUID, requestedSurfaceID: UUID?, branch: String, isDirty: Bool?)?
     var clearedGit: (workspaceID: UUID, requestedSurfaceID: UUID?)?
+    /// Live-topology kinds per identity; `nil` opts out of authoritative
+    /// classification so the coordinator falls back to the handle registry.
+    var identityKinds: [UUID: Set<ControlHandleKind>]?
+
+    func controlIdentityKinds(for uuid: UUID) -> Set<ControlHandleKind>? {
+        guard let identityKinds else { return nil }
+        return identityKinds[uuid] ?? []
+    }
 
     func controlWindowSummaries() -> [ControlWindowSummary] { [] }
     func controlResolveCurrentWindow(routing: ControlRoutingSelectors) -> ControlCurrentWindowResolution {

--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -3670,6 +3670,9 @@ class TerminalController {
     // the worker-lane resolution hop, mirroring the main-lane dispatch
     // preamble.
     func v2RefreshKnownRefs() {
+        // Identity classification snapshots live topology for the request, so
+        // it is refreshed on the same boundary as the handle refs.
+        controlCommandCoordinator.resetIdentityKindCache()
         guard let app = AppDelegate.shared else { return }
 
         let windows = app.listMainWindowSummaries()
@@ -3704,17 +3707,29 @@ class TerminalController {
         // an absent one would slide down to the active window and act on a
         // target the caller never named
         // (https://github.com/manaflow-ai/cmux/issues/9424).
-        if v2HasRejectedRoutingSelector(params) { return nil }
         if v2HasNonNullParam(params, "window_id") {
             guard let windowId = v2RoutingUUID(params, "window_id") else { return nil }
             return v2MainSync { AppDelegate.shared?.tabManagerFor(windowId: windowId) }
         }
-        if let groupId = v2RoutingUUID(params, "group_id") {
+        // Resolve each selector once, recording supplied-but-invalid as it goes,
+        // so classification does not sweep live topology twice per request.
+        var rejected = false
+        func selector(_ key: String) -> UUID? {
+            let resolved = v2RoutingUUID(params, key)
+            if resolved == nil, v2HasNonNullParam(params, key) { rejected = true }
+            return resolved
+        }
+        let groupSelector = selector("group_id")
+        let workspaceSelector = selector("workspace_id")
+        let surfaceSelector = selector("surface_id") ?? selector("terminal_id") ?? selector("tab_id")
+        let paneSelector = selector("pane_id")
+        if rejected { return nil }
+        if let groupId = groupSelector {
             if let tm = v2MainSync({ v2LocateTabManager(forGroupId: groupId) }) {
                 return tm
             }
         }
-        if let wsId = v2RoutingUUID(params, "workspace_id") {
+        if let wsId = workspaceSelector {
             if wsId == AppDelegate.windowDockAliasWorkspaceId {
                 return v2MainSync { tabManager ?? AppDelegate.shared?.currentScriptableMainWindow()?.tabManager }
             }
@@ -3727,12 +3742,10 @@ class TerminalController {
                 return tm
             }
         }
-        if let surfaceId = v2RoutingUUID(params, "surface_id")
-            ?? v2RoutingUUID(params, "terminal_id")
-            ?? v2RoutingUUID(params, "tab_id") {
+        if let surfaceId = surfaceSelector {
             if let manager = v2MainSync({ controlTabManager(surfaceID: surfaceId) }) { return manager }
         }
-        if let paneId = v2RoutingUUID(params, "pane_id") {
+        if let paneId = paneSelector {
             if let tm = v2MainSync({ controlTabManager(paneID: paneId) }) {
                 return tm
             }

--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -3622,6 +3622,12 @@ class TerminalController {
         controlCommandCoordinator.resolveRef(handle)
     }
 
+    /// Resolves a handle ref that arrived under a specific param key, restricted
+    /// to the handle kinds that key accepts.
+    func v2ResolveHandleRef(_ handle: String, forParamKey key: String) -> UUID? {
+        controlCommandCoordinator.resolveRef(handle, forParamKey: key)
+    }
+
     nonisolated func v2Ref(kind: ControlHandleKind, uuid: UUID?) -> Any {
         guard let uuid else { return NSNull() }
         return v2MainSync { v2EnsureHandleRef(kind: kind, uuid: uuid) }

--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -3699,6 +3699,12 @@ class TerminalController {
         // CLI helpers always inject caller workspace_id/surface_id, which
         // would otherwise win even when the group belongs to a different
         // window). Then use workspace/surface/pane lookup and the active window.
+        //
+        // A supplied-but-invalid selector fails closed first: treating it like
+        // an absent one would slide down to the active window and act on a
+        // target the caller never named
+        // (https://github.com/manaflow-ai/cmux/issues/9424).
+        if v2HasRejectedRoutingSelector(params) { return nil }
         if v2HasNonNullParam(params, "window_id") {
             guard let windowId = v2RoutingUUID(params, "window_id") else { return nil }
             return v2MainSync { AppDelegate.shared?.tabManagerFor(windowId: windowId) }
@@ -3788,6 +3794,10 @@ class TerminalController {
     /// active scriptable window. Lives here so it can read the controller's
     /// `private` `tabManager` / `v2LocateTabManager`.
     func resolveTabManager(routing: ControlRoutingSelectors) -> TabManager? {
+        // A supplied-but-invalid selector is not an absent one: falling through
+        // would run the command against an implicit window the caller never
+        // named (https://github.com/manaflow-ai/cmux/issues/9424).
+        if routing.hasRejectedSelector { return nil }
         if routing.hasWindowIDParam {
             guard let windowId = routing.windowID else { return nil }
             return AppDelegate.shared?.tabManagerFor(windowId: windowId)

--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -3622,10 +3622,11 @@ class TerminalController {
         controlCommandCoordinator.resolveRef(handle)
     }
 
-    /// Resolves a handle ref that arrived under a specific param key, restricted
-    /// to the handle kinds that key accepts.
-    func v2ResolveHandleRef(_ handle: String, forParamKey key: String) -> UUID? {
-        controlCommandCoordinator.resolveRef(handle, forParamKey: key)
+    /// Resolves either wire representation of an identifier (raw UUID or
+    /// `kind:N` ref) that arrived under a specific param key, restricted to the
+    /// handle kinds that key accepts.
+    func v2ResolveIdentifier(_ raw: String, forParamKey key: String) -> UUID? {
+        controlCommandCoordinator.resolveIdentifier(raw, forParamKey: key)
     }
 
     nonisolated func v2Ref(kind: ControlHandleKind, uuid: UUID?) -> Any {

--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -3625,8 +3625,12 @@ class TerminalController {
     /// Resolves either wire representation of an identifier (raw UUID or
     /// `kind:N` ref) that arrived under a specific param key, restricted to the
     /// handle kinds that key accepts.
-    func v2ResolveIdentifier(_ raw: String, forParamKey key: String) -> UUID? {
-        controlCommandCoordinator.resolveIdentifier(raw, forParamKey: key)
+    func v2ResolveIdentifier(
+        _ raw: String,
+        forParamKey key: String,
+        routing: Bool = false
+    ) -> UUID? {
+        controlCommandCoordinator.resolveIdentifier(raw, forParamKey: key, routing: routing)
     }
 
     nonisolated func v2Ref(kind: ControlHandleKind, uuid: UUID?) -> Any {
@@ -3696,15 +3700,15 @@ class TerminalController {
         // would otherwise win even when the group belongs to a different
         // window). Then use workspace/surface/pane lookup and the active window.
         if v2HasNonNullParam(params, "window_id") {
-            guard let windowId = v2UUID(params, "window_id") else { return nil }
+            guard let windowId = v2RoutingUUID(params, "window_id") else { return nil }
             return v2MainSync { AppDelegate.shared?.tabManagerFor(windowId: windowId) }
         }
-        if let groupId = v2UUID(params, "group_id") {
+        if let groupId = v2RoutingUUID(params, "group_id") {
             if let tm = v2MainSync({ v2LocateTabManager(forGroupId: groupId) }) {
                 return tm
             }
         }
-        if let wsId = v2UUID(params, "workspace_id") {
+        if let wsId = v2RoutingUUID(params, "workspace_id") {
             if wsId == AppDelegate.windowDockAliasWorkspaceId {
                 return v2MainSync { tabManager ?? AppDelegate.shared?.currentScriptableMainWindow()?.tabManager }
             }
@@ -3717,17 +3721,51 @@ class TerminalController {
                 return tm
             }
         }
-        if let surfaceId = v2UUID(params, "surface_id")
-            ?? v2UUID(params, "terminal_id")
-            ?? v2UUID(params, "tab_id") {
+        if let surfaceId = v2RoutingUUID(params, "surface_id")
+            ?? v2RoutingUUID(params, "terminal_id")
+            ?? v2RoutingUUID(params, "tab_id") {
             if let manager = v2MainSync({ controlTabManager(surfaceID: surfaceId) }) { return manager }
         }
-        if let paneId = v2UUID(params, "pane_id") {
+        if let paneId = v2RoutingUUID(params, "pane_id") {
             if let tm = v2MainSync({ controlTabManager(paneID: paneId) }) {
                 return tm
             }
         }
         return v2MainSync { tabManager ?? AppDelegate.shared?.currentScriptableMainWindow()?.tabManager }
+    }
+
+    /// Classifies a raw identifier against live topology, so a raw UUID that
+    /// names a surface is rejected when it arrives under `group_id` instead of
+    /// routing the command somewhere else
+    /// (https://github.com/manaflow-ai/cmux/issues/9424).
+    ///
+    /// Authoritative where the handle registry's mint history is not: it sees
+    /// dock-hosted and remote-tmux objects that have never been minted, and is
+    /// unaffected by `removeRef`. An empty result means the identity names
+    /// nothing live; `nil` means this controller cannot classify at all.
+    func controlIdentityKinds(for uuid: UUID) -> Set<ControlHandleKind>? {
+        guard let app = AppDelegate.shared else { return nil }
+        var kinds: Set<ControlHandleKind> = []
+        if app.tabManagerFor(windowId: uuid) != nil {
+            kinds.insert(.window)
+        }
+        // A window-Dock owner id IS its owning window's id.
+        if app.tabManagerForWindowDockOwner(uuid) != nil {
+            kinds.insert(.window)
+        }
+        if uuid == AppDelegate.windowDockAliasWorkspaceId || app.tabManagerFor(tabId: uuid) != nil {
+            kinds.insert(.workspace)
+        }
+        if v2LocateTabManager(forGroupId: uuid) != nil {
+            kinds.insert(.workspaceGroup)
+        }
+        if controlTabManager(paneID: uuid) != nil {
+            kinds.insert(.pane)
+        }
+        if controlTabManager(surfaceID: uuid) != nil {
+            kinds.insert(.surface)
+        }
+        return kinds
     }
 
     @MainActor

--- a/Sources/TerminalControllerV2ParamParsingSupport.swift
+++ b/Sources/TerminalControllerV2ParamParsingSupport.swift
@@ -86,14 +86,12 @@ extension TerminalController {
 
     nonisolated func v2UUID(_ params: [String: Any], _ key: String) -> UUID? {
         guard let s = v2String(params, key) else { return nil }
-        if let uuid = UUID(uuidString: s) {
-            return uuid
-        }
-        // A `kind:N` ref only resolves for the kinds this param key expects, so a
-        // wrong-kind ref (`group_id: "surface:1"`) fails outright instead of
-        // resolving, missing its lookup, and degrading to the active window
+        // An identifier only resolves for the kinds this param key expects, so a
+        // wrong-kind target (`group_id: "surface:1"`, or a raw surface UUID under
+        // `group_id`) fails outright instead of resolving, missing its lookup,
+        // and degrading to the active window
         // (https://github.com/manaflow-ai/cmux/issues/9424).
-        return v2MainSync { v2ResolveHandleRef(s, forParamKey: key) }
+        return v2MainSync { v2ResolveIdentifier(s, forParamKey: key) }
     }
 
     func v2UUIDAny(_ raw: Any?) -> UUID? {

--- a/Sources/TerminalControllerV2ParamParsingSupport.swift
+++ b/Sources/TerminalControllerV2ParamParsingSupport.swift
@@ -89,7 +89,11 @@ extension TerminalController {
         if let uuid = UUID(uuidString: s) {
             return uuid
         }
-        return v2MainSync { v2ResolveHandleRef(s) }
+        // A `kind:N` ref only resolves for the kinds this param key expects, so a
+        // wrong-kind ref (`group_id: "surface:1"`) fails outright instead of
+        // resolving, missing its lookup, and degrading to the active window
+        // (https://github.com/manaflow-ai/cmux/issues/9424).
+        return v2MainSync { v2ResolveHandleRef(s, forParamKey: key) }
     }
 
     func v2UUIDAny(_ raw: Any?) -> UUID? {

--- a/Sources/TerminalControllerV2ParamParsingSupport.swift
+++ b/Sources/TerminalControllerV2ParamParsingSupport.swift
@@ -94,19 +94,6 @@ extension TerminalController {
         return v2MainSync { v2ResolveIdentifier(s, forParamKey: key) }
     }
 
-    /// Whether any routing selector was supplied but failed to resolve — a
-    /// wrong-kind ref or id, an unknown `kind:N` ref, or a blank/non-string
-    /// value. Such a request must fail closed rather than slide down the
-    /// routing walk to the active window.
-    ///
-    /// `window_id` is excluded: the walk already fails closed on a
-    /// present-but-unresolvable one.
-    nonisolated func v2HasRejectedRoutingSelector(_ params: [String: Any]) -> Bool {
-        ControlCommandCoordinator.routingSelectorKeys.contains { key in
-            v2HasNonNullParam(params, key) && v2RoutingUUID(params, key) == nil
-        }
-    }
-
     /// The routing-lane twin of ``v2UUID(_:_:)``: identical, except the Window
     /// Dock's window-as-`workspace_id` alias is accepted. Only the routing walk
     /// may take that alias, so it is never granted by param name alone.

--- a/Sources/TerminalControllerV2ParamParsingSupport.swift
+++ b/Sources/TerminalControllerV2ParamParsingSupport.swift
@@ -94,6 +94,14 @@ extension TerminalController {
         return v2MainSync { v2ResolveIdentifier(s, forParamKey: key) }
     }
 
+    /// The routing-lane twin of ``v2UUID(_:_:)``: identical, except the Window
+    /// Dock's window-as-`workspace_id` alias is accepted. Only the routing walk
+    /// may take that alias, so it is never granted by param name alone.
+    nonisolated func v2RoutingUUID(_ params: [String: Any], _ key: String) -> UUID? {
+        guard let s = v2String(params, key) else { return nil }
+        return v2MainSync { v2ResolveIdentifier(s, forParamKey: key, routing: true) }
+    }
+
     func v2UUIDAny(_ raw: Any?) -> UUID? {
         guard let s = raw as? String else { return nil }
         let trimmed = s.trimmingCharacters(in: .whitespacesAndNewlines)

--- a/Sources/TerminalControllerV2ParamParsingSupport.swift
+++ b/Sources/TerminalControllerV2ParamParsingSupport.swift
@@ -94,6 +94,19 @@ extension TerminalController {
         return v2MainSync { v2ResolveIdentifier(s, forParamKey: key) }
     }
 
+    /// Whether any routing selector was supplied but failed to resolve — a
+    /// wrong-kind ref or id, an unknown `kind:N` ref, or a blank/non-string
+    /// value. Such a request must fail closed rather than slide down the
+    /// routing walk to the active window.
+    ///
+    /// `window_id` is excluded: the walk already fails closed on a
+    /// present-but-unresolvable one.
+    nonisolated func v2HasRejectedRoutingSelector(_ params: [String: Any]) -> Bool {
+        ControlCommandCoordinator.routingSelectorKeys.contains { key in
+            v2HasNonNullParam(params, key) && v2RoutingUUID(params, key) == nil
+        }
+    }
+
     /// The routing-lane twin of ``v2UUID(_:_:)``: identical, except the Window
     /// Dock's window-as-`workspace_id` alias is accepted. Only the routing walk
     /// may take that alias, so it is never granted by param name alone.


### PR DESCRIPTION
Fixes #9424 (gap 2).

An identifier can arrive under a routing/target key in either of two wire forms, and neither was checked against the kind that key means. `ControlHandleRegistry.uuid(forRef:)` searched every handle kind, so `group_id: "surface:1"` resolved to a surface UUID and `tab_id: "pane:1"` resolved to a pane UUID. Raw UUID strings skipped ref parsing entirely, so a surface's UUID handed to `group_id` sailed through too. Either way the caller got a downstream lookup miss carrying another object's id, or a fall-through to the active window, instead of a straight rejection of a target that was never valid.

Both forms now go through one `resolveIdentifier(_:forParamKey:routing:)` on the coordinator, backed by a per-param-key expected-kind table, used by the typed `uuid(_:_:)` and the legacy `[String: Any]` `v2UUID` path alike (the latter is still live via `v2ResolveTabManager`).

A `kind:N` ref names its kind outright, so it is matched directly. A raw UUID does not, so the coordinator asks the app what the identity actually is through the new `ControlIdentityKindContext` seam: `TerminalController` answers from live topology (window, Window Dock owner, workspace, group, pane, surface), reporting multiple kinds where an identity genuinely holds two. That is authoritative where the handle registry's mint history is not — it sees dock-hosted and remote-tmux objects that were never minted, and is unaffected by `removeRef` erasing what the registry knew. The registry remains the fallback for contexts with no app attached. The seam is defaulted, so existing conformers are untouched.

The `tab:N` surface alias is handled inside the registry. The Window Dock's window-as-`workspace_id` alias is deliberately NOT granted by parameter name: it is a property of the routing walk, since a Dock owner id IS its owning window's id. It lives in `routingHandleKinds` and is reachable only through `routingUUID` / `v2RoutingUUID`, which the two routing walks use. Every other caller of `workspace_id` rejects a window identity.

Scope note: a UUID that names nothing live still passes through. That is gap 1 of the issue, deliberately not addressed — the issue states it needs a product call on marking caller-injected `CMUX_WORKSPACE_ID`/`CMUX_SURFACE_ID` context distinctly on the wire before user-specified selectors can fail closed, since hard-failing today would also break ordinary commands run from a since-closed workspace.

## Testing

Regression test: `Packages/macOS/CmuxControlSocket/Tests/CmuxControlSocketTests/ControlCommandCoordinatorRoutingKindTests.swift`.

Red then green in test/fix commit pairs visible in the Commits tab: the `kind:N` pair first, then the raw-UUID pair after review caught that hole. Each test-only commit fails with 6 expectation failures, e.g.

```
✘ rawUUIDsOfAKnownWrongKindDoNotResolve() failed with 6 issues
  (routingSelectors(["group_id": .string(handles.surface.uuidString)]).groupID → 9F08999E-…) == nil
  (routingSelectors(["surface_id": .string(handles.pane.uuidString)]).surfaceID → 05B9ADE1-…) == nil
  …
```

Coverage: wrong-kind refs and raw UUIDs rejected; right-kind ones still resolve; `tab:N` and Window-Dock aliases still accepted; the window alias accepted on the routing lane but rejected on the plain lane; authoritative kinds outranking mint history for a never-minted dock surface and for an identity whose ref was removed; multi-kind identities satisfying either expectation; and an unminted/unknown UUID still passing through (the documented gap-1 boundary).

`swift test` in `Packages/macOS/CmuxControlSocket` → `Test run with 356 tests in 45 suites passed`.

App target: `xcodebuild -scheme cmux -configuration Debug` → `** BUILD SUCCEEDED **`.

Dev build: `./scripts/reload.sh --tag sym9424`, driven over `/tmp/cmux-debug-sym9424.sock` with `cmux rpc` (which sends params verbatim, so no caller context is injected). With `surface:1` in `window:1` and `window:2` active:

```
surface.action {"action":"bogus","tab_id":"tab:1"}   → invalid_params: Unknown tab action
surface.action {"action":"bogus","tab_id":"pane:1"}  → not_found: Tab not found
```

The allowlisted `tab:N` alias resolves and reaches action validation; the wrong-kind `pane:1` is rejected at resolution rather than resolving to the pane's UUID and reporting a miss against it. `surface.close {"surface_id":"pane:1"}` returns `not_found: Surface not found` and closes nothing.

That socket run covered the `kind:N` commits. The later commits are covered by the package suite and the app-target build above; the workstation this branch was developed on is at 100% disk with several other agents' builds live, so the Swift work was validated on the shared AWS builder rather than by displacing them.

Note for reviewers: repo CI cannot go green on any branch right now. `workflow-guard-tests` fails with `scripts/ghosttykit-checksums.txt is missing an entry for ghostty f0f8273b…`, introduced by main commit f4787432f2, and `linux-preflight` gates the macOS jobs behind it. Unrelated branches fail identically. That is why the build evidence above is from the builder rather than from a CI run.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation of window, workspace, group, pane, surface, terminal, and tab identifiers.
  * Prevented invalid or mismatched identifiers from resolving to unintended targets.
  * Rejected routing commands with invalid selectors instead of silently falling back.
  * Preserved supported aliases and routing-specific window-to-workspace behavior.

* **Tests**
  * Added comprehensive coverage for identifier validation, aliases, routing behavior, and rejected selectors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->