### PR TITLE
Skip directories when resolving provider executables on PATH

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1062,6 +1062,7 @@ jobs:
           CMUX_CLI_BIN="$CLI_BIN" python3 tests/test_cli_omo_fallback_path.py
           CMUX_CLI_BIN="$CLI_BIN" python3 tests/test_cli_omx_fallback_path.py
           CMUX_CLI_BIN="$CLI_BIN" python3 tests/test_cli_omc_fallback_path.py
+          CMUX_CLI_BIN="$CLI_BIN" python3 tests/test_issue_8743_path_directory_shadowing.py
           python3 tests/test_issue_2448_shell_claude_wrapper_dispatch.py
           python3 tests/test_issue_8093_ghostty_ssh_binary_path.py
           python3 tests/test_issue_6714_zsh_shim_noclobber.py

--- a/CLI/CMUXCLI+ExecutableResolution.swift
+++ b/CLI/CMUXCLI+ExecutableResolution.swift
@@ -85,7 +85,14 @@ extension CMUXCLI {
             let candidate = URL(fileURLWithPath: entry, isDirectory: true)
                 .appendingPathComponent(name, isDirectory: false)
                 .path
-            guard FileManager.default.isExecutableFile(atPath: candidate) else { continue }
+            // `isExecutableFile(atPath:)` is true for directories, so a directory named
+            // like the provider binary would otherwise shadow the real executable and
+            // fail at execv (#8743). Reject directories the way the configured-candidate
+            // path in `resolveClaudeExecutable` already does.
+            var isDirectory: ObjCBool = false
+            guard FileManager.default.fileExists(atPath: candidate, isDirectory: &isDirectory),
+                  !isDirectory.boolValue,
+                  FileManager.default.isExecutableFile(atPath: candidate) else { continue }
             guard !isBundledProviderExecutable(at: candidate) else { continue }
             if let skip, skip(candidate) { continue }
             return candidate

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -22539,7 +22539,12 @@ struct CMUXCLI {
             let candidate = URL(fileURLWithPath: entry, isDirectory: true)
                 .appendingPathComponent(name, isDirectory: false)
                 .path
-            if FileManager.default.isExecutableFile(atPath: candidate) {
+            // `isExecutableFile(atPath:)` is true for directories, so a directory named
+            // like the binary would otherwise shadow the real executable (#8743).
+            var isDirectory: ObjCBool = false
+            if FileManager.default.fileExists(atPath: candidate, isDirectory: &isDirectory),
+               !isDirectory.boolValue,
+               FileManager.default.isExecutableFile(atPath: candidate) {
                 return candidate
             }
         }

--- a/Sources/AgentExecutableResolver.swift
+++ b/Sources/AgentExecutableResolver.swift
@@ -38,7 +38,13 @@ struct AgentExecutableResolver {
                 .appendingPathComponent(executableName, isDirectory: false)
                 .standardizedFileURL
             let candidatePath = candidateURL.path
-            guard fileManager.isExecutableFile(atPath: candidatePath) else { continue }
+            // `isExecutableFile(atPath:)` is true for directories, so a directory named
+            // like the provider binary earlier on PATH would shadow the real executable
+            // and fail at launch (#8743).
+            var isDirectory: ObjCBool = false
+            guard fileManager.fileExists(atPath: candidatePath, isDirectory: &isDirectory),
+                  !isDirectory.boolValue,
+                  fileManager.isExecutableFile(atPath: candidatePath) else { continue }
             guard !isBundledProviderExecutable(candidateURL) else { continue }
             guard !isKnownCmuxClaudeCommandShim(candidateURL, provider: provider) else { continue }
             guard !isKnownCmuxClaudeWrapper(candidateURL, provider: provider) else { continue }

--- a/cmuxTests/AgentExecutableResolverTests.swift
+++ b/cmuxTests/AgentExecutableResolverTests.swift
@@ -87,6 +87,36 @@ struct AgentExecutableResolverTests {
         expectFalse(plan.executableURL.path.contains("/Contents/Resources/bin/"))
     }
 
+    /// https://github.com/manaflow-ai/cmux/issues/8743 — `isExecutableFile(atPath:)`
+    /// is true for directories, so a directory named like the provider binary earlier
+    /// on PATH used to shadow the real executable and fail at launch.
+    @Test
+    func testSkipsDirectoryNamedLikeExecutableOnSearchPath() throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent(
+                "AgentExecutableResolverTests-\(UUID().uuidString)", isDirectory: true)
+        let shadowBin = root.appendingPathComponent("shadow", isDirectory: true)
+        let realBin = root.appendingPathComponent("real", isDirectory: true)
+        let shadowDirectory = shadowBin.appendingPathComponent("codex", isDirectory: true)
+        try FileManager.default.createDirectory(at: shadowDirectory, withIntermediateDirectories: true)
+        try FileManager.default.setAttributes(
+            [.posixPermissions: 0o755], ofItemAtPath: shadowDirectory.path)
+        try FileManager.default.createDirectory(at: realBin, withIntermediateDirectories: true)
+        let executable = realBin.appendingPathComponent("codex")
+        try "#!/bin/sh\nexit 0\n".write(to: executable, atomically: true, encoding: .utf8)
+        try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: executable.path)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let resolver = AgentExecutableResolver(
+            environment: ["PATH": "\(shadowBin.path):\(realBin.path)", "HOME": root.path],
+            bundleResourceURL: root.appendingPathComponent("Resources", isDirectory: true),
+            includeStandardSearchDirectories: false
+        )
+
+        let plan = try resolver.resolve(.codex)
+        expectEqual(plan.executableURL.path, executable.standardizedFileURL.path)
+    }
+
     @Test
     func testReturnsMissingForAbsentExecutable() throws {
         let root = FileManager.default.temporaryDirectory

--- a/tests/test_issue_8743_path_directory_shadowing.py
+++ b/tests/test_issue_8743_path_directory_shadowing.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+"""
+Regression test for https://github.com/manaflow-ai/cmux/issues/8743.
+
+`FileManager.isExecutableFile(atPath:)` returns true for directories on macOS, so a
+directory named like a provider binary earlier on PATH used to shadow the real
+executable and make the launch fail at execv. The PATH walk must skip directories
+and keep looking.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import tempfile
+from pathlib import Path
+
+from claude_teams_test_utils import resolve_cmux_cli
+
+# cmux subcommand -> executable name its PATH walk looks for.
+PROVIDERS = (("omx", "omx"), ("omc", "omc"))
+
+
+def make_executable(path: Path, content: str) -> None:
+    path.write_text(content, encoding="utf-8")
+    path.chmod(0o755)
+
+
+def check_provider(cli_path: str, command: str, executable: str) -> int:
+    with tempfile.TemporaryDirectory(prefix=f"cmux-{command}-shadow-") as td:
+        root = Path(td)
+
+        # A directory named exactly like the provider binary, earlier on PATH.
+        shadow_dir = root / "shadow"
+        (shadow_dir / executable).mkdir(parents=True, exist_ok=True)
+        (shadow_dir / executable).chmod(0o755)
+
+        real_bin = root / "real"
+        real_bin.mkdir(parents=True, exist_ok=True)
+        make_executable(
+            real_bin / executable,
+            f"""#!/usr/bin/env bash
+set -euo pipefail
+printf 'real-{executable}:%s\\n' "$0"
+""",
+        )
+
+        env = os.environ.copy()
+        env["HOME"] = str(root)
+        env["PATH"] = f"{shadow_dir}:{real_bin}:/usr/bin:/bin"
+        env["CMUX_CLI_SENTRY_DISABLED"] = "1"
+        env["CMUX_SOCKET_PATH"] = str(root / "missing.sock")
+
+        proc = subprocess.run(
+            [cli_path, command, "--version"],
+            capture_output=True,
+            text=True,
+            check=False,
+            env=env,
+            timeout=30,
+        )
+
+        expected = f"real-{executable}:{real_bin / executable}"
+        if proc.returncode != 0 or expected not in proc.stdout:
+            print(f"FAIL: `cmux {command} --version` did not run the real executable")
+            print(f"exit={proc.returncode}")
+            print(f"stdout={proc.stdout.strip()}")
+            print(f"stderr={proc.stderr.strip()}")
+            return 1
+
+        if str(shadow_dir / executable) in proc.stdout or str(shadow_dir / executable) in proc.stderr:
+            print(f"FAIL: `cmux {command}` selected the shadowing directory")
+            return 1
+
+    return 0
+
+
+def main() -> int:
+    try:
+        cli_path = resolve_cmux_cli()
+    except Exception as exc:
+        print(f"FAIL: {exc}")
+        return 1
+
+    failures = sum(
+        check_provider(cli_path, command, executable) for command, executable in PROVIDERS
+    )
+    if failures:
+        return 1
+
+    print("PASS: PATH resolution skips directories named like provider binaries")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
`FileManager.isExecutableFile(atPath:)` returns true for directories on macOS. The PATH walks that resolve provider binaries only called that API, so a directory named like the binary (`~/bin/omx/`, `~/bin/claude/`) earlier on PATH was picked as the executable and the launch died at `execv` with `Failed to launch omx: Permission denied`.

Three PATH walks now reject directories with `fileExists(atPath:isDirectory:)` before the executable check, mirroring the guard `resolveClaudeExecutable` already applied to configured candidates:

- `CLI/CMUXCLI+ExecutableResolution.swift` — `resolveExecutableInSearchPath` (claude, codex, opencode, omx, omc, auto-naming summarizers)
- `CLI/cmux.swift` — `resolveExecutableInPath` (bun and the OMO/OMX/OMC helpers)
- `Sources/AgentExecutableResolver.swift` — the app-side agent resolver, same bug

Fixes #8743

## Testing

- `tests/test_issue_8743_path_directory_shadowing.py` (new, wired into `ci.yml`): puts a directory named `omx`/`omc` ahead of a real executable on PATH and asserts the real one runs. Before the fix: `FAIL ... Failed to launch omx: Permission denied` for both. After: `PASS`.
- `cmuxTests/AgentExecutableResolverTests.swift` — `testSkipsDirectoryNamedLikeExecutableOnSearchPath` covers the app-side resolver.
- Red/green is split across the two commits: commit 1 adds the tests only, commit 2 adds the fix.
- Dev build `./scripts/reload.sh --tag sym8743`, then the issue's repro against the tagged CLI: with `/tmp/.../shadow/omx` (a directory) first on PATH, `cmux omx --version` now prints `REAL OMX at /tmp/.../real/omx` instead of failing. Tagged app killed afterwards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/9476"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788387944&installation_model_id=21920&pr_number=9476&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F9476&signature=fde8bbaa27ad91d4b7b5d9f7d9997087fb3f47b0da5734e0e4996ab16b6b5fad"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Skip directories when resolving provider executables on PATH so the CLI and app don’t select a directory named like the binary and fail to launch on macOS. Fixes #8743.

- **Bug Fixes**
  - Reject directories before `isExecutableFile` in all PATH walks: `CLI/CMUXCLI+ExecutableResolution.swift`, `CLI/cmux.swift`, and `Sources/AgentExecutableResolver.swift`.
  - Added regression tests (`tests/test_issue_8743_path_directory_shadowing.py`, `cmuxTests/AgentExecutableResolverTests.swift`) and wired the new test into CI.

<sup>Written for commit 3e533036ae4f47e7ef9c8484a0db654600fe8d35. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/9476?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved command resolution to ignore directories that share a provider executable’s name.
  * Ensured the correct executable is selected from a later PATH entry when an earlier entry is shadowed by a directory.

* **Tests**
  * Added regression coverage for PATH-based executable resolution across supported command-line interfaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->