### PR TITLE
Fix infinite UA-policy restart loop on Google Sheets destinations

### DIFF
--- a/Sources/Panels/BrowserNavigationDelegate.swift
+++ b/Sources/Panels/BrowserNavigationDelegate.swift
@@ -576,7 +576,8 @@ import WebKit
         let replacedNavigation = activeMainFrameNavigation
         let reportReplacementWillStart = willReplaceNavigationForUserAgentPolicy
         return webView.restartNavigationForBrowserUserAgentPolicyIfNeeded(
-            navigationAction,
+            for: navigationAction.request,
+            targetFrameIsMainFrame: navigationAction.targetFrame?.isMainFrame,
             decisionHandler: decisionHandler,
             willRestart: {
                 reportReplacementWillStart?(webView, replacedNavigation)

--- a/Sources/Panels/BrowserPopupWindowController.swift
+++ b/Sources/Panels/BrowserPopupWindowController.swift
@@ -789,7 +789,8 @@ private class PopupUIDelegate: BrowserPDFPreviewActionUIDelegate {
         }
 
         return webView.restartNavigationForBrowserUserAgentPolicyIfNeeded(
-            navigationAction,
+            for: navigationAction.request,
+            targetFrameIsMainFrame: navigationAction.targetFrame?.isMainFrame,
             decisionHandler: decisionHandler,
             startReplacement: { restartRequest in
                 controller.requestNavigation(restartRequest, in: webView)

--- a/Sources/Panels/WKWebView+BrowserUserAgentPolicy.swift
+++ b/Sources/Panels/WKWebView+BrowserUserAgentPolicy.swift
@@ -1,5 +1,8 @@
 import CmuxBrowser
+import ObjectiveC
 import WebKit
+
+private var cmuxBrowserUserAgentPolicyRestartedURLKey: UInt8 = 0
 
 extension WKWebView {
     /// Applies the destination identity and reports whether an HTTP(S) navigation must restart.
@@ -17,7 +20,12 @@ extension WKWebView {
             return false
         }
 
-        guard customUserAgent != resolvedUserAgent else { return false }
+        // Some macOS versions report the native WebKit identity as "" instead
+        // of nil, so both must count as the webKitDefault resolution or a
+        // Sheets destination restarts on every policy pass forever
+        // (https://github.com/manaflow-ai/cmux/issues/9462).
+        let appliedUserAgent = customUserAgent.flatMap { $0.isEmpty ? nil : $0 }
+        guard appliedUserAgent != resolvedUserAgent else { return false }
         customUserAgent = resolvedUserAgent
         return true
     }
@@ -39,20 +47,47 @@ extension WKWebView {
         return browserUserAgentPolicyRestartRequest(for: request)
     }
 
+    /// Destination of the most recent user-agent-policy restart. Each
+    /// destination may restart at most once in a row: when the replacement
+    /// load still reports a mismatched identity, the comparison cannot
+    /// converge on this system and the load must proceed instead of
+    /// cancel/reload looping on the main thread (issue #9462).
+    @MainActor
+    private var browserUserAgentPolicyRestartedURL: URL? {
+        get {
+            objc_getAssociatedObject(self, &cmuxBrowserUserAgentPolicyRestartedURLKey) as? URL
+        }
+        set {
+            objc_setAssociatedObject(
+                self,
+                &cmuxBrowserUserAgentPolicyRestartedURLKey,
+                newValue,
+                .OBJC_ASSOCIATION_RETAIN_NONATOMIC
+            )
+        }
+    }
+
     @MainActor
     func restartNavigationForBrowserUserAgentPolicyIfNeeded(
-        _ navigationAction: WKNavigationAction,
+        for request: URLRequest,
+        targetFrameIsMainFrame: Bool?,
         decisionHandler: (WKNavigationActionPolicy) -> Void,
         willRestart: () -> Void = {},
         startReplacement: (URLRequest) -> Void
     ) -> Bool {
+        if targetFrameIsMainFrame == true, let url = request.url {
+            let alreadyRestartedForDestination = browserUserAgentPolicyRestartedURL == url
+            browserUserAgentPolicyRestartedURL = nil
+            if alreadyRestartedForDestination { return false }
+        }
         guard let restartRequest = browserUserAgentPolicyRestartRequest(
-            for: navigationAction.request,
-            targetFrameIsMainFrame: navigationAction.targetFrame?.isMainFrame
+            for: request,
+            targetFrameIsMainFrame: targetFrameIsMainFrame
         ) else {
             return false
         }
 
+        browserUserAgentPolicyRestartedURL = request.url
         willRestart()
         decisionHandler(.cancel)
         startReplacement(restartRequest)

--- a/cmuxTests/BrowserUserAgentPolicyWebKitTests.swift
+++ b/cmuxTests/BrowserUserAgentPolicyWebKitTests.swift
@@ -63,4 +63,61 @@ struct BrowserUserAgentPolicyWebKitTests {
         #expect(webView.browserUserAgentPolicyRestartRequest(for: request) == nil)
         #expect(webView.customUserAgent == nil)
     }
+
+    @Test func sheetsDestinationTreatsEmptyReportedIdentityAsWebKitDefault() {
+        let webView = WKWebView(frame: .zero, configuration: WKWebViewConfiguration())
+        // Some macOS versions report the native identity as "" instead of nil
+        // after a restart clears the custom identity; both must satisfy the
+        // webKitDefault resolution or Sheets restarts forever (issue #9462).
+        webView.customUserAgent = ""
+        let request = URLRequest(
+            url: URL(string: "https://docs.google.com/spreadsheets/d/example/edit")!
+        )
+
+        #expect(BrowserUserAgentPolicy.system.resolution(for: request.url) == .webKitDefault)
+        #expect(webView.browserUserAgentPolicyRestartRequest(for: request) == nil)
+    }
+
+    @Test func sheetsDestinationRestartsAtMostOnceWhenIdentityNeverConverges() throws {
+        let webView = WKWebView(frame: .zero, configuration: WKWebViewConfiguration())
+        let request = URLRequest(
+            url: URL(string: "https://docs.google.com/spreadsheets/d/example/edit")!
+        )
+        var decisions: [WKNavigationActionPolicy] = []
+        var replacementRequests: [URLRequest] = []
+
+        webView.customUserAgent = BrowserUserAgentPolicy.system.safariCompatibleUserAgent
+        #expect(webView.restartNavigationForBrowserUserAgentPolicyIfNeeded(
+            for: request,
+            targetFrameIsMainFrame: true,
+            decisionHandler: { decisions.append($0) },
+            startReplacement: { replacementRequests.append($0) }
+        ))
+        #expect(decisions == [.cancel])
+        #expect((webView.customUserAgent ?? "").isEmpty)
+        let replacementRequest = try #require(replacementRequests.first)
+
+        // Simulate a WebKit whose reported identity never matches the resolved
+        // policy: the replacement pass must proceed instead of restarting again.
+        webView.customUserAgent = BrowserUserAgentPolicy.system.safariCompatibleUserAgent
+        #expect(!webView.restartNavigationForBrowserUserAgentPolicyIfNeeded(
+            for: replacementRequest,
+            targetFrameIsMainFrame: true,
+            decisionHandler: { decisions.append($0) },
+            startReplacement: { replacementRequests.append($0) }
+        ))
+        #expect(decisions == [.cancel])
+        #expect(replacementRequests.count == 1)
+
+        // A later navigation to the same destination may restart once again.
+        webView.customUserAgent = BrowserUserAgentPolicy.system.safariCompatibleUserAgent
+        #expect(webView.restartNavigationForBrowserUserAgentPolicyIfNeeded(
+            for: request,
+            targetFrameIsMainFrame: true,
+            decisionHandler: { decisions.append($0) },
+            startReplacement: { replacementRequests.append($0) }
+        ))
+        #expect(decisions == [.cancel, .cancel])
+        #expect(replacementRequests.count == 2)
+    }
 }


### PR DESCRIPTION
On some macOS versions WebKit reports the native identity as "" rather than nil after a restart clears `customUserAgent`. The policy check `customUserAgent != resolvedUserAgent` then never converges for destinations resolved to `webKitDefault` (like docs.google.com), so every policy pass cancels the navigation and reloads — the Sheets pane hangs and the main thread spins at ~100% CPU.

- Treat an empty reported identity the same as nil when comparing against the resolved policy, so `webKitDefault` destinations no longer register a mismatch.
- As a backstop, remember the last main-frame URL we restarted for and allow at most one restart in a row per destination; if the replacement load still reports a mismatch, let it proceed instead of looping.
- Reworked `restartNavigationForBrowserUserAgentPolicyIfNeeded` to take the request and main-frame flag directly so the loop guard is testable without constructing a `WKNavigationAction`.

Added tests covering the empty-identity case and the restart-at-most-once behavior.

Fixes #9462

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/9483"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788391061&installation_model_id=21920&pr_number=9483&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F9483&signature=e30f28b5652f1049aa37f42fd5067e0e40084b87aba7ce6930222a15ff5b6780"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes an infinite user‑agent policy restart loop on Google Sheets (docs.google.com) that froze the pane and pegged CPU on some macOS versions. Treats empty identities correctly and limits restarts so navigation proceeds. Fixes #9462.

- **Bug Fixes**
  - Treat empty `customUserAgent` as nil when comparing against `webKitDefault`.
  - Allow at most one UA-policy restart per main-frame destination; if the replacement still mismatches, proceed.
  - Added tests for the empty-identity case and the single-restart behavior.

- **Refactors**
  - Updated `restartNavigationForBrowserUserAgentPolicyIfNeeded` to take `request` and `targetFrameIsMainFrame` directly for easier testing and clearer logic.
  - Track the last restarted URL via an associated object to implement the loop guard.

<sup>Written for commit 1f934919397c4ee3aee70b7c0a7550f12019efcb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/9483?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

