### PR TITLE
Make Iroh transport diagnostics human-readable

### DIFF
--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -15586,7 +15586,7 @@ struct CMUXCLI {
             return """
             Usage: cmux iroh-diag
 
-            Print the host's iroh Connection Report (cmuxdiag v1 compact export),
+            Print the host's Iroh Connection Report as a plain-language timeline,
             the same data as Settings > Networking > Connection Report.
             """
         case "capabilities":

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -15583,12 +15583,15 @@ struct CMUXCLI {
             Check connectivity to the cmux socket server.
             """
         case "iroh-diag":
-            return """
-            Usage: cmux iroh-diag
+            return String(
+                localized: "cli.help.irohDiag",
+                defaultValue: """
+                Usage: cmux iroh-diag
 
-            Print the host's Iroh Connection Report as a plain-language timeline,
-            the same data as Settings > Networking > Connection Report.
-            """
+                Print the host's Iroh Connection Report as a plain-language timeline,
+                the same data as Settings > Networking > Connection Report.
+                """
+            )
         case "capabilities":
             return """
             Usage: cmux capabilities

--- a/Packages/Shared/CMUXMobileCore/Package.swift
+++ b/Packages/Shared/CMUXMobileCore/Package.swift
@@ -4,6 +4,7 @@ import PackageDescription
 
 let package = Package(
     name: "CMUXMobileCore",
+    defaultLocalization: "en",
     platforms: [
         .iOS(.v18),
         .macOS(.v14),
@@ -17,6 +18,7 @@ let package = Package(
     targets: [
         .target(
             name: "CMUXMobileCore",
+            resources: [.process("Resources")],
             swiftSettings: [.swiftLanguageMode(.v6)]
         ),
         .testTarget(

--- a/Packages/Shared/CMUXMobileCore/Sources/CMUXMobileCore/DiagnosticEvent.swift
+++ b/Packages/Shared/CMUXMobileCore/Sources/CMUXMobileCore/DiagnosticEvent.swift
@@ -21,8 +21,8 @@ public struct DiagnosticEvent: Sendable, Codable, Equatable {
     ///
     /// Sourced from `DispatchTime.now().uptimeNanoseconds` by the convenience
     /// initializer so two events are strictly orderable without depending on
-    /// wall-clock skew. ``DiagnosticLog/export()`` writes one wall-clock anchor
-    /// in its header so a reader can convert these back to absolute time.
+    /// wall-clock skew. ``DiagnosticLog/export()`` converts this through the
+    /// ring's wall-clock anchor before presenting it.
     public var tNanos: UInt64
 
     /// An optional surface identifier the event relates to.

--- a/Packages/Shared/CMUXMobileCore/Sources/CMUXMobileCore/DiagnosticEventPresentation.swift
+++ b/Packages/Shared/CMUXMobileCore/Sources/CMUXMobileCore/DiagnosticEventPresentation.swift
@@ -9,7 +9,14 @@ import Foundation
 /// Stable machine names remain available through the `name(_:)` overloads for
 /// Sentry fingerprints, tags, and search attributes.
 public struct DiagnosticEventPresentation: Sendable {
-    public init() {}
+    private let localization: DiagnosticLocalization
+
+    /// Creates a presenter that resolves report copy for `locale`.
+    ///
+    /// - Parameter locale: Locale used for human-readable titles and values.
+    public init(locale: Locale = .current) {
+        self.localization = DiagnosticLocalization(locale: locale)
+    }
 
     /// One decoded key/value pair of a described event.
     public struct Field: Sendable, Equatable {
@@ -75,92 +82,92 @@ public struct DiagnosticEventPresentation: Sendable {
     /// Human-readable name of a diagnostic failure category.
     public func displayName(_ kind: DiagnosticFailureKind) -> String {
         switch kind {
-        case .none: "No failure"
-        case .offline: "Offline"
-        case .timedOut: "Timed out"
-        case .connectionRefused: "Connection refused"
-        case .hostUnreachable: "Host unreachable"
-        case .permissionDenied: "Permission denied"
-        case .dnsFailed: "DNS lookup failed"
-        case .secureChannelFailed: "Secure channel failed"
-        case .unsupportedRoute: "Unsupported route"
-        case .noRoute: "No route available"
-        case .credentialUnavailable: "Credentials unavailable"
-        case .policyUnavailable: "Relay policy unavailable"
-        case .endpointUnavailable: "Iroh endpoint unavailable"
-        case .identityMismatch: "Host identity mismatch"
-        case .admissionDenied: "Client admission denied"
-        case .authorizationFailed: "Authorization failed"
-        case .accountMismatch: "Account mismatch"
-        case .protocolViolation: "Protocol violation"
-        case .connectionClosed: "Connection closed"
-        case .superseded: "Superseded by a newer attempt"
-        case .cancelled: "Cancelled"
-        case .transportIdleTimedOut: "Transport idle timed out"
-        case .admissionLeaseExpired: "Admission lease expired"
-        case .admissionRevalidationFailed: "Admission revalidation failed"
-        case .sendQueueOverflow: "Send queue overflow"
-        case .routeGated: "Route already connecting"
-        case .unknown: "Unknown failure"
+        case .none: localized("diagnostics.failure.none", defaultValue: "No failure")
+        case .offline: localized("diagnostics.failure.offline", defaultValue: "Offline")
+        case .timedOut: localized("diagnostics.failure.timedOut", defaultValue: "Timed out")
+        case .connectionRefused: localized("diagnostics.failure.connectionRefused", defaultValue: "Connection refused")
+        case .hostUnreachable: localized("diagnostics.failure.hostUnreachable", defaultValue: "Host unreachable")
+        case .permissionDenied: localized("diagnostics.failure.permissionDenied", defaultValue: "Permission denied")
+        case .dnsFailed: localized("diagnostics.failure.dnsFailed", defaultValue: "DNS lookup failed")
+        case .secureChannelFailed: localized("diagnostics.failure.secureChannelFailed", defaultValue: "Secure channel failed")
+        case .unsupportedRoute: localized("diagnostics.failure.unsupportedRoute", defaultValue: "Unsupported route")
+        case .noRoute: localized("diagnostics.failure.noRoute", defaultValue: "No route available")
+        case .credentialUnavailable: localized("diagnostics.failure.credentialUnavailable", defaultValue: "Credentials unavailable")
+        case .policyUnavailable: localized("diagnostics.failure.policyUnavailable", defaultValue: "Relay policy unavailable")
+        case .endpointUnavailable: localized("diagnostics.failure.endpointUnavailable", defaultValue: "Iroh endpoint unavailable")
+        case .identityMismatch: localized("diagnostics.failure.identityMismatch", defaultValue: "Host identity mismatch")
+        case .admissionDenied: localized("diagnostics.failure.admissionDenied", defaultValue: "Client admission denied")
+        case .authorizationFailed: localized("diagnostics.failure.authorizationFailed", defaultValue: "Authorization failed")
+        case .accountMismatch: localized("diagnostics.failure.accountMismatch", defaultValue: "Account mismatch")
+        case .protocolViolation: localized("diagnostics.failure.protocolViolation", defaultValue: "Protocol violation")
+        case .connectionClosed: localized("diagnostics.failure.connectionClosed", defaultValue: "Connection closed")
+        case .superseded: localized("diagnostics.failure.superseded", defaultValue: "Superseded by a newer attempt")
+        case .cancelled: localized("diagnostics.failure.cancelled", defaultValue: "Cancelled")
+        case .transportIdleTimedOut: localized("diagnostics.failure.transportIdleTimedOut", defaultValue: "Transport idle timed out")
+        case .admissionLeaseExpired: localized("diagnostics.failure.admissionLeaseExpired", defaultValue: "Admission lease expired")
+        case .admissionRevalidationFailed: localized("diagnostics.failure.admissionRevalidationFailed", defaultValue: "Admission revalidation failed")
+        case .sendQueueOverflow: localized("diagnostics.failure.sendQueueOverflow", defaultValue: "Send queue overflow")
+        case .routeGated: localized("diagnostics.failure.routeGated", defaultValue: "Route already connecting")
+        case .unknown: localized("diagnostics.failure.unknown", defaultValue: "Unknown failure")
         }
     }
 
     /// Human-readable name of a transport category.
     public func displayName(_ kind: DiagnosticTransportKind) -> String {
         switch kind {
-        case .unknown: "Unknown transport"
-        case .iroh: "Iroh"
-        case .tailscale: "Tailscale"
-        case .websocket: "WebSocket"
-        case .debugLoopback: "Debug loopback"
+        case .unknown: localized("diagnostics.transport.unknown", defaultValue: "Unknown transport")
+        case .iroh: localized("diagnostics.transport.iroh", defaultValue: "Iroh")
+        case .tailscale: localized("diagnostics.transport.tailscale", defaultValue: "Tailscale")
+        case .websocket: localized("diagnostics.transport.websocket", defaultValue: "WebSocket")
+        case .debugLoopback: localized("diagnostics.transport.debugLoopback", defaultValue: "Debug loopback")
         }
     }
 
     /// Human-readable name of a selected network path.
     public func displayName(_ kind: DiagnosticPathKind) -> String {
         switch kind {
-        case .unknown: "Unknown path"
-        case .direct: "Direct"
-        case .relay: "Relay"
-        case .privateNetwork: "Private network"
-        case .loopback: "Loopback"
+        case .unknown: localized("diagnostics.path.unknown", defaultValue: "Unknown path")
+        case .direct: localized("diagnostics.path.direct", defaultValue: "Direct")
+        case .relay: localized("diagnostics.path.relay", defaultValue: "Relay")
+        case .privateNetwork: localized("diagnostics.path.privateNetwork", defaultValue: "Private network")
+        case .loopback: localized("diagnostics.path.loopback", defaultValue: "Loopback")
         }
     }
 
     /// Human-readable name of a transport-session lifecycle state.
     public func displayName(_ kind: DiagnosticSessionLifecycleKind) -> String {
         switch kind {
-        case .established: "Established"
-        case .controlOwnerReleased: "Control owner released"
-        case .controlReadFailed: "Control read failed"
-        case .controlWriteFailed: "Control write failed"
-        case .remoteClosed: "Remote closed"
-        case .closedSessionEvicted: "Closed session evicted"
-        case .applicationLaneFailed: "Application lane failed"
-        case .runtimeDeactivated: "Runtime deactivated"
-        case .runtimeReconfigured: "Runtime reconfigured"
-        case .explicitlyInvalidated: "Explicitly invalidated"
-        case .allPathsClosed: "All paths closed"
+        case .established: localized("diagnostics.session.established", defaultValue: "Established")
+        case .controlOwnerReleased: localized("diagnostics.session.controlOwnerReleased", defaultValue: "Control owner released")
+        case .controlReadFailed: localized("diagnostics.session.controlReadFailed", defaultValue: "Control read failed")
+        case .controlWriteFailed: localized("diagnostics.session.controlWriteFailed", defaultValue: "Control write failed")
+        case .remoteClosed: localized("diagnostics.session.remoteClosed", defaultValue: "Remote closed")
+        case .closedSessionEvicted: localized("diagnostics.session.closedSessionEvicted", defaultValue: "Closed session evicted")
+        case .applicationLaneFailed: localized("diagnostics.session.applicationLaneFailed", defaultValue: "Application lane failed")
+        case .runtimeDeactivated: localized("diagnostics.session.runtimeDeactivated", defaultValue: "Runtime deactivated")
+        case .runtimeReconfigured: localized("diagnostics.session.runtimeReconfigured", defaultValue: "Runtime reconfigured")
+        case .explicitlyInvalidated: localized("diagnostics.session.explicitlyInvalidated", defaultValue: "Explicitly invalidated")
+        case .allPathsClosed: localized("diagnostics.session.allPathsClosed", defaultValue: "All paths closed")
         }
     }
 
     /// Human-readable name of an app lifecycle phase.
     public func displayName(_ phase: DiagnosticAppLifecyclePhase) -> String {
         switch phase {
-        case .background: "Background"
-        case .active: "Active"
-        case .inactive: "Inactive"
+        case .background: localized("diagnostics.phase.background", defaultValue: "Background")
+        case .active: localized("diagnostics.phase.active", defaultValue: "Active")
+        case .inactive: localized("diagnostics.phase.inactive", defaultValue: "Inactive")
         }
     }
 
     /// Human-readable name of a report's producing runtime.
     public func displayName(_ role: DiagnosticRuntimeRole) -> String {
         switch role {
-        case .unspecified: "Unspecified runtime"
-        case .mobileClient: "iOS client"
-        case .macHost: "Mac host"
-        case .broker: "Broker"
-        case .relay: "Relay"
+        case .unspecified: localized("diagnostics.role.unspecified", defaultValue: "Unspecified runtime")
+        case .mobileClient: localized("diagnostics.role.mobileClient", defaultValue: "iOS client")
+        case .macHost: localized("diagnostics.role.macHost", defaultValue: "Mac host")
+        case .broker: localized("diagnostics.role.broker", defaultValue: "Broker")
+        case .relay: localized("diagnostics.role.relay", defaultValue: "Relay")
         }
     }
 
@@ -194,11 +201,22 @@ public struct DiagnosticEventPresentation: Sendable {
 
     /// Renders an already-described event as a title followed by labeled fields.
     public func summary(_ described: DescribedEvent) -> String {
-        guard !described.fields.isEmpty else { return described.name }
-        let details = described.fields.map { field in
-            "\(label(for: field.key)): \(field.value)"
+        let visibleFields = described.fields.filter { $0.key != "session" }
+        guard !visibleFields.isEmpty else { return described.name }
+        let details = visibleFields.map { field in
+            localized(
+                "diagnostics.summary.field",
+                defaultValue: "\(label(for: field.key)): \(field.value)"
+            )
         }
-        return "\(described.name) (\(details.joined(separator: ", ")))"
+        let separator = localized(
+            "diagnostics.summary.separator",
+            defaultValue: ", "
+        )
+        return localized(
+            "diagnostics.summary.details",
+            defaultValue: "\(described.name) (\(details.joined(separator: separator)))"
+        )
     }
 
     /// The failure kind carried in an event's `b` slot, when applicable.
@@ -236,55 +254,105 @@ public struct DiagnosticEventPresentation: Sendable {
 
     private func title(for code: DiagnosticEventCode) -> String {
         switch code {
-        case .connect: "Connection attempt started"
-        case .pairOk: "Pairing succeeded"
-        case .pairFail: "Pairing failed"
-        case .renderGridLag: "Render grid lagged"
-        case .livenessResubscribe: "Silent event stream resubscribed"
-        case .streamEnded: "Event stream ended"
-        case .inputSeqBehind: "Terminal input acknowledgements fell behind"
-        case .byteGap: "Terminal byte gap detected"
-        case .error: "Unclassified transport error"
-        case .pairUnreachable: "Pairing skipped while offline"
-        case .composerPresentedChanged: "Composer visibility changed"
-        case .composerInputTextChanged: "Composer draft changed"
-        case .composerViewAppear: "Composer appeared"
-        case .composerViewDisappear: "Composer disappeared"
-        case .composerFieldFocusChanged: "Composer focus changed"
-        case .composerActiveTransition: "Composer activation changed"
+        case .connect:
+            localized("diagnostics.event.connect", defaultValue: "Connection attempt started")
+        case .pairOk:
+            localized("diagnostics.event.pairOk", defaultValue: "Pairing succeeded")
+        case .pairFail:
+            localized("diagnostics.event.pairFail", defaultValue: "Pairing failed")
+        case .renderGridLag:
+            localized("diagnostics.event.renderGridLag", defaultValue: "Render grid lagged")
+        case .livenessResubscribe:
+            localized("diagnostics.event.livenessResubscribe", defaultValue: "Silent event stream resubscribed")
+        case .streamEnded:
+            localized("diagnostics.event.streamEnded", defaultValue: "Event stream ended")
+        case .inputSeqBehind:
+            localized("diagnostics.event.inputSeqBehind", defaultValue: "Terminal input acknowledgements fell behind")
+        case .byteGap:
+            localized("diagnostics.event.byteGap", defaultValue: "Terminal byte gap detected")
+        case .error:
+            localized("diagnostics.event.error", defaultValue: "Unclassified transport error")
+        case .pairUnreachable:
+            localized("diagnostics.event.pairUnreachable", defaultValue: "Pairing skipped while offline")
+        case .composerPresentedChanged:
+            localized("diagnostics.event.composerPresentedChanged", defaultValue: "Composer visibility changed")
+        case .composerInputTextChanged:
+            localized("diagnostics.event.composerInputTextChanged", defaultValue: "Composer draft changed")
+        case .composerViewAppear:
+            localized("diagnostics.event.composerViewAppear", defaultValue: "Composer appeared")
+        case .composerViewDisappear:
+            localized("diagnostics.event.composerViewDisappear", defaultValue: "Composer disappeared")
+        case .composerFieldFocusChanged:
+            localized("diagnostics.event.composerFieldFocusChanged", defaultValue: "Composer focus changed")
+        case .composerActiveTransition:
+            localized("diagnostics.event.composerActiveTransition", defaultValue: "Composer activation changed")
         case .composerKeyboardToggleWhilePresented:
-            "Keyboard toggled while composer was open"
-        case .transportDialStarted: "Transport dial started"
-        case .transportDialConnected: "Transport connected"
-        case .transportDialFailed: "Transport dial failed"
-        case .hostAuthenticated: "Host authenticated"
-        case .rpcReady: "RPC session ready"
-        case .recoveryStarted: "Connection recovery started"
-        case .recoverySucceeded: "Connection recovery succeeded"
-        case .recoveryFailed: "Connection recovery failed"
-        case .endpointStarting: "Iroh endpoint starting"
-        case .endpointActive: "Iroh endpoint active"
-        case .endpointStopped: "Iroh endpoint stopped"
-        case .endpointFailed: "Iroh endpoint failed"
-        case .relayPolicyRefreshStarted: "Relay policy refresh started"
-        case .relayPolicyRefreshSucceeded: "Relay policy refreshed"
-        case .relayPolicyRefreshFailed: "Relay policy refresh failed"
-        case .selectedPathChanged: "Selected network path changed"
-        case .sessionClosed: "Transport session closed"
-        case .routeUnavailable: "No usable transport route"
-        case .retryScheduled: "Retry scheduled"
-        case .discoveryStarted: "Iroh route discovery started"
-        case .discoverySucceeded: "Iroh route discovery succeeded"
-        case .discoveryFailed: "Iroh route discovery failed"
-        case .admissionSucceeded: "Client admitted"
-        case .admissionFailed: "Client admission failed"
-        case .hostAuthenticationFailed: "Host authentication failed"
-        case .rpcFailed: "RPC session failed"
-        case .transportSessionLifecycle: "Transport session state changed"
-        case .appLifecycleChanged: "App lifecycle changed"
-        case .reachabilityChanged: "Network reachability changed"
-        case .transportCloseAttribution: "Transport close attributed"
-        case .transportPathEvent: "Transport path changed"
+            localized(
+                "diagnostics.event.composerKeyboardToggleWhilePresented",
+                defaultValue: "Keyboard toggled while composer was open"
+            )
+        case .transportDialStarted:
+            localized("diagnostics.event.transportDialStarted", defaultValue: "Transport dial started")
+        case .transportDialConnected:
+            localized("diagnostics.event.transportDialConnected", defaultValue: "Transport connected")
+        case .transportDialFailed:
+            localized("diagnostics.event.transportDialFailed", defaultValue: "Transport dial failed")
+        case .hostAuthenticated:
+            localized("diagnostics.event.hostAuthenticated", defaultValue: "Host authenticated")
+        case .rpcReady:
+            localized("diagnostics.event.rpcReady", defaultValue: "RPC session ready")
+        case .recoveryStarted:
+            localized("diagnostics.event.recoveryStarted", defaultValue: "Connection recovery started")
+        case .recoverySucceeded:
+            localized("diagnostics.event.recoverySucceeded", defaultValue: "Connection recovery succeeded")
+        case .recoveryFailed:
+            localized("diagnostics.event.recoveryFailed", defaultValue: "Connection recovery failed")
+        case .endpointStarting:
+            localized("diagnostics.event.endpointStarting", defaultValue: "Iroh endpoint starting")
+        case .endpointActive:
+            localized("diagnostics.event.endpointActive", defaultValue: "Iroh endpoint active")
+        case .endpointStopped:
+            localized("diagnostics.event.endpointStopped", defaultValue: "Iroh endpoint stopped")
+        case .endpointFailed:
+            localized("diagnostics.event.endpointFailed", defaultValue: "Iroh endpoint failed")
+        case .relayPolicyRefreshStarted:
+            localized("diagnostics.event.relayPolicyRefreshStarted", defaultValue: "Relay policy refresh started")
+        case .relayPolicyRefreshSucceeded:
+            localized("diagnostics.event.relayPolicyRefreshSucceeded", defaultValue: "Relay policy refreshed")
+        case .relayPolicyRefreshFailed:
+            localized("diagnostics.event.relayPolicyRefreshFailed", defaultValue: "Relay policy refresh failed")
+        case .selectedPathChanged:
+            localized("diagnostics.event.selectedPathChanged", defaultValue: "Selected network path changed")
+        case .sessionClosed:
+            localized("diagnostics.event.sessionClosed", defaultValue: "Transport session closed")
+        case .routeUnavailable:
+            localized("diagnostics.event.routeUnavailable", defaultValue: "No usable transport route")
+        case .retryScheduled:
+            localized("diagnostics.event.retryScheduled", defaultValue: "Retry scheduled")
+        case .discoveryStarted:
+            localized("diagnostics.event.discoveryStarted", defaultValue: "Iroh route discovery started")
+        case .discoverySucceeded:
+            localized("diagnostics.event.discoverySucceeded", defaultValue: "Iroh route discovery succeeded")
+        case .discoveryFailed:
+            localized("diagnostics.event.discoveryFailed", defaultValue: "Iroh route discovery failed")
+        case .admissionSucceeded:
+            localized("diagnostics.event.admissionSucceeded", defaultValue: "Client admitted")
+        case .admissionFailed:
+            localized("diagnostics.event.admissionFailed", defaultValue: "Client admission failed")
+        case .hostAuthenticationFailed:
+            localized("diagnostics.event.hostAuthenticationFailed", defaultValue: "Host authentication failed")
+        case .rpcFailed:
+            localized("diagnostics.event.rpcFailed", defaultValue: "RPC session failed")
+        case .transportSessionLifecycle:
+            localized("diagnostics.event.transportSessionLifecycle", defaultValue: "Transport session state changed")
+        case .appLifecycleChanged:
+            localized("diagnostics.event.appLifecycleChanged", defaultValue: "App lifecycle changed")
+        case .reachabilityChanged:
+            localized("diagnostics.event.reachabilityChanged", defaultValue: "Network reachability changed")
+        case .transportCloseAttribution:
+            localized("diagnostics.event.transportCloseAttribution", defaultValue: "Transport close attributed")
+        case .transportPathEvent:
+            localized("diagnostics.event.transportPathEvent", defaultValue: "Transport path changed")
         }
     }
 
@@ -312,7 +380,7 @@ public struct DiagnosticEventPresentation: Sendable {
         case .composerPresentedChanged:
             return Field(key: "composer_visible", value: booleanName(raw))
         case .composerInputTextChanged:
-            return Field(key: "draft_size", value: count(raw, singular: "byte"))
+            return Field(key: "draft_size", value: byteCount(raw))
         case .composerFieldFocusChanged:
             return Field(key: "focused", value: booleanName(raw))
         case .composerActiveTransition:
@@ -362,7 +430,7 @@ public struct DiagnosticEventPresentation: Sendable {
         case .transportCloseAttribution:
             return Field(key: "application_error_code", value: String(raw))
         case .composerActiveTransition, .composerKeyboardToggleWhilePresented:
-            return Field(key: "keyboard_height", value: "\(raw) points")
+            return Field(key: "keyboard_height", value: pointCount(Int(raw)))
         default:
             return Field(key: "duration", value: duration(raw))
         }
@@ -384,35 +452,50 @@ public struct DiagnosticEventPresentation: Sendable {
 
     private func failureName(_ raw: Int) -> String {
         guard let value = DiagnosticFailureKind(rawValue: raw) else {
-            return "Unknown failure (\(raw))"
+            return localized(
+                "diagnostics.unknown.failure",
+                defaultValue: "Unknown failure (\(raw))"
+            )
         }
         return displayName(value)
     }
 
     private func transportName(_ raw: Int) -> String {
         guard let value = DiagnosticTransportKind(rawValue: raw) else {
-            return "Unknown transport (\(raw))"
+            return localized(
+                "diagnostics.unknown.transport",
+                defaultValue: "Unknown transport (\(raw))"
+            )
         }
         return displayName(value)
     }
 
     private func pathName(_ raw: Int) -> String {
         guard let value = DiagnosticPathKind(rawValue: raw) else {
-            return "Unknown path (\(raw))"
+            return localized(
+                "diagnostics.unknown.path",
+                defaultValue: "Unknown path (\(raw))"
+            )
         }
         return displayName(value)
     }
 
     private func sessionLifecycleName(_ raw: Int) -> String {
         guard let value = DiagnosticSessionLifecycleKind(rawValue: raw) else {
-            return "Unknown session state (\(raw))"
+            return localized(
+                "diagnostics.unknown.sessionState",
+                defaultValue: "Unknown session state (\(raw))"
+            )
         }
         return displayName(value)
     }
 
     private func appLifecycleName(_ raw: Int) -> String {
         guard let value = DiagnosticAppLifecyclePhase(rawValue: raw) else {
-            return "Unknown app phase (\(raw))"
+            return localized(
+                "diagnostics.unknown.appPhase",
+                defaultValue: "Unknown app phase (\(raw))"
+            )
         }
         return displayName(value)
     }
@@ -421,136 +504,204 @@ public struct DiagnosticEventPresentation: Sendable {
         guard let byte = UInt8(exactly: raw),
               let purpose = CmxTransportSessionPurpose(rawValue: byte)
         else {
-            return "Unknown session purpose (\(raw))"
+            return localized(
+                "diagnostics.unknown.sessionPurpose",
+                defaultValue: "Unknown session purpose (\(raw))"
+            )
         }
         switch purpose {
-        case .foregroundControl: return "Foreground control"
-        case .backgroundControl: return "Background control"
-        case .probe: return "Connection probe"
-        case .featureLane: return "Feature lane"
+        case .foregroundControl:
+            return localized("diagnostics.purpose.foregroundControl", defaultValue: "Foreground control")
+        case .backgroundControl:
+            return localized("diagnostics.purpose.backgroundControl", defaultValue: "Background control")
+        case .probe:
+            return localized("diagnostics.purpose.probe", defaultValue: "Connection probe")
+        case .featureLane:
+            return localized("diagnostics.purpose.featureLane", defaultValue: "Feature lane")
         }
     }
 
     private func responderName(_ raw: Int) -> String {
         guard let identity = InputResponderIdentity(rawValue: raw) else {
-            return "Unknown responder (\(raw))"
+            return localized(
+                "diagnostics.unknown.responder",
+                defaultValue: "Unknown responder (\(raw))"
+            )
         }
         switch identity {
-        case .none: return "None"
-        case .terminalInputProxy: return "Terminal input"
-        case .ghosttySurface: return "Terminal surface"
-        case .uiTextField: return "Text field"
-        case .uiTextView: return "Text view"
-        case .other: return "Other responder"
+        case .none:
+            return localized("diagnostics.responder.none", defaultValue: "None")
+        case .terminalInputProxy:
+            return localized("diagnostics.responder.terminalInput", defaultValue: "Terminal input")
+        case .ghosttySurface:
+            return localized("diagnostics.responder.terminalSurface", defaultValue: "Terminal surface")
+        case .uiTextField:
+            return localized("diagnostics.responder.textField", defaultValue: "Text field")
+        case .uiTextView:
+            return localized("diagnostics.responder.textView", defaultValue: "Text view")
+        case .other:
+            return localized("diagnostics.responder.other", defaultValue: "Other responder")
         }
     }
 
     private func booleanName(_ raw: Int) -> String {
         switch raw {
-        case 0: "No"
-        case 1: "Yes"
-        default: "Unknown state (\(raw))"
+        case 0: localized("diagnostics.boolean.no", defaultValue: "No")
+        case 1: localized("diagnostics.boolean.yes", defaultValue: "Yes")
+        default:
+            localized("diagnostics.unknown.state", defaultValue: "Unknown state (\(raw))")
         }
     }
 
     private func reachabilityName(_ raw: Int) -> String {
         switch raw {
-        case 0: "Offline"
-        case 1: "Online"
-        default: "Unknown network state (\(raw))"
+        case 0: localized("diagnostics.reachability.offline", defaultValue: "Offline")
+        case 1: localized("diagnostics.reachability.online", defaultValue: "Online")
+        default:
+            localized(
+                "diagnostics.unknown.networkState",
+                defaultValue: "Unknown network state (\(raw))"
+            )
         }
     }
 
     private func recoveryTriggerName(_ raw: Int) -> String {
         switch raw {
-        case 1: "Network changed"
-        case 2: "Manual retry"
-        case 3: "Presence notification"
-        case 4: "App returned to foreground"
-        case 5: "Liveness check failed"
-        case 6: "Event stream ended"
-        case 7: "Subscription failed to start"
-        case 8: "Transport write timed out"
-        case 9: "Automatic retry delay expired"
-        default: "Unknown recovery trigger (\(raw))"
+        case 1: localized("diagnostics.recoveryTrigger.networkChanged", defaultValue: "Network changed")
+        case 2: localized("diagnostics.recoveryTrigger.manualRetry", defaultValue: "Manual retry")
+        case 3: localized("diagnostics.recoveryTrigger.presenceNotification", defaultValue: "Presence notification")
+        case 4: localized("diagnostics.recoveryTrigger.foreground", defaultValue: "App returned to foreground")
+        case 5: localized("diagnostics.recoveryTrigger.livenessFailed", defaultValue: "Liveness check failed")
+        case 6: localized("diagnostics.recoveryTrigger.streamEnded", defaultValue: "Event stream ended")
+        case 7: localized("diagnostics.recoveryTrigger.subscriptionFailed", defaultValue: "Subscription failed to start")
+        case 8: localized("diagnostics.recoveryTrigger.writeTimedOut", defaultValue: "Transport write timed out")
+        case 9: localized("diagnostics.recoveryTrigger.retryDelayExpired", defaultValue: "Automatic retry delay expired")
+        default:
+            localized(
+                "diagnostics.unknown.recoveryTrigger",
+                defaultValue: "Unknown recovery trigger (\(raw))"
+            )
         }
     }
 
     private func closeInitiatorName(_ raw: Int) -> String {
         switch raw {
-        case 0: "Unknown initiator"
-        case 1: "Local app"
-        case 2: "Remote peer"
-        case 3: "Timed out"
-        default: "Unknown close initiator (\(raw))"
+        case 0: localized("diagnostics.closeInitiator.unknown", defaultValue: "Unknown initiator")
+        case 1: localized("diagnostics.closeInitiator.localApp", defaultValue: "Local app")
+        case 2: localized("diagnostics.closeInitiator.remotePeer", defaultValue: "Remote peer")
+        case 3: localized("diagnostics.closeInitiator.timedOut", defaultValue: "Timed out")
+        default:
+            localized(
+                "diagnostics.unknown.closeInitiator",
+                defaultValue: "Unknown close initiator (\(raw))"
+            )
         }
     }
 
     private func pathEventName(_ raw: Int) -> String {
         switch raw {
-        case 1: "Opened"
-        case 2: "Closed"
-        case 3: "Selected"
-        case 4: "Lagged"
-        default: "Unknown path operation (\(raw))"
+        case 1: localized("diagnostics.pathOperation.opened", defaultValue: "Opened")
+        case 2: localized("diagnostics.pathOperation.closed", defaultValue: "Closed")
+        case 3: localized("diagnostics.pathOperation.selected", defaultValue: "Selected")
+        case 4: localized("diagnostics.pathOperation.lagged", defaultValue: "Lagged")
+        default:
+            localized(
+                "diagnostics.unknown.pathOperation",
+                defaultValue: "Unknown path operation (\(raw))"
+            )
         }
     }
 
     private func duration(_ milliseconds: UInt32) -> String {
-        guard milliseconds >= 1_000 else { return "\(milliseconds) ms" }
-        let seconds = Double(milliseconds) / 1_000
-        if milliseconds.isMultiple(of: 1_000) {
-            let whole = milliseconds / 1_000
-            return count(Int(whole), singular: "second")
+        guard milliseconds >= 1_000 else {
+            return localized(
+                "diagnostics.duration.milliseconds",
+                defaultValue: "\(Int(milliseconds)) ms"
+            )
         }
-        return String(
-            format: "%.3f seconds",
-            locale: Locale(identifier: "en_US_POSIX"),
-            seconds
+        if milliseconds.isMultiple(of: 1_000) {
+            return secondCount(Int(milliseconds / 1_000))
+        }
+        let seconds = milliseconds / 1_000
+        let remainder = milliseconds % 1_000
+        let value = "\(seconds).\(paddedMilliseconds(remainder))"
+        return localized(
+            "diagnostics.duration.fractionalSeconds",
+            defaultValue: "\(value) seconds"
         )
     }
 
-    private func count(_ value: Int, singular: String) -> String {
-        "\(value) \(value == 1 ? singular : singular + "s")"
+    private func secondCount(_ value: Int) -> String {
+        if value == 1 {
+            return localized("diagnostics.duration.seconds", defaultValue: "\(value) second")
+        }
+        return localized("diagnostics.duration.seconds", defaultValue: "\(value) seconds")
+    }
+
+    private func byteCount(_ value: Int) -> String {
+        if value == 1 {
+            return localized("diagnostics.count.bytes", defaultValue: "\(value) byte")
+        }
+        return localized("diagnostics.count.bytes", defaultValue: "\(value) bytes")
+    }
+
+    private func pointCount(_ value: Int) -> String {
+        if value == 1 {
+            return localized("diagnostics.count.points", defaultValue: "\(value) point")
+        }
+        return localized("diagnostics.count.points", defaultValue: "\(value) points")
+    }
+
+    private func paddedMilliseconds(_ value: UInt32) -> String {
+        if value < 10 { return "00\(value)" }
+        if value < 100 { return "0\(value)" }
+        return String(value)
     }
 
     private func label(for key: String) -> String {
         switch key {
-        case "surface": "Surface"
-        case "transport": "Transport"
-        case "failure": "Failure"
-        case "attempt": "Attempt"
-        case "retry_delay": "Retry delay"
-        case "initiator": "Initiator"
-        case "application_error_code": "Application error code"
-        case "session": "Session"
-        case "phase": "Phase"
-        case "network": "Network"
-        case "trigger": "Trigger"
-        case "state": "State"
-        case "purpose": "Purpose"
-        case "path": "Path"
-        case "operation": "Operation"
-        case "duration": "Duration"
-        case "lag": "Lag"
-        case "silent_for": "Silent for"
-        case "composer_visible": "Composer visible"
-        case "draft_size": "Draft size"
-        case "draft_empty": "Draft empty"
-        case "focused": "Focused"
-        case "composer_active": "Composer active"
-        case "first_responder": "First responder"
-        case "keyboard_height": "Keyboard height"
-        case "terminal_input_focused": "Terminal input focused"
-        case "local_sequence": "Local sequence"
-        case "remote_sequence": "Remote sequence"
-        case "delivered_sequence": "Delivered sequence"
-        case "next_sequence": "Next sequence"
-        case "detail_1": "Detail 1"
-        case "detail_2": "Detail 2"
-        case "detail_3": "Detail 3"
+        case "surface": localized("diagnostics.field.surface", defaultValue: "Surface")
+        case "transport": localized("diagnostics.field.transport", defaultValue: "Transport")
+        case "failure": localized("diagnostics.field.failure", defaultValue: "Failure")
+        case "attempt": localized("diagnostics.field.attempt", defaultValue: "Attempt")
+        case "retry_delay": localized("diagnostics.field.retryDelay", defaultValue: "Retry delay")
+        case "initiator": localized("diagnostics.field.initiator", defaultValue: "Initiator")
+        case "application_error_code": localized("diagnostics.field.applicationErrorCode", defaultValue: "Application error code")
+        case "session": localized("diagnostics.field.session", defaultValue: "Session")
+        case "phase": localized("diagnostics.field.phase", defaultValue: "Phase")
+        case "network": localized("diagnostics.field.network", defaultValue: "Network")
+        case "trigger": localized("diagnostics.field.trigger", defaultValue: "Trigger")
+        case "state": localized("diagnostics.field.state", defaultValue: "State")
+        case "purpose": localized("diagnostics.field.purpose", defaultValue: "Purpose")
+        case "path": localized("diagnostics.field.path", defaultValue: "Path")
+        case "operation": localized("diagnostics.field.operation", defaultValue: "Operation")
+        case "duration": localized("diagnostics.field.duration", defaultValue: "Duration")
+        case "lag": localized("diagnostics.field.lag", defaultValue: "Lag")
+        case "silent_for": localized("diagnostics.field.silentFor", defaultValue: "Silent for")
+        case "composer_visible": localized("diagnostics.field.composerVisible", defaultValue: "Composer visible")
+        case "draft_size": localized("diagnostics.field.draftSize", defaultValue: "Draft size")
+        case "draft_empty": localized("diagnostics.field.draftEmpty", defaultValue: "Draft empty")
+        case "focused": localized("diagnostics.field.focused", defaultValue: "Focused")
+        case "composer_active": localized("diagnostics.field.composerActive", defaultValue: "Composer active")
+        case "first_responder": localized("diagnostics.field.firstResponder", defaultValue: "First responder")
+        case "keyboard_height": localized("diagnostics.field.keyboardHeight", defaultValue: "Keyboard height")
+        case "terminal_input_focused": localized("diagnostics.field.terminalInputFocused", defaultValue: "Terminal input focused")
+        case "local_sequence": localized("diagnostics.field.localSequence", defaultValue: "Local sequence")
+        case "remote_sequence": localized("diagnostics.field.remoteSequence", defaultValue: "Remote sequence")
+        case "delivered_sequence": localized("diagnostics.field.deliveredSequence", defaultValue: "Delivered sequence")
+        case "next_sequence": localized("diagnostics.field.nextSequence", defaultValue: "Next sequence")
+        case "detail_1": localized("diagnostics.field.detail1", defaultValue: "Detail 1")
+        case "detail_2": localized("diagnostics.field.detail2", defaultValue: "Detail 2")
+        case "detail_3": localized("diagnostics.field.detail3", defaultValue: "Detail 3")
         default:
-            key.replacingOccurrences(of: "_", with: " ").capitalized
+            key
         }
+    }
+
+    private func localized(
+        _ key: StaticString,
+        defaultValue: String.LocalizationValue
+    ) -> String {
+        localization.string(key, defaultValue: defaultValue)
     }
 }

--- a/Packages/Shared/CMUXMobileCore/Sources/CMUXMobileCore/DiagnosticEventPresentation.swift
+++ b/Packages/Shared/CMUXMobileCore/Sources/CMUXMobileCore/DiagnosticEventPresentation.swift
@@ -8,7 +8,9 @@ import Foundation
 /// while every exported title and payload explains itself without a decoder.
 /// Stable machine names remain available through the `name(_:)` overloads for
 /// Sentry fingerprints, tags, and search attributes.
-public enum DiagnosticEventPresentation {
+public struct DiagnosticEventPresentation: Sendable {
+    public init() {}
+
     /// One decoded key/value pair of a described event.
     public struct Field: Sendable, Equatable {
         /// Stable semantic key suitable for structured telemetry.
@@ -36,42 +38,42 @@ public enum DiagnosticEventPresentation {
     }
 
     /// The stable machine name of an event code.
-    public static func name(_ code: DiagnosticEventCode) -> String {
+    public func name(_ code: DiagnosticEventCode) -> String {
         String(describing: code)
     }
 
     /// The stable machine name of a failure kind.
-    public static func name(_ kind: DiagnosticFailureKind) -> String {
+    public func name(_ kind: DiagnosticFailureKind) -> String {
         String(describing: kind)
     }
 
     /// The stable machine name of a transport kind.
-    public static func name(_ kind: DiagnosticTransportKind) -> String {
+    public func name(_ kind: DiagnosticTransportKind) -> String {
         String(describing: kind)
     }
 
     /// The stable machine name of a path kind.
-    public static func name(_ kind: DiagnosticPathKind) -> String {
+    public func name(_ kind: DiagnosticPathKind) -> String {
         String(describing: kind)
     }
 
     /// The stable machine name of a session lifecycle kind.
-    public static func name(_ kind: DiagnosticSessionLifecycleKind) -> String {
+    public func name(_ kind: DiagnosticSessionLifecycleKind) -> String {
         String(describing: kind)
     }
 
     /// The stable machine name of an app lifecycle phase.
-    public static func name(_ phase: DiagnosticAppLifecyclePhase) -> String {
+    public func name(_ phase: DiagnosticAppLifecyclePhase) -> String {
         String(describing: phase)
     }
 
     /// The stable machine name of a runtime role.
-    public static func name(_ role: DiagnosticRuntimeRole) -> String {
+    public func name(_ role: DiagnosticRuntimeRole) -> String {
         String(describing: role)
     }
 
     /// Human-readable name of a diagnostic failure category.
-    public static func displayName(_ kind: DiagnosticFailureKind) -> String {
+    public func displayName(_ kind: DiagnosticFailureKind) -> String {
         switch kind {
         case .none: "No failure"
         case .offline: "Offline"
@@ -104,7 +106,7 @@ public enum DiagnosticEventPresentation {
     }
 
     /// Human-readable name of a transport category.
-    public static func displayName(_ kind: DiagnosticTransportKind) -> String {
+    public func displayName(_ kind: DiagnosticTransportKind) -> String {
         switch kind {
         case .unknown: "Unknown transport"
         case .iroh: "Iroh"
@@ -115,7 +117,7 @@ public enum DiagnosticEventPresentation {
     }
 
     /// Human-readable name of a selected network path.
-    public static func displayName(_ kind: DiagnosticPathKind) -> String {
+    public func displayName(_ kind: DiagnosticPathKind) -> String {
         switch kind {
         case .unknown: "Unknown path"
         case .direct: "Direct"
@@ -126,7 +128,7 @@ public enum DiagnosticEventPresentation {
     }
 
     /// Human-readable name of a transport-session lifecycle state.
-    public static func displayName(_ kind: DiagnosticSessionLifecycleKind) -> String {
+    public func displayName(_ kind: DiagnosticSessionLifecycleKind) -> String {
         switch kind {
         case .established: "Established"
         case .controlOwnerReleased: "Control owner released"
@@ -143,7 +145,7 @@ public enum DiagnosticEventPresentation {
     }
 
     /// Human-readable name of an app lifecycle phase.
-    public static func displayName(_ phase: DiagnosticAppLifecyclePhase) -> String {
+    public func displayName(_ phase: DiagnosticAppLifecyclePhase) -> String {
         switch phase {
         case .background: "Background"
         case .active: "Active"
@@ -152,7 +154,7 @@ public enum DiagnosticEventPresentation {
     }
 
     /// Human-readable name of a report's producing runtime.
-    public static func displayName(_ role: DiagnosticRuntimeRole) -> String {
+    public func displayName(_ role: DiagnosticRuntimeRole) -> String {
         switch role {
         case .unspecified: "Unspecified runtime"
         case .mobileClient: "iOS client"
@@ -165,7 +167,7 @@ public enum DiagnosticEventPresentation {
     /// Decodes an event's payload slots according to its documented schema.
     /// Unknown enum values retain their integer inside an explanatory label so
     /// a newer writer still produces useful text on an older reader.
-    public static func describe(_ event: DiagnosticEvent) -> DescribedEvent {
+    public func describe(_ event: DiagnosticEvent) -> DescribedEvent {
         var fields: [Field] = []
         if let surface = event.surface {
             fields.append(Field(key: "surface", value: String(surface)))
@@ -186,12 +188,12 @@ public enum DiagnosticEventPresentation {
     }
 
     /// Renders one event as a standalone human-readable sentence fragment.
-    public static func summary(_ event: DiagnosticEvent) -> String {
+    public func summary(_ event: DiagnosticEvent) -> String {
         summary(describe(event))
     }
 
     /// Renders an already-described event as a title followed by labeled fields.
-    public static func summary(_ described: DescribedEvent) -> String {
+    public func summary(_ described: DescribedEvent) -> String {
         guard !described.fields.isEmpty else { return described.name }
         let details = described.fields.map { field in
             "\(label(for: field.key)): \(field.value)"
@@ -200,19 +202,19 @@ public enum DiagnosticEventPresentation {
     }
 
     /// The failure kind carried in an event's `b` slot, when applicable.
-    public static func failureKind(of event: DiagnosticEvent) -> DiagnosticFailureKind? {
-        guard codesWithFailureB.contains(event.code), let b = event.b else { return nil }
+    public func failureKind(of event: DiagnosticEvent) -> DiagnosticFailureKind? {
+        guard Self.codesWithFailureB.contains(event.code), let b = event.b else { return nil }
         return DiagnosticFailureKind(rawValue: b)
     }
 
     /// The transport kind carried in an event's `a` slot, when applicable.
-    public static func transportKind(of event: DiagnosticEvent) -> DiagnosticTransportKind? {
-        guard codesWithTransportA.contains(event.code), let a = event.a else { return nil }
+    public func transportKind(of event: DiagnosticEvent) -> DiagnosticTransportKind? {
+        guard Self.codesWithTransportA.contains(event.code), let a = event.a else { return nil }
         return DiagnosticTransportKind(rawValue: a)
     }
 
     /// Event codes whose `b` slot carries a ``DiagnosticFailureKind``.
-    static let codesWithFailureB: Set<DiagnosticEventCode> = [
+    private static let codesWithFailureB: Set<DiagnosticEventCode> = [
         .pairFail, .transportDialFailed, .recoveryFailed, .endpointFailed,
         .relayPolicyRefreshFailed, .sessionClosed, .routeUnavailable,
         .discoveryFailed, .admissionFailed, .hostAuthenticationFailed,
@@ -220,7 +222,7 @@ public enum DiagnosticEventPresentation {
     ]
 
     /// Event codes whose `a` slot carries a ``DiagnosticTransportKind``.
-    static let codesWithTransportA: Set<DiagnosticEventCode> = [
+    private static let codesWithTransportA: Set<DiagnosticEventCode> = [
         .pairFail,
         .transportDialStarted, .transportDialConnected, .transportDialFailed,
         .hostAuthenticated, .rpcReady,
@@ -232,7 +234,7 @@ public enum DiagnosticEventPresentation {
         .hostAuthenticationFailed, .rpcFailed,
     ]
 
-    private static func title(for code: DiagnosticEventCode) -> String {
+    private func title(for code: DiagnosticEventCode) -> String {
         switch code {
         case .connect: "Connection attempt started"
         case .pairOk: "Pairing succeeded"
@@ -286,8 +288,8 @@ public enum DiagnosticEventPresentation {
         }
     }
 
-    private static func decodeA(_ raw: Int, code: DiagnosticEventCode) -> Field {
-        if codesWithTransportA.contains(code) {
+    private func decodeA(_ raw: Int, code: DiagnosticEventCode) -> Field {
+        if Self.codesWithTransportA.contains(code) {
             return Field(key: "transport", value: transportName(raw))
         }
         switch code {
@@ -322,8 +324,8 @@ public enum DiagnosticEventPresentation {
         }
     }
 
-    private static func decodeB(_ raw: Int, code: DiagnosticEventCode) -> Field {
-        if codesWithFailureB.contains(code) {
+    private func decodeB(_ raw: Int, code: DiagnosticEventCode) -> Field {
+        if Self.codesWithFailureB.contains(code) {
             return Field(key: "failure", value: failureName(raw))
         }
         switch code {
@@ -346,7 +348,7 @@ public enum DiagnosticEventPresentation {
         }
     }
 
-    private static func decodeMilliseconds(
+    private func decodeMilliseconds(
         _ raw: UInt32,
         code: DiagnosticEventCode
     ) -> Field {
@@ -366,7 +368,7 @@ public enum DiagnosticEventPresentation {
         }
     }
 
-    private static func decodeC(_ raw: Int, code: DiagnosticEventCode) -> Field {
+    private func decodeC(_ raw: Int, code: DiagnosticEventCode) -> Field {
         switch code {
         case .transportDialStarted, .transportDialConnected, .transportDialFailed:
             return Field(key: "attempt", value: String(raw))
@@ -380,42 +382,42 @@ public enum DiagnosticEventPresentation {
         }
     }
 
-    private static func failureName(_ raw: Int) -> String {
+    private func failureName(_ raw: Int) -> String {
         guard let value = DiagnosticFailureKind(rawValue: raw) else {
             return "Unknown failure (\(raw))"
         }
         return displayName(value)
     }
 
-    private static func transportName(_ raw: Int) -> String {
+    private func transportName(_ raw: Int) -> String {
         guard let value = DiagnosticTransportKind(rawValue: raw) else {
             return "Unknown transport (\(raw))"
         }
         return displayName(value)
     }
 
-    private static func pathName(_ raw: Int) -> String {
+    private func pathName(_ raw: Int) -> String {
         guard let value = DiagnosticPathKind(rawValue: raw) else {
             return "Unknown path (\(raw))"
         }
         return displayName(value)
     }
 
-    private static func sessionLifecycleName(_ raw: Int) -> String {
+    private func sessionLifecycleName(_ raw: Int) -> String {
         guard let value = DiagnosticSessionLifecycleKind(rawValue: raw) else {
             return "Unknown session state (\(raw))"
         }
         return displayName(value)
     }
 
-    private static func appLifecycleName(_ raw: Int) -> String {
+    private func appLifecycleName(_ raw: Int) -> String {
         guard let value = DiagnosticAppLifecyclePhase(rawValue: raw) else {
             return "Unknown app phase (\(raw))"
         }
         return displayName(value)
     }
 
-    private static func sessionPurposeName(_ raw: Int) -> String {
+    private func sessionPurposeName(_ raw: Int) -> String {
         guard let byte = UInt8(exactly: raw),
               let purpose = CmxTransportSessionPurpose(rawValue: byte)
         else {
@@ -429,7 +431,7 @@ public enum DiagnosticEventPresentation {
         }
     }
 
-    private static func responderName(_ raw: Int) -> String {
+    private func responderName(_ raw: Int) -> String {
         guard let identity = InputResponderIdentity(rawValue: raw) else {
             return "Unknown responder (\(raw))"
         }
@@ -443,7 +445,7 @@ public enum DiagnosticEventPresentation {
         }
     }
 
-    private static func booleanName(_ raw: Int) -> String {
+    private func booleanName(_ raw: Int) -> String {
         switch raw {
         case 0: "No"
         case 1: "Yes"
@@ -451,7 +453,7 @@ public enum DiagnosticEventPresentation {
         }
     }
 
-    private static func reachabilityName(_ raw: Int) -> String {
+    private func reachabilityName(_ raw: Int) -> String {
         switch raw {
         case 0: "Offline"
         case 1: "Online"
@@ -459,7 +461,7 @@ public enum DiagnosticEventPresentation {
         }
     }
 
-    private static func recoveryTriggerName(_ raw: Int) -> String {
+    private func recoveryTriggerName(_ raw: Int) -> String {
         switch raw {
         case 1: "Network changed"
         case 2: "Manual retry"
@@ -474,7 +476,7 @@ public enum DiagnosticEventPresentation {
         }
     }
 
-    private static func closeInitiatorName(_ raw: Int) -> String {
+    private func closeInitiatorName(_ raw: Int) -> String {
         switch raw {
         case 0: "Unknown initiator"
         case 1: "Local app"
@@ -484,7 +486,7 @@ public enum DiagnosticEventPresentation {
         }
     }
 
-    private static func pathEventName(_ raw: Int) -> String {
+    private func pathEventName(_ raw: Int) -> String {
         switch raw {
         case 1: "Opened"
         case 2: "Closed"
@@ -494,7 +496,7 @@ public enum DiagnosticEventPresentation {
         }
     }
 
-    private static func duration(_ milliseconds: UInt32) -> String {
+    private func duration(_ milliseconds: UInt32) -> String {
         guard milliseconds >= 1_000 else { return "\(milliseconds) ms" }
         let seconds = Double(milliseconds) / 1_000
         if milliseconds.isMultiple(of: 1_000) {
@@ -508,11 +510,11 @@ public enum DiagnosticEventPresentation {
         )
     }
 
-    private static func count(_ value: Int, singular: String) -> String {
+    private func count(_ value: Int, singular: String) -> String {
         "\(value) \(value == 1 ? singular : singular + "s")"
     }
 
-    private static func label(for key: String) -> String {
+    private func label(for key: String) -> String {
         switch key {
         case "surface": "Surface"
         case "transport": "Transport"

--- a/Packages/Shared/CMUXMobileCore/Sources/CMUXMobileCore/DiagnosticEventPresentation.swift
+++ b/Packages/Shared/CMUXMobileCore/Sources/CMUXMobileCore/DiagnosticEventPresentation.swift
@@ -1,21 +1,19 @@
 import Foundation
 
-/// Decodes a ``DiagnosticEvent`` into stable, human-readable names and fields
-/// for telemetry sinks (Sentry breadcrumbs, structured logs) and debug UI.
+/// Decodes a ``DiagnosticEvent`` into privacy-safe text for reports and
+/// telemetry sinks.
 ///
-/// The compact ring export stays integer-only; this presentation layer is for
-/// consumers that ship or display individual events and want them legible
-/// without the offline decoder. Everything here is derived from the fixed
-/// integer taxonomy, so the output is privacy-safe by construction: no free
-/// text from errors, peers, accounts, or terminal content can appear.
-///
-/// Case names are part of the telemetry vocabulary (Sentry issue grouping and
-/// search keys use them), so renaming a taxonomy case is a breaking telemetry
-/// change; ``DiagnosticEventPresentationTests`` pins the names.
+/// The event recorder deliberately stores only bounded integers. Formatting
+/// happens here, after recording, so hot transport paths stay allocation-free
+/// while every exported title and payload explains itself without a decoder.
+/// Stable machine names remain available through the `name(_:)` overloads for
+/// Sentry fingerprints, tags, and search attributes.
 public enum DiagnosticEventPresentation {
     /// One decoded key/value pair of a described event.
     public struct Field: Sendable, Equatable {
+        /// Stable semantic key suitable for structured telemetry.
         public let key: String
+        /// Human-readable value suitable for display.
         public let value: String
 
         public init(key: String, value: String) {
@@ -24,9 +22,9 @@ public enum DiagnosticEventPresentation {
         }
     }
 
-    /// A described event: a stable dotted name plus decoded payload fields.
+    /// A human-readable event title plus decoded payload fields.
     public struct DescribedEvent: Sendable, Equatable {
-        /// The stable event name, e.g. `transportDialFailed`.
+        /// Human-readable event title, for example `Transport dial failed`.
         public let name: String
         /// Decoded payload fields in a stable order.
         public let fields: [Field]
@@ -37,52 +35,140 @@ public enum DiagnosticEventPresentation {
         }
     }
 
-    /// The stable name of an event code (its case name).
+    /// The stable machine name of an event code.
     public static func name(_ code: DiagnosticEventCode) -> String {
         String(describing: code)
     }
 
-    /// The stable name of a failure kind (its case name).
+    /// The stable machine name of a failure kind.
     public static func name(_ kind: DiagnosticFailureKind) -> String {
         String(describing: kind)
     }
 
-    /// The stable name of a transport kind (its case name).
+    /// The stable machine name of a transport kind.
     public static func name(_ kind: DiagnosticTransportKind) -> String {
         String(describing: kind)
     }
 
-    /// The stable name of a path kind (its case name).
+    /// The stable machine name of a path kind.
     public static func name(_ kind: DiagnosticPathKind) -> String {
         String(describing: kind)
     }
 
-    /// The stable name of a session lifecycle kind (its case name).
+    /// The stable machine name of a session lifecycle kind.
     public static func name(_ kind: DiagnosticSessionLifecycleKind) -> String {
         String(describing: kind)
     }
 
-    /// The stable name of an app lifecycle phase (its case name).
+    /// The stable machine name of an app lifecycle phase.
     public static func name(_ phase: DiagnosticAppLifecyclePhase) -> String {
         String(describing: phase)
     }
 
-    /// The stable name of a runtime role (its case name).
+    /// The stable machine name of a runtime role.
     public static func name(_ role: DiagnosticRuntimeRole) -> String {
         String(describing: role)
     }
 
-    /// Decodes an event's payload slots per its code's documented semantics.
-    ///
-    /// Unknown raw values render as their integer so a newer writer's event
-    /// still describes usefully on an older reader.
+    /// Human-readable name of a diagnostic failure category.
+    public static func displayName(_ kind: DiagnosticFailureKind) -> String {
+        switch kind {
+        case .none: "No failure"
+        case .offline: "Offline"
+        case .timedOut: "Timed out"
+        case .connectionRefused: "Connection refused"
+        case .hostUnreachable: "Host unreachable"
+        case .permissionDenied: "Permission denied"
+        case .dnsFailed: "DNS lookup failed"
+        case .secureChannelFailed: "Secure channel failed"
+        case .unsupportedRoute: "Unsupported route"
+        case .noRoute: "No route available"
+        case .credentialUnavailable: "Credentials unavailable"
+        case .policyUnavailable: "Relay policy unavailable"
+        case .endpointUnavailable: "Iroh endpoint unavailable"
+        case .identityMismatch: "Host identity mismatch"
+        case .admissionDenied: "Client admission denied"
+        case .authorizationFailed: "Authorization failed"
+        case .accountMismatch: "Account mismatch"
+        case .protocolViolation: "Protocol violation"
+        case .connectionClosed: "Connection closed"
+        case .superseded: "Superseded by a newer attempt"
+        case .cancelled: "Cancelled"
+        case .transportIdleTimedOut: "Transport idle timed out"
+        case .admissionLeaseExpired: "Admission lease expired"
+        case .admissionRevalidationFailed: "Admission revalidation failed"
+        case .sendQueueOverflow: "Send queue overflow"
+        case .routeGated: "Route already connecting"
+        case .unknown: "Unknown failure"
+        }
+    }
+
+    /// Human-readable name of a transport category.
+    public static func displayName(_ kind: DiagnosticTransportKind) -> String {
+        switch kind {
+        case .unknown: "Unknown transport"
+        case .iroh: "Iroh"
+        case .tailscale: "Tailscale"
+        case .websocket: "WebSocket"
+        case .debugLoopback: "Debug loopback"
+        }
+    }
+
+    /// Human-readable name of a selected network path.
+    public static func displayName(_ kind: DiagnosticPathKind) -> String {
+        switch kind {
+        case .unknown: "Unknown path"
+        case .direct: "Direct"
+        case .relay: "Relay"
+        case .privateNetwork: "Private network"
+        case .loopback: "Loopback"
+        }
+    }
+
+    /// Human-readable name of a transport-session lifecycle state.
+    public static func displayName(_ kind: DiagnosticSessionLifecycleKind) -> String {
+        switch kind {
+        case .established: "Established"
+        case .controlOwnerReleased: "Control owner released"
+        case .controlReadFailed: "Control read failed"
+        case .controlWriteFailed: "Control write failed"
+        case .remoteClosed: "Remote closed"
+        case .closedSessionEvicted: "Closed session evicted"
+        case .applicationLaneFailed: "Application lane failed"
+        case .runtimeDeactivated: "Runtime deactivated"
+        case .runtimeReconfigured: "Runtime reconfigured"
+        case .explicitlyInvalidated: "Explicitly invalidated"
+        case .allPathsClosed: "All paths closed"
+        }
+    }
+
+    /// Human-readable name of an app lifecycle phase.
+    public static func displayName(_ phase: DiagnosticAppLifecyclePhase) -> String {
+        switch phase {
+        case .background: "Background"
+        case .active: "Active"
+        case .inactive: "Inactive"
+        }
+    }
+
+    /// Human-readable name of a report's producing runtime.
+    public static func displayName(_ role: DiagnosticRuntimeRole) -> String {
+        switch role {
+        case .unspecified: "Unspecified runtime"
+        case .mobileClient: "iOS client"
+        case .macHost: "Mac host"
+        case .broker: "Broker"
+        case .relay: "Relay"
+        }
+    }
+
+    /// Decodes an event's payload slots according to its documented schema.
+    /// Unknown enum values retain their integer inside an explanatory label so
+    /// a newer writer still produces useful text on an older reader.
     public static func describe(_ event: DiagnosticEvent) -> DescribedEvent {
         var fields: [Field] = []
         if let surface = event.surface {
             fields.append(Field(key: "surface", value: String(surface)))
-        }
-        if let ms = event.ms {
-            fields.append(Field(key: msKey(for: event.code), value: String(ms)))
         }
         if let a = event.a {
             fields.append(decodeA(a, code: event.code))
@@ -90,21 +176,36 @@ public enum DiagnosticEventPresentation {
         if let b = event.b {
             fields.append(decodeB(b, code: event.code))
         }
-        if let c = event.c {
-            fields.append(Field(key: cKey(for: event.code), value: String(c)))
+        if let ms = event.ms {
+            fields.append(decodeMilliseconds(ms, code: event.code))
         }
-        return DescribedEvent(name: name(event.code), fields: fields)
+        if let c = event.c {
+            fields.append(decodeC(c, code: event.code))
+        }
+        return DescribedEvent(name: title(for: event.code), fields: fields)
     }
 
-    /// The failure kind carried in an event's `b` slot, when its code uses `b`
-    /// for ``DiagnosticFailureKind``.
+    /// Renders one event as a standalone human-readable sentence fragment.
+    public static func summary(_ event: DiagnosticEvent) -> String {
+        summary(describe(event))
+    }
+
+    /// Renders an already-described event as a title followed by labeled fields.
+    public static func summary(_ described: DescribedEvent) -> String {
+        guard !described.fields.isEmpty else { return described.name }
+        let details = described.fields.map { field in
+            "\(label(for: field.key)): \(field.value)"
+        }
+        return "\(described.name) (\(details.joined(separator: ", ")))"
+    }
+
+    /// The failure kind carried in an event's `b` slot, when applicable.
     public static func failureKind(of event: DiagnosticEvent) -> DiagnosticFailureKind? {
         guard codesWithFailureB.contains(event.code), let b = event.b else { return nil }
         return DiagnosticFailureKind(rawValue: b)
     }
 
-    /// The transport kind carried in an event's `a` slot, when its code uses
-    /// `a` for ``DiagnosticTransportKind``.
+    /// The transport kind carried in an event's `a` slot, when applicable.
     public static func transportKind(of event: DiagnosticEvent) -> DiagnosticTransportKind? {
         guard codesWithTransportA.contains(event.code), let a = event.a else { return nil }
         return DiagnosticTransportKind(rawValue: a)
@@ -120,86 +221,334 @@ public enum DiagnosticEventPresentation {
 
     /// Event codes whose `a` slot carries a ``DiagnosticTransportKind``.
     static let codesWithTransportA: Set<DiagnosticEventCode> = [
-        .pairFail, .transportDialStarted, .transportDialConnected,
-        .transportDialFailed, .sessionClosed, .routeUnavailable,
+        .pairFail,
+        .transportDialStarted, .transportDialConnected, .transportDialFailed,
+        .hostAuthenticated, .rpcReady,
+        .recoveryStarted, .recoverySucceeded, .recoveryFailed,
+        .endpointStarting, .endpointActive, .endpointStopped, .endpointFailed,
+        .sessionClosed, .routeUnavailable, .retryScheduled,
+        .discoveryStarted, .discoverySucceeded, .discoveryFailed,
+        .admissionSucceeded, .admissionFailed,
+        .hostAuthenticationFailed, .rpcFailed,
     ]
 
-    private static func msKey(for code: DiagnosticEventCode) -> String {
+    private static func title(for code: DiagnosticEventCode) -> String {
         switch code {
-        case .retryScheduled:
-            return "delay_ms"
-        case .transportCloseAttribution:
-            return "app_error_code"
-        case .composerActiveTransition:
-            return "keyboard_height"
-        default:
-            return "ms"
+        case .connect: "Connection attempt started"
+        case .pairOk: "Pairing succeeded"
+        case .pairFail: "Pairing failed"
+        case .renderGridLag: "Render grid lagged"
+        case .livenessResubscribe: "Silent event stream resubscribed"
+        case .streamEnded: "Event stream ended"
+        case .inputSeqBehind: "Terminal input acknowledgements fell behind"
+        case .byteGap: "Terminal byte gap detected"
+        case .error: "Unclassified transport error"
+        case .pairUnreachable: "Pairing skipped while offline"
+        case .composerPresentedChanged: "Composer visibility changed"
+        case .composerInputTextChanged: "Composer draft changed"
+        case .composerViewAppear: "Composer appeared"
+        case .composerViewDisappear: "Composer disappeared"
+        case .composerFieldFocusChanged: "Composer focus changed"
+        case .composerActiveTransition: "Composer activation changed"
+        case .composerKeyboardToggleWhilePresented:
+            "Keyboard toggled while composer was open"
+        case .transportDialStarted: "Transport dial started"
+        case .transportDialConnected: "Transport connected"
+        case .transportDialFailed: "Transport dial failed"
+        case .hostAuthenticated: "Host authenticated"
+        case .rpcReady: "RPC session ready"
+        case .recoveryStarted: "Connection recovery started"
+        case .recoverySucceeded: "Connection recovery succeeded"
+        case .recoveryFailed: "Connection recovery failed"
+        case .endpointStarting: "Iroh endpoint starting"
+        case .endpointActive: "Iroh endpoint active"
+        case .endpointStopped: "Iroh endpoint stopped"
+        case .endpointFailed: "Iroh endpoint failed"
+        case .relayPolicyRefreshStarted: "Relay policy refresh started"
+        case .relayPolicyRefreshSucceeded: "Relay policy refreshed"
+        case .relayPolicyRefreshFailed: "Relay policy refresh failed"
+        case .selectedPathChanged: "Selected network path changed"
+        case .sessionClosed: "Transport session closed"
+        case .routeUnavailable: "No usable transport route"
+        case .retryScheduled: "Retry scheduled"
+        case .discoveryStarted: "Iroh route discovery started"
+        case .discoverySucceeded: "Iroh route discovery succeeded"
+        case .discoveryFailed: "Iroh route discovery failed"
+        case .admissionSucceeded: "Client admitted"
+        case .admissionFailed: "Client admission failed"
+        case .hostAuthenticationFailed: "Host authentication failed"
+        case .rpcFailed: "RPC session failed"
+        case .transportSessionLifecycle: "Transport session state changed"
+        case .appLifecycleChanged: "App lifecycle changed"
+        case .reachabilityChanged: "Network reachability changed"
+        case .transportCloseAttribution: "Transport close attributed"
+        case .transportPathEvent: "Transport path changed"
         }
     }
 
-    private static func cKey(for code: DiagnosticEventCode) -> String {
+    private static func decodeA(_ raw: Int, code: DiagnosticEventCode) -> Field {
+        if codesWithTransportA.contains(code) {
+            return Field(key: "transport", value: transportName(raw))
+        }
+        switch code {
+        case .selectedPathChanged:
+            return Field(key: "path", value: pathName(raw))
+        case .transportSessionLifecycle:
+            return Field(key: "state", value: sessionLifecycleName(raw))
+        case .appLifecycleChanged:
+            return Field(key: "phase", value: appLifecycleName(raw))
+        case .reachabilityChanged:
+            return Field(key: "network", value: reachabilityName(raw))
+        case .transportCloseAttribution:
+            return Field(key: "initiator", value: closeInitiatorName(raw))
+        case .transportPathEvent:
+            return Field(key: "operation", value: pathEventName(raw))
+        case .inputSeqBehind:
+            return Field(key: "local_sequence", value: String(raw))
+        case .byteGap:
+            return Field(key: "delivered_sequence", value: String(raw))
+        case .composerPresentedChanged:
+            return Field(key: "composer_visible", value: booleanName(raw))
+        case .composerInputTextChanged:
+            return Field(key: "draft_size", value: count(raw, singular: "byte"))
+        case .composerFieldFocusChanged:
+            return Field(key: "focused", value: booleanName(raw))
+        case .composerActiveTransition:
+            return Field(key: "composer_active", value: booleanName(raw))
+        case .composerKeyboardToggleWhilePresented:
+            return Field(key: "terminal_input_focused", value: booleanName(raw))
+        default:
+            return Field(key: "detail_1", value: String(raw))
+        }
+    }
+
+    private static func decodeB(_ raw: Int, code: DiagnosticEventCode) -> Field {
+        if codesWithFailureB.contains(code) {
+            return Field(key: "failure", value: failureName(raw))
+        }
+        switch code {
+        case .recoveryStarted:
+            return Field(key: "trigger", value: recoveryTriggerName(raw))
+        case .transportSessionLifecycle:
+            return Field(key: "purpose", value: sessionPurposeName(raw))
+        case .transportPathEvent:
+            return Field(key: "path", value: pathName(raw))
+        case .inputSeqBehind:
+            return Field(key: "remote_sequence", value: String(raw))
+        case .byteGap:
+            return Field(key: "next_sequence", value: String(raw))
+        case .composerInputTextChanged:
+            return Field(key: "draft_empty", value: booleanName(raw))
+        case .composerActiveTransition, .composerKeyboardToggleWhilePresented:
+            return Field(key: "first_responder", value: responderName(raw))
+        default:
+            return Field(key: "detail_2", value: String(raw))
+        }
+    }
+
+    private static func decodeMilliseconds(
+        _ raw: UInt32,
+        code: DiagnosticEventCode
+    ) -> Field {
+        switch code {
+        case .renderGridLag:
+            return Field(key: "lag", value: duration(raw))
+        case .livenessResubscribe:
+            return Field(key: "silent_for", value: duration(raw))
+        case .retryScheduled:
+            return Field(key: "retry_delay", value: duration(raw))
+        case .transportCloseAttribution:
+            return Field(key: "application_error_code", value: String(raw))
+        case .composerActiveTransition, .composerKeyboardToggleWhilePresented:
+            return Field(key: "keyboard_height", value: "\(raw) points")
+        default:
+            return Field(key: "duration", value: duration(raw))
+        }
+    }
+
+    private static func decodeC(_ raw: Int, code: DiagnosticEventCode) -> Field {
         switch code {
         case .transportDialStarted, .transportDialConnected, .transportDialFailed:
-            return "attempt_id"
+            return Field(key: "attempt", value: String(raw))
         case .sessionClosed, .transportSessionLifecycle,
              .transportCloseAttribution, .transportPathEvent:
-            return "session_id"
+            return Field(key: "session", value: String(raw))
+        case .composerActiveTransition:
+            return Field(key: "terminal_input_focused", value: booleanName(raw))
         default:
-            return "c"
+            return Field(key: "detail_3", value: String(raw))
         }
     }
 
-    private static func decodeA(_ a: Int, code: DiagnosticEventCode) -> Field {
-        switch code {
-        case .pairFail, .transportDialStarted, .transportDialConnected,
-             .transportDialFailed, .sessionClosed, .routeUnavailable:
-            return enumField(key: "transport", raw: a) { DiagnosticTransportKind(rawValue: $0).map(name) }
-        case .selectedPathChanged:
-            return enumField(key: "path", raw: a) { DiagnosticPathKind(rawValue: $0).map(name) }
-        case .transportSessionLifecycle:
-            return enumField(key: "lifecycle", raw: a) { DiagnosticSessionLifecycleKind(rawValue: $0).map(name) }
-        case .appLifecycleChanged:
-            return enumField(key: "phase", raw: a) { DiagnosticAppLifecyclePhase(rawValue: $0).map(name) }
-        case .reachabilityChanged:
-            return Field(key: "reachable", value: a == 1 ? "true" : "false")
-        case .transportCloseAttribution:
-            return enumField(key: "initiator", raw: a) { closeInitiatorNames[$0] }
-        case .transportPathEvent:
-            return enumField(key: "path_event", raw: a) { pathEventNames[$0] }
+    private static func failureName(_ raw: Int) -> String {
+        guard let value = DiagnosticFailureKind(rawValue: raw) else {
+            return "Unknown failure (\(raw))"
+        }
+        return displayName(value)
+    }
+
+    private static func transportName(_ raw: Int) -> String {
+        guard let value = DiagnosticTransportKind(rawValue: raw) else {
+            return "Unknown transport (\(raw))"
+        }
+        return displayName(value)
+    }
+
+    private static func pathName(_ raw: Int) -> String {
+        guard let value = DiagnosticPathKind(rawValue: raw) else {
+            return "Unknown path (\(raw))"
+        }
+        return displayName(value)
+    }
+
+    private static func sessionLifecycleName(_ raw: Int) -> String {
+        guard let value = DiagnosticSessionLifecycleKind(rawValue: raw) else {
+            return "Unknown session state (\(raw))"
+        }
+        return displayName(value)
+    }
+
+    private static func appLifecycleName(_ raw: Int) -> String {
+        guard let value = DiagnosticAppLifecyclePhase(rawValue: raw) else {
+            return "Unknown app phase (\(raw))"
+        }
+        return displayName(value)
+    }
+
+    private static func sessionPurposeName(_ raw: Int) -> String {
+        guard let byte = UInt8(exactly: raw),
+              let purpose = CmxTransportSessionPurpose(rawValue: byte)
+        else {
+            return "Unknown session purpose (\(raw))"
+        }
+        switch purpose {
+        case .foregroundControl: return "Foreground control"
+        case .backgroundControl: return "Background control"
+        case .probe: return "Connection probe"
+        case .featureLane: return "Feature lane"
+        }
+    }
+
+    private static func responderName(_ raw: Int) -> String {
+        guard let identity = InputResponderIdentity(rawValue: raw) else {
+            return "Unknown responder (\(raw))"
+        }
+        switch identity {
+        case .none: return "None"
+        case .terminalInputProxy: return "Terminal input"
+        case .ghosttySurface: return "Terminal surface"
+        case .uiTextField: return "Text field"
+        case .uiTextView: return "Text view"
+        case .other: return "Other responder"
+        }
+    }
+
+    private static func booleanName(_ raw: Int) -> String {
+        switch raw {
+        case 0: "No"
+        case 1: "Yes"
+        default: "Unknown state (\(raw))"
+        }
+    }
+
+    private static func reachabilityName(_ raw: Int) -> String {
+        switch raw {
+        case 0: "Offline"
+        case 1: "Online"
+        default: "Unknown network state (\(raw))"
+        }
+    }
+
+    private static func recoveryTriggerName(_ raw: Int) -> String {
+        switch raw {
+        case 1: "Network changed"
+        case 2: "Manual retry"
+        case 3: "Presence notification"
+        case 4: "App returned to foreground"
+        case 5: "Liveness check failed"
+        case 6: "Event stream ended"
+        case 7: "Subscription failed to start"
+        case 8: "Transport write timed out"
+        case 9: "Automatic retry delay expired"
+        default: "Unknown recovery trigger (\(raw))"
+        }
+    }
+
+    private static func closeInitiatorName(_ raw: Int) -> String {
+        switch raw {
+        case 0: "Unknown initiator"
+        case 1: "Local app"
+        case 2: "Remote peer"
+        case 3: "Timed out"
+        default: "Unknown close initiator (\(raw))"
+        }
+    }
+
+    private static func pathEventName(_ raw: Int) -> String {
+        switch raw {
+        case 1: "Opened"
+        case 2: "Closed"
+        case 3: "Selected"
+        case 4: "Lagged"
+        default: "Unknown path operation (\(raw))"
+        }
+    }
+
+    private static func duration(_ milliseconds: UInt32) -> String {
+        guard milliseconds >= 1_000 else { return "\(milliseconds) ms" }
+        let seconds = Double(milliseconds) / 1_000
+        if milliseconds.isMultiple(of: 1_000) {
+            let whole = milliseconds / 1_000
+            return count(Int(whole), singular: "second")
+        }
+        return String(
+            format: "%.3f seconds",
+            locale: Locale(identifier: "en_US_POSIX"),
+            seconds
+        )
+    }
+
+    private static func count(_ value: Int, singular: String) -> String {
+        "\(value) \(value == 1 ? singular : singular + "s")"
+    }
+
+    private static func label(for key: String) -> String {
+        switch key {
+        case "surface": "Surface"
+        case "transport": "Transport"
+        case "failure": "Failure"
+        case "attempt": "Attempt"
+        case "retry_delay": "Retry delay"
+        case "initiator": "Initiator"
+        case "application_error_code": "Application error code"
+        case "session": "Session"
+        case "phase": "Phase"
+        case "network": "Network"
+        case "trigger": "Trigger"
+        case "state": "State"
+        case "purpose": "Purpose"
+        case "path": "Path"
+        case "operation": "Operation"
+        case "duration": "Duration"
+        case "lag": "Lag"
+        case "silent_for": "Silent for"
+        case "composer_visible": "Composer visible"
+        case "draft_size": "Draft size"
+        case "draft_empty": "Draft empty"
+        case "focused": "Focused"
+        case "composer_active": "Composer active"
+        case "first_responder": "First responder"
+        case "keyboard_height": "Keyboard height"
+        case "terminal_input_focused": "Terminal input focused"
+        case "local_sequence": "Local sequence"
+        case "remote_sequence": "Remote sequence"
+        case "delivered_sequence": "Delivered sequence"
+        case "next_sequence": "Next sequence"
+        case "detail_1": "Detail 1"
+        case "detail_2": "Detail 2"
+        case "detail_3": "Detail 3"
         default:
-            return Field(key: "a", value: String(a))
+            key.replacingOccurrences(of: "_", with: " ").capitalized
         }
     }
-
-    private static func decodeB(_ b: Int, code: DiagnosticEventCode) -> Field {
-        if codesWithFailureB.contains(code) {
-            return enumField(key: "failure", raw: b) { DiagnosticFailureKind(rawValue: $0).map(name) }
-        }
-        switch code {
-        case .transportSessionLifecycle:
-            return Field(key: "purpose", value: String(b))
-        case .transportPathEvent:
-            return enumField(key: "path", raw: b) { DiagnosticPathKind(rawValue: $0).map(name) }
-        default:
-            return Field(key: "b", value: String(b))
-        }
-    }
-
-    private static func enumField(
-        key: String,
-        raw: Int,
-        name: (Int) -> String?
-    ) -> Field {
-        Field(key: key, value: name(raw) ?? String(raw))
-    }
-
-    /// Close-initiator names for ``DiagnosticEventCode/transportCloseAttribution``'s `a`.
-    private static let closeInitiatorNames: [Int: String] = [
-        0: "unknown", 1: "local", 2: "remote", 3: "timedOut",
-    ]
-
-    /// Path-event names for ``DiagnosticEventCode/transportPathEvent``'s `a`.
-    private static let pathEventNames: [Int: String] = [
-        1: "opened", 2: "closed", 3: "selected", 4: "lagged",
-    ]
 }

--- a/Packages/Shared/CMUXMobileCore/Sources/CMUXMobileCore/DiagnosticIncidentTitleFormatter.swift
+++ b/Packages/Shared/CMUXMobileCore/Sources/CMUXMobileCore/DiagnosticIncidentTitleFormatter.swift
@@ -1,0 +1,75 @@
+import Foundation
+
+/// Produces localized, correctly pluralized transport incident titles.
+struct DiagnosticIncidentTitleFormatter: Sendable {
+    private let localization: DiagnosticLocalization
+    private let presentation: DiagnosticEventPresentation
+
+    init(locale: Locale) {
+        self.localization = DiagnosticLocalization(locale: locale)
+        self.presentation = DiagnosticEventPresentation(locale: locale)
+    }
+
+    func outageTitle(
+        event: DiagnosticEvent,
+        consecutiveFailures: Int,
+        durationSeconds: Int
+    ) -> String {
+        let failures = failureCount(consecutiveFailures)
+        let duration = secondCount(durationSeconds)
+        let latest = presentation.summary(event)
+        return localization.string(
+            "diagnostics.incident.outage",
+            defaultValue: "Transport outage: \(failures) over \(duration). Latest: \(latest)"
+        )
+    }
+
+    func failureTitle(event: DiagnosticEvent, occurrenceCount: Int) -> String {
+        let summary = presentation.summary(event)
+        guard occurrenceCount > 1 else { return summary }
+        let occurrences = occurrenceCountText(occurrenceCount)
+        return localization.string(
+            "diagnostics.incident.failureWithOccurrences",
+            defaultValue: "\(summary) (\(occurrences))"
+        )
+    }
+
+    private func failureCount(_ value: Int) -> String {
+        if value == 1 {
+            return localization.string(
+                "diagnostics.incident.consecutiveFailures",
+                defaultValue: "\(value) consecutive failure"
+            )
+        }
+        return localization.string(
+            "diagnostics.incident.consecutiveFailures",
+            defaultValue: "\(value) consecutive failures"
+        )
+    }
+
+    private func secondCount(_ value: Int) -> String {
+        if value == 1 {
+            return localization.string(
+                "diagnostics.duration.seconds",
+                defaultValue: "\(value) second"
+            )
+        }
+        return localization.string(
+            "diagnostics.duration.seconds",
+            defaultValue: "\(value) seconds"
+        )
+    }
+
+    private func occurrenceCountText(_ value: Int) -> String {
+        if value == 1 {
+            return localization.string(
+                "diagnostics.incident.occurrences",
+                defaultValue: "\(value) occurrence"
+            )
+        }
+        return localization.string(
+            "diagnostics.incident.occurrences",
+            defaultValue: "\(value) occurrences"
+        )
+    }
+}

--- a/Packages/Shared/CMUXMobileCore/Sources/CMUXMobileCore/DiagnosticLocalization.swift
+++ b/Packages/Shared/CMUXMobileCore/Sources/CMUXMobileCore/DiagnosticLocalization.swift
@@ -10,6 +10,15 @@ struct DiagnosticLocalization: Sendable {
         self.bundle = Self.bundle(for: locale)
     }
 
+    /// Whether this runtime compiled the package string catalog for `locale`.
+    ///
+    /// Xcode emits localized `.lproj` resources. Command-line SwiftPM copies
+    /// `.xcstrings` verbatim, so explicit-locale behavior tests cannot resolve
+    /// translations in that runner even though app builds can.
+    static func hasCompiledLocalization(for locale: Locale) -> Bool {
+        languageBundle(for: locale) != nil
+    }
+
     func string(
         _ key: StaticString,
         defaultValue: String.LocalizationValue
@@ -23,6 +32,10 @@ struct DiagnosticLocalization: Sendable {
     }
 
     private static func bundle(for locale: Locale) -> Bundle {
+        languageBundle(for: locale) ?? .module
+    }
+
+    private static func languageBundle(for locale: Locale) -> Bundle? {
         let identifiers = [
             locale.identifier,
             locale.language.languageCode?.identifier,
@@ -34,6 +47,6 @@ struct DiagnosticLocalization: Sendable {
             ), let bundle = Bundle(path: path) else { continue }
             return bundle
         }
-        return .module
+        return nil
     }
 }

--- a/Packages/Shared/CMUXMobileCore/Sources/CMUXMobileCore/DiagnosticLocalization.swift
+++ b/Packages/Shared/CMUXMobileCore/Sources/CMUXMobileCore/DiagnosticLocalization.swift
@@ -1,0 +1,22 @@
+import Foundation
+
+/// Resolves diagnostic copy from the shared package's locale catalog.
+struct DiagnosticLocalization: Sendable {
+    let locale: Locale
+
+    init(locale: Locale = .current) {
+        self.locale = locale
+    }
+
+    func string(
+        _ key: StaticString,
+        defaultValue: String.LocalizationValue
+    ) -> String {
+        String(
+            localized: key,
+            defaultValue: defaultValue,
+            bundle: .module,
+            locale: locale
+        )
+    }
+}

--- a/Packages/Shared/CMUXMobileCore/Sources/CMUXMobileCore/DiagnosticLocalization.swift
+++ b/Packages/Shared/CMUXMobileCore/Sources/CMUXMobileCore/DiagnosticLocalization.swift
@@ -10,15 +10,6 @@ struct DiagnosticLocalization: Sendable {
         self.bundle = Self.bundle(for: locale)
     }
 
-    /// Whether this runtime compiled the package string catalog for `locale`.
-    ///
-    /// Xcode emits localized `.lproj` resources. Command-line SwiftPM copies
-    /// `.xcstrings` verbatim, so explicit-locale behavior tests cannot resolve
-    /// translations in that runner even though app builds can.
-    static func hasCompiledLocalization(for locale: Locale) -> Bool {
-        languageBundle(for: locale) != nil
-    }
-
     func string(
         _ key: StaticString,
         defaultValue: String.LocalizationValue
@@ -36,10 +27,10 @@ struct DiagnosticLocalization: Sendable {
     }
 
     private static func languageBundle(for locale: Locale) -> Bundle? {
-        let identifiers = [
-            locale.identifier,
-            locale.language.languageCode?.identifier,
-        ].compactMap { $0 }
+        let identifiers = Bundle.preferredLocalizations(
+            from: Bundle.module.localizations,
+            forPreferences: [locale.identifier]
+        )
         for identifier in identifiers {
             guard let path = Bundle.module.path(
                 forResource: identifier,

--- a/Packages/Shared/CMUXMobileCore/Sources/CMUXMobileCore/DiagnosticLocalization.swift
+++ b/Packages/Shared/CMUXMobileCore/Sources/CMUXMobileCore/DiagnosticLocalization.swift
@@ -3,9 +3,11 @@ import Foundation
 /// Resolves diagnostic copy from the shared package's locale catalog.
 struct DiagnosticLocalization: Sendable {
     let locale: Locale
+    private let bundle: Bundle
 
     init(locale: Locale = .current) {
         self.locale = locale
+        self.bundle = Self.bundle(for: locale)
     }
 
     func string(
@@ -15,8 +17,23 @@ struct DiagnosticLocalization: Sendable {
         String(
             localized: key,
             defaultValue: defaultValue,
-            bundle: .module,
+            bundle: bundle,
             locale: locale
         )
+    }
+
+    private static func bundle(for locale: Locale) -> Bundle {
+        let identifiers = [
+            locale.identifier,
+            locale.language.languageCode?.identifier,
+        ].compactMap { $0 }
+        for identifier in identifiers {
+            guard let path = Bundle.module.path(
+                forResource: identifier,
+                ofType: "lproj"
+            ), let bundle = Bundle(path: path) else { continue }
+            return bundle
+        }
+        return .module
     }
 }

--- a/Packages/Shared/CMUXMobileCore/Sources/CMUXMobileCore/DiagnosticLog.swift
+++ b/Packages/Shared/CMUXMobileCore/Sources/CMUXMobileCore/DiagnosticLog.swift
@@ -13,10 +13,9 @@ internal import os
 /// non-droppable clear commands into the ring (the only diagnostic state,
 /// held by an inner `actor`), evicting the oldest events past ``capacity``.
 ///
-/// ``export()`` drains the ring into a compact blob: a one-line header carrying
-/// a wall-clock anchor and the build stamp, then one short row per event
-/// (`tNanos,code,surface,ms,a,b,c`, omitting absent fields). The blob is small
-/// by construction (bounded by ``capacity`` rows of integers).
+/// ``export()`` snapshots the ring into a plain-language timeline with UTC
+/// timestamps, readable event titles, and labeled values. The report is small
+/// by construction because it remains bounded by ``capacity`` events.
 ///
 /// Inject one instance from the app composition root; do not add a `.shared`
 /// singleton.
@@ -30,7 +29,7 @@ public final class DiagnosticLog: Sendable {
     /// The maximum number of retained events. Oldest are dropped past this.
     public let capacity: Int
 
-    /// The build-identity stamp written into the export header. Exposed so a
+    /// The build-identity stamp written into the report header. Exposed so a
     /// caller can also carry it as a top-level field when submitting a bundle.
     public let buildStamp: String
 
@@ -168,16 +167,16 @@ public final class DiagnosticLog: Sendable {
         ingress.record(event)
     }
 
-    /// Snapshot the currently-drained ring and format a compact export blob.
+    /// Snapshot the currently-drained ring and format a plain-language report.
     ///
     /// Reads whatever the drain task has already moved into the ring; it does not
     /// force a flush of events still in flight on the stream (the AsyncStream +
     /// drain design is eventually consistent, which is fine for a human-timed
     /// submit). The result is small by construction (bounded by ``capacity``
-    /// integer rows). Tests that need an exact post-record snapshot await
+    /// event lines). Tests that need an exact post-record snapshot await
     /// ``processedCount()`` first.
     ///
-    /// - Returns: The UTF-8 encoded compact blob.
+    /// - Returns: The UTF-8 encoded human-readable report.
     public func export() async -> Data {
         await store.export()
     }
@@ -502,7 +501,7 @@ public final class DiagnosticLog: Sendable {
         }
 
         func export() -> Data {
-            snapshot(generatedAt: Date()).compactExport()
+            snapshot(generatedAt: Date()).humanReadableExport()
         }
     }
 }

--- a/Packages/Shared/CMUXMobileCore/Sources/CMUXMobileCore/DiagnosticReport.swift
+++ b/Packages/Shared/CMUXMobileCore/Sources/CMUXMobileCore/DiagnosticReport.swift
@@ -8,6 +8,8 @@ import Foundation
 /// content, or raw error descriptions.
 public struct DiagnosticReport: Sendable, Codable, Equatable {
     public static let currentSchemaVersion = 1
+    /// Version of the plain-language text report format.
+    public static let currentHumanReadableFormatVersion = 2
     public static let maximumEventCount = 4_096
 
     /// A deterministic report suitable as a controller's unavailable default.
@@ -180,29 +182,50 @@ public struct DiagnosticReport: Sendable, Codable, Equatable {
         return event.code.defaultDiagnosticFailureKind
     }
 
-    /// Encodes this exact snapshot in the compact, human-shareable v1 format.
-    /// Building the share payload from the snapshot prevents live events from
-    /// making the displayed summary and exported timeline disagree.
-    public func compactExport() -> Data {
-        var out = "cmuxdiag v1"
-        out += " anchorWallNs=\(anchorWallNanos)"
-        out += " anchorMonoNs=\(anchorMonotonicNanos)"
-        out += " count=\(events.count)"
-        out += " role=\(role.rawValue)"
+    /// Encodes this exact snapshot as a self-contained plain-language report.
+    ///
+    /// Absolute UTC timestamps are used when the snapshot has a wall-clock
+    /// anchor. Archived or synthetic reports without an anchor use elapsed
+    /// seconds from their first event. Both forms require no external decoder.
+    public func humanReadableExport() -> Data {
+        let formatter = Self.makeUTCDateFormatter()
+        var out = "cmux Iroh and transport report\n"
+        out += "Report format: \(Self.currentHumanReadableFormatVersion)\n"
+        out += "Generated: \(formatter.string(from: generatedAt))\n"
+        out += "Source: \(DiagnosticEventPresentation.displayName(role))\n"
         if !buildStamp.isEmpty {
-            out += " build=\(buildStamp)"
+            out += "Build: \(buildStamp)\n"
         }
-        out += "\n"
+        out += "Event count: \(events.count)\n\n"
+        out += "Timeline (oldest first)\n"
+
+        guard let firstEvent = events.first else {
+            out += "No events recorded.\n"
+            return Data(out.utf8)
+        }
+
         for event in events {
-            out += "\(event.tNanos),\(event.code.rawValue)"
-            out += ",\(Self.field(event.surface))"
-            out += ",\(Self.field(event.ms))"
-            out += ",\(Self.field(event.a))"
-            out += ",\(Self.field(event.b))"
-            out += ",\(Self.field(event.c))"
-            out += "\n"
+            let timestamp: String
+            if let date = wallDate(for: event) {
+                timestamp = formatter.string(from: date)
+            } else {
+                let elapsed = Double(event.tNanos - firstEvent.tNanos) / 1_000_000_000
+                timestamp = String(
+                    format: "+%.3f seconds",
+                    locale: Locale(identifier: "en_US_POSIX"),
+                    elapsed
+                )
+            }
+            out += "\(timestamp) | \(DiagnosticEventPresentation.summary(event))\n"
         }
         return Data(out.utf8)
+    }
+
+    /// Source-compatible spelling retained for existing report consumers.
+    /// The returned data is the same plain-language report as
+    /// ``humanReadableExport()`` and contains no compact integer rows.
+    public func compactExport() -> Data {
+        humanReadableExport()
     }
 
     /// Removes control characters, path separators, and unbounded caller data
@@ -229,9 +252,13 @@ public struct DiagnosticReport: Sendable, Codable, Equatable {
         return result
     }
 
-    private static func field(_ value: (some BinaryInteger)?) -> String {
-        guard let value else { return "" }
-        return String(value)
+    private static func makeUTCDateFormatter() -> DateFormatter {
+        let formatter = DateFormatter()
+        formatter.calendar = Calendar(identifier: .gregorian)
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.timeZone = TimeZone(secondsFromGMT: 0)
+        formatter.dateFormat = "yyyy-MM-dd HH:mm:ss.SSS 'UTC'"
+        return formatter
     }
 }
 

--- a/Packages/Shared/CMUXMobileCore/Sources/CMUXMobileCore/DiagnosticReport.swift
+++ b/Packages/Shared/CMUXMobileCore/Sources/CMUXMobileCore/DiagnosticReport.swift
@@ -192,7 +192,7 @@ public struct DiagnosticReport: Sendable, Codable, Equatable {
         var out = "cmux Iroh and transport report\n"
         out += "Report format: \(Self.currentHumanReadableFormatVersion)\n"
         out += "Generated: \(formatter.string(from: generatedAt))\n"
-        out += "Source: \(DiagnosticEventPresentation.displayName(role))\n"
+        out += "Source: \(DiagnosticEventPresentation().displayName(role))\n"
         if !buildStamp.isEmpty {
             out += "Build: \(buildStamp)\n"
         }
@@ -216,7 +216,7 @@ public struct DiagnosticReport: Sendable, Codable, Equatable {
                     elapsed
                 )
             }
-            out += "\(timestamp) | \(DiagnosticEventPresentation.summary(event))\n"
+            out += "\(timestamp) | \(DiagnosticEventPresentation().summary(event))\n"
         }
         return Data(out.utf8)
     }

--- a/Packages/Shared/CMUXMobileCore/Sources/CMUXMobileCore/DiagnosticReport.swift
+++ b/Packages/Shared/CMUXMobileCore/Sources/CMUXMobileCore/DiagnosticReport.swift
@@ -187,38 +187,86 @@ public struct DiagnosticReport: Sendable, Codable, Equatable {
     /// Absolute UTC timestamps are used when the snapshot has a wall-clock
     /// anchor. Archived or synthetic reports without an anchor use elapsed
     /// seconds from their first event. Both forms require no external decoder.
-    public func humanReadableExport() -> Data {
+    /// - Parameter locale: Locale used for report headings and event text.
+    /// - Returns: UTF-8 data containing the complete report.
+    public func humanReadableExport(locale: Locale = .current) -> Data {
+        let localization = DiagnosticLocalization(locale: locale)
+        let presentation = DiagnosticEventPresentation(locale: locale)
         let formatter = Self.makeUTCDateFormatter()
-        var out = "cmux Iroh and transport report\n"
-        out += "Report format: \(Self.currentHumanReadableFormatVersion)\n"
-        out += "Generated: \(formatter.string(from: generatedAt))\n"
-        out += "Source: \(DiagnosticEventPresentation().displayName(role))\n"
+        var out = ""
+        out.reserveCapacity(320 + events.count * 160)
+        out += localization.string(
+            "diagnostics.report.title",
+            defaultValue: "cmux Iroh and transport report"
+        ) + "\n"
+        out += localization.string(
+            "diagnostics.report.format",
+            defaultValue: "Report format: \(Self.currentHumanReadableFormatVersion)"
+        ) + "\n"
+        let generated = formatter.string(from: generatedAt)
+        out += localization.string(
+            "diagnostics.report.generated",
+            defaultValue: "Generated: \(generated)"
+        ) + "\n"
+        let source = presentation.displayName(role)
+        out += localization.string(
+            "diagnostics.report.source",
+            defaultValue: "Source: \(source)"
+        ) + "\n"
         if !buildStamp.isEmpty {
-            out += "Build: \(buildStamp)\n"
+            out += localization.string(
+                "diagnostics.report.build",
+                defaultValue: "Build: \(buildStamp)"
+            ) + "\n"
         }
-        out += "Event count: \(events.count)\n\n"
-        out += "Timeline (oldest first)\n"
+        out += localization.string(
+            "diagnostics.report.eventCount",
+            defaultValue: "Event count: \(events.count)"
+        ) + "\n\n"
+        out += localization.string(
+            "diagnostics.report.timeline",
+            defaultValue: "Timeline (oldest first)"
+        ) + "\n"
 
         guard let firstEvent = events.first else {
-            out += "No events recorded.\n"
+            out += localization.string(
+                "diagnostics.report.empty",
+                defaultValue: "No events recorded."
+            ) + "\n"
             return Data(out.utf8)
         }
 
+        let relativeSecondsUnit = localization.string(
+            "diagnostics.report.relativeSecondsUnit",
+            defaultValue: "seconds"
+        )
         for event in events {
             let timestamp: String
             if let date = wallDate(for: event) {
                 timestamp = formatter.string(from: date)
             } else {
-                let elapsed = Double(event.tNanos - firstEvent.tNanos) / 1_000_000_000
-                timestamp = String(
-                    format: "+%.3f seconds",
-                    locale: Locale(identifier: "en_US_POSIX"),
-                    elapsed
+                timestamp = Self.relativeTimestamp(
+                    from: firstEvent.tNanos,
+                    to: event.tNanos,
+                    secondsUnit: relativeSecondsUnit
                 )
             }
-            out += "\(timestamp) | \(DiagnosticEventPresentation().summary(event))\n"
+            out += "\(timestamp) | \(presentation.summary(event))\n"
         }
         return Data(out.utf8)
+    }
+
+    /// Formats this report away from a caller's actor executor.
+    ///
+    /// - Parameter locale: Locale used for report headings and event text.
+    /// - Returns: The complete UTF-8 report decoded as a string.
+#if compiler(>=6.2)
+    @concurrent
+#else
+    @Sendable
+#endif
+    public nonisolated func humanReadableText(locale: Locale = .current) async -> String {
+        String(decoding: humanReadableExport(locale: locale), as: UTF8.self)
     }
 
     /// Source-compatible spelling retained for existing report consumers.
@@ -259,6 +307,28 @@ public struct DiagnosticReport: Sendable, Codable, Equatable {
         formatter.timeZone = TimeZone(secondsFromGMT: 0)
         formatter.dateFormat = "yyyy-MM-dd HH:mm:ss.SSS 'UTC'"
         return formatter
+    }
+
+    private static func relativeTimestamp(
+        from firstNanos: UInt64,
+        to eventNanos: UInt64,
+        secondsUnit: String
+    ) -> String {
+        let elapsedNanos = eventNanos >= firstNanos ? eventNanos - firstNanos : 0
+        let wholeMilliseconds = elapsedNanos / 1_000_000
+        let roundedMilliseconds = wholeMilliseconds
+            + (elapsedNanos % 1_000_000 >= 500_000 ? 1 : 0)
+        let seconds = roundedMilliseconds / 1_000
+        let milliseconds = roundedMilliseconds % 1_000
+        let fraction: String
+        if milliseconds < 10 {
+            fraction = "00\(milliseconds)"
+        } else if milliseconds < 100 {
+            fraction = "0\(milliseconds)"
+        } else {
+            fraction = String(milliseconds)
+        }
+        return "+\(seconds).\(fraction) \(secondsUnit)"
     }
 }
 

--- a/Packages/Shared/CMUXMobileCore/Sources/CMUXMobileCore/InputResponderIdentity.swift
+++ b/Packages/Shared/CMUXMobileCore/Sources/CMUXMobileCore/InputResponderIdentity.swift
@@ -3,7 +3,7 @@
 ///
 /// ``DiagnosticEvent`` carries only integer payloads (no allocated strings), so
 /// the first-responder *class* is encoded as one of these small raw values and
-/// decoded back to a human-readable name by `scripts/decode-ios-diagnostic.py`.
+/// decoded by ``DiagnosticEventPresentation`` when a report is produced.
 /// The composer-dock instrumentation stamps this into the payload slots of the
 /// ``DiagnosticEventCode/composerActiveTransition`` and
 /// ``DiagnosticEventCode/composerKeyboardToggleWhilePresented`` events so a
@@ -21,8 +21,6 @@ public enum InputResponderIdentity: Int, Sendable, Codable, CaseIterable {
     case uiTextField = 3
     /// A `UITextView`.
     case uiTextView = 4
-    /// Some other `UIResponder` subclass not in this list. The decoder pairs this
-    /// with the human-readable class name carried in the companion string log
-    /// (`anchormux`) for the same event.
+    /// Some other `UIResponder` subclass not in this list.
     case other = 9
 }

--- a/Packages/Shared/CMUXMobileCore/Sources/CMUXMobileCore/Resources/Localizable.xcstrings
+++ b/Packages/Shared/CMUXMobileCore/Sources/CMUXMobileCore/Resources/Localizable.xcstrings
@@ -1,0 +1,3513 @@
+{
+  "sourceLanguage": "en",
+  "strings": {
+    "diagnostics.boolean.no": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "いいえ"
+          }
+        }
+      }
+    },
+    "diagnostics.boolean.yes": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Yes"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "はい"
+          }
+        }
+      }
+    },
+    "diagnostics.closeInitiator.localApp": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Local app"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ローカルアプリ"
+          }
+        }
+      }
+    },
+    "diagnostics.closeInitiator.remotePeer": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Remote peer"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "リモートピア"
+          }
+        }
+      }
+    },
+    "diagnostics.closeInitiator.timedOut": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Timed out"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "タイムアウト"
+          }
+        }
+      }
+    },
+    "diagnostics.closeInitiator.unknown": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown initiator"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "不明な開始元"
+          }
+        }
+      }
+    },
+    "diagnostics.count.bytes": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld byte"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld bytes"
+                }
+              }
+            }
+          }
+        },
+        "ja": {
+          "variations": {
+            "plural": {
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lldバイト"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "diagnostics.count.points": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld point"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld points"
+                }
+              }
+            }
+          }
+        },
+        "ja": {
+          "variations": {
+            "plural": {
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lldポイント"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "diagnostics.duration.fractionalSeconds": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ seconds"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@秒"
+          }
+        }
+      }
+    },
+    "diagnostics.duration.milliseconds": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lld ms"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lldミリ秒"
+          }
+        }
+      }
+    },
+    "diagnostics.duration.seconds": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld second"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld seconds"
+                }
+              }
+            }
+          }
+        },
+        "ja": {
+          "variations": {
+            "plural": {
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld秒"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "diagnostics.event.admissionFailed": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Client admission failed"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "クライアントの受け入れに失敗しました"
+          }
+        }
+      }
+    },
+    "diagnostics.event.admissionSucceeded": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Client admitted"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "クライアントを受け入れました"
+          }
+        }
+      }
+    },
+    "diagnostics.event.appLifecycleChanged": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "App lifecycle changed"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "アプリのライフサイクルが変更されました"
+          }
+        }
+      }
+    },
+    "diagnostics.event.byteGap": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Terminal byte gap detected"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ターミナルのバイト欠落を検出しました"
+          }
+        }
+      }
+    },
+    "diagnostics.event.composerActiveTransition": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Composer activation changed"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "コンポーザーのアクティブ状態が変更されました"
+          }
+        }
+      }
+    },
+    "diagnostics.event.composerFieldFocusChanged": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Composer focus changed"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "コンポーザーのフォーカスが変更されました"
+          }
+        }
+      }
+    },
+    "diagnostics.event.composerInputTextChanged": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Composer draft changed"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "コンポーザーの下書きが変更されました"
+          }
+        }
+      }
+    },
+    "diagnostics.event.composerKeyboardToggleWhilePresented": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Keyboard toggled while composer was open"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "コンポーザー表示中にキーボードが切り替わりました"
+          }
+        }
+      }
+    },
+    "diagnostics.event.composerPresentedChanged": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Composer visibility changed"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "コンポーザーの表示状態が変更されました"
+          }
+        }
+      }
+    },
+    "diagnostics.event.composerViewAppear": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Composer appeared"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "コンポーザーが表示されました"
+          }
+        }
+      }
+    },
+    "diagnostics.event.composerViewDisappear": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Composer disappeared"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "コンポーザーが閉じられました"
+          }
+        }
+      }
+    },
+    "diagnostics.event.connect": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Connection attempt started"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "接続試行を開始しました"
+          }
+        }
+      }
+    },
+    "diagnostics.event.discoveryFailed": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Iroh route discovery failed"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Iroh経路の探索に失敗しました"
+          }
+        }
+      }
+    },
+    "diagnostics.event.discoveryStarted": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Iroh route discovery started"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Iroh経路の探索を開始しました"
+          }
+        }
+      }
+    },
+    "diagnostics.event.discoverySucceeded": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Iroh route discovery succeeded"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Iroh経路を検出しました"
+          }
+        }
+      }
+    },
+    "diagnostics.event.endpointActive": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Iroh endpoint active"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Irohエンドポイントが稼働しました"
+          }
+        }
+      }
+    },
+    "diagnostics.event.endpointFailed": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Iroh endpoint failed"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Irohエンドポイントで障害が発生しました"
+          }
+        }
+      }
+    },
+    "diagnostics.event.endpointStarting": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Iroh endpoint starting"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Irohエンドポイントを起動しています"
+          }
+        }
+      }
+    },
+    "diagnostics.event.endpointStopped": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Iroh endpoint stopped"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Irohエンドポイントが停止しました"
+          }
+        }
+      }
+    },
+    "diagnostics.event.error": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unclassified transport error"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "未分類のトランスポートエラー"
+          }
+        }
+      }
+    },
+    "diagnostics.event.hostAuthenticated": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Host authenticated"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ホストを認証しました"
+          }
+        }
+      }
+    },
+    "diagnostics.event.hostAuthenticationFailed": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Host authentication failed"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ホストの認証に失敗しました"
+          }
+        }
+      }
+    },
+    "diagnostics.event.inputSeqBehind": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Terminal input acknowledgements fell behind"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ターミナル入力の確認応答が遅れました"
+          }
+        }
+      }
+    },
+    "diagnostics.event.livenessResubscribe": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Silent event stream resubscribed"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "無通信のイベントストリームを再購読しました"
+          }
+        }
+      }
+    },
+    "diagnostics.event.pairFail": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pairing failed"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ペアリングに失敗しました"
+          }
+        }
+      }
+    },
+    "diagnostics.event.pairOk": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pairing succeeded"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ペアリングに成功しました"
+          }
+        }
+      }
+    },
+    "diagnostics.event.pairUnreachable": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pairing skipped while offline"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "オフラインのためペアリングをスキップしました"
+          }
+        }
+      }
+    },
+    "diagnostics.event.reachabilityChanged": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Network reachability changed"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ネットワーク到達性が変更されました"
+          }
+        }
+      }
+    },
+    "diagnostics.event.recoveryFailed": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Connection recovery failed"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "接続の復旧に失敗しました"
+          }
+        }
+      }
+    },
+    "diagnostics.event.recoveryStarted": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Connection recovery started"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "接続の復旧を開始しました"
+          }
+        }
+      }
+    },
+    "diagnostics.event.recoverySucceeded": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Connection recovery succeeded"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "接続が復旧しました"
+          }
+        }
+      }
+    },
+    "diagnostics.event.relayPolicyRefreshFailed": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Relay policy refresh failed"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "リレーポリシーの更新に失敗しました"
+          }
+        }
+      }
+    },
+    "diagnostics.event.relayPolicyRefreshStarted": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Relay policy refresh started"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "リレーポリシーの更新を開始しました"
+          }
+        }
+      }
+    },
+    "diagnostics.event.relayPolicyRefreshSucceeded": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Relay policy refreshed"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "リレーポリシーを更新しました"
+          }
+        }
+      }
+    },
+    "diagnostics.event.renderGridLag": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Render grid lagged"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "レンダリンググリッドが遅延しました"
+          }
+        }
+      }
+    },
+    "diagnostics.event.retryScheduled": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Retry scheduled"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "再試行を予約しました"
+          }
+        }
+      }
+    },
+    "diagnostics.event.routeUnavailable": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No usable transport route"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "利用可能なトランスポート経路がありません"
+          }
+        }
+      }
+    },
+    "diagnostics.event.rpcFailed": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "RPC session failed"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "RPCセッションに失敗しました"
+          }
+        }
+      }
+    },
+    "diagnostics.event.rpcReady": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "RPC session ready"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "RPCセッションの準備ができました"
+          }
+        }
+      }
+    },
+    "diagnostics.event.selectedPathChanged": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Selected network path changed"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "選択中のネットワーク経路が変更されました"
+          }
+        }
+      }
+    },
+    "diagnostics.event.sessionClosed": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Transport session closed"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "トランスポートセッションが閉じました"
+          }
+        }
+      }
+    },
+    "diagnostics.event.streamEnded": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Event stream ended"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "イベントストリームが終了しました"
+          }
+        }
+      }
+    },
+    "diagnostics.event.transportCloseAttribution": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Transport close attributed"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "トランスポート切断の原因を特定しました"
+          }
+        }
+      }
+    },
+    "diagnostics.event.transportDialConnected": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Transport connected"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "トランスポートに接続しました"
+          }
+        }
+      }
+    },
+    "diagnostics.event.transportDialFailed": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Transport dial failed"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "トランスポートへのダイヤルに失敗しました"
+          }
+        }
+      }
+    },
+    "diagnostics.event.transportDialStarted": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Transport dial started"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "トランスポートへのダイヤルを開始しました"
+          }
+        }
+      }
+    },
+    "diagnostics.event.transportPathEvent": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Transport path changed"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "トランスポート経路が変更されました"
+          }
+        }
+      }
+    },
+    "diagnostics.event.transportSessionLifecycle": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Transport session state changed"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "トランスポートセッションの状態が変更されました"
+          }
+        }
+      }
+    },
+    "diagnostics.failure.accountMismatch": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Account mismatch"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "アカウントが一致しません"
+          }
+        }
+      }
+    },
+    "diagnostics.failure.admissionDenied": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Client admission denied"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "クライアントの受け入れが拒否されました"
+          }
+        }
+      }
+    },
+    "diagnostics.failure.admissionLeaseExpired": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Admission lease expired"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "受け入れリースの有効期限が切れました"
+          }
+        }
+      }
+    },
+    "diagnostics.failure.admissionRevalidationFailed": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Admission revalidation failed"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "受け入れの再検証に失敗しました"
+          }
+        }
+      }
+    },
+    "diagnostics.failure.authorizationFailed": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Authorization failed"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "認可に失敗しました"
+          }
+        }
+      }
+    },
+    "diagnostics.failure.cancelled": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cancelled"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "キャンセルされました"
+          }
+        }
+      }
+    },
+    "diagnostics.failure.connectionClosed": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Connection closed"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "接続が閉じられました"
+          }
+        }
+      }
+    },
+    "diagnostics.failure.connectionRefused": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Connection refused"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "接続が拒否されました"
+          }
+        }
+      }
+    },
+    "diagnostics.failure.credentialUnavailable": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Credentials unavailable"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "認証情報を利用できません"
+          }
+        }
+      }
+    },
+    "diagnostics.failure.dnsFailed": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "DNS lookup failed"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "DNS検索に失敗しました"
+          }
+        }
+      }
+    },
+    "diagnostics.failure.endpointUnavailable": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Iroh endpoint unavailable"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Irohエンドポイントを利用できません"
+          }
+        }
+      }
+    },
+    "diagnostics.failure.hostUnreachable": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Host unreachable"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ホストに到達できません"
+          }
+        }
+      }
+    },
+    "diagnostics.failure.identityMismatch": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Host identity mismatch"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ホストIDが一致しません"
+          }
+        }
+      }
+    },
+    "diagnostics.failure.noRoute": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No route available"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "利用可能な経路がありません"
+          }
+        }
+      }
+    },
+    "diagnostics.failure.none": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No failure"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "エラーなし"
+          }
+        }
+      }
+    },
+    "diagnostics.failure.offline": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Offline"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "オフライン"
+          }
+        }
+      }
+    },
+    "diagnostics.failure.permissionDenied": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Permission denied"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "権限がありません"
+          }
+        }
+      }
+    },
+    "diagnostics.failure.policyUnavailable": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Relay policy unavailable"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "リレーポリシーを利用できません"
+          }
+        }
+      }
+    },
+    "diagnostics.failure.protocolViolation": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Protocol violation"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "プロトコル違反"
+          }
+        }
+      }
+    },
+    "diagnostics.failure.routeGated": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Route already connecting"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "経路はすでに接続中です"
+          }
+        }
+      }
+    },
+    "diagnostics.failure.secureChannelFailed": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Secure channel failed"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "セキュアチャネルの確立に失敗しました"
+          }
+        }
+      }
+    },
+    "diagnostics.failure.sendQueueOverflow": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Send queue overflow"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "送信キューがあふれました"
+          }
+        }
+      }
+    },
+    "diagnostics.failure.superseded": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Superseded by a newer attempt"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "新しい試行に置き換えられました"
+          }
+        }
+      }
+    },
+    "diagnostics.failure.timedOut": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Timed out"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "タイムアウト"
+          }
+        }
+      }
+    },
+    "diagnostics.failure.transportIdleTimedOut": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Transport idle timed out"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "トランスポートのアイドルタイムアウト"
+          }
+        }
+      }
+    },
+    "diagnostics.failure.unknown": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown failure"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "不明なエラー"
+          }
+        }
+      }
+    },
+    "diagnostics.failure.unsupportedRoute": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unsupported route"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "サポートされていない経路"
+          }
+        }
+      }
+    },
+    "diagnostics.field.applicationErrorCode": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Application error code"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "アプリケーションエラーコード"
+          }
+        }
+      }
+    },
+    "diagnostics.field.attempt": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Attempt"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "試行"
+          }
+        }
+      }
+    },
+    "diagnostics.field.composerActive": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Composer active"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "コンポーザー稼働中"
+          }
+        }
+      }
+    },
+    "diagnostics.field.composerVisible": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Composer visible"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "コンポーザー表示中"
+          }
+        }
+      }
+    },
+    "diagnostics.field.deliveredSequence": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Delivered sequence"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "配信済みシーケンス"
+          }
+        }
+      }
+    },
+    "diagnostics.field.detail1": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Detail 1"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "詳細1"
+          }
+        }
+      }
+    },
+    "diagnostics.field.detail2": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Detail 2"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "詳細2"
+          }
+        }
+      }
+    },
+    "diagnostics.field.detail3": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Detail 3"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "詳細3"
+          }
+        }
+      }
+    },
+    "diagnostics.field.draftEmpty": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Draft empty"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "下書きは空"
+          }
+        }
+      }
+    },
+    "diagnostics.field.draftSize": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Draft size"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "下書きサイズ"
+          }
+        }
+      }
+    },
+    "diagnostics.field.duration": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Duration"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "期間"
+          }
+        }
+      }
+    },
+    "diagnostics.field.failure": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Failure"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "エラー"
+          }
+        }
+      }
+    },
+    "diagnostics.field.firstResponder": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "First responder"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ファーストレスポンダ"
+          }
+        }
+      }
+    },
+    "diagnostics.field.focused": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Focused"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "フォーカス中"
+          }
+        }
+      }
+    },
+    "diagnostics.field.initiator": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Initiator"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "開始元"
+          }
+        }
+      }
+    },
+    "diagnostics.field.keyboardHeight": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Keyboard height"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "キーボードの高さ"
+          }
+        }
+      }
+    },
+    "diagnostics.field.lag": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lag"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "遅延"
+          }
+        }
+      }
+    },
+    "diagnostics.field.localSequence": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Local sequence"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ローカルシーケンス"
+          }
+        }
+      }
+    },
+    "diagnostics.field.network": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Network"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ネットワーク"
+          }
+        }
+      }
+    },
+    "diagnostics.field.nextSequence": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Next sequence"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "次のシーケンス"
+          }
+        }
+      }
+    },
+    "diagnostics.field.operation": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Operation"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "操作"
+          }
+        }
+      }
+    },
+    "diagnostics.field.path": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Path"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "経路"
+          }
+        }
+      }
+    },
+    "diagnostics.field.phase": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Phase"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "フェーズ"
+          }
+        }
+      }
+    },
+    "diagnostics.field.purpose": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Purpose"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "用途"
+          }
+        }
+      }
+    },
+    "diagnostics.field.remoteSequence": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Remote sequence"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "リモートシーケンス"
+          }
+        }
+      }
+    },
+    "diagnostics.field.retryDelay": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Retry delay"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "再試行まで"
+          }
+        }
+      }
+    },
+    "diagnostics.field.session": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Session"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "セッション"
+          }
+        }
+      }
+    },
+    "diagnostics.field.silentFor": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Silent for"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "無通信時間"
+          }
+        }
+      }
+    },
+    "diagnostics.field.state": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "State"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "状態"
+          }
+        }
+      }
+    },
+    "diagnostics.field.surface": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Surface"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "サーフェス"
+          }
+        }
+      }
+    },
+    "diagnostics.field.terminalInputFocused": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Terminal input focused"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ターミナル入力にフォーカス"
+          }
+        }
+      }
+    },
+    "diagnostics.field.transport": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Transport"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "トランスポート"
+          }
+        }
+      }
+    },
+    "diagnostics.field.trigger": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Trigger"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "トリガー"
+          }
+        }
+      }
+    },
+    "diagnostics.incident.consecutiveFailures": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld consecutive failure"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld consecutive failures"
+                }
+              }
+            }
+          }
+        },
+        "ja": {
+          "variations": {
+            "plural": {
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld回連続の失敗"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "diagnostics.incident.failureWithOccurrences": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$@ (%2$@)"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$@（%2$@）"
+          }
+        }
+      }
+    },
+    "diagnostics.incident.occurrences": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld occurrence"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld occurrences"
+                }
+              }
+            }
+          }
+        },
+        "ja": {
+          "variations": {
+            "plural": {
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld回"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "diagnostics.incident.outage": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Transport outage: %1$@ over %2$@. Latest: %3$@"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "トランスポート障害: %1$@が%2$@にわたって発生しました。最新: %3$@"
+          }
+        }
+      }
+    },
+    "diagnostics.path.direct": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Direct"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "直接"
+          }
+        }
+      }
+    },
+    "diagnostics.path.loopback": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Loopback"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ループバック"
+          }
+        }
+      }
+    },
+    "diagnostics.path.privateNetwork": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Private network"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "プライベートネットワーク"
+          }
+        }
+      }
+    },
+    "diagnostics.path.relay": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Relay"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "リレー"
+          }
+        }
+      }
+    },
+    "diagnostics.path.unknown": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown path"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "不明な経路"
+          }
+        }
+      }
+    },
+    "diagnostics.pathOperation.closed": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Closed"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "終了"
+          }
+        }
+      }
+    },
+    "diagnostics.pathOperation.lagged": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lagged"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "遅延"
+          }
+        }
+      }
+    },
+    "diagnostics.pathOperation.opened": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Opened"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "開始"
+          }
+        }
+      }
+    },
+    "diagnostics.pathOperation.selected": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Selected"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "選択"
+          }
+        }
+      }
+    },
+    "diagnostics.phase.active": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Active"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "アクティブ"
+          }
+        }
+      }
+    },
+    "diagnostics.phase.background": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Background"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "バックグラウンド"
+          }
+        }
+      }
+    },
+    "diagnostics.phase.inactive": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Inactive"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "非アクティブ"
+          }
+        }
+      }
+    },
+    "diagnostics.purpose.backgroundControl": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Background control"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "バックグラウンド制御"
+          }
+        }
+      }
+    },
+    "diagnostics.purpose.featureLane": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Feature lane"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "機能レーン"
+          }
+        }
+      }
+    },
+    "diagnostics.purpose.foregroundControl": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Foreground control"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "フォアグラウンド制御"
+          }
+        }
+      }
+    },
+    "diagnostics.purpose.probe": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Connection probe"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "接続プローブ"
+          }
+        }
+      }
+    },
+    "diagnostics.reachability.offline": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Offline"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "オフライン"
+          }
+        }
+      }
+    },
+    "diagnostics.reachability.online": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Online"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "オンライン"
+          }
+        }
+      }
+    },
+    "diagnostics.recoveryTrigger.foreground": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "App returned to foreground"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "アプリがフォアグラウンドに戻りました"
+          }
+        }
+      }
+    },
+    "diagnostics.recoveryTrigger.livenessFailed": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Liveness check failed"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "稼働確認に失敗しました"
+          }
+        }
+      }
+    },
+    "diagnostics.recoveryTrigger.manualRetry": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Manual retry"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "手動再試行"
+          }
+        }
+      }
+    },
+    "diagnostics.recoveryTrigger.networkChanged": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Network changed"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ネットワークが変更されました"
+          }
+        }
+      }
+    },
+    "diagnostics.recoveryTrigger.presenceNotification": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Presence notification"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "プレゼンス通知"
+          }
+        }
+      }
+    },
+    "diagnostics.recoveryTrigger.retryDelayExpired": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Automatic retry delay expired"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "自動再試行の待機時間が終了しました"
+          }
+        }
+      }
+    },
+    "diagnostics.recoveryTrigger.streamEnded": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Event stream ended"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "イベントストリームが終了しました"
+          }
+        }
+      }
+    },
+    "diagnostics.recoveryTrigger.subscriptionFailed": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Subscription failed to start"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "購読を開始できませんでした"
+          }
+        }
+      }
+    },
+    "diagnostics.recoveryTrigger.writeTimedOut": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Transport write timed out"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "トランスポートへの書き込みがタイムアウトしました"
+          }
+        }
+      }
+    },
+    "diagnostics.report.build": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Build: %@"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ビルド: %@"
+          }
+        }
+      }
+    },
+    "diagnostics.report.empty": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No events recorded."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "記録されたイベントはありません。"
+          }
+        }
+      }
+    },
+    "diagnostics.report.eventCount": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Event count: %lld"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "イベント数: %lld"
+          }
+        }
+      }
+    },
+    "diagnostics.report.format": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Report format: %lld"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "レポート形式: %lld"
+          }
+        }
+      }
+    },
+    "diagnostics.report.generated": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Generated: %@"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "生成日時: %@"
+          }
+        }
+      }
+    },
+    "diagnostics.report.relativeSecondsUnit": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "seconds"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "秒"
+          }
+        }
+      }
+    },
+    "diagnostics.report.source": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Source: %@"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "生成元: %@"
+          }
+        }
+      }
+    },
+    "diagnostics.report.timeline": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Timeline (oldest first)"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "タイムライン（古い順）"
+          }
+        }
+      }
+    },
+    "diagnostics.report.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "cmux Iroh and transport report"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "cmux Irohとトランスポートのレポート"
+          }
+        }
+      }
+    },
+    "diagnostics.responder.none": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "None"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "なし"
+          }
+        }
+      }
+    },
+    "diagnostics.responder.other": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Other responder"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "その他のレスポンダ"
+          }
+        }
+      }
+    },
+    "diagnostics.responder.terminalInput": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Terminal input"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ターミナル入力"
+          }
+        }
+      }
+    },
+    "diagnostics.responder.terminalSurface": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Terminal surface"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ターミナルサーフェス"
+          }
+        }
+      }
+    },
+    "diagnostics.responder.textField": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Text field"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "テキストフィールド"
+          }
+        }
+      }
+    },
+    "diagnostics.responder.textView": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Text view"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "テキストビュー"
+          }
+        }
+      }
+    },
+    "diagnostics.role.broker": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Broker"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ブローカー"
+          }
+        }
+      }
+    },
+    "diagnostics.role.macHost": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mac host"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Macホスト"
+          }
+        }
+      }
+    },
+    "diagnostics.role.mobileClient": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "iOS client"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "iOSクライアント"
+          }
+        }
+      }
+    },
+    "diagnostics.role.relay": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Relay"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "リレー"
+          }
+        }
+      }
+    },
+    "diagnostics.role.unspecified": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unspecified runtime"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "未指定のランタイム"
+          }
+        }
+      }
+    },
+    "diagnostics.session.allPathsClosed": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "All paths closed"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "すべての経路が閉じました"
+          }
+        }
+      }
+    },
+    "diagnostics.session.applicationLaneFailed": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Application lane failed"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "アプリケーションレーンに失敗しました"
+          }
+        }
+      }
+    },
+    "diagnostics.session.closedSessionEvicted": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Closed session evicted"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "終了済みセッションを破棄しました"
+          }
+        }
+      }
+    },
+    "diagnostics.session.controlOwnerReleased": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Control owner released"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "制御所有者が解放されました"
+          }
+        }
+      }
+    },
+    "diagnostics.session.controlReadFailed": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Control read failed"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "制御データの読み取りに失敗しました"
+          }
+        }
+      }
+    },
+    "diagnostics.session.controlWriteFailed": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Control write failed"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "制御データの書き込みに失敗しました"
+          }
+        }
+      }
+    },
+    "diagnostics.session.established": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Established"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "確立済み"
+          }
+        }
+      }
+    },
+    "diagnostics.session.explicitlyInvalidated": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Explicitly invalidated"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "明示的に無効化されました"
+          }
+        }
+      }
+    },
+    "diagnostics.session.remoteClosed": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Remote closed"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "リモート側が閉じました"
+          }
+        }
+      }
+    },
+    "diagnostics.session.runtimeDeactivated": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Runtime deactivated"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ランタイムが無効化されました"
+          }
+        }
+      }
+    },
+    "diagnostics.session.runtimeReconfigured": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Runtime reconfigured"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ランタイムが再構成されました"
+          }
+        }
+      }
+    },
+    "diagnostics.summary.details": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$@ (%2$@)"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$@（%2$@）"
+          }
+        }
+      }
+    },
+    "diagnostics.summary.field": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$@: %2$@"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$@: %2$@"
+          }
+        }
+      }
+    },
+    "diagnostics.summary.separator": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": ", "
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "、"
+          }
+        }
+      }
+    },
+    "diagnostics.transport.debugLoopback": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Debug loopback"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "デバッグループバック"
+          }
+        }
+      }
+    },
+    "diagnostics.transport.iroh": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Iroh"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Iroh"
+          }
+        }
+      }
+    },
+    "diagnostics.transport.tailscale": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tailscale"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tailscale"
+          }
+        }
+      }
+    },
+    "diagnostics.transport.unknown": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown transport"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "不明なトランスポート"
+          }
+        }
+      }
+    },
+    "diagnostics.transport.websocket": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "WebSocket"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "WebSocket"
+          }
+        }
+      }
+    },
+    "diagnostics.unknown.appPhase": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown app phase (%lld)"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "不明なアプリフェーズ（%lld）"
+          }
+        }
+      }
+    },
+    "diagnostics.unknown.closeInitiator": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown close initiator (%lld)"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "不明な切断開始元（%lld）"
+          }
+        }
+      }
+    },
+    "diagnostics.unknown.failure": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown failure (%lld)"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "不明なエラー（%lld）"
+          }
+        }
+      }
+    },
+    "diagnostics.unknown.networkState": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown network state (%lld)"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "不明なネットワーク状態（%lld）"
+          }
+        }
+      }
+    },
+    "diagnostics.unknown.path": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown path (%lld)"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "不明な経路（%lld）"
+          }
+        }
+      }
+    },
+    "diagnostics.unknown.pathOperation": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown path operation (%lld)"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "不明な経路操作（%lld）"
+          }
+        }
+      }
+    },
+    "diagnostics.unknown.recoveryTrigger": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown recovery trigger (%lld)"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "不明な復旧トリガー（%lld）"
+          }
+        }
+      }
+    },
+    "diagnostics.unknown.responder": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown responder (%lld)"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "不明なレスポンダ（%lld）"
+          }
+        }
+      }
+    },
+    "diagnostics.unknown.sessionPurpose": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown session purpose (%lld)"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "不明なセッション用途（%lld）"
+          }
+        }
+      }
+    },
+    "diagnostics.unknown.sessionState": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown session state (%lld)"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "不明なセッション状態（%lld）"
+          }
+        }
+      }
+    },
+    "diagnostics.unknown.state": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown state (%lld)"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "不明な状態（%lld）"
+          }
+        }
+      }
+    },
+    "diagnostics.unknown.transport": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown transport (%lld)"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "不明なトランスポート（%lld）"
+          }
+        }
+      }
+    }
+  },
+  "version": "1.0"
+}

--- a/Packages/Shared/CMUXMobileCore/Sources/CMUXMobileCore/TransportIncidentPolicy.swift
+++ b/Packages/Shared/CMUXMobileCore/Sources/CMUXMobileCore/TransportIncidentPolicy.swift
@@ -173,7 +173,7 @@ public struct TransportIncidentPolicy: Sendable {
         let failure = failureKind(of: event)
         guard isReportable(event: event, failure: failure) else { return nil }
 
-        let transport = DiagnosticEventPresentation.transportKind(of: event)
+        let transport = DiagnosticEventPresentation().transportKind(of: event)
         let signature = Self.signature(code: event.code, failure: failure, transport: transport)
 
         streakCount += 1
@@ -199,18 +199,18 @@ public struct TransportIncidentPolicy: Sendable {
         failure: DiagnosticFailureKind?,
         transport: DiagnosticTransportKind?
     ) -> String {
-        var parts = [DiagnosticEventPresentation.name(code)]
+        var parts = [DiagnosticEventPresentation().name(code)]
         if let failure {
-            parts.append(DiagnosticEventPresentation.name(failure))
+            parts.append(DiagnosticEventPresentation().name(failure))
         }
         if let transport {
-            parts.append(DiagnosticEventPresentation.name(transport))
+            parts.append(DiagnosticEventPresentation().name(transport))
         }
         return parts.joined(separator: "/")
     }
 
     private func failureKind(of event: DiagnosticEvent) -> DiagnosticFailureKind? {
-        if let kind = DiagnosticEventPresentation.failureKind(of: event) {
+        if let kind = DiagnosticEventPresentation().failureKind(of: event) {
             return kind
         }
         if event.code == .pairUnreachable {
@@ -263,7 +263,7 @@ public struct TransportIncidentPolicy: Sendable {
         let durationUnit = duration == 1 ? "second" : "seconds"
         let title = "Transport outage: \(streakCount) consecutive failures "
             + "over \(duration) \(durationUnit). Latest: "
-            + DiagnosticEventPresentation.summary(event)
+            + DiagnosticEventPresentation().summary(event)
         return Incident(
             signature: "transport-outage",
             title: title,
@@ -323,7 +323,7 @@ public struct TransportIncidentPolicy: Sendable {
         let dropped = droppedByBudget
         droppedByBudget = 0
 
-        var title = DiagnosticEventPresentation.summary(event)
+        var title = DiagnosticEventPresentation().summary(event)
         if coalescedCount > 1 {
             title += " (\(coalescedCount) occurrences)"
         }

--- a/Packages/Shared/CMUXMobileCore/Sources/CMUXMobileCore/TransportIncidentPolicy.swift
+++ b/Packages/Shared/CMUXMobileCore/Sources/CMUXMobileCore/TransportIncidentPolicy.swift
@@ -260,9 +260,13 @@ public struct TransportIncidentPolicy: Sendable {
         }
         outageFiredTNanos = event.tNanos
         let duration = Int(elapsedSeconds(from: firstTNanos, to: event.tNanos).rounded())
+        let durationUnit = duration == 1 ? "second" : "seconds"
+        let title = "Transport outage: \(streakCount) consecutive failures "
+            + "over \(duration) \(durationUnit). Latest: "
+            + DiagnosticEventPresentation.summary(event)
         return Incident(
             signature: "transport-outage",
-            title: "Transport outage: \(streakCount) consecutive failures over \(duration)s, latest \(signature)",
+            title: title,
             kind: .outage,
             severity: .error,
             event: event,
@@ -319,9 +323,9 @@ public struct TransportIncidentPolicy: Sendable {
         let dropped = droppedByBudget
         droppedByBudget = 0
 
-        var title = "Transport failure: \(signature)"
+        var title = DiagnosticEventPresentation.summary(event)
         if coalescedCount > 1 {
-            title += " (\(coalescedCount)x)"
+            title += " (\(coalescedCount) occurrences)"
         }
         return Incident(
             signature: signature,

--- a/Packages/Shared/CMUXMobileCore/Sources/CMUXMobileCore/TransportIncidentPolicy.swift
+++ b/Packages/Shared/CMUXMobileCore/Sources/CMUXMobileCore/TransportIncidentPolicy.swift
@@ -101,11 +101,21 @@ public struct TransportIncidentPolicy: Sendable {
         public let appPhase: DiagnosticAppLifecyclePhase?
     }
 
-    public init(configuration: Configuration = Configuration()) {
+    /// Creates an incident policy with localized titles.
+    ///
+    /// - Parameters:
+    ///   - configuration: Thresholds and budgets used by the policy.
+    ///   - locale: Locale used for human-readable incident titles.
+    public init(
+        configuration: Configuration = Configuration(),
+        locale: Locale = .current
+    ) {
         self.configuration = configuration
+        self.titleFormatter = DiagnosticIncidentTitleFormatter(locale: locale)
     }
 
     private let configuration: Configuration
+    private let titleFormatter: DiagnosticIncidentTitleFormatter
 
     // MARK: Streak and environment state (event-time domain, nanoseconds).
 
@@ -260,10 +270,11 @@ public struct TransportIncidentPolicy: Sendable {
         }
         outageFiredTNanos = event.tNanos
         let duration = Int(elapsedSeconds(from: firstTNanos, to: event.tNanos).rounded())
-        let durationUnit = duration == 1 ? "second" : "seconds"
-        let title = "Transport outage: \(streakCount) consecutive failures "
-            + "over \(duration) \(durationUnit). Latest: "
-            + DiagnosticEventPresentation().summary(event)
+        let title = titleFormatter.outageTitle(
+            event: event,
+            consecutiveFailures: streakCount,
+            durationSeconds: duration
+        )
         return Incident(
             signature: "transport-outage",
             title: title,
@@ -323,10 +334,10 @@ public struct TransportIncidentPolicy: Sendable {
         let dropped = droppedByBudget
         droppedByBudget = 0
 
-        var title = DiagnosticEventPresentation().summary(event)
-        if coalescedCount > 1 {
-            title += " (\(coalescedCount) occurrences)"
-        }
+        let title = titleFormatter.failureTitle(
+            event: event,
+            occurrenceCount: coalescedCount
+        )
         return Incident(
             signature: signature,
             title: title,

--- a/Packages/Shared/CMUXMobileCore/Tests/CMUXMobileCoreTests/DiagnosticEventPresentationTests.swift
+++ b/Packages/Shared/CMUXMobileCore/Tests/CMUXMobileCoreTests/DiagnosticEventPresentationTests.swift
@@ -33,11 +33,11 @@ import Testing
             c: 42
         )
         let described = DiagnosticEventPresentation.describe(event)
-        #expect(described.name == "transportDialFailed")
+        #expect(described.name == "Transport dial failed")
         #expect(described.fields == [
-            .init(key: "transport", value: "iroh"),
-            .init(key: "failure", value: "policyUnavailable"),
-            .init(key: "attempt_id", value: "42"),
+            .init(key: "transport", value: "Iroh"),
+            .init(key: "failure", value: "Relay policy unavailable"),
+            .init(key: "attempt", value: "42"),
         ])
     }
 
@@ -45,7 +45,7 @@ import Testing
         let retry = DiagnosticEventPresentation.describe(
             DiagnosticEvent(code: .retryScheduled, tNanos: 1, ms: 32_331)
         )
-        #expect(retry.fields == [.init(key: "delay_ms", value: "32331")])
+        #expect(retry.fields == [.init(key: "retry_delay", value: "32.331 seconds")])
 
         let close = DiagnosticEventPresentation.describe(
             DiagnosticEvent(
@@ -58,10 +58,10 @@ import Testing
             )
         )
         #expect(close.fields == [
-            .init(key: "app_error_code", value: "7"),
-            .init(key: "initiator", value: "timedOut"),
-            .init(key: "failure", value: "transportIdleTimedOut"),
-            .init(key: "session_id", value: "9"),
+            .init(key: "initiator", value: "Timed out"),
+            .init(key: "failure", value: "Transport idle timed out"),
+            .init(key: "application_error_code", value: "7"),
+            .init(key: "session", value: "9"),
         ])
     }
 
@@ -69,12 +69,12 @@ import Testing
         let phase = DiagnosticEventPresentation.describe(
             DiagnosticEvent(code: .appLifecycleChanged, tNanos: 1, a: DiagnosticAppLifecyclePhase.background.rawValue)
         )
-        #expect(phase.fields == [.init(key: "phase", value: "background")])
+        #expect(phase.fields == [.init(key: "phase", value: "Background")])
 
         let reachability = DiagnosticEventPresentation.describe(
             DiagnosticEvent(code: .reachabilityChanged, tNanos: 1, a: 0)
         )
-        #expect(reachability.fields == [.init(key: "reachable", value: "false")])
+        #expect(reachability.fields == [.init(key: "network", value: "Offline")])
     }
 
     @Test func unknownRawValuesFallBackToIntegers() {
@@ -82,9 +82,140 @@ import Testing
             DiagnosticEvent(code: .transportDialFailed, tNanos: 1, a: 999, b: 998)
         )
         #expect(described.fields == [
-            .init(key: "transport", value: "999"),
-            .init(key: "failure", value: "998"),
+            .init(key: "transport", value: "Unknown transport (999)"),
+            .init(key: "failure", value: "Unknown failure (998)"),
         ])
+    }
+
+    @Test func everyEventCodeHasAReadableTitle() {
+        let expected: [DiagnosticEventCode: String] = [
+            .connect: "Connection attempt started",
+            .pairOk: "Pairing succeeded",
+            .pairFail: "Pairing failed",
+            .renderGridLag: "Render grid lagged",
+            .livenessResubscribe: "Silent event stream resubscribed",
+            .streamEnded: "Event stream ended",
+            .inputSeqBehind: "Terminal input acknowledgements fell behind",
+            .byteGap: "Terminal byte gap detected",
+            .error: "Unclassified transport error",
+            .pairUnreachable: "Pairing skipped while offline",
+            .composerPresentedChanged: "Composer visibility changed",
+            .composerInputTextChanged: "Composer draft changed",
+            .composerViewAppear: "Composer appeared",
+            .composerViewDisappear: "Composer disappeared",
+            .composerFieldFocusChanged: "Composer focus changed",
+            .composerActiveTransition: "Composer activation changed",
+            .composerKeyboardToggleWhilePresented: "Keyboard toggled while composer was open",
+            .transportDialStarted: "Transport dial started",
+            .transportDialConnected: "Transport connected",
+            .transportDialFailed: "Transport dial failed",
+            .hostAuthenticated: "Host authenticated",
+            .rpcReady: "RPC session ready",
+            .recoveryStarted: "Connection recovery started",
+            .recoverySucceeded: "Connection recovery succeeded",
+            .recoveryFailed: "Connection recovery failed",
+            .endpointStarting: "Iroh endpoint starting",
+            .endpointActive: "Iroh endpoint active",
+            .endpointStopped: "Iroh endpoint stopped",
+            .endpointFailed: "Iroh endpoint failed",
+            .relayPolicyRefreshStarted: "Relay policy refresh started",
+            .relayPolicyRefreshSucceeded: "Relay policy refreshed",
+            .relayPolicyRefreshFailed: "Relay policy refresh failed",
+            .selectedPathChanged: "Selected network path changed",
+            .sessionClosed: "Transport session closed",
+            .routeUnavailable: "No usable transport route",
+            .retryScheduled: "Retry scheduled",
+            .discoveryStarted: "Iroh route discovery started",
+            .discoverySucceeded: "Iroh route discovery succeeded",
+            .discoveryFailed: "Iroh route discovery failed",
+            .admissionSucceeded: "Client admitted",
+            .admissionFailed: "Client admission failed",
+            .hostAuthenticationFailed: "Host authentication failed",
+            .rpcFailed: "RPC session failed",
+            .transportSessionLifecycle: "Transport session state changed",
+            .appLifecycleChanged: "App lifecycle changed",
+            .reachabilityChanged: "Network reachability changed",
+            .transportCloseAttribution: "Transport close attributed",
+            .transportPathEvent: "Transport path changed",
+        ]
+
+        #expect(Set(expected.keys) == Set(DiagnosticEventCode.allCases))
+        for code in DiagnosticEventCode.allCases {
+            #expect(
+                DiagnosticEventPresentation.describe(
+                    DiagnosticEvent(code: code, tNanos: 1)
+                ).name == expected[code]
+            )
+        }
+    }
+
+    @Test func decodesEveryStructuredPayloadIntoSemanticFields() {
+        let recovery = DiagnosticEventPresentation.describe(DiagnosticEvent(
+            code: .recoveryStarted,
+            tNanos: 1,
+            a: DiagnosticTransportKind.iroh.rawValue,
+            b: 1
+        ))
+        #expect(recovery.fields == [
+            .init(key: "transport", value: "Iroh"),
+            .init(key: "trigger", value: "Network changed"),
+        ])
+
+        let endpoint = DiagnosticEventPresentation.describe(DiagnosticEvent(
+            code: .endpointFailed,
+            tNanos: 1,
+            a: DiagnosticTransportKind.iroh.rawValue,
+            b: DiagnosticFailureKind.endpointUnavailable.rawValue
+        ))
+        #expect(endpoint.fields == [
+            .init(key: "transport", value: "Iroh"),
+            .init(key: "failure", value: "Iroh endpoint unavailable"),
+        ])
+
+        let session = DiagnosticEventPresentation.describe(DiagnosticEvent(
+            code: .transportSessionLifecycle,
+            tNanos: 1,
+            a: DiagnosticSessionLifecycleKind.established.rawValue,
+            b: Int(CmxTransportSessionPurpose.foregroundControl.rawValue),
+            c: 12
+        ))
+        #expect(session.fields == [
+            .init(key: "state", value: "Established"),
+            .init(key: "purpose", value: "Foreground control"),
+            .init(key: "session", value: "12"),
+        ])
+
+        let composer = DiagnosticEventPresentation.describe(DiagnosticEvent(
+            code: .composerActiveTransition,
+            tNanos: 1,
+            ms: 300,
+            a: 1,
+            b: InputResponderIdentity.uiTextField.rawValue,
+            c: 0
+        ))
+        #expect(composer.fields == [
+            .init(key: "composer_active", value: "Yes"),
+            .init(key: "first_responder", value: "Text field"),
+            .init(key: "keyboard_height", value: "300 points"),
+            .init(key: "terminal_input_focused", value: "No"),
+        ])
+
+        let input = DiagnosticEventPresentation.describe(DiagnosticEvent(
+            code: .inputSeqBehind,
+            tNanos: 1,
+            surface: 7,
+            a: 10,
+            b: 20
+        ))
+        #expect(input.fields == [
+            .init(key: "surface", value: "7"),
+            .init(key: "local_sequence", value: "10"),
+            .init(key: "remote_sequence", value: "20"),
+        ])
+
+        for described in [recovery, endpoint, session, composer, input] {
+            #expect(!described.fields.contains { ["a", "b", "c", "ms"].contains($0.key) })
+        }
     }
 
     @Test func extractsFailureAndTransportKinds() {

--- a/Packages/Shared/CMUXMobileCore/Tests/CMUXMobileCoreTests/DiagnosticEventPresentationTests.swift
+++ b/Packages/Shared/CMUXMobileCore/Tests/CMUXMobileCoreTests/DiagnosticEventPresentationTests.swift
@@ -6,22 +6,22 @@ import Testing
     /// Case names are shipped telemetry vocabulary (Sentry grouping keys), so a
     /// rename is a breaking change this test makes visible.
     @Test func pinsEventCodeNames() {
-        #expect(DiagnosticEventPresentation.name(DiagnosticEventCode.transportDialFailed) == "transportDialFailed")
-        #expect(DiagnosticEventPresentation.name(DiagnosticEventCode.endpointFailed) == "endpointFailed")
-        #expect(DiagnosticEventPresentation.name(DiagnosticEventCode.pairFail) == "pairFail")
-        #expect(DiagnosticEventPresentation.name(DiagnosticEventCode.sessionClosed) == "sessionClosed")
-        #expect(DiagnosticEventPresentation.name(DiagnosticEventCode.retryScheduled) == "retryScheduled")
-        #expect(DiagnosticEventPresentation.name(DiagnosticEventCode.hostAuthenticationFailed) == "hostAuthenticationFailed")
+        #expect(DiagnosticEventPresentation().name(DiagnosticEventCode.transportDialFailed) == "transportDialFailed")
+        #expect(DiagnosticEventPresentation().name(DiagnosticEventCode.endpointFailed) == "endpointFailed")
+        #expect(DiagnosticEventPresentation().name(DiagnosticEventCode.pairFail) == "pairFail")
+        #expect(DiagnosticEventPresentation().name(DiagnosticEventCode.sessionClosed) == "sessionClosed")
+        #expect(DiagnosticEventPresentation().name(DiagnosticEventCode.retryScheduled) == "retryScheduled")
+        #expect(DiagnosticEventPresentation().name(DiagnosticEventCode.hostAuthenticationFailed) == "hostAuthenticationFailed")
     }
 
     @Test func pinsTaxonomyNames() {
-        #expect(DiagnosticEventPresentation.name(DiagnosticFailureKind.policyUnavailable) == "policyUnavailable")
-        #expect(DiagnosticEventPresentation.name(DiagnosticFailureKind.identityMismatch) == "identityMismatch")
-        #expect(DiagnosticEventPresentation.name(DiagnosticFailureKind.authorizationFailed) == "authorizationFailed")
-        #expect(DiagnosticEventPresentation.name(DiagnosticTransportKind.iroh) == "iroh")
-        #expect(DiagnosticEventPresentation.name(DiagnosticPathKind.relay) == "relay")
-        #expect(DiagnosticEventPresentation.name(DiagnosticRuntimeRole.mobileClient) == "mobileClient")
-        #expect(DiagnosticEventPresentation.name(DiagnosticAppLifecyclePhase.background) == "background")
+        #expect(DiagnosticEventPresentation().name(DiagnosticFailureKind.policyUnavailable) == "policyUnavailable")
+        #expect(DiagnosticEventPresentation().name(DiagnosticFailureKind.identityMismatch) == "identityMismatch")
+        #expect(DiagnosticEventPresentation().name(DiagnosticFailureKind.authorizationFailed) == "authorizationFailed")
+        #expect(DiagnosticEventPresentation().name(DiagnosticTransportKind.iroh) == "iroh")
+        #expect(DiagnosticEventPresentation().name(DiagnosticPathKind.relay) == "relay")
+        #expect(DiagnosticEventPresentation().name(DiagnosticRuntimeRole.mobileClient) == "mobileClient")
+        #expect(DiagnosticEventPresentation().name(DiagnosticAppLifecyclePhase.background) == "background")
     }
 
     @Test func describesDialFailure() {
@@ -32,7 +32,7 @@ import Testing
             b: DiagnosticFailureKind.policyUnavailable.rawValue,
             c: 42
         )
-        let described = DiagnosticEventPresentation.describe(event)
+        let described = DiagnosticEventPresentation().describe(event)
         #expect(described.name == "Transport dial failed")
         #expect(described.fields == [
             .init(key: "transport", value: "Iroh"),
@@ -42,12 +42,12 @@ import Testing
     }
 
     @Test func describesRetryDelayAndCloseAttribution() {
-        let retry = DiagnosticEventPresentation.describe(
+        let retry = DiagnosticEventPresentation().describe(
             DiagnosticEvent(code: .retryScheduled, tNanos: 1, ms: 32_331)
         )
         #expect(retry.fields == [.init(key: "retry_delay", value: "32.331 seconds")])
 
-        let close = DiagnosticEventPresentation.describe(
+        let close = DiagnosticEventPresentation().describe(
             DiagnosticEvent(
                 code: .transportCloseAttribution,
                 tNanos: 1,
@@ -66,19 +66,19 @@ import Testing
     }
 
     @Test func describesLifecycleAndReachability() {
-        let phase = DiagnosticEventPresentation.describe(
+        let phase = DiagnosticEventPresentation().describe(
             DiagnosticEvent(code: .appLifecycleChanged, tNanos: 1, a: DiagnosticAppLifecyclePhase.background.rawValue)
         )
         #expect(phase.fields == [.init(key: "phase", value: "Background")])
 
-        let reachability = DiagnosticEventPresentation.describe(
+        let reachability = DiagnosticEventPresentation().describe(
             DiagnosticEvent(code: .reachabilityChanged, tNanos: 1, a: 0)
         )
         #expect(reachability.fields == [.init(key: "network", value: "Offline")])
     }
 
     @Test func unknownRawValuesFallBackToIntegers() {
-        let described = DiagnosticEventPresentation.describe(
+        let described = DiagnosticEventPresentation().describe(
             DiagnosticEvent(code: .transportDialFailed, tNanos: 1, a: 999, b: 998)
         )
         #expect(described.fields == [
@@ -142,7 +142,7 @@ import Testing
         #expect(Set(expected.keys) == Set(DiagnosticEventCode.allCases))
         for code in DiagnosticEventCode.allCases {
             #expect(
-                DiagnosticEventPresentation.describe(
+                DiagnosticEventPresentation().describe(
                     DiagnosticEvent(code: code, tNanos: 1)
                 ).name == expected[code]
             )
@@ -150,7 +150,7 @@ import Testing
     }
 
     @Test func decodesEveryStructuredPayloadIntoSemanticFields() {
-        let recovery = DiagnosticEventPresentation.describe(DiagnosticEvent(
+        let recovery = DiagnosticEventPresentation().describe(DiagnosticEvent(
             code: .recoveryStarted,
             tNanos: 1,
             a: DiagnosticTransportKind.iroh.rawValue,
@@ -161,7 +161,7 @@ import Testing
             .init(key: "trigger", value: "Network changed"),
         ])
 
-        let endpoint = DiagnosticEventPresentation.describe(DiagnosticEvent(
+        let endpoint = DiagnosticEventPresentation().describe(DiagnosticEvent(
             code: .endpointFailed,
             tNanos: 1,
             a: DiagnosticTransportKind.iroh.rawValue,
@@ -172,7 +172,7 @@ import Testing
             .init(key: "failure", value: "Iroh endpoint unavailable"),
         ])
 
-        let session = DiagnosticEventPresentation.describe(DiagnosticEvent(
+        let session = DiagnosticEventPresentation().describe(DiagnosticEvent(
             code: .transportSessionLifecycle,
             tNanos: 1,
             a: DiagnosticSessionLifecycleKind.established.rawValue,
@@ -185,7 +185,7 @@ import Testing
             .init(key: "session", value: "12"),
         ])
 
-        let composer = DiagnosticEventPresentation.describe(DiagnosticEvent(
+        let composer = DiagnosticEventPresentation().describe(DiagnosticEvent(
             code: .composerActiveTransition,
             tNanos: 1,
             ms: 300,
@@ -200,7 +200,7 @@ import Testing
             .init(key: "terminal_input_focused", value: "No"),
         ])
 
-        let input = DiagnosticEventPresentation.describe(DiagnosticEvent(
+        let input = DiagnosticEventPresentation().describe(DiagnosticEvent(
             code: .inputSeqBehind,
             tNanos: 1,
             surface: 7,
@@ -224,10 +224,10 @@ import Testing
             tNanos: 1,
             b: DiagnosticFailureKind.identityMismatch.rawValue
         )
-        #expect(DiagnosticEventPresentation.failureKind(of: event) == .identityMismatch)
-        #expect(DiagnosticEventPresentation.transportKind(of: event) == nil)
+        #expect(DiagnosticEventPresentation().failureKind(of: event) == .identityMismatch)
+        #expect(DiagnosticEventPresentation().transportKind(of: event) == nil)
 
         let success = DiagnosticEvent(code: .rpcReady, tNanos: 1, b: 3)
-        #expect(DiagnosticEventPresentation.failureKind(of: success) == nil)
+        #expect(DiagnosticEventPresentation().failureKind(of: success) == nil)
     }
 }

--- a/Packages/Shared/CMUXMobileCore/Tests/CMUXMobileCoreTests/DiagnosticEventPresentationTests.swift
+++ b/Packages/Shared/CMUXMobileCore/Tests/CMUXMobileCoreTests/DiagnosticEventPresentationTests.swift
@@ -3,6 +3,10 @@ import Testing
 @testable import CMUXMobileCore
 
 @Suite struct DiagnosticEventPresentationTests {
+    private var englishPresentation: DiagnosticEventPresentation {
+        DiagnosticEventPresentation(locale: Locale(identifier: "en"))
+    }
+
     /// Case names are shipped telemetry vocabulary (Sentry grouping keys), so a
     /// rename is a breaking change this test makes visible.
     @Test func pinsEventCodeNames() {
@@ -32,7 +36,7 @@ import Testing
             b: DiagnosticFailureKind.policyUnavailable.rawValue,
             c: 42
         )
-        let described = DiagnosticEventPresentation().describe(event)
+        let described = englishPresentation.describe(event)
         #expect(described.name == "Transport dial failed")
         #expect(described.fields == [
             .init(key: "transport", value: "Iroh"),
@@ -42,27 +46,27 @@ import Testing
     }
 
     @Test func describesRetryDelayAndCloseAttribution() {
-        let retry = DiagnosticEventPresentation().describe(
+        let retry = englishPresentation.describe(
             DiagnosticEvent(code: .retryScheduled, tNanos: 1, ms: 32_331)
         )
         #expect(retry.fields == [.init(key: "retry_delay", value: "32.331 seconds")])
 
-        let oneSecond = DiagnosticEventPresentation().describe(
+        let oneSecond = englishPresentation.describe(
             DiagnosticEvent(code: .retryScheduled, tNanos: 1, ms: 1_000)
         )
         #expect(oneSecond.fields == [.init(key: "retry_delay", value: "1 second")])
 
-        let twoSeconds = DiagnosticEventPresentation().describe(
+        let twoSeconds = englishPresentation.describe(
             DiagnosticEvent(code: .retryScheduled, tNanos: 1, ms: 2_000)
         )
         #expect(twoSeconds.fields == [.init(key: "retry_delay", value: "2 seconds")])
 
-        let subSecond = DiagnosticEventPresentation().describe(
+        let subSecond = englishPresentation.describe(
             DiagnosticEvent(code: .retryScheduled, tNanos: 1, ms: 999)
         )
         #expect(subSecond.fields == [.init(key: "retry_delay", value: "999 ms")])
 
-        let close = DiagnosticEventPresentation().describe(
+        let close = englishPresentation.describe(
             DiagnosticEvent(
                 code: .transportCloseAttribution,
                 tNanos: 1,
@@ -78,25 +82,25 @@ import Testing
             .init(key: "application_error_code", value: "7"),
             .init(key: "session", value: "9"),
         ])
-        let closeSummary = DiagnosticEventPresentation().summary(close)
+        let closeSummary = englishPresentation.summary(close)
         #expect(!closeSummary.contains("Session"))
         #expect(!closeSummary.contains("9"))
     }
 
     @Test func describesLifecycleAndReachability() {
-        let phase = DiagnosticEventPresentation().describe(
+        let phase = englishPresentation.describe(
             DiagnosticEvent(code: .appLifecycleChanged, tNanos: 1, a: DiagnosticAppLifecyclePhase.background.rawValue)
         )
         #expect(phase.fields == [.init(key: "phase", value: "Background")])
 
-        let reachability = DiagnosticEventPresentation().describe(
+        let reachability = englishPresentation.describe(
             DiagnosticEvent(code: .reachabilityChanged, tNanos: 1, a: 0)
         )
         #expect(reachability.fields == [.init(key: "network", value: "Offline")])
     }
 
     @Test func unknownRawValuesFallBackToIntegers() {
-        let described = DiagnosticEventPresentation().describe(
+        let described = englishPresentation.describe(
             DiagnosticEvent(code: .transportDialFailed, tNanos: 1, a: 999, b: 998)
         )
         #expect(described.fields == [
@@ -160,7 +164,7 @@ import Testing
         #expect(Set(expected.keys) == Set(DiagnosticEventCode.allCases))
         for code in DiagnosticEventCode.allCases {
             #expect(
-                DiagnosticEventPresentation().describe(
+                englishPresentation.describe(
                     DiagnosticEvent(code: code, tNanos: 1)
                 ).name == expected[code]
             )
@@ -168,7 +172,7 @@ import Testing
     }
 
     @Test func decodesEveryStructuredPayloadIntoSemanticFields() {
-        let recovery = DiagnosticEventPresentation().describe(DiagnosticEvent(
+        let recovery = englishPresentation.describe(DiagnosticEvent(
             code: .recoveryStarted,
             tNanos: 1,
             a: DiagnosticTransportKind.iroh.rawValue,
@@ -179,7 +183,7 @@ import Testing
             .init(key: "trigger", value: "Network changed"),
         ])
 
-        let endpoint = DiagnosticEventPresentation().describe(DiagnosticEvent(
+        let endpoint = englishPresentation.describe(DiagnosticEvent(
             code: .endpointFailed,
             tNanos: 1,
             a: DiagnosticTransportKind.iroh.rawValue,
@@ -190,7 +194,7 @@ import Testing
             .init(key: "failure", value: "Iroh endpoint unavailable"),
         ])
 
-        let session = DiagnosticEventPresentation().describe(DiagnosticEvent(
+        let session = englishPresentation.describe(DiagnosticEvent(
             code: .transportSessionLifecycle,
             tNanos: 1,
             a: DiagnosticSessionLifecycleKind.established.rawValue,
@@ -203,7 +207,7 @@ import Testing
             .init(key: "session", value: "12"),
         ])
 
-        let composer = DiagnosticEventPresentation().describe(DiagnosticEvent(
+        let composer = englishPresentation.describe(DiagnosticEvent(
             code: .composerActiveTransition,
             tNanos: 1,
             ms: 300,
@@ -218,7 +222,7 @@ import Testing
             .init(key: "terminal_input_focused", value: "No"),
         ])
 
-        let input = DiagnosticEventPresentation().describe(DiagnosticEvent(
+        let input = englishPresentation.describe(DiagnosticEvent(
             code: .inputSeqBehind,
             tNanos: 1,
             surface: 7,
@@ -242,15 +246,15 @@ import Testing
             tNanos: 1,
             b: DiagnosticFailureKind.identityMismatch.rawValue
         )
-        #expect(DiagnosticEventPresentation().failureKind(of: event) == .identityMismatch)
-        #expect(DiagnosticEventPresentation().transportKind(of: event) == nil)
+        #expect(englishPresentation.failureKind(of: event) == .identityMismatch)
+        #expect(englishPresentation.transportKind(of: event) == nil)
 
         let success = DiagnosticEvent(code: .rpcReady, tNanos: 1, b: 3)
-        #expect(DiagnosticEventPresentation().failureKind(of: success) == nil)
+        #expect(englishPresentation.failureKind(of: success) == nil)
     }
 
     @Test(.enabled(
-        if: DiagnosticLocalization.hasCompiledLocalization(for: Locale(identifier: "ja")),
+        if: LocalizationTestSupport().hasCompiledLocalization(for: Locale(identifier: "ja")),
         "Command-line SwiftPM copies string catalogs without compiling locale resources"
     ))
     func presentsJapaneseReportCopy() {

--- a/Packages/Shared/CMUXMobileCore/Tests/CMUXMobileCoreTests/DiagnosticEventPresentationTests.swift
+++ b/Packages/Shared/CMUXMobileCore/Tests/CMUXMobileCoreTests/DiagnosticEventPresentationTests.swift
@@ -47,6 +47,21 @@ import Testing
         )
         #expect(retry.fields == [.init(key: "retry_delay", value: "32.331 seconds")])
 
+        let oneSecond = DiagnosticEventPresentation().describe(
+            DiagnosticEvent(code: .retryScheduled, tNanos: 1, ms: 1_000)
+        )
+        #expect(oneSecond.fields == [.init(key: "retry_delay", value: "1 second")])
+
+        let twoSeconds = DiagnosticEventPresentation().describe(
+            DiagnosticEvent(code: .retryScheduled, tNanos: 1, ms: 2_000)
+        )
+        #expect(twoSeconds.fields == [.init(key: "retry_delay", value: "2 seconds")])
+
+        let subSecond = DiagnosticEventPresentation().describe(
+            DiagnosticEvent(code: .retryScheduled, tNanos: 1, ms: 999)
+        )
+        #expect(subSecond.fields == [.init(key: "retry_delay", value: "999 ms")])
+
         let close = DiagnosticEventPresentation().describe(
             DiagnosticEvent(
                 code: .transportCloseAttribution,
@@ -63,6 +78,9 @@ import Testing
             .init(key: "application_error_code", value: "7"),
             .init(key: "session", value: "9"),
         ])
+        let closeSummary = DiagnosticEventPresentation().summary(close)
+        #expect(!closeSummary.contains("Session"))
+        #expect(!closeSummary.contains("9"))
     }
 
     @Test func describesLifecycleAndReachability() {
@@ -229,5 +247,16 @@ import Testing
 
         let success = DiagnosticEvent(code: .rpcReady, tNanos: 1, b: 3)
         #expect(DiagnosticEventPresentation().failureKind(of: success) == nil)
+    }
+
+    @Test func presentsJapaneseReportCopy() {
+        let presentation = DiagnosticEventPresentation(locale: Locale(identifier: "ja"))
+        let event = DiagnosticEvent(code: .reachabilityChanged, tNanos: 1, a: 0)
+
+        #expect(presentation.summary(event) == "ネットワーク到達性が変更されました（ネットワーク: オフライン）")
+        let retry = presentation.describe(
+            DiagnosticEvent(code: .retryScheduled, tNanos: 2, ms: 1_000)
+        )
+        #expect(retry.fields == [.init(key: "retry_delay", value: "1秒")])
     }
 }

--- a/Packages/Shared/CMUXMobileCore/Tests/CMUXMobileCoreTests/DiagnosticEventPresentationTests.swift
+++ b/Packages/Shared/CMUXMobileCore/Tests/CMUXMobileCoreTests/DiagnosticEventPresentationTests.swift
@@ -249,7 +249,11 @@ import Testing
         #expect(DiagnosticEventPresentation().failureKind(of: success) == nil)
     }
 
-    @Test func presentsJapaneseReportCopy() {
+    @Test(.enabled(
+        if: DiagnosticLocalization.hasCompiledLocalization(for: Locale(identifier: "ja")),
+        "Command-line SwiftPM copies string catalogs without compiling locale resources"
+    ))
+    func presentsJapaneseReportCopy() {
         let presentation = DiagnosticEventPresentation(locale: Locale(identifier: "ja"))
         let event = DiagnosticEvent(code: .reachabilityChanged, tNanos: 1, a: 0)
 

--- a/Packages/Shared/CMUXMobileCore/Tests/CMUXMobileCoreTests/DiagnosticLogTests.swift
+++ b/Packages/Shared/CMUXMobileCore/Tests/CMUXMobileCoreTests/DiagnosticLogTests.swift
@@ -4,6 +4,8 @@ import os
 @testable import CMUXMobileCore
 
 @Suite struct DiagnosticLogTests {
+    private var englishLocale: Locale { Locale(identifier: "en") }
+
     private enum ClassifiedTestError: Error, DiagnosticFailureProviding {
         case denied
 
@@ -67,9 +69,9 @@ import os
         let report = await log.snapshot(
             generatedAt: Date(timeIntervalSince1970: 1_700_000_001)
         )
-        let humanReadableExport = report.humanReadableExport()
+        let humanReadableExport = report.humanReadableExport(locale: englishLocale)
         let text = String(decoding: humanReadableExport, as: UTF8.self)
-        #expect(report.compactExport() == humanReadableExport)
+        #expect(report.compactExport() == report.humanReadableExport())
         let inputSequenceLine = "2023-11-14 22:13:20.500 UTC | "
             + "Terminal input acknowledgements fell behind "
             + "(Surface: 7, Local sequence: 10, Remote sequence: 20)"
@@ -89,7 +91,10 @@ import os
         """)
 
         let liveText = String(decoding: await log.export(), as: UTF8.self)
-        #expect(liveText.contains("Connection attempt started"))
+        let currentConnectTitle = DiagnosticEventPresentation().describe(
+            DiagnosticEvent(code: .connect, tNanos: 0)
+        ).name
+        #expect(liveText.contains(currentConnectTitle))
         #expect(!liveText.contains("anchorWallNs"))
         #expect(!liveText.contains("500,1,,,,,"))
     }
@@ -199,7 +204,10 @@ import os
             role: .unspecified,
             generatedAt: Date(timeIntervalSince1970: 1_700_000_001)
         )
-        let text = String(decoding: report.humanReadableExport(), as: UTF8.self)
+        let text = String(
+            decoding: report.humanReadableExport(locale: englishLocale),
+            as: UTF8.self
+        )
         #expect(text == """
         cmux Iroh and transport report
         Report format: 2
@@ -225,13 +233,16 @@ import os
             ]
         )
 
-        let text = String(decoding: report.humanReadableExport(), as: UTF8.self)
+        let text = String(
+            decoding: report.humanReadableExport(locale: englishLocale),
+            as: UTF8.self
+        )
         #expect(text.contains("+0.000 seconds | Iroh endpoint starting"))
         #expect(text.contains("+0.250 seconds | Iroh endpoint active"))
     }
 
     @Test(.enabled(
-        if: DiagnosticLocalization.hasCompiledLocalization(for: Locale(identifier: "ja")),
+        if: LocalizationTestSupport().hasCompiledLocalization(for: Locale(identifier: "ja")),
         "Command-line SwiftPM copies string catalogs without compiling locale resources"
     ))
     func exportUsesJapaneseCatalogCopy() async {

--- a/Packages/Shared/CMUXMobileCore/Tests/CMUXMobileCoreTests/DiagnosticLogTests.swift
+++ b/Packages/Shared/CMUXMobileCore/Tests/CMUXMobileCoreTests/DiagnosticLogTests.swift
@@ -49,29 +49,44 @@ import os
         let log = DiagnosticLog(
             capacity: 16,
             buildStamp: "cmux DEV test",
+            role: .mobileClient,
             anchorWallNanos: 1_700_000_000_000_000_000,
             anchorMonotonicNanos: 500
         )
-        log.record(DiagnosticEvent(code: .connect, tNanos: 1_000))
-        log.record(DiagnosticEvent(code: .pairOk, tNanos: 2_000, ms: 250))
-        log.record(DiagnosticEvent(code: .inputSeqBehind, tNanos: 3_000, surface: 7, a: 10, b: 20))
+        log.record(DiagnosticEvent(code: .connect, tNanos: 500))
+        log.record(DiagnosticEvent(code: .pairOk, tNanos: 250_000_500, ms: 250))
+        log.record(DiagnosticEvent(
+            code: .inputSeqBehind,
+            tNanos: 500_000_500,
+            surface: 7,
+            a: 10,
+            b: 20
+        ))
         await waitForProcessed(log, 3)
 
-        let blob = await log.export()
-        let text = String(decoding: blob, as: UTF8.self)
-        let lines = text.split(separator: "\n", omittingEmptySubsequences: false).map(String.init)
+        let report = await log.snapshot(
+            generatedAt: Date(timeIntervalSince1970: 1_700_000_001)
+        )
+        let text = String(decoding: report.compactExport(), as: UTF8.self)
+        #expect(text == """
+        cmux Iroh and transport report
+        Report format: 2
+        Generated: 2023-11-14 22:13:21.000 UTC
+        Source: iOS client
+        Build: cmux DEV test
+        Event count: 3
 
-        // Header: version, anchors, count, build stamp.
-        #expect(lines[0].hasPrefix("cmuxdiag v1"))
-        #expect(lines[0].contains("anchorWallNs=1700000000000000000"))
-        #expect(lines[0].contains("anchorMonoNs=500"))
-        #expect(lines[0].contains("count=3"))
-        #expect(lines[0].contains("build=cmux DEV test"))
+        Timeline (oldest first)
+        2023-11-14 22:13:20.000 UTC | Connection attempt started
+        2023-11-14 22:13:20.250 UTC | Pairing succeeded (Duration: 250 ms)
+        2023-11-14 22:13:20.500 UTC | Terminal input acknowledgements fell behind (Surface: 7, Local sequence: 10, Remote sequence: 20)
 
-        // One compact row per event: tNanos,code,surface,ms,a,b,c (absent = empty).
-        #expect(lines[1] == "1000,1,,,,,")
-        #expect(lines[2] == "2000,2,,250,,,")
-        #expect(lines[3] == "3000,7,7,,10,20,")
+        """)
+
+        let liveText = String(decoding: await log.export(), as: UTF8.self)
+        #expect(liveText.contains("Connection attempt started"))
+        #expect(!liveText.contains("anchorWallNs"))
+        #expect(!liveText.contains("500,1,,,,,"))
     }
 
     @Test func duplicateSelectedPathNotificationsDoNotExportFalseChanges() async {
@@ -131,17 +146,8 @@ import os
         }
         #expect(await log.count() == 3)
 
-        let text = String(decoding: await log.export(), as: UTF8.self)
-        let rows = text
-            .split(separator: "\n", omittingEmptySubsequences: false)
-            .dropFirst()
-            .filter { !$0.isEmpty }
-            .map(String.init)
-        #expect(rows.count == 3)
         // Oldest (tNanos 0,1,2) evicted; newest (3,4,5) retained, in order.
-        #expect(rows[0].hasPrefix("3,"))
-        #expect(rows[1].hasPrefix("4,"))
-        #expect(rows[2].hasPrefix("5,"))
+        #expect(await log.snapshot().events.map(\.tNanos) == [3, 4, 5])
     }
 
     @Test func recordIsNonBlockingUnderBurst() async {
@@ -179,30 +185,44 @@ import os
         }
         #expect(await log.count() == capacity)
 
-        let text = String(decoding: await log.export(), as: UTF8.self)
-        let rows = text
-            .split(separator: "\n", omittingEmptySubsequences: false)
-            .dropFirst()
-            .filter { !$0.isEmpty }
-            .map(String.init)
-        #expect(rows.count == capacity)
         // Newest `capacity` events are tNanos 9,10,11,12, in order.
-        #expect(rows[0].hasPrefix("9,"))
-        #expect(rows[1].hasPrefix("10,"))
-        #expect(rows[2].hasPrefix("11,"))
-        #expect(rows[3].hasPrefix("12,"))
+        #expect(await log.snapshot().events.map(\.tNanos) == [9, 10, 11, 12])
     }
 
     @Test func exportOnEmptyLogHasHeaderOnly() async {
-        let log = DiagnosticLog(capacity: 8)
-        let text = String(decoding: await log.export(), as: UTF8.self)
-        let lines = text.split(separator: "\n", omittingEmptySubsequences: false).map(String.init)
-        #expect(lines[0].hasPrefix("cmuxdiag v1"))
-        #expect(lines[0].contains("count=0"))
-        // No build stamp segment when empty default was used.
-        #expect(!lines[0].contains("build="))
-        // Nothing after the header but the trailing newline split.
-        #expect(lines.filter { !$0.isEmpty }.count == 1)
+        let report = DiagnosticReport(
+            role: .unspecified,
+            generatedAt: Date(timeIntervalSince1970: 1_700_000_001)
+        )
+        let text = String(decoding: report.compactExport(), as: UTF8.self)
+        #expect(text == """
+        cmux Iroh and transport report
+        Report format: 2
+        Generated: 2023-11-14 22:13:21.000 UTC
+        Source: Unspecified runtime
+        Event count: 0
+
+        Timeline (oldest first)
+        No events recorded.
+
+        """)
+        #expect(!text.contains("anchorWallNs"))
+        #expect(!text.contains("anchorMonoNs"))
+    }
+
+    @Test func exportUsesReadableRelativeTimesWithoutAWallClockAnchor() {
+        let report = DiagnosticReport(
+            role: .macHost,
+            generatedAt: Date(timeIntervalSince1970: 1_700_000_001),
+            events: [
+                DiagnosticEvent(code: .endpointStarting, tNanos: 5_000),
+                DiagnosticEvent(code: .endpointActive, tNanos: 250_005_000),
+            ]
+        )
+
+        let text = String(decoding: report.compactExport(), as: UTF8.self)
+        #expect(text.contains("+0.000 seconds | Iroh endpoint starting"))
+        #expect(text.contains("+0.250 seconds | Iroh endpoint active"))
     }
 
     @Test func transportDiagnosticCodesAreStableAndAppendOnly() {

--- a/Packages/Shared/CMUXMobileCore/Tests/CMUXMobileCoreTests/DiagnosticLogTests.swift
+++ b/Packages/Shared/CMUXMobileCore/Tests/CMUXMobileCoreTests/DiagnosticLogTests.swift
@@ -47,7 +47,7 @@ import os
         await waitForProcessed(log, processedAfter)
     }
 
-    @Test func recordThenExportRoundTrips() async {
+    @Test func recordThenExportRoundTrips() async throws {
         let log = DiagnosticLog(
             capacity: 16,
             buildStamp: "cmux DEV test",
@@ -70,7 +70,7 @@ import os
             generatedAt: Date(timeIntervalSince1970: 1_700_000_001)
         )
         let humanReadableExport = report.humanReadableExport(locale: englishLocale)
-        let text = String(decoding: humanReadableExport, as: UTF8.self)
+        let text = try #require(String(bytes: humanReadableExport, encoding: .utf8))
         #expect(report.compactExport() == report.humanReadableExport())
         let inputSequenceLine = "2023-11-14 22:13:20.500 UTC | "
             + "Terminal input acknowledgements fell behind "
@@ -90,7 +90,8 @@ import os
 
         """)
 
-        let liveText = String(decoding: await log.export(), as: UTF8.self)
+        let liveData = await log.export()
+        let liveText = try #require(String(bytes: liveData, encoding: .utf8))
         let currentConnectTitle = DiagnosticEventPresentation().describe(
             DiagnosticEvent(code: .connect, tNanos: 0)
         ).name
@@ -199,14 +200,16 @@ import os
         #expect(await log.snapshot().events.map(\.tNanos) == [9, 10, 11, 12])
     }
 
-    @Test func exportOnEmptyLogHasHeaderOnly() async {
+    @Test func exportOnEmptyLogHasHeaderOnly() async throws {
         let report = DiagnosticReport(
             role: .unspecified,
             generatedAt: Date(timeIntervalSince1970: 1_700_000_001)
         )
-        let text = String(
-            decoding: report.humanReadableExport(locale: englishLocale),
-            as: UTF8.self
+        let text = try #require(
+            String(
+                bytes: report.humanReadableExport(locale: englishLocale),
+                encoding: .utf8
+            )
         )
         #expect(text == """
         cmux Iroh and transport report
@@ -223,7 +226,7 @@ import os
         #expect(!text.contains("anchorMonoNs"))
     }
 
-    @Test func exportUsesReadableRelativeTimesWithoutAWallClockAnchor() {
+    @Test func exportUsesReadableRelativeTimesWithoutAWallClockAnchor() throws {
         let report = DiagnosticReport(
             role: .macHost,
             generatedAt: Date(timeIntervalSince1970: 1_700_000_001),
@@ -233,9 +236,11 @@ import os
             ]
         )
 
-        let text = String(
-            decoding: report.humanReadableExport(locale: englishLocale),
-            as: UTF8.self
+        let text = try #require(
+            String(
+                bytes: report.humanReadableExport(locale: englishLocale),
+                encoding: .utf8
+            )
         )
         #expect(text.contains("+0.000 seconds | Iroh endpoint starting"))
         #expect(text.contains("+0.250 seconds | Iroh endpoint active"))
@@ -245,7 +250,7 @@ import os
         if: LocalizationTestSupport().hasCompiledLocalization(for: Locale(identifier: "ja")),
         "Command-line SwiftPM copies string catalogs without compiling locale resources"
     ))
-    func exportUsesJapaneseCatalogCopy() async {
+    func exportUsesJapaneseCatalogCopy() async throws {
         let report = DiagnosticReport(
             role: .macHost,
             generatedAt: Date(timeIntervalSince1970: 1_700_000_001),
@@ -255,9 +260,11 @@ import os
         )
 
         let locale = Locale(identifier: "ja")
-        let text = String(
-            decoding: report.humanReadableExport(locale: locale),
-            as: UTF8.self
+        let text = try #require(
+            String(
+                bytes: report.humanReadableExport(locale: locale),
+                encoding: .utf8
+            )
         )
         #expect(text.contains("cmux Irohとトランスポートのレポート"))
         #expect(text.contains("+0.000 秒 | ネットワーク到達性が変更されました（ネットワーク: オフライン）"))
@@ -639,7 +646,7 @@ import os
         )
 
         let data = try JSONEncoder().encode(report)
-        let text = String(decoding: data, as: UTF8.self)
+        let text = try #require(String(bytes: data, encoding: .utf8))
         #expect(!text.contains("endpoint"))
         #expect(!text.contains("address"))
         #expect(!text.contains("relayURL"))

--- a/Packages/Shared/CMUXMobileCore/Tests/CMUXMobileCoreTests/DiagnosticLogTests.swift
+++ b/Packages/Shared/CMUXMobileCore/Tests/CMUXMobileCoreTests/DiagnosticLogTests.swift
@@ -230,7 +230,11 @@ import os
         #expect(text.contains("+0.250 seconds | Iroh endpoint active"))
     }
 
-    @Test func exportUsesJapaneseCatalogCopy() async {
+    @Test(.enabled(
+        if: DiagnosticLocalization.hasCompiledLocalization(for: Locale(identifier: "ja")),
+        "Command-line SwiftPM copies string catalogs without compiling locale resources"
+    ))
+    func exportUsesJapaneseCatalogCopy() async {
         let report = DiagnosticReport(
             role: .macHost,
             generatedAt: Date(timeIntervalSince1970: 1_700_000_001),

--- a/Packages/Shared/CMUXMobileCore/Tests/CMUXMobileCoreTests/DiagnosticLogTests.swift
+++ b/Packages/Shared/CMUXMobileCore/Tests/CMUXMobileCoreTests/DiagnosticLogTests.swift
@@ -67,7 +67,12 @@ import os
         let report = await log.snapshot(
             generatedAt: Date(timeIntervalSince1970: 1_700_000_001)
         )
-        let text = String(decoding: report.compactExport(), as: UTF8.self)
+        let humanReadableExport = report.humanReadableExport()
+        let text = String(decoding: humanReadableExport, as: UTF8.self)
+        #expect(report.compactExport() == humanReadableExport)
+        let inputSequenceLine = "2023-11-14 22:13:20.500 UTC | "
+            + "Terminal input acknowledgements fell behind "
+            + "(Surface: 7, Local sequence: 10, Remote sequence: 20)"
         #expect(text == """
         cmux Iroh and transport report
         Report format: 2
@@ -79,7 +84,7 @@ import os
         Timeline (oldest first)
         2023-11-14 22:13:20.000 UTC | Connection attempt started
         2023-11-14 22:13:20.250 UTC | Pairing succeeded (Duration: 250 ms)
-        2023-11-14 22:13:20.500 UTC | Terminal input acknowledgements fell behind (Surface: 7, Local sequence: 10, Remote sequence: 20)
+        \(inputSequenceLine)
 
         """)
 
@@ -194,7 +199,7 @@ import os
             role: .unspecified,
             generatedAt: Date(timeIntervalSince1970: 1_700_000_001)
         )
-        let text = String(decoding: report.compactExport(), as: UTF8.self)
+        let text = String(decoding: report.humanReadableExport(), as: UTF8.self)
         #expect(text == """
         cmux Iroh and transport report
         Report format: 2
@@ -220,7 +225,7 @@ import os
             ]
         )
 
-        let text = String(decoding: report.compactExport(), as: UTF8.self)
+        let text = String(decoding: report.humanReadableExport(), as: UTF8.self)
         #expect(text.contains("+0.000 seconds | Iroh endpoint starting"))
         #expect(text.contains("+0.250 seconds | Iroh endpoint active"))
     }

--- a/Packages/Shared/CMUXMobileCore/Tests/CMUXMobileCoreTests/DiagnosticLogTests.swift
+++ b/Packages/Shared/CMUXMobileCore/Tests/CMUXMobileCoreTests/DiagnosticLogTests.swift
@@ -230,6 +230,25 @@ import os
         #expect(text.contains("+0.250 seconds | Iroh endpoint active"))
     }
 
+    @Test func exportUsesJapaneseCatalogCopy() async {
+        let report = DiagnosticReport(
+            role: .macHost,
+            generatedAt: Date(timeIntervalSince1970: 1_700_000_001),
+            events: [
+                DiagnosticEvent(code: .reachabilityChanged, tNanos: 5_000, a: 0),
+            ]
+        )
+
+        let locale = Locale(identifier: "ja")
+        let text = String(
+            decoding: report.humanReadableExport(locale: locale),
+            as: UTF8.self
+        )
+        #expect(text.contains("cmux Irohとトランスポートのレポート"))
+        #expect(text.contains("+0.000 秒 | ネットワーク到達性が変更されました（ネットワーク: オフライン）"))
+        #expect(await report.humanReadableText(locale: locale) == text)
+    }
+
     @Test func transportDiagnosticCodesAreStableAndAppendOnly() {
         #expect(DiagnosticEventCode.transportDialStarted.rawValue == 25)
         #expect(DiagnosticEventCode.transportDialConnected.rawValue == 26)

--- a/Packages/Shared/CMUXMobileCore/Tests/CMUXMobileCoreTests/LocalizationTestSupport.swift
+++ b/Packages/Shared/CMUXMobileCore/Tests/CMUXMobileCoreTests/LocalizationTestSupport.swift
@@ -1,0 +1,23 @@
+import Foundation
+
+@testable import CMUXMobileCore
+
+struct LocalizationTestSupport {
+    private let bundle: Bundle
+
+    init(bundle: Bundle = .module) {
+        self.bundle = bundle
+    }
+
+    /// Command-line SwiftPM copies `.xcstrings` without compiling locale
+    /// resources. Xcode builds emit the `.lproj` bundles these tests exercise.
+    func hasCompiledLocalization(for locale: Locale) -> Bool {
+        let identifiers = Bundle.preferredLocalizations(
+            from: bundle.localizations,
+            forPreferences: [locale.identifier]
+        )
+        return identifiers.contains { identifier in
+            bundle.path(forResource: identifier, ofType: "lproj") != nil
+        }
+    }
+}

--- a/Packages/Shared/CMUXMobileCore/Tests/CMUXMobileCoreTests/TransportIncidentPolicyTests.swift
+++ b/Packages/Shared/CMUXMobileCore/Tests/CMUXMobileCoreTests/TransportIncidentPolicyTests.swift
@@ -48,9 +48,11 @@ import Testing
         #expect(recapture != nil)
         #expect(recapture?.coalescedCount == 3)
         #expect(recapture?.secondsSinceFirstCoalesced == 680)
+        let expectedTitle = "Transport dial failed "
+            + "(Transport: Iroh, Failure: Relay policy unavailable, Attempt: 1) "
+            + "(3 occurrences)"
         #expect(
-            recapture?.title
-                == "Transport dial failed (Transport: Iroh, Failure: Relay policy unavailable, Attempt: 1) (3 occurrences)"
+            recapture?.title == expectedTitle
         )
     }
 
@@ -148,9 +150,11 @@ import Testing
         #expect(outage?.severity == .error)
         #expect(outage?.signature == "transport-outage")
         #expect(outage?.consecutiveFailures == 5)
+        let expectedTitle = "Transport outage: 5 consecutive failures over 60 seconds. "
+            + "Latest: Transport dial failed "
+            + "(Transport: Iroh, Failure: Relay policy unavailable, Attempt: 1)"
         #expect(
-            outage?.title
-                == "Transport outage: 5 consecutive failures over 60 seconds. Latest: Transport dial failed (Transport: Iroh, Failure: Relay policy unavailable, Attempt: 1)"
+            outage?.title == expectedTitle
         )
 
         // While the outage is armed-off, further failures stay quiet.

--- a/Packages/Shared/CMUXMobileCore/Tests/CMUXMobileCoreTests/TransportIncidentPolicyTests.swift
+++ b/Packages/Shared/CMUXMobileCore/Tests/CMUXMobileCoreTests/TransportIncidentPolicyTests.swift
@@ -4,6 +4,7 @@ import Testing
 
 @Suite struct TransportIncidentPolicyTests {
     private static let second: UInt64 = 1_000_000_000
+    private var englishLocale: Locale { Locale(identifier: "en") }
 
     private func dialFailed(
         at seconds: UInt64,
@@ -24,7 +25,7 @@ import Testing
     }
 
     @Test func firstFailureCaptures() {
-        var policy = TransportIncidentPolicy()
+        var policy = TransportIncidentPolicy(locale: englishLocale)
         let incident = policy.decide(dialFailed(at: 10))
         #expect(incident?.kind == .failure)
         #expect(incident?.severity == .warning)
@@ -38,7 +39,7 @@ import Testing
     }
 
     @Test func repeatWithinCooldownCoalesces() {
-        var policy = TransportIncidentPolicy()
+        var policy = TransportIncidentPolicy(locale: englishLocale)
         #expect(policy.decide(dialFailed(at: 10)) != nil)
         #expect(policy.decide(dialFailed(at: 20)) == nil)
         #expect(policy.decide(dialFailed(at: 30)) == nil)
@@ -57,21 +58,21 @@ import Testing
     }
 
     @Test func distinctSignaturesCaptureIndependently() {
-        var policy = TransportIncidentPolicy()
+        var policy = TransportIncidentPolicy(locale: englishLocale)
         #expect(policy.decide(dialFailed(at: 10, failure: .policyUnavailable)) != nil)
         #expect(policy.decide(dialFailed(at: 11, failure: .identityMismatch)) != nil)
         #expect(policy.decide(dialFailed(at: 12, failure: .policyUnavailable)) == nil)
     }
 
     @Test func benignFailureKindsAreSuppressed() {
-        var policy = TransportIncidentPolicy()
+        var policy = TransportIncidentPolicy(locale: englishLocale)
         #expect(policy.decide(dialFailed(at: 10, failure: .cancelled)) == nil)
         #expect(policy.decide(dialFailed(at: 11, failure: .superseded)) == nil)
         #expect(policy.decide(dialFailed(at: 12, failure: .none)) == nil)
     }
 
     @Test func offlineSuppressedOnlyWhileUnreachable() {
-        var policy = TransportIncidentPolicy()
+        var policy = TransportIncidentPolicy(locale: englishLocale)
         _ = policy.decide(DiagnosticEvent(code: .reachabilityChanged, tNanos: 1, a: 0))
         #expect(policy.decide(dialFailed(at: 10, failure: .offline)) == nil)
         _ = policy.decide(DiagnosticEvent(code: .reachabilityChanged, tNanos: 11 * Self.second, a: 1))
@@ -79,12 +80,12 @@ import Testing
     }
 
     @Test func offlineReportedWhenReachabilityUnknown() {
-        var policy = TransportIncidentPolicy()
+        var policy = TransportIncidentPolicy(locale: englishLocale)
         #expect(policy.decide(dialFailed(at: 10, failure: .offline)) != nil)
     }
 
     @Test func idleTimeoutSuppressedInBackground() {
-        var policy = TransportIncidentPolicy()
+        var policy = TransportIncidentPolicy(locale: englishLocale)
         _ = policy.decide(DiagnosticEvent(
             code: .appLifecycleChanged,
             tNanos: 1,
@@ -113,19 +114,19 @@ import Testing
     }
 
     @Test func expectedSessionCloseIsSuppressed() {
-        var policy = TransportIncidentPolicy()
+        var policy = TransportIncidentPolicy(locale: englishLocale)
         let close = DiagnosticEvent(code: .sessionClosed, tNanos: Self.second, a: 1, c: 3)
         #expect(policy.decide(close) == nil)
     }
 
     @Test func pairFailWithoutKindStillCaptures() {
-        var policy = TransportIncidentPolicy()
+        var policy = TransportIncidentPolicy(locale: englishLocale)
         let incident = policy.decide(DiagnosticEvent(code: .pairFail, tNanos: Self.second))
         #expect(incident?.signature == "pairFail")
     }
 
     @Test func successResetsStreakAndCooldownKeepsCounting() {
-        var policy = TransportIncidentPolicy()
+        var policy = TransportIncidentPolicy(locale: englishLocale)
         #expect(policy.decide(dialFailed(at: 10))?.consecutiveFailures == 1)
         #expect(policy.decide(dialFailed(at: 20)) == nil)
         _ = policy.decide(connected(at: 30))
@@ -138,7 +139,7 @@ import Testing
     }
 
     @Test func outageEscalatesAfterThresholdAndDuration() {
-        var policy = TransportIncidentPolicy()
+        var policy = TransportIncidentPolicy(locale: englishLocale)
         #expect(policy.decide(dialFailed(at: 10))?.kind == .failure)
         #expect(policy.decide(dialFailed(at: 20)) == nil)
         #expect(policy.decide(dialFailed(at: 30)) == nil)
@@ -170,21 +171,27 @@ import Testing
     }
 
     @Test func outageTitlePluralizesFailureAndDurationCounts() {
-        var oneFailure = TransportIncidentPolicy(configuration: .init(
-            signatureCooldown: 0,
-            hourlyCaptureLimit: 30,
-            outageFailureThreshold: 1,
-            outageMinimumDuration: 0
-        ))
+        var oneFailure = TransportIncidentPolicy(
+            configuration: .init(
+                signatureCooldown: 0,
+                hourlyCaptureLimit: 30,
+                outageFailureThreshold: 1,
+                outageMinimumDuration: 0
+            ),
+            locale: englishLocale
+        )
         let first = oneFailure.decide(dialFailed(at: 10))
         #expect(first?.title.contains("1 consecutive failure over 0 seconds") == true)
 
-        var oneSecond = TransportIncidentPolicy(configuration: .init(
-            signatureCooldown: 0,
-            hourlyCaptureLimit: 30,
-            outageFailureThreshold: 2,
-            outageMinimumDuration: 1
-        ))
+        var oneSecond = TransportIncidentPolicy(
+            configuration: .init(
+                signatureCooldown: 0,
+                hourlyCaptureLimit: 30,
+                outageFailureThreshold: 2,
+                outageMinimumDuration: 1
+            ),
+            locale: englishLocale
+        )
         _ = oneSecond.decide(dialFailed(at: 10))
         let second = oneSecond.decide(dialFailed(at: 11))
         #expect(second?.title.contains("2 consecutive failures over 1 second") == true)
@@ -197,7 +204,8 @@ import Testing
                 hourlyCaptureLimit: 2,
                 outageFailureThreshold: 100,
                 outageMinimumDuration: 10_000
-            )
+            ),
+            locale: englishLocale
         )
         #expect(policy.decide(dialFailed(at: 10)) != nil)
         #expect(policy.decide(dialFailed(at: 20)) != nil)
@@ -217,7 +225,8 @@ import Testing
                 hourlyCaptureLimit: 1,
                 outageFailureThreshold: 100,
                 outageMinimumDuration: 10_000
-            )
+            ),
+            locale: englishLocale
         )
         // Exhaust the hourly budget with one signature...
         #expect(policy.decide(dialFailed(at: 10)) != nil)
@@ -239,7 +248,7 @@ import Testing
     }
 
     @Test func environmentRidesOnIncidents() {
-        var policy = TransportIncidentPolicy()
+        var policy = TransportIncidentPolicy(locale: englishLocale)
         _ = policy.decide(DiagnosticEvent(code: .reachabilityChanged, tNanos: 1, a: 1))
         _ = policy.decide(DiagnosticEvent(
             code: .appLifecycleChanged,

--- a/Packages/Shared/CMUXMobileCore/Tests/CMUXMobileCoreTests/TransportIncidentPolicyTests.swift
+++ b/Packages/Shared/CMUXMobileCore/Tests/CMUXMobileCoreTests/TransportIncidentPolicyTests.swift
@@ -29,6 +29,10 @@ import Testing
         #expect(incident?.kind == .failure)
         #expect(incident?.severity == .warning)
         #expect(incident?.signature == "transportDialFailed/policyUnavailable/iroh")
+        #expect(
+            incident?.title
+                == "Transport dial failed (Transport: Iroh, Failure: Relay policy unavailable, Attempt: 1)"
+        )
         #expect(incident?.coalescedCount == 1)
         #expect(incident?.consecutiveFailures == 1)
     }
@@ -44,6 +48,10 @@ import Testing
         #expect(recapture != nil)
         #expect(recapture?.coalescedCount == 3)
         #expect(recapture?.secondsSinceFirstCoalesced == 680)
+        #expect(
+            recapture?.title
+                == "Transport dial failed (Transport: Iroh, Failure: Relay policy unavailable, Attempt: 1) (3 occurrences)"
+        )
     }
 
     @Test func distinctSignaturesCaptureIndependently() {
@@ -140,6 +148,10 @@ import Testing
         #expect(outage?.severity == .error)
         #expect(outage?.signature == "transport-outage")
         #expect(outage?.consecutiveFailures == 5)
+        #expect(
+            outage?.title
+                == "Transport outage: 5 consecutive failures over 60 seconds. Latest: Transport dial failed (Transport: Iroh, Failure: Relay policy unavailable, Attempt: 1)"
+        )
 
         // While the outage is armed-off, further failures stay quiet.
         #expect(policy.decide(dialFailed(at: 80)) == nil)

--- a/Packages/Shared/CMUXMobileCore/Tests/CMUXMobileCoreTests/TransportIncidentPolicyTests.swift
+++ b/Packages/Shared/CMUXMobileCore/Tests/CMUXMobileCoreTests/TransportIncidentPolicyTests.swift
@@ -169,6 +169,27 @@ import Testing
         #expect(last?.kind == .outage)
     }
 
+    @Test func outageTitlePluralizesFailureAndDurationCounts() {
+        var oneFailure = TransportIncidentPolicy(configuration: .init(
+            signatureCooldown: 0,
+            hourlyCaptureLimit: 30,
+            outageFailureThreshold: 1,
+            outageMinimumDuration: 0
+        ))
+        let first = oneFailure.decide(dialFailed(at: 10))
+        #expect(first?.title.contains("1 consecutive failure over 0 seconds") == true)
+
+        var oneSecond = TransportIncidentPolicy(configuration: .init(
+            signatureCooldown: 0,
+            hourlyCaptureLimit: 30,
+            outageFailureThreshold: 2,
+            outageMinimumDuration: 1
+        ))
+        _ = oneSecond.decide(dialFailed(at: 10))
+        let second = oneSecond.decide(dialFailed(at: 11))
+        #expect(second?.title.contains("2 consecutive failures over 1 second") == true)
+    }
+
     @Test func hourlyBudgetDropsAndReports() {
         var policy = TransportIncidentPolicy(
             configuration: .init(

--- a/Packages/Shared/CmuxSentryTelemetry/Sources/CmuxSentryReporting/TransportSentryReporter.swift
+++ b/Packages/Shared/CmuxSentryTelemetry/Sources/CmuxSentryReporting/TransportSentryReporter.swift
@@ -113,8 +113,8 @@ public final class TransportSentryReporter: Sendable {
         logsPerHour: Int = 300,
         delivery: Delivery = .sentry()
     ) {
-        self.roleCode = DiagnosticEventPresentation.name(role)
-        self.roleDisplayName = DiagnosticEventPresentation.displayName(role)
+        self.roleCode = DiagnosticEventPresentation().name(role)
+        self.roleDisplayName = DiagnosticEventPresentation().displayName(role)
         self.exportRing = exportRing
         self.delivery = delivery
         self.state = OSAllocatedUnfairLock(initialState: MutableState(
@@ -128,7 +128,7 @@ public final class TransportSentryReporter: Sendable {
     public func ingest(_ event: DiagnosticEvent) {
         guard delivery.isEnabled() else { return }
 
-        let described = DiagnosticEventPresentation.describe(event)
+        let described = DiagnosticEventPresentation().describe(event)
         let isFailure = TransportIncidentPolicy.failureCodes.contains(event.code)
 
         let (incident, logDropCount) = state.withLock { state in
@@ -156,9 +156,9 @@ public final class TransportSentryReporter: Sendable {
     ) {
         let crumb = Breadcrumb(level: isFailure ? .warning : .info, category: "transport")
         crumb.type = isFailure ? "error" : "default"
-        crumb.message = DiagnosticEventPresentation.summary(described)
+        crumb.message = DiagnosticEventPresentation().summary(described)
         var data: [String: Any] = [
-            "event_code": DiagnosticEventPresentation.name(event.code),
+            "event_code": DiagnosticEventPresentation().name(event.code),
             "role": roleDisplayName,
         ]
         for field in described.fields {
@@ -175,7 +175,7 @@ public final class TransportSentryReporter: Sendable {
         droppedBeforeThis: Int
     ) {
         var attributes: [String: Any] = [
-            "transport.event_code": DiagnosticEventPresentation.name(event.code),
+            "transport.event_code": DiagnosticEventPresentation().name(event.code),
             "transport.role": roleDisplayName,
             "transport.role_code": roleCode,
         ]
@@ -187,7 +187,7 @@ public final class TransportSentryReporter: Sendable {
         }
         delivery.log(
             isFailure ? .warning : .info,
-            DiagnosticEventPresentation.summary(described),
+            DiagnosticEventPresentation().summary(described),
             attributes
         )
     }
@@ -214,16 +214,16 @@ public final class TransportSentryReporter: Sendable {
         event.fingerprint = ["cmux-transport", roleCode, incident.signature]
 
         var tags: [String: String] = [
-            "transport.event": DiagnosticEventPresentation.name(incident.event.code),
+            "transport.event": DiagnosticEventPresentation().name(incident.event.code),
             "transport.signature": incident.signature,
             "transport.role": roleCode,
             "transport.incident": incident.kind == .outage ? "outage" : "failure",
         ]
         if let failure = incident.failure {
-            tags["transport.failure"] = DiagnosticEventPresentation.name(failure)
+            tags["transport.failure"] = DiagnosticEventPresentation().name(failure)
         }
         if let transport = incident.transport {
-            tags["transport.kind"] = DiagnosticEventPresentation.name(transport)
+            tags["transport.kind"] = DiagnosticEventPresentation().name(transport)
         }
         event.tags = tags
 
@@ -242,10 +242,10 @@ public final class TransportSentryReporter: Sendable {
             context["reachable"] = reachable
         }
         if let phase = incident.appPhase {
-            context["app_phase"] = DiagnosticEventPresentation.displayName(phase)
-            context["app_phase_code"] = DiagnosticEventPresentation.name(phase)
+            context["app_phase"] = DiagnosticEventPresentation().displayName(phase)
+            context["app_phase_code"] = DiagnosticEventPresentation().name(phase)
         }
-        let described = DiagnosticEventPresentation.describe(incident.event)
+        let described = DiagnosticEventPresentation().describe(incident.event)
         for field in described.fields {
             context["event_\(field.key)"] = field.value
         }

--- a/Packages/Shared/CmuxSentryTelemetry/Sources/CmuxSentryReporting/TransportSentryReporter.swift
+++ b/Packages/Shared/CmuxSentryTelemetry/Sources/CmuxSentryReporting/TransportSentryReporter.swift
@@ -17,9 +17,7 @@ internal import os
 ///    with `enableLogs`), searchable without waiting for an error.
 /// 3. When it crosses ``CMUXMobileCore/TransportIncidentPolicy``'s capture
 ///    gates, a Sentry **event** fingerprinted by the failure signature and
-///    carrying the compact diagnostic ring export as an attachment — the same
-///    `cmuxdiag v1` blob that previously had to be pulled off the device by
-///    hand.
+///    carrying the plain-language diagnostic timeline as an attachment.
 ///
 /// Privacy: everything sent derives from the fixed integer diagnostic
 /// taxonomy, so no free text, peer identity, address, account, or terminal
@@ -90,8 +88,8 @@ public final class TransportSentryReporter: Sendable {
         var logBudget: TransportTelemetryLogBudget
     }
 
-    private let role: DiagnosticRuntimeRole
-    private let roleName: String
+    private let roleCode: String
+    private let roleDisplayName: String
     private let exportRing: @Sendable () async -> Data
     private let delivery: Delivery
     // lint:allow lock - ingest is synchronous on the diagnostic drain task; the
@@ -103,7 +101,7 @@ public final class TransportSentryReporter: Sendable {
     /// - Parameters:
     ///   - role: The producing runtime (`mobileClient` on iOS, `macHost` on
     ///     macOS); rides as a tag and fingerprint component.
-    ///   - exportRing: Snapshot of the diagnostic ring's compact export,
+    ///   - exportRing: Snapshot of the diagnostic ring's plain-language report,
     ///     attached to captured incidents. Pass the owning log's `export`.
     ///   - incidentConfiguration: Capture-gate thresholds.
     ///   - logsPerHour: Sliding-hour budget for structured log lines.
@@ -115,8 +113,8 @@ public final class TransportSentryReporter: Sendable {
         logsPerHour: Int = 300,
         delivery: Delivery = .sentry()
     ) {
-        self.role = role
-        self.roleName = DiagnosticEventPresentation.name(role)
+        self.roleCode = DiagnosticEventPresentation.name(role)
+        self.roleDisplayName = DiagnosticEventPresentation.displayName(role)
         self.exportRing = exportRing
         self.delivery = delivery
         self.state = OSAllocatedUnfairLock(initialState: MutableState(
@@ -137,9 +135,14 @@ public final class TransportSentryReporter: Sendable {
             (state.policy.decide(event), state.logBudget.admit(tNanos: event.tNanos))
         }
 
-        deliverBreadcrumb(described, isFailure: isFailure)
+        deliverBreadcrumb(event, described: described, isFailure: isFailure)
         if let logDropCount {
-            deliverLog(described, isFailure: isFailure, droppedBeforeThis: logDropCount)
+            deliverLog(
+                event,
+                described: described,
+                isFailure: isFailure,
+                droppedBeforeThis: logDropCount
+            )
         }
         if let incident {
             captureIncident(incident)
@@ -147,35 +150,46 @@ public final class TransportSentryReporter: Sendable {
     }
 
     private func deliverBreadcrumb(
-        _ described: DiagnosticEventPresentation.DescribedEvent,
+        _ event: DiagnosticEvent,
+        described: DiagnosticEventPresentation.DescribedEvent,
         isFailure: Bool
     ) {
         let crumb = Breadcrumb(level: isFailure ? .warning : .info, category: "transport")
         crumb.type = isFailure ? "error" : "default"
-        crumb.message = described.name
-        if !described.fields.isEmpty {
-            var data: [String: Any] = [:]
-            for field in described.fields {
-                data[field.key] = field.value
-            }
-            crumb.data = data
+        crumb.message = DiagnosticEventPresentation.summary(described)
+        crumb.setData(
+            value: DiagnosticEventPresentation.name(event.code),
+            key: "event_code"
+        )
+        crumb.setData(value: roleDisplayName, key: "role")
+        for field in described.fields {
+            crumb.setData(value: field.value, key: field.key)
         }
         delivery.addBreadcrumb(crumb)
     }
 
     private func deliverLog(
-        _ described: DiagnosticEventPresentation.DescribedEvent,
+        _ event: DiagnosticEvent,
+        described: DiagnosticEventPresentation.DescribedEvent,
         isFailure: Bool,
         droppedBeforeThis: Int
     ) {
-        var attributes: [String: Any] = ["transport.role": roleName]
+        var attributes: [String: Any] = [
+            "transport.event_code": DiagnosticEventPresentation.name(event.code),
+            "transport.role": roleDisplayName,
+            "transport.role_code": roleCode,
+        ]
         for field in described.fields {
             attributes["transport.\(field.key)"] = field.value
         }
         if droppedBeforeThis > 0 {
             attributes["transport.log_dropped_before_this"] = droppedBeforeThis
         }
-        delivery.log(isFailure ? .warning : .info, "transport.\(described.name)", attributes)
+        delivery.log(
+            isFailure ? .warning : .info,
+            DiagnosticEventPresentation.summary(described),
+            attributes
+        )
     }
 
     private func captureIncident(_ incident: TransportIncidentPolicy.Incident) {
@@ -197,12 +211,12 @@ public final class TransportSentryReporter: Sendable {
         let event = Event(level: incident.severity == .error ? .error : .warning)
         event.message = SentryMessage(formatted: incident.title)
         event.logger = "cmux.transport"
-        event.fingerprint = ["cmux-transport", roleName, incident.signature]
+        event.fingerprint = ["cmux-transport", roleCode, incident.signature]
 
         var tags: [String: String] = [
             "transport.event": DiagnosticEventPresentation.name(incident.event.code),
             "transport.signature": incident.signature,
-            "transport.role": roleName,
+            "transport.role": roleCode,
             "transport.incident": incident.kind == .outage ? "outage" : "failure",
         ]
         if let failure = incident.failure {
@@ -228,7 +242,8 @@ public final class TransportSentryReporter: Sendable {
             context["reachable"] = reachable
         }
         if let phase = incident.appPhase {
-            context["app_phase"] = DiagnosticEventPresentation.name(phase)
+            context["app_phase"] = DiagnosticEventPresentation.displayName(phase)
+            context["app_phase_code"] = DiagnosticEventPresentation.name(phase)
         }
         let described = DiagnosticEventPresentation.describe(incident.event)
         for field in described.fields {

--- a/Packages/Shared/CmuxSentryTelemetry/Sources/CmuxSentryReporting/TransportSentryReporter.swift
+++ b/Packages/Shared/CmuxSentryTelemetry/Sources/CmuxSentryReporting/TransportSentryReporter.swift
@@ -157,14 +157,14 @@ public final class TransportSentryReporter: Sendable {
         let crumb = Breadcrumb(level: isFailure ? .warning : .info, category: "transport")
         crumb.type = isFailure ? "error" : "default"
         crumb.message = DiagnosticEventPresentation.summary(described)
-        crumb.setData(
-            value: DiagnosticEventPresentation.name(event.code),
-            key: "event_code"
-        )
-        crumb.setData(value: roleDisplayName, key: "role")
+        var data: [String: Any] = [
+            "event_code": DiagnosticEventPresentation.name(event.code),
+            "role": roleDisplayName,
+        ]
         for field in described.fields {
-            crumb.setData(value: field.value, key: field.key)
+            data[field.key] = field.value
         }
+        crumb.data = data
         delivery.addBreadcrumb(crumb)
     }
 

--- a/Packages/Shared/CmuxSentryTelemetry/Tests/CmuxSentryReportingTests/TransportSentryReporterTests.swift
+++ b/Packages/Shared/CmuxSentryTelemetry/Tests/CmuxSentryReportingTests/TransportSentryReporterTests.swift
@@ -13,7 +13,7 @@ import os
         struct LogLine: Sendable {
             let level: TransportSentryReporter.LogLevel
             let message: String
-            let attributeKeys: [String]
+            let attributes: [String: String]
         }
 
         struct CapturedEvent: Sendable {
@@ -29,6 +29,7 @@ import os
             let category: String
             let message: String?
             let level: SentryLevel
+            let data: [String: String]
         }
 
         let breadcrumbs = OSAllocatedUnfairLock<[CapturedBreadcrumb]>(initialState: [])
@@ -43,7 +44,10 @@ import os
                     let captured = CapturedBreadcrumb(
                         category: crumb.category,
                         message: crumb.message,
-                        level: crumb.level
+                        level: crumb.level,
+                        data: crumb.data?.reduce(into: [:]) { result, entry in
+                            result[entry.key] = String(describing: entry.value)
+                        } ?? [:]
                     )
                     self.breadcrumbs.withLock { $0.append(captured) }
                 },
@@ -62,7 +66,9 @@ import os
                     let line = LogLine(
                         level: level,
                         message: message,
-                        attributeKeys: attributes.keys.sorted()
+                        attributes: attributes.reduce(into: [:]) { result, entry in
+                            result[entry.key] = String(describing: entry.value)
+                        }
                     )
                     self.logs.withLock { $0.append(line) }
                 }
@@ -112,13 +118,17 @@ import os
         let crumbs = recorder.breadcrumbs.withLock { $0 }
         #expect(crumbs.count == 2)
         #expect(crumbs.allSatisfy { $0.category == "transport" })
-        #expect(crumbs.map(\.message) == ["endpointStarting", "endpointActive"])
+        #expect(crumbs.map(\.message) == ["Iroh endpoint starting", "Iroh endpoint active"])
         #expect(crumbs.allSatisfy { $0.level == .info })
+        #expect(crumbs[0].data["event_code"] == "endpointStarting")
+        #expect(crumbs[1].data["event_code"] == "endpointActive")
 
         let logs = recorder.logs.withLock { $0 }
-        #expect(logs.map(\.message) == ["transport.endpointStarting", "transport.endpointActive"])
+        #expect(logs.map(\.message) == ["Iroh endpoint starting", "Iroh endpoint active"])
         #expect(logs.allSatisfy { $0.level == .info })
-        #expect(logs.allSatisfy { $0.attributeKeys.contains("transport.role") })
+        #expect(logs.allSatisfy { $0.attributes["transport.role"] == "iOS client" })
+        #expect(logs[0].attributes["transport.event_code"] == "endpointStarting")
+        #expect(logs[1].attributes["transport.event_code"] == "endpointActive")
     }
 
     @Test func failureEventsAreWarningsAndCaptureIncidents() async {
@@ -130,11 +140,18 @@ import os
 
         let crumbs = recorder.breadcrumbs.withLock { $0 }
         #expect(crumbs.first?.level == .warning)
+        #expect(
+            crumbs.first?.message
+                == "Transport dial failed (Transport: Iroh, Failure: Relay policy unavailable, Attempt: 7)"
+        )
 
         let events = recorder.events.withLock { $0 }
         #expect(events.count == 1)
         let event = events[0]
-        #expect(event.title == "Transport failure: transportDialFailed/policyUnavailable/iroh")
+        #expect(
+            event.title
+                == "Transport dial failed (Transport: Iroh, Failure: Relay policy unavailable, Attempt: 7)"
+        )
         #expect(event.level == .warning)
         #expect(event.fingerprint == [
             "cmux-transport", "mobileClient", "transportDialFailed/policyUnavailable/iroh",
@@ -198,7 +215,7 @@ import os
 
         let logs = recorder.logs.withLock { $0 }
         #expect(logs.count == 3)
-        #expect(logs[2].attributeKeys.contains("transport.log_dropped_before_this"))
+        #expect(logs[2].attributes["transport.log_dropped_before_this"] == "1")
         // Breadcrumbs are unbudgeted: they only ship attached to events.
         #expect(recorder.breadcrumbs.withLock { $0.count } == 4)
     }

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MobileIrohSettingsModel.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MobileIrohSettingsModel.swift
@@ -144,14 +144,19 @@ final class MobileIrohSettingsModel {
         let generation = diagnosticReloadGeneration
         let report = await controller.irohDiagnosticReport()
         let previous = await controller.irohPreviousLaunchDiagnosticReport()
-        guard generation == diagnosticReloadGeneration else { return }
-        diagnosticReport = report
         // The export carries the previous launch's archived block first so a
         // drop that happened before a relaunch stays in the shared timeline.
-        let blocks = [previous, report].compactMap { block -> String? in
+        let reports = [previous, report].compactMap { block -> DiagnosticReport? in
             guard let block, !block.events.isEmpty else { return nil }
-            return String(decoding: block.humanReadableExport(), as: UTF8.self)
+            return block
         }
+        var blocks: [String] = []
+        blocks.reserveCapacity(reports.count)
+        for report in reports {
+            blocks.append(await report.humanReadableText())
+        }
+        guard generation == diagnosticReloadGeneration else { return }
+        diagnosticReport = report
         diagnosticExportText = blocks.joined(separator: "\n")
     }
 }

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MobileIrohSettingsModel.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MobileIrohSettingsModel.swift
@@ -150,7 +150,7 @@ final class MobileIrohSettingsModel {
         // drop that happened before a relaunch stays in the shared timeline.
         let blocks = [previous, report].compactMap { block -> String? in
             guard let block, !block.events.isEmpty else { return nil }
-            return String(decoding: block.compactExport(), as: UTF8.self)
+            return String(decoding: block.humanReadableExport(), as: UTF8.self)
         }
         diagnosticExportText = blocks.joined(separator: "\n")
     }

--- a/Packages/iOS/CmuxMobileShellUI/Tests/CmuxMobileShellUITests/MobileIrohSettingsModelTests.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Tests/CmuxMobileShellUITests/MobileIrohSettingsModelTests.swift
@@ -122,7 +122,7 @@ struct MobileIrohSettingsModelTests {
         let controller = MobileIrohSettingsControllerDouble(snapshot: .unavailable)
         let report = diagnosticReport()
         controller.report = report
-        controller.exportData = Data("cmuxdiag v1\n25,1,,,1,,7".utf8)
+        controller.exportData = report.humanReadableExport()
         let model = MobileIrohSettingsModel(controller: controller)
 
         let observation = Task { await model.observe() }
@@ -130,7 +130,10 @@ struct MobileIrohSettingsModelTests {
         observation.cancel()
         await observation.value
 
-        #expect(model.diagnosticExportText == String(decoding: report.compactExport(), as: UTF8.self))
+        #expect(
+            model.diagnosticExportText
+                == String(decoding: report.humanReadableExport(), as: UTF8.self)
+        )
         #expect(model.diagnosticReport.events.count == 2)
         #expect(model.diagnosticReport.lastFailureKind == .timedOut)
     }
@@ -138,7 +141,7 @@ struct MobileIrohSettingsModelTests {
     @Test func clearDiagnosticReportClearsControllerAndReloadsModel() async {
         let controller = MobileIrohSettingsControllerDouble(snapshot: .unavailable)
         controller.report = diagnosticReport()
-        controller.exportData = Data("cmuxdiag v1\n25,1,,,1,,7".utf8)
+        controller.exportData = controller.report.humanReadableExport()
         let model = MobileIrohSettingsModel(controller: controller)
         let observation = Task { await model.observe() }
         await waitUntil { !model.diagnosticReport.events.isEmpty }

--- a/Packages/macOS/CmuxSettingsUI/Sources/CmuxSettingsUI/Models/IrohSettingsModel.swift
+++ b/Packages/macOS/CmuxSettingsUI/Sources/CmuxSettingsUI/Models/IrohSettingsModel.swift
@@ -110,10 +110,14 @@ final class IrohSettingsModel {
         diagnosticReloadGeneration &+= 1
         let generation = diagnosticReloadGeneration
         let report = await controller.irohDiagnosticReport()
+        let exportText: String
+        if report.events.isEmpty {
+            exportText = ""
+        } else {
+            exportText = await report.humanReadableText()
+        }
         guard generation == diagnosticReloadGeneration else { return }
         diagnosticReport = report
-        diagnosticExportText = report.events.isEmpty
-            ? ""
-            : String(decoding: report.humanReadableExport(), as: UTF8.self)
+        diagnosticExportText = exportText
     }
 }

--- a/Packages/macOS/CmuxSettingsUI/Sources/CmuxSettingsUI/Models/IrohSettingsModel.swift
+++ b/Packages/macOS/CmuxSettingsUI/Sources/CmuxSettingsUI/Models/IrohSettingsModel.swift
@@ -114,6 +114,6 @@ final class IrohSettingsModel {
         diagnosticReport = report
         diagnosticExportText = report.events.isEmpty
             ? ""
-            : String(decoding: report.compactExport(), as: UTF8.self)
+            : String(decoding: report.humanReadableExport(), as: UTF8.self)
     }
 }

--- a/Packages/macOS/CmuxSettingsUI/Tests/CmuxSettingsUITests/IrohSettingsModelTests.swift
+++ b/Packages/macOS/CmuxSettingsUI/Tests/CmuxSettingsUITests/IrohSettingsModelTests.swift
@@ -122,7 +122,7 @@ struct IrohSettingsModelTests {
         let controller = IrohSettingsControllerDouble(snapshot: .unavailable)
         let report = diagnosticReport()
         controller.report = report
-        controller.exportData = Data("cmuxdiag v1\n25,1,,,1,,7".utf8)
+        controller.exportData = report.humanReadableExport()
         let model = IrohSettingsModel(controller: controller)
 
         let observation = Task { await model.observe() }
@@ -130,7 +130,10 @@ struct IrohSettingsModelTests {
         observation.cancel()
         await observation.value
 
-        #expect(model.diagnosticExportText == String(decoding: report.compactExport(), as: UTF8.self))
+        #expect(
+            model.diagnosticExportText
+                == String(decoding: report.humanReadableExport(), as: UTF8.self)
+        )
         #expect(model.diagnosticReport.events.count == 2)
         #expect(model.diagnosticReport.lastFailureKind == .timedOut)
     }
@@ -138,7 +141,7 @@ struct IrohSettingsModelTests {
     @Test func clearDiagnosticReportClearsControllerAndReloadsModel() async {
         let controller = IrohSettingsControllerDouble(snapshot: .unavailable)
         controller.report = diagnosticReport()
-        controller.exportData = Data("cmuxdiag v1\n25,1,,,1,,7".utf8)
+        controller.exportData = controller.report.humanReadableExport()
         let model = IrohSettingsModel(controller: controller)
         let observation = Task { await model.observe() }
         await waitUntil { !model.diagnosticReport.events.isEmpty }

--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -36829,16 +36829,124 @@
     "cli.help.irohDiag": {
       "extractionState": "manual",
       "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "الاستخدام: cmux iroh-diag\n\nاطبع تقرير اتصال Iroh للمضيف كمخطط زمني بلغة واضحة،\nوهي البيانات نفسها الموجودة في الإعدادات > الشبكات > تقرير الاتصال."
+          }
+        },
+        "bs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Upotreba: cmux iroh-diag\n\nIspiši izvještaj o Iroh vezi domaćina kao vremensku liniju razumljivim jezikom,\niste podatke kao Postavke > Mreža > Izvještaj o vezi."
+          }
+        },
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Brug: cmux iroh-diag\n\nUdskriv værtens Iroh-forbindelsesrapport som en tidslinje i almindeligt sprog,\nde samme data som Indstillinger > Netværk > Forbindelsesrapport."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Verwendung: cmux iroh-diag\n\nGibt den Iroh-Verbindungsbericht des Hosts als verständliche Zeitleiste aus,\ndieselben Daten wie Einstellungen > Netzwerk > Verbindungsbericht."
+          }
+        },
         "en": {
           "stringUnit": {
             "state": "translated",
             "value": "Usage: cmux iroh-diag\n\nPrint the host's Iroh Connection Report as a plain-language timeline,\nthe same data as Settings > Networking > Connection Report."
           }
         },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Uso: cmux iroh-diag\n\nMuestra el informe de conexión Iroh del host como una cronología en lenguaje sencillo,\nlos mismos datos que Ajustes > Red > Informe de conexión."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Utilisation : cmux iroh-diag\n\nAffiche le rapport de connexion Iroh de l’hôte sous forme de chronologie en langage clair,\nles mêmes données que Réglages > Réseau > Rapport de connexion."
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Uso: cmux iroh-diag\n\nStampa il rapporto di connessione Iroh dell’host come cronologia in linguaggio semplice,\ngli stessi dati di Impostazioni > Rete > Rapporto di connessione."
+          }
+        },
         "ja": {
           "stringUnit": {
             "state": "translated",
             "value": "Usage: cmux iroh-diag\n\nホストのIroh接続レポートを読みやすいタイムラインとして出力します。\n設定 > ネットワーク > 接続レポートと同じデータです。"
+          }
+        },
+        "km": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ការប្រើប្រាស់៖ cmux iroh-diag\n\nបង្ហាញរបាយការណ៍ការតភ្ជាប់ Iroh របស់ម៉ាស៊ីនជាបន្ទាត់ពេលវេលាដែលងាយយល់\nជាទិន្នន័យដូចគ្នានឹង ការកំណត់ > បណ្តាញ > របាយការណ៍ការតភ្ជាប់។"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "사용법: cmux iroh-diag\n\n호스트의 Iroh 연결 보고서를 이해하기 쉬운 타임라인으로 출력합니다.\n설정 > 네트워킹 > 연결 보고서와 동일한 데이터입니다."
+          }
+        },
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bruk: cmux iroh-diag\n\nSkriv ut vertens Iroh-tilkoblingsrapport som en tidslinje i klart språk,\nde samme dataene som Innstillinger > Nettverk > Tilkoblingsrapport."
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Użycie: cmux iroh-diag\n\nWyświetla raport połączenia Iroh hosta jako oś czasu napisaną prostym językiem,\nte same dane co Ustawienia > Sieć > Raport połączenia."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Uso: cmux iroh-diag\n\nExibe o relatório de conexão Iroh do host como uma linha do tempo em linguagem simples,\nos mesmos dados de Ajustes > Rede > Relatório de conexão."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Использование: cmux iroh-diag\n\nВыводит отчет о подключении Iroh хоста в виде понятной временной шкалы,\nте же данные, что в Настройки > Сеть > Отчет о подключении."
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "การใช้งาน: cmux iroh-diag\n\nแสดงรายงานการเชื่อมต่อ Iroh ของโฮสต์เป็นไทม์ไลน์ที่อ่านเข้าใจง่าย\nเป็นข้อมูลเดียวกับ การตั้งค่า > เครือข่าย > รายงานการเชื่อมต่อ"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kullanım: cmux iroh-diag\n\nAna bilgisayarın Iroh Bağlantı Raporunu anlaşılır bir zaman çizelgesi olarak yazdırır,\nAyarlar > Ağ > Bağlantı Raporu ile aynı verileri içerir."
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Використання: cmux iroh-diag\n\nВиводить звіт про підключення Iroh хоста як зрозумілу часову шкалу,\nті самі дані, що в Налаштування > Мережа > Звіт про підключення."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "用法：cmux iroh-diag\n\n以易读的时间线形式输出主机的 Iroh 连接报告，\n数据与“设置 > 网络 > 连接报告”相同。"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "用法：cmux iroh-diag\n\n以易讀的時間軸形式輸出主機的 Iroh 連線報告，\n資料與「設定 > 網路 > 連線報告」相同。"
           }
         }
       }

--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -36826,6 +36826,23 @@
         }
       }
     },
+    "cli.help.irohDiag": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Usage: cmux iroh-diag\n\nPrint the host's Iroh Connection Report as a plain-language timeline,\nthe same data as Settings > Networking > Connection Report."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Usage: cmux iroh-diag\n\nホストのIroh接続レポートを読みやすいタイムラインとして出力します。\n設定 > ネットワーク > 接続レポートと同じデータです。"
+          }
+        }
+      }
+    },
     "cli.help.jumpToUnread": {
       "extractionState": "manual",
       "localizations": {

--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -10951,10 +10951,10 @@ class TerminalController {
     /// base64 encode/decode round-trip — kept verbatim so the reply bytes
     /// match the legacy `readTerminalTextBase64` pipeline exactly — run off
     /// the main actor.
-    /// Serves the v1 `iroh_diag` socket command: the host's iroh Connection
-    /// Report in the same `cmuxdiag v1` compact format the Settings pane
-    /// exports, read from the same `DiagnosticLog` snapshot path so the two
-    /// can never disagree. Empty ring prints just the header (count=0).
+    /// Serves the v1 `iroh_diag` socket command: the host's Iroh Connection
+    /// Report in the same plain-language format the Settings pane exports,
+    /// read from the same `DiagnosticLog` snapshot path so the two can never
+    /// disagree.
     private nonisolated func irohDiagText() -> String {
         let semaphore = DispatchSemaphore(value: 0)
         nonisolated(unsafe) var export = ""
@@ -10965,7 +10965,7 @@ class TerminalController {
             // log's own drain actor, and the execution policy keeps this
             // command off the main thread, so the wait cannot self-deadlock.
             let report = await MobileHostIrohRuntime.hostDiagnosticLog.snapshot()
-            export = String(decoding: report.compactExport(), as: UTF8.self)
+            export = String(decoding: report.humanReadableExport(), as: UTF8.self)
             semaphore.signal()
         }
         semaphore.wait()

--- a/docs/transport-sentry-diagnostics.md
+++ b/docs/transport-sentry-diagnostics.md
@@ -11,8 +11,10 @@ pipeline turns the existing `DiagnosticLog` ring
 any new PII egress: the ring's vocabulary is fixed integer codes
 (`DiagnosticEventCode`, `DiagnosticFailureKind`, ...), so the bridge ships
 plain-language titles and decoded values, never error strings, peers,
-addresses, accounts, or terminal content. Stable case names remain only in
-Sentry tags and fingerprints used for search and issue grouping.
+addresses, accounts, or terminal content. Stable case names remain in
+breadcrumb `event_code`, structured-log `transport.event_code` and
+`transport.role_code`, and Sentry tags and fingerprints used for search and
+issue grouping.
 
 ## Pipeline
 
@@ -61,5 +63,6 @@ Attempt: 7)`). Tags:
 `transport.event`, `transport.failure`, `transport.kind`, `transport.role`,
 `transport.incident` (`failure` | `outage`). The `cmux.transport` context
 holds streak counts and suppression counters. The attachment holds the full
-ring as an oldest-first timeline with UTC timestamps and labeled values. The
-breadcrumb trail holds the same event summaries, in order.
+ring as an oldest-first timeline with labeled values. Events use UTC timestamps
+when a wall date is available and `+<seconds>` relative timestamps otherwise.
+The breadcrumb trail holds the same event summaries, in order.

--- a/docs/transport-sentry-diagnostics.md
+++ b/docs/transport-sentry-diagnostics.md
@@ -10,8 +10,9 @@ pipeline turns the existing `DiagnosticLog` ring
 (`Packages/Shared/CMUXMobileCore`) into three Sentry surfaces without adding
 any new PII egress: the ring's vocabulary is fixed integer codes
 (`DiagnosticEventCode`, `DiagnosticFailureKind`, ...), so the bridge ships
-decoded case names and integers, never error strings, peers, addresses,
-accounts, or terminal content.
+plain-language titles and decoded values, never error strings, peers,
+addresses, accounts, or terminal content. Stable case names remain only in
+Sentry tags and fingerprints used for search and issue grouping.
 
 ## Pipeline
 
@@ -20,17 +21,17 @@ drain task) to a `TransportSentryReporter`
 (`Packages/Shared/CmuxSentryTelemetry`, target `CmuxSentryReporting`), which
 emits:
 
-1. **Breadcrumbs** — every transport event, category `transport`, decoded via
+1. **Breadcrumbs**: every transport event, category `transport`, decoded via
    `DiagnosticEventPresentation`. These ride on ALL Sentry events, including
    crashes and hangs, so any report carries the recent connection timeline.
-2. **Structured logs** — the same decoded events as searchable Sentry logs
+2. **Structured logs**: the same decoded events as searchable Sentry logs
    (`options.enableLogs`), rate-limited by a sliding hourly budget so retry
    storms cannot flood the quota.
-3. **Error events** — failures that cross `TransportIncidentPolicy`
+3. **Error events**: failures that cross `TransportIncidentPolicy`
    (`CMUXMobileCore`, pure and unit-tested) become Sentry events fingerprinted
-   by `code/failureKind/transportKind` signature, with the compact diagnostic
-   ring export attached (`cmux-transport-diag.txt`, the same `cmuxdiag v1`
-   blob the `iroh_diag` socket verb and iOS Settings export produce).
+   by `code/failureKind/transportKind` signature, with the plain-language
+   diagnostic timeline attached (`cmux-transport-diag.txt`, the same report
+   the `iroh_diag` socket verb and iOS Settings export produce).
 
 The policy suppresses what an operator can already attribute (cancelled or
 superseded dials, offline failures while reachability reports no network,
@@ -54,10 +55,11 @@ seconds since last success, consecutive-failure count) rides on every capture.
 
 ## Reading an issue
 
-A transport issue's title is the policy signature (e.g.
-`Transport failure: transportDialFailed/policyUnavailable/iroh`). Tags:
+A transport issue's title is a plain-language event summary (for example,
+`Transport dial failed (Transport: Iroh, Failure: Relay policy unavailable,
+Attempt: 7)`). Tags:
 `transport.event`, `transport.failure`, `transport.kind`, `transport.role`,
 `transport.incident` (`failure` | `outage`). The `cmux.transport` context
 holds streak counts and suppression counters. The attachment holds the full
-ring in `cmuxdiag v1` compact form (`tNanos,code,surface,ms,a,b,c` rows); the
-breadcrumb trail holds the same events decoded, in order.
+ring as an oldest-first timeline with UTC timestamps and labeled values. The
+breadcrumb trail holds the same event summaries, in order.


### PR DESCRIPTION
## Summary

- Replace compact cmuxdiag rows, camelCase event names, and numeric payload slots with a UTC plain-language timeline.
- Decode all 55 transport diagnostic event codes into human titles and labeled semantic values.
- Route Settings Share, cmux iroh-diag, report attachments, Sentry breadcrumbs, and Sentry logs through the same formatter. Stable machine codes remain only in grouping and search metadata.

## Testing

- 51 focused CMUXMobileCore diagnostics and incident-policy tests pass.
- 7 focused CmuxSentryTelemetry reporter tests pass.
- The package convention scan no longer reports DiagnosticEventPresentation.
- Tagged hrlog preflight verified Settings > Networking > Connection Report > Share > Copy and cmux iroh-diag produce the same readable report with raw format tokens absent.
- Hosted iOS/package run: https://github.com/manaflow-ai/cmux/actions/runs/30862163757

## Implementation

DiagnosticEventPresentation is an instantiated, stateless formatter shared by every export owner. This is a principled change because one exhaustive schema now owns user-facing names and payload decoding while stable machine identifiers remain available for telemetry correlation.

## Checklist

- [x] Focused behavior tests updated and run
- [x] Documentation updated
- [x] Tagged report and Share entrypoints exercised

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/9485"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788391755&installation_model_id=21920&pr_number=9485&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F9485&signature=d85db2684d60731d718e83e5fbfd04aff679b76a8609c9348eb8ed554d3525df"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaces compact `cmuxdiag v1` rows with a UTC, localized plain‑language timeline for Iroh/transport diagnostics across the app, CLI, socket command, and Sentry. Honors explicit locales for all titles and texts while keeping stable machine codes in tags and grouping.

- **New Features**
  - Localized formatter in `CMUXMobileCore` (format v2) decodes all transport event codes; adds `Resources/Localizable.xcstrings` and `defaultLocalization: "en"` with resources processed by the package.
  - `DiagnosticLocalization` resolves strings for an explicit `Locale` with a runtime check for compiled catalogs; `DiagnosticIncidentTitleFormatter` produces localized, pluralized incident titles; `TransportIncidentPolicy` accepts and honors a `Locale`.
  - `DiagnosticLog.export()` and sharing produce a localized timeline with UTC timestamps (or relative time if no wall‑clock anchor) and valid UTF‑8 text.
  - `cmux iroh-diag` and the `iroh_diag` socket command print the same readable report; CLI help text is localized via `cli.help.irohDiag`.
  - Sentry breadcrumbs/logs use readable summaries with structured data; captured events attach the timeline text. Tags keep stable codes like `transport.event_code` and `transport.role_code`.

- **Migration**
  - `DiagnosticReport.compactExport()` now returns the same human‑readable report as `humanReadableExport()` (format v2). Update any parser expecting numeric `cmuxdiag v1` rows.
  - CLI and Settings exports now output text timelines; remove downstream decoders for integer rows.
  - Sentry messages are readable summaries; tags keep stable codes (e.g., `transport.event_code`, `transport.role_code`). Attachments are the plain‑language timeline.

<sup>Written for commit d6ec333e54dff3cbe3e972a591ee47bbb4de0c19. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/9485?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Diagnostic exports now provide readable, labeled timelines with timestamps, event descriptions, durations, and decoded values.
  * Reports support English and Japanese localization, clearer transport incident titles, and detailed summaries.
  * Empty reports clearly indicate that no events were recorded.
  * Telemetry attachments and logs now include human-readable diagnostic context.
* **Bug Fixes**
  * Timestamps use wall-clock references when available, with relative timing otherwise.
* **Documentation**
  * Updated CLI, settings, and diagnostic guidance for the human-readable export format.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->