### PR TITLE
Make terminal font-size shortcuts work while the text box has focus

### DIFF
--- a/Packages/macOS/CmuxTerminal/Sources/CmuxTerminal/Events/TerminalSurfaceNotifications.swift
+++ b/Packages/macOS/CmuxTerminal/Sources/CmuxTerminal/Events/TerminalSurfaceNotifications.swift
@@ -11,4 +11,10 @@ public extension Notification.Name {
     /// completes (`object`: the surface model).
     static let terminalSurfaceDidCompleteClipboardRead =
         Notification.Name("terminalSurfaceDidCompleteClipboardRead")
+
+    /// Posted by ``TerminalSurface`` after its font-size lineage changes
+    /// (runtime zoom, reset, or config reconciliation; `object`: the
+    /// surface model).
+    static let terminalSurfaceFontSizeLineageDidChange =
+        Notification.Name("cmux.terminalSurfaceFontSizeLineageDidChange")
 }

--- a/Packages/macOS/CmuxTerminal/Sources/CmuxTerminal/Surface/TerminalSurface+FontSizeLineage.swift
+++ b/Packages/macOS/CmuxTerminal/Sources/CmuxTerminal/Surface/TerminalSurface+FontSizeLineage.swift
@@ -886,6 +886,10 @@ extension TerminalSurface {
         guard lastKnownFontSizeLineage != lineage else { return }
         lastKnownFontSizeLineage = lineage
         onFontSizeLineageChanged?(lineage)
+        NotificationCenter.default.post(
+            name: .terminalSurfaceFontSizeLineageDidChange,
+            object: self
+        )
     }
 
     /// Makes a runtime deferred across config replacement consume the newly

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -14305,20 +14305,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
             )
         if let workspaceTerminalFontSizeAction,
            !matchingExplicitActionShouldPreemptFontSizeDefault {
-            let routedContext = preferredMainWindowContextForShortcutRouting(event: event)
-            let routedTabs = routedContext?.tabManager ?? tabManager
-            if let selectedWorkspace = routedTabs?.selectedWorkspace {
-                let accepted =
-                    enqueueWorkspaceTerminalFontSizeChange(
-                        workspaceTerminalFontSizeAction,
-                        workspace: selectedWorkspace,
-                        tabManager: routedTabs,
-                        deferFlush: event.isARepeat
-                    )
-                if !accepted {
-                    NSSound.beep()
-                }
-            }
+            performWorkspaceTerminalFontSizeShortcut(
+                workspaceTerminalFontSizeAction,
+                event: event
+            )
             return true
         }
         if equalizeSplitsMatches && !matchingExplicitActionShouldPreemptEqualizeDefault {
@@ -14619,6 +14609,28 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         }
 
         return false
+    }
+
+    /// Shared action path for the workspace terminal font-size shortcuts so
+    /// the app-level monitor and the focused text box route identically
+    /// (issue #9463).
+    func performWorkspaceTerminalFontSizeShortcut(
+        _ action: KeyboardShortcutSettings.Action,
+        event: NSEvent
+    ) {
+        let routedContext = preferredMainWindowContextForShortcutRouting(event: event)
+        let routedTabs = routedContext?.tabManager ?? tabManager
+        guard let selectedWorkspace = routedTabs?.selectedWorkspace else { return }
+        let accepted =
+            enqueueWorkspaceTerminalFontSizeChange(
+                action,
+                workspace: selectedWorkspace,
+                tabManager: routedTabs,
+                deferFlush: event.isARepeat
+            )
+        if !accepted {
+            NSSound.beep()
+        }
     }
 
     private func enqueueWorkspaceTerminalFontSizeChange(

--- a/Sources/Panels/TerminalPanelView.swift
+++ b/Sources/Panels/TerminalPanelView.swift
@@ -5,6 +5,7 @@ import Bonsplit
 import CmuxAppKitSupportUI
 import CmuxTestSupport
 import CmuxTerminal
+import CmuxTerminalCore
 import CmuxFoundation
 import CmuxSettings
 
@@ -180,9 +181,46 @@ struct TerminalPanelView: View {
             }
         }
         .background(Color(nsColor: appearance.contentBackgroundColor))
-        .onReceive(NotificationCenter.default.publisher(for: .ghosttyConfigDidReload)) { _ in
-            terminalFontSize = GhosttyConfig.load(globalFontMagnificationPercent: GlobalFontMagnification.storedPercent).fontSize
+        .onAppear {
+            refreshTerminalFontSize()
         }
+        .onReceive(NotificationCenter.default.publisher(for: .ghosttyConfigDidReload)) { _ in
+            refreshTerminalFontSize()
+        }
+        .onReceive(
+            NotificationCenter.default.publisher(
+                for: .terminalSurfaceFontSizeLineageDidChange,
+                object: panel.surface
+            )
+        ) { _ in
+            refreshTerminalFontSize()
+        }
+    }
+
+    /// Keeps the text box font in sync with the surface's runtime zoom
+    /// (Cmd+Ctrl+= / - / 0), not just the configured Ghostty size (issue #9463).
+    private func refreshTerminalFontSize() {
+        terminalFontSize = Self.resolvedTerminalFontSize(
+            lineage: panel.surface.fontSizeLineageSnapshot(),
+            configuredFontSize: GhosttyConfig.load(
+                globalFontMagnificationPercent: GlobalFontMagnification.storedPercent
+            ).fontSize,
+            magnificationPercent: GlobalFontMagnification.storedPercent
+        )
+    }
+
+    static func resolvedTerminalFontSize(
+        lineage: TerminalFontSizeLineage?,
+        configuredFontSize: CGFloat,
+        magnificationPercent: Int
+    ) -> CGFloat {
+        guard let lineage else { return configuredFontSize }
+        return CGFloat(
+            CmuxSurfaceConfigTemplate.runtimeFontSize(
+                fromBasePoints: lineage.basePoints,
+                percent: magnificationPercent
+            )
+        )
     }
 
     private var sessionContentWidthPresentation: SessionContentWidthPresentation {

--- a/Sources/TextBoxInput.swift
+++ b/Sources/TextBoxInput.swift
@@ -3245,12 +3245,20 @@ final class TextBoxInputTextView: NSTextView {
     var onPaste: (NSPasteboard, TextBoxInputTextView) -> Bool = { _, _ in false }
     var onInsertFileURLs: ([URL], TextBoxInputTextView) -> Bool = { _, _ in false }
     var onChooseFiles: () -> Void = {}
+    var onPerformWorkspaceTerminalFontSizeShortcut: @MainActor (KeyboardShortcutSettings.Action, NSEvent) -> Void = { action, event in
+        AppDelegate.shared?.performWorkspaceTerminalFontSizeShortcut(action, event: event)
+    }
     var onMoveToWindow: (TextBoxInputTextView) -> Void = { _ in }
     var onLayoutCompleted: (TextBoxInputTextView, Int) -> Void = { _, _ in }
     var onMarkedTextStateChanged: (Bool) -> Void = { _ in }
     private var isReportingLayoutCompletion = false
 
     private static let localControlKeys: Set<String> = ["a", "e", "f", "b", "n", "p", "k", "h"]
+    private static let workspaceTerminalFontSizeShortcutActions: [KeyboardShortcutSettings.Action] = [
+        .increaseWorkspaceTerminalFontSize,
+        .decreaseWorkspaceTerminalFontSize,
+        .resetWorkspaceTerminalFontSize,
+    ]
     private static let pendingAttachmentUploadPlaceholderCharacter = "\u{200B}"
     private static let pendingAttachmentUploadPlaceholderAttribute = NSAttributedString.Key(
         "cmux.textBoxPendingAttachmentUploadID"
@@ -4803,6 +4811,13 @@ final class TextBoxInputTextView: NSTextView {
         }
         if textBoxShortcut(event, matches: .attachTextBoxFile) {
             onChooseFiles()
+            return true
+        }
+        // Per-workspace terminal font-size zoom must keep working while the
+        // text box owns focus (issue #9463).
+        for action in Self.workspaceTerminalFontSizeShortcutActions
+        where textBoxShortcut(event, matches: action) {
+            onPerformWorkspaceTerminalFontSizeShortcut(action, event)
             return true
         }
         return false

--- a/cmuxTests/TerminalFontZoomSessionPersistenceTests.swift
+++ b/cmuxTests/TerminalFontZoomSessionPersistenceTests.swift
@@ -20,6 +20,31 @@ struct TerminalFontZoomSessionPersistenceTests {
         #expect(GhosttyConfig().fontSize == 13)
     }
 
+    @Test("text box terminal font size follows runtime zoom lineage")
+    func textBoxTerminalFontSizeFollowsRuntimeZoomLineage() {
+        #expect(
+            TerminalPanelView.resolvedTerminalFontSize(
+                lineage: nil,
+                configuredFontSize: 13,
+                magnificationPercent: 100
+            ) == 13
+        )
+        #expect(
+            TerminalPanelView.resolvedTerminalFontSize(
+                lineage: TerminalFontSizeLineage(basePoints: 16, isExplicitOverride: true),
+                configuredFontSize: 13,
+                magnificationPercent: 100
+            ) == 16
+        )
+        #expect(
+            TerminalPanelView.resolvedTerminalFontSize(
+                lineage: TerminalFontSizeLineage(basePoints: 16, isExplicitOverride: true),
+                configuredFontSize: 13,
+                magnificationPercent: 150
+            ) == 24
+        )
+    }
+
     @Test("workspace font-size shortcuts and equalize default stay distinct")
     func workspaceFontSizeShortcutDefaults() {
         #expect(

--- a/cmuxTests/TextBoxSubmitActionTests.swift
+++ b/cmuxTests/TextBoxSubmitActionTests.swift
@@ -1127,6 +1127,34 @@ struct TextBoxSubmitActionTests {
     }
 
     @Test
+    func testTextBoxFontSizeShortcutsForwardToWorkspaceZoom() {
+        let textView = TextBoxInputTextView(frame: NSRect(x: 0, y: 0, width: 320, height: 30))
+        var receivedActions: [KeyboardShortcutSettings.Action] = []
+        textView.onPerformWorkspaceTerminalFontSizeShortcut = { action, _ in
+            receivedActions.append(action)
+        }
+
+        let strokes: [(key: String, keyCode: UInt16, action: KeyboardShortcutSettings.Action)] = [
+            ("=", UInt16(kVK_ANSI_Equal), .increaseWorkspaceTerminalFontSize),
+            ("-", UInt16(kVK_ANSI_Minus), .decreaseWorkspaceTerminalFontSize),
+            ("0", UInt16(kVK_ANSI_0), .resetWorkspaceTerminalFontSize),
+        ]
+        for stroke in strokes {
+            guard let event = makeKeyDownEvent(
+                key: stroke.key,
+                modifiers: [.command, .control],
+                keyCode: stroke.keyCode
+            ) else {
+                XCTFail("Failed to construct Cmd+Ctrl+\(stroke.key) event")
+                return
+            }
+            XCTAssertTrue(textView.handleConfiguredTextBoxShortcut(event))
+            #expect(receivedActions.last == stroke.action)
+        }
+        XCTAssertEqual(receivedActions.count, 3)
+    }
+
+    @Test
     func testFocusTextBoxOnNewTerminalsDefaultDoesNotFocusBackgroundOrAutomationTerminals() {
         let showKey = TerminalTextBoxInputSettings.showOnNewTerminalsKey
         let focusKey = TerminalTextBoxInputSettings.focusOnNewTerminalsKey


### PR DESCRIPTION
When the text box owned focus, Cmd+Ctrl+=/-/0 never reached the app-level key monitor, so the workspace terminal font size couldn't be changed. On top of that, the text box computed its own font purely from the configured Ghostty size, so it ignored runtime zoom even when the shortcut did fire.

- Extract the monitor's handling into `performWorkspaceTerminalFontSizeShortcut` and forward the three font-size actions from `TextBoxInputTextView` to it, so both paths route identically.
- Post `terminalSurfaceFontSizeLineageDidChange` whenever a surface's font-size lineage changes, and have `TerminalPanelView` resolve its font from the lineage snapshot (falling back to the configured size), including the global magnification percent.
- Add tests covering the lineage-based font resolution and the shortcut forwarding for =, - and 0.

Fixes #9463

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/9488"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788391955&installation_model_id=21920&pr_number=9488&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F9488&signature=8d1946f20cc08694601d4cb02f147aaec2967146cbad9f54dcf722bd8c7b2d75"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make Cmd+Ctrl+=/−/0 terminal font-size shortcuts work while the text box is focused, and keep the text box font synced with runtime zoom. Fixes #9463.

- **Bug Fixes**
  - Forward font-size shortcuts from the text box to a shared handler (`performWorkspaceTerminalFontSizeShortcut`) so shortcuts work identically with or without focus.
  - Post `terminalSurfaceFontSizeLineageDidChange` and resolve the text box font from the surface lineage plus global magnification, falling back to the configured size.
  - Add tests for lineage-based font resolution and shortcut forwarding for =, −, and 0.

<sup>Written for commit 6e22c780bebfc728221757bd45d9294f1e1496b3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/9488?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Workspace terminal font-size shortcuts now work while text fields are focused.
  * Terminal font sizes stay synchronized after zooming, resetting, configuration reloads, and reopening surfaces.
  * Runtime font-size changes are communicated consistently across terminal views.

* **Bug Fixes**
  * Corrected font-size resolution so explicit zoom settings take precedence over configured defaults.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->