### PR TITLE
Prefetch visible iOS workspace scrollback

### DIFF
--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+TerminalOutputDelivery.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+TerminalOutputDelivery.swift
@@ -457,6 +457,24 @@ extension MobileShellComposite {
         return true
     }
 
+    func deliverVisibleWorkspaceScrollbackPrefetch(_ delivery: TerminalOutputDelivery, surfaceID: String) {
+        guard deliverTerminalOutput(delivery, surfaceID: surfaceID) else { return }
+        if let frame = delivery.sourceRenderGridFrame {
+            recordTerminalRenderGridDelivery(frame)
+            recordTerminalRenderGridHistoryContinuity(frame)
+            if frame.full, frame.scrollbackRows > 0 {
+                terminalMirrorHydrationNeededSurfaceIDs.remove(surfaceID)
+            }
+        }
+        if let endSequence = delivery.endSequence {
+            markTerminalBytesDelivered(
+                surfaceID: surfaceID,
+                endSeq: endSequence,
+                fullReplacement: true
+            )
+        }
+    }
+
     /// Whether a chunk must apply through the verified freeze/replay/verify/
     /// reveal pipeline. Screen-anchored primary-screen deltas apply directly:
     /// they are ordered by the same stateSeq floors, their scroll prologue

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+VisibleWorkspaceScrollbackPrefetch.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+VisibleWorkspaceScrollbackPrefetch.swift
@@ -1,0 +1,140 @@
+internal import CMUXMobileCore
+internal import CmuxMobileRPC
+public import CmuxMobileShellModel
+internal import Foundation
+
+struct VisibleWorkspaceScrollbackPrefetch {
+    let delivery: TerminalOutputDelivery
+    let fetchedAt: Date
+}
+
+extension MobileShellComposite {
+    private static var visibleWorkspaceScrollbackPrefetchLifetime: TimeInterval { 15 }
+
+    /// Warms the focused terminal for each workspace row currently on screen.
+    ///
+    /// The replay is retained briefly and applied synchronously when a terminal
+    /// surface mounts. A normal cold replay still follows, repairing any output
+    /// produced between this fetch and the tap.
+    public func prefetchScrollback(
+        forVisibleWorkspaceIDs workspaceIDs: Set<MobileWorkspacePreview.ID>
+    ) {
+        guard usesScreenAnchoredRenderGrid else { return }
+        let surfaceIDs: [String] = workspaceIDs.compactMap { workspaceID in
+            guard let workspace = workspaces.first(where: { $0.id == workspaceID }) else {
+                return nil
+            }
+            return (workspace.terminals.first(where: { $0.isFocused && $0.isReady })
+                ?? workspace.terminals.first(where: \.isReady))?.id.rawValue
+        }
+        let surfaces = Set(surfaceIDs)
+        visibleWorkspaceScrollbackPrefetchSurfaceIDs = surfaces
+
+        let departedSurfaceIDs = visibleWorkspaceScrollbackPrefetchTasksBySurfaceID.keys.filter {
+            !surfaces.contains($0)
+        }
+        for surfaceID in departedSurfaceIDs {
+            visibleWorkspaceScrollbackPrefetchTasksBySurfaceID[surfaceID]?.cancel()
+            visibleWorkspaceScrollbackPrefetchTasksBySurfaceID.removeValue(forKey: surfaceID)
+            visibleWorkspaceScrollbackPrefetchRequestIDsBySurfaceID.removeValue(forKey: surfaceID)
+        }
+
+        let now = runtime?.now() ?? Date()
+        visibleWorkspaceScrollbackPrefetchesBySurfaceID = visibleWorkspaceScrollbackPrefetchesBySurfaceID.filter {
+            now.timeIntervalSince($0.value.fetchedAt) < Self.visibleWorkspaceScrollbackPrefetchLifetime
+        }
+
+        for surfaceID in surfaces {
+            guard !hasTerminalOutputSink(surfaceID: surfaceID),
+                  visibleWorkspaceScrollbackPrefetchTasksBySurfaceID[surfaceID] == nil,
+                  visibleWorkspaceScrollbackPrefetchesBySurfaceID[surfaceID] == nil,
+                  let workspaceID = workspaceID(forTerminalID: surfaceID) else {
+                continue
+            }
+            let target = workspaceMutationTarget(for: workspaceID)
+            guard let client = target.client else { continue }
+            let remoteWorkspaceID = remoteWorkspaceID(for: workspaceID)
+            let requestID = UUID()
+            visibleWorkspaceScrollbackPrefetchRequestIDsBySurfaceID[surfaceID] = requestID
+            visibleWorkspaceScrollbackPrefetchTasksBySurfaceID[surfaceID] = Task { @MainActor [weak self] in
+                defer {
+                    if self?.visibleWorkspaceScrollbackPrefetchRequestIDsBySurfaceID[surfaceID]
+                        == requestID {
+                        self?.visibleWorkspaceScrollbackPrefetchTasksBySurfaceID.removeValue(forKey: surfaceID)
+                        self?.visibleWorkspaceScrollbackPrefetchRequestIDsBySurfaceID.removeValue(forKey: surfaceID)
+                    }
+                }
+                do {
+                    let request = try MobileCoreRPCClient.requestData(
+                        method: "mobile.terminal.replay",
+                        params: [
+                            "workspace_id": remoteWorkspaceID.rawValue,
+                            "surface_id": surfaceID,
+                            "anchor": MobileTerminalRenderGridFrame.Anchor.screen.rawValue,
+                            "max_scrollback_rows": MobileTerminalScrollbackPreference.resolve(),
+                        ]
+                    )
+                    let data = try await client.sendRequest(request)
+                    guard
+                        let self,
+                        !Task.isCancelled,
+                        self.visibleWorkspaceScrollbackPrefetchSurfaceIDs.contains(surfaceID),
+                        !self.hasTerminalOutputSink(surfaceID: surfaceID),
+                        let payload = try? MobileTerminalReplayResponse.decode(data),
+                        let delivery = self.visibleWorkspaceScrollbackDelivery(
+                            payload: payload,
+                            surfaceID: surfaceID
+                        )
+                    else { return }
+                    self.visibleWorkspaceScrollbackPrefetchesBySurfaceID[surfaceID] =
+                        VisibleWorkspaceScrollbackPrefetch(
+                            delivery: delivery,
+                            fetchedAt: self.runtime?.now() ?? Date()
+                        )
+                } catch is CancellationError {
+                    return
+                } catch {
+                    return
+                }
+            }
+        }
+    }
+
+    private func visibleWorkspaceScrollbackDelivery(
+        payload: MobileTerminalReplayResponse,
+        surfaceID: String
+    ) -> TerminalOutputDelivery? {
+        if let frame = payload.renderGrid, frame.surfaceID == surfaceID, frame.full {
+            return TerminalOutputDelivery(
+                renderGrid: frame,
+                replaceable: true,
+                viewportPolicy: frame.mobileViewportPolicy
+            )
+        }
+        if let snapshot = payload.snapshotBase64.flatMap({ Data(base64Encoded: $0) }),
+           !snapshot.isEmpty {
+            return TerminalOutputDelivery(
+                bytes: Self.terminalSnapshotReplacementBytes(snapshot),
+                replaceable: true,
+                viewportPolicy: .natural,
+                endSequence: payload.sequence
+            )
+        }
+        return nil
+    }
+
+    func deliverVisibleWorkspaceScrollbackPrefetchIfAvailable(surfaceID: String) {
+        visibleWorkspaceScrollbackPrefetchTasksBySurfaceID[surfaceID]?.cancel()
+        visibleWorkspaceScrollbackPrefetchTasksBySurfaceID.removeValue(forKey: surfaceID)
+        visibleWorkspaceScrollbackPrefetchRequestIDsBySurfaceID.removeValue(forKey: surfaceID)
+        guard let prefetched = visibleWorkspaceScrollbackPrefetchesBySurfaceID.removeValue(
+            forKey: surfaceID
+        ) else { return }
+        let now = runtime?.now() ?? Date()
+        guard now.timeIntervalSince(prefetched.fetchedAt)
+            < Self.visibleWorkspaceScrollbackPrefetchLifetime else {
+            return
+        }
+        deliverVisibleWorkspaceScrollbackPrefetch(prefetched.delivery, surfaceID: surfaceID)
+    }
+}

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
@@ -1160,6 +1160,10 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
     var terminalScrollQueueTokensBySurfaceID: [String: UUID]
     var terminalScrollQueuesBySurfaceID: [String: TerminalScrollDeliveryQueue]
     var terminalScrollbackPrefetchStatesBySurfaceID: [String: TerminalScrollbackPrefetchState]
+    var visibleWorkspaceScrollbackPrefetchTasksBySurfaceID: [String: Task<Void, Never>]
+    var visibleWorkspaceScrollbackPrefetchRequestIDsBySurfaceID: [String: UUID]
+    var visibleWorkspaceScrollbackPrefetchesBySurfaceID: [String: VisibleWorkspaceScrollbackPrefetch]
+    var visibleWorkspaceScrollbackPrefetchSurfaceIDs: Set<String>
     /// Per-surface continuations for the Mac-pushed live font-size signal. A
     /// mounted surface obtains ``terminalLiveFontStream(surfaceID:)`` and applies
     /// each yielded point size; the Mac emits `terminal.set_font` to drive a live
@@ -1492,6 +1496,10 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         self.terminalScrollQueueTokensBySurfaceID = [:]
         self.terminalScrollQueuesBySurfaceID = [:]
         self.terminalScrollbackPrefetchStatesBySurfaceID = [:]
+        self.visibleWorkspaceScrollbackPrefetchTasksBySurfaceID = [:]
+        self.visibleWorkspaceScrollbackPrefetchRequestIDsBySurfaceID = [:]
+        self.visibleWorkspaceScrollbackPrefetchesBySurfaceID = [:]
+        self.visibleWorkspaceScrollbackPrefetchSurfaceIDs = []
         self.terminalLiveFontContinuationsBySurfaceID = [:]
         self.terminalLiveFontTokensBySurfaceID = [:]
         self.rawTerminalInputBuffer = MobileTerminalInputSendBuffer()
@@ -8993,6 +9001,11 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         terminalScrollQueueTokensBySurfaceID = [:]
         terminalScrollQueuesBySurfaceID = [:]
         terminalScrollbackPrefetchStatesBySurfaceID = [:]
+        visibleWorkspaceScrollbackPrefetchTasksBySurfaceID.values.forEach { $0.cancel() }
+        visibleWorkspaceScrollbackPrefetchTasksBySurfaceID = [:]
+        visibleWorkspaceScrollbackPrefetchRequestIDsBySurfaceID = [:]
+        visibleWorkspaceScrollbackPrefetchesBySurfaceID = [:]
+        visibleWorkspaceScrollbackPrefetchSurfaceIDs = []
         terminalOutputTransport = .rawBytes
         deactivateAllTerminalLanes()
         supportedHostCapabilities = []
@@ -11072,7 +11085,7 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         terminalInputAckResubscribeRetrySurfaceID = nil
     }
 
-    private static func terminalSnapshotReplacementBytes(_ snapshotBytes: Data) -> Data {
+    static func terminalSnapshotReplacementBytes(_ snapshotBytes: Data) -> Data {
         var bytes = Data("\u{1B}c\u{1B}[H\u{1B}[2J\u{1B}[3J".utf8)
         bytes.append(snapshotBytes)
         return bytes
@@ -11098,6 +11111,7 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         cancelTerminalInputAckResubscribeRetry(surfaceID: surfaceID)
         pendingTerminalByteEndSeqBySurfaceID.removeValue(forKey: surfaceID)
         pendingTerminalInputDroppedRenderGridSurfaceIDs.remove(surfaceID)
+        deliverVisibleWorkspaceScrollbackPrefetchIfAvailable(surfaceID: surfaceID)
         #if DEBUG
         mobileShellLog.info("CMUX_REPLAY register sink surface=\(surfaceID, privacy: .public) connected=\(self.connectionState == .connected, privacy: .public) hasClient=\(self.remoteClient != nil, privacy: .public) workspaceCount=\(self.workspaces.count, privacy: .public)")
         startLatencyProbeIfReady()

--- a/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/VisibleWorkspaceScrollbackPrefetchTests.swift
+++ b/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/VisibleWorkspaceScrollbackPrefetchTests.swift
@@ -1,0 +1,36 @@
+import CMUXMobileCore
+import CmuxMobileShellModel
+import Foundation
+import Testing
+@testable import CmuxMobileShell
+
+@MainActor
+@Test func cachedVisibleWorkspaceScrollbackIsFirstOutputOnMount() async throws {
+    let surfaceID = "terminal-visible-prefetch"
+    let frame = try MobileTerminalRenderGridFrame(
+        surfaceID: surfaceID,
+        stateSeq: 42,
+        columns: 4,
+        rows: 1,
+        rowSpans: [],
+        scrollbackRows: 8,
+        scrollbackSpans: []
+    )
+    let store = MobileShellComposite.preview()
+    store.visibleWorkspaceScrollbackPrefetchesBySurfaceID[surfaceID] =
+        VisibleWorkspaceScrollbackPrefetch(
+            delivery: TerminalOutputDelivery(
+                renderGrid: frame,
+                replaceable: true,
+                viewportPolicy: frame.mobileViewportPolicy
+            ),
+            fetchedAt: Date()
+        )
+
+    var output = store.terminalOutputStream(surfaceID: surfaceID).makeAsyncIterator()
+    let first = try #require(await output.next())
+
+    #expect(first.sourceRenderGridFrame?.stateSeq == 42)
+    #expect(first.sourceRenderGridFrame?.scrollbackRows == 8)
+    #expect(!store.visibleWorkspaceScrollbackPrefetchesBySurfaceID.keys.contains(surfaceID))
+}

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListTable.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListTable.swift
@@ -57,6 +57,7 @@ struct WorkspaceListTable: UIViewControllerRepresentable {
     let showAddDevice: (() -> Void)?
     let reconnect: (() -> Void)?
     let refresh: (@Sendable () async -> Void)?
+    var visibleWorkspaceIDsChanged: ((Set<MobileWorkspacePreview.ID>) -> Void)? = nil
 
     func makeCoordinator() -> WorkspaceListTableCoordinator {
         WorkspaceListTableCoordinator(configuration: self)

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListTableCoordinator.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListTableCoordinator.swift
@@ -79,6 +79,7 @@ final class WorkspaceListTableCoordinator: NSObject, UITableViewDelegate,
         sourceView: UIView,
         contextMenuIdentifier: String
     )?
+    private var visibleWorkspaceIDs: Set<MobileWorkspacePreview.ID> = []
 
     init(configuration: WorkspaceListTable) {
         self.configuration = configuration
@@ -129,8 +130,38 @@ final class WorkspaceListTableCoordinator: NSObject, UITableViewDelegate,
     }
 
     func detach() {
+        if !visibleWorkspaceIDs.isEmpty {
+            visibleWorkspaceIDs.removeAll()
+            configuration.visibleWorkspaceIDsChanged?([])
+        }
         pendingContextMenuWorkspaceClose = nil
         tableViewController = nil
+    }
+
+    func tableView(
+        _ tableView: UITableView,
+        willDisplay cell: UITableViewCell,
+        forRowAt indexPath: IndexPath
+    ) {
+        guard
+            let item = dataSource?.itemIdentifier(for: indexPath),
+            case .workspace(let workspaceID, _) = item,
+            visibleWorkspaceIDs.insert(workspaceID).inserted
+        else { return }
+        configuration.visibleWorkspaceIDsChanged?(visibleWorkspaceIDs)
+    }
+
+    func tableView(
+        _ tableView: UITableView,
+        didEndDisplaying cell: UITableViewCell,
+        forRowAt indexPath: IndexPath
+    ) {
+        guard
+            let item = dataSource?.itemIdentifier(for: indexPath),
+            case .workspace(let workspaceID, _) = item,
+            visibleWorkspaceIDs.remove(workspaceID) != nil
+        else { return }
+        configuration.visibleWorkspaceIDsChanged?(visibleWorkspaceIDs)
     }
 
     func update(configuration next: WorkspaceListTable, in tableView: UITableView) {

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListView+Table.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListView+Table.swift
@@ -135,7 +135,10 @@ extension WorkspaceListView {
             retryInitialConnection: initialConnectionTimedOut ? retryInitialConnection : nil,
             showAddDevice: initialConnectionTimedOut ? showAddDevice : nil,
             reconnect: reconnect,
-            refresh: refresh
+            refresh: refresh,
+            visibleWorkspaceIDsChanged: { ids in
+                store?.prefetchScrollback(forVisibleWorkspaceIDs: ids)
+            }
         )
     }
 }

--- a/Packages/iOS/CmuxMobileShellUI/Tests/CmuxMobileShellUITests/WorkspaceListScrollUpdateTests.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Tests/CmuxMobileShellUITests/WorkspaceListScrollUpdateTests.swift
@@ -47,6 +47,40 @@ import UIKit
         )
     }
 
+    @Test func coordinatorReportsOnlyWorkspaceRowsVisibleOnScreen() {
+        var snapshots: [Set<MobileWorkspacePreview.ID>] = []
+        let initial = configuration(
+            workspaceIDs: ["workspace-1", "workspace-2"],
+            visibleWorkspaceIDsChanged: { snapshots.append($0) }
+        )
+        let coordinator = WorkspaceListTableCoordinator(configuration: initial)
+        let tableView = makeTableView()
+        coordinator.attach(to: tableView)
+        let cell = UITableViewCell()
+
+        coordinator.tableView(
+            tableView,
+            willDisplay: cell,
+            forRowAt: IndexPath(row: 0, section: 0)
+        )
+        coordinator.tableView(
+            tableView,
+            willDisplay: cell,
+            forRowAt: IndexPath(row: 1, section: 0)
+        )
+        coordinator.tableView(
+            tableView,
+            didEndDisplaying: cell,
+            forRowAt: IndexPath(row: 0, section: 0)
+        )
+
+        #expect(snapshots == [
+            [.init(rawValue: "workspace-1")],
+            [.init(rawValue: "workspace-1"), .init(rawValue: "workspace-2")],
+            [.init(rawValue: "workspace-2")],
+        ])
+    }
+
     @Test func structuralUpdateAppliesThroughNativeDataSource() {
         let initial = configuration(workspaceIDs: ["workspace-1"])
         let coordinator = WorkspaceListTableCoordinator(configuration: initial)
@@ -621,7 +655,8 @@ import UIKit
         ungroupWorkspaceGroup: ((MobileWorkspaceGroupPreview.ID) -> Void)? = nil,
         ungroupWorkspaceGroupRequest: ((MobileWorkspaceGroupPreview.ID) -> Void)? = nil,
         deleteWorkspaceGroup: ((MobileWorkspaceGroupPreview.ID) -> Void)? = nil,
-        deleteWorkspaceGroupRequest: ((MobileWorkspaceGroupPreview.ID) -> Void)? = nil
+        deleteWorkspaceGroupRequest: ((MobileWorkspaceGroupPreview.ID) -> Void)? = nil,
+        visibleWorkspaceIDsChanged: ((Set<MobileWorkspacePreview.ID>) -> Void)? = nil
     ) -> WorkspaceListTable {
         let workspaces = workspaceIDs.map { rawID in
             var workspace = MobileWorkspacePreview(
@@ -650,7 +685,8 @@ import UIKit
             ungroupWorkspaceGroup: ungroupWorkspaceGroup,
             ungroupWorkspaceGroupRequest: ungroupWorkspaceGroupRequest,
             deleteWorkspaceGroup: deleteWorkspaceGroup,
-            deleteWorkspaceGroupRequest: deleteWorkspaceGroupRequest
+            deleteWorkspaceGroupRequest: deleteWorkspaceGroupRequest,
+            visibleWorkspaceIDsChanged: visibleWorkspaceIDsChanged
         )
     }
 
@@ -671,7 +707,8 @@ import UIKit
         ungroupWorkspaceGroup: ((MobileWorkspaceGroupPreview.ID) -> Void)? = nil,
         ungroupWorkspaceGroupRequest: ((MobileWorkspaceGroupPreview.ID) -> Void)? = nil,
         deleteWorkspaceGroup: ((MobileWorkspaceGroupPreview.ID) -> Void)? = nil,
-        deleteWorkspaceGroupRequest: ((MobileWorkspaceGroupPreview.ID) -> Void)? = nil
+        deleteWorkspaceGroupRequest: ((MobileWorkspaceGroupPreview.ID) -> Void)? = nil,
+        visibleWorkspaceIDsChanged: ((Set<MobileWorkspacePreview.ID>) -> Void)? = nil
     ) -> WorkspaceListTable {
         return WorkspaceListTable(
             items: items ?? workspaces.map { .workspace($0.id, indented: false) },
@@ -718,7 +755,8 @@ import UIKit
             retryInitialConnection: nil,
             showAddDevice: nil,
             reconnect: nil,
-            refresh: nil
+            refresh: nil,
+            visibleWorkspaceIDsChanged: visibleWorkspaceIDsChanged
         )
     }
 }


### PR DESCRIPTION
## Summary
- prefetch scrollback for terminal workspaces currently visible in the iOS workspace list
- consume the short-lived replay cache immediately on terminal mount, then run the normal authoritative replay
- cancel offscreen work and route multi-Mac prefetches through each workspace owner

## Testing
- `swift test --package-path Packages/iOS/CmuxMobileShell --filter cachedVisibleWorkspaceScrollbackIsFirstOutputOnMount`
- iOS tagged cloud reload: in progress

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/9494"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788395054&installation_model_id=21920&pr_number=9494&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F9494&signature=06233d929f0291e0f32921313af572dd05fdf7a52bf69587db543cbc96a6c0d8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prefetches terminal scrollback for workspaces currently visible in the iOS list and renders it immediately on mount; the normal authoritative replay still runs to catch up.

- **New Features**
  - Prefetches focused/ready terminal scrollback for visible workspace rows (15s TTL) and cancels tasks when rows leave the screen.
  - On mount, delivers the cached replay first via a new delivery path, then runs the standard replay; marks hydration complete on full frames with scrollback.
  - Routes prefetch requests through each workspace owner to avoid duplicate multi‑Mac calls.
  - Adds `visibleWorkspaceIDsChanged` in `WorkspaceListTable` and wires it in the coordinator to report on-screen workspaces.
  - Adds tests: `cachedVisibleWorkspaceScrollbackIsFirstOutputOnMount` and `coordinatorReportsOnlyWorkspaceRowsVisibleOnScreen`.

<sup>Written for commit b6c05e30d775f9f1bd1333c09a040d57708c04e0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/9494?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added automatic terminal scrollback prefetching for workspaces currently visible in the workspace list.
  - Prefetched output is delivered immediately when a terminal opens, preserving render state and scrollback history.
  - Cached data expires automatically and is discarded after delivery.

- **Bug Fixes**
  - Improved handling of cancelled, stale, unavailable, or invalid scrollback requests.

- **Tests**
  - Added coverage for visible workspace tracking and first-output scrollback delivery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->