### PR TITLE
fix: AppKit workspace double-click rename no longer commits instantly

### DIFF
--- a/Sources/Sidebar/AppKitList/Cells/SidebarWorkspaceRowCellView.swift
+++ b/Sources/Sidebar/AppKitList/Cells/SidebarWorkspaceRowCellView.swift
@@ -1009,12 +1009,22 @@ final class SidebarWorkspaceRowTableCellView: NSTableCellView {
         renameField.onCancel = { [weak self] in
             self?.endInlineRename(commit: false)
         }
+        // Lay out (and thus size/position `renameField`) BEFORE attaching the
+        // field editor. Setting a text field's frame while its field editor is
+        // attached ends editing — AppKit tears the editor down on frame change,
+        // which fires controlTextDidEndEditing and instantly commits the
+        // untouched title, so the field flashes and the user can never type.
+        needsLayout = true
+        layoutSubtreeIfNeeded()
         let tookFocus = window?.makeFirstResponder(renameField) ?? false
 #if DEBUG
         cmuxDebugLog("sidebar.row.beginInlineRename tookFocus=\(tookFocus ? 1 : 0) window=\(window == nil ? 0 : 1)")
 #endif
-        renameField.selectText(nil)
-        needsLayout = true
+        // Do NOT call selectText(nil) here: makeFirstResponder already starts
+        // editing an editable NSTextField (selecting all by default), and the
+        // extra selectText(nil) re-enters the field-editor machinery and
+        // synchronously fires controlTextDidEndEditing, which commits the
+        // untouched title before the user can type.
     }
 
     private func endInlineRename(commit: Bool) {
@@ -1383,5 +1393,16 @@ final class SidebarRowInlineRenameField: NSTextField, NSTextFieldDelegate {
     func controlTextDidEndEditing(_ obj: Notification) {
         guard !isHidden else { return }
         onCommit?(stringValue)
+    }
+
+    func controlTextDidBeginEditing(_ obj: Notification) {
+        // The shared field editor (NSTextView) AppKit loans to edit this
+        // borderless field draws its own white background by default, putting
+        // white selected-row text on a white box. Make it transparent so the
+        // row's accent fill shows through, matching how the title renders.
+        if let editor = window?.firstResponder as? NSTextView {
+            editor.drawsBackground = false
+            editor.backgroundColor = .clear
+        }
     }
 }

--- a/Sources/Sidebar/AppKitList/Cells/SidebarWorkspaceRowCellView.swift
+++ b/Sources/Sidebar/AppKitList/Cells/SidebarWorkspaceRowCellView.swift
@@ -1016,9 +1016,11 @@ final class SidebarWorkspaceRowTableCellView: NSTableCellView {
         // untouched title, so the field flashes and the user can never type.
         needsLayout = true
         layoutSubtreeIfNeeded()
-        let tookFocus = window?.makeFirstResponder(renameField) ?? false
 #if DEBUG
+        let tookFocus = window?.makeFirstResponder(renameField) ?? false
         cmuxDebugLog("sidebar.row.beginInlineRename tookFocus=\(tookFocus ? 1 : 0) window=\(window == nil ? 0 : 1)")
+#else
+        _ = window?.makeFirstResponder(renameField)
 #endif
         // Do NOT call selectText(nil) here: makeFirstResponder already starts
         // editing an editable NSTextField (selecting all by default), and the
@@ -1363,6 +1365,11 @@ final class SidebarWorkspaceRowTableCellView: NSTableCellView {
 final class SidebarRowInlineRenameField: NSTextField, NSTextFieldDelegate {
     var onCommit: ((String) -> Void)?
     var onCancel: (() -> Void)?
+    /// Prior field-editor styling captured in controlTextDidBeginEditing and
+    /// restored on end-editing so the shared editor does not leak its
+    /// transparent background to later controls in the window.
+    private var savedEditorDrawsBackground: Bool?
+    private var savedEditorBackgroundColor: NSColor?
 
     init() {
         super.init(frame: .zero)
@@ -1391,6 +1398,10 @@ final class SidebarRowInlineRenameField: NSTextField, NSTextFieldDelegate {
     }
 
     func controlTextDidEndEditing(_ obj: Notification) {
+        // Restore the shared field editor's prior styling before committing,
+        // so the transparent background set in controlTextDidBeginEditing
+        // does not leak to the next control edited in this window.
+        restoreFieldEditorStyling()
         guard !isHidden else { return }
         onCommit?(stringValue)
     }
@@ -1400,9 +1411,20 @@ final class SidebarRowInlineRenameField: NSTextField, NSTextFieldDelegate {
         // borderless field draws its own white background by default, putting
         // white selected-row text on a white box. Make it transparent so the
         // row's accent fill shows through, matching how the title renders.
-        if let editor = window?.firstResponder as? NSTextView {
-            editor.drawsBackground = false
-            editor.backgroundColor = .clear
-        }
+        guard let editor = window?.firstResponder as? NSTextView else { return }
+        savedEditorDrawsBackground = editor.drawsBackground
+        savedEditorBackgroundColor = editor.backgroundColor
+        editor.drawsBackground = false
+        editor.backgroundColor = .clear
+    }
+
+    private func restoreFieldEditorStyling() {
+        let drawsBackground = savedEditorDrawsBackground
+        let backgroundColor = savedEditorBackgroundColor
+        savedEditorDrawsBackground = nil
+        savedEditorBackgroundColor = nil
+        guard let editor = window?.firstResponder as? NSTextView else { return }
+        if let drawsBackground { editor.drawsBackground = drawsBackground }
+        if let backgroundColor { editor.backgroundColor = backgroundColor }
     }
 }

--- a/cmuxTests/SidebarAppKitRowCellTests.swift
+++ b/cmuxTests/SidebarAppKitRowCellTests.swift
@@ -162,7 +162,8 @@ struct SidebarAppKitRowCellTests {
         tab: Workspace? = nil,
         tabManager: TabManager? = nil,
         onOpenWorkspaceDescriptionURL: @escaping (URL) -> Void = { _ in },
-        onOpenStatusURL: @escaping (URL) -> Void = { _ in }
+        onOpenStatusURL: @escaping (URL) -> Void = { _ in },
+        commitRename: @escaping (String) -> Void = { _ in }
     ) -> SidebarAppKitRowActions {
         let resolvedTab = tab ?? Workspace()
         let commands = SidebarWorkspaceRowCommands(
@@ -208,7 +209,7 @@ struct SidebarAppKitRowCellTests {
             onEndChecklistItemEdit: { _ in },
             applyTodoStatus: { _ in },
             hideTodoStatus: {},
-            commitRename: { _ in }
+            commitRename: commitRename
         )
     }
 
@@ -217,6 +218,7 @@ struct SidebarAppKitRowCellTests {
         tab: Workspace? = nil,
         tabManager: TabManager? = nil,
         onOpenWorkspaceDescriptionURL: @escaping (URL) -> Void = { _ in },
+        commitRename: @escaping (String) -> Void = { _ in },
         onOpenStatusURL: @escaping (URL) -> Void = { _ in }
     ) -> SidebarWorkspaceRowTableCellView {
         let cell = SidebarWorkspaceRowTableCellView()
@@ -227,7 +229,8 @@ struct SidebarAppKitRowCellTests {
                 tab: tab,
                 tabManager: tabManager,
                 onOpenWorkspaceDescriptionURL: onOpenWorkspaceDescriptionURL,
-                onOpenStatusURL: onOpenStatusURL
+                onOpenStatusURL: onOpenStatusURL,
+                commitRename: commitRename
             ),
             isPointerHovering: false,
             contextMenuDidOpen: {},
@@ -1071,6 +1074,40 @@ struct SidebarAppKitRowCellTests {
             #expect(!Self.makeSwiftUIRow(settings: settings).settings.details[keyPath: detailKey])
             #expect(!Self.makeModel(settings: settings).settings.details[keyPath: detailKey])
         }
+    }
+
+    @Test
+    func beginInlineRenameLeavesFieldEditingWithoutCommittingPrefilledTitle() throws {
+        // Regression test for the workspace double-click rename flashing and
+        // committing instantly: the inline field appeared then vanished before
+        // the user could type. beginInlineRename must attach the field editor
+        // and leave the field editable; it must NOT synchronously fire onCommit
+        // with the pre-filled, unchanged title.
+        let model = Self.makeModel()
+        var committedTitles: [String] = []
+        let cell = Self.configuredCell(
+            model: model,
+            commitRename: { committedTitles.append($0) }
+        )
+
+        // The shared field editor only attaches when the cell is in a window.
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 260, height: 40),
+            styleMask: [],
+            backing: .buffered,
+            defer: false
+        )
+        window.contentView?.addSubview(cell)
+        cell.frame = NSRect(x: 0, y: 0, width: 260, height: 40)
+        cell.layoutSubtreeIfNeeded()
+
+        cell.beginInlineRename()
+
+        // On the buggy path, selectText(nil) re-entered the field-editor
+        // machinery and fired controlTextDidEndEditing synchronously,
+        // committing the untouched title. The field must stay editable with
+        // no spurious commit.
+        #expect(committedTitles.isEmpty)
     }
 }
 

--- a/cmuxTests/SidebarAppKitRowCellTests.swift
+++ b/cmuxTests/SidebarAppKitRowCellTests.swift
@@ -1103,6 +1103,10 @@ struct SidebarAppKitRowCellTests {
 
         cell.beginInlineRename()
 
+        // Editing must actually start (the field editor attaches), not merely
+        // avoid a spurious commit.
+        #expect(cell.renameField.currentEditor() != nil)
+
         // On the buggy path, selectText(nil) re-entered the field-editor
         // machinery and fired controlTextDidEndEditing synchronously,
         // committing the untouched title. The field must stay editable with


### PR DESCRIPTION
## Summary

Fixes the workspace double-click inline rename flashing and committing instantly on the AppKit sidebar (regression of #8270 / #8390). Double-clicking a workspace name created the field and it took first responder, but the field editor was torn down ~1 ms later and the untouched title was committed before the user could type.

Closes https://github.com/manaflow-ai/cmux/issues/9495.

## Root cause

`SidebarWorkspaceRowTableCellView.beginInlineRename()` called `window.makeFirstResponder(renameField)` (attaches the field editor, begins editing) and then `renameField.selectText(nil)`. The extra `selectText(nil)` re-enters AppKit's field-editor machinery and synchronously fires `controlTextDidEndEditing`, which `SidebarRowInlineRenameField` honors by committing `stringValue` — the pre-filled, unchanged title.

## How the root cause was isolated

A `firstResponder` probe in `controlTextDidEndEditing` showed the responder at blur time was still the shared field editor (`NSTextView`), not the terminal (`GhosttyNSView`) — so the editing session was being torn down and restarted synchronously inside `beginInlineRename`, not stolen by async focus reconciliation. The teardown aligned to the single call that followed `makeFirstResponder` in the same stack frame: `selectText(nil)`. Removing it (an editable `NSTextField` already selects all on becoming first responder) eliminated the spurious commit.

Debug timeline before / after:

```
# before (every double-click, 100% reproducible)
sidebar.table.doubleClick row=1
sidebar.row.beginInlineRename tookFocus=1
sidebar.row.rename.endEditing isHidden=false   ← +1 ms, spurious commit
workspace.customTitle.write title=<unchanged>

# after
sidebar.row.beginInlineRename tookFocus=1
sidebar.row.rename.beginEditing                  ← field editor attaches, stays
( … user types … )
workspace.customTitle.write title=<new>          ← commit only on Enter
sidebar.row.rename.endEditing isHidden=true      ← guarded, no double-commit
```

## Changes

- `Sources/Sidebar/AppKitList/Cells/SidebarWorkspaceRowCellView.swift`
  - `beginInlineRename()`: removed the redundant `selectText(nil)` after `makeFirstResponder` (the fix). Also lay out before attaching the field editor so the field's frame is stable.
  - `SidebarRowInlineRenameField.controlTextDidBeginEditing`: make the shared field editor's background transparent so the white selected-row text is visible (was white-on-white once editing stuck).
- `cmuxTests/SidebarAppKitRowCellTests.swift`: regression test `beginInlineRenameLeavesFieldEditingWithoutCommittingPrefilledTitle` — hosts the cell in a real `NSWindow` (so the field editor attaches), calls `beginInlineRename()`, and asserts `commitRename` is **not** invoked. Fails on the buggy path (selectText → spurious commit), passes with the fix.

## Test plan

- [x] `cmux-unit` `-only-testing:cmuxTests/SidebarAppKitRowCellTests/beginInlineRenameLeavesFieldEditingWithoutCommittingPrefilledTitle` (green with the fix)
- [x] Manual dogfood on a tagged Debug build: double-click workspace name → inline field appears, caret visible, type + Enter commits, Esc cancels.
- [ ] CI: PR is structured as two commits — (1) failing test only, (2) the fix — so the Commits tab shows the test genuinely fails without the fix.

## Notes

- No user-facing strings changed; localization audit: N/A.
- The SwiftUI sidebar path is unaffected (uses a SwiftUI `TextField`), so no change there.

/cc @lawrencecchen

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/9496"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788396133&installation_model_id=21920&pr_number=9496&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F9496&signature=59c111ae83c7a825af91839e310ed612594334a7f50adbc32a266b4e8b4807b4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the AppKit sidebar double-click rename so it no longer commits instantly or flashes; the field stays editable and commits only when expected. Closes #9495.

- **Bug Fixes**
  - Laid out before attaching the field editor and removed the redundant `selectText(nil)` after `makeFirstResponder` to prevent a synchronous end-edit and spurious commit.
  - Made the shared field editor transparent during rename and restored its prior styling to avoid leaks; the regression test now hosts the cell in a real window, asserts the editor attaches, and no prefilled title is committed; scoped the focus debug log to `#if DEBUG`.

<sup>Written for commit b8fd6cd2478c5d953e131817663061278737d775. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/9496?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved inline workspace renaming so the rename field is immediately editable and remains visible over selected rows.
  * Prevented unchanged names from being committed prematurely when renaming begins.
  * Preserved the rename field’s normal styling after editing ends.
* **Tests**
  * Added regression coverage for field-editor attachment, title editing, and rename commit behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->