### PR TITLE
Make the mobile browser stream self-healing

### DIFF
--- a/Packages/Shared/CMUXMobileCore/Sources/CMUXMobileCore/MobileBrowserStreamPacing.swift
+++ b/Packages/Shared/CMUXMobileCore/Sources/CMUXMobileCore/MobileBrowserStreamPacing.swift
@@ -8,6 +8,8 @@ public struct MobileBrowserStreamPacing: Equatable, Sendable {
     public let minimumFrameInterval: TimeInterval
     /// Quiet interval before a lossless settle frame.
     public let settleDelay: TimeInterval
+    /// Interval a full unacked window may stall before it is treated as lost.
+    public let ackStallTimeout: TimeInterval
     /// Most recently allocated sequence, or zero before the first frame.
     public private(set) var lastSequence: UInt64 = 0
     /// Sequences still awaiting cumulative acknowledgement.
@@ -16,21 +18,26 @@ public struct MobileBrowserStreamPacing: Equatable, Sendable {
     private var dirtyGeneration: UInt64 = 0
     private var hasDirtyFrame = false
     private var settleFramePending = false
+    private var reconcileFramePending = false
     private var lastDirtyAt: TimeInterval?
     private var lastEmissionAt: TimeInterval?
+    private var windowFullSince: TimeInterval?
 
     /// Creates pacing state for a new subscription.
     public init(
         maximumUnackedFrames: Int = 3,
         minimumFrameInterval: TimeInterval = 0.033,
-        settleDelay: TimeInterval = 0.300
+        settleDelay: TimeInterval = 0.300,
+        ackStallTimeout: TimeInterval = 3.0
     ) {
         precondition(maximumUnackedFrames > 0)
         precondition(minimumFrameInterval >= 0)
         precondition(settleDelay >= 0)
+        precondition(ackStallTimeout > 0)
         self.maximumUnackedFrames = maximumUnackedFrames
         self.minimumFrameInterval = minimumFrameInterval
         self.settleDelay = settleDelay
+        self.ackStallTimeout = ackStallTimeout
     }
 
     /// Coalesces a new dirty signal and restarts the settle deadline.
@@ -48,19 +55,50 @@ public struct MobileBrowserStreamPacing: Equatable, Sendable {
         noteDirty(at: timestamp)
     }
 
+    /// Requests one lossless reconciliation frame from an otherwise idle stream.
+    ///
+    /// Liveness normally depends on page-driven dirty signals; those can be
+    /// silently lost (WebKit suspends `requestAnimationFrame` for occluded
+    /// windows, killing the injected beacon). A periodic reconciliation frame
+    /// bounds how long the subscriber can display stale content when that
+    /// happens. No-op while dirty or settle work is already pending.
+    public mutating func requestSettleReconciliation() {
+        guard !hasDirtyFrame, !settleFramePending else { return }
+        reconcileFramePending = true
+    }
+
     /// Chooses the next capture, deadline, or flow-control state.
-    public func decision(at timestamp: TimeInterval) -> MobileBrowserStreamPacingDecision {
+    ///
+    /// A full unacked window does not block forever: after `ackStallTimeout`
+    /// with no acknowledgement progress the in-flight frames are treated as
+    /// lost (subscriber not yet wired, connection route swap) and the window
+    /// is abandoned in favor of a fresh capture. Frames are self-contained
+    /// images, so recapturing instead of retransmitting is always safe.
+    /// Without this, acknowledgements for frames the subscriber never saw can
+    /// never arrive and the stream deadlocks.
+    public mutating func decision(at timestamp: TimeInterval) -> MobileBrowserStreamPacingDecision {
         guard unackedSequences.count < maximumUnackedFrames else {
-            return .flowControlled
+            guard let windowFullSince else { return .flowControlled }
+            let stallRemaining = windowFullSince + ackStallTimeout - timestamp
+            if stallRemaining > 0 {
+                return .wait(stallRemaining)
+            }
+            unackedSequences.removeAll()
+            self.windowFullSince = nil
+            noteDirty(at: timestamp)
+            return .captureJPEG(dirtyGeneration: dirtyGeneration)
         }
         if let lastEmissionAt {
             let cadenceRemaining = minimumFrameInterval - max(0, timestamp - lastEmissionAt)
-            if cadenceRemaining > 0, hasDirtyFrame || settleFramePending {
+            if cadenceRemaining > 0, hasDirtyFrame || settleFramePending || reconcileFramePending {
                 return .wait(cadenceRemaining)
             }
         }
         if hasDirtyFrame {
             return .captureJPEG(dirtyGeneration: dirtyGeneration)
+        }
+        if reconcileFramePending {
+            return .capturePNG(dirtyGeneration: dirtyGeneration)
         }
         if settleFramePending, let lastDirtyAt {
             let settleRemaining = settleDelay - max(0, timestamp - lastDirtyAt)
@@ -87,6 +125,9 @@ public struct MobileBrowserStreamPacing: Equatable, Sendable {
         guard unackedSequences.count < maximumUnackedFrames else { return nil }
         lastSequence &+= 1
         unackedSequences.append(lastSequence)
+        if unackedSequences.count >= maximumUnackedFrames, windowFullSince == nil {
+            windowFullSince = timestamp
+        }
         lastEmissionAt = timestamp
         guard observedDirtyGeneration == dirtyGeneration else { return lastSequence }
         switch format {
@@ -95,6 +136,7 @@ public struct MobileBrowserStreamPacing: Equatable, Sendable {
         case .png:
             hasDirtyFrame = false
             settleFramePending = false
+            reconcileFramePending = false
         case .unknown:
             break
         }
@@ -104,5 +146,8 @@ public struct MobileBrowserStreamPacing: Equatable, Sendable {
     /// Applies a cumulative frame acknowledgement.
     public mutating func acknowledge(sequence: UInt64) {
         unackedSequences.removeAll { $0 <= sequence }
+        if unackedSequences.count < maximumUnackedFrames {
+            windowFullSince = nil
+        }
     }
 }

--- a/Packages/Shared/CMUXMobileCore/Tests/CMUXMobileCoreTests/MobileBrowserStreamTests.swift
+++ b/Packages/Shared/CMUXMobileCore/Tests/CMUXMobileCoreTests/MobileBrowserStreamTests.swift
@@ -217,6 +217,23 @@ struct MobileBrowserStreamTests {
     }
 
     @Test
+    func fullUnackedWindowRecoversAfterAckStallInsteadOfDeadlocking() {
+        var pacing = MobileBrowserStreamPacing()
+        pacing.noteDirty(at: 0)
+        #expect(pacing.recordEmission(format: .jpeg, observedDirtyGeneration: 1, at: 0) == 1)
+        pacing.noteDirty(at: 0.04)
+        #expect(pacing.recordEmission(format: .jpeg, observedDirtyGeneration: 2, at: 0.04) == 2)
+        pacing.noteDirty(at: 0.08)
+        #expect(pacing.recordEmission(format: .jpeg, observedDirtyGeneration: 3, at: 0.08) == 3)
+        // No acknowledgement ever arrives: the subscriber never saw these
+        // frames (not yet wired, or the connection route swapped). The stream
+        // must not deadlock waiting for acks that cannot come; after the
+        // stall timeout it abandons the window and captures fresh.
+        #expect(pacing.decision(at: 60) == .captureJPEG(dirtyGeneration: 4))
+        #expect(pacing.unackedSequences.isEmpty)
+    }
+
+    @Test
     func replayedInputMarksStreamDirtyAndRequestsCapture() {
         var pacing = MobileBrowserStreamPacing()
         #expect(pacing.decision(at: 42) == .idle)

--- a/Packages/Shared/CMUXMobileCore/Tests/CMUXMobileCoreTests/MobileBrowserStreamTests.swift
+++ b/Packages/Shared/CMUXMobileCore/Tests/CMUXMobileCoreTests/MobileBrowserStreamTests.swift
@@ -210,7 +210,12 @@ struct MobileBrowserStreamTests {
         pacing.noteDirty(at: 0.040)
         #expect(pacing.recordEmission(format: .jpeg, observedDirtyGeneration: 3, at: 0.066) == 3)
         pacing.noteDirty(at: 0.070)
-        #expect(pacing.decision(at: 1) == .flowControlled)
+        // Window full at 0.066: capture pauses, bounded by the stall deadline.
+        guard case let .wait(stallRemaining) = pacing.decision(at: 1) else {
+            Issue.record("Expected ack-stall deadline while the window is full")
+            return
+        }
+        #expect(abs(stallRemaining - 2.066) < 0.000_001)
         pacing.acknowledge(sequence: 2)
         #expect(pacing.unackedSequences == [3])
         #expect(pacing.decision(at: 1) == .captureJPEG(dirtyGeneration: 4))
@@ -231,6 +236,52 @@ struct MobileBrowserStreamTests {
         // stall timeout it abandons the window and captures fresh.
         #expect(pacing.decision(at: 60) == .captureJPEG(dirtyGeneration: 4))
         #expect(pacing.unackedSequences.isEmpty)
+    }
+
+    @Test
+    func ackProgressReplacesStallDeadlineWithNormalPacing() {
+        var pacing = MobileBrowserStreamPacing()
+        for step in 0..<3 {
+            pacing.noteDirty(at: Double(step) * 0.04)
+            _ = pacing.recordEmission(
+                format: .jpeg,
+                observedDirtyGeneration: UInt64(step + 1),
+                at: Double(step) * 0.04
+            )
+        }
+        pacing.noteDirty(at: 0.12)
+        pacing.acknowledge(sequence: 3)
+        #expect(pacing.unackedSequences.isEmpty)
+        // A drained window must not inherit the old stall anchor: the next
+        // fill measures its own stall from its own fill time.
+        #expect(pacing.decision(at: 0.12) == .captureJPEG(dirtyGeneration: 4))
+    }
+
+    @Test
+    func idleReconciliationEmitsOneSettleFrame() {
+        var pacing = MobileBrowserStreamPacing()
+        pacing.noteDirty(at: 0)
+        _ = pacing.recordEmission(format: .jpeg, observedDirtyGeneration: 1, at: 0)
+        #expect(pacing.decision(at: 0.300) == .capturePNG(dirtyGeneration: 1))
+        _ = pacing.recordEmission(format: .png, observedDirtyGeneration: 1, at: 0.300)
+        pacing.acknowledge(sequence: 2)
+        #expect(pacing.decision(at: 5) == .idle)
+
+        pacing.requestSettleReconciliation()
+
+        #expect(pacing.decision(at: 10.300) == .capturePNG(dirtyGeneration: 1))
+        _ = pacing.recordEmission(format: .png, observedDirtyGeneration: 1, at: 10.300)
+        #expect(pacing.decision(at: 11) == .idle)
+    }
+
+    @Test
+    func settleReconciliationDoesNotPreemptPendingDirtyWork() {
+        var pacing = MobileBrowserStreamPacing()
+        pacing.noteDirty(at: 0)
+
+        pacing.requestSettleReconciliation()
+
+        #expect(pacing.decision(at: 5) == .captureJPEG(dirtyGeneration: 1))
     }
 
     @Test

--- a/Sources/Mobile/MobileBrowserStreamSession.swift
+++ b/Sources/Mobile/MobileBrowserStreamSession.swift
@@ -221,8 +221,12 @@ final class MobileBrowserStreamSession {
         format: MobileBrowserFrameFormat,
         dirtyGeneration: UInt64
     ) async -> Bool {
+        // Captured once so the snapshot, its measured page size, and the
+        // committed-frame bookkeeping all describe the SAME web view even
+        // if the panel replaces its web view while the capture awaits.
+        let capturedWebView = panel.webView
         do {
-            let pageSize = panel.webView.bounds.size
+            let pageSize = capturedWebView.bounds.size
             // Continuous JPEG frames drive motion (scroll, drag, animation). The
             // active dirty loop must not block each snapshot on a synchronized
             // screen-update cycle. `false` captures the currently committed render
@@ -240,12 +244,15 @@ final class MobileBrowserStreamSession {
             let captureStart = DispatchTime.now()
             #endif
             let image = try await BrowserScreenshotWebViewSnapshotter.captureVisibleViewport(
-                from: panel.webView,
+                from: capturedWebView,
                 afterScreenUpdates: waitForScreenUpdate,
                 timeout: forceSynchronizedFirstCapture ? Self.firstCaptureTimeout : Self.captureTimeout
             )
             guard !isStopped, !Task.isCancelled else { return false }
-            if waitForScreenUpdate {
+            // A capture that raced a web view replacement proves nothing about
+            // the panel's CURRENT web view: its first synchronized capture is
+            // still owed, or the next first frame is the blank bitmap again.
+            if waitForScreenUpdate, panel.webView === capturedWebView {
                 hasCapturedCommittedFrame = true
                 synchronizedFirstCaptureFailures = 0
             }
@@ -295,7 +302,9 @@ final class MobileBrowserStreamSession {
         } catch is CancellationError {
             return false
         } catch {
-            if !hasCapturedCommittedFrame {
+            // A stale capture's failure must not consume the replacement web
+            // view's bounded synchronized-first-capture attempts.
+            if !hasCapturedCommittedFrame, panel.webView === capturedWebView {
                 synchronizedFirstCaptureFailures += 1
             }
             return false

--- a/Sources/Mobile/MobileBrowserStreamSession.swift
+++ b/Sources/Mobile/MobileBrowserStreamSession.swift
@@ -31,6 +31,23 @@ final class MobileBrowserStreamSession {
     private var isDriving = false
     private var needsDrive = false
     private var isStopped = false
+    /// Whether at least one synchronized (post-commit) capture succeeded for
+    /// the current web view. Until then every capture waits for WebKit's next
+    /// committed render, because an unsynchronized snapshot of a freshly
+    /// (re)hosted or still-loading web view is a blank white bitmap.
+    private var hasCapturedCommittedFrame = false
+    private var synchronizedFirstCaptureFailures = 0
+
+    /// Bound on the synchronized first capture so an occluded render host
+    /// cannot wedge the stream; expiry falls back through the retry path.
+    private static let firstCaptureTimeout: TimeInterval = 1.0
+    /// Bound on every other capture; a synchronized settle snapshot waits on
+    /// WebKit's next commit, which an occluded host may never produce.
+    private static let captureTimeout: TimeInterval = 2.0
+    /// Synchronized first-capture attempts before degrading to unsynchronized.
+    private static let maximumSynchronizedFirstCaptureFailures = 3
+    /// Quiet interval before an idle stream emits one reconciliation frame.
+    private static let idleReconcileInterval: TimeInterval = 10.0
 
     init(
         connectionID: UUID,
@@ -99,6 +116,8 @@ final class MobileBrowserStreamSession {
         case .stateChanged:
             scheduleStateEmission()
         case .webViewReplaced:
+            hasCapturedCommittedFrame = false
+            synchronizedFirstCaptureFailures = 0
             noteDirty()
             emitStateImmediately()
         case let .dialog(dialog):
@@ -185,7 +204,14 @@ final class MobileBrowserStreamSession {
             case let .wait(interval):
                 scheduleDeadline(after: interval)
                 return
-            case .flowControlled, .idle:
+            case .flowControlled:
+                // Pacing converts a full window into bounded `.wait`s and then
+                // ack-stall recovery, so this is defensive: re-check rather
+                // than park with no deadline armed.
+                scheduleDeadline(after: pacing.ackStallTimeout)
+                return
+            case .idle:
+                scheduleIdleReconciliation()
                 return
             }
         }
@@ -201,16 +227,28 @@ final class MobileBrowserStreamSession {
             // active dirty loop must not block each snapshot on a synchronized
             // screen-update cycle. `false` captures the currently committed render
             // without that wait, while the rare, correctness-critical lossless PNG
-            // settle frame keeps the synchronized path.
-            let waitForScreenUpdate = (format == .png)
+            // settle frame keeps the synchronized path. The FIRST capture for a
+            // web view is always synchronized: it races the view's first commit
+            // after offscreen rehosting or replacement, and the unsynchronized
+            // snapshot of that state is a blank white bitmap the subscriber
+            // would display until the next dirty signal. Bounded by a timeout
+            // and a fallback so an occluded host cannot wedge the stream.
+            let forceSynchronizedFirstCapture = !hasCapturedCommittedFrame
+                && synchronizedFirstCaptureFailures < Self.maximumSynchronizedFirstCaptureFailures
+            let waitForScreenUpdate = (format == .png) || forceSynchronizedFirstCapture
             #if DEBUG
             let captureStart = DispatchTime.now()
             #endif
             let image = try await BrowserScreenshotWebViewSnapshotter.captureVisibleViewport(
                 from: panel.webView,
-                afterScreenUpdates: waitForScreenUpdate
+                afterScreenUpdates: waitForScreenUpdate,
+                timeout: forceSynchronizedFirstCapture ? Self.firstCaptureTimeout : Self.captureTimeout
             )
             guard !isStopped, !Task.isCancelled else { return false }
+            if waitForScreenUpdate {
+                hasCapturedCommittedFrame = true
+                synchronizedFirstCaptureFailures = 0
+            }
             panel.updateMobileBrowserStreamMirror(image)
             #if DEBUG
             let encodeStart = DispatchTime.now()
@@ -257,6 +295,9 @@ final class MobileBrowserStreamSession {
         } catch is CancellationError {
             return false
         } catch {
+            if !hasCapturedCommittedFrame {
+                synchronizedFirstCaptureFailures += 1
+            }
             return false
         }
     }
@@ -271,6 +312,28 @@ final class MobileBrowserStreamSession {
                 try await clock.sleep(for: max(0, interval))
                 guard !Task.isCancelled else { return }
                 self?.requestDrive()
+            } catch {}
+        }
+    }
+
+    /// Schedules one lossless reconciliation frame after a quiet interval.
+    ///
+    /// An idle stream's correctness otherwise hangs entirely on page-driven
+    /// dirty signals, which are silently lost when WebKit suspends
+    /// `requestAnimationFrame` for the occluded offscreen host. This bounds
+    /// how long the phone can display a stale (or blank first) frame to
+    /// `idleReconcileInterval`. Any real dirty signal cancels it via
+    /// `requestDrive`, and a fresh one is armed when the stream idles again.
+    private func scheduleIdleReconciliation() {
+        guard !isStopped else { return }
+        deadlineTask?.cancel()
+        let clock = clock
+        deadlineTask = Task { @MainActor [weak self, clock] in
+            do {
+                try await clock.sleep(for: Self.idleReconcileInterval)
+                guard !Task.isCancelled, let self, !self.isStopped else { return }
+                self.pacing.requestSettleReconciliation()
+                self.requestDrive()
             } catch {}
         }
     }


### PR DESCRIPTION
Fixes two failure modes of the iOS browser mirror that both required a manual reload to escape.

**White first frame.** On stream start the Mac snapshots the web view immediately after reparenting it into the offscreen render host (or after hidden-webview discard replaced it). The unsynchronized snapshot of that uncommitted state is a blank white bitmap, and nothing recaptures if the page's dirty beacon is dead, because WebKit suspends `requestAnimationFrame` for occluded windows and the render host is deliberately near-invisible. The first capture for a (re)hosted web view now waits for WebKit's next committed render, bounded by a 1s timeout and a 3-attempt fallback so an occluded host cannot wedge the stream. Every other capture gets a 2s timeout for the same reason.

**Permanent "Waiting for Browser".** Frame emission stops after 3 unacked frames, and acks only come from frames the phone actually processed. Losing the in-flight frames (phone-side wiring race at start, connection route swap) deadlocked the stream: acks for frames the subscriber never saw can never arrive, and there was no retransmission timeout. A full window now converts to a bounded wait; after 3s with no ack progress the window is abandoned and a fresh frame is captured. Frames are self-contained images, so recapture is a safe retransmission.

**Idle reconciliation.** As a backstop for every lost-dirty-signal path, an idle stream emits one lossless settle frame after 10s of quiet, bounding any staleness (including a white first frame that slipped through) to 10s at ~0.1 frames/sec cost.

Commit 1 adds the ack-stall regression test only (red); commit 2 adds the fix (green). `CMUXMobileCore` package suite: 352 tests pass. All changes are Mac-side (`MobileBrowserStreamPacing`, `MobileBrowserStreamSession`); the iOS app is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/9498"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788396349&installation_model_id=21920&pr_number=9498&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F9498&signature=a16f7eff6bd18d4c5c946240a4dd34c5b0dd0b7387f923a96e60867d80d722b7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes the iOS browser mirror self-healing to prevent white first frames and permanent “Waiting for Browser” states. Adds bounded timeouts and a periodic settle frame so the stream recovers without manual reloads.

- **Bug Fixes**
  - Ack-stall recovery: if 3 frames go unacked for 3s, drop the window and recapture to unblock the stream.
  - First capture sync: the first frame after rehosting waits for a WebKit commit (1s timeout, up to 3 tries; others use 2s) and is scoped to the captured web view so a replacement race doesn’t consume retries or mark committed.
  - Idle reconciliation: emit one lossless PNG after 10s of quiet; does not preempt pending dirty work.
  - Tests and scope: added tests for ack-stall recovery, stall-anchor reset, and idle reconciliation; all changes are Mac-side in `MobileBrowserStreamPacing` and `MobileBrowserStreamSession` under `CMUXMobileCore`; iOS app unchanged.

<sup>Written for commit 06c154d6fa626ead81610969528aa474941c604d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/9498?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved initial screen capture reliability to reduce blank first frames.
  * Added recovery when frame acknowledgements stall for too long.
  * Improved synchronization after replacing the web view.
  * Added fallback handling for screenshot capture failures.

* **Performance**
  * Added lossless reconciliation captures during idle periods and flow-control delays.
  * Improved frame pacing and recovery while maintaining responsive updates.
  * Added bounded retries and timeouts for more reliable capture handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->