### PR TITLE
Fix custom sidebar function return and file-scope bindings

### DIFF
--- a/Packages/macOS/CmuxSwiftRender/Sources/CmuxSwiftRender/SwiftViewInterpreter.swift
+++ b/Packages/macOS/CmuxSwiftRender/Sources/CmuxSwiftRender/SwiftViewInterpreter.swift
@@ -63,6 +63,7 @@ public struct SwiftViewInterpreter: Sendable {
         onLargeStack {
             let env = EvalEnvironment(values: state)
             self.registerFunctions(program.file.statements, env)
+            self.bindTopLevelVariables(program.file.statements, env)
             for item in program.file.statements {
                 if let expr = item.item.as(ExprSyntax.self), let node = self.evalView(expr, env) {
                     // A tripped node budget means the tree was truncated
@@ -110,6 +111,16 @@ public struct SwiftViewInterpreter: Sendable {
         for item in items {
             if let fn = item.item.as(FunctionDeclSyntax.self) {
                 env.defineFunction(fn.name.text, fn)
+            }
+        }
+    }
+
+    /// Binds file-scope variables into the root environment so user functions
+    /// can resolve constants declared outside their bodies.
+    private func bindTopLevelVariables(_ items: CodeBlockItemListSyntax, _ env: EvalEnvironment) {
+        for item in items {
+            if let decl = item.item.as(VariableDeclSyntax.self) {
+                applyBinding(decl, env)
             }
         }
     }
@@ -296,7 +307,7 @@ public struct SwiftViewInterpreter: Sendable {
             // called in view position; evaluate its body as view items.
             if let decl = env.lookupFunction(ref.baseName.text), let body = decl.body {
                 let scope = bindParameters(decl, call, env)
-                let nodes = evalItems(body.statements, scope)
+                let nodes = evalItemsResult(body.statements, scope).nodes
                 if nodes.count == 1 { return nodes[0] }
                 return RenderNode(kind: .vstack, children: nodes)
             }
@@ -306,10 +317,28 @@ public struct SwiftViewInterpreter: Sendable {
 
     // MARK: - ViewBuilder statements
 
+    /// The rendered nodes from a block and whether an explicit `return`
+    /// terminated the current function evaluation.
+    private enum ViewBlockResult {
+        case completed([RenderNode])
+        case returned([RenderNode])
+
+        var nodes: [RenderNode] {
+            switch self {
+            case let .completed(nodes), let .returned(nodes):
+                nodes
+            }
+        }
+    }
+
     private func evalItems(_ items: CodeBlockItemListSyntax, _ env: EvalEnvironment) -> [RenderNode] {
+        evalItemsResult(items, env).nodes
+    }
+
+    private func evalItemsResult(_ items: CodeBlockItemListSyntax, _ env: EvalEnvironment) -> ViewBlockResult {
         env.budget.enter()
         defer { env.budget.leave() }
-        guard !env.budget.exceeded, !env.budget.nodesExceeded else { return [] }
+        guard !env.budget.exceeded, !env.budget.nodesExceeded else { return .completed([]) }
         registerFunctions(items, env)
         var out: [RenderNode] = []
         for item in items {
@@ -320,21 +349,39 @@ public struct SwiftViewInterpreter: Sendable {
             if let decl = node.as(VariableDeclSyntax.self) {
                 applyBinding(decl, env)
             } else if let loop = node.as(ForStmtSyntax.self) {
-                out += evalFor(loop, env)
+                switch evalFor(loop, env) {
+                case let .completed(nodes):
+                    out += nodes
+                case let .returned(nodes):
+                    return .returned(nodes)
+                }
             } else if let ifExpr = ifExpression(node) {
-                out += evalIf(ifExpr, env)
+                switch evalIf(ifExpr, env) {
+                case let .completed(nodes):
+                    out += nodes
+                case let .returned(nodes):
+                    return .returned(nodes)
+                }
             } else if let switchExpr = switchExpression(node) {
-                out += evalSwitch(switchExpr, env)
+                switch evalSwitch(switchExpr, env) {
+                case let .completed(nodes):
+                    out += nodes
+                case let .returned(nodes):
+                    return .returned(nodes)
+                }
             } else if let ret = node.as(ReturnStmtSyntax.self), let expr = ret.expression {
                 // A view helper with an explicit `return SomeView` (or
                 // `return ForEach(...) { }`) renders its returned expression,
-                // not nothing.
+                // not nothing, and exits the function instead of appending to
+                // the surrounding builder output.
+                var returned: [RenderNode] = []
                 if let call = expr.as(FunctionCallExprSyntax.self), isForEach(call) {
-                    out += evalForEach(call, env)
+                    returned = evalForEach(call, env)
                 } else if let child = evalView(expr, env) {
                     env.budget.recordNode()
-                    out.append(child)
+                    returned = [child]
                 }
+                return .returned(returned)
             } else if let expr = node.as(ExprSyntax.self) {
                 if let call = expr.as(FunctionCallExprSyntax.self), isForEach(call) {
                     out += evalForEach(call, env)
@@ -344,7 +391,7 @@ public struct SwiftViewInterpreter: Sendable {
                 }
             }
         }
-        return out
+        return .completed(out)
     }
 
     /// Extracts an `if` from a code-block item, whether it appears directly
@@ -530,15 +577,15 @@ public struct SwiftViewInterpreter: Sendable {
 
     /// Evaluates a view-position `switch`: the first matching (or `default`)
     /// case's statements are rendered.
-    private func evalSwitch(_ switchExpr: SwitchExprSyntax, _ env: EvalEnvironment) -> [RenderNode] {
+    private func evalSwitch(_ switchExpr: SwitchExprSyntax, _ env: EvalEnvironment) -> ViewBlockResult {
         let subject = expressions.eval(switchExpr.subject, env)
         for caseSyntax in switchExpr.cases {
             guard let switchCase = caseSyntax.as(SwitchCaseSyntax.self) else { continue }
             if switchCaseMatches(switchCase.label, subject, env) {
-                return evalItems(switchCase.statements, env.makeChild())
+                return evalItemsResult(switchCase.statements, env.makeChild())
             }
         }
-        return []
+        return .completed([])
     }
 
     /// Whether a `switch` case label matches `subject` (literal/`.member`
@@ -561,35 +608,40 @@ public struct SwiftViewInterpreter: Sendable {
         }
     }
 
-    private func evalFor(_ loop: ForStmtSyntax, _ env: EvalEnvironment) -> [RenderNode] {
+    private func evalFor(_ loop: ForStmtSyntax, _ env: EvalEnvironment) -> ViewBlockResult {
         guard let name = loop.pattern.as(IdentifierPatternSyntax.self)?.identifier.text,
               let sequence = expressions.eval(loop.sequence, env),
-              let values = sequence.iterationValues else { return [] }
+              let values = sequence.iterationValues else { return .completed([]) }
         var out: [RenderNode] = []
         for value in values {
             if env.budget.nodesExceeded { break } // same early-out as evalForEach
             let scope = env.makeChild()
             scope.define(name, value)
-            out += evalItems(loop.body.statements, scope)
+            switch evalItemsResult(loop.body.statements, scope) {
+            case let .completed(nodes):
+                out += nodes
+            case let .returned(nodes):
+                return .returned(nodes)
+            }
         }
-        return out
+        return .completed(out)
     }
 
-    private func evalIf(_ ifExpr: IfExprSyntax, _ env: EvalEnvironment) -> [RenderNode] {
+    private func evalIf(_ ifExpr: IfExprSyntax, _ env: EvalEnvironment) -> ViewBlockResult {
         // The then-branch runs in a child scope so `if let x = …` bindings are
         // visible to it.
         let scope = env.makeChild()
         if conditionsPass(ifExpr.conditions, scope) {
-            return evalItems(ifExpr.body.statements, scope)
+            return evalItemsResult(ifExpr.body.statements, scope)
         }
-        guard let elseBody = ifExpr.elseBody else { return [] }
+        guard let elseBody = ifExpr.elseBody else { return .completed([]) }
         if let block = elseBody.as(CodeBlockSyntax.self) {
-            return evalItems(block.statements, env.makeChild())
+            return evalItemsResult(block.statements, env.makeChild())
         }
         if let elseIf = elseBody.as(IfExprSyntax.self) {
             return evalIf(elseIf, env)
         }
-        return []
+        return .completed([])
     }
 
     /// Evaluates an `if`/`guard` condition list against `scope`, binding any

--- a/Packages/macOS/CmuxSwiftRender/Tests/CmuxSwiftRenderTests/SwiftViewInterpreterTests.swift
+++ b/Packages/macOS/CmuxSwiftRender/Tests/CmuxSwiftRenderTests/SwiftViewInterpreterTests.swift
@@ -319,6 +319,32 @@ import Testing
         #expect(node?.children.first?.children.first?.text == "one")
     }
 
+    @Test func returnExitsViewFunctionBeforeFallthrough() {
+        let node = interp.evaluate("""
+        func badge(_ w) -> some View {
+            if w.unread == 0 { return AnyView(Text("EARLY")) }
+            return AnyView(Text("FALLTHROUGH"))
+        }
+        VStack { badge(w) }
+        """, state: [
+            "w": .object(["unread": .int(0)]),
+        ])
+        #expect(node?.kind == .vstack)
+        #expect(node?.children.map(\.text) == ["EARLY"])
+    }
+
+    @Test func topLevelLetIsVisibleInsideFunction() {
+        let node = interp.evaluate("""
+        let MARK = "X:"
+        func label(_ v) -> String { return "\\(MARK)\\(v)" }
+        VStack { Text(label(s)) }
+        """, state: [
+            "s": .string("a-b-c"),
+        ])
+        #expect(node?.kind == .vstack)
+        #expect(node?.children.map(\.text) == ["X:a-b-c"])
+    }
+
     @Test func numberFormattedCurrencyAndReduce() {
         let items = SwiftValue.array([
             .object(["cost": .double(1.5)]),


### PR DESCRIPTION
## Summary

- bind top-level variable declarations into the interpreter's root environment so user functions can resolve file-scope constants
- propagate explicit `return` through view-position `if`, `switch`, and `for` evaluation so a view function exits instead of appending fallthrough nodes
- add focused regression coverage for both reported snippets

Fixes #7945

## Testing

- Red on test-only commit `ca520f1703` on fleet builder `aws-m4pro-6`:
  - `swift test --filter returnExitsViewFunctionBeforeFallthrough` failed because the rendered child was a nested node containing both return paths
  - `swift test --filter topLevelLetIsVisibleInsideFunction` failed with `a-b-c` instead of `X:a-b-c`
- Green on fix commit `7b168f0fd7` on the same fleet builder:
  - both focused `swift test --filter ...` commands passed
  - full `swift test` passed all 68 tests in `CmuxSwiftRender`
- Dev build: cloud fleet path only (no local fallback): `reload-cloud.sh --tag sym7945 --builder fleet --pool-tag tag:macbuilder --slot cmuxs-mac-mini-2.1 --launch` completed with `BUILD_OK`
- Tagged runtime verification over `/tmp/cmux-debug-sym7945.sock`:
  - `sidebar validate`, `sidebar select`, and `sidebar reload` succeeded for both repro sidebars
  - `debug.window.screenshot` showed only `EARLY` after the early return, with no `FALLTHROUGH`
  - the file-scope constant repro rendered `X:a-b-c`
  - quit the tagged app with `pkill -f "DerivedData/cmux-sym7945"` and removed its stale socket

Localization audit: no user-facing strings changed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/9501"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788399687&installation_model_id=21920&pr_number=9501&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F9501&signature=9ffd62dc714b5c7302aa39091f02c5846b90f2b6a61aecc3d4ee14676e53e8ba"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the custom sidebar interpreter in `CmuxSwiftRender` so explicit returns exit view functions and file-scope constants are visible inside user functions.

- **Bug Fixes**
  - Bind top-level `let`/`var` declarations into the root eval environment so helper functions can read file-scope constants.
  - Propagate explicit `return` through view-position `if`, `switch`, and `for` so a view function returns early instead of appending fallthrough nodes.

<sup>Written for commit 7b168f0fd764ba341ae5f62c806aec62a58b9b10. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/9501?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed view helper functions so explicit returns correctly stop further evaluation.
  * Improved return handling across loops, conditionals, switches, and nested view helpers.
  * Top-level constants are now available inside user-defined view functions.

* **Tests**
  * Added coverage for early returns and access to file-scope constants.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->