### PR TITLE
Scope shortcut settings notifications to their config file

### DIFF
--- a/Sources/HostSettingsActions.swift
+++ b/Sources/HostSettingsActions.swift
@@ -97,8 +97,8 @@ final class HostSettingsActions: SettingsHostActions {
         // contents changed; posting again here double-notified every
         // listener. Only post when the reload saw no change, so callers
         // still get exactly one notification either way.
-        if !KeyboardShortcutSettings.settingsFileStore.reload() {
-            KeyboardShortcutSettings.notifySettingsFileDidChange()
+        if !KeyboardShortcutSettings.settingsFileStore.reload(notificationSourceURL: configFileURL) {
+            KeyboardShortcutSettings.notifySettingsFileDidChange(sourceURL: configFileURL)
         }
     }
 

--- a/Sources/KeyboardShortcutSettings.swift
+++ b/Sources/KeyboardShortcutSettings.swift
@@ -1021,7 +1021,12 @@ enum KeyboardShortcutSettings {
         return true
     }
 
-    static func notifySettingsFileDidChange(center: NotificationCenter = .default) { postDidChangeNotification(center: center) }
+    static func notifySettingsFileDidChange(
+        center: NotificationCenter = .default,
+        sourceURL: URL? = nil
+    ) {
+        center.post(name: didChangeNotification, object: sourceURL)
+    }
 
     static func resetShortcut(for action: Action) {
         UserDefaults.standard.removeObject(forKey: action.defaultsKey)

--- a/Sources/KeyboardShortcutSettingsFileStore.swift
+++ b/Sources/KeyboardShortcutSettingsFileStore.swift
@@ -115,9 +115,13 @@ final class CmuxSettingsFileStore {
 
     /// Returns whether the reload posted `didChangeNotification`, so callers
     /// that must guarantee a notification can post one without double-firing.
+    /// When provided, `notificationSourceURL` identifies the reload's post.
     @discardableResult
-    func reload() -> Bool {
-        reload(applyLiveDefaultSideEffects: true)
+    func reload(notificationSourceURL: URL? = nil) -> Bool {
+        reload(
+            applyLiveDefaultSideEffects: true,
+            notificationSourceURL: notificationSourceURL
+        )
     }
 
     func applyDeferredManagedDefaultSideEffects() {
@@ -125,7 +129,10 @@ final class CmuxSettingsFileStore {
     }
 
     @discardableResult
-    private func reload(applyLiveDefaultSideEffects: Bool) -> Bool {
+    private func reload(
+        applyLiveDefaultSideEffects: Bool,
+        notificationSourceURL: URL? = nil
+    ) -> Bool {
         let previousState = synchronized {
             (
                 shortcuts: shortcutsByAction,
@@ -161,7 +168,10 @@ final class CmuxSettingsFileStore {
             || previousState.managedShortcutActions != resolved.managedShortcutActions
             || previousState.whenClauses != resolved.whenClauses
             || previousState.sourcePath != resolved.path {
-            KeyboardShortcutSettings.notifySettingsFileDidChange(center: notificationCenter)
+            KeyboardShortcutSettings.notifySettingsFileDidChange(
+                center: notificationCenter,
+                sourceURL: notificationSourceURL
+            )
             return true
         }
         return false

--- a/cmuxTests/HostSettingsShortcutNotificationTests.swift
+++ b/cmuxTests/HostSettingsShortcutNotificationTests.swift
@@ -56,7 +56,8 @@ struct HostSettingsShortcutNotificationTests {
             forName: KeyboardShortcutSettings.didChangeNotification,
             object: nil,
             queue: nil
-        ) { _ in
+        ) { notification in
+            guard notification.object as? URL == settingsFileURL else { return }
             counter.increment()
         }
         defer { NotificationCenter.default.removeObserver(observer) }


### PR DESCRIPTION
## Summary

- attach the originating config file URL to host shortcut-settings change notifications
- preserve the existing exactly-once behavior for both changed and unchanged reloads
- scope the regression test to its temporary config file so unrelated posts on the default notification center cannot affect its count

Fixes #8159

## Testing

- Red at test-only commit `13e0d4405a`: `gh workflow run test-e2e.yml --repo manaflow-ai/cmux -f ref=issue-8159-flaky-changedsettingsfilepostsoneshortcu -f test_filter="cmuxTests/HostSettingsShortcutNotificationTests"` — [run 30866645886](https://github.com/manaflow-ai/cmux/actions/runs/30866645886) failed both tests because the notifications did not yet carry the expected source URL.
- Green at fix commit `21125da74c`: the same focused workflow command — [run 30867700006](https://github.com/manaflow-ai/cmux/actions/runs/30867700006) passed both tests (2 executed).
- Concurrent app-host coverage: [CI run 30867702054, shard 4](https://github.com/manaflow-ai/cmux/actions/runs/30867702054/job/91863650215) passed `Run notification routing regressions` while the other app-host shards were active. That shard later stopped on an unrelated remote-tmux regression.
- Tagged dev build: `BB_QUEUE_FALLBACK_SECS=1800 reload-cloud.sh --tag sym8159 --builder blacksmith --launch` — [Blacksmith run 30868710953](https://github.com/manaflow-ai/cmux/actions/runs/30868710953) succeeded with no local-build fallback.
- Against `/tmp/cmux-debug-sym8159.sock`, `reload-config` returned `OK Reloaded config`, `ping` returned `PONG`, and a terminal send/read-screen round trip succeeded. The tagged app was then stopped and its stale socket removed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/9502"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788399798&installation_model_id=21920&pr_number=9502&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F9502&signature=4c74f0c4f1e78fd6e6a0f7f9118a0c2a14565f676d6d2e8c5fade708e533caf4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Scopes keyboard shortcut change notifications to the originating config file by attaching its URL to the notification. Keeps exactly-once behavior on reloads and stabilizes the host shortcut notification test. Fixes #8159.

- **Bug Fixes**
  - Posts the change notification with the config file URL as the object so listeners can filter by file.
  - Threads the source URL through reload to avoid double posts while preserving once-per-reload semantics.
  - Updates the test to only count notifications for its temporary config file.

<sup>Written for commit 21125da74c4edf0244a7e61bb639210b3c477555. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/9502?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved shortcut settings change notifications by identifying the settings file that triggered them.
  * Prevented unrelated settings notifications from being treated as changes to the active shortcut configuration.
  * Preserved existing behavior when no source file is provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->