### PR TITLE
Serve cached social preview images without redirects

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -27,6 +27,7 @@
     "db:url": "bash scripts/db-local.sh url",
     "start": "next start",
     "test": "bash scripts/run-tests.sh",
+    "test:social-images": "bash scripts/test-social-image-delivery.sh",
     "test:db:behavior": "bash scripts/run-db-behavior-tests.sh",
     "typecheck": "tsgo --noEmit",
     "lint": "eslint"

--- a/web/proxy.ts
+++ b/web/proxy.ts
@@ -13,6 +13,7 @@ import {
 import { buildAlternateLinkHeader } from "./i18n/seo";
 
 const intlMiddleware = createMiddleware(routing);
+const localeSet = new Set<string>(routing.locales);
 
 export default function middleware(request: NextRequest) {
   const host = request.headers.get("host") ?? "";
@@ -69,6 +70,17 @@ export default function middleware(request: NextRequest) {
 
   if (pathname === "/app-pricing" || pathname === "/app-pricing/") {
     return NextResponse.next();
+  }
+
+  // Social crawlers can retain metadata URLs after the page HTML changes.
+  // Serve the hashed paths emitted by the former metadata-file route through
+  // today's stable endpoint without exposing a redirect to the crawler.
+  const legacyOpenGraphImagePath = legacyOpenGraphImageRewritePath(pathname);
+  if (legacyOpenGraphImagePath) {
+    const url = request.nextUrl.clone();
+    url.pathname = legacyOpenGraphImagePath;
+    url.search = "";
+    return NextResponse.rewrite(url);
   }
 
   // This is a localized image endpoint, but the default-locale URL is
@@ -300,6 +312,32 @@ function setFeatureWorkflowDocLinkHeader(
 
 function requestOrigin(request: NextRequest) {
   return request.nextUrl.origin;
+}
+
+function legacyOpenGraphImageRewritePath(pathname: string): string | undefined {
+  const segments = pathname.split("/").filter(Boolean);
+  let locale = routing.defaultLocale;
+  let imageSegment: string;
+
+  if (segments.length === 1) {
+    imageSegment = segments[0];
+  } else if (segments.length === 2 && localeSet.has(segments[0])) {
+    locale = segments[0] as (typeof routing.locales)[number];
+    imageSegment = segments[1];
+  } else {
+    return undefined;
+  }
+
+  if (
+    !imageSegment.startsWith("opengraph-image-") ||
+    imageSegment.length === "opengraph-image-".length
+  ) {
+    return undefined;
+  }
+
+  return locale === routing.defaultLocale
+    ? "/opengraph-image"
+    : `/${locale}/opengraph-image`;
 }
 
 export const config = {

--- a/web/scripts/test-social-image-delivery.sh
+++ b/web/scripts/test-social-image-delivery.sh
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+base_url="${1:-${CMUX_SOCIAL_IMAGE_BASE_URL:-}}"
+if [[ -z "$base_url" ]]; then
+  echo "Usage: $0 <base-url>" >&2
+  exit 2
+fi
+base_url="${base_url%/}"
+
+scratch_dir="$(mktemp -d "${TMPDIR:-/tmp}/cmux-social-images.XXXXXX")"
+cleanup() {
+  rm -rf -- "$scratch_dir"
+}
+trap cleanup EXIT
+
+fail() {
+  echo "FAIL: $*" >&2
+  exit 1
+}
+
+url_on_test_origin() {
+  local advertised_url="$1"
+  local path_and_query
+
+  advertised_url="${advertised_url//&amp;/&}"
+  case "$advertised_url" in
+    http://*|https://*)
+      path_and_query="${advertised_url#*://}"
+      path_and_query="/${path_and_query#*/}"
+      ;;
+    /*)
+      path_and_query="$advertised_url"
+      ;;
+    *)
+      fail "social image URL is neither absolute nor root-relative: $advertised_url"
+      ;;
+  esac
+
+  printf '%s%s\n' "$base_url" "$path_and_query"
+}
+
+advertised_image_url() {
+  local html_file="$1"
+  local metadata_key="$2"
+  local meta_tag
+  local image_url
+
+  meta_tag="$(
+    grep -oE '<meta[^>]+>' "$html_file" |
+      grep -E "(property|name)=\"${metadata_key}\"" |
+      head -n 1 || true
+  )"
+  [[ -n "$meta_tag" ]] ||
+    fail "served HTML does not advertise ${metadata_key}"
+
+  image_url="$(printf '%s\n' "$meta_tag" | sed -nE 's/.*content="([^"]+)".*/\1/p')"
+  [[ -n "$image_url" ]] ||
+    fail "${metadata_key} metadata has no content URL: $meta_tag"
+
+  printf '%s\n' "$image_url"
+}
+
+assert_direct_png() {
+  local label="$1"
+  local image_url="$2"
+  local headers_file="$scratch_dir/headers-${RANDOM}.txt"
+  local status
+  local content_type
+
+  if ! curl --silent --show-error --head --max-redirs 0 \
+    --dump-header "$headers_file" --output /dev/null "$image_url"; then
+    fail "${label} could not be fetched: $image_url"
+  fi
+
+  status="$(
+    awk '/^HTTP\// { value = $2 } END { print value }' "$headers_file"
+  )"
+  content_type="$(
+    awk '
+      tolower($1) == "content-type:" {
+        value = tolower($2)
+        sub(/\r$/, "", value)
+      }
+      END { print value }
+    ' "$headers_file"
+  )"
+
+  if [[ "$status" != "200" ]]; then
+    cat "$headers_file" >&2
+    fail "${label} returned HTTP ${status:-unknown}, expected 200: $image_url"
+  fi
+  if [[ "$content_type" != "image/png" ]]; then
+    cat "$headers_file" >&2
+    fail "${label} returned ${content_type:-no content-type}, expected image/png: $image_url"
+  fi
+  if grep -Eiq '^location:' "$headers_file"; then
+    cat "$headers_file" >&2
+    fail "${label} returned a Location header: $image_url"
+  fi
+
+  echo "PASS: ${label} -> HTTP 200 image/png with no redirect"
+}
+
+for page_path in "/" "/ja"; do
+  html_file="$scratch_dir/page-${page_path//\//_}.html"
+  page_url="${base_url}${page_path}"
+  curl --silent --show-error --fail --max-redirs 0 \
+    --output "$html_file" "$page_url" ||
+    fail "could not fetch served HTML: $page_url"
+
+  for metadata_key in "og:image" "twitter:image"; do
+    advertised_url="$(advertised_image_url "$html_file" "$metadata_key")"
+    image_url="$(url_on_test_origin "$advertised_url")"
+    assert_direct_png "${page_path} ${metadata_key}" "$image_url"
+  done
+done
+
+# Link-preview services can cache metadata independently from the page HTML.
+# Keep the exact URL reported in #7865 working while those caches expire.
+assert_direct_png \
+  "legacy advertised og:image" \
+  "${base_url}/en/opengraph-image-e6it15?f656b4354be9c5cd"


### PR DESCRIPTION
## Summary

- add a served-page curl regression for the `og:image` and `twitter:image` URLs advertised by `/` and `/ja`
- internally rewrite previously emitted `opengraph-image-*` URLs to the current stable localized image route
- remove the obsolete cache-buster during the internal rewrite so cached preview metadata receives the PNG directly

The stable image routes added after the original report fixed newly fetched HTML, but link-preview services can cache metadata separately from the page. The exact URL reported in the issue still returned `307`; this keeps those cached URLs working while preserving the current canonical routes.

Fixes #7865

## Testing

- Red on test-only commit `7a8afb40d3`: `bash web/scripts/test-social-image-delivery.sh https://cmux.com` passed the four current advertised URLs, then failed the reported legacy URL with `HTTP 307` and a `Location` header.
- Green on fix commit `cf83e81f62`: remote Node 24.18.0/Bun 1.3.14 production build followed by `next start`; all five curl assertions returned `HTTP 200`, `image/png`, and no `Location` header.
- `bun run typecheck`
- `bun run lint -- proxy.ts`
- Fleet tagged build (fleet path; no local fallback): `reload-cloud.sh --tag sym7865 --builder fleet --launch` (`sym7865-98a7de237d63`), succeeded from pushed HEAD.
- Vercel preview: https://cmux-h6iuowkre-manaflow.vercel.app (protected; verified with Vercel automation bypass): `/` and `/ja` advertise the stable localized URLs, and `/opengraph-image`, `/ja/opengraph-image`, and the exact reported cached URL all return direct `HTTP 200 image/png` responses with no `Location` header.
- Tagged runtime check: drove the fleet-built `sym7865` app through `/tmp/cmux-debug-sym7865.sock` and repeated the metadata and response-header checks in its terminal; the tagged app was quit after verification.

## Localization

No user-facing copy changed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/9503"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788400113&installation_model_id=21920&pr_number=9503&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F9503&signature=2780cf820912f0663bd0eacf2cae0005b33ab49ae0b6ddb939ad85bf9971135f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Serve legacy social preview image URLs directly (no redirects) to prevent blank link previews. We rewrite old `opengraph-image-*` paths to the stable localized `/opengraph-image` route and add a regression test. Fixes #7865.

- **Bug Fixes**
  - Middleware rewrites `opengraph-image-*` (optionally locale-prefixed) to the current image route and strips cache-busters, returning PNG with HTTP 200 and no Location header.
  - Adds `web/scripts/test-social-image-delivery.sh` and `npm run test:social-images` to verify `og:image` and `twitter:image` for `/` and `/ja`, plus the reported legacy URL.

<sup>Written for commit cf83e81f620ac74e8a4b97c9cbd7858b762c73a0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/9503?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Social sharing images now use stable, localized image URLs.
  - Legacy hashed Open Graph image links are automatically rewritten to supported endpoints without redirects.
  - Image URLs no longer retain unnecessary query parameters.

- **Bug Fixes**
  - Improved handling of localized paths, including the default locale.
  - Unsupported or malformed legacy image paths are rejected safely.

- **Tests**
  - Added automated checks confirming social image metadata links resolve directly to valid PNG images.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->