### PR TITLE
Prevent stale Claude session state in spawned panes

### DIFF
--- a/Packages/macOS/CmuxTerminal/Sources/CmuxTerminal/Spawn/TerminalSurface+StartupEnvironment.swift
+++ b/Packages/macOS/CmuxTerminal/Sources/CmuxTerminal/Spawn/TerminalSurface+StartupEnvironment.swift
@@ -265,8 +265,8 @@ extension TerminalSurface {
     }
 
     /// Merges base, additional, and override environments with key
-    /// protection, Claude auth-selection inheritance, and config-dir
-    /// normalization.
+    /// protection, independent Claude launch sanitization, auth-selection
+    /// inheritance, and config-dir normalization.
     public static func mergedStartupEnvironment(
         base: [String: String],
         protectedKeys: Set<String>,
@@ -284,6 +284,9 @@ extension TerminalSurface {
         }
         for (key, value) in initialEnvironmentOverrides where !protectedKeys.contains(key) {
             merged[key] = value
+        }
+        for key in ClaudeSessionEnvironmentPolicy().inheritedIndependentLaunchKeys {
+            merged.removeValue(forKey: key)
         }
         if let claudeConfigDir = merged["CLAUDE_CONFIG_DIR"], !claudeConfigDir.isEmpty {
             merged["CLAUDE_CONFIG_DIR"] = ClaudeConfigDirectoryPath.preferredPath(claudeConfigDir)

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -869,6 +869,14 @@ class GhosttyApp {
     }
 
     private func initializeGhostty() {
+        // Embedded Ghostty snapshots the host process environment here and
+        // clones it into every surface. A GUI launch from inside Claude Code is
+        // an independent session boundary, so remove the launching session's
+        // identity and trust state before Ghostty captures that snapshot.
+        for key in ClaudeSessionEnvironmentPolicy().inheritedIndependentLaunchKeys {
+            unsetenv(key)
+        }
+
         // Ensure TUI apps can use colors even if NO_COLOR is set in the launcher env.
         if getenv("NO_COLOR") != nil {
             unsetenv("NO_COLOR")

--- a/cmuxTests/GhosttyTerminalStartupEnvironmentTests.swift
+++ b/cmuxTests/GhosttyTerminalStartupEnvironmentTests.swift
@@ -1,5 +1,6 @@
-import Foundation
+import CMUXAgentLaunch
 import CmuxTerminal
+import Foundation
 import Testing
 
 #if canImport(cmux_DEV)
@@ -495,6 +496,58 @@ struct GhosttyTerminalStartupEnvironmentTests {
         expectEqual(merged["TERM"], TerminalSurface.managedTerminalType)
         expectEqual(merged["COLORTERM"], TerminalSurface.managedColorTerm)
         expectEqual(merged["TERM_PROGRAM"], TerminalSurface.managedTerminalProgram)
+    }
+
+    @Test
+    func spawnedPaneDoesNotInheritClaudeSessionOrTrustState() throws {
+        let policy = ClaudeSessionEnvironmentPolicy()
+        let staleKeys = policy.inheritedIndependentLaunchKeys.sorted()
+        var inheritedEnvironment = Dictionary(
+            uniqueKeysWithValues: staleKeys.map { ($0, "stale-parent-value") }
+        )
+        inheritedEnvironment["PATH"] = "/usr/bin:/bin"
+        inheritedEnvironment["CLAUDE_CODE_USE_VERTEX"] = "1"
+        inheritedEnvironment["ANTHROPIC_AUTH_TOKEN"] = "third-party-auth-token"
+        inheritedEnvironment["CUSTOM_FLAG"] = "preserved"
+
+        let merged = TerminalSurface.mergedStartupEnvironment(
+            base: inheritedEnvironment,
+            protectedKeys: [],
+            additionalEnvironment: [
+                staleKeys[0]: "stale-workspace-value"
+            ],
+            initialEnvironmentOverrides: [
+                staleKeys[1]: "stale-surface-value",
+                "CLAUDE_CODE_USE_VERTEX": "1",
+            ],
+            ambientEnvironment: inheritedEnvironment
+        )
+
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/env")
+        process.environment = merged
+        let outputPipe = Pipe()
+        process.standardOutput = outputPipe
+        process.standardError = FileHandle.nullDevice
+        try process.run()
+        process.waitUntilExit()
+
+        let outputData = outputPipe.fileHandleForReading.readDataToEndOfFile()
+        let output = try #require(
+            String(data: outputData, encoding: .utf8),
+            "spawned env output was not UTF-8"
+        )
+        let childKeys = Set(output.split(separator: "\n").compactMap { line in
+            line.split(separator: "=", maxSplits: 1).first.map(String.init)
+        })
+
+        #expect(process.terminationStatus == 0, Comment(rawValue: output))
+        for key in staleKeys {
+            #expect(!childKeys.contains(key), Comment(rawValue: output))
+        }
+        #expect(output.contains("CLAUDE_CODE_USE_VERTEX=1"), Comment(rawValue: output))
+        #expect(output.contains("ANTHROPIC_AUTH_TOKEN=third-party-auth-token"), Comment(rawValue: output))
+        #expect(output.contains("CUSTOM_FLAG=preserved"), Comment(rawValue: output))
     }
 
     @Test


### PR DESCRIPTION
## Summary

- clear inherited Claude session and trust state before embedded Ghostty snapshots the host process environment
- strip the same canonical independent-launch keys after pane environment merging so workspace or surface overrides cannot restore stale state
- preserve unrelated Claude API credentials and other non-session environment values

Fixes #7700

## Testing

- Red: [`30870407050`](https://github.com/manaflow-ai/cmux/actions/runs/30870407050) at `a9373240d1` ran 30 `GhosttyTerminalStartupEnvironmentTests`; the new regression failed on all 11 leaked session/trust keys.
- Green: [`30871086973`](https://github.com/manaflow-ai/cmux/actions/runs/30871086973) at `9d93652174` ran the same 30 tests; all passed.
- Fleet build: `/Users/austinwang/manaflow/cmuxterm-hq2/scripts/reload-cloud.sh --tag sym7700 --builder fleet --slot cmuxs-mac-mini-3.1` succeeded and downloaded the tagged app. No local Xcode build or test was used.
- Runtime: launched the tagged app with all 11 policy keys set to stale parent values. Both the initial terminal and a newly spawned right split reported `CLAUDE_IDENTITY_CLEAN`; an unrelated `CMUX_ISSUE_7700_MARKER` remained `preserved`. The tagged app was then terminated and its debug socket removed.
- Guards: `generate-claude-launch-environment-policy.py --check`, `check-package-resolved-policy.py`, `lint-pbxproj-test-wiring.sh`, and `git diff --check` pass.
- Localization audit: no user-facing strings changed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Terminal panes now start with inherited Claude session identity and trust-state variables removed.
  * Custom environment settings and unrelated third-party Claude variables continue to be preserved.
  * Applies consistently when launching terminal surfaces and newly spawned panes, preventing stale session or trust information from carrying over between environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->