### PR TITLE
Keep local cwd out of remote workspace auto-resume

### DIFF
--- a/Sources/AgentRelaunchCommandBuilder.swift
+++ b/Sources/AgentRelaunchCommandBuilder.swift
@@ -11,7 +11,8 @@ struct AgentRelaunchCommandBuilder {
         kind: RestorableAgentKind,
         launchCommand: AgentLaunchCommandSnapshot?,
         workingDirectory: String?,
-        includeWorkingDirectoryPrefix: Bool = true
+        includeWorkingDirectoryPrefix: Bool = true,
+        allowCapturedWorkingDirectoryFallback: Bool = true
     ) -> String? {
         guard kind.restoreMode == .relaunchCommand,
               let launchCommand,
@@ -43,7 +44,8 @@ struct AgentRelaunchCommandBuilder {
         guard includeWorkingDirectoryPrefix else { return command }
         return TerminalStartupWorkingDirectoryPrefix.prefix(
             command,
-            workingDirectory: workingDirectory ?? launchCommand.workingDirectory
+            workingDirectory: workingDirectory
+                ?? (allowCapturedWorkingDirectoryFallback ? launchCommand.workingDirectory : nil)
         )
     }
 }

--- a/Sources/RestorableAgentSession.swift
+++ b/Sources/RestorableAgentSession.swift
@@ -327,7 +327,8 @@ enum AgentResumeCommandBuilder {
         workingDirectory: String?,
         registrationOverride: CmuxVaultAgentRegistration? = nil,
         includeWorkingDirectoryPrefix: Bool = true,
-        observedPermissionMode: String? = nil
+        observedPermissionMode: String? = nil,
+        allowCapturedWorkingDirectoryFallback: Bool = true
     ) -> String? {
         let customRegistration = registrationOverride
         guard !sessionId.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
@@ -349,7 +350,8 @@ enum AgentResumeCommandBuilder {
             launchCommand: launchCommand,
             workingDirectory: workingDirectory,
             customRegistration: customRegistration,
-            includeWorkingDirectoryPrefix: includeWorkingDirectoryPrefix
+            includeWorkingDirectoryPrefix: includeWorkingDirectoryPrefix,
+            allowCapturedWorkingDirectoryFallback: allowCapturedWorkingDirectoryFallback
         )
     }
 
@@ -392,7 +394,8 @@ enum AgentResumeCommandBuilder {
         launchCommand: AgentLaunchCommandSnapshot?,
         workingDirectory: String?,
         customRegistration: CmuxVaultAgentRegistration?,
-        includeWorkingDirectoryPrefix: Bool
+        includeWorkingDirectoryPrefix: Bool,
+        allowCapturedWorkingDirectoryFallback: Bool = true
     ) -> String {
         var commandParts: [String] = []
         let environmentParts = launchEnvironmentParts(kind: kind, environment: launchCommand?.environment)
@@ -404,7 +407,10 @@ enum AgentResumeCommandBuilder {
 
         let cwd = customRegistration?.cwd == .ignore
             ? nil
-            : normalized(workingDirectory ?? launchCommand?.workingDirectory)
+            : normalized(
+                workingDirectory
+                    ?? (allowCapturedWorkingDirectoryFallback ? launchCommand?.workingDirectory : nil)
+            )
         let workingDirectoriesToRemove = [
             cwd,
             normalized(launchCommand?.workingDirectory),
@@ -801,7 +807,8 @@ struct SessionRestorableAgentSnapshot: Codable, Sendable {
 
     func resumeStartupInput(
         useLocalRestoreVerb: Bool = true,
-        restoringWorkingDirectory: String? = nil
+        restoringWorkingDirectory: String? = nil,
+        allowCapturedWorkingDirectoryFallback: Bool = true
     ) -> String? {
         if useLocalRestoreVerb {
             let executable = AgentRestoreLaunch.cliStartupExecutableToken
@@ -812,11 +819,13 @@ struct SessionRestorableAgentSnapshot: Codable, Sendable {
             return " \(executable) restore \(kind.rawValue) \(sessionId)\n"
         }
         let effectiveWorkingDirectory = resumeWorkingDirectory(
-            preferred: restoringWorkingDirectory
+            preferred: restoringWorkingDirectory,
+            allowCapturedWorkingDirectoryFallback: allowCapturedWorkingDirectoryFallback
         )
         let restoreCommand = resumeCommand(
             includeWorkingDirectoryPrefix: true,
-            restoringWorkingDirectory: effectiveWorkingDirectory
+            restoringWorkingDirectory: effectiveWorkingDirectory,
+            allowCapturedWorkingDirectoryFallback: allowCapturedWorkingDirectoryFallback
         ).map { command in
             AgentRestoreLaunch(kind: kind.rawValue, sessionID: sessionId)?
                 .applying(toStoredCommand: command) ?? command
@@ -863,9 +872,15 @@ struct SessionRestorableAgentSnapshot: Codable, Sendable {
         return scriptInput.utf8.count <= Self.maxInlineForkInputBytes ? scriptInput : nil
     }
 
-    private func resumeWorkingDirectory(preferred: String?) -> String? {
+    private func resumeWorkingDirectory(
+        preferred: String?,
+        allowCapturedWorkingDirectoryFallback: Bool
+    ) -> String? {
         guard registration?.cwd != .ignore else { return nil }
-        for candidate in [preferred, workingDirectory, launchCommand?.workingDirectory] {
+        let candidates = allowCapturedWorkingDirectoryFallback
+            ? [preferred, workingDirectory, launchCommand?.workingDirectory]
+            : [preferred]
+        for candidate in candidates {
             guard let trimmed = candidate?.trimmingCharacters(in: .whitespacesAndNewlines),
                   !trimmed.isEmpty else {
                 continue

--- a/Sources/SessionRestorableAgentSnapshot+Commands.swift
+++ b/Sources/SessionRestorableAgentSnapshot+Commands.swift
@@ -47,15 +47,18 @@ extension SessionRestorableAgentSnapshot {
 
     func resumeCommand(
         includeWorkingDirectoryPrefix: Bool,
-        restoringWorkingDirectory: String? = nil
+        restoringWorkingDirectory: String? = nil,
+        allowCapturedWorkingDirectoryFallback: Bool = true
     ) -> String? {
-        let effectiveWorkingDirectory = restoringWorkingDirectory ?? workingDirectory
+        let effectiveWorkingDirectory = restoringWorkingDirectory
+            ?? (allowCapturedWorkingDirectoryFallback ? workingDirectory : nil)
         if kind.restoreMode == .relaunchCommand {
             return AgentRelaunchCommandBuilder().shellCommand(
                 kind: kind,
                 launchCommand: launchCommand,
                 workingDirectory: effectiveWorkingDirectory,
-                includeWorkingDirectoryPrefix: includeWorkingDirectoryPrefix
+                includeWorkingDirectoryPrefix: includeWorkingDirectoryPrefix,
+                allowCapturedWorkingDirectoryFallback: allowCapturedWorkingDirectoryFallback
             )
         }
         return AgentResumeCommandBuilder.resumeShellCommand(
@@ -65,7 +68,8 @@ extension SessionRestorableAgentSnapshot {
             workingDirectory: effectiveWorkingDirectory,
             registrationOverride: registration,
             includeWorkingDirectoryPrefix: includeWorkingDirectoryPrefix,
-            observedPermissionMode: permissionMode
+            observedPermissionMode: permissionMode,
+            allowCapturedWorkingDirectoryFallback: allowCapturedWorkingDirectoryFallback
         )
     }
 

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -1405,8 +1405,13 @@ extension Workspace {
                 ?? (restoresUntrustedSavedDirectory ? nil : snapshot.terminal?.workingDirectory)
                 ?? (restoresUntrustedSavedDirectory ? nil : restorableAgent?.workingDirectory)
                 ?? (restoresUntrustedSavedDirectory ? nil : snapshot.directory)
-            let workingDirectory = savedWorkingDirectory
-                ?? currentDirectory
+            // A remote restore may only use a cwd with remote provenance.
+            // `currentDirectory` is local workspace metadata on this Mac.
+            let workingDirectory: String? = if restoresRemoteWorkspaceTerminalSnapshot {
+                savedWorkingDirectory
+            } else {
+                savedWorkingDirectory ?? currentDirectory
+            }
             // A persisted terminal cwd can already be the stray fallback cwd
             // from a prior auto-resume restore; the transient rescue/guard must
             // remember where the resume launcher actually sends the agent.
@@ -1471,7 +1476,8 @@ extension Workspace {
                     if restoresRemoteWorkspaceTerminalSnapshot {
                         restorableAgent?.resumeStartupInput(
                             useLocalRestoreVerb: false,
-                            restoringWorkingDirectory: resumeSessionWorkingDirectory
+                            restoringWorkingDirectory: resumeSessionWorkingDirectory,
+                            allowCapturedWorkingDirectoryFallback: false
                         )
                             .map(SurfaceResumeStartupLaunch.input)
                     } else {

--- a/cmuxTests/AgentSessionAutoResumeSettingsTests.swift
+++ b/cmuxTests/AgentSessionAutoResumeSettingsTests.swift
@@ -207,9 +207,9 @@ final class AgentSessionAutoResumeSettingsTests: XCTestCase {
             let defaults = UserDefaults.standard
             defaults.removeObject(forKey: AgentSessionAutoResumeSettings.autoResumeAgentSessionsKey) // autoResumeAgentSessions = true (default)
 
-            let source = Workspace()
+            let localWorkingDirectory = "/Users/cmux-local-runner"
+            let source = Workspace(workingDirectory: localWorkingDirectory)
             let remoteCommand = "ssh cmux-macmini"
-            let expectedRestoredRemoteCommand = "ssh -tt cmux-macmini"
             source.configureRemoteConnection(
                 WorkspaceRemoteConfiguration(
                     destination: "cmux-macmini",
@@ -226,8 +226,37 @@ final class AgentSessionAutoResumeSettingsTests: XCTestCase {
                 autoConnect: false
             )
             let sourcePanelId = try XCTUnwrap(source.focusedPanelId)
+            let sourceWithoutRemoteDirectoryIndex = try makeRestorableAgentIndex(
+                workspaceId: source.id,
+                panelId: sourcePanelId,
+                sessionId: "codex-remote-no-cwd-session"
+            )
+            source.updatePanelShellActivityState(panelId: sourcePanelId, state: .commandRunning)
+            let snapshotWithoutRemoteDirectory = source.sessionSnapshot(
+                includeScrollback: false,
+                restorableAgentIndex: sourceWithoutRemoteDirectoryIndex
+            )
+
+            let restoredWithoutRemoteDirectory = Workspace()
+            restoredWithoutRemoteDirectory.restoreSessionSnapshot(snapshotWithoutRemoteDirectory)
+            let restoredWithoutRemoteDirectoryPanelId = try XCTUnwrap(
+                restoredWithoutRemoteDirectory.focusedPanelId
+            )
+            let restoredWithoutRemoteDirectoryPanel = try XCTUnwrap(
+                restoredWithoutRemoteDirectory.terminalPanel(
+                    for: restoredWithoutRemoteDirectoryPanelId
+                )
+            )
+            let inputWithoutRemoteDirectory = try XCTUnwrap(
+                restoredWithoutRemoteDirectoryPanel.surface.initialInput
+            )
+
+            XCTAssertNil(restoredWithoutRemoteDirectoryPanel.requestedWorkingDirectory)
+            XCTAssertFalse(inputWithoutRemoteDirectory.contains(localWorkingDirectory))
+            XCTAssertFalse(inputWithoutRemoteDirectory.contains("/tmp/repo"))
+
             let remoteWorkingDirectory = "/home/dev/cmux-remote-running"
-            source.updatePanelDirectory(
+            source.updateRemotePanelDirectory(
                 panelId: sourcePanelId,
                 directory: remoteWorkingDirectory
             )
@@ -236,7 +265,6 @@ final class AgentSessionAutoResumeSettingsTests: XCTestCase {
                 panelId: sourcePanelId,
                 sessionId: "codex-remote-running-session"
             )
-            source.updatePanelShellActivityState(panelId: sourcePanelId, state: .commandRunning)
             let snapshot = source.sessionSnapshot(includeScrollback: false, restorableAgentIndex: sourceIndex)
 
             let restored = Workspace()
@@ -246,8 +274,8 @@ final class AgentSessionAutoResumeSettingsTests: XCTestCase {
             let restoredInput = restoredPanel.surface.debugInitialInputMetadata()
             let restoredRemoteCommand = try XCTUnwrap(restored.remoteConfiguration?.terminalStartupCommand)
 
-            XCTAssertEqual(restoredRemoteCommand, expectedRestoredRemoteCommand)
-            XCTAssertEqual(restoredPanel.surface.debugInitialCommand(), expectedRestoredRemoteCommand)
+            XCTAssertTrue(restoredRemoteCommand.hasSuffix("ssh -tt cmux-macmini"), restoredRemoteCommand)
+            XCTAssertEqual(restoredPanel.surface.debugInitialCommand(), restoredRemoteCommand)
             XCTAssertTrue(restoredInput.hasInitialInput)
             XCTAssertGreaterThan(restoredInput.byteCount, 0)
             let input = try XCTUnwrap(restoredPanel.surface.initialInput)


### PR DESCRIPTION
## Summary

- ignore an untrusted local workspace directory when recreating a remote terminal
- prevent the captured local agent cwd from becoming a remote auto-resume prefix while retaining it for launch-argument sanitization
- extend the existing regression to cover both local cwd fallbacks and preserve the trusted remote-directory control case

Fixes #7575

## Testing

- Hosted exact-test red run at the test-only commit: [run 30875357096](https://github.com/manaflow-ai/cmux/actions/runs/30875357096)
- Hosted exact-test green run at the fix commit: [run 30875358658](https://github.com/manaflow-ai/cmux/actions/runs/30875358658)
- Fleet macOS runner, `-only-testing:cmuxTests/AgentSessionAutoResumeSettingsTests/testRemoteWorkspaceAutoResumeKeepsRemoteStartupCommand`: test-only commit failed with the local workspace cwd in `requestedWorkingDirectory` and startup input; fix commit passed 1 test with 0 failures
- `./scripts/reload-cloud.sh --tag sym7575` on the fix commit: [cloud build 30874356769](https://github.com/manaflow-ai/cmux/actions/runs/30874356769) (`BUILD_OK`; cloud path used, no local fallback)
- Tagged-socket dogfood: restored a disposable remote agent snapshot over SSH to the macOS fleet host. The recreated terminal reported `requested_working_directory: null`, retained `/usr/bin/ssh -tt ardrec@aws-m4pro-5` as its startup command, and executed the resume command without either local cwd sentinel. The tagged app was then quit and its isolated socket/session fixtures removed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/9511"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788406776&installation_model_id=21920&pr_number=9511&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F9511&signature=a92ff2bc497d7c94555c8168f553262b4e4a03e5060a8fb5364e67243e23a072"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop using the local working directory when auto-resuming a remote workspace. Only remote-provenance paths are used, and the SSH startup command stays intact. Fixes #7575.

- **Bug Fixes**
  - For remote restores, ignore the local cwd; `Workspace` now prefers only saved remote directories and passes `allowCapturedWorkingDirectoryFallback: false`.
  - Added `allowCapturedWorkingDirectoryFallback` to resume/relaunch builders to control cwd prefixing and sanitization.
  - Expanded tests to cover sessions with and without a remote cwd; verify no local paths appear in input and the `ssh -tt` command is preserved.

<sup>Written for commit 1f09cd7ea39931bfe3682e9e959fec4e70c49d71. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/9511?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved session restoration for remote terminals by avoiding inappropriate local-directory fallbacks.
  * Remote sessions now rely on their saved directory when available, while local sessions retain existing fallback behavior.
  * Added controls to prevent captured working directories from being reused when restoring or resuming sessions.
* **Tests**
  * Expanded coverage for remote session auto-resume and restoration scenarios.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->