### PR TITLE
Keep Codex running while subagents are active

### DIFF
--- a/CLI/CMUXCLI+AgentHookDefinitions.swift
+++ b/CLI/CMUXCLI+AgentHookDefinitions.swift
@@ -136,7 +136,9 @@ extension CMUXCLI {
     }
 
     enum AgentHookAction {
-        case sessionStart, promptSubmit, stop, notification, approvalResponse, sessionEnd, sessionFinalize, noop
+        case sessionStart, promptSubmit, stop, notification, approvalResponse
+        case codexSubagentStart, codexSubagentStop
+        case sessionEnd, sessionFinalize, noop
     }
 
     static let subcommandActions: [String: AgentHookAction] = [
@@ -149,6 +151,8 @@ extension CMUXCLI {
         "approval-response": .approvalResponse,
         "shell-exec": .promptSubmit,
         "shell-done": .noop,
+        "subagent-start": .codexSubagentStart,
+        "subagent-stop": .codexSubagentStop,
         "session-end": .sessionEnd,
         "session-finalize": .sessionFinalize,
     ]
@@ -235,7 +239,7 @@ extension CMUXCLI {
     private static let grokPinnedHookMarker = "cmux-grok-hook-v2"
     private static let antigravityPinnedHookMarker = "cmux-antigravity-hook-v2"
 
-    private static func agentHookShellCommand(
+    static func agentHookShellCommand(
         _ command: String,
         for def: AgentHookDef,
         noOpCommand: String = "echo '{}'"

--- a/CLI/CMUXCLI+CodexFireAndForgetHooks.swift
+++ b/CLI/CMUXCLI+CodexFireAndForgetHooks.swift
@@ -3,13 +3,14 @@ import Foundation
 
 extension CMUXCLI {
     /// Emit, NUL-separated to stdout, the exact codex arg list the wrapper must
-    /// splice ahead of the user's args to enable + inject cmux's fire-and-forget
-    /// hooks for one codex invocation. Returns the arg list:
+    /// splice ahead of the user's args to enable + inject cmux's hooks for one
+    /// codex invocation. Returns the arg list:
     ///   --enable\0hooks\0--dangerously-bypass-hook-trust\0
     ///   -c\0hooks.SessionStart=[{hooks=[{type="command",command='''<ff>''',timeout=10000}]}]\0
     ///   -c\0hooks.UserPromptSubmit=...\0 ... (one `-c` pair per event)
-    /// where `<ff>` is `codexFireAndForgetAgentHookShellCommand(...)` so each
-    /// hook returns `{}` to codex instantly and backgrounds the real cmux call.
+    /// Completion/status hooks return `{}` instantly and background the real
+    /// cmux call. Subagent lifecycle hooks run synchronously so their locked
+    /// state write happens before Codex can emit the following lifecycle event.
     /// Requires no live socket: pure string construction from the agent def.
     func emitCodexWrapperInjectArgs() throws {
         guard let codexDef = Self.agentDef(named: "codex") else {
@@ -28,16 +29,28 @@ extension CMUXCLI {
         let hooksDir = Self.codexHookScriptsDirectory()
         var args: [String] = ["--enable", "hooks", "--dangerously-bypass-hook-trust"]
         for event in CodexHookInjectionSchema.current.events {
-            let ff = Self.codexFireAndForgetAgentHookShellCommand(
-                "cmux hooks codex \(event.cmuxSubcommand)", for: codexDef
-            )
+            let hookCommand = "cmux hooks codex \(event.cmuxSubcommand)"
+            let hookBody: String
+            if event.cmuxSubcommand == "subagent-start"
+                || event.cmuxSubcommand == "subagent-stop" {
+                hookBody = Self.agentHookShellCommand(hookCommand, for: codexDef)
+            } else {
+                hookBody = Self.codexFireAndForgetAgentHookShellCommand(
+                    hookCommand,
+                    for: codexDef
+                )
+            }
             let command: String
             if let scriptPath = hooksDir.flatMap({
-                Self.writeCodexHookScript(subcommand: event.cmuxSubcommand, body: ff, in: $0)
+                Self.writeCodexHookScript(
+                    subcommand: event.cmuxSubcommand,
+                    body: hookBody,
+                    in: $0
+                )
             }), !scriptPath.contains("'''") {
                 command = scriptPath
             } else {
-                command = ff
+                command = hookBody
             }
             // TOML multi-line literal string ('''...''') preserves bytes verbatim
             // and may contain single quotes, so the embedded `echo '{}'` / `sh -c

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -154,6 +154,10 @@ struct ClaudeHookSessionRecord: Codable {
     var activePromptTurnIds: [String]?
     var lastPromptTurnId: String?
     var terminalPromptTurnIds: [String]?
+    /// Native Codex subagents currently running under this parent session.
+    /// Optional for compatibility with stores written before lifecycle hooks
+    /// became authoritative for the pending-work notification decision.
+    var activeCodexSubagentIds: [String]?
     var startedAt: TimeInterval
     var updatedAt: TimeInterval
     /// Immutable age anchor for a demoted record awaiting external cleanup.
@@ -758,6 +762,9 @@ final class ClaudeHookSessionStore {
             if codexSessionStartIsStale(record, incomingPID: pid) {
                 return false
             }
+            if let existingPID = record.pid, let pid, existingPID != pid {
+                record.activeCodexSubagentIds = nil
+            }
             clearCodexSessionStartTurnState(on: &record)
             update(
                 &record,
@@ -854,6 +861,79 @@ final class ClaudeHookSessionStore {
         return try withLockedState { state in
             guard let record = state.sessions[normalized] else { return false }
             return terminalPromptTurnSet(from: record).contains(normalizedTurnId)
+        }
+    }
+
+    /// Applies a native Codex subagent lifecycle event inside the same file
+    /// lock used by Stop. A minimal record is synthesized when SubagentStart
+    /// wins the race with the fire-and-forget SessionStart hook.
+    func recordCodexSubagentLifecycle(
+        sessionId: String,
+        agentId: String,
+        isActive: Bool,
+        workspaceId: String?,
+        surfaceId: String?,
+        cwd: String?,
+        pid: Int?
+    ) throws {
+        let normalizedSessionId = normalizeSessionId(sessionId)
+        guard !normalizedSessionId.isEmpty,
+              let normalizedAgentId = normalizeOptional(agentId) else {
+            return
+        }
+        try withLockedState { state in
+            let existing = state.sessions[normalizedSessionId]
+            guard existing != nil
+                || (normalizeOptional(workspaceId) != nil && normalizeOptional(surfaceId) != nil) else {
+                return
+            }
+            let now = Date().timeIntervalSince1970
+            var record = makeSessionRecord(
+                state: state,
+                sessionId: normalizedSessionId,
+                workspaceId: normalizeOptional(workspaceId) ?? existing?.workspaceId ?? "",
+                surfaceId: normalizeOptional(surfaceId) ?? existing?.surfaceId ?? "",
+                now: now
+            )
+            update(
+                &record,
+                workspaceId: normalizeOptional(workspaceId) ?? record.workspaceId,
+                surfaceId: normalizeOptional(surfaceId) ?? record.surfaceId,
+                cwd: cwd,
+                transcriptPath: nil,
+                pid: pid,
+                launchCommand: nil,
+                isRestorable: nil,
+                agentLifecycle: nil,
+                lastSubtitle: nil,
+                lastBody: nil,
+                lastNotificationStatus: nil,
+                updateLastNotificationStatus: false,
+                runtimeStatus: nil,
+                updateRuntimeStatus: false,
+                now: now
+            )
+            var activeIds = Set(
+                record.activeCodexSubagentIds?.compactMap { normalizeOptional($0) } ?? []
+            )
+            if isActive {
+                activeIds.insert(normalizedAgentId)
+            } else {
+                activeIds.remove(normalizedAgentId)
+            }
+            record.activeCodexSubagentIds = activeIds.isEmpty ? nil : activeIds.sorted()
+            state.sessions[normalizedSessionId] = record
+        }
+    }
+
+    func hasActiveCodexSubagents(sessionId: String) throws -> Bool {
+        let normalized = normalizeSessionId(sessionId)
+        guard !normalized.isEmpty else { return false }
+        return try withLockedState { state in
+            guard let ids = state.sessions[normalized]?.activeCodexSubagentIds else {
+                return false
+            }
+            return ids.contains { normalizeOptional($0) != nil }
         }
     }
 
@@ -27947,6 +28027,15 @@ struct CMUXCLI {
         return false
     }
 
+    /// Uses native Codex SubagentStart/SubagentStop state rather than the
+    /// transcript, whose final lifecycle lines can race the parent Stop hook.
+    func hasActiveCodexBackgroundWork(
+        sessionId: String,
+        store: ClaudeHookSessionStore
+    ) -> Bool {
+        (try? store.hasActiveCodexSubagents(sessionId: sessionId)) == true
+    }
+
     private func mergedNodeOptions(existing: String?, restoreModulePath: String) -> String {
         let requireOption = "--require=\(restoreModulePath)"
         let memoryOption = "--max-old-space-size=4096"
@@ -31271,6 +31360,31 @@ export default CMUXSessionRestore;
 #endif
             return target
         }
+        func recordCodexSubagentLifecycle(isActive: Bool) {
+            guard def.name == "codex",
+                  !sessionId.isEmpty,
+                  let agentId = input.rawObject.flatMap({
+                      firstString(in: $0, keys: ["agent_id", "agentId"])
+                  }) ?? input.object.flatMap({
+                      firstString(in: $0, keys: ["agent_id", "agentId"])
+                  }) else {
+                return
+            }
+            let mapped = try? store.lookup(sessionId: sessionId)
+            try? store.recordCodexSubagentLifecycle(
+                sessionId: sessionId,
+                agentId: agentId,
+                isActive: isActive,
+                workspaceId: resolvedDirectWorkspaceArg ?? mapped?.workspaceId ?? directWorkspaceArg,
+                surfaceId: resolvedDirectSurfaceArg ?? mapped?.surfaceId ?? directSurfaceArg,
+                cwd: hookCwd ?? mapped?.cwd,
+                pid: preferredAgentHookEventPID(
+                    agentName: def.name,
+                    mappedPID: mapped?.pid,
+                    inferredPID: inferredPID
+                )
+            )
+        }
         defer {
             if !didSendFeedTelemetry, !shouldSuppressGenericFeedTelemetry() {
                 sendAgentFeedTelemetry()
@@ -31278,6 +31392,12 @@ export default CMUXSessionRestore;
         }
 
         switch action {
+        case .codexSubagentStart:
+            recordCodexSubagentLifecycle(isActive: true)
+
+        case .codexSubagentStop:
+            recordCodexSubagentLifecycle(isActive: false)
+
         case .sessionStart:
             let mapped = sessionId.isEmpty ? nil : (try? store.lookup(sessionId: sessionId))
             guard let target = resolveAgentHookTarget(mapped: mapped) else {
@@ -31876,9 +31996,13 @@ export default CMUXSessionRestore;
                     def.displayName
             )
             let antigravityHasActiveBackgroundWork = hasActiveAntigravityBackgroundWork()
+            let codexHasActiveBackgroundWork = def.name == "codex"
+                && hasActiveCodexBackgroundWork(sessionId: sessionId, store: store)
+            let hasActiveBackgroundWork = antigravityHasActiveBackgroundWork
+                || codexHasActiveBackgroundWork
             let stopNotificationStatus: AgentHookNotificationStatus = (codexFailure == nil && antigravityFailure == nil) ? .idle : .error
             let lifecycleAfterStop: AgentHibernationLifecycleState = {
-                if antigravityHasActiveBackgroundWork && stopNotificationStatus == .idle {
+                if hasActiveBackgroundWork && stopNotificationStatus == .idle {
                     return .running
                 }
                 return stopNotificationStatus == .idle ? .idle : .needsInput
@@ -31953,7 +32077,7 @@ export default CMUXSessionRestore;
                                   lastBody: body,
                                   lastNotificationStatus: stopNotificationStatus,
                                   updateLastNotificationStatus: true,
-                                  runtimeStatus: (antigravityHasActiveBackgroundWork && stopNotificationStatus == .idle) ? .running : runtimeStatus(for: stopNotificationStatus),
+                                  runtimeStatus: (hasActiveBackgroundWork && stopNotificationStatus == .idle) ? .running : runtimeStatus(for: stopNotificationStatus),
                                   updateRuntimeStatus: true)
                 publishAgentSurfaceResumeBinding(
                     client: client,
@@ -32006,7 +32130,7 @@ export default CMUXSessionRestore;
             if shouldPublishStopAlert, shouldSendNotification(fingerprint: notificationFingerprint) {
                 // Tag successful turn-end pings; error alerts always deliver.
                 let stopMeta: String? = stopNotificationStatus == .idle
-                    ? AgentHookNotifyCategory.turnComplete.metaSegment(pending: antigravityHasActiveBackgroundWork)
+                    ? AgentHookNotifyCategory.turnComplete.metaSegment(pending: hasActiveBackgroundWork)
                     : nil
                 let payload = notificationPayload(
                     title: notificationTitle(workspaceId: workspaceId, surfaceId: surfaceId),
@@ -32081,7 +32205,7 @@ export default CMUXSessionRestore;
                         "set_status \(def.statusKey) \(statusValue) --icon=exclamationmark.triangle.fill --color=#FF453A --priority=100 --tab=\(workspaceId)\(socketPanelOption(surfaceId))",
                         client: client
                     )
-                } else if antigravityHasActiveBackgroundWork {
+                } else if hasActiveBackgroundWork {
                     setAgentLifecycle(
                         client: client,
                         key: def.statusKey,
@@ -33126,6 +33250,8 @@ export default CMUXSessionRestore;
         case "prompt-submit": return "UserPromptSubmit"
         case "pre-tool-use", "cron-create-guard": return "PreToolUse"
         case "post-tool-use", "push-notification": return "PostToolUse"
+        case "subagent-start": return "SubagentStart"
+        case "subagent-stop": return "SubagentStop"
         case "stop", "idle": return "Stop"
         case "session-end": return "SessionEnd"
         case "notification", "notify": return "Notification"
@@ -34650,6 +34776,35 @@ export default CMUXSessionRestore;
             in: stdinObj,
             keys: ["session_id", "sessionId", "conversation_id", "conversationId"]
         ) ?? stableFallbackFeedSessionId(source: source, rawObject: stdinObj, agentPid: agentPid)
+
+        if source == "codex",
+           hookEventName == "SubagentStart" || hookEventName == "SubagentStop",
+           let agentId = firstString(in: stdinObj, keys: ["agent_id", "agentId"]) {
+            let store = ClaudeHookSessionStore(
+                processEnv: env.merging(
+                    ["CMUX_CLAUDE_HOOK_STATE_PATH": agentHookStatePath(
+                        sessionStoreSuffix: "codex",
+                        env: env
+                    )],
+                    uniquingKeysWith: { _, new in new }
+                )
+            )
+            try? store.recordCodexSubagentLifecycle(
+                sessionId: sessionId,
+                agentId: agentId,
+                isActive: hookEventName == "SubagentStart",
+                workspaceId: feedWorkspaceId(
+                    rawObject: stdinObj,
+                    fallback: env["CMUX_WORKSPACE_ID"]
+                ),
+                surfaceId: env["CMUX_SURFACE_ID"],
+                cwd: firstString(
+                    in: stdinObj,
+                    keys: ["cwd", "working_directory", "workingDirectory"]
+                ),
+                pid: agentPid
+            )
+        }
 
         var eventDict: [String: Any] = [
             "session_id": "\(source)-\(sessionId)",

--- a/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/CodexHookInjectionSchema.swift
+++ b/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/CodexHookInjectionSchema.swift
@@ -19,6 +19,8 @@ public struct CodexHookInjectionSchema: Equatable, Sendable {
         .init(agentEvent: "Stop", cmuxSubcommand: "stop", timeoutMs: 10000),
         .init(agentEvent: "PreToolUse", cmuxSubcommand: "pre-tool-use", timeoutMs: 120000),
         .init(agentEvent: "PostToolUse", cmuxSubcommand: "post-tool-use", timeoutMs: 10000),
+        .init(agentEvent: "SubagentStart", cmuxSubcommand: "subagent-start", timeoutMs: 10000),
+        .init(agentEvent: "SubagentStop", cmuxSubcommand: "subagent-stop", timeoutMs: 10000),
         .init(agentEvent: "PermissionRequest", cmuxSubcommand: "notification", timeoutMs: 120000),
     ])
 
@@ -28,6 +30,14 @@ public struct CodexHookInjectionSchema: Equatable, Sendable {
     /// arbitrary prefixes: hook config is user-controlled argv.
     static let recognized = [
         current,
+        Self(events: [
+            .init(agentEvent: "SessionStart", cmuxSubcommand: "session-start", timeoutMs: 10000),
+            .init(agentEvent: "UserPromptSubmit", cmuxSubcommand: "prompt-submit", timeoutMs: 10000),
+            .init(agentEvent: "Stop", cmuxSubcommand: "stop", timeoutMs: 10000),
+            .init(agentEvent: "PreToolUse", cmuxSubcommand: "pre-tool-use", timeoutMs: 120000),
+            .init(agentEvent: "PostToolUse", cmuxSubcommand: "post-tool-use", timeoutMs: 10000),
+            .init(agentEvent: "PermissionRequest", cmuxSubcommand: "notification", timeoutMs: 120000),
+        ]),
         Self(events: [
             .init(agentEvent: "SessionStart", cmuxSubcommand: "session-start", timeoutMs: 10000),
             .init(agentEvent: "UserPromptSubmit", cmuxSubcommand: "prompt-submit", timeoutMs: 10000),

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -864,6 +864,7 @@ C0DE71B10000000000000001 /* AppDelegate+AgentChatNotifications.swift in Sources 
 		A9F200000000000000000016 /* CodexAppServerQueuedInput.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9F100000000000000000016 /* CodexAppServerQueuedInput.swift */; };
 		A9E02000000000000000000E /* CodexAppServerSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9E01000000000000000000E /* CodexAppServerSession.swift */; };
 		A9E040000000000000000002 /* CodexAppServerSessionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9E040000000000000000001 /* CodexAppServerSessionTests.swift */; };
+		7520C0DE0000000000000001 /* CodexBackgroundWorkNotifyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7520C0DE0000000000000002 /* CodexBackgroundWorkNotifyTests.swift */; };
 		C8711B000000000000000002 /* CodexCodeModeRolloutIdentityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8711B000000000000000001 /* CodexCodeModeRolloutIdentityTests.swift */; };
 		918100000000000000000051 /* CodexHookFailureCandidate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 918100000000000000000050 /* CodexHookFailureCandidate.swift */; };
 		918100000000000000000041 /* CodexHookFailureSummary.swift in Sources */ = {isa = PBXBuildFile; fileRef = 918100000000000000000040 /* CodexHookFailureSummary.swift */; };
@@ -3468,6 +3469,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 		A9F100000000000000000016 /* CodexAppServerQueuedInput.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/CodexAppServerQueuedInput.swift; sourceTree = "<group>"; };
 		A9E01000000000000000000E /* CodexAppServerSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/CodexAppServerSession.swift; sourceTree = "<group>"; };
 		A9E040000000000000000001 /* CodexAppServerSessionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodexAppServerSessionTests.swift; sourceTree = "<group>"; };
+		7520C0DE0000000000000002 /* CodexBackgroundWorkNotifyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodexBackgroundWorkNotifyTests.swift; sourceTree = "<group>"; };
 		C8711B000000000000000001 /* CodexCodeModeRolloutIdentityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodexCodeModeRolloutIdentityTests.swift; sourceTree = "<group>"; };
 		918100000000000000000050 /* CodexHookFailureCandidate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodexHookFailureCandidate.swift; sourceTree = "<group>"; };
 		918100000000000000000040 /* CodexHookFailureSummary.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodexHookFailureSummary.swift; sourceTree = "<group>"; };
@@ -7846,6 +7848,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				A5D41231A1B2C3D4E5F60718 /* AgentNotificationGateTests.swift */,
 				A76110020000000000000002 /* AgentHookNotificationPolicyTests.swift */,
 				A5D41233A1B2C3D4E5F60718 /* ClaudeBackgroundWorkNotifyTests.swift */,
+				7520C0DE0000000000000002 /* CodexBackgroundWorkNotifyTests.swift */,
 				F0F0CF0E0000000000000002 /* CLINotifyClaudeForkOfForkRegressionTests.swift */,
 				C72280000000000000000003 /* CLINotifyClaudeHookWorkspaceRoutingTests.swift */,
 				A5D41204A1B2C3D4E5F60718 /* CLINotifyProcessIntegrationRegressionTests.swift */,
@@ -10499,6 +10502,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 					A6AC72080000000000000001 /* CMUXWorkspaceLoadingCLIRegressionTests.swift in Sources */,
 				AAE06C3AEC68484DA33D42A1 /* CoalesceLatestPublisherDemandTests.swift in Sources */,
 				A9E040000000000000000002 /* CodexAppServerSessionTests.swift in Sources */,
+				7520C0DE0000000000000001 /* CodexBackgroundWorkNotifyTests.swift in Sources */,
 				C8711B000000000000000002 /* CodexCodeModeRolloutIdentityTests.swift in Sources */,
 				C0DECAFE0000000000000003 /* CodexTeamsApprovalBridge.swift in Sources */,
 				C0DEBACC0000000000000001 /* CodexTeamsAppServerFixture.swift in Sources */,

--- a/cmuxTests/CodexBackgroundWorkNotifyTests.swift
+++ b/cmuxTests/CodexBackgroundWorkNotifyTests.swift
@@ -1,0 +1,227 @@
+import Dispatch
+import Foundation
+import Testing
+
+#if canImport(cmux_DEV)
+@testable import cmux_DEV
+#elseif canImport(cmux)
+@testable import cmux
+#endif
+
+/// Behavioral coverage for Codex native subagent lifecycle events feeding the
+/// Stop hook's pending-work decision. The payloads deliberately omit a
+/// transcript path so this cannot pass through the transcript relay scan.
+@Suite(.serialized)
+struct CodexBackgroundWorkNotifyTests {
+    private struct Harness {
+        let support: ClaudeHookSurfaceResolutionSwiftTests
+        let context: ClaudeHookSurfaceResolutionSwiftTests.ClaudeHookContext
+        let handled: DispatchSemaphore
+        let environment: [String: String]
+        let sessionId: String
+    }
+
+    @Test func stopWithActiveSubagentTagsPendingAndWhenIdleGateDropsNotification() throws {
+        let harness = try makeHarness(name: "codex-bg-gate")
+        defer { harness.context.cleanup() }
+
+        try establishActiveSubagent(harness, agentId: "agent-gate")
+        let commandsBeforeStop = harness.context.state.snapshot().count
+        try runHook(
+            harness,
+            arguments: ["hooks", "codex", "stop"],
+            input: stopPayload(harness, turnId: "turn-1")
+        )
+
+        let stopCommands = Array(harness.context.state.snapshot().dropFirst(commandsBeforeStop))
+        let notification = try #require(
+            stopCommands.first { $0.hasPrefix("notify_target_async ") },
+            "Codex Stop must emit a turn-complete notification; saw \(stopCommands)"
+        )
+        #expect(
+            notification.contains("c=turn-complete;p=1"),
+            "Stop with an active Codex subagent must tag the notification pending; saw \(notification)"
+        )
+
+        let metaText = try #require(notification.split(separator: "|").last.map(String.init))
+        let meta = try #require(AgentNotificationMeta(meta: metaText))
+        #expect(meta.category == .turnComplete)
+        #expect(meta.pending)
+        #expect(
+            agentNotificationShouldDeliver(
+                category: meta.category,
+                pending: meta.pending,
+                permissionEnabled: true,
+                turnMode: .whenIdle,
+                idleEnabled: true
+            ) == false,
+            "The default when-idle gate must drop a pending Codex completion"
+        )
+    }
+
+    @Test func hasActiveCodexBackgroundWorkUsesSubagentLifecycleWithoutTranscriptScan() throws {
+        let harness = try makeHarness(name: "codex-bg-state")
+        defer { harness.context.cleanup() }
+
+        try establishActiveSubagent(harness, agentId: "agent-state")
+        let commandsBeforePendingStop = harness.context.state.snapshot().count
+        try runHook(
+            harness,
+            arguments: ["hooks", "codex", "stop"],
+            input: stopPayload(harness, turnId: "turn-1")
+        )
+
+        let pendingStopCommands = Array(
+            harness.context.state.snapshot().dropFirst(commandsBeforePendingStop)
+        )
+        #expect(
+            pendingStopCommands.contains { $0.hasPrefix("set_status codex Running ") },
+            "An active subagent must keep the Codex status Running; saw \(pendingStopCommands)"
+        )
+        #expect(
+            pendingStopCommands.contains { $0.hasPrefix("set_agent_lifecycle codex running ") },
+            "An active subagent must keep the Codex lifecycle running; saw \(pendingStopCommands)"
+        )
+        #expect(
+            pendingStopCommands.contains {
+                $0.hasPrefix("notify_target_async ") && $0.contains("c=turn-complete;p=1")
+            },
+            "Active Codex background work must be detected without transcript output; saw \(pendingStopCommands)"
+        )
+
+        try runHook(
+            harness,
+            arguments: ["hooks", "feed", "--source", "codex", "--event", "SubagentStop"],
+            input: subagentPayload(
+                harness,
+                event: "SubagentStop",
+                agentId: "agent-state",
+                turnId: "turn-1"
+            )
+        )
+        try runHook(
+            harness,
+            arguments: ["hooks", "codex", "prompt-submit"],
+            input: promptPayload(harness, turnId: "turn-2")
+        )
+
+        let commandsBeforeIdleStop = harness.context.state.snapshot().count
+        try runHook(
+            harness,
+            arguments: ["hooks", "codex", "stop"],
+            input: stopPayload(harness, turnId: "turn-2")
+        )
+        let idleStopCommands = Array(harness.context.state.snapshot().dropFirst(commandsBeforeIdleStop))
+        #expect(
+            idleStopCommands.contains {
+                $0.hasPrefix("notify_target_async ") && $0.contains("c=turn-complete;p=0")
+            },
+            "Once SubagentStop drains the last child, Codex must emit a real idle completion; saw \(idleStopCommands)"
+        )
+        #expect(
+            idleStopCommands.contains { $0.hasPrefix("set_status codex Idle ") },
+            "A drained Codex session must return to Idle; saw \(idleStopCommands)"
+        )
+    }
+
+    private func makeHarness(name: String) throws -> Harness {
+        let support = ClaudeHookSurfaceResolutionSwiftTests()
+        let context = try support.makeClaudeHookContext(name: name)
+        let handled = support.startClaudeSurfaceResolutionServer(
+            context: context,
+            surfaces: [(context.surfaceId, "surface:1", true)],
+            ttyName: "ttys-\(name)",
+            ttySurfaceId: context.surfaceId
+        )
+        let environment: [String: String] = [
+            "HOME": context.root.path,
+            "PATH": "/usr/bin:/bin:/usr/sbin:/sbin",
+            "PWD": context.root.path,
+            "CMUX_SOCKET_PATH": context.socketPath,
+            "CMUX_WORKSPACE_ID": context.workspaceId,
+            "CMUX_SURFACE_ID": context.surfaceId,
+            "CMUX_CLI_TTY_NAME": "ttys-\(name)",
+            "CMUX_CODEX_PID": "42424",
+            "CMUX_AGENT_HOOK_STATE_DIR": context.root.path,
+            "CMUX_CLI_SENTRY_DISABLED": "1",
+            "CMUX_AGENT_LAUNCH_KIND": "codex",
+            "CMUX_AGENT_LAUNCH_EXECUTABLE": "/usr/local/bin/codex",
+            "CMUX_AGENT_LAUNCH_CWD": context.root.path,
+        ]
+        return Harness(
+            support: support,
+            context: context,
+            handled: handled,
+            environment: environment,
+            sessionId: "session-\(name)"
+        )
+    }
+
+    private func establishActiveSubagent(_ harness: Harness, agentId: String) throws {
+        try runHook(
+            harness,
+            arguments: ["hooks", "codex", "session-start"],
+            input: sessionStartPayload(harness)
+        )
+        try runHook(
+            harness,
+            arguments: ["hooks", "codex", "prompt-submit"],
+            input: promptPayload(harness, turnId: "turn-1")
+        )
+        try runHook(
+            harness,
+            arguments: ["hooks", "feed", "--source", "codex", "--event", "SubagentStart"],
+            input: subagentPayload(
+                harness,
+                event: "SubagentStart",
+                agentId: agentId,
+                turnId: "turn-1"
+            )
+        )
+    }
+
+    private func runHook(
+        _ harness: Harness,
+        arguments: [String],
+        input: String
+    ) throws {
+        let result = harness.support.runProcess(
+            executablePath: harness.context.cliPath,
+            arguments: arguments,
+            environment: harness.environment,
+            standardInput: input,
+            timeout: 5
+        )
+        #expect(harness.handled.wait(timeout: .now() + 5) == .success)
+        harness.support.assertSuccessfulHook(result)
+    }
+
+    private func sessionStartPayload(_ harness: Harness) -> String {
+        #"""
+        {"session_id":"\#(harness.sessionId)","cwd":"\#(harness.context.root.path)","hook_event_name":"SessionStart"}
+        """#
+    }
+
+    private func promptPayload(_ harness: Harness, turnId: String) -> String {
+        #"""
+        {"session_id":"\#(harness.sessionId)","turn_id":"\#(turnId)","cwd":"\#(harness.context.root.path)","hook_event_name":"UserPromptSubmit"}
+        """#
+    }
+
+    private func stopPayload(_ harness: Harness, turnId: String) -> String {
+        #"""
+        {"session_id":"\#(harness.sessionId)","turn_id":"\#(turnId)","cwd":"\#(harness.context.root.path)","hook_event_name":"Stop","last_assistant_message":"done"}
+        """#
+    }
+
+    private func subagentPayload(
+        _ harness: Harness,
+        event: String,
+        agentId: String,
+        turnId: String
+    ) -> String {
+        #"""
+        {"session_id":"\#(harness.sessionId)","turn_id":"\#(turnId)","cwd":"\#(harness.context.root.path)","hook_event_name":"\#(event)","agent_id":"\#(agentId)","agent_type":"default"}
+        """#
+    }
+}


### PR DESCRIPTION
## Summary

- Track native Codex `SubagentStart` and `SubagentStop` events in the locked session store instead of inferring active work from a racy transcript tail.
- Treat a parent Stop with active children as pending work, preserving the Running status and lifecycle while tagging the completion notification for the when-idle gate.
- Inject ordered subagent lifecycle hooks into wrapper-launched Codex sessions and preserve compatibility with older captured hook schemas.

Fixes #7520

## Testing

- Regression red at `042a46bb8a`: the fleet-hosted `cmuxTests/CodexBackgroundWorkNotifyTests` run failed both tests with `pending=0`, Idle status, and idle lifecycle while a subagent was active.
- Regression green at `071ef9bf9d`: the same isolated fleet command passed 2 tests in 1 suite in 2.499 seconds and reported `TEST SUCCEEDED`:
  `scripts/ci/run-in-console-session.sh scripts/ci/run-app-host-xcodebuild.sh -project cmux.xcodeproj -scheme cmux-unit -configuration Debug -destination platform=macOS -only-testing:cmuxTests/CodexBackgroundWorkNotifyTests test`
- `./scripts/lint-pbxproj-test-wiring.sh` passed, and `python3 tests/test_codex_wrapper_resume_hooks.py` passed.
- Tagged dev build used the cloud fleet path, not a successful local build: `./scripts/reload-cloud.sh --tag sym7520 --builder fleet --host cmux8s-mac-mini` completed with `BUILD_OK` for run `sym7520-0d3dc6b099f0`; the downloaded app reported `CMUXCommit=071ef9bf9`.
- Replayed SessionStart → prompt → SubagentStart → Stop against `/tmp/cmux-debug-sym7520.sock`. Codex remained Running, the child stayed in durable state, and `list-notifications` remained empty under the when-idle gate. After SubagentStop and a final Stop, Codex returned to Idle, the child state cleared, and one real completion appeared. The tagged app was then quit and its socket was removed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/9512"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788407313&installation_model_id=21920&pr_number=9512&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F9512&signature=d4be19d7533edb72da9f9e7da1d88634dce23eac759d18ad13c8c484753c7e3b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keep Codex sessions Running while native subagents are active by tracking `SubagentStart`/`SubagentStop`, and delay completion notifications until the session is idle. Fixes #7520.

- **Bug Fixes**
  - Track Codex subagent lifecycle in the locked session store (`activeCodexSubagentIds`) and use it to detect background work instead of scanning transcripts.
  - On Stop with active subagents: keep Codex status/lifecycle Running and tag the completion notification as pending so the when-idle gate suppresses it.
  - Inject synchronous `subagent-start`/`subagent-stop` hooks into wrapper-launched Codex sessions; keep other hooks fire-and-forget and remain compatible with older hook schemas.
  - Add `CodexBackgroundWorkNotifyTests` to verify pending-notify gating and idle transition after the last subagent stops.

<sup>Written for commit 071ef9bf9dbe1f8e8df32445071ead48eaf15a3e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/9512?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Codex subagent start and stop lifecycle events.
  * Background activity now remains accurately tracked while Codex subagents are running.
  * Completion notifications are deferred until active subagents finish, helping prevent premature idle or completion states.
  * Subagent activity is detected directly, without requiring transcript scanning.

* **Bug Fixes**
  * Improved session cleanup and status restoration after Codex subagents stop.
  * Ensured background-work notifications reflect active subagent activity consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->