### PR TITLE
Keep Dock shortcuts routed after empty-pane actions

### DIFF
--- a/Sources/DockSplitContentView.swift
+++ b/Sources/DockSplitContentView.swift
@@ -1,3 +1,4 @@
+import AppKit
 import Bonsplit
 import CmuxAppKitSupportUI
 import Foundation
@@ -18,10 +19,27 @@ struct DockSplitContentView: View {
             dockContent(tab: tab, paneId: paneId)
         } emptyPane: { paneId in
             DockEmptyPaneView(
-                onNewTerminal: { _ = store.newSurface(kind: .terminal, inPane: paneId, focus: true) },
-                onNewBrowser: { _ = store.newSurface(kind: .browser, inPane: paneId, focus: true) }
+                onNewTerminal: {
+                    store.newSurfaceFromDockAffordance(
+                        kind: .terminal,
+                        inPane: paneId,
+                        window: NSApp.keyWindow ?? NSApp.mainWindow
+                    )
+                },
+                onNewBrowser: {
+                    store.newSurfaceFromDockAffordance(
+                        kind: .browser,
+                        inPane: paneId,
+                        window: NSApp.keyWindow ?? NSApp.mainWindow
+                    )
+                }
             )
-            .onTapGesture { store.bonsplitController.focusPane(paneId) }
+            .onTapGesture {
+                store.focusPaneFromDockInteraction(
+                    paneId,
+                    window: NSApp.keyWindow ?? NSApp.mainWindow
+                )
+            }
         }
     }
 
@@ -44,13 +62,35 @@ struct DockSplitContentView: View {
         if let panel = store.panel(for: tab.id) {
             panelView(panel: panel, tabID: tab.id, paneID: paneId)
                 .equatable()
-                .onTapGesture { store.bonsplitController.focusPane(paneId) }
+                .onTapGesture {
+                    store.focusPaneFromDockInteraction(
+                        paneId,
+                        window: NSApp.keyWindow ?? NSApp.mainWindow
+                    )
+                }
         } else {
             DockEmptyPaneView(
-                onNewTerminal: { _ = store.newSurface(kind: .terminal, inPane: paneId, focus: true) },
-                onNewBrowser: { _ = store.newSurface(kind: .browser, inPane: paneId, focus: true) }
+                onNewTerminal: {
+                    store.newSurfaceFromDockAffordance(
+                        kind: .terminal,
+                        inPane: paneId,
+                        window: NSApp.keyWindow ?? NSApp.mainWindow
+                    )
+                },
+                onNewBrowser: {
+                    store.newSurfaceFromDockAffordance(
+                        kind: .browser,
+                        inPane: paneId,
+                        window: NSApp.keyWindow ?? NSApp.mainWindow
+                    )
+                }
             )
-            .onTapGesture { store.bonsplitController.focusPane(paneId) }
+            .onTapGesture {
+                store.focusPaneFromDockInteraction(
+                    paneId,
+                    window: NSApp.keyWindow ?? NSApp.mainWindow
+                )
+            }
         }
     }
 }

--- a/Sources/DockSplitStore+PaneFocus.swift
+++ b/Sources/DockSplitStore+PaneFocus.swift
@@ -67,6 +67,25 @@ extension DockSplitStore {
         )
     }
 
+    /// Applies the window-scoped focus intent before a pointer interaction
+    /// focuses an otherwise empty Dock pane.
+    func focusPaneFromDockInteraction(_ paneId: PaneID, window: NSWindow?) {
+        noteKeyboardFocusIntent(window: window)
+        bonsplitController.focusPane(paneId)
+    }
+
+    /// Creates a surface from a Dock UI affordance while keeping subsequent
+    /// keyboard shortcuts routed to this window's Dock.
+    @discardableResult
+    func newSurfaceFromDockAffordance(
+        kind: DockSurfaceKind,
+        inPane paneId: PaneID,
+        window: NSWindow?
+    ) -> UUID? {
+        noteKeyboardFocusIntent(window: window)
+        return newSurface(kind: kind, inPane: paneId, focus: true)
+    }
+
     /// Resolves both workspace and per-window Docks through their shared live
     /// registry before applying pointer focus. The terminal portal can outlive a
     /// SwiftUI host callback briefly, so pointer activation cannot depend on that
@@ -139,7 +158,11 @@ extension DockSplitStore {
     func newInFocusedPane(kind: DockSurfaceKind) {
         ensureLoaded()
         guard let paneId = bonsplitController.focusedPaneId ?? bonsplitController.allPaneIds.first else { return }
-        _ = newSurface(kind: kind, inPane: paneId, focus: true)
+        newSurfaceFromDockAffordance(
+            kind: kind,
+            inPane: paneId,
+            window: NSApp.keyWindow ?? NSApp.mainWindow
+        )
     }
 
     func collapseToSingleEmptyPane() {

--- a/cmuxTests/DockShortcutRoutingTests.swift
+++ b/cmuxTests/DockShortcutRoutingTests.swift
@@ -280,6 +280,51 @@ struct DockShortcutRoutingTests {
         }
     }
 
+    @Test("Empty-pane New Terminal keeps subsequent browser creation in the Dock")
+    @MainActor
+    func emptyPaneNewTerminalKeepsSubsequentBrowserCreationInDock() async throws {
+        try await AppContextSerialGate.withExclusiveAppContext {
+            try Self.withHarness { harness in
+                let mainPanelId = try #require(harness.mainWorkspace.focusedPanelId)
+                let mainPanelIdsBefore = Set(harness.mainWorkspace.panels.keys)
+                harness.appDelegate.noteMainPanelKeyboardFocusIntent(
+                    workspaceId: harness.mainWorkspace.id,
+                    panelId: mainPanelId,
+                    in: harness.window
+                )
+                #expect(
+                    harness.appDelegate.focusedDockStoreForShortcut(
+                        preferredWindow: harness.window
+                    ) == nil
+                )
+
+                let dockPanelIdsBefore = Set(harness.dock.panels.keys)
+                harness.dock.newInFocusedPane(kind: .terminal)
+                #expect(
+                    Set(harness.dock.panels.keys).subtracting(dockPanelIdsBefore).count == 1
+                )
+                #expect(
+                    harness.appDelegate.focusedDockStoreForShortcut(
+                        preferredWindow: harness.window
+                    ) === harness.dock
+                )
+
+                let dockBrowserId = harness.appDelegate.routeCreateToFocusedDock(
+                    .browser,
+                    focusAddressBar: false,
+                    preferredWindow: harness.window
+                )
+                if dockBrowserId == nil {
+                    _ = harness.appDelegate.openBrowserAndFocusAddressBar(insertAtEnd: true)
+                }
+
+                let routedBrowserId = try #require(dockBrowserId)
+                #expect(harness.dock.browserPanel(for: routedBrowserId) != nil)
+                #expect(Set(harness.mainWorkspace.panels.keys) == mainPanelIdsBefore)
+            }
+        }
+    }
+
     @Test("Customized zoom and flash shortcuts target the focused Dock")
     @MainActor
     func customizedZoomAndFlashTargetFocusedDock() async throws {


### PR DESCRIPTION
Fixes #7522

## Summary

- Record right-sidebar Dock keyboard-focus intent before empty-pane affordances create a surface or pane clicks change selection.
- Route Dock toolbar creation through the same shared store path.
- Keep plain socket `newSurface` calls focus-neutral so automation does not steal keyboard intent.

## Testing

- Red at `3e88f4cc70`: `./scripts/reload-cloud.sh xctest --tag sym7522-red2 --scheme cmux-unit --only-testing cmuxTests/DockShortcutRoutingTests --test-timeout 300` (`sym7522-red2-a8178506d54a`) ran 15 tests; the 14 existing tests passed and the new regression failed because the focused Dock store and Dock browser were both nil.
- Green at `0aef4cf83c`: the same remote suite with `--tag sym7522-green` (`sym7522-green-8f9904b52b5b`) passed all 15 tests.
- Tagged dev build: the fleet path was attempted first; the known-good slot was leased and the two acquired mini-cluster slots failed before packaging because their Zig toolchains were older than the required 0.16.0. Used the documented fallback `./scripts/reload.sh --tag sym7522 --launch`; the build succeeded in 419 seconds.
- Runtime: enabled Dock only for the tagged bundle, opened a fresh empty Dock, clicked New Terminal, then sent `debug.shortcut.simulate` with `cmd+shift+l` to `/tmp/cmux-debug-sym7522.sock`. The main pane remained at 1 surface, while the Dock went from 1 to 2 surfaces and the selected new browser reported `[dock:global]`.
- Quit the tagged app with `pkill -f "DerivedData/cmux-sym7522"` and verified that no process owned its debug socket.
- Localization audit: no new user-facing strings and no string-catalog or web message changes.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/9514"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788408345&installation_model_id=21920&pr_number=9514&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F9514&signature=218a08642ff8e597a60ac1a858c2f07113df21e7ccea8b0e19026a03054050a6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keep Dock keyboard shortcuts routed to the right sidebar after empty-pane actions or pane clicks. Fixes #7522 by recording window-scoped keyboard focus intent before creating Dock surfaces or focusing panes, so follow-up shortcuts target the Dock, not the main workspace.

- **Bug Fixes**
  - Added helpers to record focus intent: focusPaneFromDockInteraction and newSurfaceFromDockAffordance.
  - Wired empty-pane New Terminal/New Browser and pane taps to these helpers; toolbar creation uses the same path.
  - Left plain newSurface calls focus-neutral to avoid stealing focus from automation.
  - Added a regression test to ensure creating a terminal from an empty Dock keeps subsequent browser creation in the Dock.

<sup>Written for commit 0aef4cf83c6ca2624c96677b3a89d6b7fb8ef348. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/9514?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Dock interactions when creating terminals and browsers, including in empty panes.
  * Ensured subsequent Dock actions remain routed to the correct Dock instead of adding panels to the main workspace.
  * Improved pane focus handling across windows.

* **Tests**
  * Added regression coverage for Dock focus and terminal/browser creation workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->