### PR TITLE
Iroh broker: linux platform, TUI pair-grant profile, headless enrollment tokens

### DIFF
--- a/web/app/api/account/route.ts
+++ b/web/app/api/account/route.ts
@@ -22,6 +22,7 @@ import {
   irohRelayPreferences,
   irohAccountSecurityStates,
   irohEndpointBindings,
+  irohEnrollmentTokens,
   irohRegistrationChallenges,
   notificationSendEvents,
   proWelcomeFulfillments,
@@ -1077,6 +1078,7 @@ async function deleteCmuxOwnedAccountRows(userId: string, accountTeamIds: readon
     await tx.delete(deviceTokens).where(eq(deviceTokens.userId, userId));
     await tx.delete(notificationSendEvents).where(eq(notificationSendEvents.userId, userId));
     await tx.delete(irohRelayPreferences).where(eq(irohRelayPreferences.accountId, userId));
+    await tx.delete(irohEnrollmentTokens).where(eq(irohEnrollmentTokens.userId, userId));
     await tx.delete(irohRegistrationChallenges).where(eq(irohRegistrationChallenges.userId, userId));
     await tx.delete(irohEndpointBindings).where(eq(irohEndpointBindings.userId, userId));
     await tx.delete(irohAccountSecurityStates).where(eq(irohAccountSecurityStates.userId, userId));

--- a/web/app/api/devices/iroh/enroll/route.ts
+++ b/web/app/api/devices/iroh/enroll/route.ts
@@ -1,0 +1,8 @@
+import { handleIrohEnrollment } from "../../../../../services/iroh/enrollment";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+export async function POST(request: Request): Promise<Response> {
+  return handleIrohEnrollment(request);
+}

--- a/web/app/api/devices/iroh/enrollment-tokens/route.ts
+++ b/web/app/api/devices/iroh/enrollment-tokens/route.ts
@@ -1,0 +1,8 @@
+import { handleIrohEnrollmentTokenMint } from "../../../../../services/iroh/enrollment";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+export async function POST(request: Request): Promise<Response> {
+  return handleIrohEnrollmentTokenMint(request);
+}

--- a/web/db/migrations/20260803120000_iroh_tui_platform_linux/migration.sql
+++ b/web/db/migrations/20260803120000_iroh_tui_platform_linux/migration.sql
@@ -1,10 +1,13 @@
 -- Allow headless cmux-tui session servers to register iroh endpoint bindings.
--- The new constraint is strictly weaker than the old one ('mac', 'ios'), so
--- every existing row already satisfies it and the validation scan is a no-op
--- rewrite-free pass over a small table.
+-- The re-added constraint is NOT VALID so the ACCESS EXCLUSIVE lock taken by
+-- the DDL never waits on a full-table validation scan; the follow-up
+-- migration (20260803120500) validates it under a weaker lock, mirroring
+-- 20260730210000/20260730211000_connectivity_route_revision. The new
+-- constraint is strictly weaker than the old one ('mac', 'ios'), so every
+-- existing row already satisfies it and validation cannot fail.
 ALTER TABLE "iroh_endpoint_bindings"
   DROP CONSTRAINT "iroh_endpoint_bindings_platform_check";
 --> statement-breakpoint
 ALTER TABLE "iroh_endpoint_bindings"
   ADD CONSTRAINT "iroh_endpoint_bindings_platform_check"
-  CHECK ("platform" in ('mac', 'ios', 'linux'));
+  CHECK ("platform" in ('mac', 'ios', 'linux')) NOT VALID;

--- a/web/db/migrations/20260803120000_iroh_tui_platform_linux/migration.sql
+++ b/web/db/migrations/20260803120000_iroh_tui_platform_linux/migration.sql
@@ -1,0 +1,10 @@
+-- Allow headless cmux-tui session servers to register iroh endpoint bindings.
+-- The new constraint is strictly weaker than the old one ('mac', 'ios'), so
+-- every existing row already satisfies it and the validation scan is a no-op
+-- rewrite-free pass over a small table.
+ALTER TABLE "iroh_endpoint_bindings"
+  DROP CONSTRAINT "iroh_endpoint_bindings_platform_check";
+--> statement-breakpoint
+ALTER TABLE "iroh_endpoint_bindings"
+  ADD CONSTRAINT "iroh_endpoint_bindings_platform_check"
+  CHECK ("platform" in ('mac', 'ios', 'linux'));

--- a/web/db/migrations/20260803120500_validate_iroh_tui_platform_linux/migration.sql
+++ b/web/db/migrations/20260803120500_validate_iroh_tui_platform_linux/migration.sql
@@ -1,0 +1,5 @@
+-- Validate the widened platform CHECK in its own migration (transaction), so
+-- the scan runs under SHARE UPDATE EXCLUSIVE without blocking concurrent
+-- writes. VALIDATE CONSTRAINT is idempotent on an already-valid constraint.
+ALTER TABLE "iroh_endpoint_bindings"
+  VALIDATE CONSTRAINT "iroh_endpoint_bindings_platform_check";

--- a/web/db/migrations/20260803121000_iroh_enrollment_tokens/migration.sql
+++ b/web/db/migrations/20260803121000_iroh_enrollment_tokens/migration.sql
@@ -1,0 +1,24 @@
+-- One-use headless enrollment tokens for cmux-tui iroh peers. A signed-in user
+-- mints a token (15-minute TTL, at most 8 outstanding per user), provisioning
+-- injects it into the container, and the unauthenticated exchange route
+-- consumes it exactly once for a Stack session. Only the SHA-256 hash of the
+-- random token is persisted.
+CREATE TABLE "iroh_enrollment_tokens" (
+  "id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+  "user_id" text NOT NULL,
+  "token_hash" text NOT NULL,
+  "created_at" timestamp with time zone DEFAULT now() NOT NULL,
+  "expires_at" timestamp with time zone NOT NULL,
+  "consumed_at" timestamp with time zone,
+  CONSTRAINT "iroh_enrollment_tokens_token_hash_check"
+    CHECK ("token_hash" ~ '^[0-9a-f]{64}$')
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX "iroh_enrollment_tokens_token_hash_unique"
+  ON "iroh_enrollment_tokens" ("token_hash");
+--> statement-breakpoint
+CREATE INDEX "iroh_enrollment_tokens_user_expires_idx"
+  ON "iroh_enrollment_tokens" ("user_id", "expires_at");
+--> statement-breakpoint
+CREATE INDEX "iroh_enrollment_tokens_expires_idx"
+  ON "iroh_enrollment_tokens" ("expires_at", "id");

--- a/web/db/schema.ts
+++ b/web/db/schema.ts
@@ -778,7 +778,7 @@ export const irohEndpointBindings = pgTable(
     check("iroh_endpoint_bindings_endpoint_id_check", sql`${table.endpointId} ~ '^[0-9a-f]{64}$'`),
     check("iroh_endpoint_bindings_identity_generation_check", sql`${table.identityGeneration} between 1 and 2147483647`),
     check("iroh_endpoint_bindings_tag_check", sql`${table.tag} ~ '^[A-Za-z0-9._-]{1,64}$'`),
-    check("iroh_endpoint_bindings_platform_check", sql`${table.platform} in ('mac', 'ios')`),
+    check("iroh_endpoint_bindings_platform_check", sql`${table.platform} in ('mac', 'ios', 'linux')`),
     check("iroh_endpoint_bindings_display_name_check", sql`${table.displayName} is null or ${table.displayName} !~ '[[:cntrl:]]'`),
     check("iroh_endpoint_bindings_capabilities_check", sql`jsonb_typeof(${table.capabilities}) = 'array' and jsonb_array_length(${table.capabilities}) <= 32`),
     check("iroh_endpoint_bindings_direct_port_v4_check", sql`${table.directPortV4} is null or ${table.directPortV4} between 1 and 65535`),
@@ -926,6 +926,30 @@ export const irohRelayTokenIssuances = pgTable(
     index("iroh_relay_token_issuances_binding_requested_idx").on(table.bindingId, table.requestedAt),
     index("iroh_relay_token_issuances_user_requested_idx").on(table.userId, table.requestedAt, table.id),
     index("iroh_relay_token_issuances_requested_idx").on(table.requestedAt, table.id),
+  ],
+);
+
+/**
+ * One-use headless enrollment tokens. A signed-in user mints one, provisioning
+ * injects it into a container, and the unauthenticated exchange route consumes
+ * it exactly once for a Stack session. Only the SHA-256 hash of the random
+ * token is persisted; the plaintext is returned once at mint time.
+ */
+export const irohEnrollmentTokens = pgTable(
+  "iroh_enrollment_tokens",
+  {
+    id: uuid("id").defaultRandom().primaryKey(),
+    userId: text("user_id").notNull(),
+    tokenHash: text("token_hash").notNull(),
+    createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+    expiresAt: timestamp("expires_at", { withTimezone: true }).notNull(),
+    consumedAt: timestamp("consumed_at", { withTimezone: true }),
+  },
+  (table) => [
+    check("iroh_enrollment_tokens_token_hash_check", sql`${table.tokenHash} ~ '^[0-9a-f]{64}$'`),
+    uniqueIndex("iroh_enrollment_tokens_token_hash_unique").on(table.tokenHash),
+    index("iroh_enrollment_tokens_user_expires_idx").on(table.userId, table.expiresAt),
+    index("iroh_enrollment_tokens_expires_idx").on(table.expiresAt, table.id),
   ],
 );
 

--- a/web/services/iroh/crypto.ts
+++ b/web/services/iroh/crypto.ts
@@ -18,9 +18,14 @@ import {
   IROH_PAIR_GRANT_LIFETIME_SECONDS,
   IROH_PAIR_GRANT_TYP,
   IROH_PAIR_SCOPE,
+  IROH_TUI_ALPN,
+  IROH_TUI_PAIR_SCOPE,
   endpointId,
+  isIrohPlatform,
+  pairGrantProfileForAcceptorPlatform,
   POSTGRES_INT32_MAX,
   sha256,
+  type IrohPlatform,
 } from "./model";
 import { IrohConfigurationError, IrohForbiddenError, IrohInvalidInputError } from "./errors";
 
@@ -30,7 +35,7 @@ export type PairGrantPeer = {
   readonly bindingId: string;
   readonly deviceId: string;
   readonly tag: string;
-  readonly platform: "mac" | "ios";
+  readonly platform: IrohPlatform;
   readonly endpointId: string;
   readonly identityGeneration: number;
 };
@@ -40,8 +45,8 @@ export type PairGrantClaims = {
   readonly iat: number;
   readonly nbf: number;
   readonly exp: number;
-  readonly alpn: typeof IROH_ALPN;
-  readonly scope: typeof IROH_PAIR_SCOPE;
+  readonly alpn: typeof IROH_ALPN | typeof IROH_TUI_ALPN;
+  readonly scope: typeof IROH_PAIR_SCOPE | typeof IROH_TUI_PAIR_SCOPE;
   readonly initiator: PairGrantPeer;
   readonly acceptor: PairGrantPeer;
 };
@@ -77,7 +82,7 @@ export type EndpointAttestationClaims = {
   readonly deviceId: string;
   readonly endpointId: string;
   readonly identityGeneration: number;
-  readonly platform: "mac" | "ios";
+  readonly platform: IrohPlatform;
   readonly iat: number;
   readonly nbf: number;
   readonly exp: number;
@@ -90,7 +95,7 @@ export type EndpointAttestationExpectation = {
   readonly deviceId: string;
   readonly endpointId: string;
   readonly identityGeneration: number;
-  readonly platform: "mac" | "ios";
+  readonly platform: IrohPlatform;
   readonly nowSeconds: number;
 };
 
@@ -515,8 +520,6 @@ function validatePairGrantClaims(
   if (typeof value.jti !== "string" || !UUID_PATTERN.test(value.jti)) {
     throw new IrohForbiddenError({ code: "invalid_pair_grant_claims" });
   }
-  if (value.alpn !== IROH_ALPN) throw new IrohForbiddenError({ code: "invalid_pair_grant_alpn" });
-  if (value.scope !== IROH_PAIR_SCOPE) throw new IrohForbiddenError({ code: "invalid_pair_grant_scope" });
   if (!Number.isSafeInteger(value.iat) || !Number.isSafeInteger(value.nbf) || !Number.isSafeInteger(value.exp)) {
     throw new IrohForbiddenError({ code: "invalid_pair_grant_expiry" });
   }
@@ -531,9 +534,14 @@ function validatePairGrantClaims(
   }
   validatePeer(value.initiator, "initiator");
   validatePeer(value.acceptor, "acceptor");
-  if (value.initiator.platform !== "ios" || value.acceptor.platform !== "mac") {
+  // The ALPN and scope are bound to the acceptor-platform profile: a grant for
+  // a Linux TUI acceptor carrying the mobile ALPN must fail, and vice versa.
+  const profile = pairGrantProfileForAcceptorPlatform(value.acceptor.platform);
+  if (!profile || !profile.initiatorPlatforms.includes(value.initiator.platform)) {
     throw new IrohForbiddenError({ code: "invalid_pair_grant_platforms" });
   }
+  if (value.alpn !== profile.alpn) throw new IrohForbiddenError({ code: "invalid_pair_grant_alpn" });
+  if (value.scope !== profile.scope) throw new IrohForbiddenError({ code: "invalid_pair_grant_scope" });
   if (
     value.initiator.bindingId === value.acceptor.bindingId ||
     value.initiator.deviceId === value.acceptor.deviceId ||
@@ -579,7 +587,7 @@ function validateEndpointAttestationClaims(
     !Number.isSafeInteger(value.identityGeneration) ||
     value.identityGeneration < 1 ||
     value.identityGeneration > POSTGRES_INT32_MAX ||
-    (value.platform !== "mac" && value.platform !== "ios") ||
+    !isIrohPlatform(value.platform) ||
     value.alpn !== IROH_ALPN ||
     value.scope !== IROH_ENDPOINT_ATTESTATION_SCOPE
   ) {
@@ -620,7 +628,7 @@ function validatePeer(peer: PairGrantPeer, side: string): void {
     !Number.isSafeInteger(peer.identityGeneration) ||
     peer.identityGeneration < 1 ||
     peer.identityGeneration > POSTGRES_INT32_MAX ||
-    (peer.platform !== "mac" && peer.platform !== "ios")
+    !isIrohPlatform(peer.platform)
   ) {
     throw new IrohForbiddenError({ code: `invalid_pair_grant_${side}` });
   }
@@ -801,7 +809,7 @@ function validateOfflinePairSessionWindow(nowSeconds: number, expiresAtSeconds: 
 
 function validateEndpointExpectation(
   value: OfflinePairVerificationExpectation["acceptor"],
-  platform: "mac" | "ios",
+  platform: IrohPlatform,
 ): void {
   if (
     !UUID_PATTERN.test(value.bindingId) ||

--- a/web/services/iroh/enrollment.ts
+++ b/web/services/iroh/enrollment.ts
@@ -1,0 +1,334 @@
+import { randomBytes } from "node:crypto";
+import { and, asc, count, eq, gt, isNull, lte, sql } from "drizzle-orm";
+import { checkRateLimit } from "@vercel/firewall";
+import { env } from "../../app/env";
+import { getStackServerApp } from "../../app/lib/stack";
+import { cloudDb } from "../../db/client";
+import { irohEnrollmentTokens } from "../../db/schema";
+import { unauthorized, verifyRequest } from "../vms/auth";
+import { enforceBrowserMutationProtection, jsonResponse } from "../vms/routeHelpers";
+import { IrohQuotaExceededError } from "./errors";
+import { sha256 } from "./model";
+import { assertIrohUserMutationAllowed } from "./repository";
+import { irohErrorResponse } from "./routeHandler";
+
+export const IROH_ENROLLMENT_TOKEN_LIFETIME_MS = 15 * 60 * 1_000;
+export const IROH_ENROLLMENT_TOKEN_BYTES = 32;
+/** Outstanding = unconsumed and unexpired, counted per user at mint time. */
+export const IROH_ENROLLMENT_MAX_OUTSTANDING_TOKENS = 8;
+/** Mirrors the vault CLI device-flow session lifetime (auth/poll). */
+export const IROH_ENROLLMENT_SESSION_LIFETIME_MS = 90 * 24 * 60 * 60 * 1_000;
+
+const MAX_BODY_BYTES = 64 * 1_024;
+/** 32 random bytes encode to exactly 43 unpadded base64url characters. */
+const ENROLLMENT_TOKEN_PATTERN = /^[A-Za-z0-9_-]{43}$/;
+const MAX_TOKEN_FIELD_LENGTH = 128;
+const EXPIRED_TOKEN_GC_AGE_MS = 60 * 60 * 1_000;
+
+export type IrohEnrollmentSessionTokens = {
+  readonly accessToken: string;
+  readonly refreshToken: string;
+};
+
+export type IrohEnrollmentStoreShape = {
+  /**
+   * Persists the token hash under the account-deletion fence and a per-user
+   * advisory lock, enforcing the outstanding-token cap atomically. Throws
+   * IrohQuotaExceededError when the cap is reached.
+   */
+  readonly mintToken: (input: {
+    readonly userId: string;
+    readonly tokenHash: string;
+    readonly now: Date;
+    readonly expiresAt: Date;
+  }) => Promise<void>;
+  /**
+   * Single-use consume: matches an unconsumed, unexpired row and stamps
+   * consumed_at in one atomic UPDATE, so a concurrent double-spend fails for
+   * the loser. Returns null without distinguishing missing/consumed/expired.
+   */
+  readonly consumeToken: (input: {
+    readonly tokenHash: string;
+    readonly now: Date;
+  }) => Promise<{ readonly userId: string } | null>;
+};
+
+export type IrohEnrollmentDependencies = {
+  readonly verify?: typeof verifyRequest;
+  readonly store?: IrohEnrollmentStoreShape;
+  readonly mintSession?: (userId: string) => Promise<IrohEnrollmentSessionTokens | null>;
+  readonly rateLimit?: (request: Request) => Promise<Response | null>;
+  readonly now?: () => Date;
+};
+
+/** POST /api/devices/iroh/enrollment-tokens (authenticated, native bearer). */
+export async function handleIrohEnrollmentTokenMint(
+  request: Request,
+  dependencies: IrohEnrollmentDependencies = {},
+): Promise<Response> {
+  const verify = dependencies.verify ?? verifyRequest;
+  let user: Awaited<ReturnType<typeof verifyRequest>>;
+  try {
+    user = await verify(request, { allowCookie: false });
+  } catch {
+    return jsonResponse({ error: "unauthorized" }, 401);
+  }
+  if (!user) return unauthorized();
+
+  const mutationForbidden = enforceBrowserMutationProtection(request);
+  if (mutationForbidden) return mutationForbidden;
+
+  const body = await readOptionalEmptyJsonObject(request);
+  if (!body.ok) return body.response;
+
+  const now = (dependencies.now ?? (() => new Date()))();
+  const token = randomBytes(IROH_ENROLLMENT_TOKEN_BYTES).toString("base64url");
+  const expiresAt = new Date(now.getTime() + IROH_ENROLLMENT_TOKEN_LIFETIME_MS);
+  try {
+    await (dependencies.store ?? drizzleIrohEnrollmentStore()).mintToken({
+      userId: user.id,
+      tokenHash: sha256(token),
+      now,
+      expiresAt,
+    });
+  } catch (error) {
+    return irohErrorResponse(error, "enrollment_token_mint");
+  }
+  return irohJson({ token, expires_at: expiresAt.toISOString() }, 201);
+}
+
+/**
+ * POST /api/devices/iroh/enroll (unauthenticated: the caller is a headless
+ * container that only holds the one-use provisioning token).
+ */
+export async function handleIrohEnrollment(
+  request: Request,
+  dependencies: IrohEnrollmentDependencies = {},
+): Promise<Response> {
+  const throttled = await (dependencies.rateLimit ?? enrollmentFirewallRateLimit)(request);
+  if (throttled) return throttled;
+
+  const body = await readRequiredJsonObject(request);
+  if (!body.ok) return body.response;
+  const record = body.value;
+  if (Object.keys(record).some((key) => key !== "token")) {
+    return jsonResponse({ error: "unknown_field" }, 400);
+  }
+  const token = record.token;
+  // One uniform failure for every unusable token (malformed, unknown, already
+  // consumed, expired) so the response never distinguishes them.
+  if (
+    typeof token !== "string" ||
+    token.length > MAX_TOKEN_FIELD_LENGTH ||
+    !ENROLLMENT_TOKEN_PATTERN.test(token)
+  ) {
+    return invalidEnrollmentToken();
+  }
+
+  const now = (dependencies.now ?? (() => new Date()))();
+  try {
+    const consumed = await (dependencies.store ?? drizzleIrohEnrollmentStore()).consumeToken({
+      tokenHash: sha256(token),
+      now,
+    });
+    if (!consumed) return invalidEnrollmentToken();
+    const sessionTokens = await (dependencies.mintSession ?? mintStackSession)(consumed.userId);
+    if (!sessionTokens) return invalidEnrollmentToken();
+    return irohJson({
+      accessToken: sessionTokens.accessToken,
+      refreshToken: sessionTokens.refreshToken,
+    }, 201);
+  } catch (error) {
+    return irohErrorResponse(error, "enrollment_exchange");
+  }
+}
+
+export function drizzleIrohEnrollmentStore(): IrohEnrollmentStoreShape {
+  return {
+    mintToken: async (input) => {
+      const db = cloudDb();
+      await db.transaction(async (tx) => {
+        await assertIrohUserMutationAllowed(tx, input.userId);
+        await tx.execute(sql`select pg_advisory_xact_lock(hashtextextended(${`iroh:enrollment:${input.userId}`}, 0))`);
+        // Opportunistic per-user GC: rows dead for over an hour carry no
+        // audit value and would otherwise linger for deleted provisioning runs.
+        const gcCutoff = new Date(input.now.getTime() - EXPIRED_TOKEN_GC_AGE_MS);
+        await tx
+          .delete(irohEnrollmentTokens)
+          .where(and(
+            eq(irohEnrollmentTokens.userId, input.userId),
+            lte(irohEnrollmentTokens.expiresAt, gcCutoff),
+          ));
+        const outstandingWhere = and(
+          eq(irohEnrollmentTokens.userId, input.userId),
+          isNull(irohEnrollmentTokens.consumedAt),
+          gt(irohEnrollmentTokens.expiresAt, input.now),
+        );
+        const [outstanding] = await tx
+          .select({ value: count() })
+          .from(irohEnrollmentTokens)
+          .where(outstandingWhere);
+        if ((outstanding?.value ?? 0) >= IROH_ENROLLMENT_MAX_OUTSTANDING_TOKENS) {
+          const [oldest] = await tx
+            .select({ expiresAt: irohEnrollmentTokens.expiresAt })
+            .from(irohEnrollmentTokens)
+            .where(outstandingWhere)
+            .orderBy(asc(irohEnrollmentTokens.expiresAt))
+            .limit(1);
+          const retryAfterSeconds = Math.max(1, Math.ceil(
+            ((oldest?.expiresAt ?? input.expiresAt).getTime() - input.now.getTime()) / 1_000,
+          ));
+          throw new IrohQuotaExceededError({
+            code: "enrollment_token_quota",
+            retryAfterSeconds,
+          });
+        }
+        await tx.insert(irohEnrollmentTokens).values({
+          userId: input.userId,
+          tokenHash: input.tokenHash,
+          createdAt: input.now,
+          expiresAt: input.expiresAt,
+        });
+      });
+    },
+
+    consumeToken: async (input) => {
+      const [consumed] = await cloudDb()
+        .update(irohEnrollmentTokens)
+        .set({ consumedAt: input.now })
+        .where(and(
+          eq(irohEnrollmentTokens.tokenHash, input.tokenHash),
+          isNull(irohEnrollmentTokens.consumedAt),
+          gt(irohEnrollmentTokens.expiresAt, input.now),
+        ))
+        .returning({ userId: irohEnrollmentTokens.userId });
+      return consumed ?? null;
+    },
+  };
+}
+
+/**
+ * Mints a real Stack session for the enrolled user, mirroring the vault CLI
+ * device-flow precedent (app/api/vault/cli/auth/poll). Tokens are returned
+ * once and never persisted server-side.
+ */
+async function mintStackSession(userId: string): Promise<IrohEnrollmentSessionTokens | null> {
+  const user = await getStackServerApp().getUser(userId);
+  if (!user) return null;
+  const session = await user.createSession({
+    expiresInMillis: IROH_ENROLLMENT_SESSION_LIFETIME_MS,
+  });
+  const tokens = await session.getTokens();
+  if (!tokens.accessToken || !tokens.refreshToken) return null;
+  return { accessToken: tokens.accessToken, refreshToken: tokens.refreshToken };
+}
+
+/**
+ * Per-IP throttle through the platform firewall, same pattern as the other
+ * unauthenticated POST endpoints (vault CLI auth start, waitlist, feedback).
+ * Only active on Vercel with the optional Iroh rule configured; the one-use
+ * token itself remains the primary control.
+ */
+async function enrollmentFirewallRateLimit(request: Request): Promise<Response | null> {
+  if (process.env.VERCEL !== "1" || !env.CMUX_IROH_RATE_LIMIT_ID) return null;
+  const { error, rateLimited } = await checkRateLimit(env.CMUX_IROH_RATE_LIMIT_ID, { request });
+  if (rateLimited || error === "blocked") {
+    return jsonResponse({ error: "throttled" }, 429);
+  }
+  return null;
+}
+
+function invalidEnrollmentToken(): Response {
+  return irohJson({ error: "invalid_enrollment_token" }, 404);
+}
+
+function irohJson(value: unknown, status: number): Response {
+  return new Response(JSON.stringify(value), {
+    status,
+    headers: { "content-type": "application/json", "cache-control": "no-store" },
+  });
+}
+
+type BodyResult<T> =
+  | { readonly ok: true; readonly value: T }
+  | { readonly ok: false; readonly response: Response };
+
+/**
+ * The mint route takes no parameters: accept a missing body, an empty body,
+ * or an empty JSON object, and reject anything carrying unknown content.
+ */
+async function readOptionalEmptyJsonObject(
+  request: Request,
+): Promise<BodyResult<Record<string, never>>> {
+  const text = await readBoundedText(request);
+  if (!text.ok) return text;
+  if (text.value.trim().length === 0) return { ok: true, value: {} };
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(text.value);
+  } catch {
+    return { ok: false, response: jsonResponse({ error: "invalid_json" }, 400) };
+  }
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    return { ok: false, response: jsonResponse({ error: "invalid_json" }, 400) };
+  }
+  if (Object.keys(parsed).length > 0) {
+    return { ok: false, response: jsonResponse({ error: "unknown_field" }, 400) };
+  }
+  return { ok: true, value: {} };
+}
+
+async function readRequiredJsonObject(
+  request: Request,
+): Promise<BodyResult<Record<string, unknown>>> {
+  if (request.headers.get("content-type")?.split(";", 1)[0]?.trim().toLowerCase() !== "application/json") {
+    return { ok: false, response: jsonResponse({ error: "unsupported_media_type" }, 415) };
+  }
+  const text = await readBoundedText(request);
+  if (!text.ok) return text;
+  if (text.value.length === 0) {
+    return { ok: false, response: jsonResponse({ error: "missing_body" }, 400) };
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(text.value);
+  } catch {
+    return { ok: false, response: jsonResponse({ error: "invalid_json" }, 400) };
+  }
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    return { ok: false, response: jsonResponse({ error: "invalid_json" }, 400) };
+  }
+  return { ok: true, value: parsed as Record<string, unknown> };
+}
+
+async function readBoundedText(request: Request): Promise<BodyResult<string>> {
+  const contentLength = request.headers.get("content-length");
+  if (contentLength) {
+    const parsed = Number(contentLength);
+    if (!Number.isSafeInteger(parsed) || parsed < 0 || parsed > MAX_BODY_BYTES) {
+      return { ok: false, response: jsonResponse({ error: "request_too_large" }, 413) };
+    }
+  }
+  const reader = request.body?.getReader();
+  if (!reader) return { ok: true, value: "" };
+  const chunks: Uint8Array[] = [];
+  let total = 0;
+  try {
+    while (true) {
+      const next = await reader.read();
+      if (next.done) break;
+      total += next.value.byteLength;
+      if (total > MAX_BODY_BYTES) {
+        await reader.cancel();
+        return { ok: false, response: jsonResponse({ error: "request_too_large" }, 413) };
+      }
+      chunks.push(next.value);
+    }
+  } catch {
+    return { ok: false, response: jsonResponse({ error: "invalid_body" }, 400) };
+  }
+  return {
+    ok: true,
+    value: Buffer.concat(chunks.map((chunk) => Buffer.from(chunk)), total).toString("utf8"),
+  };
+}

--- a/web/services/iroh/enrollment.ts
+++ b/web/services/iroh/enrollment.ts
@@ -7,7 +7,7 @@ import { cloudDb } from "../../db/client";
 import { irohEnrollmentTokens } from "../../db/schema";
 import { unauthorized, verifyRequest } from "../vms/auth";
 import { enforceBrowserMutationProtection, jsonResponse } from "../vms/routeHelpers";
-import { IrohQuotaExceededError } from "./errors";
+import { IrohConflictError, IrohQuotaExceededError } from "./errors";
 import { sha256 } from "./model";
 import { assertIrohUserMutationAllowed } from "./repository";
 import { irohErrorResponse } from "./routeHandler";
@@ -193,16 +193,36 @@ export function drizzleIrohEnrollmentStore(): IrohEnrollmentStoreShape {
     },
 
     consumeToken: async (input) => {
-      const [consumed] = await cloudDb()
-        .update(irohEnrollmentTokens)
-        .set({ consumedAt: input.now })
-        .where(and(
-          eq(irohEnrollmentTokens.tokenHash, input.tokenHash),
-          isNull(irohEnrollmentTokens.consumedAt),
-          gt(irohEnrollmentTokens.expiresAt, input.now),
-        ))
-        .returning({ userId: irohEnrollmentTokens.userId });
-      return consumed ?? null;
+      try {
+        return await cloudDb().transaction(async (tx) => {
+          const [consumed] = await tx
+            .update(irohEnrollmentTokens)
+            .set({ consumedAt: input.now })
+            .where(and(
+              eq(irohEnrollmentTokens.tokenHash, input.tokenHash),
+              isNull(irohEnrollmentTokens.consumedAt),
+              gt(irohEnrollmentTokens.expiresAt, input.now),
+            ))
+            .returning({ userId: irohEnrollmentTokens.userId });
+          if (!consumed) return null;
+          // Account-deletion fence, same as mintToken: a token minted before
+          // deletion must not redeem a Stack session once deletion is
+          // pending. Throwing aborts the transaction, so the conditional
+          // consume above also rolls back.
+          await assertIrohUserMutationAllowed(tx, consumed.userId);
+          return consumed;
+        });
+      } catch (error) {
+        // The exchange route is unauthenticated: a fenced account must
+        // answer exactly like an unknown, spent, or expired token.
+        if (
+          error instanceof IrohConflictError &&
+          error.code === "account_deletion_in_progress"
+        ) {
+          return null;
+        }
+        throw error;
+      }
     },
   };
 }

--- a/web/services/iroh/model.ts
+++ b/web/services/iroh/model.ts
@@ -5,6 +5,8 @@ export { MANAGED_RELAY_URLS } from "./publicationPolicy";
 
 export const IROH_ALPN = "cmux/mobile/1";
 export const IROH_PAIR_SCOPE = "cmux.mobile.attach";
+export const IROH_TUI_ALPN = "cmux/tui/1";
+export const IROH_TUI_PAIR_SCOPE = "cmux.tui.attach";
 export const IROH_PAIR_GRANT_TYP = "cmux-pair-grant+jwt";
 export const IROH_ENDPOINT_ATTESTATION_VERSION = 1;
 export const IROH_ENDPOINT_ATTESTATION_TYP = "cmux-endpoint-attestation-v1+jwt";
@@ -18,6 +20,53 @@ export const IROH_RELAY_TOKEN_LIFETIME_SECONDS = 24 * 60 * 60;
 export const IROH_RELAY_TOKEN_REFRESH_SECONDS = 12 * 60 * 60;
 export const IROH_ROUTE_CONTRACT_VERSION = 1;
 export const POSTGRES_INT32_MAX = 2_147_483_647;
+
+/**
+ * Platforms an iroh endpoint binding may register as. "linux" is a headless
+ * cmux-tui session server (often a Docker container); it participates in TUI
+ * pair grants only, never in the mobile-attach or offline-pairing profiles.
+ */
+export const IROH_PLATFORMS = ["mac", "ios", "linux"] as const;
+export type IrohPlatform = (typeof IROH_PLATFORMS)[number];
+
+export function isIrohPlatform(value: unknown): value is IrohPlatform {
+  return value === "mac" || value === "ios" || value === "linux";
+}
+
+export type IrohPairGrantProfile = {
+  readonly alpn: typeof IROH_ALPN | typeof IROH_TUI_ALPN;
+  readonly scope: typeof IROH_PAIR_SCOPE | typeof IROH_TUI_PAIR_SCOPE;
+  readonly initiatorPlatforms: readonly IrohPlatform[];
+};
+
+/**
+ * The pair-grant profile is selected by the ACCEPTOR's platform. A Mac
+ * acceptor keeps the original mobile-attach rule byte-for-byte (iOS initiator
+ * only). A Linux acceptor is a headless cmux-tui session server: any
+ * same-account mac/ios/linux peer may initiate, and the minted claims carry
+ * the TUI ALPN and scope so a mobile grant can never admit a TUI stream, and
+ * vice versa. Every layer (route gate, repository audit, claims validation on
+ * sign and verify) derives the profile from this one function.
+ */
+export function pairGrantProfileForAcceptorPlatform(
+  platform: string,
+): IrohPairGrantProfile | null {
+  if (platform === "mac") {
+    return {
+      alpn: IROH_ALPN,
+      scope: IROH_PAIR_SCOPE,
+      initiatorPlatforms: ["ios"],
+    };
+  }
+  if (platform === "linux") {
+    return {
+      alpn: IROH_TUI_ALPN,
+      scope: IROH_TUI_PAIR_SCOPE,
+      initiatorPlatforms: ["mac", "ios", "linux"],
+    };
+  }
+  return null;
+}
 
 export type IrohPathHint = {
   readonly kind: "direct_address" | "relay_url";
@@ -42,7 +91,7 @@ export type IrohRegistrationPayload = {
   readonly deviceId: string;
   readonly appInstanceId: string;
   readonly tag: string;
-  readonly platform: "mac" | "ios";
+  readonly platform: IrohPlatform;
   readonly displayName?: string;
   readonly endpointId: string;
   readonly identityGeneration: number;
@@ -155,7 +204,7 @@ export function parseRegistrationPayload(value: unknown, now: Date): IrohRegistr
     deviceId: uuid(body.deviceId, "invalid_device_id"),
     appInstanceId: uuid(body.appInstanceId, "invalid_app_instance_id"),
     tag: safeTag(body.tag),
-    platform: oneOf(body.platform, ["mac", "ios"] as const, "invalid_platform"),
+    platform: oneOf(body.platform, IROH_PLATFORMS, "invalid_platform"),
     ...(body.displayName === undefined || body.displayName === null
       ? {}
       : { displayName: safeDisplayName(body.displayName) }),

--- a/web/services/iroh/model.ts
+++ b/web/services/iroh/model.ts
@@ -30,7 +30,7 @@ export const IROH_PLATFORMS = ["mac", "ios", "linux"] as const;
 export type IrohPlatform = (typeof IROH_PLATFORMS)[number];
 
 export function isIrohPlatform(value: unknown): value is IrohPlatform {
-  return value === "mac" || value === "ios" || value === "linux";
+  return (IROH_PLATFORMS as readonly unknown[]).includes(value);
 }
 
 export type IrohPairGrantProfile = {

--- a/web/services/iroh/repository.ts
+++ b/web/services/iroh/repository.ts
@@ -25,9 +25,11 @@ import type { PairGrantPeer } from "./crypto";
 import type { IrohDiscoveryCursor } from "./discoveryPagination";
 import {
   nextPathHintExpiry,
+  pairGrantProfileForAcceptorPlatform,
   parseIrohPathHint,
   sha256,
   type IrohPathHint,
+  type IrohPlatform,
   type IrohRegistrationPayload,
 } from "./model";
 
@@ -145,7 +147,7 @@ export type IrohRepositoryShape = {
     readonly deviceId: string;
     readonly endpointId: string;
     readonly identityGeneration: number;
-    readonly platform: "mac" | "ios";
+    readonly platform: IrohPlatform;
   }) => Effect.Effect<void, RepositoryError>;
   readonly recordPairGrant: (input: {
     readonly userId: string;
@@ -834,8 +836,19 @@ function makeLiveRepository(): IrohRepositoryShape {
         if (initiator.deviceUuid === acceptor.deviceUuid) {
           throw new IrohForbiddenError({ code: "pair_grant_same_device" });
         }
-        if (initiator.platform !== "ios" || acceptor.platform !== "mac" || !acceptor.pairingEnabled) {
+        // Re-derive the acceptor-platform profile under the row locks and bind
+        // the audited ALPN/scope to it, so a raced platform change between the
+        // route gate and this commit cannot record a cross-profile grant.
+        const profile = pairGrantProfileForAcceptorPlatform(acceptor.platform);
+        if (
+          !profile ||
+          !(profile.initiatorPlatforms as readonly string[]).includes(initiator.platform) ||
+          !acceptor.pairingEnabled
+        ) {
           throw new IrohForbiddenError({ code: "target_not_pairable" });
+        }
+        if (input.alpn !== profile.alpn || input.scope !== profile.scope) {
+          throw new IrohConflictError({ code: "pair_grant_profile_mismatch" });
         }
         await tx.insert(irohPairGrantIssuances).values({
           userId: input.userId,
@@ -1503,7 +1516,7 @@ function databaseCause(cause: unknown): {
   return null;
 }
 
-async function assertIrohUserMutationAllowed(
+export async function assertIrohUserMutationAllowed(
   tx: CloudDbTransaction,
   userId: string,
 ): Promise<void> {

--- a/web/services/iroh/routeHandler.ts
+++ b/web/services/iroh/routeHandler.ts
@@ -100,13 +100,20 @@ export async function handleIrohRoute(
       "cache-control": "no-store",
     });
   } catch (error) {
-    const expected = irohExpectedError(error);
-    if (expected) return expectedErrorResponse(expected);
-    // Do not include EndpointIDs, hints, grants, or tokens in logs. The route
-    // and coarse failure class are enough for operational correlation.
-    console.error("iroh trust broker request failed", { operation, failure: "unexpected" });
-    return jsonResponse({ error: "iroh_internal_error" }, 500);
+    return irohErrorResponse(error, operation);
   }
+}
+
+/**
+ * Maps any thrown Iroh domain error to its typed JSON response, and everything
+ * else to an opaque 500. Do not include EndpointIDs, hints, grants, or tokens
+ * in logs; the route and coarse failure class are enough for correlation.
+ */
+export function irohErrorResponse(error: unknown, operation: string): Response {
+  const expected = irohExpectedError(error);
+  if (expected) return expectedErrorResponse(expected);
+  console.error("iroh trust broker request failed", { operation, failure: "unexpected" });
+  return jsonResponse({ error: "iroh_internal_error" }, 500);
 }
 
 function mutationRevision(

--- a/web/services/iroh/trustBroker.ts
+++ b/web/services/iroh/trustBroker.ts
@@ -39,11 +39,12 @@ import {
   IROH_ENDPOINT_ATTESTATION_SCOPE,
   IROH_ENDPOINT_ATTESTATION_VERSION,
   IROH_PAIR_GRANT_LIFETIME_SECONDS,
-  IROH_PAIR_SCOPE,
   IROH_RELAY_TOKEN_LIFETIME_SECONDS,
   IROH_RELAY_TOKEN_REFRESH_SECONDS,
   assertChallengeMatchesPayload,
   decodeRegistrationPayload,
+  isIrohPlatform,
+  pairGrantProfileForAcceptorPlatform,
   parseBindingIdBody,
   parseChallengeRequest,
   parseIrohPathHint,
@@ -51,6 +52,7 @@ import {
   parseRegisterRequest,
   sha256,
   type IrohPathHint,
+  type IrohPlatform,
 } from "./model";
 import {
   IrohRepository,
@@ -381,7 +383,15 @@ export function makeIrohTrustBroker(
       const initiator = byId.get(request.initiatorBindingId);
       const acceptor = byId.get(request.acceptorBindingId);
       if (!initiator || !acceptor) return yield* Effect.fail(new IrohNotFoundError({ resource: "binding" }));
-      if (initiator.platform !== "ios" || acceptor.platform !== "mac" || !acceptor.pairingEnabled) {
+      // The grant profile follows the ACCEPTOR's platform: a Mac acceptor keeps
+      // the mobile rule (iOS initiator), a Linux TUI acceptor admits any
+      // same-account mac/ios/linux initiator. Both require pairingEnabled.
+      const profile = pairGrantProfileForAcceptorPlatform(acceptor.platform);
+      if (
+        !profile ||
+        !(profile.initiatorPlatforms as readonly string[]).includes(initiator.platform) ||
+        !acceptor.pairingEnabled
+      ) {
         return yield* Effect.fail(new IrohForbiddenError({ code: "target_not_pairable" }));
       }
       if (initiator.deviceUuid === acceptor.deviceUuid) {
@@ -393,8 +403,8 @@ export function makeIrohTrustBroker(
         iat: issuedAtSeconds,
         nbf: issuedAtSeconds - 5,
         exp: issuedAtSeconds + IROH_PAIR_GRANT_LIFETIME_SECONDS,
-        alpn: IROH_ALPN,
-        scope: IROH_PAIR_SCOPE,
+        alpn: profile.alpn,
+        scope: profile.scope,
         initiator: grantPeer(initiator),
         acceptor: grantPeer(acceptor),
       };
@@ -416,8 +426,8 @@ export function makeIrohTrustBroker(
         initiator: claims.initiator,
         acceptor: claims.acceptor,
         signingKeyId,
-        alpn: IROH_ALPN,
-        scope: IROH_PAIR_SCOPE,
+        alpn: profile.alpn,
+        scope: profile.scope,
         issuedAt: new Date(claims.iat * 1_000),
         notBefore: new Date(claims.nbf * 1_000),
         expiresAt: new Date(claims.exp * 1_000),
@@ -582,8 +592,8 @@ function signingVerificationKeys(config: IrohTrustBrokerConfigShape) {
   return verificationKeys;
 }
 
-function bindingPlatform(binding: IrohBindingRecord): "mac" | "ios" {
-  if (binding.platform !== "mac" && binding.platform !== "ios") {
+function bindingPlatform(binding: IrohBindingRecord): IrohPlatform {
+  if (!isIrohPlatform(binding.platform)) {
     throw new IrohConfigurationError({ component: "grant_signing" });
   }
   return binding.platform;

--- a/web/tests/iroh-db-behavior.test.ts
+++ b/web/tests/iroh-db-behavior.test.ts
@@ -673,11 +673,20 @@ describe("Iroh trust broker database behavior", () => {
     // share it (the slot is keyed on user + device + tag instead).
     await insertBinding({ userId: "user-b", appInstanceId, endpointId: "41".repeat(32) });
     await expectPostgresError(insertBinding({ userId: "user-a", endpointId: "not-an-endpoint" }), "23514");
-    await expectPostgresError(requiredSql()`
+    // 'linux' (headless cmux-tui session server) is a valid platform; anything
+    // outside the fixed mac/ios/linux set still trips the CHECK constraint.
+    await requiredSql()`
       insert into iroh_endpoint_bindings (
         user_id, device_uuid, app_instance_id, tag, platform, endpoint_id, identity_generation
       ) values (
         'user-a', ${randomUUID()}, ${randomUUID()}, 'stable', 'linux', ${"42".repeat(32)}, 1
+      )
+    `;
+    await expectPostgresError(requiredSql()`
+      insert into iroh_endpoint_bindings (
+        user_id, device_uuid, app_instance_id, tag, platform, endpoint_id, identity_generation
+      ) values (
+        'user-a', ${randomUUID()}, ${randomUUID()}, 'stable', 'windows', ${"49".repeat(32)}, 1
       )
     `, "23514");
     await expectPostgresError(requiredSql()`
@@ -1510,6 +1519,48 @@ describe("Iroh trust broker database behavior", () => {
     expect(total).toBe("0");
   });
 
+  dbTest("binds the pair-grant audit to the acceptor-platform profile inside the transaction", async () => {
+    const userId = "user-pair-tui-profile";
+    const initiatorId = await insertBinding({
+      userId,
+      platform: "mac",
+      endpointId: "57".repeat(32),
+    });
+    const acceptorId = await insertBinding({
+      userId,
+      platform: "linux",
+      endpointId: "58".repeat(32),
+    });
+    const initiator = await pairPeer(initiatorId);
+    const acceptor = await pairPeer(acceptorId);
+    const record = (alpn: string, scope: string) => requiredRepository().recordPairGrant({
+      userId,
+      jti: randomUUID(),
+      initiator,
+      acceptor,
+      signingKeyId: "current",
+      alpn,
+      scope,
+      issuedAt: NOW,
+      notBefore: NOW,
+      expiresAt: new Date(NOW.getTime() + 7 * 24 * 60 * 60 * 1_000),
+    });
+
+    // A linux TUI acceptor must never commit an audit row carrying the mobile
+    // profile, even if a raced platform change slipped past the route gate.
+    const mismatch = await Effect.runPromiseExit(record("cmux/mobile/1", "cmux.mobile.attach"));
+    expect(mismatch._tag).toBe("Failure");
+    expect(String(mismatch)).toContain("pair_grant_profile_mismatch");
+
+    await Effect.runPromise(record("cmux/tui/1", "cmux.tui.attach"));
+    const [{ total }] = await requiredSql()<Array<{ total: string }>>`
+      select count(*)::text as total
+      from iroh_pair_grant_issuances
+      where user_id = ${userId} and alpn = 'cmux/tui/1' and scope = 'cmux.tui.attach'
+    `;
+    expect(total).toBe("1");
+  });
+
   dbTest("rejects pair-grant peers that resolve to one physical device", async () => {
     const userId = "user-pair-same-device";
     const deviceUuid = randomUUID();
@@ -1987,7 +2038,7 @@ async function insertBinding(input: {
   readonly deviceUuid?: string;
   readonly appInstanceId?: string;
   readonly endpointId: string;
-  readonly platform?: "mac" | "ios";
+  readonly platform?: "mac" | "ios" | "linux";
   readonly tag?: string;
   readonly pathHints?: unknown[];
 }): Promise<string> {
@@ -2017,7 +2068,7 @@ async function pairPeer(bindingId: string): Promise<PairGrantPeer> {
     bindingId: string;
     deviceId: string;
     tag: string;
-    platform: "mac" | "ios";
+    platform: "mac" | "ios" | "linux";
     endpointId: string;
     identityGeneration: number;
   }>>`

--- a/web/tests/iroh-enrollment.test.ts
+++ b/web/tests/iroh-enrollment.test.ts
@@ -274,6 +274,16 @@ describe("Iroh enrollment database behavior", () => {
     if (!sql) {
       const databaseURL = process.env.DIRECT_DATABASE_URL ?? process.env.DATABASE_URL;
       if (!databaseURL) throw new Error("DATABASE_URL is required when CMUX_DB_TEST=1");
+      // This suite truncates tables. Refuse a non-local target so a shared or
+      // production DATABASE_URL can never be wiped by running the tests.
+      const host = new URL(databaseURL).hostname;
+      const isLocal = host === "localhost" || host === "127.0.0.1" || host === "::1" || host === "[::1]";
+      if (!isLocal && process.env.CMUX_DB_TEST_ALLOW_REMOTE !== "1") {
+        throw new Error(
+          "CMUX_DB_TEST=1 refuses to truncate a non-local database; " +
+            "set CMUX_DB_TEST_ALLOW_REMOTE=1 only for a disposable remote database",
+        );
+      }
       sql = postgres(databaseURL, { max: 1 });
     }
     await sql`truncate iroh_enrollment_tokens, account_deletion_tombstones restart identity cascade`;

--- a/web/tests/iroh-enrollment.test.ts
+++ b/web/tests/iroh-enrollment.test.ts
@@ -1,6 +1,10 @@
-import { describe, expect, test } from "bun:test";
+import { afterAll, beforeEach, describe, expect, test } from "bun:test";
+import postgres, { type Sql } from "postgres";
+import { closeCloudDbForTests } from "../db/client";
+import { accountDeletionUserHash } from "../services/account/deletionLock";
 import {
   IROH_ENROLLMENT_TOKEN_LIFETIME_MS,
+  drizzleIrohEnrollmentStore,
   handleIrohEnrollment,
   handleIrohEnrollmentTokenMint,
   type IrohEnrollmentDependencies,
@@ -9,6 +13,9 @@ import {
 import { IrohQuotaExceededError } from "../services/iroh/errors";
 import { sha256 } from "../services/iroh/model";
 import type { AuthedUser } from "../services/vms/auth";
+
+const runDbTests = process.env.CMUX_DB_TEST === "1";
+const dbTest = runDbTests ? test : test.skip;
 
 const NOW = new Date("2026-07-09T20:00:00.000Z");
 const USER = { id: "user-enroll-1" } as AuthedUser;
@@ -251,5 +258,87 @@ describe("Iroh enrollment exchange", () => {
     );
     expect(response.status).toBe(500);
     expect(await response.json()).toEqual({ error: "iroh_internal_error" });
+  });
+});
+
+describe("Iroh enrollment database behavior", () => {
+  let sql: Sql | null = null;
+
+  function requiredSql(): Sql {
+    if (!sql) throw new Error("test database not initialized");
+    return sql;
+  }
+
+  beforeEach(async () => {
+    if (!runDbTests) return;
+    if (!sql) {
+      const databaseURL = process.env.DIRECT_DATABASE_URL ?? process.env.DATABASE_URL;
+      if (!databaseURL) throw new Error("DATABASE_URL is required when CMUX_DB_TEST=1");
+      sql = postgres(databaseURL, { max: 1 });
+    }
+    await sql`truncate iroh_enrollment_tokens, account_deletion_tombstones restart identity cascade`;
+  });
+
+  afterAll(async () => {
+    await closeCloudDbForTests();
+    await sql?.end();
+  });
+
+  dbTest("a token minted before account deletion cannot be redeemed once deletion is pending", async () => {
+    const userId = "user-enroll-fence";
+    const plaintext = "f".repeat(43);
+    const store = drizzleIrohEnrollmentStore();
+    await store.mintToken({
+      userId,
+      tokenHash: sha256(plaintext),
+      now: NOW,
+      expiresAt: new Date(NOW.getTime() + IROH_ENROLLMENT_TOKEN_LIFETIME_MS),
+    });
+
+    // Deletion becomes pending after the mint but before the container
+    // redeems its token.
+    await requiredSql()`
+      insert into account_deletion_tombstones (user_id_hash, user_id, status)
+      values (${accountDeletionUserHash(userId)}, ${userId}, 'pending')
+    `;
+
+    const mintedSessions: string[] = [];
+    const dependencies: IrohEnrollmentDependencies = {
+      store,
+      rateLimit: async () => null,
+      mintSession: async (sessionUserId) => {
+        mintedSessions.push(sessionUserId);
+        return { accessToken: "stack-access", refreshToken: "stack-refresh" };
+      },
+      now: () => NOW,
+    };
+    const fenced = await handleIrohEnrollment(
+      enrollRequest(JSON.stringify({ token: plaintext })),
+      dependencies,
+    );
+    // Uniform unauthenticated failure: indistinguishable from an unknown or
+    // spent token, and no Stack session is ever minted.
+    expect(fenced.status).toBe(404);
+    expect(await fenced.json()).toEqual({ error: "invalid_enrollment_token" });
+    expect(mintedSessions).toHaveLength(0);
+
+    // The fence aborts the transaction, so the conditional consume rolled
+    // back and the token is still outstanding rather than silently burned.
+    const [row] = await requiredSql()<Array<{ consumedAt: Date | null }>>`
+      select consumed_at as "consumedAt" from iroh_enrollment_tokens
+      where token_hash = ${sha256(plaintext)}
+    `;
+    expect(row?.consumedAt).toBeNull();
+
+    // Once the deletion tombstone is gone (e.g. deletion failed and was
+    // cleared), the same token redeems normally, proving the fence and not
+    // token consumption produced the earlier refusal.
+    await requiredSql()`delete from account_deletion_tombstones where user_id_hash = ${accountDeletionUserHash(userId)}`;
+    const redeemed = await handleIrohEnrollment(
+      enrollRequest(JSON.stringify({ token: plaintext })),
+      dependencies,
+    );
+    expect(redeemed.status).toBe(201);
+    expect(mintedSessions).toEqual([userId]);
   });
 });

--- a/web/tests/iroh-enrollment.test.ts
+++ b/web/tests/iroh-enrollment.test.ts
@@ -1,0 +1,255 @@
+import { describe, expect, test } from "bun:test";
+import {
+  IROH_ENROLLMENT_TOKEN_LIFETIME_MS,
+  handleIrohEnrollment,
+  handleIrohEnrollmentTokenMint,
+  type IrohEnrollmentDependencies,
+  type IrohEnrollmentStoreShape,
+} from "../services/iroh/enrollment";
+import { IrohQuotaExceededError } from "../services/iroh/errors";
+import { sha256 } from "../services/iroh/model";
+import type { AuthedUser } from "../services/vms/auth";
+
+const NOW = new Date("2026-07-09T20:00:00.000Z");
+const USER = { id: "user-enroll-1" } as AuthedUser;
+const BASE64URL_43 = /^[A-Za-z0-9_-]{43}$/;
+
+type MintCall = { userId: string; tokenHash: string; now: Date; expiresAt: Date };
+type ConsumeCall = { tokenHash: string; now: Date };
+
+function fakeStore(options: {
+  mintError?: unknown;
+  consumeResult?: { userId: string } | null;
+  consumeError?: unknown;
+} = {}) {
+  const mints: MintCall[] = [];
+  const consumes: ConsumeCall[] = [];
+  const store: IrohEnrollmentStoreShape = {
+    mintToken: async (input) => {
+      if (options.mintError) throw options.mintError;
+      mints.push(input);
+    },
+    consumeToken: async (input) => {
+      if (options.consumeError) throw options.consumeError;
+      consumes.push(input);
+      return options.consumeResult ?? null;
+    },
+  };
+  return { store, mints, consumes };
+}
+
+function nativeMintRequest(body?: BodyInit): Request {
+  return new Request("https://cmux.example/api/devices/iroh/enrollment-tokens", {
+    method: "POST",
+    headers: {
+      authorization: "Bearer test-access",
+      "x-stack-refresh-token": "test-refresh",
+      ...(body === undefined ? {} : { "content-type": "application/json" }),
+    },
+    ...(body === undefined ? {} : { body }),
+  });
+}
+
+function enrollRequest(body: string, contentType = "application/json"): Request {
+  return new Request("https://cmux.example/api/devices/iroh/enroll", {
+    method: "POST",
+    headers: { "content-type": contentType },
+    body,
+  });
+}
+
+function mintDependencies(
+  store: IrohEnrollmentStoreShape,
+  overrides: IrohEnrollmentDependencies = {},
+): IrohEnrollmentDependencies {
+  return {
+    verify: async () => USER,
+    store,
+    now: () => NOW,
+    ...overrides,
+  };
+}
+
+describe("Iroh enrollment token mint", () => {
+  test("mints a one-use token, persists only its SHA-256, and reports the 15-minute expiry", async () => {
+    const { store, mints } = fakeStore();
+    const response = await handleIrohEnrollmentTokenMint(nativeMintRequest(), mintDependencies(store));
+    expect(response.status).toBe(201);
+    expect(response.headers.get("cache-control")).toBe("no-store");
+    const body = await response.json() as { token: string; expires_at: string };
+    expect(body.token).toMatch(BASE64URL_43);
+    expect(body.expires_at).toBe(new Date(NOW.getTime() + IROH_ENROLLMENT_TOKEN_LIFETIME_MS).toISOString());
+    expect(mints).toHaveLength(1);
+    expect(mints[0]?.userId).toBe(USER.id);
+    expect(mints[0]?.tokenHash).toBe(sha256(body.token));
+    expect(mints[0]?.tokenHash).toMatch(/^[0-9a-f]{64}$/);
+    expect(mints[0]?.tokenHash).not.toBe(body.token);
+    expect(mints[0]?.expiresAt.toISOString()).toBe(body.expires_at);
+  });
+
+  test("requires a native bearer session and never reaches the store unauthenticated", async () => {
+    const { store, mints } = fakeStore();
+    const seenOptions: unknown[] = [];
+    const response = await handleIrohEnrollmentTokenMint(
+      nativeMintRequest(),
+      mintDependencies(store, {
+        verify: async (_request, options) => {
+          seenOptions.push(options);
+          return null;
+        },
+      }),
+    );
+    expect(response.status).toBe(401);
+    // Cookie sessions may not mint provisioning tokens: the handler must ask
+    // verifyRequest for the native-bearer-only path.
+    expect(seenOptions).toEqual([{ allowCookie: false }]);
+    expect(mints).toHaveLength(0);
+  });
+
+  test("blocks cross-origin browser-shaped mutations even for an authenticated user", async () => {
+    const { store, mints } = fakeStore();
+    const request = new Request("https://cmux.example/api/devices/iroh/enrollment-tokens", {
+      method: "POST",
+      headers: { origin: "https://evil.example" },
+    });
+    const response = await handleIrohEnrollmentTokenMint(request, mintDependencies(store));
+    expect(response.status).toBe(403);
+    expect(mints).toHaveLength(0);
+  });
+
+  test("accepts only an empty body and rejects unknown parameters", async () => {
+    const { store, mints } = fakeStore();
+    expect((await handleIrohEnrollmentTokenMint(nativeMintRequest("{}"), mintDependencies(store))).status).toBe(201);
+    const rejected = await handleIrohEnrollmentTokenMint(
+      nativeMintRequest(JSON.stringify({ ttl: "forever" })),
+      mintDependencies(store),
+    );
+    expect(rejected.status).toBe(400);
+    expect(mints).toHaveLength(1);
+  });
+
+  test("maps the outstanding-token cap to 429 with a retry-after", async () => {
+    const { store } = fakeStore({
+      mintError: new IrohQuotaExceededError({ code: "enrollment_token_quota", retryAfterSeconds: 37 }),
+    });
+    const response = await handleIrohEnrollmentTokenMint(nativeMintRequest(), mintDependencies(store));
+    expect(response.status).toBe(429);
+    expect(response.headers.get("retry-after")).toBe("37");
+    expect(await response.json()).toEqual({
+      error: "enrollment_token_quota",
+      retry_after_seconds: 37,
+    });
+  });
+});
+
+describe("Iroh enrollment exchange", () => {
+  const PLAINTEXT = "u".repeat(43);
+
+  function exchangeDependencies(
+    store: IrohEnrollmentStoreShape,
+    overrides: IrohEnrollmentDependencies = {},
+  ): IrohEnrollmentDependencies {
+    return {
+      store,
+      rateLimit: async () => null,
+      mintSession: async () => ({ accessToken: "stack-access", refreshToken: "stack-refresh" }),
+      now: () => NOW,
+      ...overrides,
+    };
+  }
+
+  test("exchanges a valid token exactly once for a Stack session", async () => {
+    const { store, consumes } = fakeStore({ consumeResult: { userId: USER.id } });
+    const mintedFor: string[] = [];
+    const response = await handleIrohEnrollment(
+      enrollRequest(JSON.stringify({ token: PLAINTEXT })),
+      exchangeDependencies(store, {
+        mintSession: async (userId) => {
+          mintedFor.push(userId);
+          return { accessToken: "stack-access", refreshToken: "stack-refresh" };
+        },
+      }),
+    );
+    expect(response.status).toBe(201);
+    expect(response.headers.get("cache-control")).toBe("no-store");
+    expect(await response.json()).toEqual({
+      accessToken: "stack-access",
+      refreshToken: "stack-refresh",
+    });
+    // The wire token never reaches storage: lookup happens by SHA-256 only.
+    expect(consumes).toEqual([{ tokenHash: sha256(PLAINTEXT), now: NOW }]);
+    expect(mintedFor).toEqual([USER.id]);
+  });
+
+  test("answers one uniform 404 for malformed, unknown, consumed, and expired tokens", async () => {
+    const { store, consumes } = fakeStore({ consumeResult: null });
+    const dependencies = exchangeDependencies(store);
+    for (const malformed of ["", "short", "!".repeat(43), "v".repeat(44), "w".repeat(200)]) {
+      const response = await handleIrohEnrollment(
+        enrollRequest(JSON.stringify({ token: malformed })),
+        dependencies,
+      );
+      expect(response.status).toBe(404);
+      expect(await response.json()).toEqual({ error: "invalid_enrollment_token" });
+    }
+    // Malformed tokens are rejected before any store lookup.
+    expect(consumes).toHaveLength(0);
+
+    const unusable = await handleIrohEnrollment(
+      enrollRequest(JSON.stringify({ token: PLAINTEXT })),
+      dependencies,
+    );
+    expect(unusable.status).toBe(404);
+    expect(await unusable.json()).toEqual({ error: "invalid_enrollment_token" });
+    expect(consumes).toHaveLength(1);
+  });
+
+  test("does not leak whether the enrolled account still exists", async () => {
+    const { store } = fakeStore({ consumeResult: { userId: "user-deleted" } });
+    const response = await handleIrohEnrollment(
+      enrollRequest(JSON.stringify({ token: PLAINTEXT })),
+      exchangeDependencies(store, { mintSession: async () => null }),
+    );
+    expect(response.status).toBe(404);
+    expect(await response.json()).toEqual({ error: "invalid_enrollment_token" });
+  });
+
+  test("rejects non-JSON media, unknown fields, and oversized bodies before consuming", async () => {
+    const { store, consumes } = fakeStore({ consumeResult: { userId: USER.id } });
+    const dependencies = exchangeDependencies(store);
+    expect((await handleIrohEnrollment(enrollRequest("token=x", "text/plain"), dependencies)).status).toBe(415);
+    expect((await handleIrohEnrollment(enrollRequest(""), dependencies)).status).toBe(400);
+    expect((await handleIrohEnrollment(enrollRequest("not json"), dependencies)).status).toBe(400);
+    expect((await handleIrohEnrollment(
+      enrollRequest(JSON.stringify({ token: PLAINTEXT, extra: true })),
+      dependencies,
+    )).status).toBe(400);
+    expect((await handleIrohEnrollment(
+      enrollRequest(JSON.stringify({ token: "x".repeat(70 * 1_024) })),
+      dependencies,
+    )).status).toBe(413);
+    expect(consumes).toHaveLength(0);
+  });
+
+  test("honors the platform rate limiter before touching the store", async () => {
+    const { store, consumes } = fakeStore({ consumeResult: { userId: USER.id } });
+    const response = await handleIrohEnrollment(
+      enrollRequest(JSON.stringify({ token: PLAINTEXT })),
+      exchangeDependencies(store, {
+        rateLimit: async () => new Response(JSON.stringify({ error: "throttled" }), { status: 429 }),
+      }),
+    );
+    expect(response.status).toBe(429);
+    expect(consumes).toHaveLength(0);
+  });
+
+  test("maps unexpected store failures to an opaque 500", async () => {
+    const { store } = fakeStore({ consumeError: new Error("database down") });
+    const response = await handleIrohEnrollment(
+      enrollRequest(JSON.stringify({ token: PLAINTEXT })),
+      exchangeDependencies(store),
+    );
+    expect(response.status).toBe(500);
+    expect(await response.json()).toEqual({ error: "iroh_internal_error" });
+  });
+});

--- a/web/tests/iroh-model-crypto.test.ts
+++ b/web/tests/iroh-model-crypto.test.ts
@@ -32,6 +32,8 @@ import {
   IROH_ENDPOINT_ATTESTATION_VERSION,
   IROH_PAIR_GRANT_TYP,
   IROH_PAIR_SCOPE,
+  IROH_TUI_ALPN,
+  IROH_TUI_PAIR_SCOPE,
   MANAGED_RELAY_URLS,
   parseRegistrationPayload,
 } from "../services/iroh/model";
@@ -206,10 +208,18 @@ describe("Iroh route wire contract", () => {
     expect(parseRegistrationPayload(registrationPayload(hint), NOW).pathHints[0]?.value).toBe("[fd00::1]:4433");
   });
 
-  test("rejects an unknown platform before it can affect Mac pairability", () => {
-    expect(() => parseRegistrationPayload({
+  test("accepts a linux headless registration and still rejects unknown platforms", () => {
+    expect(parseRegistrationPayload({
       ...registrationPayload(directHint({ value: "8.8.8.8:4433" })),
       platform: "linux",
+    }, NOW).platform).toBe("linux");
+    expect(parseRegistrationPayload({
+      ...registrationPayload(directHint({ value: "8.8.8.8:4433" })),
+      platform: "ios",
+    }, NOW).platform).toBe("ios");
+    expect(() => parseRegistrationPayload({
+      ...registrationPayload(directHint({ value: "8.8.8.8:4433" })),
+      platform: "windows",
     }, NOW)).toThrow();
   });
 
@@ -363,6 +373,72 @@ describe("Iroh pair-grant verification", () => {
     test(`rejects invalid ${name}`, () => {
       const token = manuallySignedJws(header, changedClaims, current.privateKey);
       expect(() => verifyPairGrant(token, keys, { initiator, acceptor, nowSeconds })).toThrow();
+    });
+  }
+
+  // TUI profile: a linux acceptor carries cmux/tui/1 + cmux.tui.attach and
+  // admits mac, ios, and linux initiators. The mobile profile above stays the
+  // authority for mac acceptors, so a grant minted for one profile can never
+  // verify under the other.
+  const tuiAcceptor: PairGrantPeer = { ...acceptor, platform: "linux", tag: "tui" };
+  const tuiClaims: PairGrantClaims = {
+    ...claims,
+    alpn: IROH_TUI_ALPN,
+    scope: IROH_TUI_PAIR_SCOPE,
+    acceptor: tuiAcceptor,
+  };
+
+  for (const platform of ["mac", "ios", "linux"] as const) {
+    test(`accepts a TUI grant for a linux acceptor from a ${platform} initiator`, () => {
+      const tuiInitiator: PairGrantPeer = { ...initiator, platform };
+      const token = signPairGrant({
+        privateKeyPem: currentPrivate,
+        kid: "current",
+        claims: { ...tuiClaims, initiator: tuiInitiator },
+      });
+      const verified = verifyPairGrant(token, keys, {
+        initiator: tuiInitiator,
+        acceptor: tuiAcceptor,
+        nowSeconds: claims.iat,
+      });
+      expect(verified.alpn).toBe(IROH_TUI_ALPN);
+      expect(verified.scope).toBe(IROH_TUI_PAIR_SCOPE);
+    });
+  }
+
+  test("refuses to sign a grant whose ALPN or scope disagrees with the acceptor profile", () => {
+    expect(() => signPairGrant({
+      privateKeyPem: currentPrivate,
+      kid: "current",
+      claims: { ...tuiClaims, alpn: IROH_ALPN, scope: IROH_PAIR_SCOPE },
+    })).toThrow();
+    expect(() => signPairGrant({
+      privateKeyPem: currentPrivate,
+      kid: "current",
+      claims: { ...claims, alpn: IROH_TUI_ALPN, scope: IROH_TUI_PAIR_SCOPE },
+    })).toThrow();
+  });
+
+  for (const [name, crossClaims] of [
+    ["a mobile ALPN on a TUI grant", { ...tuiClaims, alpn: IROH_ALPN }],
+    ["a mobile scope on a TUI grant", { ...tuiClaims, scope: IROH_PAIR_SCOPE }],
+    ["a TUI ALPN on a mobile grant", { ...claims, alpn: IROH_TUI_ALPN }],
+    ["a TUI scope on a mobile grant", { ...claims, scope: IROH_TUI_PAIR_SCOPE }],
+    ["an iOS acceptor", { ...tuiClaims, acceptor: { ...tuiAcceptor, platform: "ios" } }],
+    ["a linux initiator toward a mac acceptor", { ...claims, initiator: { ...initiator, platform: "linux" } }],
+  ] as const) {
+    test(`rejects ${name}`, () => {
+      const token = manuallySignedJws(
+        { alg: "EdDSA", typ: IROH_PAIR_GRANT_TYP, kid: "current" },
+        crossClaims,
+        current.privateKey,
+      );
+      const expected = crossClaims as PairGrantClaims;
+      expect(() => verifyPairGrant(token, keys, {
+        initiator: expected.initiator,
+        acceptor: expected.acceptor,
+        nowSeconds: claims.iat,
+      })).toThrow();
     });
   }
 });

--- a/web/tests/iroh-trust-broker.test.ts
+++ b/web/tests/iroh-trust-broker.test.ts
@@ -16,9 +16,15 @@ import {
   IrohRelayMintError,
 } from "../services/iroh/errors";
 import {
+  IROH_ALPN,
+  IROH_PAIR_SCOPE,
   IROH_RELAY_TOKEN_LIFETIME_SECONDS,
+  IROH_TUI_ALPN,
+  IROH_TUI_PAIR_SCOPE,
   MANAGED_RELAY_URLS,
+  pairGrantProfileForAcceptorPlatform,
   sha256,
+  type IrohPlatform,
   type IrohRegistrationPayload,
 } from "../services/iroh/model";
 import {
@@ -657,6 +663,61 @@ describe("Iroh discovery and grants", () => {
     expect(fixture.repository.pairGrantAudits).toHaveLength(0);
   });
 
+  test("keeps the mobile mac-acceptor grant on the mobile ALPN and scope", async () => {
+    const fixture = makeFixture();
+    const initiator = binding({ userId: USER_A, platform: "ios" });
+    const acceptor = binding({ userId: USER_A, platform: "mac", pairingEnabled: true });
+    fixture.repository.bindings.push(initiator, acceptor);
+    const result = await Effect.runPromise(fixture.broker.issuePairGrant(USER_A, {
+      initiatorBindingId: initiator.id,
+      acceptorBindingId: acceptor.id,
+    }, NOW)) as { grant: string };
+    const claims = grantClaims(result.grant);
+    expect(claims.alpn).toBe(IROH_ALPN);
+    expect(claims.scope).toBe(IROH_PAIR_SCOPE);
+    expect(IROH_ALPN).toBe("cmux/mobile/1");
+    expect(IROH_PAIR_SCOPE).toBe("cmux.mobile.attach");
+  });
+
+  test("mints the TUI profile for a linux acceptor from mac, ios, and linux initiators", async () => {
+    const fixture = makeFixture();
+    const acceptor = binding({ userId: USER_A, platform: "linux", tag: "tui", pairingEnabled: true });
+    fixture.repository.bindings.push(acceptor);
+    for (const platform of ["mac", "ios", "linux"] as const) {
+      const initiator = binding({ userId: USER_A, platform });
+      fixture.repository.bindings.push(initiator);
+      const result = await Effect.runPromise(fixture.broker.issuePairGrant(USER_A, {
+        initiatorBindingId: initiator.id,
+        acceptorBindingId: acceptor.id,
+      }, NOW)) as { grant: string };
+      const claims = grantClaims(result.grant);
+      expect(claims.alpn).toBe(IROH_TUI_ALPN);
+      expect(claims.scope).toBe(IROH_TUI_PAIR_SCOPE);
+      expect(claims.acceptor.platform).toBe("linux");
+    }
+    // The memory repository rejects any audit whose ALPN/scope disagrees with
+    // the acceptor profile, so three recorded audits prove the broker sent the
+    // TUI profile to the repository as well as into the signed claims.
+    expect(fixture.repository.pairGrantAudits).toHaveLength(3);
+  });
+
+  test("never treats an iOS acceptor or a pairing-disabled linux acceptor as pairable", async () => {
+    const fixture = makeFixture();
+    const initiator = binding({ userId: USER_A, platform: "mac" });
+    const iosAcceptor = binding({ userId: USER_A, platform: "ios", pairingEnabled: true });
+    const parkedTui = binding({ userId: USER_A, platform: "linux", pairingEnabled: false });
+    fixture.repository.bindings.push(initiator, iosAcceptor, parkedTui);
+    await expectEffectFailure(fixture.broker.issuePairGrant(USER_A, {
+      initiatorBindingId: initiator.id,
+      acceptorBindingId: iosAcceptor.id,
+    }, NOW), "IrohForbiddenError");
+    await expectEffectFailure(fixture.broker.issuePairGrant(USER_A, {
+      initiatorBindingId: initiator.id,
+      acceptorBindingId: parkedTui.id,
+    }, NOW), "IrohForbiddenError");
+    expect(fixture.repository.pairGrantAudits).toHaveLength(0);
+  });
+
   test("issues a short-lived opaque same-account attestation only for an owned active binding", async () => {
     const fixture = makeFixture();
     const active = binding({ userId: USER_A, platform: "ios", identityGeneration: 4 });
@@ -1059,8 +1120,18 @@ class MemoryRepository implements IrohRepositoryShape {
     const acceptor = this.bindings.find((row) =>
       row.id === input.acceptor.bindingId && row.userId === input.userId && !row.revokedAt);
     if (!initiator || !acceptor) return Effect.fail(new IrohNotFoundError({ resource: "binding" }));
-    if (initiator.platform !== "ios" || acceptor.platform !== "mac" || !acceptor.pairingEnabled) {
+    // Mirror the live repository: the acceptor's platform selects the grant
+    // profile, and the audited ALPN/scope must match it exactly.
+    const profile = pairGrantProfileForAcceptorPlatform(acceptor.platform);
+    if (
+      !profile ||
+      !(profile.initiatorPlatforms as readonly string[]).includes(initiator.platform) ||
+      !acceptor.pairingEnabled
+    ) {
       return Effect.fail(new IrohForbiddenError({ code: "target_not_pairable" }));
+    }
+    if (input.alpn !== profile.alpn || input.scope !== profile.scope) {
+      return Effect.fail(new IrohConflictError({ code: "pair_grant_profile_mismatch" }));
     }
     this.pairGrantAudits.push(input);
     return Effect.void;
@@ -1072,7 +1143,7 @@ class MemoryRepository implements IrohRepositoryShape {
     readonly deviceId: string;
     readonly endpointId: string;
     readonly identityGeneration: number;
-    readonly platform: "mac" | "ios";
+    readonly platform: IrohPlatform;
   }) {
     this.beforeFinalizeEndpointAttestation?.();
     const active = this.bindings.find((row) =>
@@ -1296,6 +1367,17 @@ function binding(overrides: Partial<MutableBinding> = {}): MutableBinding {
     revokedReason: null,
     ...overrides,
   };
+}
+
+function grantClaims(grant: string): {
+  alpn: string;
+  scope: string;
+  initiator: { platform: string };
+  acceptor: { platform: string };
+} {
+  const payload = grant.split(".")[1];
+  if (!payload) throw new Error("grant is not a compact JWS");
+  return JSON.parse(Buffer.from(payload, "base64url").toString("utf8"));
 }
 
 async function expectEffectFailure(


### PR DESCRIPTION
Adds the broker-side plumbing for headless cmux-tui iroh peers (Linux containers).

**Platform "linux".** `iroh_endpoint_bindings.platform` now accepts `linux` alongside `mac`/`ios` (registration payload parsing, schema, and a widening `CHECK` migration `20260803120000_iroh_tui_platform_linux`; strictly weaker constraint, no rewrite).

**TUI pair-grant profile.** `pairGrantProfileForAcceptorPlatform` in `web/services/iroh/model.ts` is the single source of truth: a `mac` acceptor keeps the mobile profile byte for byte (`cmux/mobile/1`, `cmux.mobile.attach`, iOS initiators only), a pairing-enabled `linux` acceptor mints `cmux/tui/1` + `cmux.tui.attach` for same-account `mac|ios|linux` initiators, and an `ios` acceptor stays unpairable. Enforced three times: broker route gate (`issuePairGrant`), pair-grant claims validation on sign and verify (`crypto.ts`), and re-derived under the row locks in `recordPairGrant` so a raced platform flip cannot commit a cross-profile audit (`pair_grant_profile_mismatch`, 409).

**Headless enrollment.** `POST /api/devices/iroh/enrollment-tokens` (native bearer auth, no cookie sessions) mints a one-use provisioning token: response `{token, expires_at}`, only the SHA-256 stored, 15-minute TTL, cap 8 outstanding per user enforced under a per-user advisory lock (429 + `retry-after` at the cap). `POST /api/devices/iroh/enroll` (unauthenticated container side, body `{token}`) consumes the hash exactly once via an atomic conditional UPDATE and mints a Stack session, returning `{accessToken, refreshToken}` (201), mirroring the vault CLI `auth/poll` precedent; every unusable token answers a uniform 404. New table migration `20260803121000_iroh_enrollment_tokens`; rows are purged on account deletion.

**Tests.** TUI/mobile profile matrix at claims level (`iroh-model-crypto.test.ts`), broker gate + minted-claims assertions (`iroh-trust-broker.test.ts`, memory repo now mirrors the live profile check), repository profile enforcement and the widened platform CHECK against real Postgres (`iroh-db-behavior.test.ts`), and full handler coverage for both enrollment routes (`iroh-enrollment.test.ts`).

Verified locally: `bun install --frozen-lockfile`, `bun tools/generate-managed-iroh-relay-catalog.ts --check`, `bun run typecheck`, targeted iroh suites (123 pass), and the CMUX_DB_TEST-gated iroh/account/schema suites (98 pass) against a scratch Postgres with both migrations applied twice (idempotent).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/9515"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788408765&installation_model_id=21920&pr_number=9515&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F9515&signature=eba96978bb49b7d85f4a679110c696619b1ccbf6eaf499c249b2830d3e2f7ad3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Linux support for headless cmux‑tui peers, ties pair‑grant behavior to the acceptor’s platform, and adds one‑use headless enrollment tokens for containers. Also adds a safeguard to prevent DB test truncation on non‑local databases.

- **New Features**
  - `linux` is accepted in `iroh_endpoint_bindings.platform` for headless TUI session servers.
  - Pair‑grant profile derives from the acceptor platform:
    - `mac` acceptor → mobile profile (`cmux/mobile/1`, `cmux.mobile.attach`), iOS initiator only.
    - `linux` acceptor → TUI profile (`cmux/tui/1`, `cmux.tui.attach`), initiators `mac|ios|linux` on the same account.
    - `ios` acceptor remains unpairable; cross‑profile attempts fail with 409 (`pair_grant_profile_mismatch`).
  - Headless enrollment:
    - `POST /api/devices/iroh/enrollment-tokens` returns `{token, expires_at}`; 15‑minute TTL; max 8 outstanding per user; only SHA‑256 stored.
    - `POST /api/devices/iroh/enroll` consumes the token exactly once and returns `{accessToken, refreshToken}`; unusable tokens return 404; optional per‑IP rate limit; redemption is blocked if account deletion is pending (uniform 404, consume rolls back).
  - Tests: when `CMUX_DB_TEST=1`, refuse truncating a non‑local `DATABASE_URL` unless `CMUX_DB_TEST_ALLOW_REMOTE=1`.

- **Migration**
  - Apply migrations:
    - `20260803120000_iroh_tui_platform_linux` widens the platform CHECK to include `linux` (added NOT VALID).
    - `20260803120500_validate_iroh_tui_platform_linux` validates the widened CHECK.
    - `20260803121000_iroh_enrollment_tokens` creates the enrollment tokens table and indexes.
  - Adoption: mint a token via `POST /api/devices/iroh/enrollment-tokens`, pass it to the container, then call `POST /api/devices/iroh/enroll` to obtain Stack session tokens.

<sup>Written for commit 85e82b4b186164e2ffbee033d89c23ff2390cd2f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/9515?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added secure, short-lived, single-use enrollment tokens for headless device setup.
  - Added enrollment and token-exchange API endpoints.
  - Added Linux support for Iroh TUI devices and platform-specific pairing.
  - Expanded device registration and pairing compatibility across supported platforms.

- **Security**
  - Added token expiry, one-time consumption, rate limiting, validation, and privacy-preserving error responses.
  - Enrollment records are removed when an account is deleted.

- **Bug Fixes**
  - Improved Iroh error handling with safer, consistent responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->