### PR TITLE
Match workspace group pin tint

### DIFF
--- a/Sources/Sidebar/AppKitList/Cells/SidebarGroupHeaderRowView.swift
+++ b/Sources/Sidebar/AppKitList/Cells/SidebarGroupHeaderRowView.swift
@@ -59,7 +59,6 @@ final class SidebarGroupHeaderTableCellView: NSTableCellView {
         addSubview(backgroundView)
 
         pinImageView.imageScaling = .scaleProportionallyDown
-        pinImageView.contentTintColor = NSColor.secondaryLabelColor.withAlphaComponent(0.8)
         addSubview(pinImageView)
 
         chevronButton.onClick = { [weak self] in self?.actions?.onToggleCollapsed() }
@@ -150,6 +149,7 @@ final class SidebarGroupHeaderTableCellView: NSTableCellView {
                 pointSize: GlobalFontMagnification.scaledSize(metrics.pinnedIconFontSize, percent: percent),
                 weight: .semibold
             )
+            pinImageView.contentTintColor = .secondaryLabelColor
             pinImageView.toolTip = String(localized: "workspaceGroup.pinned.tooltip", defaultValue: "Pinned group")
         }
 

--- a/Sources/SidebarWorkspaceGroupHeaderView.swift
+++ b/Sources/SidebarWorkspaceGroupHeaderView.swift
@@ -146,7 +146,7 @@ struct SidebarWorkspaceGroupHeaderView: View, Equatable {
                     pointSize: metrics.pinnedIconFontSize,
                     weight: .semibold
                 )
-                .foregroundStyle(Color.secondary.opacity(0.8))
+                .foregroundStyle(.secondary)
                 .frame(width: metrics.iconFrame, height: metrics.iconFrame)
                 .safeHelp(pinnedGroupTooltip)
                 .accessibilityLabel(Text(pinnedGroupTooltip))

--- a/cmuxTests/SidebarAppKitRowCellTests.swift
+++ b/cmuxTests/SidebarAppKitRowCellTests.swift
@@ -10,6 +10,7 @@ import Testing
 struct SidebarAppKitRowCellTests {
     private static func makeSnapshot(
         title: String = "Workspace",
+        isPinned: Bool = false,
         metadataEntries: [SidebarStatusEntry] = []
     ) -> SidebarWorkspaceSnapshotBuilder.Snapshot {
         SidebarWorkspaceSnapshotBuilder.Snapshot(
@@ -19,7 +20,7 @@ struct SidebarAppKitRowCellTests {
             ),
             title: title,
             customDescription: nil,
-            isPinned: false,
+            isPinned: isPinned,
             customColorHex: nil,
             remoteWorkspaceSidebarText: nil,
             remoteConnectionStatusText: "",
@@ -51,9 +52,10 @@ struct SidebarAppKitRowCellTests {
         )
     }
 
-    private static func makeModel(
+    fileprivate static func makeModel(
         workspaceId: UUID = UUID(),
         isActive: Bool = false,
+        isPinned: Bool = false,
         canClose: Bool = true,
         settings: SidebarTabItemSettingsSnapshot? = nil,
         metadataEntries: [SidebarStatusEntry] = [],
@@ -64,7 +66,7 @@ struct SidebarAppKitRowCellTests {
         return SidebarWorkspaceRowModel(
             workspaceId: workspaceId,
             index: 0,
-            snapshot: makeSnapshot(metadataEntries: metadataEntries),
+            snapshot: makeSnapshot(isPinned: isPinned, metadataEntries: metadataEntries),
             settings: resolvedSettings,
             isActive: isActive,
             isMultiSelected: false,
@@ -202,7 +204,7 @@ struct SidebarAppKitRowCellTests {
         )
     }
 
-    private static func configuredCell(
+    fileprivate static func configuredCell(
         model: SidebarWorkspaceRowModel,
         tab: Workspace? = nil,
         tabManager: TabManager? = nil,
@@ -224,7 +226,7 @@ struct SidebarAppKitRowCellTests {
         return cell
     }
 
-    private static func descendants(of view: NSView) -> [NSView] {
+    fileprivate static func descendants(of view: NSView) -> [NSView] {
         view.subviews + view.subviews.flatMap { descendants(of: $0) }
     }
 
@@ -866,5 +868,60 @@ struct SidebarAppKitRowCellTests {
             #expect(!Self.makeSwiftUIRow(settings: settings).settings.details[keyPath: detailKey])
             #expect(!Self.makeModel(settings: settings).settings.details[keyPath: detailKey])
         }
+    }
+}
+
+@Suite
+@MainActor
+struct SidebarPinnedIndicatorColorTests {
+    @Test
+    func pinnedGroupUsesWorkspacePinColor() throws {
+        let workspaceCell = SidebarAppKitRowCellTests.configuredCell(
+            model: SidebarAppKitRowCellTests.makeModel(isPinned: true)
+        )
+        let groupCell = SidebarGroupHeaderTableCellView()
+        groupCell.configurePresentation(model: SidebarGroupHeaderRowModel(
+            groupId: UUID(),
+            anchorWorkspaceId: UUID(),
+            name: "Group",
+            iconSymbol: "folder",
+            tintHex: nil,
+            isCollapsed: false,
+            isPinned: true,
+            isAnchorActive: false,
+            isMultiSelected: false,
+            multiSelectionBackgroundStyle: .clear,
+            memberCount: 1,
+            anchorUnreadCount: 0,
+            canMarkRead: false,
+            canMarkUnread: false,
+            hasLatestNotifications: false,
+            canMarkAllRead: false,
+            canMarkAllUnread: false,
+            shortcutHintText: nil,
+            shortcutHintXOffset: 0,
+            shortcutHintYOffset: 0,
+            fontScale: 1,
+            globalFontMagnificationPercent: 100,
+            cwdContextMenuItems: [],
+            rowSpacing: 2,
+            isFirstRow: true,
+            isBeingDragged: false,
+            topDropIndicatorVisible: false,
+            bottomDropIndicatorVisible: false
+        ))
+
+        let workspacePin = try #require(
+            SidebarAppKitRowCellTests.descendants(of: workspaceCell)
+                .compactMap { $0 as? NSImageView }
+                .first { !$0.isHidden && $0.toolTip != nil }
+        )
+        let groupPin = try #require(
+            SidebarAppKitRowCellTests.descendants(of: groupCell)
+                .compactMap { $0 as? NSImageView }
+                .first { !$0.isHidden && $0.toolTip != nil }
+        )
+
+        #expect(groupPin.contentTintColor == workspacePin.contentTintColor)
     }
 }


### PR DESCRIPTION
## Summary

- Match the workspace-group pin tint to the workspace pin in AppKit and SwiftUI.
- Apply the AppKit semantic tint during row configuration so reused cells remain correct.

## Testing

- Red regression: https://github.com/manaflow-ai/cmux/actions/runs/30874218702
- Green regression: https://github.com/manaflow-ai/cmux/actions/runs/30876225573
- Sidebar UI, 4 tests passed: https://github.com/manaflow-ai/cmux/actions/runs/30876288138
- Tagged app compiled successfully: https://github.com/manaflow-ai/cmux/actions/runs/30876346967
- Manual: selected Active comparison in gpin and captured both inactive pins at the same muted gray.

## Demo Video

- Not needed. This is a static color-only change with no time-dependent behavior; the exact tint assertion and tagged-app screenshot cover the result.

## Review Trigger

- Automatic CodeRabbit and Cubic reviews completed on the latest commit. Codex review was not requested because it requires explicit user opt-in.

## Checklist

- [x] I tested the change locally
- [x] I added or updated tests for behavior changes
- [x] Docs and changelog are not needed for this color-parity fix
- [x] Automatic bot reviews completed after the latest commit
- [x] All code review bot comments are resolved
- [x] All human review comments are resolved