### PR TITLE
fix(app): remove NSDockTilePlugIn to prevent false background dock status on macOS 27

### DIFF
--- a/Resources/Info.plist
+++ b/Resources/Info.plist
@@ -61,8 +61,6 @@
 	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
-	<key>NSDockTilePlugIn</key>
-	<string>CmuxDockTilePlugin.plugin</string>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.developer-tools</string>
 	<key>LSArchitecturePriority</key>


### PR DESCRIPTION
## Summary
Removes `NSDockTilePlugIn` from `Resources/Info.plist`.

## Problem
On macOS 27, the Dock introduces background process attribution tracking. When `NSDockTilePlugIn` is declared in `Info.plist`, macOS automatically loads `CmuxDockTilePlugin.plugin` into the OS Dock helper process (`com.apple.dock.extra`). Because the plugin stays loaded in `com.apple.dock.extra` even after the main `cmux` executable process exits, macOS 27 attributes this running background plugin to `cmux.app` and leaves a "Running in Background" status with an indicator dot under the app icon in the Dock.

## Why `NSDockTilePlugIn` is unnecessary
- **While running**: `cmux` updates its own Dock icon dynamically in real-time via `NSApp.applicationIconImage` directly inside the app process. The plugin target was unused while the app was running.
- **While closed**: The plugin's sole function was to swap Light/Dark app icon variants while closed by listening to system appearance changes inside `com.apple.dock.extra`. Standard macOS apps simply display their default bundle app icon (`AppIcon.icns`) when quit. Keeping a background plugin process running inside the OS Dock host just for inactive icon theme swaps is unnecessary.

## Solution
Removing `NSDockTilePlugIn` registration prevents `com.apple.dock.extra` from hosting the background plugin bundle. When `cmux` exits, no background process is left running and the Dock indicator dot extinguishes cleanly.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/9522"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788412499&installation_model_id=21920&pr_number=9522&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F9522&signature=3e95c879025e64e08f0c802f83e4b01a2df8ce5d659c88bc3f6d1a91fb73a227"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the `NSDockTilePlugIn` entry from `Resources/Info.plist` to stop macOS 27 from loading the Dock plugin and falsely marking cmux as “Running in Background.” This removes the lingering Dock indicator dot after the app quits.

<sup>Written for commit 86cb2ed7d0322a8d99badae53927b3a2b03a8fb5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/9522?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed the unused Dock Tile plug-in configuration from the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->