### PR TITLE
Fix iOS search tab state after primary tab switches

### DIFF
--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MobilePrimaryTabScaffold.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MobilePrimaryTabScaffold.swift
@@ -104,6 +104,11 @@ struct MobilePrimaryTabScaffold<
                    newValue.searchScope != nil {
                     searchCoordinator.deactivateCurrentSearch()
                 }
+                // A primary-tab tap and a following Search tap can arrive
+                // before onChange runs. Set the scope first so Search never
+                // mounts the previous tab's destination and replaces it while
+                // native presentation is activating.
+                searchCoordinator.synchronizeSelection(newValue)
                 selection = newValue
             }
         )

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MobilePrimaryTabScaffold.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MobilePrimaryTabScaffold.swift
@@ -47,14 +47,13 @@ struct MobilePrimaryTabScaffold<
                     primaryTabs
 
                     Tab(value: MobilePrimaryTab.search, role: .search) {
-                        // Scoped to the search tab's content: a TabView-level
-                        // searchable is inherited by every tab's navigation bar,
-                        // which rendered a second, top search field on the
-                        // workspaces and notifications tabs.
+                        // The search-role tab owns native presentation. A second
+                        // writable isPresented binding can receive a stale false
+                        // during a tab transition and collapse the field while
+                        // Search remains selected.
                         searchDestination
                             .searchable(
                                 text: activeSearchText,
-                                isPresented: searchPresentation,
                                 prompt: activeSearchPrompt
                             )
                             .onSubmit(of: .search) {
@@ -106,15 +105,6 @@ struct MobilePrimaryTabScaffold<
                     searchCoordinator.deactivateCurrentSearch()
                 }
                 selection = newValue
-            }
-        )
-    }
-
-    private var searchPresentation: Binding<Bool> {
-        Binding(
-            get: { searchCoordinator.isPresented },
-            set: { presented in
-                searchCoordinator.setPresentation(presented)
             }
         )
     }


### PR DESCRIPTION
## Summary

- let the SwiftUI search-role tab remain the sole owner of native search presentation
- synchronize the contextual search scope before publishing a primary-tab selection
- prevent a rapid root switch followed by Search from remounting the search destination during activation

## Root cause

The scaffold coupled native search-tab selection to a second writable presentation binding, while updating the contextual search scope later in onChange. During a fast tab transition, the old search destination could unmount and write a stale false presentation value after Search was already selected. SwiftUI then retained the selected Search control but rendered the field in the navigation toolbar.

## Verification

- iOS simulator build succeeded for dev.cmux.ios.tabsrc
- Workspaces and Notifications preview roots render without a stray top search field
- focused hosted iPhone UI test passed: primary-root switch followed by Search
- focused hosted iPhone UI test passed: search presentation immediately before Search selection

The aggregate verification workflows also ran unrelated package-conventions and package checks that currently fail outside this one-file product diff.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/9525"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788415699&installation_model_id=21920&pr_number=9525&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F9525&signature=78da8fbd10121d569f8e4a82b8a1296a903e973016fd70b758ba14a98d6dfabc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes iOS search tab state by making the `.search` tab the only owner of native search presentation and syncing the search scope before switching tabs. Prevents stray search fields on other tabs and stops remounting during fast tab changes.

- **Bug Fixes**
  - Removed the secondary `isPresented` binding; the `.search` tab now solely controls presentation.
  - Synced search scope before updating `selection` to avoid stale state and destination remounts.

<sup>Written for commit d8ea76c204a10716172d268a4027a4ac0d8275af. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/9525?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved search tab behavior on iOS 26 by ensuring search activation and tab transitions remain synchronized.
  * Prevented stale search destinations when switching tabs rapidly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->