### PR TITLE
Prevent WebAuthn presentation-window leaks

### DIFF
--- a/Sources/Panels/BrowserWebAuthnFallbackPresentationWindow.swift
+++ b/Sources/Panels/BrowserWebAuthnFallbackPresentationWindow.swift
@@ -1,0 +1,34 @@
+import AppKit
+
+@MainActor
+final class BrowserWebAuthnFallbackPresentationWindow: NSPanel {
+    override var canBecomeKey: Bool { false }
+    override var canBecomeMain: Bool { false }
+
+    init() {
+        super.init(
+            contentRect: NSRect(x: -10_000, y: -10_000, width: 1, height: 1),
+            styleMask: [.borderless, .nonactivatingPanel],
+            backing: .buffered,
+            defer: false
+        )
+        self.identifier = NSUserInterfaceItemIdentifier("cmux.browserWebAuthnFallbackPresentation")
+        isReleasedWhenClosed = false
+        isRestorable = false
+        isExcludedFromWindowsMenu = true
+        collectionBehavior = [.transient, .ignoresCycle, .stationary]
+        level = .normal
+        isOpaque = false
+        backgroundColor = .clear
+        alphaValue = 0
+        hasShadow = false
+        ignoresMouseEvents = true
+        animationBehavior = .none
+        orderOut(nil)
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}

--- a/Sources/Panels/BrowserWebAuthnSupport.swift
+++ b/Sources/Panels/BrowserWebAuthnSupport.swift
@@ -1006,12 +1006,31 @@ private final class BrowserPasskeyAuthorizationGate {
 @MainActor
 final class BrowserWebAuthnCoordinator: NSObject, WKScriptMessageHandlerWithReply {
     private weak var installedWebView: WKWebView?
+    private let existingPresentationWindowProvider: () -> NSWindow?
     private var activeAuthorizationController: ASAuthorizationController?
     private var activeAuthorizationContinuation: CheckedContinuation<[String: Any], Error>?
     private var activePresentationWindow: NSWindow?
+    private var fallbackPresentationWindow: BrowserWebAuthnFallbackPresentationWindow?
 
     override init() {
+        existingPresentationWindowProvider = {
+            NSApp.keyWindow ?? NSApp.mainWindow
+        }
         super.init()
+    }
+
+    init(existingPresentationWindowProvider: @escaping () -> NSWindow?) {
+        self.existingPresentationWindowProvider = existingPresentationWindowProvider
+        super.init()
+    }
+
+    deinit {
+        let window = fallbackPresentationWindow
+        // Swift 5 deinitializers are nonisolated; keep AppKit cleanup on its owner.
+        Task { @MainActor in
+            window?.orderOut(nil)
+            window?.close()
+        }
     }
 
     func install(on webView: WKWebView) {
@@ -1053,6 +1072,7 @@ final class BrowserWebAuthnCoordinator: NSObject, WKScriptMessageHandlerWithRepl
         activePresentationWindow = nil
         controller?.delegate = nil
         controller?.presentationContextProvider = nil
+        retireFallbackPresentationWindow()
         if #available(macOS 13.0, *) {
             controller?.cancel()
         }
@@ -1170,7 +1190,9 @@ extension BrowserWebAuthnCoordinator: ASAuthorizationControllerDelegate, ASAutho
     }
 
     func presentationAnchor(for controller: ASAuthorizationController) -> ASPresentationAnchor {
-        let anchor = activePresentationWindow ?? NSApp.keyWindow ?? NSApp.mainWindow ?? NSWindow()
+        let anchor = activePresentationWindow
+            ?? existingPresentationWindowProvider()
+            ?? reusableFallbackPresentationWindow()
         #if DEBUG
         cmuxDebugLog("webauthn.asAuth.presentationAnchor hasTitle=\(anchor.title.isEmpty ? 0 : 1) isVisible=\(anchor.isVisible) isKey=\(anchor.isKeyWindow)")
         #endif
@@ -1387,10 +1409,14 @@ private extension BrowserWebAuthnCoordinator {
     }
 
     func finishAuthorization(with result: Result<[String: Any], Error>) {
+        let controller = activeAuthorizationController
         let continuation = activeAuthorizationContinuation
         activeAuthorizationController = nil
         activeAuthorizationContinuation = nil
         activePresentationWindow = nil
+        controller?.delegate = nil
+        controller?.presentationContextProvider = nil
+        retireFallbackPresentationWindow()
 
         switch result {
         case .success(let reply):
@@ -1398,6 +1424,23 @@ private extension BrowserWebAuthnCoordinator {
         case .failure(let error):
             continuation?.resume(throwing: error)
         }
+    }
+
+    func reusableFallbackPresentationWindow() -> NSWindow {
+        if let fallbackPresentationWindow {
+            return fallbackPresentationWindow
+        }
+
+        let window = BrowserWebAuthnFallbackPresentationWindow()
+        fallbackPresentationWindow = window
+        return window
+    }
+
+    func retireFallbackPresentationWindow() {
+        guard let window = fallbackPresentationWindow else { return }
+        fallbackPresentationWindow = nil
+        window.orderOut(nil)
+        window.close()
     }
 
     func buildCreationPlan(

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -473,6 +473,7 @@ C0DE71B10000000000000001 /* AppDelegate+AgentChatNotifications.swift in Sources 
 		A50100000000000000000016 /* BrowserWebAuthnCreationRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = A50100000000000000000015 /* BrowserWebAuthnCreationRequest.swift */; };
 		A50100000000000000000010 /* BrowserWebAuthnCredentialDescriptor.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5010000000000000000000F /* BrowserWebAuthnCredentialDescriptor.swift */; };
 		A50100000000000000000012 /* BrowserWebAuthnCredentialParameter.swift in Sources */ = {isa = PBXBuildFile; fileRef = A50100000000000000000011 /* BrowserWebAuthnCredentialParameter.swift */; };
+		A75030010000000000000001 /* BrowserWebAuthnFallbackPresentationWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = A75030010000000000000002 /* BrowserWebAuthnFallbackPresentationWindow.swift */; };
 		A50100000000000000000018 /* BrowserWebAuthnMessageEnvelope.swift in Sources */ = {isa = PBXBuildFile; fileRef = A50100000000000000000017 /* BrowserWebAuthnMessageEnvelope.swift */; };
 		A5010000000000000000001A /* BrowserWebAuthnRelyingPartyDescriptor.swift in Sources */ = {isa = PBXBuildFile; fileRef = A50100000000000000000019 /* BrowserWebAuthnRelyingPartyDescriptor.swift */; };
 		A5007426 /* BrowserWebAuthnRequestParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5007427 /* BrowserWebAuthnRequestParser.swift */; };
@@ -3150,6 +3151,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 		A50100000000000000000015 /* BrowserWebAuthnCreationRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/BrowserWebAuthnCreationRequest.swift; sourceTree = "<group>"; };
 		A5010000000000000000000F /* BrowserWebAuthnCredentialDescriptor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/BrowserWebAuthnCredentialDescriptor.swift; sourceTree = "<group>"; };
 		A50100000000000000000011 /* BrowserWebAuthnCredentialParameter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/BrowserWebAuthnCredentialParameter.swift; sourceTree = "<group>"; };
+		A75030010000000000000002 /* BrowserWebAuthnFallbackPresentationWindow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/BrowserWebAuthnFallbackPresentationWindow.swift; sourceTree = "<group>"; };
 		A50100000000000000000017 /* BrowserWebAuthnMessageEnvelope.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/BrowserWebAuthnMessageEnvelope.swift; sourceTree = "<group>"; };
 		A50100000000000000000019 /* BrowserWebAuthnRelyingPartyDescriptor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/BrowserWebAuthnRelyingPartyDescriptor.swift; sourceTree = "<group>"; };
 		A5007427 /* BrowserWebAuthnRequestParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/BrowserWebAuthnRequestParser.swift; sourceTree = "<group>"; };
@@ -6733,6 +6735,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				A5007425 /* BrowserWebAuthnSecurityOrigin.swift */,
 				A5007427 /* BrowserWebAuthnRequestParser.swift */,
 				A5010000000000000000001B /* BrowserWebAuthnStringValidation.swift */,
+				A75030010000000000000002 /* BrowserWebAuthnFallbackPresentationWindow.swift */,
 				A5007423 /* BrowserWebAuthnSupport.swift */,
 				A5010000000000000000001D /* BrowserWebAuthnTransport.swift */,
 				A5010000000000000000001F /* BrowserWebAuthnTransportSummary.swift */,
@@ -8758,6 +8761,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				A50100000000000000000016 /* BrowserWebAuthnCreationRequest.swift in Sources */,
 				A50100000000000000000010 /* BrowserWebAuthnCredentialDescriptor.swift in Sources */,
 				A50100000000000000000012 /* BrowserWebAuthnCredentialParameter.swift in Sources */,
+				A75030010000000000000001 /* BrowserWebAuthnFallbackPresentationWindow.swift in Sources */,
 				A50100000000000000000018 /* BrowserWebAuthnMessageEnvelope.swift in Sources */,
 				A5010000000000000000001A /* BrowserWebAuthnRelyingPartyDescriptor.swift in Sources */,
 				A5007426 /* BrowserWebAuthnRequestParser.swift in Sources */,

--- a/cmuxTests/BrowserWebContentProcessTests.swift
+++ b/cmuxTests/BrowserWebContentProcessTests.swift
@@ -1,3 +1,5 @@
+import AppKit
+import AuthenticationServices
 import CMUXAuthCore
 import CmuxAuthRuntime
 import CmuxBrowser
@@ -953,6 +955,46 @@ struct BrowserWebContentProcessTests {
         ) as? [String: Bool]
         #expect(result?["bridge"] == true)
         #expect(result?["handler"] == false)
+    }
+
+    @Test
+    func webAuthnPresentationAnchorDoesNotAccumulateFallbackWindows() {
+        let previouslyVisibleWindows = NSApp.windows.filter(\.isVisible)
+        let previouslyKeyWindow = NSApp.keyWindow
+        previouslyVisibleWindows.forEach { $0.orderOut(nil) }
+        defer {
+            previouslyVisibleWindows.forEach { $0.orderFront(nil) }
+            previouslyKeyWindow?.makeKey()
+        }
+
+        #expect(NSApp.keyWindow == nil)
+        #expect(NSApp.mainWindow == nil)
+
+        let windowsBefore = Set(NSApp.windows.map(ObjectIdentifier.init))
+        var coordinator: BrowserWebAuthnCoordinator? = BrowserWebAuthnCoordinator()
+        let authorizationRequest = ASAuthorizationAppleIDProvider().createRequest()
+        let controller = ASAuthorizationController(authorizationRequests: [authorizationRequest])
+        let anchors = (0..<3).map { _ in
+            coordinator!.presentationAnchor(for: controller)
+        }
+        defer {
+            anchors.forEach {
+                $0.isReleasedWhenClosed = false
+                $0.orderOut(nil)
+                $0.close()
+            }
+        }
+
+        let newWindows = NSApp.windows.filter {
+            !windowsBefore.contains(ObjectIdentifier($0))
+        }
+        #expect(Set(anchors.map(ObjectIdentifier.init)).count == 1)
+        #expect(newWindows.count == 1)
+        #expect(newWindows.first === anchors.first)
+
+        coordinator = nil
+
+        #expect(!NSApp.windows.contains { $0 === anchors.first })
     }
 
     @Test

--- a/cmuxTests/BrowserWebContentProcessTests.swift
+++ b/cmuxTests/BrowserWebContentProcessTests.swift
@@ -958,43 +958,70 @@ struct BrowserWebContentProcessTests {
     }
 
     @Test
-    func webAuthnPresentationAnchorDoesNotAccumulateFallbackWindows() {
-        let previouslyVisibleWindows = NSApp.windows.filter(\.isVisible)
-        let previouslyKeyWindow = NSApp.keyWindow
-        previouslyVisibleWindows.forEach { $0.orderOut(nil) }
-        defer {
-            previouslyVisibleWindows.forEach { $0.orderFront(nil) }
-            previouslyKeyWindow?.makeKey()
-        }
+    func webAuthnPresentationAnchorDoesNotAccumulateFallbackWindows() async {
+        weak var retiredCoordinator: BrowserWebAuthnCoordinator?
+        weak var delegateRetiredAnchor: NSWindow?
+        weak var teardownRetiredAnchor: NSWindow?
+        weak var deinitRetiredAnchor: NSWindow?
 
-        #expect(NSApp.keyWindow == nil)
-        #expect(NSApp.mainWindow == nil)
+        autoreleasepool {
+            let coordinator = BrowserWebAuthnCoordinator(
+                existingPresentationWindowProvider: { nil }
+            )
+            retiredCoordinator = coordinator
+            let authorizationRequest = ASAuthorizationAppleIDProvider().createRequest()
+            let controller = ASAuthorizationController(authorizationRequests: [authorizationRequest])
 
-        let windowsBefore = Set(NSApp.windows.map(ObjectIdentifier.init))
-        var coordinator: BrowserWebAuthnCoordinator? = BrowserWebAuthnCoordinator()
-        let authorizationRequest = ASAuthorizationAppleIDProvider().createRequest()
-        let controller = ASAuthorizationController(authorizationRequests: [authorizationRequest])
-        let anchors = (0..<3).map { _ in
-            coordinator!.presentationAnchor(for: controller)
-        }
-        defer {
-            anchors.forEach {
-                $0.isReleasedWhenClosed = false
-                $0.orderOut(nil)
-                $0.close()
+            autoreleasepool {
+                let anchors = (0..<3).map { _ in
+                    coordinator.presentationAnchor(for: controller)
+                }
+                #expect(Set(anchors.map(ObjectIdentifier.init)).count == 1)
+                #expect(anchors.first?.isVisible == false)
+                #expect(anchors.first?.canBecomeKey == false)
+                #expect(anchors.first?.ignoresMouseEvents == true)
+                #expect(anchors.first?.isExcludedFromWindowsMenu == true)
+
+                delegateRetiredAnchor = anchors.first
             }
+
+            #expect(delegateRetiredAnchor != nil)
+            autoreleasepool {
+                coordinator.authorizationController(
+                    controller: controller,
+                    didCompleteWithError: NSError(
+                        domain: "BrowserWebContentProcessTests",
+                        code: 1
+                    )
+                )
+            }
+            #expect(delegateRetiredAnchor == nil)
+
+            let webView = WKWebView(frame: .zero, configuration: WKWebViewConfiguration())
+            coordinator.install(on: webView)
+            autoreleasepool {
+                let anchor = coordinator.presentationAnchor(for: controller)
+                teardownRetiredAnchor = anchor
+            }
+
+            #expect(teardownRetiredAnchor != nil)
+            autoreleasepool {
+                coordinator.tearDown(from: webView)
+            }
+            #expect(teardownRetiredAnchor == nil)
+
+            autoreleasepool {
+                let anchor = coordinator.presentationAnchor(for: controller)
+                deinitRetiredAnchor = anchor
+            }
+            #expect(deinitRetiredAnchor != nil)
         }
 
-        let newWindows = NSApp.windows.filter {
-            !windowsBefore.contains(ObjectIdentifier($0))
+        #expect(retiredCoordinator == nil)
+        for _ in 0..<10 where deinitRetiredAnchor != nil {
+            await Task.yield()
         }
-        #expect(Set(anchors.map(ObjectIdentifier.init)).count == 1)
-        #expect(newWindows.count == 1)
-        #expect(newWindows.first === anchors.first)
-
-        coordinator = nil
-
-        #expect(!NSApp.windows.contains { $0 === anchors.first })
+        #expect(deinitRetiredAnchor == nil)
     }
 
     @Test

--- a/scripts/lint_auxiliary_window_close_shortcuts.py
+++ b/scripts/lint_auxiliary_window_close_shortcuts.py
@@ -17,6 +17,9 @@ OWNER_LIST_NAME = "cmuxAuxiliaryWindowIdentifiers"
 # main window. Add to this set only when a window is intentionally not user
 # closable.
 IGNORED_IDENTIFIERS = {
+    # Hidden AuthenticationServices presentation fallback; it never becomes
+    # key/main and must not take Cmd+W away from the active user window.
+    "cmux.browserWebAuthnFallbackPresentation",
     # Hidden WebKit preload host; it is not user closable and must not own Cmd+W.
     "cmux.browserBackgroundPreload",
     # Hidden WebKit hover-prewarm host; it is not user closable and must not own Cmd+W.

--- a/tests/test_ci_auxiliary_window_close_shortcuts.sh
+++ b/tests/test_ci_auxiliary_window_close_shortcuts.sh
@@ -97,6 +97,33 @@ SWIFT
 
 python3 scripts/lint_auxiliary_window_close_shortcuts.py --repo-root "$TMP_DIR"
 
+# A bare identifier assignment is ambiguous without Swift type information.
+# In particular, NSView also inherits an identifier property, so the lint must
+# ignore the bare form instead of treating every view identifier as a window.
+cat > "$TMP_DIR/Sources/cmuxApp.swift" <<'SWIFT'
+private let cmuxAuxiliaryWindowIdentifiers: Set<String> = [
+    "cmux.settings",
+]
+SWIFT
+
+cat > "$TMP_DIR/Sources/NewWindow.swift" <<'SWIFT'
+import AppKit
+
+final class IdentifiedView: NSView {
+    init() {
+        super.init(frame: .zero)
+        identifier = NSUserInterfaceItemIdentifier("cmux.viewIdentifier")
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}
+SWIFT
+
+python3 scripts/lint_auxiliary_window_close_shortcuts.py --repo-root "$TMP_DIR"
+
 # Identifier assigned through a named constant (the MobilePairingWindowController
 # pattern) must be resolved and enforced, not silently skipped.
 cat > "$TMP_DIR/Sources/cmuxApp.swift" <<'SWIFT'

--- a/verification.html
+++ b/verification.html
@@ -1,0 +1,54 @@
+<!doctype html>
+<html lang="en">
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Issue 7503 verification</title>
+<style>
+  :root { color-scheme: light dark; font: 15px/1.38 system-ui, sans-serif; }
+  body { margin: 0; background: Canvas; color: CanvasText; }
+  main { max-width: 1050px; margin: 0 auto; padding: 24px; }
+  h1 { margin: 0 0 10px; font-size: 24px; }
+  p { margin: 7px 0; }
+  .claim { padding: 10px 12px; border-left: 4px solid #e58b20; background: color-mix(in srgb, #e58b20 12%, Canvas); }
+  ol { margin: 14px 0 0; padding-left: 24px; display: grid; gap: 10px; }
+  li > strong { display: block; }
+  pre { margin: 5px 0; padding: 8px 10px; overflow-x: auto; border-radius: 6px; background: color-mix(in srgb, CanvasText 8%, Canvas); font: 12px/1.35 ui-monospace, monospace; }
+  .verdict { margin-top: 14px; padding-top: 10px; border-top: 1px solid color-mix(in srgb, CanvasText 20%, Canvas); }
+</style>
+<main>
+  <h1>Human verification for #7503</h1>
+  <p>WebAuthn now reuses one hidden, noninteractive, non-restorable fallback panel instead of returning a fresh default window for every presentation callback. The fallback is retired when authorization finishes, the browser tears down, or its coordinator is destroyed.</p>
+  <p class="claim"><strong>Unverified claim:</strong> after hours or days of real use—including sleep/wake and external-display reconnects—the tagged build no longer accumulates the reporter’s untitled WindowServer entries or level-20 click-intercepting dead zones.</p>
+  <ol>
+    <li>
+      <strong>Build and launch the isolated app; verify its socket.</strong>
+      <pre>if [[ -x ./scripts/reload-cloud.sh ]]; then
+  ./scripts/reload-cloud.sh --tag sym7503
+else
+  ./scripts/reload.sh --tag sym7503
+fi
+open -b com.cmuxterm.app.debug.sym7503
+CMUX_TAG=sym7503 scripts/cmux-debug-cli.sh list-workspaces</pre>
+      Correct: the command lists the tagged app’s workspaces. Bug/blocker: the socket is absent or the command targets a different build.
+    </li>
+    <li>
+      <strong>Capture a quiet WindowServer baseline and save it.</strong>
+      <pre>CMUX_PID="$(pgrep -n -f 'DerivedData/cmux-sym7503.*cmux DEV sym7503.app')"
+xcrun swift -e 'import CoreGraphics; import Foundation; let p=Int32(CommandLine.arguments[1])!; let a=CGWindowListCopyWindowInfo([.optionAll],kCGNullWindowID) as! [[String:Any]]; for w in a where (w[kCGWindowOwnerPID as String] as? NSNumber)?.int32Value == p { print("id=\(w[kCGWindowNumber as String] ?? -1) layer=\(w[kCGWindowLayer as String] ?? -1) alpha=\(w[kCGWindowAlpha as String] ?? -1) onscreen=\(w[kCGWindowIsOnscreen as String] ?? false) title=\(w[kCGWindowName as String] ?? "") bounds=\(w[kCGWindowBounds as String] ?? [:])") }' "$CMUX_PID" | tee /tmp/sym7503-windows-before.txt</pre>
+      Correct: only intentional windows appear; record the count. The old bug included hidden untitled 800×600 windows and opaque on-screen untitled level-20 rectangles.
+    </li>
+    <li>
+      <strong>Run real WebAuthn ceremonies before and between every lifecycle cycle.</strong>
+      In a cmux browser pane, open <code>https://webauthn.io</code>, enter a unique username, click <strong>Register</strong>, and complete the macOS passkey sheet. Click <strong>Authenticate</strong> ten times, completing some sheets and canceling others. Repeat those authentications before and after each of these cycles: create/close many browser and terminal panes while hovering sidebar controls, sleep/wake the Mac, and disconnect/reconnect an external display. Close and reopen the WebAuthn browser pane between some runs so browser teardown is exercised. After each quiet period, re-run the step-2 dump to <code>/tmp/sym7503-windows-after-N.txt</code>.
+      Correct: every WebAuthn sheet completes or cancels normally, transient entries disappear, and the quiet count returns to the intentional-window baseline. Bug: a ceremony hangs or untitled entries grow monotonically, especially level 20 at full alpha or hidden 800×600/display-strip windows.
+    </li>
+    <li>
+      <strong>Check click routing, then clean up.</strong>
+      Put another app beneath every suspicious rectangle from the dump and click it.
+      Correct: the underlying app receives the click; cmux does not activate. Bug: a visually empty rectangle intercepts the click and activates cmux.
+      <pre>pkill -f 'DerivedData/cmux-sym7503'</pre>
+    </li>
+  </ol>
+  <p class="verdict"><strong>The fix is disproven by:</strong> any repeatable growth in quiet untitled-window count, any surviving opaque on-screen level-20 rectangle without visible cmux UI, or any such rectangle stealing a click from another app. Attach the before/after dumps and the exact hover/display cycle.</p>
+</main>
+</html>


### PR DESCRIPTION
## Summary

- reuse one coordinator-owned hidden, nonactivating WebAuthn fallback panel instead of allocating a default window for every presentation callback
- retire that panel and detach authorization-controller delegates on completion, browser teardown, and coordinator destruction
- cover fallback reuse and lifecycle behavior while keeping the auxiliary-window close-shortcut lint aware of this intentionally non-user window

Fixes #7503

## Testing

- Red proof on test-only commit `58faefe8fa`: remote `cmux-unit` run `sym7503-red-valid-aa900688704d` with `-only-testing:cmuxTests/BrowserWebContentProcessTests`; the regression recorded 3 distinct anchors and 3 new windows instead of 1 (exit 65).
- Green proof on fixed commit `c769c288dc`: remote `cmux-unit` run `sym7503-review6b-e4804120e40a` with `-only-testing:cmuxTests/BrowserWebContentProcessTests/webAuthnPresentationAnchorDoesNotAccumulateFallbackWindows()`; 1 test passed in 0.056 seconds.
- `bash tests/test_ci_auxiliary_window_close_shortcuts.sh`
- `python3 scripts/lint_auxiliary_window_close_shortcuts.py`
- `./scripts/check-pbxproj.sh`
- `./scripts/lint-pbxproj-test-wiring.sh`
- `./scripts/reload-cloud.sh --tag sym7503`: [cloud build 30966165608](https://github.com/manaflow-ai/cmux/actions/runs/30966165608) succeeded on `blacksmith-6vcpu-macos-26` and downloaded the tagged app.
- Tagged runtime via `/tmp/cmux-debug-sym7503.sock`: 11 real registration attempts on `https://webauthn.io/` all completed with the expected site-level failure and no browser errors. The app-owned WindowServer count stayed at the exact 10-window quiet baseline before and after the requests, with no level-20 window. A fresh browser reopen/request/close cycle also returned to the same baseline. The tagged app was then terminated by its validated socket-owner PID and the socket was removed.

## Needs human verification

The deterministic lifecycle regression and immediate tagged-app stress loop are verified. The reported hours-or-days scenario across sustained multi-workspace churn, sleep/wake, and external-display reconnects cannot be compressed into this run. Follow [verification.html](https://github.com/manaflow-ai/cmux/blob/c769c288dce98afbf8a2cfbf234c91440c243884/verification.html) for that single remaining claim; the fix is disproven if quiet untitled-window counts grow, a level-20 rectangle survives, or an invisible cmux window intercepts clicks.