### PR TITLE
fix: recover ssh-tmux sizing after peer detach

### DIFF
--- a/Sources/RemoteTmuxControlConnection+Commands.swift
+++ b/Sources/RemoteTmuxControlConnection+Commands.swift
@@ -345,30 +345,33 @@ extension RemoteTmuxControlConnection {
         return seedID
     }
 
-    func reseedAfterReconnect() {
-        // The fresh ssh client has been sent nothing: the dedup baseline
-        // must reset with it, or requests matching pre-drop sends would be
-        // suppressed against a server that no longer has them.
+    /// Replays this control client's recorded sizing authority after an event
+    /// that may have changed tmux's effective minimum. Reconnect needs this
+    /// because a fresh client has no claims; peer detach needs it because tmux
+    /// does not otherwise ask surviving clients to resend their desired sizes.
+    func replayRecordedSizeClaims() {
+        // Reset the dedup baseline before replay, or claims matching prior sends
+        // would be suppressed even though tmux may need to recompute them.
         sentWindowSizes.removeAll()
-        // Parity episodes are per connection too: a re-arm budget spent
-        // against the old transport must not suppress re-arms when this
-        // reseed's own resends get lost or raced the same way.
+        // Open a fresh parity episode for every replayed claim. A budget spent
+        // while a smaller peer legitimately clamped the window must not suppress
+        // recovery after that peer leaves.
         windowClaimParityRearmsSpent.removeAll()
-        // The border-status watches were dropped at `beginReconnecting()` — before
-        // this reseed's own list-windows restage, which is what re-issues them.
-        // Clearing them here would be too late: the restage has already run.
         if let size = lastClientSize {
             send("refresh-client -C \(size.columns)x\(size.rows)")
         }
-        // Re-pin every per-window size: pins are per-client state, and the
-        // fresh ssh client starts with none (windows would sit at 80×24 or
-        // the session-wide size). Feed-forward by nature — replays recorded
-        // requests, reads nothing back.
         if supportsPerWindowSize {
             for (windowId, size) in lastWindowSizes.sorted(by: { $0.key < $1.key }) {
                 sendPerWindowSize(windowId: windowId, columns: size.0, rows: size.1)
             }
         }
+    }
+
+    func reseedAfterReconnect() {
+        replayRecordedSizeClaims()
+        // The border-status watches were dropped at `beginReconnecting()` — before
+        // this reseed's own list-windows restage, which is what re-issues them.
+        // Clearing them here would be too late: the restage has already run.
         pendingReconnectSeedIDs.removeAll(keepingCapacity: true)
         var seenPaneIDs: Set<Int> = []
         pendingReconnectPaneIDs = windowsByID.keys.sorted().flatMap { windowId in

--- a/Sources/RemoteTmuxControlConnection.swift
+++ b/Sources/RemoteTmuxControlConnection.swift
@@ -830,8 +830,8 @@ final class RemoteTmuxControlConnection {
             applySessionNameChange(sessionId: id, name: renameName, event: "session-renamed", refetchWindows: false)
         case .sessionsChanged:
             record("sessions-changed")
-        case let .clientDetached(client):
-            record("client-detached \(client)")
+        case .clientDetached:
+            record("client-detached")
             replayRecordedSizeClaims()
         case let .windowAdd(id):
             record("window-add @\(id)")

--- a/Sources/RemoteTmuxControlConnection.swift
+++ b/Sources/RemoteTmuxControlConnection.swift
@@ -830,6 +830,9 @@ final class RemoteTmuxControlConnection {
             applySessionNameChange(sessionId: id, name: renameName, event: "session-renamed", refetchWindows: false)
         case .sessionsChanged:
             record("sessions-changed")
+        case let .clientDetached(client):
+            record("client-detached \(client)")
+            replayRecordedSizeClaims()
         case let .windowAdd(id):
             record("window-add @\(id)")
             requestWindows()

--- a/Sources/RemoteTmuxControlMessage.swift
+++ b/Sources/RemoteTmuxControlMessage.swift
@@ -29,6 +29,9 @@ enum RemoteTmuxControlMessage: Sendable, Equatable {
     /// `%sessions-changed` — the set of sessions changed (re-list to refresh).
     case sessionsChanged
 
+    /// `%client-detached <client>` — another client detached from the server.
+    case clientDetached(client: String)
+
     /// `%window-add @<id>` — a window was added to the attached session.
     case windowAdd(windowId: Int)
 

--- a/Sources/RemoteTmuxControlStreamParser.swift
+++ b/Sources/RemoteTmuxControlStreamParser.swift
@@ -209,6 +209,12 @@ struct RemoteTmuxControlStreamParser {
             return .sessionRenamed(sessionId: nil, name: Self.fieldsFrom(line, 1), idBearingName: nil)
         }
         if line == "%sessions-changed" { return .sessionsChanged }
+        if line.hasPrefix("%client-detached ") {
+            guard let client = Self.field(line, 1), !client.isEmpty else {
+                return .unparsed(line)
+            }
+            return .clientDetached(client: client)
+        }
         if line.hasPrefix("%window-add ") {
             guard let id = Self.fieldId(line, 1, sigil: "@") else { return .unparsed(line) }
             return .windowAdd(windowId: id)

--- a/Sources/RemoteTmuxControlStreamParser.swift
+++ b/Sources/RemoteTmuxControlStreamParser.swift
@@ -209,7 +209,7 @@ struct RemoteTmuxControlStreamParser {
             return .sessionRenamed(sessionId: nil, name: Self.fieldsFrom(line, 1), idBearingName: nil)
         }
         if line == "%sessions-changed" { return .sessionsChanged }
-        if line.hasPrefix("%client-detached ") {
+        if line == "%client-detached" || line.hasPrefix("%client-detached ") {
             guard let client = Self.field(line, 1), !client.isEmpty else {
                 return .unparsed(line)
             }

--- a/cmuxTests/RemoteTmuxControlParserTests.swift
+++ b/cmuxTests/RemoteTmuxControlParserTests.swift
@@ -147,6 +147,11 @@ import Testing
         #expect(messages == [.sessionChanged(sessionId: 1, name: "my session name")])
     }
 
+    @Test func clientDetachedPreservesClientName() {
+        let messages = parse("%client-detached /dev/pts/22\r\n")
+        #expect(messages == [.clientDetached(client: "/dev/pts/22")])
+    }
+
     @Test func sessionRenamedParsesToDistinctMessage() {
         // tmux emits %session-renamed (NOT %session-changed) for `rename-session`;
         // cmux must parse it so a remote rename re-titles the mirror workspace.

--- a/cmuxTests/RemoteTmuxControlParserTests.swift
+++ b/cmuxTests/RemoteTmuxControlParserTests.swift
@@ -152,6 +152,11 @@ import Testing
         #expect(messages == [.clientDetached(client: "/dev/pts/22")])
     }
 
+    @Test func bareClientDetachedIsUnparsed() {
+        let messages = parse("%client-detached\r\n")
+        #expect(messages == [.unparsed("%client-detached")])
+    }
+
     @Test func sessionRenamedParsesToDistinctMessage() {
         // tmux emits %session-renamed (NOT %session-changed) for `rename-session`;
         // cmux must parse it so a remote rename re-titles the mirror workspace.

--- a/cmuxTests/RemoteTmuxPaneSeedTransportTests.swift
+++ b/cmuxTests/RemoteTmuxPaneSeedTransportTests.swift
@@ -58,6 +58,7 @@ import Testing
         #expect(fixture.connection.sentWindowSizes[9]?.0 == 242)
         #expect(fixture.connection.sentWindowSizes[9]?.1 == 62)
         #expect(fixture.connection.windowClaimParityRearmsSpent.isEmpty)
+        #expect(fixture.connection.snapshot().recentEvents.last == "client-detached")
     }
 
     @Test func laggingControlOutputCursorCannotReplayCapturedReconnectOutput() throws {

--- a/cmuxTests/RemoteTmuxPaneSeedTransportTests.swift
+++ b/cmuxTests/RemoteTmuxPaneSeedTransportTests.swift
@@ -19,6 +19,47 @@ import Testing
 /// after the capture block must be replayed exactly once after pane state.
 @MainActor
 @Suite struct RemoteTmuxPaneSeedTransportTests {
+    @Test func peerDetachReplaysEveryRecordedSizeClaimInStableOrder() throws {
+        let fixture = attachedConnection()
+        defer { fixture.close() }
+
+        fixture.connection.lastClientSize = (columns: 242, rows: 62)
+        fixture.connection.lastWindowSizes = [
+            9: (242, 62),
+            3: (180, 50),
+        ]
+        fixture.connection.sentWindowSizes = fixture.connection.lastWindowSizes
+        fixture.connection.windowClaimParityRearmsSpent = [3: 1, 9: 3]
+        _ = fixture.pipe.fileHandleForReading.availableData
+
+        fixture.connection.handleMessageForTesting(
+            .clientDetached(client: "/dev/pts/22")
+        )
+
+        let commands = String(
+            decoding: fixture.pipe.fileHandleForReading.availableData,
+            as: UTF8.self
+        )
+        let envelope = try #require(commands.range(of: "refresh-client -C 242x62"))
+        let window3 = try #require(
+            commands.range(of: "refresh-client -C '@3:180x50'")
+        )
+        let window9 = try #require(
+            commands.range(of: "refresh-client -C '@9:242x62'")
+        )
+
+        #expect(envelope.lowerBound < window3.lowerBound)
+        #expect(window3.lowerBound < window9.lowerBound)
+        #expect(commands.components(separatedBy: "refresh-client -C 242x62").count - 1 == 1)
+        #expect(commands.components(separatedBy: "refresh-client -C '@3:180x50'").count - 1 == 1)
+        #expect(commands.components(separatedBy: "refresh-client -C '@9:242x62'").count - 1 == 1)
+        #expect(fixture.connection.sentWindowSizes[3]?.0 == 180)
+        #expect(fixture.connection.sentWindowSizes[3]?.1 == 50)
+        #expect(fixture.connection.sentWindowSizes[9]?.0 == 242)
+        #expect(fixture.connection.sentWindowSizes[9]?.1 == 62)
+        #expect(fixture.connection.windowClaimParityRearmsSpent.isEmpty)
+    }
+
     @Test func laggingControlOutputCursorCannotReplayCapturedReconnectOutput() throws {
         let fixture = attachedConnection()
         defer { fixture.close() }


### PR DESCRIPTION
## Summary

- Parse tmux `%client-detached` control-mode notifications.
- When a peer detaches, replay this surviving client’s last client-size envelope and every recorded per-window size claim in stable window-ID order.
- Share the same replay path with reconnect reseeding so dedup and parity-rearm state reset consistently.

## Why

With multiple cmux `ssh-tmux` clients at different resolutions, the smaller client can clamp tmux windows. After it exits, surviving clients still have their desired sizes in memory, but their send ledger suppresses identical `refresh-client -C` commands. The windows therefore remain at the departed client’s size until the larger client reconnects. `%client-detached` is the event that tells every survivor to reassert its own claims.

## Testing

- Added a parser regression test for `%client-detached /dev/pts/...`.
- Added a transport-level regression test verifying client envelope plus all per-window claims are replayed once, in stable order, with dedup/parity state refreshed.
- Verified both new regression tests with `xcodebuild test` on macOS arm64.
- Verified the existing reconnect reseed behavior test independently.
- `./scripts/lint-pbxproj-test-wiring.sh`
- `git diff --check`
- `./scripts/reload.sh --tag ssh-tmux-detach-sizing`

## Demo Video

- Not attached; a tagged build is available for the A-large/B-small multi-device dogfood scenario.

## Checklist

- [x] I tested the change locally
- [x] I added or updated tests for behavior changes
- [x] No user-facing strings, docs, or changelog changes are required
- [ ] I requested bot reviews after my latest commit
- [ ] All code review bot comments are resolved
- [ ] All human review comments are resolved

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/9530"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788416842&installation_model_id=21920&pr_number=9530&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F9530&signature=5f82388bf834ed067c4ee64a16198dd301e75b2c11a099a5f5e8f9e4aad91d2d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restore correct window sizing in `ssh-tmux` after a peer detaches by parsing `%client-detached` and replaying the surviving client’s size claims. Prevents windows from staying clamped to a smaller peer’s size until reconnect.

- **Bug Fixes**
  - Parse `%client-detached <client>`; on detach, replay this client’s envelope and per-window size claims once in window-ID order. Ignore bare `%client-detached`.
  - Reset dedup/parity state before replay and factor out `replayRecordedSizeClaims()` (also used on reconnect). Added parser and transport tests.

<sup>Written for commit 2b4902ebd0c48e2dedfa4290ccbc964a3075f936. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/9530?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved recovery after a tmux client detaches or reconnects.
  * Restores recorded pane and window dimensions more reliably and in a stable order.
  * Prevents duplicate refresh commands during size restoration.

* **Tests**
  * Added coverage for client-detached notifications and dimension replay behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->