### PR TITLE
Launch zsh terminal sessions without bash

### DIFF
--- a/Packages/macOS/CmuxTerminal/Sources/CmuxTerminal/Spawn/TerminalLaunchCommandPolicy.swift
+++ b/Packages/macOS/CmuxTerminal/Sources/CmuxTerminal/Spawn/TerminalLaunchCommandPolicy.swift
@@ -3,12 +3,32 @@ public struct TerminalLaunchCommandPolicy: Sendable {
     /// Creates a launch-command policy.
     public init() {}
 
+    /// Builds the Ghostty app-level default command for a directly launchable shell.
+    ///
+    /// Ghostty's embedded per-surface command is always shell-expanded, while
+    /// its app configuration preserves the `direct:` command form. zsh accepts
+    /// an explicit login flag, so cmux can bypass shell expansion without
+    /// changing login-shell startup behavior.
+    ///
+    /// - Parameter resolvedShell: The executable user-shell fallback.
+    /// - Returns: A Ghostty app command, or `nil` when the shell needs the
+    ///   existing per-surface fallback.
+    public func ghosttyAppCommand(resolvedShell: String?) -> String? {
+        guard let resolvedShell,
+              !resolvedShell.isEmpty,
+              !resolvedShell.contains(where: \.isWhitespace),
+              resolvedShell.split(separator: "/").last == "zsh"
+        else { return nil }
+        return "direct:\(resolvedShell) -l"
+    }
+
     /// Resolves the first non-empty command in launch-precedence order.
     ///
     /// Explicit per-surface commands win first. When Ghostty's app config owns
-    /// the default command, this returns `nil` so Ghostty preserves its parsed
-    /// direct-versus-shell execution semantics. Otherwise cmux supplies its
-    /// shell-integration wrapper or resolved user-shell fallback.
+    /// the default command, either from the user or cmux's direct zsh fallback,
+    /// this returns `nil` so Ghostty preserves its parsed direct-versus-shell
+    /// execution semantics. Otherwise cmux supplies its shell-integration
+    /// wrapper or resolved user-shell fallback.
     ///
     /// - Parameters:
     ///   - initialCommand: The command requested for this surface.
@@ -30,10 +50,14 @@ public struct TerminalLaunchCommandPolicy: Sendable {
             }
         }
         if hasUserGhosttyCommand { return nil }
-        for candidate in [managedShellCommand, resolvedShell] {
-            if let candidate, !candidate.isEmpty {
-                return candidate
-            }
+        if let managedShellCommand, !managedShellCommand.isEmpty {
+            return managedShellCommand
+        }
+        if ghosttyAppCommand(resolvedShell: resolvedShell) != nil {
+            return nil
+        }
+        if let resolvedShell, !resolvedShell.isEmpty {
+            return resolvedShell
         }
         return nil
     }

--- a/Packages/macOS/CmuxTerminal/Tests/CmuxTerminalTests/TerminalShellResolverTests.swift
+++ b/Packages/macOS/CmuxTerminal/Tests/CmuxTerminalTests/TerminalShellResolverTests.swift
@@ -75,7 +75,10 @@ struct TerminalShellResolverTests {
 
     @Test
     func resolvedZshLaunchesDirectlyAsALoginShell() {
-        let command = TerminalLaunchCommandPolicy().resolve(
+        let policy = TerminalLaunchCommandPolicy()
+
+        let appCommand = policy.ghosttyAppCommand(resolvedShell: "/bin/zsh")
+        let surfaceCommand = policy.resolve(
             initialCommand: nil,
             surfaceCommand: nil,
             hasUserGhosttyCommand: false,
@@ -83,7 +86,53 @@ struct TerminalShellResolverTests {
             resolvedShell: "/bin/zsh"
         )
 
-        #expect(command == "direct:/bin/zsh -l")
+        #expect(appCommand == "direct:/bin/zsh -l")
+        #expect(surfaceCommand == nil)
+    }
+
+    @Test
+    func explicitGhosttyCommandWinsForResolvedZsh() {
+        let command = TerminalLaunchCommandPolicy().resolve(
+            initialCommand: nil,
+            surfaceCommand: nil,
+            hasUserGhosttyCommand: true,
+            managedShellCommand: "/bin/zsh --init-command source",
+            resolvedShell: "/bin/zsh"
+        )
+
+        #expect(command == nil)
+    }
+
+    @Test
+    func managedZshCommandWinsOverDirectFallback() {
+        let managedCommand = "/bin/zsh --init-command source"
+        let command = TerminalLaunchCommandPolicy().resolve(
+            initialCommand: nil,
+            surfaceCommand: nil,
+            hasUserGhosttyCommand: false,
+            managedShellCommand: managedCommand,
+            resolvedShell: "/bin/zsh"
+        )
+
+        #expect(command == managedCommand)
+    }
+
+    @Test
+    func zshPathWithWhitespaceKeepsTheSurfaceFallback() {
+        let policy = TerminalLaunchCommandPolicy()
+        let shell = "/Applications/Custom Shell/zsh"
+
+        let appCommand = policy.ghosttyAppCommand(resolvedShell: shell)
+        let surfaceCommand = policy.resolve(
+            initialCommand: nil,
+            surfaceCommand: nil,
+            hasUserGhosttyCommand: false,
+            managedShellCommand: nil,
+            resolvedShell: shell
+        )
+
+        #expect(appCommand == nil)
+        #expect(surfaceCommand == shell)
     }
 
     @Test

--- a/Packages/macOS/CmuxTerminal/Tests/CmuxTerminalTests/TerminalShellResolverTests.swift
+++ b/Packages/macOS/CmuxTerminal/Tests/CmuxTerminalTests/TerminalShellResolverTests.swift
@@ -74,6 +74,19 @@ struct TerminalShellResolverTests {
     }
 
     @Test
+    func resolvedZshLaunchesDirectlyAsALoginShell() {
+        let command = TerminalLaunchCommandPolicy().resolve(
+            initialCommand: nil,
+            surfaceCommand: nil,
+            hasUserGhosttyCommand: false,
+            managedShellCommand: nil,
+            resolvedShell: "/bin/zsh"
+        )
+
+        #expect(command == "direct:/bin/zsh -l")
+    }
+
+    @Test
     func explicitGhosttyCommandIsInheritedWithoutSurfaceOverride() {
         let command = TerminalLaunchCommandPolicy().resolve(
             initialCommand: nil,

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -1085,6 +1085,7 @@ class GhosttyApp {
                 prefix: "cmux-shell-integration-override",
                 logLabel: "shell integration override (fallback)"
             )
+            loadResolvedUserShellCommandIfNeeded(fallbackConfig)
             loadCmuxManagedTerminalSettingsConfig(fallbackConfig)
             loadGlobalFontMagnificationConfig(fallbackConfig)
             loadCmuxOwnedGhosttyKeybindOverrides(fallbackConfig)
@@ -1308,6 +1309,7 @@ class GhosttyApp {
         #else
         loadRealUserGhosttyConfig(config, preferredColorScheme: preferredColorScheme, themeColorScheme: themeColorScheme)
         #endif
+        loadResolvedUserShellCommandIfNeeded(config)
         loadCJKFontFallbackIfNeeded(config)
         let renderingModeChanged = setUsesHostLayerBackground(
             true,
@@ -1357,6 +1359,20 @@ class GhosttyApp {
         ghostty_config_finalize(config)
         return renderingModeChanged
     }
+
+    private func loadResolvedUserShellCommandIfNeeded(_ config: ghostty_config_t) {
+        guard !hasUserGhosttyCommand,
+              let command = TerminalLaunchCommandPolicy()
+                .ghosttyAppCommand(resolvedShell: resolvedUserShell)
+        else { return }
+        loadInlineGhosttyConfig(
+            "command = \(command)",
+            into: config,
+            prefix: "cmux-resolved-user-shell",
+            logLabel: "resolved user shell"
+        )
+    }
+
     func loadGlobalFontMagnificationConfig(_ config: ghostty_config_t) {
         guard !GlobalFontMagnification.isDefault else { return }
         var fontSize: Float32 = 0


### PR DESCRIPTION
Fixes #7465

## Summary

When the resolved login shell is zsh and no explicit Ghostty command overrides it, configure Ghostty's app-level command as `direct:<zsh-path> -l`. Keeping this at the app-config layer preserves Ghostty's parsed direct-command semantics; the embedded per-surface command API treats every command as shell text and would otherwise route it through bash.

Explicit surface commands, user-configured Ghostty commands, and managed shell-integration commands keep their existing precedence. A zsh path containing whitespace retains the existing per-surface fallback because Ghostty's direct-command parser cannot represent that path safely.

## Testing

- Regression test commit `7d4d151d62` (fleet checkout):
  - `swift test --package-path Packages/macOS/CmuxTerminal --filter TerminalShellResolverTests`
  - Failed as expected: `Expectation failed: (command → "/bin/zsh") == "direct:/bin/zsh -l"`; 8 tests, 1 issue.
- Fix commit `608f293456` (leased fleet checkout under `~/cmux-runners/`, isolated SwiftPM scratch path):
  - Same focused command passed: 11 tests in 1 suite, including zsh precedence coverage.
  - The repository CI-tolerated cosmetic GhosttyKit `unexpected binary name ... ghostty-internal.a` diagnostic was present; all focused tests completed successfully.
- Tagged development build:
  - Built the pushed head with `./scripts/reload-cloud.sh --builder fleet --tag sym7465 --host cmuxs-mac-mini-2` (leased fleet path; no local fallback).
  - Fleet run `sym7465-7026ecc2a539` on `cmuxs-mac-mini-2.1`; downloaded app reported `cmux 0.64.22 (102) [608f29345]`.
- Tagged-socket runtime verification on `/tmp/cmux-debug-sym7465.sock`:
  - Before: `/usr/bin/login -flp <user> /bin/bash --noprofile --norc -c exec -l /bin/zsh`, with child `-/bin/zsh`.
  - After, on a newly created terminal: `/usr/bin/login -flp <user> /bin/zsh -l`, with child `zsh -l`; no `/bin/bash` process was present on that TTY.
  - In-terminal transcript reported `SHELL=/bin/zsh`, `ARGV0=zsh`, and login/interactive flags.
  - Quit the tagged app with `pkill -f "DerivedData/cmux-sym7465"` and confirmed its process and tagged socket were gone.
- Full CI: manually dispatched `ci.yml` for the exact pushed head because repository PR-triggered CI is currently paused: https://github.com/manaflow-ai/cmux/actions/runs/30888839774
