### PR TITLE
Filter Iroh discovery by runtime scope

### DIFF
--- a/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxConnectivityAuthorityServing.swift
+++ b/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxConnectivityAuthorityServing.swift
@@ -36,7 +36,7 @@ struct CmxAuthoritativeDiscoveryResolver: Sendable {
             knownRevision: cached?.revision
         )
         if let snapshot = response.snapshot,
-           response.snapshotComplete == true {
+           response.snapshotIsComplete {
             try Self.requireRevision(snapshot, atLeast: minimumRevision)
             if !response.reset {
                 try Self.requireRevision(snapshot, atLeast: cached?.revision)

--- a/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxConnectivityDiscoveryScope+LocalBinding.swift
+++ b/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxConnectivityDiscoveryScope+LocalBinding.swift
@@ -1,0 +1,24 @@
+extension CmxConnectivityDiscoveryScope {
+    /// The caller's own binding, which remains visible even when it does not
+    /// satisfy the peer selector.
+    public struct LocalBinding: Codable, Equatable, Sendable {
+        /// The durable device identifier that owns the local endpoint.
+        public let deviceID: String
+
+        /// The app installation identifier that owns the local endpoint.
+        public let appInstanceID: String
+
+        /// The exact build tag registered by the local app.
+        public let tag: String
+
+        /// The platform hosting the local endpoint.
+        public let platform: CmxIrohPlatform
+
+        private enum CodingKeys: String, CodingKey {
+            case deviceID = "device_id"
+            case appInstanceID = "app_instance_id"
+            case tag
+            case platform
+        }
+    }
+}

--- a/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxConnectivityDiscoveryScope+PeerBindings.swift
+++ b/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxConnectivityDiscoveryScope+PeerBindings.swift
@@ -1,0 +1,19 @@
+extension CmxConnectivityDiscoveryScope {
+    /// Opposite-platform bindings that this runtime may connect to or admit.
+    public struct PeerBindings: Codable, Equatable, Sendable {
+        /// The platform required for every selected peer binding.
+        public let platform: CmxIrohPlatform
+
+        /// Canonical build tags accepted by the peer selector, or all tags when absent.
+        public let tags: [String]?
+
+        /// The required pairing state, or either state when absent.
+        public let pairingEnabled: Bool?
+
+        private enum CodingKeys: String, CodingKey {
+            case platform
+            case tags
+            case pairingEnabled = "pairing_enabled"
+        }
+    }
+}

--- a/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxConnectivityDiscoveryScope.swift
+++ b/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxConnectivityDiscoveryScope.swift
@@ -1,0 +1,116 @@
+public import Foundation
+
+/// The exact local binding and bounded peer set required by one app runtime.
+public struct CmxConnectivityDiscoveryScope: Codable, Equatable, Sendable {
+    /// The caller's own binding, which remains visible even when it does not
+    /// satisfy the peer selector.
+    public struct LocalBinding: Codable, Equatable, Sendable {
+        public let deviceID: String
+        public let appInstanceID: String
+        public let tag: String
+        public let platform: CmxIrohPlatform
+
+        private enum CodingKeys: String, CodingKey {
+            case deviceID = "device_id"
+            case appInstanceID = "app_instance_id"
+            case tag
+            case platform
+        }
+    }
+
+    /// Opposite-platform bindings that this runtime may connect to or admit.
+    public struct PeerBindings: Codable, Equatable, Sendable {
+        public let platform: CmxIrohPlatform
+        public let tags: [String]?
+        public let pairingEnabled: Bool?
+
+        private enum CodingKeys: String, CodingKey {
+            case platform
+            case tags
+            case pairingEnabled = "pairing_enabled"
+        }
+    }
+
+    public let localBinding: LocalBinding
+    public let peerBindings: PeerBindings
+
+    private enum CodingKeys: String, CodingKey {
+        case localBinding = "local_binding"
+        case peerBindings = "peer_bindings"
+    }
+
+    /// Creates the canonical scope echoed by connectivity v3.
+    ///
+    /// Peer tags are deduplicated by rejection and sorted so request and
+    /// response equality is stable across implementations.
+    public init(
+        deviceID: String,
+        appInstanceID: String,
+        tag: String,
+        platform: CmxIrohPlatform,
+        peerPlatform: CmxIrohPlatform,
+        peerTags: [String]? = nil,
+        peerPairingEnabled: Bool? = nil
+    ) throws {
+        let sortedTags = peerTags?.sorted()
+        guard Self.isCanonicalUUID(deviceID),
+              Self.isCanonicalUUID(appInstanceID),
+              Self.isSafeTag(tag),
+              platform != peerPlatform,
+              sortedTags.map({ (1 ... 8).contains($0.count) }) ?? true,
+              sortedTags.map({ Set($0).count == $0.count }) ?? true,
+              sortedTags?.allSatisfy(Self.isSafeTag) ?? true else {
+            throw CmxConnectivityDiscoveryScopeError.invalidScope
+        }
+        localBinding = LocalBinding(
+            deviceID: deviceID,
+            appInstanceID: appInstanceID,
+            tag: tag,
+            platform: platform
+        )
+        peerBindings = PeerBindings(
+            platform: peerPlatform,
+            tags: sortedTags,
+            pairingEnabled: peerPairingEnabled
+        )
+    }
+
+    public init(from decoder: any Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let local = try container.decode(LocalBinding.self, forKey: .localBinding)
+        let peers = try container.decode(PeerBindings.self, forKey: .peerBindings)
+        try self.init(
+            deviceID: local.deviceID,
+            appInstanceID: local.appInstanceID,
+            tag: local.tag,
+            platform: local.platform,
+            peerPlatform: peers.platform,
+            peerTags: peers.tags,
+            peerPairingEnabled: peers.pairingEnabled
+        )
+    }
+
+    private static func isCanonicalUUID(_ value: String) -> Bool {
+        guard UUID(uuidString: value)?.uuidString.lowercased() == value,
+              value.count == 36 else { return false }
+        let characters = Array(value.utf8)
+        guard (49 ... 56).contains(characters[14]),
+              [56, 57, 97, 98].contains(characters[19]) else { return false }
+        return true
+    }
+
+    private static func isSafeTag(_ value: String) -> Bool {
+        guard (1 ... 64).contains(value.utf8.count) else { return false }
+        return value.utf8.allSatisfy { byte in
+            (48 ... 57).contains(byte)
+                || (65 ... 90).contains(byte)
+                || (97 ... 122).contains(byte)
+                || [45, 46, 95].contains(byte)
+        }
+    }
+}
+
+/// Validation failures for connectivity discovery scopes.
+public enum CmxConnectivityDiscoveryScopeError: Error, Equatable, Sendable {
+    case invalidScope
+}

--- a/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxConnectivityDiscoveryScope.swift
+++ b/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxConnectivityDiscoveryScope.swift
@@ -41,8 +41,8 @@ public struct CmxConnectivityDiscoveryScope: Codable, Equatable, Sendable {
 
     /// Creates the canonical scope echoed by connectivity v3.
     ///
-    /// Peer tags are deduplicated by rejection and sorted so request and
-    /// response equality is stable across implementations.
+    /// Peer tags are lowercased, deduplicated by rejection, and sorted so the
+    /// case-insensitive compatibility contract is stable across implementations.
     public init(
         deviceID: String,
         appInstanceID: String,
@@ -57,11 +57,14 @@ public struct CmxConnectivityDiscoveryScope: Codable, Equatable, Sendable {
               Self.isSafeTag(tag),
               platform != peerPlatform,
               peerTags.map({ (1 ... 8).contains($0.count) }) ?? true,
-              peerTags?.allSatisfy(Self.isSafeTag) ?? true,
-              peerTags.map({ Set($0).count == $0.count }) ?? true else {
+              peerTags?.allSatisfy(Self.isSafeTag) ?? true else {
             throw CmxConnectivityDiscoveryScopeError.invalidScope
         }
-        let sortedTags = peerTags?.sorted()
+        let canonicalPeerTags = peerTags?.map { $0.lowercased() }
+        guard canonicalPeerTags.map({ Set($0).count == $0.count }) ?? true else {
+            throw CmxConnectivityDiscoveryScopeError.invalidScope
+        }
+        let sortedTags = canonicalPeerTags?.sorted()
         localBinding = LocalBinding(
             deviceID: deviceID,
             appInstanceID: appInstanceID,

--- a/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxConnectivityDiscoveryScope.swift
+++ b/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxConnectivityDiscoveryScope.swift
@@ -57,8 +57,8 @@ public struct CmxConnectivityDiscoveryScope: Codable, Equatable, Sendable {
               Self.isSafeTag(tag),
               platform != peerPlatform,
               peerTags.map({ (1 ... 8).contains($0.count) }) ?? true,
-              peerTags.map({ Set($0).count == $0.count }) ?? true,
-              peerTags?.allSatisfy(Self.isSafeTag) ?? true else {
+              peerTags?.allSatisfy(Self.isSafeTag) ?? true,
+              peerTags.map({ Set($0).count == $0.count }) ?? true else {
             throw CmxConnectivityDiscoveryScopeError.invalidScope
         }
         let sortedTags = peerTags?.sorted()

--- a/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxConnectivityDiscoveryScope.swift
+++ b/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxConnectivityDiscoveryScope.swift
@@ -52,16 +52,16 @@ public struct CmxConnectivityDiscoveryScope: Codable, Equatable, Sendable {
         peerTags: [String]? = nil,
         peerPairingEnabled: Bool? = nil
     ) throws {
-        let sortedTags = peerTags?.sorted()
         guard Self.isCanonicalUUID(deviceID),
               Self.isCanonicalUUID(appInstanceID),
               Self.isSafeTag(tag),
               platform != peerPlatform,
-              sortedTags.map({ (1 ... 8).contains($0.count) }) ?? true,
-              sortedTags.map({ Set($0).count == $0.count }) ?? true,
-              sortedTags?.allSatisfy(Self.isSafeTag) ?? true else {
+              peerTags.map({ (1 ... 8).contains($0.count) }) ?? true,
+              peerTags.map({ Set($0).count == $0.count }) ?? true,
+              peerTags?.allSatisfy(Self.isSafeTag) ?? true else {
             throw CmxConnectivityDiscoveryScopeError.invalidScope
         }
+        let sortedTags = peerTags?.sorted()
         localBinding = LocalBinding(
             deviceID: deviceID,
             appInstanceID: appInstanceID,

--- a/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxConnectivityDiscoveryScope.swift
+++ b/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxConnectivityDiscoveryScope.swift
@@ -2,36 +2,10 @@ public import Foundation
 
 /// The exact local binding and bounded peer set required by one app runtime.
 public struct CmxConnectivityDiscoveryScope: Codable, Equatable, Sendable {
-    /// The caller's own binding, which remains visible even when it does not
-    /// satisfy the peer selector.
-    public struct LocalBinding: Codable, Equatable, Sendable {
-        public let deviceID: String
-        public let appInstanceID: String
-        public let tag: String
-        public let platform: CmxIrohPlatform
-
-        private enum CodingKeys: String, CodingKey {
-            case deviceID = "device_id"
-            case appInstanceID = "app_instance_id"
-            case tag
-            case platform
-        }
-    }
-
-    /// Opposite-platform bindings that this runtime may connect to or admit.
-    public struct PeerBindings: Codable, Equatable, Sendable {
-        public let platform: CmxIrohPlatform
-        public let tags: [String]?
-        public let pairingEnabled: Bool?
-
-        private enum CodingKeys: String, CodingKey {
-            case platform
-            case tags
-            case pairingEnabled = "pairing_enabled"
-        }
-    }
-
+    /// The caller's own binding, preserved independently from the peer selector.
     public let localBinding: LocalBinding
+
+    /// The bounded opposite-platform bindings visible to this runtime.
     public let peerBindings: PeerBindings
 
     private enum CodingKeys: String, CodingKey {
@@ -52,12 +26,12 @@ public struct CmxConnectivityDiscoveryScope: Codable, Equatable, Sendable {
         peerTags: [String]? = nil,
         peerPairingEnabled: Bool? = nil
     ) throws {
-        guard Self.isCanonicalUUID(deviceID),
-              Self.isCanonicalUUID(appInstanceID),
-              Self.isSafeTag(tag),
+        guard isCanonicalUUID(deviceID),
+              isCanonicalUUID(appInstanceID),
+              isSafeTag(tag),
               platform != peerPlatform,
               peerTags.map({ (1 ... 8).contains($0.count) }) ?? true,
-              peerTags?.allSatisfy(Self.isSafeTag) ?? true else {
+              peerTags?.allSatisfy(isSafeTag) ?? true else {
             throw CmxConnectivityDiscoveryScopeError.invalidScope
         }
         let canonicalPeerTags = peerTags?.map { $0.lowercased() }
@@ -78,6 +52,7 @@ public struct CmxConnectivityDiscoveryScope: Codable, Equatable, Sendable {
         )
     }
 
+    /// Decodes and validates a canonical discovery scope.
     public init(from decoder: any Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         let local = try container.decode(LocalBinding.self, forKey: .localBinding)
@@ -93,27 +68,23 @@ public struct CmxConnectivityDiscoveryScope: Codable, Equatable, Sendable {
         )
     }
 
-    private static func isCanonicalUUID(_ value: String) -> Bool {
-        guard UUID(uuidString: value)?.uuidString.lowercased() == value,
-              value.count == 36 else { return false }
-        let characters = Array(value.utf8)
-        guard (49 ... 56).contains(characters[14]),
-              [56, 57, 97, 98].contains(characters[19]) else { return false }
-        return true
-    }
-
-    private static func isSafeTag(_ value: String) -> Bool {
-        guard (1 ... 64).contains(value.utf8.count) else { return false }
-        return value.utf8.allSatisfy { byte in
-            (48 ... 57).contains(byte)
-                || (65 ... 90).contains(byte)
-                || (97 ... 122).contains(byte)
-                || [45, 46, 95].contains(byte)
-        }
-    }
 }
 
-/// Validation failures for connectivity discovery scopes.
-public enum CmxConnectivityDiscoveryScopeError: Error, Equatable, Sendable {
-    case invalidScope
+private func isCanonicalUUID(_ value: String) -> Bool {
+    guard UUID(uuidString: value)?.uuidString.lowercased() == value,
+          value.count == 36 else { return false }
+    let characters = Array(value.utf8)
+    guard (49 ... 56).contains(characters[14]),
+          [56, 57, 97, 98].contains(characters[19]) else { return false }
+    return true
+}
+
+private func isSafeTag(_ value: String) -> Bool {
+    guard (1 ... 64).contains(value.utf8.count) else { return false }
+    return value.utf8.allSatisfy { byte in
+        (48 ... 57).contains(byte)
+            || (65 ... 90).contains(byte)
+            || (97 ... 122).contains(byte)
+            || [45, 46, 95].contains(byte)
+    }
 }

--- a/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxConnectivityDiscoveryScopeError.swift
+++ b/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxConnectivityDiscoveryScopeError.swift
@@ -1,0 +1,5 @@
+/// Validation failures for connectivity discovery scopes.
+public enum CmxConnectivityDiscoveryScopeError: Error, Equatable, Sendable {
+    /// The scope contains an invalid identity, tag, platform pair, or peer selector.
+    case invalidScope
+}

--- a/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxConnectivitySyncResponse.swift
+++ b/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxConnectivitySyncResponse.swift
@@ -1,7 +1,9 @@
 /// Versioned response from the authoritative connectivity reconciliation route.
 public struct CmxConnectivitySyncResponse: Decodable, Equatable, Sendable {
-    /// The only protocol version accepted by this implementation.
+    /// The global-snapshot protocol used when scoped discovery is unavailable.
     public static let protocolVersion = 2
+    /// The bounded discovery protocol used by current clients.
+    public static let scopedProtocolVersion = 3
 
     /// Backend connectivity protocol version.
     public let protocolVersion: Int
@@ -22,6 +24,18 @@ public struct CmxConnectivitySyncResponse: Decodable, Equatable, Sendable {
     /// Older servers omit this field, so clients fetch paginated discovery.
     public let snapshotComplete: Bool?
 
+    /// The bounded projection represented by a connectivity v3 snapshot.
+    public let discoveryScope: CmxConnectivityDiscoveryScope?
+
+    /// True only when the server proves `snapshot` covers the echoed scope.
+    public let snapshotScopeComplete: Bool?
+
+    /// Whether the snapshot carries either global or scoped completeness proof.
+    public var snapshotIsComplete: Bool {
+        snapshot != nil
+            && (snapshotComplete == true || snapshotScopeComplete == true)
+    }
+
     private enum CodingKeys: String, CodingKey {
         case protocolVersion = "protocol_version"
         case revision
@@ -29,6 +43,8 @@ public struct CmxConnectivitySyncResponse: Decodable, Equatable, Sendable {
         case reset
         case snapshot
         case snapshotComplete = "snapshot_complete"
+        case discoveryScope = "discovery_scope"
+        case snapshotScopeComplete = "snapshot_scope_complete"
     }
 
     /// Decodes and validates one atomic reconciliation response.
@@ -46,10 +62,27 @@ public struct CmxConnectivitySyncResponse: Decodable, Equatable, Sendable {
             Bool.self,
             forKey: .snapshotComplete
         )
-        guard protocolVersion == Self.protocolVersion,
+        let discoveryScope = try container.decodeIfPresent(
+            CmxConnectivityDiscoveryScope.self,
+            forKey: .discoveryScope
+        )
+        let snapshotScopeComplete = try container.decodeIfPresent(
+            Bool.self,
+            forKey: .snapshotScopeComplete
+        )
+        let validCompletenessContract = switch protocolVersion {
+        case Self.protocolVersion:
+            discoveryScope == nil && snapshotScopeComplete == nil
+        case Self.scopedProtocolVersion:
+            discoveryScope != nil && snapshotComplete == nil
+        default:
+            false
+        }
+        guard validCompletenessContract,
               changed == (snapshot != nil),
               !reset || changed,
               snapshot != nil || snapshotComplete == nil,
+              snapshot != nil || snapshotScopeComplete == nil,
               (snapshot?.routeContractVersion ?? 1) == 1,
               (snapshot?.revision ?? revision) == revision else {
             throw DecodingError.dataCorrupted(
@@ -65,6 +98,8 @@ public struct CmxConnectivitySyncResponse: Decodable, Equatable, Sendable {
         self.reset = reset
         self.snapshot = snapshot
         self.snapshotComplete = snapshotComplete
+        self.discoveryScope = discoveryScope
+        self.snapshotScopeComplete = snapshotScopeComplete
     }
 
     init(
@@ -78,5 +113,7 @@ public struct CmxConnectivitySyncResponse: Decodable, Equatable, Sendable {
         reset = false
         snapshot = legacySnapshot
         self.snapshotComplete = snapshotComplete
+        discoveryScope = nil
+        snapshotScopeComplete = nil
     }
 }

--- a/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohBrokerModels.swift
+++ b/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohBrokerModels.swift
@@ -304,6 +304,8 @@ public struct CmxIrohRegistrationResponse: Decodable, Equatable, Sendable {
         case relay
         case discovery
         case discoveryComplete = "discovery_complete"
+        case discoveryScope = "discovery_scope"
+        case discoveryScopeComplete = "discovery_scope_complete"
     }
 
     /// Monotonic account route revision after this registration commit.
@@ -316,6 +318,17 @@ public struct CmxIrohRegistrationResponse: Decodable, Equatable, Sendable {
     /// True only when the embedded snapshot covers every active binding.
     /// Older brokers omit this proof, so clients must fetch paginated discovery.
     public let discoveryComplete: Bool?
+    /// The exact bounded projection represented by embedded discovery.
+    public let discoveryScope: CmxConnectivityDiscoveryScope?
+    /// True only when embedded discovery covers every binding in its scope.
+    public let discoveryScopeComplete: Bool?
+
+    /// Whether the embedded discovery is proven complete globally or for its
+    /// validated scoped-registration request.
+    public var embeddedDiscoveryComplete: Bool {
+        discovery != nil
+            && (discoveryComplete == true || discoveryScopeComplete == true)
+    }
 
     /// Creates a registration response for alternate brokers and tests.
     public init(
@@ -323,13 +336,17 @@ public struct CmxIrohRegistrationResponse: Decodable, Equatable, Sendable {
         binding: CmxIrohBrokerBinding,
         relay: CmxIrohRegistrationRelay,
         discovery: CmxIrohDiscoveryResponse? = nil,
-        discoveryComplete: Bool? = nil
+        discoveryComplete: Bool? = nil,
+        discoveryScope: CmxConnectivityDiscoveryScope? = nil,
+        discoveryScopeComplete: Bool? = nil
     ) {
         self.revision = revision
         self.binding = binding
         self.relay = relay
         self.discovery = discovery
         self.discoveryComplete = discoveryComplete
+        self.discoveryScope = discoveryScope
+        self.discoveryScopeComplete = discoveryScopeComplete
     }
 }
 

--- a/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohBrokerModels.swift
+++ b/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohBrokerModels.swift
@@ -327,7 +327,8 @@ public struct CmxIrohRegistrationResponse: Decodable, Equatable, Sendable {
     /// validated scoped-registration request.
     public var embeddedDiscoveryComplete: Bool {
         discovery != nil
-            && (discoveryComplete == true || discoveryScopeComplete == true)
+            && (discoveryComplete == true
+                || (discoveryScope != nil && discoveryScopeComplete == true))
     }
 
     /// Creates a registration response for alternate brokers and tests.

--- a/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohClientRuntime+Policy.swift
+++ b/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohClientRuntime+Policy.swift
@@ -132,7 +132,7 @@ extension CmxIrohClientRuntime {
         let discovery: CmxIrohDiscoveryResponse
         do {
             if let embedded = registration?.discovery,
-               registration?.discoveryComplete == true {
+               registration?.embeddedDiscoveryComplete == true {
                 guard let snapshotRevision = embedded.revision,
                       let registrationRevision = registration?.revision,
                       snapshotRevision >= registrationRevision,

--- a/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohHostRuntime+PolicyRefresh.swift
+++ b/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohHostRuntime+PolicyRefresh.swift
@@ -133,7 +133,7 @@ extension CmxIrohHostRuntime {
         let discovery: CmxIrohDiscoveryResponse
         do {
             if let embedded = registration.discovery,
-               registration.discoveryComplete == true {
+               registration.embeddedDiscoveryComplete {
                 guard let snapshotRevision = embedded.revision,
                       let registrationRevision = registration.revision,
                       snapshotRevision == registrationRevision,

--- a/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohHostRuntime+PolicyRefresh.swift
+++ b/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohHostRuntime+PolicyRefresh.swift
@@ -427,8 +427,18 @@ extension CmxIrohHostRuntime {
         binding: CmxIrohBrokerBinding,
         now: Date
     ) -> Date? {
-        guard let expiry = binding.pathHints.compactMap(\.expiresAt).min(),
-              expiry > now else { return nil }
+        // Clients accept the binding's signed direct ports for private-path
+        // synthesis only while `lastSeenAt` is younger than this same window.
+        // Keep that broker lease fresh even when the endpoint has no public
+        // path hints, otherwise an unchanged Mac silently becomes undialable.
+        let bindingFreshnessExpiry = CmxIrohISO8601Date
+            .parse(binding.lastSeenAt)?
+            .addingTimeInterval(CmxIrohPathHint.maximumPrivateHintTTL)
+        let pathHintExpiry = binding.pathHints.compactMap(\.expiresAt).min()
+        let expiry = [bindingFreshnessExpiry, pathHintExpiry]
+            .compactMap { $0 }
+            .min()
+        guard let expiry else { return nil }
         let remaining = expiry.timeIntervalSince(now)
         let safetyWindow = min(15 * 60, max(30, remaining / 4))
         return max(now, expiry.addingTimeInterval(-safetyWindow))

--- a/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohHostRuntime+PolicyRefresh.swift
+++ b/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohHostRuntime+PolicyRefresh.swift
@@ -435,8 +435,11 @@ extension CmxIrohHostRuntime {
             .parse(binding.lastSeenAt)?
             .addingTimeInterval(CmxIrohPathHint.maximumPrivateHintTTL)
         let pathHintExpiry = binding.pathHints.compactMap(\.expiresAt).min()
+        // A stale authoritative timestamp cannot safely arm an immediate
+        // renewal: another stale success would otherwise spin registration.
         let expiry = [bindingFreshnessExpiry, pathHintExpiry]
             .compactMap { $0 }
+            .filter { $0 > now }
             .min()
         guard let expiry else { return nil }
         let remaining = expiry.timeIntervalSince(now)

--- a/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohHostRuntime+PolicyRefresh.swift
+++ b/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohHostRuntime+PolicyRefresh.swift
@@ -434,17 +434,17 @@ extension CmxIrohHostRuntime {
         let bindingFreshnessExpiry = CmxIrohISO8601Date
             .parse(binding.lastSeenAt)?
             .addingTimeInterval(CmxIrohPathHint.maximumPrivateHintTTL)
-        let pathHintExpiry = binding.pathHints.compactMap(\.expiresAt).min()
-        // A stale authoritative timestamp cannot safely arm an immediate
-        // renewal: another stale success would otherwise spin registration.
-        let expiry = [bindingFreshnessExpiry, pathHintExpiry]
+        let expiries = ([bindingFreshnessExpiry] + binding.pathHints.map(\.expiresAt))
             .compactMap { $0 }
-            .filter { $0 > now }
-            .min()
-        guard let expiry else { return nil }
-        let remaining = expiry.timeIntervalSince(now)
-        let safetyWindow = min(15 * 60, max(30, remaining / 4))
-        return max(now, expiry.addingTimeInterval(-safetyWindow))
+        return expiries.compactMap { expiry -> Date? in
+            let remaining = expiry.timeIntervalSince(now)
+            guard remaining > 0 else { return nil }
+            let safetyWindow = min(15 * 60, max(30, remaining / 4))
+            let deadline = expiry.addingTimeInterval(-safetyWindow)
+            // A stale or near-expiry authority cannot safely arm an immediate
+            // renewal: another unchanged success would otherwise spin.
+            return deadline > now ? deadline : nil
+        }.min()
     }
 
     func refreshRegistration(revision: UInt64) async {

--- a/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohRegisterRequest.swift
+++ b/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohRegisterRequest.swift
@@ -8,11 +8,30 @@ public struct CmxIrohRegisterRequest: Encodable, Equatable, Sendable {
     public let payload: String
     /// Base64url Ed25519 signature over the registration transcript.
     public let signature: String
+    /// Optional bounded discovery projection returned with registration.
+    public let discoveryScope: CmxConnectivityDiscoveryScope?
 
-    init(challengeID: String, nonce: String, payload: String, signature: String) {
+    init(
+        challengeID: String,
+        nonce: String,
+        payload: String,
+        signature: String,
+        discoveryScope: CmxConnectivityDiscoveryScope? = nil
+    ) {
         challengeId = challengeID
         self.nonce = nonce
         self.payload = payload
         self.signature = signature
+        self.discoveryScope = discoveryScope
+    }
+
+    func including(discoveryScope: CmxConnectivityDiscoveryScope?) -> Self {
+        Self(
+            challengeID: challengeId,
+            nonce: nonce,
+            payload: payload,
+            signature: signature,
+            discoveryScope: discoveryScope
+        )
     }
 }

--- a/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohTrustBrokerClient.swift
+++ b/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohTrustBrokerClient.swift
@@ -174,10 +174,12 @@ public actor CmxIrohTrustBrokerClient: CmxIrohRelayPolicyServing {
     private struct ConnectivitySyncRequest: Encodable {
         let protocolVersion: Int
         let knownRevision: UInt64?
+        let discoveryScope: CmxConnectivityDiscoveryScope?
 
         private enum CodingKeys: String, CodingKey {
             case protocolVersion = "protocol_version"
             case knownRevision = "known_revision"
+            case discoveryScope = "discovery_scope"
         }
 
         func encode(to encoder: any Encoder) throws {
@@ -186,12 +188,13 @@ public actor CmxIrohTrustBrokerClient: CmxIrohRelayPolicyServing {
             if let knownRevision {
                 try container.encode(knownRevision, forKey: .knownRevision)
             } else {
-                // The v2 wire contract distinguishes an initial sync (`null`)
+                // The wire contract distinguishes an initial sync (`null`)
                 // from an absent field. Swift's synthesized Optional encoding
                 // omits nil values, which the bounded server parser correctly
                 // rejects as an incomplete request.
                 try container.encodeNil(forKey: .knownRevision)
             }
+            try container.encodeIfPresent(discoveryScope, forKey: .discoveryScope)
         }
     }
 
@@ -252,17 +255,20 @@ public actor CmxIrohTrustBrokerClient: CmxIrohRelayPolicyServing {
     private let transport: any CmxIrohHTTPTransport
     private let requestTimeout: TimeInterval
     private let backpressureGate: CmxIrohBrokerBackpressureGate?
+    private let discoveryScope: CmxConnectivityDiscoveryScope?
 
     /// Creates a client that rejects cleartext non-loopback API origins.
     public init(
         baseURL: URL,
         tokenSource: CmxIrohBrokerTokenSource,
+        discoveryScope: CmxConnectivityDiscoveryScope? = nil,
         requestTimeout: TimeInterval = 10,
         backpressureMode: CmxIrohBrokerBackpressureMode = .automatic
     ) throws {
         try self.init(
             baseURL: baseURL,
             tokenSource: tokenSource,
+            discoveryScope: discoveryScope,
             transport: CmxIrohURLSessionTransport(),
             requestTimeout: requestTimeout,
             backpressureMode: backpressureMode
@@ -273,6 +279,7 @@ public actor CmxIrohTrustBrokerClient: CmxIrohRelayPolicyServing {
     init(
         baseURL: URL,
         tokenSource: CmxIrohBrokerTokenSource,
+        discoveryScope: CmxConnectivityDiscoveryScope? = nil,
         transport: any CmxIrohHTTPTransport,
         requestTimeout: TimeInterval = 10,
         backpressureMode: CmxIrohBrokerBackpressureMode = .automatic
@@ -284,6 +291,7 @@ public actor CmxIrohTrustBrokerClient: CmxIrohRelayPolicyServing {
         self.tokenSource = tokenSource
         self.transport = transport
         self.requestTimeout = requestTimeout
+        self.discoveryScope = discoveryScope
         switch backpressureMode {
         case .automatic:
             backpressureGate = CmxIrohBrokerBackpressureGate()
@@ -314,12 +322,9 @@ public actor CmxIrohTrustBrokerClient: CmxIrohRelayPolicyServing {
     public func register(
         _ request: CmxIrohRegisterRequest
     ) async throws -> CmxIrohRegistrationResponse {
-        try await send(
-            path: "api/devices/iroh/register",
-            method: "POST",
-            body: request,
-            operation: .registration
-        )
+        try await withBackpressure(operation: .registration) {
+            try await self.registerUngated(request)
+        }
     }
 
     /// Runs the challenge and signed registration legs without regenerating payload bytes.
@@ -334,33 +339,38 @@ public actor CmxIrohTrustBrokerClient: CmxIrohRelayPolicyServing {
                 body: prepared.challengeRequest
             )
             let request = try signer.sign(prepared: prepared, challenge: challenge)
-            return try await self.sendUngated(
-                path: "api/devices/iroh/register",
-                method: "POST",
-                body: request
-            )
+            return try await self.registerUngated(request)
         }
     }
 
     public func discover() async throws -> CmxIrohDiscoveryResponse {
         try await withBackpressure(operation: .discovery) {
-            try await self.discoverAllPages()
+            if self.discoveryScope != nil {
+                do {
+                    let response = try await self.syncConnectivityUngated(
+                        knownRevision: nil
+                    )
+                    if let snapshot = response.snapshot,
+                       response.snapshotIsComplete {
+                        return snapshot
+                    }
+                } catch let error as CmxIrohTrustBrokerClientError
+                    where Self.isMissingScopedDiscoveryRoute(error) {
+                    // Older servers have only paginated global discovery.
+                }
+            }
+            return try await self.discoverAllPages()
         }
     }
 
-    /// Reconciles one completely installed route revision with connectivity v2.
+    /// Reconciles one completely installed route revision with connectivity v3,
+    /// falling back to global connectivity v2 on older servers.
     public func syncConnectivity(
         knownRevision: UInt64?
     ) async throws -> CmxConnectivitySyncResponse {
-        try await send(
-            path: "api/connectivity/v2/sync",
-            method: "POST",
-            body: ConnectivitySyncRequest(
-                protocolVersion: CmxConnectivitySyncResponse.protocolVersion,
-                knownRevision: knownRevision
-            ),
-            operation: .discovery
-        )
+        try await withBackpressure(operation: .discovery) {
+            try await self.syncConnectivityUngated(knownRevision: knownRevision)
+        }
     }
 
     public func issuePairGrant(
@@ -470,6 +480,92 @@ public actor CmxIrohTrustBrokerClient: CmxIrohRelayPolicyServing {
         guard response.revoked, response.lanRendezvousRotated else {
             throw CmxIrohTrustBrokerClientError.invalidResponse
         }
+    }
+
+    private func registerUngated(
+        _ request: CmxIrohRegisterRequest
+    ) async throws -> CmxIrohRegistrationResponse {
+        guard let discoveryScope else {
+            return try await sendUngated(
+                path: "api/devices/iroh/register",
+                method: "POST",
+                body: request.including(discoveryScope: nil)
+            )
+        }
+        do {
+            let response: CmxIrohRegistrationResponse = try await sendUngated(
+                path: "api/devices/iroh/register",
+                method: "POST",
+                body: request.including(discoveryScope: discoveryScope)
+            )
+            guard response.discovery != nil,
+                  response.discoveryScope == discoveryScope,
+                  response.discoveryScopeComplete == true,
+                  response.discoveryComplete != true else {
+                throw CmxIrohTrustBrokerClientError.invalidResponse
+            }
+            return response
+        } catch let error as CmxIrohTrustBrokerClientError
+            where Self.isUnsupportedRegistrationScope(error) {
+            // Registration parsing happens before challenge consumption, so
+            // retrying the identical signature without the optional field is
+            // safe against older strict servers.
+            return try await sendUngated(
+                path: "api/devices/iroh/register",
+                method: "POST",
+                body: request.including(discoveryScope: nil)
+            )
+        }
+    }
+
+    private func syncConnectivityUngated(
+        knownRevision: UInt64?
+    ) async throws -> CmxConnectivitySyncResponse {
+        if let discoveryScope {
+            do {
+                let response: CmxConnectivitySyncResponse = try await sendUngated(
+                    path: "api/connectivity/v3/sync",
+                    method: "POST",
+                    body: ConnectivitySyncRequest(
+                        protocolVersion: CmxConnectivitySyncResponse.scopedProtocolVersion,
+                        knownRevision: knownRevision,
+                        discoveryScope: discoveryScope
+                    )
+                )
+                guard response.protocolVersion
+                        == CmxConnectivitySyncResponse.scopedProtocolVersion,
+                      response.discoveryScope == discoveryScope else {
+                    throw CmxIrohTrustBrokerClientError.invalidResponse
+                }
+                return response
+            } catch let error as CmxIrohTrustBrokerClientError
+                where Self.isMissingScopedDiscoveryRoute(error) {
+                // Continue with connectivity v2 below.
+            }
+        }
+        return try await sendUngated(
+            path: "api/connectivity/v2/sync",
+            method: "POST",
+            body: ConnectivitySyncRequest(
+                protocolVersion: CmxConnectivitySyncResponse.protocolVersion,
+                knownRevision: knownRevision,
+                discoveryScope: nil
+            )
+        )
+    }
+
+    private static func isUnsupportedRegistrationScope(
+        _ error: CmxIrohTrustBrokerClientError
+    ) -> Bool {
+        guard case let .rejected(statusCode, code) = error else { return false }
+        return statusCode == 400 && code == "unknown_field"
+    }
+
+    private static func isMissingScopedDiscoveryRoute(
+        _ error: CmxIrohTrustBrokerClientError
+    ) -> Bool {
+        guard case let .rejected(statusCode, _) = error else { return false }
+        return statusCode == 404
     }
 
     private func send<Response: Decodable & Sendable, Body: Encodable>(

--- a/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohTrustBrokerClient.swift
+++ b/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohTrustBrokerClient.swift
@@ -538,7 +538,9 @@ public actor CmxIrohTrustBrokerClient: CmxIrohRelayPolicyServing {
                 )
                 guard response.protocolVersion
                         == CmxConnectivitySyncResponse.scopedProtocolVersion,
-                      response.discoveryScope == discoveryScope else {
+                      response.discoveryScope == discoveryScope,
+                      !response.changed
+                        || response.snapshotScopeComplete == true else {
                     throw CmxIrohTrustBrokerClientError.invalidResponse
                 }
                 return response

--- a/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohTrustBrokerClient.swift
+++ b/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohTrustBrokerClient.swift
@@ -25,6 +25,20 @@ public struct CmxIrohBrokerCredentials: Sendable, CustomStringConvertible,
     public var debugDescription: String { description }
 }
 
+private func isUnsupportedRegistrationScope(
+    _ error: CmxIrohTrustBrokerClientError
+) -> Bool {
+    guard case let .rejected(statusCode, code) = error else { return false }
+    return statusCode == 400 && code == "unknown_field"
+}
+
+private func isMissingScopedDiscoveryRoute(
+    _ error: CmxIrohTrustBrokerClientError
+) -> Bool {
+    guard case let .rejected(statusCode, _) = error else { return false }
+    return statusCode == 404
+}
+
 /// One authenticated account and credential pair captured atomically.
 ///
 /// Platform auth coordinators map their native session snapshot into this
@@ -359,7 +373,7 @@ public actor CmxIrohTrustBrokerClient: CmxIrohRelayPolicyServing {
                         throw CmxIrohTrustBrokerClientError.invalidResponse
                     }
                 } catch let error as CmxIrohTrustBrokerClientError
-                    where Self.isMissingScopedDiscoveryRoute(error) {
+                    where isMissingScopedDiscoveryRoute(error) {
                     // Older servers have only paginated global discovery.
                 }
             }
@@ -510,7 +524,7 @@ public actor CmxIrohTrustBrokerClient: CmxIrohRelayPolicyServing {
             }
             return response
         } catch let error as CmxIrohTrustBrokerClientError
-            where Self.isUnsupportedRegistrationScope(error) {
+            where isUnsupportedRegistrationScope(error) {
             // Registration parsing happens before challenge consumption, so
             // retrying the identical signature without the optional field is
             // safe against older strict servers.
@@ -545,7 +559,7 @@ public actor CmxIrohTrustBrokerClient: CmxIrohRelayPolicyServing {
                 }
                 return response
             } catch let error as CmxIrohTrustBrokerClientError
-                where Self.isMissingScopedDiscoveryRoute(error) {
+                where isMissingScopedDiscoveryRoute(error) {
                 // Continue with connectivity v2 below.
             }
         }
@@ -558,20 +572,6 @@ public actor CmxIrohTrustBrokerClient: CmxIrohRelayPolicyServing {
                 discoveryScope: nil
             )
         )
-    }
-
-    private static func isUnsupportedRegistrationScope(
-        _ error: CmxIrohTrustBrokerClientError
-    ) -> Bool {
-        guard case let .rejected(statusCode, code) = error else { return false }
-        return statusCode == 400 && code == "unknown_field"
-    }
-
-    private static func isMissingScopedDiscoveryRoute(
-        _ error: CmxIrohTrustBrokerClientError
-    ) -> Bool {
-        guard case let .rejected(statusCode, _) = error else { return false }
-        return statusCode == 404
     }
 
     private func send<Response: Decodable & Sendable, Body: Encodable>(

--- a/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohTrustBrokerClient.swift
+++ b/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohTrustBrokerClient.swift
@@ -354,6 +354,10 @@ public actor CmxIrohTrustBrokerClient: CmxIrohRelayPolicyServing {
                        response.snapshotIsComplete {
                         return snapshot
                     }
+                    if response.protocolVersion
+                        == CmxConnectivitySyncResponse.scopedProtocolVersion {
+                        throw CmxIrohTrustBrokerClientError.invalidResponse
+                    }
                 } catch let error as CmxIrohTrustBrokerClientError
                     where Self.isMissingScopedDiscoveryRoute(error) {
                     // Older servers have only paginated global discovery.

--- a/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohHostRuntimeLifecycleTests.swift
+++ b/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohHostRuntimeLifecycleTests.swift
@@ -50,6 +50,20 @@ extension CmxIrohHostRuntimeTests {
     }
 
     @Test
+    func stalePrivatePortFreshnessDoesNotScheduleImmediateRenewal() throws {
+        let bindingTime = Date(timeIntervalSince1970: 1_800_000_000)
+        let fixture = try HostRuntimeFixture(now: bindingTime)
+        let staleNow = bindingTime.addingTimeInterval(
+            CmxIrohPathHint.maximumPrivateHintTTL + 1
+        )
+
+        #expect(CmxIrohHostRuntime.registrationRenewalDeadline(
+            binding: fixture.binding,
+            now: staleNow
+        ) == nil)
+    }
+
+    @Test
     func unchangedReachabilityRenewsRegistrationBeforeHintExpiry() async throws {
         let now = Date(timeIntervalSince1970: 1_800_000_000)
         let fixture = try HostRuntimeFixture(now: now, publicHintLifetime: 60 * 60)

--- a/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohHostRuntimeLifecycleTests.swift
+++ b/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohHostRuntimeLifecycleTests.swift
@@ -7,6 +7,49 @@ import Testing
 
 extension CmxIrohHostRuntimeTests {
     @Test
+    func emptyPublicHintsRenewRegistrationBeforePrivatePortFreshnessExpires() async throws {
+        let now = Date(timeIntervalSince1970: 1_800_000_000)
+        let fixture = try HostRuntimeFixture(now: now)
+        let renewalDeadline = try #require(
+            CmxIrohHostRuntime.registrationRenewalDeadline(
+                binding: fixture.binding,
+                now: now
+            )
+        )
+        #expect(
+            renewalDeadline < now.addingTimeInterval(
+                CmxIrohPathHint.maximumPrivateHintTTL
+            )
+        )
+
+        let endpoint = TestIrohEndpoint(identity: fixture.endpointID)
+        let broker = TestIrohHostBroker(
+            registrationBinding: fixture.binding,
+            discovery: fixture.discovery
+        )
+        let clock = HostRegistrationRenewalClock(now: now)
+        let runtime = CmxIrohHostRuntime(
+            factory: TestIrohEndpointFactory(endpoints: [endpoint]),
+            broker: broker,
+            configuration: fixture.configuration,
+            pendingRevocations: fixture.pendingRevocations(),
+            now: { clock.now() },
+            registrationClock: clock,
+            handleTransport: { session, _ in await session.close() }
+        )
+
+        try await runtime.start()
+        await clock.waitUntilSleeping()
+        #expect(clock.observedSleepDeadlines().first == renewalDeadline)
+
+        clock.advance(to: renewalDeadline)
+        await broker.waitForRegistrationCount(2)
+
+        #expect(await broker.observedRegistrationCount() == 2)
+        await runtime.stop()
+    }
+
+    @Test
     func unchangedReachabilityRenewsRegistrationBeforeHintExpiry() async throws {
         let now = Date(timeIntervalSince1970: 1_800_000_000)
         let fixture = try HostRuntimeFixture(now: now, publicHintLifetime: 60 * 60)

--- a/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohHostRuntimeLifecycleTests.swift
+++ b/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohHostRuntimeLifecycleTests.swift
@@ -530,6 +530,9 @@ extension CmxIrohHostRuntimeTests {
         #expect(await factory.observedConfigurations().count == 1)
         #expect(clock.observedSleepDeadlines() == [
             now.addingTimeInterval(600),
+            now.addingTimeInterval(
+                CmxIrohPathHint.maximumPrivateHintTTL - 15 * 60
+            ),
         ])
         await runtime.stop()
     }

--- a/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohHostRuntimeLifecycleTests.swift
+++ b/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohHostRuntimeLifecycleTests.swift
@@ -64,6 +64,22 @@ extension CmxIrohHostRuntimeTests {
     }
 
     @Test
+    func nearExpiryPublicHintDoesNotScheduleImmediateRenewal() throws {
+        let now = Date(timeIntervalSince1970: 1_800_000_000)
+        let fixture = try HostRuntimeFixture(
+            now: now,
+            publicHintLifetime: 10
+        )
+
+        #expect(CmxIrohHostRuntime.registrationRenewalDeadline(
+            binding: fixture.binding,
+            now: now
+        ) == now.addingTimeInterval(
+            CmxIrohPathHint.maximumPrivateHintTTL - 15 * 60
+        ))
+    }
+
+    @Test
     func unchangedReachabilityRenewsRegistrationBeforeHintExpiry() async throws {
         let now = Date(timeIntervalSince1970: 1_800_000_000)
         let fixture = try HostRuntimeFixture(now: now, publicHintLifetime: 60 * 60)

--- a/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohHostRuntimeTestSupport.swift
+++ b/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohHostRuntimeTestSupport.swift
@@ -29,6 +29,7 @@ struct HostRuntimeFixture {
         managedRelays = Set(Self.relayURLs)
         binding = try Self.binding(
             endpointID: endpointID.endpointID,
+            lastSeenAt: now,
             publicHintObservedAt: publicHintLifetime == nil ? nil : now,
             publicHintExpiresAt: publicHintLifetime.map(now.addingTimeInterval)
         )
@@ -97,6 +98,7 @@ struct HostRuntimeFixture {
     static func binding(
         endpointID: String,
         bindingID: String = "123e4567-e89b-42d3-a456-426614174010",
+        lastSeenAt: Date = Date(timeIntervalSince1970: 1_800_000_000),
         publicHintObservedAt: Date? = nil,
         publicHintExpiresAt: Date? = nil
     ) throws -> CmxIrohBrokerBinding {
@@ -105,6 +107,7 @@ struct HostRuntimeFixture {
             from: bindingJSON(
                 endpointID: endpointID,
                 bindingID: bindingID,
+                lastSeenAt: lastSeenAt,
                 publicHintObservedAt: publicHintObservedAt,
                 publicHintExpiresAt: publicHintExpiresAt
             )
@@ -154,6 +157,7 @@ struct HostRuntimeFixture {
         endpointID: String,
         bindingID: String = "123e4567-e89b-42d3-a456-426614174010",
         deviceID: String = "123e4567-e89b-42d3-a456-426614174011",
+        lastSeenAt: Date = Date(timeIntervalSince1970: 1_800_000_000),
         publicHintObservedAt: Date? = nil,
         publicHintExpiresAt: Date? = nil
     ) throws -> Data {
@@ -182,7 +186,7 @@ struct HostRuntimeFixture {
             "pairing_enabled": true,
             "capabilities": ["rpc", "multistream"],
             "path_hints": pathHints,
-            "last_seen_at": "2026-07-09T12:00:00.000Z",
+            "last_seen_at": ISO8601DateFormatter().string(from: lastSeenAt),
         ])
     }
 }

--- a/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohTrustBrokerClientTests.swift
+++ b/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohTrustBrokerClientTests.swift
@@ -854,6 +854,42 @@ struct CmxIrohTrustBrokerClientTests {
         #expect(object["discovery_scope"] != nil)
     }
 
+    @Test(arguments: [Bool?.none, false])
+    func connectivityV3RejectsChangedSnapshotWithoutScopedCompleteness(
+        completeness: Bool?
+    ) async throws {
+        let scope = try iosDiscoveryScope()
+        let snapshot = try Self.discoveryObject(revision: 2)
+        var responseObject: [String: Any] = [
+            "protocol_version": 3,
+            "revision": 2,
+            "changed": true,
+            "reset": false,
+            "discovery_scope": try scopeObject(scope),
+            "snapshot": snapshot,
+        ]
+        if let completeness {
+            responseObject["snapshot_scope_complete"] = completeness
+        }
+        let transport = RecordingBrokerTransport(responses: [
+            .json(
+                status: 200,
+                body: try Self.jsonString(responseObject)
+            ),
+        ])
+        let client = try makeClient(
+            transport: transport,
+            discoveryScope: scope
+        )
+
+        await #expect(throws: CmxIrohTrustBrokerClientError.invalidResponse) {
+            _ = try await client.syncConnectivity(knownRevision: nil)
+        }
+        #expect(await transport.requests().compactMap { $0.url?.path } == [
+            "/api/connectivity/v3/sync",
+        ])
+    }
+
     @Test
     func scopedDiscoveryRejectsIncompleteV3WithoutFetchingGlobalBindings() async throws {
         let scope = try iosDiscoveryScope()

--- a/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohTrustBrokerClientTests.swift
+++ b/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohTrustBrokerClientTests.swift
@@ -6,6 +6,21 @@ import Testing
 @Suite(.serialized)
 struct CmxIrohTrustBrokerClientTests {
     @Test
+    func discoveryScopeNormalizesOnlyPeerTags() throws {
+        let scope = try CmxConnectivityDiscoveryScope(
+            deviceID: "123e4567-e89b-42d3-a456-426614174001",
+            appInstanceID: "123e4567-e89b-42d3-a456-426614174002",
+            tag: "LocalFeatureA",
+            platform: .ios,
+            peerPlatform: .mac,
+            peerTags: ["FeatureA"]
+        )
+
+        #expect(scope.localBinding.tag == "LocalFeatureA")
+        #expect(scope.peerBindings.tags == ["featurea"])
+    }
+
+    @Test
     func challengeUsesNativeStackHeadersAndExactJSON() async throws {
         let transport = RecordingBrokerTransport(responses: [
             .json(

--- a/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohTrustBrokerClientTests.swift
+++ b/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohTrustBrokerClientTests.swift
@@ -160,6 +160,36 @@ struct CmxIrohTrustBrokerClientTests {
     }
 
     @Test
+    func scopedRegistrationCompletenessRequiresAnEchoedScope() async throws {
+        var responseObject = try #require(
+            JSONSerialization.jsonObject(
+                with: Data(Self.registrationResponse.utf8)
+            ) as? [String: Any]
+        )
+        responseObject["revision"] = 7
+        responseObject["discovery"] = try Self.discoveryObject(revision: 7)
+        responseObject["discovery_complete"] = false
+        responseObject["discovery_scope_complete"] = true
+        let transport = RecordingBrokerTransport(responses: [
+            .json(status: 201, body: try Self.jsonString(responseObject)),
+        ])
+        let client = try makeClient(transport: transport)
+
+        let response = try await client.register(
+            CmxIrohRegisterRequest(
+                challengeID: "123e4567-e89b-42d3-a456-426614174000",
+                nonce: "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                payload: "e30",
+                signature: String(repeating: "A", count: 86)
+            )
+        )
+
+        #expect(response.discoveryScope == nil)
+        #expect(response.discoveryScopeComplete == true)
+        #expect(!response.embeddedDiscoveryComplete)
+    }
+
+    @Test
     func issuedRegistrationBuildsTheExactManagedRelayFleet() async throws {
         let transport = RecordingBrokerTransport(responses: [
             .json(status: 201, body: Self.registrationResponse),
@@ -822,6 +852,35 @@ struct CmxIrohTrustBrokerClientTests {
         )
         #expect(object["protocol_version"] as? Int == 3)
         #expect(object["discovery_scope"] != nil)
+    }
+
+    @Test
+    func scopedDiscoveryRejectsIncompleteV3WithoutFetchingGlobalBindings() async throws {
+        let scope = try iosDiscoveryScope()
+        let snapshot = try Self.discoveryObject(revision: 2)
+        let responseBody = try Self.jsonString([
+            "protocol_version": 3,
+            "revision": 2,
+            "changed": true,
+            "reset": false,
+            "discovery_scope": try scopeObject(scope),
+            "snapshot": snapshot,
+            "snapshot_scope_complete": false,
+        ])
+        let transport = RecordingBrokerTransport(responses: [
+            .json(status: 200, body: responseBody),
+        ])
+        let client = try makeClient(
+            transport: transport,
+            discoveryScope: scope
+        )
+
+        await #expect(throws: CmxIrohTrustBrokerClientError.invalidResponse) {
+            _ = try await client.discover()
+        }
+        #expect(await transport.requests().compactMap { $0.url?.path } == [
+            "/api/connectivity/v3/sync",
+        ])
     }
 
     @Test

--- a/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohTrustBrokerClientTests.swift
+++ b/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohTrustBrokerClientTests.swift
@@ -88,6 +88,78 @@ struct CmxIrohTrustBrokerClientTests {
     }
 
     @Test
+    func scopedRegistrationFallsBackWithoutRegeneratingSignedPayload() async throws {
+        let transport = RecordingBrokerTransport(responses: [
+            .json(
+                status: 201,
+                body: #"{"challenge_id":"123e4567-e89b-42d3-a456-426614174000","nonce":"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA","expires_at":"2026-07-10T01:00:00.000Z"}"#
+            ),
+            .json(status: 400, body: #"{"error":"unknown_field"}"#),
+            .json(status: 201, body: Self.registrationResponse),
+        ])
+        let client = try makeClient(
+            transport: transport,
+            discoveryScope: iosDiscoveryScope()
+        )
+        let signer = try registrationSigner()
+        let prepared = try signer.prepare(payload: registrationPayload())
+
+        _ = try await client.register(prepared: prepared, signer: signer)
+
+        let requests = await transport.requests()
+        #expect(requests.compactMap { $0.url?.path } == [
+            "/api/devices/iroh/challenge",
+            "/api/devices/iroh/register",
+            "/api/devices/iroh/register",
+        ])
+        let scopedBody = try #require(requests[1].httpBody)
+        let fallbackBody = try #require(requests[2].httpBody)
+        var scopedObject = try #require(
+            JSONSerialization.jsonObject(with: scopedBody) as? [String: Any]
+        )
+        let fallbackObject = try #require(
+            JSONSerialization.jsonObject(with: fallbackBody) as? [String: Any]
+        )
+        #expect(scopedObject.removeValue(forKey: "discoveryScope") != nil)
+        #expect(scopedObject as NSDictionary == fallbackObject as NSDictionary)
+    }
+
+    @Test
+    func scopedRegistrationAcceptsOnlyItsEchoedCompleteProjection() async throws {
+        let scope = try iosDiscoveryScope()
+        var responseObject = try #require(
+            JSONSerialization.jsonObject(
+                with: Data(Self.registrationResponse.utf8)
+            ) as? [String: Any]
+        )
+        responseObject["revision"] = 7
+        responseObject["discovery"] = try Self.discoveryObject(revision: 7)
+        responseObject["discovery_complete"] = false
+        responseObject["discovery_scope"] = try scopeObject(scope)
+        responseObject["discovery_scope_complete"] = true
+        let transport = RecordingBrokerTransport(responses: [
+            .json(status: 201, body: try Self.jsonString(responseObject)),
+        ])
+        let client = try makeClient(
+            transport: transport,
+            discoveryScope: scope
+        )
+
+        let response = try await client.register(
+            CmxIrohRegisterRequest(
+                challengeID: "123e4567-e89b-42d3-a456-426614174000",
+                nonce: "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                payload: "e30",
+                signature: String(repeating: "A", count: 86)
+            )
+        )
+
+        #expect(response.discoveryScope == scope)
+        #expect(response.discoveryScopeComplete == true)
+        #expect(response.embeddedDiscoveryComplete)
+    }
+
+    @Test
     func issuedRegistrationBuildsTheExactManagedRelayFleet() async throws {
         let transport = RecordingBrokerTransport(responses: [
             .json(status: 201, body: Self.registrationResponse),
@@ -717,6 +789,78 @@ struct CmxIrohTrustBrokerClientTests {
     }
 
     @Test
+    func connectivityV3SendsAndAcceptsOnlyTheEchoedScope() async throws {
+        let scope = try iosDiscoveryScope()
+        let snapshot = try Self.discoveryObject(revision: 2)
+        let responseBody = try Self.jsonString([
+            "protocol_version": 3,
+            "revision": 2,
+            "changed": true,
+            "reset": false,
+            "discovery_scope": try scopeObject(scope),
+            "snapshot": snapshot,
+            "snapshot_scope_complete": true,
+        ])
+        let transport = RecordingBrokerTransport(responses: [
+            .json(status: 200, body: responseBody),
+        ])
+        let client = try makeClient(
+            transport: transport,
+            discoveryScope: scope
+        )
+
+        let response = try await client.syncConnectivity(knownRevision: nil)
+
+        #expect(response.protocolVersion == 3)
+        #expect(response.discoveryScope == scope)
+        #expect(response.snapshotIsComplete)
+        let request = try #require(await transport.requests().first)
+        #expect(request.url?.path == "/api/connectivity/v3/sync")
+        let body = try #require(request.httpBody)
+        let object = try #require(
+            JSONSerialization.jsonObject(with: body) as? [String: Any]
+        )
+        #expect(object["protocol_version"] as? Int == 3)
+        #expect(object["discovery_scope"] != nil)
+    }
+
+    @Test
+    func connectivityV3FallsBackToGlobalV2OnOlderServers() async throws {
+        let snapshot = try Self.discoveryObject(revision: 2)
+        let v2Response = try Self.jsonString([
+            "protocol_version": 2,
+            "revision": 2,
+            "changed": true,
+            "reset": false,
+            "snapshot": snapshot,
+            "snapshot_complete": true,
+        ])
+        let transport = RecordingBrokerTransport(responses: [
+            .json(status: 404, body: #"{"error":"not_found"}"#),
+            .json(status: 200, body: v2Response),
+        ])
+        let client = try makeClient(
+            transport: transport,
+            discoveryScope: iosDiscoveryScope()
+        )
+
+        let response = try await client.syncConnectivity(knownRevision: nil)
+
+        #expect(response.protocolVersion == 2)
+        #expect(response.snapshotComplete == true)
+        let requests = await transport.requests()
+        #expect(requests.compactMap { $0.url?.path } == [
+            "/api/connectivity/v3/sync",
+            "/api/connectivity/v2/sync",
+        ])
+        let v2Body = try #require(requests[1].httpBody)
+        let v2Object = try #require(
+            JSONSerialization.jsonObject(with: v2Body) as? [String: Any]
+        )
+        #expect(v2Object["discovery_scope"] == nil)
+    }
+
+    @Test
     func connectivitySyncRequiresAnAtomicSnapshotAtTheEnvelopeRevision() async throws {
         let snapshot = try Self.discoveryObject(revision: 42)
         let body = try Self.jsonString([
@@ -772,12 +916,36 @@ struct CmxIrohTrustBrokerClientTests {
     }
 
     private func makeClient(
-        transport: RecordingBrokerTransport
+        transport: RecordingBrokerTransport,
+        discoveryScope: CmxConnectivityDiscoveryScope? = nil
     ) throws -> CmxIrohTrustBrokerClient {
         try CmxIrohTrustBrokerClient(
             baseURL: #require(URL(string: "https://cmux.example")),
             tokenSource: Self.tokenSource,
+            discoveryScope: discoveryScope,
             transport: transport
+        )
+    }
+
+    private func iosDiscoveryScope() throws -> CmxConnectivityDiscoveryScope {
+        try CmxConnectivityDiscoveryScope(
+            deviceID: "123e4567-e89b-42d3-a456-426614174001",
+            appInstanceID: "123e4567-e89b-42d3-a456-426614174002",
+            tag: "stable",
+            platform: .ios,
+            peerPlatform: .mac,
+            peerTags: ["nightly", "default"],
+            peerPairingEnabled: true
+        )
+    }
+
+    private func scopeObject(
+        _ scope: CmxConnectivityDiscoveryScope
+    ) throws -> [String: Any] {
+        try #require(
+            JSONSerialization.jsonObject(
+                with: JSONEncoder().encode(scope)
+            ) as? [String: Any]
         )
     }
 

--- a/Sources/Mobile/MobileHostIrohRuntime+Activation.swift
+++ b/Sources/Mobile/MobileHostIrohRuntime+Activation.swift
@@ -143,6 +143,13 @@ extension MobileHostIrohRuntime {
                     _ = try await auth.forceRefreshAccessToken()
                 }
             ),
+            discoveryScope: try CmxConnectivityDiscoveryScope(
+                deviceID: deviceID,
+                appInstanceID: appInstanceID,
+                tag: tag,
+                platform: .mac,
+                peerPlatform: .ios
+            ),
             backpressureMode: .callerOwned
         )
         let broker = CmxIrohBackpressuredHostBroker(

--- a/ios/cmuxPackage/Sources/cmuxFeature/MobileIrohRuntimeComposition.swift
+++ b/ios/cmuxPackage/Sources/cmuxFeature/MobileIrohRuntimeComposition.swift
@@ -107,7 +107,8 @@ public final class MobileIrohRuntimeComposition:
         case unavailableCustomPrivatePath
     }
     typealias BrokerFactory = @Sendable (
-        _ tokenSource: CmxIrohBrokerTokenSource
+        _ tokenSource: CmxIrohBrokerTokenSource,
+        _ discoveryScope: CmxConnectivityDiscoveryScope?
     ) throws -> any CmxIrohClientBrokerServing
 
     private struct BrokerBundle {
@@ -371,13 +372,14 @@ public final class MobileIrohRuntimeComposition:
             },
             transportVerificationMode: transportVerificationMode,
             automaticRelayCredentialRefreshEnabled: automaticRelayCredentialRefreshEnabled,
-            brokerFactory: { tokenSource in
+            brokerFactory: { tokenSource, discoveryScope in
                 guard let baseURL else {
                     throw CmxIrohTrustBrokerClientError.invalidBaseURL
                 }
                 return try CmxIrohTrustBrokerClient(
                     baseURL: baseURL,
                     tokenSource: tokenSource,
+                    discoveryScope: discoveryScope,
                     backpressureMode: .callerOwned
                 )
             },
@@ -488,9 +490,10 @@ public final class MobileIrohRuntimeComposition:
 
     private func makeBrokerBundle(
         accountID: String,
-        tokenSource: CmxIrohBrokerTokenSource
+        tokenSource: CmxIrohBrokerTokenSource,
+        discoveryScope: CmxConnectivityDiscoveryScope? = nil
     ) throws -> BrokerBundle {
-        let rawClient = try brokerFactory(tokenSource)
+        let rawClient = try brokerFactory(tokenSource, discoveryScope)
         let client = CmxIrohBackpressuredClientBroker(
             broker: rawClient,
             gate: brokerBackpressureGate,
@@ -1712,7 +1715,18 @@ public final class MobileIrohRuntimeComposition:
         }
         let brokerBundle = try makeBrokerBundle(
             accountID: accountID,
-            tokenSource: brokerTokenSource(pinnedTo: accountID)
+            tokenSource: brokerTokenSource(pinnedTo: accountID),
+            discoveryScope: try CmxConnectivityDiscoveryScope(
+                deviceID: deviceID,
+                appInstanceID: appInstanceID,
+                tag: tag,
+                platform: .ios,
+                peerPlatform: .mac,
+                peerTags: Self.discoveryPeerTags(
+                    for: discoveryCompatibilityPolicy
+                ),
+                peerPairingEnabled: true
+            )
         )
         let broker = brokerBundle.client
         let endpointRelayProfile: CmxIrohEndpointRelayProfile?
@@ -2188,6 +2202,19 @@ public final class MobileIrohRuntimeComposition:
         for error: any Error
     ) -> DiagnosticFailureKind {
         DiagnosticFailureKind.classify(error)
+    }
+
+    private static func discoveryPeerTags(
+        for policy: MobileMacBuildCompatibilityPolicy?
+    ) -> [String]? {
+        switch policy {
+        case .development(let expectedInstanceTag):
+            [expectedInstanceTag.lowercased()]
+        case .official:
+            ["default", "nightly"]
+        case nil:
+            nil
+        }
     }
 
     private static func currentTag(

--- a/ios/cmuxPackage/Sources/cmuxFeature/MobileIrohRuntimeComposition.swift
+++ b/ios/cmuxPackage/Sources/cmuxFeature/MobileIrohRuntimeComposition.swift
@@ -2204,7 +2204,7 @@ public final class MobileIrohRuntimeComposition:
         DiagnosticFailureKind.classify(error)
     }
 
-    nonisolated private static func discoveryPeerTags(
+    nonisolated static func discoveryPeerTags(
         for policy: MobileMacBuildCompatibilityPolicy?
     ) -> [String]? {
         switch policy {

--- a/ios/cmuxPackage/Sources/cmuxFeature/MobileIrohRuntimeComposition.swift
+++ b/ios/cmuxPackage/Sources/cmuxFeature/MobileIrohRuntimeComposition.swift
@@ -2209,7 +2209,7 @@ public final class MobileIrohRuntimeComposition:
     ) -> [String]? {
         switch policy {
         case .development(let expectedInstanceTag):
-            [expectedInstanceTag.lowercased()]
+            [expectedInstanceTag]
         case .official:
             ["default", "nightly"]
         case nil:

--- a/ios/cmuxPackage/Sources/cmuxFeature/MobileIrohRuntimeComposition.swift
+++ b/ios/cmuxPackage/Sources/cmuxFeature/MobileIrohRuntimeComposition.swift
@@ -2204,7 +2204,7 @@ public final class MobileIrohRuntimeComposition:
         DiagnosticFailureKind.classify(error)
     }
 
-    private static func discoveryPeerTags(
+    nonisolated private static func discoveryPeerTags(
         for policy: MobileMacBuildCompatibilityPolicy?
     ) -> [String]? {
         switch policy {

--- a/ios/cmuxPackage/Sources/cmuxFeature/MobileIrohRuntimeComposition.swift
+++ b/ios/cmuxPackage/Sources/cmuxFeature/MobileIrohRuntimeComposition.swift
@@ -2204,7 +2204,7 @@ public final class MobileIrohRuntimeComposition:
         DiagnosticFailureKind.classify(error)
     }
 
-    nonisolated static func discoveryPeerTags(
+    nonisolated private static func discoveryPeerTags(
         for policy: MobileMacBuildCompatibilityPolicy?
     ) -> [String]? {
         switch policy {

--- a/ios/cmuxPackage/Tests/cmuxFeatureTests/MobileIrohRuntimeCompositionCooldownTests.swift
+++ b/ios/cmuxPackage/Tests/cmuxFeatureTests/MobileIrohRuntimeCompositionCooldownTests.swift
@@ -534,7 +534,7 @@ private struct MobileIrohCooldownFixture {
                 customRelayCredentials: customRelayCredentials,
                 relayPolicyTrustRoot: relayPolicyTrustRoot,
                 endpointFactory: endpointFactory,
-                brokerFactory: { _ in broker },
+                brokerFactory: { _, _ in broker },
                 brokerBackpressureGate: CmxIrohBrokerBackpressureGate(
                     store: CmxIrohUserDefaultsInstallStateStore(defaults: defaults),
                     now: { clock.now() }

--- a/ios/cmuxPackage/Tests/cmuxFeatureTests/MobileIrohRuntimeCompositionTests.swift
+++ b/ios/cmuxPackage/Tests/cmuxFeatureTests/MobileIrohRuntimeCompositionTests.swift
@@ -631,7 +631,7 @@ struct MobileIrohRuntimeCompositionTests {
                 )
             ),
             endpointFactory: MobileIrohNeverEndpointFactory(),
-            brokerFactory: { _ in throw TestCompositionError.unavailable },
+            brokerFactory: { _, _ in throw TestCompositionError.unavailable },
             deviceID: { "123e4567-e89b-42d3-a456-426614174040" },
             tag: "test",
             now: { Date(timeIntervalSince1970: 1_000) },
@@ -1084,7 +1084,7 @@ struct MobileIrohRuntimeCompositionTests {
         ])
         let capture = MobileIrohBrokerCapture()
         let fixture = try await MobileIrohSignOutFixture.make(
-            brokerFactory: { tokenSource in
+            brokerFactory: { tokenSource, _ in
                 let broker = MobileIrohCredentialFetchingBroker(
                     tokenSource: tokenSource,
                     discovery: discovery
@@ -1120,7 +1120,7 @@ struct MobileIrohRuntimeCompositionTests {
     @Test
     func activationBrokerCredentialsFailClosedAfterAccountSwitch() async throws {
         let sources = MobileIrohTokenSourceCapture()
-        let fixture = try await MobileIrohSignOutFixture.make(brokerFactory: { tokenSource in
+        let fixture = try await MobileIrohSignOutFixture.make(brokerFactory: { tokenSource, _ in
             sources.append(tokenSource)
             return MobileIrohRevocationBroker()
         })
@@ -1153,7 +1153,7 @@ struct MobileIrohRuntimeCompositionTests {
     @Test
     func activationBrokerCredentialsRethrowTransientTokenMiss() async throws {
         let sources = MobileIrohTokenSourceCapture()
-        let fixture = try await MobileIrohSignOutFixture.make(brokerFactory: { tokenSource in
+        let fixture = try await MobileIrohSignOutFixture.make(brokerFactory: { tokenSource, _ in
             sources.append(tokenSource)
             return MobileIrohRevocationBroker()
         })
@@ -1455,7 +1455,7 @@ private struct MobileIrohSignOutFixture {
                 endpointFactoryModes.record(mode)
                 return endpointFactory
             },
-            brokerFactory: brokerFactory ?? { _ in broker },
+            brokerFactory: brokerFactory ?? { _, _ in broker },
             deviceID: { resolvableDeviceID ? stableDeviceID : nil },
             tag: tag,
             now: { Date(timeIntervalSince1970: 1_000) },

--- a/ios/cmuxPackage/Tests/cmuxFeatureTests/MobileIrohRuntimeCompositionTests.swift
+++ b/ios/cmuxPackage/Tests/cmuxFeatureTests/MobileIrohRuntimeCompositionTests.swift
@@ -16,13 +16,6 @@ import Testing
 @Suite
 struct MobileIrohRuntimeCompositionTests {
     @Test
-    func developmentDiscoveryScopePreservesPeerTagCase() {
-        #expect(MobileIrohRuntimeComposition.discoveryPeerTags(
-            for: .development(expectedInstanceTag: "FeatureA")
-        ) == ["FeatureA"])
-    }
-
-    @Test
     @MainActor
     func foregroundRevalidatesAuthBeforeConnectionReadinessCompletes() async throws {
         let fixture = try await MobileIrohSignOutFixture.make()

--- a/ios/cmuxPackage/Tests/cmuxFeatureTests/MobileIrohRuntimeCompositionTests.swift
+++ b/ios/cmuxPackage/Tests/cmuxFeatureTests/MobileIrohRuntimeCompositionTests.swift
@@ -16,6 +16,13 @@ import Testing
 @Suite
 struct MobileIrohRuntimeCompositionTests {
     @Test
+    func developmentDiscoveryScopePreservesPeerTagCase() {
+        #expect(MobileIrohRuntimeComposition.discoveryPeerTags(
+            for: .development(expectedInstanceTag: "FeatureA")
+        ) == ["FeatureA"])
+    }
+
+    @Test
     @MainActor
     func foregroundRevalidatesAuthBeforeConnectionReadinessCompletes() async throws {
         let fixture = try await MobileIrohSignOutFixture.make()

--- a/web/app/api/connectivity/v3/sync/route.ts
+++ b/web/app/api/connectivity/v3/sync/route.ts
@@ -1,0 +1,8 @@
+import { handleScopedConnectivitySync } from "../../../../../services/connectivity/routeHandler";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+export async function POST(request: Request): Promise<Response> {
+  return handleScopedConnectivitySync(request);
+}

--- a/web/db/migrations/20260804030000_iroh_scoped_discovery_indexes/migration.sql
+++ b/web/db/migrations/20260804030000_iroh_scoped_discovery_indexes/migration.sql
@@ -1,0 +1,7 @@
+CREATE INDEX "iroh_endpoint_bindings_active_pairable_mac_scope_idx"
+ON "iroh_endpoint_bindings" USING btree ("user_id", "tag", "id")
+WHERE "revoked_at" is null and "platform" = 'mac' and "pairing_enabled" = true;
+--> statement-breakpoint
+CREATE INDEX "iroh_endpoint_bindings_active_ios_scope_idx"
+ON "iroh_endpoint_bindings" USING btree ("user_id", "id")
+WHERE "revoked_at" is null and "platform" = 'ios';

--- a/web/db/migrations/20260804030000_iroh_scoped_discovery_indexes/migration.sql
+++ b/web/db/migrations/20260804030000_iroh_scoped_discovery_indexes/migration.sql
@@ -1,5 +1,5 @@
 CREATE INDEX "iroh_endpoint_bindings_active_pairable_mac_scope_idx"
-ON "iroh_endpoint_bindings" USING btree ("user_id", "tag", "id")
+ON "iroh_endpoint_bindings" USING btree ("user_id", lower("tag"), "id")
 WHERE "revoked_at" is null and "platform" = 'mac' and "pairing_enabled" = true;
 --> statement-breakpoint
 CREATE INDEX "iroh_endpoint_bindings_active_ios_scope_idx"

--- a/web/db/schema.ts
+++ b/web/db/schema.ts
@@ -804,6 +804,12 @@ export const irohEndpointBindings = pgTable(
     index("iroh_endpoint_bindings_user_active_page_idx")
       .on(table.userId, table.id)
       .where(sql`${table.revokedAt} is null`),
+    index("iroh_endpoint_bindings_active_pairable_mac_scope_idx")
+      .on(table.userId, table.tag, table.id)
+      .where(sql`${table.revokedAt} is null and ${table.platform} = 'mac' and ${table.pairingEnabled} = true`),
+    index("iroh_endpoint_bindings_active_ios_scope_idx")
+      .on(table.userId, table.id)
+      .where(sql`${table.revokedAt} is null and ${table.platform} = 'ios'`),
     index("iroh_endpoint_bindings_user_idx")
       .on(table.userId),
     index("iroh_endpoint_bindings_user_revoked_idx")

--- a/web/db/schema.ts
+++ b/web/db/schema.ts
@@ -805,7 +805,7 @@ export const irohEndpointBindings = pgTable(
       .on(table.userId, table.id)
       .where(sql`${table.revokedAt} is null`),
     index("iroh_endpoint_bindings_active_pairable_mac_scope_idx")
-      .on(table.userId, table.tag, table.id)
+      .on(table.userId, sql`lower(${table.tag})`, table.id)
       .where(sql`${table.revokedAt} is null and ${table.platform} = 'mac' and ${table.pairingEnabled} = true`),
     index("iroh_endpoint_bindings_active_ios_scope_idx")
       .on(table.userId, table.id)

--- a/web/services/connectivity/authority.ts
+++ b/web/services/connectivity/authority.ts
@@ -12,8 +12,11 @@ import {
 } from "../iroh/trustBroker";
 import {
   CONNECTIVITY_PROTOCOL_VERSION,
+  SCOPED_CONNECTIVITY_PROTOCOL_VERSION,
   parseConnectivitySyncRequest,
+  parseScopedConnectivitySyncRequest,
 } from "./model";
+import { irohDiscoveryScopeJSON } from "../iroh/discoveryScope";
 
 export type ConnectivityDiscoverySnapshot = Readonly<Record<string, unknown>> & {
   readonly route_contract_version: 1;
@@ -29,12 +32,27 @@ export type ConnectivitySyncResponse = {
   readonly snapshot_complete?: true;
 };
 
+export type ScopedConnectivitySyncResponse = {
+  readonly protocol_version: typeof SCOPED_CONNECTIVITY_PROTOCOL_VERSION;
+  readonly revision: number;
+  readonly changed: boolean;
+  readonly reset: boolean;
+  readonly discovery_scope: Readonly<Record<string, unknown>>;
+  readonly snapshot?: ConnectivityDiscoverySnapshot;
+  readonly snapshot_scope_complete?: true;
+};
+
 export type ConnectivityAuthorityShape = {
   readonly sync: (
     userId: string,
     raw: unknown,
     now?: Date,
   ) => Effect.Effect<ConnectivitySyncResponse, IrohExpectedError>;
+  readonly syncScoped: (
+    userId: string,
+    raw: unknown,
+    now?: Date,
+  ) => Effect.Effect<ScopedConnectivitySyncResponse, IrohExpectedError>;
 };
 
 export class ConnectivityAuthority extends Context.Tag("cmux/ConnectivityAuthority")<
@@ -43,7 +61,7 @@ export class ConnectivityAuthority extends Context.Tag("cmux/ConnectivityAuthori
 >() {}
 
 export function makeConnectivityAuthority(
-  broker: Pick<IrohTrustBrokerShape, "discoverComplete">,
+  broker: Pick<IrohTrustBrokerShape, "discoverComplete" | "discoverScoped">,
 ): ConnectivityAuthorityShape {
   return {
     sync: (userId, raw, now = new Date()) => Effect.gen(function* () {
@@ -62,6 +80,27 @@ export function makeConnectivityAuthority(
         reset: request.known_revision !== null
           && request.known_revision > snapshot.revision,
         ...(changed ? { snapshot, snapshot_complete: true as const } : {}),
+      };
+    }),
+    syncScoped: (userId, raw, now = new Date()) => Effect.gen(function* () {
+      const request = yield* Effect.try({
+        try: () => parseScopedConnectivitySyncRequest(raw),
+        catch: (error) => error as IrohExpectedError,
+      });
+      const snapshot = yield* parseDiscoverySnapshot(
+        yield* broker.discoverScoped(userId, request.discovery_scope, now),
+      );
+      const changed = request.known_revision !== snapshot.revision;
+      return {
+        protocol_version: SCOPED_CONNECTIVITY_PROTOCOL_VERSION,
+        revision: snapshot.revision,
+        changed,
+        reset: request.known_revision !== null
+          && request.known_revision > snapshot.revision,
+        discovery_scope: irohDiscoveryScopeJSON(request.discovery_scope),
+        ...(changed
+          ? { snapshot, snapshot_scope_complete: true as const }
+          : {}),
       };
     }),
   };

--- a/web/services/connectivity/model.ts
+++ b/web/services/connectivity/model.ts
@@ -1,10 +1,21 @@
 import { IrohInvalidInputError } from "../iroh/errors";
+import {
+  parseIrohDiscoveryScope,
+  type IrohDiscoveryScope,
+} from "../iroh/discoveryScope";
 
 export const CONNECTIVITY_PROTOCOL_VERSION = 2;
+export const SCOPED_CONNECTIVITY_PROTOCOL_VERSION = 3;
 
 export type ConnectivitySyncRequest = {
   readonly protocol_version: typeof CONNECTIVITY_PROTOCOL_VERSION;
   readonly known_revision: number | null;
+};
+
+export type ScopedConnectivitySyncRequest = {
+  readonly protocol_version: typeof SCOPED_CONNECTIVITY_PROTOCOL_VERSION;
+  readonly known_revision: number | null;
+  readonly discovery_scope: IrohDiscoveryScope;
 };
 
 export function parseConnectivitySyncRequest(value: unknown): ConnectivitySyncRequest {
@@ -32,5 +43,40 @@ export function parseConnectivitySyncRequest(value: unknown): ConnectivitySyncRe
   return {
     protocol_version: CONNECTIVITY_PROTOCOL_VERSION,
     known_revision: knownRevision as number | null,
+  };
+}
+
+export function parseScopedConnectivitySyncRequest(
+  value: unknown,
+): ScopedConnectivitySyncRequest {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new IrohInvalidInputError({ code: "invalid_connectivity_sync" });
+  }
+  const record = value as Record<string, unknown>;
+  const keys = Object.keys(record);
+  if (
+    keys.length !== 3
+    || keys.some((key) =>
+      key !== "protocol_version"
+      && key !== "known_revision"
+      && key !== "discovery_scope")
+    || record.protocol_version !== SCOPED_CONNECTIVITY_PROTOCOL_VERSION
+  ) {
+    throw new IrohInvalidInputError({ code: "invalid_connectivity_sync" });
+  }
+  const knownRevision = record.known_revision;
+  if (
+    knownRevision !== null
+    && (
+      !Number.isSafeInteger(knownRevision)
+      || (knownRevision as number) < 0
+    )
+  ) {
+    throw new IrohInvalidInputError({ code: "invalid_connectivity_sync" });
+  }
+  return {
+    protocol_version: SCOPED_CONNECTIVITY_PROTOCOL_VERSION,
+    known_revision: knownRevision as number | null,
+    discovery_scope: parseIrohDiscoveryScope(record.discovery_scope),
   };
 }

--- a/web/services/connectivity/routeHandler.ts
+++ b/web/services/connectivity/routeHandler.ts
@@ -21,6 +21,21 @@ export async function handleConnectivitySync(
   request: Request,
   dependencies: ConnectivityRouteDependencies = {},
 ): Promise<Response> {
+  return handleConnectivitySyncMethod(request, "sync", dependencies);
+}
+
+export async function handleScopedConnectivitySync(
+  request: Request,
+  dependencies: ConnectivityRouteDependencies = {},
+): Promise<Response> {
+  return handleConnectivitySyncMethod(request, "syncScoped", dependencies);
+}
+
+async function handleConnectivitySyncMethod(
+  request: Request,
+  method: "sync" | "syncScoped",
+  dependencies: ConnectivityRouteDependencies,
+): Promise<Response> {
   const verify = dependencies.verify ?? verifyRequest;
   let user: Awaited<ReturnType<typeof verifyRequest>>;
   try {
@@ -35,13 +50,22 @@ export async function handleConnectivitySync(
 
   try {
     const response = dependencies.authority
-      ? await Effect.runPromise(dependencies.authority.sync(user.id, body.value))
-      : await Effect.runPromise(
-        Effect.gen(function* () {
-          const authority = yield* ConnectivityAuthority;
-          return yield* authority.sync(user.id, body.value);
-        }).pipe(Effect.provide(dependencies.runtime ?? ConnectivityAuthorityRuntime)),
-      );
+      ? method === "sync"
+        ? await Effect.runPromise(dependencies.authority.sync(user.id, body.value))
+        : await Effect.runPromise(dependencies.authority.syncScoped(user.id, body.value))
+      : method === "sync"
+        ? await Effect.runPromise(
+          Effect.gen(function* () {
+            const authority = yield* ConnectivityAuthority;
+            return yield* authority.sync(user.id, body.value);
+          }).pipe(Effect.provide(dependencies.runtime ?? ConnectivityAuthorityRuntime)),
+        )
+        : await Effect.runPromise(
+          Effect.gen(function* () {
+            const authority = yield* ConnectivityAuthority;
+            return yield* authority.syncScoped(user.id, body.value);
+          }).pipe(Effect.provide(dependencies.runtime ?? ConnectivityAuthorityRuntime)),
+        );
     return connectivityJsonResponse(response, 200);
   } catch (error) {
     const expected = irohExpectedError(error);

--- a/web/services/iroh/discoveryScope.ts
+++ b/web/services/iroh/discoveryScope.ts
@@ -107,7 +107,10 @@ export function bindingMatchesDiscoveryScope(
   }
   const peers = scope.peerBindings;
   return binding.platform === peers.platform
-    && (peers.tags === undefined || peers.tags.includes(binding.tag))
+    && (
+      peers.tags === undefined
+      || peers.tags.includes(binding.tag.toLowerCase())
+    )
     && (
       peers.pairingEnabled === undefined
       || binding.pairingEnabled === peers.pairingEnabled
@@ -122,7 +125,7 @@ function peerTags(value: unknown): readonly string[] {
   ) {
     throw new IrohInvalidInputError({ code: "invalid_discovery_scope" });
   }
-  const tags = value.map(safeTag);
+  const tags = value.map(safeTag).map((tag) => tag.toLowerCase());
   if (new Set(tags).size !== tags.length) {
     throw new IrohInvalidInputError({ code: "invalid_discovery_scope" });
   }

--- a/web/services/iroh/discoveryScope.ts
+++ b/web/services/iroh/discoveryScope.ts
@@ -1,0 +1,174 @@
+import { IrohInvalidInputError } from "./errors";
+
+const MAX_DISCOVERY_SCOPE_TAGS = 8;
+
+export type IrohDiscoveryScope = {
+  readonly localBinding: {
+    readonly deviceId: string;
+    readonly appInstanceId: string;
+    readonly tag: string;
+    readonly platform: "mac" | "ios";
+  };
+  readonly peerBindings: {
+    readonly platform: "mac" | "ios";
+    readonly tags?: readonly string[];
+    readonly pairingEnabled?: boolean;
+  };
+};
+
+export function parseIrohDiscoveryScope(value: unknown): IrohDiscoveryScope {
+  const scope = record(value);
+  rejectUnknownKeys(scope, ["local_binding", "peer_bindings"]);
+  const local = record(scope.local_binding);
+  rejectUnknownKeys(local, ["device_id", "app_instance_id", "tag", "platform"]);
+  const peers = record(scope.peer_bindings);
+  rejectUnknownKeys(peers, ["platform", "tags", "pairing_enabled"]);
+
+  const localPlatform = platform(local.platform);
+  const peerPlatform = platform(peers.platform);
+  if (localPlatform === peerPlatform) {
+    throw new IrohInvalidInputError({ code: "invalid_discovery_scope" });
+  }
+
+  const tags = peers.tags === undefined ? undefined : peerTags(peers.tags);
+  const pairingEnabled = peers.pairing_enabled;
+  if (pairingEnabled !== undefined && typeof pairingEnabled !== "boolean") {
+    throw new IrohInvalidInputError({ code: "invalid_discovery_scope" });
+  }
+
+  return {
+    localBinding: {
+      deviceId: canonicalUuid(local.device_id),
+      appInstanceId: canonicalUuid(local.app_instance_id),
+      tag: safeTag(local.tag),
+      platform: localPlatform,
+    },
+    peerBindings: {
+      platform: peerPlatform,
+      ...(tags ? { tags } : {}),
+      ...(pairingEnabled === undefined ? {} : { pairingEnabled }),
+    },
+  };
+}
+
+export function irohDiscoveryScopeJSON(
+  scope: IrohDiscoveryScope,
+): Record<string, unknown> {
+  return {
+    local_binding: {
+      device_id: scope.localBinding.deviceId,
+      app_instance_id: scope.localBinding.appInstanceId,
+      tag: scope.localBinding.tag,
+      platform: scope.localBinding.platform,
+    },
+    peer_bindings: {
+      platform: scope.peerBindings.platform,
+      ...(scope.peerBindings.tags ? { tags: scope.peerBindings.tags } : {}),
+      ...(scope.peerBindings.pairingEnabled === undefined
+        ? {}
+        : { pairing_enabled: scope.peerBindings.pairingEnabled }),
+    },
+  };
+}
+
+export function discoveryScopeMatchesRegistration(
+  scope: IrohDiscoveryScope,
+  registration: {
+    readonly deviceId: string;
+    readonly appInstanceId: string;
+    readonly tag: string;
+    readonly platform: "mac" | "ios";
+  },
+): boolean {
+  return scope.localBinding.deviceId === registration.deviceId
+    && scope.localBinding.appInstanceId === registration.appInstanceId
+    && scope.localBinding.tag === registration.tag
+    && scope.localBinding.platform === registration.platform;
+}
+
+export function bindingMatchesDiscoveryScope(
+  binding: {
+    readonly deviceUuid: string;
+    readonly appInstanceId: string;
+    readonly tag: string;
+    readonly platform: string;
+    readonly pairingEnabled: boolean;
+  },
+  scope: IrohDiscoveryScope,
+): boolean {
+  const local = scope.localBinding;
+  if (
+    binding.deviceUuid === local.deviceId
+    && binding.appInstanceId === local.appInstanceId
+    && binding.tag === local.tag
+    && binding.platform === local.platform
+  ) {
+    return true;
+  }
+  const peers = scope.peerBindings;
+  return binding.platform === peers.platform
+    && (peers.tags === undefined || peers.tags.includes(binding.tag))
+    && (
+      peers.pairingEnabled === undefined
+      || binding.pairingEnabled === peers.pairingEnabled
+    );
+}
+
+function peerTags(value: unknown): readonly string[] {
+  if (
+    !Array.isArray(value)
+    || value.length === 0
+    || value.length > MAX_DISCOVERY_SCOPE_TAGS
+  ) {
+    throw new IrohInvalidInputError({ code: "invalid_discovery_scope" });
+  }
+  const tags = value.map(safeTag);
+  if (new Set(tags).size !== tags.length) {
+    throw new IrohInvalidInputError({ code: "invalid_discovery_scope" });
+  }
+  return [...tags].sort();
+}
+
+function canonicalUuid(value: unknown): string {
+  if (
+    typeof value !== "string"
+    || !/^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/.test(value)
+  ) {
+    throw new IrohInvalidInputError({ code: "invalid_discovery_scope" });
+  }
+  return value;
+}
+
+function safeTag(value: unknown): string {
+  if (
+    typeof value !== "string"
+    || !/^[A-Za-z0-9._-]{1,64}$/.test(value)
+  ) {
+    throw new IrohInvalidInputError({ code: "invalid_discovery_scope" });
+  }
+  return value;
+}
+
+function platform(value: unknown): "mac" | "ios" {
+  if (value !== "mac" && value !== "ios") {
+    throw new IrohInvalidInputError({ code: "invalid_discovery_scope" });
+  }
+  return value;
+}
+
+function record(value: unknown): Record<string, unknown> {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new IrohInvalidInputError({ code: "invalid_discovery_scope" });
+  }
+  return value as Record<string, unknown>;
+}
+
+function rejectUnknownKeys(
+  value: Record<string, unknown>,
+  allowed: readonly string[],
+): void {
+  const allowedKeys = new Set(allowed);
+  if (Object.keys(value).some((key) => !allowedKeys.has(key))) {
+    throw new IrohInvalidInputError({ code: "invalid_discovery_scope" });
+  }
+}

--- a/web/services/iroh/model.ts
+++ b/web/services/iroh/model.ts
@@ -1,6 +1,10 @@
 import { createHash } from "node:crypto";
 import { isIP } from "node:net";
 import { IrohInvalidInputError } from "./errors";
+import {
+  parseIrohDiscoveryScope,
+  type IrohDiscoveryScope,
+} from "./discoveryScope";
 export { MANAGED_RELAY_URLS } from "./publicationPolicy";
 
 export const IROH_ALPN = "cmux/mobile/1";
@@ -64,6 +68,7 @@ export type IrohRegisterRequest = {
   readonly nonce: string;
   readonly payload: string;
   readonly signature: string;
+  readonly discoveryScope?: IrohDiscoveryScope;
 };
 
 export function parseChallengeRequest(value: unknown): IrohChallengeRequest {
@@ -94,8 +99,17 @@ export function parseRegisterRequest(value: unknown): IrohRegisterRequest {
     nonce: base64url(body.nonce, 32, "invalid_nonce"),
     payload: boundedString(body.payload, 1, 48_000, "invalid_payload"),
     signature: base64url(body.signature, 64, "invalid_signature"),
+    ...(body.discoveryScope === undefined
+      ? {}
+      : { discoveryScope: parseIrohDiscoveryScope(body.discoveryScope) }),
   };
-  rejectUnknownKeys(body, ["challengeId", "nonce", "payload", "signature"]);
+  rejectUnknownKeys(body, [
+    "challengeId",
+    "nonce",
+    "payload",
+    "signature",
+    "discoveryScope",
+  ]);
   return parsed;
 }
 

--- a/web/services/iroh/repository.ts
+++ b/web/services/iroh/repository.ts
@@ -597,7 +597,7 @@ function makeLiveRepository(): IrohRepositoryShape {
                   ),
                   input.scope.peerBindings.tags
                     ? inArray(
-                      irohEndpointBindings.tag,
+                      sql<string>`lower(${irohEndpointBindings.tag})`,
                       [...input.scope.peerBindings.tags],
                     )
                     : undefined,

--- a/web/services/iroh/repository.ts
+++ b/web/services/iroh/repository.ts
@@ -30,6 +30,7 @@ import {
   type IrohPathHint,
   type IrohRegistrationPayload,
 } from "./model";
+import type { IrohDiscoveryScope } from "./discoveryScope";
 
 export const IROH_RETENTION_BATCH_SIZE = 500;
 export const IROH_RETENTION_MAX_ROWS = 10_000;
@@ -111,6 +112,7 @@ export type IrohRepositoryShape = {
   readonly discoverySnapshot: (input: {
     readonly userId: string;
     readonly now: Date;
+    readonly scope?: IrohDiscoveryScope;
   }) => Effect.Effect<{
     readonly bindings: IrohBindingRecord[];
     readonly lanDiscoveryGeneration: number;
@@ -571,6 +573,43 @@ function makeLiveRepository(): IrohRepositoryShape {
           .where(and(
             eq(irohEndpointBindings.userId, input.userId),
             isNull(irohEndpointBindings.revokedAt),
+            input.scope
+              ? or(
+                and(
+                  eq(
+                    irohEndpointBindings.deviceUuid,
+                    input.scope.localBinding.deviceId,
+                  ),
+                  eq(
+                    irohEndpointBindings.appInstanceId,
+                    input.scope.localBinding.appInstanceId,
+                  ),
+                  eq(irohEndpointBindings.tag, input.scope.localBinding.tag),
+                  eq(
+                    irohEndpointBindings.platform,
+                    input.scope.localBinding.platform,
+                  ),
+                ),
+                and(
+                  eq(
+                    irohEndpointBindings.platform,
+                    input.scope.peerBindings.platform,
+                  ),
+                  input.scope.peerBindings.tags
+                    ? inArray(
+                      irohEndpointBindings.tag,
+                      [...input.scope.peerBindings.tags],
+                    )
+                    : undefined,
+                  input.scope.peerBindings.pairingEnabled === undefined
+                    ? undefined
+                    : eq(
+                      irohEndpointBindings.pairingEnabled,
+                      input.scope.peerBindings.pairingEnabled,
+                    ),
+                ),
+              )
+              : undefined,
           ))
           .orderBy(asc(irohEndpointBindings.id));
         return {

--- a/web/services/iroh/trustBroker.ts
+++ b/web/services/iroh/trustBroker.ts
@@ -81,6 +81,11 @@ import {
   MANAGED_RELAY_URLS,
   accountPrivateIrohPathHints,
 } from "./publicationPolicy";
+import {
+  discoveryScopeMatchesRegistration,
+  irohDiscoveryScopeJSON,
+  type IrohDiscoveryScope,
+} from "./discoveryScope";
 
 export type IrohTrustBrokerShape = {
   readonly issueChallenge: (
@@ -100,6 +105,11 @@ export type IrohTrustBrokerShape = {
   ) => Effect.Effect<unknown, IrohExpectedError>;
   readonly discoverComplete: (
     userId: string,
+    now?: Date,
+  ) => Effect.Effect<unknown, IrohExpectedError>;
+  readonly discoverScoped: (
+    userId: string,
+    scope: IrohDiscoveryScope,
     now?: Date,
   ) => Effect.Effect<unknown, IrohExpectedError>;
   readonly revoke: (
@@ -237,6 +247,22 @@ export function makeIrohTrustBroker(
     return yield* serializeDiscovery(userId, now, snapshot);
   });
 
+  const discoverScoped = (
+    userId: string,
+    scope: IrohDiscoveryScope,
+    now = new Date(),
+    knownCustomRelayURLs?: ReadonlySet<string>,
+  ): Effect.Effect<unknown, IrohExpectedError> => Effect.gen(function* () {
+    yield* repository.pruneExpiredState({ userId, now });
+    const snapshot = yield* repository.discoverySnapshot({ userId, now, scope });
+    return yield* serializeDiscovery(
+      userId,
+      now,
+      snapshot,
+      knownCustomRelayURLs,
+    );
+  });
+
   const serializeDiscovery = (
     userId: string,
     now: Date,
@@ -309,6 +335,17 @@ export function makeIrohTrustBroker(
         return yield* Effect.fail(new IrohForbiddenError({ code: "invalid_challenge_nonce" }));
       }
       yield* parseEffect(() => assertChallengeMatchesPayload(challenge, decoded.payload));
+      if (
+        request.discoveryScope
+        && !discoveryScopeMatchesRegistration(
+          request.discoveryScope,
+          decoded.payload,
+        )
+      ) {
+        return yield* Effect.fail(new IrohInvalidInputError({
+          code: "invalid_discovery_scope",
+        }));
+      }
       yield* parseEffect(() => verifyEndpointRegistrationSignature({
         endpointId: decoded.payload.endpointId,
         challengeId: request.challengeId,
@@ -341,23 +378,39 @@ export function makeIrohTrustBroker(
           Effect.catchAll(() => Effect.succeed({ status: "unavailable" as const })),
         )
         : { status: "not_requested" as const };
-      const discovery = (yield* discover(
-        userId,
-        now,
-        { pageSize: "128" },
-        savedCustomRelayURLs,
-      )) as Record<string, unknown>;
+      const discovery = request.discoveryScope
+        ? (yield* discoverScoped(
+          userId,
+          request.discoveryScope,
+          now,
+          savedCustomRelayURLs,
+        )) as Record<string, unknown>
+        : (yield* discover(
+          userId,
+          now,
+          { pageSize: "128" },
+          savedCustomRelayURLs,
+        )) as Record<string, unknown>;
       return {
         revision: registration.accountRevision,
         binding: publicBinding(registration.binding, now, savedCustomRelayURLs),
         relay,
         discovery,
-        discovery_complete: discovery.next_cursor === null,
+        discovery_complete: request.discoveryScope
+          ? false
+          : discovery.next_cursor === null,
+        ...(request.discoveryScope
+          ? {
+            discovery_scope: irohDiscoveryScopeJSON(request.discoveryScope),
+            discovery_scope_complete: true as const,
+          }
+          : {}),
       };
     }),
 
     discover,
     discoverComplete,
+    discoverScoped,
 
     revoke: (userId, raw, now = new Date()) => Effect.gen(function* () {
       const { bindingId } = yield* parseEffect(() => parseBindingIdBody(raw));

--- a/web/tests/connectivity-authority.test.ts
+++ b/web/tests/connectivity-authority.test.ts
@@ -3,7 +3,10 @@ import * as Effect from "effect/Effect";
 import {
   makeConnectivityAuthority,
 } from "../services/connectivity/authority";
-import { handleConnectivitySync } from "../services/connectivity/routeHandler";
+import {
+  handleConnectivitySync,
+  handleScopedConnectivitySync,
+} from "../services/connectivity/routeHandler";
 import type { AuthedUser } from "../services/vms/auth";
 
 const USER: AuthedUser = {
@@ -29,11 +32,44 @@ const snapshot = {
   bindings: [{ binding_id: "binding-a" }],
 };
 
+const scope = {
+  localBinding: {
+    deviceId: "123e4567-e89b-42d3-a456-426614174000",
+    appInstanceId: "223e4567-e89b-42d3-a456-426614174000",
+    tag: "stable",
+    platform: "ios" as const,
+  },
+  peerBindings: {
+    platform: "mac" as const,
+    tags: ["default", "nightly"],
+    pairingEnabled: true,
+  },
+};
+
+const scopeWire = {
+  local_binding: {
+    device_id: scope.localBinding.deviceId,
+    app_instance_id: scope.localBinding.appInstanceId,
+    tag: scope.localBinding.tag,
+    platform: scope.localBinding.platform,
+  },
+  peer_bindings: {
+    platform: scope.peerBindings.platform,
+    tags: scope.peerBindings.tags,
+    pairing_enabled: true,
+  },
+};
+
+function snapshotBroker() {
+  return {
+    discoverComplete: () => Effect.succeed(snapshot),
+    discoverScoped: () => Effect.succeed(snapshot),
+  };
+}
+
 describe("Connectivity authority", () => {
   test("returns a complete snapshot on initial sync", async () => {
-    const authority = makeConnectivityAuthority({
-      discoverComplete: () => Effect.succeed(snapshot),
-    });
+    const authority = makeConnectivityAuthority(snapshotBroker());
 
     const response = await Effect.runPromise(authority.sync("user-a", {
       protocol_version: 2,
@@ -69,6 +105,7 @@ describe("Connectivity authority", () => {
         completeCalls += 1;
         return Effect.succeed({ ...snapshot, bindings });
       },
+      discoverScoped: () => Effect.succeed({ ...snapshot, bindings }),
     };
     const authority = makeConnectivityAuthority(broker);
 
@@ -84,9 +121,7 @@ describe("Connectivity authority", () => {
   });
 
   test("omits an unchanged snapshot and identifies backend revision reset", async () => {
-    const authority = makeConnectivityAuthority({
-      discoverComplete: () => Effect.succeed(snapshot),
-    });
+    const authority = makeConnectivityAuthority(snapshotBroker());
 
     expect(await Effect.runPromise(authority.sync("user-a", {
       protocol_version: 2,
@@ -125,6 +160,7 @@ describe("Connectivity authority", () => {
             reset: false,
           });
         },
+        syncScoped: () => Effect.die(new Error("unexpected scoped sync")),
       },
     });
 
@@ -133,9 +169,7 @@ describe("Connectivity authority", () => {
   });
 
   test("serves an authenticated no-store sync response", async () => {
-    const authority = makeConnectivityAuthority({
-      discoverComplete: () => Effect.succeed(snapshot),
-    });
+    const authority = makeConnectivityAuthority(snapshotBroker());
     const response = await handleConnectivitySync(syncRequest(null), {
       verify: async () => USER,
       authority,
@@ -157,6 +191,7 @@ describe("Connectivity authority", () => {
         calls += 1;
         return Effect.succeed(snapshot);
       },
+      discoverScoped: () => Effect.succeed(snapshot),
     });
     const malformed = await handleConnectivitySync(new Request(
       "https://cmux.test/api/connectivity/v2/sync",
@@ -189,6 +224,60 @@ describe("Connectivity authority", () => {
     expect(oversized.status).toBe(413);
     expect(calls).toBe(0);
   });
+
+  test("returns completeness only for the echoed v3 discovery scope", async () => {
+    let receivedScope: unknown;
+    const authority = makeConnectivityAuthority({
+      discoverComplete: () => Effect.succeed(snapshot),
+      discoverScoped: (_userId, requestedScope) => {
+        receivedScope = requestedScope;
+        return Effect.succeed(snapshot);
+      },
+    });
+
+    const response = await Effect.runPromise(authority.syncScoped("user-a", {
+      protocol_version: 3,
+      known_revision: null,
+      discovery_scope: scopeWire,
+    }));
+
+    expect(receivedScope).toEqual(scope);
+    expect(response).toEqual({
+      protocol_version: 3,
+      revision: 7,
+      changed: true,
+      reset: false,
+      discovery_scope: scopeWire,
+      snapshot,
+      snapshot_scope_complete: true,
+    });
+    expect("snapshot_complete" in response).toBe(false);
+  });
+
+  test("serves authenticated v3 sync and rejects malformed scopes", async () => {
+    const authority = makeConnectivityAuthority(snapshotBroker());
+    const response = await handleScopedConnectivitySync(
+      scopedSyncRequest(scopeWire),
+      { verify: async () => USER, authority },
+    );
+    expect(response.status).toBe(200);
+    expect(response.headers.get("cache-control")).toBe("no-store");
+    expect(await response.json()).toMatchObject({
+      protocol_version: 3,
+      discovery_scope: scopeWire,
+      snapshot_scope_complete: true,
+    });
+
+    const malformed = await handleScopedConnectivitySync(scopedSyncRequest({
+      ...scopeWire,
+      peer_bindings: {
+        ...scopeWire.peer_bindings,
+        platform: "ios",
+      },
+    }), { verify: async () => USER, authority });
+    expect(malformed.status).toBe(400);
+    expect(await malformed.json()).toEqual({ error: "invalid_discovery_scope" });
+  });
 });
 
 function syncRequest(knownRevision: number | null): Request {
@@ -202,6 +291,22 @@ function syncRequest(knownRevision: number | null): Request {
     body: JSON.stringify({
       protocol_version: 2,
       known_revision: knownRevision,
+    }),
+  });
+}
+
+function scopedSyncRequest(discoveryScope: unknown): Request {
+  return new Request("https://cmux.test/api/connectivity/v3/sync", {
+    method: "POST",
+    headers: {
+      authorization: "Bearer test-access",
+      "x-stack-refresh-token": "test-refresh",
+      "content-type": "application/json",
+    },
+    body: JSON.stringify({
+      protocol_version: 3,
+      known_revision: null,
+      discovery_scope: discoveryScope,
     }),
   });
 }

--- a/web/tests/iroh-db-behavior.test.ts
+++ b/web/tests/iroh-db-behavior.test.ts
@@ -1304,7 +1304,7 @@ describe("Iroh trust broker database behavior", () => {
       userId,
       endpointId: "d2".repeat(32),
       platform: "mac",
-      tag: "default",
+      tag: "FeatureA",
       pairingEnabled: true,
     });
     await insertBinding({
@@ -1359,7 +1359,7 @@ describe("Iroh trust broker database behavior", () => {
         },
         peerBindings: {
           platform: "mac",
-          tags: ["default", "nightly"],
+          tags: ["featurea", "nightly"],
           pairingEnabled: true,
         },
       },

--- a/web/tests/iroh-db-behavior.test.ts
+++ b/web/tests/iroh-db-behavior.test.ts
@@ -1287,6 +1287,89 @@ describe("Iroh trust broker database behavior", () => {
     expect(complete.accountRevision).toBe(registration.accountRevision);
   });
 
+  dbTest("filters scoped discovery in the authoritative SQL snapshot", async () => {
+    const repo = requiredRepository();
+    const userId = "user-scoped-discovery";
+    const deviceId = randomUUID();
+    const appInstanceId = randomUUID();
+    const localId = await insertBinding({
+      userId,
+      deviceUuid: deviceId,
+      appInstanceId,
+      endpointId: "d1".repeat(32),
+      platform: "ios",
+      tag: "stable",
+    });
+    const eligibleMacId = await insertBinding({
+      userId,
+      endpointId: "d2".repeat(32),
+      platform: "mac",
+      tag: "default",
+      pairingEnabled: true,
+    });
+    await insertBinding({
+      userId,
+      endpointId: "d3".repeat(32),
+      platform: "mac",
+      tag: "other",
+      pairingEnabled: true,
+    });
+    await insertBinding({
+      userId,
+      endpointId: "d4".repeat(32),
+      platform: "mac",
+      tag: "default",
+      pairingEnabled: false,
+    });
+    await insertBinding({
+      userId,
+      endpointId: "d5".repeat(32),
+      platform: "ios",
+      tag: "stable",
+    });
+    const revokedMacId = await insertBinding({
+      userId,
+      endpointId: "d6".repeat(32),
+      platform: "mac",
+      tag: "nightly",
+      pairingEnabled: true,
+    });
+    await requiredSql()`
+      update iroh_endpoint_bindings
+      set revoked_at = ${NOW}, revoked_reason = 'test'
+      where id = ${revokedMacId}
+    `;
+    await insertBinding({
+      userId: "other-user",
+      endpointId: "d7".repeat(32),
+      platform: "mac",
+      tag: "default",
+      pairingEnabled: true,
+    });
+
+    const snapshot = await Effect.runPromise(repo.discoverySnapshot({
+      userId,
+      now: NOW,
+      scope: {
+        localBinding: {
+          deviceId,
+          appInstanceId,
+          tag: "stable",
+          platform: "ios",
+        },
+        peerBindings: {
+          platform: "mac",
+          tags: ["default", "nightly"],
+          pairingEnabled: true,
+        },
+      },
+    }));
+
+    expect(snapshot.bindings.map((binding) => binding.id)).toEqual(
+      [localId, eligibleMacId].sort(),
+    );
+  });
+
   dbTest("enforces the UDP port range for each direct-address family", async () => {
     const bindingId = await insertBinding({
       userId: "user-direct-port-checks",
@@ -1989,6 +2072,7 @@ async function insertBinding(input: {
   readonly endpointId: string;
   readonly platform?: "mac" | "ios";
   readonly tag?: string;
+  readonly pairingEnabled?: boolean;
   readonly pathHints?: unknown[];
 }): Promise<string> {
   const [row] = await requiredSql()<Array<{ id: string }>>`
@@ -1998,7 +2082,8 @@ async function insertBinding(input: {
       path_hints_next_expiry
     ) values (
       ${input.userId}, ${input.deviceUuid ?? randomUUID()}, ${input.appInstanceId ?? randomUUID()}, ${input.tag ?? "stable"},
-      ${input.platform ?? "mac"}, ${input.endpointId}, 1, true, '[]'::jsonb,
+      ${input.platform ?? "mac"}, ${input.endpointId}, 1,
+      ${input.pairingEnabled ?? true}, '[]'::jsonb,
       ${requiredSql().json((input.pathHints ?? []) as never)},
       ${earliestStoredHintExpiry(input.pathHints ?? [])}
     ) returning id::text

--- a/web/tests/iroh-route-handler.test.ts
+++ b/web/tests/iroh-route-handler.test.ts
@@ -382,6 +382,7 @@ function broker(overrides: Partial<IrohTrustBrokerShape> = {}): IrohTrustBrokerS
     register: unavailable,
     discover: unavailable,
     discoverComplete: unavailable,
+    discoverScoped: unavailable,
     issueEndpointAttestation: unavailable,
     revoke: unavailable,
     issuePairGrant: unavailable,

--- a/web/tests/iroh-trust-broker.test.ts
+++ b/web/tests/iroh-trust-broker.test.ts
@@ -237,7 +237,7 @@ describe("Iroh trust broker registration", () => {
     const eligibleMac = binding({
       id: "123e4567-e89b-42d3-a456-426614174020",
       platform: "mac",
-      tag: "stable",
+      tag: "featurea",
       pairingEnabled: true,
     });
     const irrelevantMac = binding({
@@ -256,8 +256,15 @@ describe("Iroh trust broker registration", () => {
       },
       peer_bindings: {
         platform: "mac",
-        tags: ["stable"],
+        tags: ["FeatureA"],
         pairing_enabled: true,
+      },
+    };
+    const normalizedDiscoveryScope = {
+      ...discoveryScope,
+      peer_bindings: {
+        ...discoveryScope.peer_bindings,
+        tags: ["featurea"],
       },
     };
 
@@ -277,7 +284,7 @@ describe("Iroh trust broker registration", () => {
 
     expect(result.discovery_complete).toBe(false);
     expect(result.discovery_scope_complete).toBe(true);
-    expect(result.discovery_scope).toEqual(discoveryScope);
+    expect(result.discovery_scope).toEqual(normalizedDiscoveryScope);
     expect(result.discovery.bindings.map((row) => row.binding_id)).toEqual([
       eligibleMac.id,
       fixture.repository.bindings.find((row) =>

--- a/web/tests/iroh-trust-broker.test.ts
+++ b/web/tests/iroh-trust-broker.test.ts
@@ -28,6 +28,7 @@ import {
 } from "../services/iroh/repository";
 import type { IrohRelayMinterShape } from "../services/iroh/relayMinter";
 import { makeIrohTrustBroker } from "../services/iroh/trustBroker";
+import { bindingMatchesDiscoveryScope } from "../services/iroh/discoveryScope";
 import type { RelayPreference } from "../services/relay/model";
 
 const NOW = new Date("2026-07-09T20:00:00.000Z");
@@ -231,6 +232,86 @@ describe("Iroh trust broker registration", () => {
     expect(result.discovery_complete).toBe(false);
   });
 
+  test("returns only the requested complete scope with registration", async () => {
+    const fixture = makeFixture();
+    const eligibleMac = binding({
+      id: "123e4567-e89b-42d3-a456-426614174020",
+      platform: "mac",
+      tag: "stable",
+      pairingEnabled: true,
+    });
+    const irrelevantMac = binding({
+      id: "123e4567-e89b-42d3-a456-426614174021",
+      platform: "mac",
+      tag: "other",
+      pairingEnabled: true,
+    });
+    fixture.repository.bindings.push(eligibleMac, irrelevantMac);
+    const discoveryScope = {
+      local_binding: {
+        device_id: fixture.deviceId,
+        app_instance_id: fixture.appInstanceId,
+        tag: "stable",
+        platform: "ios",
+      },
+      peer_bindings: {
+        platform: "mac",
+        tags: ["stable"],
+        pairing_enabled: true,
+      },
+    };
+
+    const result = await Effect.runPromise(fixture.broker.register(
+      USER_A,
+      {
+        ...await fixture.signedRegistration("ios"),
+        discoveryScope,
+      },
+      NOW,
+    )) as {
+      discovery_complete: boolean;
+      discovery_scope_complete: boolean;
+      discovery_scope: unknown;
+      discovery: { bindings: Array<{ binding_id: string }> };
+    };
+
+    expect(result.discovery_complete).toBe(false);
+    expect(result.discovery_scope_complete).toBe(true);
+    expect(result.discovery_scope).toEqual(discoveryScope);
+    expect(result.discovery.bindings.map((row) => row.binding_id)).toEqual([
+      eligibleMac.id,
+      fixture.repository.bindings.find((row) =>
+        row.deviceUuid === fixture.deviceId
+        && row.appInstanceId === fixture.appInstanceId
+        && row.platform === "ios")?.id,
+    ].sort());
+  });
+
+  test("rejects a mismatched registration scope before consuming its challenge", async () => {
+    const fixture = makeFixture();
+    const signed = await fixture.signedRegistration("ios");
+    await expectEffectFailure(
+      fixture.broker.register(USER_A, {
+        ...signed,
+        discoveryScope: {
+          local_binding: {
+            device_id: fixture.deviceId,
+            app_instance_id: randomUUID(),
+            tag: "stable",
+            platform: "ios",
+          },
+          peer_bindings: { platform: "mac" },
+        },
+      }, NOW),
+      "IrohInvalidInputError",
+    );
+
+    const retried = await Effect.runPromise(
+      fixture.broker.register(USER_A, signed, NOW),
+    ) as { binding: { endpoint_id: string } };
+    expect(retried.binding.endpoint_id).toBe(fixture.endpointId);
+  });
+
   test("rejects the wrong key and a changed payload", async () => {
     const wrongKeyFixture = makeFixture();
     const wrongRequest = await wrongKeyFixture.signedRegistration();
@@ -304,6 +385,68 @@ describe("Iroh trust broker registration", () => {
 });
 
 describe("Iroh discovery and grants", () => {
+  test("reduces a 341-binding account to the three bindings iOS can use", async () => {
+    const fixture = makeFixture();
+    const local = binding({
+      id: "123e4567-e89b-42d3-a456-426614174001",
+      deviceUuid: fixture.deviceId,
+      appInstanceId: fixture.appInstanceId,
+      tag: "stable",
+      platform: "ios",
+    });
+    const stableMac = binding({
+      id: "123e4567-e89b-42d3-a456-426614174002",
+      tag: "default",
+      platform: "mac",
+      pairingEnabled: true,
+    });
+    const nightlyMac = binding({
+      id: "123e4567-e89b-42d3-a456-426614174003",
+      tag: "nightly",
+      platform: "mac",
+      pairingEnabled: true,
+    });
+    fixture.repository.bindings.push(local, stableMac, nightlyMac);
+    for (let index = 4; index <= 341; index += 1) {
+      fixture.repository.bindings.push(binding({
+        id: `123e4567-e89b-42d3-a456-${String(index).padStart(12, "0")}`,
+        tag: index % 2 === 0 ? "other" : "default",
+        platform: index % 2 === 0 ? "mac" : "ios",
+        pairingEnabled: false,
+      }));
+    }
+    const scope = {
+      localBinding: {
+        deviceId: fixture.deviceId,
+        appInstanceId: fixture.appInstanceId,
+        tag: "stable",
+        platform: "ios" as const,
+      },
+      peerBindings: {
+        platform: "mac" as const,
+        tags: ["default", "nightly"],
+        pairingEnabled: true,
+      },
+    };
+
+    const full = await Effect.runPromise(
+      fixture.broker.discoverComplete(USER_A, NOW),
+    ) as { bindings: unknown[] };
+    const scoped = await Effect.runPromise(
+      fixture.broker.discoverScoped(USER_A, scope, NOW),
+    ) as { bindings: Array<{ binding_id: string }> };
+    const fullBytes = Buffer.byteLength(JSON.stringify(full));
+    const scopedBytes = Buffer.byteLength(JSON.stringify(scoped));
+
+    expect(full.bindings).toHaveLength(341);
+    expect(scoped.bindings.map((row) => row.binding_id)).toEqual([
+      local.id,
+      stableMac.id,
+      nightlyMac.id,
+    ]);
+    expect(scopedBytes).toBeLessThan(fullBytes / 20);
+  });
+
   test("publishes one monotonic account revision across registration and revocation", async () => {
     const fixture = makeFixture();
     const first = await Effect.runPromise(fixture.broker.register(
@@ -964,7 +1107,10 @@ class MemoryRepository implements IrohRepositoryShape {
       await this.beforeDiscoverySnapshot?.();
       return {
         bindings: this.bindings
-          .filter((row) => row.userId === input.userId && !row.revokedAt)
+          .filter((row) =>
+            row.userId === input.userId
+            && !row.revokedAt
+            && (!input.scope || bindingMatchesDiscoveryScope(row, input.scope)))
           .sort((left, right) => left.id.localeCompare(right.id)),
         lanDiscoveryGeneration: this.lanGenerations.get(input.userId) ?? 1,
         accountRevision: this.routeRevisions.get(input.userId) ?? 0,


### PR DESCRIPTION
Adds connectivity v3 discovery scopes for the exact local binding and usable opposite-platform peers. iOS requests pairable compatible Macs; macOS requests active iOS bindings.

Registration uses the same scope, with strict completeness markers. Current clients fall back to global v2 sync and unscoped registration when talking to older servers.

The repository filters in SQL with partial indexes. A representative 341-binding test returns three usable bindings and less than one twentieth of the full serialized payload.

Verification: focused Bun tests, TypeScript typecheck, ESLint, Drizzle schema check, shared Swift package build, and tagged macOS cloud build 30883369906.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/9535"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788417765&installation_model_id=21920&pr_number=9535&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F9535&signature=aeae3ace4b8c9086c85daf8856bb8716003582bfb0c71fa1b3b5a286ee2c4b77"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds scoped connectivity discovery (v3) that filters Iroh bindings by runtime `discovery_scope`, echoes the scope, and only marks snapshots authoritative with scoped/global completeness; clients prefer v3 and fall back to v2 only on older servers. Also renews host registrations for empty routes using private‑hint freshness so Macs stay dialable.

- **New Features**
  - New `POST /api/connectivity/v3/sync` that validates and echoes `discovery_scope`, returning `snapshot_scope_complete`; v2 responses are unchanged.
  - Registration accepts optional `discoveryScope`; server validates it matches the registering binding and echoes it with `discovery_scope_complete`; clients accept only echoed, complete projections and retry without scope on 400 `unknown_field`.
  - Swift adds `scopedProtocolVersion`, `snapshotIsComplete`, and `embeddedDiscoveryComplete`; `CmxIrohTrustBrokerClient` sends scoped sync/registration by default, falls back to v2 on 404, and does not downgrade on incomplete v3.
  - Canonical scope parsing/matching on server and client: reject unknown keys, require canonical UUIDs and safe tags, and lowercase/dedupe/sort peer tags; repository filters by scope in SQL using `lower(tag)` and new partial indexes.
  - iOS requests pairable Macs (`default|nightly` or a dev tag); macOS requests active iOS; a 341‑binding account returns 3 bindings and under 5% of the bytes.
  - Host runtime renews empty‑route registrations before private‑hint freshness expires; tests cover scoped sync/registration echo/completeness, peer‑tag normalization, and renewal deadlines.

- **Migration**
  - Apply the DB migration adding partial indexes for scoped queries.
  - Backend now exposes `/api/connectivity/v3/sync`; existing v2 clients continue working.
  - To enable v3, clients pass `discoveryScope` to the broker; otherwise they use v2.

<sup>Written for commit 8843fb938940b91f5fd1aa4780e282b6cd2454d7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/9535?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added scoped device discovery for paired Mac and iOS connections.
  * Added connectivity synchronization v3 with scope-aware results and completion status.
  * Registration now supports scoped discovery metadata, with compatibility fallback for older servers.
  * Added validation for device identities, platforms, tags, pairing settings, and scope combinations.
  * Added a dedicated scoped synchronization endpoint and optimized discovery lookups.

* **Bug Fixes**
  * Improved snapshot completeness handling for authoritative results.
  * Preserved unscoped discovery when scoped synchronization is unavailable.
  * Improved registration renewal when public connection hints are empty.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches connectivity reconciliation, registration wire contracts, and discovery SQL filtering across Swift and web; fallbacks limit breakage on older servers, but incorrect scope or completeness handling could strand discovery or reject valid registrations.
> 
> **Overview**
> Introduces **connectivity v3** scoped discovery: clients send a `discovery_scope` (local binding plus opposite-platform peer filters) and accept snapshots only when the server echoes the same scope and marks **`snapshot_scope_complete`** or global **`snapshot_complete`**. **`CmxIrohTrustBrokerClient`** prefers `/api/connectivity/v3/sync` and scoped registration, then falls back to v2 sync, paginated global discovery, or unscoped registration on **404** / **`unknown_field`**.
> 
> On the server, **`POST /api/connectivity/v3/sync`**, scope parsing/matching, scoped **`discoverySnapshot`** SQL (with new partial indexes), and registration that returns **`discovery_scope_complete`** when the optional scope matches the signed binding.
> 
> iOS and macOS runtimes now build a **`CmxConnectivityDiscoveryScope`** at broker creation (iOS: pairable Mac tags from build policy; macOS: active iOS peers).
> 
> Separately, **host registration renewal** also considers **`lastSeenAt` + private-hint TTL** when public path hints are empty, so Mac hosts stay dialable without spinning immediate renewals when deadlines are already past.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8843fb938940b91f5fd1aa4780e282b6cd2454d7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->