### PR TITLE
Fix shortcuts on Dvorak–QWERTY Command layouts

### DIFF
--- a/Sources/App/CommandPaletteShortcutRouting.swift
+++ b/Sources/App/CommandPaletteShortcutRouting.swift
@@ -6,7 +6,7 @@ func commandPaletteSelectionDeltaForKeyboardNavigation(
     keyCode: UInt16,
     nextShortcut: StoredShortcut?,
     previousShortcut: StoredShortcut?,
-    layoutCharacterProvider: (UInt16, NSEvent.ModifierFlags) -> String? = KeyboardLayout.character(forKeyCode:modifierFlags:)
+    layoutCharacterProvider: @escaping (UInt16, NSEvent.ModifierFlags) -> String? = KeyboardLayout.character(forKeyCode:modifierFlags:)
 ) -> Int? {
     let normalizedFlags = flags
         .intersection(.deviceIndependentFlagsMask)
@@ -43,12 +43,48 @@ func commandPaletteSelectionDeltaForKeyboardNavigation(
     return nil
 }
 
+private func commandPaletteSelectionDeltaForKeyboardNavigation(
+    event: NSEvent,
+    nextShortcut: StoredShortcut?,
+    previousShortcut: StoredShortcut?,
+    characterResolver: ShortcutEventCharacterResolver
+) -> Int? {
+    let normalizedFlags = ShortcutStroke.normalizedModifierFlags(
+        from: event.modifierFlags
+    )
+    if normalizedFlags.isEmpty {
+        switch event.keyCode {
+        case 125: return 1
+        case 126: return -1
+        default: break
+        }
+    }
+
+    if nextShortcut?.hasChord == false,
+       nextShortcut?.matches(
+           event: event,
+           characterResolver: characterResolver
+       ) == true {
+        return 1
+    }
+
+    if previousShortcut?.hasChord == false,
+       previousShortcut?.matches(
+           event: event,
+           characterResolver: characterResolver
+       ) == true {
+        return -1
+    }
+
+    return nil
+}
+
 @MainActor
 func commandPaletteSelectionDeltaForKeyboardNavigation(
     flags: NSEvent.ModifierFlags,
     chars: String,
     keyCode: UInt16,
-    layoutCharacterProvider: (UInt16, NSEvent.ModifierFlags) -> String? = KeyboardLayout.character(forKeyCode:modifierFlags:)
+    layoutCharacterProvider: @escaping (UInt16, NSEvent.ModifierFlags) -> String? = KeyboardLayout.character(forKeyCode:modifierFlags:)
 ) -> Int? {
     commandPaletteSelectionDeltaForKeyboardNavigation(
         flags: flags,
@@ -62,7 +98,8 @@ func commandPaletteSelectionDeltaForKeyboardNavigation(
 
 @MainActor
 func contextAwareCommandPaletteSelectionDelta(
-    for event: NSEvent
+    for event: NSEvent,
+    characterResolver: ShortcutEventCharacterResolver? = nil
 ) -> Int? {
     let normalizedFlags = event.modifierFlags
         .intersection(.deviceIndependentFlagsMask)
@@ -75,7 +112,15 @@ func contextAwareCommandPaletteSelectionDelta(
         }
     }
 
-    let characters = event.characters ?? event.charactersIgnoringModifiers ?? ""
+    var cachedCharacterResolver = characterResolver
+    func resolveCharacters() -> ShortcutEventCharacterResolver {
+        if let cachedCharacterResolver {
+            return cachedCharacterResolver
+        }
+        let resolved = ShortcutEventCharacterResolver.live(for: event)
+        cachedCharacterResolver = resolved
+        return resolved
+    }
     for (action, delta) in [
         (KeyboardShortcutSettings.Action.commandPaletteNext, 1),
         (.commandPalettePrevious, -1),
@@ -83,10 +128,8 @@ func contextAwareCommandPaletteSelectionDelta(
         guard let shortcut = KeyboardShortcutSettings.shortcutIfBound(for: action),
               !shortcut.hasChord,
               shortcut.matches(
-                keyCode: event.keyCode,
-                modifierFlags: event.modifierFlags,
-                eventCharacter: characters,
-                layoutCharacterProvider: KeyboardLayout.character(forKeyCode:modifierFlags:)
+                event: event,
+                characterResolver: resolveCharacters()
               ),
               AppDelegate.shared?.shortcutWhenClauseAllows(action: action, event: event) != false else { continue }
         return delta
@@ -100,7 +143,12 @@ func commandPaletteSelectionDeltaForFieldEditorCommand(
     event: NSEvent?,
     nextShortcut: StoredShortcut? = KeyboardShortcutSettings.shortcutIfBound(for: .commandPaletteNext),
     previousShortcut: StoredShortcut? = KeyboardShortcutSettings.shortcutIfBound(for: .commandPalettePrevious),
-    layoutCharacterProvider: (UInt16, NSEvent.ModifierFlags) -> String? = KeyboardLayout.character(forKeyCode:modifierFlags:)
+    exactCharacterProvider: @escaping ShortcutEventCharacterResolver.ExactCharacterProvider = {
+        event,
+        modifiers in
+        event.characters(byApplyingModifiers: modifiers)
+    },
+    layoutCharacterProvider: @escaping (UInt16, NSEvent.ModifierFlags) -> String? = KeyboardLayout.character(forKeyCode:modifierFlags:)
 ) -> Int? {
     let selectorDelta: Int
     switch commandSelector {
@@ -120,13 +168,16 @@ func commandPaletteSelectionDeltaForFieldEditorCommand(
         return shortcut == defaultShortcut ? selectorDelta : nil
     }
 
+    let characterResolver = ShortcutEventCharacterResolver(
+        event: event,
+        exactCharacterProvider: exactCharacterProvider,
+        layoutCharacterProvider: layoutCharacterProvider
+    )
     if let eventDelta = commandPaletteSelectionDeltaForKeyboardNavigation(
-        flags: event.modifierFlags,
-        chars: event.characters ?? event.charactersIgnoringModifiers ?? "",
-        keyCode: event.keyCode,
+        event: event,
         nextShortcut: nextShortcut,
         previousShortcut: previousShortcut,
-        layoutCharacterProvider: layoutCharacterProvider
+        characterResolver: characterResolver
     ),
        eventDelta == selectorDelta {
         return eventDelta

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -13230,10 +13230,25 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
             return false
         }
 
-        let chars = KeyboardLayout.normalizedCharacters(for: event)
         let hasControl = flags.contains(.control)
         let hasCommand = flags.contains(.command)
         let hasOption = flags.contains(.option)
+        let eventCharacterResolver = hasCommand
+            ? shortcutEventCharacterResolver(for: event)
+            : nil
+        let chars: String = {
+            if let eventCharacterResolver,
+               hasOption || hasControl {
+                return (eventCharacterResolver.primaryCharacters ?? "").lowercased()
+            }
+            if let eventCharacterResolver {
+                return KeyboardLayout.normalizedCharacters(
+                    for: event,
+                    characterResolver: eventCharacterResolver
+                )
+            }
+            return KeyboardLayout.normalizedCharacters(for: event)
+        }()
         let isControlOnly = hasControl && !hasCommand && !hasOption
         let controlDChar = chars == "d" || event.characters == "\u{04}"
         let isControlD = isControlOnly && (controlDChar || event.keyCode == 2)
@@ -13429,7 +13444,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
 
         let paletteUsesInlineTextHandling = commandPaletteShortcutWindow.map { isCommandPaletteMultilineTextResponderActive(in: $0) } ?? false
 
-        let paletteSelectionDelta = contextAwareCommandPaletteSelectionDelta(for: event)
+        let paletteSelectionDelta = contextAwareCommandPaletteSelectionDelta(
+            for: event,
+            characterResolver: eventCharacterResolver
+        )
 
         if shouldRouteCommandPaletteSelectionNavigation(
             delta: paletteSelectionDelta,
@@ -15666,7 +15684,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
            shortcutResponderHasMarkedText(shortcutWindow?.firstResponder) {
             return nil
         }
-        return KeyboardShortcutSettingsObserver.shared.rightSidebarModeShortcutMatcher.modeShortcut(for: event) { [self] action in
+        return KeyboardShortcutSettingsObserver.shared.rightSidebarModeShortcutMatcher.modeShortcut(
+            for: event,
+            characterResolver: shortcutEventCharacterResolver(for: event)
+        ) { [self] action in
             shortcutWhenClauseAllows(action: action, event: event)
         }
     }
@@ -16034,11 +16055,17 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
 
     /// Match a shortcut stroke against an event, handling normal keys.
     func matchShortcutStroke(event: NSEvent, stroke: ShortcutStroke) -> Bool {
-        stroke.matches(event: event, layoutCharacterProvider: shortcutLayoutCharacterProvider)
+        stroke.matches(
+            event: event,
+            characterResolver: shortcutEventCharacterResolver(for: event)
+        )
     }
 
     private func matchShortcut(event: NSEvent, shortcut: StoredShortcut) -> Bool {
-        shortcut.matches(event: event, layoutCharacterProvider: shortcutLayoutCharacterProvider)
+        shortcut.matches(
+            event: event,
+            characterResolver: shortcutEventCharacterResolver(for: event)
+        )
     }
 
     fileprivate func shouldRouteGhosttyGotoSplitCycleShortcutToTerminal(_ event: NSEvent) -> Bool {
@@ -16173,7 +16200,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         let hasUsableASCIIEventChars = !(eventCharsIgnoringModifiers?.isEmpty ?? true)
             && (eventCharsIgnoringModifiers?.allSatisfy(\.isASCII) ?? true)
         if !hasUsableASCIIEventChars || numberKeyDigit != nil {
-            let layoutCharacter = shortcutLayoutCharacterProvider(event.keyCode, event.modifierFlags)
+            let layoutCharacter = shortcutEventCharacterResolver(
+                for: event
+            ).asciiFallbackCharacters
             if let digit = numberedShortcutDigit(
                 eventCharacter: layoutCharacter,
                 applyShiftSymbolNormalization: false,

--- a/Sources/KeyboardLayout.swift
+++ b/Sources/KeyboardLayout.swift
@@ -109,16 +109,40 @@ class KeyboardLayout {
     }
     #endif
 
-    /// Return the ASCII-normalized equivalent of `event.charactersIgnoringModifiers`,
-    /// falling back through the ASCII-capable input source for non-Latin input methods.
+    /// Return the ASCII-normalized shortcut characters for an event, falling
+    /// back through the ASCII-capable input source for non-Latin input methods.
     /// Use this wherever code compares raw event characters against Latin shortcut keys.
     static func normalizedCharacters(for event: NSEvent) -> String {
-        let raw = (event.charactersIgnoringModifiers ?? "").lowercased()
-        if raw.allSatisfy(\.isASCII) { return raw }
-        if let layoutChar = character(forKeyCode: event.keyCode, modifierFlags: []) {
-            return layoutChar
+        let flags = ShortcutStroke.normalizedModifierFlags(
+            from: event.modifierFlags
+        )
+        if !flags.contains(.command) {
+            let raw = (event.charactersIgnoringModifiers ?? "").lowercased()
+            let isPrintableASCII = !raw.isEmpty && raw.unicodeScalars.allSatisfy {
+                $0.isASCII && !CharacterSet.controlCharacters.contains($0)
+            }
+            if isPrintableASCII { return raw }
+            return character(forKeyCode: event.keyCode)?.lowercased() ?? raw
         }
-        return raw
+        return normalizedCharacters(
+            for: event,
+            characterResolver: .live(for: event)
+        )
+    }
+
+    /// Normalize with an event-scoped resolver so exact and ASCII fallback
+    /// translations are shared with every shortcut candidate for this event.
+    static func normalizedCharacters(
+        for event: NSEvent,
+        characterResolver: ShortcutEventCharacterResolver
+    ) -> String {
+        assert(characterResolver.event === event)
+        let raw = (characterResolver.primaryCharacters ?? "").lowercased()
+        let isPrintableASCII = !raw.isEmpty && raw.unicodeScalars.allSatisfy {
+            $0.isASCII && !CharacterSet.controlCharacters.contains($0)
+        }
+        if isPrintableASCII { return raw }
+        return characterResolver.asciiFallbackCharacters?.lowercased() ?? raw
     }
 
     private static func characterFromInputSource(

--- a/Sources/KeyboardShortcutContext.swift
+++ b/Sources/KeyboardShortcutContext.swift
@@ -61,9 +61,21 @@ func shortcutResponderAcceptsTextEditing(_ responder: NSResponder) -> Bool {
     return false
 }
 
-struct ShortcutEventFocusContextCache {
+final class ShortcutEventFocusContextCache {
     let event: NSEvent
-    let context: ShortcutEventFocusContext
+    var context: ShortcutEventFocusContext?
+    var characterResolver: ShortcutEventCharacterResolver?
+
+    init(
+        event: NSEvent,
+        context: ShortcutEventFocusContext?,
+        characterResolver: ShortcutEventCharacterResolver?
+    ) {
+        self.event = event
+        self.context = context
+        self.characterResolver = characterResolver
+    }
+
 }
 
 extension Notification.Name {
@@ -95,8 +107,22 @@ extension AppDelegate {
     }
 
     func shortcutEventFocusContext(_ event: NSEvent) -> ShortcutEventFocusContext {
-        if let cache = shortcutEventFocusContextCache, cache.event === event {
-            return cache.context
+        if let cache = shortcutEventFocusContextCache,
+           cache.event === event,
+           let context = cache.context {
+            return context
+        }
+        let cache: ShortcutEventFocusContextCache
+        if let existingCache = shortcutEventFocusContextCache,
+           existingCache.event === event {
+            cache = existingCache
+        } else {
+            cache = ShortcutEventFocusContextCache(
+                event: event,
+                context: nil,
+                characterResolver: nil
+            )
+            shortcutEventFocusContextCache = cache
         }
 
         let shortcutWindow = shortcutResolvedEventWindow(event) ?? NSApp.keyWindow ?? NSApp.mainWindow
@@ -132,8 +158,35 @@ extension AppDelegate {
             rightSidebarFocused: rightSidebarFocused,
             shortcutContext: buildShortcutContext(focusState: focusState, window: shortcutWindow)
         )
-        shortcutEventFocusContextCache = ShortcutEventFocusContextCache(event: event, context: context)
+        cache.context = context
         return context
+    }
+
+    /// The event-scoped character resolver shared by every shortcut candidate
+    /// routed through AppDelegate. It lives with the existing focus snapshot so
+    /// both caches have the same NSEvent identity and cleanup boundary.
+    func shortcutEventCharacterResolver(
+        for event: NSEvent
+    ) -> ShortcutEventCharacterResolver {
+        if let cache = shortcutEventFocusContextCache,
+           cache.event === event,
+           let characterResolver = cache.characterResolver {
+            return characterResolver
+        }
+        let characterResolver = ShortcutEventCharacterResolver.live(
+            for: event,
+            layoutCharacterProvider: shortcutLayoutCharacterProvider
+        )
+        if let cache = shortcutEventFocusContextCache, cache.event === event {
+            cache.characterResolver = characterResolver
+        } else {
+            shortcutEventFocusContextCache = ShortcutEventFocusContextCache(
+                event: event,
+                context: nil,
+                characterResolver: characterResolver
+            )
+        }
+        return characterResolver
     }
 
     /// Builds the full ``ShortcutContext`` for a shortcut event: the focus atoms

--- a/Sources/KeyboardShortcutSettings.swift
+++ b/Sources/KeyboardShortcutSettings.swift
@@ -1618,24 +1618,45 @@ struct ShortcutStroke: Equatable, Hashable {
 
     func matches(
         event: NSEvent,
-        layoutCharacterProvider: (UInt16, NSEvent.ModifierFlags) -> String? = KeyboardLayout.character(forKeyCode:modifierFlags:)
+        layoutCharacterProvider: @escaping (UInt16, NSEvent.ModifierFlags) -> String? = KeyboardLayout.character(forKeyCode:modifierFlags:)
     ) -> Bool {
-        let shortcutKey = key.lowercased()
-        if shortcutKey.hasPrefix("media.") {
-            guard let eventMediaKey = Self.mediaKey(from: event)?.key.lowercased() else {
-                return false
-            }
-            return eventMediaKey == shortcutKey &&
-                Self.normalizedModifierFlags(from: event.modifierFlags) == modifierFlags
+        let preparation = matchPreparation(for: event)
+        if let result = preparation.resolvedResult {
+            return result
         }
-
-        guard event.type == .keyDown else { return false }
-
-        return matches(
-            keyCode: Self.recordableKey(from: event)?.keyCode ?? event.keyCode,
-            modifierFlags: event.modifierFlags,
-            eventCharacter: event.charactersIgnoringModifiers,
+        let characterResolver = ShortcutEventCharacterResolver.live(
+            for: event,
             layoutCharacterProvider: layoutCharacterProvider
+        )
+        return matchesCharacters(
+            keyCode: preparation.keyCode,
+            flags: preparation.flags,
+            shortcutKey: preparation.shortcutKey,
+            eventCharacter: characterResolver.primaryCharacters,
+            layoutCharacterProvider: { _, _ in
+                characterResolver.asciiFallbackCharacters
+            }
+        )
+    }
+
+    func matches(
+        event: NSEvent,
+        characterResolver: @autoclosure () -> ShortcutEventCharacterResolver
+    ) -> Bool {
+        let preparation = matchPreparation(for: event)
+        if let result = preparation.resolvedResult {
+            return result
+        }
+        let characterResolver = characterResolver()
+        assert(characterResolver.event === event)
+        return matchesCharacters(
+            keyCode: preparation.keyCode,
+            flags: preparation.flags,
+            shortcutKey: preparation.shortcutKey,
+            eventCharacter: characterResolver.primaryCharacters,
+            layoutCharacterProvider: { _, _ in
+                characterResolver.asciiFallbackCharacters
+            }
         )
     }
 
@@ -1648,22 +1669,89 @@ struct ShortcutStroke: Equatable, Hashable {
         let flags = Self.normalizedModifierFlags(from: modifierFlags)
         guard flags == self.modifierFlags else { return false }
 
+        let shortcutKey = key.lowercased()
+        if let directMatch = directKeyCodeMatch(
+            keyCode: keyCode,
+            shortcutKey: shortcutKey
+        ) {
+            return directMatch
+        }
+
+        return matchesCharacters(
+            keyCode: keyCode,
+            flags: flags,
+            shortcutKey: shortcutKey,
+            eventCharacter: eventCharacter,
+            layoutCharacterProvider: layoutCharacterProvider
+        )
+    }
+
+    private func matchPreparation(
+        for event: NSEvent
+    ) -> (
+        resolvedResult: Bool?,
+        keyCode: UInt16,
+        flags: NSEvent.ModifierFlags,
+        shortcutKey: String
+    ) {
+        let shortcutKey = key.lowercased()
+        let flags = Self.normalizedModifierFlags(from: event.modifierFlags)
+        if shortcutKey.hasPrefix("media.") {
+            guard let eventMediaKey = Self.mediaKey(from: event)?.key.lowercased() else {
+                return (false, event.keyCode, flags, shortcutKey)
+            }
+            return (
+                eventMediaKey == shortcutKey
+                    && flags == modifierFlags,
+                event.keyCode,
+                flags,
+                shortcutKey
+            )
+        }
+
+        guard event.type == .keyDown else {
+            return (false, event.keyCode, flags, shortcutKey)
+        }
+        guard flags == modifierFlags else {
+            return (false, event.keyCode, flags, shortcutKey)
+        }
+
+        let keyCode = Self.recordableKey(from: event)?.keyCode ?? event.keyCode
+        if let directMatch = directKeyCodeMatch(
+            keyCode: keyCode,
+            shortcutKey: shortcutKey
+        ) {
+            return (directMatch, keyCode, flags, shortcutKey)
+        }
+        return (nil, keyCode, flags, shortcutKey)
+    }
+
+    private func directKeyCodeMatch(
+        keyCode: UInt16,
+        shortcutKey: String
+    ) -> Bool? {
         if let recordedKeyCode = self.keyCode {
             return keyCode == recordedKeyCode
         }
-
-        let shortcutKey = key.lowercased()
         if Self.usesDirectKeyCodeMatching(shortcutKey) {
-            guard let expectedKeyCode = self.keyCode ?? Self.keyCodeForShortcutKey(shortcutKey) else {
+            guard let expectedKeyCode = Self.keyCodeForShortcutKey(shortcutKey) else {
                 return false
             }
             return keyCode == expectedKeyCode
         }
-
         if shortcutKey == "\r" {
             return keyCode == 36 || keyCode == 76
         }
+        return nil
+    }
 
+    private func matchesCharacters(
+        keyCode: UInt16,
+        flags: NSEvent.ModifierFlags,
+        shortcutKey: String,
+        eventCharacter: String?,
+        layoutCharacterProvider: (UInt16, NSEvent.ModifierFlags) -> String?
+    ) -> Bool {
         if Self.shortcutCharacterMatches(
             eventCharacter: eventCharacter,
             shortcutKey: shortcutKey,
@@ -1697,7 +1785,7 @@ struct ShortcutStroke: Equatable, Hashable {
             return false
         }
 
-        let layoutCharacter = layoutCharacterProvider(keyCode, modifierFlags)
+        let layoutCharacter = layoutCharacterProvider(keyCode, flags)
         if Self.shortcutCharacterMatches(
             eventCharacter: layoutCharacter,
             shortcutKey: shortcutKey,
@@ -2246,10 +2334,21 @@ struct StoredShortcut: Codable, Equatable, Hashable {
 
     func matches(
         event: NSEvent,
-        layoutCharacterProvider: (UInt16, NSEvent.ModifierFlags) -> String? = KeyboardLayout.character(forKeyCode:modifierFlags:)
+        layoutCharacterProvider: @escaping (UInt16, NSEvent.ModifierFlags) -> String? = KeyboardLayout.character(forKeyCode:modifierFlags:)
     ) -> Bool {
         guard !isUnbound, !hasChord else { return false }
         return firstStroke.matches(event: event, layoutCharacterProvider: layoutCharacterProvider)
+    }
+
+    func matches(
+        event: NSEvent,
+        characterResolver: @autoclosure () -> ShortcutEventCharacterResolver
+    ) -> Bool {
+        guard !isUnbound, !hasChord else { return false }
+        return firstStroke.matches(
+            event: event,
+            characterResolver: characterResolver()
+        )
     }
 
     func matches(

--- a/Sources/Panels/BrowserScreenshot.swift
+++ b/Sources/Panels/BrowserScreenshot.swift
@@ -56,7 +56,7 @@ private enum BrowserScreenshotFlash {
 }
 
 @MainActor
-private final class BrowserScreenshotSelectionOverlayView: NSView {
+final class BrowserScreenshotSelectionOverlayView: NSView {
     private let onFinish: (NSRect?) -> Void
     private let instructionBadgeView = FileDropHintBadgeView(frame: .zero)
     private var dragStart: NSPoint?
@@ -183,12 +183,14 @@ private final class BrowserScreenshotSelectionOverlayView: NSView {
         )
     }
 
-    private static func isCancelEvent(_ event: NSEvent) -> Bool {
+    nonisolated static func isCancelEvent(_ event: NSEvent) -> Bool {
         if event.keyCode == 53 {
             return true
         }
-        let modifiers = event.modifierFlags.intersection(.deviceIndependentFlagsMask)
-        return modifiers.contains(.command) && event.charactersIgnoringModifiers == "."
+        let modifiers = event.modifierFlags.intersection(
+            .deviceIndependentFlagsMask
+        )
+        return modifiers.contains(.command) && event.characters == "."
     }
 
     private func clampedPoint(_ point: NSPoint) -> NSPoint {

--- a/Sources/RightSidebarModeShortcutMatcher.swift
+++ b/Sources/RightSidebarModeShortcutMatcher.swift
@@ -34,22 +34,29 @@ final class RightSidebarModeShortcutMatcher {
         for event: NSEvent,
         allowingAction: (KeyboardShortcutSettings.Action) -> Bool
     ) -> RightSidebarMode? {
+        modeShortcut(
+            for: event,
+            characterResolver: .live(
+                for: event,
+                layoutCharacterProvider: layoutCharacterProvider
+            ),
+            allowingAction: allowingAction
+        )
+    }
+
+    func modeShortcut(
+        for event: NSEvent,
+        characterResolver: @autoclosure () -> ShortcutEventCharacterResolver,
+        allowingAction: (KeyboardShortcutSettings.Action) -> Bool
+    ) -> RightSidebarMode? {
         guard event.type == .keyDown else { return nil }
         let flags = ShortcutStroke.normalizedModifierFlags(from: event.modifierFlags)
         guard let entries = entriesByModifierRawValue[flags.rawValue] else { return nil }
-        var didResolveLayoutCharacter = false
-        var layoutCharacter: String?
-        let cachedLayoutCharacterProvider: LayoutCharacterProvider = { [layoutCharacterProvider] keyCode, modifiers in
-            if !didResolveLayoutCharacter {
-                layoutCharacter = layoutCharacterProvider(keyCode, modifiers)
-                didResolveLayoutCharacter = true
-            }
-            return layoutCharacter
-        }
+        let characterResolver = characterResolver()
         for entry in entries {
             guard entry.shortcut.matches(
                 event: event,
-                layoutCharacterProvider: cachedLayoutCharacterProvider
+                characterResolver: characterResolver
             ), availability(entry.mode), allowingAction(entry.action) else { continue }
             return entry.mode
         }

--- a/Sources/Search/GlobalSearchKeyEvent+QueryEditing.swift
+++ b/Sources/Search/GlobalSearchKeyEvent+QueryEditing.swift
@@ -26,8 +26,13 @@ extension GlobalSearchKeyEvent {
     }
 
     private var isCommandEditingCharacter: Bool {
-        guard let character = charactersIgnoringModifiers?.lowercased() else { return false }
+        guard let character = characters?.lowercased() else { return false }
         return ["a", "c", "v", "x", "z"].contains(character)
+    }
+
+    var isSystemCommand: Bool {
+        guard let character = characters?.lowercased() else { return false }
+        return ["h", "m", "q", "w", ","].contains(character)
     }
 
     private var isControlEditingCharacter: Bool {

--- a/Sources/Search/MenubarSearchPopover.swift
+++ b/Sources/Search/MenubarSearchPopover.swift
@@ -252,7 +252,7 @@ private struct GlobalSearchPaletteView: View {
         if flags.contains(.command),
            !flags.contains(.option),
            !flags.contains(.control),
-           let rawDigit = event.charactersIgnoringModifiers,
+           let rawDigit = event.characters,
            let digit = Int(rawDigit),
            (1...9).contains(digit) {
             openResult(at: digit - 1)
@@ -276,15 +276,10 @@ private struct GlobalSearchPaletteView: View {
             if flags.contains(.command),
                !flags.contains(.option),
                !flags.contains(.control) {
-                return !event.queryOwnsEditingShortcut && !isSystemCommand(event)
+                return !event.queryOwnsEditingShortcut && !event.isSystemCommand
             }
             return false
         }
-    }
-
-    private func isSystemCommand(_ event: GlobalSearchKeyEvent) -> Bool {
-        guard let characters = event.charactersIgnoringModifiers?.lowercased() else { return false }
-        return ["h", "m", "q", "w", ","].contains(characters)
     }
 
     private func openSelectedResult() {

--- a/Sources/ShortcutEventCharacterResolver.swift
+++ b/Sources/ShortcutEventCharacterResolver.swift
@@ -1,0 +1,98 @@
+import AppKit
+
+/// Resolves and caches the character planes used to match one AppKit key event.
+///
+/// Plain Command events trust `characters` because AppKit has already applied
+/// command-aware layouts such as Dvorak–QWERTY ⌘. When Option or Control is
+/// also held, those modifiers must not alter the shortcut key, so the exact
+/// current-layout Command/Shift plane is resolved first. A non-ASCII
+/// `charactersIgnoringModifiers` value preserves key-code-less Unicode
+/// bindings if exact retranslation is unavailable. The ASCII-capable layout is
+/// a separate fallback and is consulted only after those exact values miss.
+final class ShortcutEventCharacterResolver {
+    typealias ExactCharacterProvider = (NSEvent, NSEvent.ModifierFlags) -> String?
+    typealias LayoutCharacterProvider = (UInt16, NSEvent.ModifierFlags) -> String?
+
+    let event: NSEvent
+
+    private let exactCharacterProvider: ExactCharacterProvider
+    private let layoutCharacterProvider: LayoutCharacterProvider
+    private let normalizedModifierFlags: NSEvent.ModifierFlags
+    private var didResolvePrimaryCharacters = false
+    private var cachedPrimaryCharacters: String?
+    private var didResolveASCIIFallbackCharacters = false
+    private var cachedASCIIFallbackCharacters: String?
+
+    init(
+        event: NSEvent,
+        exactCharacterProvider: @escaping ExactCharacterProvider,
+        layoutCharacterProvider: @escaping LayoutCharacterProvider
+    ) {
+        self.event = event
+        self.exactCharacterProvider = exactCharacterProvider
+        self.layoutCharacterProvider = layoutCharacterProvider
+        normalizedModifierFlags = ShortcutStroke.normalizedModifierFlags(
+            from: event.modifierFlags
+        )
+    }
+
+    static func live(
+        for event: NSEvent,
+        layoutCharacterProvider: @escaping LayoutCharacterProvider =
+            KeyboardLayout.character(forKeyCode:modifierFlags:)
+    ) -> ShortcutEventCharacterResolver {
+        ShortcutEventCharacterResolver(
+            event: event,
+            exactCharacterProvider: { event, modifiers in
+                event.characters(byApplyingModifiers: modifiers)
+            },
+            layoutCharacterProvider: layoutCharacterProvider
+        )
+    }
+
+    var primaryCharacters: String? {
+        if !didResolvePrimaryCharacters {
+            cachedPrimaryCharacters = resolvePrimaryCharacters()
+            didResolvePrimaryCharacters = true
+        }
+        return cachedPrimaryCharacters
+    }
+
+    var asciiFallbackCharacters: String? {
+        if !didResolveASCIIFallbackCharacters {
+            cachedASCIIFallbackCharacters = layoutCharacterProvider(
+                event.keyCode,
+                normalizedModifierFlags
+            )
+            didResolveASCIIFallbackCharacters = true
+        }
+        return cachedASCIIFallbackCharacters
+    }
+
+    private func resolvePrimaryCharacters() -> String? {
+        guard normalizedModifierFlags.contains(.command) else {
+            return event.charactersIgnoringModifiers
+        }
+        guard normalizedModifierFlags.contains(.option)
+            || normalizedModifierFlags.contains(.control) else {
+            return event.characters
+        }
+
+        let commandPlaneModifiers = normalizedModifierFlags.intersection([
+            .command,
+            .shift,
+        ])
+        if let exactCharacters = exactCharacterProvider(
+            event,
+            commandPlaneModifiers
+        ), !exactCharacters.isEmpty {
+            return exactCharacters
+        }
+
+        if let charactersIgnoringModifiers = event.charactersIgnoringModifiers,
+           charactersIgnoringModifiers.unicodeScalars.contains(where: { !$0.isASCII }) {
+            return charactersIgnoringModifiers
+        }
+        return nil
+    }
+}

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -1844,6 +1844,7 @@ C0DE71B10000000000000001 /* AppDelegate+AgentChatNotifications.swift in Sources 
 		1521D55DC63D5E5FC4955E31 /* ShortcutAndCommandPaletteTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6083A7DAD962E287FC2FFE94 /* ShortcutAndCommandPaletteTests.swift */; };
 		76027A12C93B4538BF22C71E /* ShortcutBareStartRouting.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB7F2E9143904957AAA70726 /* ShortcutBareStartRouting.swift */; };
 		5C0DE0DE0000000000000004 /* ShortcutDiscoveryButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C0DE0DE0000000000000003 /* ShortcutDiscoveryButton.swift */; };
+		7511C0DE0000000000000001 /* ShortcutEventCharacterResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7511C0DE0000000000000002 /* ShortcutEventCharacterResolver.swift */; };
 		6042A0036042A0036042A003 /* ShortcutHintDebugSettingsBindingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6042B0036042B0036042B003 /* ShortcutHintDebugSettingsBindingTests.swift */; };
 		6042A0016042A0016042A001 /* ShortcutHintModifierPolicyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6042B0016042B0016042B001 /* ShortcutHintModifierPolicyTests.swift */; };
 		125BAEF2FE3B454547B964D1 /* ShortcutHintPill.swift in Sources */ = {isa = PBXBuildFile; fileRef = A080D1F6CCCBFBED8D95DD1D /* ShortcutHintPill.swift */; };
@@ -4436,6 +4437,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 		6083A7DAD962E287FC2FFE94 /* ShortcutAndCommandPaletteTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShortcutAndCommandPaletteTests.swift; sourceTree = "<group>"; };
 		AB7F2E9143904957AAA70726 /* ShortcutBareStartRouting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = App/ShortcutBareStartRouting.swift; sourceTree = "<group>"; };
 		5C0DE0DE0000000000000003 /* ShortcutDiscoveryButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShortcutDiscoveryButton.swift; sourceTree = "<group>"; };
+		7511C0DE0000000000000002 /* ShortcutEventCharacterResolver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShortcutEventCharacterResolver.swift; sourceTree = "<group>"; };
 		6042B0036042B0036042B003 /* ShortcutHintDebugSettingsBindingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShortcutHintDebugSettingsBindingTests.swift; sourceTree = "<group>"; };
 		6042B0016042B0016042B001 /* ShortcutHintModifierPolicyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShortcutHintModifierPolicyTests.swift; sourceTree = "<group>"; };
 		A080D1F6CCCBFBED8D95DD1D /* ShortcutHintPill.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShortcutHintPill.swift; sourceTree = "<group>"; };
@@ -5977,6 +5979,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				A5FB1309 /* JSONCObjectEditor+Remove.swift */,
 				A5FB1310 /* JSONCObjectEditor+Set.swift */,
 				A50012F4 /* KeyboardLayout.swift */,
+				7511C0DE0000000000000002 /* ShortcutEventCharacterResolver.swift */,
 				C06552010000000000000004 /* NotificationBurstCoalescer.swift */,
 				C06552010000000000000002 /* PanelTitleUpdateCoalescingSettings.swift */,
 				A5001013 /* TabManager.swift */,
@@ -9506,6 +9509,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				F0ACC0DE0000000000000007 /* SharedLiveAgentIndexLoader.swift in Sources */,
 				76027A12C93B4538BF22C71E /* ShortcutBareStartRouting.swift in Sources */,
 				5C0DE0DE0000000000000004 /* ShortcutDiscoveryButton.swift in Sources */,
+				7511C0DE0000000000000001 /* ShortcutEventCharacterResolver.swift in Sources */,
 				125BAEF2FE3B454547B964D1 /* ShortcutHintPill.swift in Sources */,
 				6042C0046042C0046042C004 /* ShortcutHintTitlebarPolicy.swift in Sources */,
 				D35A00000000000000000010 /* ShortcutRecorderRejectedAttempt.swift in Sources */,

--- a/cmuxTests/BrowserScreenshotCropTests.swift
+++ b/cmuxTests/BrowserScreenshotCropTests.swift
@@ -75,6 +75,37 @@ struct BrowserScreenshotCropTests {
     }()
 
     @Test
+    func selectionCancelUsesResolvedCommandPlaneCharacter() throws {
+        let cancelEvent = try #require(NSEvent.keyEvent(
+            with: .keyDown,
+            location: .zero,
+            modifierFlags: [.command],
+            timestamp: 0,
+            windowNumber: 0,
+            context: nil,
+            characters: ".",
+            charactersIgnoringModifiers: "e",
+            isARepeat: false,
+            keyCode: 47
+        ))
+        let nonCancelEvent = try #require(NSEvent.keyEvent(
+            with: .keyDown,
+            location: .zero,
+            modifierFlags: [.command],
+            timestamp: 0,
+            windowNumber: 0,
+            context: nil,
+            characters: "e",
+            charactersIgnoringModifiers: ".",
+            isARepeat: false,
+            keyCode: 47
+        ))
+
+        #expect(BrowserScreenshotSelectionOverlayView.isCancelEvent(cancelEvent))
+        #expect(!BrowserScreenshotSelectionOverlayView.isCancelEvent(nonCancelEvent))
+    }
+
+    @Test
     func extremeAspectRatioBoundIsConstantTimeAndWithinPixelLimit() throws {
         let size = try BrowserScreenshotCaptureBounds.boundedOutputSize(
             for: NSSize(width: 100_000_000, height: 1),

--- a/cmuxTests/GlobalSearchVisiblePopoverShortcutTests.swift
+++ b/cmuxTests/GlobalSearchVisiblePopoverShortcutTests.swift
@@ -255,6 +255,34 @@ extension GlobalSearchShortcutBehaviorTests {
         )
     }
 
+    @Test func commandPlaneDrivesDvorakEditingAndSystemCommands() throws {
+        let copyEvent = try makeKeyDownEvent(
+            key: "j",
+            characters: "c",
+            modifiers: [.command],
+            keyCode: 8,
+            windowNumber: 0
+        )
+        let quitEvent = try makeKeyDownEvent(
+            key: "'",
+            characters: "q",
+            modifiers: [.command],
+            keyCode: 12,
+            windowNumber: 0
+        )
+        let settingsEvent = try makeKeyDownEvent(
+            key: "w",
+            characters: ",",
+            modifiers: [.command],
+            keyCode: 43,
+            windowNumber: 0
+        )
+
+        #expect(GlobalSearchKeyEvent(copyEvent).queryOwnsEditingShortcut)
+        #expect(GlobalSearchKeyEvent(quitEvent).isSystemCommand)
+        #expect(GlobalSearchKeyEvent(settingsEvent).isSystemCommand)
+    }
+
     @Test func visibleGlobalSearchQueryOwnsBareSpaceShortcut() throws {
 #if DEBUG
         let appDelegate = try #require(AppDelegate.shared)

--- a/cmuxTests/KeyboardShortcutContextSwiftTests.swift
+++ b/cmuxTests/KeyboardShortcutContextSwiftTests.swift
@@ -1,3 +1,4 @@
+import AppKit
 import CmuxCommandPalette
 import CmuxSettings
 import Foundation
@@ -273,6 +274,35 @@ extension CMUXCLIErrorOutputRegressionTests {
 
 @Suite("Stored shortcut physical-key matching")
 struct StoredShortcutPhysicalKeyMatchingTests {
+    @Test("Command-plane character matches on Dvorak – QWERTY Command")
+    func commandPlaneCharacterMatchesOnDvorakQwertyCommand() throws {
+        let shortcut = SimulatorStoredShortcut(
+            key: "t",
+            command: true,
+            shift: false,
+            option: false,
+            control: false
+        )
+        let event = try #require(NSEvent.keyEvent(
+            with: .keyDown,
+            location: .zero,
+            modifierFlags: [.command],
+            timestamp: ProcessInfo.processInfo.systemUptime,
+            windowNumber: 0,
+            context: nil,
+            characters: "t",
+            charactersIgnoringModifiers: "y",
+            isARepeat: false,
+            keyCode: 17
+        ))
+
+        #expect(KeyboardLayout.normalizedCharacters(for: event) == "t")
+        #expect(shortcut.matches(
+            event: event,
+            layoutCharacterProvider: { _, _ in "t" }
+        ))
+    }
+
     @Test("recorded Option shortcut matches its physical key across layouts")
     func recordedOptionShortcutMatchesPhysicalKeyAcrossLayouts() {
         let shortcut = StoredShortcut(

--- a/cmuxTests/KeyboardShortcutContextSwiftTests.swift
+++ b/cmuxTests/KeyboardShortcutContextSwiftTests.swift
@@ -297,10 +297,374 @@ struct StoredShortcutPhysicalKeyMatchingTests {
         ))
 
         #expect(KeyboardLayout.normalizedCharacters(for: event) == "t")
+        var providerWasCalled = false
         #expect(shortcut.matches(
             event: event,
-            layoutCharacterProvider: { _, _ in "t" }
+            layoutCharacterProvider: { _, _ in
+                providerWasCalled = true
+                return "y"
+            }
         ))
+        let unmodifiedPlaneShortcut = SimulatorStoredShortcut(
+            key: "y",
+            command: true,
+            shift: false,
+            option: false,
+            control: false
+        )
+        #expect(!unmodifiedPlaneShortcut.matches(
+            event: event,
+            layoutCharacterProvider: { _, _ in
+                providerWasCalled = true
+                return "y"
+            }
+        ))
+        #expect(!providerWasCalled)
+    }
+
+    @Test("Command-Option matching keeps the base shortcut key")
+    func commandOptionMatchingKeepsBaseShortcutKey() throws {
+        let shortcut = StoredShortcut(
+            key: "n",
+            command: true,
+            shift: false,
+            option: true,
+            control: false
+        )
+        let event = try #require(NSEvent.keyEvent(
+            with: .keyDown,
+            location: .zero,
+            modifierFlags: [.command, .option],
+            timestamp: ProcessInfo.processInfo.systemUptime,
+            windowNumber: 0,
+            context: nil,
+            characters: "~",
+            charactersIgnoringModifiers: "n",
+            isARepeat: false,
+            keyCode: 45
+        ))
+
+        var resolvedFlags: NSEvent.ModifierFlags?
+        var fallbackCallCount = 0
+        let characterResolver = ShortcutEventCharacterResolver(
+            event: event,
+            exactCharacterProvider: { _, flags in
+                resolvedFlags = flags
+                return "n"
+            },
+            layoutCharacterProvider: { _, _ in
+                fallbackCallCount += 1
+                return "n"
+            }
+        )
+        #expect(shortcut.matches(
+            event: event,
+            characterResolver: characterResolver
+        ))
+        #expect(resolvedFlags == [.command])
+        #expect(fallbackCallCount == 0)
+    }
+
+    @Test("Command palette field editor uses the Command plane")
+    @MainActor
+    func commandPaletteFieldEditorUsesCommandPlane() throws {
+        let previousShortcut = StoredShortcut(
+            key: "n",
+            command: true,
+            shift: false,
+            option: true,
+            control: false
+        )
+        let event = try #require(NSEvent.keyEvent(
+            with: .keyDown,
+            location: .zero,
+            modifierFlags: [.command, .option],
+            timestamp: 0,
+            windowNumber: 0,
+            context: nil,
+            characters: "~",
+            charactersIgnoringModifiers: "n",
+            isARepeat: false,
+            keyCode: 45
+        ))
+
+        var exactModifiers: NSEvent.ModifierFlags?
+        var fallbackCallCount = 0
+        #expect(
+            commandPaletteSelectionDeltaForFieldEditorCommand(
+                #selector(NSResponder.moveUp(_:)),
+                event: event,
+                previousShortcut: previousShortcut,
+                exactCharacterProvider: { _, modifiers in
+                    exactModifiers = modifiers
+                    return "n"
+                },
+                layoutCharacterProvider: { _, _ in
+                    fallbackCallCount += 1
+                    return "n"
+                }
+            ) == -1
+        )
+        #expect(exactModifiers == [.command])
+        #expect(fallbackCallCount == 0)
+    }
+
+    @Test("Modifier mismatch performs no character translation")
+    func modifierMismatchPerformsNoCharacterTranslation() throws {
+        let shortcut = StoredShortcut(
+            key: "n",
+            command: true,
+            shift: false,
+            option: true,
+            control: false
+        )
+        let event = try #require(NSEvent.keyEvent(
+            with: .keyDown,
+            location: .zero,
+            modifierFlags: [.command],
+            timestamp: 0,
+            windowNumber: 0,
+            context: nil,
+            characters: "n",
+            charactersIgnoringModifiers: "n",
+            isARepeat: false,
+            keyCode: 45
+        ))
+
+        var exactCallCount = 0
+        var fallbackCallCount = 0
+        let characterResolver = ShortcutEventCharacterResolver(
+            event: event,
+            exactCharacterProvider: { _, _ in
+                exactCallCount += 1
+                return "n"
+            },
+            layoutCharacterProvider: { _, _ in
+                fallbackCallCount += 1
+                return "n"
+            }
+        )
+
+        #expect(!shortcut.matches(
+            event: event,
+            characterResolver: characterResolver
+        ))
+        #expect(exactCallCount == 0)
+        #expect(fallbackCallCount == 0)
+    }
+
+    @Test("Recorded key code performs no character translation")
+    func recordedKeyCodePerformsNoCharacterTranslation() throws {
+        let shortcut = StoredShortcut(
+            key: "n",
+            command: true,
+            shift: false,
+            option: true,
+            control: false,
+            keyCode: 45
+        )
+        let event = try #require(NSEvent.keyEvent(
+            with: .keyDown,
+            location: .zero,
+            modifierFlags: [.command, .option],
+            timestamp: 0,
+            windowNumber: 0,
+            context: nil,
+            characters: "~",
+            charactersIgnoringModifiers: "n",
+            isARepeat: false,
+            keyCode: 45
+        ))
+
+        var exactCallCount = 0
+        var fallbackCallCount = 0
+        let characterResolver = ShortcutEventCharacterResolver(
+            event: event,
+            exactCharacterProvider: { _, _ in
+                exactCallCount += 1
+                return "n"
+            },
+            layoutCharacterProvider: { _, _ in
+                fallbackCallCount += 1
+                return "n"
+            }
+        )
+
+        #expect(shortcut.matches(
+            event: event,
+            characterResolver: characterResolver
+        ))
+        #expect(exactCallCount == 0)
+        #expect(fallbackCallCount == 0)
+    }
+
+    @Test("Multiple candidates share one exact and fallback translation")
+    func multipleCandidatesShareCharacterTranslation() throws {
+        let event = try #require(NSEvent.keyEvent(
+            with: .keyDown,
+            location: .zero,
+            modifierFlags: [.command, .option],
+            timestamp: 0,
+            windowNumber: 0,
+            context: nil,
+            characters: "~",
+            charactersIgnoringModifiers: "n",
+            isARepeat: false,
+            keyCode: 45
+        ))
+
+        var exactCallCount = 0
+        var fallbackCallCount = 0
+        let characterResolver = ShortcutEventCharacterResolver(
+            event: event,
+            exactCharacterProvider: { _, _ in
+                exactCallCount += 1
+                return "ø"
+            },
+            layoutCharacterProvider: { _, _ in
+                fallbackCallCount += 1
+                return "z"
+            }
+        )
+        let firstCandidate = StoredShortcut(
+            key: "x",
+            command: true,
+            shift: false,
+            option: true,
+            control: false
+        )
+        let secondCandidate = StoredShortcut(
+            key: "z",
+            command: true,
+            shift: false,
+            option: true,
+            control: false
+        )
+
+        #expect(!firstCandidate.matches(
+            event: event,
+            characterResolver: characterResolver
+        ))
+        #expect(secondCandidate.matches(
+            event: event,
+            characterResolver: characterResolver
+        ))
+        #expect(exactCallCount == 1)
+        #expect(fallbackCallCount == 1)
+    }
+
+    @Test("Exact Unicode Command plane wins before ASCII fallback")
+    func exactUnicodeCommandPlaneWinsBeforeASCIIFallback() throws {
+        let event = try #require(NSEvent.keyEvent(
+            with: .keyDown,
+            location: .zero,
+            modifierFlags: [.command, .option],
+            timestamp: 0,
+            windowNumber: 0,
+            context: nil,
+            characters: "~",
+            charactersIgnoringModifiers: "ㄴ",
+            isARepeat: false,
+            keyCode: 45
+        ))
+        var fallbackCallCount = 0
+        let characterResolver = ShortcutEventCharacterResolver(
+            event: event,
+            exactCharacterProvider: { _, _ in "ㄴ" },
+            layoutCharacterProvider: { _, _ in
+                fallbackCallCount += 1
+                return "n"
+            }
+        )
+        let shortcut = StoredShortcut(
+            key: "ㄴ",
+            command: true,
+            shift: false,
+            option: true,
+            control: false
+        )
+
+        #expect(shortcut.matches(
+            event: event,
+            characterResolver: characterResolver
+        ))
+        #expect(fallbackCallCount == 0)
+    }
+
+    @Test("Missing exact translation preserves non-ASCII event characters")
+    func missingExactTranslationPreservesUnicodeEventCharacters() throws {
+        let event = try #require(NSEvent.keyEvent(
+            with: .keyDown,
+            location: .zero,
+            modifierFlags: [.command, .option],
+            timestamp: 0,
+            windowNumber: 0,
+            context: nil,
+            characters: "",
+            charactersIgnoringModifiers: "ㄴ",
+            isARepeat: false,
+            keyCode: 45
+        ))
+        var fallbackCallCount = 0
+        let characterResolver = ShortcutEventCharacterResolver(
+            event: event,
+            exactCharacterProvider: { _, _ in nil },
+            layoutCharacterProvider: { _, _ in
+                fallbackCallCount += 1
+                return "n"
+            }
+        )
+        let shortcut = StoredShortcut(
+            key: "ㄴ",
+            command: true,
+            shift: false,
+            option: true,
+            control: false
+        )
+
+        #expect(shortcut.matches(
+            event: event,
+            characterResolver: characterResolver
+        ))
+        #expect(fallbackCallCount == 0)
+    }
+
+    @Test("Dead-key exact miss falls back to the ASCII shortcut plane")
+    func deadKeyExactMissFallsBackToASCIIPlane() throws {
+        let event = try #require(NSEvent.keyEvent(
+            with: .keyDown,
+            location: .zero,
+            modifierFlags: [.command, .option],
+            timestamp: 0,
+            windowNumber: 0,
+            context: nil,
+            characters: "",
+            charactersIgnoringModifiers: "n",
+            isARepeat: false,
+            keyCode: 45
+        ))
+        var fallbackCallCount = 0
+        let characterResolver = ShortcutEventCharacterResolver(
+            event: event,
+            exactCharacterProvider: { _, _ in nil },
+            layoutCharacterProvider: { _, _ in
+                fallbackCallCount += 1
+                return "n"
+            }
+        )
+        let shortcut = StoredShortcut(
+            key: "n",
+            command: true,
+            shift: false,
+            option: true,
+            control: false
+        )
+
+        #expect(shortcut.matches(
+            event: event,
+            characterResolver: characterResolver
+        ))
+        #expect(fallbackCallCount == 1)
     }
 
     @Test("recorded Option shortcut matches its physical key across layouts")

--- a/cmuxTests/ViewerNavigationTests.swift
+++ b/cmuxTests/ViewerNavigationTests.swift
@@ -227,7 +227,8 @@ struct ViewerNavigationTests {
                 simulatorFocused: false,
                 rightSidebarFocused: false,
                 shortcutContext: shortcutContext
-            )
+            ),
+            characterResolver: .live(for: event)
         )
 
         #expect(contextAwareCommandPaletteSelectionDelta(for: event) == nil)
@@ -379,7 +380,8 @@ struct ViewerNavigationTests {
                 simulatorFocused: false,
                 rightSidebarFocused: false,
                 shortcutContext: shortcutContext
-            )
+            ),
+            characterResolver: .live(for: event)
         )
     }
 


### PR DESCRIPTION
## Summary

- Resolve Command shortcuts from AppKit modifier-aware event characters so Dvorak–QWERTY ⌘ uses its QWERTY Command plane.
- Reuse one event-scoped `ShortcutEventCharacterResolver` across stored bindings, command palette routing, global search, sidebar modes, and screenshot cancellation.
- Preserve the intended base key for Command+Option/Control shortcuts by translating the exact Command/Shift plane before using the ASCII-capable fallback.

Fixes #7511

## Testing

- Red proof: [hosted run 30886812511](https://github.com/manaflow-ai/cmux/actions/runs/30886812511) checked out test-only commit `b0e8893d5b4d69a9696e9b3282695fb9abf859f0`; the new Dvorak–QWERTY Command regression failed with `"y" != "t"` and rejected Cmd+T.
- Green proof: [hosted run 30887675353](https://github.com/manaflow-ai/cmux/actions/runs/30887675353) passed the focused regression after the implementation landed.
- Final-head fleet proof: run `sym7511-tests9-e484fe733958` tested commit `a4afd132bcdc351ce613c47f38b61b05259e3404` with the `cmux-unit` scheme and five focused `-only-testing` filters; all 14 tests in 5 suites passed. A broader run exposed the existing global-search chord failure, and exact pre-PR baseline run `sym7511-basechord-3540f994f8e7` failed at the same assertion on the same fleet host.
- Project guards: `./scripts/check-pbxproj.sh`, `./scripts/lint-pbxproj-test-wiring.sh`, `python3 scripts/check-package-resolved-policy.py`, and `git diff --check f4cd2774de..HEAD`.
- Tagged dev build: `./scripts/reload-cloud.sh --builder fleet --host cmux9s-mac-mini --tag sym7511 --launch` built exact final commit `a4afd132bcdc351ce613c47f38b61b05259e3404` as fleet run `sym7511-496d68181db1`; no local fallback was used.
- Dogfood on `/tmp/cmux-debug-sym7511.sock`: with `com.apple.keylayout.DVORAK-QWERTYCMD` active, the app had 5 surfaces; simulated Cmd+physical-QWERTY-Y left it at 5, while Cmd+physical-QWERTY-T created and selected `surface:6` (6 total). Restored the U.S. layout, disabled the temporary Dvorak input source, quit with `pkill -f "DerivedData/cmux-sym7511"`, and confirmed the tagged process and socket were gone.
- Clean-head review: the canonical branch autoreview exited 0 with no findings at 0.93 confidence; the merge-conflict gate and cmux policy checks were clean.
- Localization audit: no user-facing strings, shortcut definitions, Settings schema, docs, localization resources, or message catalogs changed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/9537"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788418111&installation_model_id=21920&pr_number=9537&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F9537&signature=14f648ec1754ed7b456ae91e80c7aa5a7c8cb71e939d1f77149f9db22aba85e2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Command shortcuts on macOS Dvorak–QWERTY Command layouts by honoring AppKit’s Command-plane characters across the app. Cmd+T and similar now fire on the QWERTY Command layer, and Command+Option/Control keeps the intended base key. Fixes #7511.

- **Bug Fixes**
  - Use a per-event `ShortcutEventCharacterResolver` to trust Command-plane `characters` and cache an ASCII fallback; shared via AppDelegate’s focus-context and applied to shortcut matching, command palette (incl. field editor), right sidebar modes, global search, and screenshot overlay cancel (Cmd+.).
  - For Command+Option/Control, resolve the exact Command/Shift plane first; preserve non-ASCII/dead-key `charactersIgnoringModifiers`; skip translation on modifier mismatch or recorded key codes; ensure global search digits (Cmd+1–9) and system/editing commands read command-plane `characters`. Add tests for Dvorak–QWERTY ⌘, Command+Option base key, Unicode vs ASCII fallback, single resolver reuse across candidates, and field editor behavior.

- **Refactors**
  - Introduced `ShortcutEventCharacterResolver`; updated `KeyboardLayout.normalizedCharacters`, `KeyboardShortcutSettings` matching, and the focus-context cache to share one resolver per event and avoid redundant translations.

<sup>Written for commit a4afd132bcdc351ce613c47f38b61b05259e3404. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/9537?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved keyboard shortcut recognition across different keyboard layouts, including Dvorak and QWERTY.
  - Corrected matching for Command-Option shortcuts while preserving the intended physical key.
  - Improved handling of non-printable and layout-translated shortcut characters.

- **Tests**
  - Added regression coverage for keyboard-layout-specific shortcut matching.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
