### PR TITLE
Preserve Iroh sessions across relay policy refresh

### DIFF
--- a/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohClientRuntime+RelayPolicy.swift
+++ b/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohClientRuntime+RelayPolicy.swift
@@ -40,10 +40,34 @@ extension CmxIrohClientRuntime {
             throw CmxIrohClientRuntimeError.relayFleetMismatch
         }
         let revision = lifecycleRevision
-        try await connectivityEngine.replaceRelayProfile(
-            profile,
-            expectedIdentity: binding.endpointID
-        )
+
+        await relayCoordinator?.deactivate()
+        relayCoordinator = nil
+        if profile.source == .managed, !profile.allowedRelayURLs.isEmpty {
+            let coordinator = CmxIrohRelayCredentialCoordinator(
+                supervisor: connectivityEngine,
+                broker: broker,
+                managedRelayURLs: replacementManagedURLs,
+                selectedRelayURLs: profile.allowedRelayURLs,
+                retrySchedule: .foregroundClient,
+                automaticRefreshEnabled: automaticRelayCredentialRefreshEnabled,
+                credentialDidInstall: { [handleRelayCredential] response in
+                    await handleRelayCredential(response, binding)
+                }
+            )
+            relayCoordinator = coordinator
+            try await coordinator.activateManagedPolicy(
+                bindingID: binding.bindingID,
+                endpointIdentity: binding.endpointID,
+                profile: profile,
+                bootstrap: relayBootstrap
+            )
+        } else {
+            try await connectivityEngine.replaceRelayProfile(
+                profile,
+                expectedIdentity: binding.endpointID
+            )
+        }
         try requireCurrent(revision)
 
         managedRelayURLs = replacementManagedURLs
@@ -98,32 +122,5 @@ extension CmxIrohClientRuntime {
         }
         await contextRouter.install(provider)
         try requireCurrent(revision)
-
-        await relayCoordinator?.deactivate()
-        relayCoordinator = nil
-        guard profile.source == .managed,
-              !profile.allowedRelayURLs.isEmpty else { return }
-        let coordinator = CmxIrohRelayCredentialCoordinator(
-            supervisor: connectivityEngine,
-            broker: broker,
-            managedRelayURLs: replacementManagedURLs,
-            selectedRelayURLs: profile.allowedRelayURLs,
-            retrySchedule: .foregroundClient,
-            automaticRefreshEnabled: automaticRelayCredentialRefreshEnabled,
-            credentialDidInstall: { [handleRelayCredential] response in
-                await handleRelayCredential(response, binding)
-            }
-        )
-        relayCoordinator = coordinator
-        do {
-            try await coordinator.activate(
-                bindingID: binding.bindingID,
-                endpointIdentity: binding.endpointID,
-                bootstrap: relayBootstrap
-            )
-        } catch {
-            // The verified allowlist is already live; direct paths remain usable
-            // while the coordinator retries a managed credential refresh.
-        }
     }
 }

--- a/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohClientRuntime+RelayPolicy.swift
+++ b/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohClientRuntime+RelayPolicy.swift
@@ -56,12 +56,20 @@ extension CmxIrohClientRuntime {
                 }
             )
             relayCoordinator = coordinator
-            try await coordinator.activateManagedPolicy(
-                bindingID: binding.bindingID,
-                endpointIdentity: binding.endpointID,
-                profile: profile,
-                bootstrap: relayBootstrap
-            )
+            do {
+                try await coordinator.activateManagedPolicy(
+                    bindingID: binding.bindingID,
+                    endpointIdentity: binding.endpointID,
+                    profile: profile,
+                    bootstrap: relayBootstrap
+                )
+            } catch {
+                await coordinator.deactivate()
+                if relayCoordinator === coordinator {
+                    relayCoordinator = nil
+                }
+                throw error
+            }
         } else {
             try await connectivityEngine.replaceRelayProfile(
                 profile,

--- a/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohHostRuntime+RelayPolicy.swift
+++ b/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohHostRuntime+RelayPolicy.swift
@@ -42,42 +42,39 @@ extension CmxIrohHostRuntime {
             throw CmxIrohHostRuntimeError.relayFleetMismatch
         }
         let revision = lifecycleRevision
-        try await connectivityEngine.replaceRelayProfile(
-            profile,
-            expectedIdentity: binding.endpointID
-        )
+
+        relayActivationTask?.cancel()
+        relayActivationTask = nil
+        await relayCoordinator?.deactivate()
+        relayCoordinator = nil
+        if profile.source == .managed, !profile.allowedRelayURLs.isEmpty {
+            let coordinator = CmxIrohRelayCredentialCoordinator(
+                supervisor: connectivityEngine,
+                broker: broker,
+                managedRelayURLs: replacementManagedURLs,
+                selectedRelayURLs: profile.allowedRelayURLs,
+                credentialDidInstall: { [handleRelayCredential] response in
+                    await handleRelayCredential(response, binding)
+                }
+            )
+            relayCoordinator = coordinator
+            try await coordinator.activateManagedPolicy(
+                bindingID: binding.bindingID,
+                endpointIdentity: binding.endpointID,
+                profile: profile,
+                bootstrap: relayBootstrap
+            )
+        } else {
+            try await connectivityEngine.replaceRelayProfile(
+                profile,
+                expectedIdentity: binding.endpointID
+            )
+        }
         try requireCurrent(revision)
 
         managedRelayURLs = replacementManagedURLs
         currentEndpointRelayProfile = profile
         await admissionController?.updateManagedRelayURLs(replacementManagedURLs)
         try requireCurrent(revision)
-
-        relayActivationTask?.cancel()
-        relayActivationTask = nil
-        await relayCoordinator?.deactivate()
-        relayCoordinator = nil
-        guard profile.source == .managed,
-              !profile.allowedRelayURLs.isEmpty else { return }
-        let coordinator = CmxIrohRelayCredentialCoordinator(
-            supervisor: connectivityEngine,
-            broker: broker,
-            managedRelayURLs: replacementManagedURLs,
-            selectedRelayURLs: profile.allowedRelayURLs,
-            credentialDidInstall: { [handleRelayCredential] response in
-                await handleRelayCredential(response, binding)
-            }
-        )
-        relayCoordinator = coordinator
-        do {
-            try await coordinator.activate(
-                bindingID: binding.bindingID,
-                endpointIdentity: binding.endpointID,
-                bootstrap: relayBootstrap
-            )
-        } catch {
-            // The verified allowlist is already live; direct paths remain usable
-            // while the coordinator retries a managed credential refresh.
-        }
     }
 }

--- a/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohHostRuntime+RelayPolicy.swift
+++ b/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohHostRuntime+RelayPolicy.swift
@@ -58,12 +58,20 @@ extension CmxIrohHostRuntime {
                 }
             )
             relayCoordinator = coordinator
-            try await coordinator.activateManagedPolicy(
-                bindingID: binding.bindingID,
-                endpointIdentity: binding.endpointID,
-                profile: profile,
-                bootstrap: relayBootstrap
-            )
+            do {
+                try await coordinator.activateManagedPolicy(
+                    bindingID: binding.bindingID,
+                    endpointIdentity: binding.endpointID,
+                    profile: profile,
+                    bootstrap: relayBootstrap
+                )
+            } catch {
+                await coordinator.deactivate()
+                if relayCoordinator === coordinator {
+                    relayCoordinator = nil
+                }
+                throw error
+            }
         } else {
             try await connectivityEngine.replaceRelayProfile(
                 profile,

--- a/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohRelayCredentialCoordinator.swift
+++ b/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohRelayCredentialCoordinator.swift
@@ -92,14 +92,10 @@ public actor CmxIrohRelayCredentialCoordinator {
         bootstrap: CmxIrohRelayTokenResponse? = nil,
         waitForInitialCredential: Bool = false
     ) async throws {
-        lifecycleRevision &+= 1
-        let revision = lifecycleRevision
-        refreshTask?.cancel()
-        inFlightRefresh?.task.cancel()
-        inFlightRefresh = nil
-        let expectedBinding = Binding(id: bindingID, endpointIdentity: endpointIdentity)
-        binding = expectedBinding
-        installedCredential = nil
+        let (expectedBinding, revision) = beginActivation(
+            bindingID: bindingID,
+            endpointIdentity: endpointIdentity
+        )
 
         if let bootstrap {
             do {
@@ -165,6 +161,111 @@ public actor CmxIrohRelayCredentialCoordinator {
                 )
             }
         }
+    }
+
+    /// Replaces one live managed relay policy and starts credential refresh.
+    ///
+    /// The coordinator owns the endpoint mutation so a policy bootstrap is
+    /// installed exactly once. This preserves active QUIC sessions while the
+    /// endpoint's relay client adopts the replacement credentials.
+    ///
+    /// - Parameters:
+    ///   - bindingID: The broker binding that owns the endpoint.
+    ///   - endpointIdentity: The pinned endpoint identity being updated.
+    ///   - profile: The complete managed relay profile to install.
+    ///   - bootstrap: Credentials already represented by `profile`, when available.
+    /// - Throws: A policy mismatch, endpoint mutation failure, or cancellation.
+    public func activateManagedPolicy(
+        bindingID: String,
+        endpointIdentity: CmxIrohPeerIdentity,
+        profile: CmxIrohEndpointRelayProfile,
+        bootstrap: CmxIrohRelayTokenResponse?
+    ) async throws {
+        guard profile.source == .managed,
+              !selectedRelayURLs.isEmpty,
+              selectedRelayURLs.isSubset(of: managedRelayURLs),
+              profile.allowedRelayURLs == selectedRelayURLs else {
+            throw CmxIrohRelayCredentialCoordinatorError.relayFleetMismatch
+        }
+
+        let bootstrapConfigurations: [CmxIrohRelayConfiguration]?
+        if let bootstrap {
+            let selectedConfigurations = try validatedSelectedConfigurations(bootstrap)
+            guard profile.managedRelays.count == selectedConfigurations.count,
+                  profile.managedRelays.allSatisfy(selectedConfigurations.contains) else {
+                throw CmxIrohRelayCredentialCoordinatorError.relayFleetMismatch
+            }
+            bootstrapConfigurations = selectedConfigurations
+        } else {
+            bootstrapConfigurations = nil
+        }
+
+        let (expectedBinding, revision) = beginActivation(
+            bindingID: bindingID,
+            endpointIdentity: endpointIdentity
+        )
+        try await supervisor.replaceRelayProfile(
+            profile,
+            expectedIdentity: endpointIdentity
+        )
+        try Task.checkCancellation()
+        guard isCurrent(revision), binding == expectedBinding else {
+            throw CancellationError()
+        }
+
+        if let bootstrap, let bootstrapConfigurations {
+            let installed = try recordInstallation(
+                bootstrap,
+                selectedConfigurations: bootstrapConfigurations,
+                binding: expectedBinding,
+                revision: revision
+            )
+            startLoopIfEnabled(revision: revision, firstRefresh: installed.refreshAfter)
+            return
+        }
+
+        do {
+            let response = try await broker.issueRelayToken(
+                bindingID: bindingID,
+                endpointID: endpointIdentity
+            )
+            let installed = try await install(
+                response,
+                binding: expectedBinding,
+                revision: revision
+            )
+            startLoopIfEnabled(revision: revision, firstRefresh: installed.refreshAfter)
+        } catch {
+            guard isCurrent(revision), !Task.isCancelled else {
+                throw CancellationError()
+            }
+            let delay = retryDelay(failureCount: 0, error: error)
+            startLoopIfEnabled(
+                revision: revision,
+                firstRefresh: retryDeadline(
+                    now: clock.now(),
+                    backoff: delay,
+                    honorsServerFloor: (error as? any CmxRetryAfterProviding)?
+                        .retryAfterSeconds != nil
+                ),
+                initialFailureCount: 1
+            )
+        }
+    }
+
+    private func beginActivation(
+        bindingID: String,
+        endpointIdentity: CmxIrohPeerIdentity
+    ) -> (Binding, UInt64) {
+        lifecycleRevision &+= 1
+        let revision = lifecycleRevision
+        refreshTask?.cancel()
+        inFlightRefresh?.task.cancel()
+        inFlightRefresh = nil
+        let expectedBinding = Binding(id: bindingID, endpointIdentity: endpointIdentity)
+        binding = expectedBinding
+        installedCredential = nil
+        return (expectedBinding, revision)
     }
 
     private func installInitialCredentialAfterRetry(
@@ -415,27 +516,14 @@ public actor CmxIrohRelayCredentialCoordinator {
         guard isCurrent(revision), binding == expectedBinding else {
             throw CancellationError()
         }
-        guard response.relayFleet.count == managedRelayURLs.count,
-              Set(response.relayFleet) == managedRelayURLs else {
-            throw CmxIrohRelayCredentialCoordinatorError.relayFleetMismatch
-        }
-        let now = clock.now()
-        let configurations = try response.relayConfigurations(now: now)
-        let selectedConfigurations = configurations.filter {
-            selectedRelayURLs.contains($0.url)
-        }
-        guard !selectedRelayURLs.isEmpty,
-              selectedConfigurations.count == selectedRelayURLs.count,
-              selectedRelayURLs.isSubset(of: managedRelayURLs) else {
-            throw CmxIrohRelayCredentialCoordinatorError.relayFleetMismatch
-        }
+        let selectedConfigurations = try validatedSelectedConfigurations(response)
         try Task.checkCancellation()
         guard isCurrent(revision), binding == expectedBinding else {
             throw CancellationError()
         }
         if selectedRelayURLs == managedRelayURLs {
             try await supervisor.replaceRelays(
-                configurations,
+                selectedConfigurations,
                 expectedIdentity: expectedBinding.endpointIdentity
             )
         } else {
@@ -448,6 +536,39 @@ public actor CmxIrohRelayCredentialCoordinator {
                 expectedIdentity: expectedBinding.endpointIdentity
             )
         }
+        return try recordInstallation(
+            response,
+            selectedConfigurations: selectedConfigurations,
+            binding: expectedBinding,
+            revision: revision
+        )
+    }
+
+    private func validatedSelectedConfigurations(
+        _ response: CmxIrohRelayTokenResponse
+    ) throws -> [CmxIrohRelayConfiguration] {
+        guard response.relayFleet.count == managedRelayURLs.count,
+              Set(response.relayFleet) == managedRelayURLs else {
+            throw CmxIrohRelayCredentialCoordinatorError.relayFleetMismatch
+        }
+        let configurations = try response.relayConfigurations(now: clock.now())
+        let selectedConfigurations = configurations.filter {
+            selectedRelayURLs.contains($0.url)
+        }
+        guard !selectedRelayURLs.isEmpty,
+              selectedConfigurations.count == selectedRelayURLs.count,
+              selectedRelayURLs.isSubset(of: managedRelayURLs) else {
+            throw CmxIrohRelayCredentialCoordinatorError.relayFleetMismatch
+        }
+        return selectedConfigurations
+    }
+
+    private func recordInstallation(
+        _ response: CmxIrohRelayTokenResponse,
+        selectedConfigurations: [CmxIrohRelayConfiguration],
+        binding expectedBinding: Binding,
+        revision: UInt64
+    ) throws -> InstalledCredential {
         try Task.checkCancellation()
         guard isCurrent(revision), binding == expectedBinding,
               let refreshAfter = selectedConfigurations.map(\.refreshAfter).min(),

--- a/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohRelayCredentialCoordinator.swift
+++ b/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohRelayCredentialCoordinator.swift
@@ -188,16 +188,16 @@ public actor CmxIrohRelayCredentialCoordinator {
             throw CmxIrohRelayCredentialCoordinatorError.relayFleetMismatch
         }
 
-        let bootstrapConfigurations: [CmxIrohRelayConfiguration]?
-        if let bootstrap {
-            let selectedConfigurations = try validatedSelectedConfigurations(bootstrap)
+        let bootstrapInstallation: (
+            response: CmxIrohRelayTokenResponse,
+            configurations: [CmxIrohRelayConfiguration]
+        )? = try bootstrap.map { response in
+            let selectedConfigurations = try validatedSelectedConfigurations(response)
             guard profile.managedRelays.count == selectedConfigurations.count,
                   profile.managedRelays.allSatisfy(selectedConfigurations.contains) else {
                 throw CmxIrohRelayCredentialCoordinatorError.relayFleetMismatch
             }
-            bootstrapConfigurations = selectedConfigurations
-        } else {
-            bootstrapConfigurations = nil
+            return (response, selectedConfigurations)
         }
 
         let (expectedBinding, revision) = beginActivation(
@@ -213,10 +213,10 @@ public actor CmxIrohRelayCredentialCoordinator {
             throw CancellationError()
         }
 
-        if let bootstrap, let bootstrapConfigurations {
+        if let bootstrapInstallation {
             let installed = try recordInstallation(
-                bootstrap,
-                selectedConfigurations: bootstrapConfigurations,
+                bootstrapInstallation.response,
+                selectedConfigurations: bootstrapInstallation.configurations,
                 binding: expectedBinding,
                 revision: revision
             )

--- a/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohCustomRelayRuntimeTests.swift
+++ b/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohCustomRelayRuntimeTests.swift
@@ -78,6 +78,71 @@ struct CmxIrohCustomRelayRuntimeTests {
     }
 
     @Test
+    func clientManagedPolicyFailureDeactivatesUncommittedCoordinator() async throws {
+        let fixture = try ClientRuntimeTestFixture()
+        let endpoint = TestIrohEndpoint(identity: fixture.endpointID)
+        let runtime = try CmxIrohClientRuntime(
+            factory: TestIrohEndpointFactory(endpoints: [endpoint]),
+            broker: TestIrohClientBroker(
+                binding: fixture.binding,
+                discovery: fixture.discovery,
+                relay: fixture.relayResponse()
+            ),
+            configuration: fixture.configuration,
+            pendingRevocations: fixture.pendingRevocations(),
+            now: { fixture.now }
+        )
+        try await runtime.start()
+        try await Self.waitForRelayMutation(endpoint)
+        await endpoint.setRelayUpdateShouldFail(true)
+
+        await #expect(throws: TestIrohTransportError.relayUpdateFailed) {
+            try await runtime.replaceRelayPolicy(try Self.managedPolicy(
+                response: fixture.relayResponse(),
+                relayURLs: Set(ClientRuntimeTestFixture.relayURLs),
+                now: fixture.now
+            ))
+        }
+
+        #expect(await runtime.relayCoordinator == nil)
+        #expect(await endpoint.observedCloseCallCount() == 0)
+        await runtime.stop()
+    }
+
+    @Test
+    func hostManagedPolicyFailureDeactivatesUncommittedCoordinator() async throws {
+        let fixture = try HostRuntimeFixture()
+        let endpoint = TestIrohEndpoint(identity: fixture.endpointID)
+        let runtime = CmxIrohHostRuntime(
+            factory: TestIrohEndpointFactory(endpoints: [endpoint]),
+            broker: TestIrohHostBroker(
+                registrationBinding: fixture.binding,
+                discovery: fixture.discovery
+            ),
+            configuration: fixture.configuration,
+            pendingRevocations: fixture.pendingRevocations(),
+            now: { Date(timeIntervalSince1970: 1_800_000_000) },
+            handleTransport: { session, _ in await session.close() }
+        )
+        try await runtime.start()
+        try await Self.waitForRelayMutation(endpoint)
+        await endpoint.setRelayUpdateShouldFail(true)
+        let response = try ClientRuntimeTestFixture().relayResponse()
+
+        await #expect(throws: TestIrohTransportError.relayUpdateFailed) {
+            try await runtime.replaceRelayPolicy(try Self.managedPolicy(
+                response: response,
+                relayURLs: fixture.managedRelays,
+                now: Date(timeIntervalSince1970: 1_800_000_000)
+            ))
+        }
+
+        #expect(await runtime.relayCoordinator == nil)
+        #expect(await endpoint.observedCloseCallCount() == 0)
+        await runtime.stop()
+    }
+
+    @Test
     func clientOverrideSkipsManagedTokenIssuance() async throws {
         let fixture = try ClientRuntimeTestFixture()
         let custom = try CmxIrohCustomRelayProfile(
@@ -259,6 +324,13 @@ struct CmxIrohCustomRelayRuntimeTests {
             if credentialUpdates + profileUpdates > 0 { return }
             await Task.yield()
         }
-        throw TestIrohTransportError.unsupported
+        let credentialUpdates = await endpoint.observedRelayUpdates().count
+        let profileUpdates = await endpoint.observedRelayProfileUpdates().count
+        let counts = "credential updates: \(credentialUpdates), "
+            + "profile updates: \(profileUpdates)"
+        Issue.record("Timed out waiting for relay mutation (\(counts))")
+        throw RelayMutationTimeout()
     }
 }
+
+private struct RelayMutationTimeout: Error {}

--- a/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohCustomRelayRuntimeTests.swift
+++ b/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohCustomRelayRuntimeTests.swift
@@ -1,8 +1,82 @@
+import Foundation
 import Testing
 @testable import CmuxIrohTransport
 
 @Suite
 struct CmxIrohCustomRelayRuntimeTests {
+    @Test
+    func clientManagedPolicyRefreshMutatesEndpointExactlyOnce() async throws {
+        let fixture = try ClientRuntimeTestFixture()
+        let endpoint = TestIrohEndpoint(identity: fixture.endpointID)
+        let runtime = try CmxIrohClientRuntime(
+            factory: TestIrohEndpointFactory(endpoints: [endpoint]),
+            broker: TestIrohClientBroker(
+                binding: fixture.binding,
+                discovery: fixture.discovery,
+                relay: fixture.relayResponse()
+            ),
+            configuration: fixture.configuration,
+            pendingRevocations: fixture.pendingRevocations(),
+            now: { fixture.now }
+        )
+        try await runtime.start()
+        try await Self.waitForRelayMutation(endpoint)
+        let initialCredentialUpdates = await endpoint.observedRelayUpdates().count
+        let initialProfileUpdates = await endpoint.observedRelayProfileUpdates().count
+
+        try await runtime.replaceRelayPolicy(try Self.managedPolicy(
+            response: fixture.relayResponse(),
+            relayURLs: Set(ClientRuntimeTestFixture.relayURLs),
+            now: fixture.now
+        ))
+
+        let credentialUpdates = await endpoint.observedRelayUpdates().count
+            - initialCredentialUpdates
+        let profileUpdates = await endpoint.observedRelayProfileUpdates().count
+            - initialProfileUpdates
+        #expect(credentialUpdates + profileUpdates == 1)
+        #expect(await endpoint.observedCloseCallCount() == 0)
+        #expect(await runtime.snapshot().endpointID == fixture.endpointID)
+        await runtime.stop()
+    }
+
+    @Test
+    func hostManagedPolicyRefreshMutatesEndpointExactlyOnce() async throws {
+        let fixture = try HostRuntimeFixture()
+        let endpoint = TestIrohEndpoint(identity: fixture.endpointID)
+        let runtime = CmxIrohHostRuntime(
+            factory: TestIrohEndpointFactory(endpoints: [endpoint]),
+            broker: TestIrohHostBroker(
+                registrationBinding: fixture.binding,
+                discovery: fixture.discovery
+            ),
+            configuration: fixture.configuration,
+            pendingRevocations: fixture.pendingRevocations(),
+            now: { Date(timeIntervalSince1970: 1_800_000_000) },
+            handleTransport: { session, _ in await session.close() }
+        )
+        try await runtime.start()
+        try await Self.waitForRelayMutation(endpoint)
+        let initialCredentialUpdates = await endpoint.observedRelayUpdates().count
+        let initialProfileUpdates = await endpoint.observedRelayProfileUpdates().count
+        let response = try ClientRuntimeTestFixture().relayResponse()
+
+        try await runtime.replaceRelayPolicy(try Self.managedPolicy(
+            response: response,
+            relayURLs: fixture.managedRelays,
+            now: Date(timeIntervalSince1970: 1_800_000_000)
+        ))
+
+        let credentialUpdates = await endpoint.observedRelayUpdates().count
+            - initialCredentialUpdates
+        let profileUpdates = await endpoint.observedRelayProfileUpdates().count
+            - initialProfileUpdates
+        #expect(credentialUpdates + profileUpdates == 1)
+        #expect(await endpoint.observedCloseCallCount() == 0)
+        #expect(await runtime.snapshot().endpointID == fixture.endpointID)
+        await runtime.stop()
+    }
+
     @Test
     func clientOverrideSkipsManagedTokenIssuance() async throws {
         let fixture = try ClientRuntimeTestFixture()
@@ -152,5 +226,39 @@ struct CmxIrohCustomRelayRuntimeTests {
         #expect(await endpoint.observedCloseCallCount() == 0)
         #expect(await runtime.snapshot().endpointID == fixture.endpointID)
         await runtime.stop()
+    }
+
+    private static func managedPolicy(
+        response: CmxIrohRelayTokenResponse,
+        relayURLs: Set<String>,
+        now: Date
+    ) throws -> CmxIrohEffectiveRelayPolicy {
+        let profile = try CmxIrohEndpointRelayProfile(
+            managedRelayURLs: relayURLs,
+            relays: response.relayConfigurations(now: now)
+        )
+        return CmxIrohEffectiveRelayPolicy(
+            endpointRelayProfile: profile,
+            managedSnapshot: nil,
+            managedPolicy: nil,
+            requestedConfiguration: nil,
+            effectivePreference: .automatic,
+            source: .managed,
+            usedCachedPolicy: false,
+            preferenceRevision: nil,
+            relayBootstrap: response
+        )
+    }
+
+    private static func waitForRelayMutation(_ endpoint: TestIrohEndpoint) async throws {
+        let clock = ContinuousClock()
+        let deadline = clock.now.advanced(by: .seconds(1))
+        while clock.now < deadline {
+            let credentialUpdates = await endpoint.observedRelayUpdates().count
+            let profileUpdates = await endpoint.observedRelayProfileUpdates().count
+            if credentialUpdates + profileUpdates > 0 { return }
+            await Task.yield()
+        }
+        throw TestIrohTransportError.unsupported
     }
 }


### PR DESCRIPTION
## What changed
- prove client and host managed-policy refresh performs one endpoint mutation
- make the relay credential coordinator the sole owner of managed profile replacement
- seed refresh scheduling from the already-installed bootstrap without reinstalling credentials

## Why
Signed policy refresh previously installed the same relay credentials twice. The back-to-back native relay-client rotations could interrupt active relay-only sessions at the five-minute policy refresh boundary.

## Verification
- `swift test --package-path Packages/Shared/CmuxIrohTransport` (566 tests)
- focused client/host policy replacement, credential refresh, lifecycle-race, and failed-restart suites

The fix is principled: one component owns managed endpoint relay mutations, while custom and no-relay transitions retain the existing direct runtime path.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/9538"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788418730&installation_model_id=21920&pr_number=9538&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F9538&signature=5fa63cced6dfe9d8fb3b34cc7a2296c6307feff28018e8ed5a947ca5d6cda396"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves active Iroh sessions during relay policy refresh by making `CmxIrohRelayCredentialCoordinator` the single owner of managed profile installation. The endpoint mutates once per refresh, and failed activations cleanly roll back to avoid dangling state.

- **Bug Fixes**
  - Managed-policy updates now use `activateManagedPolicy` in `CmxIrohRelayCredentialCoordinator` to install the profile once, validate fleets, and seed refresh from any bootstrap.
  - Client and host runtimes route managed profiles through the coordinator; custom or no-relay policies still use the direct runtime path.
  - On activation failure, the coordinator is deactivated and cleared without committing runtime state, preventing partial installs or orphaned refresh loops.
  - New tests prove client and host managed-policy refresh mutate the endpoint exactly once with no session closes, and verify failure paths clean up correctly.

<sup>Written for commit 0012be51e5ae62eff761903fdc645fc812339495. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/9538?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added more reliable activation of managed relay policies, including credential validation and token refresh handling.
  - Relay configuration updates now apply only after successful policy activation.
- **Bug Fixes**
  - Failed relay policy activation is properly cleaned up and reported.
  - Relay refreshes preserve the existing connection and endpoint identity while applying updates exactly once.
  - Improved synchronization of relay settings and connection state after policy changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->