### PR TITLE
Fix the Sleepy Mode lock button on macOS 26

### DIFF
--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -229001,6 +229001,23 @@
         }
       }
     },
+    "sleepyMode.lockFailed": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Couldn't lock the Mac \u2014 use the Apple menu \u203a Lock Screen"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mac \u3092\u30ed\u30c3\u30af\u3067\u304d\u307e\u305b\u3093\u3067\u3057\u305f \u2014 Apple \u30e1\u30cb\u30e5\u30fc \u203a \u300c\u753b\u9762\u3092\u30ed\u30c3\u30af\u300d\u3092\u4f7f\u3063\u3066\u304f\u3060\u3055\u3044"
+          }
+        }
+      }
+    },
     "sleepyMode.mascot.cat": {
       "extractionState": "manual",
       "localizations": {

--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -229004,16 +229004,124 @@
     "sleepyMode.lockFailed": {
       "extractionState": "manual",
       "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "تعذّر قفل الـ Mac — استخدم قائمة النظام › قفل الشاشة"
+          }
+        },
+        "bs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nije moguće zaključati Mac — koristite sistemski meni › Zaključaj ekran"
+          }
+        },
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kunne ikke låse din Mac — brug systemmenuen › Lås skærm"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mac konnte nicht gesperrt werden — verwende das Systemmenü › Bildschirm sperren"
+          }
+        },
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "Couldn't lock the Mac \u2014 use the Apple menu \u203a Lock Screen"
+            "value": "Couldn't lock the Mac — use the system menu › Lock Screen"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No se pudo bloquear el Mac — usa el menú del sistema › Bloquear pantalla"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Impossible de verrouiller le Mac — utilisez le menu système › Verrouiller l'écran"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Impossibile bloccare il Mac — usa il menu di sistema › Blocca schermo"
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "Mac \u3092\u30ed\u30c3\u30af\u3067\u304d\u307e\u305b\u3093\u3067\u3057\u305f \u2014 Apple \u30e1\u30cb\u30e5\u30fc \u203a \u300c\u753b\u9762\u3092\u30ed\u30c3\u30af\u300d\u3092\u4f7f\u3063\u3066\u304f\u3060\u3055\u3044"
+            "value": "Mac をロックできませんでした — システムメニュー › 「画面をロック」を使ってください"
+          }
+        },
+        "km": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "មិនអាចចាក់សោ Mac បានទេ — សូមប្រើម៉ឺនុយប្រព័ន្ធ › ចាក់សោអេក្រង់"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mac을 잠글 수 없습니다 — 시스템 메뉴 › 화면 잠금을 사용하세요"
+          }
+        },
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kunne ikke låse Mac-en — bruk systemmenyen › Lås skjerm"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nie można zablokować Maca — użyj menu systemowego › Zablokuj ekran"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Não foi possível bloquear o Mac — use o menu do sistema › Bloquear tela"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Не удалось заблокировать Mac — используйте системное меню › Заблокировать экран"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ล็อก Mac ไม่ได้ — ใช้เมนูระบบ › ล็อกหน้าจอ"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mac kilitlenemedi — sistem menüsü › Ekranı Kilitle seçeneğini kullanın"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Не вдалося заблокувати Mac — скористайтеся системним меню › Заблокувати екран"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "无法锁定 Mac — 请使用系统菜单 › 锁定屏幕"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "無法鎖定 Mac — 請使用系統選單 › 鎖定螢幕"
           }
         }
       }

--- a/Sources/SleepyCommandRunning.swift
+++ b/Sources/SleepyCommandRunning.swift
@@ -3,31 +3,56 @@ import Foundation
 /// Seam for system command execution so UI/tests can inject a fake instead of
 /// mutating the real machine. Async so callers never block a thread on a slow
 /// command or the admin prompt.
+///
+/// Every requirement is `nonisolated`: implementations do process and
+/// filesystem work that must stay off the main actor, and conformers are plain
+/// `Sendable` types rather than actors.
 protocol SleepyCommandRunning: Sendable {
     /// Fire-and-forget (e.g. `pmset displaysleepnow`).
     ///
+    /// - Parameters:
+    ///   - tool: Absolute path of the executable.
+    ///   - args: Arguments passed to the executable.
     /// - Returns: `false` when the tool could not be launched at all (missing
     ///   binary, not executable). Callers use this to fall back to another
     ///   mechanism instead of silently doing nothing — a missing system tool is
     ///   exactly how the Sleepy Mode lock button broke on macOS 26.
-    @discardableResult func run(_ tool: String, _ args: [String]) async -> Bool
+    @discardableResult nonisolated func run(_ tool: String, _ args: [String]) async -> Bool
     /// Whether `tool` exists and is executable, so a caller can choose between
     /// mechanisms by capability rather than by guessing at an OS version.
-    func canRun(_ tool: String) async -> Bool
+    ///
+    /// - Parameter tool: Absolute path to probe.
+    /// - Returns: `true` when the file can be executed.
+    nonisolated func canRun(_ tool: String) async -> Bool
     /// Runs `tool` and waits for it to exit, reporting `true` only on a zero
     /// exit status.
     ///
     /// Use this where the caller must know the action actually happened rather
     /// than merely that the process started — locking the screen must not be
     /// reported as successful just because the binary launched.
-    @discardableResult func runAwaitingExit(_ tool: String, _ args: [String]) async -> Bool
+    ///
+    /// - Parameters:
+    ///   - tool: Absolute path of the executable.
+    ///   - args: Arguments passed to the executable.
+    /// - Returns: `true` only on a zero exit status.
+    @discardableResult nonisolated func runAwaitingExit(_ tool: String, _ args: [String]) async -> Bool
     /// Run and capture stdout (e.g. `pmset -g`). No privileges.
-    func capture(_ tool: String, _ args: [String]) async -> String?
+    ///
+    /// - Parameters:
+    ///   - tool: Absolute path of the executable.
+    ///   - args: Arguments passed to the executable.
+    /// - Returns: Captured stdout, or `nil` when the tool could not run.
+    nonisolated func capture(_ tool: String, _ args: [String]) async -> String?
     /// Run a privileged tool via Authorization Services, awaiting its exit.
-    @discardableResult func runPrivileged(_ tool: String, _ args: [String]) async -> Bool
+    ///
+    /// - Parameters:
+    ///   - tool: Absolute path of the executable.
+    ///   - args: Arguments passed to the executable.
+    /// - Returns: `true` when the tool ran and exited successfully.
+    @discardableResult nonisolated func runPrivileged(_ tool: String, _ args: [String]) async -> Bool
     /// Engages the macOS login lock in-process, for systems where the supported
     /// command-line tool no longer ships.
     ///
     /// - Returns: `false` when no lock mechanism is available.
-    @discardableResult func lockScreen() async -> Bool
+    @discardableResult nonisolated func lockScreen() async -> Bool
 }

--- a/Sources/SleepyCommandRunning.swift
+++ b/Sources/SleepyCommandRunning.swift
@@ -4,10 +4,23 @@ import Foundation
 /// mutating the real machine. Async so callers never block a thread on a slow
 /// command or the admin prompt.
 protocol SleepyCommandRunning: Sendable {
-    /// Fire-and-forget (e.g. `pmset displaysleepnow`, `CGSession -suspend`).
-    func run(_ tool: String, _ args: [String]) async
+    /// Fire-and-forget (e.g. `pmset displaysleepnow`).
+    ///
+    /// - Returns: `false` when the tool could not be launched at all (missing
+    ///   binary, not executable). Callers use this to fall back to another
+    ///   mechanism instead of silently doing nothing — a missing system tool is
+    ///   exactly how the Sleepy Mode lock button broke on macOS 26.
+    @discardableResult func run(_ tool: String, _ args: [String]) async -> Bool
+    /// Whether `tool` exists and is executable, so a caller can choose between
+    /// mechanisms by capability rather than by guessing at an OS version.
+    func canRun(_ tool: String) async -> Bool
     /// Run and capture stdout (e.g. `pmset -g`). No privileges.
     func capture(_ tool: String, _ args: [String]) async -> String?
     /// Run a privileged tool via Authorization Services, awaiting its exit.
     @discardableResult func runPrivileged(_ tool: String, _ args: [String]) async -> Bool
+    /// Engages the macOS login lock in-process, for systems where the supported
+    /// command-line tool no longer ships.
+    ///
+    /// - Returns: `false` when no lock mechanism is available.
+    @discardableResult func lockScreen() async -> Bool
 }

--- a/Sources/SleepyCommandRunning.swift
+++ b/Sources/SleepyCommandRunning.swift
@@ -14,6 +14,13 @@ protocol SleepyCommandRunning: Sendable {
     /// Whether `tool` exists and is executable, so a caller can choose between
     /// mechanisms by capability rather than by guessing at an OS version.
     func canRun(_ tool: String) async -> Bool
+    /// Runs `tool` and waits for it to exit, reporting `true` only on a zero
+    /// exit status.
+    ///
+    /// Use this where the caller must know the action actually happened rather
+    /// than merely that the process started — locking the screen must not be
+    /// reported as successful just because the binary launched.
+    @discardableResult func runAwaitingExit(_ tool: String, _ args: [String]) async -> Bool
     /// Run and capture stdout (e.g. `pmset -g`). No privileges.
     func capture(_ tool: String, _ args: [String]) async -> String?
     /// Run a privileged tool via Authorization Services, awaiting its exit.

--- a/Sources/SleepyFaceView.swift
+++ b/Sources/SleepyFaceView.swift
@@ -23,9 +23,6 @@ struct SleepyFaceView: View {
     @State private var lastMascotPokeAt = 0.0
     @State private var petReactAt: [Int: Double] = [:]
     @State private var moonReactAt: Double?
-    /// Set when "Lock Mac" could not engage any lock mechanism, so the scene can
-    /// say so rather than leaving the button looking inert.
-    @State private var lockFailed = false
 
     var body: some View {
         let config = store.snapshot()
@@ -139,17 +136,29 @@ struct SleepyFaceView: View {
                 Button {
                     // The real macOS login lock — genuinely secure (Apple's), unlike
                     // the overlay. The screensaver stays up behind it as the backdrop.
+                    //
+                    // Gated on the shared UI state exactly like Low Power below, so
+                    // clicks from two displays (or a double click) can't run
+                    // overlapping lock attempts whose completions race to report a
+                    // stale result on one overlay.
+                    guard !powerUIState.isLocking else { return }
+                    powerUIState.isLocking = true
+                    powerUIState.lockFailed = false
                     let power = power
+                    let ui = powerUIState
                     Task {
                         // Surface a failed lock: this button silently did nothing on
                         // systems missing the CGSession tool, which reads as "the
                         // lock is broken" with no explanation.
-                        lockFailed = !(await power.lockMacNow())
+                        let locked = await power.lockMacNow()
+                        ui.lockFailed = !locked
+                        ui.isLocking = false
                     }
                 } label: {
                     Label(String(localized: "sleepyMode.button.lockMac", defaultValue: "Lock Mac"), systemImage: "lock.fill")
                 }
                 .buttonStyle(SleepyPixelButtonStyle(tint: Color(red: 0.34, green: 0.30, blue: 0.60)))
+                .disabled(powerUIState.isLocking)
 
                 Button {
                     let power = power
@@ -185,7 +194,7 @@ struct SleepyFaceView: View {
                 .buttonStyle(SleepyPixelButtonStyle(tint: powerUIState.isOn ? Color(red: 0.24, green: 0.56, blue: 0.32) : Color(red: 0.30, green: 0.42, blue: 0.46)))
                 .disabled(powerUIState.isBusy)
             }
-            if lockFailed {
+            if powerUIState.lockFailed {
                 Text(String(
                     localized: "sleepyMode.lockFailed",
                     defaultValue: "Couldn't lock the Mac \u{2014} use the Apple menu \u{203A} Lock Screen"

--- a/Sources/SleepyFaceView.swift
+++ b/Sources/SleepyFaceView.swift
@@ -197,7 +197,7 @@ struct SleepyFaceView: View {
             if powerUIState.lockFailed {
                 Text(String(
                     localized: "sleepyMode.lockFailed",
-                    defaultValue: "Couldn't lock the Mac \u{2014} use the Apple menu \u{203A} Lock Screen"
+                    defaultValue: "Couldn't lock the Mac \u{2014} use the system menu \u{203A} Lock Screen"
                 ))
                 .font(.system(size: 13, weight: .bold, design: .monospaced))
                 .foregroundStyle(Color(red: 0.95, green: 0.62, blue: 0.30))

--- a/Sources/SleepyFaceView.swift
+++ b/Sources/SleepyFaceView.swift
@@ -134,26 +134,17 @@ struct SleepyFaceView: View {
                 .buttonStyle(SleepyPixelButtonStyle(tint: Color(red: 0.52, green: 0.30, blue: 0.40)))
 
                 Button {
-                    // The real macOS login lock — genuinely secure (Apple's), unlike
-                    // the overlay. The screensaver stays up behind it as the backdrop.
+                    // The real macOS login lock — genuinely secure (the system's),
+                    // unlike the overlay. The screensaver stays up behind it as the
+                    // backdrop.
                     //
-                    // Gated on the shared UI state exactly like Low Power below, so
-                    // clicks from two displays (or a double click) can't run
-                    // overlapping lock attempts whose completions race to report a
-                    // stale result on one overlay.
-                    guard !powerUIState.isLocking else { return }
-                    powerUIState.isLocking = true
-                    powerUIState.lockFailed = false
-                    let power = power
-                    let ui = powerUIState
-                    Task {
-                        // Surface a failed lock: this button silently did nothing on
-                        // systems missing the CGSession tool, which reads as "the
-                        // lock is broken" with no explanation.
-                        let locked = await power.lockMacNow()
-                        ui.lockFailed = !locked
-                        ui.isLocking = false
-                    }
+                    // The attempt is owned by the shared state, which the controller
+                    // cancels on teardown: every display shows this button, and a
+                    // lock finishing after Sleepy Mode ended must not report onto a
+                    // later session. Failure is surfaced there too, because this
+                    // button silently did nothing on systems missing the CGSession
+                    // tool, which reads as "the lock is broken" with no explanation.
+                    powerUIState.lockMac(using: power)
                 } label: {
                     Label(String(localized: "sleepyMode.button.lockMac", defaultValue: "Lock Mac"), systemImage: "lock.fill")
                 }

--- a/Sources/SleepyFaceView.swift
+++ b/Sources/SleepyFaceView.swift
@@ -23,6 +23,9 @@ struct SleepyFaceView: View {
     @State private var lastMascotPokeAt = 0.0
     @State private var petReactAt: [Int: Double] = [:]
     @State private var moonReactAt: Double?
+    /// Set when "Lock Mac" could not engage any lock mechanism, so the scene can
+    /// say so rather than leaving the button looking inert.
+    @State private var lockFailed = false
 
     var body: some View {
         let config = store.snapshot()
@@ -137,7 +140,12 @@ struct SleepyFaceView: View {
                     // The real macOS login lock — genuinely secure (Apple's), unlike
                     // the overlay. The screensaver stays up behind it as the backdrop.
                     let power = power
-                    Task { await power.lockMacNow() }
+                    Task {
+                        // Surface a failed lock: this button silently did nothing on
+                        // systems missing the CGSession tool, which reads as "the
+                        // lock is broken" with no explanation.
+                        lockFailed = !(await power.lockMacNow())
+                    }
                 } label: {
                     Label(String(localized: "sleepyMode.button.lockMac", defaultValue: "Lock Mac"), systemImage: "lock.fill")
                 }
@@ -176,6 +184,15 @@ struct SleepyFaceView: View {
                 }
                 .buttonStyle(SleepyPixelButtonStyle(tint: powerUIState.isOn ? Color(red: 0.24, green: 0.56, blue: 0.32) : Color(red: 0.30, green: 0.42, blue: 0.46)))
                 .disabled(powerUIState.isBusy)
+            }
+            if lockFailed {
+                Text(String(
+                    localized: "sleepyMode.lockFailed",
+                    defaultValue: "Couldn't lock the Mac \u{2014} use the Apple menu \u{203A} Lock Screen"
+                ))
+                .font(.system(size: 13, weight: .bold, design: .monospaced))
+                .foregroundStyle(Color(red: 0.95, green: 0.62, blue: 0.30))
+                .padding(.top, 18)
             }
             Spacer().frame(height: 50)
             Text(hintText)

--- a/Sources/SleepyModeController.swift
+++ b/Sources/SleepyModeController.swift
@@ -90,6 +90,9 @@ final class SleepyModeController {
     func deactivate() {
         guard isActive else { return }
         isActive = false
+        // Drop any in-flight lock attempt: `powerUIState` outlives this session,
+        // so a late completion would otherwise report its result onto the next one.
+        powerUIState.cancelLock()
         removeScreenObserver()
         endPowerAssertions()
         tearDownOverlayWindows()

--- a/Sources/SleepyPowerControlling.swift
+++ b/Sources/SleepyPowerControlling.swift
@@ -4,8 +4,11 @@ import Foundation
 protocol SleepyPowerControlling: Sendable {
     /// Turns the display off now (system idle-sleep assertion still holds).
     func sleepDisplayNow() async
-    /// Engages the real macOS login lock (`CGSession -suspend`).
-    func lockMacNow() async
+    /// Engages the real macOS login lock.
+    ///
+    /// - Returns: `false` when no lock mechanism was available, so the UI can
+    ///   say so instead of appearing to do nothing.
+    @discardableResult func lockMacNow() async -> Bool
     /// Whether Low Power Mode is currently on.
     func isLowPowerOn() async -> Bool
     /// Enables/disables Low Power Mode; returns the re-read state.

--- a/Sources/SleepyPowerControls.swift
+++ b/Sources/SleepyPowerControls.swift
@@ -38,11 +38,25 @@ final class SleepyPowerControls: SleepyPowerControlling {
         await runner.run("/usr/bin/pmset", ["displaysleepnow"])
     }
 
-    /// Engages the real macOS login lock via the supported `CGSession -suspend`
-    /// mechanism (returning to the session requires the account password /
-    /// Touch ID) — Apple's loginwindow, not our overlay, and no private symbol.
-    func lockMacNow() async {
-        await runner.run("/System/Library/CoreServices/Menu Extras/User.menu/Contents/Resources/CGSession", ["-suspend"])
+    /// The supported `CGSession -suspend` tool. Apple removed `User.menu` from
+    /// `Menu Extras` (it is gone on macOS 26, still present on macOS 15), which
+    /// is why this path can no longer be assumed to exist.
+    nonisolated static let legacyLockTool = "/System/Library/CoreServices/Menu Extras/User.menu/Contents/Resources/CGSession"
+
+    /// Engages the real macOS login lock — Apple's loginwindow, not our overlay,
+    /// so returning to the session requires the account password / Touch ID.
+    ///
+    /// Prefers the supported `CGSession` tool and only falls back to the private
+    /// `SACLockScreenImmediate` where that tool is absent. The choice is made by
+    /// probing for the tool rather than by comparing OS versions: the exact
+    /// release Apple dropped it in is not something to guess at, and a wrong
+    /// threshold would break every version in between.
+    @discardableResult
+    func lockMacNow() async -> Bool {
+        if await runner.canRun(Self.legacyLockTool), await runner.run(Self.legacyLockTool, ["-suspend"]) {
+            return true
+        }
+        return await runner.lockScreen()
     }
 
     func isLowPowerOn() async -> Bool {

--- a/Sources/SleepyPowerControls.swift
+++ b/Sources/SleepyPowerControls.swift
@@ -51,9 +51,14 @@ final class SleepyPowerControls: SleepyPowerControlling {
     /// probing for the tool rather than by comparing OS versions: the exact
     /// release Apple dropped it in is not something to guess at, and a wrong
     /// threshold would break every version in between.
+    ///
+    /// The legacy tool is awaited to completion rather than fire-and-forget: a
+    /// process that starts and then exits non-zero has not locked anything, and
+    /// reporting that as success would leave the user staring at an unlocked Mac
+    /// with no fallback attempted.
     @discardableResult
     func lockMacNow() async -> Bool {
-        if await runner.canRun(Self.legacyLockTool), await runner.run(Self.legacyLockTool, ["-suspend"]) {
+        if await runner.canRun(Self.legacyLockTool), await runner.runAwaitingExit(Self.legacyLockTool, ["-suspend"]) {
             return true
         }
         return await runner.lockScreen()

--- a/Sources/SleepyPowerUIState.swift
+++ b/Sources/SleepyPowerUIState.swift
@@ -1,9 +1,9 @@
 import Observation
 
-/// Shared, observable Low Power UI state. Sleepy Mode creates one overlay window
-/// per display; injecting a single instance into every `SleepyFaceView` keeps
-/// their labels in sync and makes each button compute its next action from one
-/// authoritative value (instead of per-window `@State` that goes stale when
+/// Shared, observable power-button UI state. Sleepy Mode creates one overlay
+/// window per display; injecting a single instance into every `SleepyFaceView`
+/// keeps their labels in sync and makes each button compute its next action from
+/// one authoritative value (instead of per-window `@State` that goes stale when
 /// another display toggles).
 @MainActor
 @Observable
@@ -12,4 +12,11 @@ final class SleepyPowerUIState {
     var isOn = false
     /// Whether a privileged toggle is in flight (disables the button).
     var isBusy = false
+    /// Whether a lock attempt is in flight. Shared for the same reason as
+    /// `isBusy`: every display shows a Lock Mac button, and overlapping clicks
+    /// must not stack concurrent lock attempts whose completions race.
+    var isLocking = false
+    /// Whether the last lock attempt found no working mechanism. Lives here
+    /// rather than in each view's `@State` so all overlays report one outcome.
+    var lockFailed = false
 }

--- a/Sources/SleepyPowerUIState.swift
+++ b/Sources/SleepyPowerUIState.swift
@@ -5,6 +5,12 @@ import Observation
 /// keeps their labels in sync and makes each button compute its next action from
 /// one authoritative value (instead of per-window `@State` that goes stale when
 /// another display toggles).
+///
+/// This instance is owned by `SleepyModeController` and outlives any single
+/// activation, so the lock attempt it starts is retained and cancellable here
+/// rather than being an unstructured `Task` fired from a button: a lock that
+/// completed after teardown would otherwise report its result onto the *next*
+/// Sleepy Mode session.
 @MainActor
 @Observable
 final class SleepyPowerUIState {
@@ -15,8 +21,41 @@ final class SleepyPowerUIState {
     /// Whether a lock attempt is in flight. Shared for the same reason as
     /// `isBusy`: every display shows a Lock Mac button, and overlapping clicks
     /// must not stack concurrent lock attempts whose completions race.
-    var isLocking = false
+    private(set) var isLocking = false
     /// Whether the last lock attempt found no working mechanism. Lives here
     /// rather than in each view's `@State` so all overlays report one outcome.
-    var lockFailed = false
+    private(set) var lockFailed = false
+
+    /// The in-flight lock attempt, retained so teardown can cancel it and so a
+    /// second click cannot start a competing one.
+    @ObservationIgnored private var lockTask: Task<Void, Never>?
+
+    /// Starts a lock attempt, ignoring the request when one is already running.
+    ///
+    /// The single start path for every Lock Mac button across every display.
+    ///
+    /// - Parameter power: The power service that performs the lock.
+    func lockMac(using power: any SleepyPowerControlling) {
+        guard lockTask == nil else { return }
+        isLocking = true
+        lockFailed = false
+        lockTask = Task { [weak self] in
+            let locked = await power.lockMacNow()
+            guard let self, !Task.isCancelled else { return }
+            self.lockFailed = !locked
+            self.isLocking = false
+            self.lockTask = nil
+        }
+    }
+
+    /// Cancels any in-flight lock attempt and clears its transient state.
+    ///
+    /// Called on Sleepy Mode teardown so a late completion cannot surface a
+    /// result belonging to a session the user has already left.
+    func cancelLock() {
+        lockTask?.cancel()
+        lockTask = nil
+        isLocking = false
+        lockFailed = false
+    }
 }

--- a/Sources/SystemCommandRunner.swift
+++ b/Sources/SystemCommandRunner.swift
@@ -70,6 +70,32 @@ final class SystemCommandRunner: SleepyCommandRunning, @unchecked Sendable {
         FileManager.default.isExecutableFile(atPath: tool)
     }
 
+    @discardableResult
+    func runAwaitingExit(_ tool: String, _ args: [String]) async -> Bool {
+        await withCheckedContinuation { (continuation: CheckedContinuation<Bool, Never>) in
+            DispatchQueue.global(qos: .userInitiated).async {
+                let process = Process()
+                process.executableURL = URL(fileURLWithPath: tool)
+                process.arguments = args
+                process.standardOutput = FileHandle.nullDevice
+                process.standardError = FileHandle.nullDevice
+                do {
+                    try process.run()
+                } catch {
+                    sleepyCommandLogger.error("Failed to launch \(tool, privacy: .public): \(error.localizedDescription, privacy: .public)")
+                    continuation.resume(returning: false)
+                    return
+                }
+                process.waitUntilExit()
+                let status = process.terminationStatus
+                if status != 0 {
+                    sleepyCommandLogger.error("\(tool, privacy: .public) exited with status \(status, privacy: .public)")
+                }
+                continuation.resume(returning: status == 0)
+            }
+        }
+    }
+
     /// Locks the screen through `login.framework`'s `SACLockScreenImmediate`,
     /// resolved at runtime with the same `dlsym` approach this type already uses
     /// for `AuthorizationExecuteWithPrivileges`.

--- a/Sources/SystemCommandRunner.swift
+++ b/Sources/SystemCommandRunner.swift
@@ -3,7 +3,9 @@ import Foundation
 import OSLog
 import Security
 
-private let sleepyCommandLogger = Logger(subsystem: "com.cmuxterm.app", category: "SleepyMode.command")
+/// Logs system-command failures for Sleepy Mode's power actions, so a tool that
+/// is missing or exits non-zero leaves a trace instead of vanishing.
+nonisolated private let sleepyCommandLogger = Logger(subsystem: "com.cmuxterm.app", category: "SleepyMode.command")
 
 /// Real command runner. Blocking work happens on background queues and is
 /// surfaced through async APIs, so awaiting callers (including MainActor UI)
@@ -42,56 +44,79 @@ final class SystemCommandRunner: SleepyCommandRunning, @unchecked Sendable {
     private let privilegedQueue = DispatchQueue(label: "com.cmux.sleepyMode.privileged")
     private var authorization: AuthorizationRef?  // accessed only on privilegedQueue
 
+    /// Builds a process with both output streams discarded.
+    ///
+    /// - Parameters:
+    ///   - tool: Absolute path of the executable.
+    ///   - args: Arguments passed to the executable.
+    /// - Returns: A configured, unstarted process.
+    nonisolated private func makeProcess(_ tool: String, _ args: [String]) -> Process {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: tool)
+        process.arguments = args
+        process.standardOutput = FileHandle.nullDevice
+        process.standardError = FileHandle.nullDevice
+        return process
+    }
+
     /// Launches `tool` without waiting for it to exit, reporting whether the
-    /// launch itself succeeded. The previous `try?` discarded that error, which
-    /// turned a system tool Apple had removed into a button that silently did
-    /// nothing; a launch failure is now both logged and returned.
+    /// launch itself succeeded.
+    ///
+    /// The previous `try?` discarded that error, which turned a removed system
+    /// tool into a button that silently did nothing; a launch failure is now
+    /// both logged and returned.
+    ///
+    /// - Parameters:
+    ///   - tool: Absolute path of the executable.
+    ///   - args: Arguments passed to the executable.
+    /// - Returns: `true` when the process started.
     @discardableResult
-    func run(_ tool: String, _ args: [String]) async -> Bool {
-        await withCheckedContinuation { (continuation: CheckedContinuation<Bool, Never>) in
-            DispatchQueue.global(qos: .userInitiated).async {
-                let process = Process()
-                process.executableURL = URL(fileURLWithPath: tool)
-                process.arguments = args
-                process.standardOutput = FileHandle.nullDevice
-                process.standardError = FileHandle.nullDevice
-                do {
-                    try process.run()
-                    continuation.resume(returning: true)
-                } catch {
-                    sleepyCommandLogger.error("Failed to launch \(tool, privacy: .public): \(error.localizedDescription, privacy: .public)")
-                    continuation.resume(returning: false)
-                }
-            }
+    nonisolated func run(_ tool: String, _ args: [String]) async -> Bool {
+        do {
+            try makeProcess(tool, args).run()
+            return true
+        } catch {
+            sleepyCommandLogger.error("Failed to launch \(tool, privacy: .public): \(error.localizedDescription, privacy: .public)")
+            return false
         }
     }
 
-    func canRun(_ tool: String) async -> Bool {
+    /// Whether `tool` exists and is executable.
+    ///
+    /// - Parameter tool: Absolute path to probe.
+    /// - Returns: `true` when the file can be executed.
+    nonisolated func canRun(_ tool: String) async -> Bool {
         FileManager.default.isExecutableFile(atPath: tool)
     }
 
+    /// Runs `tool` and resumes once it exits, reporting whether it exited zero.
+    ///
+    /// Termination is observed through `Process.terminationHandler` rather than
+    /// `waitUntilExit()`, so no thread is parked waiting for the child.
+    ///
+    /// - Parameters:
+    ///   - tool: Absolute path of the executable.
+    ///   - args: Arguments passed to the executable.
+    /// - Returns: `true` only on a zero exit status.
     @discardableResult
-    func runAwaitingExit(_ tool: String, _ args: [String]) async -> Bool {
+    nonisolated func runAwaitingExit(_ tool: String, _ args: [String]) async -> Bool {
         await withCheckedContinuation { (continuation: CheckedContinuation<Bool, Never>) in
-            DispatchQueue.global(qos: .userInitiated).async {
-                let process = Process()
-                process.executableURL = URL(fileURLWithPath: tool)
-                process.arguments = args
-                process.standardOutput = FileHandle.nullDevice
-                process.standardError = FileHandle.nullDevice
-                do {
-                    try process.run()
-                } catch {
-                    sleepyCommandLogger.error("Failed to launch \(tool, privacy: .public): \(error.localizedDescription, privacy: .public)")
-                    continuation.resume(returning: false)
-                    return
-                }
-                process.waitUntilExit()
-                let status = process.terminationStatus
+            let process = makeProcess(tool, args)
+            process.terminationHandler = { finished in
+                let status = finished.terminationStatus
                 if status != 0 {
                     sleepyCommandLogger.error("\(tool, privacy: .public) exited with status \(status, privacy: .public)")
                 }
                 continuation.resume(returning: status == 0)
+            }
+            do {
+                try process.run()
+            } catch {
+                // The handler never fires for a process that never started, so
+                // clear it and resume exactly once here.
+                process.terminationHandler = nil
+                sleepyCommandLogger.error("Failed to launch \(tool, privacy: .public): \(error.localizedDescription, privacy: .public)")
+                continuation.resume(returning: false)
             }
         }
     }
@@ -101,21 +126,19 @@ final class SystemCommandRunner: SleepyCommandRunning, @unchecked Sendable {
     /// for `AuthorizationExecuteWithPrivileges`.
     ///
     /// This is a fallback for systems where the supported `CGSession -suspend`
-    /// tool no longer ships (Apple removed `User.menu` from `Menu Extras`), so
-    /// the caller should prefer that tool whenever it is still present.
+    /// tool no longer ships, so the caller should prefer that tool whenever it
+    /// is still present.
+    ///
+    /// - Returns: `true` when a lock mechanism was available and invoked.
     @discardableResult
-    func lockScreen() async -> Bool {
+    nonisolated func lockScreen() async -> Bool {
         guard let lock = Self.lockScreenImmediate else {
             sleepyCommandLogger.error("No screen-lock mechanism available: SACLockScreenImmediate could not be resolved")
             return false
         }
-        return await withCheckedContinuation { (continuation: CheckedContinuation<Bool, Never>) in
-            // Locking is UI-adjacent; keep it on the main queue.
-            DispatchQueue.main.async {
-                lock()
-                continuation.resume(returning: true)
-            }
-        }
+        // Locking is UI-adjacent, so hop to the main actor for the call itself.
+        await MainActor.run { lock() }
+        return true
     }
 
     func capture(_ tool: String, _ args: [String]) async -> String? {

--- a/Sources/SystemCommandRunner.swift
+++ b/Sources/SystemCommandRunner.swift
@@ -1,6 +1,9 @@
 import Darwin
 import Foundation
+import OSLog
 import Security
+
+private let sleepyCommandLogger = Logger(subsystem: "com.cmuxterm.app", category: "SleepyMode.command")
 
 /// Real command runner. Blocking work happens on background queues and is
 /// surfaced through async APIs, so awaiting callers (including MainActor UI)
@@ -25,19 +28,66 @@ final class SystemCommandRunner: SleepyCommandRunning, @unchecked Sendable {
         return unsafeBitCast(symbol, to: AuthExecFn.self)
     }()
 
+    private typealias LockScreenFn = @convention(c) () -> Void
+
+    /// `SACLockScreenImmediate` from the private `login.framework`. Resolved
+    /// lazily and cached; `nil` on a system that does not export it, which the
+    /// caller reports rather than pretending the lock happened.
+    private static let lockScreenImmediate: LockScreenFn? = {
+        guard let handle = dlopen("/System/Library/PrivateFrameworks/login.framework/Versions/A/login", RTLD_LAZY),
+              let symbol = dlsym(handle, "SACLockScreenImmediate") else { return nil }
+        return unsafeBitCast(symbol, to: LockScreenFn.self)
+    }()
+
     private let privilegedQueue = DispatchQueue(label: "com.cmux.sleepyMode.privileged")
     private var authorization: AuthorizationRef?  // accessed only on privilegedQueue
 
-    func run(_ tool: String, _ args: [String]) async {
-        await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
+    /// Launches `tool` without waiting for it to exit, reporting whether the
+    /// launch itself succeeded. The previous `try?` discarded that error, which
+    /// turned a system tool Apple had removed into a button that silently did
+    /// nothing; a launch failure is now both logged and returned.
+    @discardableResult
+    func run(_ tool: String, _ args: [String]) async -> Bool {
+        await withCheckedContinuation { (continuation: CheckedContinuation<Bool, Never>) in
             DispatchQueue.global(qos: .userInitiated).async {
                 let process = Process()
                 process.executableURL = URL(fileURLWithPath: tool)
                 process.arguments = args
                 process.standardOutput = FileHandle.nullDevice
                 process.standardError = FileHandle.nullDevice
-                try? process.run()
-                continuation.resume()
+                do {
+                    try process.run()
+                    continuation.resume(returning: true)
+                } catch {
+                    sleepyCommandLogger.error("Failed to launch \(tool, privacy: .public): \(error.localizedDescription, privacy: .public)")
+                    continuation.resume(returning: false)
+                }
+            }
+        }
+    }
+
+    func canRun(_ tool: String) async -> Bool {
+        FileManager.default.isExecutableFile(atPath: tool)
+    }
+
+    /// Locks the screen through `login.framework`'s `SACLockScreenImmediate`,
+    /// resolved at runtime with the same `dlsym` approach this type already uses
+    /// for `AuthorizationExecuteWithPrivileges`.
+    ///
+    /// This is a fallback for systems where the supported `CGSession -suspend`
+    /// tool no longer ships (Apple removed `User.menu` from `Menu Extras`), so
+    /// the caller should prefer that tool whenever it is still present.
+    @discardableResult
+    func lockScreen() async -> Bool {
+        guard let lock = Self.lockScreenImmediate else {
+            sleepyCommandLogger.error("No screen-lock mechanism available: SACLockScreenImmediate could not be resolved")
+            return false
+        }
+        return await withCheckedContinuation { (continuation: CheckedContinuation<Bool, Never>) in
+            // Locking is UI-adjacent; keep it on the main queue.
+            DispatchQueue.main.async {
+                lock()
+                continuation.resume(returning: true)
             }
         }
     }

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -2026,6 +2026,7 @@ C0DE71B10000000000000001 /* AppDelegate+AgentChatNotifications.swift in Sources 
 		C7B0FACE0000000000000008 /* SleepyCommandRunning.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7B0FACE0000000000000009 /* SleepyCommandRunning.swift */; };
 		C7B0FACE0000000000000006 /* SleepyEnergyMode.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7B0FACE0000000000000007 /* SleepyEnergyMode.swift */; };
 		C7B0000000000000000000B2 /* SleepyFaceView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7B0000000000000000000B1 /* SleepyFaceView.swift */; };
+		A11CE0010000000000000CB2 /* SleepyLockMechanismTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A11CE0020000000000000CB1 /* SleepyLockMechanismTests.swift */; };
 		C7B0000000000000000000A2 /* SleepyModeController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7B0000000000000000000A1 /* SleepyModeController.swift */; };
 		C7B0FACE0000000000000000 /* SleepyOverlayWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7B0FACE0000000000000001 /* SleepyOverlayWindow.swift */; };
 		C7B0FACE000000000000001C /* SleepyPalette.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7B0FACE000000000000001D /* SleepyPalette.swift */; };
@@ -4616,6 +4617,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 		C7B0FACE0000000000000009 /* SleepyCommandRunning.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SleepyCommandRunning.swift; sourceTree = "<group>"; };
 		C7B0FACE0000000000000007 /* SleepyEnergyMode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SleepyEnergyMode.swift; sourceTree = "<group>"; };
 		C7B0000000000000000000B1 /* SleepyFaceView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SleepyFaceView.swift; sourceTree = "<group>"; };
+		A11CE0020000000000000CB1 /* SleepyLockMechanismTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SleepyLockMechanismTests.swift; sourceTree = "<group>"; };
 		C7B0000000000000000000A1 /* SleepyModeController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SleepyModeController.swift; sourceTree = "<group>"; };
 		C7B0FACE0000000000000001 /* SleepyOverlayWindow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SleepyOverlayWindow.swift; sourceTree = "<group>"; };
 		C7B0FACE000000000000001D /* SleepyPalette.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SleepyPalette.swift; sourceTree = "<group>"; };
@@ -7265,6 +7267,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 			isa = PBXGroup;
 			children = (
 				A11CE0020000000000000001 /* AboutLicensesResourceTests.swift */,
+				A11CE0020000000000000CB1 /* SleepyLockMechanismTests.swift */,
 				F2000001A1B2C3D4E5F60718 /* UpdatePillReleaseVisibilityTests.swift */,
 				F3000001A1B2C3D4E5F60718 /* CJKIMEInputTests.swift */,
 				D3571003A1B2C3D4E5F60718 /* CJKIMEMarkedSelectionTests.swift */,
@@ -10812,6 +10815,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				B804C0010000000000000001 /* SidebarWorkspaceTableTests.swift in Sources */,
 				C51A720000000000000000B1 /* SimulatorPanelIntegrationTests.swift in Sources */,
 				C51A760000000000000000D1 /* SimulatorPanelThemeTests.swift in Sources */,
+				A11CE0010000000000000CB2 /* SleepyLockMechanismTests.swift in Sources */,
 				A7984AE10000000000000001 /* SocketACLReloadRegressionTests+Connections.swift in Sources */,
 				A79840010000000000000001 /* SocketACLReloadRegressionTests.swift in Sources */,
 				5830CA11BAC0000000000002 /* SocketCallbackAwaiterMainThreadTests.swift in Sources */,

--- a/cmuxTests/SleepyLockMechanismTests.swift
+++ b/cmuxTests/SleepyLockMechanismTests.swift
@@ -15,18 +15,26 @@ import Testing
 /// launch error was discarded by a `try?`, so the button silently did nothing.
 @Suite("Sleepy Mode lock mechanism")
 struct SleepyLockMechanismTests {
+    /// One invocation the controls asked the system to perform. Arguments are
+    /// recorded too: launching `CGSession` *without* `-suspend` would exit
+    /// cleanly while locking nothing, which a tool-only assertion would miss.
+    private struct Invocation: Sendable, Equatable {
+        let tool: String
+        let args: [String]
+    }
+
     /// Records what a `SleepyPowerControls` asked the system to do, and lets a
     /// test decide which mechanisms are available.
     private actor FakeRunner: SleepyCommandRunning {
         private let toolExists: Bool
-        private let launchSucceeds: Bool
+        private let legacyExitsZero: Bool
         private let lockScreenSucceeds: Bool
-        private(set) var launchedTools: [String] = []
+        private(set) var invocations: [Invocation] = []
         private(set) var lockScreenCalls = 0
 
-        init(toolExists: Bool, launchSucceeds: Bool = true, lockScreenSucceeds: Bool = true) {
+        init(toolExists: Bool, legacyExitsZero: Bool = true, lockScreenSucceeds: Bool = true) {
             self.toolExists = toolExists
-            self.launchSucceeds = launchSucceeds
+            self.legacyExitsZero = legacyExitsZero
             self.lockScreenSucceeds = lockScreenSucceeds
         }
 
@@ -34,8 +42,14 @@ struct SleepyLockMechanismTests {
 
         @discardableResult
         func run(_ tool: String, _ args: [String]) async -> Bool {
-            launchedTools.append(tool)
-            return launchSucceeds
+            invocations.append(Invocation(tool: tool, args: args))
+            return legacyExitsZero
+        }
+
+        @discardableResult
+        func runAwaitingExit(_ tool: String, _ args: [String]) async -> Bool {
+            invocations.append(Invocation(tool: tool, args: args))
+            return legacyExitsZero
         }
 
         func capture(_ tool: String, _ args: [String]) async -> String? { nil }
@@ -50,19 +64,25 @@ struct SleepyLockMechanismTests {
         }
     }
 
+    /// The invocation a working lock must make on systems that still ship the tool.
+    private static let expectedLegacyCall = Invocation(
+        tool: SleepyPowerControls.legacyLockTool,
+        args: ["-suspend"]
+    )
+
     private func makeControls(_ runner: FakeRunner) async -> SleepyPowerControls {
         await MainActor.run {
             SleepyPowerControls(runner: runner, defaults: UserDefaults(suiteName: "sleepy.lock.tests." + UUID().uuidString)!)
         }
     }
 
-    @Test("Uses the supported CGSession tool when the system still ships it")
+    @Test("Uses the supported CGSession tool, with -suspend, when the system ships it")
     func prefersSupportedToolWhenPresent() async throws {
         let runner = FakeRunner(toolExists: true)
         let controls = await makeControls(runner)
 
         #expect(await controls.lockMacNow())
-        #expect(await runner.launchedTools == [SleepyPowerControls.legacyLockTool])
+        #expect(await runner.invocations == [Self.expectedLegacyCall])
         // No need for the private symbol while Apple's tool is available.
         #expect(await runner.lockScreenCalls == 0)
     }
@@ -74,16 +94,19 @@ struct SleepyLockMechanismTests {
 
         #expect(await controls.lockMacNow())
         // The missing tool must not even be launched, and the lock must happen.
-        #expect(await runner.launchedTools.isEmpty)
+        #expect(await runner.invocations.isEmpty)
         #expect(await runner.lockScreenCalls == 1)
     }
 
-    @Test("Falls back when the tool exists but cannot be launched")
-    func fallsBackWhenLaunchFails() async throws {
-        let runner = FakeRunner(toolExists: true, launchSucceeds: false)
+    @Test("Falls back when the tool exists but exits non-zero")
+    func fallsBackWhenLegacyExitsNonZero() async throws {
+        let runner = FakeRunner(toolExists: true, legacyExitsZero: false)
         let controls = await makeControls(runner)
 
         #expect(await controls.lockMacNow())
+        // A process that starts and fails has locked nothing: the legacy command
+        // must have been attempted with -suspend, then the fallback used.
+        #expect(await runner.invocations == [Self.expectedLegacyCall])
         #expect(await runner.lockScreenCalls == 1)
     }
 

--- a/cmuxTests/SleepyLockMechanismTests.swift
+++ b/cmuxTests/SleepyLockMechanismTests.swift
@@ -1,0 +1,98 @@
+import Foundation
+import Testing
+
+#if canImport(cmux_DEV)
+@testable import cmux_DEV
+#elseif canImport(cmux)
+@testable import cmux
+#endif
+
+/// Regression coverage for the Sleepy Mode "Lock Mac" button.
+///
+/// Apple removed `User.menu` from `Menu Extras`, so the `CGSession -suspend`
+/// tool the button shelled out to no longer exists on macOS 26 (it is still
+/// present on the macOS 15 build fleet, which is why CI never saw it). The
+/// launch error was discarded by a `try?`, so the button silently did nothing.
+@Suite("Sleepy Mode lock mechanism")
+struct SleepyLockMechanismTests {
+    /// Records what a `SleepyPowerControls` asked the system to do, and lets a
+    /// test decide which mechanisms are available.
+    private actor FakeRunner: SleepyCommandRunning {
+        private let toolExists: Bool
+        private let launchSucceeds: Bool
+        private let lockScreenSucceeds: Bool
+        private(set) var launchedTools: [String] = []
+        private(set) var lockScreenCalls = 0
+
+        init(toolExists: Bool, launchSucceeds: Bool = true, lockScreenSucceeds: Bool = true) {
+            self.toolExists = toolExists
+            self.launchSucceeds = launchSucceeds
+            self.lockScreenSucceeds = lockScreenSucceeds
+        }
+
+        func canRun(_ tool: String) async -> Bool { toolExists }
+
+        @discardableResult
+        func run(_ tool: String, _ args: [String]) async -> Bool {
+            launchedTools.append(tool)
+            return launchSucceeds
+        }
+
+        func capture(_ tool: String, _ args: [String]) async -> String? { nil }
+
+        @discardableResult
+        func runPrivileged(_ tool: String, _ args: [String]) async -> Bool { true }
+
+        @discardableResult
+        func lockScreen() async -> Bool {
+            lockScreenCalls += 1
+            return lockScreenSucceeds
+        }
+    }
+
+    private func makeControls(_ runner: FakeRunner) async -> SleepyPowerControls {
+        await MainActor.run {
+            SleepyPowerControls(runner: runner, defaults: UserDefaults(suiteName: "sleepy.lock.tests." + UUID().uuidString)!)
+        }
+    }
+
+    @Test("Uses the supported CGSession tool when the system still ships it")
+    func prefersSupportedToolWhenPresent() async throws {
+        let runner = FakeRunner(toolExists: true)
+        let controls = await makeControls(runner)
+
+        #expect(await controls.lockMacNow())
+        #expect(await runner.launchedTools == [SleepyPowerControls.legacyLockTool])
+        // No need for the private symbol while Apple's tool is available.
+        #expect(await runner.lockScreenCalls == 0)
+    }
+
+    @Test("Falls back to the in-process lock when the tool was removed")
+    func fallsBackWhenToolMissing() async throws {
+        let runner = FakeRunner(toolExists: false)
+        let controls = await makeControls(runner)
+
+        #expect(await controls.lockMacNow())
+        // The missing tool must not even be launched, and the lock must happen.
+        #expect(await runner.launchedTools.isEmpty)
+        #expect(await runner.lockScreenCalls == 1)
+    }
+
+    @Test("Falls back when the tool exists but cannot be launched")
+    func fallsBackWhenLaunchFails() async throws {
+        let runner = FakeRunner(toolExists: true, launchSucceeds: false)
+        let controls = await makeControls(runner)
+
+        #expect(await controls.lockMacNow())
+        #expect(await runner.lockScreenCalls == 1)
+    }
+
+    @Test("Reports failure when no lock mechanism is available")
+    func reportsFailureWhenNothingAvailable() async throws {
+        let runner = FakeRunner(toolExists: false, lockScreenSucceeds: false)
+        let controls = await makeControls(runner)
+
+        // The UI relies on this to say the lock failed instead of looking inert.
+        #expect(await controls.lockMacNow() == false)
+    }
+}

--- a/cmuxTests/SleepyLockMechanismTests.swift
+++ b/cmuxTests/SleepyLockMechanismTests.swift
@@ -9,57 +9,94 @@ import Testing
 
 /// Regression coverage for the Sleepy Mode "Lock Mac" button.
 ///
-/// Apple removed `User.menu` from `Menu Extras`, so the `CGSession -suspend`
-/// tool the button shelled out to no longer exists on macOS 26 (it is still
-/// present on the macOS 15 build fleet, which is why CI never saw it). The
-/// launch error was discarded by a `try?`, so the button silently did nothing.
+/// The button shelled out to a `CGSession -suspend` tool that no longer ships
+/// on macOS 26 (it is still present on the macOS 15 build fleet, which is why
+/// CI never saw it). The launch error was discarded by a `try?`, so the button
+/// silently did nothing.
 @Suite("Sleepy Mode lock mechanism")
 struct SleepyLockMechanismTests {
-    /// One invocation the controls asked the system to perform. Arguments are
-    /// recorded too: launching `CGSession` *without* `-suspend` would exit
-    /// cleanly while locking nothing, which a tool-only assertion would miss.
+    /// One invocation the controls asked the system to perform.
+    ///
+    /// Arguments are recorded too: launching `CGSession` *without* `-suspend`
+    /// would exit cleanly while locking nothing, which a tool-only assertion
+    /// would miss.
     private struct Invocation: Sendable, Equatable {
+        /// Absolute path of the executable that was asked to run.
         let tool: String
+        /// Arguments it was invoked with.
         let args: [String]
     }
 
     /// Records what a `SleepyPowerControls` asked the system to do, and lets a
     /// test decide which mechanisms are available.
-    private actor FakeRunner: SleepyCommandRunning {
+    ///
+    /// A lock-guarded class rather than an actor, because `SleepyCommandRunning`
+    /// declares `nonisolated` requirements that actor-isolated members cannot
+    /// satisfy.
+    private final class FakeRunner: SleepyCommandRunning, @unchecked Sendable {
+        /// Guards the recorded state, which the controls touch off the main actor.
+        private let lock = NSLock()
+        /// Whether the fake system has the legacy `CGSession` tool installed.
         private let toolExists: Bool
+        /// Whether that tool reports a zero exit status.
         private let legacyExitsZero: Bool
+        /// Whether the in-process lock fallback is available.
         private let lockScreenSucceeds: Bool
-        private(set) var invocations: [Invocation] = []
-        private(set) var lockScreenCalls = 0
+        /// Commands the controls asked to run, in order.
+        private var recordedInvocations: [Invocation] = []
+        /// How many times the in-process lock fallback was used.
+        private var recordedLockScreenCalls = 0
 
+        /// Creates a runner describing which lock mechanisms the "system" offers.
+        ///
+        /// - Parameters:
+        ///   - toolExists: Whether the legacy `CGSession` tool is installed.
+        ///   - legacyExitsZero: Whether that tool exits successfully.
+        ///   - lockScreenSucceeds: Whether the in-process lock is available.
         init(toolExists: Bool, legacyExitsZero: Bool = true, lockScreenSucceeds: Bool = true) {
             self.toolExists = toolExists
             self.legacyExitsZero = legacyExitsZero
             self.lockScreenSucceeds = lockScreenSucceeds
         }
 
-        func canRun(_ tool: String) async -> Bool { toolExists }
+        /// Every command invocation recorded so far, in order.
+        var invocations: [Invocation] {
+            lock.withLock { recordedInvocations }
+        }
 
+        /// How many times the in-process lock was used.
+        var lockScreenCalls: Int {
+            lock.withLock { recordedLockScreenCalls }
+        }
+
+        /// Reports whether the fake "system" has `tool` installed.
+        nonisolated func canRun(_ tool: String) async -> Bool { toolExists }
+
+        /// Records a fire-and-forget invocation.
         @discardableResult
-        func run(_ tool: String, _ args: [String]) async -> Bool {
-            invocations.append(Invocation(tool: tool, args: args))
+        nonisolated func run(_ tool: String, _ args: [String]) async -> Bool {
+            lock.withLock { recordedInvocations.append(Invocation(tool: tool, args: args)) }
             return legacyExitsZero
         }
 
+        /// Records an invocation that the caller waits on for an exit status.
         @discardableResult
-        func runAwaitingExit(_ tool: String, _ args: [String]) async -> Bool {
-            invocations.append(Invocation(tool: tool, args: args))
+        nonisolated func runAwaitingExit(_ tool: String, _ args: [String]) async -> Bool {
+            lock.withLock { recordedInvocations.append(Invocation(tool: tool, args: args)) }
             return legacyExitsZero
         }
 
-        func capture(_ tool: String, _ args: [String]) async -> String? { nil }
+        /// Unused by these tests; no command output is needed.
+        nonisolated func capture(_ tool: String, _ args: [String]) async -> String? { nil }
 
+        /// Unused by these tests; no privileged command is issued.
         @discardableResult
-        func runPrivileged(_ tool: String, _ args: [String]) async -> Bool { true }
+        nonisolated func runPrivileged(_ tool: String, _ args: [String]) async -> Bool { true }
 
+        /// Records use of the in-process lock fallback.
         @discardableResult
-        func lockScreen() async -> Bool {
-            lockScreenCalls += 1
+        nonisolated func lockScreen() async -> Bool {
+            lock.withLock { recordedLockScreenCalls += 1 }
             return lockScreenSucceeds
         }
     }
@@ -70,23 +107,29 @@ struct SleepyLockMechanismTests {
         args: ["-suspend"]
     )
 
+    /// Builds controls wired to `runner` with isolated defaults.
+    ///
+    /// - Parameter runner: The fake system the controls should drive.
+    /// - Returns: Controls under test.
     private func makeControls(_ runner: FakeRunner) async -> SleepyPowerControls {
         await MainActor.run {
             SleepyPowerControls(runner: runner, defaults: UserDefaults(suiteName: "sleepy.lock.tests." + UUID().uuidString)!)
         }
     }
 
+    /// Apple's own tool is preferred, and invoked correctly, where it exists.
     @Test("Uses the supported CGSession tool, with -suspend, when the system ships it")
     func prefersSupportedToolWhenPresent() async throws {
         let runner = FakeRunner(toolExists: true)
         let controls = await makeControls(runner)
 
         #expect(await controls.lockMacNow())
-        #expect(await runner.invocations == [Self.expectedLegacyCall])
-        // No need for the private symbol while Apple's tool is available.
-        #expect(await runner.lockScreenCalls == 0)
+        #expect(runner.invocations == [Self.expectedLegacyCall])
+        // No need for the private symbol while the supported tool is available.
+        #expect(runner.lockScreenCalls == 0)
     }
 
+    /// The macOS 26 case: the tool is gone, so the in-process lock must run.
     @Test("Falls back to the in-process lock when the tool was removed")
     func fallsBackWhenToolMissing() async throws {
         let runner = FakeRunner(toolExists: false)
@@ -94,22 +137,23 @@ struct SleepyLockMechanismTests {
 
         #expect(await controls.lockMacNow())
         // The missing tool must not even be launched, and the lock must happen.
-        #expect(await runner.invocations.isEmpty)
-        #expect(await runner.lockScreenCalls == 1)
+        #expect(runner.invocations.isEmpty)
+        #expect(runner.lockScreenCalls == 1)
     }
 
+    /// A tool that starts and then fails has locked nothing.
     @Test("Falls back when the tool exists but exits non-zero")
     func fallsBackWhenLegacyExitsNonZero() async throws {
         let runner = FakeRunner(toolExists: true, legacyExitsZero: false)
         let controls = await makeControls(runner)
 
         #expect(await controls.lockMacNow())
-        // A process that starts and fails has locked nothing: the legacy command
-        // must have been attempted with -suspend, then the fallback used.
-        #expect(await runner.invocations == [Self.expectedLegacyCall])
-        #expect(await runner.lockScreenCalls == 1)
+        // The legacy command must have been attempted with -suspend first.
+        #expect(runner.invocations == [Self.expectedLegacyCall])
+        #expect(runner.lockScreenCalls == 1)
     }
 
+    /// With nothing available the caller must learn the lock did not happen.
     @Test("Reports failure when no lock mechanism is available")
     func reportsFailureWhenNothingAvailable() async throws {
         let runner = FakeRunner(toolExists: false, lockScreenSucceeds: false)


### PR DESCRIPTION
## The bug

Sleepy Mode's **Lock Mac** button does nothing on macOS 26. No lock, no error, nothing in the logs.

## Root cause

`SleepyPowerControls.lockMacNow()` shelled out to:

```
/System/Library/CoreServices/Menu Extras/User.menu/Contents/Resources/CGSession -suspend
```

Apple removed `User.menu` from `Menu Extras`. On macOS 26.5.2 it is absent — the folder still holds `AirPort.menu`, `Eject.menu` and friends, but there is no `CGSession` anywhere under `CoreServices`.

It failed *silently* because `SystemCommandRunner.run()` used `try? process.run()` with stdout and stderr both routed to `/dev/null` and no exit-status check. A missing executable throws, `try?` discards it, and the function returns as though the lock happened.

Per the macOS-version note in `CLAUDE.md`, the AWS builders run macOS 15.7.4, where `User.menu` still exists — so this works on CI and on maintainer machines and breaks for users on 26. Same shape as #4529.

## The fix

Choose the mechanism by **capability, not OS version**: use the supported `CGSession` tool wherever it still ships, and fall back to `login.framework`'s `SACLockScreenImmediate` only when it is absent. I verified the symbol resolves on 26.5.2 (lookup only, not called), using the same `dlsym` approach `SystemCommandRunner` already uses for `AuthorizationExecuteWithPrivileges`.

Probing beats a version threshold: the exact release Apple dropped the tool in isn't something to guess at, and a wrong threshold would break every version in between.

Also:
- `run()` now reports whether the launch succeeded and logs failures, so a missing system tool can't present as a working button again.
- `lockMacNow()` returns `Bool`, and the scene shows "Couldn't lock the Mac" (localized en + ja) instead of looking inert.

## Tests

`cmuxTests/SleepyLockMechanismTests.swift` covers: prefers the supported tool when present, falls back when the tool is missing, falls back when it exists but won't launch, and reports failure when nothing is available. Wired into the pbxproj (`lint-pbxproj-test-wiring.sh` passes).

Deviates from the two-commit regression policy: the fix changes the `SleepyCommandRunning` protocol the test drives, so a test-only first commit wouldn't compile.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/9541"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788419377&installation_model_id=21920&pr_number=9541&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F9541&signature=e0f6fb2778e4191125d4a5abd6ad49c5df0e563091b5b3b1456c3e50f3c25e2a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Sleepy Mode "Lock Mac" button on macOS 26 by preferring `CGSession -suspend` when available, awaiting a zero exit, and falling back to the system login lock; the lock attempt is now owned and cancellable to avoid stale UI after teardown.

- **Bug Fixes**
  - Prefer `CGSession -suspend` when present and require exit status 0; otherwise call `SACLockScreenImmediate` on the main actor.
  - `SystemCommandRunner`: added `canRun()`, `runAwaitingExit()`, `lockScreen()`; `run()` returns Bool and logs via `OSLog`; uses `Process.terminationHandler` (no blocked threads); `SleepyCommandRunning` methods are `nonisolated`.
  - Shared `SleepyPowerUIState` owns a single in-flight lock across displays (`isLocking`, `lockFailed`), disables the button, and cancels on controller teardown so late completions don’t surface in a new session; shows "Couldn't lock the Mac — use the system menu › Lock Screen" localized in 20 locales.
  - Added `SleepyLockMechanismTests` for prefer/fallback behavior, non-zero exit handling, and `-suspend` arg assertion.

<sup>Written for commit ae1e563ab6741e07f5d7b17cea9b7a49d1db3307. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/9541?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Lock Mac now uses an available fallback when the primary locking method is unavailable.
  * Sleepy Mode reports successful and unsuccessful lock attempts.
  * Overlapping lock attempts are prevented.

* **Bug Fixes**
  * Lock failures are no longer silently ignored.
  * Added a localized warning with Apple menu → Lock Screen instructions in 20 languages.
  * Improved handling of unavailable or unsuccessful locking methods.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->