### PR TITLE
Add per-version changelog pages

### DIFF
--- a/web/app/[locale]/(landing)/docs/changelog/[version]/page.tsx
+++ b/web/app/[locale]/(landing)/docs/changelog/[version]/page.tsx
@@ -18,12 +18,10 @@ import {
   changelogPath,
   changelogVersionDescription,
   changelogVersionPath,
-  findChangelogVersion,
-  findChangelogVersionContext,
   localizedChangelogPath,
-  readChangelog,
   type ChangelogVersion,
 } from "@/app/lib/changelog";
+import { changelogStore } from "@/app/lib/changelog-store";
 import { changelogMedia, type VersionMedia } from "../changelog-media";
 import { ChangelogRelease } from "../changelog-release";
 
@@ -32,7 +30,9 @@ type PageParams = { locale: string; version: string };
 export const dynamicParams = false;
 
 export function generateStaticParams() {
-  return readChangelog().map((release) => ({ version: release.version }));
+  return changelogStore
+    .versions()
+    .map((release) => ({ version: release.version }));
 }
 
 export async function generateMetadata({
@@ -41,7 +41,7 @@ export async function generateMetadata({
   params: Promise<PageParams>;
 }): Promise<Metadata> {
   const { locale, version } = await params;
-  const release = findChangelogVersion(version);
+  const release = changelogStore.findVersion(version);
   if (!release) notFound();
 
   const t = await getTranslations({ locale, namespace: "docs.changelog" });
@@ -80,7 +80,7 @@ export default async function ChangelogVersionPage({
   params: Promise<PageParams>;
 }) {
   const { locale, version } = await params;
-  const context = findChangelogVersionContext(version);
+  const context = changelogStore.findVersionContext(version);
   if (!context) notFound();
 
   const { release, index: releaseIndex, versions } = context;

--- a/web/app/[locale]/(landing)/docs/changelog/[version]/page.tsx
+++ b/web/app/[locale]/(landing)/docs/changelog/[version]/page.tsx
@@ -27,6 +27,7 @@ import { ChangelogRelease } from "../changelog-release";
 
 type PageParams = { locale: string; version: string };
 
+export const dynamic = "force-static";
 export const dynamicParams = false;
 
 export function generateStaticParams() {

--- a/web/app/[locale]/(landing)/docs/changelog/[version]/page.tsx
+++ b/web/app/[locale]/(landing)/docs/changelog/[version]/page.tsx
@@ -1,0 +1,193 @@
+import type { Metadata } from "next";
+import { getTranslations } from "next-intl/server";
+import { notFound } from "next/navigation";
+import {
+  buildAlternates,
+  openGraphDefaults,
+  seoDescription,
+  seoTitle,
+  twitterSummary,
+} from "@/i18n/seo";
+import {
+  articleSchema,
+  breadcrumbList,
+  JsonLd,
+} from "@/app/[locale]/components/json-ld";
+import {
+  changelogPath,
+  changelogVersionDescription,
+  changelogVersionPath,
+  findChangelogVersion,
+  localizedChangelogPath,
+  readChangelog,
+  type ChangelogVersion,
+} from "@/app/lib/changelog";
+import { changelogMedia, type VersionMedia } from "../changelog-media";
+import { ChangelogRelease } from "../changelog-release";
+
+type PageParams = { locale: string; version: string };
+
+export const dynamicParams = false;
+
+export function generateStaticParams() {
+  return readChangelog().map((release) => ({ version: release.version }));
+}
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<PageParams>;
+}): Promise<Metadata> {
+  const { locale, version } = await params;
+  const release = findChangelogVersion(version);
+  if (!release) notFound();
+
+  const t = await getTranslations({ locale, namespace: "docs.changelog" });
+  const path = changelogVersionPath(release.version);
+  const alternates = buildAlternates(locale, path);
+  const { title, description } = versionSeoCopy(
+    locale,
+    release,
+    changelogMedia[release.version],
+    t("metaTitle"),
+  );
+
+  return {
+    title: { absolute: title },
+    description,
+    alternates,
+    openGraph: {
+      ...openGraphDefaults(locale, "article"),
+      title,
+      description,
+      url: alternates.canonical,
+      publishedTime: release.date,
+      modifiedTime: release.date,
+    },
+    twitter: twitterSummary(locale, title, description),
+  };
+}
+
+export default async function ChangelogVersionPage({
+  params,
+}: {
+  params: Promise<PageParams>;
+}) {
+  const { locale, version } = await params;
+  const versions = readChangelog();
+  const releaseIndex = versions.findIndex(
+    (candidate) => candidate.version === version,
+  );
+  if (releaseIndex < 0) notFound();
+
+  const release = versions[releaseIndex];
+  const media = changelogMedia[release.version];
+  const [t, links, nav] = await Promise.all([
+    getTranslations({ locale, namespace: "docs.changelog" }),
+    getTranslations({ locale, namespace: "landing.links" }),
+    getTranslations({ locale, namespace: "nav" }),
+  ]);
+  const path = changelogVersionPath(release.version);
+  const { description } = versionSeoCopy(
+    locale,
+    release,
+    media,
+    t("metaTitle"),
+  );
+  const headline = media?.title
+    ? `cmux ${release.version}: ${media.title}`
+    : `cmux ${release.version}`;
+  const newerRelease = versions[releaseIndex - 1];
+  const olderRelease = versions[releaseIndex + 1];
+
+  return (
+    <div className="w-full max-w-[640px] min-w-0">
+      <JsonLd
+        data={articleSchema({
+          locale,
+          path,
+          headline,
+          description,
+          datePublished: release.date,
+          dateModified: release.date,
+        })}
+      />
+      <JsonLd
+        data={breadcrumbList(locale, [
+          { name: links("home"), path: "/" },
+          { name: nav("docs"), path: "/docs" },
+          { name: t("title"), path: changelogPath },
+          { name: `cmux ${release.version}`, path },
+        ])}
+      />
+
+      <div className="not-prose" style={{ paddingBottom: 20 }}>
+        <a
+          href={localizedChangelogPath(locale)}
+          className="text-[13px] text-muted hover:text-foreground transition-colors"
+        >
+          <span aria-hidden>&larr;</span> {t("title")}
+        </a>
+      </div>
+
+      <ChangelogRelease
+        release={release}
+        locale={locale}
+        media={media}
+        standalone
+      />
+
+      {(olderRelease || newerRelease) && (
+        <nav
+          aria-label={`${t("title")} ${release.version}`}
+          className="not-prose flex items-center justify-between border-t border-border pt-6 text-[13px]"
+        >
+          {olderRelease ? (
+            <a
+              href={localizedChangelogPath(locale, olderRelease.version)}
+              className="text-muted hover:text-foreground transition-colors"
+            >
+              <span aria-hidden>&larr;</span> cmux {olderRelease.version}
+            </a>
+          ) : (
+            <span />
+          )}
+          {newerRelease ? (
+            <a
+              href={localizedChangelogPath(locale, newerRelease.version)}
+              className="text-muted hover:text-foreground transition-colors"
+            >
+              cmux {newerRelease.version} <span aria-hidden>&rarr;</span>
+            </a>
+          ) : (
+            <span />
+          )}
+        </nav>
+      )}
+    </div>
+  );
+}
+
+function versionSeoCopy(
+  locale: string,
+  release: ChangelogVersion,
+  media: VersionMedia | undefined,
+  changelogTitle: string,
+) {
+  const conciseTitle = `cmux ${release.version} · ${changelogTitle}`;
+  const titleCandidate = media?.title
+    ? `cmux ${release.version}: ${media.title}`
+    : conciseTitle;
+  const title = seoTitle(locale, titleCandidate, {
+    appendLocalizedContext: false,
+    fallbackCandidates: [conciseTitle],
+  });
+  const description = seoDescription(
+    locale,
+    changelogVersionDescription(
+      release,
+      media?.features?.[0]?.description,
+    ),
+  );
+  return { title, description };
+}

--- a/web/app/[locale]/(landing)/docs/changelog/[version]/page.tsx
+++ b/web/app/[locale]/(landing)/docs/changelog/[version]/page.tsx
@@ -3,6 +3,7 @@ import { getTranslations } from "next-intl/server";
 import { notFound } from "next/navigation";
 import {
   buildAlternates,
+  joinMetadataSentences,
   openGraphDefaults,
   seoDescription,
   seoTitle,
@@ -18,6 +19,7 @@ import {
   changelogVersionDescription,
   changelogVersionPath,
   findChangelogVersion,
+  findChangelogVersionContext,
   localizedChangelogPath,
   readChangelog,
   type ChangelogVersion,
@@ -45,11 +47,15 @@ export async function generateMetadata({
   const t = await getTranslations({ locale, namespace: "docs.changelog" });
   const path = changelogVersionPath(release.version);
   const alternates = buildAlternates(locale, path);
+  const localizedVersionTitle = t("versionTitle", {
+    version: release.version,
+  });
   const { title, description } = versionSeoCopy(
     locale,
     release,
     changelogMedia[release.version],
-    t("metaTitle"),
+    localizedVersionTitle,
+    t("metaDescription"),
   );
 
   return {
@@ -74,13 +80,10 @@ export default async function ChangelogVersionPage({
   params: Promise<PageParams>;
 }) {
   const { locale, version } = await params;
-  const versions = readChangelog();
-  const releaseIndex = versions.findIndex(
-    (candidate) => candidate.version === version,
-  );
-  if (releaseIndex < 0) notFound();
+  const context = findChangelogVersionContext(version);
+  if (!context) notFound();
 
-  const release = versions[releaseIndex];
+  const { release, index: releaseIndex, versions } = context;
   const media = changelogMedia[release.version];
   const [t, links, nav] = await Promise.all([
     getTranslations({ locale, namespace: "docs.changelog" }),
@@ -88,15 +91,26 @@ export default async function ChangelogVersionPage({
     getTranslations({ locale, namespace: "nav" }),
   ]);
   const path = changelogVersionPath(release.version);
+  const localizedVersionTitle = t("versionTitle", {
+    version: release.version,
+  });
   const { description } = versionSeoCopy(
     locale,
     release,
     media,
-    t("metaTitle"),
+    localizedVersionTitle,
+    t("metaDescription"),
   );
-  const headline = media?.title
+  const headline = locale === "en" && media?.title
     ? `cmux ${release.version}: ${media.title}`
-    : `cmux ${release.version}`;
+    : localizedVersionTitle;
+  const sectionLabels = {
+    added: t("sections.added"),
+    changed: t("sections.changed"),
+    fixed: t("sections.fixed"),
+    removed: t("sections.removed"),
+    contributors: t("sections.contributors"),
+  };
   const newerRelease = versions[releaseIndex - 1];
   const olderRelease = versions[releaseIndex + 1];
 
@@ -134,12 +148,16 @@ export default async function ChangelogVersionPage({
         release={release}
         locale={locale}
         media={media}
+        sectionLabels={sectionLabels}
+        standaloneHeading={headline}
         standalone
       />
 
       {(olderRelease || newerRelease) && (
         <nav
-          aria-label={`${t("title")} ${release.version}`}
+          aria-label={t("releaseNavLabel", {
+            version: release.version,
+          })}
           className="not-prose flex items-center justify-between border-t border-border pt-6 text-[13px]"
         >
           {olderRelease ? (
@@ -172,22 +190,28 @@ function versionSeoCopy(
   locale: string,
   release: ChangelogVersion,
   media: VersionMedia | undefined,
-  changelogTitle: string,
+  localizedVersionTitle: string,
+  changelogDescription: string,
 ) {
-  const conciseTitle = `cmux ${release.version} · ${changelogTitle}`;
-  const titleCandidate = media?.title
+  const conciseTitle = localizedVersionTitle;
+  const titleCandidate = locale === "en" && media?.title
     ? `cmux ${release.version}: ${media.title}`
     : conciseTitle;
   const title = seoTitle(locale, titleCandidate, {
     appendLocalizedContext: false,
     fallbackCandidates: [conciseTitle],
   });
-  const description = seoDescription(
-    locale,
-    changelogVersionDescription(
-      release,
-      media?.features?.[0]?.description,
-    ),
-  );
+  const descriptionCandidate =
+    locale === "en"
+      ? changelogVersionDescription(
+          release,
+          media?.features?.[0]?.description,
+        )
+      : joinMetadataSentences(
+          locale,
+          `cmux ${release.version}`,
+          changelogDescription,
+        );
+  const description = seoDescription(locale, descriptionCandidate);
   return { title, description };
 }

--- a/web/app/[locale]/(landing)/docs/changelog/changelog-release.tsx
+++ b/web/app/[locale]/(landing)/docs/changelog/changelog-release.tsx
@@ -4,10 +4,20 @@ import type { ChangelogVersion } from "@/app/lib/changelog";
 import { pngDimensions } from "./png-dimensions";
 import type { VersionMedia } from "./changelog-media";
 
+export interface ChangelogSectionLabels {
+  added: string;
+  changed: string;
+  fixed: string;
+  removed: string;
+  contributors: string;
+}
+
 export function ChangelogRelease({
   release,
   locale,
   media,
+  sectionLabels,
+  standaloneHeading,
   versionHref,
   standalone = false,
   first = false,
@@ -15,13 +25,17 @@ export function ChangelogRelease({
   release: ChangelogVersion;
   locale: string;
   media?: VersionMedia;
+  sectionLabels: ChangelogSectionLabels;
+  standaloneHeading?: string;
   versionHref?: string;
   standalone?: boolean;
   first?: boolean;
 }) {
-  const heading = media?.title
-    ? `cmux ${release.version}: ${media.title}`
-    : `cmux ${release.version}`;
+  const heading =
+    standaloneHeading ??
+    (locale === "en" && media?.title
+      ? `cmux ${release.version}: ${media.title}`
+      : `cmux ${release.version}`);
 
   return (
     <article
@@ -136,7 +150,10 @@ export function ChangelogRelease({
           if (isContributors) {
             return (
               <div key={index}>
-                <SectionBadge heading={section.heading} />
+                <SectionBadge
+                  heading={section.heading}
+                  labels={sectionLabels}
+                />
                 <ContributorList items={section.items} />
               </div>
             );
@@ -145,7 +162,10 @@ export function ChangelogRelease({
           return (
             <div key={index}>
               {section.heading && (
-                <SectionBadge heading={section.heading} />
+                <SectionBadge
+                  heading={section.heading}
+                  labels={sectionLabels}
+                />
               )}
               <ul
                 style={{
@@ -325,7 +345,13 @@ function ContributorList({ items }: { items: string[] }) {
   );
 }
 
-function SectionBadge({ heading }: { heading: string }) {
+function SectionBadge({
+  heading,
+  labels,
+}: {
+  heading: string;
+  labels: ChangelogSectionLabels;
+}) {
   const lower = heading.toLowerCase();
 
   let color = "bg-border/50 text-muted";
@@ -333,16 +359,19 @@ function SectionBadge({ heading }: { heading: string }) {
 
   if (lower === "added") {
     color = "bg-emerald-500/10 text-emerald-600 dark:text-emerald-400";
-    label = "Added";
+    label = labels.added;
   } else if (lower === "changed") {
     color = "bg-blue-500/10 text-blue-600 dark:text-blue-400";
-    label = "Changed";
+    label = labels.changed;
   } else if (lower === "fixed") {
     color = "bg-amber-500/10 text-amber-600 dark:text-amber-400";
-    label = "Fixed";
+    label = labels.fixed;
+  } else if (lower === "removed") {
+    color = "bg-red-500/10 text-red-600 dark:text-red-400";
+    label = labels.removed;
   } else if (lower.startsWith("thanks")) {
     color = "bg-purple-500/10 text-purple-600 dark:text-purple-400";
-    label = "Contributors";
+    label = labels.contributors;
   }
 
   return (

--- a/web/app/[locale]/(landing)/docs/changelog/changelog-release.tsx
+++ b/web/app/[locale]/(landing)/docs/changelog/changelog-release.tsx
@@ -1,0 +1,355 @@
+import Image from "next/image";
+import { DocsHeading } from "@/app/[locale]/components/docs-heading";
+import type { ChangelogVersion } from "@/app/lib/changelog";
+import { pngDimensions } from "./png-dimensions";
+import type { VersionMedia } from "./changelog-media";
+
+export function ChangelogRelease({
+  release,
+  locale,
+  media,
+  versionHref,
+  standalone = false,
+  first = false,
+}: {
+  release: ChangelogVersion;
+  locale: string;
+  media?: VersionMedia;
+  versionHref?: string;
+  standalone?: boolean;
+  first?: boolean;
+}) {
+  const heading = media?.title
+    ? `cmux ${release.version}: ${media.title}`
+    : `cmux ${release.version}`;
+
+  return (
+    <article
+      id={standalone ? undefined : `v${release.version}`}
+      className={
+        standalone
+          ? undefined
+          : "border-t border-border first:border-t-0"
+      }
+      style={{
+        display: "flex",
+        flexDirection: "column",
+        paddingTop: standalone || first ? 0 : 40,
+        paddingBottom: 40,
+      }}
+    >
+      {standalone ? (
+        <>
+          <DocsHeading
+            level={1}
+            id={`v${release.version}`}
+            className="docs-heading-compact"
+          >
+            {heading}
+          </DocsHeading>
+          <time
+            className="text-[13px] text-muted"
+            dateTime={release.date}
+            style={{ paddingTop: 8 }}
+          >
+            {formatDate(release.date, locale)}
+          </time>
+        </>
+      ) : (
+        <>
+          <div style={{ display: "flex", alignItems: "center", gap: 12 }}>
+            {versionHref ? (
+              <a
+                href={versionHref}
+                className="no-underline! hover:no-underline!"
+              >
+                <VersionBadge version={release.version} />
+              </a>
+            ) : (
+              <VersionBadge version={release.version} />
+            )}
+            <time className="text-[13px] text-muted" dateTime={release.date}>
+              {formatDate(release.date, locale)}
+            </time>
+          </div>
+
+          {media?.title && (
+            <div
+              className="max-w-full"
+              style={{
+                paddingTop: 12,
+                margin: 0,
+                fontSize: "1.5rem",
+                fontWeight: 700,
+                letterSpacing: 0,
+                lineHeight: 1.25,
+                overflowWrap: "anywhere",
+              }}
+            >
+              {versionHref ? (
+                <a
+                  href={versionHref}
+                  className="text-foreground no-underline! hover:no-underline!"
+                >
+                  {media.title}
+                </a>
+              ) : (
+                media.title
+              )}
+            </div>
+          )}
+        </>
+      )}
+
+      {media?.hero && (
+        <HeroImage
+          src={media.hero}
+          version={release.version}
+          priority={standalone || first}
+        />
+      )}
+
+      {media && <FeatureList media={media} />}
+
+      {release.intro && !media && (
+        <div
+          className="text-[14px] text-muted italic"
+          style={{ paddingTop: 12 }}
+        >
+          {release.intro.replace(/^_/, "").replace(/_$/, "")}
+        </div>
+      )}
+
+      <div
+        style={{
+          paddingTop: 20,
+          display: "flex",
+          flexDirection: "column",
+          gap: 16,
+        }}
+      >
+        {release.sections.map((section, index) => {
+          const isContributors = section.heading
+            .toLowerCase()
+            .startsWith("thanks");
+
+          if (isContributors) {
+            return (
+              <div key={index}>
+                <SectionBadge heading={section.heading} />
+                <ContributorList items={section.items} />
+              </div>
+            );
+          }
+
+          return (
+            <div key={index}>
+              {section.heading && (
+                <SectionBadge heading={section.heading} />
+              )}
+              <ul
+                style={{
+                  margin: 0,
+                  paddingTop: 8,
+                  paddingBottom: 0,
+                  paddingLeft: 24,
+                  listStyle: "disc",
+                }}
+              >
+                {section.items.map((item, itemIndex) => (
+                  <li
+                    key={itemIndex}
+                    style={{
+                      margin: 0,
+                      padding: 0,
+                      fontSize: 14,
+                      lineHeight: 1.6,
+                      color: "var(--muted)",
+                    }}
+                  >
+                    <InlineMarkdown text={item} />
+                  </li>
+                ))}
+              </ul>
+            </div>
+          );
+        })}
+      </div>
+    </article>
+  );
+}
+
+function VersionBadge({ version }: { version: string }) {
+  return (
+    <span className="inline-block text-[13px] font-mono text-muted bg-code-bg px-2 py-0.5 rounded-md">
+      {version}
+    </span>
+  );
+}
+
+function InlineMarkdown({ text }: { text: string }) {
+  const parts = text.split(/(`[^`]+`|\[[^\]]+\]\([^)]+\))/g);
+  return (
+    <>
+      {parts.map((part, index) => {
+        if (part.startsWith("`") && part.endsWith("`")) {
+          return <code key={index}>{part.slice(1, -1)}</code>;
+        }
+        const linkMatch = part.match(/^\[([^\]]+)\]\(([^)]+)\)$/);
+        if (linkMatch) {
+          return (
+            <a key={index} href={linkMatch[2]}>
+              {linkMatch[1]}
+            </a>
+          );
+        }
+        return <span key={index}>{part}</span>;
+      })}
+    </>
+  );
+}
+
+function formatDate(date: string, locale: string): string {
+  return new Intl.DateTimeFormat(locale, {
+    month: "long",
+    day: "numeric",
+    year: "numeric",
+    timeZone: "UTC",
+  }).format(new Date(`${date}T00:00:00Z`));
+}
+
+function HeroImage({
+  src,
+  version,
+  priority,
+}: {
+  src: string;
+  version: string;
+  priority: boolean;
+}) {
+  const { width, height } = pngDimensions(src);
+  return (
+    <div style={{ paddingTop: 16, paddingBottom: 24 }}>
+      <div className="overflow-hidden rounded-lg">
+        <Image
+          src={src}
+          alt={`cmux ${version}`}
+          width={width}
+          height={height}
+          sizes="(max-width: 640px) 100vw, 640px"
+          className="w-full h-auto"
+          priority={priority}
+        />
+      </div>
+    </div>
+  );
+}
+
+function FeatureImage({ src, alt }: { src: string; alt: string }) {
+  const { width, height } = pngDimensions(src);
+  return (
+    <div style={{ paddingTop: 12 }}>
+      <div className="overflow-hidden rounded-lg">
+        <Image
+          src={src}
+          alt={alt}
+          width={width}
+          height={height}
+          sizes="(max-width: 640px) 100vw, 640px"
+          className="block w-full max-w-full h-auto"
+        />
+      </div>
+    </div>
+  );
+}
+
+function FeatureList({ media }: { media: VersionMedia }) {
+  if (!media.features?.length) return null;
+
+  return (
+    <div
+      style={{
+        paddingTop: 20,
+        display: "flex",
+        flexDirection: "column",
+        gap: 24,
+      }}
+    >
+      {media.features.map((feature, index) => (
+        <div key={index}>
+          <p style={{ margin: 0, padding: 0 }}>
+            <strong>{feature.title}.</strong>{" "}
+            <span className="text-muted">{feature.description}</span>
+          </p>
+          {feature.image && (
+            <FeatureImage src={feature.image} alt={feature.title} />
+          )}
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function ContributorList({ items }: { items: string[] }) {
+  return (
+    <div className="flex flex-wrap gap-2" style={{ paddingTop: 8 }}>
+      {items.map((item, index) => {
+        const match = item.match(
+          /\[@([^\]]+)\]\((https:\/\/github\.com\/[^)]+)\)/,
+        );
+        if (match) {
+          return (
+            <a
+              key={index}
+              href={match[2]}
+              className="inline-flex items-center gap-1.5 px-2 py-1 rounded-md border border-border text-[13px] text-muted hover:text-foreground transition-colors no-underline!"
+            >
+              <Image
+                src={`https://github.com/${match[1]}.png?size=48`}
+                alt={match[1]}
+                width={18}
+                height={18}
+                className="rounded-full"
+              />
+              {match[1]}
+            </a>
+          );
+        }
+        return (
+          <span key={index} className="text-[13px] text-muted">
+            <InlineMarkdown text={item} />
+          </span>
+        );
+      })}
+    </div>
+  );
+}
+
+function SectionBadge({ heading }: { heading: string }) {
+  const lower = heading.toLowerCase();
+
+  let color = "bg-border/50 text-muted";
+  let label = heading;
+
+  if (lower === "added") {
+    color = "bg-emerald-500/10 text-emerald-600 dark:text-emerald-400";
+    label = "Added";
+  } else if (lower === "changed") {
+    color = "bg-blue-500/10 text-blue-600 dark:text-blue-400";
+    label = "Changed";
+  } else if (lower === "fixed") {
+    color = "bg-amber-500/10 text-amber-600 dark:text-amber-400";
+    label = "Fixed";
+  } else if (lower.startsWith("thanks")) {
+    color = "bg-purple-500/10 text-purple-600 dark:text-purple-400";
+    label = "Contributors";
+  }
+
+  return (
+    <span
+      className={`inline-block text-[12px] font-medium px-2 py-0.5 rounded-md ${color}`}
+    >
+      {label}
+    </span>
+  );
+}

--- a/web/app/[locale]/(landing)/docs/changelog/page.tsx
+++ b/web/app/[locale]/(landing)/docs/changelog/page.tsx
@@ -1,15 +1,24 @@
-import fs from "fs";
-import path from "path";
-import Image from "next/image";
-import { useTranslations } from "next-intl";
 import { getTranslations } from "next-intl/server";
-import { buildAlternates, openGraphDefaults, seoDescription, twitterSummary } from "@/i18n/seo";
-import { changelogMedia, type VersionMedia } from "./changelog-media";
-import { pngDimensions } from "./png-dimensions";
+import {
+  buildAlternates,
+  openGraphDefaults,
+  seoDescription,
+  twitterSummary,
+} from "@/i18n/seo";
+import {
+  localizedChangelogPath,
+  readChangelog,
+} from "@/app/lib/changelog";
 import { DocsHeading } from "@/app/[locale]/components/docs-heading";
 import { DocsSchema } from "../docs-schema";
+import { changelogMedia } from "./changelog-media";
+import { ChangelogRelease } from "./changelog-release";
 
-export async function generateMetadata({ params }: { params: Promise<{ locale: string }> }) {
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ locale: string }>;
+}) {
   const { locale } = await params;
   const t = await getTranslations({ locale, namespace: "docs.changelog" });
   const alternates = buildAlternates(locale, "/docs/changelog");
@@ -29,325 +38,33 @@ export async function generateMetadata({ params }: { params: Promise<{ locale: s
   };
 }
 
-interface ChangelogSection {
-  heading: string;
-  items: string[];
-}
-
-interface ChangelogVersion {
-  version: string;
-  date: string;
-  intro?: string;
-  sections: ChangelogSection[];
-}
-
-function parseChangelog(markdown: string): ChangelogVersion[] {
-  const versions: ChangelogVersion[] = [];
-  let current: ChangelogVersion | null = null;
-  let currentSection: ChangelogSection | null = null;
-
-  for (const line of markdown.split("\n")) {
-    const versionMatch = line.match(/^## \[(.+?)\] - (.+)$/);
-    if (versionMatch) {
-      if (current) versions.push(current);
-      current = {
-        version: versionMatch[1],
-        date: versionMatch[2],
-        sections: [],
-      };
-      currentSection = null;
-      continue;
-    }
-
-    if (!current) continue;
-
-    const sectionMatch = line.match(/^### (.+)$/);
-    if (sectionMatch) {
-      currentSection = { heading: sectionMatch[1], items: [] };
-      current.sections.push(currentSection);
-      continue;
-    }
-
-    const itemMatch = line.match(/^- (.+)$/);
-    if (itemMatch) {
-      if (currentSection) {
-        currentSection.items.push(itemMatch[1]);
-      } else {
-        if (!current.sections.length) {
-          currentSection = { heading: "", items: [] };
-          current.sections.push(currentSection);
-        }
-        current.sections[current.sections.length - 1].items.push(
-          itemMatch[1]
-        );
-      }
-      continue;
-    }
-
-    const trimmed = line.trim();
-    if (trimmed && !trimmed.startsWith("#")) {
-      current.intro = trimmed;
-    }
-  }
-
-  if (current) versions.push(current);
-  return versions;
-}
-
-function InlineMarkdown({ text }: { text: string }) {
-  const parts = text.split(/(`[^`]+`|\[[^\]]+\]\([^)]+\))/g);
-  return (
-    <>
-      {parts.map((part, i) => {
-        if (part.startsWith("`") && part.endsWith("`")) {
-          return <code key={i}>{part.slice(1, -1)}</code>;
-        }
-        const linkMatch = part.match(/^\[([^\]]+)\]\(([^)]+)\)$/);
-        if (linkMatch) {
-          return (
-            <a key={i} href={linkMatch[2]}>
-              {linkMatch[1]}
-            </a>
-          );
-        }
-        return <span key={i}>{part}</span>;
-      })}
-    </>
-  );
-}
-
-function formatDate(dateStr: string): string {
-  const d = new Date(dateStr + "T00:00:00");
-  return d.toLocaleDateString("en-US", {
-    month: "long",
-    day: "numeric",
-    year: "numeric",
-  });
-}
-
-function HeroImage({ src, version }: { src: string; version: string }) {
-  const { width, height } = pngDimensions(src);
-  return (
-    <div style={{ paddingTop: 16, paddingBottom: 24 }}>
-      <div className="overflow-hidden rounded-lg">
-        <Image
-          src={src}
-          alt={`cmux ${version}`}
-          width={width}
-          height={height}
-          sizes="(max-width: 640px) 100vw, 640px"
-          className="w-full h-auto"
-          priority
-        />
-      </div>
-    </div>
-  );
-}
-
-function FeatureImage({ src, alt }: { src: string; alt: string }) {
-  const { width, height } = pngDimensions(src);
-  return (
-    <div style={{ paddingTop: 12 }}>
-      <div className="overflow-hidden rounded-lg">
-        <Image
-          src={src}
-          alt={alt}
-          width={width}
-          height={height}
-          sizes="(max-width: 640px) 100vw, 640px"
-          className="block w-full max-w-full h-auto"
-        />
-      </div>
-    </div>
-  );
-}
-
-function FeatureList({ media }: { media: VersionMedia }) {
-  if (!media.features?.length) return null;
-
-  return (
-    <div style={{ paddingTop: 20, display: "flex", flexDirection: "column", gap: 24 }}>
-      {media.features.map((feature, i) => (
-        <div key={i}>
-          <p style={{ margin: 0, padding: 0 }}>
-            <strong>{feature.title}.</strong>{" "}
-            <span className="text-muted">{feature.description}</span>
-          </p>
-          {feature.image && (
-            <FeatureImage src={feature.image} alt={feature.title} />
-          )}
-        </div>
-      ))}
-    </div>
-  );
-}
-
-function ContributorList({ items }: { items: string[] }) {
-  return (
-    <div className="flex flex-wrap gap-2" style={{ paddingTop: 8 }}>
-      {items.map((item, i) => {
-        const match = item.match(
-          /\[@([^\]]+)\]\((https:\/\/github\.com\/[^)]+)\)/
-        );
-        if (match) {
-          return (
-            <a
-              key={i}
-              href={match[2]}
-              className="inline-flex items-center gap-1.5 px-2 py-1 rounded-md border border-border text-[13px] text-muted hover:text-foreground transition-colors no-underline!"
-            >
-              <Image
-                src={`https://github.com/${match[1]}.png?size=48`}
-                alt={match[1]}
-                width={18}
-                height={18}
-                className="rounded-full"
-              />
-              {match[1]}
-            </a>
-          );
-        }
-        return (
-          <span key={i} className="text-[13px] text-muted">
-            <InlineMarkdown text={item} />
-          </span>
-        );
-      })}
-    </div>
-  );
-}
-
-function SectionBadge({ heading }: { heading: string }) {
-  const lower = heading.toLowerCase();
-
-  let color = "bg-border/50 text-muted";
-  let label = heading;
-
-  if (lower === "added") {
-    color = "bg-emerald-500/10 text-emerald-600 dark:text-emerald-400";
-    label = "Added";
-  } else if (lower === "changed") {
-    color = "bg-blue-500/10 text-blue-600 dark:text-blue-400";
-    label = "Changed";
-  } else if (lower === "fixed") {
-    color = "bg-amber-500/10 text-amber-600 dark:text-amber-400";
-    label = "Fixed";
-  } else if (lower.startsWith("thanks")) {
-    color = "bg-purple-500/10 text-purple-600 dark:text-purple-400";
-    label = "Contributors";
-  }
-
-  return (
-    <span
-      className={`inline-block text-[12px] font-medium px-2 py-0.5 rounded-md ${color}`}
-    >
-      {label}
-    </span>
-  );
-}
-
-export default function ChangelogPage() {
-  const t = useTranslations("docs.changelog");
-  const changelogPath = path.join(process.cwd(), "..", "CHANGELOG.md");
-  const markdown = fs.readFileSync(changelogPath, "utf-8");
-  const versions = parseChangelog(markdown);
+export default async function ChangelogPage({
+  params,
+}: {
+  params: Promise<{ locale: string }>;
+}) {
+  const { locale } = await params;
+  const t = await getTranslations({ locale, namespace: "docs.changelog" });
+  const versions = readChangelog();
 
   return (
     <div className="w-full max-w-[640px] min-w-0">
       <DocsSchema namespace="docs.changelog" path="/docs/changelog" />
-      <DocsHeading level={1} id="title" className="docs-heading-compact">{t("title")}</DocsHeading>
+      <DocsHeading level={1} id="title" className="docs-heading-compact">
+        {t("title")}
+      </DocsHeading>
 
       <div style={{ paddingTop: 16 }}>
-        {versions.map((v, vi) => {
-          const media = changelogMedia[v.version];
-
-          return (
-            <article
-              key={v.version}
-              id={`v${v.version}`}
-              className="border-t border-border first:border-t-0"
-              style={{ display: "flex", flexDirection: "column", paddingTop: vi === 0 ? 0 : 40, paddingBottom: 40 }}
-            >
-              <div style={{ display: "flex", alignItems: "center", gap: 12 }}>
-                <a
-                  href={`#v${v.version}`}
-                  className="no-underline! hover:no-underline!"
-                >
-                  <span className="inline-block text-[13px] font-mono text-muted bg-code-bg px-2 py-0.5 rounded-md">
-                    {v.version}
-                  </span>
-                </a>
-                <time
-                  className="text-[13px] text-muted"
-                  dateTime={v.date}
-                >
-                  {formatDate(v.date)}
-                </time>
-              </div>
-
-              {media?.title && (
-                <div
-                  className="max-w-full"
-                  style={{
-                    paddingTop: 12,
-                    margin: 0,
-                    fontSize: "1.5rem",
-                    fontWeight: 700,
-                    letterSpacing: 0,
-                    lineHeight: 1.25,
-                    overflowWrap: "anywhere",
-                  }}
-                >
-                  {media.title}
-                </div>
-              )}
-
-              {media?.hero && (
-                <HeroImage src={media.hero} version={v.version} />
-              )}
-
-              {media && <FeatureList media={media} />}
-
-              {v.intro && !media && (
-                <div className="text-[14px] text-muted italic" style={{ paddingTop: 12 }}>
-                  {v.intro.replace(/^_/, "").replace(/_$/, "")}
-                </div>
-              )}
-
-              <div style={{ paddingTop: 20, display: "flex", flexDirection: "column", gap: 16 }}>
-                {v.sections.map((section, i) => {
-                  const isContributors = section.heading
-                    .toLowerCase()
-                    .startsWith("thanks");
-
-                  if (isContributors) {
-                    return (
-                      <div key={i}>
-                        <SectionBadge heading={section.heading} />
-                        <ContributorList items={section.items} />
-                      </div>
-                    );
-                  }
-
-                  return (
-                    <div key={i}>
-                      {section.heading && (
-                        <SectionBadge heading={section.heading} />
-                      )}
-                      <ul style={{ margin: 0, paddingTop: 8, paddingBottom: 0, paddingLeft: 24, listStyle: "disc" }}>
-                        {section.items.map((item, j) => (
-                          <li key={j} style={{ margin: 0, padding: 0, fontSize: 14, lineHeight: 1.6, color: "var(--muted)" }}>
-                            <InlineMarkdown text={item} />
-                          </li>
-                        ))}
-                      </ul>
-                    </div>
-                  );
-                })}
-              </div>
-            </article>
-          );
-        })}
+        {versions.map((release, index) => (
+          <ChangelogRelease
+            key={release.version}
+            release={release}
+            locale={locale}
+            media={changelogMedia[release.version]}
+            versionHref={localizedChangelogPath(locale, release.version)}
+            first={index === 0}
+          />
+        ))}
       </div>
     </div>
   );

--- a/web/app/[locale]/(landing)/docs/changelog/page.tsx
+++ b/web/app/[locale]/(landing)/docs/changelog/page.tsx
@@ -14,6 +14,8 @@ import { DocsSchema } from "../docs-schema";
 import { changelogMedia } from "./changelog-media";
 import { ChangelogRelease } from "./changelog-release";
 
+export const dynamic = "force-static";
+
 export async function generateMetadata({
   params,
 }: {

--- a/web/app/[locale]/(landing)/docs/changelog/page.tsx
+++ b/web/app/[locale]/(landing)/docs/changelog/page.tsx
@@ -7,8 +7,8 @@ import {
 } from "@/i18n/seo";
 import {
   localizedChangelogPath,
-  readChangelog,
 } from "@/app/lib/changelog";
+import { changelogStore } from "@/app/lib/changelog-store";
 import { DocsHeading } from "@/app/[locale]/components/docs-heading";
 import { DocsSchema } from "../docs-schema";
 import { changelogMedia } from "./changelog-media";
@@ -45,7 +45,7 @@ export default async function ChangelogPage({
 }) {
   const { locale } = await params;
   const t = await getTranslations({ locale, namespace: "docs.changelog" });
-  const versions = readChangelog();
+  const versions = changelogStore.versions();
   const sectionLabels = {
     added: t("sections.added"),
     changed: t("sections.changed"),

--- a/web/app/[locale]/(landing)/docs/changelog/page.tsx
+++ b/web/app/[locale]/(landing)/docs/changelog/page.tsx
@@ -46,6 +46,13 @@ export default async function ChangelogPage({
   const { locale } = await params;
   const t = await getTranslations({ locale, namespace: "docs.changelog" });
   const versions = readChangelog();
+  const sectionLabels = {
+    added: t("sections.added"),
+    changed: t("sections.changed"),
+    fixed: t("sections.fixed"),
+    removed: t("sections.removed"),
+    contributors: t("sections.contributors"),
+  };
 
   return (
     <div className="w-full max-w-[640px] min-w-0">
@@ -61,6 +68,7 @@ export default async function ChangelogPage({
             release={release}
             locale={locale}
             media={changelogMedia[release.version]}
+            sectionLabels={sectionLabels}
             versionHref={localizedChangelogPath(locale, release.version)}
             first={index === 0}
           />

--- a/web/app/[locale]/components/docs-pager.tsx
+++ b/web/app/[locale]/components/docs-pager.tsx
@@ -8,6 +8,7 @@ import {
 } from "./docs-nav-items";
 import { ContentLocaleLink } from "./content-locale-link";
 import { docsChannelUrl, docsNavPath } from "@/app/lib/docs-channel";
+import { docsPagerItemIndex } from "@/app/lib/docs-pager-path";
 import { useDocsChannel } from "./docs-channel-context";
 
 export function DocsPager() {
@@ -17,11 +18,7 @@ export function DocsPager() {
   const t = useTranslations("docs.navItems");
   const flat = flatNavItems(navItemsForLocale(locale, channel));
   const releasePathname = docsNavPath(pathname, locale);
-  const index = flat.findIndex(
-    (item) =>
-      item.href === releasePathname ||
-      releasePathname.startsWith(`${item.href}/`),
-  );
+  const index = docsPagerItemIndex(flat, releasePathname);
   const prev = index > 0 ? flat[index - 1] : null;
   const next = index < flat.length - 1 ? flat[index + 1] : null;
 

--- a/web/app/[locale]/components/docs-pager.tsx
+++ b/web/app/[locale]/components/docs-pager.tsx
@@ -17,7 +17,11 @@ export function DocsPager() {
   const t = useTranslations("docs.navItems");
   const flat = flatNavItems(navItemsForLocale(locale, channel));
   const releasePathname = docsNavPath(pathname, locale);
-  const index = flat.findIndex((item) => item.href === releasePathname);
+  const index = flat.findIndex(
+    (item) =>
+      item.href === releasePathname ||
+      releasePathname.startsWith(`${item.href}/`),
+  );
   const prev = index > 0 ? flat[index - 1] : null;
   const next = index < flat.length - 1 ? flat[index + 1] : null;
 

--- a/web/app/[locale]/components/docs-pager.tsx
+++ b/web/app/[locale]/components/docs-pager.tsx
@@ -8,7 +8,7 @@ import {
 } from "./docs-nav-items";
 import { ContentLocaleLink } from "./content-locale-link";
 import { docsChannelUrl, docsNavPath } from "@/app/lib/docs-channel";
-import { docsPagerItemIndex } from "@/app/lib/docs-pager-path";
+import { docsPagerAdjacentItems } from "@/app/lib/docs-pager-path";
 import { useDocsChannel } from "./docs-channel-context";
 
 export function DocsPager() {
@@ -18,9 +18,7 @@ export function DocsPager() {
   const t = useTranslations("docs.navItems");
   const flat = flatNavItems(navItemsForLocale(locale, channel));
   const releasePathname = docsNavPath(pathname, locale);
-  const index = docsPagerItemIndex(flat, releasePathname);
-  const prev = index > 0 ? flat[index - 1] : null;
-  const next = index < flat.length - 1 ? flat[index + 1] : null;
+  const { prev, next } = docsPagerAdjacentItems(flat, releasePathname);
 
   if (!prev && !next) return null;
 

--- a/web/app/lib/changelog-store.ts
+++ b/web/app/lib/changelog-store.ts
@@ -1,0 +1,30 @@
+import fs from "node:fs";
+import path from "node:path";
+import { ChangelogStore } from "./changelog";
+
+const sourcePath = resolveChangelogPath(process.cwd(), fs.existsSync);
+
+export const changelogStore = new ChangelogStore({
+  fingerprint() {
+    const stats = fs.statSync(sourcePath);
+    return `${stats.mtimeMs}:${stats.ctimeMs}:${stats.size}`;
+  },
+  read() {
+    return fs.readFileSync(sourcePath, "utf-8");
+  },
+});
+
+function resolveChangelogPath(
+  workingDirectory: string,
+  exists: (candidate: string) => boolean,
+): string {
+  const candidates = [
+    path.resolve(workingDirectory, "..", "CHANGELOG.md"),
+    path.resolve(workingDirectory, "CHANGELOG.md"),
+  ];
+  const changelog = candidates.find(exists);
+  if (!changelog) {
+    throw new Error("Changelog unavailable");
+  }
+  return changelog;
+}

--- a/web/app/lib/changelog.ts
+++ b/web/app/lib/changelog.ts
@@ -1,6 +1,3 @@
-import fs from "node:fs";
-import path from "node:path";
-
 export interface ChangelogSection {
   heading: string;
   items: string[];
@@ -24,16 +21,59 @@ export interface ChangelogVersionContext extends ChangelogVersionEntry {
   versions: readonly ChangelogVersion[];
 }
 
+export interface ChangelogSource {
+  fingerprint(): string;
+  read(): string;
+}
+
 interface ChangelogSnapshot {
-  path: string;
-  modifiedAt: number;
-  changedAt: number;
-  size: number;
+  fingerprint: string;
   versions: readonly ChangelogVersion[];
   entries: ReadonlyMap<string, ChangelogVersionEntry>;
 }
 
-let cachedChangelog: ChangelogSnapshot | undefined;
+export class ChangelogStore {
+  private snapshot: ChangelogSnapshot | undefined;
+
+  constructor(private readonly source: ChangelogSource) {}
+
+  /** Returns the current ordered release list. */
+  versions(): readonly ChangelogVersion[] {
+    return this.readSnapshot().versions;
+  }
+
+  /** Looks up one release by its version number. */
+  findVersion(version: string): ChangelogVersion | undefined {
+    return this.readSnapshot().entries.get(version)?.release;
+  }
+
+  /** Looks up one release together with its adjacent-release source list. */
+  findVersionContext(version: string): ChangelogVersionContext | undefined {
+    const snapshot = this.readSnapshot();
+    const entry = snapshot.entries.get(version);
+    return entry ? { ...entry, versions: snapshot.versions } : undefined;
+  }
+
+  private readSnapshot(): ChangelogSnapshot {
+    const fingerprint = this.source.fingerprint();
+    if (this.snapshot?.fingerprint === fingerprint) {
+      return this.snapshot;
+    }
+
+    const versions = parseChangelog(this.source.read());
+    this.snapshot = {
+      fingerprint,
+      versions,
+      entries: new Map(
+        versions.map((release, index) => [
+          release.version,
+          { release, index },
+        ]),
+      ),
+    };
+    return this.snapshot;
+  }
+}
 
 /** Parses the repository changelog into ordered release records. */
 export function parseChangelog(markdown: string): ChangelogVersion[] {
@@ -85,27 +125,6 @@ export function parseChangelog(markdown: string): ChangelogVersion[] {
   return versions;
 }
 
-/** Returns the current changelog, refreshing the cache when its source changes. */
-export function readChangelog(): readonly ChangelogVersion[] {
-  return readChangelogSnapshot().versions;
-}
-
-/** Looks up one release together with its adjacent-release source list. */
-export function findChangelogVersionContext(
-  version: string,
-): ChangelogVersionContext | undefined {
-  const snapshot = readChangelogSnapshot();
-  const entry = snapshot.entries.get(version);
-  return entry ? { ...entry, versions: snapshot.versions } : undefined;
-}
-
-/** Looks up one release by its version number. */
-export function findChangelogVersion(
-  version: string,
-): ChangelogVersion | undefined {
-  return readChangelogSnapshot().entries.get(version)?.release;
-}
-
 /** Returns the canonical path for one changelog release. */
 export function changelogVersionPath(version: string): string {
   return `${changelogPath}/${encodeURIComponent(version)}`;
@@ -141,47 +160,6 @@ export function changelogVersionDescription(
   return truncateMetadataDescription(
     plainText ? `cmux ${release.version}: ${plainText}` : `cmux ${release.version}`,
   );
-}
-
-function readChangelogSnapshot(): ChangelogSnapshot {
-  const changelog = resolveChangelogPath();
-  const stats = fs.statSync(changelog);
-  if (
-    cachedChangelog?.path === changelog &&
-    cachedChangelog.modifiedAt === stats.mtimeMs &&
-    cachedChangelog.changedAt === stats.ctimeMs &&
-    cachedChangelog.size === stats.size
-  ) {
-    return cachedChangelog;
-  }
-
-  const versions = parseChangelog(fs.readFileSync(changelog, "utf-8"));
-  cachedChangelog = {
-    path: changelog,
-    modifiedAt: stats.mtimeMs,
-    changedAt: stats.ctimeMs,
-    size: stats.size,
-    versions,
-    entries: new Map(
-      versions.map((release, index) => [
-        release.version,
-        { release, index },
-      ]),
-    ),
-  };
-  return cachedChangelog;
-}
-
-function resolveChangelogPath(): string {
-  const candidates = [
-    path.resolve(process.cwd(), "..", "CHANGELOG.md"),
-    path.resolve(process.cwd(), "CHANGELOG.md"),
-  ];
-  const changelog = candidates.find((candidate) => fs.existsSync(candidate));
-  if (!changelog) {
-    throw new Error("Changelog unavailable");
-  }
-  return changelog;
 }
 
 function inlineMarkdownToText(markdown: string): string {

--- a/web/app/lib/changelog.ts
+++ b/web/app/lib/changelog.ts
@@ -1,0 +1,155 @@
+import fs from "node:fs";
+import path from "node:path";
+
+export interface ChangelogSection {
+  heading: string;
+  items: string[];
+}
+
+export interface ChangelogVersion {
+  version: string;
+  date: string;
+  intro?: string;
+  sections: ChangelogSection[];
+}
+
+export const changelogPath = "/docs/changelog";
+
+let cachedChangelog: readonly ChangelogVersion[] | undefined;
+
+export function parseChangelog(markdown: string): ChangelogVersion[] {
+  const versions: ChangelogVersion[] = [];
+  let current: ChangelogVersion | null = null;
+  let currentSection: ChangelogSection | null = null;
+
+  for (const line of markdown.split("\n")) {
+    const versionMatch = line.match(/^## \[(.+?)\] - (.+)$/);
+    if (versionMatch) {
+      if (current) versions.push(current);
+      current = {
+        version: versionMatch[1],
+        date: versionMatch[2],
+        sections: [],
+      };
+      currentSection = null;
+      continue;
+    }
+
+    if (!current) continue;
+
+    const sectionMatch = line.match(/^### (.+)$/);
+    if (sectionMatch) {
+      currentSection = { heading: sectionMatch[1], items: [] };
+      current.sections.push(currentSection);
+      continue;
+    }
+
+    const itemMatch = line.match(/^- (.+)$/);
+    if (itemMatch) {
+      if (!currentSection) {
+        currentSection = { heading: "", items: [] };
+        current.sections.push(currentSection);
+      }
+      currentSection.items.push(itemMatch[1]);
+      continue;
+    }
+
+    const trimmed = line.trim();
+    if (trimmed && !trimmed.startsWith("#")) {
+      current.intro = current.intro
+        ? `${current.intro} ${trimmed}`
+        : trimmed;
+    }
+  }
+
+  if (current) versions.push(current);
+  return versions;
+}
+
+export function readChangelog(): readonly ChangelogVersion[] {
+  if (cachedChangelog) return cachedChangelog;
+
+  cachedChangelog = parseChangelog(
+    fs.readFileSync(resolveChangelogPath(), "utf-8"),
+  );
+  return cachedChangelog;
+}
+
+export function findChangelogVersion(
+  version: string,
+): ChangelogVersion | undefined {
+  return readChangelog().find((release) => release.version === version);
+}
+
+export function changelogVersionPath(version: string): string {
+  return `${changelogPath}/${encodeURIComponent(version)}`;
+}
+
+export function localizedChangelogPath(
+  locale: string,
+  version?: string,
+): string {
+  const releasePath = version ? changelogVersionPath(version) : changelogPath;
+  return locale === "en" ? releasePath : `/${locale}${releasePath}`;
+}
+
+export function changelogVersionDescription(
+  release: ChangelogVersion,
+  featuredDescription?: string,
+): string {
+  const firstReleaseItem = release.sections
+    .find(
+      (section) =>
+        !section.heading.toLowerCase().startsWith("thanks") &&
+        section.items.length > 0,
+    )
+    ?.items[0];
+  const source =
+    featuredDescription ??
+    firstReleaseItem ??
+    release.intro ??
+    "";
+  const plainText = inlineMarkdownToText(source);
+  return truncateMetadataDescription(
+    plainText ? `cmux ${release.version}: ${plainText}` : `cmux ${release.version}`,
+  );
+}
+
+function resolveChangelogPath(): string {
+  const candidates = [
+    path.resolve(process.cwd(), "..", "CHANGELOG.md"),
+    path.resolve(process.cwd(), "CHANGELOG.md"),
+  ];
+  const changelog = candidates.find((candidate) => fs.existsSync(candidate));
+  if (!changelog) {
+    throw new Error(
+      `CHANGELOG.md not found from ${process.cwd()}`,
+    );
+  }
+  return changelog;
+}
+
+function inlineMarkdownToText(markdown: string): string {
+  return markdown
+    .replace(/\[([^\]]+)\]\([^)]+\)/g, "$1")
+    .replace(/`([^`]+)`/g, "$1")
+    .replace(/[*_~]/g, "")
+    .replace(/\s+--\s+thanks\b.*$/i, "")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+function truncateMetadataDescription(
+  description: string,
+  maximumLength = 160,
+): string {
+  if (description.length <= maximumLength) return description;
+
+  const candidate = description.slice(0, maximumLength - 1);
+  const lastSpace = candidate.lastIndexOf(" ");
+  const cutoff =
+    lastSpace >= Math.floor(maximumLength * 0.7)
+      ? lastSpace
+      : candidate.length;
+  return `${candidate.slice(0, cutoff).trimEnd()}…`;
+}

--- a/web/app/lib/changelog.ts
+++ b/web/app/lib/changelog.ts
@@ -15,8 +15,27 @@ export interface ChangelogVersion {
 
 export const changelogPath = "/docs/changelog";
 
-let cachedChangelog: readonly ChangelogVersion[] | undefined;
+export interface ChangelogVersionEntry {
+  release: ChangelogVersion;
+  index: number;
+}
 
+export interface ChangelogVersionContext extends ChangelogVersionEntry {
+  versions: readonly ChangelogVersion[];
+}
+
+interface ChangelogSnapshot {
+  path: string;
+  modifiedAt: number;
+  changedAt: number;
+  size: number;
+  versions: readonly ChangelogVersion[];
+  entries: ReadonlyMap<string, ChangelogVersionEntry>;
+}
+
+let cachedChangelog: ChangelogSnapshot | undefined;
+
+/** Parses the repository changelog into ordered release records. */
 export function parseChangelog(markdown: string): ChangelogVersion[] {
   const versions: ChangelogVersion[] = [];
   let current: ChangelogVersion | null = null;
@@ -66,25 +85,33 @@ export function parseChangelog(markdown: string): ChangelogVersion[] {
   return versions;
 }
 
+/** Returns the current changelog, refreshing the cache when its source changes. */
 export function readChangelog(): readonly ChangelogVersion[] {
-  if (cachedChangelog) return cachedChangelog;
-
-  cachedChangelog = parseChangelog(
-    fs.readFileSync(resolveChangelogPath(), "utf-8"),
-  );
-  return cachedChangelog;
+  return readChangelogSnapshot().versions;
 }
 
+/** Looks up one release together with its adjacent-release source list. */
+export function findChangelogVersionContext(
+  version: string,
+): ChangelogVersionContext | undefined {
+  const snapshot = readChangelogSnapshot();
+  const entry = snapshot.entries.get(version);
+  return entry ? { ...entry, versions: snapshot.versions } : undefined;
+}
+
+/** Looks up one release by its version number. */
 export function findChangelogVersion(
   version: string,
 ): ChangelogVersion | undefined {
-  return readChangelog().find((release) => release.version === version);
+  return readChangelogSnapshot().entries.get(version)?.release;
 }
 
+/** Returns the canonical path for one changelog release. */
 export function changelogVersionPath(version: string): string {
   return `${changelogPath}/${encodeURIComponent(version)}`;
 }
 
+/** Returns the locale-prefixed path for the changelog or one release. */
 export function localizedChangelogPath(
   locale: string,
   version?: string,
@@ -93,6 +120,7 @@ export function localizedChangelogPath(
   return locale === "en" ? releasePath : `/${locale}${releasePath}`;
 }
 
+/** Builds a bounded English search summary from one release. */
 export function changelogVersionDescription(
   release: ChangelogVersion,
   featuredDescription?: string,
@@ -115,6 +143,35 @@ export function changelogVersionDescription(
   );
 }
 
+function readChangelogSnapshot(): ChangelogSnapshot {
+  const changelog = resolveChangelogPath();
+  const stats = fs.statSync(changelog);
+  if (
+    cachedChangelog?.path === changelog &&
+    cachedChangelog.modifiedAt === stats.mtimeMs &&
+    cachedChangelog.changedAt === stats.ctimeMs &&
+    cachedChangelog.size === stats.size
+  ) {
+    return cachedChangelog;
+  }
+
+  const versions = parseChangelog(fs.readFileSync(changelog, "utf-8"));
+  cachedChangelog = {
+    path: changelog,
+    modifiedAt: stats.mtimeMs,
+    changedAt: stats.ctimeMs,
+    size: stats.size,
+    versions,
+    entries: new Map(
+      versions.map((release, index) => [
+        release.version,
+        { release, index },
+      ]),
+    ),
+  };
+  return cachedChangelog;
+}
+
 function resolveChangelogPath(): string {
   const candidates = [
     path.resolve(process.cwd(), "..", "CHANGELOG.md"),
@@ -122,9 +179,7 @@ function resolveChangelogPath(): string {
   ];
   const changelog = candidates.find((candidate) => fs.existsSync(candidate));
   if (!changelog) {
-    throw new Error(
-      `CHANGELOG.md not found from ${process.cwd()}`,
-    );
+    throw new Error("Changelog unavailable");
   }
   return changelog;
 }

--- a/web/app/lib/docs-pager-path.ts
+++ b/web/app/lib/docs-pager-path.ts
@@ -1,0 +1,21 @@
+/** Finds the exact docs item, then falls back to the deepest ancestor item. */
+export function docsPagerItemIndex(
+  items: readonly { href: string }[],
+  pathname: string,
+): number {
+  const exactIndex = items.findIndex((item) => item.href === pathname);
+  if (exactIndex >= 0) return exactIndex;
+
+  let ancestorIndex = -1;
+  let ancestorLength = -1;
+  items.forEach((item, index) => {
+    if (
+      pathname.startsWith(`${item.href}/`) &&
+      item.href.length > ancestorLength
+    ) {
+      ancestorIndex = index;
+      ancestorLength = item.href.length;
+    }
+  });
+  return ancestorIndex;
+}

--- a/web/app/lib/docs-pager-path.ts
+++ b/web/app/lib/docs-pager-path.ts
@@ -19,3 +19,17 @@ export function docsPagerItemIndex(
   });
   return ancestorIndex;
 }
+
+/** Returns adjacent docs items only when the current path belongs to the docs nav. */
+export function docsPagerAdjacentItems<T extends { href: string }>(
+  items: readonly T[],
+  pathname: string,
+): { prev: T | null; next: T | null } {
+  const index = docsPagerItemIndex(items, pathname);
+  if (index < 0) return { prev: null, next: null };
+
+  return {
+    prev: index > 0 ? items[index - 1] : null,
+    next: index < items.length - 1 ? items[index + 1] : null,
+  };
+}

--- a/web/app/sitemap.ts
+++ b/web/app/sitemap.ts
@@ -12,10 +12,17 @@ import {
   PLATFORM_DOWNLOADS,
 } from "./lib/download";
 import { genericCodingAgents } from "../i18n/coding-agents";
+import {
+  changelogPath,
+  changelogVersionPath,
+  readChangelog,
+} from "./lib/changelog";
 
 /** Builds localized sitemap entries, excluding unreleased download pages. */
 export default function sitemap(): MetadataRoute.Sitemap {
   const base = "https://cmux.com";
+  const changelog = readChangelog();
+  const latestChangelogDate = changelog[0]?.date ?? "2026-03-18";
 
   const paths: Array<{
     path: string;
@@ -78,7 +85,13 @@ export default function sitemap(): MetadataRoute.Sitemap {
     { path: "/docs/agent-integrations/oh-my-codex", lastModified: "2026-03-30", changeFrequency: "monthly" as const, priority: 0.7 },
     { path: "/docs/agent-integrations/oh-my-pi", lastModified: "2026-07-07", changeFrequency: "monthly" as const, priority: 0.7, locales: fallbackContentLocales },
     { path: "/docs/agent-integrations/oh-my-claudecode", lastModified: "2026-03-30", changeFrequency: "monthly" as const, priority: 0.7 },
-    { path: "/docs/changelog", lastModified: "2026-03-18", changeFrequency: "weekly" as const, priority: 0.5 },
+    { path: changelogPath, lastModified: latestChangelogDate, changeFrequency: "weekly" as const, priority: 0.5 },
+    ...changelog.map((release) => ({
+      path: changelogVersionPath(release.version),
+      lastModified: release.date,
+      changeFrequency: "never" as const,
+      priority: 0.4,
+    })),
     { path: "/community", lastModified: "2026-03-18", changeFrequency: "monthly" as const, priority: 0.5 },
     { path: "/wall-of-love", lastModified: "2026-03-18", changeFrequency: "monthly" as const, priority: 0.5 },
     { path: "/nightly", lastModified: "2026-03-18", changeFrequency: "weekly" as const, priority: 0.6 },

--- a/web/app/sitemap.ts
+++ b/web/app/sitemap.ts
@@ -15,13 +15,13 @@ import { genericCodingAgents } from "../i18n/coding-agents";
 import {
   changelogPath,
   changelogVersionPath,
-  readChangelog,
 } from "./lib/changelog";
+import { changelogStore } from "./lib/changelog-store";
 
 /** Builds localized sitemap entries, excluding unreleased download pages. */
 export default function sitemap(): MetadataRoute.Sitemap {
   const base = "https://cmux.com";
-  const changelog = readChangelog();
+  const changelog = changelogStore.versions();
   const latestChangelogDate = changelog[0]?.date ?? "2026-03-18";
 
   const paths: Array<{

--- a/web/messages/ar.json
+++ b/web/messages/ar.json
@@ -1407,7 +1407,16 @@
     "changelog": {
       "title": "سجل التغييرات",
       "metaDescription": "ملاحظات إصدار cmux وسجل الإصدارات. الميزات الجديدة وإصلاحات الأخطاء والتغييرات لطرفية macOS الأصلية.",
-      "metaTitle": "سجل التغييرات"
+      "metaTitle": "سجل التغييرات",
+      "versionTitle": "cmux {version} · سجل التغييرات",
+      "releaseNavLabel": "الإصدارات القريبة من cmux {version}",
+      "sections": {
+        "added": "تمت الإضافة",
+        "changed": "تم التغيير",
+        "fixed": "تم الإصلاح",
+        "removed": "تمت الإزالة",
+        "contributors": "المساهمون"
+      }
     },
     "navItems": {
       "gettingStarted": "البدء",

--- a/web/messages/bs.json
+++ b/web/messages/bs.json
@@ -1408,7 +1408,16 @@
     "changelog": {
       "title": "Zapisnik promjena",
       "metaDescription": "cmux bilješke o izdanjima i historija verzija. Nove funkcionalnosti, ispravke grešaka i promjene za nativni macOS terminal.",
-      "metaTitle": "Dnevnik promjena"
+      "metaTitle": "Dnevnik promjena",
+      "versionTitle": "cmux {version} · Dnevnik promjena",
+      "releaseNavLabel": "Izdanja oko cmux {version}",
+      "sections": {
+        "added": "Dodano",
+        "changed": "Promijenjeno",
+        "fixed": "Ispravljeno",
+        "removed": "Uklonjeno",
+        "contributors": "Doprinositelji"
+      }
     },
     "navItems": {
       "gettingStarted": "Početak rada",

--- a/web/messages/da.json
+++ b/web/messages/da.json
@@ -1407,7 +1407,16 @@
     "changelog": {
       "title": "Ændringslog",
       "metaDescription": "cmux udgivelsesnoter og versionshistorik. Nye funktioner, fejlrettelser og ændringer for den native macOS-terminal.",
-      "metaTitle": "Ændringslog"
+      "metaTitle": "Ændringslog",
+      "versionTitle": "cmux {version} · Ændringslog",
+      "releaseNavLabel": "Udgivelser omkring cmux {version}",
+      "sections": {
+        "added": "Tilføjet",
+        "changed": "Ændret",
+        "fixed": "Rettet",
+        "removed": "Fjernet",
+        "contributors": "Bidragydere"
+      }
     },
     "navItems": {
       "gettingStarted": "Kom i gang",

--- a/web/messages/de.json
+++ b/web/messages/de.json
@@ -1407,7 +1407,16 @@
     "changelog": {
       "title": "Changelog",
       "metaDescription": "cmux Release-Notes und Versionshistorie. Neue Funktionen, Fehlerbehebungen und Änderungen für das native macOS-Terminal.",
-      "metaTitle": "Änderungsprotokoll"
+      "metaTitle": "Änderungsprotokoll",
+      "versionTitle": "cmux {version} · Änderungsprotokoll",
+      "releaseNavLabel": "Versionen rund um cmux {version}",
+      "sections": {
+        "added": "Hinzugefügt",
+        "changed": "Geändert",
+        "fixed": "Behoben",
+        "removed": "Entfernt",
+        "contributors": "Mitwirkende"
+      }
     },
     "navItems": {
       "gettingStarted": "Erste Schritte",

--- a/web/messages/en.json
+++ b/web/messages/en.json
@@ -2459,7 +2459,16 @@
     "changelog": {
       "title": "Changelog",
       "metaTitle": "Changelog",
-      "metaDescription": "cmux release notes and version history. New features, bug fixes, and changes for the native macOS terminal."
+      "metaDescription": "cmux release notes and version history. New features, bug fixes, and changes for the native macOS terminal.",
+      "versionTitle": "cmux {version} · Changelog",
+      "releaseNavLabel": "Releases near cmux {version}",
+      "sections": {
+        "added": "Added",
+        "changed": "Changed",
+        "fixed": "Fixed",
+        "removed": "Removed",
+        "contributors": "Contributors"
+      }
     },
     "claudeCodeTeams": {
       "title": "Claude Code Teams",

--- a/web/messages/es.json
+++ b/web/messages/es.json
@@ -1407,7 +1407,16 @@
     "changelog": {
       "title": "Changelog",
       "metaDescription": "Notas de versión e historial de versiones de cmux. Nuevas funciones, correcciones de errores y cambios para la terminal nativa de macOS.",
-      "metaTitle": "Registro de cambios"
+      "metaTitle": "Registro de cambios",
+      "versionTitle": "cmux {version} · Registro de cambios",
+      "releaseNavLabel": "Versiones cercanas a cmux {version}",
+      "sections": {
+        "added": "Añadido",
+        "changed": "Cambiado",
+        "fixed": "Corregido",
+        "removed": "Eliminado",
+        "contributors": "Colaboradores"
+      }
     },
     "navItems": {
       "gettingStarted": "Primeros pasos",

--- a/web/messages/fr.json
+++ b/web/messages/fr.json
@@ -1410,7 +1410,16 @@
     "changelog": {
       "title": "Changelog",
       "metaDescription": "Notes de version et historique des versions de cmux. Nouvelles fonctionnalités, corrections de bugs et changements pour le terminal macOS natif.",
-      "metaTitle": "Journal des modifications"
+      "metaTitle": "Journal des modifications",
+      "versionTitle": "cmux {version} · Journal des modifications",
+      "releaseNavLabel": "Versions proches de cmux {version}",
+      "sections": {
+        "added": "Ajouts",
+        "changed": "Modifications",
+        "fixed": "Corrections",
+        "removed": "Suppressions",
+        "contributors": "Contributeurs"
+      }
     },
     "navItems": {
       "gettingStarted": "Premiers pas",

--- a/web/messages/it.json
+++ b/web/messages/it.json
@@ -1411,10 +1411,10 @@
       "versionTitle": "cmux {version} · Registro modifiche",
       "releaseNavLabel": "Versioni vicine a cmux {version}",
       "sections": {
-        "added": "Aggiunto",
-        "changed": "Modificato",
-        "fixed": "Corretto",
-        "removed": "Rimosso",
+        "added": "Aggiunte",
+        "changed": "Modifiche",
+        "fixed": "Correzioni",
+        "removed": "Rimozioni",
         "contributors": "Collaboratori"
       }
     },

--- a/web/messages/it.json
+++ b/web/messages/it.json
@@ -1407,7 +1407,16 @@
     "changelog": {
       "title": "Changelog",
       "metaDescription": "Note di rilascio e cronologia delle versioni di cmux. Nuove funzionalità, correzioni di bug e modifiche per il terminale macOS nativo.",
-      "metaTitle": "Registro modifiche"
+      "metaTitle": "Registro modifiche",
+      "versionTitle": "cmux {version} · Registro modifiche",
+      "releaseNavLabel": "Versioni vicine a cmux {version}",
+      "sections": {
+        "added": "Aggiunto",
+        "changed": "Modificato",
+        "fixed": "Corretto",
+        "removed": "Rimosso",
+        "contributors": "Collaboratori"
+      }
     },
     "navItems": {
       "gettingStarted": "Per iniziare",

--- a/web/messages/ja.json
+++ b/web/messages/ja.json
@@ -2320,7 +2320,16 @@
     "changelog": {
       "title": "変更履歴",
       "metaDescription": "cmuxのリリースノートとバージョン履歴。ネイティブmacOSターミナルの新機能、バグ修正、変更点。",
-      "metaTitle": "変更履歴"
+      "metaTitle": "変更履歴",
+      "versionTitle": "cmux {version} · 変更履歴",
+      "releaseNavLabel": "cmux {version} 付近のリリース",
+      "sections": {
+        "added": "追加",
+        "changed": "変更",
+        "fixed": "修正",
+        "removed": "削除",
+        "contributors": "コントリビューター"
+      }
     },
     "claudeCodeTeams": {
       "title": "Claude Code Teams",

--- a/web/messages/km.json
+++ b/web/messages/km.json
@@ -1408,7 +1408,16 @@
     "changelog": {
       "title": "កំណត់ត្រាផ្លាស់ប្ដូរ",
       "metaDescription": "កំណត់ត្រាការចេញផ្សាយ cmux និងប្រវត្តិកំណែ។ មុខងារថ្មី, ការជួសជុលកំហុស, និងការផ្លាស់ប្ដូរសម្រាប់ទែមីណល macOS ដើម។",
-      "metaTitle": "កំណត់ហេតុផ្លាស់ប្ដូរ"
+      "metaTitle": "កំណត់ហេតុផ្លាស់ប្ដូរ",
+      "versionTitle": "cmux {version} · កំណត់ហេតុផ្លាស់ប្ដូរ",
+      "releaseNavLabel": "កំណែជិត cmux {version}",
+      "sections": {
+        "added": "បានបន្ថែម",
+        "changed": "បានផ្លាស់ប្តូរ",
+        "fixed": "បានជួសជុល",
+        "removed": "បានដកចេញ",
+        "contributors": "អ្នករួមចំណែក"
+      }
     },
     "navItems": {
       "gettingStarted": "ចាប់ផ្ដើម",

--- a/web/messages/ko.json
+++ b/web/messages/ko.json
@@ -1407,7 +1407,16 @@
     "changelog": {
       "title": "변경 로그",
       "metaDescription": "cmux 릴리스 노트 및 버전 히스토리. 네이티브 macOS 터미널의 새로운 기능, 버그 수정, 변경 사항.",
-      "metaTitle": "변경 내역"
+      "metaTitle": "변경 내역",
+      "versionTitle": "cmux {version} · 변경 내역",
+      "releaseNavLabel": "cmux {version} 전후 릴리스",
+      "sections": {
+        "added": "추가",
+        "changed": "변경",
+        "fixed": "수정",
+        "removed": "제거",
+        "contributors": "기여자"
+      }
     },
     "navItems": {
       "gettingStarted": "시작하기",

--- a/web/messages/no.json
+++ b/web/messages/no.json
@@ -1407,7 +1407,16 @@
     "changelog": {
       "title": "Endringslogg",
       "metaDescription": "cmux utgivelsesnotater og versjonshistorikk. Nye funksjoner, feilrettinger og endringer for den native macOS-terminalen.",
-      "metaTitle": "Endringslogg"
+      "metaTitle": "Endringslogg",
+      "versionTitle": "cmux {version} · Endringslogg",
+      "releaseNavLabel": "Utgivelser rundt cmux {version}",
+      "sections": {
+        "added": "Lagt til",
+        "changed": "Endret",
+        "fixed": "Rettet",
+        "removed": "Fjernet",
+        "contributors": "Bidragsytere"
+      }
     },
     "navItems": {
       "gettingStarted": "Kom i gang",

--- a/web/messages/pl.json
+++ b/web/messages/pl.json
@@ -1409,7 +1409,16 @@
     "changelog": {
       "title": "Dziennik zmian",
       "metaDescription": "Notatki wydań i historia wersji cmux. Nowe funkcje, poprawki błędów i zmiany dla natywnego terminala macOS.",
-      "metaTitle": "Historia zmian"
+      "metaTitle": "Historia zmian",
+      "versionTitle": "cmux {version} · Historia zmian",
+      "releaseNavLabel": "Wydania w pobliżu cmux {version}",
+      "sections": {
+        "added": "Dodano",
+        "changed": "Zmieniono",
+        "fixed": "Naprawiono",
+        "removed": "Usunięto",
+        "contributors": "Współtwórcy"
+      }
     },
     "navItems": {
       "gettingStarted": "Szybki start",

--- a/web/messages/pt-BR.json
+++ b/web/messages/pt-BR.json
@@ -1407,7 +1407,16 @@
     "changelog": {
       "title": "Changelog",
       "metaDescription": "Notas de lançamento e histórico de versões do cmux. Novos recursos, correções de bugs e mudanças para o terminal macOS nativo.",
-      "metaTitle": "Registro de alterações"
+      "metaTitle": "Registro de alterações",
+      "versionTitle": "cmux {version} · Registro de alterações",
+      "releaseNavLabel": "Versões próximas do cmux {version}",
+      "sections": {
+        "added": "Adicionado",
+        "changed": "Alterado",
+        "fixed": "Corrigido",
+        "removed": "Removido",
+        "contributors": "Colaboradores"
+      }
     },
     "navItems": {
       "gettingStarted": "Primeiros Passos",

--- a/web/messages/ru.json
+++ b/web/messages/ru.json
@@ -1407,7 +1407,16 @@
     "changelog": {
       "title": "История изменений",
       "metaDescription": "Заметки о релизах cmux и история версий. Новые функции, исправления ошибок и изменения для нативного macOS-терминала.",
-      "metaTitle": "Журнал изменений"
+      "metaTitle": "Журнал изменений",
+      "versionTitle": "cmux {version} · Журнал изменений",
+      "releaseNavLabel": "Версии рядом с cmux {version}",
+      "sections": {
+        "added": "Добавлено",
+        "changed": "Изменено",
+        "fixed": "Исправлено",
+        "removed": "Удалено",
+        "contributors": "Участники"
+      }
     },
     "navItems": {
       "gettingStarted": "Начало работы",

--- a/web/messages/th.json
+++ b/web/messages/th.json
@@ -1412,7 +1412,16 @@
     "changelog": {
       "title": "Changelog",
       "metaDescription": "บันทึกการอัปเดต cmux และประวัติเวอร์ชัน ฟีเจอร์ใหม่, แก้ไขบั๊ก และการเปลี่ยนแปลงสำหรับเทอร์มินัล macOS เนทีฟ",
-      "metaTitle": "บันทึกการเปลี่ยนแปลง"
+      "metaTitle": "บันทึกการเปลี่ยนแปลง",
+      "versionTitle": "cmux {version} · บันทึกการเปลี่ยนแปลง",
+      "releaseNavLabel": "รุ่นใกล้เคียง cmux {version}",
+      "sections": {
+        "added": "เพิ่มแล้ว",
+        "changed": "เปลี่ยนแปลงแล้ว",
+        "fixed": "แก้ไขแล้ว",
+        "removed": "นำออกแล้ว",
+        "contributors": "ผู้มีส่วนร่วม"
+      }
     },
     "navItems": {
       "gettingStarted": "เริ่มต้นใช้งาน",

--- a/web/messages/tr.json
+++ b/web/messages/tr.json
@@ -1407,7 +1407,16 @@
     "changelog": {
       "title": "Değişiklik Günlüğü",
       "metaDescription": "cmux sürüm notları ve sürüm geçmişi. Yerel macOS terminali için yeni özellikler, hata düzeltmeleri ve değişiklikler.",
-      "metaTitle": "Değişiklik günlüğü"
+      "metaTitle": "Değişiklik günlüğü",
+      "versionTitle": "cmux {version} · Değişiklik günlüğü",
+      "releaseNavLabel": "cmux {version} civarındaki sürümler",
+      "sections": {
+        "added": "Eklendi",
+        "changed": "Değiştirildi",
+        "fixed": "Düzeltildi",
+        "removed": "Kaldırıldı",
+        "contributors": "Katkıda bulunanlar"
+      }
     },
     "navItems": {
       "gettingStarted": "Başlarken",

--- a/web/messages/uk.json
+++ b/web/messages/uk.json
@@ -1407,7 +1407,16 @@
     "changelog": {
       "title": "Журнал змін",
       "metaTitle": "Журнал змін",
-      "metaDescription": "Примітки до випусків та історія версій cmux. Нові можливості, виправлення помилок та зміни для нативного терміналу macOS."
+      "metaDescription": "Примітки до випусків та історія версій cmux. Нові можливості, виправлення помилок та зміни для нативного терміналу macOS.",
+      "versionTitle": "cmux {version} · Журнал змін",
+      "releaseNavLabel": "Версії поруч із cmux {version}",
+      "sections": {
+        "added": "Додано",
+        "changed": "Змінено",
+        "fixed": "Виправлено",
+        "removed": "Видалено",
+        "contributors": "Учасники"
+      }
     },
     "claudeCodeTeams": {
       "title": "Claude Code Teams",

--- a/web/messages/zh-CN.json
+++ b/web/messages/zh-CN.json
@@ -1408,7 +1408,16 @@
     "changelog": {
       "title": "更新日志",
       "metaDescription": "cmux 发布说明和版本历史。原生 macOS 终端的新功能、问题修复和变更记录。",
-      "metaTitle": "更新日志"
+      "metaTitle": "更新日志",
+      "versionTitle": "cmux {version} · 更新日志",
+      "releaseNavLabel": "cmux {version} 附近的版本",
+      "sections": {
+        "added": "新增",
+        "changed": "更改",
+        "fixed": "修复",
+        "removed": "移除",
+        "contributors": "贡献者"
+      }
     },
     "navItems": {
       "gettingStarted": "入门指南",

--- a/web/messages/zh-TW.json
+++ b/web/messages/zh-TW.json
@@ -1407,7 +1407,16 @@
     "changelog": {
       "title": "更新日誌",
       "metaDescription": "cmux 版本說明和版本歷史。原生 macOS 終端機的新功能、錯誤修復和變更。",
-      "metaTitle": "更新日誌"
+      "metaTitle": "更新日誌",
+      "versionTitle": "cmux {version} · 更新日誌",
+      "releaseNavLabel": "cmux {version} 附近的版本",
+      "sections": {
+        "added": "新增",
+        "changed": "變更",
+        "fixed": "修正",
+        "removed": "移除",
+        "contributors": "貢獻者"
+      }
     },
     "navItems": {
       "gettingStarted": "入門指南",

--- a/web/proxy.ts
+++ b/web/proxy.ts
@@ -49,11 +49,14 @@ export default function middleware(request: NextRequest) {
     return NextResponse.next();
   }
 
-  // Temporary redirect: /changelog → /docs/changelog, preserving any locale prefix.
-  const changelogMatch = pathname.match(/^(\/[a-z]{2}(?:-[A-Z]{2})?)?\/changelog\/?$/);
+  // Temporary redirect: /changelog[/<version>] → /docs/changelog[/<version>],
+  // preserving any locale prefix.
+  const changelogMatch = pathname.match(
+    /^(\/[a-z]{2}(?:-[A-Z]{2})?)?\/changelog(\/[^/]+)?\/?$/,
+  );
   if (changelogMatch) {
     const url = request.nextUrl.clone();
-    url.pathname = `${changelogMatch[1] ?? ""}/docs/changelog`;
+    url.pathname = `${changelogMatch[1] ?? ""}/docs/changelog${changelogMatch[2] ?? ""}`;
     return NextResponse.redirect(url, 307);
   }
 
@@ -117,7 +120,11 @@ export default function middleware(request: NextRequest) {
     return NextResponse.next();
   }
 
-  if (pathname.includes(".")) {
+  const isChangelogVersionPath =
+    /^(?:\/[a-z]{2}(?:-[A-Z]{2})?)?\/docs\/changelog\/[^/]+\/?$/.test(
+      pathname,
+    );
+  if (pathname.includes(".") && !isChangelogVersionPath) {
     return NextResponse.next();
   }
 

--- a/web/tests/changelog-pages.test.tsx
+++ b/web/tests/changelog-pages.test.tsx
@@ -1,0 +1,136 @@
+import { describe, expect, test } from "bun:test";
+import { NextRequest } from "next/server";
+import { renderToStaticMarkup } from "react-dom/server";
+import {
+  changelogPath,
+  changelogVersionDescription,
+  changelogVersionPath,
+  localizedChangelogPath,
+  parseChangelog,
+  readChangelog,
+} from "../app/lib/changelog";
+import sitemap from "../app/sitemap";
+import middleware from "../proxy";
+import { ChangelogRelease } from "../app/[locale]/(landing)/docs/changelog/changelog-release";
+import { generateStaticParams } from "../app/[locale]/(landing)/docs/changelog/[version]/page";
+
+describe("per-version changelog pages", () => {
+  test("parses each release into independently renderable content", () => {
+    const [release] = parseChangelog(`
+# Changelog
+
+## [1.2.3] - 2026-08-03
+
+Release intro.
+
+### Added
+- Added \`cmux example\` ([#123](https://github.com/manaflow-ai/cmux/pull/123))
+`);
+
+    expect(release).toEqual({
+      version: "1.2.3",
+      date: "2026-08-03",
+      intro: "Release intro.",
+      sections: [
+        {
+          heading: "Added",
+          items: [
+            "Added `cmux example` ([#123](https://github.com/manaflow-ai/cmux/pull/123))",
+          ],
+        },
+      ],
+    });
+
+    const html = renderToStaticMarkup(
+      <ChangelogRelease
+        release={release}
+        locale="ja"
+        versionHref={localizedChangelogPath("ja", release.version)}
+        first
+      />,
+    );
+    expect(html).toContain('href="/ja/docs/changelog/1.2.3"');
+    expect(html).toContain('dateTime="2026-08-03"');
+    expect(html).toContain("2026年8月3日");
+    expect(html).toContain("cmux example");
+  });
+
+  test("pre-renders a route for every version in the source changelog", () => {
+    const versions = readChangelog().map((release) => release.version);
+
+    expect(generateStaticParams()).toEqual(
+      versions.map((version) => ({ version })),
+    );
+    expect(versions.length).toBeGreaterThan(80);
+    expect(versions[0]).toMatch(/^\d+\.\d+\.\d+$/);
+  });
+
+  test("emits unique release summaries without Markdown URLs", () => {
+    const release = readChangelog()[0];
+    const description = changelogVersionDescription(release);
+
+    expect(description.startsWith(`cmux ${release.version}:`)).toBe(true);
+    expect(description).not.toContain("https://");
+    expect(description).not.toContain("[");
+    expect(description.length).toBeLessThanOrEqual(160);
+  });
+
+  test("publishes every version and locale through the sitemap", () => {
+    const releases = readChangelog();
+    const entries = sitemap();
+    const latest = releases[0];
+    const indexEntry = entries.find(
+      (entry) => entry.url === `https://cmux.com${changelogPath}`,
+    );
+
+    expect(indexEntry?.lastModified).toBe(latest.date);
+
+    for (const release of releases) {
+      const path = changelogVersionPath(release.version);
+      const entry = entries.find(
+        (candidate) => candidate.url === `https://cmux.com${path}`,
+      );
+      expect(entry?.lastModified).toBe(release.date);
+      expect(entry?.changeFrequency).toBe("never");
+      expect(entry?.alternates?.languages?.ja).toBe(
+        `https://cmux.com/ja${path}`,
+      );
+      expect(
+        entries.some(
+          (candidate) => candidate.url === `https://cmux.com/ja${path}`,
+        ),
+      ).toBe(true);
+    }
+  });
+
+  test("localizes dotted canonical paths and redirects the short alias", () => {
+    const previousDocsChannel = process.env.CMUX_DOCS_CHANNEL;
+    process.env.CMUX_DOCS_CHANNEL = "release";
+
+    try {
+      const canonical = middleware(
+        new NextRequest("https://cmux.com/docs/changelog/0.64.22", {
+          headers: { "accept-language": "en" },
+        }),
+      );
+      expect(canonical.status).toBe(200);
+      expect(canonical.headers.get("x-middleware-rewrite")).toBe(
+        "https://cmux.com/en/docs/changelog/0.64.22",
+      );
+
+      const alias = middleware(
+        new NextRequest("https://cmux.com/changelog/0.64.22"),
+      );
+      expect(alias.status).toBe(307);
+      expect(alias.headers.get("location")).toBe(
+        "https://cmux.com/docs/changelog/0.64.22",
+      );
+    } finally {
+      if (previousDocsChannel === undefined) {
+        delete process.env.CMUX_DOCS_CHANNEL;
+      } else {
+        process.env.CMUX_DOCS_CHANNEL = previousDocsChannel;
+      }
+    }
+  });
+});

--- a/web/tests/changelog-pages.test.tsx
+++ b/web/tests/changelog-pages.test.tsx
@@ -7,9 +7,10 @@ import {
   changelogVersionDescription,
   changelogVersionPath,
   localizedChangelogPath,
+  ChangelogStore,
   parseChangelog,
-  readChangelog,
 } from "../app/lib/changelog";
+import { changelogStore } from "../app/lib/changelog-store";
 import sitemap from "../app/sitemap";
 import middleware from "../proxy";
 import { locales } from "../i18n/routing";
@@ -67,8 +68,40 @@ Release intro.
     expect(html).toContain("cmux example");
   });
 
+  test("refreshes and isolates injected changelog stores", () => {
+    let fingerprint = "first";
+    let reads = 0;
+    let markdown = "## [1.0.0] - 2026-08-03\n\n### Added\n- First";
+    const store = new ChangelogStore({
+      fingerprint: () => fingerprint,
+      read: () => {
+        reads += 1;
+        return markdown;
+      },
+    });
+
+    expect(store.findVersion("1.0.0")?.version).toBe("1.0.0");
+    expect(store.versions()[0]?.version).toBe("1.0.0");
+    expect(reads).toBe(1);
+
+    markdown = "## [2.0.0] - 2026-08-04\n\n### Changed\n- Second";
+    expect(store.versions()[0]?.version).toBe("1.0.0");
+    fingerprint = "second";
+    expect(store.versions()[0]?.version).toBe("2.0.0");
+    expect(reads).toBe(2);
+
+    const isolatedStore = new ChangelogStore({
+      fingerprint: () => "isolated",
+      read: () => "## [9.0.0] - 2026-08-05",
+    });
+    expect(isolatedStore.versions()[0]?.version).toBe("9.0.0");
+    expect(store.versions()[0]?.version).toBe("2.0.0");
+  });
+
   test("pre-renders a route for every version in the source changelog", () => {
-    const versions = readChangelog().map((release) => release.version);
+    const versions = changelogStore
+      .versions()
+      .map((release) => release.version);
 
     expect(generateStaticParams()).toEqual(
       versions.map((version) => ({ version })),
@@ -78,7 +111,7 @@ Release intro.
   });
 
   test("emits unique release summaries without Markdown URLs", () => {
-    const release = readChangelog()[0];
+    const release = changelogStore.versions()[0];
     const description = changelogVersionDescription(release);
 
     expect(description.startsWith(`cmux ${release.version}:`)).toBe(true);
@@ -88,7 +121,7 @@ Release intro.
   });
 
   test("publishes every version and locale through the sitemap", () => {
-    const releases = readChangelog();
+    const releases = changelogStore.versions();
     const entries = sitemap();
     const latest = releases[0];
     const indexEntry = entries.find(

--- a/web/tests/changelog-pages.test.tsx
+++ b/web/tests/changelog-pages.test.tsx
@@ -11,7 +11,10 @@ import {
   parseChangelog,
 } from "../app/lib/changelog";
 import { changelogStore } from "../app/lib/changelog-store";
-import { docsPagerItemIndex } from "../app/lib/docs-pager-path";
+import {
+  docsPagerAdjacentItems,
+  docsPagerItemIndex,
+} from "../app/lib/docs-pager-path";
 import sitemap from "../app/sitemap";
 import middleware from "../proxy";
 import { locales } from "../i18n/routing";
@@ -123,6 +126,10 @@ Release intro.
     expect(
       docsPagerItemIndex(items, "/docs/changelog/archive/0.17.0"),
     ).toBe(2);
+    expect(docsPagerAdjacentItems(items, "/outside-docs")).toEqual({
+      prev: null,
+      next: null,
+    });
   });
 
   test("emits unique release summaries without Markdown URLs", () => {

--- a/web/tests/changelog-pages.test.tsx
+++ b/web/tests/changelog-pages.test.tsx
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import { NextRequest } from "next/server";
 import { renderToStaticMarkup } from "react-dom/server";
+import { createTranslator } from "use-intl/core";
 import {
   changelogPath,
   changelogVersionDescription,
@@ -11,8 +12,11 @@ import {
 } from "../app/lib/changelog";
 import sitemap from "../app/sitemap";
 import middleware from "../proxy";
+import { locales } from "../i18n/routing";
 import { ChangelogRelease } from "../app/[locale]/(landing)/docs/changelog/changelog-release";
 import { generateStaticParams } from "../app/[locale]/(landing)/docs/changelog/[version]/page";
+
+type Messages = typeof import("../messages/en.json");
 
 describe("per-version changelog pages", () => {
   test("parses each release into independently renderable content", () => {
@@ -45,6 +49,13 @@ Release intro.
       <ChangelogRelease
         release={release}
         locale="ja"
+        sectionLabels={{
+          added: "追加",
+          changed: "変更",
+          fixed: "修正",
+          removed: "削除",
+          contributors: "コントリビューター",
+        }}
         versionHref={localizedChangelogPath("ja", release.version)}
         first
       />,
@@ -52,6 +63,7 @@ Release intro.
     expect(html).toContain('href="/ja/docs/changelog/1.2.3"');
     expect(html).toContain('dateTime="2026-08-03"');
     expect(html).toContain("2026年8月3日");
+    expect(html).toContain("追加");
     expect(html).toContain("cmux example");
   });
 
@@ -131,6 +143,34 @@ Release intro.
       } else {
         process.env.CMUX_DOCS_CHANNEL = previousDocsChannel;
       }
+    }
+  });
+
+  test("provides changelog section labels for every supported locale", async () => {
+    for (const locale of locales) {
+      // The locale is dynamic so this test follows the routing registry.
+      const messages = (
+        await import(`../messages/${locale}.json`)
+      ).default as Messages;
+      const labels = messages.docs.changelog.sections;
+      const t = createTranslator({
+        locale,
+        messages,
+        namespace: "docs.changelog",
+      });
+
+      expect(Object.keys(labels).sort()).toEqual([
+        "added",
+        "changed",
+        "contributors",
+        "fixed",
+        "removed",
+      ]);
+      for (const label of Object.values(labels)) {
+        expect(label.trim().length).toBeGreaterThan(0);
+      }
+      expect(t("versionTitle", { version: "1.2.3" })).toContain("1.2.3");
+      expect(t("releaseNavLabel", { version: "1.2.3" })).toContain("1.2.3");
     }
   });
 });

--- a/web/tests/changelog-pages.test.tsx
+++ b/web/tests/changelog-pages.test.tsx
@@ -11,6 +11,7 @@ import {
   parseChangelog,
 } from "../app/lib/changelog";
 import { changelogStore } from "../app/lib/changelog-store";
+import { docsPagerItemIndex } from "../app/lib/docs-pager-path";
 import sitemap from "../app/sitemap";
 import middleware from "../proxy";
 import { locales } from "../i18n/routing";
@@ -108,6 +109,20 @@ Release intro.
     );
     expect(versions.length).toBeGreaterThan(80);
     expect(versions[0]).toMatch(/^\d+\.\d+\.\d+$/);
+  });
+
+  test("uses the exact or deepest docs page for nested release routes", () => {
+    const items = [
+      { href: "/docs" },
+      { href: "/docs/changelog" },
+      { href: "/docs/changelog/archive" },
+    ];
+
+    expect(docsPagerItemIndex(items, "/docs/changelog")).toBe(1);
+    expect(docsPagerItemIndex(items, "/docs/changelog/0.64.22")).toBe(1);
+    expect(
+      docsPagerItemIndex(items, "/docs/changelog/archive/0.17.0"),
+    ).toBe(2);
   });
 
   test("emits unique release summaries without Markdown URLs", () => {


### PR DESCRIPTION
## Summary
- add canonical `/docs/changelog/<version>` pages generated from `CHANGELOG.md`
- link each release from the changelog index and connect adjacent releases
- publish localized release URLs, metadata, JSON-LD, and release dates in the sitemap
- preserve dotted version URLs through locale routing and the `/changelog/<version>` alias

## Testing
- `cd web && bun run test tests/changelog-pages.test.tsx tests/seo.test.ts`
- `cd web && bun run typecheck`
- `cd web && bun run lint app/lib/changelog.ts app/[locale]/\(landing\)/docs/changelog/page.tsx app/[locale]/\(landing\)/docs/changelog/changelog-release.tsx app/[locale]/\(landing\)/docs/changelog/[version]/page.tsx app/[locale]/components/docs-pager.tsx app/sitemap.ts proxy.ts tests/changelog-pages.test.tsx`
- `cd web && CMUX_DOCS_CHANNEL=release SKIP_ENV_VALIDATION=1 bun run build`
- verified index links, English and Japanese canonicals, alias redirect, unknown-version 404, metadata, JSON-LD, and sitemap against the production build

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/9543"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788419569&installation_model_id=21920&pr_number=9543&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F9543&signature=184034386fc21f4d87e4a40f7f2d3afe88eb7a3b94e6e6a971899f77393af021"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds statically pre-rendered, localized per‑version changelog pages at `/docs/changelog/<version>` from `CHANGELOG.md`, with structured SEO and per‑version sitemap entries. Index links point to localized release pages, and each release has prev/next navigation.

- **New Features**
  - Per‑version pages are statically pre‑rendered (`generateStaticParams`, `dynamic: "force-static"`) with localized titles, section labels, breadcrumbs, and prev/next; index links go to localized release pages.
  - Localized SEO (canonical alternates, Open Graph/Twitter) and JSON‑LD; sitemap lists each release and updates the index `lastModified` via a shared `ChangelogStore` with fingerprint‑based refresh.

- **Bug Fixes**
  - Docs pager now matches nested changelog routes by exact or deepest ancestor and hides the pager for paths outside the docs nav.
  - Middleware: dotted version slugs are treated as pages; `/changelog[/<version>]` redirects to `/docs/changelog[/<version>]` with locales preserved.

<sup>Written for commit 1e9ad0acb62bea44272b0ebd46e9f9b5ee669926. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/9543?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added dedicated, localized pages for each changelog release.
  - Changelog entries now include release metadata, hero media, feature sections, contributors, formatted content, and navigation between releases.
  - Added localized SEO metadata, social previews, structured data, and sitemap entries for individual releases.
  - Added translated changelog labels across all supported locales.

- **Bug Fixes**
  - Improved documentation pager positioning on nested pages.
  - Updated changelog redirects to preserve locale and version paths.

- **Tests**
  - Added coverage for localized changelog pages, navigation, redirects, and sitemap entries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->