### PR TITLE
Restore native Window menu move controls

### DIFF
--- a/Sources/App/CmuxMainWindow.swift
+++ b/Sources/App/CmuxMainWindow.swift
@@ -90,7 +90,9 @@ final class MainWindowHostingView<Content: View>: NSHostingView<Content> {
 @MainActor
 func configureCmuxMainWindowDragBehavior(_ window: NSWindow) {
     window.isMovableByWindowBackground = false
-    window.isMovable = false
+    if !isWindowDragSuppressed(window: window) {
+        window.isMovable = true
+    }
 }
 
 @MainActor
@@ -99,9 +101,9 @@ final class CmuxMainWindow: NSWindow {
     /// No content may resize this window past the attached display union. The content view
     /// hosts AppKit subtrees whose subviews carry REQUIRED autoresizing-mask
     /// constraints, and if any of them is ever laid out oversized, AppKit
-    /// satisfies those constraints by growing the WINDOW — and since this
-    /// window is non-movable, nothing ever constrains it back. A layout bug
-    /// then compounds through everything derived from window geometry
+    /// satisfies those constraints by growing the WINDOW. Nothing in the
+    /// content layout then constrains it back, so a layout bug compounds
+    /// through everything derived from window geometry
     /// (observed live: the window at 29,000 points wide, growing every
     /// pass). The user sizes this window; layout does not.
     override func setFrame(_ frameRect: NSRect, display flag: Bool) {
@@ -290,15 +292,14 @@ final class CmuxMainWindow: NSWindow {
     ///
     /// "Reachable" means a grabbable slice of the window's *titlebar* — its top
     /// strip — is on some screen's visible area, not merely that some corner of
-    /// the window overlaps a screen. The main window is non-movable
-    /// (``configureCmuxMainWindowDragBehavior`` sets `isMovable = false`) and can
-    /// only be dragged by ``WindowDragHandleView`` in the titlebar band, so a
-    /// window whose titlebar is off-screen cannot be recovered by the user even
-    /// when its body still overlaps a display. Requiring the top strip to remain
-    /// reachable lets AppKit re-clamp a window stranded above the screen (e.g.
-    /// after disconnecting an external monitor that sat above the built-in
-    /// display) while still leaving a genuinely on-screen frame untouched, which
-    /// is what stops the sleep/wake drift (#6305).
+    /// the window overlaps a screen. The main window uses
+    /// ``WindowDragHandleView`` in the titlebar band instead of background
+    /// dragging, so a window whose titlebar is off-screen cannot be recovered by
+    /// the user even when its body still overlaps a display. Requiring the top
+    /// strip to remain reachable lets AppKit re-clamp a window stranded above
+    /// the screen (e.g. after disconnecting an external monitor that sat above
+    /// the built-in display) while still leaving a genuinely on-screen frame
+    /// untouched, which is what stops the sleep/wake drift (#6305).
     ///
     /// Delegates to the shared ``isTitlebarReachable(frame:visibleFrame:)``
     /// predicate used by the reactive titlebar-stranding safety net. Persisted
@@ -318,9 +319,8 @@ final class CmuxMainWindow: NSWindow {
     /// (``shouldPreserveFrameDuringConstrain``) and AppDelegate's reactive
     /// titlebar-stranding safety net.
     ///
-    /// The window is non-movable (``configureCmuxMainWindowDragBehavior`` sets
-    /// `isMovable = false`) and can only be dragged by ``WindowDragHandleView``
-    /// in the titlebar band, so a window whose titlebar is off-screen cannot be
+    /// The window uses ``WindowDragHandleView`` in the titlebar band instead of
+    /// background dragging, so a window whose titlebar is off-screen cannot be
     /// recovered even when its body still overlaps a display. Requiring the top
     /// strip to remain reachable lets a stranded window be re-clamped while a
     /// genuinely on-screen frame is left untouched (which is what stops the

--- a/Sources/AppDelegate+WindowFramePolicy.swift
+++ b/Sources/AppDelegate+WindowFramePolicy.swift
@@ -54,15 +54,13 @@ extension AppDelegate {
     /// grabbable slice of its titlebar is already reachable on some display, or
     /// there are no displays to reason about.
     ///
-    /// This is the reactive counterpart to `CmuxMainWindow.constrainFrameRect`:
-    /// a cmux main window sets `isMovable = false` for its custom titlebar drag
-    /// handling, and a non-movable `NSWindow` is excluded from AppKit's automatic
-    /// on-screen constraining when displays change -- so `constrainFrameRect` is
-    /// never invoked on that path and nothing pulls a stranded window back. When
-    /// an external monitor that sat above the built-in display is disconnected,
-    /// the window is left with its titlebar in the now-gone monitor's coordinate
-    /// space, above every remaining screen and unreachable (the user cannot drag
-    /// it back because the only drag affordance is that off-screen titlebar).
+    /// This is the reactive counterpart to `CmuxMainWindow.constrainFrameRect`.
+    /// AppKit does not reliably re-constrain every custom full-size-content main
+    /// window after a display change, so a window can remain in a disconnected
+    /// monitor's coordinate space without invoking that override. When an
+    /// external monitor that sat above the built-in display is disconnected,
+    /// the window is left with its titlebar above every remaining screen and
+    /// unreachable because the only drag affordance is that off-screen titlebar.
     ///
     /// Pure and `nonisolated` so it is unit-testable without live `NSScreen`s.
     nonisolated static func reconciledFrameAfterScreenChange(

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -3402,9 +3402,9 @@ struct ContentView: View {
         window.isRestorable = false
         setMinimalModeSidebarTitlebarControlsAvailable(sidebarState.isVisible, in: window)
         window.titlebarAppearsTransparent = true
-        // Native AppKit titlebar dragging steals pane-tab drags in minimal
-        // mode. Keep the main window immovable by default; explicit chrome
-        // drag zones temporarily enable performDrag for real app moves.
+        // Keep background dragging disabled so explicit chrome owns window
+        // movement. Pane-tab and folder drags temporarily suppress movability
+        // through the shared NSWindow event path.
         configureCmuxMainWindowDragBehavior(window)
         window.styleMask.insert(.fullSizeContentView)
 

--- a/cmuxTests/AppDelegateWindowFrameReconcileTests.swift
+++ b/cmuxTests/AppDelegateWindowFrameReconcileTests.swift
@@ -10,8 +10,9 @@ import XCTest
 final class AppDelegateWindowFrameReconcileTests: XCTestCase {
     // A window stranded above the only remaining display after disconnecting an
     // external monitor that sat above the built-in must be pulled back so its
-    // titlebar is reachable. AppKit does not auto-constrain the non-movable main
-    // window on a display change, so this reactive reconcile is the only defense.
+    // titlebar is reachable. AppKit does not reliably auto-constrain the custom
+    // full-size-content main window on a display change, so the reactive
+    // reconcile remains the final defense.
     func testReconciledFrameAfterScreenChangePullsBackStrandedWindow() {
         // Built-in display only; the window's titlebar (top ~64pt near y~=1520)
         // is far above the built-in's visible top (944), with only its bottom

--- a/cmuxTests/CmuxMainWindowConstrainFrameTests.swift
+++ b/cmuxTests/CmuxMainWindowConstrainFrameTests.swift
@@ -111,8 +111,8 @@ final class CmuxMainWindowConstrainFrameTests: XCTestCase {
     // {300,884 1000x700}: its bottom 60pt still overlaps the built-in display, but
     // its titlebar (top 64pt) is at y≈1520, far above the built-in's visible top
     // (944) — i.e. off the top of every remaining screen and unreachable. Because
-    // the window is non-movable (isMovable=false) and only draggable via the
-    // titlebar handle, the user cannot pull it back down.
+    // cmux's drag affordance lives in that titlebar, the user cannot pull it back
+    // down.
     //
     // AppKit's default constrain pass would clamp this window back onto the
     // built-in display. The #6305 override must NOT veto that clamp here: a frame

--- a/cmuxTests/TitlebarInteractiveControlTests.swift
+++ b/cmuxTests/TitlebarInteractiveControlTests.swift
@@ -169,7 +169,7 @@ struct TitlebarInteractiveControlTests {
         #expect(hitView === container)
         #expect(
             !hitView.mouseDownCanMoveWindow,
-            "Empty accessory chrome must not rely on native AppKit window dragging because main windows are normally immovable."
+            "Empty accessory chrome must use the explicit drag path even while window movement is temporarily suppressed."
         )
 
         let event = Self.makeLeftMouseDownEvent(location: emptyTopRightPoint, window: window)
@@ -182,7 +182,7 @@ struct TitlebarInteractiveControlTests {
         )
         #expect(
             !window.isMovable,
-            "Explicit accessory dragging must restore the main window to its normal immovable state."
+            "Explicit accessory dragging must restore the window's temporarily suppressed movability state."
         )
     }
 

--- a/cmuxTests/WindowAndDragTests.swift
+++ b/cmuxTests/WindowAndDragTests.swift
@@ -2032,34 +2032,42 @@ final class MainWindowDragBehaviorTests: XCTestCase {
         )
     }
 
-    func testMainWindowDragBehaviorRequiresExplicitDragZones() {
+    func testMainWindowDragBehaviorKeepsNativeWindowMovableOutsideExplicitSuppression() {
         let window = CmuxMainWindow(
             contentRect: NSRect(x: 0, y: 0, width: 320, height: 180),
             styleMask: [.titled, .closable, .miniaturizable, .resizable, .fullSizeContentView],
             backing: .buffered,
             defer: false
         )
-        defer { window.orderOut(nil) }
-        window.isMovable = true
+        defer {
+            _ = finishWindowMoveSuppressionSequence(window: window)
+            window.orderOut(nil)
+        }
+        window.isMovable = false
         window.isMovableByWindowBackground = true
 
         configureCmuxMainWindowDragBehavior(window)
 
-        XCTAssertFalse(
+        XCTAssertTrue(
             window.isMovable,
-            "Main windows must not use native AppKit titlebar dragging because pane tabs live in the titlebar band"
+            "Main windows must stay movable so AppKit enables Window > Move & Resize"
         )
         XCTAssertFalse(window.isMovableByWindowBackground)
 
-        let previous = withTemporaryWindowMovableEnabled(window: window) {
-            XCTAssertTrue(window.isMovable)
-        }
+        XCTAssertEqual(
+            beginWindowMoveSuppressionSequence(window: window, reason: .bonsplitPaneTabDrag),
+            .bonsplitPaneTabDrag
+        )
+        XCTAssertFalse(window.isMovable)
 
-        XCTAssertEqual(previous, false)
+        configureCmuxMainWindowDragBehavior(window)
         XCTAssertFalse(
             window.isMovable,
-            "Explicit chrome drag zones may temporarily enable movement, but the main window must return to pane-tab-safe immovable state"
+            "Reapplying main-window configuration must not interrupt an active pane-tab drag"
         )
+
+        XCTAssertEqual(finishWindowMoveSuppressionSequence(window: window), .bonsplitPaneTabDrag)
+        XCTAssertTrue(window.isMovable)
     }
 }
 


### PR DESCRIPTION
## Summary

- keep normal cmux main windows movable so AppKit enables its native Window menu move and resize commands
- keep background dragging disabled and preserve the shared pane-tab/folder drag suppression lifecycle
- retain the existing frame-reconciliation safeguards for disconnected displays

Fixes #7446

## Testing

- Red regression proof at test-only commit `4ae7bec5ae`: `./scripts/reload-cloud.sh xctest --tag sym7446-red-unit --only-testing cmuxTests/MainWindowDragBehaviorTests` (`sym7446-red-unit-6b28fc63f950`) failed the two new movability assertions as expected.
- Green focused proof at `f7e50e3b24`: `./scripts/reload-cloud.sh xctest --tag sym7446-green-unit` with `MainWindowDragBehaviorTests`, `FolderWindowMoveSuppressionTests`, `WindowMoveSuppressionHitPathTests`, `TitlebarInteractiveControlTests`, `CmuxMainWindowConstrainFrameTests`, and `AppDelegateWindowFrameReconcileTests` (`sym7446-green-unit-2fbb500a73f0`) passed 33 XCTest cases and 6 Swift Testing cases.
- Dev build: `./scripts/reload-cloud.sh --tag sym7446 --builder blacksmith --launch` succeeded on Blacksmith macOS 26 run [30959268214](https://github.com/manaflow-ai/cmux/actions/runs/30959268214); no local-build fallback was used. The downloaded app embedded ephemeral build commit `cb3d7566d`, whose parent is exact PR HEAD `f7e50e3b24`. `/tmp/cmux-debug-sym7446.sock` returned `PONG`. With the tagged app active and its `CmuxMainWindow` both main and key on Studio Display XDR, runtime inspection saw both Studio Display XDR and Built-in Retina Display, `isMovable == true`, `isMovableByWindowBackground == false`, and the tracked Window menu reported Fill, Center, Move & Resize, and Move to Built-in Retina Display all enabled. The tagged app was stopped with `pkill -f "DerivedData/cmux-sym7446"`; PID 82759 exited and the tagged socket was removed.
- Localization audit: no user-facing strings or localization catalogs changed; a diff scan found no new Swift UI string candidates.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/9546"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788419854&installation_model_id=21920&pr_number=9546&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F9546&signature=6dc2f73b5d070f10f5d9aa1c4714d597d39bef563a177c6c9303176ee9a11b73"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores native Window menu move controls for main windows by keeping them movable except during explicit suppression. Background dragging stays off, and off‑screen/titlebar safety remains in place.

- **Bug Fixes**
  - Set `isMovable = true` unless `isWindowDragSuppressed` to re-enable Window > Fill, Center, and Move & Resize.
  - Keep `isMovableByWindowBackground = false` so titlebar drag zones control movement and pane-tab/folder drags can suppress it.
  - Preserve frame clamping and reactive reconcile to keep the titlebar reachable after display changes.
  - Updated tests to cover movability, suppression lifecycle, and frame safety.

<sup>Written for commit f7e50e3b24f36965ab98130b214ba684a95f9e49. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/9546?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Main windows now remain natively movable while background dragging stays disabled.
  * Pane-tab and folder drag operations temporarily suppress window movement, then restore the prior behavior.
  * Window positioning remains safeguarded when display configurations change.

* **Tests**
  * Updated coverage verifies native movability, controlled drag suppression, restoration behavior, and display-change positioning.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->