### PR TITLE
Recover legacy keyboard shortcut customizations

### DIFF
--- a/Packages/macOS/CmuxSettings/Sources/CmuxSettings/Stores/UserDefaultsSettingsStore+LegacyShortcutBindings.swift
+++ b/Packages/macOS/CmuxSettings/Sources/CmuxSettings/Stores/UserDefaultsSettingsStore+LegacyShortcutBindings.swift
@@ -10,10 +10,10 @@ extension UserDefaultsSettingsStore {
         return Dictionary(uniqueKeysWithValues: ShortcutAction.allCases.compactMap { action in
             let key = legacyShortcutKey(for: action)
             guard let data = storage.valueIfPresent(for: key),
-                  let payload = try? decoder.decode(LegacyStoredShortcutPayload.self, from: data) else {
+                  let shortcut = try? decoder.decode(StoredShortcut.self, from: data) else {
                 return nil
             }
-            return (action.rawValue, payload.storedShortcut)
+            return (action.rawValue, shortcut)
         })
     }
 

--- a/Packages/macOS/CmuxSettings/Sources/CmuxSettings/Values/LegacyStoredShortcutPayload.swift
+++ b/Packages/macOS/CmuxSettings/Sources/CmuxSettings/Values/LegacyStoredShortcutPayload.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-/// The flat Codable representation written by the app's legacy shortcut store.
+/// The flat Codable representation written by cmux 0.64.10 and earlier.
 struct LegacyStoredShortcutPayload: Decodable {
     let key: String
     let command: Bool

--- a/Packages/macOS/CmuxSettings/Sources/CmuxSettings/Values/StoredShortcut.swift
+++ b/Packages/macOS/CmuxSettings/Sources/CmuxSettings/Values/StoredShortcut.swift
@@ -24,6 +24,27 @@ public struct StoredShortcut: Sendable, Equatable, Hashable, Codable, SettingCod
         self.second = second
     }
 
+    private enum CodingKeys: String, CodingKey {
+        case first
+        case second
+    }
+
+    /// Decodes the current nested format or the flat format written by cmux 0.64.10 and earlier.
+    ///
+    /// - Parameter decoder: The decoder containing a persisted shortcut binding.
+    /// - Throws: A decoding error when the payload matches neither supported format or contains
+    ///   invalid field values.
+    public init(from decoder: any Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        if container.contains(.first) {
+            first = try container.decode(ShortcutStroke.self, forKey: .first)
+            second = try container.decodeIfPresent(ShortcutStroke.self, forKey: .second)
+            return
+        }
+
+        self = try LegacyStoredShortcutPayload(from: decoder).storedShortcut
+    }
+
     /// True when this binding is the explicit "no shortcut" marker.
     public var isUnbound: Bool { first.key.isEmpty && second == nil }
 

--- a/Packages/macOS/CmuxSettings/Tests/CmuxSettingsTests/StoredShortcutCodableTests.swift
+++ b/Packages/macOS/CmuxSettings/Tests/CmuxSettingsTests/StoredShortcutCodableTests.swift
@@ -1,0 +1,118 @@
+import Foundation
+import Testing
+import CmuxSettings
+
+@Suite("StoredShortcut Codable")
+struct StoredShortcutCodableTests {
+    @Test func legacySingleStrokeDecodes() throws {
+        let data = Data(
+            #"""
+            {
+              "key": "t",
+              "command": true,
+              "shift": false,
+              "option": false,
+              "control": false,
+              "keyCode": 17,
+              "chordCommand": false,
+              "chordShift": false,
+              "chordOption": false,
+              "chordControl": false
+            }
+            """#.utf8
+        )
+
+        let shortcut = try JSONDecoder().decode(StoredShortcut.self, from: data)
+
+        #expect(
+            shortcut.first
+                == ShortcutStroke(
+                    key: "t",
+                    command: true,
+                    keyCode: 17
+                )
+        )
+        #expect(shortcut.second == nil)
+    }
+
+    @Test func legacyChordDecodes() throws {
+        let data = Data(
+            #"""
+            {
+              "key": "b",
+              "command": false,
+              "shift": false,
+              "option": false,
+              "control": true,
+              "keyCode": 11,
+              "chordKey": "c",
+              "chordCommand": false,
+              "chordShift": true,
+              "chordOption": false,
+              "chordControl": false,
+              "chordKeyCode": 8
+            }
+            """#.utf8
+        )
+
+        let shortcut = try JSONDecoder().decode(StoredShortcut.self, from: data)
+
+        #expect(
+            shortcut.first
+                == ShortcutStroke(
+                    key: "b",
+                    control: true,
+                    keyCode: 11
+                )
+        )
+        #expect(
+            shortcut.second
+                == ShortcutStroke(
+                    key: "c",
+                    shift: true,
+                    keyCode: 8
+                )
+        )
+    }
+
+    @Test func legacyUnboundDecodesFromUserDefaults() {
+        let data = Data(
+            #"""
+            {
+              "key": "",
+              "command": false,
+              "shift": false,
+              "option": false,
+              "control": false,
+              "chordCommand": false,
+              "chordShift": false,
+              "chordOption": false,
+              "chordControl": false
+            }
+            """#.utf8
+        )
+
+        #expect(StoredShortcut.decodeFromUserDefaults(data) == .unbound)
+    }
+
+    @Test func currentNestedFormatRoundTrips() throws {
+        let original = StoredShortcut(
+            first: ShortcutStroke(
+                key: "p",
+                command: true,
+                shift: true,
+                keyCode: 35
+            ),
+            second: ShortcutStroke(
+                key: "k",
+                option: true,
+                keyCode: 40
+            )
+        )
+
+        let data = try JSONEncoder().encode(original)
+        let decoded = try JSONDecoder().decode(StoredShortcut.self, from: data)
+
+        #expect(decoded == original)
+    }
+}


### PR DESCRIPTION
## Summary

- decode `StoredShortcut` from both the current nested stroke shape and the flat shape written by cmux 0.64.10 and earlier
- reuse that compatibility decoder when loading legacy per-action UserDefaults bindings
- keep encoding in the current nested format, so existing data is recovered without a destructive migration

Fixes #5422

## Testing

- Red: [test-only CI package job](https://github.com/manaflow-ai/cmux/actions/runs/30882609786/job/91907612749) on `23b251edde` passed the current nested round-trip but failed all three legacy cases with `keyNotFound("first")` / `nil`.
- Green: on leased runner `cmux-aws-m4pro.1`, ran `swift test --package-path Packages/macOS/CmuxSettings --filter StoredShortcutCodableTests`; all 4 tests passed on `0d3699548c`.
- Dev build: ran `./scripts/reload-cloud.sh --tag sym5422`; after the Blacksmith queue timed out, used its leased-fleet path, with the successful retry pinned to `cmux9s-mac-mini`. No local build was used. [Hosted build run](https://github.com/manaflow-ai/cmux/actions/runs/30885296159) · [tagged build](http://127.0.0.1:17320/sym5422)
- Runtime: seeded the tagged bundle’s `shortcut.newSurface` UserDefaults key with a legacy flat `cmd+ctrl+opt+shift+y` binding and tested against `/tmp/cmux-debug-sym5422.sock`. Surface counts were `baseline=2`, `after default cmd+t=2`, and `after legacy custom shortcut=3`, proving the recovered binding replaced the default. The tagged app was then stopped, and the fixture and socket were removed.
- Localization audit: no user-facing strings, shortcut metadata, schema/docs text, or localization catalogs changed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/9547"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788419871&installation_model_id=21920&pr_number=9547&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F9547&signature=5ac466d756a16a17f887ad0ec01378ba5c7060854632b523d01493de98b02af5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Recover legacy keyboard shortcut customizations by decoding both the current nested format and the flat format from cmux 0.64.10 and earlier. Keeps encoding unchanged so settings are restored without a migration (fixes #5422).

- **Bug Fixes**
  - Add a custom decoder to `StoredShortcut` to read both formats and reuse it when loading legacy per‑action `UserDefaults` bindings.
  - Add regression tests for legacy single stroke, chord, unbound, and current nested round‑trip.

<sup>Written for commit 0d3699548c597246176433add5e1d2d5375bf2e0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/9547?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

