### PR TITLE
Strip control characters from feedback attachment filenames

### DIFF
--- a/Packages/macOS/CmuxFeedback/Sources/CmuxFeedback/Client/FeedbackComposerClient.swift
+++ b/Packages/macOS/CmuxFeedback/Sources/CmuxFeedback/Client/FeedbackComposerClient.swift
@@ -237,7 +237,10 @@ public struct FeedbackComposerClient {
         to body: inout Data,
         boundary: String
     ) {
-        let sanitizedFileName = attachment.fileName.replacingOccurrences(of: "\"", with: "")
+        let sanitizedFileName = attachment.fileName
+            .components(separatedBy: .controlCharacters)
+            .joined()
+            .replacingOccurrences(of: "\"", with: "")
 
         body.append(Data("--\(boundary)\r\n".utf8))
         body.append(

--- a/Packages/macOS/CmuxFeedback/Tests/CmuxFeedbackTests/FeedbackComposerClientTests.swift
+++ b/Packages/macOS/CmuxFeedback/Tests/CmuxFeedbackTests/FeedbackComposerClientTests.swift
@@ -1,0 +1,114 @@
+import Foundation
+import Testing
+
+@testable import CmuxFeedback
+
+@Suite("Feedback composer client", .serialized)
+struct FeedbackComposerClientTests {
+    @Test("multipart filenames cannot contain control characters")
+    func multipartFilenameStripsControlCharacters() async throws {
+        FeedbackComposerURLProtocol.reset()
+        let registered = URLProtocol.registerClass(FeedbackComposerURLProtocol.self)
+        defer { URLProtocol.unregisterClass(FeedbackComposerURLProtocol.self) }
+        #expect(registered)
+
+        let temporaryDirectory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cmux-feedback-client-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(
+            at: temporaryDirectory,
+            withIntermediateDirectories: true
+        )
+        defer { try? FileManager.default.removeItem(at: temporaryDirectory) }
+
+        let unsafeFileName = "capture\"\r\ninjected\u{0001}\t\u{007F}.png"
+        let fileURL = temporaryDirectory.appendingPathComponent(unsafeFileName)
+        try Data("attachment-data".utf8).write(to: fileURL)
+        let attachment = try FeedbackComposerAttachment(url: fileURL)
+        #expect(attachment.fileName == unsafeFileName)
+
+        let settings = FeedbackComposerSettings(
+            endpointEnvironmentKey: "CMUX_FEEDBACK_CLIENT_TEST_ENDPOINT_\(UUID().uuidString)",
+            defaultEndpoint: "https://feedback.test/submit"
+        )
+        try await FeedbackComposerClient(settings: settings).submit(
+            email: "test@example.com",
+            message: "multipart filename test",
+            attachments: [attachment]
+        )
+
+        let body = try #require(FeedbackComposerURLProtocol.capturedBody())
+        let bodyString = try #require(String(data: body, encoding: .utf8))
+        let markerRange = try #require(bodyString.range(of: #"filename=""#))
+        let filenameStart = markerRange.upperBound
+        let filenameEnd = try #require(bodyString[filenameStart...].firstIndex(of: "\""))
+        let filenameField = bodyString[filenameStart..<filenameEnd]
+
+        #expect(filenameField == "captureinjected.png")
+        #expect(filenameField.unicodeScalars.allSatisfy {
+            !CharacterSet.controlCharacters.contains($0)
+        })
+    }
+}
+
+private final class FeedbackComposerURLProtocol: URLProtocol, @unchecked Sendable {
+    private static let lock = NSLock()
+    private nonisolated(unsafe) static var body: Data?
+
+    static func reset() {
+        lock.withLock { body = nil }
+    }
+
+    static func capturedBody() -> Data? {
+        lock.withLock { body }
+    }
+
+    override class func canInit(with request: URLRequest) -> Bool {
+        request.url?.host == "feedback.test"
+    }
+
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest {
+        request
+    }
+
+    override func startLoading() {
+        let requestBody = Self.requestBody(from: request)
+        Self.lock.withLock { Self.body = requestBody }
+        guard let url = request.url,
+              let response = HTTPURLResponse(
+                  url: url,
+                  statusCode: 200,
+                  httpVersion: nil,
+                  headerFields: nil
+              ) else {
+            client?.urlProtocol(self, didFailWithError: URLError(.badServerResponse))
+            return
+        }
+
+        client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+        client?.urlProtocol(self, didLoad: Data())
+        client?.urlProtocolDidFinishLoading(self)
+    }
+
+    override func stopLoading() {}
+
+    private static func requestBody(from request: URLRequest) -> Data? {
+        if let body = request.httpBody {
+            return body
+        }
+        guard let stream = request.httpBodyStream else {
+            return nil
+        }
+
+        stream.open()
+        defer { stream.close() }
+
+        var body = Data()
+        var buffer = [UInt8](repeating: 0, count: 4_096)
+        while true {
+            let count = stream.read(&buffer, maxLength: buffer.count)
+            guard count >= 0 else { return nil }
+            guard count > 0 else { return body }
+            body.append(contentsOf: buffer.prefix(count))
+        }
+    }
+}


### PR DESCRIPTION
Fixes #5717

## Summary

- Strip Foundation control characters from feedback attachment filenames before interpolating them into multipart `Content-Disposition` headers.
- Exercise the real `FeedbackComposerClient.submit` request path with a filesystem filename containing a quote, CR/LF, tab, DEL, and another C0 control.

## Testing

- Red at `3f54edb0d8`: `swift test --package-path Packages/macOS/CmuxFeedback --scratch-path <isolated-path> --filter FeedbackComposerClientTests` on `aws-m4pro-6` failed because the captured filename field still contained raw control bytes.
- Green at `8d3737500e`: the same remote command passed the regression test (1 test, 1 suite).
- `./scripts/reload-cloud.sh --tag sym5717`: remote build completed on leased fleet slot `cmux9s-mac-mini.1`; no local fallback was used. The default Blacksmith lane queued, and an earlier fleet slot was skipped after exposing a missing Zig 0.16.0 toolchain.
- Tagged runtime check through `/tmp/cmux-debug-sym5717.sock`: `cmux feedback --email test@example.com --body <test-message> --image <fixture>` sent a filename whose input hex was `63617074757265220d0a696e6a656374656401097f2e706e67`; the local capture endpoint received `captureinjected.png` with no control bytes. The tagged app was then stopped and its stale socket removed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/9548"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788419935&installation_model_id=21920&pr_number=9548&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F9548&signature=c5c98c482859d0d0ec54155ca736e02740c53cfb8af3fc81aa89d014eec2862d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Strip control characters from feedback attachment filenames before building multipart Content-Disposition headers to prevent header injection and malformed uploads (fixes #5717). Added a test through `FeedbackComposerClient.submit` that uses a filename with quotes, CR/LF, tab, DEL, and other C0 controls, and asserts the sent name is sanitized.

<sup>Written for commit 8d3737500e3c7da8bf2c6a20fa4decb524cc6415. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/9548?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

