### PR TITLE
Fix Pi fork probes without slowing Pi hooks

### DIFF
--- a/CLI/CMUXCLI+PiExtensionSourcePart1.swift
+++ b/CLI/CMUXCLI+PiExtensionSourcePart1.swift
@@ -220,43 +220,84 @@ function looksLikePiScript(value: string): boolean {
   );
 }
 
-function normalizedLaunchArgv(): string[] {
-  const raw = Array.isArray(process.argv) ? process.argv.map((value) => String(value)) : [];
-  if (raw.length === 0) return [resolveExecutable("pi")];
-  if (looksLikePiExecutable(raw[0])) return raw;
-  if (raw.length > 1 && looksLikePiScript(raw[1])) {
-    return [resolveExecutable("pi"), ...raw.slice(2)];
-  }
-  return [resolveExecutable("pi"), ...raw.slice(1)];
+interface NormalizedLaunchArgvCache {
+  key: string;
+  argv: string[];
 }
 
+let normalizedLaunchArgvCache: NormalizedLaunchArgvCache | undefined;
+
+function normalizedLaunchArgv(): string[] {
+  const raw = Array.isArray(process.argv) ? process.argv.map((value) => String(value)) : [];
+  // Pi's argv and inherited PATH are stable for the lifetime of this extension.
+  // Memoize executable discovery so every hook subprocess does not synchronously
+  // stat the full PATH again. Keep the key dynamic for test harnesses and hosts
+  // that deliberately rewrite process argv at runtime.
+  const cacheKey = [process.env.PATH || "", ...raw].join("\0");
+  if (normalizedLaunchArgvCache?.key === cacheKey) {
+    return normalizedLaunchArgvCache.argv;
+  }
+
+  let argv: string[];
+  if (raw.length === 0) {
+    argv = [resolveExecutable("pi")];
+  } else if (looksLikePiExecutable(raw[0])) {
+    argv = raw;
+  } else if (raw.length > 1 && looksLikePiScript(raw[1])) {
+    argv = [resolveExecutable("pi"), ...raw.slice(2)];
+  } else {
+    argv = [resolveExecutable("pi"), ...raw.slice(1)];
+  }
+  normalizedLaunchArgvCache = { key: cacheKey, argv };
+  return argv;
+}
+
+interface DetectedPiVersionCache {
+  key: string;
+  version: string | null;
+}
+
+let detectedPiVersionCache: DetectedPiVersionCache | undefined;
+
 function detectedPiVersion(): string | null {
+  const cacheKey = [
+    process.cwd(),
+    ...process.argv.slice(0, 2).map((value) => String(value)),
+  ].join("\0");
+  if (detectedPiVersionCache?.key === cacheKey) {
+    return detectedPiVersionCache.version;
+  }
+
   const script = process.argv.slice(0, 2).find((value) => {
     const candidate = String(value);
     return looksLikePiScript(candidate) || looksLikePiExecutable(candidate);
   });
-  if (!script) return null;
-  let scriptPath = path.resolve(String(script));
-  try {
-    // npm launches through bin symlinks, so inspect the package containing the resolved script.
-    scriptPath = fs.realpathSync(scriptPath);
-  } catch (_) {}
-  let directory = path.dirname(scriptPath);
-  for (let depth = 0; depth < 8; depth += 1) {
+  let version: string | null = null;
+  if (script) {
+    let scriptPath = path.resolve(String(script));
     try {
-      const packageJSON = JSON.parse(fs.readFileSync(path.join(directory, "package.json"), "utf8"));
-      if (
-        packageJSON?.name === "@earendil-works/pi-coding-agent" ||
-        packageJSON?.name === "@mariozechner/pi-coding-agent"
-      ) {
-        return firstString(packageJSON.version);
-      }
+      // npm launches through bin symlinks, so inspect the package containing the resolved script.
+      scriptPath = fs.realpathSync(scriptPath);
     } catch (_) {}
-    const parent = path.dirname(directory);
-    if (parent === directory) break;
-    directory = parent;
+    let directory = path.dirname(scriptPath);
+    for (let depth = 0; depth < 8; depth += 1) {
+      try {
+        const packageJSON = JSON.parse(fs.readFileSync(path.join(directory, "package.json"), "utf8"));
+        if (
+          packageJSON?.name === "@earendil-works/pi-coding-agent" ||
+          packageJSON?.name === "@mariozechner/pi-coding-agent"
+        ) {
+          version = firstString(packageJSON.version);
+          break;
+        }
+      } catch (_) {}
+      const parent = path.dirname(directory);
+      if (parent === directory) break;
+      directory = parent;
+    }
   }
-  return null;
+  detectedPiVersionCache = { key: cacheKey, version };
+  return version;
 }
 
 function supportsAgentSettled(): boolean {

--- a/CLI/CMUXCLI+PiExtensionSourcePart2.swift
+++ b/CLI/CMUXCLI+PiExtensionSourcePart2.swift
@@ -299,37 +299,43 @@ function prepareFeedDispatch(
   const cwd = context.cwd;
   const toolCallId = firstString(objectValue(event, ["toolCallId", "tool_call_id", "id"]));
   const toolName = firstString(objectValue(event, ["toolName", "tool_name", "name"]));
-  const projectionState: PiFeedProjectionState = { remainingNodes: 48, seen: new WeakSet() };
-  const payload: HookExtra = {
-    session_id: utf8Prefix(sessionId, 256),
-    cwd: utf8Prefix(cwd, 2048),
-    hook_event_name: eventName,
-    event: eventName,
-    turn_id: utf8Prefix(currentTurnId(sessionStates, sessionId, event), 256),
-  };
-  const boundedToolCallId = utf8Prefix(toolCallId, 256);
-  if (boundedToolCallId !== undefined) payload.tool_call_id = boundedToolCallId;
-  const boundedToolName = utf8Prefix(toolName, 256);
-  if (boundedToolName !== undefined) payload.tool_name = boundedToolName;
+  const turnId = currentTurnId(sessionStates, sessionId, event);
   const toolInput = objectValue(event, ["args", "input"]);
-  if (toolInput !== undefined) payload.tool_input = projectPiFeedValue(toolInput, projectionState);
-  if (isTerminalFeedEvent(eventName)) {
-    const toolResult = objectValue(event, ["result", "details", "content"]);
-    if (toolResult !== undefined) {
-      payload.tool_result = projectPiFeedValue(toolResult, projectionState, 0, false);
-    }
-    const isError = objectValue(event, ["isError", "is_error"]);
-    if (isError !== undefined) payload.is_error = projectPiFeedValue(isError, projectionState);
-  }
+  const terminal = isTerminalFeedEvent(eventName);
+  const toolResult = terminal
+    ? objectValue(event, ["result", "details", "content"])
+    : undefined;
+  const isError = terminal ? objectValue(event, ["isError", "is_error"]) : undefined;
   return () => {
     const target = surfaceTargetArgs(dispatcher, sessionId);
     if (!target) return;
+
+    // Pi invokes tool lifecycle handlers on its UI event loop. Keep those
+    // callbacks lightweight by traversing and bounding tool payloads only in
+    // the already-detached lifecycle task.
+    const projectionState: PiFeedProjectionState = { remainingNodes: 48, seen: new WeakSet() };
+    const payload: HookExtra = {
+      session_id: utf8Prefix(sessionId, 256),
+      cwd: utf8Prefix(cwd, 2048),
+      hook_event_name: eventName,
+      event: eventName,
+      turn_id: utf8Prefix(turnId, 256),
+    };
+    const boundedToolCallId = utf8Prefix(toolCallId, 256);
+    if (boundedToolCallId !== undefined) payload.tool_call_id = boundedToolCallId;
+    const boundedToolName = utf8Prefix(toolName, 256);
+    if (boundedToolName !== undefined) payload.tool_name = boundedToolName;
+    if (toolInput !== undefined) payload.tool_input = projectPiFeedValue(toolInput, projectionState);
+    if (toolResult !== undefined) {
+      payload.tool_result = projectPiFeedValue(toolResult, projectionState, 0, false);
+    }
+    if (isError !== undefined) payload.is_error = projectPiFeedValue(isError, projectionState);
     dispatcher.enqueueFeed(`${sessionId}:${toolCallId || toolName || "unknown"}`, {
       args: ["hooks", "feed", "--source", "pi", "--event", eventName, ...target],
       cwd,
       payload,
       context,
-      terminal: isTerminalFeedEvent(eventName),
+      terminal,
       onFailure: () => { state.feedDeliveryFailed = true; },
     });
   };

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -28703,7 +28703,7 @@ struct CMUXCLI {
     }
 
     private func selectedAgentLaunchEnvironment(from env: [String: String], kind: String? = nil) -> [String: String] {
-        var selected = AgentLaunchEnvironmentPolicy().selectedEnvironment(from: env, kind: kind)
+        var selected = AgentLaunchEnvironmentPolicy().selectedRestoreEnvironment(from: env, kind: kind)
         if kind == "hermes-agent" {
             selected = HermesAgentCodexEnvironment.applyingDefaultCodexBaseURL(
                 to: selected,

--- a/cmuxTests/CLIOmpHookBindingTests.swift
+++ b/cmuxTests/CLIOmpHookBindingTests.swift
@@ -40,6 +40,76 @@ struct CLIOmpHookBindingTests {
     }
 
     @Test
+    func piSessionStartPreservesPathRequiredByForkVersionProbe() async throws {
+        let context = try Harness.makeContext(name: "pi-fork-path")
+        defer { context.cleanup() }
+
+        let sessionId = "pi-fork-path-session"
+        let stateDirectory = context.root.appendingPathComponent(".cmuxterm", isDirectory: true)
+        let binDirectory = context.root.appendingPathComponent("custom-bin", isDirectory: true)
+        try FileManager.default.createDirectory(at: stateDirectory, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: binDirectory, withIntermediateDirectories: true)
+
+        let runtimeName = "cmux-pi-fork-test-runtime"
+        let runtime = binDirectory.appendingPathComponent(runtimeName, isDirectory: false)
+        try "#!/bin/sh\nprintf '0.83.0\\n'\n"
+            .write(to: runtime, atomically: true, encoding: .utf8)
+        try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: runtime.path)
+
+        let pi = binDirectory.appendingPathComponent("pi", isDirectory: false)
+        try "#!/usr/bin/env \(runtimeName)\n"
+            .write(to: pi, atomically: true, encoding: .utf8)
+        try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: pi.path)
+
+        let serverHandled = Harness.startDeliveryTargetServer(
+            context: context,
+            surfacesByWorkspace: [Self.liveWorkspaceId: [Self.liveSurfaceId]],
+            pidTarget: nil
+        )
+        let launchPath = "\(binDirectory.path):/usr/bin:/bin:/usr/sbin:/sbin"
+        var environment = Harness.hookEnvironment(context: context)
+        environment["PATH"] = launchPath
+        environment["CMUX_AGENT_HOOK_STATE_DIR"] = stateDirectory.path
+        environment["CMUX_AGENT_LAUNCH_KIND"] = "pi"
+        environment["CMUX_AGENT_LAUNCH_EXECUTABLE"] = pi.path
+        environment["CMUX_AGENT_LAUNCH_ARGV_B64"] = Self.base64NULSeparated([pi.path])
+        environment["CMUX_AGENT_LAUNCH_CWD"] = context.root.path
+
+        let result = Harness.runHookProcess(
+            context: context,
+            arguments: [
+                "hooks", "pi", "session-start",
+                "--workspace", Self.liveWorkspaceId,
+                "--surface", Self.liveSurfaceId,
+            ],
+            environment: environment,
+            standardInput: #"{"session_id":"\#(sessionId)","cwd":"\#(context.root.path)","hook_event_name":"SessionStart"}"#
+        )
+
+        #expect(serverHandled.wait(timeout: .now() + 5) == .success)
+        #expect(!result.timedOut, Comment(rawValue: result.stderr))
+        #expect(result.status == 0, Comment(rawValue: result.stderr))
+
+        let workspaceId = try #require(UUID(uuidString: Self.liveWorkspaceId))
+        let surfaceId = try #require(UUID(uuidString: Self.liveSurfaceId))
+        let snapshot = try #require(
+            RestorableAgentSessionIndex.load(
+                homeDirectory: context.root.path,
+                fileManager: .default
+            )
+            .snapshot(
+                workspaceId: workspaceId,
+                panelId: surfaceId
+            )
+        )
+        #expect(snapshot.launchCommand?.environment?["PATH"] == launchPath)
+        #expect(
+            await AgentForkSupport.supportsFork(snapshot: snapshot),
+            "Fork availability must probe Pi with the PATH captured by its session-start hook."
+        )
+    }
+
+    @Test
     func resumedSessionUsesLivePIDTTYTargetAndSupersedesPriorProcessClaim() throws {
         let context = try Harness.makeContext(name: "omp-live-pid")
         defer { context.cleanup() }

--- a/tests/test_pi_extension_dispatch.py
+++ b/tests/test_pi_extension_dispatch.py
@@ -275,6 +275,148 @@ while (performance.now() < deadline) {
     return 0
 
 
+def check_hot_path_defers_projection_and_reuses_launch_probes(
+    bun: str,
+    root: Path,
+    extension_path: Path,
+) -> int:
+    fake_cmux = root / "hot-path-cmux"
+    make_executable(
+        fake_cmux,
+        """#!/usr/bin/env bash
+set -euo pipefail
+cat >/dev/null
+printf '{}\n'
+""",
+    )
+
+    projection_source = """
+const extensionPath = process.env.CMUX_TEST_PI_EXTENSION_PATH;
+const mod = await import(extensionPath);
+const handlers = new Map();
+mod.default({ on(name, handler) { handlers.set(name, handler); } });
+const ctx = {
+  cwd: "/tmp/pi-hot-path-project",
+  sessionManager: { getSessionId() { return "pi-hot-path-session"; } }
+};
+let handlerReturned = false;
+let projectedSynchronously = false;
+let projectionCount = 0;
+const guardedToolInput = new Proxy(
+  { command: "printf hot-path" },
+  {
+    ownKeys(target) {
+      projectionCount += 1;
+      if (!handlerReturned) projectedSynchronously = true;
+      return Reflect.ownKeys(target);
+    },
+    getOwnPropertyDescriptor(target, property) {
+      return Reflect.getOwnPropertyDescriptor(target, property);
+    },
+    get(target, property, receiver) {
+      return Reflect.get(target, property, receiver);
+    }
+  }
+);
+handlers.get("tool_execution_start")({
+  toolCallId: "hot-path-tool",
+  toolName: "bash",
+  args: guardedToolInput
+}, ctx);
+handlerReturned = true;
+await handlers.get("session_shutdown")({ reason: "hot path test complete" }, ctx);
+if (projectedSynchronously) {
+  throw new Error("tool payload was traversed before the Pi event handler returned");
+}
+if (projectionCount !== 1) {
+  throw new Error(`expected one deferred payload projection, got ${projectionCount}`);
+}
+"""
+    projection = run_extension(
+        bun=bun,
+        root=root,
+        extension_path=extension_path,
+        fake_cmux=fake_cmux,
+        source=projection_source,
+        extra_env={},
+    )
+    if projection.returncode != 0:
+        print("FAIL: Pi tool-event hot path performed synchronous payload work")
+        print(f"exit={projection.returncode}")
+        print(f"stdout={projection.stdout.strip()}")
+        print(f"stderr={projection.stderr.strip()}")
+        return 1
+
+    package_root = (
+        root
+        / "hot-path-node-modules"
+        / "@earendil-works"
+        / "pi-coding-agent"
+    )
+    package_cli = package_root / "dist" / "cli.js"
+    package_cli.parent.mkdir(parents=True)
+    make_executable(package_cli, "#!/usr/bin/env node\n")
+    package_json = package_root / "package.json"
+    package_json.write_text(
+        json.dumps({"name": "@earendil-works/pi-coding-agent", "version": "0.83.0"}),
+        encoding="utf-8",
+    )
+    probe_bin = root / "hot-path-bin"
+    probe_bin.mkdir()
+    probe_pi = probe_bin / "pi"
+    probe_pi.symlink_to(package_cli)
+    inspectable_extension = root / "hot-path-cmux-session.ts"
+    inspectable_extension.write_text(
+        extension_path.read_text(encoding="utf-8")
+        + "\nexport { normalizedLaunchArgv, supportsAgentSettled };\n",
+        encoding="utf-8",
+    )
+    launch_probe_source = """
+import { unlinkSync } from "node:fs";
+const extensionPath = process.env.CMUX_TEST_PI_EXTENSION_PATH;
+const mod = await import(extensionPath);
+process.argv.splice(
+  0,
+  process.argv.length,
+  "/usr/bin/node",
+  process.env.CMUX_TEST_PI_PACKAGE_CLI
+);
+const firstArgv = mod.normalizedLaunchArgv();
+const firstSettled = mod.supportsAgentSettled();
+unlinkSync(process.env.CMUX_TEST_PI_BIN);
+unlinkSync(process.env.CMUX_TEST_PI_PACKAGE_JSON);
+const secondArgv = mod.normalizedLaunchArgv();
+const secondSettled = mod.supportsAgentSettled();
+if (
+  JSON.stringify(firstArgv) !== JSON.stringify(secondArgv)
+  || firstSettled !== true
+  || secondSettled !== true
+) {
+  throw new Error(JSON.stringify({ firstArgv, secondArgv, firstSettled, secondSettled }));
+}
+"""
+    launch_probe = run_extension(
+        bun=bun,
+        root=root,
+        extension_path=inspectable_extension,
+        fake_cmux=fake_cmux,
+        source=launch_probe_source,
+        extra_env={
+            "PATH": str(probe_bin),
+            "CMUX_TEST_PI_BIN": str(probe_pi),
+            "CMUX_TEST_PI_PACKAGE_CLI": str(package_cli),
+            "CMUX_TEST_PI_PACKAGE_JSON": str(package_json),
+        },
+    )
+    if launch_probe.returncode != 0:
+        print("FAIL: Pi extension repeated synchronous launch filesystem probes")
+        print(f"exit={launch_probe.returncode}")
+        print(f"stdout={launch_probe.stdout.strip()}")
+        print(f"stderr={launch_probe.stderr.strip()}")
+        return 1
+    return 0
+
+
 def check_completion_precedes_next_prompt(bun: str, root: Path, extension_path: Path) -> int:
     transition_log = root / "turn-transition.log"
     transition_cmux = root / "turn-transition-cmux"
@@ -2446,6 +2588,7 @@ def run_checks(bun: str, root: Path, extension_path: Path) -> int:
     checks = (
         check_responsiveness,
         check_ui_lifecycle_handlers_return_immediately,
+        check_hot_path_defers_projection_and_reuses_launch_probes,
         check_completion_precedes_next_prompt,
         check_cross_session_lifecycle_isolation,
         check_panel_only_target_fails_closed,


### PR DESCRIPTION
## Summary

- Preserve the captured `PATH` in Pi/OMP hook launch records using the existing restore-safe environment policy.
- Let Pi fork capability probes run Bun, Nix, and other `#!/usr/bin/env`-based launch shims even when cmux itself was started with the GUI's minimal PATH.
- Keep the Pi extension off Pi's event-handler hot path by deferring tool-payload projection and memoizing synchronous executable/package discovery.
- Add test-first regressions for both the fork probe and extension hot-path behavior.

## Why

The Pi hook captured an absolute launcher such as `~/.bun/bin/pi`, but hook persistence discarded `PATH`. Fork availability runs that launcher with `--version`; from a GUI-launched cmux, `/usr/bin/env node` could not resolve `node`, the probe returned false, and **Fork Conversation** stayed hidden.

The environment change still uses cmux's secret-redacting policy and retains `PATH` only for Pi-family agents. The extension's subprocess dispatch remains asynchronous and bounded; this also removes repeated synchronous PATH/package filesystem scans and moves bounded payload traversal out of Pi callbacks.

## Testing

- Exact pushed HEAD `f329787412`: tagged macOS build succeeded with `./scripts/reload.sh --tag pifork --launch --no-global-cli-links`.
- Manually captured a tagged Pi hook record and verified it retained `PATH`; running the captured Bun Pi launcher under that saved environment returned `0.83.0`.
- Added Swift Testing coverage for hook persistence through the real bundled CLI and deterministic generated-extension regressions for deferred payload work and memoized filesystem probes.
- Per repository policy, test suites were not run locally; CI is the test authority.

## Demo Video

Not applicable: this fixes launch-environment persistence and generated-extension performance; it does not change UI layout or visuals.

- Video URL or attachment: N/A

## Review Trigger (Copy/Paste as PR comment)

```text
@codex review
@coderabbitai review
@greptile-apps review
@cubic-dev-ai review
```

## Checklist

- [x] I tested the change locally
- [x] I added or updated tests for behavior changes
- [x] I updated docs/changelog if needed (not needed; no user-facing contract changed)
- [x] I requested bot reviews after my latest commit
- [ ] All code review bot comments are resolved
- [ ] All human review comments are resolved

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/9549"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788420042&installation_model_id=21920&pr_number=9549&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F9549&signature=3eadf4dbbe889e394f6c13e0b4340d05455ea961896d2e1d4a4bedc427f046b4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Pi fork capability probes by preserving the Pi launch PATH and keeps Pi hooks fast by deferring payload work and memoizing executable discovery. This restores Fork Conversation visibility and reduces synchronous filesystem scans.

- **Bug Fixes**
  - Preserve `PATH` for Pi-family agents using restore-safe env policy (`selectedRestoreEnvironment`), so fork probes can run Bun/Nix and other `#!/usr/bin/env` shims even from GUI-launched cmux.
  - Add tests to verify the saved PATH is persisted in session snapshots and that fork availability succeeds.

- **Refactors**
  - Defer tool payload projection out of Pi event-loop callbacks into the detached lifecycle task to keep handlers lightweight.
  - Memoize `normalizedLaunchArgv` and `detectedPiVersion` to avoid repeated PATH scans and package lookups; add tests confirming deferred projection and probe reuse.

<sup>Written for commit f32978741269f0fad5dc65d5f3cd12faa42dac9f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/9549?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved responsiveness during Pi event handling by deferring nonessential payload processing.
  * Cached launch configuration and capability checks to reduce repeated detection work.

* **Bug Fixes**
  * Improved reliability when launching Pi with restored environment settings.
  * Preserved the correct `PATH` for session startup and fork capability detection.
  * Ensured terminal and nonterminal events include the appropriate feed information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->