### PR TITLE
Fix gated connect attempts misclassified as handshake timeouts

### DIFF
--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobilePairingFailure.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobilePairingFailure.swift
@@ -431,7 +431,7 @@ extension MobilePairingFailureCategory {
 
         if let connectionError = error as? MobileShellConnectionError {
             switch connectionError {
-            case .requestTimedOut, .connectAttemptGated:
+            case .requestTimedOut:
                 return .handshakeTimedOut(host: host, port: port)
             case .connectAttemptGated:
                 // Another attempt owns this route: the Mac did not time out,


### PR DESCRIPTION
https://github.com/manaflow-ai/cmux/pull/9493 added `.connectAttemptGated` to the `.requestTimedOut` pattern in `MobilePairingFailureCategory.classify`, which shadows the dedicated `.connectAttemptGated` case below it (unreachable pattern). A gated dial attempt was presented as "No response from <host>:<port>" timeout copy, reverting the UX contract from https://github.com/manaflow-ai/cmux/pull/9347 that a mid-reconnect attempt must not tell the user their Mac is unresponsive.

One-line fix: drop `.connectAttemptGated` from the timeout pattern so the dedicated case matches again.

The existing test `MobilePairingFailureTests/gatedConnectAttemptIsNotPresentedAsATimeout` covers exactly this regression: it fails on current `main` and passes with this change (all 26 tests in the suite pass locally). It slipped through because the package test suites don't run as a required check on macOS CI.

Dictionary:
- unreachable pattern: a switch case that can never match because an earlier case already covers its value; Swift compiles it with only a warning.
- required check: a GitHub CI job that must pass before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/9551"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788420287&installation_model_id=21920&pr_number=9551&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F9551&signature=2b0eab27939eeaf35b7198ac27fa0ccbfa4155f826d7a7bfd1b03ca886f0bd51"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes gated connect attempts being shown as handshake timeouts by removing `.connectAttemptGated` from the `.requestTimedOut` pattern in `MobilePairingFailureCategory.classify`, restoring the correct mid-reconnect copy.

- **Bug Fixes**
  - Let the dedicated `.connectAttemptGated` case match by dropping it from the timeout pattern.
  - Test `MobilePairingFailureTests/gatedConnectAttemptIsNotPresentedAsATimeout` now passes, preventing this regression.

<sup>Written for commit 7321e2089c5f320476c1e58a074fd35f815e2961. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/9551?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved mobile pairing error handling by distinguishing connection attempt restrictions from request timeouts.
  * Connection attempts that are gated now display the appropriate error instead of being reported as handshake timeouts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->