### PR TITLE
Cover bash split-pane replay after reattach

### DIFF
--- a/.github/workflows/cmux-tui.yml
+++ b/.github/workflows/cmux-tui.yml
@@ -169,6 +169,16 @@ jobs:
         working-directory: cmux-tui
         run: cargo clippy --workspace --all-targets --locked -- -D warnings
 
+      - name: Build cmux-tui for attach smoke test
+        working-directory: cmux-tui
+        run: cargo build -p cmux-tui
+
+      - name: Detach/reattach smoke test
+        working-directory: cmux-tui
+        env:
+          SHELL: /bin/bash
+        run: python3 scripts/smoke-attach.py
+
       - name: cargo test
         working-directory: cmux-tui
         run: cargo test --workspace --locked
@@ -182,10 +192,6 @@ jobs:
         run: |
           cargo build -p cmux-tui
           python3 scripts/smoke-tui.py
-
-      - name: Detach/reattach smoke test
-        working-directory: cmux-tui
-        run: python3 scripts/smoke-attach.py
 
   bindings-e2e:
     runs-on: ${{ vars.LINUX_RUNNER || 'blacksmith-4vcpu-ubuntu-2404' }}

--- a/cmux-tui/scripts/smoke-attach.py
+++ b/cmux-tui/scripts/smoke-attach.py
@@ -491,20 +491,23 @@ try:
     live_screen = rpc({"id": 3, "cmd": "read-screen", "surface": surface_id})
     assert "live-after-reattach" in live_screen["data"]["text"], live_screen["data"]["text"]
 
-    # Resize churn while an attach mirror is live must not strand zsh's
-    # reverse-video partial-line marker in the final client frame.
-    storm_start = len(c2.output)
+    # Create split surfaces while one mirror is live, then detach before that
+    # client consumes the resulting redraws. A fresh attach must converge from
+    # replay alone, including bash's macOS default-shell banner and prompt.
     for i in range(4):
         ws = rpc({"id": 100 + i, "cmd": "list-workspaces"})
         pane = ws["data"]["workspaces"][0]["screens"][0]["panes"][0]["id"]
         direction = "right" if i % 2 == 0 else "down"
         split = rpc({"id": 110 + i, "cmd": "split", "pane": pane, "dir": direction})
         assert split["ok"], split
-        time.sleep(0.03)
-        c2.drain(0.2)
+    c2.detach()
+    c2 = Client()
+    storm_start = 0
     c2.drain_until_quiet()
     frame = render_client_frame(c2.output)
     assert not reverse_percent_cells(frame), c2.output[storm_start:][-2000:]
+    assert_client_matches_server(c2)
+    print("split storm detach + reattach converged without repaint")
 
     repaint = base64.b64encode(b"\x0c").decode()
     for surface in active_surfaces():


### PR DESCRIPTION
## Summary

- extend the attach smoke test with the split-storm timing from #7450: create four surfaces, detach before the live client consumes their redraws, attach a fresh client, and compare every pane with the server before any synthetic repaint
- run that smoke under `SHELL=/bin/bash` before the broader Rust suite so macOS exercises the zsh-migration banner and `bash-3.2$` prompt deterministically
- close the tracking issue now that the production viewport fix from #7488 is covered by the stricter end-to-end sequence

Fixes #7450

## Mechanism

The production bug was fixed in #7488: `read-screen` had used `Terminal::plain_text()`, which included scrollback containing the macOS zsh-advice banner, while attach clients correctly rendered only the live viewport. That PR changed `read-screen` to the read-only `Terminal::viewport_text()` path but did not close #7450.

This PR hardens the integration smoke around the original report. The client now detaches immediately after the split RPC storm, before draining any resulting redraws; a fresh attach must converge from replay alone and match each server viewport before the later repaint step.

## Testing

- Historical red: [macOS mux run 28780824726](https://github.com/manaflow-ai/cmux/actions/runs/28780824726/job/85339530059) failed deterministically with pane 12 / surface 11 showing `bash-3.2$` on the client while `read-screen` retained the zsh-migration banner.
- Production red → green: #7488 contains the [test-only failing commit](https://github.com/manaflow-ai/cmux/commit/42d02822d356f1a5a74958037147d8cf6b9bdc4e) followed by the [viewport fix](https://github.com/manaflow-ai/cmux/commit/40347a814de0fa7dc950dcccb0165cba52f35807); its [macOS mux job](https://github.com/manaflow-ai/cmux/actions/runs/28839494185/job/85530336048) passed.
- Stricter current smoke: the `Detach/reattach smoke test` step passed on macOS 15.7.4 in [run 30887248437](https://github.com/manaflow-ai/cmux/actions/runs/30887248437/job/91921137972), including `split storm detach + reattach converged without repaint` and `ATTACH SMOKE OK`. The broader manually dispatched job later failed in unrelated existing Rust tests.
- Tagged dev build: `./scripts/reload-cloud.sh --tag sym7450 --host cmuxs-mac-mini-3 -- --launch` completed on the leased fleet builder `cmuxs-mac-mini-3`; no local-build fallback was used.
- Tagged socket dogfood: on `/tmp/cmux-debug-sym7450.sock`, created four rapid splits, selected away and back to detach/reattach their terminal portals, and confirmed all five surfaces remained readable and accepted new input. After filling one surface with zsh-advice rows and clearing only the viewport, default `read-screen` returned only `bash-3.2$ viewport-7450`; the explicit scrollback read retained the old banner rows. The tagged app was then stopped and its socket removed.

Localization audit: no user-facing strings changed.
