### PR TITLE
Stabilize hosted tenant capability payload

### DIFF
--- a/web/services/subrouter/hostedClient.ts
+++ b/web/services/subrouter/hostedClient.ts
@@ -160,9 +160,9 @@ export function createHostedSubrouterClient(options: {
             "x-subrouter-stack-control-token": tenantDeleteToken,
           },
           body: JSON.stringify({
+            capabilities,
             teamId: team.teamId,
             teamName: team.teamName,
-            capabilities,
           }),
         },
         "caller",


### PR DESCRIPTION
Serializes tenant capabilities first in the trusted Stack exchange payload. This is behavior-preserving, but makes the capability scope explicit at the beginning of the upstream request and easier to verify during the hosted cutover.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/9556"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788421146&installation_model_id=21920&pr_number=9556&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F9556&signature=201da6e9c7b46fd57ba95618b877196164e049a45007e2b152b430e68ce7ed40"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Send `capabilities` first in the hosted subrouter request body to make the tenant capability scope explicit and easier to verify during the hosted cutover. No behavior change—only the JSON field order is updated to align with upstream validation.

<sup>Written for commit 0427973ad6b3d0be533fc18334837b22c6396c84. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/9556?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated authentication request serialization to ensure capabilities are sent in the expected order.
  * No changes to request values or user-facing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->