### PR TITLE
Keep sidebar current-work summaries with their workspace

### DIFF
--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -14007,6 +14007,7 @@ struct VerticalTabsSidebar: View, Equatable {
         )
         let settings = renderContext.tabItemSettings
         let expectedPresentationKey = SidebarWorkspaceSnapshotFactory.presentationKey(
+            workspaceId: tab.id,
             settings: settings,
             showsAgentActivity: renderContext.showsAgentActivity
         )

--- a/Sources/SidebarWorkspaceSnapshotBuilder.swift
+++ b/Sources/SidebarWorkspaceSnapshotBuilder.swift
@@ -5,6 +5,8 @@ import Foundation
 /// Workspace sidebar snapshot value types extracted from `ContentView.swift`, which sits at its file-length budget.
 struct SidebarWorkspaceSnapshotBuilder {
     struct PresentationKey: Equatable {
+        // A cache candidate must belong to the row it is about to render.
+        let workspaceId: UUID
         let showsWorkspaceDescription: Bool
         let usesVerticalBranchLayout: Bool
         let showsGitBranch: Bool

--- a/Sources/SidebarWorkspaceSnapshotFactory.swift
+++ b/Sources/SidebarWorkspaceSnapshotFactory.swift
@@ -122,14 +122,20 @@ struct SidebarWorkspaceSnapshotFactory {
     }
 
     private var presentationKey: SidebarWorkspaceSnapshotBuilder.PresentationKey {
-        Self.presentationKey(settings: settings, showsAgentActivity: showsAgentActivity)
+        Self.presentationKey(
+            workspaceId: workspace.id,
+            settings: settings,
+            showsAgentActivity: showsAgentActivity
+        )
     }
 
     static func presentationKey(
+        workspaceId: UUID,
         settings: SidebarTabItemSettingsSnapshot,
         showsAgentActivity: Bool
     ) -> SidebarWorkspaceSnapshotBuilder.PresentationKey {
         SidebarWorkspaceSnapshotBuilder.PresentationKey(
+            workspaceId: workspaceId,
             showsWorkspaceDescription: settings.showsWorkspaceDescription,
             usesVerticalBranchLayout: settings.branchDirectory.branchLayout == .vertical,
             showsGitBranch: settings.showsGitBranch,

--- a/cmuxTests/SidebarAppKitRowCellTests.swift
+++ b/cmuxTests/SidebarAppKitRowCellTests.swift
@@ -9,11 +9,13 @@ import Testing
 @MainActor
 struct SidebarAppKitRowCellTests {
     private static func makeSnapshot(
+        workspaceId: UUID,
         title: String = "Workspace",
         metadataEntries: [SidebarStatusEntry] = []
     ) -> SidebarWorkspaceSnapshotBuilder.Snapshot {
         SidebarWorkspaceSnapshotBuilder.Snapshot(
             presentationKey: SidebarWorkspaceSnapshotFactory.presentationKey(
+                workspaceId: workspaceId,
                 settings: SidebarTabItemSettingsSnapshot(defaults: UserDefaults(suiteName: UUID().uuidString)!),
                 showsAgentActivity: false
             ),
@@ -64,7 +66,10 @@ struct SidebarAppKitRowCellTests {
         return SidebarWorkspaceRowModel(
             workspaceId: workspaceId,
             index: 0,
-            snapshot: makeSnapshot(metadataEntries: metadataEntries),
+            snapshot: makeSnapshot(
+                workspaceId: workspaceId,
+                metadataEntries: metadataEntries
+            ),
             settings: resolvedSettings,
             isActive: isActive,
             isMultiSelected: false,
@@ -96,12 +101,13 @@ struct SidebarAppKitRowCellTests {
     private static func makeSwiftUIRow(
         settings: SidebarTabItemSettingsSnapshot
     ) -> SidebarWorkspaceRowSnapshot {
-        SidebarWorkspaceRowSnapshot(
-            workspaceId: UUID(),
+        let workspaceId = UUID()
+        return SidebarWorkspaceRowSnapshot(
+            workspaceId: workspaceId,
             groupId: nil,
             index: 0,
             workspaceCount: 1,
-            workspace: makeSnapshot(),
+            workspace: makeSnapshot(workspaceId: workspaceId),
             isActive: false,
             isMultiSelected: false,
             hasUserCustomTitle: false,

--- a/cmuxTests/SidebarWorkspaceRowSuspensionTests.swift
+++ b/cmuxTests/SidebarWorkspaceRowSuspensionTests.swift
@@ -9,11 +9,13 @@ import Testing
 @MainActor
 struct SidebarWorkspaceRowSuspensionTests {
     private static func makeSnapshot(
+        workspaceId: UUID,
         manualTaskStatus: WorkspaceTaskStatus? = nil,
         checklistItems: [WorkspaceChecklistItem] = []
     ) -> SidebarWorkspaceSnapshotBuilder.Snapshot {
         SidebarWorkspaceSnapshotBuilder.Snapshot(
             presentationKey: SidebarWorkspaceSnapshotFactory.presentationKey(
+                workspaceId: workspaceId,
                 settings: SidebarTabItemSettingsSnapshot(defaults: UserDefaults(suiteName: UUID().uuidString)!),
                 showsAgentActivity: false
             ),
@@ -78,6 +80,7 @@ struct SidebarWorkspaceRowSuspensionTests {
             workspaceId: workspaceId,
             index: 0,
             snapshot: makeSnapshot(
+                workspaceId: workspaceId,
                 manualTaskStatus: manualTaskStatus,
                 checklistItems: checklistItems
             ),

--- a/cmuxTests/SidebarWorkspaceSnapshotRefreshPolicyTests.swift
+++ b/cmuxTests/SidebarWorkspaceSnapshotRefreshPolicyTests.swift
@@ -177,6 +177,64 @@ import Testing
         #expect(!decision.hasDeferredWorkspaceObservationInvalidation)
     }
 
+    @Test @MainActor
+    func currentWorkSnapshotStaysWithStableWorkspaceIdAfterInsertion() throws {
+        let settings = SidebarTabItemSettingsSnapshot(
+            defaults: UserDefaults(suiteName: UUID().uuidString)!
+        )
+        let workspaceA = Workspace()
+        workspaceA.title = "Workspace A"
+        let workspaceB = Workspace()
+        workspaceB.title = "Workspace B"
+        var workspaces = [workspaceA, workspaceB]
+        let currentWork = SidebarStatusEntry(
+            key: "current_work",
+            value: "Needs input"
+        )
+        workspaceA.statusEntries[currentWork.key] = currentWork
+
+        func snapshot(
+            for workspace: Workspace
+        ) -> SidebarWorkspaceSnapshotBuilder.Snapshot {
+            SidebarWorkspaceSnapshotFactory(
+                workspace: workspace,
+                settings: settings,
+                showsAgentActivity: false
+            ).makeSnapshot()
+        }
+
+        let snapshotsByWorkspaceId = Dictionary(
+            uniqueKeysWithValues: workspaces.map { ($0.id, snapshot(for: $0)) }
+        )
+        let cachedRowZeroSnapshot = try #require(snapshotsByWorkspaceId[workspaceA.id])
+        let workspaceAInitialIndex = try #require(
+            workspaces.firstIndex { $0.id == workspaceA.id }
+        )
+
+        let addedWorkspace = Workspace()
+        addedWorkspace.title = "New Workspace"
+        workspaces.insert(addedWorkspace, at: 0)
+
+        #expect(workspaces.first?.id == addedWorkspace.id)
+        #expect(
+            workspaces.firstIndex { $0.id == workspaceA.id } == workspaceAInitialIndex + 1
+        )
+        #expect(snapshotsByWorkspaceId[workspaceA.id]?.metadataEntries == [currentWork])
+        #expect(snapshotsByWorkspaceId[workspaceB.id]?.metadataEntries.isEmpty == true)
+
+        let addedWorkspaceSnapshot = snapshot(for: addedWorkspace)
+        let displayedRowZeroSnapshot =
+            cachedRowZeroSnapshot.presentationKey == addedWorkspaceSnapshot.presentationKey
+                ? cachedRowZeroSnapshot
+                : addedWorkspaceSnapshot
+
+        #expect(addedWorkspaceSnapshot.metadataEntries.isEmpty)
+        #expect(
+            displayedRowZeroSnapshot.metadataEntries.isEmpty,
+            "A recycled row must not render workspace A's current-work recap for the newly inserted workspace."
+        )
+    }
+
     static func snapshot(
         presentationKey: SidebarWorkspaceSnapshotBuilder.PresentationKey? = nil,
         title: String = "workspace",

--- a/cmuxTests/SidebarWorkspaceSnapshotRefreshPolicyTests.swift
+++ b/cmuxTests/SidebarWorkspaceSnapshotRefreshPolicyTests.swift
@@ -223,6 +223,8 @@ import Testing
         #expect(snapshotsByWorkspaceId[workspaceB.id]?.metadataEntries.isEmpty == true)
 
         let addedWorkspaceSnapshot = snapshot(for: addedWorkspace)
+        #expect(cachedRowZeroSnapshot.presentationKey.workspaceId == workspaceA.id)
+        #expect(addedWorkspaceSnapshot.presentationKey.workspaceId == addedWorkspace.id)
         let displayedRowZeroSnapshot =
             cachedRowZeroSnapshot.presentationKey == addedWorkspaceSnapshot.presentationKey
                 ? cachedRowZeroSnapshot
@@ -236,6 +238,7 @@ import Testing
     }
 
     static func snapshot(
+        workspaceId: UUID = UUID(uuidString: "00000000-0000-0000-0000-000000007252")!,
         presentationKey: SidebarWorkspaceSnapshotBuilder.PresentationKey? = nil,
         title: String = "workspace",
         customDescription: String? = nil,
@@ -249,7 +252,7 @@ import Testing
         activeCodingAgentCount: Int = 0
     ) -> SidebarWorkspaceSnapshotBuilder.Snapshot {
         SidebarWorkspaceSnapshotBuilder.Snapshot(
-            presentationKey: presentationKey ?? Self.presentationKey(),
+            presentationKey: presentationKey ?? Self.presentationKey(workspaceId: workspaceId),
             title: title,
             customDescription: customDescription,
             isPinned: isPinned,
@@ -285,6 +288,7 @@ import Testing
     }
 
     static func presentationKey(
+        workspaceId: UUID = UUID(uuidString: "00000000-0000-0000-0000-000000007252")!,
         showsWorkspaceDescription: Bool = true,
         usesVerticalBranchLayout: Bool = true,
         showsGitBranch: Bool = true,
@@ -300,6 +304,7 @@ import Testing
         )
     ) -> SidebarWorkspaceSnapshotBuilder.PresentationKey {
         SidebarWorkspaceSnapshotBuilder.PresentationKey(
+            workspaceId: workspaceId,
             showsWorkspaceDescription: showsWorkspaceDescription,
             usesVerticalBranchLayout: usesVerticalBranchLayout,
             showsGitBranch: showsGitBranch,


### PR DESCRIPTION
## Summary

- include the stable workspace UUID in each sidebar snapshot's presentation key
- validate cached row snapshots against the workspace UUID as well as display settings
- keep test row fixtures aligned with the same owner identity invariant

This prevents a recycled or misrouted sidebar snapshot from being accepted for a newly inserted workspace just because both rows share the same presentation settings.

Fixes #7252

## Testing

- Red: [hosted suite run 30886811221](https://github.com/manaflow-ai/cmux/actions/runs/30886811221) on test-only commit `c9529c86cc` executed 10 tests; the new insertion regression was the sole failure because Workspace A's `current_work` entry appeared in the recycled new-workspace row.
- Green: [hosted suite run 30887894229](https://github.com/manaflow-ai/cmux/actions/runs/30887894229) on fix commit `c22bd7b2c3` executed the same 10 tests successfully.
- `./scripts/lint-pbxproj-test-wiring.sh`
- `python3 scripts/check-sidebar-lazy-layout.py`
- `./scripts/reload-cloud.sh --tag sym7252` succeeded through the Blacksmith cloud path: [build run 30887933741](https://github.com/manaflow-ai/cmux/actions/runs/30887933741) on `blacksmith-6vcpu-macos-26`.
- Tagged dogfood against `/tmp/cmux-debug-sym7252.sock`: created Workspace A and B, set `current_work=Needs input` on A's UUID, then created New Workspace. The insertion shifted B from index 1 to 2; `sidebar-state` still reported one status only for A and zero for New Workspace/B. A window capture confirmed the rendered sidebar showed “Needs input” only under Workspace A. The tagged app was quit and its socket removed afterward.
- Localization audit: the production diff adds no user-facing strings and touches no localization catalogs; the only new English strings found were test fixture workspace titles.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/9557"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788421396&installation_model_id=21920&pr_number=9557&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F9557&signature=a749e849591d5cbb440bf506e8da6b2c019fa3918c97f8ae13b586da4dcc7637"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bind sidebar snapshots to their workspace by adding the workspace UUID to the presentation key, so a recycled row can’t render `current_work` under a newly inserted workspace (fixes #7252).

**Bug Fixes**
- Added `workspaceId` to `PresentationKey` and the factory API; `ContentView` now passes the tab’s ID.
- Cached row snapshots are only reused when the workspace UUID and display settings match.
- Added a regression test that inserts a workspace and verifies `current_work` stays with its original workspace.

<sup>Written for commit e5db2bccaf42ce4c68722f58bb3a5f71e9091916. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/9557?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sidebar workspace identity tracking to prevent recycled rows from displaying another workspace’s stale metadata.
  * Preserved workspace-specific snapshot identity when adding or switching workspaces.
  * Improved consistency between the selected workspace and its displayed sidebar content.

* **Tests**
  * Added coverage verifying workspace identity remains consistent during sidebar updates and row reuse.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->