### PR TITLE
Isolate global search databases by bundle identifier

### DIFF
--- a/Sources/Search/GlobalSearchCoordinator.swift
+++ b/Sources/Search/GlobalSearchCoordinator.swift
@@ -5,6 +5,7 @@ import Foundation
 final class GlobalSearchCoordinator {
     static let shared = GlobalSearchCoordinator()
 
+    private let databaseURL: URL
     private var panelPurgeTasks: [UUID: Task<Void, Never>] = [:]
     private var panelPurgeTaskIDs: [UUID: UUID] = [:]
     private var startupIndexTask: Task<Void, Never>?
@@ -20,11 +21,14 @@ final class GlobalSearchCoordinator {
     )
     private lazy var popover = MenubarSearchPopover(coordinator: self)
 
-    private init() {}
+    init(databaseURL: URL = .cmuxSearchDatabaseURL) {
+        self.databaseURL = databaseURL
+    }
 
-    func start() {
+    @discardableResult
+    func start() -> Task<Void, Never> {
         startupIndexTask?.cancel()
-        startupIndexTask = Task { @MainActor [weak self] in
+        let task = Task { @MainActor [weak self] in
             guard let self, let index = await self.ensureIndex() else { return }
             do {
                 try await index.deleteAll()
@@ -40,6 +44,8 @@ final class GlobalSearchCoordinator {
                 self.startupIndexTask = nil
             }
         }
+        startupIndexTask = task
+        return task
     }
 
     func togglePalette(anchor: NSStatusBarButton, onDismiss: (() -> Void)? = nil) {
@@ -163,7 +169,8 @@ final class GlobalSearchCoordinator {
     }
 
     private func openIndex() async -> SearchIndex? {
-        let task = Task { try await SearchIndex.open() }
+        let databaseURL = databaseURL
+        let task = Task { try await SearchIndex.open(databaseURL: databaseURL) }
         indexState = .opening(task)
         return await resolveIndexOpeningTask(task)
     }

--- a/Sources/Search/SearchIndex.swift
+++ b/Sources/Search/SearchIndex.swift
@@ -480,8 +480,29 @@ actor SearchIndex {
 
 extension URL {
     static var cmuxSearchDatabaseURL: URL {
-        FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask)[0]
-            .appendingPathComponent("cmux", isDirectory: true)
+        cmuxSearchDatabaseURL(
+            applicationSupportDirectory: FileManager.default.urls(
+                for: .applicationSupportDirectory,
+                in: .userDomainMask
+            )[0],
+            bundleIdentifier: Bundle.main.bundleIdentifier ?? "com.cmuxterm.app"
+        )
+    }
+
+    static func cmuxSearchDatabaseURL(
+        applicationSupportDirectory: URL,
+        bundleIdentifier: String
+    ) -> URL {
+        let trimmedBundleIdentifier = bundleIdentifier.trimmingCharacters(in: .whitespacesAndNewlines)
+        let namespace = trimmedBundleIdentifier.isEmpty ? "com.cmuxterm.app" : trimmedBundleIdentifier
+        let safeNamespace = namespace.replacingOccurrences(
+            of: "[^A-Za-z0-9._-]",
+            with: "_",
+            options: .regularExpression
+        )
+
+        return applicationSupportDirectory
+            .appendingPathComponent(safeNamespace, isDirectory: true)
             .appendingPathComponent("search.db", isDirectory: false)
     }
 }

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -1178,6 +1178,7 @@ C0DE71B10000000000000001 /* AppDelegate+AgentChatNotifications.swift in Sources 
 		3865A0023865A0023865A002 /* GlobalSearchCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3865B0023865B0023865B002 /* GlobalSearchCoordinator.swift */; };
 		3865A0073865A0073865A007 /* GlobalSearchDocuments.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3865B0073865B0073865B007 /* GlobalSearchDocuments.swift */; };
 		8561A0018561A0018561A001 /* GlobalSearchInputOwnershipTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8561B0018561B0018561B001 /* GlobalSearchInputOwnershipTests.swift */; };
+		7440A0017440A0017440A001 /* GlobalSearchInstanceIsolationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7440B0017440B0017440B001 /* GlobalSearchInstanceIsolationTests.swift */; };
 		8561A0058561A0058561A005 /* GlobalSearchKeyEvent+QueryEditing.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8561B0058561B0058561B005 /* GlobalSearchKeyEvent+QueryEditing.swift */; };
 		3865A0083865A0083865A008 /* GlobalSearchPanelCaptureManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3865B0083865B0083865B008 /* GlobalSearchPanelCaptureManager.swift */; };
 		D5AAB5856FF095F610EB565A /* GlobalSearchShortcutBehaviorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5AAB5856FF095F610EB565B /* GlobalSearchShortcutBehaviorTests.swift */; };
@@ -3783,6 +3784,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 		3865B0023865B0023865B002 /* GlobalSearchCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Search/GlobalSearchCoordinator.swift; sourceTree = "<group>"; };
 		3865B0073865B0073865B007 /* GlobalSearchDocuments.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Search/GlobalSearchDocuments.swift; sourceTree = "<group>"; };
 		8561B0018561B0018561B001 /* GlobalSearchInputOwnershipTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GlobalSearchInputOwnershipTests.swift; sourceTree = "<group>"; };
+		7440B0017440B0017440B001 /* GlobalSearchInstanceIsolationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GlobalSearchInstanceIsolationTests.swift; sourceTree = "<group>"; };
 		8561B0058561B0058561B005 /* GlobalSearchKeyEvent+QueryEditing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Search/GlobalSearchKeyEvent+QueryEditing.swift"; sourceTree = "<group>"; };
 		3865B0083865B0083865B008 /* GlobalSearchPanelCaptureManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Search/GlobalSearchPanelCaptureManager.swift; sourceTree = "<group>"; };
 		D5AAB5856FF095F610EB565B /* GlobalSearchShortcutBehaviorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GlobalSearchShortcutBehaviorTests.swift; sourceTree = "<group>"; };
@@ -7397,6 +7399,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				F54100A1A1B2C3D4E5F60718 /* RestorableAgentSessionStalePIDTests.swift */,
 				F5300001A1B2C3D4E5F60718 /* RovoDevSessionIndexTests.swift */,
 				3865B0043865B0043865B004 /* SearchIndexTests.swift */,
+				7440B0017440B0017440B001 /* GlobalSearchInstanceIsolationTests.swift */,
 				F5300003A1B2C3D4E5F60718 /* RovoDevTranscriptPreviewTests.swift */,
 				F5310001A1B2C3D4E5F60718 /* RovoDevHookConfigTests.swift */,
 				FA100001A1B2C3D4E5F60718 /* BrowserImportMappingTests.swift */,
@@ -10593,6 +10596,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				C13519000000000000000003 /* GhosttyTerminalStartupEnvironmentTests.swift in Sources */,
 				D7AB34400000000000000003 /* GhosttyTerminalViewVisibilityPolicyTests.swift in Sources */,
 				8561A0018561A0018561A001 /* GlobalSearchInputOwnershipTests.swift in Sources */,
+				7440A0017440A0017440A001 /* GlobalSearchInstanceIsolationTests.swift in Sources */,
 				D5AAB5856FF095F610EB565A /* GlobalSearchShortcutBehaviorTests.swift in Sources */,
 				8561A0068561A0068561A006 /* GlobalSearchShortcutPersistencePolicyTests.swift in Sources */,
 				8561A0028561A0028561A002 /* GlobalSearchShortcutPriorityTests.swift in Sources */,

--- a/cmuxTests/GlobalSearchInstanceIsolationTests.swift
+++ b/cmuxTests/GlobalSearchInstanceIsolationTests.swift
@@ -1,0 +1,88 @@
+import Foundation
+import Testing
+
+#if canImport(cmux_DEV)
+@testable import cmux_DEV
+#elseif canImport(cmux)
+@testable import cmux
+#endif
+
+@MainActor
+@Suite(.serialized)
+struct GlobalSearchInstanceIsolationTests {
+    @Test
+    func databaseURLsAreScopedByBundleIdentifier() {
+        let applicationSupportDirectory = URL(
+            fileURLWithPath: "/tmp/cmux-search-instance-isolation",
+            isDirectory: true
+        )
+
+        let stableURL = URL.cmuxSearchDatabaseURL(
+            applicationSupportDirectory: applicationSupportDirectory,
+            bundleIdentifier: "com.cmuxterm.app"
+        )
+        let taggedURL = URL.cmuxSearchDatabaseURL(
+            applicationSupportDirectory: applicationSupportDirectory,
+            bundleIdentifier: "com.cmuxterm.app.debug.sym7440"
+        )
+
+        #expect(stableURL != taggedURL)
+        #expect(stableURL.path == "/tmp/cmux-search-instance-isolation/com.cmuxterm.app/search.db")
+        #expect(taggedURL.path == "/tmp/cmux-search-instance-isolation/com.cmuxterm.app.debug.sym7440/search.db")
+    }
+
+    @Test
+    func startingSecondBundleDoesNotClearFirstBundleIndex() async throws {
+        let fixtureDirectory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cmux-search-instance-isolation-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: fixtureDirectory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: fixtureDirectory) }
+
+        let firstDatabaseURL = URL.cmuxSearchDatabaseURL(
+            applicationSupportDirectory: fixtureDirectory,
+            bundleIdentifier: "com.cmuxterm.app.debug.first"
+        )
+        let secondDatabaseURL = URL.cmuxSearchDatabaseURL(
+            applicationSupportDirectory: fixtureDirectory,
+            bundleIdentifier: "com.cmuxterm.app.debug.second"
+        )
+
+        let firstIndex = try SearchIndex(databaseURL: firstDatabaseURL)
+        try await firstIndex.upsert(
+            SearchIndexDocument(
+                id: "first-instance-document",
+                windowID: UUID(),
+                workspaceID: UUID(),
+                panelID: UUID(),
+                kind: .markdown,
+                title: "First Instance",
+                location: "/tmp/first.md",
+                anchor: "/tmp/first.md",
+                text: "firstinstanceisolationtoken"
+            )
+        )
+        let firstCoordinator = GlobalSearchCoordinator(databaseURL: firstDatabaseURL)
+        #expect(await firstCoordinator.search(query: "firstinstanceisolationtoken").count == 1)
+
+        let staleSecondIndex = try SearchIndex(databaseURL: secondDatabaseURL)
+        try await staleSecondIndex.upsert(
+            SearchIndexDocument(
+                id: "stale-second-instance-document",
+                windowID: UUID(),
+                workspaceID: UUID(),
+                panelID: UUID(),
+                kind: .title,
+                title: "Stale Second Instance",
+                location: "Old Window",
+                anchor: "title",
+                text: "stalesecondinstanceindextoken"
+            )
+        )
+
+        let secondCoordinator = GlobalSearchCoordinator(databaseURL: secondDatabaseURL)
+        await secondCoordinator.start().value
+
+        #expect(await firstCoordinator.search(query: "firstinstanceisolationtoken").count == 1)
+        #expect(await secondCoordinator.search(query: "stalesecondinstanceindextoken").isEmpty)
+    }
+}


### PR DESCRIPTION
## Summary

- store the global search index under a bundle-identifier namespace in Application Support
- inject the database URL into `GlobalSearchCoordinator` so startup cleanup and rebuild affect only the current app instance
- leave the legacy shared index unused; live documents continue to rebuild on startup

Fixes #7440

## Testing

- Red: [test-only run 30885098460](https://github.com/manaflow-ai/cmux/actions/runs/30885098460) on `dd153151d2` failed while compiling `GlobalSearchInstanceIsolationTests` because the bundle-scoped URL helper and injectable coordinator initializer did not exist.
- Green: [fixed run 30887241952](https://github.com/manaflow-ai/cmux/actions/runs/30887241952) on `f48427b959` executed 2 tests: distinct bundle identifiers produced distinct database URLs, and starting a second coordinator cleared only its own stale index while preserving the first index.
- Dev build: `./scripts/reload-cloud.sh --tag sym7440 --builder blacksmith` succeeded in [run 30887248064](https://github.com/manaflow-ai/cmux/actions/runs/30887248064). The Blacksmith path was used after two leased fleet builders failed before source compilation because their image lacked required Zig 0.16; no local fallback was used.
- Runtime: launched `sym7440`, created a second workspace through `/tmp/cmux-debug-sym7440.sock`, and indexed a 12,148-character `CLAUDE.md` document. Then built/launched `sym7440peer` in [run 30888155981](https://github.com/manaflow-ai/cmux/actions/runs/30888155981). The two processes opened `Application Support/com.cmuxterm.app.debug.sym7440/search.db` and `Application Support/com.cmuxterm.app.debug.sym7440peer/search.db` respectively. The first index retained all 3 rows, including the unchanged `CLAUDE.md:12148` sentinel, after peer startup; the peer built its own 1-row index. Both tagged apps were quit and both debug sockets removed.
- `./scripts/lint-pbxproj-test-wiring.sh`
- `./scripts/check-pbxproj.sh`
- `python3 scripts/check-package-resolved-policy.py`
- `python3 scripts/check-workspace-package-groups.py --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/9558"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788421612&installation_model_id=21920&pr_number=9558&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F9558&signature=4a32f09811230210285caee286a3358e53a076efe8fb8689b08e13cba8647464"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Isolated the global search index by bundle identifier so each app build uses its own database; startup cleanup now only affects the current app’s index. Addresses #7440 to prevent cross-instance data clearing.

- **Bug Fixes**
  - Database path is now scoped: Application Support/<bundle>/search.db via `URL.cmuxSearchDatabaseURL` (sanitizes bundle ID, falls back to `com.cmuxterm.app`).
  - `GlobalSearchCoordinator` accepts an injected database URL; `start()` uses it and returns a task for callers.
  - Added `GlobalSearchInstanceIsolationTests` to verify distinct URLs and that rebuilding one bundle’s index doesn’t clear another’s.

<sup>Written for commit f48427b959264e66bec126977167a388bbf63626. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/9558?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

