### PR TITLE
Add outline style for workspace selection

### DIFF
--- a/Packages/macOS/CmuxSettings/Sources/CmuxSettings/Values/WorkspaceIndicatorStyle.swift
+++ b/Packages/macOS/CmuxSettings/Sources/CmuxSettings/Values/WorkspaceIndicatorStyle.swift
@@ -2,7 +2,7 @@ import Foundation
 
 /// Visual style for the active-workspace indicator in the sidebar.
 public enum WorkspaceIndicatorStyle: String, CaseIterable, Sendable, SettingCodable {
-    case leftRail, solidFill
+    case leftRail, solidFill, outline
 
     /// Maps raw strings written by earlier iterations of the indicator
     /// setting onto the closest modern case, exactly as the legacy

--- a/Packages/macOS/CmuxSettingsUI/Sources/CmuxSettingsUI/Sections/WorkspaceColorsSection.swift
+++ b/Packages/macOS/CmuxSettingsUI/Sources/CmuxSettingsUI/Sections/WorkspaceColorsSection.swift
@@ -102,7 +102,7 @@ public struct WorkspaceColorsSection: View {
 
             colorRow(
                 title: String(localized: "settings.workspaceColors.selectionColor", defaultValue: "Selection Highlight"),
-                subtitle: String(localized: "settings.workspaceColors.selectionColor.subtitle", defaultValue: "Background color of the selected workspace in the sidebar."),
+                subtitle: String(localized: "settings.workspaceColors.selectionColor.subtitle", defaultValue: "Background or outline color of the selected workspace in the sidebar."),
                 json: "workspaceColors.selectionColor",
                 resetLabel: String(localized: "settings.workspaceColors.selectionColor.reset", defaultValue: "Reset"),
                 model: selectionHex
@@ -272,6 +272,7 @@ public struct WorkspaceColorsSection: View {
         switch style {
         case .leftRail: return String(localized: "sidebar.activeTabIndicator.leftRail", defaultValue: "Left Rail")
         case .solidFill: return String(localized: "sidebar.activeTabIndicator.solidFill", defaultValue: "Solid Fill")
+        case .outline: return String(localized: "sidebar.activeTabIndicator.outline", defaultValue: "Outline")
         }
     }
 

--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -201704,13 +201704,13 @@
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "Background color of the selected workspace in the sidebar."
+            "value": "Background or outline color of the selected workspace in the sidebar."
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "サイドバーで選択中のワークスペースの背景色。"
+            "value": "サイドバーで選択中のワークスペースの背景色またはアウトラインの色。"
           }
         }
       }
@@ -214168,6 +214168,35 @@
           "stringUnit": {
             "state": "translated",
             "value": "Лівий рейл"
+          }
+        }
+      }
+    },
+    "sidebar.activeTabIndicator.outline": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Outline"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "アウトライン"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "윤곽선"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Контур"
           }
         }
       }

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -15161,33 +15161,38 @@ struct TabItemView: View, Equatable {
         explicitRailColor(for: workspaceSnapshot) != nil
     }
 
+    private var activeBorderStyle: SidebarWorkspaceRowBorderStyle {
+        sidebarWorkspaceRowBorderStyle(
+            activeTabIndicatorStyle: activeTabIndicatorStyle,
+            isActive: isActive,
+            colorScheme: colorScheme,
+            sidebarSelectionColorHex: sidebarSelectionColorHex
+        )
+    }
+
     private var activeBorderLineWidth: CGFloat {
-        switch activeTabIndicatorStyle {
-        case .leftRail:
-            return 0
-        case .solidFill:
-            return isActive ? 1.5 : 0
-        }
+        activeBorderStyle.width
     }
 
     private var activeBorderColor: Color {
-        guard isActive else { return .clear }
-        switch activeTabIndicatorStyle {
-        case .leftRail:
-            return .clear
-        case .solidFill:
-            return Color.primary.opacity(0.5)
-        }
+        Color(nsColor: activeBorderStyle.color ?? .clear)
     }
 
     private var usesInvertedActiveForeground: Bool {
-        isActive
+        sidebarWorkspaceRowUsesInvertedForeground(
+            activeTabIndicatorStyle: activeTabIndicatorStyle,
+            isActive: isActive
+        )
+    }
+
+    private var activePrimaryTextNSColor: NSColor {
+        usesInvertedActiveForeground
+            ? selectedWorkspaceForegroundNSColor(opacity: 1.0)
+            : .labelColor
     }
 
     private var activePrimaryTextColor: Color {
-        usesInvertedActiveForeground
-            ? Color(nsColor: selectedWorkspaceForegroundNSColor(opacity: 1.0))
-            : .primary
+        Color(nsColor: activePrimaryTextNSColor)
     }
 
     private func activeSecondaryColor(_ opacity: Double = 0.75) -> Color {
@@ -15452,7 +15457,8 @@ struct TabItemView: View, Equatable {
                 if isEditing {
                     SidebarInlineRenameField(
                         initialText: renameDraft,
-                        fontSize: GlobalFontMagnification.scaledSize(scaledFontSize(12.5), percent: globalFontMagnificationPercent), textColor: selectedWorkspaceForegroundNSColor(opacity: 1.0),
+                        fontSize: GlobalFontMagnification.scaledSize(scaledFontSize(12.5), percent: globalFontMagnificationPercent),
+                        textColor: activePrimaryTextNSColor,
                         accessibilityLabel: String(
                             localized: "sidebar.workspace.rename.field.accessibilityLabel",
                             defaultValue: "Rename workspace"

--- a/Sources/Sidebar/AppKitList/Cells/SidebarWorkspaceRowCellView.swift
+++ b/Sources/Sidebar/AppKitList/Cells/SidebarWorkspaceRowCellView.swift
@@ -361,12 +361,14 @@ final class SidebarWorkspaceRowTableCellView: NSTableCellView {
             sidebarSelectionColorHex: settings.selectionColorHex
         )
         applyBackgroundStyle(style)
-        if settings.activeTabIndicatorStyle == .solidFill, model.isActive {
-            backgroundView.layer?.borderWidth = 1.5
-            backgroundView.layer?.borderColor = NSColor.labelColor.withAlphaComponent(0.5).cgColor
-        } else {
-            backgroundView.layer?.borderWidth = 0
-        }
+        let borderStyle = sidebarWorkspaceRowBorderStyle(
+            activeTabIndicatorStyle: settings.activeTabIndicatorStyle,
+            isActive: model.isActive,
+            colorScheme: palette.colorScheme,
+            sidebarSelectionColorHex: settings.selectionColorHex
+        )
+        backgroundView.layer?.borderWidth = borderStyle.width
+        backgroundView.layer?.borderColor = (borderStyle.color ?? .clear).cgColor
         let railColor = sidebarWorkspaceRowExplicitRailNSColor(
             activeTabIndicatorStyle: settings.activeTabIndicatorStyle,
             customColorHex: snapshot.customColorHex,
@@ -421,7 +423,7 @@ final class SidebarWorkspaceRowTableCellView: NSTableCellView {
                 model: .init(
                     status: taskStatus,
                     hasOverride: true,
-                    usesMonochrome: model.isActive,
+                    usesMonochrome: palette.usesInvertedActiveForeground,
                     fontScale: model.fontScale
                 ),
                 monochromeColor: palette.secondary(0.8),
@@ -476,12 +478,16 @@ final class SidebarWorkspaceRowTableCellView: NSTableCellView {
                 descriptionView.attributedStringValue = SidebarRowPalette.attributed(
                     rendered,
                     font: .systemFont(ofSize: model.scaled(10.5)),
-                    color: model.isActive ? palette.secondary(0.84) : NSColor.secondaryLabelColor.withAlphaComponent(0.95)
+                    color: palette.usesInvertedActiveForeground
+                        ? palette.secondary(0.84)
+                        : NSColor.secondaryLabelColor.withAlphaComponent(0.95)
                 )
             } else {
                 descriptionView.stringValue = display
                 descriptionView.font = .systemFont(ofSize: model.scaled(10.5))
-                descriptionView.textColor = model.isActive ? palette.secondary(0.84) : NSColor.secondaryLabelColor.withAlphaComponent(0.95)
+                descriptionView.textColor = palette.usesInvertedActiveForeground
+                    ? palette.secondary(0.84)
+                    : NSColor.secondaryLabelColor.withAlphaComponent(0.95)
             }
         }
 
@@ -553,7 +559,7 @@ final class SidebarWorkspaceRowTableCellView: NSTableCellView {
         hintPill.configure(
             text: model.shortcutHintText,
             fontSize: model.scaled(9),
-            emphasis: model.isActive ? 1.0 : 0.9,
+            emphasis: palette.usesInvertedActiveForeground ? 1.0 : 0.9,
             representedIdentity: model.workspaceId
         )
         topDropIndicator.layer?.backgroundColor = cmuxAccentNSColor().cgColor
@@ -599,9 +605,11 @@ final class SidebarWorkspaceRowTableCellView: NSTableCellView {
             if let hex = model.settings.notificationBadgeColorHex, let color = NSColor(hex: hex) {
                 return color
             }
-            return model.isActive ? palette.primaryText.withAlphaComponent(0.25) : cmuxAccentNSColor()
+            return palette.usesInvertedActiveForeground
+                ? palette.primaryText.withAlphaComponent(0.25)
+                : cmuxAccentNSColor()
         }()
-        let badgeText: NSColor = model.isActive ? palette.primaryText : .white
+        let badgeText: NSColor = palette.usesInvertedActiveForeground ? palette.primaryText : .white
         let badgeFont = NSFont.systemFont(ofSize: model.scaled(9), weight: .semibold)
 
         let leadingBadgeVisible = badgeVisible && model.settings.notificationBadgePosition == .leading
@@ -618,7 +626,7 @@ final class SidebarWorkspaceRowTableCellView: NSTableCellView {
             trailingBadge.configure(count: model.unreadCount, fillColor: badgeFill, textColor: badgeText, font: badgeFont)
         }
 
-        let spinnerColor: NSColor = model.isActive
+        let spinnerColor: NSColor = palette.usesInvertedActiveForeground
             ? palette.selectedForeground(0.55)
             : .secondaryLabelColor
         leadingSpinner = Self.updateSpinner(
@@ -709,7 +717,7 @@ final class SidebarWorkspaceRowTableCellView: NSTableCellView {
             // highlight. Explicit colors only apply on unselected rows.
             let explicitColor = entry.color.flatMap { NSColor(hex: $0) }
             let entryColor: NSColor
-            if model.isActive {
+            if palette.usesInvertedActiveForeground {
                 entryColor = explicitColor != nil
                     ? palette.selectedForeground(1.0)
                     : palette.secondary(0.95).withAlphaComponent(0.84)
@@ -726,7 +734,7 @@ final class SidebarWorkspaceRowTableCellView: NSTableCellView {
             }
         }
         let toggleFont = NSFont.systemFont(ofSize: model.scaled(10), weight: .semibold)
-        let toggleColor = model.isActive
+        let toggleColor = palette.usesInvertedActiveForeground
             ? palette.secondary(0.9)
             : NSColor.secondaryLabelColor.withAlphaComponent(0.9)
         metadataToggleButton.isHidden = allEntries.count <= 3
@@ -760,12 +768,16 @@ final class SidebarWorkspaceRowTableCellView: NSTableCellView {
                 view.attributedStringValue = SidebarRowPalette.attributed(
                     rendered,
                     font: .systemFont(ofSize: model.scaled(10)),
-                    color: model.isActive ? palette.secondary(0.8) : .secondaryLabelColor
+                    color: palette.usesInvertedActiveForeground
+                        ? palette.secondary(0.8)
+                        : .secondaryLabelColor
                 )
             } else {
                 view.stringValue = display
                 view.font = .systemFont(ofSize: model.scaled(10))
-                view.textColor = model.isActive ? palette.secondary(0.8) : .secondaryLabelColor
+                view.textColor = palette.usesInvertedActiveForeground
+                    ? palette.secondary(0.8)
+                    : .secondaryLabelColor
             }
         }
     }
@@ -783,8 +795,12 @@ final class SidebarWorkspaceRowTableCellView: NSTableCellView {
             progressView.configure(
                 fraction: CGFloat(progress.value),
                 barHeight: max(3, 3 * model.fontScale),
-                trackColor: model.isActive ? palette.selectedForeground(0.15) : NSColor.secondaryLabelColor.withAlphaComponent(0.2),
-                fillColor: model.isActive ? palette.selectedForeground(0.8) : cmuxAccentNSColor(),
+                trackColor: palette.usesInvertedActiveForeground
+                    ? palette.selectedForeground(0.15)
+                    : NSColor.secondaryLabelColor.withAlphaComponent(0.2),
+                fillColor: palette.usesInvertedActiveForeground
+                    ? palette.selectedForeground(0.8)
+                    : cmuxAccentNSColor(),
                 labelText: progress.label,
                 labelFont: labelFont,
                 labelColor: palette.secondary(0.6)

--- a/Sources/Sidebar/AppKitList/Cells/SidebarWorkspaceRowSupportViews.swift
+++ b/Sources/Sidebar/AppKitList/Cells/SidebarWorkspaceRowSupportViews.swift
@@ -12,6 +12,13 @@ struct SidebarRowPalette {
 
     var colorScheme: ColorScheme { model.colorSchemeIsDark ? .dark : .light }
 
+    var usesInvertedActiveForeground: Bool {
+        sidebarWorkspaceRowUsesInvertedForeground(
+            activeTabIndicatorStyle: model.settings.activeTabIndicatorStyle,
+            isActive: model.isActive
+        )
+    }
+
     var selectedBackground: NSColor {
         sidebarSelectedWorkspaceBackgroundNSColor(
             for: colorScheme,
@@ -24,11 +31,11 @@ struct SidebarRowPalette {
     }
 
     var primaryText: NSColor {
-        model.isActive ? selectedForeground(1.0) : .labelColor
+        usesInvertedActiveForeground ? selectedForeground(1.0) : .labelColor
     }
 
     func secondary(_ opacity: CGFloat = 0.75) -> NSColor {
-        model.isActive ? selectedForeground(opacity) : .secondaryLabelColor
+        usesInvertedActiveForeground ? selectedForeground(opacity) : .secondaryLabelColor
     }
 
     static func attributed(_ source: AttributedString, font: NSFont, color: NSColor) -> NSAttributedString {
@@ -342,7 +349,7 @@ final class SidebarRowIconTextLine: NSView {
         case .error: iconName = "xmark.circle.fill"
         }
         let color: NSColor
-        if model.isActive {
+        if palette.usesInvertedActiveForeground {
             switch log.level {
             case .info: color = palette.secondary(0.5)
             case .progress: color = palette.secondary(0.8)
@@ -524,7 +531,9 @@ final class SidebarRowPullRequestLine: NSView {
         clickable: Bool,
         onOpen: @escaping () -> Void
     ) {
-        let color = model.isActive ? palette.secondary(0.75) : NSColor.secondaryLabelColor
+        let color = palette.usesInvertedActiveForeground
+            ? palette.secondary(0.75)
+            : NSColor.secondaryLabelColor
         let font = NSFont.systemFont(ofSize: model.scaled(10), weight: .semibold)
         iconView.configure(status: display.status, color: color, fontScale: model.fontScale)
         iconSize = SidebarRowPullRequestIconView.size(status: display.status, fontScale: model.fontScale)

--- a/Sources/Sidebar/SidebarAppearanceSupport.swift
+++ b/Sources/Sidebar/SidebarAppearanceSupport.swift
@@ -272,6 +272,20 @@ struct SidebarWorkspaceRowBackgroundStyle: Equatable, Hashable {
     static let clear = Self(color: nil, opacity: 0)
 }
 
+struct SidebarWorkspaceRowBorderStyle: Equatable, Hashable {
+    let color: NSColor?
+    let width: CGFloat
+
+    static let clear = Self(color: nil, width: 0)
+}
+
+func sidebarWorkspaceRowUsesInvertedForeground(
+    activeTabIndicatorStyle: WorkspaceIndicatorStyle,
+    isActive: Bool
+) -> Bool {
+    isActive && activeTabIndicatorStyle != .outline
+}
+
 func sidebarWorkspaceRowExplicitRailNSColor(
     activeTabIndicatorStyle: WorkspaceIndicatorStyle,
     customColorHex: String?,
@@ -309,6 +323,19 @@ func sidebarWorkspaceRowBackgroundStyle(
         )
     }
 
+    func workspaceColorBackground() -> SidebarWorkspaceRowBackgroundStyle {
+        if let customBackground {
+            return SidebarWorkspaceRowBackgroundStyle(
+                color: customBackground,
+                opacity: isMultiSelected ? 0.35 : 0.7
+            )
+        }
+        if isMultiSelected {
+            return SidebarWorkspaceRowBackgroundStyle(color: accentBackground, opacity: 0.25)
+        }
+        return .clear
+    }
+
     switch activeTabIndicatorStyle {
     case .leftRail:
         if isActive {
@@ -329,15 +356,36 @@ func sidebarWorkspaceRowBackgroundStyle(
                 opacity: 1
             )
         }
-        if let customBackground {
-            return SidebarWorkspaceRowBackgroundStyle(
-                color: customBackground,
-                opacity: isMultiSelected ? 0.35 : 0.7
-            )
-        }
-        if isMultiSelected {
-            return SidebarWorkspaceRowBackgroundStyle(color: accentBackground, opacity: 0.25)
-        }
+        return workspaceColorBackground()
+
+    case .outline:
+        return workspaceColorBackground()
+    }
+}
+
+func sidebarWorkspaceRowBorderStyle(
+    activeTabIndicatorStyle: WorkspaceIndicatorStyle,
+    isActive: Bool,
+    colorScheme: ColorScheme,
+    sidebarSelectionColorHex: String?
+) -> SidebarWorkspaceRowBorderStyle {
+    guard isActive else { return .clear }
+
+    switch activeTabIndicatorStyle {
+    case .leftRail:
         return .clear
+    case .solidFill:
+        return SidebarWorkspaceRowBorderStyle(
+            color: NSColor.labelColor.withAlphaComponent(0.5),
+            width: 1.5
+        )
+    case .outline:
+        return SidebarWorkspaceRowBorderStyle(
+            color: sidebarSelectedWorkspaceBackgroundNSColor(
+                for: colorScheme,
+                sidebarSelectionColorHex: sidebarSelectionColorHex
+            ),
+            width: 1.5
+        )
     }
 }

--- a/Sources/WorkspaceIndicatorStyle+Display.swift
+++ b/Sources/WorkspaceIndicatorStyle+Display.swift
@@ -11,6 +11,8 @@ extension WorkspaceIndicatorStyle {
             return String(localized: "sidebar.activeTabIndicator.leftRail", defaultValue: "Left Rail")
         case .solidFill:
             return String(localized: "sidebar.activeTabIndicator.solidFill", defaultValue: "Solid Fill")
+        case .outline:
+            return String(localized: "sidebar.activeTabIndicator.outline", defaultValue: "Outline")
         }
     }
 }

--- a/cmuxTests/SidebarAppKitRowCellTests.swift
+++ b/cmuxTests/SidebarAppKitRowCellTests.swift
@@ -1,4 +1,5 @@
 import AppKit
+import CmuxFoundation
 import CmuxSidebar
 import Testing
 @testable import cmux_DEV
@@ -11,6 +12,7 @@ struct SidebarAppKitRowCellTests {
     private static func makeSnapshot(
         title: String = "Workspace",
         isPinned: Bool = false,
+        customColorHex: String? = nil,
         metadataEntries: [SidebarStatusEntry] = []
     ) -> SidebarWorkspaceSnapshotBuilder.Snapshot {
         SidebarWorkspaceSnapshotBuilder.Snapshot(
@@ -21,7 +23,7 @@ struct SidebarAppKitRowCellTests {
             title: title,
             customDescription: nil,
             isPinned: isPinned,
-            customColorHex: nil,
+            customColorHex: customColorHex,
             remoteWorkspaceSidebarText: nil,
             remoteConnectionStatusText: "",
             remoteStateHelpText: "",
@@ -58,15 +60,21 @@ struct SidebarAppKitRowCellTests {
         isPinned: Bool = false,
         canClose: Bool = true,
         settings: SidebarTabItemSettingsSnapshot? = nil,
+        customColorHex: String? = nil,
         metadataEntries: [SidebarStatusEntry] = [],
-        shortcutHintText: String? = nil
+        shortcutHintText: String? = nil,
+        colorSchemeIsDark: Bool = true
     ) -> SidebarWorkspaceRowModel {
         let resolvedSettings = settings
             ?? SidebarTabItemSettingsSnapshot(defaults: UserDefaults(suiteName: UUID().uuidString)!)
         return SidebarWorkspaceRowModel(
             workspaceId: workspaceId,
             index: 0,
-            snapshot: makeSnapshot(isPinned: isPinned, metadataEntries: metadataEntries),
+            snapshot: makeSnapshot(
+                isPinned: isPinned,
+                customColorHex: customColorHex,
+                metadataEntries: metadataEntries
+            ),
             settings: resolvedSettings,
             isActive: isActive,
             isMultiSelected: false,
@@ -83,7 +91,7 @@ struct SidebarAppKitRowCellTests {
             isFirstRow: true,
             shortcutHintText: shortcutHintText,
             showsShortcutHints: shortcutHintText != nil,
-            colorSchemeIsDark: true,
+            colorSchemeIsDark: colorSchemeIsDark,
             globalFontMagnificationPercent: 100,
             isChecklistExpanded: false,
             checklistAddFieldActivationToken: 0,
@@ -147,7 +155,7 @@ struct SidebarAppKitRowCellTests {
         )
     }
 
-    private static func makeDefaults() -> UserDefaults {
+    fileprivate static func makeDefaults() -> UserDefaults {
         UserDefaults(suiteName: "SidebarAppKitRowCellTests.\(UUID().uuidString)")!
     }
 
@@ -923,5 +931,37 @@ struct SidebarPinnedIndicatorColorTests {
         )
 
         #expect(groupPin.contentTintColor == workspacePin.contentTintColor)
+    }
+}
+
+@Suite
+@MainActor
+struct SidebarOutlineIndicatorTests {
+    @Test
+    func outlineIndicatorPreservesWorkspaceFillAndUsesSelectionColorForStroke() throws {
+        let defaults = SidebarAppKitRowCellTests.makeDefaults()
+        defaults.set("outline", forKey: "sidebarActiveTabIndicatorStyle")
+        defaults.set("#123456", forKey: "sidebarSelectionColorHex")
+        let settings = SidebarTabItemSettingsSnapshot(defaults: defaults)
+        let model = SidebarAppKitRowCellTests.makeModel(
+            isActive: true,
+            settings: settings,
+            customColorHex: "#C0392B",
+            colorSchemeIsDark: false
+        )
+
+        let cell = SidebarAppKitRowCellTests.configuredCell(model: model)
+        let backgroundView = try #require(
+            cell.subviews.first { $0.layer?.cornerRadius == 6 }
+        )
+        let fillCGColor = try #require(backgroundView.layer?.backgroundColor)
+        let fillColor = try #require(NSColor(cgColor: fillCGColor))
+        let strokeCGColor = try #require(backgroundView.layer?.borderColor)
+        let strokeColor = try #require(NSColor(cgColor: strokeCGColor))
+
+        #expect(settings.activeTabIndicatorStyle.rawValue == "outline")
+        #expect(fillColor.hexString(includeAlpha: true) == "#C0392BB2")
+        #expect(backgroundView.layer?.borderWidth == 1.5)
+        #expect(strokeColor.hexString(includeAlpha: true) == "#123456FF")
     }
 }

--- a/skills/cmux-settings/references/all-keys.md
+++ b/skills/cmux-settings/references/all-keys.md
@@ -80,8 +80,8 @@ Workspace tab and badge colors from Settings > Workspace Colors.
 
 | Key | Type | Default | Description |
 |---|---|---|---|
-| `workspaceColors.indicatorStyle` | `"leftRail"` or `"solidFill"` or `"rail"` or `"border"` or `"wash"` or `"lift"` or `"typography"` or `"washRail"` or `"blueWashColorRail"` | `"leftRail"` | Active workspace indicator style. Legacy aliases are accepted and normalized. |
-| `workspaceColors.selectionColor` | colorHexOrNull | `null` | Override the selected workspace background color. |
+| `workspaceColors.indicatorStyle` | `"leftRail"` or `"solidFill"` or `"outline"` or `"rail"` or `"border"` or `"wash"` or `"lift"` or `"typography"` or `"washRail"` or `"blueWashColorRail"` | `"leftRail"` | Active workspace indicator style. Legacy aliases are accepted and normalized. |
+| `workspaceColors.selectionColor` | colorHexOrNull | `null` | Override the selected workspace background or outline color. |
 | `workspaceColors.notificationBadgeColor` | colorHexOrNull | `null` | Override the unread notification badge color. |
 | `workspaceColors.colors` | object | `{"Red": "#C0392B", "Crimson": "#922B21", "Orange": "#A04000", "Amber": "#7D6608", "Olive": "#4A5C18", "Green": "#196F3D", "Teal": "#006B6B", "Aqua": "#0E6B8C", "Blue": "#1565C0", "Navy": "#1A5276", "Indigo": "#283593", "Purple": "#6A1B9A", "Magenta": "#AD1457", "Rose": "#880E4F", "Brown": "#7B3F00", "Charcoal": "#3E4B5E"}` | Full named workspace color palette. Include built-in entries you want to keep, remove keys to remove colors, and add more named entries to extend the picker. |
 | `workspaceColors.paletteOverrides` | object | `{}` | Legacy workspace color overrides for built-in palette names. Prefer workspaceColors.colors for new configs. |

--- a/web/data/cmux.schema.json
+++ b/web/data/cmux.schema.json
@@ -1135,6 +1135,7 @@
           "enum": [
             "leftRail",
             "solidFill",
+            "outline",
             "rail",
             "border",
             "wash",
@@ -1149,7 +1150,7 @@
         "selectionColor": {
           "$ref": "#/$defs/colorHexOrNull",
           "default": null,
-          "description": "Override the selected workspace background color."
+          "description": "Override the selected workspace background or outline color."
         },
         "notificationBadgeColor": {
           "$ref": "#/$defs/colorHexOrNull",


### PR DESCRIPTION
## Summary

- Add an Outline workspace indicator style that preserves the workspace-color fill and draws the configured selection color as a 1.5-point active-row border.
- Share background, border, and foreground policy between the AppKit and legacy SwiftUI sidebar row paths.
- Expose the new style in Settings, the configuration schema/reference, and the localized indicator label.

Fixes #7460

## Testing

- Regression proof before the production fix: `./scripts/reload-cloud.sh xctest --tag sym7460-red3 --scheme cmux-unit --only-testing cmuxTests/SidebarAppKitRowCellTests` (fleet run `sym7460-red3-461055e1ea59`) failed the new test on all four intended assertions: decoded style, preserved fill, 1.5-point border, and selection-color stroke.
- Tagged app build: `./scripts/reload-cloud.sh --tag sym7460 --launch` via the cloud Blacksmith path, [run 30884758925](https://github.com/manaflow-ai/cmux/actions/runs/30884758925), including deep-signature verification.
- Socket-driven dogfood against `/tmp/cmux-debug-sym7460.sock`: with workspace color `#C0392B`, `workspaceColors.indicatorStyle = outline`, and selection color `#123456`, the active row retained the red fill and showed a distinct dark outline. Pixel sampling measured the border as `srgba(27,51,83,1)` and the interior as `srgba(93,47,43,1)`.
- Quit the tagged app after verification; the tagged CLI now returns connection refused for `/tmp/cmux-debug-sym7460.sock`.
- `./scripts/lint-pbxproj-test-wiring.sh`
- Parsed `Resources/Localizable.xcstrings` and `web/data/cmux.schema.json` with `jq`; audited the changed Swift/UI strings and verified the Outline label matches the existing indicator locales.

## Checklist

- [x] I tested the change in a tagged dev build
- [x] I added or updated tests for behavior changes
- [x] I updated the settings reference and schema
- [ ] All code review bot comments are resolved
- [ ] All human review comments are resolved

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/9559"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788422239&installation_model_id=21920&pr_number=9559&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F9559&signature=47a985623488ef770192d2fdb8b8249b136ab224fc749a88e5f18950c7099675"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an Outline active-workspace indicator that keeps the workspace fill and draws a 1.5pt border using the selection color. Unifies sidebar selection visuals across AppKit and SwiftUI, exposes the option in Settings and the config schema. Fixes #7460.

- **New Features**
  - New `outline` indicator style in Settings with a localized label; selection color subtitle now says “Background or outline.”
  - Active rows use a 1.5pt selection-color border for `outline` while preserving the workspace fill; inverted foreground is off for `outline`.
  - Centralized background/border/foreground logic shared by AppKit and SwiftUI.
  - Schema/docs updated to include `outline`; tests verify style decoding, preserved fill, 1.5pt stroke, and selection-color usage.

- **Bug Fixes**
  - Better contrast for active text, badges, spinners, metadata, and progress across indicator styles.

<sup>Written for commit 2ab0cc768b6f2bf89ac63bdf67e5f372b1252967. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/9559?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an outline-style indicator for the active workspace.
  * Active workspace rows now support configurable outline colors while preserving their existing fill color.
  * Updated workspace style labels and settings descriptions to include the new outline option.

* **Documentation**
  * Updated settings references and schema documentation with the outline indicator and selection-color behavior.

* **Bug Fixes**
  * Improved active workspace text, badges, metadata, and progress styling for consistent contrast across indicator styles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->