### PR TITLE
Fix SettingCatalog storage alias validation

### DIFF
--- a/Packages/macOS/CmuxSettings/Sources/CmuxSettings/Keys/SidebarCatalogSection.swift
+++ b/Packages/macOS/CmuxSettings/Sources/CmuxSettings/Keys/SidebarCatalogSection.swift
@@ -176,9 +176,14 @@ public struct SidebarCatalogSection: SettingCatalogSection {
         userDefaultsKey: RightSidebarWidthSettings.rememberedMaxWidthKey
     )
 
-    public let activeTabIndicatorStyle = DefaultsKey<String>(
+    /// Legacy sidebar alias for the active-workspace indicator style.
+    ///
+    /// Shares the storage key, value type, and default with
+    /// ``WorkspaceColorsCatalogSection/indicatorStyle`` so either catalog ID
+    /// reads and writes the same `UserDefaults` value.
+    public let activeTabIndicatorStyle = DefaultsKey<WorkspaceIndicatorStyle>(
         id: "sidebar.activeTabIndicatorStyle",
-        defaultValue: "leftRail",
+        defaultValue: .leftRail,
         userDefaultsKey: "sidebarActiveTabIndicatorStyle"
     )
 

--- a/Packages/macOS/CmuxSettings/Tests/CmuxSettingsTests/SettingCatalogTests.swift
+++ b/Packages/macOS/CmuxSettings/Tests/CmuxSettingsTests/SettingCatalogTests.swift
@@ -76,6 +76,15 @@ struct SettingCatalogTests {
         }
     }
 
+    @Test func userDefaultsStorageKeysAreUniqueRegression() {
+        let keys = SettingCatalog().all.compactMap { entry -> String? in
+            guard case let .userDefaults(storageKey, _, _) = entry.kind else { return nil }
+            return storageKey
+        }
+
+        #expect(keys.count == Set(keys).count)
+    }
+
     @Test func jsonBackedKeysUseTheirIdAsPath() {
         for entry in SettingCatalog().all where entry.kind == .jsonConfig {
             #expect(!entry.id.isEmpty)

--- a/Packages/macOS/CmuxSettings/Tests/CmuxSettingsTests/SettingCatalogTests.swift
+++ b/Packages/macOS/CmuxSettings/Tests/CmuxSettingsTests/SettingCatalogTests.swift
@@ -9,80 +9,30 @@ struct SettingCatalogTests {
         #expect(ids.count == Set(ids).count)
     }
 
-    @Test func userDefaultsStorageKeysAreUnique() {
-        let expectedAliases: [String: Set<String>] = [
-            "ampHooksEnabled": [
-                "automation.ampIntegration",
-                "integrations.amp.hooksEnabled",
-            ],
-            "claudeCodeCustomClaudePath": [
-                "automation.claudeBinaryPath",
-                "integrations.claudeCode.customClaudePath",
-            ],
-            "claudeCodeHooksEnabled": [
-                "automation.claudeCodeIntegration",
-                "integrations.claudeCode.hooksEnabled",
-            ],
-            "cursorHooksEnabled": [
-                "automation.cursorIntegration",
-                "integrations.cursor.hooksEnabled",
-            ],
-            "geminiHooksEnabled": [
-                "automation.geminiIntegration",
-                "integrations.gemini.hooksEnabled",
-            ],
-            "kiroHooksEnabled": [
-                "automation.kiroIntegration",
-                "integrations.kiro.hooksEnabled",
-            ],
-            "kiroNotificationLevel": [
-                "automation.kiroNotificationLevel",
-                "integrations.kiro.notificationLevel",
-            ],
-            "ripgrepCustomBinaryPath": [
-                "automation.ripgrepBinaryPath",
-                "integrations.ripgrep.customBinaryPath",
-            ],
-            "suppressSubagentNotifications": [
-                "automation.suppressSubagentNotifications",
-                "integrations.suppressSubagentNotifications",
-            ],
-            "sidebarActiveTabIndicatorStyle": [
-                "sidebar.activeTabIndicatorStyle",
-                "workspaceColors.indicatorStyle",
-            ],
-            "sidebarNotificationBadgeColorHex": [
-                "sidebar.notificationBadgeColor",
-                "workspaceColors.notificationBadgeColor",
-            ],
-            "sidebarSelectionColorHex": [
-                "sidebar.selectionColor",
-                "workspaceColors.selectionColor",
-            ],
-        ]
-
-        var idsByStorageKey: [String: Set<String>] = [:]
+    @Test func sharedUserDefaultsStorageKeysHaveCompatibleTypesAndDefaults() throws {
+        var entriesByStorageKey: [String: [AnySettingKey]] = [:]
         for entry in SettingCatalog().all {
             if case let .userDefaults(storageKey, _, _) = entry.kind {
-                idsByStorageKey[storageKey, default: []].insert(entry.id)
+                entriesByStorageKey[storageKey, default: []].append(entry)
             }
         }
 
-        let aliases = idsByStorageKey.filter { $0.value.count > 1 }
-        #expect(aliases == expectedAliases)
+        for (storageKey, entries) in entriesByStorageKey where entries.count > 1 {
+            let reference = entries[0]
+            let referenceDefault = try #require(reference.userDefaultsDefaultValue)
 
-        for storageKey in expectedAliases.keys {
-            #expect(idsByStorageKey[storageKey] == expectedAliases[storageKey])
+            for entry in entries.dropFirst() {
+                let defaultValue = try #require(entry.userDefaultsDefaultValue)
+                #expect(
+                    ObjectIdentifier(type(of: defaultValue)) == ObjectIdentifier(type(of: referenceDefault)),
+                    "UserDefaults storage key '\(storageKey)' has different Value types for '\(reference.id)' and '\(entry.id)'"
+                )
+                #expect(
+                    settingDefaultsAreEqual(referenceDefault, defaultValue),
+                    "UserDefaults storage key '\(storageKey)' has different defaults for '\(reference.id)' and '\(entry.id)'"
+                )
+            }
         }
-    }
-
-    @Test func userDefaultsStorageKeysAreUniqueRegression() {
-        let keys = SettingCatalog().all.compactMap { entry -> String? in
-            guard case let .userDefaults(storageKey, _, _) = entry.kind else { return nil }
-            return storageKey
-        }
-
-        #expect(keys.count == Set(keys).count)
     }
 
     @Test func jsonBackedKeysUseTheirIdAsPath() {
@@ -120,5 +70,15 @@ struct SettingCatalogTests {
         for key in catalog.automation.all { #expect(key.id.hasPrefix("automation.")) }
         #expect(catalog.paneChrome.paneBorderColorHex.id == "paneBorderColor")
         #expect(catalog.paneChrome.activePaneBorderColorHex.id == "activePaneBorderColor")
+    }
+
+    private func settingDefaultsAreEqual(_ lhs: any Sendable, _ rhs: any Sendable) -> Bool {
+        guard let lhs = lhs as? any SettingCodable else { return false }
+        return settingDefaultEquals(lhs, rhs)
+    }
+
+    private func settingDefaultEquals<Value: SettingCodable>(_ lhs: Value, _ rhs: any Sendable) -> Bool {
+        guard let rhs = rhs as? Value else { return false }
+        return lhs == rhs
     }
 }


### PR DESCRIPTION
## Summary

- validate shared UserDefaults storage keys by requiring matching concrete value types and defaults instead of global uniqueness or a fixed alias allowlist
- align the legacy sidebar indicator alias with `WorkspaceIndicatorStyle` while preserving its existing on-disk string representation

Fixes #5337

## Testing

- Red (`ef076e7a78`): on `cmux-aws-m4pro`, `swift test --package-path Packages/macOS/CmuxSettings --scratch-path /tmp/cmux-sym5337-red-ef076e7a78 --filter userDefaultsStorageKeysAreUniqueRegression` failed as expected with 173 keys versus 161 unique keys.
- Green (`6c7ba8093a`): on `cmux-aws-m4pro`, the focused compatibility test passed, then the full `CmuxSettingsTests` package run passed all 266 tests.
- Dev build: `./scripts/reload-cloud.sh --tag sym5337` used the hosted macOS 26 cloud path with no local fallback. [Run 30888793534](https://github.com/manaflow-ai/cmux/actions/runs/30888793534) built successfully. After a transient first artifact-download failure, retrying that run's artifact download succeeded; the archive passed integrity checks, the installed tag passed code-signature verification, and no tagged process was left running.
- Localization audit: no user-facing surfaces or strings changed, and no localization catalog changes were needed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/9560"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788422376&installation_model_id=21920&pr_number=9560&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F9560&signature=865b59dc3942ca828473dd0a9b1232d3a07d85f925ce033dc1108dc16978bccc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Allow shared `UserDefaults` storage keys in `SettingCatalog` when entries have the same concrete value type and default, removing the alias allowlist. Align the sidebar indicator setting with `WorkspaceIndicatorStyle` while preserving the existing `UserDefaults` key; fixes #5337.

- **Bug Fixes**
  - Replace the uniqueness/allowlist test with a compatibility check that asserts matching concrete types and equal defaults using `SettingCodable` equality for entries sharing a storage key.
  - Change `SidebarCatalogSection.activeTabIndicatorStyle` to `DefaultsKey<WorkspaceIndicatorStyle>` with default `.leftRail`, keeping `userDefaultsKey` `"sidebarActiveTabIndicatorStyle"` so it aliases `workspaceColors.indicatorStyle`.

<sup>Written for commit 6c7ba8093a443df46a64928689a9c7df27f8c4b7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/9560?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


