### PR TITLE
Allow browser user-agent overrides

### DIFF
--- a/Packages/macOS/CmuxBrowser/Sources/CmuxBrowser/BrowserUserAgentPolicy.swift
+++ b/Packages/macOS/CmuxBrowser/Sources/CmuxBrowser/BrowserUserAgentPolicy.swift
@@ -57,16 +57,31 @@ public struct BrowserUserAgentPolicy: Sendable {
 
     /// Resolves the browser identity policy for a top-level destination.
     ///
-    /// Google Sheets intentionally uses WebKit's default embedded identity.
-    /// Non-web destinations have no applicable user-agent policy.
+    /// A non-empty override takes precedence over destination-specific
+    /// behavior, including Google Sheets. Without an override, Google Sheets
+    /// intentionally uses WebKit's default embedded identity. Non-web
+    /// destinations have no applicable user-agent policy.
     ///
-    /// - Parameter url: The destination of the top-level navigation.
+    /// - Parameters:
+    ///   - url: The destination of the top-level navigation.
+    ///   - userAgentOverride: A configured identity to advertise. Leading and
+    ///     trailing whitespace is ignored; an empty value selects automatic
+    ///     behavior.
     /// - Returns: The user-agent policy resolution for the destination.
-    public func resolution(for url: URL?) -> BrowserUserAgentPolicyResolution {
+    public func resolution(
+        for url: URL?,
+        userAgentOverride: String? = nil
+    ) -> BrowserUserAgentPolicyResolution {
         guard let url,
               let scheme = url.scheme?.lowercased(),
               scheme == "http" || scheme == "https" else {
             return .notApplicable
+        }
+        if let userAgentOverride {
+            let normalizedOverride = userAgentOverride.trimmingCharacters(in: .whitespacesAndNewlines)
+            if !normalizedOverride.isEmpty {
+                return .custom(normalizedOverride)
+            }
         }
         guard let host = url.host?.lowercased() else {
             return .custom(safariCompatibleUserAgent)

--- a/Packages/macOS/CmuxBrowser/Tests/CmuxBrowserTests/BrowserUserAgentPolicyTests.swift
+++ b/Packages/macOS/CmuxBrowser/Tests/CmuxBrowserTests/BrowserUserAgentPolicyTests.swift
@@ -15,6 +15,50 @@ struct BrowserUserAgentPolicyTests {
         #expect(policy.safariCompatibleUserAgent.contains("Version/26.6 Safari/605.1.15"))
     }
 
+    @Test func configuredIdentityOverridesDestinationSpecificPolicy() {
+        let configuredUserAgent = "Configured Browser/1.0"
+        let paddedUserAgent = " \n\(configuredUserAgent)\t"
+        let duoURL = URL(string: "https://api-example.duosecurity.com/frame/v4/auth")!
+        let sheetURL = URL(string: "https://docs.google.com/spreadsheets/d/example/edit")!
+
+        #expect(
+            policy.resolution(for: duoURL, userAgentOverride: paddedUserAgent)
+                == .custom(configuredUserAgent)
+        )
+        #expect(
+            policy.resolution(for: sheetURL, userAgentOverride: configuredUserAgent)
+                == .custom(configuredUserAgent)
+        )
+    }
+
+    @Test func blankConfiguredIdentityPreservesAutomaticPolicy() {
+        let duoURL = URL(string: "https://api-example.duosecurity.com/frame/v4/auth")!
+        let sheetURL = URL(string: "https://docs.google.com/spreadsheets/d/example/edit")!
+
+        #expect(
+            policy.resolution(for: duoURL, userAgentOverride: " \n\t ")
+                == .custom(policy.safariCompatibleUserAgent)
+        )
+        #expect(policy.resolution(for: sheetURL, userAgentOverride: "") == .webKitDefault)
+    }
+
+    @Test func configuredIdentityDoesNotApplyToNonWebDestinations() {
+        let configuredUserAgent = "Configured Browser/1.0"
+
+        #expect(
+            policy.resolution(
+                for: URL(string: "about:blank")!,
+                userAgentOverride: configuredUserAgent
+            ) == .notApplicable
+        )
+        #expect(
+            policy.resolution(
+                for: URL(fileURLWithPath: "/tmp/example.html"),
+                userAgentOverride: configuredUserAgent
+            ) == .notApplicable
+        )
+    }
+
     @Test func staleInstalledSafariIsRaisedToCurrentCompatibilityFloor() {
         let stalePolicy = BrowserUserAgentPolicy(safariVersion: "26.4")
 

--- a/Packages/macOS/CmuxSettings/Sources/CmuxSettings/Keys/BrowserCatalogSection.swift
+++ b/Packages/macOS/CmuxSettings/Sources/CmuxSettings/Keys/BrowserCatalogSection.swift
@@ -2,6 +2,15 @@ import Foundation
 
 /// Settings under the dotted-id prefix `browser.*`.
 public struct BrowserCatalogSection: SettingCatalogSection {
+    /// Overrides the user-agent identity for top-level HTTP and HTTPS navigations.
+    ///
+    /// An empty value preserves cmux's destination-aware automatic policy.
+    public let userAgent = DefaultsKey<String>(
+        id: "browser.userAgent",
+        defaultValue: "",
+        userDefaultsKey: "browserUserAgent"
+    )
+
     public let defaultSearchEngine = DefaultsKey<BrowserSearchEngine>(
         id: "browser.defaultSearchEngine",
         defaultValue: BrowserSearchSettingsStore.defaultSearchEngine,

--- a/Sources/CmuxSettingsJSONPathSupport.swift
+++ b/Sources/CmuxSettingsJSONPathSupport.swift
@@ -342,6 +342,8 @@ enum AutomationSettingsFileMapping {
 }
 
 enum BrowserSettingsFileMapping {
+    private static let browser = BrowserCatalogSection()
+
     static let booleanSettings: [SettingsFileBooleanMapping] = [
         .init(jsonKey: "showSearchSuggestions", defaultsKey: BrowserSearchSettingsStore.searchSuggestionsEnabledKey),
         .init(jsonKey: "discardHiddenWebViews", defaultsKey: BrowserHiddenWebViewDiscardPolicy.enabledKey),
@@ -361,6 +363,7 @@ enum BrowserSettingsFileMapping {
     ]
 
     static let stringSettings: [SettingsFileStringMapping] = [
+        .init(jsonKey: "userAgent", defaultsKey: browser.userAgent.userDefaultsKey),
         .init(jsonKey: "reactGrabVersion", defaultsKey: ReactGrabSettings.versionKey),
     ]
 
@@ -497,6 +500,7 @@ extension CmuxSettingsFileStore {
         "automation.kiroNotificationLevel",
         "automation.portBase",
         "automation.portRange",
+        "browser.userAgent",
         "browser.defaultSearchEngine",
         "browser.customSearchEngineName",
         "browser.customSearchEngineURLTemplate",

--- a/Sources/KeyboardShortcutSettingsFileStore+Template.swift
+++ b/Sources/KeyboardShortcutSettingsFileStore+Template.swift
@@ -197,6 +197,7 @@ extension CmuxSettingsFileStore {
             ],
             [
                 "browser": [
+                    "userAgent": SettingCatalog().browser.userAgent.defaultValue,
                     "defaultSearchEngine": BrowserSearchSettingsStore.defaultSearchEngine.rawValue,
                     "customSearchEngineName": BrowserSearchSettingsStore.defaultCustomSearchEngineName,
                     "customSearchEngineURLTemplate": BrowserSearchSettingsStore.defaultCustomSearchEngineURLTemplate,

--- a/Sources/Panels/WKWebView+BrowserUserAgentPolicy.swift
+++ b/Sources/Panels/WKWebView+BrowserUserAgentPolicy.swift
@@ -1,4 +1,5 @@
 import CmuxBrowser
+import CmuxSettings
 import WebKit
 
 extension WKWebView {
@@ -8,8 +9,13 @@ extension WKWebView {
     func applyBrowserUserAgentPolicy(for url: URL?) -> Bool {
         // WebKit exposes its native identity as either nil or an empty string across load phases.
         let currentUserAgent = customUserAgent.flatMap { $0.isEmpty ? nil : $0 }
+        let userAgentOverride = UserDefaultsSettingsClient(defaults: .standard)
+            .value(for: SettingCatalog().browser.userAgent)
         let resolvedUserAgent: String?
-        switch BrowserUserAgentPolicy.system.resolution(for: url) {
+        switch BrowserUserAgentPolicy.system.resolution(
+            for: url,
+            userAgentOverride: userAgentOverride
+        ) {
         case .custom(let userAgent):
             resolvedUserAgent = userAgent
         case .webKitDefault:

--- a/cmuxTests/BrowserUserAgentPolicyWebKitTests.swift
+++ b/cmuxTests/BrowserUserAgentPolicyWebKitTests.swift
@@ -1,7 +1,8 @@
+import CmuxBrowser
+import CmuxSettings
 import Foundation
 import Testing
 import WebKit
-import CmuxBrowser
 
 #if canImport(cmux_DEV)
 @testable import cmux_DEV
@@ -10,11 +11,11 @@ import CmuxBrowser
 #endif
 
 @MainActor
-@Suite
+@Suite(.serialized)
 struct BrowserUserAgentPolicyWebKitTests {
     @Test func duoNavigationUsesUserAgentOverrideFromCmuxConfig() throws {
         let defaults = UserDefaults.standard
-        let userAgentDefaultsKey = "browserUserAgent"
+        let userAgentDefaultsKey = SettingCatalog().browser.userAgent.userDefaultsKey
         let backupsDefaultsKey = "cmux.settingsFile.backups.v1"
         let importedDefaultsKey = "cmux.settingsFile.importedManagedDefaults.v1"
         let previousUserAgent = defaults.object(forKey: userAgentDefaultsKey)

--- a/cmuxTests/BrowserUserAgentPolicyWebKitTests.swift
+++ b/cmuxTests/BrowserUserAgentPolicyWebKitTests.swift
@@ -12,6 +12,73 @@ import CmuxBrowser
 @MainActor
 @Suite
 struct BrowserUserAgentPolicyWebKitTests {
+    @Test func duoNavigationUsesUserAgentOverrideFromCmuxConfig() throws {
+        let defaults = UserDefaults.standard
+        let userAgentDefaultsKey = "browserUserAgent"
+        let backupsDefaultsKey = "cmux.settingsFile.backups.v1"
+        let importedDefaultsKey = "cmux.settingsFile.importedManagedDefaults.v1"
+        let previousUserAgent = defaults.object(forKey: userAgentDefaultsKey)
+        let previousBackups = defaults.object(forKey: backupsDefaultsKey)
+        let previousImportedDefaults = defaults.object(forKey: importedDefaultsKey)
+        defer {
+            if let previousUserAgent {
+                defaults.set(previousUserAgent, forKey: userAgentDefaultsKey)
+            } else {
+                defaults.removeObject(forKey: userAgentDefaultsKey)
+            }
+            if let previousBackups {
+                defaults.set(previousBackups, forKey: backupsDefaultsKey)
+            } else {
+                defaults.removeObject(forKey: backupsDefaultsKey)
+            }
+            if let previousImportedDefaults {
+                defaults.set(previousImportedDefaults, forKey: importedDefaultsKey)
+            } else {
+                defaults.removeObject(forKey: importedDefaultsKey)
+            }
+        }
+        defaults.removeObject(forKey: userAgentDefaultsKey)
+        defaults.removeObject(forKey: backupsDefaultsKey)
+        defaults.removeObject(forKey: importedDefaultsKey)
+
+        let configuredUserAgent =
+            "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) " +
+            "AppleWebKit/537.36 (KHTML, like Gecko) " +
+            "Chrome/126.0.0.0 Safari/537.36"
+        let directoryURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(
+            at: directoryURL,
+            withIntermediateDirectories: true
+        )
+        defer { try? FileManager.default.removeItem(at: directoryURL) }
+
+        let settingsURL = directoryURL.appendingPathComponent("cmux.json")
+        try """
+        {
+          "browser": {
+            "userAgent": "\(configuredUserAgent)"
+          }
+        }
+        """.write(to: settingsURL, atomically: true, encoding: .utf8)
+
+        _ = CmuxSettingsFileStore(
+            primaryPath: settingsURL.path,
+            fallbackPath: nil,
+            additionalFallbackPaths: [],
+            startWatching: false
+        )
+
+        let webView = WKWebView(frame: .zero, configuration: WKWebViewConfiguration())
+        let duoRequest = URLRequest(
+            url: URL(string: "https://api-example.duosecurity.com/frame/v4/auth")!
+        )
+
+        #expect(defaults.string(forKey: userAgentDefaultsKey) == configuredUserAgent)
+        _ = webView.browserUserAgentPolicyRestartRequest(for: duoRequest)
+        #expect(webView.customUserAgent == configuredUserAgent)
+    }
+
     @Test func restartRequestChangesIdentityOnceAndStripsStaleHeader() throws {
         let webView = WKWebView(frame: .zero, configuration: WKWebViewConfiguration())
         var request = URLRequest(url: URL(string: "https://workspace.google.com/")!)

--- a/skills/cmux-settings/references/all-keys.md
+++ b/skills/cmux-settings/references/all-keys.md
@@ -120,6 +120,7 @@ Embedded browser settings from Settings > Browser.
 
 | Key | Type | Default | Description |
 |---|---|---|---|
+| `browser.userAgent` | string | `""` | Custom user-agent string for top-level HTTP(S) browser navigations. Leave empty to use cmux's automatic WebKit/Safari identity. This changes only the advertised identity, not the browser engine. |
 | `browser.defaultSearchEngine` | `"google"` or `"duckduckgo"` or `"bing"` or `"kagi"` or `"startpage"` | `"google"` | Default search engine for non-URL queries. |
 | `browser.showSearchSuggestions` | boolean | `true` | Show omnibar search suggestions. |
 | `browser.theme` | `"system"` or `"light"` or `"dark"` | `"system"` | Embedded browser theme. |

--- a/verification.html
+++ b/verification.html
@@ -1,0 +1,53 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Issue 7513 — Duo SSO verification</title>
+  <style>
+    :root { color-scheme: light dark; font: 14px/1.35 system-ui, sans-serif; }
+    body { max-width: 980px; margin: 24px auto; padding: 0 18px; }
+    h1 { font-size: 22px; margin: 0 0 8px; }
+    p, ol { margin: 8px 0; }
+    li { margin: 10px 0; padding-left: 4px; }
+    code { font: 12px/1.35 ui-monospace, monospace; }
+    pre { padding: 8px 10px; overflow-x: auto; border: 1px solid #8886; border-radius: 6px; margin: 6px 0; }
+    .claim { border-left: 4px solid #e98b22; padding-left: 10px; }
+  </style>
+</head>
+<body>
+  <h1>Cisco Duo SSO verification for #7513</h1>
+  <p>This fix imports <code>browser.userAgent</code> from <code>cmux.json</code> and applies it to every top-level HTTP(S) navigation; an empty or absent value restores cmux’s automatic policy. The single unverified claim is that a real corporate Duo session completes inside the browser pane with the tenant account and hardware key or push.</p>
+  <p class="claim"><strong>Pass:</strong> Duo no longer shows “Safari version too old/unsupported,” authentication completes, and the company tool loads in cmux. <strong>Fail:</strong> that browser-version block remains, or Duo reaches WebAuthn/push but cannot complete despite the configured UA being visible.</p>
+  <ol>
+    <li>Build and launch the isolated app from this worktree:
+      <pre><code>./scripts/reload-cloud.sh --builder fleet --tag sym7513 --launch
+CMUX_TAG=sym7513 scripts/cmux-debug-cli.sh list-workspaces --json</code></pre>
+      Correct: the app launches and the helper connects to <code>/tmp/cmux-debug-sym7513.sock</code>.
+    </li>
+    <li>In the same shell, back up the config and advertise the installed Chrome version:
+      <pre><code>config_path=$(skills/cmux-settings/scripts/cmux-settings path)
+config_backup=$(mktemp /tmp/cmux-7513-config.XXXXXX)
+cp -p "$config_path" "$config_backup"
+CHROME_VERSION=$(defaults read '/Applications/Google Chrome.app/Contents/Info' CFBundleShortVersionString)
+UA="Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/$CHROME_VERSION Safari/537.36"
+skills/cmux-settings/scripts/cmux-settings set browser.userAgent "$(jq -Rn --arg value "$UA" '$value')"
+skills/cmux-settings/scripts/cmux-settings get browser.userAgent</code></pre>
+      Correct: the printed value contains the installed Chrome version.
+    </li>
+    <li>Open the company SSO URL in the tagged app, replacing the placeholder:
+      <pre><code>DUO_SSO_URL='https://YOUR-COMPANY-SSO-URL'
+SURFACE=$(CMUX_TAG=sym7513 scripts/cmux-debug-cli.sh browser open "$DUO_SSO_URL" --workspace workspace:1 --focus true --json | jq -r .surface_ref)
+CMUX_TAG=sym7513 scripts/cmux-debug-cli.sh browser "$SURFACE" eval 'navigator.userAgent'</code></pre>
+      Correct: the evaluated UA exactly matches step 2. Wrong UA here disproves the fix before testing Duo.
+    </li>
+    <li>Continue through Duo and approve the hardware-key or push challenge. Correct: no unsupported-Safari page appears and the redirect returns to the company tool inside cmux. The old bug is the browser-version rejection before completion; any equivalent rejection with the step-2 UA visible proves the fix insufficient.</li>
+    <li>Restore the setting and quit only the tagged app:
+      <pre><code>cp -p "$config_backup" "$config_path"
+CMUX_TAG=sym7513 scripts/cmux-debug-cli.sh reload-config
+/usr/bin/trash "$config_backup"
+pkill -f '/DerivedData/cmux-sym7513/.*/Contents/MacOS/cmux DEV$'</code></pre>
+    </li>
+  </ol>
+</body>
+</html>

--- a/web/data/cmux.schema.json
+++ b/web/data/cmux.schema.json
@@ -1354,6 +1354,12 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "userAgent": {
+          "type": "string",
+          "default": "",
+          "descriptionKey": "schemaDescriptions.browser.userAgent",
+          "description": "Custom user-agent string for top-level HTTP(S) browser navigations. Leave empty to use cmux's automatic WebKit/Safari identity. This changes only the advertised identity, not the browser engine."
+        },
         "defaultSearchEngine": {
           "type": "string",
           "enum": ["google", "duckduckgo", "bing", "kagi", "startpage", "brave", "perplexity", "exa", "yahoo", "ecosia", "qwant", "mojeek", "wikipedia", "github", "baidu", "yandex", "custom"],

--- a/web/messages/en.json
+++ b/web/messages/en.json
@@ -1851,6 +1851,7 @@
           "textBoxSubmitActionBackgroundColorHex": "Action color metadata as RGB or RGBA hex. The submit button fill stays white and only changes opacity between enabled and disabled states."
         },
         "browser": {
+          "userAgent": "Custom user-agent string for top-level HTTP(S) browser navigations. Leave empty to use cmux's automatic WebKit/Safari identity. This changes only the advertised identity, not the browser engine.",
           "defaultSearchEngine": "Default search engine for non-URL browser address bar queries. Use custom with customSearchEngineURLTemplate for arbitrary providers.",
           "customSearchEngineName": "Display name used when defaultSearchEngine is custom.",
           "customSearchEngineURLTemplate": "Search URL used when defaultSearchEngine is custom. Include the query placeholder or %s for the encoded query. If omitted, cmux appends q= to the URL.",

--- a/web/messages/ja.json
+++ b/web/messages/ja.json
@@ -1774,6 +1774,7 @@
           "textBoxSubmitActionBackgroundColorHex": "アクション色のメタデータを RGB または RGBA の 16 進数で指定します。送信ボタンの塗りは白のままで、有効状態と無効状態では不透明度だけが変わります。"
         },
         "browser": {
+          "userAgent": "トップレベルの HTTP(S) ブラウザナビゲーションで使うカスタム User-Agent 文字列です。空欄の場合は cmux の自動 WebKit/Safari ID を使います。変更されるのは通知される ID だけで、ブラウザエンジンは変わりません。",
           "defaultSearchEngine": "ブラウザのアドレスバーでURLではない入力に使う既定の検索エンジンです。任意のプロバイダには custom と customSearchEngineURLTemplate を使います。",
           "customSearchEngineName": "defaultSearchEngine が custom のときに使う表示名です。",
           "customSearchEngineURLTemplate": "defaultSearchEngine が custom のときに使う検索URLです。エンコード済み検索語にはクエリ用プレースホルダーまたは %s を含めます。省略すると cmux が URL に q= を追加します。",


### PR DESCRIPTION
## Summary

- add `browser.userAgent` to `cmux.json`, the schema, generated template, and settings-key documentation
- apply non-empty overrides through the shared top-level `WKWebView` identity policy, including redirects, popups, prewarmed views, history, and Google Sheets
- preserve the destination-aware automatic policy when the value is empty or absent; this changes the advertised identity only and keeps WebKit as the browser engine

Fixes #7513

## Testing

- Regression (red): [hosted run 30887950947](https://github.com/manaflow-ai/cmux/actions/runs/30887950947) on test-only commit `b2d78c40a5` executed seven `BrowserUserAgentPolicyWebKitTests`; the new Duo path failed because `cmux.json` did not import the override and WebKit advertised Safari 26.6.
- Fix (green): [hosted run 30887865875](https://github.com/manaflow-ai/cmux/actions/runs/30887865875) on `565692e072` executed the same seven tests and passed.
- Current HEAD: [hosted run 30901172698](https://github.com/manaflow-ai/cmux/actions/runs/30901172698) checked out `df11029bb3`, executed all seven `BrowserUserAgentPolicyWebKitTests`, and passed.
- Dev build: `./scripts/reload-cloud.sh --builder fleet --slot cmuxs-mac-mini-2.1 --tag sym7513` succeeded through the mac fleet and downloaded run `sym7513-eb5a022a4a4d` for `df11029bb`.
- Dev-build socket: against `/tmp/cmux-debug-sym7513.sock`, automatic mode advertised Safari 26.6 in both `navigator.userAgent` and the received HTTP request header; setting `browser.userAgent` to `CmuxIssue7513/1.0` changed both values exactly, and unsetting it restored Safari 26.6. Browser errors remained empty, the original config was restored byte-for-byte, and the tagged app was quit.
- Localization audit: parsed the schema and both message catalogs, confirmed `docs.configuration.schemaDescriptions.browser.userAgent` exists in English and Japanese, checked the changed Swift files for new bare user-facing strings, and confirmed the settings helper lists `browser.userAgent`.

## Needs human verification

Completing a live corporate Cisco Duo flow with the tenant account and hardware key or push remains unverified. Follow `verification.html`; the fix is disproved if Duo still rejects the configured identity or the factor cannot complete inside the browser pane.
