### PR TITLE
Route all surface shortcuts through focused Dock

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -268,6 +268,9 @@ jobs:
       - name: Validate sidebar lazy-layout guard
         run: python3 tests/test_ci_sidebar_lazy_layout_guard.py
 
+      - name: Validate focused Dock shortcut routing guard
+        run: python3 tests/test_dock_shortcut_routing_guard.py
+
       - name: Validate bash prompt bootstrap composes with user PROMPT_COMMAND (starship)
         run: python3 tests/test_issue_5164_starship_prompt_composition.py
 

--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -16465,6 +16465,12 @@
             "value": "キャンセル"
           }
         },
+        "km": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "បោះបង់"
+          }
+        },
         "ko": {
           "stringUnit": {
             "state": "translated",
@@ -16505,6 +16511,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "İptal"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Скасувати"
           }
         },
         "zh-Hans": {
@@ -18434,6 +18446,12 @@
             "value": "このタブのカスタム名を入力してください。"
           }
         },
+        "km": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "បញ្ចូលឈ្មោះផ្ទាល់ខ្លួនសម្រាប់ផ្ទាំងនេះ។"
+          }
+        },
         "ko": {
           "stringUnit": {
             "state": "translated",
@@ -18474,6 +18492,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Bu sekme için özel bir ad girin."
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Введіть власну назву для цієї вкладки."
           }
         },
         "zh-Hans": {
@@ -18547,6 +18571,12 @@
             "value": "タブ名"
           }
         },
+        "km": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ឈ្មោះផ្ទាំង"
+          }
+        },
         "ko": {
           "stringUnit": {
             "state": "translated",
@@ -18587,6 +18617,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Sekme adı"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Назва вкладки"
           }
         },
         "zh-Hans": {
@@ -18660,6 +18696,12 @@
             "value": "変更"
           }
         },
+        "km": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ប្តូរឈ្មោះ"
+          }
+        },
         "ko": {
           "stringUnit": {
             "state": "translated",
@@ -18700,6 +18742,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Yeniden Adlandır"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Перейменувати"
           }
         },
         "zh-Hans": {
@@ -18773,6 +18821,12 @@
             "value": "タブ名を変更"
           }
         },
+        "km": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ប្តូរឈ្មោះផ្ទាំង"
+          }
+        },
         "ko": {
           "stringUnit": {
             "state": "translated",
@@ -18813,6 +18867,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Sekmeyi Yeniden Adlandır"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Перейменувати вкладку"
           }
         },
         "zh-Hans": {

--- a/Sources/AppDelegate+AdjacentNavigationShortcut.swift
+++ b/Sources/AppDelegate+AdjacentNavigationShortcut.swift
@@ -7,22 +7,46 @@ extension AppDelegate {
         let routedTabs = preferredMainWindowContextForShortcutRouting(event: event)?.tabManager
             ?? tabManager
         if matchConfiguredShortcut(event: event, action: .nextSurface) {
-            if performFocusedDockShortcut(.selectNextSurface, event: event) { return true }
+            if performFocusedDockShortcut(
+                .selectNextSurface,
+                action: .nextSurface,
+                event: event
+            ) {
+                return true
+            }
             routedTabs?.selectNextSurface()
             return true
         }
         if matchConfiguredShortcut(event: event, action: .prevSurface) {
-            if performFocusedDockShortcut(.selectPreviousSurface, event: event) { return true }
+            if performFocusedDockShortcut(
+                .selectPreviousSurface,
+                action: .prevSurface,
+                event: event
+            ) {
+                return true
+            }
             routedTabs?.selectPreviousSurface()
             return true
         }
         if matchConfiguredShortcut(event: event, action: .moveSurfaceLeft) {
-            if performFocusedDockShortcut(.moveSurface(offset: -1), event: event) { return true }
+            if performFocusedDockShortcut(
+                .moveSurface(offset: -1),
+                action: .moveSurfaceLeft,
+                event: event
+            ) {
+                return true
+            }
             routedTabs?.selectedWorkspace?.moveSelectedSurface(by: -1)
             return true
         }
         if matchConfiguredShortcut(event: event, action: .moveSurfaceRight) {
-            if performFocusedDockShortcut(.moveSurface(offset: 1), event: event) { return true }
+            if performFocusedDockShortcut(
+                .moveSurface(offset: 1),
+                action: .moveSurfaceRight,
+                event: event
+            ) {
+                return true
+            }
             routedTabs?.selectedWorkspace?.moveSelectedSurface(by: 1)
             return true
         }
@@ -59,8 +83,17 @@ extension AppDelegate {
         preferredWindow: NSWindow?,
         allowMissingDestinationSplit: Bool = true
     ) -> Bool {
-        guard focusedDockStoreForShortcut(preferredWindow: preferredWindow) == nil else {
-            return false
+        if let dock = focusedDockStoreForShortcut(
+            action: movement.shortcutAction,
+            preferredWindow: preferredWindow
+        ) {
+            return dock.performShortcutCommand(
+                .moveSurfaceToPane(
+                    movement,
+                    allowMissingDestinationSplit:
+                        allowMissingDestinationSplit
+                )
+            )
         }
         return tabManager?.selectedWorkspace?.moveFocusedSurface(
             to: movement,

--- a/Sources/AppDelegate+DockShortcutRouting.swift
+++ b/Sources/AppDelegate+DockShortcutRouting.swift
@@ -8,6 +8,110 @@ enum GhosttyGotoSplitRoute {
     case next
 }
 
+extension KeyboardShortcutSettings.Action {
+    var dockShortcutRoutingDisposition:
+        DockShortcutRoutingDisposition {
+        switch self {
+        case .triggerFlash,
+             .nextSurface, .prevSurface,
+             .moveSurfaceLeft, .moveSurfaceRight,
+             .moveSurfaceToPreviousPane, .moveSurfaceToNextPane,
+             .moveSurfaceToPaneLeft, .moveSurfaceToPaneRight,
+             .moveSurfaceToPaneUp, .moveSurfaceToPaneDown,
+             .selectSurfaceByNumber,
+             .focusHistoryBack, .focusHistoryForward,
+             .renameTab,
+             .closeTab, .closeOtherTabsInPane,
+             .reopenClosedBrowserPanel,
+             .newSurface,
+             .toggleTerminalCopyMode,
+             .focusTextBoxInput, .attachTextBoxFile,
+             .sendCtrlFToTerminal,
+             .clearScreenKeepScrollback,
+             .focusLeft, .focusRight, .focusUp, .focusDown,
+             .focusPreviousPane, .focusNextPane,
+             .splitRight, .splitDown, .toggleSplitZoom,
+             .equalizeSplits,
+             .splitBrowserRight, .splitBrowserDown,
+             .openBrowser, .focusBrowserAddressBar,
+             .find, .findNext, .findPrevious, .hideFind,
+             .useSelectionForFind,
+             .toggleReactGrab:
+            .dockScoped
+
+        case .commandPaletteNext, .commandPalettePrevious,
+             .toggleChecklistItemComplete,
+             .cycleTextBoxSubmitAction,
+             .fileExplorerOpenSelection,
+             .fileExplorerOpenSelectionFinderAlias,
+             .saveFilePreview,
+             .browserBack, .browserForward,
+             .browserReload, .browserHardReload,
+             .browserZoomIn, .browserZoomOut, .browserZoomReset,
+             .markdownZoomIn, .markdownZoomOut, .markdownZoomReset,
+             .toggleBrowserDeveloperTools,
+             .showBrowserJavaScriptConsole,
+             .toggleBrowserFocusMode,
+             .toggleBrowserDesignMode,
+             .diffViewerScrollDown, .diffViewerScrollUp,
+             .diffViewerScrollHalfPageDown,
+             .diffViewerScrollHalfPageUp,
+             .diffViewerScrollDownEmacs,
+             .diffViewerScrollUpEmacs,
+             .diffViewerScrollToBottom,
+             .diffViewerScrollToTop,
+             .diffViewerOpenFileSearch,
+             .simulatorHome, .simulatorRotateLeft,
+             .simulatorRotateRight,
+             .simulatorToggleAppearance,
+             .simulatorToggleSoftwareKeyboard,
+             .diffViewerNextFile, .diffViewerPreviousFile:
+            .focusResolved
+
+        case .openSettings, .reloadConfiguration,
+             .showHideAllWindows, .globalSearch,
+             .newWindow, .closeWindow, .toggleFullScreen, .quit,
+             .toggleSidebar, .newTab, .newBrowserWorkspace,
+             .saveLayoutTemplate, .openFolder,
+             .reopenPreviousSession, .goToWorkspace,
+             .commandPalette, .sendFeedback,
+             .showNotifications, .jumpToUnread, .toggleUnread,
+             .markOldestUnreadAndJumpNext,
+             .focusRightSidebar,
+             .switchRightSidebarToFiles,
+             .switchRightSidebarToFind,
+             .switchRightSidebarToSessions,
+             .switchRightSidebarToFeed,
+             .switchRightSidebarToDock,
+             .nextSidebarTab, .prevSidebarTab,
+             .moveWorkspaceUp, .moveWorkspaceDown,
+             .selectWorkspaceByNumber,
+             .renameWorkspace, .editWorkspaceDescription,
+             .markWorkspaceDone, .cycleWorkspaceStatus,
+             .closeWorkspace,
+             .newWorkspaceGroup, .groupSelectedWorkspaces,
+             .toggleFocusedWorkspaceGroupCollapsed,
+             .reopenClosedWorkspace,
+             .increaseWorkspaceTerminalFontSize,
+             .decreaseWorkspaceTerminalFontSize,
+             .resetWorkspaceTerminalFontSize,
+             .toggleCanvasLayout,
+             .canvasRevealFocusedPane, .canvasOverview,
+             .canvasZoomIn, .canvasZoomOut, .canvasZoomReset,
+             .canvasTidy,
+             .canvasAlignLeft, .canvasAlignRight,
+             .canvasAlignTop, .canvasAlignBottom,
+             .canvasEqualizeWidths, .canvasEqualizeHeights,
+             .canvasDistributeHorizontally,
+             .canvasDistributeVertically,
+             .toggleRightSidebar,
+             .findInDirectory,
+             .openDiffViewer:
+            .mainContainer
+        }
+    }
+}
+
 /// Routes "create a surface" keyboard shortcuts (New Browser, New Terminal,
 /// Split Right/Down) into the Dock when the Dock currently owns keyboard focus.
 ///
@@ -35,6 +139,23 @@ extension AppDelegate {
         return windowDock(forWindowId: context.windowId)
     }
 
+    func focusedDockStoreForShortcut(
+        action: KeyboardShortcutSettings.Action,
+        preferredWindow: NSWindow?
+    ) -> DockSplitStore? {
+        guard case .dockScoped =
+            action.dockShortcutRoutingDisposition else {
+            assertionFailure(
+                "Non-Dock-scoped shortcut requested the Dock gate: " +
+                    action.rawValue
+            )
+            return nil
+        }
+        return focusedDockStoreForShortcut(
+            preferredWindow: preferredWindow
+        )
+    }
+
     /// Creates a New Terminal / New Browser surface in the focused Dock pane.
     /// Returns the created Dock panel id when handled, or `nil` to fall through to
     /// the main-area creation path.
@@ -42,12 +163,16 @@ extension AppDelegate {
     func routeCreateToFocusedDock(
         _ kind: DockSurfaceKind,
         focusAddressBar: Bool,
+        action: KeyboardShortcutSettings.Action,
         preferredWindow: NSWindow?
     ) -> UUID? {
         if kind == .browser, !BrowserAvailabilitySettings.isEnabled() {
             return nil
         }
-        guard let store = focusedDockStoreForShortcut(preferredWindow: preferredWindow),
+        guard let store = focusedDockStoreForShortcut(
+                  action: action,
+                  preferredWindow: preferredWindow
+              ),
               let pane = store.resolvePane(requestedPaneID: nil),
               let panelId = store.newSurface(kind: kind, inPane: pane, focus: true) else {
             return nil
@@ -66,12 +191,16 @@ extension AppDelegate {
     func routeSplitToFocusedDock(
         kind: DockSurfaceKind,
         direction: SplitDirection,
+        action: KeyboardShortcutSettings.Action,
         preferredWindow: NSWindow?
     ) -> Bool {
         if kind == .browser, !BrowserAvailabilitySettings.isEnabled() {
             return false
         }
-        guard let store = focusedDockStoreForShortcut(preferredWindow: preferredWindow) else {
+        guard let store = focusedDockStoreForShortcut(
+            action: action,
+            preferredWindow: preferredWindow
+        ) else {
             return false
         }
         return store.newSplit(
@@ -87,8 +216,15 @@ extension AppDelegate {
     /// focus. Callers invoke this from the command's existing dispatcher
     /// position so configured and compatibility shortcuts keep the same
     /// conflict precedence as the main area.
-    func performFocusedDockShortcut(_ command: DockShortcutCommand, event: NSEvent) -> Bool {
-        guard let store = focusedDockStoreForShortcut(preferredWindow: event.window) else {
+    func performFocusedDockShortcut(
+        _ command: DockShortcutCommand,
+        action: KeyboardShortcutSettings.Action,
+        event: NSEvent
+    ) -> Bool {
+        guard let store = focusedDockStoreForShortcut(
+            action: action,
+            preferredWindow: event.window
+        ) else {
             return false
         }
         if command.isFocusHistoryNavigation, !store.focusHistoryIncludesPanesAndTabs {

--- a/Sources/AppDelegate+WindowDock.swift
+++ b/Sources/AppDelegate+WindowDock.swift
@@ -175,7 +175,11 @@ extension AppDelegate {
     @discardableResult
     func closeWindowDockRuntimeSurface(surfaceId: UUID, force: Bool) -> Bool {
         guard let dock = windowDockContainingPanel(surfaceId) else { return false }
-        if dock.closePanel(surfaceId, force: force) {
+        if dock.closePanel(
+            surfaceId,
+            force: force,
+            recordsHistory: false
+        ) {
             notificationStore?.clearNotifications(forTabId: dock.workspaceId, surfaceId: surfaceId)
         }
         return true

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -13662,6 +13662,13 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         if cmuxCloseFocusedTerminalFindForEscape(event: event, appDelegate: self) { return true }
         if handleSimulatorShortcutRouting(event) { return true }
         if matchConfiguredShortcut(event: event, action: .find) {
+            if performFocusedDockShortcut(
+                .startFind,
+                action: .find,
+                event: event
+            ) {
+                return true
+            }
             let shortcutWindow = resolvedShortcutEventWindow(event)
             cmuxRememberFindSelectionBeforePanelFocusMove(tabManager: tabManager, window: shortcutWindow ?? shortcutRoutingKeyWindow); return performFindShortcutInActiveMainWindow(preferredWindow: shortcutWindow)
         }
@@ -13948,7 +13955,13 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
 
         // Flash the currently focused panel so the user can visually confirm focus.
         if matchConfiguredShortcut(event: event, action: .triggerFlash) {
-            if performFocusedDockShortcut(.triggerFlash, event: event) { return true }
+            if performFocusedDockShortcut(
+                .triggerFlash,
+                action: .triggerFlash,
+                event: event
+            ) {
+                return true
+            }
             let targetManager = preferredMainWindowContextForShortcutRouting(event: event)?.tabManager ?? tabManager
             targetManager?.triggerFocusFlash()
             return true
@@ -13957,6 +13970,13 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         if handleAdjacentNavigationShortcut(event: event) { return true }
 
         if matchConfiguredShortcut(event: event, action: .toggleTerminalCopyMode) {
+            if performFocusedDockShortcut(
+                .toggleTerminalCopyMode,
+                action: .toggleTerminalCopyMode,
+                event: event
+            ) {
+                return true
+            }
             let handled = tabManager?.toggleFocusedTerminalCopyMode() ?? false
 #if DEBUG
             cmuxDebugLog(
@@ -13970,18 +13990,39 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         }
 
         if matchConfiguredShortcut(event: event, action: .focusTextBoxInput) {
+            if performFocusedDockShortcut(
+                .focusTextBoxInput,
+                action: .focusTextBoxInput,
+                event: event
+            ) {
+                return true
+            }
             let routedManager = preferredMainWindowContextForShortcutRouting(event: event)?.tabManager ?? tabManager
             let handled = routedManager?.focusFocusedTerminalTextBoxInputOrTerminal() ?? false
             return handled
         }
 
         if matchConfiguredShortcut(event: event, action: .attachTextBoxFile) {
+            if performFocusedDockShortcut(
+                .attachTextBoxFile,
+                action: .attachTextBoxFile,
+                event: event
+            ) {
+                return true
+            }
             let routedManager = preferredMainWindowContextForShortcutRouting(event: event)?.tabManager ?? tabManager
             let handled = routedManager?.attachFileToFocusedTerminalTextBoxInput() ?? false
             return handled
         }
 
         if matchConfiguredShortcut(event: event, action: .sendCtrlFToTerminal) {
+            if performFocusedDockShortcut(
+                .sendCtrlFToTerminal,
+                action: .sendCtrlFToTerminal,
+                event: event
+            ) {
+                return true
+            }
             let routedManager = preferredMainWindowContextForShortcutRouting(event: event)?.tabManager ?? tabManager
             let handled = routedManager?.sendCtrlFToFocusedTerminal() ?? false
 #if DEBUG
@@ -13995,6 +14036,13 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         }
 
         if matchConfiguredShortcut(event: event, action: .clearScreenKeepScrollback) {
+            if performFocusedDockShortcut(
+                .clearScreenKeepScrollback,
+                action: .clearScreenKeepScrollback,
+                event: event
+            ) {
+                return true
+            }
             let routedManager = preferredMainWindowContextForShortcutRouting(event: event)?.tabManager ?? tabManager
             let handled = routedManager?.clearFocusedTerminalKeepingScrollback() ?? false
 #if DEBUG
@@ -14089,6 +14137,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
             if let targetWindow = event.window ?? shortcutRoutingActiveWindow,
                targetWindow.identifier?.rawValue == "cmux.settings" {
                 targetWindow.performClose(nil)
+            } else if performFocusedDockShortcut(
+                .closeOtherTabsInPane,
+                action: .closeOtherTabsInPane,
+                event: event
+            ) {
+                return true
             } else {
                 let targetWindow = event.window ?? shortcutRoutingActiveWindow
                 if let terminalContext = focusedTerminalShortcutContext(preferredWindow: targetWindow) {
@@ -14156,6 +14210,16 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         }
 
         if matchConfiguredShortcut(event: event, action: .renameTab) {
+            if performFocusedDockShortcut(
+                .renameSurface(
+                    presentingWindow:
+                        event.window ?? shortcutRoutingActiveWindow
+                ),
+                action: .renameTab,
+                event: event
+            ) {
+                return true
+            }
             let targetWindow = commandPaletteTargetWindow ?? event.window ?? shortcutRoutingActiveWindow
             requestCommandPaletteRenameTab(preferredWindow: targetWindow, source: "shortcut.renameTab")
             return true
@@ -14179,7 +14243,13 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         // Numeric shortcuts for surfaces: focused pane in split layout,
         // workspace Canvas order in Canvas layout (9 = last).
         if let digit = routableNumberedConfiguredShortcutDigit(event: event, action: .selectSurfaceByNumber) {
-            if performFocusedDockShortcut(.selectSurface(number: digit), event: event) { return true }
+            if performFocusedDockShortcut(
+                .selectSurface(number: digit),
+                action: .selectSurfaceByNumber,
+                event: event
+            ) {
+                return true
+            }
             let manager = tabManagerForNumberedShortcut(event: event)
             if digit == 9 {
                 manager?.selectLastSurface()
@@ -14196,7 +14266,13 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
             arrowGlyph: "←",
             arrowKeyCode: 123
         ) || matchesGhosttyGotoSplitFallback(event: event, route: .direction(.left)) {
-            if performFocusedDockShortcut(.focusPane(.left), event: event) { return true }
+            if performFocusedDockShortcut(
+                .focusPane(.left),
+                action: .focusLeft,
+                event: event
+            ) {
+                return true
+            }
             let routedTabs = preferredMainWindowContextForShortcutRouting(event: event)?.tabManager ?? tabManager
             cmuxRememberFindSelectionBeforePanelFocusMove(tabManager: routedTabs, window: shortcutRoutingKeyWindow)
             routedTabs?.movePaneFocus(direction: .left)
@@ -14211,7 +14287,13 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
             arrowGlyph: "→",
             arrowKeyCode: 124
         ) || matchesGhosttyGotoSplitFallback(event: event, route: .direction(.right)) {
-            if performFocusedDockShortcut(.focusPane(.right), event: event) { return true }
+            if performFocusedDockShortcut(
+                .focusPane(.right),
+                action: .focusRight,
+                event: event
+            ) {
+                return true
+            }
             let routedTabs = preferredMainWindowContextForShortcutRouting(event: event)?.tabManager ?? tabManager
             cmuxRememberFindSelectionBeforePanelFocusMove(tabManager: routedTabs, window: shortcutRoutingKeyWindow)
             routedTabs?.movePaneFocus(direction: .right)
@@ -14226,7 +14308,13 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
             arrowGlyph: "↑",
             arrowKeyCode: 126
         ) || matchesGhosttyGotoSplitFallback(event: event, route: .direction(.up)) {
-            if performFocusedDockShortcut(.focusPane(.up), event: event) { return true }
+            if performFocusedDockShortcut(
+                .focusPane(.up),
+                action: .focusUp,
+                event: event
+            ) {
+                return true
+            }
             let routedTabs = preferredMainWindowContextForShortcutRouting(event: event)?.tabManager ?? tabManager
             cmuxRememberFindSelectionBeforePanelFocusMove(tabManager: routedTabs, window: shortcutRoutingKeyWindow)
             routedTabs?.movePaneFocus(direction: .up)
@@ -14241,7 +14329,13 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
             arrowGlyph: "↓",
             arrowKeyCode: 125
         ) || matchesGhosttyGotoSplitFallback(event: event, route: .direction(.down)) {
-            if performFocusedDockShortcut(.focusPane(.down), event: event) { return true }
+            if performFocusedDockShortcut(
+                .focusPane(.down),
+                action: .focusDown,
+                event: event
+            ) {
+                return true
+            }
             let routedTabs = preferredMainWindowContextForShortcutRouting(event: event)?.tabManager ?? tabManager
             cmuxRememberFindSelectionBeforePanelFocusMove(tabManager: routedTabs, window: shortcutRoutingKeyWindow)
             routedTabs?.movePaneFocus(direction: .down)
@@ -14259,6 +14353,13 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         // Focus Back/Forward keeps ⌘[ / ⌘] on global focus history.
         if matchConfiguredShortcut(event: event, action: .focusPreviousPane) ||
             matchesGhosttyGotoSplitFallback(event: event, route: .previous) {
+            if performFocusedDockShortcut(
+                .cyclePaneFocus(forward: false),
+                action: .focusPreviousPane,
+                event: event
+            ) {
+                return true
+            }
             let routedTabs = preferredMainWindowContextForShortcutRouting(event: event)?.tabManager ?? tabManager
             cmuxRememberFindSelectionBeforePanelFocusMove(tabManager: routedTabs, window: shortcutRoutingKeyWindow)
             let moved = routedTabs?.cyclePaneFocus(forward: false) ?? false
@@ -14276,6 +14377,13 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
 
         if matchConfiguredShortcut(event: event, action: .focusNextPane) ||
             matchesGhosttyGotoSplitFallback(event: event, route: .next) {
+            if performFocusedDockShortcut(
+                .cyclePaneFocus(forward: true),
+                action: .focusNextPane,
+                event: event
+            ) {
+                return true
+            }
             let routedTabs = preferredMainWindowContextForShortcutRouting(event: event)?.tabManager ?? tabManager
             cmuxRememberFindSelectionBeforePanelFocusMove(tabManager: routedTabs, window: shortcutRoutingKeyWindow)
             let moved = routedTabs?.cyclePaneFocus(forward: true) ?? false
@@ -14292,7 +14400,13 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         }
 
         if matchConfiguredShortcut(event: event, action: .toggleSplitZoom) {
-            if performFocusedDockShortcut(.togglePaneZoom, event: event) { return true }
+            if performFocusedDockShortcut(
+                .togglePaneZoom,
+                action: .toggleSplitZoom,
+                event: event
+            ) {
+                return true
+            }
             let routedManager = preferredMainWindowContextForShortcutRouting(event: event)?.tabManager ?? tabManager
             performToggleSplitZoomShortcut(tabManager: routedManager)
 #if DEBUG
@@ -14352,6 +14466,13 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
             return true
         }
         if equalizeSplitsMatches && !matchingExplicitActionShouldPreemptEqualizeDefault {
+            if performFocusedDockShortcut(
+                .equalizeSplits,
+                action: .equalizeSplits,
+                event: event
+            ) {
+                return true
+            }
             performEqualizeSplitsShortcut()
             return true
         }
@@ -14375,7 +14496,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
             // When the Dock owns keyboard focus, split the focused Dock pane
             // instead of the main area (checked before the transient-focus
             // suppression, which only guards main-terminal states).
-            if routeSplitToFocusedDock(kind: .terminal, direction: .right, preferredWindow: event.window) {
+            if routeSplitToFocusedDock(
+                kind: .terminal,
+                direction: .right,
+                action: .splitRight,
+                preferredWindow: event.window
+            ) {
                 return true
             }
             if shouldSuppressSplitShortcutForTransientTerminalFocusState(direction: .right) {
@@ -14392,7 +14518,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
 #if DEBUG
             cmuxDebugLog("shortcut.action name=splitDown \(debugShortcutRouteSnapshot(event: event))")
 #endif
-            if routeSplitToFocusedDock(kind: .terminal, direction: .down, preferredWindow: event.window) {
+            if routeSplitToFocusedDock(
+                kind: .terminal,
+                direction: .down,
+                action: .splitDown,
+                preferredWindow: event.window
+            ) {
                 return true
             }
             if shouldSuppressSplitShortcutForTransientTerminalFocusState(direction: .down) {
@@ -14409,7 +14540,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
 #if DEBUG
             cmuxDebugLog("shortcut.action name=splitBrowserRight \(debugShortcutRouteSnapshot(event: event))")
 #endif
-            if routeSplitToFocusedDock(kind: .browser, direction: .right, preferredWindow: event.window) {
+            if routeSplitToFocusedDock(
+                kind: .browser,
+                direction: .right,
+                action: .splitBrowserRight,
+                preferredWindow: event.window
+            ) {
                 return true
             }
             _ = performBrowserSplitShortcut(direction: .right)
@@ -14420,28 +14556,52 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
 #if DEBUG
             cmuxDebugLog("shortcut.action name=splitBrowserDown \(debugShortcutRouteSnapshot(event: event))")
 #endif
-            if routeSplitToFocusedDock(kind: .browser, direction: .down, preferredWindow: event.window) {
+            if routeSplitToFocusedDock(
+                kind: .browser,
+                direction: .down,
+                action: .splitBrowserDown,
+                preferredWindow: event.window
+            ) {
                 return true
             }
             _ = performBrowserSplitShortcut(direction: .down)
             return true
         }
 
-        // Surface navigation (legacy Ctrl+Tab support)
+        // Legacy Ctrl+Tab has no configurable action of its own. It
+        // intentionally reuses nextSurface/prevSurface for Dock ownership so
+        // both strokes follow the same routing classification.
         if matchesLegacyNextSurfaceShortcut(event: event) {
-            if performFocusedDockShortcut(.selectNextSurface, event: event) { return true }
+            if performFocusedDockShortcut(
+                .selectNextSurface,
+                action: .nextSurface,
+                event: event
+            ) {
+                return true
+            }
             (preferredMainWindowContextForShortcutRouting(event: event)?.tabManager ?? tabManager)?.selectNextSurface()
             return true
         }
         if matchesLegacyPreviousSurfaceShortcut(event: event) {
-            if performFocusedDockShortcut(.selectPreviousSurface, event: event) { return true }
+            if performFocusedDockShortcut(
+                .selectPreviousSurface,
+                action: .prevSurface,
+                event: event
+            ) {
+                return true
+            }
             (preferredMainWindowContextForShortcutRouting(event: event)?.tabManager ?? tabManager)?.selectPreviousSurface()
             return true
         }
 
         // New surface: Cmd+T
         if matchConfiguredShortcut(event: event, action: .newSurface) {
-            if routeCreateToFocusedDock(.terminal, focusAddressBar: false, preferredWindow: event.window) != nil {
+            if routeCreateToFocusedDock(
+                .terminal,
+                focusAddressBar: false,
+                action: .newSurface,
+                preferredWindow: event.window
+            ) != nil {
                 return true
             }
             tabManager?.newSurface()
@@ -14450,7 +14610,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
 
         // Open browser: Cmd+Shift+L
         if matchConfiguredShortcut(event: event, action: .openBrowser) {
-            if routeCreateToFocusedDock(.browser, focusAddressBar: true, preferredWindow: event.window) != nil {
+            if routeCreateToFocusedDock(
+                .browser,
+                focusAddressBar: true,
+                action: .openBrowser,
+                preferredWindow: event.window
+            ) != nil {
                 return true
             }
             _ = openBrowserAndFocusAddressBar(insertAtEnd: true)
@@ -14458,6 +14623,17 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         }
 
         if matchConfiguredShortcut(event: event, action: .focusBrowserAddressBar) {
+            if let dock = focusedDockStoreForShortcut(
+                action: .focusBrowserAddressBar,
+                preferredWindow: event.window
+            ),
+            let focusedPanelId = dock.focusedPanelId,
+            let focusedBrowser = dock.browserPanel(
+                for: focusedPanelId
+            ) {
+                focusBrowserAddressBar(in: focusedBrowser)
+                return true
+            }
             if let focusedPanel = tabManager?.focusedBrowserPanel {
                 focusBrowserAddressBar(in: focusedPanel)
                 return true
@@ -14474,7 +14650,13 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         }
 
         if matchConfiguredShortcut(event: event, action: .focusHistoryBack) {
-            if performFocusedDockShortcut(.focusHistoryBack, event: event) { return true }
+            if performFocusedDockShortcut(
+                .focusHistoryBack,
+                action: .focusHistoryBack,
+                event: event
+            ) {
+                return true
+            }
             let routedManager = preferredMainWindowContextForShortcutRouting(event: event)?.tabManager ?? tabManager
             if routedManager?.navigateBack() != true {
                 NSSound.beep()
@@ -14483,7 +14665,13 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         }
 
         if matchConfiguredShortcut(event: event, action: .focusHistoryForward) {
-            if performFocusedDockShortcut(.focusHistoryForward, event: event) { return true }
+            if performFocusedDockShortcut(
+                .focusHistoryForward,
+                action: .focusHistoryForward,
+                event: event
+            ) {
+                return true
+            }
             let routedManager = preferredMainWindowContextForShortcutRouting(event: event)?.tabManager ?? tabManager
             if routedManager?.navigateForward() != true {
                 NSSound.beep()
@@ -14569,6 +14757,13 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         }
 
         if matchConfiguredShortcut(event: event, action: .toggleReactGrab) {
+            if performFocusedDockShortcut(
+                .toggleReactGrab,
+                action: .toggleReactGrab,
+                event: event
+            ) {
+                return true
+            }
             let didHandle = tabManager?.toggleReactGrabFromCurrentFocus() ?? false
             if !didHandle { NSSound.beep() }
             return true
@@ -14600,6 +14795,13 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
             guard !shouldLetFocusedBrowserOwnFindShortcut(event) else {
                 return false
             }
+            if performFocusedDockShortcut(
+                .findNext,
+                action: .findNext,
+                event: event
+            ) {
+                return true
+            }
             restoreFocusedMainPanelFocusForShortcut(event: event)
             tabManager?.findNext()
             return true
@@ -14608,6 +14810,13 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         if matchConfiguredShortcut(event: event, action: .findPrevious) {
             guard !shouldLetFocusedBrowserOwnFindShortcut(event) else {
                 return false
+            }
+            if performFocusedDockShortcut(
+                .findPrevious,
+                action: .findPrevious,
+                event: event
+            ) {
+                return true
             }
             restoreFocusedMainPanelFocusForShortcut(event: event)
             tabManager?.findPrevious()
@@ -14618,12 +14827,26 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
             guard !shouldLetFocusedBrowserOwnFindShortcut(event) else {
                 return false
             }
+            if performFocusedDockShortcut(
+                .hideFind,
+                action: .hideFind,
+                event: event
+            ) {
+                return true
+            }
             restoreFocusedMainPanelFocusForShortcut(event: event)
             tabManager?.hideFind()
             return true
         }
 
         if matchConfiguredShortcut(event: event, action: .useSelectionForFind) {
+            if performFocusedDockShortcut(
+                .useSelectionForFind,
+                action: .useSelectionForFind,
+                event: event
+            ) {
+                return true
+            }
             restoreFocusedMainPanelFocusForShortcut(event: event)
             tabManager?.searchSelection()
             return true
@@ -14643,6 +14866,13 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         }
 
         if matchConfiguredShortcut(event: event, action: .reopenClosedBrowserPanel) {
+            if performFocusedDockShortcut(
+                .reopenClosedPanel,
+                action: .reopenClosedBrowserPanel,
+                event: event
+            ) {
+                return true
+            }
             let routedManager = preferredMainWindowContextForShortcutRouting(event: event)?.tabManager ?? tabManager
             _ = reopenMostRecentlyClosedItem(preferredTabManager: routedManager)
             return true
@@ -15378,6 +15608,13 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
     @discardableResult
     func handleBrowserSurfaceKeyEquivalentBeforeMainMenu(_ event: NSEvent) -> Bool {
         if matchConfiguredShortcut(event: event, action: .find) {
+            if performFocusedDockShortcut(
+                .startFind,
+                action: .find,
+                event: event
+            ) {
+                return true
+            }
             let shortcutWindow = resolvedShortcutEventWindow(event)
             cmuxRememberFindSelectionBeforePanelFocusMove(tabManager: tabManager, window: shortcutWindow ?? shortcutRoutingKeyWindow); return performFindShortcutInActiveMainWindow(preferredWindow: shortcutWindow)
         }

--- a/Sources/ClosedItemHistory.swift
+++ b/Sources/ClosedItemHistory.swift
@@ -22,6 +22,13 @@ struct ClosedPanelHistoryEntry: Codable {
     let tabIndex: Int
     let snapshot: SessionPanelSnapshot
     let fallbackSplitPlacement: ClosedPanelSplitPlacement?
+    /// Live workspace that owns a transferred Dock panel's restore machinery.
+    /// Dock history is not persisted, so this identity is valid only for the
+    /// current process.
+    let sourceWorkspaceId: UUID?
+    /// Workspace identity encoded into the panel snapshot. This can differ
+    /// from `sourceWorkspaceId` after a session restore.
+    let sourceSnapshotWorkspaceId: UUID?
 
     init(
         workspaceId: UUID,
@@ -30,7 +37,9 @@ struct ClosedPanelHistoryEntry: Codable {
         restoreInOriginalPane: Bool = true,
         tabIndex: Int,
         snapshot: SessionPanelSnapshot,
-        fallbackSplitPlacement: ClosedPanelSplitPlacement? = nil
+        fallbackSplitPlacement: ClosedPanelSplitPlacement? = nil,
+        sourceWorkspaceId: UUID? = nil,
+        sourceSnapshotWorkspaceId: UUID? = nil
     ) {
         self.workspaceId = workspaceId
         self.paneId = paneId
@@ -39,6 +48,8 @@ struct ClosedPanelHistoryEntry: Codable {
         self.tabIndex = tabIndex
         self.snapshot = snapshot
         self.fallbackSplitPlacement = fallbackSplitPlacement
+        self.sourceWorkspaceId = sourceWorkspaceId
+        self.sourceSnapshotWorkspaceId = sourceSnapshotWorkspaceId
     }
 }
 
@@ -492,7 +503,10 @@ final class ClosedItemHistoryStore: ObservableObject {
                 restoreInOriginalPane: false,
                 tabIndex: panelEntry.tabIndex,
                 snapshot: panelEntry.snapshot,
-                fallbackSplitPlacement: fallbackSplitPlacement
+                fallbackSplitPlacement: fallbackSplitPlacement,
+                sourceWorkspaceId: panelEntry.sourceWorkspaceId,
+                sourceSnapshotWorkspaceId:
+                    panelEntry.sourceSnapshotWorkspaceId
             )))
         }
         return (remappedRecords, didUpdate)
@@ -530,7 +544,10 @@ final class ClosedItemHistoryStore: ObservableObject {
                 restoreInOriginalPane: panelEntry.restoreInOriginalPane,
                 tabIndex: panelEntry.tabIndex,
                 snapshot: panelEntry.snapshot,
-                fallbackSplitPlacement: fallbackSplitPlacement
+                fallbackSplitPlacement: fallbackSplitPlacement,
+                sourceWorkspaceId: panelEntry.sourceWorkspaceId,
+                sourceSnapshotWorkspaceId:
+                    panelEntry.sourceSnapshotWorkspaceId
             )))
         }
         return (remappedRecords, didUpdate)

--- a/Sources/DockShortcutRoutingDisposition.swift
+++ b/Sources/DockShortcutRoutingDisposition.swift
@@ -1,0 +1,14 @@
+/// Every configurable shortcut must make an explicit Dock-routing decision.
+/// The exhaustive switch intentionally has no `default`: adding a new action
+/// fails compilation until its ownership is classified.
+enum DockShortcutRoutingDisposition {
+    /// The action mutates or navigates a surface tree and must check the
+    /// focused Dock before using the main TabManager.
+    case dockScoped
+    /// The action already resolves its target from the event's first
+    /// responder or focused panel, which includes Dock-owned panels.
+    case focusResolved
+    /// The action intentionally targets app, window, workspace, sidebar, or
+    /// Canvas state rather than either surface tree.
+    case mainContainer
+}

--- a/Sources/DockSplitStore+CloseConfirmation.swift
+++ b/Sources/DockSplitStore+CloseConfirmation.swift
@@ -36,18 +36,37 @@ extension DockSplitStore {
         }
 
         let tabCloseButtonClose = tabCloseButtonCloseDockTabIds.remove(tab.id) != nil
+        if tabCloseButtonClose,
+           let panelId = surfaceIdToPanelId[tab.id] {
+            markDockCloseHistoryEligible(panelId: panelId)
+        }
         let closeSource: CloseTabCloseSource = tabCloseButtonClose ? .tabCloseButton : .shortcut
-        guard let panel = panel(for: tab.id) else { return true }
-        guard CloseTabWarningStore(defaults: .standard).shouldConfirmClose(
+        guard let panel = panel(for: tab.id) else {
+            discardDockClosedPanelHistory(tabId: tab.id)
+            return true
+        }
+        let confirmationManager = dockCloseConfirmationManager()
+        let closeWarningStore = CloseTabWarningStore(
+            defaults: confirmationManager?.closeTabWarningDefaults ?? .standard
+        )
+        guard closeWarningStore.shouldConfirmClose(
             requiresConfirmation: dockPanelNeedsConfirmClose(panel),
             source: closeSource
         ) else {
+            if closeHistoryEligibleDockTabIds.contains(tab.id) {
+                stageDockClosedPanelHistory(
+                    tabIds: Set([tab.id]),
+                    inPane: pane
+                )
+            }
             return true
         }
         guard !pendingCloseConfirmDockTabIds.contains(tab.id) else { return false }
 
-        let confirmationManager = dockCloseConfirmationManager()
-        if confirmationManager?.isCloseConfirmationInFlight == true { return false }
+        if confirmationManager?.isCloseConfirmationInFlight == true {
+            discardDockClosedPanelHistory(tabId: tab.id)
+            return false
+        }
 
         pendingCloseConfirmDockTabIds.insert(tab.id)
         let tabId = tab.id
@@ -58,37 +77,70 @@ extension DockSplitStore {
             defer {
                 self.pendingCloseConfirmDockTabIds.remove(tabId)
             }
-            guard let panel = self.panel(for: tabId) else { return }
-            guard self.confirmCloseDockPanel(panel, confirmationManager: confirmationManager) else { return }
+            guard let panel = self.panel(for: tabId) else {
+                self.discardDockClosedPanelHistory(tabId: tabId)
+                return
+            }
+            guard self.confirmCloseDockPanel(
+                panel,
+                confirmationManager: confirmationManager
+            ) else {
+                self.discardDockClosedPanelHistory(tabId: tabId)
+                return
+            }
 
+            if self.closeHistoryEligibleDockTabIds.contains(tabId) {
+                self.stageDockClosedPanelHistory(
+                    tabIds: Set([tabId]),
+                    inPane: pane
+                )
+            }
             self.forceCloseDockTabIds.insert(tabId)
             let closed = self.bonsplitController.closeTab(tabId)
             if !closed {
                 self.forceCloseDockTabIds.remove(tabId)
+                self.discardDockClosedPanelHistory(tabId: tabId)
             }
         }
         return false
     }
 
     func splitTabBar(_ controller: BonsplitController, shouldClosePane pane: PaneID) -> Bool {
+        let tabs = controller.tabs(inPane: pane)
+        let userCloseTabIds = Set(
+            tabs.lazy
+                .filter { !self.forceCloseDockTabIds.contains($0.id) }
+                .map(\.id)
+        )
+        guard !userCloseTabIds.isEmpty else { return true }
+
+        let confirmationManager = dockCloseConfirmationManager()
+        let closeWarningStore = CloseTabWarningStore(
+            defaults: confirmationManager?.closeTabWarningDefaults ?? .standard
+        )
         var paneTitles: [String] = []
         var confirmableTabIds = Set<TabID>()
-        for tab in controller.tabs(inPane: pane) {
+        for tab in tabs {
             let panel = panel(for: tab.id)
             paneTitles.append(CloseOtherTabsConfirmationPrompt.displayTitle(panel?.displayTitle ?? tab.title))
-            guard !forceCloseDockTabIds.contains(tab.id), let panel else { continue }
-            if CloseTabWarningStore(defaults: .standard).shouldConfirmClose(
+            guard userCloseTabIds.contains(tab.id), let panel else { continue }
+            if closeWarningStore.shouldConfirmClose(
                 requiresConfirmation: dockPanelNeedsConfirmClose(panel),
                 source: .shortcut
             ) {
                 confirmableTabIds.insert(tab.id)
             }
         }
-        guard !confirmableTabIds.isEmpty else { return true }
+        guard !confirmableTabIds.isEmpty else {
+            stageDockClosedPaneHistory(
+                pane,
+                tabIds: userCloseTabIds
+            )
+            return true
+        }
 
         guard pendingCloseConfirmDockTabIds.isDisjoint(with: confirmableTabIds) else { return false }
 
-        let confirmationManager = dockCloseConfirmationManager()
         if confirmationManager?.isCloseConfirmationInFlight == true { return false }
 
         pendingCloseConfirmDockTabIds.formUnion(confirmableTabIds)
@@ -96,11 +148,32 @@ extension DockSplitStore {
         Task { @MainActor [weak self] in
             guard let self else { return }
             defer { self.pendingCloseConfirmDockTabIds.subtract(confirmableTabIds) }
-            guard self.confirmCloseDockPane(prompt, confirmationManager: confirmationManager) else { return }
+            guard self.confirmCloseDockPane(
+                prompt,
+                confirmationManager: confirmationManager
+            ) else {
+                self.discardDockClosedPaneHistory(pane)
+                return
+            }
 
-            self.forceCloseDockTabIds.formUnion(confirmableTabIds)
-            defer { self.forceCloseDockTabIds.subtract(confirmableTabIds) }
-            _ = self.bonsplitController.closePane(pane)
+            let acceptedTabIds = Set(
+                self.bonsplitController.tabs(inPane: pane).lazy
+                    .filter {
+                        !self.forceCloseDockTabIds.contains($0.id)
+                    }
+                    .map(\.id)
+            )
+            self.stageDockClosedPaneHistory(
+                pane,
+                tabIds: acceptedTabIds
+            )
+            self.forceCloseDockTabIds.formUnion(acceptedTabIds)
+            defer {
+                self.forceCloseDockTabIds.subtract(acceptedTabIds)
+            }
+            if !self.bonsplitController.closePane(pane) {
+                self.discardDockClosedPaneHistory(pane)
+            }
         }
         return false
     }
@@ -109,10 +182,12 @@ extension DockSplitStore {
         forceCloseDockTabIds.remove(tabId)
         pendingCloseConfirmDockTabIds.remove(tabId)
         tabCloseButtonCloseDockTabIds.remove(tabId)
+        commitDockClosedPanelHistory(tabId: tabId)
         reconcilePanels()
     }
 
     func splitTabBar(_ controller: BonsplitController, didClosePane paneId: PaneID) {
+        commitDockClosedPaneHistory(paneId)
         reconcilePanels()
     }
 
@@ -131,7 +206,7 @@ extension DockSplitStore {
     /// The manager that owns Dock close confirmation state and sheet
     /// presentation. Window Docks use a window id as `workspaceId`, so they
     /// must resolve through the Dock owner rather than `tabManagerFor(tabId:)`.
-    private func dockCloseConfirmationManager() -> TabManager? {
+    func dockCloseConfirmationManager() -> TabManager? {
         guard let app = AppDelegate.shared else { return nil }
         return app.dockReferenceTabManager(for: self)
     }

--- a/Sources/DockSplitStore+ClosedItemHistory.swift
+++ b/Sources/DockSplitStore+ClosedItemHistory.swift
@@ -1,0 +1,374 @@
+import Bonsplit
+import CmuxPanes
+import Foundation
+
+private struct DockClosedPanelFallbackPlan {
+    let orientation: SplitOrientation
+    let insertFirst: Bool
+    let anchorPanelId: UUID?
+}
+
+extension DockSplitStore {
+    /// Marks a user-requested close without snapshotting live panel state.
+    /// Snapshotting happens only after any close confirmation is accepted.
+    func markDockCloseHistoryEligible(panelId: UUID) {
+        guard let tabId = surfaceId(forPanelId: panelId) else { return }
+        closeHistoryEligibleDockTabIds.insert(tabId)
+        pendingClosedPanelHistoryEntries.removeValue(forKey: tabId)
+    }
+
+    /// Stages one close batch from a single immutable pane/tree snapshot.
+    func stageDockClosedPanelHistory(
+        tabIds: Set<TabID>,
+        inPane paneId: PaneID
+    ) {
+        let paneTabs = bonsplitController.tabs(inPane: paneId)
+        let eligibleTabs = paneTabs.filter { tabIds.contains($0.id) }
+        guard !eligibleTabs.isEmpty else { return }
+
+        let eligibleTabIds = Set(eligibleTabs.map(\.id))
+        closeHistoryEligibleDockTabIds.formUnion(eligibleTabIds)
+        for tabId in eligibleTabIds {
+            pendingClosedPanelHistoryEntries.removeValue(forKey: tabId)
+        }
+
+        let fallbackPlan = dockClosedPanelFallbackPlan(for: paneId)
+        let agentIndex = dockClosedPanelAgentIndex(for: eligibleTabs)
+        for (tabIndex, tab) in paneTabs.enumerated()
+        where eligibleTabIds.contains(tab.id) {
+            pendingClosedPanelHistoryEntries[tab.id] =
+                dockClosedPanelHistoryEntry(
+                    tabId: tab.id,
+                    inPane: paneId,
+                    tabIndex: tabIndex,
+                    paneTabs: paneTabs,
+                    fallbackPlan: fallbackPlan,
+                    restorableAgentIndex: agentIndex
+                )
+        }
+    }
+
+    func discardDockClosedPanelHistory(tabId: TabID) {
+        closeHistoryEligibleDockTabIds.remove(tabId)
+        pendingClosedPanelHistoryEntries.removeValue(forKey: tabId)
+    }
+
+    func commitDockClosedPanelHistory(tabId: TabID) {
+        let wasEligible =
+            closeHistoryEligibleDockTabIds.remove(tabId) != nil
+        let entry =
+            pendingClosedPanelHistoryEntries.removeValue(forKey: tabId)
+        guard wasEligible, let entry else { return }
+        closedItemHistoryStore.push(.panel(entry))
+    }
+
+    func stageDockClosedPaneHistory(
+        _ paneId: PaneID,
+        tabIds: Set<TabID>
+    ) {
+        let paneTabs = bonsplitController.tabs(inPane: paneId)
+        let tabs = paneTabs.filter { tabIds.contains($0.id) }
+        for tab in tabs {
+            closeHistoryEligibleDockTabIds.remove(tab.id)
+            pendingClosedPanelHistoryEntries.removeValue(
+                forKey: tab.id
+            )
+        }
+        let fallbackPlan = dockClosedPanelFallbackPlan(for: paneId)
+        let agentIndex = dockClosedPanelAgentIndex(for: tabs)
+        let entries: [ClosedPanelHistoryEntry] =
+            paneTabs.enumerated().compactMap { tabIndex, tab in
+                guard tabIds.contains(tab.id) else { return nil }
+                return dockClosedPanelHistoryEntry(
+                    tabId: tab.id,
+                    inPane: paneId,
+                    tabIndex: tabIndex,
+                    paneTabs: paneTabs,
+                    fallbackPlan: fallbackPlan,
+                    restorableAgentIndex: agentIndex
+                )
+            }
+        if entries.isEmpty {
+            pendingClosedPaneHistoryEntries.removeValue(
+                forKey: paneId.id
+            )
+        } else {
+            pendingClosedPaneHistoryEntries[paneId.id] = entries
+        }
+    }
+
+    func discardDockClosedPaneHistory(_ paneId: PaneID) {
+        pendingClosedPaneHistoryEntries.removeValue(forKey: paneId.id)
+    }
+
+    func commitDockClosedPaneHistory(_ paneId: PaneID) {
+        let entries =
+            pendingClosedPaneHistoryEntries.removeValue(forKey: paneId.id)
+            ?? []
+        for entry in entries {
+            closedItemHistoryStore.push(.panel(entry))
+        }
+    }
+
+    @discardableResult
+    func reopenMostRecentlyClosedPanel() -> Bool {
+        closedItemHistoryStore.restoreFirstRestorable(
+            newerThan: nil,
+            matching: { entry in
+                guard case .panel(let panelEntry) = entry else {
+                    return false
+                }
+                return panelEntry.workspaceId == self.workspaceId
+            },
+            using: { entry in
+                guard case .panel(let panelEntry) = entry,
+                      let restoredPanelId =
+                        self.restoreDockClosedPanel(panelEntry) else {
+                    return false
+                }
+                self.closedItemHistoryStore.remapPanelAnchorIds(
+                    from: panelEntry.snapshot.id,
+                    to: restoredPanelId
+                )
+                return true
+            }
+        )
+    }
+
+    private func dockClosedPanelHistoryEntry(
+        tabId: TabID,
+        inPane paneId: PaneID,
+        tabIndex: Int,
+        paneTabs: [Bonsplit.Tab],
+        fallbackPlan: DockClosedPanelFallbackPlan?,
+        restorableAgentIndex: RestorableAgentSessionIndex?
+    ) -> ClosedPanelHistoryEntry? {
+        guard let panelId = surfaceIdToPanelId[tabId],
+              let snapshot = closedPanelSessionSnapshot(
+                  panelId: panelId,
+                  restorableAgentIndex: restorableAgentIndex
+              ) else {
+            return nil
+        }
+
+        let paneAnchorPanelId: UUID?
+        if tabIndex + 1 < paneTabs.count {
+            paneAnchorPanelId =
+                surfaceIdToPanelId[paneTabs[tabIndex + 1].id]
+        } else if tabIndex > 0 {
+            paneAnchorPanelId =
+                surfaceIdToPanelId[paneTabs[tabIndex - 1].id]
+        } else {
+            paneAnchorPanelId = nil
+        }
+
+        let sourceTransfer = detachedSurfaceTransfersByPanelId[panelId]
+        return ClosedPanelHistoryEntry(
+            workspaceId: workspaceId,
+            paneId: paneId.id,
+            paneAnchorPanelId: paneAnchorPanelId,
+            tabIndex: tabIndex,
+            snapshot: snapshot,
+            fallbackSplitPlacement: fallbackPlan.map {
+                ClosedPanelSplitPlacement(
+                    orientation: $0.orientation,
+                    insertFirst: $0.insertFirst,
+                    anchorPanelId: $0.anchorPanelId
+                )
+            },
+            sourceWorkspaceId: sourceTransfer?.sourceWorkspaceId,
+            sourceSnapshotWorkspaceId:
+                sourceTransfer?.sessionRestoreWorkspaceId
+        )
+    }
+
+    /// Resolves at most one agent index for a close batch. A warm shared index
+    /// avoids disk work; the cold fallback loads once for the whole batch.
+    /// Restore revalidates cached process evidence before relaunching an agent.
+    private func dockClosedPanelAgentIndex(
+        for tabs: [Bonsplit.Tab]
+    ) -> RestorableAgentSessionIndex? {
+        let containsTerminal = tabs.contains { tab in
+            guard let panelId = surfaceIdToPanelId[tab.id] else {
+                return false
+            }
+            return panels[panelId] is TerminalPanel
+        }
+        guard containsTerminal else { return nil }
+        return SharedLiveAgentIndex.shared.currentIndexSchedulingRefresh()
+            ?? RestorableAgentSessionIndex.load()
+    }
+
+    private func restoreDockClosedPanel(
+        _ entry: ClosedPanelHistoryEntry
+    ) -> UUID? {
+        if entry.restoreInOriginalPane,
+           let originalPane = bonsplitController.allPaneIds.first(
+               where: { $0.id == entry.paneId }
+           ) {
+            return restoreDockClosedPanel(entry, inPane: originalPane)
+        }
+        if let paneAnchorPanelId = entry.paneAnchorPanelId,
+           let paneId = paneId(forPanelId: paneAnchorPanelId) {
+            return restoreDockClosedPanel(entry, inPane: paneId)
+        }
+        if let restoredPanelId =
+            restoreDockClosedPanelInFallbackSplit(entry) {
+            return restoredPanelId
+        }
+        guard let paneId =
+            bonsplitController.focusedPaneId
+            ?? bonsplitController.allPaneIds.first else {
+            return nil
+        }
+        return restoreDockClosedPanel(entry, inPane: paneId)
+    }
+
+    private func restoreDockClosedPanel(
+        _ entry: ClosedPanelHistoryEntry,
+        inPane paneId: PaneID
+    ) -> UUID? {
+        guard let panelId = restoreClosedPanelSessionSnapshot(
+            entry.snapshot,
+            inPane: paneId,
+            sourceWorkspaceId: entry.sourceWorkspaceId,
+            sourceSnapshotWorkspaceId:
+                entry.sourceSnapshotWorkspaceId,
+            sourceWorkspaceResolver: { sourceWorkspaceId in
+                AppDelegate.shared?.workspaceFor(
+                    tabId: sourceWorkspaceId
+                )
+            }
+        ) else {
+            return nil
+        }
+
+        if let tabId = surfaceId(forPanelId: panelId) {
+            let maximumIndex = max(
+                0,
+                bonsplitController.tabs(inPane: paneId).count - 1
+            )
+            _ = bonsplitController.reorderTab(
+                tabId,
+                toIndex: min(max(entry.tabIndex, 0), maximumIndex)
+            )
+            bonsplitController.focusPane(paneId)
+            bonsplitController.selectTab(tabId)
+        }
+        focusPanel(panelId)
+        triggerFocusFlash(panelId: panelId)
+        return panelId
+    }
+
+    private func restoreDockClosedPanelInFallbackSplit(
+        _ entry: ClosedPanelHistoryEntry
+    ) -> UUID? {
+        guard let placement = entry.fallbackSplitPlacement,
+              let anchorPanelId = placement.anchorPanelId,
+              panels[anchorPanelId] != nil,
+              let anchorPaneId = paneId(forPanelId: anchorPanelId) else {
+            return nil
+        }
+
+        let layoutCodec = SessionSplitContainerLayoutCodec(
+            controller: bonsplitController
+        )
+        guard let placeholder = withProgrammaticDockSplit({
+            layoutCodec.createRestorePlaceholderSplit(
+                inPane: anchorPaneId,
+                orientation: placement.orientation,
+                insertFirst: placement.insertFirst
+            )
+        }) else {
+            return nil
+        }
+        defer {
+            forceCloseDockTabIds.insert(placeholder.tabId)
+            _ = bonsplitController.closeTab(placeholder.tabId)
+            forceCloseDockTabIds.remove(placeholder.tabId)
+        }
+        return restoreDockClosedPanel(entry, inPane: placeholder.paneId)
+    }
+
+    private func dockClosedPanelFallbackPlan(
+        for paneId: PaneID
+    ) -> DockClosedPanelFallbackPlan? {
+        let paneIdsById = Dictionary(
+            uniqueKeysWithValues:
+                bonsplitController.allPaneIds.map { ($0.id, $0) }
+        )
+        return dockClosedPanelFallbackPlan(
+            forPaneId: paneId.id.uuidString,
+            in: bonsplitController.treeSnapshot(),
+            paneIdsById: paneIdsById
+        )
+    }
+
+    private func dockClosedPanelFallbackPlan(
+        forPaneId targetPaneId: String,
+        in node: ExternalTreeNode,
+        paneIdsById: [UUID: PaneID]
+    ) -> DockClosedPanelFallbackPlan? {
+        switch node {
+        case .pane:
+            return nil
+        case .split(let split):
+            if split.first.orderedPaneIds.contains(targetPaneId) {
+                if let nested = dockClosedPanelFallbackPlan(
+                    forPaneId: targetPaneId,
+                    in: split.first,
+                    paneIdsById: paneIdsById
+                ) {
+                    return nested
+                }
+                return DockClosedPanelFallbackPlan(
+                    orientation: split.orientation.lowercased() == "vertical"
+                        ? .vertical
+                        : .horizontal,
+                    insertFirst: true,
+                    anchorPanelId: firstDockPanelId(
+                        in: split.second,
+                        paneIdsById: paneIdsById
+                    )
+                )
+            }
+            if split.second.orderedPaneIds.contains(targetPaneId) {
+                if let nested = dockClosedPanelFallbackPlan(
+                    forPaneId: targetPaneId,
+                    in: split.second,
+                    paneIdsById: paneIdsById
+                ) {
+                    return nested
+                }
+                return DockClosedPanelFallbackPlan(
+                    orientation: split.orientation.lowercased() == "vertical"
+                        ? .vertical
+                        : .horizontal,
+                    insertFirst: false,
+                    anchorPanelId: firstDockPanelId(
+                        in: split.first,
+                        paneIdsById: paneIdsById
+                    )
+                )
+            }
+            return nil
+        }
+    }
+
+    private func firstDockPanelId(
+        in node: ExternalTreeNode,
+        paneIdsById: [UUID: PaneID]
+    ) -> UUID? {
+        for paneIdString in node.orderedPaneIds {
+            guard let paneUUID = UUID(uuidString: paneIdString),
+                  let paneId = paneIdsById[paneUUID],
+                  let tab = bonsplitController.selectedTab(inPane: paneId)
+                    ?? bonsplitController.tabs(inPane: paneId).first,
+                  let panelId = surfaceIdToPanelId[tab.id] else {
+                continue
+            }
+            return panelId
+        }
+        return nil
+    }
+}

--- a/Sources/DockSplitStore+PanelDestruction.swift
+++ b/Sources/DockSplitStore+PanelDestruction.swift
@@ -15,6 +15,7 @@ extension DockSplitStore {
 
     @discardableResult
     func discardPanelStateAndClose(panelId: UUID) -> (any Panel)? {
+        cancelDockReactGrabTask(targetingPanelId: panelId)
         appLinkHandoffCoordinator.cancel(sourcePanelID: panelId)
         panelCancellables[panelId]?.cancel()
         panelCancellables.removeValue(forKey: panelId)

--- a/Sources/DockSplitStore+Reset.swift
+++ b/Sources/DockSplitStore+Reset.swift
@@ -2,9 +2,13 @@ import Bonsplit
 
 extension DockSplitStore {
     func removeAllPanels() {
+        cancelDockReactGrabTask()
         let tabIds = Set(bonsplitController.allTabIds)
         pendingCloseConfirmDockTabIds.removeAll()
         tabCloseButtonCloseDockTabIds.removeAll()
+        closeHistoryEligibleDockTabIds.removeAll()
+        pendingClosedPanelHistoryEntries.removeAll()
+        pendingClosedPaneHistoryEntries.removeAll()
         forceCloseDockTabIds.formUnion(tabIds)
         defer { forceCloseDockTabIds.subtract(tabIds) }
         for tabId in tabIds { _ = bonsplitController.closeTab(tabId) }

--- a/Sources/DockSplitStore+SessionRestore.swift
+++ b/Sources/DockSplitStore+SessionRestore.swift
@@ -35,6 +35,8 @@ extension DockSplitStore {
                           inPane: leaf.paneId,
                           excludingStableIdentities: excludingStableIdentities,
                           sourceWorkspaceId: snapshot.sourceWorkspaceIdsByPanelId?[oldPanelId],
+                          sourceSnapshotWorkspaceId:
+                            snapshot.sourceWorkspaceIdsByPanelId?[oldPanelId],
                           sourceWorkspaceResolver: sourceWorkspaceResolver
                       ) else {
                     continue
@@ -78,20 +80,43 @@ extension DockSplitStore {
         return oldToNewPanelIds
     }
 
+    /// Recreates one panel inside an existing Dock pane for Dock-local
+    /// closed-item history. Unlike a full session restore, this preserves the
+    /// rest of the live Dock tree.
+    @discardableResult
+    func restoreClosedPanelSessionSnapshot(
+        _ snapshot: SessionPanelSnapshot,
+        inPane paneId: PaneID,
+        sourceWorkspaceId: UUID?,
+        sourceSnapshotWorkspaceId: UUID?,
+        sourceWorkspaceResolver: (UUID) -> Workspace?
+    ) -> UUID? {
+        createSessionRestoredPanel(
+            from: snapshot,
+            inPane: paneId,
+            excludingStableIdentities: [],
+            sourceWorkspaceId: sourceWorkspaceId,
+            sourceSnapshotWorkspaceId: sourceSnapshotWorkspaceId,
+            sourceWorkspaceResolver: sourceWorkspaceResolver
+        )
+    }
+
     private func createSessionRestoredPanel(
         from snapshot: SessionPanelSnapshot,
         inPane paneId: PaneID,
         excludingStableIdentities: Set<UUID>,
         sourceWorkspaceId: UUID?,
+        sourceSnapshotWorkspaceId: UUID?,
         sourceWorkspaceResolver: (UUID) -> Workspace?
     ) -> UUID? {
         if let sourceWorkspaceId,
            let sourceWorkspace = sourceWorkspaceResolver(sourceWorkspaceId),
            let detached = sourceWorkspace.detachedSurfaceForDockSessionRestore(
                snapshot,
-               snapshotWorkspaceId: sourceWorkspaceId,
+               snapshotWorkspaceId:
+                sourceSnapshotWorkspaceId ?? sourceWorkspaceId,
                excludingStableIdentities: excludingStableIdentities
-            ) {
+           ) {
             let restoredPanelId = attachDetachedSurface(detached, inPane: paneId, focus: false)
             if restoredPanelId == nil {
                 AgentHibernationController.shared.discardTrackingStateForClosedPanel(
@@ -102,7 +127,8 @@ extension DockSplitStore {
             }
             return restoredPanelId
         }
-        if sourceWorkspaceId != nil, snapshot.terminal?.isRemoteTerminal == true {
+        if sourceWorkspaceId != nil,
+           snapshot.terminal?.isRemoteTerminal == true {
             return nil
         }
         switch snapshot.type {

--- a/Sources/DockSplitStore+SessionSnapshot.swift
+++ b/Sources/DockSplitStore+SessionSnapshot.swift
@@ -86,6 +86,60 @@ extension DockSplitStore {
         )
     }
 
+    /// Captures one Dock panel for the Dock-local closed-item history without
+    /// walking every other panel in the split tree.
+    func closedPanelSessionSnapshot(
+        panelId: UUID,
+        restorableAgentIndex: RestorableAgentSessionIndex?
+    ) -> SessionPanelSnapshot? {
+        let transfer = detachedSurfaceTransfersByPanelId[panelId]
+        let observationWorkspaceId =
+            transfer?.sessionRestoreWorkspaceId ?? workspaceId
+        let terminalFontSizeSnapshotProjection:
+            WorkspaceTerminalFontSizeSnapshotProjection?
+        if panels[panelId] is TerminalPanel {
+            if let workspace = terminalFontSizeOwningWorkspace {
+                terminalFontSizeSnapshotProjection =
+                    terminalFontSizeChangeArbiter?
+                        .snapshotProjection(
+                            for: workspace,
+                            panelIds: [panelId]
+                        )
+            } else {
+                terminalFontSizeSnapshotProjection =
+                    terminalFontSizeChangeArbiter?
+                        .snapshotProjection(
+                            for: self,
+                            panelIds: [panelId]
+                        )
+            }
+        } else {
+            terminalFontSizeSnapshotProjection = nil
+        }
+
+        return sessionPanelSnapshot(
+            panelId: panelId,
+            includeScrollback: true,
+            observation: restorableAgentIndex?.entry(
+                workspaceId: observationWorkspaceId,
+                panelId: panelId
+            ),
+            detectedResumeBinding: nil,
+            terminalFontSizeSnapshotProjection:
+                terminalFontSizeSnapshotProjection,
+            currentAgentProcessIdentity: {
+                guard $0 > 0, $0 <= Int(Int32.max) else { return nil }
+                return AgentPIDProcessIdentity(pid: pid_t($0))
+            },
+            agentProcessPresence: {
+                guard $0 > 0, $0 <= Int(Int32.max) else {
+                    return .absent
+                }
+                return PIDPresence.current(pid: pid_t($0))
+            }
+        )
+    }
+
     private func orderedSessionPanelIds() -> [UUID] {
         var result: [UUID] = []
         var seen: Set<UUID> = []

--- a/Sources/DockSplitStore+ShortcutCommands.swift
+++ b/Sources/DockSplitStore+ShortcutCommands.swift
@@ -1,4 +1,8 @@
+import AppKit
 import Bonsplit
+import CmuxPanes
+import CmuxSettings
+import CmuxTerminal
 import CmuxWorkspaces
 import Foundation
 
@@ -7,11 +11,31 @@ enum DockShortcutCommand {
     case selectPreviousSurface
     case selectSurface(number: Int)
     case moveSurface(offset: Int)
+    case moveSurfaceToPane(
+        SurfacePaneMovement,
+        allowMissingDestinationSplit: Bool
+    )
     case focusPane(NavigationDirection)
+    case cyclePaneFocus(forward: Bool)
     case togglePaneZoom
+    case equalizeSplits
     case focusHistoryBack
     case focusHistoryForward
     case triggerFlash
+    case renameSurface(presentingWindow: NSWindow?)
+    case closeOtherTabsInPane
+    case toggleTerminalCopyMode
+    case focusTextBoxInput
+    case attachTextBoxFile
+    case sendCtrlFToTerminal
+    case clearScreenKeepScrollback
+    case startFind
+    case findNext
+    case findPrevious
+    case hideFind
+    case useSelectionForFind
+    case toggleReactGrab
+    case reopenClosedPanel
 
     var isFocusHistoryNavigation: Bool {
         switch self {
@@ -42,13 +66,30 @@ extension DockSplitStore {
             return selectDockSurface(number: number)
         case .moveSurface(let offset):
             return moveSelectedDockSurface(by: offset)
+        case let .moveSurfaceToPane(
+            movement,
+            allowMissingDestinationSplit
+        ):
+            return moveFocusedDockSurface(
+                to: movement,
+                allowMissingDestinationSplit:
+                    allowMissingDestinationSplit
+            )
         case .focusPane(let direction):
             bonsplitController.navigateFocus(direction: direction)
             applyFocusedShortcutSelection()
             return true
+        case .cyclePaneFocus(let forward):
+            return cycleDockPaneFocus(forward: forward)
         case .togglePaneZoom:
             guard let pane = bonsplitController.focusedPaneId else { return false }
             return toggleDockPaneZoom(inPane: pane)
+        case .equalizeSplits:
+            let result = PaneLayoutService().equalizeSplits(
+                in: bonsplitController.treeSnapshot(),
+                controller: bonsplitController
+            )
+            return result.foundSplit && result.allSucceeded
         case .focusHistoryBack:
             return focusHistoryNavigation.navigateBack()
         case .focusHistoryForward:
@@ -57,6 +98,59 @@ extension DockSplitStore {
             guard let focusedPanelId else { return false }
             triggerUserInitiatedFocusFlash(panelId: focusedPanelId)
             return true
+        case .renameSurface(let presentingWindow):
+            return promptRenameFocusedDockSurface(
+                presentingWindow: presentingWindow
+            )
+        case .closeOtherTabsInPane:
+            return closeOtherDockTabsInFocusedPane()
+        case .toggleTerminalCopyMode:
+            guard let terminal = focusedDockTerminalPanel else {
+                return false
+            }
+            return terminal.surface.toggleKeyboardCopyMode()
+        case .focusTextBoxInput:
+            return focusedDockTerminalPanel?
+                .focusTextBoxInputOrTerminal() ?? false
+        case .attachTextBoxFile:
+            return focusedDockTerminalPanel?
+                .attachFileToTextBoxInput() ?? false
+        case .sendCtrlFToTerminal:
+            guard let terminal = focusedDockTerminalPanel else {
+                return false
+            }
+            let result = terminal.sendNamedKeyResult("ctrl-f")
+            if result == .sent {
+                terminal.surface.forceRefresh(
+                    reason: "dock.sendCtrlFToFocusedTerminal"
+                )
+            }
+            return result.accepted
+        case .clearScreenKeepScrollback:
+            guard let terminal = focusedDockTerminalPanel else {
+                return false
+            }
+            let didClear = terminal.clearScreenKeepingScrollback()
+            if didClear {
+                terminal.surface.forceRefresh(
+                    reason: "dock.clearFocusedTerminalKeepingScrollback"
+                )
+            }
+            return didClear
+        case .startFind:
+            return startDockFind()
+        case .findNext:
+            return performDockFindNavigation(.next)
+        case .findPrevious:
+            return performDockFindNavigation(.previous)
+        case .hideFind:
+            return hideDockFind()
+        case .useSelectionForFind:
+            return useDockSelectionForFind()
+        case .toggleReactGrab:
+            return toggleDockReactGrab()
+        case .reopenClosedPanel:
+            return reopenMostRecentlyClosedPanel()
         }
     }
 
@@ -95,6 +189,438 @@ extension DockSplitStore {
         guard finalIndex != currentIndex else { return true }
         let insertionIndex = finalIndex > currentIndex ? finalIndex + 1 : finalIndex
         return bonsplitController.reorderTab(selectedTab.id, toIndex: insertionIndex)
+    }
+
+    private var focusedDockTerminalPanel: TerminalPanel? {
+        guard let focusedPanelId else { return nil }
+        return panels[focusedPanelId] as? TerminalPanel
+    }
+
+    private var focusedDockBrowserPanel: BrowserPanel? {
+        guard let focusedPanelId else { return nil }
+        return panels[focusedPanelId] as? BrowserPanel
+    }
+
+    private func promptRenameFocusedDockSurface(
+        presentingWindow: NSWindow?
+    ) -> Bool {
+        guard let panelId = focusedPanelId,
+              let panel = panels[panelId],
+              let tabId = surfaceId(forPanelId: panelId),
+              let tab = bonsplitController.tab(tabId) else {
+            return false
+        }
+
+        let alert = NSAlert()
+        alert.messageText = String(
+            localized: "alert.renameTab.title",
+            defaultValue: "Rename Tab"
+        )
+        alert.informativeText = String(
+            localized: "alert.renameTab.message",
+            defaultValue: "Enter a custom name for this tab."
+        )
+        let input = NSTextField(string: tab.title)
+        input.placeholderString = String(
+            localized: "alert.renameTab.placeholder",
+            defaultValue: "Tab name"
+        )
+        input.frame = NSRect(x: 0, y: 0, width: 240, height: 22)
+        alert.accessoryView = input
+        alert.addButton(
+            withTitle: String(
+                localized: "alert.renameTab.rename",
+                defaultValue: "Rename"
+            )
+        )
+        alert.addButton(
+            withTitle: String(
+                localized: "alert.cancel",
+                defaultValue: "Cancel"
+            )
+        )
+        let alertWindow = alert.window
+        alertWindow.initialFirstResponder = input
+        let response = alert.runCmuxModal(
+            presentingWindow: presentingWindow
+        ) { _ in
+            alertWindow.makeFirstResponder(input)
+            input.selectText(nil)
+        }
+        guard response == .alertFirstButtonReturn else { return true }
+
+        let customTitle = input.stringValue.trimmingCharacters(
+            in: .whitespacesAndNewlines
+        )
+        bonsplitController.updateTab(
+            tabId,
+            title: customTitle.isEmpty
+                ? panel.displayTitle
+                : customTitle,
+            hasCustomTitle: !customTitle.isEmpty
+        )
+        return true
+    }
+
+    private func cycleDockPaneFocus(forward: Bool) -> Bool {
+        let orderedPaneIds = bonsplitController.treeSnapshot()
+            .orderedPaneIds
+            .compactMap(UUID.init(uuidString:))
+        guard let targetPaneId = PaneCycleNavigator().targetPane(
+            orderedPaneIds: orderedPaneIds,
+            livePaneIds: bonsplitController.allPaneIds,
+            focusedPaneId: bonsplitController.focusedPaneId,
+            forward: forward
+        ) else {
+            return false
+        }
+        bonsplitController.focusPane(targetPaneId)
+        applyFocusedShortcutSelection()
+        return true
+    }
+
+    private func moveFocusedDockSurface(
+        to movement: SurfacePaneMovement,
+        allowMissingDestinationSplit: Bool
+    ) -> Bool {
+        guard let panelId = focusedPanelId,
+              let tabId = surfaceId(forPanelId: panelId),
+              let sourcePaneId = paneId(forPanelId: panelId) else {
+            return false
+        }
+
+        let destinationPaneId = dockDestinationPane(
+            from: sourcePaneId,
+            for: movement
+        )
+        let directionalSplit = allowMissingDestinationSplit
+            ? dockDirectionalSplit(for: movement)
+            : nil
+        guard destinationPaneId != nil || directionalSplit != nil else {
+            return false
+        }
+
+        let zoomedPaneId = bonsplitController.zoomedPaneId
+        if let zoomedPaneId {
+            _ = toggleDockPaneZoom(inPane: zoomedPaneId)
+        }
+
+        let didMove: Bool
+        if let destinationPaneId {
+            let destinationTabs =
+                bonsplitController.tabs(inPane: destinationPaneId)
+            let insertionIndex: Int
+            if let selectedTabId = bonsplitController
+                .selectedTab(inPane: destinationPaneId)?.id,
+               let selectedIndex = destinationTabs.firstIndex(
+                   where: { $0.id == selectedTabId }
+               ) {
+                insertionIndex = selectedIndex + 1
+            } else {
+                insertionIndex = destinationTabs.count
+            }
+            didMove = bonsplitController.moveTab(
+                tabId,
+                toPane: destinationPaneId,
+                atIndex: insertionIndex
+            )
+            if didMove {
+                bonsplitController.focusPane(destinationPaneId)
+                bonsplitController.selectTab(tabId)
+                applyFocusedShortcutSelection()
+            }
+        } else if let directionalSplit,
+                  let newPaneId = bonsplitController.splitPane(
+                      sourcePaneId,
+                      orientation: directionalSplit.orientation,
+                      movingTab: tabId,
+                      insertFirst: directionalSplit.insertFirst
+                  ) {
+            bonsplitController.focusPane(newPaneId)
+            bonsplitController.selectTab(tabId)
+            applyFocusedShortcutSelection()
+            didMove = true
+        } else {
+            didMove = false
+        }
+
+        if !didMove, let zoomedPaneId {
+            _ = toggleDockPaneZoom(inPane: zoomedPaneId)
+        }
+        return didMove
+    }
+
+    private func dockDestinationPane(
+        from sourcePaneId: PaneID,
+        for movement: SurfacePaneMovement
+    ) -> PaneID? {
+        if let direction =
+            dockDirectionalSplit(for: movement)?.direction {
+            return bonsplitController.adjacentPane(
+                to: sourcePaneId,
+                direction: direction
+            )
+        }
+
+        let orderedPaneIds = bonsplitController.treeSnapshot()
+            .orderedPaneIds
+            .compactMap(UUID.init(uuidString:))
+        guard orderedPaneIds.count > 1,
+              let sourceIndex = orderedPaneIds.firstIndex(
+                  of: sourcePaneId.id
+              ) else {
+            return nil
+        }
+        let offset = movement == .previous ? -1 : 1
+        let destinationIndex =
+            (sourceIndex + offset + orderedPaneIds.count)
+            % orderedPaneIds.count
+        let destinationId = orderedPaneIds[destinationIndex]
+        return bonsplitController.allPaneIds.first {
+            $0.id == destinationId
+        }
+    }
+
+    private func dockDirectionalSplit(
+        for movement: SurfacePaneMovement
+    ) -> (
+        direction: NavigationDirection,
+        orientation: SplitOrientation,
+        insertFirst: Bool
+    )? {
+        switch movement {
+        case .left:
+            (.left, .horizontal, true)
+        case .right:
+            (.right, .horizontal, false)
+        case .up:
+            (.up, .vertical, true)
+        case .down:
+            (.down, .vertical, false)
+        case .previous, .next:
+            nil
+        }
+    }
+
+    private func closeOtherDockTabsInFocusedPane() -> Bool {
+        guard let paneId =
+                bonsplitController.focusedPaneId
+                ?? bonsplitController.allPaneIds.first else {
+            return true
+        }
+        let tabs = bonsplitController.tabs(inPane: paneId)
+        guard let selectedTabId =
+                bonsplitController.selectedTab(inPane: paneId)?.id
+                ?? tabs.first?.id else {
+            return true
+        }
+        let targets = tabs.compactMap {
+            tab -> (tabId: TabID, panelId: UUID, title: String)? in
+            guard tab.id != selectedTabId,
+                  let panelId = surfaceIdToPanelId[tab.id] else {
+                return nil
+            }
+            return (
+                tab.id,
+                panelId,
+                CloseOtherTabsConfirmationPrompt.displayTitle(
+                    panels[panelId]?.displayTitle ?? tab.title
+                )
+            )
+        }
+        guard !targets.isEmpty else { return true }
+        guard let manager = dockCloseConfirmationManager() else {
+            return false
+        }
+
+        if CloseTabWarningStore(
+            defaults: manager.closeTabWarningDefaults
+        )
+            .shouldConfirmClose(
+                requiresConfirmation: true,
+                source: .shortcut
+            ) {
+            let prompt = CloseOtherTabsConfirmationPrompt(
+                titles: targets.map(\.title)
+            )
+            guard manager.confirmClose(
+                title: prompt.title,
+                message: prompt.message,
+                scrollableDetails: prompt.details,
+                acceptCmdD: false
+            ) else {
+                return true
+            }
+        }
+
+        stageDockClosedPanelHistory(
+            tabIds: Set(targets.map(\.tabId)),
+            inPane: paneId
+        )
+        for target in targets {
+            if !closePanel(target.panelId, force: true) {
+                discardDockClosedPanelHistory(tabId: target.tabId)
+            }
+        }
+        return true
+    }
+
+    private func startDockFind() -> Bool {
+        if let terminal = focusedDockTerminalPanel {
+            let hadExistingSearch = terminal.searchState != nil
+            terminal.hostedView.preparePanelFocusIntentForActivation(
+                .findField
+            )
+            let recoveredNeedle = hadExistingSearch
+                ? ""
+                : terminal.surface.lastSearchNeedle
+            return startOrFocusTerminalSearch(
+                terminal.surface,
+                initialNeedle: recoveredNeedle
+            ) { surface in
+                NotificationCenter.default.post(
+                    name: .ghosttySearchFocus,
+                    object: surface,
+                    userInfo: [
+                        FindFocusNotificationKey.selectAll:
+                            !hadExistingSearch
+                            && !recoveredNeedle.isEmpty
+                    ]
+                )
+            }
+        }
+        guard let browser = focusedDockBrowserPanel else {
+            return false
+        }
+        browser.startFind()
+        return browser.searchState != nil
+    }
+
+    private func performDockFindNavigation(
+        _ navigation: TerminalSearchNavigation
+    ) -> Bool {
+        if let terminal = focusedDockTerminalPanel {
+            return navigation.perform {
+                terminal.performBindingAction($0)
+            }
+        }
+        guard let browser = focusedDockBrowserPanel else {
+            return false
+        }
+        switch navigation {
+        case .next:
+            browser.findNext()
+        case .previous:
+            browser.findPrevious()
+        }
+        return true
+    }
+
+    private func hideDockFind() -> Bool {
+        if let terminal = focusedDockTerminalPanel {
+            terminal.surface.closeSearchFromExplicitInput()
+            return true
+        }
+        guard let browser = focusedDockBrowserPanel else {
+            return false
+        }
+        browser.hideFind()
+        return true
+    }
+
+    private func useDockSelectionForFind() -> Bool {
+        guard let terminal = focusedDockTerminalPanel else {
+            return false
+        }
+        if terminal.searchState == nil {
+            terminal.searchState = TerminalSurface.SearchState()
+        }
+        NotificationCenter.default.post(
+            name: .ghosttySearchFocus,
+            object: terminal.surface
+        )
+        _ = terminal.performBindingAction("search_selection")
+        return true
+    }
+
+    private func toggleDockReactGrab() -> Bool {
+        let snapshots = panels.values.map {
+            ReactGrabShortcutPanelSnapshot(
+                id: $0.id,
+                panelType: $0.panelType,
+                isFocused: $0.id == focusedPanelId
+            )
+        }
+        guard let route = resolveReactGrabShortcutRoute(
+            panels: snapshots
+        ),
+        let browser = panels[route.browserPanelId] as? BrowserPanel else {
+            return false
+        }
+
+        if let returnTerminalPanelId = route.returnTerminalPanelId {
+            browser.armReactGrabRoundTrip(
+                returnTo: returnTerminalPanelId
+            )
+        } else {
+            browser.clearReactGrabRoundTrip(
+                reason: "shortcut.noReturnTarget"
+            )
+        }
+        if focusedPanelId != browser.id {
+            if let zoomedPaneId = bonsplitController.zoomedPaneId {
+                _ = toggleDockPaneZoom(inPane: zoomedPaneId)
+            }
+            focusPanelFromDockInteraction(browser.id, window: nil)
+        }
+
+        let didRequestExplicitWebViewFocus =
+            browser.requestExplicitWebViewFocus()
+        cancelDockReactGrabTask()
+        let taskID = UUID()
+        reactGrabTaskID = taskID
+        reactGrabTaskPanelId = browser.id
+        reactGrabTask = Task { @MainActor [weak self, weak browser] in
+            defer {
+                if self?.reactGrabTaskID == taskID {
+                    self?.reactGrabTask = nil
+                    self?.reactGrabTaskID = nil
+                    self?.reactGrabTaskPanelId = nil
+                }
+            }
+            guard !Task.isCancelled,
+                  self?.reactGrabTaskID == taskID,
+                  let browser else {
+                return
+            }
+            if route.returnTerminalPanelId != nil {
+                await browser.ensureReactGrabActive()
+            } else {
+                await browser.toggleOrInjectReactGrab()
+            }
+            guard !Task.isCancelled,
+                  self?.reactGrabTaskID == taskID else {
+                return
+            }
+            if !didRequestExplicitWebViewFocus {
+                _ = browser.requestExplicitWebViewFocus()
+            }
+        }
+        return true
+    }
+
+    /// Cancels pending Dock React Grab work when a newer command supersedes it
+    /// or its owning browser is torn down.
+    func cancelDockReactGrabTask(
+        targetingPanelId panelId: UUID? = nil
+    ) {
+        if let panelId, reactGrabTaskPanelId != panelId {
+            return
+        }
+        reactGrabTask?.cancel()
+        reactGrabTask = nil
+        reactGrabTaskID = nil
+        reactGrabTaskPanelId = nil
     }
 }
 

--- a/Sources/DockSplitStore.swift
+++ b/Sources/DockSplitStore.swift
@@ -85,6 +85,15 @@ final class DockSplitStore: BonsplitDelegate {
     @ObservationIgnored var forceCloseDockTabIds: Set<TabID> = []
     @ObservationIgnored var pendingCloseConfirmDockTabIds: Set<TabID> = []
     @ObservationIgnored var tabCloseButtonCloseDockTabIds: Set<TabID> = []
+    @ObservationIgnored var closeHistoryEligibleDockTabIds: Set<TabID> = []
+    @ObservationIgnored var pendingClosedPanelHistoryEntries:
+        [TabID: ClosedPanelHistoryEntry] = [:]
+    @ObservationIgnored var pendingClosedPaneHistoryEntries:
+        [UUID: [ClosedPanelHistoryEntry]] = [:]
+    @ObservationIgnored let closedItemHistoryStore: ClosedItemHistoryStore
+    @ObservationIgnored var reactGrabTask: Task<Void, Never>?
+    @ObservationIgnored var reactGrabTaskID: UUID?
+    @ObservationIgnored var reactGrabTaskPanelId: UUID?
     @ObservationIgnored var terminalViewReattachCoalescingDepth = 0
     @ObservationIgnored var pendingTerminalViewReattachPanelIds: Set<UUID> = []
     @ObservationIgnored let focusHistoryNavigation: any FocusHistoryNavigating
@@ -248,7 +257,8 @@ final class DockSplitStore: BonsplitDelegate {
         browserAvailabilityProvider: @escaping () -> Bool = { BrowserAvailabilitySettings.isEnabled() },
         settings: any SettingsReading = UserDefaultsSettingsClient(defaults: .standard),
         agentSessionAutoResumeDefaults: UserDefaults = .standard,
-        terminalWorkingDirectoryResolver: TerminalWorkingDirectoryResolver = TerminalWorkingDirectoryResolver()
+        terminalWorkingDirectoryResolver: TerminalWorkingDirectoryResolver = TerminalWorkingDirectoryResolver(),
+        closedItemHistoryStore: ClosedItemHistoryStore? = nil
     ) {
         self.workspaceId = workspaceId
         self.scope = scope
@@ -258,6 +268,12 @@ final class DockSplitStore: BonsplitDelegate {
         self.settings = settings
         self.agentSessionAutoResumeDefaults = agentSessionAutoResumeDefaults
         self.terminalWorkingDirectoryResolver = terminalWorkingDirectoryResolver
+        self.closedItemHistoryStore =
+            closedItemHistoryStore
+            ?? ClosedItemHistoryStore(
+                capacity: 100,
+                loadPersisted: false
+            )
         let focusHistoryScopeKey = SettingCatalog().app.focusHistoryIncludesPanesAndTabs
         self.focusHistoryNavigation = FocusHistoryModel(navigationScope: {
             settings.value(for: focusHistoryScopeKey) ? .panesAndTabs : .workspacesOnly
@@ -900,7 +916,10 @@ final class DockSplitStore: BonsplitDelegate {
                 // guarded path in Workspace.installBrowserPanelSubscription.
                 let resolvedTitle = browser.displayTitle
                 let favicon = browser.faviconPNGData
-                let titleUpdate: String? = existing.title == resolvedTitle ? nil : resolvedTitle
+                let titleUpdate: String? =
+                    existing.hasCustomTitle || existing.title == resolvedTitle
+                    ? nil
+                    : resolvedTitle
                 let faviconUpdate: Data?? = existing.iconImageData == favicon ? nil : .some(favicon)
                 let loadingUpdate: Bool? = existing.isLoading == browser.isLoading ? nil : browser.isLoading
                 let mutedUpdate: Bool? = existing.isAudioMuted == browser.isMuted ? nil : browser.isMuted
@@ -925,7 +944,10 @@ final class DockSplitStore: BonsplitDelegate {
                     // unchanged, so a terminal re-emitting the same title does not
                     // re-render the Dock tree.
                     let resolvedTitle = terminal.displayTitle
-                    guard existing.title != resolvedTitle else { return }
+                    guard !existing.hasCustomTitle,
+                          existing.title != resolvedTitle else {
+                        return
+                    }
                     self.bonsplitController.updateTab(tabId, title: resolvedTitle)
                 }
             panelCancellables[panel.id] = cancellable

--- a/Sources/SessionSplitContainerLayoutCodec.swift
+++ b/Sources/SessionSplitContainerLayoutCodec.swift
@@ -78,6 +78,27 @@ struct SessionSplitContainerLayoutCodec {
         return RestoreScaffold(leaves: leaves, placeholderTabIds: placeholders)
     }
 
+    /// Creates one pane-tree placeholder without constructing a live panel.
+    func createRestorePlaceholderSplit(
+        inPane paneId: PaneID,
+        orientation: SplitOrientation,
+        insertFirst: Bool
+    ) -> (paneId: PaneID, tabId: TabID)? {
+        let placeholder = Bonsplit.Tab(title: "", kind: "restoring")
+        guard let newPaneId = controller.splitPane(
+            paneId,
+            orientation: orientation,
+            withTab: placeholder,
+            insertFirst: insertFirst
+        ) else {
+            return nil
+        }
+        return (
+            paneId: newPaneId,
+            tabId: placeholder.id
+        )
+    }
+
     func applyDividerPositions(
         snapshotNode: SessionWorkspaceLayoutSnapshot,
         liveNode: ExternalTreeNode
@@ -157,18 +178,15 @@ struct SessionSplitContainerLayoutCodec {
                 ))
                 return
             }
-            let newPlaceholder = Bonsplit.Tab(title: "", kind: "restoring")
-            placeholders.insert(newPlaceholder.id)
-            guard let secondPaneId = controller.splitPane(
-                paneId,
+            guard let placeholderSplit = createRestorePlaceholderSplit(
+                inPane: paneId,
                 orientation: split.orientation.splitOrientation,
-                withTab: newPlaceholder,
                 insertFirst: false
             ) else {
-                placeholders.remove(newPlaceholder.id)
                 leaves.append(RestoreLeaf(paneId: paneId, snapshot: split.first.paneFallback))
                 return
             }
+            placeholders.insert(placeholderSplit.tabId)
             restoreNode(
                 split.first,
                 inPane: paneId,
@@ -177,7 +195,7 @@ struct SessionSplitContainerLayoutCodec {
             )
             restoreNode(
                 split.second,
-                inPane: secondPaneId,
+                inPane: placeholderSplit.paneId,
                 leaves: &leaves,
                 placeholders: &placeholders
             )

--- a/Sources/TabManager.swift
+++ b/Sources/TabManager.swift
@@ -2797,7 +2797,14 @@ class TabManager: ObservableObject {
     /// They must not escalate into workspace/window-close semantics for "last tab".
     func closeRuntimeSurfaceWithConfirmation(tabId: UUID, surfaceId: UUID) {
         guard let tab = tabs.first(where: { $0.id == tabId }) else { return }
-        if tab.panels[surfaceId] == nil { tab.closeDockPanelAndClearNotifications(surfaceId, force: false); return }
+        if tab.panels[surfaceId] == nil {
+            tab.closeDockPanelAndClearNotifications(
+                surfaceId,
+                force: false,
+                recordsHistory: false
+            )
+            return
+        }
 
         let requiresConfirmation: Bool
         if let terminalPanel = tab.terminalPanel(for: surfaceId),
@@ -2826,7 +2833,14 @@ class TabManager: ObservableObject {
     /// This path must only close the addressed surface and must never close the workspace window.
     func closeRuntimeSurface(tabId: UUID, surfaceId: UUID) {
         guard let tab = tabs.first(where: { $0.id == tabId }) else { return }
-        if tab.panels[surfaceId] == nil { tab.closeDockPanelAndClearNotifications(surfaceId, force: true); return }
+        if tab.panels[surfaceId] == nil {
+            tab.closeDockPanelAndClearNotifications(
+                surfaceId,
+                force: true,
+                recordsHistory: false
+            )
+            return
+        }
 
 #if DEBUG
         cmuxDebugLog(
@@ -2858,7 +2872,14 @@ class TabManager: ObservableObject {
         keepSurfaceVisible: Bool = false
     ) {
         guard let tab = tabs.first(where: { $0.id == tabId }) else { return }
-        if tab.panels[surfaceId] == nil { tab.closeDockPanelAndClearNotifications(surfaceId, force: true); return }
+        if tab.panels[surfaceId] == nil {
+            tab.closeDockPanelAndClearNotifications(
+                surfaceId,
+                force: true,
+                recordsHistory: false
+            )
+            return
+        }
         if let runtimeSurface, tab.terminalPanel(for: surfaceId)?.surface !== runtimeSurface { return }
         let ownsRemoteChildExit = tab.isRemoteTerminalSurface(surfaceId) ||
             tab.pendingRemoteTerminalChildExitSurfaceIds.contains(surfaceId) || tab.remoteDisconnectPlaceholderPanelIds.contains(surfaceId)

--- a/Sources/Workspace+DockBrowserLookup.swift
+++ b/Sources/Workspace+DockBrowserLookup.swift
@@ -29,13 +29,31 @@ extension Workspace {
     }
 
     @discardableResult
-    func closeDockPanel(_ panelId: UUID, force: Bool = false) -> Bool {
-        _dockSplit?.closePanel(panelId, force: force) ?? false
+    func closeDockPanel(
+        _ panelId: UUID,
+        force: Bool = false,
+        recordsHistory: Bool = true
+    ) -> Bool {
+        _dockSplit?.closePanel(
+            panelId,
+            force: force,
+            recordsHistory: recordsHistory
+        ) ?? false
     }
 
     @discardableResult
-    func closeDockPanelAndClearNotifications(_ panelId: UUID, force: Bool = false) -> Bool {
-        guard closeDockPanel(panelId, force: force) else { return false }
+    func closeDockPanelAndClearNotifications(
+        _ panelId: UUID,
+        force: Bool = false,
+        recordsHistory: Bool = true
+    ) -> Bool {
+        guard closeDockPanel(
+            panelId,
+            force: force,
+            recordsHistory: recordsHistory
+        ) else {
+            return false
+        }
         AppDelegate.shared?.notificationStore?.clearNotifications(forTabId: id, surfaceId: panelId)
         return true
     }
@@ -79,18 +97,19 @@ extension Workspace {
 extension AppDelegate {
     @discardableResult
     func closeFocusedDockPanelForCommand(preferredWindow: NSWindow?) -> Bool {
-        guard let context = preferredRegisteredMainWindowContext(preferredWindow: preferredWindow) else { return false }
-        guard context.keyboardFocusCoordinator.activeRightSidebarMode == .dock else { return false }
-        if let windowDock = existingWindowDock(forWindowId: context.windowId) {
-            guard let panelId = windowDock.focusedPanelId else { return true }
-            if windowDock.closePanel(panelId, force: false) {
-                notificationStore?.clearNotifications(forTabId: windowDock.workspaceId, surfaceId: panelId)
-            }
-            return true
+        guard let dock = focusedDockStoreForShortcut(
+            action: .closeTab,
+            preferredWindow: preferredWindow
+        ) else {
+            return false
         }
-        guard let workspace = context.tabManager.selectedWorkspace,
-              let panelId = workspace.focusedDockPanelId else { return true }
-        _ = workspace.closeDockPanelAndClearNotifications(panelId, force: false)
+        guard let panelId = dock.focusedPanelId else { return true }
+        if dock.closePanel(panelId, force: false) {
+            notificationStore?.clearNotifications(
+                forTabId: dock.workspaceId,
+                surfaceId: panelId
+            )
+        }
         return true
     }
 }
@@ -297,11 +316,22 @@ extension DockSplitStore {
     }
 
     @discardableResult
-    func closePanel(_ panelId: UUID, force: Bool = false) -> Bool {
+    func closePanel(
+        _ panelId: UUID,
+        force: Bool = false,
+        recordsHistory: Bool = true
+    ) -> Bool {
         guard let tabId = surfaceId(forPanelId: panelId) else { return false }
+        if recordsHistory, !force {
+            markDockCloseHistoryEligible(panelId: panelId)
+        }
         if force { forceCloseDockTabIds.insert(tabId) }
         let closed = bonsplitController.closeTab(tabId)
         if force && !closed { forceCloseDockTabIds.remove(tabId) }
+        if !closed,
+           !pendingCloseConfirmDockTabIds.contains(tabId) {
+            discardDockClosedPanelHistory(tabId: tabId)
+        }
         return closed
     }
 

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -965,6 +965,7 @@ C0DE71B10000000000000001 /* AppDelegate+AgentChatNotifications.swift in Sources 
 		8777D0018777D0018777D001 /* DockRuntimeParityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8777D0028777D0028777D002 /* DockRuntimeParityTests.swift */; };
 		DCDC1000000000000000C020 /* DockScope.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCDC1000000000000000C021 /* DockScope.swift */; };
 		D86840000000000000000001 /* DockSessionPersistenceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D86840000000000000000002 /* DockSessionPersistenceTests.swift */; };
+		9518D0C20000000000000001 /* DockShortcutRoutingDisposition.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9518D0C20000000000000002 /* DockShortcutRoutingDisposition.swift */; };
 		D81390010000000000000001 /* DockShortcutRoutingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D81390010000000000000002 /* DockShortcutRoutingTests.swift */; };
 		D6212D0C0000000000000001 /* DockSocketLifecycleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6212D0C0000000000000002 /* DockSocketLifecycleTests.swift */; };
 		904090409040904090409043 /* DockSplitContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 904090409040904090409044 /* DockSplitContentView.swift */; };
@@ -972,6 +973,7 @@ C0DE71B10000000000000001 /* AppDelegate+AgentChatNotifications.swift in Sources 
 		DCDC1000000000000000B011 /* DockSplitStore+Appearance.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCDC1000000000000000B012 /* DockSplitStore+Appearance.swift */; };
 		8777D0038777D0038777D003 /* DockSplitStore+AttentionRouting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8777D0048777D0048777D004 /* DockSplitStore+AttentionRouting.swift */; };
 		DCDC1000000000000000B021 /* DockSplitStore+CloseConfirmation.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCDC1000000000000000B022 /* DockSplitStore+CloseConfirmation.swift */; };
+		9518D0C10000000000000001 /* DockSplitStore+ClosedItemHistory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9518D0C10000000000000002 /* DockSplitStore+ClosedItemHistory.swift */; };
 		DCDC0000000000000000A003 /* DockSplitStore+Config.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCDC0000000000000000A004 /* DockSplitStore+Config.swift */; };
 		DCDC1000000000000000B019 /* DockSplitStore+PaneFocus.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCDC1000000000000000B020 /* DockSplitStore+PaneFocus.swift */; };
 		8997E0038997E0038997E003 /* DockSplitStore+PanelDestruction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8997F0038997F0038997F003 /* DockSplitStore+PanelDestruction.swift */; };
@@ -3573,6 +3575,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 		8777D0028777D0028777D002 /* DockRuntimeParityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DockRuntimeParityTests.swift; sourceTree = "<group>"; };
 		DCDC1000000000000000C021 /* DockScope.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DockScope.swift; sourceTree = "<group>"; };
 		D86840000000000000000002 /* DockSessionPersistenceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DockSessionPersistenceTests.swift; sourceTree = "<group>"; };
+		9518D0C20000000000000002 /* DockShortcutRoutingDisposition.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DockShortcutRoutingDisposition.swift; sourceTree = "<group>"; };
 		D81390010000000000000002 /* DockShortcutRoutingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DockShortcutRoutingTests.swift; sourceTree = "<group>"; };
 		D6212D0C0000000000000002 /* DockSocketLifecycleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DockSocketLifecycleTests.swift; sourceTree = "<group>"; };
 		904090409040904090409044 /* DockSplitContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DockSplitContentView.swift; sourceTree = "<group>"; };
@@ -3580,6 +3583,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 		DCDC1000000000000000B012 /* DockSplitStore+Appearance.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DockSplitStore+Appearance.swift"; sourceTree = "<group>"; };
 		8777D0048777D0048777D004 /* DockSplitStore+AttentionRouting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DockSplitStore+AttentionRouting.swift"; sourceTree = "<group>"; };
 		DCDC1000000000000000B022 /* DockSplitStore+CloseConfirmation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DockSplitStore+CloseConfirmation.swift"; sourceTree = "<group>"; };
+		9518D0C10000000000000002 /* DockSplitStore+ClosedItemHistory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DockSplitStore+ClosedItemHistory.swift"; sourceTree = "<group>"; };
 		DCDC0000000000000000A004 /* DockSplitStore+Config.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DockSplitStore+Config.swift"; sourceTree = "<group>"; };
 		DCDC1000000000000000B020 /* DockSplitStore+PaneFocus.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DockSplitStore+PaneFocus.swift"; sourceTree = "<group>"; };
 		8997F0038997F0038997F003 /* DockSplitStore+PanelDestruction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DockSplitStore+PanelDestruction.swift"; sourceTree = "<group>"; };
@@ -7068,8 +7072,10 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				904090409040904090409046 /* DockUnreadProjectionContextBridge.swift */,
 				904090409040904090409042 /* DockUnreadPanelProjection.swift */,
 				DCDC1000000000000000B00C /* DockRemoteBrowserSettings.swift */,
+				9518D0C20000000000000002 /* DockShortcutRoutingDisposition.swift */,
 				8777D0048777D0048777D004 /* DockSplitStore+AttentionRouting.swift */,
 				DCDC1000000000000000B012 /* DockSplitStore+Appearance.swift */,
+				9518D0C10000000000000002 /* DockSplitStore+ClosedItemHistory.swift */,
 				DCDC1000000000000000B022 /* DockSplitStore+CloseConfirmation.swift */,
 				DCDC0000000000000000A004 /* DockSplitStore+Config.swift */,
 				DCDC1000000000000000B020 /* DockSplitStore+PaneFocus.swift */,
@@ -8939,11 +8945,13 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				D0C0D0C0D0C0D0C0D0C0D001 /* DockPanelView.swift in Sources */,
 				DCDC1000000000000000B00B /* DockRemoteBrowserSettings.swift in Sources */,
 				DCDC1000000000000000C020 /* DockScope.swift in Sources */,
+				9518D0C20000000000000001 /* DockShortcutRoutingDisposition.swift in Sources */,
 				904090409040904090409043 /* DockSplitContentView.swift in Sources */,
 				904090409040904090409047 /* DockSplitPanelContentView.swift in Sources */,
 				DCDC1000000000000000B011 /* DockSplitStore+Appearance.swift in Sources */,
 				8777D0038777D0038777D003 /* DockSplitStore+AttentionRouting.swift in Sources */,
 				DCDC1000000000000000B021 /* DockSplitStore+CloseConfirmation.swift in Sources */,
+				9518D0C10000000000000001 /* DockSplitStore+ClosedItemHistory.swift in Sources */,
 				DCDC0000000000000000A003 /* DockSplitStore+Config.swift in Sources */,
 				DCDC1000000000000000B019 /* DockSplitStore+PaneFocus.swift in Sources */,
 				8997E0038997E0038997E003 /* DockSplitStore+PanelDestruction.swift in Sources */,

--- a/cmuxTests/DockControlDefinitionDecodingTests.swift
+++ b/cmuxTests/DockControlDefinitionDecodingTests.swift
@@ -380,6 +380,17 @@ struct DockControlDefinitionDecodingTests {
         let cleanPanel = try terminalPanel(in: store, panelId: cleanPanelId)
         dirtyPanel.surface.setNeedsConfirmCloseOverrideForTesting(true)
         cleanPanel.surface.setNeedsConfirmCloseOverrideForTesting(false)
+        let resumeBinding = SurfaceResumeBindingSnapshot(
+            name: "tmux",
+            kind: "tmux",
+            command: "tmux attach-session -t dock-cancelled-pane",
+            cwd: "/tmp",
+            checkpointId: "dock-cancelled-pane",
+            source: "process-detected",
+            autoResume: true,
+            updatedAt: 1_999_999_999
+        )
+        store.surfaceResumeBindingsByPanelId[dirtyPanelId] = resumeBinding
         defer {
             dirtyPanel.surface.setNeedsConfirmCloseOverrideForTesting(nil)
             cleanPanel.surface.setNeedsConfirmCloseOverrideForTesting(nil)
@@ -408,6 +419,78 @@ struct DockControlDefinitionDecodingTests {
         #expect(capturedPrompt?.title == String(localized: "dialog.closePane.title", defaultValue: "Close pane?"))
         #expect(capturedPrompt?.message == expectedMessage)
         #expect(capturedPrompt?.acceptCmdD == false)
+        #expect(store.containsPanel(dirtyPanelId))
+        #expect(store.surfaceResumeBindingsByPanelId[dirtyPanelId] == resumeBinding)
+    }
+
+    @Test("Cancelled Dock tab close preserves its live resume binding")
+    @MainActor
+    func cancelledDockTabClosePreservesResumeBinding() async throws {
+        try await AppContextSerialGate.withExclusiveAppContext {
+            let previousAppDelegate = AppDelegate.shared
+            let appDelegate = AppDelegate()
+            let manager = TabManager(autoWelcomeIfNeeded: false)
+            AppDelegate.shared = appDelegate
+            appDelegate.tabManager = manager
+            defer {
+                manager.tabs.forEach { $0.teardownAllPanels() }
+                AppDelegate.shared = previousAppDelegate
+            }
+
+            let workspace = try #require(manager.tabs.first)
+            let store = workspace.dockSplit
+            let rootPane = try #require(
+                store.bonsplitController.allPaneIds.first
+            )
+            let panelId = try #require(
+                store.newSurface(
+                    kind: .terminal,
+                    inPane: rootPane,
+                    focus: true
+                )
+            )
+            let terminal = try terminalPanel(
+                in: store,
+                panelId: panelId
+            )
+            terminal.surface.setNeedsConfirmCloseOverrideForTesting(true)
+            defer {
+                terminal.surface.setNeedsConfirmCloseOverrideForTesting(nil)
+            }
+
+            let resumeBinding = SurfaceResumeBindingSnapshot(
+                name: "tmux",
+                kind: "tmux",
+                command: "tmux attach-session -t dock-cancelled-tab",
+                cwd: "/tmp",
+                checkpointId: "dock-cancelled-tab",
+                source: "process-detected",
+                autoResume: true,
+                updatedAt: 1_999_999_999
+            )
+            store.surfaceResumeBindingsByPanelId[panelId] = resumeBinding
+
+            let promptHandled = AsyncStream<Void>.makeStream()
+            var promptCount = 0
+            manager.confirmCloseHandler = { _, _, _ in
+                promptCount += 1
+                promptHandled.continuation.yield()
+                promptHandled.continuation.finish()
+                return false
+            }
+
+            #expect(!store.closePanel(panelId))
+            for await _ in promptHandled.stream {
+                break
+            }
+
+            #expect(promptCount == 1)
+            #expect(store.containsPanel(panelId))
+            #expect(
+                store.surfaceResumeBindingsByPanelId[panelId] ==
+                    resumeBinding
+            )
+        }
     }
 
     @Test("Dock browser closes when WebKit requests close")

--- a/cmuxTests/DockShortcutRoutingTests.swift
+++ b/cmuxTests/DockShortcutRoutingTests.swift
@@ -3,6 +3,7 @@ import Bonsplit
 import Combine
 import CmuxSimulatorUI
 import CmuxSettings
+import CmuxTerminal
 import CmuxWorkspaces
 import Testing
 
@@ -20,7 +21,7 @@ struct DockShortcutRoutingTests {
     @MainActor
     func customizedNextSurfaceTargetsFocusedDock() async throws {
         try await AppContextSerialGate.withExclusiveAppContext {
-            try Self.withHarness { harness in
+            try await Self.withHarness { harness in
                 let firstPanel = try #require(
                     harness.dock.newSurface(kind: .terminal, inPane: harness.rootPane, focus: true)
                 )
@@ -50,7 +51,7 @@ struct DockShortcutRoutingTests {
     @MainActor
     func customizedDirectionalFocusTargetsFocusedDock() async throws {
         try await AppContextSerialGate.withExclusiveAppContext {
-            try Self.withHarness { harness in
+            try await Self.withHarness { harness in
                 let leftPanel = try #require(
                     harness.dock.newSurface(kind: .terminal, inPane: harness.rootPane, focus: true)
                 )
@@ -87,7 +88,7 @@ struct DockShortcutRoutingTests {
     @MainActor
     func legacyTabShortcutsTargetFocusedDock() async throws {
         try await AppContextSerialGate.withExclusiveAppContext {
-            try Self.withHarness { harness in
+            try await Self.withHarness { harness in
                 let firstPanel = try #require(
                     harness.dock.newSurface(kind: .terminal, inPane: harness.rootPane, focus: true)
                 )
@@ -127,7 +128,7 @@ struct DockShortcutRoutingTests {
     @MainActor
     func configuredActionPrecedesLegacyDockTabShortcut() async throws {
         try await AppContextSerialGate.withExclusiveAppContext {
-            try Self.withHarness { harness in
+            try await Self.withHarness { harness in
                 let firstPanel = try #require(
                     harness.dock.newSurface(kind: .terminal, inPane: harness.rootPane, focus: true)
                 )
@@ -155,7 +156,7 @@ struct DockShortcutRoutingTests {
     @MainActor
     func ghosttySplitNavigationTargetsFocusedDock() async throws {
         try await AppContextSerialGate.withExclusiveAppContext {
-            try Self.withHarness { harness in
+            try await Self.withHarness { harness in
                 let leftPanel = try #require(
                     harness.dock.newSurface(kind: .terminal, inPane: harness.rootPane, focus: true)
                 )
@@ -190,7 +191,7 @@ struct DockShortcutRoutingTests {
     @MainActor
     func focusHistoryNavigatesFocusedDockSurfaces() async throws {
         try await AppContextSerialGate.withExclusiveAppContext {
-            try Self.withHarness { harness in
+            try await Self.withHarness { harness in
                 let firstPanel = try #require(
                     harness.dock.newSurface(kind: .terminal, inPane: harness.rootPane, focus: true)
                 )
@@ -217,7 +218,7 @@ struct DockShortcutRoutingTests {
     @MainActor
     func customizedPreviousAndNumberedSurfaceTargetFocusedDock() async throws {
         try await AppContextSerialGate.withExclusiveAppContext {
-            try Self.withHarness { harness in
+            try await Self.withHarness { harness in
                 let firstPanel = try #require(
                     harness.dock.newSurface(kind: .terminal, inPane: harness.rootPane, focus: true)
                 )
@@ -254,7 +255,7 @@ struct DockShortcutRoutingTests {
     @MainActor
     func customizedMoveSurfaceReordersFocusedDock() async throws {
         try await AppContextSerialGate.withExclusiveAppContext {
-            try Self.withHarness { harness in
+            try await Self.withHarness { harness in
                 let firstPanel = try #require(
                     harness.dock.newSurface(kind: .terminal, inPane: harness.rootPane, focus: true)
                 )
@@ -284,7 +285,7 @@ struct DockShortcutRoutingTests {
     @MainActor
     func customizedZoomAndFlashTargetFocusedDock() async throws {
         try await AppContextSerialGate.withExclusiveAppContext {
-            try Self.withHarness { harness in
+            try await Self.withHarness { harness in
                 let panel = try harness.dock.seedShortcutTestPanel(inPane: harness.rootPane)
                 _ = try #require(
                     harness.dock.newSplit(
@@ -313,11 +314,437 @@ struct DockShortcutRoutingTests {
         }
     }
 
-    @Test("Move-to-pane shortcut does not mutate the background workspace while Dock is focused")
+    @Test("Focus address bar targets the focused Dock browser")
     @MainActor
-    func moveToPaneDoesNotMutateBackgroundWorkspaceWhileDockFocused() async throws {
+    func focusAddressBarTargetsFocusedDockBrowser() async throws {
         try await AppContextSerialGate.withExclusiveAppContext {
-            try Self.withHarness { harness in
+            try await Self.withHarness { harness in
+                let dockBrowserId = try #require(
+                    harness.dock.newSurface(
+                        kind: .browser,
+                        inPane: harness.rootPane,
+                        focus: true
+                    )
+                )
+                let mainPanelIdsBefore = Set(harness.mainWorkspace.panels.keys)
+                let shortcut = KeyboardShortcutSettings.Action
+                    .focusBrowserAddressBar.defaultShortcut
+                KeyboardShortcutSettings.setShortcut(
+                    shortcut,
+                    for: .focusBrowserAddressBar
+                )
+
+                #expect(Self.dispatch(shortcut, in: harness))
+                #expect(
+                    harness.appDelegate.focusedBrowserAddressBarPanelId() ==
+                        dockBrowserId
+                )
+                #expect(Set(harness.mainWorkspace.panels.keys) == mainPanelIdsBefore)
+            }
+        }
+    }
+
+    @Test("Focus address bar preserves main fallback without a focused Dock browser")
+    @MainActor
+    func focusAddressBarFallsBackWithoutFocusedDockBrowser() async throws {
+        try await AppContextSerialGate.withExclusiveAppContext {
+            try await Self.withHarness { harness in
+                let mainPane = try #require(
+                    harness.mainWorkspace.bonsplitController.focusedPaneId
+                )
+                let mainBrowser = try #require(
+                    harness.mainWorkspace.newBrowserSurface(
+                        inPane: mainPane,
+                        focus: true
+                    )
+                )
+                let dockTerminalId = try #require(
+                    harness.dock.newSurface(
+                        kind: .terminal,
+                        inPane: harness.rootPane,
+                        focus: true
+                    )
+                )
+                let shortcut = KeyboardShortcutSettings.Action
+                    .focusBrowserAddressBar.defaultShortcut
+                KeyboardShortcutSettings.setShortcut(
+                    shortcut,
+                    for: .focusBrowserAddressBar
+                )
+
+                #expect(Self.dispatch(shortcut, in: harness))
+                #expect(
+                    harness.appDelegate.focusedBrowserAddressBarPanelId() ==
+                        mainBrowser.id
+                )
+                #expect(harness.dock.focusedPanelId == dockTerminalId)
+            }
+        }
+    }
+
+    @Test("Reopen closed panel restores Dock history without consuming main history")
+    @MainActor
+    func reopenClosedPanelUsesFocusedDockHistory() async throws {
+        try await AppContextSerialGate.withExclusiveAppContext {
+            try await Self.withHarness { harness in
+                ClosedItemHistoryStore.shared.removeAll()
+                defer { ClosedItemHistoryStore.shared.removeAll() }
+
+                let mainPane = try #require(
+                    harness.mainWorkspace.bonsplitController.focusedPaneId
+                )
+                let mainBrowser = try #require(
+                    harness.mainWorkspace.newBrowserSurface(
+                        inPane: mainPane,
+                        url: URL(string: "https://example.com"),
+                        focus: true
+                    )
+                )
+                harness.mainWorkspace.markCloseHistoryEligible(
+                    panelId: mainBrowser.id
+                )
+                #expect(
+                    harness.mainWorkspace.closePanel(
+                        mainBrowser.id,
+                        force: true
+                    )
+                )
+                #expect(ClosedItemHistoryStore.shared.canReopen)
+
+                let dockTerminalId = try #require(
+                    harness.dock.newSurface(
+                        kind: .terminal,
+                        inPane: harness.rootPane,
+                        focus: true
+                    )
+                )
+                let restoredURL = try #require(
+                    URL(string: "https://example.org/")
+                )
+                let dockBrowserId = try #require(
+                    harness.dock.newSurface(
+                        kind: .browser,
+                        inPane: harness.rootPane,
+                        url: restoredURL,
+                        focus: true
+                    )
+                )
+                #expect(harness.dock.closePanel(dockBrowserId))
+                harness.dock.focusPanel(dockTerminalId)
+
+                let shortcut = KeyboardShortcutSettings.Action
+                    .reopenClosedBrowserPanel.defaultShortcut
+                KeyboardShortcutSettings.setShortcut(
+                    shortcut,
+                    for: .reopenClosedBrowserPanel
+                )
+
+                #expect(Self.dispatch(shortcut, in: harness))
+                let restoredBrowser = try #require(
+                    harness.dock.panels.values.compactMap {
+                        $0 as? BrowserPanel
+                    }.first
+                )
+                #expect(restoredBrowser.currentURL == restoredURL)
+                #expect(
+                    !harness.mainWorkspace.panels.values.contains {
+                        $0 is BrowserPanel
+                    }
+                )
+                #expect(ClosedItemHistoryStore.shared.canReopen)
+            }
+        }
+    }
+
+    @Test("Previous and next pane shortcuts cycle focused Dock panes")
+    @MainActor
+    func paneCyclingTargetsFocusedDock() async throws {
+        try await AppContextSerialGate.withExclusiveAppContext {
+            try await Self.withHarness { harness in
+                let leftPanel = try #require(
+                    harness.dock.newSurface(
+                        kind: .terminal,
+                        inPane: harness.rootPane,
+                        focus: true
+                    )
+                )
+                let rightPanel = try #require(
+                    harness.dock.newSplit(
+                        kind: .terminal,
+                        orientation: .horizontal,
+                        insertFirst: false,
+                        sourcePanelId: leftPanel,
+                        focus: true
+                    )
+                )
+                let rightPane = try #require(
+                    harness.dock.paneId(forPanelId: rightPanel)
+                )
+                harness.dock.focusPanel(leftPanel)
+                let mainPanelBefore = harness.mainWorkspace.focusedPanelId
+
+                let previous = Self.customShortcut(key: "y")
+                KeyboardShortcutSettings.setShortcut(
+                    previous,
+                    for: .focusPreviousPane
+                )
+                #expect(Self.dispatch(previous, in: harness))
+                #expect(
+                    harness.dock.bonsplitController.focusedPaneId == rightPane
+                )
+
+                let next = Self.customShortcut(key: "u")
+                KeyboardShortcutSettings.setShortcut(next, for: .focusNextPane)
+                #expect(Self.dispatch(next, in: harness))
+                #expect(
+                    harness.dock.bonsplitController.focusedPaneId ==
+                        harness.rootPane
+                )
+                #expect(harness.mainWorkspace.focusedPanelId == mainPanelBefore)
+            }
+        }
+    }
+
+    @Test("Equalize splits targets the focused Dock")
+    @MainActor
+    func equalizeSplitsTargetsFocusedDock() async throws {
+        try await AppContextSerialGate.withExclusiveAppContext {
+            try await Self.withHarness { harness in
+                let firstPanel = try #require(
+                    harness.dock.newSurface(
+                        kind: .terminal,
+                        inPane: harness.rootPane,
+                        focus: true
+                    )
+                )
+                _ = try #require(
+                    harness.dock.newSplit(
+                        kind: .terminal,
+                        orientation: .horizontal,
+                        insertFirst: false,
+                        sourcePanelId: firstPanel,
+                        focus: true
+                    )
+                )
+                let split = try #require(
+                    Self.splitNodes(
+                        in: harness.dock.bonsplitController.treeSnapshot()
+                    ).first
+                )
+                let splitId = try #require(UUID(uuidString: split.id))
+                #expect(
+                    harness.dock.bonsplitController.setDividerPosition(
+                        0.2,
+                        forSplit: splitId
+                    )
+                )
+
+                let shortcut = Self.customShortcut(key: "y")
+                KeyboardShortcutSettings.setShortcut(
+                    shortcut,
+                    for: .equalizeSplits
+                )
+                #expect(Self.dispatch(shortcut, in: harness))
+
+                let updatedSplit = try #require(
+                    Self.splitNodes(
+                        in: harness.dock.bonsplitController.treeSnapshot()
+                    ).first { $0.id == split.id }
+                )
+                #expect(abs(updatedSplit.dividerPosition - 0.5) < 0.000_1)
+            }
+        }
+    }
+
+    @Test("Close other tabs targets the focused Dock pane")
+    @MainActor
+    func closeOtherTabsTargetsFocusedDockPane() async throws {
+        try await AppContextSerialGate.withExclusiveAppContext {
+            try await Self.withHarness { harness in
+                let warningStore = CloseTabWarningStore(
+                    defaults: harness.tabManager.closeTabWarningDefaults
+                )
+                let previousWarning = warningStore.warnsBeforeClosingTab
+                warningStore.setWarnsBeforeClosingTab(false)
+                defer {
+                    warningStore.setWarnsBeforeClosingTab(previousWarning)
+                }
+
+                _ = try #require(
+                    harness.dock.newSurface(
+                        kind: .terminal,
+                        inPane: harness.rootPane,
+                        focus: true
+                    )
+                )
+                let retainedPanel = try #require(
+                    harness.dock.newSurface(
+                        kind: .terminal,
+                        inPane: harness.rootPane,
+                        focus: true
+                    )
+                )
+                _ = try #require(
+                    harness.dock.newSurface(
+                        kind: .terminal,
+                        inPane: harness.rootPane,
+                        focus: true
+                    )
+                )
+                harness.dock.focusPanel(retainedPanel)
+                let mainPanelIdsBefore = Set(harness.mainWorkspace.panels.keys)
+
+                let shortcut = Self.customShortcut(key: "y")
+                KeyboardShortcutSettings.setShortcut(
+                    shortcut,
+                    for: .closeOtherTabsInPane
+                )
+                #expect(Self.dispatch(shortcut, in: harness))
+                #expect(Set(harness.dock.panels.keys) == [retainedPanel])
+                #expect(Set(harness.mainWorkspace.panels.keys) == mainPanelIdsBefore)
+            }
+        }
+    }
+
+    @Test("Terminal and find shortcuts target the focused Dock terminal")
+    @MainActor
+    func terminalAndFindShortcutsTargetFocusedDock() async throws {
+        try await AppContextSerialGate.withExclusiveAppContext {
+            try await Self.withHarness { harness in
+                let dockTerminalId = try #require(
+                    harness.dock.newSurface(
+                        kind: .terminal,
+                        inPane: harness.rootPane,
+                        focus: true
+                    )
+                )
+                let dockTerminal = try #require(
+                    harness.dock.panels[dockTerminalId] as? TerminalPanel
+                )
+                let mainTerminal = try #require(
+                    harness.mainWorkspace.focusedTerminalInputTarget()?.panel
+                )
+                dockTerminal.surface.requestInputDemandSurfaceStartIfNeeded()
+                await Self.waitForLiveSurface(dockTerminal.surface)
+                try #require(dockTerminal.surface.hasLiveSurface)
+
+                let copyMode = Self.customShortcut(key: "y")
+                KeyboardShortcutSettings.setShortcut(
+                    copyMode,
+                    for: .toggleTerminalCopyMode
+                )
+                #expect(Self.dispatch(copyMode, in: harness))
+                #expect(
+                    dockTerminal.hostedView.surfaceView
+                        .isKeyboardCopyModeActive
+                )
+                #expect(
+                    !mainTerminal.hostedView.surfaceView
+                        .isKeyboardCopyModeActive
+                )
+
+                let textBox = Self.customShortcut(key: "u")
+                KeyboardShortcutSettings.setShortcut(
+                    textBox,
+                    for: .focusTextBoxInput
+                )
+                #expect(Self.dispatch(textBox, in: harness))
+                #expect(dockTerminal.isTextBoxActive)
+                #expect(!mainTerminal.isTextBoxActive)
+
+                let find = Self.customShortcut(key: "o")
+                KeyboardShortcutSettings.setShortcut(find, for: .find)
+                let searchFocusNotifications =
+                    NotificationCenter.default.notifications(
+                        named: .ghosttySearchFocus,
+                        object: dockTerminal.surface
+                    )
+                try #require(Self.dispatch(find, in: harness))
+                for await _ in searchFocusNotifications { break }
+                #expect(dockTerminal.searchState != nil)
+                #expect(mainTerminal.searchState == nil)
+
+                mainTerminal.searchState = nil
+                dockTerminal.searchState = TerminalSurface.SearchState(
+                    needle: "dock"
+                )
+                let hideFind = Self.customShortcut(key: "p")
+                KeyboardShortcutSettings.setShortcut(
+                    hideFind,
+                    for: .hideFind
+                )
+                #expect(Self.dispatch(hideFind, in: harness))
+                #expect(dockTerminal.searchState == nil)
+                #expect(mainTerminal.searchState == nil)
+            }
+        }
+    }
+
+    @Test("React Grab shortcut does not target the background workspace")
+    @MainActor
+    func reactGrabDoesNotTargetBackgroundWorkspace() async throws {
+        try await AppContextSerialGate.withExclusiveAppContext {
+            try await Self.withHarness { harness in
+                let mainTerminalId = try #require(
+                    harness.mainWorkspace.focusedPanelId
+                )
+                let mainPane = try #require(
+                    harness.mainWorkspace.paneId(
+                        forPanelId: mainTerminalId
+                    )
+                )
+                let mainBrowser = try #require(
+                    harness.mainWorkspace.newBrowserSurface(
+                        inPane: mainPane,
+                        focus: false
+                    )
+                )
+                harness.mainWorkspace.focusPanel(mainTerminalId)
+
+                let dockBrowserId = try #require(
+                    harness.dock.newSurface(
+                        kind: .browser,
+                        inPane: harness.rootPane,
+                        focus: false
+                    )
+                )
+                let dockBrowser = try #require(
+                    harness.dock.browserPanel(for: dockBrowserId)
+                )
+                let dockTerminalId = try #require(
+                    harness.dock.newSurface(
+                        kind: .terminal,
+                        inPane: harness.rootPane,
+                        focus: true
+                    )
+                )
+                let shortcut = Self.customShortcut(key: "y")
+                KeyboardShortcutSettings.setShortcut(
+                    shortcut,
+                    for: .toggleReactGrab
+                )
+
+                #expect(Self.dispatch(shortcut, in: harness))
+                #expect(
+                    harness.mainWorkspace.focusedPanelId == mainTerminalId
+                )
+                #expect(
+                    harness.mainWorkspace.focusedPanelId != mainBrowser.id
+                )
+                #expect(harness.dock.focusedPanelId == dockBrowserId)
+                #expect(
+                    dockBrowser.pendingReactGrabReturnTargetPanelId ==
+                        dockTerminalId
+                )
+            }
+        }
+    }
+
+    @Test("Move-to-pane shortcut moves the focused Dock surface")
+    @MainActor
+    func moveToPaneTargetsFocusedDock() async throws {
+        try await AppContextSerialGate.withExclusiveAppContext {
+            try await Self.withHarness { harness in
                 let movedPanelId = try #require(
                     harness.mainWorkspace.focusedPanelId
                 )
@@ -332,7 +759,34 @@ struct DockShortcutRoutingTests {
                     )
                 )
                 harness.mainWorkspace.focusPanel(movedPanelId)
-                let dockPanelBefore = harness.dock.focusedPanelId
+
+                let dockPanelToMove = try #require(
+                    harness.dock.newSurface(
+                        kind: .terminal,
+                        inPane: harness.rootPane,
+                        focus: true
+                    )
+                )
+                _ = try #require(
+                    harness.dock.newSurface(
+                        kind: .terminal,
+                        inPane: harness.rootPane,
+                        focus: false
+                    )
+                )
+                let destinationPanel = try #require(
+                    harness.dock.newSplit(
+                        kind: .terminal,
+                        orientation: .horizontal,
+                        insertFirst: false,
+                        sourcePanelId: dockPanelToMove,
+                        focus: false
+                    )
+                )
+                let destinationPane = try #require(
+                    harness.dock.paneId(forPanelId: destinationPanel)
+                )
+                harness.dock.focusPanel(dockPanelToMove)
                 let shortcut = Self.customShortcut(key: "y")
                 KeyboardShortcutSettings.setShortcut(
                     shortcut,
@@ -345,7 +799,11 @@ struct DockShortcutRoutingTests {
                         sourcePaneId
                 )
                 #expect(harness.mainWorkspace.focusedPanelId == movedPanelId)
-                #expect(harness.dock.focusedPanelId == dockPanelBefore)
+                #expect(
+                    harness.dock.paneId(forPanelId: dockPanelToMove) ==
+                        destinationPane
+                )
+                #expect(harness.dock.focusedPanelId == dockPanelToMove)
             }
         }
     }
@@ -354,7 +812,7 @@ struct DockShortcutRoutingTests {
     @MainActor
     func repeatedMoveToPaneDoesNotCreateMissingPane() async throws {
         try await AppContextSerialGate.withExclusiveAppContext {
-            try Self.withHarness { harness in
+            try await Self.withHarness { harness in
                 let movedPanelId = try #require(harness.mainWorkspace.focusedPanelId)
                 let paneIdsBefore = harness.mainWorkspace.bonsplitController.allPaneIds
                 let panelIdsBefore = Set(harness.mainWorkspace.panels.keys)
@@ -381,7 +839,7 @@ struct DockShortcutRoutingTests {
     @MainActor
     func repeatedMoveToPaneUsesExistingDestination() async throws {
         try await AppContextSerialGate.withExclusiveAppContext {
-            try Self.withHarness { harness in
+            try await Self.withHarness { harness in
                 let movedPanelId = try #require(harness.mainWorkspace.focusedPanelId)
                 let sourcePaneId = try #require(
                     harness.mainWorkspace.paneId(forPanelId: movedPanelId)
@@ -427,7 +885,7 @@ struct DockShortcutRoutingTests {
     @MainActor
     func simulatorShortcutTargetsFocusedDock() async throws {
         try await AppContextSerialGate.withExclusiveAppContext {
-            try Self.withHarness { harness in
+            try await Self.withHarness { harness in
                 let flags = CmuxFeatureFlags.shared
                 let simulatorFlag = CmuxFeatureFlags.allFlags[5]
                 let previousOverride = flags.overrideValue(for: simulatorFlag)
@@ -453,7 +911,7 @@ struct DockShortcutRoutingTests {
     @MainActor
     func simulatorToolEditorRetainsPanelFocus() async throws {
         try await AppContextSerialGate.withExclusiveAppContext {
-            try Self.withHarness { harness in
+            try await Self.withHarness { harness in
                 let flags = CmuxFeatureFlags.shared
                 let simulatorFlag = CmuxFeatureFlags.allFlags[5]
                 let previousOverride = flags.overrideValue(for: simulatorFlag)
@@ -506,12 +964,15 @@ private extension DockShortcutRoutingTests {
         let appDelegate: AppDelegate
         let dock: DockSplitStore
         let mainWorkspace: Workspace
+        let tabManager: TabManager
         let rootPane: PaneID
         let window: NSWindow
     }
 
     @MainActor
-    static func withHarness(_ body: (Harness) throws -> Void) throws {
+    static func withHarness(
+        _ body: (Harness) async throws -> Void
+    ) async throws {
         let previousAppDelegate = AppDelegate.shared
         let previousManager = TerminalController.shared.activeTabManagerForCallerNotification()
         let originalSettingsFileStore = KeyboardShortcutSettings.installIsolatedTestFileStore(
@@ -524,7 +985,11 @@ private extension DockShortcutRoutingTests {
         let defaults = try #require(UserDefaults(suiteName: suiteName))
         let settings = UserDefaultsSettingsClient(defaults: defaults)
         settings.set(true, for: SettingCatalog().app.focusHistoryIncludesPanesAndTabs)
-        let manager = TabManager(autoWelcomeIfNeeded: false, settings: settings)
+        let manager = TabManager(
+            autoWelcomeIfNeeded: false,
+            settings: settings,
+            closeTabWarningDefaults: defaults
+        )
         let fileExplorerState = FileExplorerState()
         let windowId = UUID()
         let window = NSWindow(
@@ -569,13 +1034,29 @@ private extension DockShortcutRoutingTests {
             AppDelegate.shared = previousAppDelegate
         }
 
-        try body(Harness(
+        try await body(Harness(
             appDelegate: appDelegate,
             dock: dock,
             mainWorkspace: mainWorkspace,
+            tabManager: manager,
             rootPane: rootPane,
             window: window
         ))
+    }
+
+    @MainActor
+    static func waitForLiveSurface(_ surface: TerminalSurface) async {
+        guard !surface.hasLiveSurface else { return }
+        let previousOnRuntimeReady = surface.onRuntimeReady
+        defer { surface.onRuntimeReady = previousOnRuntimeReady }
+        let readiness = AsyncStream<Void> { continuation in
+            surface.onRuntimeReady = {
+                previousOnRuntimeReady?()
+                continuation.yield()
+                continuation.finish()
+            }
+        }
+        for await _ in readiness { break }
     }
 
     @MainActor
@@ -626,6 +1107,16 @@ private extension DockShortcutRoutingTests {
             option: true,
             control: true
         )
+    }
+
+    static func splitNodes(in node: ExternalTreeNode) -> [ExternalSplitNode] {
+        switch node {
+        case .pane:
+            []
+        case .split(let split):
+            [split] + splitNodes(in: split.first) +
+                splitNodes(in: split.second)
+        }
     }
 }
 

--- a/tests/test_dock_shortcut_routing_guard.py
+++ b/tests/test_dock_shortcut_routing_guard.py
@@ -1,0 +1,212 @@
+#!/usr/bin/env python3
+"""Guard the exhaustive Dock ownership and dispatcher-gate audit."""
+
+from pathlib import Path
+import re
+import unittest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+ROUTING_SOURCE = REPO_ROOT / "Sources" / "AppDelegate+DockShortcutRouting.swift"
+ACTION_SOURCE = REPO_ROOT / "Sources" / "KeyboardShortcutSettings.swift"
+MOVEMENT_SOURCE = REPO_ROOT / "Sources" / "SurfacePaneMovement.swift"
+DISPATCH_SOURCES = tuple((REPO_ROOT / "Sources").glob("AppDelegate*.swift")) + (
+    REPO_ROOT / "Sources" / "Workspace+DockBrowserLookup.swift",
+)
+GATE_CALLS = (
+    "focusedDockStoreForShortcut",
+    "performFocusedDockShortcut",
+    "routeCreateToFocusedDock",
+    "routeSplitToFocusedDock",
+)
+
+
+def source_between(
+    source: str,
+    start_anchor: str,
+    end_anchor: str,
+    source_name: str,
+) -> str:
+    _, start_separator, remainder = source.partition(start_anchor)
+    if not start_separator:
+        raise AssertionError(
+            f"{source_name}: missing start anchor {start_anchor!r}"
+        )
+    body, end_separator, _ = remainder.partition(end_anchor)
+    if not end_separator:
+        raise AssertionError(
+            f"{source_name}: missing end anchor {end_anchor!r}"
+        )
+    return body
+
+
+def action_cases() -> set[str]:
+    source = ACTION_SOURCE.read_text(encoding="utf-8")
+    enum_body = source_between(
+        source,
+        "enum Action: String, CaseIterable, Identifiable {",
+        "var id: String",
+        ACTION_SOURCE.name,
+    )
+    actions: set[str] = set()
+    for line in enum_body.splitlines():
+        stripped = line.strip()
+        if not stripped.startswith("case "):
+            continue
+        declarations = stripped.removeprefix("case ").split("=", maxsplit=1)[0]
+        actions.update(
+            declaration.strip()
+            for declaration in declarations.split(",")
+        )
+    return actions
+
+
+def disposition_actions() -> dict[str, set[str]]:
+    source = ROUTING_SOURCE.read_text(encoding="utf-8")
+    property_body = source_between(
+        source,
+        "var dockShortcutRoutingDisposition:",
+        "extension AppDelegate {",
+        ROUTING_SOURCE.name,
+    )
+    result: dict[str, set[str]] = {}
+    for cases, disposition in re.findall(
+        r"case\s+(.*?)\s*:\s*\.(dockScoped|focusResolved|mainContainer)",
+        property_body,
+        flags=re.DOTALL,
+    ):
+        result.setdefault(disposition, set()).update(
+            re.findall(r"\.([A-Za-z][A-Za-z0-9_]*)", cases)
+        )
+    return result
+
+
+def balanced_call_bodies(source: str, call_name: str) -> list[str]:
+    # Gate calls currently use ordinary quoted strings. This lightweight scanner
+    # intentionally does not parse Swift multiline or raw string delimiters.
+    bodies: list[str] = []
+    pattern = re.compile(r"\b" + re.escape(call_name) + r"\s*\(")
+    for match in pattern.finditer(source):
+        opening = source.find("(", match.start())
+        depth = 1
+        index = opening + 1
+        in_string = False
+        escaped = False
+        line_comment = False
+        block_comment_depth = 0
+        while index < len(source) and depth:
+            character = source[index]
+            following = source[index + 1] if index + 1 < len(source) else ""
+            if line_comment:
+                if character == "\n":
+                    line_comment = False
+                index += 1
+                continue
+            if block_comment_depth:
+                if character == "/" and following == "*":
+                    block_comment_depth += 1
+                    index += 2
+                elif character == "*" and following == "/":
+                    block_comment_depth -= 1
+                    index += 2
+                else:
+                    index += 1
+                continue
+            if in_string:
+                if escaped:
+                    escaped = False
+                elif character == "\\":
+                    escaped = True
+                elif character == '"':
+                    in_string = False
+                index += 1
+                continue
+            if character == "/" and following == "/":
+                line_comment = True
+                index += 2
+                continue
+            if character == "/" and following == "*":
+                block_comment_depth = 1
+                index += 2
+                continue
+            if character == '"':
+                in_string = True
+            elif character == "(":
+                depth += 1
+            elif character == ")":
+                depth -= 1
+            index += 1
+        if depth == 0:
+            bodies.append(source[opening + 1:index - 1])
+    return bodies
+
+
+def movement_shortcut_actions() -> set[str]:
+    source = MOVEMENT_SOURCE.read_text(encoding="utf-8")
+    property_body = source_between(
+        source,
+        "var shortcutAction: KeyboardShortcutSettings.Action {",
+        "init?(shortcutAction:",
+        MOVEMENT_SOURCE.name,
+    )
+    return set(
+        re.findall(
+            r"case\s+\.[A-Za-z][A-Za-z0-9_]*\s*:\s*"
+            r"\.([A-Za-z][A-Za-z0-9_]*)",
+            property_body,
+        )
+    )
+
+
+def explicitly_gated_actions() -> set[str]:
+    actions: set[str] = set()
+    has_movement_gate = False
+    for path in DISPATCH_SOURCES:
+        source = path.read_text(encoding="utf-8")
+        for call_name in GATE_CALLS:
+            for body in balanced_call_bodies(source, call_name):
+                actions.update(
+                    re.findall(
+                        r"\baction\s*:\s*\.([A-Za-z][A-Za-z0-9_]*)",
+                        body,
+                    )
+                )
+                if re.search(
+                    r"\baction\s*:\s*movement\.shortcutAction\b",
+                    body,
+                ):
+                    has_movement_gate = True
+    if has_movement_gate:
+        actions.update(movement_shortcut_actions())
+    return actions
+
+
+class DockShortcutRoutingGuardTests(unittest.TestCase):
+    def test_every_action_has_one_explicit_ownership_disposition(self) -> None:
+        dispositions = disposition_actions()
+        classified = set().union(*dispositions.values())
+        duplicate_actions = set()
+        disposition_names = tuple(dispositions)
+        for index, name in enumerate(disposition_names):
+            for other_name in disposition_names[index + 1:]:
+                duplicate_actions.update(
+                    dispositions[name] & dispositions[other_name]
+                )
+
+        self.assertEqual(duplicate_actions, set())
+        self.assertEqual(classified, action_cases())
+
+    def test_every_dock_scoped_action_reaches_the_focused_dock_gate(self) -> None:
+        dock_scoped = disposition_actions()["dockScoped"]
+        gated = explicitly_gated_actions()
+
+        self.assertEqual(
+            gated,
+            dock_scoped,
+            "Every dockScoped action must appear in an action-aware Dock gate "
+            "call. Add the route before adding its main-area fallback.",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- classify every configurable shortcut as Dock-scoped, focus-resolved, or main-container-owned
- route every surface-scoped shortcut through the focused Dock before any main-area fallback
- add a per-Dock closed-panel history so Cmd+Shift+T restores the focused Dock most recently closed panel
- add behavior regressions plus a CI routing guard for future shortcuts

## Structural safeguard

`KeyboardShortcutSettings.Action.dockShortcutRoutingDisposition` exhaustively classifies all 143 actions with no default case: 44 Dock-scoped, 37 focus-resolved, and 62 main-container-owned. Adding an action now fails compilation until its ownership is explicit.

`tests/test_dock_shortcut_routing_guard.py`, run by `workflow-guard-tests`, independently scans the action-aware Dock gate calls in the dispatcher sources and requires exact equality with the Dock-scoped set. A new surface-scoped action therefore cannot pass CI with classification alone; its handler must also call `focusedDockStoreForShortcut`, `performFocusedDockShortcut`, `routeCreateToFocusedDock`, or `routeSplitToFocusedDock`. The routing helpers accept the action and assert if a non-Dock-scoped action attempts to use the gate.

## Dispatcher audit

Already Dock-aware before this change:

- `triggerFlash`
- `nextSurface`, `prevSurface`, and legacy Ctrl+Tab surface navigation
- `moveSurfaceLeft`, `moveSurfaceRight`
- `selectSurfaceByNumber`
- `focusLeft`, `focusRight`, `focusUp`, `focusDown`
- `toggleSplitZoom`
- `splitRight`, `splitDown`, `splitBrowserRight`, `splitBrowserDown`
- `newSurface`, `openBrowser`
- `focusHistoryBack`, `focusHistoryForward`
- `closeTab`

Focus-resolved handlers already target the event responder or focused panel, including Dock panels. These include browser navigation, reload, zoom, developer tools, focus/design mode, Simulator commands, Markdown/file preview zoom, diff viewer navigation, and focused TextBox/checklist commands.

The audit found these missing or incomplete Dock routes, all addressed here:

- `focusBrowserAddressBar`
- `reopenClosedBrowserPanel`
- `focusPreviousPane`, `focusNextPane`
- `equalizeSplits`
- `closeOtherTabsInPane`
- `renameTab`
- `toggleTerminalCopyMode`
- `focusTextBoxInput`
- `attachTextBoxFile`
- `sendCtrlFToTerminal`
- `clearScreenKeepScrollback`
- `find`
- `findNext`, `findPrevious`, `hideFind`, `useSelectionForFind`
- `toggleReactGrab`
- `moveSurfaceToPreviousPane`, `moveSurfaceToNextPane`
- `moveSurfaceToPaneLeft`, `moveSurfaceToPaneRight`, `moveSurfaceToPaneUp`, `moveSurfaceToPaneDown`

App, window, workspace, sidebar, Canvas, workspace terminal-font-size, directory-search, and diff-viewer-opening actions remain intentionally main-container-owned.

## Behavior details

Cmd+L focuses the focused Dock browser address bar. If the focused Dock panel is not a browser, the handler preserves the existing main-area fallback. The existing main-area behavior also remains when no Dock owns focus.

Cmd+Shift+T uses a real non-persisted `ClosedItemHistoryStore` owned by each `DockSplitStore`. User tab closes, pane closes, and Close Other Tabs stage snapshots before teardown. Configuration resets, runtime force-closes, transfers, and restore teardown are excluded. Restore prefers the original pane, then a same-pane anchor, then the former split placement, and finally the focused or root pane. Dock reopen never consumes the main-area shared history. If the focused Dock has no restorable item, the shortcut is consumed and beeps.

Transferred terminal history preserves both the live source-workspace identity and the snapshot workspace identity. A remote terminal fails closed if its live restore owner cannot be resolved, so reopen cannot silently create a local shell. Pane close and Close Other Tabs snapshot each batch once, reuse at most one agent index, and use indexed pane lookup for fallback anchors.

Dock rename writes Bonsplit custom-title state and prevents live terminal or browser title updates from overwriting it. The custom title round-trips through the existing Dock session snapshot fields.

## Tests and validation

The first commit contains the failing behavior regressions and CI guard. The second commit contains the implementation.

Completed locally without invoking xcodebuild:

- Swift parser checks for every changed Swift source and test file
- `python3 tests/test_dock_shortcut_routing_guard.py`
- `python3 scripts/check-test-determinism.py --strict`
- `python3 tests/test_ci_change_areas.py`
- `git diff --check`
- `./scripts/check-pbxproj.sh`
- `./scripts/lint-pbxproj-test-wiring.sh`
- workspace package-group and Package.resolved policy checks
- cmux architectural policy check
- localization catalog validation for every locale, including Khmer and Ukrainian
- cancellation regressions proving process-detected resume bindings survive cancelled tab and pane closes
- placeholder-only fallback split restoration, without launching a temporary terminal

Remote validation on pre-rebase feature head `faada6719b`: `DockShortcutRoutingTests` and `DockControlDefinitionDecodingTests` passed, and every required PR check is green. A manually dispatched full CI run also passed the routing guard, Swift warning budget, app/test build, runtime regressions, and Swift package tests; its app-host matrix hit pre-existing baseline failures tracked by #8614 and #9574, so that non-required run was stopped rather than adding unrelated test repairs to this PR.

Local xcodebuild tests and a local tagged build were intentionally not run per the task instructions.

Closes #9518

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded keyboard shortcuts for Dock pane movement, focus cycling, split management, tab renaming, terminal and browser search, and related actions.
  * Added reopening of recently closed Dock panels and panes, restoring layout, focus, and session state when possible.
  * Browser address-bar shortcuts now target the focused Dock browser panel.
* **Bug Fixes**
  * Closing and cancelling panel or tab closes now preserves state more reliably and avoids stale notifications.
  * Dock title updates better preserve custom tab names.
* **Localization**
  * Added Khmer and Ukrainian translations for tab naming and cancellation actions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Tagged dogfood

- Built and user-tested feature head faada6719b with CMUX_SKIP_ZIG_BUILD=1 /Users/austinwang/manaflow/cmuxterm-hq/scripts/reload-cloud.sh --tag issue-9518-dock-focus-cmd-l-cmd-shift-t --launch. Cloud build [30954884110](https://github.com/manaflow-ai/cmux/actions/runs/30954884110) completed successfully on blacksmith-6vcpu-macos-26.
- Launched the isolated tagged app and created a dedicated Dock Shortcut QA workspace with Dock terminals, a Dock browser, and a distinct main-area browser as a negative control.
- Confirmed that live Settings bindings resolve to semantic actions before focus routing, so the same user-customized binding targets the main container or Dock solely according to keyboard focus. No shortcut behavior is hardcoded to its default key combination.
- User dogfood confirmed the Dock shortcuts work in the tagged build. The tagged app was left running for follow-up testing.
