### PR TITLE
iOS: unify phone browsers on the streamed Mac surface (create, blank-page state, Mac click counts, discarded-tab restore)

### DIFF
--- a/Packages/Shared/CMUXMobileCore/Sources/CMUXMobileCore/MobileBrowserStreamCapability.swift
+++ b/Packages/Shared/CMUXMobileCore/Sources/CMUXMobileCore/MobileBrowserStreamCapability.swift
@@ -8,4 +8,6 @@ public struct MobileBrowserStreamCapability: Sendable {
     public static let viewportIdentifier = "browser.stream.viewport.v1"
     /// Version-one native browser dialog mirroring capability identifier.
     public static let dialogIdentifier = "browser.stream.dialog.v1"
+    /// Version-one phone-initiated browser panel creation capability identifier.
+    public static let createIdentifier = "browser.stream.create.v1"
 }

--- a/Packages/iOS/CmuxMobileBrowserStream/Sources/CmuxMobileBrowserStream/BrowserStreamContentView.swift
+++ b/Packages/iOS/CmuxMobileBrowserStream/Sources/CmuxMobileBrowserStream/BrowserStreamContentView.swift
@@ -26,6 +26,7 @@ final class BrowserStreamContentView: UIView, UIScrollViewDelegate, UIGestureRec
     private var panStartOffset = CGPoint.zero
     private var displayLink: CADisplayLink?
     private var viewportPolicy = BrowserStreamViewportEmissionPolicy()
+    private var tapClickCounter = BrowserStreamTapClickCounter()
 
     private lazy var scrollMechanicsView: UIScrollView = {
         let view = UIScrollView()
@@ -68,12 +69,12 @@ final class BrowserStreamContentView: UIView, UIScrollViewDelegate, UIGestureRec
         addSubview(scrollMechanicsView)
         addSubview(inputProxy)
 
+        // One tap recognizer, forwarded immediately with a rising click count
+        // (see BrowserStreamTapClickCounter): double tap means Mac double
+        // click, never local zoom, and single clicks never wait on a
+        // double-tap recognizer to fail. Pinch owns zooming.
         let tap = UITapGestureRecognizer(target: self, action: #selector(handleTap(_:)))
-        let doubleTap = UITapGestureRecognizer(target: self, action: #selector(handleDoubleTap(_:)))
-        doubleTap.numberOfTapsRequired = 2
-        tap.require(toFail: doubleTap)
         addGestureRecognizer(tap)
-        addGestureRecognizer(doubleTap)
 
         let pinch = UIPinchGestureRecognizer(target: self, action: #selector(handlePinch(_:)))
         addGestureRecognizer(pinch)
@@ -260,32 +261,17 @@ final class BrowserStreamContentView: UIView, UIScrollViewDelegate, UIGestureRec
     }
 
     @objc private func handleTap(_ gesture: UITapGestureRecognizer) {
-        guard let point = currentTransform.pagePoint(fromViewPoint: gesture.location(in: self)) else { return }
+        let viewPoint = gesture.location(in: self)
+        guard let point = currentTransform.pagePoint(fromViewPoint: viewPoint) else { return }
         let input = MobileBrowserPointerInput(
             panelID: panelID,
             kind: .click,
             x: Double(point.x),
             y: Double(point.y),
-            clickCount: 1,
+            clickCount: tapClickCounter.register(at: viewPoint, time: CACurrentMediaTime()),
             button: .left
         )
         delegate?.browserStreamContentView(self, didProducePointer: input)
-    }
-
-    @objc private func handleDoubleTap(_ gesture: UITapGestureRecognizer) {
-        if zoomScale > 1.001 {
-            zoomScale = 1
-            viewportOffset = .zero
-        } else {
-            zoomScale = 2
-            let location = gesture.location(in: self)
-            viewportOffset = CGPoint(
-                x: (location.x - bounds.midX) * (zoomScale - 1),
-                y: (location.y - bounds.midY) * (zoomScale - 1)
-            )
-        }
-        updateGestureModes()
-        layoutImageLayer()
     }
 
     @objc private func handlePinch(_ gesture: UIPinchGestureRecognizer) {

--- a/Packages/iOS/CmuxMobileBrowserStream/Sources/CmuxMobileBrowserStream/BrowserStreamEventReceiving.swift
+++ b/Packages/iOS/CmuxMobileBrowserStream/Sources/CmuxMobileBrowserStream/BrowserStreamEventReceiving.swift
@@ -12,6 +12,9 @@ public protocol BrowserStreamEventReceiving: AnyObject {
     /// Marks a stream active after the Mac accepts `stream.start`.
     /// - Parameter descriptor: The descriptor returned by the start request.
     func browserStreamDidStart(_ descriptor: MobileBrowserPanelDescriptor)
+    /// Registers a panel the Mac just created on the phone's behalf.
+    /// - Parameter descriptor: The descriptor returned by the create request.
+    func browserPanelCreated(_ descriptor: MobileBrowserPanelDescriptor)
     /// Resets subscription-local sequencing immediately before `stream.start`.
     /// - Parameter panelID: The Mac browser panel identifier.
     func browserStreamWillStart(panelID: String) async

--- a/Packages/iOS/CmuxMobileBrowserStream/Sources/CmuxMobileBrowserStream/BrowserStreamPane.swift
+++ b/Packages/iOS/CmuxMobileBrowserStream/Sources/CmuxMobileBrowserStream/BrowserStreamPane.swift
@@ -179,6 +179,8 @@ public struct BrowserStreamPane: View {
                 symbol: "pause.circle"
             )
             .accessibilityIdentifier("BrowserStreamPausedOverlay")
+        } else if state.isBlankPage {
+            newPagePlaceholder
         } else if state.latestFrame == nil {
             statusOverlay(
                 title: L10n.string("mobile.browserStream.waiting", defaultValue: "Waiting for Browser"),
@@ -187,6 +189,33 @@ public struct BrowserStreamPane: View {
             )
             .accessibilityIdentifier("BrowserStreamPlaceholder")
         }
+    }
+
+    /// Deliberate empty state for a browser that has not opened a page yet.
+    ///
+    /// A fresh pane's mirror is an empty white capture, which looks like a
+    /// glitch; this opaque placeholder replaces it until the first navigation.
+    private var newPagePlaceholder: some View {
+        ZStack {
+            Color(red: 0.055, green: 0.063, blue: 0.075)
+            VStack(spacing: 12) {
+                Image(systemName: "globe")
+                    .font(.system(size: 36))
+                    .foregroundStyle(.secondary)
+                Text(L10n.string("mobile.browserStream.newPage", defaultValue: "New Browser"))
+                    .font(.headline)
+                Text(L10n.string(
+                    "mobile.browserStream.newPageDetail",
+                    defaultValue: "Search or enter an address in the bar below."
+                ))
+                .font(.subheadline)
+                .foregroundStyle(.secondary)
+                .multilineTextAlignment(.center)
+            }
+            .foregroundStyle(.white)
+            .padding(28)
+        }
+        .accessibilityIdentifier("BrowserStreamNewPagePlaceholder")
     }
 
     private var disconnectedOverlay: some View {

--- a/Packages/iOS/CmuxMobileBrowserStream/Sources/CmuxMobileBrowserStream/BrowserStreamStore.swift
+++ b/Packages/iOS/CmuxMobileBrowserStream/Sources/CmuxMobileBrowserStream/BrowserStreamStore.swift
@@ -184,16 +184,17 @@ public final class BrowserStreamStore: BrowserStreamEventReceiving {
         replacePanels(in: workspaceID, with: descriptors)
     }
 
+    /// Registers a panel the Mac just created on the phone's behalf, so it can
+    /// be activated and streamed before any discovery refresh lands.
+    /// - Parameter descriptor: The descriptor returned by the create request.
+    public func browserPanelCreated(_ descriptor: MobileBrowserPanelDescriptor) {
+        upsertPanel(descriptor)
+    }
+
     /// Reconciles the descriptor returned by a successful start request.
     /// - Parameter descriptor: The descriptor accepted by the Mac.
     public func browserStreamDidStart(_ descriptor: MobileBrowserPanelDescriptor) {
-        var descriptors = panels(in: descriptor.workspaceID)
-        if let index = descriptors.firstIndex(where: { $0.panelID == descriptor.panelID }) {
-            descriptors[index] = descriptor
-        } else {
-            descriptors.append(descriptor)
-        }
-        replacePanels(in: descriptor.workspaceID, with: descriptors)
+        upsertPanel(descriptor)
         guard let state = statesByPanel[descriptor.panelID] else { return }
         state.connectionStatus = .connected
         if state.streamStatus != .streaming {
@@ -313,6 +314,16 @@ public final class BrowserStreamStore: BrowserStreamEventReceiving {
             descriptorsByWorkspace[workspaceID] = descriptors.filter { $0.panelID != event.panelID }
         }
         return event.panelID
+    }
+
+    private func upsertPanel(_ descriptor: MobileBrowserPanelDescriptor) {
+        var descriptors = panels(in: descriptor.workspaceID)
+        if let index = descriptors.firstIndex(where: { $0.panelID == descriptor.panelID }) {
+            descriptors[index] = descriptor
+        } else {
+            descriptors.append(descriptor)
+        }
+        replacePanels(in: descriptor.workspaceID, with: descriptors)
     }
 
     private func installDialog(_ dialog: MobileBrowserDialogEvent) {

--- a/Packages/iOS/CmuxMobileBrowserStream/Sources/CmuxMobileBrowserStream/BrowserStreamSurfaceState.swift
+++ b/Packages/iOS/CmuxMobileBrowserStream/Sources/CmuxMobileBrowserStream/BrowserStreamSurfaceState.swift
@@ -160,6 +160,16 @@ public final class BrowserStreamSurfaceState: Identifiable {
     /// Whether the hidden input proxy should hold first responder.
     public var shouldFocusInput: Bool { keyboardPolicy.shouldFocusInput }
 
+    /// Whether the panel has never opened a page (a fresh New Browser pane).
+    ///
+    /// A blank pane mirrors an empty white surface, which reads as a rendering
+    /// glitch; the pane shows a purposeful new-page placeholder instead until
+    /// the first navigation gives the panel a URL.
+    public var isBlankPage: Bool {
+        let trimmed = url?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        return trimmed.isEmpty || trimmed == "about:blank"
+    }
+
     /// Prepares sequence and status state for a new Mac stream subscription.
     public func prepareForStreamStart() {
         newestDisplayedSequence = nil

--- a/Packages/iOS/CmuxMobileBrowserStream/Sources/CmuxMobileBrowserStream/BrowserStreamTapClickCounter.swift
+++ b/Packages/iOS/CmuxMobileBrowserStream/Sources/CmuxMobileBrowserStream/BrowserStreamTapClickCounter.swift
@@ -1,0 +1,48 @@
+import CoreGraphics
+import Foundation
+
+/// Computes Mac-style click counts from successive phone taps.
+///
+/// The mirror preserves Mac pointer semantics: a double tap is a double click
+/// (word selection), a triple tap a triple click (paragraph selection). Taps
+/// are forwarded immediately with a rising click count, exactly like a
+/// physical mouse, so single clicks never wait on a double-tap recognizer to
+/// fail. Zooming belongs to the pinch gesture alone.
+struct BrowserStreamTapClickCounter {
+    /// Maximum seconds between taps that still chain the click count.
+    let chainInterval: TimeInterval
+    /// Maximum view-point distance between taps that still chain the count.
+    let chainRadius: CGFloat
+
+    private var lastTime: TimeInterval?
+    private var lastLocation: CGPoint?
+    private var count = 0
+
+    /// Creates a counter with Mac-like double-click chaining thresholds.
+    /// - Parameters:
+    ///   - chainInterval: Seconds within which a tap continues the chain.
+    ///   - chainRadius: View points within which a tap continues the chain.
+    init(chainInterval: TimeInterval = 0.45, chainRadius: CGFloat = 28) {
+        self.chainInterval = chainInterval
+        self.chainRadius = chainRadius
+    }
+
+    /// Registers one tap and returns the click count to forward to the Mac.
+    /// - Parameters:
+    ///   - location: The tap location in view points.
+    ///   - time: A monotonic timestamp for the tap.
+    /// - Returns: The Mac click count for this tap (1 for a lone tap, 2 for a
+    ///   double click, and so on).
+    mutating func register(at location: CGPoint, time: TimeInterval) -> Int {
+        if let lastTime, let lastLocation,
+           time - lastTime <= chainInterval,
+           hypot(location.x - lastLocation.x, location.y - lastLocation.y) <= chainRadius {
+            count += 1
+        } else {
+            count = 1
+        }
+        lastTime = time
+        lastLocation = location
+        return count
+    }
+}

--- a/Packages/iOS/CmuxMobileBrowserStream/Tests/CmuxMobileBrowserStreamTests/BrowserStreamStorePanelCreationTests.swift
+++ b/Packages/iOS/CmuxMobileBrowserStream/Tests/CmuxMobileBrowserStreamTests/BrowserStreamStorePanelCreationTests.swift
@@ -1,0 +1,55 @@
+import CMUXMobileCore
+import Foundation
+import Testing
+@testable import CmuxMobileBrowserStream
+
+/// Coverage for phone-initiated panel creation: the New Browser button relies
+/// on the created descriptor being activatable before any discovery refresh.
+@MainActor
+struct BrowserStreamStorePanelCreationTests {
+    private func descriptor(
+        panelID: String,
+        workspaceID: String,
+        title: String? = nil
+    ) -> MobileBrowserPanelDescriptor {
+        MobileBrowserPanelDescriptor(
+            panelID: panelID,
+            workspaceID: workspaceID,
+            url: nil,
+            title: title,
+            pageWidth: 800,
+            pageHeight: 600,
+            canGoBack: false,
+            canGoForward: false,
+            isLoading: false
+        )
+    }
+
+    @Test func createdPanelIsImmediatelyActivatable() {
+        let store = BrowserStreamStore()
+        store.browserPanelCreated(descriptor(panelID: "panel-new", workspaceID: "ws-1"))
+
+        #expect(store.panels(in: "ws-1").map(\.panelID) == ["panel-new"])
+        let state = store.activate(panelID: "panel-new", in: "ws-1")
+        #expect(state != nil)
+        #expect(store.activeState(in: "ws-1")?.id == "panel-new")
+    }
+
+    @Test func repeatedCreationUpdatesInsteadOfDuplicating() {
+        let store = BrowserStreamStore()
+        store.browserPanelCreated(descriptor(panelID: "panel-new", workspaceID: "ws-1"))
+        store.browserPanelCreated(descriptor(panelID: "panel-new", workspaceID: "ws-1", title: "Example"))
+
+        let panels = store.panels(in: "ws-1")
+        #expect(panels.count == 1)
+        #expect(panels.first?.title == "Example")
+    }
+
+    @Test func createdPanelJoinsExistingDiscovery() {
+        let store = BrowserStreamStore()
+        store.replacePanels(in: "ws-1", with: [descriptor(panelID: "panel-old", workspaceID: "ws-1")])
+        store.browserPanelCreated(descriptor(panelID: "panel-new", workspaceID: "ws-1"))
+
+        #expect(store.panels(in: "ws-1").map(\.panelID) == ["panel-old", "panel-new"])
+    }
+}

--- a/Packages/iOS/CmuxMobileBrowserStream/Tests/CmuxMobileBrowserStreamTests/BrowserStreamSurfaceStateTests.swift
+++ b/Packages/iOS/CmuxMobileBrowserStream/Tests/CmuxMobileBrowserStreamTests/BrowserStreamSurfaceStateTests.swift
@@ -37,6 +37,46 @@ import Testing
         #expect(state.streamStatus == .streaming)
     }
 
+    @Test @MainActor func blankPageTracksNavigationState() {
+        let descriptor = MobileBrowserPanelDescriptor(
+            panelID: "panel-new",
+            workspaceID: "workspace-1",
+            url: nil,
+            title: nil,
+            pageWidth: 400,
+            pageHeight: 300,
+            canGoBack: false,
+            canGoForward: false,
+            isLoading: false
+        )
+        let state = BrowserStreamSurfaceState(descriptor: descriptor)
+        #expect(state.isBlankPage)
+
+        state.apply(MobileBrowserStateEvent(
+            panelID: "panel-new",
+            url: "about:blank",
+            title: nil,
+            canGoBack: false,
+            canGoForward: false,
+            isLoading: false,
+            progress: 1,
+            editableFocused: false
+        ))
+        #expect(state.isBlankPage)
+
+        state.apply(MobileBrowserStateEvent(
+            panelID: "panel-new",
+            url: "https://example.com",
+            title: "Example",
+            canGoBack: true,
+            canGoForward: false,
+            isLoading: false,
+            progress: 1,
+            editableFocused: false
+        ))
+        #expect(!state.isBlankPage)
+    }
+
     private func makeImage() -> CGImage? {
         CGContext(
             data: nil,

--- a/Packages/iOS/CmuxMobileBrowserStream/Tests/CmuxMobileBrowserStreamTests/BrowserStreamTapClickCounterTests.swift
+++ b/Packages/iOS/CmuxMobileBrowserStream/Tests/CmuxMobileBrowserStreamTests/BrowserStreamTapClickCounterTests.swift
@@ -1,0 +1,40 @@
+import CoreGraphics
+import Testing
+@testable import CmuxMobileBrowserStream
+
+/// Mac click-count semantics for phone taps: a double tap must reach the Mac
+/// as a double click (word selection), never as a local zoom gesture.
+struct BrowserStreamTapClickCounterTests {
+    @Test func quickSecondTapBecomesDoubleClick() {
+        var counter = BrowserStreamTapClickCounter()
+        #expect(counter.register(at: CGPoint(x: 100, y: 100), time: 10.0) == 1)
+        #expect(counter.register(at: CGPoint(x: 104, y: 98), time: 10.3) == 2)
+    }
+
+    @Test func thirdTapBecomesTripleClick() {
+        var counter = BrowserStreamTapClickCounter()
+        #expect(counter.register(at: CGPoint(x: 50, y: 50), time: 1.0) == 1)
+        #expect(counter.register(at: CGPoint(x: 50, y: 50), time: 1.3) == 2)
+        #expect(counter.register(at: CGPoint(x: 50, y: 50), time: 1.6) == 3)
+    }
+
+    @Test func slowSecondTapRestartsAtSingleClick() {
+        var counter = BrowserStreamTapClickCounter()
+        #expect(counter.register(at: CGPoint(x: 100, y: 100), time: 10.0) == 1)
+        #expect(counter.register(at: CGPoint(x: 100, y: 100), time: 10.6) == 1)
+    }
+
+    @Test func distantSecondTapRestartsAtSingleClick() {
+        var counter = BrowserStreamTapClickCounter()
+        #expect(counter.register(at: CGPoint(x: 100, y: 100), time: 10.0) == 1)
+        #expect(counter.register(at: CGPoint(x: 180, y: 100), time: 10.2) == 1)
+    }
+
+    @Test func chainRestartsAfterBreak() {
+        var counter = BrowserStreamTapClickCounter()
+        #expect(counter.register(at: CGPoint(x: 10, y: 10), time: 1.0) == 1)
+        #expect(counter.register(at: CGPoint(x: 10, y: 10), time: 1.2) == 2)
+        #expect(counter.register(at: CGPoint(x: 10, y: 10), time: 5.0) == 1)
+        #expect(counter.register(at: CGPoint(x: 10, y: 10), time: 5.2) == 2)
+    }
+}

--- a/Packages/iOS/CmuxMobileRPC/Sources/CmuxMobileRPC/MobileBrowserCreateParameters.swift
+++ b/Packages/iOS/CmuxMobileRPC/Sources/CmuxMobileRPC/MobileBrowserCreateParameters.swift
@@ -1,0 +1,12 @@
+import Foundation
+
+/// Typed parameters for `mobile.browser.create`.
+struct MobileBrowserCreateParameters: Encodable, Sendable {
+    /// The Mac-local workspace identifier.
+    let workspaceID: String
+
+    /// Creates browser-create parameters.
+    init(workspaceID: String) { self.workspaceID = workspaceID }
+
+    private enum CodingKeys: String, CodingKey { case workspaceID = "workspace_id" }
+}

--- a/Packages/iOS/CmuxMobileRPC/Sources/CmuxMobileRPC/MobileCoreRPCClient+BrowserStream.swift
+++ b/Packages/iOS/CmuxMobileRPC/Sources/CmuxMobileRPC/MobileCoreRPCClient+BrowserStream.swift
@@ -14,6 +14,18 @@ extension MobileCoreRPCClient {
         return try MobileBrowserListResponse.decode(data).panels
     }
 
+    /// Creates a new browser panel in one workspace for immediate streaming.
+    /// - Parameter workspaceID: The Mac-local workspace identifier.
+    /// - Returns: The descriptor of the freshly created panel.
+    /// - Throws: A transport, authorization, RPC, or response-decoding error.
+    public func createMobileBrowserPanel(workspaceID: String) async throws -> MobileBrowserPanelDescriptor {
+        let data = try await sendBrowserRequest(
+            method: "mobile.browser.create",
+            parameters: MobileBrowserCreateParameters(workspaceID: workspaceID)
+        )
+        return try JSONDecoder().decode(MobileBrowserPanelDescriptor.self, from: data)
+    }
+
     /// Starts streaming one browser panel and returns its descriptor.
     /// - Parameters:
     ///   - panelID: The Mac browser panel identifier.

--- a/Packages/iOS/CmuxMobileRPC/Sources/CmuxMobileRPC/MobileCoreRPCClient.swift
+++ b/Packages/iOS/CmuxMobileRPC/Sources/CmuxMobileRPC/MobileCoreRPCClient.swift
@@ -723,7 +723,7 @@ public final class MobileCoreRPCClient: MobileSyncing, Sendable {
             // token so legacy pairings cannot accidentally narrow the global
             // feed; Stack auth is still attached to every TCP request.
             return true
-        case "mobile.browser.list":
+        case "mobile.browser.list", "mobile.browser.create":
             return !ticketCoverage.ticketCoversWorkspaceRequest(
                 ticket: ticket,
                 workspaceSelection: workspaceSelection.value

--- a/Packages/iOS/CmuxMobileRPC/Tests/CmuxMobileRPCTests/MobileBrowserRPCDTOTests.swift
+++ b/Packages/iOS/CmuxMobileRPC/Tests/CmuxMobileRPCTests/MobileBrowserRPCDTOTests.swift
@@ -105,6 +105,16 @@ import Testing
         #expect(frame.stackAccessToken == "test-stack-token")
     }
 
+    @Test func browserCreateCarriesMatchingWorkspaceTicketContext() async throws {
+        let frame = try await recordedRequest(
+            method: "mobile.browser.create",
+            params: ["workspace_id": "workspace-main"],
+            ticketWorkspaceID: "workspace-main"
+        )
+        #expect(frame.attachToken == "ticket-secret")
+        #expect(frame.stackAccessToken == "test-stack-token")
+    }
+
     @Test func panelCommandUsesMacWideTicketContext() async throws {
         let frame = try await recordedRequest(
             method: "mobile.browser.stream.start",

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+BrowserStream.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+BrowserStream.swift
@@ -17,6 +17,21 @@ extension MobileShellComposite {
         browserStreamEvents?.replaceBrowserPanels(in: workspaceID, with: panels)
     }
 
+    /// Creates a new Mac browser panel in a workspace so the phone can stream
+    /// it with the same surface as discovered panels.
+    /// - Parameter workspaceID: The Mac-local workspace identifier.
+    /// - Returns: The created panel's descriptor, or `nil` when creation is
+    ///   unsupported, disconnected, or rejected by the Mac.
+    public func createMobileBrowserPanel(workspaceID: String) async -> MobileBrowserPanelDescriptor? {
+        guard connectionState == .connected,
+              supportsBrowserStreamCreate,
+              let client = remoteClient else { return nil }
+        guard let descriptor = try? await client.createMobileBrowserPanel(workspaceID: workspaceID),
+              remoteClient === client else { return nil }
+        browserStreamEvents?.browserPanelCreated(descriptor)
+        return descriptor
+    }
+
     /// Starts streaming a discovered Mac browser panel.
     /// - Parameter panelID: The Mac browser panel identifier.
     public func startMobileBrowserStream(panelID: String) async {

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+BrowserStream.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+BrowserStream.swift
@@ -27,7 +27,14 @@ extension MobileShellComposite {
               supportsBrowserStreamCreate,
               let client = remoteClient else { return nil }
         guard let descriptor = try? await client.createMobileBrowserPanel(workspaceID: workspaceID),
-              remoteClient === client else { return nil }
+              remoteClient === client else {
+            // The Mac may have committed the panel even though the outcome was
+            // lost (timeout, decode failure, or a client swap mid-flight).
+            // Reconcile discovery so a committed panel surfaces in the picker
+            // instead of becoming an orphan the phone never learns about.
+            await refreshMobileBrowserPanels(workspaceID: workspaceID)
+            return nil
+        }
         browserStreamEvents?.browserPanelCreated(descriptor)
         return descriptor
     }

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+Capabilities.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+Capabilities.swift
@@ -9,6 +9,10 @@ extension MobileShellComposite {
     public var supportsBrowserStreamDialogs: Bool {
         supportsBrowserStream && supportedHostCapabilities.contains(Self.browserStreamDialogCapability)
     }
+    /// Whether the connected Mac can create a browser panel for the phone to stream.
+    public var supportsBrowserStreamCreate: Bool {
+        supportsBrowserStream && supportedHostCapabilities.contains(Self.browserStreamCreateCapability)
+    }
     static let chatArtifactFoldersCapability = "chat.artifact.folders.v1"
     static let terminalArtifactListCapability = "terminal.artifact.list.v1"
 

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
@@ -108,6 +108,7 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
     static let browserStreamCapability = MobileBrowserStreamCapability.identifier
     static let browserStreamViewportCapability = MobileBrowserStreamCapability.viewportIdentifier
     static let browserStreamDialogCapability = MobileBrowserStreamCapability.dialogIdentifier
+    static let browserStreamCreateCapability = MobileBrowserStreamCapability.createIdentifier
     static let terminalReplayCapability = "terminal.replay.v1"
     static let terminalInputOrderedCapability = "terminal.input.ordered.v1"
     static let maxTerminalReplayBarrierDroppedOutputBeforeFailOpen: UInt64 = 256

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceDetailView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceDetailView.swift
@@ -607,7 +607,7 @@ struct WorkspaceDetailView: View {
                 createWorkspace: createWorkspaceFromToolbar,
                 createTerminal: createTerminalFromToolbar,
                 openBrowser: openBrowserFromToolbar,
-                selectBrowserStream: selectBrowserStreamFromToolbar,
+                selectBrowserStream: { selectBrowserStreamFromToolbar($0) },
                 openTextSheet: openTextSheetFromMenu,
                 copyDebugLogs: {
                     #if DEBUG
@@ -851,15 +851,36 @@ struct WorkspaceDetailView: View {
 
     private func openBrowserFromToolbar() {
         dismissTerminalKeyboardForChrome()
-        // Opens (or reveals the existing) browser pane for this workspace. The
-        // detail view flips to the browser because `activeBrowser` becomes
-        // non-nil; the picker shows a check next to "New Browser" while it is up.
+        // New Browser creates a real Mac browser pane and streams it, so it
+        // shows the same surface as the Mac Browsers rows. The phone-local
+        // WKWebView pane remains only as a fallback for Macs that cannot
+        // create panels (older builds, disconnected, or creation rejected).
+        guard store.supportsBrowserStreamCreate else {
+            openLocalBrowserFallback()
+            return
+        }
+        let workspaceID = workspace.rpcWorkspaceID.rawValue
+        Task {
+            guard let descriptor = await store.createMobileBrowserPanel(workspaceID: workspaceID) else {
+                openLocalBrowserFallback()
+                return
+            }
+            selectBrowserStreamFromToolbar(descriptor.panelID, dismissKeyboard: false)
+        }
+    }
+
+    /// Opens (or reveals) the phone-local browser pane for this workspace. The
+    /// detail view flips to the browser because `activeBrowser` becomes
+    /// non-nil; the picker shows a check next to "New Browser" while it is up.
+    private func openLocalBrowserFallback() {
         browserStore.openBrowser(for: workspace.id.rawValue)
         stopActiveBrowserStream()
     }
 
-    private func selectBrowserStreamFromToolbar(_ panelID: String) {
-        dismissTerminalKeyboardForChrome()
+    private func selectBrowserStreamFromToolbar(_ panelID: String, dismissKeyboard: Bool = true) {
+        if dismissKeyboard {
+            dismissTerminalKeyboardForChrome()
+        }
         browserStore.closeBrowser(for: workspace.id.rawValue)
         if let previous = activeBrowserStream, previous.id != panelID {
             Task { await store.stopMobileBrowserStream(panelID: previous.id) }

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceDetailView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceDetailView.swift
@@ -66,6 +66,10 @@ struct WorkspaceDetailView: View {
     @State private var contentWidth: CGFloat = 0
     /// Terminal captured for the current "View as Text" sheet presentation.
     @State private var textSheetSurfaceID: String?
+    /// Identity of the in-flight New Browser creation. A late RPC result must
+    /// not activate its panel over a selection the user made in the meantime,
+    /// so completion applies only while its request is still current.
+    @State private var browserCreateRequest: UUID?
     @State var terminalPickerRows: [TerminalPickerMenuRow] = []
     /// Chat-mode toggle for inline agent chat in place of the terminal.
     @State var isChatMode = false
@@ -841,6 +845,7 @@ struct WorkspaceDetailView: View {
 
     private func createTerminalFromToolbar() {
         dismissTerminalKeyboardForChrome()
+        browserCreateRequest = nil
         // Creating a terminal from the (shared) chrome must surface it. If a
         // browser pane is up, close it so `body` leaves the browser branch and
         // shows the new terminal instead of staying on the browser.
@@ -860,8 +865,13 @@ struct WorkspaceDetailView: View {
             return
         }
         let workspaceID = workspace.rpcWorkspaceID.rawValue
+        let request = UUID()
+        browserCreateRequest = request
         Task {
-            guard let descriptor = await store.createMobileBrowserPanel(workspaceID: workspaceID) else {
+            let descriptor = await store.createMobileBrowserPanel(workspaceID: workspaceID)
+            guard browserCreateRequest == request else { return }
+            browserCreateRequest = nil
+            guard let descriptor else {
                 openLocalBrowserFallback()
                 return
             }
@@ -881,6 +891,7 @@ struct WorkspaceDetailView: View {
         if dismissKeyboard {
             dismissTerminalKeyboardForChrome()
         }
+        browserCreateRequest = nil
         browserStore.closeBrowser(for: workspace.id.rawValue)
         if let previous = activeBrowserStream, previous.id != panelID {
             Task { await store.stopMobileBrowserStream(panelID: previous.id) }
@@ -897,6 +908,7 @@ struct WorkspaceDetailView: View {
 
     private func selectTerminalFromPicker(_ terminalID: MobileTerminalPreview.ID) {
         dismissTerminalKeyboardForChrome()
+        browserCreateRequest = nil
         // Choosing a terminal returns from the browser pane (if up) to the
         // terminal. Closing the browser is enough to flip the detail view back.
         browserStore.closeBrowser(for: workspace.id.rawValue)

--- a/Sources/Mobile/MobileHostService+Capabilities.swift
+++ b/Sources/Mobile/MobileHostService+Capabilities.swift
@@ -39,6 +39,7 @@ extension MobileHostService {
             MobileBrowserStreamCapability.identifier,
             MobileBrowserStreamCapability.viewportIdentifier,
             MobileBrowserStreamCapability.dialogIdentifier,
+            MobileBrowserStreamCapability.createIdentifier,
             "events.v1",
             "notification.badge.v1",
             "notification.dismiss.v1",

--- a/Sources/Panels/BrowserPanel+MobileBrowserStreaming.swift
+++ b/Sources/Panels/BrowserPanel+MobileBrowserStreaming.swift
@@ -127,6 +127,12 @@ extension BrowserPanel {
         let wasInactive = mobileBrowserStreamSignalHandlers.isEmpty
         mobileBrowserStreamSignalHandlers[handlerID] = handler
         if wasInactive {
+            // A phone mirror is a visibility touch. A session-restored or
+            // memory-discarded background tab holds only a blank web shell,
+            // and every capture of that shell is a white frame; without this
+            // restore, only a manual reload or revealing the tab on the Mac
+            // ever starts the restore navigation.
+            restoreDiscardedWebViewIfNeeded(reason: "mobile_browser_stream_start")
             installMobileBrowserDirtyBeaconIfNeeded()
             reevaluateHiddenWebViewDiscardScheduling(reason: "mobile_browser_stream_started")
         }

--- a/Sources/TerminalController+MobileBrowser.swift
+++ b/Sources/TerminalController+MobileBrowser.swift
@@ -191,7 +191,7 @@ extension TerminalController {
         }
         let encoder = MobileBrowserWireEncoder()
         guard let payload = encoder.object(encoder.descriptor(panel: panel)) else {
-            return .err(code: "internal_error", message: "Failed to encode browser panel", data: nil)
+            return .err(code: "internal_error", message: "Browser creation is unavailable", data: nil)
         }
         return .ok(payload)
     }

--- a/Sources/TerminalController+MobileBrowser.swift
+++ b/Sources/TerminalController+MobileBrowser.swift
@@ -12,6 +12,8 @@ extension TerminalController {
         switch method {
         case "mobile.browser.list":
             return v2MobileBrowserList(params: params)
+        case "mobile.browser.create":
+            return v2MobileBrowserCreate(params: params)
         case "mobile.browser.stream.start":
             guard let connectionID else {
                 return .err(code: "unavailable", message: "Browser streaming requires a mobile connection", data: nil)
@@ -166,6 +168,32 @@ extension TerminalController {
             }
         }
         return .ok(["panels": panels])
+    }
+
+    /// Creates a new browser panel in a workspace so the phone can stream it
+    /// immediately, mirroring `v2MobileTerminalCreate`. The panel is created
+    /// without stealing Mac focus; the caller starts the stream separately.
+    private func v2MobileBrowserCreate(params: [String: Any]) -> V2CallResult {
+        guard let tabManager = v2ResolveTabManager(params: params) else {
+            return .err(code: "unavailable", message: "Workspace context is unavailable", data: nil)
+        }
+        if let error = mobileWorkspaceIDValidationError(params: params) {
+            return error
+        }
+        guard let workspace = v2ResolveWorkspace(params: params, tabManager: tabManager) else {
+            return .err(code: "not_found", message: "Workspace not found", data: nil)
+        }
+        guard let paneId = workspace.bonsplitController.focusedPaneId ?? workspace.bonsplitController.allPaneIds.first else {
+            return .err(code: "not_found", message: "Pane not found", data: nil)
+        }
+        guard let panel = workspace.newBrowserSurface(inPane: paneId, focus: false) else {
+            return .err(code: "unavailable", message: "Browser creation is unavailable", data: nil)
+        }
+        let encoder = MobileBrowserWireEncoder()
+        guard let payload = encoder.object(encoder.descriptor(panel: panel)) else {
+            return .err(code: "internal_error", message: "Failed to encode browser panel", data: nil)
+        }
+        return .ok(payload)
     }
 
     private func v2MobileBrowserPointerInput(

--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -2512,6 +2512,7 @@ class TerminalController {
             "mobile.terminal.paste",
             "mobile.terminal.replay",
             "mobile.browser.list",
+            "mobile.browser.create",
             "mobile.browser.stream.start",
             "mobile.browser.stream.stop",
             "mobile.browser.viewport",

--- a/cmuxTests/BrowserDiscardedWebViewRestoreRetryTests.swift
+++ b/cmuxTests/BrowserDiscardedWebViewRestoreRetryTests.swift
@@ -127,6 +127,35 @@ struct BrowserDiscardedWebViewRestoreRetryTests {
         #expect(panel.restoreDiscardedWebViewIfNeeded(reason: "test.restore2"))
     }
 
+    @Test func mobileStreamStartRestoresDiscardedWebView() throws {
+        // RED: streaming a discarded background tab (a restored session's
+        // never-revealed pane) mirrors a blank web shell, so the phone shows
+        // white until a manual reload. Starting a mobile stream must kick the
+        // discard-restore navigation exactly like revealing the tab does.
+        let url = try #require(URL(string: "http://127.0.0.1:1/cmux-mobile-stream-discard"))
+        let discardedAt = Date(timeIntervalSince1970: 300)
+        let panel = BrowserPanel(
+            workspaceId: UUID(),
+            initialURL: url,
+            isRemoteWorkspace: false
+        )
+        defer { panel.close() }
+
+        #expect(waitForDiscardRestoreRetryWebViewToSettle(panel))
+
+        panel.noteWebViewVisibility(false, reason: "test.hidden", now: discardedAt)
+        #expect(panel.discardHiddenWebViewForMemory(reason: "test.discard", now: discardedAt))
+
+        let handlerID = UUID()
+        panel.addMobileBrowserStreamSignalHandler(id: handlerID) { _ in }
+        defer { panel.removeMobileBrowserStreamSignalHandler(id: handlerID) }
+
+        #expect(
+            panel.webViewLifecycleTopPayload()["restore_pending"] as? Bool == true,
+            "Mobile stream start must begin the discard-restore navigation"
+        )
+    }
+
     @Test func remoteSessionRestoreQueuedForProxyEndpointDoesNotMarkNavigationPending() throws {
         let url = try #require(URL(string: "http://localhost:3000/cmux-issue-7504"))
         let workspaceId = UUID()

--- a/cmuxTests/TerminalAndGhosttyTests.swift
+++ b/cmuxTests/TerminalAndGhosttyTests.swift
@@ -1756,6 +1756,48 @@ final class TerminalOffscreenStartupTests: XCTestCase {
             "Mobile background terminal creation should not schedule sidebar metadata probes on the macOS main path."
         )
     }
+
+    func testMobileBrowserCreateReturnsStreamableDescriptorAndKeepsMacSelection() async throws {
+        let previousManager = TerminalController.shared.activeTabManagerForCallerNotification()
+        let manager = RecordingMobileTabManager()
+        TerminalController.shared.setActiveTabManager(manager)
+        defer {
+            TerminalController.shared.setActiveTabManager(previousManager)
+        }
+
+        let selectedWorkspace = try XCTUnwrap(manager.selectedWorkspace)
+        let mobileWorkspace = manager.addWorkspace(
+            title: "Mobile Browser Workspace",
+            select: false,
+            eagerLoadTerminal: false,
+            autoRefreshMetadata: false
+        )
+
+        let response = await TerminalController.shared.mobileHostHandleRPC(
+            MobileHostRPCRequest(
+                id: "browser-create",
+                method: "mobile.browser.create",
+                params: ["workspace_id": mobileWorkspace.id.uuidString],
+                auth: nil
+            )
+        )
+
+        guard case let .ok(rawPayload) = response,
+              let payload = rawPayload as? [String: Any],
+              let panelID = payload["panel_id"] as? String,
+              let panelUUID = UUID(uuidString: panelID) else {
+            XCTFail("Expected mobile browser.create to return the created panel descriptor")
+            return
+        }
+
+        XCTAssertEqual(payload["workspace_id"] as? String, mobileWorkspace.id.uuidString)
+        XCTAssertNotNil(mobileWorkspace.browserPanel(for: panelUUID))
+        XCTAssertEqual(
+            manager.selectedWorkspace?.id,
+            selectedWorkspace.id,
+            "Mobile background browser creation should not steal the Mac's workspace selection."
+        )
+    }
 #endif
 
     private func waitForMobileHostRoutesForTesting() async -> Bool {

--- a/ios/cmux/Resources/Localizable.xcstrings
+++ b/ios/cmux/Resources/Localizable.xcstrings
@@ -1004,6 +1004,40 @@
         }
       }
     },
+    "mobile.browserStream.newPage": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "New Browser"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "新しいブラウザ"
+          }
+        }
+      }
+    },
+    "mobile.browserStream.newPageDetail": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Search or enter an address in the bar below."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "下のバーで検索するか、アドレスを入力してください。"
+          }
+        }
+      }
+    },
     "mobile.browserStream.noAddress": {
       "extractionState": "manual",
       "localizations": {


### PR DESCRIPTION
## Summary

Three fixes that make phone browsers consistently use, and behave like, the streamed Mac-browser surface.

**1. New Browser creates and streams a Mac browser pane.** The iOS "New Browser" button opened the phone-local WKWebView pane (top chrome bar, browses on the phone), which no longer matches the streamed Mac-browser surface that "Mac Browsers" rows open. It now creates a real browser pane on the paired Mac via a new `mobile.browser.create` RPC (mirroring `mobile.terminal.create`, no Mac focus steal) gated by a new `browser.stream.create.v1` capability, then routes through the same activate-and-start stream path as selecting a Mac Browsers row. The local WKWebView pane remains only as a fallback for Macs without the capability, while disconnected, or when creation is rejected (e.g. remote tmux mirror workspaces).

**2. Blank pages show a purposeful placeholder; taps carry Mac click counts.** A fresh pane mirrored an empty white capture that read as a glitch; `BrowserStreamPane` now shows an opaque "New Browser / Search or enter an address in the bar below" state (`isBlankPage`: nil/empty/`about:blank` URL) until the first navigation. Double tap no longer zooms locally: the double-tap recognizer is gone, taps forward immediately with a rising Mac click count (`BrowserStreamTapClickCounter`: double tap = double click for word selection, triple = paragraph), which also removes the recognizer-failure delay from every single click. Pinch keeps owning zoom; the Mac replayer already honored `click_count`.

**3. Preexisting background tabs stream content instead of white.** Opening a never-revealed tab (e.g. right after Mac launch, when session restore leaves background tabs memory-discarded) mirrored a blank web shell until a manual reload. Stream start now counts as a visibility touch: `addMobileBrowserStreamSignalHandler` kicks `restoreDiscardedWebViewIfNeeded` before the first capture. Red/green commit pair: `mobileStreamStartRestoresDiscardedWebView`.

## Tests

- `BrowserStreamStorePanelCreationTests` (new): created descriptor is immediately activatable, upsert does not duplicate, joins existing discovery.
- `BrowserStreamTapClickCounterTests` (new): chaining window and radius produce Mac click counts 1/2/3; slow or distant taps restart at 1.
- `BrowserStreamSurfaceStateTests.blankPageTracksNavigationState` (new): nil and `about:blank` URLs are blank, real navigation clears it.
- `MobileBrowserRPCDTOTests.browserCreateCarriesMatchingWorkspaceTicketContext` (new): create carries the workspace-scoped attach token like list.
- `testMobileBrowserCreateReturnsStreamableDescriptorAndKeepsMacSelection` (new, `TerminalAndGhosttyTests`): the RPC returns a streamable descriptor without stealing Mac selection.
- `mobileStreamStartRestoresDiscardedWebView` (new, `BrowserDiscardedWebViewRestoreRetryTests`, red/green pair): stream start begins the discard-restore navigation.
- Package suites: CmuxMobileBrowserStream 40/40, CmuxMobileRPC 176/176 green locally.

Localization audit: two new keys (`mobile.browserStream.newPage`, `mobile.browserStream.newPageDetail`) added to `ios/cmux/Resources/Localizable.xcstrings` with en and ja translations; no other user-facing strings changed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Create and open Mac browser panels directly from the mobile app when supported.
  - Newly created panels appear immediately and remain synchronized.
  - Blank browser panels show a dedicated “New Browser” screen with guidance.

- **Improvements**
  - Mobile taps support Mac-style single-, double-, and triple-click behavior.
  - Creation preserves workspace selection and falls back locally when unavailable.
  - Discarded browser views are restored when streaming resumes, with stale results prevented from changing selection.

- **Localization**
  - Added English and Japanese text for the new browser experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->