### PR TITLE
web: expose versioned changelog agent-page variants

### DIFF
--- a/web/app/lib/agent-page-paths.ts
+++ b/web/app/lib/agent-page-paths.ts
@@ -6,6 +6,7 @@ import {
   PLATFORM_DOWNLOADS,
   type DownloadPlatform,
 } from "./download";
+import { changelogPath } from "./changelog";
 import {
   englishFallbackContentLocales,
   fallbackContentLocales,
@@ -439,8 +440,19 @@ const agentReadablePageByPath: Map<string, AgentReadablePage> = new Map(
 function isKnownAgentReadablePage(canonicalPath: string): boolean {
   const { path, locale } = basePagePath(canonicalPath);
   const page = agentReadablePageByPath.get(path);
-  if (!page) return false;
-  return !locale || !page.locales || page.locales.includes(locale);
+  if (page) {
+    return !locale || !page.locales || page.locales.includes(locale);
+  }
+
+  return isChangelogVersionPage(path);
+}
+
+function isChangelogVersionPage(path: string): boolean {
+  const prefix = `${changelogPath}/`;
+  if (!path.startsWith(prefix)) return false;
+
+  const version = path.slice(prefix.length);
+  return version.length > 0 && !version.includes("/");
 }
 
 function basePagePath(canonicalPath: string): { path: string; locale: string | null } {

--- a/web/tests/agent-page-variants.test.ts
+++ b/web/tests/agent-page-variants.test.ts
@@ -434,6 +434,24 @@ describe("agent page variants", () => {
     expect(header).not.toContain("/de/docs/vault");
   });
 
+  test("maps versioned changelog variants across locales", () => {
+    expect(resolveAgentPageVariant("/docs/changelog/0.64.22.md")).toEqual({
+      kind: "page",
+      format: "md",
+      requestedPath: "/docs/changelog/0.64.22.md",
+      canonicalPath: "/docs/changelog/0.64.22",
+    });
+    expect(resolveAgentPageVariant("/ja/docs/changelog/0.64.22.txt")).toEqual({
+      kind: "page",
+      format: "txt",
+      requestedPath: "/ja/docs/changelog/0.64.22.txt",
+      canonicalPath: "/ja/docs/changelog/0.64.22",
+    });
+    expect(
+      resolveAgentPageVariant("/docs/changelog/0.64.22/notes.md"),
+    ).toBeNull();
+  });
+
   test("supports Markdown and text variants for sitemap pages", () => {
     for (const entry of sitemap()) {
       const pathname = new URL(String(entry.url)).pathname || "/";


### PR DESCRIPTION
## Summary

- Recognize one-segment `/docs/changelog/<version>` pages as agent-readable routes in every supported locale.
- Restore the existing sitemap invariant after #9543 added 1,740 localized version URLs: each public sitemap page now resolves both `.md` and `.txt` variants.
- Keep the canonical HTML fetch authoritative, so nonexistent versions still return 404.

## Testing

- `bun run typecheck`
- `bun test tests/agent-page-variants.test.ts tests/changelog-pages.test.tsx` (32 passed)
- Verified the pre-fix focused test failed on the first versioned changelog URL and the post-fix sitemap invariant passes across all releases/locales.

## Demo Video

Not applicable: routing-only behavior with automated coverage and no visual UI change.

## Review Trigger (Copy/Paste as PR comment)

```text
@codex review
@coderabbitai review
@greptile-apps review
@cubic-dev-ai review
```

## Checklist

- [x] I tested the change locally
- [x] I added or updated tests for behavior changes
- [x] I updated docs/changelog if needed (not needed)
- [ ] I requested bot reviews after my latest commit
- [ ] All code review bot comments are resolved
- [ ] All human review comments are resolved

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/9579"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788429267&installation_model_id=21920&pr_number=9579&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F9579&signature=f23b139626d3180bf0045deccfdaa14c6c60dff5b1529b63997327e3265784d1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expose `/docs/changelog/<version>` pages as agent-readable across locales and restore the sitemap invariant so each entry resolves both `.md` and `.txt`. Invalid versions still return 404.

- **Bug Fixes**
  - Treat single-segment changelog version paths as agent pages in all locales.
  - Keep canonical HTML authoritative to preserve 404s for nonexistent versions.
  - Add tests for changelog variant mapping and sitemap `.md`/`.txt` coverage.

<sup>Written for commit 400744dd686afe29c7b9c86792bbff1b80a5baa2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/9579?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for accessing versioned changelog pages in English and Japanese.
  * Added support for Markdown and text variants of changelog pages.

* **Bug Fixes**
  * Prevented nested changelog paths from being incorrectly recognized as valid pages.

* **Tests**
  * Added coverage for localized changelog page variants and invalid nested paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->