### PR TITLE
Stagger Iroh relay credential refreshes

### DIFF
--- a/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohClientRuntime+RelayPolicy.swift
+++ b/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohClientRuntime+RelayPolicy.swift
@@ -44,11 +44,18 @@ extension CmxIrohClientRuntime {
         await relayCoordinator?.deactivate()
         relayCoordinator = nil
         if profile.source == .managed, !profile.allowedRelayURLs.isEmpty {
+            let refreshSchedule = CmxIrohRelayRefreshSchedule(
+                role: .client,
+                endpointIdentity: binding.endpointID
+            )
             let coordinator = CmxIrohRelayCredentialCoordinator(
                 supervisor: connectivityEngine,
                 broker: broker,
                 managedRelayURLs: replacementManagedURLs,
                 selectedRelayURLs: profile.allowedRelayURLs,
+                jitter: { now, refreshAfter in
+                    refreshSchedule.deadline(now: now, refreshAfter: refreshAfter)
+                },
                 retrySchedule: .foregroundClient,
                 automaticRefreshEnabled: automaticRelayCredentialRefreshEnabled,
                 credentialDidInstall: { [handleRelayCredential] response in

--- a/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohHostRuntime+RelayPolicy.swift
+++ b/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohHostRuntime+RelayPolicy.swift
@@ -48,11 +48,18 @@ extension CmxIrohHostRuntime {
         await relayCoordinator?.deactivate()
         relayCoordinator = nil
         if profile.source == .managed, !profile.allowedRelayURLs.isEmpty {
+            let refreshSchedule = CmxIrohRelayRefreshSchedule(
+                role: .host,
+                endpointIdentity: binding.endpointID
+            )
             let coordinator = CmxIrohRelayCredentialCoordinator(
                 supervisor: connectivityEngine,
                 broker: broker,
                 managedRelayURLs: replacementManagedURLs,
                 selectedRelayURLs: profile.allowedRelayURLs,
+                jitter: { now, refreshAfter in
+                    refreshSchedule.deadline(now: now, refreshAfter: refreshAfter)
+                },
                 credentialDidInstall: { [handleRelayCredential] response in
                     await handleRelayCredential(response, binding)
                 }

--- a/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohRelayRefreshSchedule.swift
+++ b/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohRelayRefreshSchedule.swift
@@ -1,0 +1,47 @@
+import CMUXMobileCore
+import Foundation
+
+/// Assigns endpoint-stable, non-overlapping relay credential refresh slots.
+struct CmxIrohRelayRefreshSchedule: Sendable {
+    enum Role: Sendable {
+        case host
+        case client
+
+        fileprivate var phaseStart: Int {
+            switch self {
+            case .host: 0
+            case .client: 30
+            }
+        }
+    }
+
+    private static let phaseWidth = 15
+    private static let minuteDuration: TimeInterval = 60
+    private static let fnvOffsetBasis: UInt64 = 14_695_981_039_346_656_037
+    private static let fnvPrime: UInt64 = 1_099_511_628_211
+
+    private let secondWithinMinute: Int
+
+    init(role: Role, endpointIdentity: CmxIrohPeerIdentity) {
+        var hash = Self.fnvOffsetBasis
+        for byte in endpointIdentity.endpointID.utf8 {
+            hash ^= UInt64(byte)
+            hash &*= Self.fnvPrime
+        }
+        secondWithinMinute = role.phaseStart + Int(hash % UInt64(Self.phaseWidth))
+    }
+
+    func deadline(now: Date, refreshAfter: Date) -> Date {
+        let refreshEpoch = refreshAfter.timeIntervalSince1970
+        let minuteStart = floor(refreshEpoch / Self.minuteDuration)
+            * Self.minuteDuration
+        var candidateEpoch = minuteStart + TimeInterval(secondWithinMinute)
+        if candidateEpoch > refreshEpoch {
+            candidateEpoch -= Self.minuteDuration
+        }
+        return min(
+            refreshAfter,
+            max(now, Date(timeIntervalSince1970: candidateEpoch))
+        )
+    }
+}

--- a/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohRelayCredentialCoordinatorTests.swift
+++ b/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohRelayCredentialCoordinatorTests.swift
@@ -6,6 +6,63 @@ import Testing
 @Suite
 struct CmxIrohRelayCredentialCoordinatorTests {
     @Test
+    func hostAndClientRefreshSlotsStaySeparatedAcrossCredentialCycles() throws {
+        let hostIdentity = try CmxIrohPeerIdentity(
+            endpointID: String(repeating: "1a", count: 32)
+        )
+        let clientIdentity = try CmxIrohPeerIdentity(
+            endpointID: String(repeating: "b7", count: 32)
+        )
+        let hostSchedule = CmxIrohRelayRefreshSchedule(
+            role: .host,
+            endpointIdentity: hostIdentity
+        )
+        let clientSchedule = CmxIrohRelayRefreshSchedule(
+            role: .client,
+            endpointIdentity: clientIdentity
+        )
+        let now = Date(timeIntervalSince1970: 1_700_000_000)
+
+        for cycle in 1 ... 8 {
+            let refreshAfter = now.addingTimeInterval(TimeInterval(cycle * 240))
+            let hostDeadline = hostSchedule.deadline(
+                now: now,
+                refreshAfter: refreshAfter
+            )
+            let clientDeadline = clientSchedule.deadline(
+                now: now,
+                refreshAfter: refreshAfter
+            )
+            let hostSecond = Int(hostDeadline.timeIntervalSince1970) % 60
+            let clientSecond = Int(clientDeadline.timeIntervalSince1970) % 60
+
+            #expect((0 ... 14).contains(hostSecond))
+            #expect((30 ... 44).contains(clientSecond))
+            #expect(hostDeadline <= refreshAfter)
+            #expect(clientDeadline <= refreshAfter)
+        }
+    }
+
+    @Test
+    func refreshSlotsSpreadEndpointsWithinEachRole() throws {
+        let refreshAfter = Date(timeIntervalSince1970: 1_700_000_240)
+        let now = refreshAfter.addingTimeInterval(-240)
+        let hostSlots = try (0 ..< 16).map { index in
+            let identity = try CmxIrohPeerIdentity(
+                endpointID: String(format: "%064x", index + 1)
+            )
+            return Int(
+                CmxIrohRelayRefreshSchedule(role: .host, endpointIdentity: identity)
+                    .deadline(now: now, refreshAfter: refreshAfter)
+                    .timeIntervalSince1970
+            ) % 60
+        }
+
+        #expect(Set(hostSlots).count > 1)
+        #expect(hostSlots.allSatisfy { (0 ... 14).contains($0) })
+    }
+
+    @Test
     func bootstrapInstallsCompleteFleetBeforeSleepingUntilRefresh() async throws {
         let fixture = try RelayCoordinatorFixture()
         let endpoint = TestIrohEndpoint(identity: fixture.identity)

--- a/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohRelayCredentialCoordinatorTests.swift
+++ b/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohRelayCredentialCoordinatorTests.swift
@@ -22,6 +22,8 @@ struct CmxIrohRelayCredentialCoordinatorTests {
             endpointIdentity: clientIdentity
         )
         let now = Date(timeIntervalSince1970: 1_700_000_000)
+        var hostSeconds: [Int] = []
+        var clientSeconds: [Int] = []
 
         for cycle in 1 ... 8 {
             let refreshAfter = now.addingTimeInterval(TimeInterval(cycle * 240))
@@ -35,12 +37,19 @@ struct CmxIrohRelayCredentialCoordinatorTests {
             )
             let hostSecond = Int(hostDeadline.timeIntervalSince1970) % 60
             let clientSecond = Int(clientDeadline.timeIntervalSince1970) % 60
+            hostSeconds.append(hostSecond)
+            clientSeconds.append(clientSecond)
 
             #expect((0 ... 14).contains(hostSecond))
             #expect((30 ... 44).contains(clientSecond))
+            #expect(hostDeadline >= now)
+            #expect(clientDeadline >= now)
             #expect(hostDeadline <= refreshAfter)
             #expect(clientDeadline <= refreshAfter)
         }
+
+        #expect(Set(hostSeconds).count == 1)
+        #expect(Set(clientSeconds).count == 1)
     }
 
     @Test

--- a/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohRelayCredentialCoordinatorTests.swift
+++ b/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohRelayCredentialCoordinatorTests.swift
@@ -57,9 +57,21 @@ struct CmxIrohRelayCredentialCoordinatorTests {
                     .timeIntervalSince1970
             ) % 60
         }
+        let clientSlots = try (0 ..< 16).map { index in
+            let identity = try CmxIrohPeerIdentity(
+                endpointID: String(format: "%064x", index + 1)
+            )
+            return Int(
+                CmxIrohRelayRefreshSchedule(role: .client, endpointIdentity: identity)
+                    .deadline(now: now, refreshAfter: refreshAfter)
+                    .timeIntervalSince1970
+            ) % 60
+        }
 
         #expect(Set(hostSlots).count > 1)
         #expect(hostSlots.allSatisfy { (0 ... 14).contains($0) })
+        #expect(Set(clientSlots).count > 1)
+        #expect(clientSlots.allSatisfy { (30 ... 44).contains($0) })
     }
 
     @Test


### PR DESCRIPTION
## Summary
- assign stable refresh slots from each endpoint identity
- keep Mac refreshes in seconds 0–14 and iOS refreshes in seconds 30–44
- prevent both peers from rotating relay credentials together while preserving the endpoint

## Verification
- regression tests committed first and failed on the missing scheduler: https://github.com/manaflow-ai/cmux/actions/runs/30906067161
- Swift parse and diff checks pass
- hosted package and relay-only staging gates dispatched for the fix commit

Principled fix: refresh ownership is encoded as a deterministic scheduling invariant instead of a timing retry.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/9581"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788436782&installation_model_id=21920&pr_number=9581&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F9581&signature=facc2c77dc0b0d74ddb8d6ce130facd8892da3c854085c01827a013349d6f56b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Staggered Iroh relay credential refreshes by role and endpoint so host and client don’t rotate at the same time. Slots are stable per endpoint to reduce reconnect churn.

- **Bug Fixes**
  - Introduced a deterministic scheduler (`CmxIrohRelayRefreshSchedule`) that assigns per-endpoint refresh slots using FNV hashing: host 0–14s, client 30–44s within each minute.
  - Wired the schedule into client and host runtimes via the `jitter` callback to compute deadlines clamped between `now` and `refreshAfter`.
  - Expanded tests to assert stable per-endpoint slots across cycles, per-role slot spread, and bounded deadlines.

<sup>Written for commit a30cdb1d3a49fbe515d5ed3a0276f85544999e0c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/9581?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Relay credentials now refresh on client- and host-specific schedules, reducing simultaneous refresh activity.
  * Refresh timing is deterministically distributed across short time windows while still respecting required deadlines.
  * Relay connectivity management is more balanced and predictable across endpoints.

* **Tests**
  * Added coverage to verify refresh timing separation, deadline compliance, and distribution across multiple scheduling slots.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->