### PR TITLE
Fix Files pane refresh after filesystem changes

### DIFF
--- a/Sources/FileExplorerView.swift
+++ b/Sources/FileExplorerView.swift
@@ -94,6 +94,7 @@ struct FileExplorerPanelView: NSViewRepresentable {
         weak var containerView: FileExplorerContainerView?
         weak var outlineView: NSOutlineView?
         private var lastRootNodeCount: Int = -1
+        private var lastContentRevision: Int = -1
         private var observationCancellable: AnyCancellable?
         private var styleObserver: Any?
         private var isUpdatingOutlineProgrammatically = false
@@ -182,9 +183,11 @@ struct FileExplorerPanelView: NSViewRepresentable {
             )
 
             let newCount = store.rootNodes.count
+            let newContentRevision = store.contentRevision
             withProgrammaticOutlineUpdate {
-                if newCount != lastRootNodeCount {
+                if newCount != lastRootNodeCount || newContentRevision != lastContentRevision {
                     lastRootNodeCount = newCount
+                    lastContentRevision = newContentRevision
                     let expandedPaths = store.expandedPaths
                     outlineView.reloadData()
                     restoreExpansionState(expandedPaths, in: outlineView)

--- a/Sources/FileExplorerView.swift
+++ b/Sources/FileExplorerView.swift
@@ -199,11 +199,15 @@ struct FileExplorerPanelView: NSViewRepresentable {
         }
 
         private func restoreExpansionState(_ expandedPaths: Set<String>, in outlineView: NSOutlineView) {
-            for row in 0..<outlineView.numberOfRows {
-                guard let node = outlineView.item(atRow: row) as? FileExplorerNode else { continue }
-                if expandedPaths.contains(node.path) && outlineView.isExpandable(node) {
+            // Expanding a row can reveal descendants, so re-read the row count each iteration.
+            var row = 0
+            while row < outlineView.numberOfRows {
+                if let node = outlineView.item(atRow: row) as? FileExplorerNode,
+                   expandedPaths.contains(node.path),
+                   outlineView.isExpandable(node) {
                     outlineView.expandItem(node)
                 }
+                row += 1
             }
         }
 

--- a/cmuxTests/FileExplorerStoreTests.swift
+++ b/cmuxTests/FileExplorerStoreTests.swift
@@ -642,7 +642,7 @@ struct FileExplorerStoreTests {
             (outlineView.item(atRow: $0) as? FileExplorerNode)?.name
         }
         #expect(visibleNames == ["Sources", "Added.swift"])
-        _ = container
+        withExtendedLifetime(container) {}
     }
 
     @Test
@@ -685,8 +685,6 @@ struct FileExplorerStoreTests {
         let container = FileExplorerContainerView(coordinator: coordinator, presentation: .files)
         coordinator.reloadIfNeeded()
         let outlineView = try #require(coordinator.outlineView)
-        outlineView.expandItem(sourceNode)
-        coordinator.reloadIfNeeded()
 
         provider.listings[sourcePath] = .success([
             FileExplorerEntry(name: "Added.swift", path: "\(sourcePath)/Added.swift", isDirectory: false),
@@ -706,7 +704,7 @@ struct FileExplorerStoreTests {
         }
         #expect(visibleNames == ["App", "Sources", "Added.swift", "Keep.swift"])
         #expect(selectedNames == ["Keep.swift"])
-        _ = container
+        withExtendedLifetime(container) {}
     }
 
     // MARK: - Collapse/Expand

--- a/cmuxTests/FileExplorerStoreTests.swift
+++ b/cmuxTests/FileExplorerStoreTests.swift
@@ -594,6 +594,57 @@ struct FileExplorerStoreTests {
         )
     }
 
+    // MARK: - Outline refresh
+
+    @Test
+    func testOutlineReplacesNestedRowsWhenContentRevisionChangesWithoutCountChanges() async throws {
+        let rootPath = "/home/user/project"
+        let sourcePath = "\(rootPath)/Sources"
+        let provider = MockFileExplorerProvider()
+        provider.listings[rootPath] = .success([
+            FileExplorerEntry(name: "Sources", path: sourcePath, isDirectory: true),
+        ])
+        provider.listings[sourcePath] = .success([
+            FileExplorerEntry(name: "Removed.swift", path: "\(sourcePath)/Removed.swift", isDirectory: false),
+        ])
+
+        let store = FileExplorerStore()
+        store.setProviderForTesting(provider)
+        store.setRootPath(rootPath)
+        try await waitFor("initial root loaded") { store.rootNodes.count == 1 }
+
+        let sourceNode = try #require(store.rootNodes.first)
+        store.expand(node: sourceNode)
+        try await waitFor("initial nested file loaded") {
+            sourceNode.children?.map(\.name) == ["Removed.swift"]
+        }
+
+        let coordinator = FileExplorerPanelView.Coordinator(
+            store: store,
+            state: FileExplorerState(),
+            onOpenFilePreview: { _ in }
+        )
+        let container = FileExplorerContainerView(coordinator: coordinator, presentation: .files)
+        coordinator.reloadIfNeeded()
+        let outlineView = try #require(coordinator.outlineView)
+        #expect((outlineView.item(atRow: 1) as? FileExplorerNode)?.name == "Removed.swift")
+
+        provider.listings[sourcePath] = .success([
+            FileExplorerEntry(name: "Added.swift", path: "\(sourcePath)/Added.swift", isDirectory: false),
+        ])
+        store.reload()
+        try await waitFor("reloaded nested file") {
+            store.rootNodes.first?.children?.map(\.name) == ["Added.swift"]
+        }
+        coordinator.reloadIfNeeded()
+
+        let visibleNames = (0..<outlineView.numberOfRows).compactMap {
+            (outlineView.item(atRow: $0) as? FileExplorerNode)?.name
+        }
+        #expect(visibleNames == ["Sources", "Added.swift"])
+        _ = container
+    }
+
     // MARK: - Collapse/Expand
 
     @Test

--- a/cmuxTests/FileExplorerStoreTests.swift
+++ b/cmuxTests/FileExplorerStoreTests.swift
@@ -645,6 +645,70 @@ struct FileExplorerStoreTests {
         _ = container
     }
 
+    @Test
+    func testRevisionReloadRestoresNestedExpansionAndSelection() async throws {
+        let rootPath = "/home/user/project"
+        let projectPath = "\(rootPath)/App"
+        let sourcePath = "\(projectPath)/Sources"
+        let keepPath = "\(sourcePath)/Keep.swift"
+        let provider = MockFileExplorerProvider()
+        provider.listings[rootPath] = .success([
+            FileExplorerEntry(name: "App", path: projectPath, isDirectory: true),
+        ])
+        provider.listings[projectPath] = .success([
+            FileExplorerEntry(name: "Sources", path: sourcePath, isDirectory: true),
+        ])
+        provider.listings[sourcePath] = .success([
+            FileExplorerEntry(name: "Keep.swift", path: keepPath, isDirectory: false),
+            FileExplorerEntry(name: "Removed.swift", path: "\(sourcePath)/Removed.swift", isDirectory: false),
+        ])
+
+        let store = FileExplorerStore()
+        store.setProviderForTesting(provider)
+        store.setRootPath(rootPath)
+        try await waitFor("nested root loaded") { store.rootNodes.count == 1 }
+
+        let projectNode = try #require(store.rootNodes.first)
+        store.expand(node: projectNode)
+        try await waitFor("nested project loaded") { projectNode.children?.count == 1 }
+        let sourceNode = try #require(projectNode.children?.first)
+        store.expand(node: sourceNode)
+        try await waitFor("nested source loaded") { sourceNode.children?.count == 2 }
+        let keepNode = try #require(sourceNode.children?.first { $0.path == keepPath })
+        store.select(node: keepNode)
+
+        let coordinator = FileExplorerPanelView.Coordinator(
+            store: store,
+            state: FileExplorerState(),
+            onOpenFilePreview: { _ in }
+        )
+        let container = FileExplorerContainerView(coordinator: coordinator, presentation: .files)
+        coordinator.reloadIfNeeded()
+        let outlineView = try #require(coordinator.outlineView)
+        outlineView.expandItem(sourceNode)
+        coordinator.reloadIfNeeded()
+
+        provider.listings[sourcePath] = .success([
+            FileExplorerEntry(name: "Added.swift", path: "\(sourcePath)/Added.swift", isDirectory: false),
+            FileExplorerEntry(name: "Keep.swift", path: keepPath, isDirectory: false),
+        ])
+        store.reload()
+        try await waitFor("reloaded nested hierarchy") {
+            store.rootNodes.first?.children?.first?.children?.map(\.name) == ["Added.swift", "Keep.swift"]
+        }
+        coordinator.reloadIfNeeded()
+
+        let visibleNames = (0..<outlineView.numberOfRows).compactMap {
+            (outlineView.item(atRow: $0) as? FileExplorerNode)?.name
+        }
+        let selectedNames = outlineView.selectedRowIndexes.compactMap {
+            (outlineView.item(atRow: $0) as? FileExplorerNode)?.name
+        }
+        #expect(visibleNames == ["App", "Sources", "Added.swift", "Keep.swift"])
+        #expect(selectedNames == ["Keep.swift"])
+        _ = container
+    }
+
     // MARK: - Collapse/Expand
 
     @Test


### PR DESCRIPTION
## Summary

- Reload the AppKit file outline when `FileExplorerStore.contentRevision` changes, even when the root item count stays the same.
- Restore multi-level directory expansion and path-based selection after replacement nodes are loaded.
- Add behavior-level regression coverage for nested file additions/removals and deep expansion/selection preservation.

## Why

`FileExplorerStore.reload()` replaces the tree with new `FileExplorerNode` instances and increments `contentRevision`. The outline coordinator previously called `reloadData()` only when the root node count changed. Adding or removing a file inside an expanded directory leaves that count unchanged, so `NSOutlineView` continued displaying the pre-reload node instances.

The coordinator now treats a content revision change as a full outline invalidation. Expansion restoration uses a dynamic row-count loop because expanding a parent reveals additional descendant rows during the same pass.

## References

- https://github.com/manaflow-ai/cmux/pull/1963 introduced the current `NSOutlineView`-based file explorer and expansion-state restoration behavior.
- https://github.com/manaflow-ai/cmux/pull/5244 migrated `FileExplorerStore` to the shared `FileWatcher` infrastructure.
- Related file-explorer background: https://github.com/manaflow-ai/cmux/issues/888

## Testing

Added to `cmuxTests/FileExplorerStoreTests.swift`:

- `testOutlineReplacesNestedRowsWhenContentRevisionChangesWithoutCountChanges`
- `testRevisionReloadRestoresNestedExpansionAndSelection`

Available local checks:

- `swiftc -frontend -parse Sources/FileExplorerView.swift cmuxTests/FileExplorerStoreTests.swift` passed.
- `./scripts/lint-pbxproj-test-wiring.sh` passed (`651` test files checked).

Local verification limitations on this workstation:

- Focused `cmux-unit` test execution is unavailable because no full Xcode installation is present; `xcode-select` points to CommandLineTools.
- A tagged app build is unavailable because Zig and full Xcode are missing.
- CI is therefore the first compile/test signal for the AppKit regression tests.
- Manual dogfood verification and a demo recording remain required before merge.

## Demo Video

Pending a tagged build and manual dogfood verification.

- Video URL or attachment: Not yet available.

## Checklist

- [ ] I tested the change locally
- [x] I added or updated tests for behavior changes
- [x] I updated docs/changelog if needed (not needed; no user-facing copy or public API changed)
- [ ] I requested bot reviews after my latest commit
- [ ] All code review bot comments are resolved
- [ ] All human review comments are resolved


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * File explorer outlines now refresh when file contents change, even if the number of visible rows remains the same.
  * Nested expanded folders and selected files are preserved during refreshes.
  * Newly revealed nested items are correctly restored when expanding folders.

* **Tests**
  * Added regression coverage for outline updates, expansion preservation, and file selection across reloads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->