### PR TITLE
Add copy-paste CLI authorization page

### DIFF
--- a/web/app/authorize/page.tsx
+++ b/web/app/authorize/page.tsx
@@ -1,0 +1,62 @@
+import { redirect } from "next/navigation";
+
+type AuthorizePageProps = {
+  searchParams: Promise<{ code?: string | string[] }>;
+};
+
+const authorizationCode = (value: string | string[] | undefined): string | null => {
+  const code = (Array.isArray(value) ? value[0] : value)?.trim();
+  if (!code || code.length > 256 || !/^[a-zA-Z0-9_-]+$/.test(code)) {
+    return null;
+  }
+  return code;
+};
+
+export default async function AuthorizePage({
+  searchParams,
+}: AuthorizePageProps) {
+  const code = authorizationCode((await searchParams).code);
+  if (code) {
+    redirect(
+      `/handler/cli-auth-confirm?login_code=${encodeURIComponent(code)}`,
+    );
+  }
+
+  return (
+    <main className="flex min-h-screen items-center justify-center bg-black px-6 text-white">
+      <section className="w-full max-w-sm">
+        <p className="mb-8 text-sm text-neutral-500">CodeRouter</p>
+        <h1 className="text-2xl font-medium tracking-tight">
+          Authorize a device
+        </h1>
+        <p className="mt-2 text-sm leading-6 text-neutral-400">
+          Paste the authorization code shown by{" "}
+          <code className="text-neutral-200">cr login --device-auth</code>.
+        </p>
+        <form className="mt-8 space-y-3">
+          <label className="sr-only" htmlFor="code">
+            Authorization code
+          </label>
+          <input
+            autoCapitalize="none"
+            autoComplete="one-time-code"
+            autoCorrect="off"
+            autoFocus
+            className="h-11 w-full rounded-md border border-neutral-800 bg-neutral-950 px-3 font-mono text-sm outline-none placeholder:text-neutral-700 focus:border-neutral-600"
+            id="code"
+            name="code"
+            placeholder="Paste code"
+            required
+            spellCheck={false}
+          />
+          <button
+            className="h-11 w-full rounded-md bg-white text-sm font-medium text-black hover:bg-neutral-200"
+            type="submit"
+          >
+            Continue
+          </button>
+        </form>
+      </section>
+    </main>
+  );
+}

--- a/web/proxy.ts
+++ b/web/proxy.ts
@@ -348,5 +348,7 @@ function legacyOpenGraphImageRewritePath(pathname: string): string | undefined {
 }
 
 export const config = {
-  matcher: ["/((?!api|_next|_vercel|agent-page-variant|handler).*)"],
+  matcher: [
+    "/((?!api|_next|_vercel|agent-page-variant|authorize|handler).*)",
+  ],
 };


### PR DESCRIPTION
Adds a minimal `/authorize` page for remote/headless CodeRouter logins. Users paste the code printed by `cr login --device-auth`; valid codes redirect into the existing Stack Auth CLI confirmation handler. Invalid or missing values never reach Stack.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/9597"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788475111&installation_model_id=21920&pr_number=9597&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F9597&signature=439634c2895f350e0f939d87e86801214401f816226b08e74f5da8973e38a67a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a minimal `/authorize` page for CodeRouter device auth, excluded from locale routing. Users paste the code from `cr login --device-auth`; valid codes (trimmed, <=256, alphanumeric/underscore/dash) redirect to `/handler/cli-auth-confirm?login_code=...`, while invalid or missing codes stay on the page and never reach Stack.

<sup>Written for commit f04bfa515ae36217ef549cd83197544623eec78d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/9597?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a device authorization page for CLI sign-in.
  * Valid authorization codes are securely validated and redirected to confirmation.
  * Invalid or missing codes display the authorization form.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->