### PR TITLE
Detach Workstream persistence scheduling from MainActor

### DIFF
--- a/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/Workstream/WorkstreamStore.swift
+++ b/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/Workstream/WorkstreamStore.swift
@@ -135,7 +135,7 @@ public final class WorkstreamStore {
         insert(item)
         updateContextIndex(with: item)
         if let persistence {
-            Task { [persistence, item] in
+            Task.detached { [persistence, item] in
                 try? await persistence.append(item)
             }
         }

--- a/Packages/macOS/CMUXAgentLaunch/Tests/CMUXAgentLaunchTests/Workstream/WorkstreamStorePersistenceSchedulingTests.swift
+++ b/Packages/macOS/CMUXAgentLaunch/Tests/CMUXAgentLaunchTests/Workstream/WorkstreamStorePersistenceSchedulingTests.swift
@@ -1,0 +1,69 @@
+import Darwin
+import Dispatch
+import Foundation
+import Testing
+@testable import CMUXAgentLaunch
+
+@Suite("WorkstreamStore persistence scheduling")
+struct WorkstreamStorePersistenceSchedulingTests {
+    @Test("ingest submits persistence appends without waiting for MainActor")
+    func ingestSubmitsPersistenceAppendOffMainActor() async throws {
+        let fileURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cmux-workstream-ingest-scheduling-\(UUID().uuidString).jsonl")
+        #expect(FileManager.default.createFile(atPath: fileURL.path, contents: nil))
+
+        let fileDescriptor = open(fileURL.path, O_EVTONLY)
+        try #require(fileDescriptor >= 0, "failed to observe the persistence file")
+
+        let appendObserved = DispatchSemaphore(value: 0)
+        let observerCancelled = DispatchSemaphore(value: 0)
+        let observer = DispatchSource.makeFileSystemObjectSource(
+            fileDescriptor: fileDescriptor,
+            eventMask: .extend,
+            queue: .global(qos: .userInitiated)
+        )
+        observer.setEventHandler {
+            appendObserved.signal()
+        }
+        observer.setCancelHandler {
+            close(fileDescriptor)
+            observerCancelled.signal()
+        }
+        observer.resume()
+        defer {
+            observer.cancel()
+            _ = Self.wait(for: observerCancelled, timeout: .now() + .seconds(1))
+            try? FileManager.default.removeItem(at: fileURL)
+        }
+
+        let persistence = WorkstreamPersistence(fileURL: fileURL)
+        let appendedWhileMainActorWasOccupied = await MainActor.run {
+            let store = WorkstreamStore(persistence: persistence, ringCapacity: 10)
+            store.ingest(WorkstreamEvent(
+                sessionId: "persistence-scheduling",
+                hookEventName: .sessionStart,
+                source: "codex"
+            ))
+            return appendObserved.wait(timeout: .now() + .seconds(1)) == .success
+        }
+
+        #expect(
+            appendedWhileMainActorWasOccupied,
+            "the persistence append must make progress while MainActor is occupied"
+        )
+
+        if !appendedWhileMainActorWasOccupied {
+            #expect(
+                Self.wait(for: appendObserved, timeout: .now() + .seconds(2)) == .success,
+                "the queued append did not complete after MainActor was released"
+            )
+        }
+    }
+
+    private static func wait(
+        for semaphore: DispatchSemaphore,
+        timeout: DispatchTime
+    ) -> DispatchTimeoutResult {
+        semaphore.wait(timeout: timeout)
+    }
+}


### PR DESCRIPTION
## Summary

- detach the fire-and-forget persistence task created by `WorkstreamStore.ingest`
- keep `WorkstreamPersistence` as the serialized actor boundary while allowing append submission to progress independently of MainActor
- cover the behavior by occupying MainActor and observing the real JSONL file append

Fixes #4604

## Testing

- Red CI: [`swift-package-tests`](https://github.com/manaflow-ai/cmux/actions/runs/30958240861/job/92156881197) on test-only commit `c10d39a7ae` ran 282 tests and failed only `ingest submits persistence appends without waiting for MainActor` at the expected assertion.
- Red fleet repro: `swift test --filter WorkstreamStorePersistenceSchedulingTests` on `cmux-austin-mini-0` failed the new test after 1.015 seconds before the fix.
- Green fleet suite: `swift test --filter Workstream` on `cmux-austin-mini-0` passed 31 tests across 5 suites after the fix.
- Green CI: [`swift-package-tests`](https://github.com/manaflow-ai/cmux/actions/runs/30958381606/job/92161455724) on fixed commit `4552be95dc` passed, including all 282 `CMUXAgentLaunch` tests across 41 suites.
- Dev build: `./scripts/reload-cloud.sh --tag sym4604` succeeded on pushed HEAD via [remote build run 30958404159](https://github.com/manaflow-ai/cmux/actions/runs/30958404159); no local-build fallback was used.
- Tagged dogfood on `/tmp/cmux-debug-sym4604.sock`: ten real Codex `PostToolUse` hooks at 0.38-second intervals persisted all ten rows; a terminal command completed in 0.34 seconds during the burst versus a 0.32-second idle baseline. The tagged app was then terminated and the socket removed.
