### PR TITLE
Fix remote tmux show-options and short formats

### DIFF
--- a/daemon/remote/cmd/cmuxd-remote/tmux_compat.go
+++ b/daemon/remote/cmd/cmuxd-remote/tmux_compat.go
@@ -7,7 +7,6 @@ import (
 	"math"
 	"os"
 	"path/filepath"
-	"regexp"
 	"strings"
 	"time"
 )
@@ -167,23 +166,63 @@ func parseTmuxArgs(args []string, valueFlags, boolFlags []string) *tmuxParsed {
 
 // --- Format string rendering ---
 
-var tmuxFormatVarRe = regexp.MustCompile(`#\{[^}]+\}`)
+var tmuxShortFormatKeys = map[byte]string{
+	'S': "session_name",
+	'I': "window_index",
+	'W': "window_name",
+	'P': "pane_index",
+}
 
 func tmuxRenderFormat(format string, context map[string]string, fallback string) string {
 	if format == "" {
 		return fallback
 	}
-	rendered := format
-	for key, value := range context {
-		rendered = strings.ReplaceAll(rendered, "#{"+key+"}", value)
+
+	var rendered strings.Builder
+	for i := 0; i < len(format); {
+		if format[i] != '#' {
+			rendered.WriteByte(format[i])
+			i++
+			continue
+		}
+		if i+1 >= len(format) {
+			rendered.WriteByte('#')
+			i++
+			continue
+		}
+
+		next := format[i+1]
+		if next == '#' {
+			rendered.WriteByte('#')
+			i += 2
+			continue
+		}
+		if next == '{' {
+			closeOffset := strings.IndexByte(format[i+2:], '}')
+			if closeOffset < 0 {
+				rendered.WriteString(format[i:])
+				break
+			}
+			closeIndex := i + 2 + closeOffset
+			rendered.WriteString(context[format[i+2:closeIndex]])
+			i = closeIndex + 1
+			continue
+		}
+		if key, ok := tmuxShortFormatKeys[next]; ok {
+			rendered.WriteString(context[key])
+			i += 2
+			continue
+		}
+
+		rendered.WriteByte('#')
+		i++
 	}
-	// Remove any remaining unresolved #{...} variables
-	rendered = tmuxFormatVarRe.ReplaceAllString(rendered, "")
-	rendered = strings.TrimSpace(rendered)
-	if rendered == "" {
+
+	result := strings.TrimSpace(rendered.String())
+	if result == "" {
 		return fallback
 	}
-	return rendered
+	return result
 }
 
 // --- Format context building ---
@@ -1415,6 +1454,8 @@ func dispatchTmuxCommand(rc *rpcContext, command string, args []string) error {
 		return tmuxSelectLayout(rc, args)
 	case "show-buffer", "showb":
 		return tmuxShowBuffer(args)
+	case "show-options", "show-option", "show":
+		return tmuxShowOptions(args)
 	case "save-buffer", "saveb":
 		return tmuxSaveBuffer(args)
 
@@ -1865,6 +1906,29 @@ func tmuxDisplayMessage(rc *rpcContext, args []string) error {
 	rendered := tmuxRenderFormat(format, ctx, "")
 	if p.hasFlag("-p") || rendered != "" {
 		fmt.Println(rendered)
+	}
+	return nil
+}
+
+func tmuxShowOptions(args []string) error {
+	p := parseTmuxArgs(args, []string{"-t"}, []string{"-g", "-q", "-s", "-v", "-w"})
+	if len(p.positional) == 0 {
+		return nil
+	}
+
+	optionName := p.positional[len(p.positional)-1]
+	if optionName != "extended-keys" {
+		if p.hasFlag("-q") {
+			return nil
+		}
+		return fmt.Errorf("unsupported tmux option: %s", optionName)
+	}
+
+	const value = "on"
+	if p.hasFlag("-v") {
+		fmt.Println(value)
+	} else {
+		fmt.Printf("%s %s\n", optionName, value)
 	}
 	return nil
 }

--- a/daemon/remote/cmd/cmuxd-remote/tmux_compat_test.go
+++ b/daemon/remote/cmd/cmuxd-remote/tmux_compat_test.go
@@ -281,6 +281,66 @@ func TestTmuxDisplayReporterFormatFields(t *testing.T) {
 	assertTmuxFieldMatch(t, values["session_attached"], `^[01]$`, "session_attached")
 }
 
+func TestTmuxCompatReadOnlyProbesAgainstRunningSession(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("CMUX_WORKSPACE_ID", "workspace:1")
+	t.Setenv("CMUX_SURFACE_ID", "surface:1")
+	t.Setenv("TMUX_PANE", "%"+tmuxStableNumericId("33333333-3333-4333-8333-333333333333"))
+
+	sockPath := startMockTmuxCompatSocket(t)
+	tests := []struct {
+		name        string
+		args        []string
+		wantOutput  string
+		checkOutput bool
+	}{
+		{
+			name: "global options",
+			args: []string{"show-options", "-g"},
+		},
+		{
+			name:        "session name short format",
+			args:        []string{"display-message", "-p", "#S"},
+			wantOutput:  "cmux\n",
+			checkOutput: true,
+		},
+		{
+			name:        "window index short format",
+			args:        []string{"display-message", "-p", "#I"},
+			wantOutput:  "1\n",
+			checkOutput: true,
+		},
+		{
+			name:        "window name short format",
+			args:        []string{"display-message", "-p", "#W"},
+			wantOutput:  "demo\n",
+			checkOutput: true,
+		},
+		{
+			name:        "pane index short format",
+			args:        []string{"display-message", "-p", "#P"},
+			wantOutput:  "1\n",
+			checkOutput: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var exitCode int
+			output := captureStdout(t, func() {
+				args := append([]string{"--socket", sockPath, "__tmux-compat"}, tt.args...)
+				exitCode = runCLI(args)
+			})
+			if exitCode != 0 {
+				t.Fatalf("cmux __tmux-compat %v exited %d, want 0", tt.args, exitCode)
+			}
+			if tt.checkOutput && output != tt.wantOutput {
+				t.Fatalf("cmux __tmux-compat %v output = %q, want %q", tt.args, output, tt.wantOutput)
+			}
+		})
+	}
+}
+
 func assertTmuxFieldMatch(t *testing.T, got string, pattern string, field string) {
 	t.Helper()
 	if !regexp.MustCompile(pattern).MatchString(got) {


### PR DESCRIPTION
## Summary

- Add `show-options` handling to the remote Go tmux compatibility shim, including the Swift shim behavior for `extended-keys`.
- Render tmux short formats (`#S`, `#I`, `#W`, and `#P`) with the same context used by the existing long forms.
- Exercise the real Go CLI entrypoint against a running mock session so command dispatch, exit status, and output substitution stay covered.

Fixes #7369

## Testing

- Regression commit `2ee0219a23`: [`remote-daemon-tests` failed as expected](https://github.com/manaflow-ai/cmux/actions/runs/30958102786/job/92155771525) in `go test ./...` because `show-options` was unsupported and `#S/#I/#W/#P` remained literal.
- Fix commit `efb8145064`: [`remote-daemon-tests` passed](https://github.com/manaflow-ai/cmux/actions/runs/30958275091/job/92156306854), including `go test ./...` and remote-daemon release-asset validation.
- `./scripts/reload-cloud.sh --tag sym7369`: [hosted Blacksmith build passed](https://github.com/manaflow-ai/cmux/actions/runs/30958386604); no local fallback was used.
- Tagged runtime confirmation through `/tmp/cmux-debug-sym7369.sock` and a loopback SSH workspace: `show-options -g` exited 0; `display-message -p` returned `cmux`, `1`, `issue-7369-dogfood`, and `0` for `#S`, `#I`, `#W`, and `#P`, all with exit 0 and no literal tokens.
- Closed the SSH workspace, stopped the task SSH harness and persistent daemon, quit the tagged app, and confirmed the tagged process and socket were gone.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/9600"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788477724&installation_model_id=21920&pr_number=9600&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F9600&signature=02b37caaaa089f37eb2f3a733689469f54127b4a0795cd9b7daf4fc00cedf683"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `show-options` support to the remote tmux shim and correctly renders short formats `#S`, `#I`, `#W`, and `#P`. Closes #7369 by aligning read-only behavior with tmux and our Swift shim.

- **Bug Fixes**
  - Implemented `show-options` with `extended-keys` returning "on"; supports `-v` and respects `-q` for unknown options.
  - Rendered short tokens using the same context as long forms; handles `##` and `#{...}` correctly.
  - Added tests that run the Go CLI against a mock session to verify dispatch, exit codes, and outputs.

<sup>Written for commit efb8145064b1e275bb9f1089beb12bfc9a4be0dd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/9600?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved compatibility with tmux format strings, including escaped characters, variables, and common short keys.
  * Added support for querying the `extended-keys` option through tmux-compatible commands.
  * Supports quiet and value-only query modes.

* **Bug Fixes**
  * Improved handling of read-only tmux compatibility probes for session, window, and pane metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->