### PR TITLE
Fix sidebar top gradient overlapping the first row

### DIFF
--- a/Sources/WindowChromeMetrics.swift
+++ b/Sources/WindowChromeMetrics.swift
@@ -61,8 +61,8 @@ enum SidebarWorkspaceListMetrics {
     static let rowVerticalPadding: CGFloat = 8
     static let rowOuterHorizontalPadding: CGFloat = 6
     static let rowContentHorizontalPadding: CGFloat = 10
-    static let topScrimHeight: CGFloat = firstRowTopOffset + 20
-    static let bottomScrimHeight: CGFloat = topScrimHeight
+    static let topScrimHeight: CGFloat = firstRowTopOffset
+    static let bottomScrimHeight: CGFloat = firstRowTopOffset + 20
 
     static var trailingAccessoryRightEdgeOffset: CGFloat {
         rowOuterHorizontalPadding + rowContentHorizontalPadding

--- a/cmuxTests/SidebarWorkspaceScrollLayoutTests.swift
+++ b/cmuxTests/SidebarWorkspaceScrollLayoutTests.swift
@@ -10,6 +10,14 @@ import Testing
 @MainActor
 @Suite("Sidebar workspace scroll layout")
 struct SidebarWorkspaceScrollLayoutTests {
+    @Test func topScrimDoesNotOverlapFirstWorkspaceRow() {
+        #expect(
+            SidebarWorkspaceListMetrics.topScrimHeight
+                <= SidebarWorkspaceListMetrics.firstRowTopOffset,
+            "the top fade must end before the first workspace row begins"
+        )
+    }
+
     @Test func contentMinHeightSubtractsInsetsFromViewport() {
         let contentMinHeight = SidebarWorkspaceScrollLayout.contentMinHeight(
             viewportHeight: 720,


### PR DESCRIPTION
## Summary

- stop the sidebar top scroll-edge scrim at the first workspace row offset so the unscrolled row is fully opaque
- preserve the existing bottom fade height
- add a regression test for the top-scrim boundary

Fixes #5339

## Testing

- Red: [focused hosted run 30957904952](https://github.com/manaflow-ai/cmux/actions/runs/30957904952) on test-only commit `870cbd276a` failed `SidebarWorkspaceScrollLayoutTests`: `topScrimHeight` was 50pt while `firstRowTopOffset` was 30pt.
- Green: [focused hosted run 30958821275](https://github.com/manaflow-ai/cmux/actions/runs/30958821275) on fixed commit `153d07408d` passed the same four-test suite.
- Dev build: `./scripts/reload-cloud.sh --tag sym5339` used the cloud path with no local fallback; [remote build 30958836740](https://github.com/manaflow-ai/cmux/actions/runs/30958836740) succeeded.
- Dogfood: against `/tmp/cmux-debug-sym5339.sock`, ran completed commands in `First Row` and `Second Row`, selected each workspace, and captured the composited window through `debug.window.screenshot`. Before the fix, the first-row highlight changed from RGB `55/110/184` near its top to `63/143/247` below while the second row stayed uniform. After the fix, both selected rows stayed `63/143/247` at every sampled height. The tagged app was then quit and its socket removed.
- Localization audit: no user-facing strings or localization catalogs changed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sidebar workspace scrolling visuals by preventing the top scrim from overlapping the first workspace row.
  * Adjusted bottom scrim spacing for more consistent layout behavior.

* **Tests**
  * Added coverage to verify correct top scrim placement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->