### PR TITLE
Clean up command palette observers when windows close

### DIFF
--- a/Packages/macOS/CmuxCommandPalette/Sources/CmuxCommandPalette/Interaction/CommandPaletteInteractionDismissal.swift
+++ b/Packages/macOS/CmuxCommandPalette/Sources/CmuxCommandPalette/Interaction/CommandPaletteInteractionDismissal.swift
@@ -6,6 +6,9 @@ public enum CommandPaletteInteractionDismissal: Sendable, Equatable {
     /// The palette's host window stopped being the key window.
     case windowResignedKey
 
+    /// The palette's host window is closing.
+    case windowClosed
+
     /// The application main menu entered its nested tracking loop.
     case mainMenuBeganTracking
 }

--- a/Packages/macOS/CmuxCommandPalette/Sources/CmuxCommandPalette/Interaction/CommandPaletteInteractionMonitor.swift
+++ b/Packages/macOS/CmuxCommandPalette/Sources/CmuxCommandPalette/Interaction/CommandPaletteInteractionMonitor.swift
@@ -4,11 +4,12 @@ import AppKit
 ///
 /// Activation is idempotent for a window: repeated render updates refresh the
 /// callbacks without installing duplicate monitors. Deactivation removes the
-/// local pointer monitor and both window-key observers as one lifecycle unit.
+/// local pointer monitor and every window-lifecycle observer as one unit.
 @MainActor
 public final class CommandPaletteInteractionMonitor {
     static let windowDidBecomeKeyNotification = NSWindow.didBecomeKeyNotification
     static let windowDidResignKeyNotification = NSWindow.didResignKeyNotification
+    static let windowWillCloseNotification = NSWindow.willCloseNotification
     static let menuDidBeginTrackingNotification = NSMenu.didBeginTrackingNotification
     private let notificationCenter: NotificationCenter
     private let eventSource: any CommandPaletteEventMonitorSource
@@ -85,6 +86,7 @@ public final class CommandPaletteInteractionMonitor {
         windowObserverTokens = [
             observe(Self.windowDidBecomeKeyNotification, window: window, dismissal: nil),
             observe(Self.windowDidResignKeyNotification, window: window, dismissal: .windowResignedKey),
+            observeWindowWillClose(window: window),
             observeMainMenuTracking(),
         ]
     }
@@ -121,6 +123,21 @@ public final class CommandPaletteInteractionMonitor {
                 if let dismissal {
                     self.onDismiss?(dismissal)
                 }
+            }
+        }
+    }
+
+    private func observeWindowWillClose(window: AnyObject) -> any NSObjectProtocol {
+        notificationCenter.addObserver(
+            forName: Self.windowWillCloseNotification,
+            object: window,
+            queue: .main
+        ) { [weak self] _ in
+            MainActor.assumeIsolated {
+                guard let self else { return }
+                let onDismiss = self.onDismiss
+                self.deactivate()
+                onDismiss?(.windowClosed)
             }
         }
     }

--- a/Packages/macOS/CmuxCommandPalette/Tests/CmuxCommandPaletteTests/CommandPaletteInteractionMonitorTests.swift
+++ b/Packages/macOS/CmuxCommandPalette/Tests/CmuxCommandPaletteTests/CommandPaletteInteractionMonitorTests.swift
@@ -213,6 +213,33 @@ struct CommandPaletteInteractionMonitorTests {
         #expect(secondDismissCount == 1)
     }
 
+    @Test("closing a non-key window dismisses and removes every observer")
+    func windowCloseDismissesAndCleansUp() {
+        let notificationCenter = RecordingCommandPaletteNotificationCenter()
+        let eventSource = RecordingCommandPaletteEventMonitorSource()
+        let monitor = CommandPaletteInteractionMonitor(
+            notificationCenter: notificationCenter,
+            eventSource: eventSource
+        )
+        let window = NSObject()
+        var dismissals: [CommandPaletteInteractionDismissal] = []
+
+        monitor.activate(
+            for: window,
+            shouldDismiss: { _ in false },
+            onWindowStateChange: {},
+            onDismiss: { dismissals.append($0) }
+        )
+
+        notificationCenter.send(name: NSWindow.willCloseNotification, object: window)
+
+        #expect(dismissals.count == 1)
+        #expect(eventSource.removeCount == 1)
+        #expect(
+            notificationCenter.removedObserverIDs == notificationCenter.addedObservers.map { $0.token.id }
+        )
+    }
+
     @Test("deinit removes pointer and key-window observation")
     func deinitRemovesObservation() {
         let notificationCenter = RecordingCommandPaletteNotificationCenter()

--- a/Packages/macOS/CmuxCommandPalette/Tests/CmuxCommandPaletteTests/CommandPaletteInteractionMonitorTests.swift
+++ b/Packages/macOS/CmuxCommandPalette/Tests/CmuxCommandPaletteTests/CommandPaletteInteractionMonitorTests.swift
@@ -134,6 +134,7 @@ struct CommandPaletteInteractionMonitorTests {
         #expect(notificationCenter.addedObservers.map { $0.name } == [
             CommandPaletteInteractionMonitor.windowDidBecomeKeyNotification,
             CommandPaletteInteractionMonitor.windowDidResignKeyNotification,
+            CommandPaletteInteractionMonitor.windowWillCloseNotification,
             CommandPaletteInteractionMonitor.menuDidBeginTrackingNotification,
         ])
 


### PR DESCRIPTION
## Summary

- dismiss the command palette when its host window closes, including windows that never became key
- synchronously deactivate the interaction monitor before delivering the close dismissal so its pointer monitor and every block-based NotificationCenter token are removed
- add behavioral coverage for the non-key window-close lifecycle

Fixes #5718

## Testing

- Red on `8c3feea97d`: remote `swift test --package-path Packages/macOS/CmuxCommandPalette --filter windowCloseDismissesAndCleansUp` failed as expected with 0 dismissals, 0 pointer-monitor removals, and no observer-token removals.
- Green on `ed69c6f0a0`: remote `swift test --package-path Packages/macOS/CmuxCommandPalette --filter CommandPaletteInteractionMonitorTests` passed all 6 tests.
- `python3 scripts/check-package-resolved-policy.py`
- `python3 scripts/check-workspace-package-groups.py --check`
- `git diff --check`
- `./scripts/reload-cloud.sh --tag sym5718 --builder fleet --host cmux9s-mac-mini` built pushed HEAD successfully on leased slot `cmux9s-mac-mini.1` and downloaded the tagged app.
- Tagged socket dogfood: forced app focus inactive, created a non-key window, showed its palette, closed it, and observed `visible: true` before close and `visible: false` after close across 6 cycles; the socket still returned `PONG`. The tagged app was then quit and its stale socket removed.

Localization audit: no user-facing strings or localization resources changed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/9602"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788478097&installation_model_id=21920&pr_number=9602&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F9602&signature=78a95d958a892b9c5bc4d4679655ad3e991bf80987140048efe058801042f190"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Dismisses the command palette when its host window closes and cleans up all observers, even if the window never became key. Deactivates the interaction monitor before the close dismissal to remove the pointer monitor and NotificationCenter observers. Fixes #5718.

- **Bug Fixes**
  - Added `.windowClosed` dismissal and observation of `NSWindow.willCloseNotification`.
  - On window close, deactivate first, then call `onDismiss` to prevent leaks and stale monitors.
  - Added tests to cover non-key window close, verifying dismissal and full observer removal.

<sup>Written for commit ed69c6f0a05c1a4e7649ac65652512a38d33402c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/9602?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Command palettes now dismiss cleanly when their host window is closing.
  - Interaction monitoring stops automatically when the window closes, preventing lingering event or notification handling.
  - Window closure is reported as a distinct dismissal outcome for more reliable behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->