### PR TITLE
Preserve process title updates after detaching a panel

### DIFF
--- a/Sources/AppDelegate+MoveTabToNewWorkspace.swift
+++ b/Sources/AppDelegate+MoveTabToNewWorkspace.swift
@@ -110,7 +110,7 @@ extension AppDelegate {
 
         guard let destinationWorkspace = targetManager.addWorkspace(
             fromDetachedSurface: detached,
-            title: destinationTitle,
+            title: hasExplicitTitle ? destinationTitle : nil,
             titleSource: hasExplicitTitle ? .user : .auto,
             select: false,
             placementOverride: placementOverride,

--- a/cmuxTests/AppDelegateMoveTabToNewWorkspaceTests.swift
+++ b/cmuxTests/AppDelegateMoveTabToNewWorkspaceTests.swift
@@ -48,7 +48,7 @@ struct AppDelegateMoveTabToNewWorkspaceTests {
     }
 
     @Test
-    func moveSurfaceToNewWorkspaceFlushesPendingTitleBeforeDerivingDestinationTitle() async throws {
+    func moveSurfaceToNewWorkspaceKeepsFollowingProcessTitleUpdatesAfterDetach() async throws {
         let suiteName = "AppDelegateMoveSurfaceTitle.\(UUID().uuidString)"
         let defaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
         defaults.removePersistentDomain(forName: suiteName)
@@ -76,6 +76,7 @@ struct AppDelegateMoveTabToNewWorkspaceTests {
         let remainingPanelId = try XCTUnwrap(workspace.focusedPanelId)
         let movedPanel = try XCTUnwrap(workspace.newTerminalSurface(inPane: paneId, focus: false))
         let movedTitle = "Moved Surface Title - grok"
+        let updatedTitle = "✳ Investigate detached workspace title updates"
 
         NotificationCenter.default.post(
             name: .ghosttyDidSetTitle,
@@ -101,13 +102,28 @@ struct AppDelegateMoveTabToNewWorkspaceTests {
 
         #expect(workspace.panels[movedPanel.id] == nil)
         #expect(workspace.panels[remainingPanelId] != nil)
-        #expect(destinationWorkspace.customTitle == movedTitle)
+        #expect(destinationWorkspace.customTitle == nil)
         #expect(destinationWorkspace.title == movedTitle)
         #expect(destinationWorkspace.panelTitle(panelId: movedPanel.id) == movedTitle)
 
-        scheduler.fire(at: 0)
-        #expect(destinationWorkspace.title == movedTitle)
-        #expect(destinationWorkspace.panelTitle(panelId: movedPanel.id) == movedTitle)
+        NotificationCenter.default.post(
+            name: .ghosttyDidSetTitle,
+            object: destinationWorkspace.terminalPanel(for: movedPanel.id)?.surface,
+            userInfo: [
+                GhosttyNotificationKey.tabId: destinationWorkspace.id,
+                GhosttyNotificationKey.surfaceId: movedPanel.id,
+                GhosttyNotificationKey.title: updatedTitle
+            ]
+        )
+
+        await drainMainQueue()
+        #expect(scheduler.delays == [0.5, 0.5])
+        scheduler.fire(at: 1)
+
+        #expect(destinationWorkspace.customTitle == nil)
+        #expect(destinationWorkspace.processTitle == updatedTitle)
+        #expect(destinationWorkspace.title == updatedTitle)
+        #expect(destinationWorkspace.panelTitle(panelId: movedPanel.id) == updatedTitle)
     }
 
     @Test


### PR DESCRIPTION
## Summary

- keep process-derived titles in the automatic title path when a panel moves into a new workspace
- pass a destination title into workspace customization only when the caller supplied an explicit title
- cover a second OSC title update after the detach, including the destination workspace and moved panel titles

Previously, the process-derived destination title was passed through workspace creation as though it were a custom title. That pinned the new workspace and prevented later OSC title changes from becoming visible. The detached surface still seeds the automatic title, while explicit caller titles retain their existing behavior.

Fixes #4946

## Testing

- Red regression commit `d8fb72a44b`: the focused remote `cmux-unit` run failed with exit 65 before the fix:
  `TEST_RUNNER_CMUX_TEST_PROCESS=1 xcodebuild -project cmux.xcodeproj -scheme cmux-unit -configuration Debug -destination 'platform=macOS' -derivedDataPath <isolated> -clonedSourcePackagesDirPath <isolated>/.ci-source-packages -resultBundlePath <isolated>/focused.xcresult CMUX_SKIP_ZIG_BUILD=1 SWIFT_SUPPRESS_WARNINGS=YES GCC_WARN_INHIBIT_ALL_WARNINGS=YES -only-testing:cmuxTests/AppDelegateMoveTabToNewWorkspaceTests test`
- Green fix commit `2c4e482811`: the same focused remote command exited 0; the result bundle reported 7 passed, 0 failed.
- `./scripts/reload-cloud.sh --tag sym4946` succeeded through the cloud path on `blacksmith-6vcpu-macos-26` ([run 30960418147](https://github.com/manaflow-ai/cmux/actions/runs/30960418147)).
- Tagged socket dogfood on `/tmp/cmux-debug-sym4946.sock`: created a second panel, emitted `Initial detached OSC title`, ran `break-pane`, and observed the destination workspace with `custom_title: null`. A subsequent OSC update changed both workspace and moved-surface titles to `Updated detached OSC title`; scripted assertions passed. The tagged app was then quit with `pkill -f "DerivedData/cmux-sym4946"` and its stale tag socket was removed.
- Localization audit: no user-facing strings changed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/9603"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788479179&installation_model_id=21920&pr_number=9603&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F9603&signature=f6c8f7c311fc86b2309a3e7d0343857953657d405a7ede6aa97dd1fde1c60809"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves process-driven titles after detaching a panel so the new workspace keeps following OSC/process title updates instead of pinning a custom title. Fixes #4946.

- **Bug Fixes**
  - Pass `nil` for the destination workspace title unless the caller provided one; keep `titleSource` as `.auto`.
  - Apply subsequent OSC title updates to both the destination workspace and the moved panel.
  - Rename and extend test to cover post-detach title updates and scheduler behavior.

<sup>Written for commit 2c4e48281143bb2c785161270dbd936a7ecd0480. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/9603?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Moved tabs now derive their destination workspace title from the active process title when no custom title is provided.
  * Destination workspace and panel titles continue updating when the moved process changes its title.

* **Tests**
  * Expanded coverage for title updates after moving a tab to a new workspace.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->