### PR TITLE
Normalize Dock config roots outside the home directory

### DIFF
--- a/Sources/DockSplitStore+Config.swift
+++ b/Sources/DockSplitStore+Config.swift
@@ -244,11 +244,12 @@ extension DockSplitStore {
 
     nonisolated private static func existingDirectory(_ rawPath: String) -> String? {
         let expanded = (rawPath as NSString).expandingTildeInPath
+        let normalized = (expanded as NSString).standardizingPath
         var isDirectory: ObjCBool = false
-        guard FileManager.default.fileExists(atPath: expanded, isDirectory: &isDirectory) else {
+        guard FileManager.default.fileExists(atPath: normalized, isDirectory: &isDirectory) else {
             return nil
         }
-        return isDirectory.boolValue ? expanded : (expanded as NSString).deletingLastPathComponent
+        return isDirectory.boolValue ? normalized : (normalized as NSString).deletingLastPathComponent
     }
 
     nonisolated private static func canonicalConfigPath(_ url: URL) -> String {

--- a/cmuxTests/DockControlDefinitionDecodingTests.swift
+++ b/cmuxTests/DockControlDefinitionDecodingTests.swift
@@ -222,9 +222,56 @@ struct DockControlDefinitionDecodingTests {
     @Test("Project config parent traversal stops at the filesystem root")
     @MainActor
     func projectConfigParentTraversalStopsAtRoot() {
+        let foundationParentOfRoot = URL(fileURLWithPath: "/", isDirectory: true)
+            .deletingLastPathComponent()
+            .path
+
+        #expect(DockSplitStore.parentDirectoryPath(for: foundationParentOfRoot) == nil)
         #expect(DockSplitStore.parentDirectoryPath(for: "/") == nil)
         #expect(DockSplitStore.parentDirectoryPath(for: "/..") == nil)
         #expect(DockSplitStore.parentDirectoryPath(for: "/Users") == "/")
+    }
+
+    @Test(
+        "Project config resolution terminates outside the home directory",
+        .timeLimit(.minutes(1))
+    )
+    func projectConfigResolutionTerminatesOutsideHome() throws {
+        let fileManager = FileManager.default
+        let root = URL(fileURLWithPath: "/tmp", isDirectory: true)
+            .appendingPathComponent("cmux-dock-root-walk-\(UUID().uuidString)", isDirectory: true)
+        try fileManager.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? fileManager.removeItem(at: root) }
+
+        let homePath = fileManager.homeDirectoryForCurrentUser.path
+        #expect(root.path != homePath)
+        #expect(!root.path.hasPrefix(homePath + "/"))
+
+        let ancestorConfigURLs = [
+            URL(fileURLWithPath: "/tmp", isDirectory: true),
+            URL(fileURLWithPath: "/", isDirectory: true),
+        ].map {
+            $0.appendingPathComponent(".cmux", isDirectory: true)
+                .appendingPathComponent("dock.json", isDirectory: false)
+        }
+        for configURL in ancestorConfigURLs {
+            try #require(!fileManager.fileExists(atPath: configURL.path))
+        }
+
+        let clock = ContinuousClock()
+        let start = clock.now
+        let resolution = try DockSplitStore.resolve(rootDirectory: root.path)
+        let foundationParentOfRoot = URL(fileURLWithPath: "/", isDirectory: true)
+            .deletingLastPathComponent()
+            .path
+        let rootResolution = try DockSplitStore.resolve(rootDirectory: foundationParentOfRoot)
+        let elapsed = start.duration(to: clock.now)
+
+        #expect(resolution.sourceURL == nil)
+        #expect(resolution.baseDirectory == root.path)
+        #expect(rootResolution.sourceURL == nil)
+        #expect(rootResolution.baseDirectory == "/")
+        #expect(elapsed < .seconds(1))
     }
 
     @Test("Dock surface creation without focus preserves the selected tab")


### PR DESCRIPTION
## Summary

- add resolver-level regression coverage for Dock config traversal from a directory outside the user's home
- normalize expanded existing paths before both config lookup and base-directory reporting
- cover Foundation's macOS 14/15 parent-of-root representation (`/..`) with bounded execution

Current `main` already has the bounded `parentDirectoryPath` ancestor walk that landed with #6219, so it no longer contains the original unbounded loop from the reported build. The remaining macOS 15 edge case was that Foundation can produce `/..` as the parent of `/`; `FileManager` accepts that path, and `existingDirectory` returned it unchanged. Standardizing the expanded path collapses it to `/` before lookup and return.

The broader Dock config-loading architecture is unchanged; this keeps the change scoped to filesystem-root normalization and regression coverage.

Fixes #7012

## Testing

- [Test-only run (red)](https://github.com/manaflow-ai/cmux/actions/runs/30960013557) at `aa9ea826a6`: the class-wide filter executed 24 tests and failed only because root resolution returned `/..` instead of `/`
- [Fixed run (green)](https://github.com/manaflow-ai/cmux/actions/runs/30960662902) at `492650b06e`: the same 24-test class-wide filter completed successfully
- `./scripts/reload-cloud.sh --builder fleet --host cmux8s-mac-mini --tag sym7012 --launch`: `BUILD_OK` on `cmux8s-mac-mini.1` (fleet build; no local fallback)
- Tagged socket dogfood on final HEAD: created a fresh workspace rooted at `/tmp/cmux-7012-final.LptWfb` with no ancestor Dock config, opened Dock in 0.14s, confirmed `{"visible":true,"mode":"dock"}`, received five consecutive `PONG` responses plus a final cleanup ping, and confirmed the terminal cwd. The process repeatedly returned to a sleeping/near-idle state instead of remaining pegged, then the tagged app was quit and its temporary directory/socket were removed.
- `./scripts/lint-pbxproj-test-wiring.sh`
- `git diff --check origin/main...HEAD`

## Localization

No user-facing strings changed; localization catalogs were audited and do not need updates.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/9605"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788479625&installation_model_id=21920&pr_number=9605&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F9605&signature=a219ac419e7d5588bde376e24a9e0d01d50ed5206736a7b96704d97ef2d752ed"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Normalize Dock config root path resolution by standardizing expanded paths and handling Foundation’s `/..` parent-of-root on macOS 14/15. This ensures traversal stops at `/`, resolves configs outside the home directory without spinning, and fixes #7012.

- **Bug Fixes**
  - Standardize expanded paths before existence checks and base-directory reporting.
  - Treat `/..` as `/` during traversal to bound resolution at the filesystem root.

<sup>Written for commit 492650b06ee2048b3dd1822fcd1a4c765dc26d0d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/9605?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

