### PR TITLE
Devbox: one persistent Daytona VM per user with persistent volume, pause/resume, and cmux TUI

### DIFF
--- a/web/app/api/devbox/attach-endpoint/route.ts
+++ b/web/app/api/devbox/attach-endpoint/route.ts
@@ -1,0 +1,87 @@
+// Mint a WebSocket PTY attach lease for the caller's devbox. The underlying
+// workflow auto-resumes a paused devbox before minting, so attach transparently
+// wakes the VM. The default shell inside a devbox sandbox is the cmux TUI.
+
+import {
+  isDevboxNotFoundError,
+  openDevboxAttach,
+  runDevboxWorkflow,
+} from "../../../../services/vms/devbox";
+import {
+  jsonResponse,
+  resolveVmRouteAccountScope,
+  withAuthedVmApiRoute,
+} from "../../../../services/vms/routeHelpers";
+import { setSpanAttributes } from "../../../../services/telemetry";
+import { devboxNotFoundResponse } from "../shared";
+
+export const dynamic = "force-dynamic";
+
+export async function POST(request: Request): Promise<Response> {
+  return withAuthedVmApiRoute(
+    request,
+    "/api/devbox/attach-endpoint",
+    { "cmux.vm.operation": "devbox_open_attach" },
+    "/api/devbox/attach-endpoint POST failed",
+    async ({ user, span }) => {
+      const body = await parseAttachBody(request);
+      const requireDaemon = body.requireDaemon === true || body.require_daemon === true;
+      let sessionId: string | undefined;
+      let attachmentId: string | undefined;
+      try {
+        sessionId = optionalClientIdentifier(body.sessionId ?? body.session_id, "sessionId");
+        attachmentId = optionalClientIdentifier(body.attachmentId ?? body.attachment_id, "attachmentId");
+      } catch (err) {
+        return jsonResponse({
+          error: "invalid_request",
+          message: err instanceof Error ? err.message : "Invalid devbox attach request.",
+        }, 400);
+      }
+      const sessionTitle = optionalString(body.title ?? body.sessionTitle ?? body.session_title);
+      const account = resolveVmRouteAccountScope(user, request);
+      if (!account.ok) return account.response;
+      setSpanAttributes(span, { "cmux.vm.attach.require_daemon": requireDaemon });
+      try {
+        const endpoint = await runDevboxWorkflow(openDevboxAttach({
+          userId: user.id,
+          billingTeamId: account.entitlements.billingTeamId,
+          teamIds: user.teamIds,
+          sessionTitle,
+          options: { requireDaemon, sessionId, attachmentId },
+        }));
+        setSpanAttributes(span, { "cmux.vm.attach.transport": endpoint.transport });
+        return jsonResponse(endpoint);
+      } catch (err) {
+        if (isDevboxNotFoundError(err)) return devboxNotFoundResponse();
+        throw err;
+      }
+    },
+  );
+}
+
+async function parseAttachBody(request: Request): Promise<Record<string, unknown>> {
+  const raw = await request.text();
+  if (!raw.trim()) return {};
+  try {
+    const parsed = JSON.parse(raw) as unknown;
+    if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) return {};
+    return parsed as Record<string, unknown>;
+  } catch {
+    return {};
+  }
+}
+
+function optionalString(value: unknown): string | null {
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim();
+  return trimmed || null;
+}
+
+function optionalClientIdentifier(value: unknown, fieldName: string): string | undefined {
+  const trimmed = optionalString(value);
+  if (!trimmed) return undefined;
+  if (!/^[A-Za-z0-9._:-]{1,128}$/.test(trimmed)) {
+    throw new Error(`${fieldName} must be 1-128 characters of letters, numbers, dot, underscore, colon, or dash`);
+  }
+  return trimmed;
+}

--- a/web/app/api/devbox/pause/route.ts
+++ b/web/app/api/devbox/pause/route.ts
@@ -1,0 +1,37 @@
+import {
+  isDevboxNotFoundError,
+  pauseDevbox,
+  runDevboxWorkflow,
+} from "../../../../services/vms/devbox";
+import {
+  jsonResponse,
+  resolveVmRouteAccountScope,
+  withAuthedVmApiRoute,
+} from "../../../../services/vms/routeHelpers";
+import { devboxNotFoundResponse } from "../shared";
+
+export const dynamic = "force-dynamic";
+
+export async function POST(request: Request): Promise<Response> {
+  return withAuthedVmApiRoute(
+    request,
+    "/api/devbox/pause",
+    { "cmux.vm.operation": "devbox_pause" },
+    "/api/devbox/pause POST failed",
+    async ({ user }) => {
+      const account = resolveVmRouteAccountScope(user, request);
+      if (!account.ok) return account.response;
+      try {
+        const devbox = await runDevboxWorkflow(pauseDevbox({
+          userId: user.id,
+          billingTeamId: account.entitlements.billingTeamId,
+          teamIds: user.teamIds,
+        }));
+        return jsonResponse({ devbox });
+      } catch (err) {
+        if (isDevboxNotFoundError(err)) return devboxNotFoundResponse();
+        throw err;
+      }
+    },
+  );
+}

--- a/web/app/api/devbox/resume/route.ts
+++ b/web/app/api/devbox/resume/route.ts
@@ -1,0 +1,37 @@
+import {
+  isDevboxNotFoundError,
+  resumeDevbox,
+  runDevboxWorkflow,
+} from "../../../../services/vms/devbox";
+import {
+  jsonResponse,
+  resolveVmRouteAccountScope,
+  withAuthedVmApiRoute,
+} from "../../../../services/vms/routeHelpers";
+import { devboxNotFoundResponse } from "../shared";
+
+export const dynamic = "force-dynamic";
+
+export async function POST(request: Request): Promise<Response> {
+  return withAuthedVmApiRoute(
+    request,
+    "/api/devbox/resume",
+    { "cmux.vm.operation": "devbox_resume" },
+    "/api/devbox/resume POST failed",
+    async ({ user }) => {
+      const account = resolveVmRouteAccountScope(user, request);
+      if (!account.ok) return account.response;
+      try {
+        const devbox = await runDevboxWorkflow(resumeDevbox({
+          userId: user.id,
+          billingTeamId: account.entitlements.billingTeamId,
+          teamIds: user.teamIds,
+        }));
+        return jsonResponse({ devbox });
+      } catch (err) {
+        if (isDevboxNotFoundError(err)) return devboxNotFoundResponse();
+        throw err;
+      }
+    },
+  );
+}

--- a/web/app/api/devbox/route.ts
+++ b/web/app/api/devbox/route.ts
@@ -1,0 +1,184 @@
+// Devbox REST surface: one persistent Daytona VM per user with a persistent volume.
+// GET reports the caller's devbox (or null), POST is get-or-create, DELETE destroys
+// the VM and releases the claim while keeping the volume for the next create.
+
+import { assertDevboxEnabled, assertVmCreateEnabled } from "../../../services/vms/config";
+import {
+  ensureDevbox,
+  getDevbox,
+  isDevboxNotFoundError,
+  releaseDevbox,
+  runDevboxWorkflow,
+  DEVBOX_PROVIDER,
+} from "../../../services/vms/devbox";
+import { isVmProGateBlocked } from "../../../services/vms/entitlements";
+import {
+  isVmCreateCreditsInsufficientError,
+  isVmCreateDisabledError,
+  isVmCreateFailedError,
+  isVmCreateInProgressError,
+  isVmImageConfigError,
+  isVmLimitExceededError,
+} from "../../../services/vms/errors";
+import { resolveVmImage } from "../../../services/vms/images/resolver";
+import {
+  jsonResponse,
+  resolveVmRouteAccountScope,
+  vmErrorResponse,
+  vmRequiresProResponse,
+  withAuthedVmApiRoute,
+} from "../../../services/vms/routeHelpers";
+import { setSpanAttributes } from "../../../services/telemetry";
+import { devboxNotFoundResponse } from "./shared";
+
+export const dynamic = "force-dynamic";
+
+export async function GET(request: Request): Promise<Response> {
+  return withAuthedVmApiRoute(
+    request,
+    "/api/devbox",
+    { "cmux.vm.operation": "devbox_get" },
+    "/api/devbox GET failed",
+    async ({ user }) => {
+      const account = resolveVmRouteAccountScope(user, request);
+      if (!account.ok) return account.response;
+      const devbox = await runDevboxWorkflow(getDevbox({
+        userId: user.id,
+        billingTeamId: account.entitlements.billingTeamId,
+        teamIds: user.teamIds,
+      }));
+      return jsonResponse({ devbox });
+    },
+  );
+}
+
+export async function POST(request: Request): Promise<Response> {
+  return withAuthedVmApiRoute(
+    request,
+    "/api/devbox",
+    { "cmux.vm.operation": "devbox_ensure" },
+    "/api/devbox POST failed",
+    async ({ user, span }) => {
+      const account = resolveVmRouteAccountScope(user, request, { requireTeam: true });
+      if (!account.ok) return account.response;
+      if (isVmProGateBlocked(account.entitlements)) {
+        return vmRequiresProResponse();
+      }
+
+      let imageSelection;
+      try {
+        assertDevboxEnabled();
+        assertVmCreateEnabled(DEVBOX_PROVIDER);
+        imageSelection = resolveVmImage(DEVBOX_PROVIDER, undefined);
+      } catch (err) {
+        if (isVmCreateDisabledError(err)) {
+          return vmErrorResponse({
+            error: "devbox_create_disabled",
+            status: 503,
+            message: "Devbox creation is disabled for this environment.",
+            action: "Ask an admin to enable devbox creation, then retry.",
+            reason: err.reason,
+          });
+        }
+        if (isVmImageConfigError(err)) {
+          return vmErrorResponse({
+            error: "devbox_image_config_error",
+            status: 503,
+            message: "The devbox image is not configured in this environment.",
+            action: "Ask an admin to configure DAYTONA_SANDBOX_SNAPSHOT.",
+            reason: "Devbox image configuration is unavailable.",
+          });
+        }
+        throw err;
+      }
+
+      const rawKey = (
+        request.headers.get("idempotency-key") ||
+        request.headers.get("x-cmux-idempotency-key") ||
+        ""
+      ).trim();
+      const idempotencyKey = rawKey ? rawKey.slice(0, 128) : undefined;
+      setSpanAttributes(span, {
+        "cmux.vm.provider": DEVBOX_PROVIDER,
+        "cmux.vm.image_version": imageSelection.imageVersion,
+        "cmux.idempotency_key_set": !!idempotencyKey,
+      });
+
+      try {
+        const result = await runDevboxWorkflow(ensureDevbox({
+          userId: user.id,
+          billingCustomerType: account.entitlements.billingCustomerType,
+          billingTeamId: account.entitlements.billingTeamId,
+          billingPlanId: account.entitlements.planId,
+          maxActiveVms: account.entitlements.maxActiveVms,
+          teamIds: user.teamIds,
+          image: imageSelection.image,
+          imageVersion: imageSelection.imageVersion,
+          idempotencyKey,
+        }));
+        setSpanAttributes(span, { "cmux.devbox.created": result.created });
+        return jsonResponse({ devbox: result.devbox, created: result.created }, result.created ? 201 : 200);
+      } catch (err) {
+        if (isVmCreateInProgressError(err)) {
+          return vmErrorResponse({
+            error: "devbox_create_in_progress",
+            status: 409,
+            message: "A devbox create is already running for this account.",
+            action: "Wait for the first create to finish, then retry the same request.",
+          });
+        }
+        if (isVmCreateFailedError(err)) {
+          return vmErrorResponse({
+            error: "devbox_create_failed",
+            status: 500,
+            message: "The previous devbox create attempt failed.",
+            action: "Retry. If it fails again, copy the details and contact support.",
+            details: { failureCode: err.code, failureMessage: err.message },
+          });
+        }
+        if (isVmLimitExceededError(err)) {
+          return vmErrorResponse({
+            error: "vm_limit_exceeded",
+            status: 429,
+            message: "This team already has the maximum number of active Cloud VMs.",
+            action: "Pause or destroy another Cloud VM, then retry.",
+            details: { limit: err.limit },
+          });
+        }
+        if (isVmCreateCreditsInsufficientError(err)) {
+          return vmErrorResponse({
+            error: "vm_create_credits_insufficient",
+            status: 402,
+            message: "This account has no Cloud VM create credits left.",
+            action: "Upgrade the plan or contact support for more credits.",
+          });
+        }
+        throw err;
+      }
+    },
+  );
+}
+
+export async function DELETE(request: Request): Promise<Response> {
+  return withAuthedVmApiRoute(
+    request,
+    "/api/devbox",
+    { "cmux.vm.operation": "devbox_release" },
+    "/api/devbox DELETE failed",
+    async ({ user }) => {
+      const account = resolveVmRouteAccountScope(user, request);
+      if (!account.ok) return account.response;
+      try {
+        const result = await runDevboxWorkflow(releaseDevbox({
+          userId: user.id,
+          billingTeamId: account.entitlements.billingTeamId,
+          teamIds: user.teamIds,
+        }));
+        return jsonResponse({ released: result.released, volumeName: result.volumeName });
+      } catch (err) {
+        if (isDevboxNotFoundError(err)) return devboxNotFoundResponse();
+        throw err;
+      }
+    },
+  );
+}

--- a/web/app/api/devbox/shared.ts
+++ b/web/app/api/devbox/shared.ts
@@ -1,0 +1,10 @@
+import { vmErrorResponse } from "../../../services/vms/routeHelpers";
+
+export function devboxNotFoundResponse(): Response {
+  return vmErrorResponse({
+    error: "devbox_not_found",
+    status: 404,
+    message: "This account has no active devbox.",
+    action: "Create one with `POST /api/devbox`.",
+  });
+}

--- a/web/db/migrations/20260804140000_cloud_devbox_single_vm/migration.sql
+++ b/web/db/migrations/20260804140000_cloud_devbox_single_vm/migration.sql
@@ -1,0 +1,20 @@
+CREATE TABLE IF NOT EXISTS "cloud_devboxes" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"user_id" text NOT NULL,
+	"vm_id" uuid NOT NULL,
+	"volume_id" text NOT NULL,
+	"volume_name" text NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"released_at" timestamp with time zone
+);
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "cloud_devboxes" ADD CONSTRAINT "cloud_devboxes_vm_id_cloud_vms_id_fk" FOREIGN KEY ("vm_id") REFERENCES "public"."cloud_vms"("id") ON DELETE no action ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS "cloud_devboxes_user_active_unique" ON "cloud_devboxes" ("user_id") WHERE "released_at" is null;
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "cloud_devboxes_vm_id_idx" ON "cloud_devboxes" ("vm_id");

--- a/web/db/schema.ts
+++ b/web/db/schema.ts
@@ -80,6 +80,33 @@ export const cloudVms = pgTable(
   ],
 );
 
+// Devbox product: exactly one persistent Daytona VM per user, backed by a per-user
+// provider volume that survives VM destroy/recreate. The VM itself is a normal
+// `cloud_vms` row (leases, usage events, reconcile, and account deletion all apply);
+// this table is the single-active claim plus the volume binding. The partial unique
+// index is the invariant: one unreleased claim per user, enforced by Postgres.
+export const cloudDevboxes = pgTable(
+  "cloud_devboxes",
+  {
+    id: uuid("id").defaultRandom().primaryKey(),
+    userId: text("user_id").notNull(),
+    vmId: uuid("vm_id")
+      .notNull()
+      .references(() => cloudVms.id),
+    volumeId: text("volume_id").notNull(),
+    volumeName: text("volume_name").notNull(),
+    createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+    updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
+    releasedAt: timestamp("released_at", { withTimezone: true }),
+  },
+  (table) => [
+    uniqueIndex("cloud_devboxes_user_active_unique")
+      .on(table.userId)
+      .where(sql`${table.releasedAt} is null`),
+    index("cloud_devboxes_vm_id_idx").on(table.vmId),
+  ],
+);
+
 export const accountDeletionTombstones = pgTable(
   "account_deletion_tombstones",
   {

--- a/web/scripts/build-cloud-vm-images.ts
+++ b/web/scripts/build-cloud-vm-images.ts
@@ -85,6 +85,12 @@ const DAYTONA_SNAPSHOT_CREATE_TIMEOUT_MS = positiveIntFromEnv(
   20 * 60 * 1000,
 );
 const DAYTONA_ENTRYPOINT_PATH = "/usr/local/bin/cmux-daytona-entrypoint";
+// cmux TUI release baked into every cloud image at /usr/local/bin/cmux-tui. The npm
+// platform packages ship static musl Linux binaries with no `bin` field, so the
+// installer copies the file out of node_modules instead of relying on npm linking.
+// Devbox sandboxes (CMUX_DEVBOX=1) boot straight into it via cmux-cloud-shell.
+const CMUX_TUI_VERSION_ENV = "CMUX_CLOUD_IMAGE_CMUX_TUI_VERSION";
+const CMUX_TUI_DEFAULT_VERSION = "0.9.9";
 const CLOUD_AGENT_TOOLS = [
   {
     name: "claude",
@@ -517,7 +523,7 @@ function cloudShellProfileCommands(): string[] {
     "cat > /etc/cmux/zshrc <<'CMUX_ZSHRC'\n# cmux default zsh profile. Put personal overrides in ~/.zshrc.local.\nexport PATH=\"/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:${PATH:-}\"\nexport SHELL=\"$(command -v zsh)\"\nmkdir -p \"$HOME/.cmux\" 2>/dev/null || true\nprintf '%s' '/tmp/cmux-cloud-cli.sock' > \"$HOME/.cmux/socket_addr\" 2>/dev/null || true\nexport CMUX_SOCKET_PATH=\"${CMUX_SOCKET_PATH:-/tmp/cmux-cloud-cli.sock}\"\nautoload -Uz colors 2>/dev/null && colors\nsetopt prompt_subst interactivecomments no_beep hist_ignore_dups share_history 2>/dev/null || true\nPROMPT_EOL_MARK=''\nunsetopt prompt_sp 2>/dev/null || true\nHISTFILE=\"${HISTFILE:-$HOME/.zsh_history}\"\nHISTSIZE=\"${HISTSIZE:-50000}\"\nSAVEHIST=\"${SAVEHIST:-50000}\"\nbindkey -e 2>/dev/null || true\nif [ -r /usr/share/zsh-autosuggestions/zsh-autosuggestions.zsh ]; then\n  source /usr/share/zsh-autosuggestions/zsh-autosuggestions.zsh\n  ZSH_AUTOSUGGEST_HIGHLIGHT_STYLE=\"${ZSH_AUTOSUGGEST_HIGHLIGHT_STYLE:-fg=8}\"\nfi\n: ${CMUX_PROMPT_USER:=cmux-cloud}\n: ${CMUX_PROMPT_CHAR:=$'\\u03bb'}\nPROMPT='%F{magenta}${CMUX_PROMPT_USER}%f in %F{green}%~%f ${CMUX_PROMPT_CHAR} '\nCMUX_ZSHRC",
     "cat > /home/cmux/.zshrc <<'CMUX_USER_ZSHRC'\n# cmux-managed zsh defaults. Edit ~/.zshrc.local for personal overrides.\nmkdir -p \"$HOME/.cmux\" 2>/dev/null || true\nprintf '%s' '/tmp/cmux-cloud-cli.sock' > \"$HOME/.cmux/socket_addr\" 2>/dev/null || true\nexport CMUX_SOCKET_PATH=\"${CMUX_SOCKET_PATH:-/tmp/cmux-cloud-cli.sock}\"\n[ -r /etc/cmux/zshrc ] && source /etc/cmux/zshrc\n[ -r \"$HOME/.zshrc.local\" ] && source \"$HOME/.zshrc.local\"\nif [ \"${CMUX_CLOUD_WELCOME:-1}\" != \"0\" ] && [ -z \"${CMUX_CLOUD_WELCOME_SHOWN:-}\" ] && [ -t 1 ]; then\n  export CMUX_CLOUD_WELCOME_SHOWN=1\n  printf '\\033[38;2;0;212;255m  ::\\033[0m\\n'\n  printf '\\033[38;2;24;181;250m    ::::              \\033[38;2;0;212;255mc\\033[38;2;24;181;250mm\\033[38;2;48;150;245mu\\033[38;2;124;58;237mx cloud\\033[0m\\n'\n  printf '\\033[38;2;48;150;245m      ::::::\\033[0m\\n'\n  printf '\\033[38;2;72;119;241m        ::::::\\033[0m        \\033[38;2;130;130;140mpersistent cloud VM\\033[0m\\n'\n  printf '\\033[38;2;96;88;239m      ::::::\\033[0m          \\033[38;2;130;130;140mready for coding agents\\033[0m\\n'\n  printf '\\033[38;2;110;73;238m    ::::\\033[0m\\n'\n  printf '\\033[38;2;124;58;237m  ::\\033[0m\\n'\n  printf '\\n'\nfi\nCMUX_USER_ZSHRC",
     "cat > /home/cmux/.zshrc.local <<'CMUX_LOCAL_ZSHRC'\n# Personal zsh overrides for this cloud VM.\n# Examples:\n#   CMUX_CLOUD_WELCOME=0\n#   CMUX_PROMPT_USER='cmux-cloud'\n#   CMUX_PROMPT_CHAR='>'\n#   PROMPT='%F{cyan}%n%f:%F{green}%~%f %# '\nCMUX_LOCAL_ZSHRC",
-    "cat > /usr/local/bin/cmux-cloud-shell <<'CMUX_CLOUD_SHELL'\n#!/bin/sh\ncd /home/cmux 2>/dev/null || true\nexport HOME=/home/cmux\nexport USER=cmux\nexport LOGNAME=cmux\nexport SHELL=/bin/zsh\nexec runuser -u cmux -- /bin/zsh -l\nCMUX_CLOUD_SHELL\nchmod 0755 /usr/local/bin/cmux-cloud-shell",
+    "cat > /usr/local/bin/cmux-cloud-shell <<'CMUX_CLOUD_SHELL'\n#!/bin/sh\ncd /home/cmux 2>/dev/null || true\nexport HOME=/home/cmux\nexport USER=cmux\nexport LOGNAME=cmux\nexport SHELL=/bin/zsh\n# Devbox sandboxes boot straight into the cmux TUI; every other cloud VM keeps\n# the zsh login shell. CMUX_DEVBOX is set on the sandbox at create time.\nif [ \"${CMUX_DEVBOX:-0}\" = \"1\" ] && [ -x /usr/local/bin/cmux-tui ]; then\n  exec runuser -u cmux -- /usr/local/bin/cmux-tui --session devbox\nfi\nexec runuser -u cmux -- /bin/zsh -l\nCMUX_CLOUD_SHELL\nchmod 0755 /usr/local/bin/cmux-cloud-shell",
     "touch /home/cmux/.hushlogin",
     "chown -R cmux:cmux /home/cmux/.zshrc /home/cmux/.zshrc.local /home/cmux/.hushlogin /home/cmux/.config /home/cmux/.cmux",
   ];
@@ -582,6 +588,9 @@ export function cloudImageSmokeTestCommands(): string[] {
     `${toolchainEnv} rustup show active-toolchain >/tmp/cmux-rustup-toolchain.txt 2>&1 && grep -q '^stable' /tmp/cmux-rustup-toolchain.txt && rustc --version >/tmp/cmux-rustc-version.txt 2>&1 && cargo --version >/tmp/cmux-cargo-version.txt 2>&1`,
     "mise --version >/tmp/cmux-mise-version.txt 2>&1",
     "test -x /usr/local/bin/cmuxd-remote && test -x /usr/local/bin/cmux",
+    ...(cmuxTuiResolvedVersion()
+      ? ["/usr/local/bin/cmux-tui --version >/tmp/cmux-tui-version.txt 2>&1"]
+      : []),
     "cmux --help >/tmp/cmux-cli-help.txt 2>&1",
     "cmux --socket /tmp/cmux-browser-smoke.sock browser >/tmp/cmux-browser-help.txt 2>&1; status=$?; test \"$status\" -eq 2 && grep -q 'requires a subcommand' /tmp/cmux-browser-help.txt",
     "cmuxd-remote version >/tmp/cmuxd-remote-version.txt 2>&1",
@@ -640,6 +649,7 @@ export function cloudToolInstallCommands(): string[] {
     toolPackages.length > 0
       ? `npm install -g --omit=dev --no-audit --fund=false ${toolPackages.map((tool) => shellQuote(tool.packageSpec)).join(" ")} >/tmp/cmux-npm-install.txt 2>&1`
       : "true",
+    cmuxTuiInstallCommand(),
     miseInstallCommand(),
     rustupInstallCommand(),
     toolchainProfileCommand(),
@@ -649,6 +659,32 @@ export function cloudToolInstallCommands(): string[] {
 
 function isDisabledValue(value: string): boolean {
   return ["0", "false", "off", "disabled", "none"].includes(value.trim().toLowerCase());
+}
+
+export function cmuxTuiResolvedVersion(): string | null {
+  const raw = process.env[CMUX_TUI_VERSION_ENV]?.trim();
+  if (raw && isDisabledValue(raw)) return null;
+  const version = raw || CMUX_TUI_DEFAULT_VERSION;
+  if (!STRICT_SEMVER_RE.test(version)) {
+    throw new Error(`${CMUX_TUI_VERSION_ENV} must be an exact version like ${CMUX_TUI_DEFAULT_VERSION}; got ${version}`);
+  }
+  return version;
+}
+
+function cmuxTuiInstallCommand(): string {
+  const version = cmuxTuiResolvedVersion();
+  if (!version) return "true";
+  const commands = [
+    "set -eu",
+    "arch=\"$(dpkg --print-architecture)\"",
+    "case \"$arch\" in amd64) pkg=\"cmux-tui-linux-x64\" ;; arm64) pkg=\"cmux-tui-linux-arm64\" ;; *) echo \"unsupported architecture: $arch\"; exit 1 ;; esac",
+    "rm -rf /tmp/cmux-tui-install",
+    "mkdir -p /tmp/cmux-tui-install",
+    `npm install --prefix /tmp/cmux-tui-install --omit=dev --no-audit --fund=false "$pkg@${version}"`,
+    "install -m 0755 \"/tmp/cmux-tui-install/node_modules/$pkg/bin/cmux-tui\" /usr/local/bin/cmux-tui",
+    "rm -rf /tmp/cmux-tui-install",
+  ];
+  return `{ ${commands.join(" && ")}; } >/tmp/cmux-tui-install.txt 2>&1`;
 }
 
 function bunInstallCommand(): string {

--- a/web/services/vms/README.md
+++ b/web/services/vms/README.md
@@ -22,6 +22,40 @@ db/
   migrations/         SQL migrations applied by `bun db:migrate`
 ```
 
+## Devbox: one persistent VM per user
+
+The devbox is a separate product on the same control plane: exactly one Daytona VM per
+user, with a per-user Daytona Volume mounted at `/home/cmux/persist` so data survives
+destroy/recreate, explicit pause/resume, and the cmux TUI as the sandbox shell.
+
+The VM is a normal `cloud_vms` row (leases, usage events, reconcile, billing, and
+account deletion all apply). `cloud_devboxes` adds the single-active claim and the
+volume binding; the partial unique index on `(user_id) WHERE released_at is null` is
+the one-per-user invariant, enforced by Postgres. Concurrent first-creates are resolved
+by that index: the loser destroys its VM and adopts the winner's claim.
+
+Routes (`services/vms/devbox.ts` workflows):
+
+- `POST /api/devbox` get-or-create (201 created, 200 existing). Accepts `Idempotency-Key`.
+- `GET /api/devbox` current devbox with provider-reconciled status, or `null`.
+- `POST /api/devbox/pause` Daytona stop: filesystem preserved, processes killed.
+- `POST /api/devbox/resume` limit-gated Daytona start plus cmuxd health repair.
+- `POST /api/devbox/attach-endpoint` WebSocket PTY lease; auto-resumes a paused devbox.
+- `DELETE /api/devbox` destroys the VM, releases the claim, keeps the volume. The next
+  create reattaches the same volume by stable per-user name (`cmux-devbox-<sha256[:24]>`).
+
+Devbox sandboxes are created with `CMUX_DEVBOX=1`, which makes `cmux-cloud-shell` exec
+`cmux-tui --session devbox` instead of zsh (falls back to zsh when the TUI binary is
+missing). The TUI is baked into cloud images from the published static musl npm package
+(`cmux-tui-linux-{x64,arm64}`), pinned by `CMUX_CLOUD_IMAGE_CMUX_TUI_VERSION` in
+`web/scripts/build-cloud-vm-images.ts`.
+
+Kill switch: `CMUX_DEVBOX_ENABLED=0` blocks devbox create while keeping get, pause,
+resume, attach, and delete available. Devbox create also passes the normal
+`CMUX_VM_CREATE_ENABLED`/`CMUX_VM_DAYTONA_ENABLED` gates, consumes an active-VM slot
+under the team plan limit, and uses the standard Daytona image manifest entry
+(`DAYTONA_SANDBOX_SNAPSHOT`).
+
 ## HTTP surface
 
 - `/api/vm`, authenticated `GET` list and `POST` create.

--- a/web/services/vms/config.ts
+++ b/web/services/vms/config.ts
@@ -23,6 +23,17 @@ export function assertVmCreateEnabled(
   }
 }
 
+// Devbox product kill switch. Opt-out like the other VM switches: unset means
+// enabled. The devbox also passes the normal Daytona create gates.
+export function assertDevboxEnabled(env: VmRuntimeEnv = process.env): void {
+  if (isFalseFlag(env.CMUX_DEVBOX_ENABLED)) {
+    throw new VmCreateDisabledError({
+      provider: "daytona",
+      reason: "Devbox creation is disabled",
+    });
+  }
+}
+
 export function providerEnabledEnvKey(provider: ProviderId): string {
   switch (provider) {
     case "e2b":

--- a/web/services/vms/devbox.ts
+++ b/web/services/vms/devbox.ts
@@ -1,0 +1,441 @@
+// Devbox product: exactly one persistent Daytona VM per user with a per-user
+// persistent volume. The VM is a normal `cloud_vms` row so leases, usage events,
+// reconcile, billing, and account deletion all keep working; `cloud_devboxes` adds
+// the single-active claim (partial unique index on user_id) and the volume binding.
+//
+// Lifecycle:
+// - ensure: get-or-create. Volume is get-or-create by stable per-user name, so a
+//   recreated devbox mounts the same data. Concurrent first-creates are resolved by
+//   the unique index; the loser destroys its VM and adopts the winner's claim.
+// - pause/resume: explicit workflows over Daytona stop/start. Stop preserves the
+//   sandbox filesystem; resume restarts cmuxd-remote and is limit-gated in Postgres.
+// - release: destroys the VM and releases the claim. The volume is deliberately
+//   retained; the next ensure reattaches it.
+
+import { createHash } from "node:crypto";
+import { and, eq, isNull } from "drizzle-orm";
+import * as Context from "effect/Context";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+import { cloudDb } from "../../db/client";
+import { cloudDevboxes, cloudVms } from "../../db/schema";
+import type { BillingCustomerType } from "./billingGateway";
+import { ensureDaytonaVolume } from "./drivers/daytona";
+import {
+  VmDatabaseError,
+  VmNotFoundError,
+  VmProviderOperationError,
+  vmWorkflowErrorCause,
+  type VmWorkflowError,
+} from "./errors";
+import { VmBillingGateway } from "./billingGateway";
+import { VmProviderGateway } from "./providerGateway";
+import { VmRepository, type CloudVmRow } from "./repository";
+import {
+  createVm,
+  destroyVm,
+  getVm,
+  openAttachEndpoint,
+  pauseVm,
+  resumeVm,
+  VmWorkflowLive,
+} from "./workflows";
+import type { AttachOptions } from "./drivers";
+
+export const DEVBOX_PERSIST_MOUNT_PATH = "/home/cmux/persist";
+export const DEVBOX_PROVIDER = "daytona" as const;
+
+export type CloudDevboxRow = typeof cloudDevboxes.$inferSelect;
+
+export type DevboxEntry = {
+  readonly id: string;
+  readonly status: CloudVmRow["status"];
+  readonly provider: typeof DEVBOX_PROVIDER;
+  readonly providerVmId: string | null;
+  readonly image: string;
+  readonly imageVersion: string | null;
+  readonly volume: {
+    readonly id: string;
+    readonly name: string;
+    readonly mountPath: string;
+  };
+  readonly createdAt: number;
+};
+
+type ActiveDevbox = {
+  readonly devbox: CloudDevboxRow;
+  readonly vm: CloudVmRow;
+};
+
+export type DevboxRepositoryShape = {
+  readonly findActive: (userId: string) => Effect.Effect<ActiveDevbox | null, VmDatabaseError>;
+  readonly claim: (input: {
+    readonly userId: string;
+    readonly vmId: string;
+    readonly volumeId: string;
+    readonly volumeName: string;
+  }) => Effect.Effect<{ readonly inserted: boolean; readonly devbox: CloudDevboxRow }, VmDatabaseError>;
+  readonly release: (userId: string) => Effect.Effect<CloudDevboxRow | null, VmDatabaseError>;
+};
+
+export class DevboxRepository extends Context.Tag("cmux/DevboxRepository")<
+  DevboxRepository,
+  DevboxRepositoryShape
+>() {}
+
+async function selectActive(userId: string) {
+  const db = cloudDb();
+  const [row] = await db
+    .select({ devbox: cloudDevboxes, vm: cloudVms })
+    .from(cloudDevboxes)
+    .innerJoin(cloudVms, eq(cloudDevboxes.vmId, cloudVms.id))
+    .where(and(eq(cloudDevboxes.userId, userId), isNull(cloudDevboxes.releasedAt)))
+    .limit(1);
+  return row ?? null;
+}
+
+async function releaseClaim(userId: string): Promise<CloudDevboxRow | null> {
+  const db = cloudDb();
+  const [released] = await db
+    .update(cloudDevboxes)
+    .set({ releasedAt: new Date(), updatedAt: new Date() })
+    .where(and(eq(cloudDevboxes.userId, userId), isNull(cloudDevboxes.releasedAt)))
+    .returning();
+  return released ?? null;
+}
+
+export const DevboxRepositoryLive = Layer.succeed(DevboxRepository, {
+  findActive: (userId) =>
+    Effect.tryPromise({
+      try: async () => {
+        const row = await selectActive(userId);
+        if (!row) return null;
+        // Heal drift: the VM can be destroyed through /api/vm/[id] without going
+        // through releaseDevbox. A claim on a destroyed VM would block ensure
+        // forever, so release it here and report no devbox.
+        if (row.vm.status === "destroyed") {
+          await releaseClaim(userId);
+          return null;
+        }
+        return row;
+      },
+      catch: (cause) => new VmDatabaseError({ operation: "devboxFindActive", cause }),
+    }),
+  claim: (input) =>
+    Effect.tryPromise({
+      try: async () => {
+        const db = cloudDb();
+        try {
+          const [devbox] = await db
+            .insert(cloudDevboxes)
+            .values({
+              userId: input.userId,
+              vmId: input.vmId,
+              volumeId: input.volumeId,
+              volumeName: input.volumeName,
+            })
+            .returning();
+          if (!devbox) throw new Error("insert returned no devbox row");
+          return { inserted: true as const, devbox };
+        } catch (err) {
+          // 23505 on the partial unique index means a concurrent ensure won the
+          // single-active slot; surface the winner so the caller can adopt it.
+          if (pgErrorCode(err) === "23505") {
+            const existing = await selectActive(input.userId);
+            if (existing) return { inserted: false as const, devbox: existing.devbox };
+          }
+          throw err;
+        }
+      },
+      catch: (cause) => new VmDatabaseError({ operation: "devboxClaim", cause }),
+    }),
+  release: (userId) =>
+    Effect.tryPromise({
+      try: () => releaseClaim(userId),
+      catch: (cause) => new VmDatabaseError({ operation: "devboxRelease", cause }),
+    }),
+});
+
+export const DevboxWorkflowLive = Layer.mergeAll(VmWorkflowLive, DevboxRepositoryLive);
+
+type DevboxWorkflowContext =
+  | VmRepository
+  | VmProviderGateway
+  | VmBillingGateway
+  | DevboxRepository;
+
+export async function runDevboxWorkflow<A>(
+  program: Effect.Effect<A, VmWorkflowError, DevboxWorkflowContext>,
+): Promise<A> {
+  try {
+    return await Effect.runPromise(program.pipe(Effect.provide(DevboxWorkflowLive)));
+  } catch (err) {
+    throw vmWorkflowErrorCause(err) ?? err;
+  }
+}
+
+/**
+ * Stable per-user volume name. Hashed so no user identifier lands in provider-side
+ * resource names; stable so destroy + recreate reattaches the same data.
+ */
+export function devboxVolumeName(userId: string): string {
+  const digest = createHash("sha256").update(userId).digest("hex").slice(0, 24);
+  return `cmux-devbox-${digest}`;
+}
+
+function devboxEntry(active: ActiveDevbox): DevboxEntry {
+  return {
+    id: active.devbox.id,
+    status: active.vm.status,
+    provider: DEVBOX_PROVIDER,
+    providerVmId: active.vm.providerVmId,
+    image: active.vm.imageId,
+    imageVersion: active.vm.imageVersion,
+    volume: {
+      id: active.devbox.volumeId,
+      name: active.devbox.volumeName,
+      mountPath: DEVBOX_PERSIST_MOUNT_PATH,
+    },
+    createdAt: active.devbox.createdAt.getTime(),
+  };
+}
+
+const devboxNotFound = () => new VmNotFoundError({ vmId: "devbox" });
+
+type DevboxScope = {
+  readonly userId: string;
+  readonly billingTeamId?: string | null;
+  readonly teamIds?: readonly string[];
+};
+
+function requireActiveDevbox(userId: string) {
+  return Effect.gen(function* () {
+    const devboxes = yield* DevboxRepository;
+    const active = yield* devboxes.findActive(userId);
+    if (!active) return yield* Effect.fail(devboxNotFound());
+    return active;
+  });
+}
+
+function requireAttachedDevbox(userId: string) {
+  return Effect.gen(function* () {
+    const active = yield* requireActiveDevbox(userId);
+    const providerVmId = active.vm.providerVmId;
+    if (!providerVmId) {
+      return yield* Effect.fail(
+        new VmProviderOperationError({
+          provider: DEVBOX_PROVIDER,
+          operation: "requireAttachedDevbox",
+          cause: new Error("devbox VM is still provisioning"),
+        }),
+      );
+    }
+    return { active, providerVmId };
+  });
+}
+
+export function ensureDevbox(input: DevboxScope & {
+  readonly billingCustomerType: BillingCustomerType;
+  readonly billingTeamId: string;
+  readonly billingPlanId: string;
+  readonly maxActiveVms: number;
+  readonly image: string;
+  readonly imageVersion?: string | null;
+  readonly idempotencyKey?: string;
+}): Effect.Effect<
+  { readonly devbox: DevboxEntry; readonly created: boolean },
+  VmWorkflowError,
+  DevboxWorkflowContext
+> {
+  return Effect.gen(function* () {
+    const devboxes = yield* DevboxRepository;
+    const repo = yield* VmRepository;
+
+    const existing = yield* devboxes.findActive(input.userId);
+    if (existing) return { devbox: devboxEntry(existing), created: false };
+
+    const volumeName = devboxVolumeName(input.userId);
+    const volume = yield* Effect.tryPromise({
+      try: () => ensureDaytonaVolume(volumeName),
+      catch: (cause) =>
+        new VmProviderOperationError({
+          provider: DEVBOX_PROVIDER,
+          operation: `ensureVolume(${volumeName})`,
+          cause,
+        }),
+    });
+
+    const vmEntry = yield* createVm({
+      userId: input.userId,
+      billingCustomerType: input.billingCustomerType,
+      billingTeamId: input.billingTeamId,
+      billingPlanId: input.billingPlanId,
+      maxActiveVms: input.maxActiveVms,
+      provider: DEVBOX_PROVIDER,
+      image: input.image,
+      imageVersion: input.imageVersion,
+      idempotencyKey: input.idempotencyKey,
+      volumes: [{ volumeId: volume.id, mountPath: DEVBOX_PERSIST_MOUNT_PATH }],
+      envVars: {
+        CMUX_DEVBOX: "1",
+        CMUX_DEVBOX_PERSIST: DEVBOX_PERSIST_MOUNT_PATH,
+      },
+    });
+
+    const vmRow = yield* repo.findUserVm({
+      userId: input.userId,
+      billingTeamId: input.billingTeamId,
+      providerVmId: vmEntry.providerVmId,
+      provider: DEVBOX_PROVIDER,
+    });
+    if (!vmRow) return yield* Effect.fail(new VmNotFoundError({ vmId: vmEntry.providerVmId }));
+
+    const claim = yield* devboxes.claim({
+      userId: input.userId,
+      vmId: vmRow.id,
+      volumeId: volume.id,
+      volumeName: volume.name,
+    });
+
+    if (!claim.inserted && claim.devbox.vmId !== vmRow.id) {
+      // A concurrent ensure claimed the slot with a different VM. The invariant
+      // is one VM per user, so destroy the VM this call just created and adopt
+      // the winner's devbox.
+      yield* destroyVm({
+        userId: input.userId,
+        billingTeamId: input.billingTeamId,
+        teamIds: input.teamIds,
+        providerVmId: vmEntry.providerVmId,
+        provider: DEVBOX_PROVIDER,
+      }).pipe(Effect.catchAll(() => Effect.void));
+      const winner = yield* devboxes.findActive(input.userId);
+      if (!winner) return yield* Effect.fail(devboxNotFound());
+      return { devbox: devboxEntry(winner), created: false };
+    }
+
+    return {
+      devbox: devboxEntry({ devbox: claim.devbox, vm: vmRow }),
+      created: claim.inserted,
+    };
+  });
+}
+
+export function getDevbox(input: DevboxScope): Effect.Effect<
+  DevboxEntry | null,
+  VmWorkflowError,
+  DevboxWorkflowContext
+> {
+  return Effect.gen(function* () {
+    const devboxes = yield* DevboxRepository;
+    const active = yield* devboxes.findActive(input.userId);
+    if (!active) return null;
+    if (!active.vm.providerVmId) return devboxEntry(active);
+    // getVm reconciles provider-observed status into the row, so pause/resume
+    // performed out of band is reflected in the durable answer.
+    const vm = yield* getVm({
+      userId: input.userId,
+      billingTeamId: input.billingTeamId,
+      teamIds: input.teamIds,
+      providerVmId: active.vm.providerVmId,
+    });
+    return devboxEntry({ devbox: active.devbox, vm: { ...active.vm, status: vm.status } });
+  });
+}
+
+export function pauseDevbox(input: DevboxScope): Effect.Effect<
+  DevboxEntry,
+  VmWorkflowError,
+  DevboxWorkflowContext
+> {
+  return Effect.gen(function* () {
+    const { active, providerVmId } = yield* requireAttachedDevbox(input.userId);
+    const vm = yield* pauseVm({
+      userId: input.userId,
+      billingTeamId: input.billingTeamId,
+      teamIds: input.teamIds,
+      providerVmId,
+      provider: DEVBOX_PROVIDER,
+    });
+    return devboxEntry({ devbox: active.devbox, vm: { ...active.vm, status: vm.status } });
+  });
+}
+
+export function resumeDevbox(input: DevboxScope): Effect.Effect<
+  DevboxEntry,
+  VmWorkflowError,
+  DevboxWorkflowContext
+> {
+  return Effect.gen(function* () {
+    const { active, providerVmId } = yield* requireAttachedDevbox(input.userId);
+    const vm = yield* resumeVm({
+      userId: input.userId,
+      billingTeamId: input.billingTeamId,
+      teamIds: input.teamIds,
+      providerVmId,
+      provider: DEVBOX_PROVIDER,
+    });
+    return devboxEntry({ devbox: active.devbox, vm: { ...active.vm, status: vm.status } });
+  });
+}
+
+export function releaseDevbox(input: DevboxScope): Effect.Effect<
+  { readonly released: boolean; readonly volumeName: string },
+  VmWorkflowError,
+  DevboxWorkflowContext
+> {
+  return Effect.gen(function* () {
+    const devboxes = yield* DevboxRepository;
+    const active = yield* requireActiveDevbox(input.userId);
+    if (active.vm.providerVmId && active.vm.status !== "destroyed") {
+      yield* destroyVm({
+        userId: input.userId,
+        billingTeamId: input.billingTeamId,
+        teamIds: input.teamIds,
+        providerVmId: active.vm.providerVmId,
+        provider: DEVBOX_PROVIDER,
+      }).pipe(
+        // Already gone on the provider or another destroy raced us: releasing
+        // the claim is still correct.
+        Effect.catchTag("VmNotFoundError", () => Effect.void),
+      );
+    }
+    yield* devboxes.release(input.userId);
+    // The volume is retained on purpose: it is the persistence story. The next
+    // ensure for this user reattaches it by stable name.
+    return { released: true, volumeName: active.devbox.volumeName };
+  });
+}
+
+export function openDevboxAttach(input: DevboxScope & {
+  readonly sessionTitle?: string | null;
+  readonly options?: AttachOptions;
+}): Effect.Effect<
+  Effect.Effect.Success<ReturnType<typeof openAttachEndpoint>>,
+  VmWorkflowError,
+  DevboxWorkflowContext
+> {
+  return Effect.gen(function* () {
+    const { providerVmId } = yield* requireAttachedDevbox(input.userId);
+    // openAttachEndpoint auto-resumes a paused VM before minting the lease, so
+    // attaching to a paused devbox transparently resumes it.
+    return yield* openAttachEndpoint({
+      userId: input.userId,
+      billingTeamId: input.billingTeamId,
+      teamIds: input.teamIds,
+      providerVmId,
+      sessionTitle: input.sessionTitle,
+      options: input.options,
+    });
+  });
+}
+
+export function isDevboxNotFoundError(err: unknown): boolean {
+  return (err as { _tag?: string; vmId?: string } | null)?._tag === "VmNotFoundError"
+    && (err as { vmId?: string }).vmId === "devbox";
+}
+
+function pgErrorCode(cause: unknown): string | null {
+  if (typeof cause !== "object" || cause === null) return null;
+  const code = (cause as { code?: unknown }).code;
+  return typeof code === "string" ? code : null;
+}

--- a/web/services/vms/drivers/daytona.ts
+++ b/web/services/vms/drivers/daytona.ts
@@ -453,10 +453,15 @@ export class DaytonaProvider implements VMProvider {
   }
 }
 
+const VOLUME_READY_TIMEOUT_MS = 3 * 60 * 1000;
+const VOLUME_READY_POLL_INTERVAL_MS = 2_000;
+
 /**
- * Get-or-create a Daytona Volume by name. Volumes are S3-backed shared storage that
- * survives sandbox destroy/recreate; the devbox product mounts one per user so data
- * outlives the VM itself. `get(name, true)` is the SDK's atomic get-or-create.
+ * Get-or-create a Daytona Volume by name and wait until it is mountable. Volumes are
+ * S3-backed shared storage that survives sandbox destroy/recreate; the devbox product
+ * mounts one per user so data outlives the VM itself. `get(name, true)` is the SDK's
+ * atomic get-or-create, but creation is asynchronous (`pending_create`) and sandbox
+ * create rejects any volume that is not `ready`, so this polls until it is.
  */
 export async function ensureDaytonaVolume(name: string): Promise<VolumeHandle> {
   return withVmSpan(
@@ -464,7 +469,21 @@ export async function ensureDaytonaVolume(name: string): Promise<VolumeHandle> {
     { "cmux.vm.provider": "daytona", "cmux.vm.operation": "ensure_volume" },
     async (span) => {
       try {
-        const volume = await client().volume.get(name, true);
+        let volume = await client().volume.get(name, true);
+        const deadline = Date.now() + VOLUME_READY_TIMEOUT_MS;
+        while (volume.state !== "ready") {
+          if (
+            volume.state === "error" || volume.state === "deleted"
+            || volume.state === "deleting" || volume.state === "pending_delete"
+          ) {
+            throw new Error(`volume ${name} entered state ${volume.state}`);
+          }
+          if (Date.now() >= deadline) {
+            throw new Error(`volume ${name} did not become ready (state: ${volume.state})`);
+          }
+          await new Promise((resolve) => setTimeout(resolve, VOLUME_READY_POLL_INTERVAL_MS));
+          volume = await client().volume.get(name);
+        }
         setSpanAttributes(span, { "cmux.volume.id": volume.id });
         return { id: volume.id, name: volume.name };
       } catch (err) {

--- a/web/services/vms/drivers/daytona.ts
+++ b/web/services/vms/drivers/daytona.ts
@@ -12,6 +12,7 @@ import {
   type VMHandle,
   type VMProvider,
   type VMStatus,
+  type VolumeHandle,
 } from "./types";
 import { recordSpanError, setSpanAttributes, withVmSpan } from "../telemetry";
 import {
@@ -116,10 +117,18 @@ export class DaytonaProvider implements VMProvider {
           const sandbox = await client().create(
             {
               snapshot: image,
-              envVars: DEFAULT_SANDBOX_ENVS,
+              envVars: { ...DEFAULT_SANDBOX_ENVS, ...(options.envVars ?? {}) },
               // Persistent cloud computer shape: never auto-stop. Pause/resume is an explicit
               // cmux workflow, mapped onto Daytona stop/start below.
               autoStopInterval: 0,
+              ...(options.volumes?.length
+                ? {
+                  volumes: options.volumes.map((volume) => ({
+                    volumeId: volume.volumeId,
+                    mountPath: volume.mountPath,
+                  })),
+                }
+                : {}),
             },
             { timeout: CREATE_TIMEOUT_SECONDS },
           );
@@ -442,6 +451,27 @@ export class DaytonaProvider implements VMProvider {
     }
     throw lastError;
   }
+}
+
+/**
+ * Get-or-create a Daytona Volume by name. Volumes are S3-backed shared storage that
+ * survives sandbox destroy/recreate; the devbox product mounts one per user so data
+ * outlives the VM itself. `get(name, true)` is the SDK's atomic get-or-create.
+ */
+export async function ensureDaytonaVolume(name: string): Promise<VolumeHandle> {
+  return withVmSpan(
+    "cmux.vm.provider.ensure_volume",
+    { "cmux.vm.provider": "daytona", "cmux.vm.operation": "ensure_volume" },
+    async (span) => {
+      try {
+        const volume = await client().volume.get(name, true);
+        setSpanAttributes(span, { "cmux.volume.id": volume.id });
+        return { id: volume.id, name: volume.name };
+      } catch (err) {
+        throw new ProviderError("daytona", `ensureVolume(${name})`, err);
+      }
+    },
+  );
 }
 
 function httpsToWss(url: string): string {

--- a/web/services/vms/drivers/e2b.ts
+++ b/web/services/vms/drivers/e2b.ts
@@ -40,6 +40,9 @@ export class E2BProvider implements VMProvider {
     if (!image) {
       throw new ProviderError("e2b", "create requires a resolved image");
     }
+    if (options.volumes?.length || options.envVars) {
+      throw new ProviderError("e2b", "create: persistent volumes and custom env are Daytona-only");
+    }
     return withVmSpan(
       "cmux.vm.provider.create",
       {

--- a/web/services/vms/drivers/freestyle.ts
+++ b/web/services/vms/drivers/freestyle.ts
@@ -90,6 +90,9 @@ export class FreestyleProvider implements VMProvider {
     if (!image) {
       throw new ProviderError("freestyle", "create requires a resolved image");
     }
+    if (options.volumes?.length || options.envVars) {
+      throw new ProviderError("freestyle", "create: persistent volumes and custom env are Daytona-only");
+    }
     const signedAdmin = freestyleAdminSigningConfig();
     if (options.bakedFreestyleSignedAdmin === true && !signedAdmin) {
       throw new ProviderError(

--- a/web/services/vms/drivers/types.ts
+++ b/web/services/vms/drivers/types.ts
@@ -19,6 +19,27 @@ export type CreateOptions = {
   image: string; // provider-specific template/snapshot identifier
   providerMetadata?: Record<string, unknown>;
   bakedFreestyleSignedAdmin?: boolean;
+  /**
+   * Provider-persistent volumes to mount into the VM at create. Only Daytona
+   * supports this today; drivers without volume support must fail closed
+   * rather than silently provisioning without the mount.
+   */
+  volumes?: ReadonlyArray<VolumeMountSpec>;
+  /**
+   * Extra environment baked into the VM at create, merged over the driver's
+   * defaults. Drivers that cannot honor it must fail closed.
+   */
+  envVars?: Readonly<Record<string, string>>;
+};
+
+export type VolumeMountSpec = {
+  readonly volumeId: string;
+  readonly mountPath: string;
+};
+
+export type VolumeHandle = {
+  readonly id: string;
+  readonly name: string;
 };
 
 export type SSHEndpoint = {

--- a/web/services/vms/images/manifest.json
+++ b/web/services/vms/images/manifest.json
@@ -147,6 +147,24 @@
       },
       "validationStatus": "passed",
       "notes": "Validated Daytona preview gate (healthz 401 without x-daytona-preview-token), WS PTY lease auth + single-use replay rejection, shell round trip, RPC hello + reusable lease, and RPC HTTP proxy to healthz. Region: shared us (runner in Corona, CA). binarySha256=d7d2a6b1ef9080ae0deadca3ced6fefbb4aeb88292d136b31bd0ea0784c01461 nodeMajor=22 agentTools=@anthropic-ai/claude-code@2.1.137,opencode-ai@1.14.41,@openai/codex@0.130.0,@earendil-works/pi-coding-agent@0.74.0"
+    },
+    {
+      "provider": "daytona",
+      "version": "daytona-devbox-20260804",
+      "imageId": "cmuxd-ws-devbox-20260804",
+      "envVar": "DAYTONA_SANDBOX_SNAPSHOT",
+      "defaultForLocalDev": false,
+      "cmuxdRemoteCommit": "baa7d9e166c663c8922d9fb977c2e490a4880157",
+      "builtAt": "2026-08-05T00:24:03.639Z",
+      "builderScriptVersion": "6a0620b45d884aee2cdede41a1cdf6b23d9fc7ab78564f476afae2ad7d904868",
+      "agentToolResolvedVersions": {
+        "claude": "2.1.137",
+        "opencode": "1.14.41",
+        "codex": "0.130.0",
+        "pi": "0.74.0"
+      },
+      "validationStatus": "passed",
+      "notes": "Validated devbox E2E on local dev server: create with volume mount at /home/cmux/persist, pause/resume via stop/start, WS PTY attach, and data persistence across destroy+recreate on the same volume. First image with cmux-tui 0.9.9 baked at /usr/local/bin/cmux-tui and devbox-aware cmux-cloud-shell (CMUX_DEVBOX=1 boots cmux-tui --session devbox). binarySha256=a5ff3e9e49b564a2d2c0baff45c3d1e38ced2b546c6065d0eb610afe77cad33e nodeMajor=22 agentTools=@anthropic-ai/claude-code@2.1.137,opencode-ai@1.14.41,@openai/codex@0.130.0,@earendil-works/pi-coding-agent@0.74.0 cmuxTui=0.9.9"
     }
   ]
 }

--- a/web/services/vms/workflows.ts
+++ b/web/services/vms/workflows.ts
@@ -198,6 +198,8 @@ export function createVm(input: {
   readonly imageVersion?: string | null;
   readonly idempotencyKey?: string;
   readonly bakedFreestyleSignedAdmin?: boolean;
+  readonly volumes?: ReadonlyArray<{ readonly volumeId: string; readonly mountPath: string }>;
+  readonly envVars?: Readonly<Record<string, string>>;
   readonly timing?: VmTimingSink;
 }): Effect.Effect<VmEntry, VmWorkflowError, VmRepository | VmProviderGateway | VmBillingGateway> {
   return Effect.gen(function* () {
@@ -235,6 +237,8 @@ export function createVm(input: {
         image: input.image,
         providerMetadata: create.vm.providerMetadata,
         bakedFreestyleSignedAdmin: input.bakedFreestyleSignedAdmin,
+        volumes: input.volumes,
+        envVars: input.envVars,
       }),
     ).pipe(
       Effect.tapError((err) =>
@@ -932,7 +936,7 @@ function boundedVmStatusReconcileLimit(limit: number | undefined): number {
 const RESUME_STATUS_PROBE_TIMEOUT = "5 seconds";
 const RESUME_SETTLE_ATTEMPTS = 10;
 const RESUME_SETTLE_INTERVAL = "1 second";
-type VmResumeSource = "exec" | "attach" | "ssh" | "fork";
+type VmResumeSource = "exec" | "attach" | "ssh" | "fork" | "api";
 
 // resume() can legitimately return a not-yet-running handle (Freestyle maps a
 // post-start "starting" state to "creating"), so poll briefly until the VM is
@@ -1277,6 +1281,73 @@ export function destroyVm(input: {
       provider: vm.provider,
       imageId: vm.imageId,
     }).pipe(Effect.catchAll(() => Effect.void));
+  });
+}
+
+export function pauseVm(input: {
+  readonly userId: string;
+  readonly billingTeamId?: string | null;
+  readonly teamIds?: readonly string[];
+  readonly providerVmId: string;
+  readonly provider?: ProviderId;
+}) {
+  return Effect.gen(function* () {
+    const repo = yield* VmRepository;
+    const providers = yield* VmProviderGateway;
+    const vm = yield* requireUserVm(input);
+    if (vm.status === "paused") return vmEntryFromRow(vm);
+    const providerVmId = vm.providerVmId ?? input.providerVmId;
+    const pause = providers.pause;
+    if (!pause) {
+      return yield* Effect.fail(
+        new VmProviderOperationError({
+          provider: vm.provider,
+          operation: `pause(${providerVmId})`,
+          cause: new Error("provider does not support pause"),
+        }),
+      );
+    }
+    yield* pause(vm.provider, providerVmId);
+    const recorded = yield* repo.markProviderObservedStatus({
+      id: vm.id,
+      providerVmId,
+      status: "paused",
+    });
+    if (!recorded) {
+      return yield* Effect.fail(new VmNotFoundError({ vmId: providerVmId }));
+    }
+    yield* repo.recordUsageEvent({
+      userId: input.userId,
+      billingTeamId: vm.billingTeamId,
+      billingPlanId: vm.billingPlanId,
+      vmId: vm.id,
+      eventType: "vm.paused",
+      provider: vm.provider,
+      imageId: vm.imageId,
+      metadata: { source: "api" },
+    }).pipe(Effect.catchAll(() => Effect.void));
+    return vmEntryFromRow({ ...vm, status: "paused" });
+  });
+}
+
+export function resumeVm(input: {
+  readonly userId: string;
+  readonly billingTeamId?: string | null;
+  readonly teamIds?: readonly string[];
+  readonly providerVmId: string;
+  readonly provider?: ProviderId;
+}) {
+  return Effect.gen(function* () {
+    const repo = yield* VmRepository;
+    const providers = yield* VmProviderGateway;
+    const vm = yield* requireUserVm(input);
+    const providerVmId = vm.providerVmId ?? input.providerVmId;
+    // Same limit-gated, compensated path the implicit exec/attach resume uses:
+    // reserve the active slot in Postgres first, roll back to paused if the
+    // provider start fails, and record the vm.resumed usage event once.
+    yield* preflightResumeIfSuspended(repo, providers, vm, providerVmId, "api");
+    const refreshed = yield* requireUserVm(input);
+    return vmEntryFromRow(refreshed);
   });
 }
 

--- a/web/tests/devbox-db-schema.test.ts
+++ b/web/tests/devbox-db-schema.test.ts
@@ -1,0 +1,87 @@
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import postgres, { type Sql } from "postgres";
+
+const runDbTests = process.env.CMUX_DB_TEST === "1";
+const dbTest = runDbTests ? test : test.skip;
+
+let sql: Sql | null = null;
+
+beforeAll(() => {
+  if (!runDbTests) return;
+  const databaseURL = process.env.DIRECT_DATABASE_URL ?? process.env.DATABASE_URL;
+  if (!databaseURL) {
+    throw new Error("DATABASE_URL is required when CMUX_DB_TEST=1");
+  }
+  sql = postgres(databaseURL, { max: 1 });
+});
+
+afterAll(async () => {
+  await sql?.end();
+});
+
+describe("devbox database schema", () => {
+  dbTest("enforces one active devbox per user and frees the slot on release", async () => {
+    if (!sql) throw new Error("test database not initialized");
+
+    await sql`truncate cloud_devboxes, cloud_vm_billing_grants, cloud_vm_usage_events, cloud_vm_leases, cloud_vms restart identity cascade`;
+
+    const insertVm = (providerVmId: string) => sql!<{ id: string }[]>`
+      insert into cloud_vms (user_id, billing_team_id, provider, provider_vm_id, image_id, status)
+      values ('user-1', 'team-1', 'daytona', ${providerVmId}, 'cmuxd-ws:test', 'running')
+      returning id
+    `;
+
+    const [vm1] = await insertVm("sandbox-1");
+    const [vm2] = await insertVm("sandbox-2");
+    if (!vm1 || !vm2) throw new Error("VM fixture insert failed");
+
+    const [claim] = await sql<{ id: string }[]>`
+      insert into cloud_devboxes (user_id, vm_id, volume_id, volume_name)
+      values ('user-1', ${vm1.id}, 'vol-1', 'cmux-devbox-abc')
+      returning id
+    `;
+    expect(claim?.id).toBeTruthy();
+
+    // Second active claim for the same user must hit the partial unique index.
+    let duplicateError: unknown;
+    try {
+      await sql`
+        insert into cloud_devboxes (user_id, vm_id, volume_id, volume_name)
+        values ('user-1', ${vm2.id}, 'vol-1', 'cmux-devbox-abc')
+      `;
+    } catch (err) {
+      duplicateError = err;
+    }
+    expect((duplicateError as { code?: string } | undefined)?.code).toBe("23505");
+
+    // A different user is unaffected by user-1's claim.
+    const [vm3] = await sql<{ id: string }[]>`
+      insert into cloud_vms (user_id, billing_team_id, provider, provider_vm_id, image_id, status)
+      values ('user-2', 'team-2', 'daytona', 'sandbox-3', 'cmuxd-ws:test', 'running')
+      returning id
+    `;
+    if (!vm3) throw new Error("VM fixture insert failed");
+    const [otherClaim] = await sql<{ id: string }[]>`
+      insert into cloud_devboxes (user_id, vm_id, volume_id, volume_name)
+      values ('user-2', ${vm3.id}, 'vol-2', 'cmux-devbox-def')
+      returning id
+    `;
+    expect(otherClaim?.id).toBeTruthy();
+
+    // Releasing the claim frees the slot; the released row stays for audit.
+    await sql`
+      update cloud_devboxes set released_at = now() where user_id = 'user-1' and released_at is null
+    `;
+    const [reclaim] = await sql<{ id: string }[]>`
+      insert into cloud_devboxes (user_id, vm_id, volume_id, volume_name)
+      values ('user-1', ${vm2.id}, 'vol-1', 'cmux-devbox-abc')
+      returning id
+    `;
+    expect(reclaim?.id).toBeTruthy();
+
+    const [{ total }] = await sql<{ total: string }[]>`
+      select count(*)::text as total from cloud_devboxes where user_id = 'user-1'
+    `;
+    expect(Number(total)).toBe(2);
+  });
+});

--- a/web/tests/devbox-route-auth.test.ts
+++ b/web/tests/devbox-route-auth.test.ts
@@ -222,9 +222,10 @@ describe("devbox REST auth", () => {
   test("maps a missing devbox to devbox_not_found on pause", async () => {
     getUser.mockResolvedValue(authedStackUser());
     const { VmNotFoundError } = await import("../services/vms/errors");
-    runDevboxWorkflow.mockImplementation(async () => {
-      throw new VmNotFoundError({ vmId: "devbox" });
-    });
+    (runDevboxWorkflow as unknown as { mockImplementation(next: () => Promise<never>): void })
+      .mockImplementation(async () => {
+        throw new VmNotFoundError({ vmId: "devbox" });
+      });
 
     const response = await pauseRoute.POST(
       new Request("https://cmux.test/api/devbox/pause", {

--- a/web/tests/devbox-route-auth.test.ts
+++ b/web/tests/devbox-route-auth.test.ts
@@ -1,0 +1,263 @@
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, mock, test } from "bun:test";
+
+const getUser = mock(async () => null);
+const runDevboxWorkflow = mock(async () => {
+  throw new Error("unauthenticated devbox routes must not reach the devbox workflow");
+});
+const ensureDevbox = mock(() => ({ workflow: "devbox.ensure" }));
+const getDevbox = mock(() => ({ workflow: "devbox.get" }));
+const pauseDevbox = mock(() => ({ workflow: "devbox.pause" }));
+const resumeDevbox = mock(() => ({ workflow: "devbox.resume" }));
+const releaseDevbox = mock(() => ({ workflow: "devbox.release" }));
+const openDevboxAttach = mock(() => ({ workflow: "devbox.attach" }));
+
+const DEVBOX_ENV_KEYS = [
+  "CMUX_DEVBOX_ENABLED",
+  "CMUX_VM_CREATE_ENABLED",
+  "CMUX_VM_DAYTONA_ENABLED",
+  "CMUX_VM_ALLOW_UNMANIFESTED_IMAGES",
+  "DAYTONA_SANDBOX_SNAPSHOT",
+  "CMUX_VM_REQUIRE_PRO",
+  "VERCEL",
+  "VERCEL_ENV",
+] as const;
+const originalEnv = Object.fromEntries(
+  DEVBOX_ENV_KEYS.map((key) => [key, process.env[key]]),
+) as Record<(typeof DEVBOX_ENV_KEYS)[number], string | undefined>;
+
+// Capture the real implementations BY VALUE before mocking (see
+// vm-route-auth.test.ts for why namespace captures or delegating wrappers
+// would self-recurse under bun's in-place mock.module semantics).
+const devboxModule = await import("../services/vms/devbox");
+const realEnsureDevbox = devboxModule.ensureDevbox;
+const realGetDevbox = devboxModule.getDevbox;
+const realPauseDevbox = devboxModule.pauseDevbox;
+const realResumeDevbox = devboxModule.resumeDevbox;
+const realReleaseDevbox = devboxModule.releaseDevbox;
+const realOpenDevboxAttach = devboxModule.openDevboxAttach;
+const realRunDevboxWorkflow = devboxModule.runDevboxWorkflow;
+const realIsDevboxNotFoundError = devboxModule.isDevboxNotFoundError;
+const realDevboxVolumeName = devboxModule.devboxVolumeName;
+const realDevboxRepository = devboxModule.DevboxRepository;
+const realDevboxRepositoryLive = devboxModule.DevboxRepositoryLive;
+const realDevboxWorkflowLive = devboxModule.DevboxWorkflowLive;
+const dbClientModule = await import("../db/client");
+const realCloudDb = dbClientModule.cloudDb;
+const realCloseCloudDbForTests = dbClientModule.closeCloudDbForTests;
+const realCreateAwsRdsIamPool = dbClientModule.createAwsRdsIamPool;
+
+let useWorkflowStubs = false;
+let useStubDb = false;
+
+function callMock(fn: unknown, args: unknown[]) {
+  return (fn as (...args: unknown[]) => unknown)(...args);
+}
+
+mock.module("../app/lib/stack", () => ({
+  getStackServerApp: () => ({ getUser }),
+  isStackConfigured: () => true,
+  stackServerApp: { getUser },
+}));
+
+mock.module("../services/vms/devbox", () => ({
+  DEVBOX_PERSIST_MOUNT_PATH: devboxModule.DEVBOX_PERSIST_MOUNT_PATH,
+  DEVBOX_PROVIDER: devboxModule.DEVBOX_PROVIDER,
+  DevboxRepository: realDevboxRepository,
+  DevboxRepositoryLive: realDevboxRepositoryLive,
+  DevboxWorkflowLive: realDevboxWorkflowLive,
+  devboxVolumeName: realDevboxVolumeName,
+  isDevboxNotFoundError: realIsDevboxNotFoundError,
+  ensureDevbox: ((...args: Parameters<typeof realEnsureDevbox>) =>
+    useWorkflowStubs ? callMock(ensureDevbox, args) : realEnsureDevbox(...args)) as typeof realEnsureDevbox,
+  getDevbox: ((...args: Parameters<typeof realGetDevbox>) =>
+    useWorkflowStubs ? callMock(getDevbox, args) : realGetDevbox(...args)) as typeof realGetDevbox,
+  pauseDevbox: ((...args: Parameters<typeof realPauseDevbox>) =>
+    useWorkflowStubs ? callMock(pauseDevbox, args) : realPauseDevbox(...args)) as typeof realPauseDevbox,
+  resumeDevbox: ((...args: Parameters<typeof realResumeDevbox>) =>
+    useWorkflowStubs ? callMock(resumeDevbox, args) : realResumeDevbox(...args)) as typeof realResumeDevbox,
+  releaseDevbox: ((...args: Parameters<typeof realReleaseDevbox>) =>
+    useWorkflowStubs ? callMock(releaseDevbox, args) : realReleaseDevbox(...args)) as typeof realReleaseDevbox,
+  openDevboxAttach: ((...args: Parameters<typeof realOpenDevboxAttach>) =>
+    useWorkflowStubs ? callMock(openDevboxAttach, args) : realOpenDevboxAttach(...args)) as typeof realOpenDevboxAttach,
+  runDevboxWorkflow: ((...args: Parameters<typeof realRunDevboxWorkflow>) =>
+    useWorkflowStubs ? callMock(runDevboxWorkflow, args) : realRunDevboxWorkflow(...args)) as typeof realRunDevboxWorkflow,
+}));
+
+// Same self-shield as vm-route-auth.test.ts: keep the auth path's tombstone
+// lookup and the Pro reconcile away from a real Postgres pool.
+mock.module("../db/client", () => ({
+  createAwsRdsIamPool: realCreateAwsRdsIamPool,
+  closeCloudDbForTests: realCloseCloudDbForTests,
+  cloudDb: () => {
+    if (!useStubDb) return realCloudDb();
+    throw new Error("DATABASE_URL is required for Cloud VM database access");
+  },
+}));
+
+const devboxRoute = await import("../app/api/devbox/route");
+const pauseRoute = await import("../app/api/devbox/pause/route");
+const resumeRoute = await import("../app/api/devbox/resume/route");
+const attachRoute = await import("../app/api/devbox/attach-endpoint/route");
+
+beforeAll(() => {
+  useWorkflowStubs = true;
+  useStubDb = true;
+});
+
+afterAll(() => {
+  useWorkflowStubs = false;
+  useStubDb = false;
+});
+
+beforeEach(() => {
+  restoreDevboxEnv();
+  getUser.mockClear();
+  getUser.mockResolvedValue(null);
+  runDevboxWorkflow.mockClear();
+  ensureDevbox.mockClear();
+  getDevbox.mockClear();
+  pauseDevbox.mockClear();
+  resumeDevbox.mockClear();
+  releaseDevbox.mockClear();
+  openDevboxAttach.mockClear();
+});
+
+afterEach(() => {
+  restoreDevboxEnv();
+});
+
+describe("devbox REST auth", () => {
+  const unauthenticatedCalls: Array<[string, () => Promise<Response>]> = [
+    ["GET /api/devbox", () => devboxRoute.GET(new Request("https://cmux.test/api/devbox"))],
+    ["POST /api/devbox", () => devboxRoute.POST(new Request("https://cmux.test/api/devbox", { method: "POST" }))],
+    ["DELETE /api/devbox", () => devboxRoute.DELETE(new Request("https://cmux.test/api/devbox", { method: "DELETE" }))],
+    ["POST /api/devbox/pause", () => pauseRoute.POST(new Request("https://cmux.test/api/devbox/pause", { method: "POST" }))],
+    ["POST /api/devbox/resume", () => resumeRoute.POST(new Request("https://cmux.test/api/devbox/resume", { method: "POST" }))],
+    ["POST /api/devbox/attach-endpoint", () => attachRoute.POST(new Request("https://cmux.test/api/devbox/attach-endpoint", { method: "POST" }))],
+  ];
+
+  for (const [name, call] of unauthenticatedCalls) {
+    test(`rejects unauthenticated ${name} before reaching the workflow`, async () => {
+      const response = await call();
+      expect(response.status).toBe(401);
+      expect(await response.json()).toEqual({ error: "unauthorized" });
+      expect(runDevboxWorkflow).not.toHaveBeenCalled();
+    });
+  }
+
+  test("rejects cross-site cookie mutations before reaching the workflow", async () => {
+    getUser.mockResolvedValue(authedStackUser());
+    const response = await devboxRoute.POST(
+      new Request("https://cmux.test/api/devbox", {
+        method: "POST",
+        headers: {
+          cookie: "stack-session=abc",
+          origin: "https://evil.example",
+          "sec-fetch-site": "cross-site",
+        },
+      }),
+    );
+    expect(response.status).toBe(403);
+    expect(runDevboxWorkflow).not.toHaveBeenCalled();
+  });
+
+  test("forwards entitlements and image selection into ensureDevbox", async () => {
+    process.env.DAYTONA_SANDBOX_SNAPSHOT = "cmuxd-ws-test";
+    process.env.CMUX_VM_ALLOW_UNMANIFESTED_IMAGES = "1";
+    getUser.mockResolvedValue(authedStackUser());
+    runDevboxWorkflow.mockResolvedValue({
+      devbox: {
+        id: "devbox-1",
+        status: "running",
+        provider: "daytona",
+        providerVmId: "sandbox-1",
+        image: "cmuxd-ws-test",
+        imageVersion: null,
+        volume: { id: "vol-1", name: "cmux-devbox-abc", mountPath: "/home/cmux/persist" },
+        createdAt: 1_777_000_000_000,
+      },
+      created: true,
+    });
+
+    const response = await devboxRoute.POST(
+      new Request("https://cmux.test/api/devbox", {
+        method: "POST",
+        headers: { origin: "https://cmux.test", "idempotency-key": "devbox-idem-1" },
+      }),
+    );
+
+    expect(response.status).toBe(201);
+    const payload = await response.json() as { created: boolean; devbox: { id: string } };
+    expect(payload.created).toBe(true);
+    expect(payload.devbox.id).toBe("devbox-1");
+    expect(ensureDevbox).toHaveBeenCalledWith(expect.objectContaining({
+      userId: "user-1",
+      billingCustomerType: "team",
+      billingTeamId: "team-1",
+      billingPlanId: "pro",
+      maxActiveVms: 10,
+      image: "cmuxd-ws-test",
+      idempotencyKey: "devbox-idem-1",
+    }));
+  });
+
+  test("returns 503 when the devbox kill switch is off, before any workflow", async () => {
+    process.env.CMUX_DEVBOX_ENABLED = "0";
+    process.env.DAYTONA_SANDBOX_SNAPSHOT = "cmuxd-ws-test";
+    process.env.CMUX_VM_ALLOW_UNMANIFESTED_IMAGES = "1";
+    getUser.mockResolvedValue(authedStackUser());
+
+    const response = await devboxRoute.POST(
+      new Request("https://cmux.test/api/devbox", {
+        method: "POST",
+        headers: { origin: "https://cmux.test" },
+      }),
+    );
+
+    expect(response.status).toBe(503);
+    expect((await response.json() as { error: string }).error).toBe("devbox_create_disabled");
+    expect(runDevboxWorkflow).not.toHaveBeenCalled();
+  });
+
+  test("maps a missing devbox to devbox_not_found on pause", async () => {
+    getUser.mockResolvedValue(authedStackUser());
+    const { VmNotFoundError } = await import("../services/vms/errors");
+    runDevboxWorkflow.mockImplementation(async () => {
+      throw new VmNotFoundError({ vmId: "devbox" });
+    });
+
+    const response = await pauseRoute.POST(
+      new Request("https://cmux.test/api/devbox/pause", {
+        method: "POST",
+        headers: { origin: "https://cmux.test" },
+      }),
+    );
+
+    expect(response.status).toBe(404);
+    expect((await response.json() as { error: string }).error).toBe("devbox_not_found");
+  });
+});
+
+function restoreDevboxEnv(): void {
+  for (const key of DEVBOX_ENV_KEYS) {
+    const value = originalEnv[key];
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+  }
+}
+
+function authedStackUser() {
+  return {
+    id: "user-1",
+    displayName: null,
+    primaryEmail: "user@example.com",
+    selectedTeam: {
+      id: "team-1",
+      clientReadOnlyMetadata: { cmuxVmPlan: "pro" },
+    },
+    listTeams: async () => [{
+      id: "team-1",
+      clientReadOnlyMetadata: { cmuxVmPlan: "pro" },
+    }],
+  };
+}


### PR DESCRIPTION
New cloud product on the existing Cloud VM control plane: each user gets exactly one persistent Daytona devbox.

The devbox VM is a normal `cloud_vms` row, so leases, usage events, reconcile, billing, and account deletion keep working unchanged. A new `cloud_devboxes` table holds the single-active claim and the volume binding. The one-VM-per-user invariant is a Postgres partial unique index on `(user_id) WHERE released_at is null`; concurrent first-creates are resolved by that index, with the loser destroying its VM and adopting the winner's claim.

Persistence has two layers. Pause maps to Daytona `sandbox.stop` (filesystem preserved, processes killed) and resume to `sandbox.start` with cmuxd health repair, limit-gated through the same `reservePausedResume` path the implicit exec/attach resume uses. On top of that, a per-user Daytona Volume (get-or-create by stable hashed name) is mounted at `/home/cmux/persist`, and `DELETE /api/devbox` deliberately keeps it, so destroy + recreate reattaches the same data.

Routes: `POST /api/devbox` (get-or-create, Idempotency-Key supported), `GET /api/devbox` (provider-reconciled status), `POST /api/devbox/pause`, `POST /api/devbox/resume`, `POST /api/devbox/attach-endpoint` (WebSocket PTY lease, auto-resumes a paused devbox), `DELETE /api/devbox`. All behind Stack Auth plus the existing CSRF and team entitlement checks. Kill switch `CMUX_DEVBOX_ENABLED=0` blocks create only.

cmux TUI is baked into the cloud images from the published `cmux-tui-linux-{x64,arm64}` static musl npm packages (pinned, override via `CMUX_CLOUD_IMAGE_CMUX_TUI_VERSION`), smoke-tested with `cmux-tui --version`. Devbox sandboxes are created with `CMUX_DEVBOX=1`, which makes `cmux-cloud-shell` exec `cmux-tui --session devbox` instead of zsh, with a zsh fallback when the binary is absent. Non-devbox VMs are unchanged.

Driver contract grows optional `volumes`/`envVars` on `CreateOptions`; E2B and Freestyle fail closed when either is requested. Explicit `pauseVm`/`resumeVm` workflows are added alongside the existing implicit resume.

Tests: `tests/devbox-route-auth.test.ts` (401 before workflow on all six routes, cross-site cookie rejection, entitlement forwarding, kill-switch 503, devbox_not_found mapping), `tests/devbox-db-schema.test.ts` (partial unique index behavior under `bun db:test`, migrations applied twice). Full runs: devbox route auth 10/10, db behavior suite 75/0, vm-route-auth + vm-workflows 72/0, image builder + daytona provider + cron reconcile + account route 98/0, `bun run typecheck` clean.

Not in this PR: a dashboard UI page, CLI verbs (`cmux devbox ...`), a rebuilt Daytona snapshot in the image manifest (the TUI bake lands in the next image build; until then devbox sandboxes fall back to zsh), and volume GC (released volumes are retained deliberately as the persistence story; an admin cleanup path for long-abandoned volumes is a follow-up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/9606"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788481171&installation_model_id=21920&pr_number=9606&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F9606&signature=88916f4fe3a21925660c5fe169d28806086559915dc4b639e294334517b2a2c9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Devbox: a single persistent Daytona VM per user with a per-user volume, pause/resume, and a TUI-first shell. Also waits for Daytona volume readiness and registers the first TUI-baked snapshot.

- **New Features**
  - One persistent devbox per user with a Daytona Volume mounted at `/home/cmux/persist`; destroy + recreate reattaches data.
  - Enforced by `cloud_devboxes` with a partial unique index on active claims; devbox VMs are standard `cloud_vms` (leases, usage, reconcile, billing).
  - Routes: `POST|GET|DELETE /api/devbox`, `POST /api/devbox/{pause,resume,attach-endpoint}`; create supports `Idempotency-Key`; attach auto-resumes; Stack auth + team entitlements; create gated by `CMUX_DEVBOX_ENABLED` and provider gates.
  - Driver API adds `volumes` and `envVars` on create; Daytona mounts volumes; `e2b`/`freestyle` reject volume/env requests; explicit `pauseVm`/`resumeVm` workflows.
  - Cloud images bake `cmux-tui` from `cmux-tui-linux-{x64,arm64}`; pin via `CMUX_CLOUD_IMAGE_CMUX_TUI_VERSION`; devbox sandboxes (`CMUX_DEVBOX=1`) launch `cmux-tui --session devbox` (zsh fallback).
  - Reliability: Daytona volume get-or-create now waits until `ready` before VM create; image manifest registers `daytona-devbox-20260804` with `cmux-tui 0.9.9`.

- **Migration**
  - Run DB migrations to create `cloud_devboxes`.
  - Configure a Daytona image snapshot via `DAYTONA_SANDBOX_SNAPSHOT`.
  - Ensure create gates allow it: `CMUX_VM_CREATE_ENABLED`, `CMUX_VM_DAYTONA_ENABLED`, and keep `CMUX_DEVBOX_ENABLED` on (unset or not `0`).
  - Optionally pin or disable TUI via `CMUX_CLOUD_IMAGE_CMUX_TUI_VERSION` (default `0.9.9`; set to a falsey value to skip baking).

<sup>Written for commit f86c31497c5ffe47d476fd58a12adff1ce02cf86. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/9606?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added persistent per-user Devboxes with reusable storage.
  * Added APIs to create, view, attach, pause, resume, and release Devboxes.
  * Added support for persistent volumes and environment variables where supported.
  * Cloud images can optionally include the cmux TUI.

* **Bug Fixes**
  * Added clearer handling for missing Devboxes and invalid requests.
  * Prevented duplicate active Devboxes per user.

* **Documentation**
  * Documented Devbox lifecycle, storage, billing, limits, and configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
