### PR TITLE
Fix cmux TUI release packaging

### DIFF
--- a/.github/workflows/cmux-tui-build-package.yml
+++ b/.github/workflows/cmux-tui-build-package.yml
@@ -94,7 +94,7 @@ jobs:
         if: runner.os == 'Linux'
         run: |
           sudo apt-get update
-          sudo apt-get install -y binutils clang libclang-dev pkg-config
+          sudo apt-get install -y binutils clang libclang-dev musl-tools pkg-config
 
       - name: Resolve Ghostty Zig version
         id: ghostty-zig-version
@@ -120,7 +120,7 @@ jobs:
         run: rustup target add ${{ matrix.target }}
 
       - name: Install cargo-zigbuild
-        if: matrix.cross == true
+        if: matrix.cross == true && runner.os == 'Linux'
         shell: bash
         run: cargo install --locked cargo-zigbuild@0.20.0
 
@@ -145,8 +145,8 @@ jobs:
           cargo build -p cmux-tui --bin cmux-tui --release --locked --target ${{ matrix.build_target }}
           cargo build -p cmux-relay --bin cmux-relay --release --locked --target ${{ matrix.build_target }}
 
-      - name: Build cmux-tui (cross)
-        if: matrix.cross == true
+      - name: Build cmux-tui (Linux cross)
+        if: matrix.cross == true && runner.os == 'Linux'
         env:
           CMUX_TUI_DISTRIBUTION_VERSION: ${{ inputs.version }}
           PACKAGE_NPM: ${{ inputs.package_npm }}
@@ -165,6 +165,27 @@ jobs:
           fi
           cargo zigbuild -p cmux-tui --bin cmux-tui --release --locked --target ${{ matrix.build_target }}
           cargo zigbuild -p cmux-relay --bin cmux-relay --release --locked --target ${{ matrix.build_target }}
+
+      - name: Build cmux-tui (macOS cross)
+        if: matrix.cross == true && runner.os == 'macOS'
+        env:
+          CMUX_TUI_DISTRIBUTION_VERSION: ${{ inputs.version }}
+          PACKAGE_NPM: ${{ inputs.package_npm }}
+        working-directory: cmux-tui
+        shell: bash
+        run: |
+          # Xcode's macOS SDK natively supports cross-architecture builds.
+          # cargo-zigbuild cannot resolve SDK frameworks when the host is arm64.
+          unset CMUX_GHOSTTY_SRC
+          CMUX_TUI_BUILD_COMMIT="$(git -C .. rev-parse HEAD)"
+          CMUX_TUI_GHOSTTY_COMMIT="$(git -C ../ghostty rev-parse HEAD)"
+          export CMUX_TUI_BUILD_COMMIT CMUX_TUI_GHOSTTY_COMMIT CMUX_TUI_DISTRIBUTION_VERSION
+          if [[ "$PACKAGE_NPM" == "true" ]]; then
+            CMUX_TUI_NPM_BOOTSTRAP_VERSION="$CMUX_TUI_DISTRIBUTION_VERSION"
+            export CMUX_TUI_NPM_BOOTSTRAP_VERSION
+          fi
+          cargo build -p cmux-tui --bin cmux-tui --release --locked --target ${{ matrix.build_target }}
+          cargo build -p cmux-relay --bin cmux-relay --release --locked --target ${{ matrix.build_target }}
 
       - name: Stage binary
         shell: bash

--- a/.github/workflows/cmux-tui-release.yml
+++ b/.github/workflows/cmux-tui-release.yml
@@ -49,30 +49,21 @@ jobs:
         env:
           DISPATCH_VERSION: ${{ inputs.version }}
           PUBLISH_NPM: ${{ inputs.publish_npm }}
-          PUBLISH_PYPI: ${{ inputs.publish_pypi }}
           CONFIRM_TUI_CMUX: ${{ inputs.confirm_tui_cmux }}
         run: |
           set -euo pipefail
-          if [[ "${GITHUB_REF_TYPE:-}" == "tag" ]]; then
-            [[ "$GITHUB_REF_NAME" =~ ^cmux-tui-v[0-9]+\.[0-9]+\.[0-9]+$ ]] || {
-              echo "tag must match cmux-tui-vX.Y.Z" >&2
-              exit 1
-            }
-            version="${GITHUB_REF_NAME#cmux-tui-v}"
-            if [[ -n "$DISPATCH_VERSION" && "$DISPATCH_VERSION" != "$version" ]]; then
-              echo "workflow_dispatch version $DISPATCH_VERSION does not match tag version $version" >&2
-              exit 1
-            fi
-          else
-            if [[ "$PUBLISH_NPM" == "true" || "$PUBLISH_PYPI" == "true" ]]; then
-              echo "Registry publishing requires a cmux-tui-vX.Y.Z tag ref." >&2
-              exit 1
-            fi
-            [[ "$DISPATCH_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] || {
-              echo "branch dry runs require an explicit X.Y.Z version" >&2
-              exit 1
-            }
-            version="$DISPATCH_VERSION"
+          if [[ "${GITHUB_REF_TYPE:-}" != "tag" ]]; then
+            echo "Stable artifacts require a cmux-tui-vX.Y.Z tag ref." >&2
+            exit 1
+          fi
+          [[ "$GITHUB_REF_NAME" =~ ^cmux-tui-v[0-9]+\.[0-9]+\.[0-9]+$ ]] || {
+            echo "tag must match cmux-tui-vX.Y.Z" >&2
+            exit 1
+          }
+          version="${GITHUB_REF_NAME#cmux-tui-v}"
+          if [[ -n "$DISPATCH_VERSION" && "$DISPATCH_VERSION" != "$version" ]]; then
+            echo "workflow_dispatch version $DISPATCH_VERSION does not match tag version $version" >&2
+            exit 1
           fi
 
           if [[ "$PUBLISH_NPM" == "true" && "$CONFIRM_TUI_CMUX" != "true" ]]; then

--- a/.github/workflows/cmux-tui-release.yml
+++ b/.github/workflows/cmux-tui-release.yml
@@ -49,21 +49,30 @@ jobs:
         env:
           DISPATCH_VERSION: ${{ inputs.version }}
           PUBLISH_NPM: ${{ inputs.publish_npm }}
+          PUBLISH_PYPI: ${{ inputs.publish_pypi }}
           CONFIRM_TUI_CMUX: ${{ inputs.confirm_tui_cmux }}
         run: |
           set -euo pipefail
-          if [[ "${GITHUB_REF_TYPE:-}" != "tag" ]]; then
-            echo "Stable artifacts require a cmux-tui-vX.Y.Z tag ref." >&2
-            exit 1
-          fi
-          [[ "$GITHUB_REF_NAME" =~ ^cmux-tui-v[0-9]+\.[0-9]+\.[0-9]+$ ]] || {
-            echo "tag must match cmux-tui-vX.Y.Z" >&2
-            exit 1
-          }
-          version="${GITHUB_REF_NAME#cmux-tui-v}"
-          if [[ -n "$DISPATCH_VERSION" && "$DISPATCH_VERSION" != "$version" ]]; then
-            echo "workflow_dispatch version $DISPATCH_VERSION does not match tag version $version" >&2
-            exit 1
+          if [[ "${GITHUB_REF_TYPE:-}" == "tag" ]]; then
+            [[ "$GITHUB_REF_NAME" =~ ^cmux-tui-v[0-9]+\.[0-9]+\.[0-9]+$ ]] || {
+              echo "tag must match cmux-tui-vX.Y.Z" >&2
+              exit 1
+            }
+            version="${GITHUB_REF_NAME#cmux-tui-v}"
+            if [[ -n "$DISPATCH_VERSION" && "$DISPATCH_VERSION" != "$version" ]]; then
+              echo "workflow_dispatch version $DISPATCH_VERSION does not match tag version $version" >&2
+              exit 1
+            fi
+          else
+            if [[ "$PUBLISH_NPM" == "true" || "$PUBLISH_PYPI" == "true" ]]; then
+              echo "Registry publishing requires a cmux-tui-vX.Y.Z tag ref." >&2
+              exit 1
+            fi
+            [[ "$DISPATCH_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] || {
+              echo "branch dry runs require an explicit X.Y.Z version" >&2
+              exit 1
+            }
+            version="$DISPATCH_VERSION"
           fi
 
           if [[ "$PUBLISH_NPM" == "true" && "$CONFIRM_TUI_CMUX" != "true" ]]; then

--- a/cmux-tui/dist/scripts/test_linux_packages.py
+++ b/cmux-tui/dist/scripts/test_linux_packages.py
@@ -115,7 +115,7 @@ while [ ! -S "$socket" ]; do
   fi
   sleep 0.05
 done
-{command} --socket "$socket" ping
+{command} --socket "$socket" session main ping
 kill -TERM "$server_pid"
 wait "$server_pid" || true
 server_pid=""

--- a/cmux-tui/relays/cloudflare-do/package-lock.json
+++ b/cmux-tui/relays/cloudflare-do/package-lock.json
@@ -6,7 +6,7 @@
     "": {
       "name": "cmux-cloudflare-relay",
       "devDependencies": {
-        "wrangler": "4.113.0"
+        "wrangler": "4.118.0"
       }
     },
     "node_modules/@cloudflare/kv-asset-handler": {
@@ -36,9 +36,9 @@
       }
     },
     "node_modules/@cloudflare/workerd-darwin-64": {
-      "version": "1.20260721.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20260721.1.tgz",
-      "integrity": "sha512-VivNMhiEdZIB4JBWxf1RMJGROErv53qmQ+dvhjA1evrCouvqRYW718VqDideU3PSV7Ythl5Df48NqZYWoaEHpQ==",
+      "version": "1.20260730.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20260730.1.tgz",
+      "integrity": "sha512-+MBHmPaiTe2KajryW0T24rZvWFxb41hD3d8anNzQqHzft6vSEb18+sp0znSwxgij7ApPhSM1+vhkNg4f3YMguA==",
       "cpu": [
         "x64"
       ],
@@ -53,9 +53,9 @@
       }
     },
     "node_modules/@cloudflare/workerd-darwin-arm64": {
-      "version": "1.20260721.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20260721.1.tgz",
-      "integrity": "sha512-k7oye1ZiuwnnBBA2eTMduconr/ud5ZxFtRNTsYwMdmJeeeislw2+M72otrHxxvybCP7JWPPlJ38uhfajpcyhOA==",
+      "version": "1.20260730.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20260730.1.tgz",
+      "integrity": "sha512-SBHKntPkKvNPgaCrTe99xC1CAl8ygJDzlYfK0LbuJ1muKadIw35WnhO0wu894fKBtllsVQdNzDLee+cm0ppLSQ==",
       "cpu": [
         "arm64"
       ],
@@ -70,9 +70,9 @@
       }
     },
     "node_modules/@cloudflare/workerd-linux-64": {
-      "version": "1.20260721.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20260721.1.tgz",
-      "integrity": "sha512-hon0lW4ZQ4boAVgaw+0ZFTNS8v5MWPWvK0HZnt4tDpKYnDUviLZawtUW3KqvFmCQTipVHl1S34j3J8Eqb93hGQ==",
+      "version": "1.20260730.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20260730.1.tgz",
+      "integrity": "sha512-ouyPOSMbiKPeSwUJUvxtMcxGAXs2J4aPE4T5ABIYX5ClcQx5j5bbHTmnqOQEY8sAuLTPjH7dY+iB6UI5ISlwwA==",
       "cpu": [
         "x64"
       ],
@@ -87,9 +87,9 @@
       }
     },
     "node_modules/@cloudflare/workerd-linux-arm64": {
-      "version": "1.20260721.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20260721.1.tgz",
-      "integrity": "sha512-nAl+HRQqpX5b7xVwWcvLPZmCk8NQ2yjI0yvJTWcHiRswbMEg1ZZckVmjJUAn0PHzZARbCSyIV7v3UjM+SPRmIQ==",
+      "version": "1.20260730.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20260730.1.tgz",
+      "integrity": "sha512-YQ+Mi78U3TPdgBPtwq+Sm6rJU+Ihl2y0pjYtuuKkdmUbYzL7oLR6Xqq9wljhasnuCFICssDJaqhMep5WizYoEQ==",
       "cpu": [
         "arm64"
       ],
@@ -104,9 +104,9 @@
       }
     },
     "node_modules/@cloudflare/workerd-windows-64": {
-      "version": "1.20260721.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20260721.1.tgz",
-      "integrity": "sha512-9paFG5cMTKz/CRixnEEnZbe5uvFPBFSDthxJHANfCWhUtBj49GSL1FPIokIg+Q+H8DGJEExU0lL92LtxD0lTxQ==",
+      "version": "1.20260730.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20260730.1.tgz",
+      "integrity": "sha512-27fAN+vUECW1oYVc1KOcHYpkL8COM2Uxtxql7TL595kxbjoqS5yckw7NLz7bTf2pALFCZWjqXDjZGJ/xbG4ZKQ==",
       "cpu": [
         "x64"
       ],
@@ -134,9 +134,9 @@
       }
     },
     "node_modules/@emnapi/runtime": {
-      "version": "1.11.2",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.2.tgz",
-      "integrity": "sha512-kyOl3X0DuTiT1h2ft8r2fYO8JYtU9a9Xis/zBSiGArNaagCOWx90N1k2wxp18czFDH+OgcWGb5ZP/XMt3dcyPA==",
+      "version": "1.11.3",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.3.tgz",
+      "integrity": "sha512-Xz4Tpyki7XyrpbUK1jR1AhdAdaXyhhY4lZ3neLodmhpuWfy2PAQN5B46sAiU4liOXGLkHypn/qU+jvfWSCYYLA==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -1184,9 +1184,9 @@
       }
     },
     "node_modules/@speed-highlight/core": {
-      "version": "1.2.17",
-      "resolved": "https://registry.npmjs.org/@speed-highlight/core/-/core-1.2.17.tgz",
-      "integrity": "sha512-Z92FwKpCtfaW1V0jTU/fh3QzYEZN8wDwrzRIBoADCJfn4mJCNcJN/XegifX7BDrQ8/h9Xh/JnbyMchL0FqXrkg==",
+      "version": "1.2.23",
+      "resolved": "https://registry.npmjs.org/@speed-highlight/core/-/core-1.2.23.tgz",
+      "integrity": "sha512-iRoq6i6JDJP6Mt2A5JaPvzw0pgYHH6k92ij+yXiTrB7T2y9N789aWE3EHWj/5ztlJBokcCBja3iYLVdu5wgnkg==",
       "dev": true,
       "license": "CC0-1.0"
     },
@@ -1299,21 +1299,18 @@
       }
     },
     "node_modules/miniflare": {
-      "version": "4.20260721.0",
-      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-4.20260721.0.tgz",
-      "integrity": "sha512-fBLaCxZ2i/nPH8iyLzvza0C8/sSF4sjD1ma1Skf+pkZVK0TlaW5ujHJlUHwcwR66v2JZt+Q28d4DCX/oaLG0cA==",
+      "version": "5.20260730.0-alpha",
+      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-5.20260730.0-alpha.tgz",
+      "integrity": "sha512-8/dspSXDshP6nSkCpjKO7BYc2qZoYSXm7iM+QxY7qJyJpAB3onnQSaiu0cvKJlfuMGwULl55hG69FJCcCMXU1Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@cspotcode/source-map-support": "0.8.1",
-        "sharp": "0.34.5",
+        "sharp": "0.35.2",
         "undici": "7.28.0",
-        "workerd": "1.20260721.1",
+        "workerd": "1.20260730.1",
         "ws": "8.21.0",
         "youch": "4.1.0-beta.10"
-      },
-      "bin": {
-        "miniflare": "bootstrap.js"
       },
       "engines": {
         "node": ">=22.0.0"
@@ -1418,9 +1415,9 @@
       "optional": true
     },
     "node_modules/undici": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
-      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
+      "integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1438,9 +1435,9 @@
       }
     },
     "node_modules/workerd": {
-      "version": "1.20260721.1",
-      "resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20260721.1.tgz",
-      "integrity": "sha512-b/DWhpV0jTudzQpLhDovcOgBz233386q+3Hbari7CLCNT9UXxjQziSTZ9yCoKdT2K3TSx5jrwlOisq8hlLWXYg==",
+      "version": "1.20260730.1",
+      "resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20260730.1.tgz",
+      "integrity": "sha512-zmfNIjwYSWFY5chGBOjWtH3xAE7p97FTC6vR4Ep98290ho6AeAR/NVcBD274YCLEUYzqm8yxdtZlxMybU8a3jA==",
       "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
@@ -1451,17 +1448,17 @@
         "node": ">=16"
       },
       "optionalDependencies": {
-        "@cloudflare/workerd-darwin-64": "1.20260721.1",
-        "@cloudflare/workerd-darwin-arm64": "1.20260721.1",
-        "@cloudflare/workerd-linux-64": "1.20260721.1",
-        "@cloudflare/workerd-linux-arm64": "1.20260721.1",
-        "@cloudflare/workerd-windows-64": "1.20260721.1"
+        "@cloudflare/workerd-darwin-64": "1.20260730.1",
+        "@cloudflare/workerd-darwin-arm64": "1.20260730.1",
+        "@cloudflare/workerd-linux-64": "1.20260730.1",
+        "@cloudflare/workerd-linux-arm64": "1.20260730.1",
+        "@cloudflare/workerd-windows-64": "1.20260730.1"
       }
     },
     "node_modules/wrangler": {
-      "version": "4.113.0",
-      "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-4.113.0.tgz",
-      "integrity": "sha512-ROGzSloJv0y21It6Oc9LaruNcu1tdiQ/XzL3Jc3YkFjzXEMXzTqVhA8vQaGMTdZHTjFP0PVcwAHNgaw3gXu4wA==",
+      "version": "4.118.0",
+      "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-4.118.0.tgz",
+      "integrity": "sha512-9pkBw/b8zWqGx2S+oLhgHMR1M/4VOE8SynUFABnGWiSFGlcOQ4xiI/B71Xf66RYP2xzngU37IQFPtUruij3lYw==",
       "dev": true,
       "license": "MIT OR Apache-2.0",
       "dependencies": {
@@ -1469,10 +1466,10 @@
         "@cloudflare/unenv-preset": "2.16.1",
         "blake3-wasm": "2.1.5",
         "esbuild": "0.28.1",
-        "miniflare": "4.20260721.0",
+        "miniflare": "5.20260730.0-alpha",
         "path-to-regexp": "6.3.0",
         "unenv": "2.0.0-rc.24",
-        "workerd": "1.20260721.1"
+        "workerd": "1.20260730.1"
       },
       "bin": {
         "cf-wrangler": "bin/cf-wrangler.js",
@@ -1486,7 +1483,7 @@
         "fsevents": "2.3.3"
       },
       "peerDependencies": {
-        "@cloudflare/workers-types": "^5.20260721.1"
+        "@cloudflare/workers-types": "^5.20260730.1"
       },
       "peerDependenciesMeta": {
         "@cloudflare/workers-types": {

--- a/cmux-tui/relays/cloudflare-do/package.json
+++ b/cmux-tui/relays/cloudflare-do/package.json
@@ -7,9 +7,10 @@
     "deploy": "wrangler deploy"
   },
   "devDependencies": {
-    "wrangler": "4.113.0"
+    "wrangler": "4.118.0"
   },
   "overrides": {
-    "sharp": "0.35.3"
+    "sharp": "0.35.3",
+    "undici": "7.29.0"
   }
 }


### PR DESCRIPTION
## Summary
- use Xcode's SDK directly for Intel macOS cross-builds
- install the musl compiler needed by the release-only rollback test
- update Wrangler and pin the patched Undici release

## Testing
- `npm ci --no-audit --no-fund`
- `npm audit --audit-level=high`
- `python3 tests/validate_wrangler_config.py`

## Release failure
- Fixes blockers from https://github.com/manaflow-ai/cmux/actions/runs/30962936943

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/9608"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788481937&installation_model_id=21920&pr_number=9608&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F9608&signature=377b78facf0838604a19a8fe361387019710add0f5d716ec57194c98ff940d13"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes cmux TUI release packaging for v0.9.11: macOS cross-builds use Xcode’s SDK, Linux installs `musl`, and `cargo-zigbuild` runs only on Linux; relay dependencies are aligned and the smoke test command is updated. Reverts the dry-run workflow; publishing stays restricted to `cmux-tui-vX.Y.Z` tags.

- **Bug Fixes**
  - macOS cross-builds use Xcode SDK; `cargo-zigbuild` limited to Linux with `musl-tools` installed.
  - Update Linux smoke test to "session main ping".
  - Revert branch dry-run path; releases publish only from `cmux-tui-vX.Y.Z` tags.

- **Dependencies**
  - Bump `wrangler` to `4.118.0`.
  - Align `workerd` to `1.20260730.1` and `miniflare` to `5.20260730.0-alpha`.
  - Pin `undici` to `7.29.0`; keep `sharp` at `0.35.3`.

<sup>Written for commit 350b774df738b14521169f19f05a13507c467a2b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/9608?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved release workflows to support versioned tags and controlled dry runs.
  * Added clearer validation for release versions and publishing options.
  * Improved cross-platform build support for Linux and macOS architectures.

* **Chores**
  * Updated Cloudflare deployment tooling and networking dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->