### PR TITLE
Use shared Finder opener for session working directories

### DIFF
--- a/Sources/SessionIndexView.swift
+++ b/Sources/SessionIndexView.swift
@@ -700,7 +700,11 @@ private func sessionRowMenuItems(entry: SessionEntry, onResume: ((SessionEntry) 
     }
     if let cwd = entry.cwd, !cwd.isEmpty {
         Button {
-            NSWorkspace.shared.open(URL(fileURLWithPath: cwd))
+            Task { @MainActor in
+                await WorkspaceFinderDirectoryOpener.openInFinder(
+                    URL(fileURLWithPath: cwd, isDirectory: true)
+                )
+            }
         } label: {
             Text(String(localized: "sessionIndex.row.openCwd", defaultValue: "Open Working Directory"))
         }

--- a/cmuxTests/SessionIndexTableViewportTests.swift
+++ b/cmuxTests/SessionIndexTableViewportTests.swift
@@ -1,4 +1,5 @@
 import AppKit
+import ObjectiveC.runtime
 import SwiftUI
 import Testing
 
@@ -7,6 +8,121 @@ import Testing
 #elseif canImport(cmux)
 @testable import cmux
 #endif
+
+@Suite(.serialized)
+struct SessionIndexOpenWorkingDirectoryTests {
+    @MainActor
+    @Test(.timeLimit(.minutes(1)))
+    func openWorkingDirectoryMenuChecksStalePathInsteadOfOpeningItDirectly() async throws {
+        let stalePath = "/private/tmp/cmux-issue-5977-stale-\(UUID().uuidString)"
+        let entry = SessionEntry(
+            id: "claude:\(stalePath)/session.jsonl",
+            agent: .claude,
+            sessionId: "issue-5977",
+            title: "Stale working directory",
+            cwd: stalePath,
+            gitBranch: nil,
+            pullRequest: nil,
+            modified: Date(timeIntervalSince1970: 1),
+            fileURL: nil,
+            specifics: .claude(
+                model: nil,
+                permissionMode: nil,
+                configDirectoryForResume: nil
+            )
+        )
+        let section = IndexSection(
+            key: .directory(stalePath),
+            title: "stale",
+            icon: .folder,
+            entries: [entry]
+        )
+        let controller = SessionIndexTableController()
+        let container = controller.makeContainerView()
+        container.frame = NSRect(x: 0, y: 0, width: 320, height: 160)
+        let window = NSWindow(
+            contentRect: container.frame,
+            styleMask: [.borderless],
+            backing: .buffered,
+            defer: false
+        )
+        window.contentView = container
+        window.orderFront(nil)
+        defer { window.orderOut(nil) }
+
+        controller.apply(
+            rows: [SessionIndexTableViewportTests.makeSectionRow(section: section)],
+            environment: .init(
+                colorScheme: .light,
+                globalFontMagnificationPercent: 100
+            )
+        )
+        await flushStagedTableMutations()
+        window.displayIfNeeded()
+        container.layoutSubtreeIfNeeded()
+        container.tableView.layoutSubtreeIfNeeded()
+
+        let cell = try #require(container.tableView.view(
+            atColumn: 0,
+            row: 0,
+            makeIfNecessary: false
+        ) as? SessionIndexTableCellView)
+        cell.layoutSubtreeIfNeeded()
+        let title = String(
+            localized: "sessionIndex.row.openCwd",
+            defaultValue: "Open Working Directory"
+        )
+        let menu = try #require(contextMenu(in: cell, containing: title))
+        let item = try #require(menu.items.first { $0.title == title })
+        let action = try #require(item.action)
+
+        let event = await SessionIndexWorkingDirectoryOpenProbe.captureFirstEvent {
+            #expect(NSApp.sendAction(action, to: item.target, from: item))
+        }
+
+        #expect(event == .stalePathChecked(stalePath))
+    }
+
+    @MainActor
+    private func contextMenu(in cell: NSView, containing title: String) -> NSMenu? {
+        let x = cell.bounds.midX
+        for y in stride(from: CGFloat(1), to: cell.bounds.height, by: 2) {
+            let point = NSPoint(x: x, y: y)
+            guard let event = NSEvent.mouseEvent(
+                with: .rightMouseDown,
+                location: cell.convert(point, to: nil),
+                modifierFlags: [],
+                timestamp: 0,
+                windowNumber: cell.window?.windowNumber ?? 0,
+                context: nil,
+                eventNumber: 0,
+                clickCount: 1,
+                pressure: 1
+            ) else {
+                continue
+            }
+            var candidate = cell.hitTest(point)
+            while let view = candidate {
+                if let menu = view.menu(for: event),
+                   menu.items.contains(where: { $0.title == title }) {
+                    return menu
+                }
+                guard view !== cell else { break }
+                candidate = view.superview
+            }
+        }
+        return nil
+    }
+
+    @MainActor
+    private func flushStagedTableMutations() async {
+        await withCheckedContinuation { continuation in
+            RunLoop.main.perform(inModes: [.common]) {
+                continuation.resume()
+            }
+        }
+    }
+}
 
 @Suite(.serialized)
 struct SessionIndexTableViewportTests {
@@ -375,7 +491,7 @@ struct SessionIndexTableViewportTests {
     }
 
     @MainActor
-    private static func makeSectionRow(
+    fileprivate static func makeSectionRow(
         section: IndexSection,
         popoverIdentity: SessionIndexTablePopoverIdentity? = nil,
         onSetPopoverOpen: @escaping @MainActor (Bool) -> Void = { _ in }
@@ -397,6 +513,111 @@ struct SessionIndexTableViewportTests {
             setCollapsed: { _ in },
             setPopoverOpen: onSetPopoverOpen
         )
+    }
+
+}
+
+private enum SessionIndexWorkingDirectoryOpenEvent: Equatable {
+    case rawWorkspaceOpen(String)
+    case stalePathChecked(String)
+    case timedOut
+}
+
+@MainActor
+private enum SessionIndexWorkingDirectoryOpenProbe {
+    static let stalePathMarker = "cmux-issue-5977-stale-"
+    private static var continuation: CheckedContinuation<SessionIndexWorkingDirectoryOpenEvent, Never>?
+    private static var timeoutTask: Task<Void, Never>?
+
+    static func captureFirstEvent(
+        perform: () -> Void
+    ) async -> SessionIndexWorkingDirectoryOpenEvent {
+        installInterceptors()
+        defer { removeInterceptors() }
+
+        return await withCheckedContinuation { continuation in
+            precondition(Self.continuation == nil)
+            Self.continuation = continuation
+            timeoutTask = Task { @MainActor in
+                try? await Task.sleep(for: .seconds(10))
+                guard !Task.isCancelled else { return }
+                record(.timedOut)
+            }
+            perform()
+        }
+    }
+
+    static func record(_ event: SessionIndexWorkingDirectoryOpenEvent) {
+        guard let continuation else { return }
+        Self.continuation = nil
+        timeoutTask?.cancel()
+        timeoutTask = nil
+        continuation.resume(returning: event)
+    }
+
+    private static func installInterceptors() {
+        exchange(
+            on: NSWorkspace.self,
+            #selector(NSWorkspace.open(_:)),
+            #selector(NSWorkspace.cmuxIssue5977_open(_:))
+        )
+        exchange(
+            on: FileManager.self,
+            #selector(FileManager.fileExists(atPath:isDirectory:)),
+            #selector(FileManager.cmuxIssue5977_fileExists(atPath:isDirectory:))
+        )
+    }
+
+    private static func removeInterceptors() {
+        exchange(
+            on: FileManager.self,
+            #selector(FileManager.fileExists(atPath:isDirectory:)),
+            #selector(FileManager.cmuxIssue5977_fileExists(atPath:isDirectory:))
+        )
+        exchange(
+            on: NSWorkspace.self,
+            #selector(NSWorkspace.open(_:)),
+            #selector(NSWorkspace.cmuxIssue5977_open(_:))
+        )
+    }
+
+    private static func exchange(
+        on type: AnyClass,
+        _ original: Selector,
+        _ replacement: Selector
+    ) {
+        guard let originalMethod = class_getInstanceMethod(type, original),
+              let replacementMethod = class_getInstanceMethod(type, replacement) else {
+            preconditionFailure("Missing issue #5977 AppKit test interceptor")
+        }
+        method_exchangeImplementations(originalMethod, replacementMethod)
+    }
+}
+
+private extension NSWorkspace {
+    @MainActor
+    @objc dynamic func cmuxIssue5977_open(_ url: URL) -> Bool {
+        guard url.path.contains(SessionIndexWorkingDirectoryOpenProbe.stalePathMarker) else {
+            return cmuxIssue5977_open(url)
+        }
+        SessionIndexWorkingDirectoryOpenProbe.record(.rawWorkspaceOpen(url.path))
+        return true
+    }
+}
+
+private extension FileManager {
+    @objc dynamic func cmuxIssue5977_fileExists(
+        atPath path: String,
+        isDirectory: UnsafeMutablePointer<ObjCBool>?
+    ) -> Bool {
+        guard path.contains(SessionIndexWorkingDirectoryOpenProbe.stalePathMarker) else {
+            return cmuxIssue5977_fileExists(atPath: path, isDirectory: isDirectory)
+        }
+        isDirectory?.pointee = false
+        Task { @MainActor in
+            SessionIndexWorkingDirectoryOpenProbe.record(.stalePathChecked(path))
+        }
+        return false
     }
 }
 


### PR DESCRIPTION
## Summary

- Route the session-index `Open Working Directory` menu action through the shared Finder opener.
- Reuse the existing directory-existence check, stale-path feedback, and Finder reveal behavior instead of opening the stored URL directly.
- Cover the actual session row context-menu action with a regression test that distinguishes shared stale-path handling from raw `NSWorkspace.open`.

Fixes #5977

## Testing

- Red: [test-only run 30960616559](https://github.com/manaflow-ai/cmux/actions/runs/30960616559) on `e64180cd7e` executed one test and failed with `.rawWorkspaceOpen(stalePath)` instead of `.stalePathChecked(stalePath)`.
- Green: [fix run 30963094999](https://github.com/manaflow-ai/cmux/actions/runs/30963094999) on `aa858022b3` executed and passed `cmuxTests/SessionIndexOpenWorkingDirectoryTests`.
- `./scripts/lint-pbxproj-test-wiring.sh` — passed (652 test files checked).
- Cloud dev build: `./scripts/reload-cloud.sh --tag sym5977 --builder fleet --host cmux9s-mac-mini` — succeeded on `cmux9s-mac-mini` as run `sym5977-e3b5d1dd6c67` (fleet path; no local build fallback).
- Tagged dogfood on `/tmp/cmux-debug-sym5977.sock`: loaded a session whose cwd does not exist, invoked the real row-menu `Open Working Directory` item, and observed one hit in `WorkspaceFinderDirectoryResolver.existingDirectoryURL(for:)` with zero hits in `-[NSWorkspace openURL:]`. The tagged app was then quit and its socket removed.
- Localization audit: no user-facing text or localization catalog changed; the existing `sessionIndex.row.openCwd` key remains translated in English and Japanese.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/9609"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788482259&installation_model_id=21920&pr_number=9609&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F9609&signature=5c09845386d25a73fe0ccf8cf057286bcc22b37bc942ef1c319eed06336a19b9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Routes the Session Index “Open Working Directory” action through the shared Finder opener to reuse existence checks and reveal behavior, preventing attempts to open stale paths. Fixes #5977.

- **Bug Fixes**
  - Use `WorkspaceFinderDirectoryOpener.openInFinder` for session rows to apply directory-existence checks, stale-path feedback, and Finder reveal behavior.
  - Add a regression test to verify stale paths are validated and not opened directly via `NSWorkspace.open`.

<sup>Written for commit aa858022b3de00739b1d64e1fe0116a526b62001. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/9609?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the working-directory context-menu action to safely handle stale or unavailable session paths.
  * Prevented invalid directory-opening attempts when a session’s working directory is no longer accessible.

* **Tests**
  * Added regression coverage for stale working-directory menu behavior and deferred table updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->