### PR TITLE
Don't leak the host's TERM_PROGRAM/COLORTERM into remote PTY sessions

### DIFF
--- a/daemon/remote/cmd/cmuxd-remote/ws_pty.go
+++ b/daemon/remote/cmd/cmuxd-remote/ws_pty.go
@@ -745,8 +745,12 @@ func defaultWebSocketPTYEnv(shellPath string) []string {
 
 	set("PATH", pathWithStandardExecutableDirectories(env["PATH"]))
 	set("TERM", "xterm-256color")
-	setIfMissing("COLORTERM", "truecolor")
-	setIfMissing("TERM_PROGRAM", "ghostty")
+	// Force cmux's own terminal identity. These are inherited from the daemon's
+	// host environment (tmux, iTerm, Apple Terminal, ...); leaking the host
+	// values lets apps in the session mis-detect the terminal, so set them
+	// rather than only setting them when absent.
+	set("COLORTERM", "truecolor")
+	set("TERM_PROGRAM", "ghostty")
 	setIfMissing("SHELL", shellPath)
 	set("CMUX_REMOTE_TRANSPORT", "ws")
 	if !envHasUTF8Locale(env) {

--- a/daemon/remote/cmd/cmuxd-remote/ws_pty_env_test.go
+++ b/daemon/remote/cmd/cmuxd-remote/ws_pty_env_test.go
@@ -1,0 +1,23 @@
+package main
+
+import "testing"
+
+// The daemon inherits its own process environment when seeding a remote PTY
+// session. Terminal-identity variables set on the host (for example when
+// cmuxd-remote is launched from tmux, iTerm, or Apple Terminal) must not leak
+// into the session: the remote PTY always presents cmux's own identity.
+func TestDefaultWebSocketPTYEnvForcesTerminalIdentity(t *testing.T) {
+	t.Setenv("TERM_PROGRAM", "iTerm.app")
+	t.Setenv("COLORTERM", "24bit")
+
+	env, _ := envMapWithOrder(defaultWebSocketPTYEnv("/bin/zsh"))
+
+	for _, tc := range []struct{ key, want string }{
+		{"TERM_PROGRAM", "ghostty"},
+		{"COLORTERM", "truecolor"},
+	} {
+		if got := env[tc.key]; got != tc.want {
+			t.Errorf("%s = %q, want %q (host value must not leak into the remote PTY)", tc.key, got, tc.want)
+		}
+	}
+}


### PR DESCRIPTION
## Problem

`defaultWebSocketPTYEnv` (`daemon/remote/cmd/cmuxd-remote/ws_pty.go`) seeds a remote websocket PTY's environment starting from the daemon **host's** `os.Environ()`, and used `setIfMissing` for `TERM_PROGRAM` and `COLORTERM`:

```go
setIfMissing("COLORTERM", "truecolor")
setIfMissing("TERM_PROGRAM", "ghostty")
```

`setIfMissing` only sets a value when it's absent, so when `cmuxd-remote` runs on a host that already has these set (launched from tmux, iTerm, Apple Terminal, or another ghostty), the **host's terminal identity leaks into every remote PTY session**. Apps in the session then mis-detect the terminal (the same reason the agent-launch path deliberately clears `TERM_PROGRAM`).

This isn't only theoretical: `TestWebSocketPTYSeedsUTF8LocaleAndTerminalEnv` hard-asserts `|truecolor|ghostty|`, and it **fails on any host with `TERM_PROGRAM` set** — e.g. on a checkout run under tmux it sees `TERM_PROGRAM=tmux` and never matches. `TERM` right above is already forced unconditionally, so this is the outlier.

## Fix

Force cmux's own terminal identity, matching `TERM`:

```go
set("COLORTERM", "truecolor")
set("TERM_PROGRAM", "ghostty")
```

`SHELL` is intentionally left as `setIfMissing` (a user's login shell is legitimately host-provided; `shellPath` is only a fallback).

## Tests

Per the regression-test convention, this is two commits: the first adds a failing unit test (`TestDefaultWebSocketPTYEnvForcesTerminalIdentity`) that forces the leak condition with `t.Setenv` so it's deterministic regardless of the runner's ambient env; the second adds the fix. The previously host-dependent `TestWebSocketPTYSeedsUTF8LocaleAndTerminalEnv` now passes under tmux too. `go test ./...`, `go vet ./...`, and `gofmt` are clean.

---

Used AI assistance on this; I reviewed and tested it.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/9610"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788482887&installation_model_id=21920&pr_number=9610&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F9610&signature=0ad63609cd22272c8c775d7e596c512750366c06bf2052b39c6e63e27ef7f55f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop leaking the host’s `TERM_PROGRAM`/`COLORTERM` into remote WebSocket PTY sessions. We now always advertise cmux’s terminal identity to prevent terminal mis-detection and stabilize tests across hosts.

- **Bug Fixes**
  - Force `TERM_PROGRAM=ghostty` and `COLORTERM=truecolor` in `defaultWebSocketPTYEnv` (in `daemon/remote/cmd/cmuxd-remote/ws_pty.go`), matching the unconditional `TERM`.
  - Keep `SHELL` as set-if-missing (uses the host value when present).
  - Add a unit test (`ws_pty_env_test.go`) that sets host env and asserts forced values; the existing UTF-8/terminal env test is now stable under tmux.

<sup>Written for commit e606d10a61f3bc2ba544ef4d4b9e62a86ce4a79a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/9610?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Remote terminal sessions now consistently use truecolor support and identify as the cmux terminal, regardless of the host environment’s terminal settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->