### PR TITLE
Route browser shortcuts to the focused Dock

### DIFF
--- a/Sources/AppDelegate+DockShortcutRouting.swift
+++ b/Sources/AppDelegate+DockShortcutRouting.swift
@@ -58,6 +58,54 @@ extension AppDelegate {
         return panelId
     }
 
+    /// Focuses the selected Dock browser's address bar, or creates a browser in
+    /// the focused Dock pane when another panel type is selected. Once the Dock
+    /// owns focus the shortcut is consumed even when no browser can be opened,
+    /// so it never mutates the main split tree.
+    func routeFocusBrowserAddressBarToFocusedDock(
+        preferredWindow: NSWindow?
+    ) -> Bool {
+        guard let store = focusedDockStoreForShortcut(
+            preferredWindow: preferredWindow
+        ) else {
+            return false
+        }
+
+        if let panelId = store.focusedPanelId,
+           let browser = store.browserPanel(for: panelId) {
+            store.focusPanel(panelId)
+            focusBrowserAddressBar(in: browser)
+            return true
+        }
+
+        guard store.isBrowserAvailable(),
+              let pane = store.resolvePane(requestedPaneID: nil),
+              let panelId = store.newSurface(
+                  kind: .browser,
+                  inPane: pane,
+                  focus: true
+              ), let browser = store.browserPanel(for: panelId) else {
+            return true
+        }
+        focusBrowserAddressBar(in: browser)
+        return true
+    }
+
+    /// Reopens Dock browser history when the Dock owns keyboard focus. The
+    /// shortcut is consumed even when the Dock history is empty so the main
+    /// area's closed-item stack is never changed from a Dock-focused command.
+    func routeReopenClosedBrowserPanelToFocusedDock(
+        preferredWindow: NSWindow?
+    ) -> Bool {
+        guard let store = focusedDockStoreForShortcut(
+            preferredWindow: preferredWindow
+        ) else {
+            return false
+        }
+        _ = store.reopenMostRecentlyClosedBrowserPanel()
+        return true
+    }
+
     /// Splits the focused Dock pane (terminal or browser). Returns `true` when
     /// handled, or `false` to fall through to the main-area split path. Reuses the
     /// main area's `SplitDirection` → orientation/insert mapping so Dock splits

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -14458,6 +14458,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         }
 
         if matchConfiguredShortcut(event: event, action: .focusBrowserAddressBar) {
+            if routeFocusBrowserAddressBarToFocusedDock(preferredWindow: event.window) {
+                return true
+            }
             if let focusedPanel = tabManager?.focusedBrowserPanel {
                 focusBrowserAddressBar(in: focusedPanel)
                 return true
@@ -14643,6 +14646,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         }
 
         if matchConfiguredShortcut(event: event, action: .reopenClosedBrowserPanel) {
+            if routeReopenClosedBrowserPanelToFocusedDock(preferredWindow: event.window) {
+                return true
+            }
             let routedManager = preferredMainWindowContextForShortcutRouting(event: event)?.tabManager ?? tabManager
             _ = reopenMostRecentlyClosedItem(preferredTabManager: routedManager)
             return true

--- a/Sources/DockSplitStore+CloseConfirmation.swift
+++ b/Sources/DockSplitStore+CloseConfirmation.swift
@@ -31,6 +31,7 @@ private struct DockPaneCloseConfirmationPrompt: Sendable {
 
 extension DockSplitStore {
     func splitTabBar(_ controller: BonsplitController, shouldCloseTab tab: Bonsplit.Tab, inPane pane: PaneID) -> Bool {
+        stageClosedBrowserRestoreSnapshotIfEligible(for: tab, inPane: pane)
         if forceCloseDockTabIds.contains(tab.id) {
             return true
         }
@@ -47,7 +48,10 @@ extension DockSplitStore {
         guard !pendingCloseConfirmDockTabIds.contains(tab.id) else { return false }
 
         let confirmationManager = dockCloseConfirmationManager()
-        if confirmationManager?.isCloseConfirmationInFlight == true { return false }
+        if confirmationManager?.isCloseConfirmationInFlight == true {
+            clearClosedBrowserHistoryState(for: tab.id)
+            return false
+        }
 
         pendingCloseConfirmDockTabIds.insert(tab.id)
         let tabId = tab.id
@@ -58,13 +62,20 @@ extension DockSplitStore {
             defer {
                 self.pendingCloseConfirmDockTabIds.remove(tabId)
             }
-            guard let panel = self.panel(for: tabId) else { return }
-            guard self.confirmCloseDockPanel(panel, confirmationManager: confirmationManager) else { return }
+            guard let panel = self.panel(for: tabId) else {
+                self.clearClosedBrowserHistoryState(for: tabId)
+                return
+            }
+            guard self.confirmCloseDockPanel(panel, confirmationManager: confirmationManager) else {
+                self.clearClosedBrowserHistoryState(for: tabId)
+                return
+            }
 
             self.forceCloseDockTabIds.insert(tabId)
             let closed = self.bonsplitController.closeTab(tabId)
             if !closed {
                 self.forceCloseDockTabIds.remove(tabId)
+                self.clearClosedBrowserHistoryState(for: tabId)
             }
         }
         return false
@@ -109,6 +120,7 @@ extension DockSplitStore {
         forceCloseDockTabIds.remove(tabId)
         pendingCloseConfirmDockTabIds.remove(tabId)
         tabCloseButtonCloseDockTabIds.remove(tabId)
+        commitClosedBrowserRestoreSnapshot(for: tabId)
         reconcilePanels()
     }
 

--- a/Sources/DockSplitStore+ClosedBrowserHistory.swift
+++ b/Sources/DockSplitStore+ClosedBrowserHistory.swift
@@ -1,0 +1,258 @@
+import Bonsplit
+import CmuxBrowser
+import Foundation
+
+private struct DockBrowserCloseFallbackPlan {
+    let orientation: SplitOrientation
+    let insertFirst: Bool
+    let anchorPaneId: UUID?
+}
+
+extension DockSplitStore {
+    func markExplicitBrowserCloseFromTabStrip(
+        tabId: TabID,
+        source: TabCloseRequestSource
+    ) {
+        if source == .closeButton {
+            tabCloseButtonCloseDockTabIds.insert(tabId)
+        }
+        markClosedBrowserHistoryEligible(tabId: tabId)
+    }
+
+    func markClosedBrowserHistoryEligible(tabId: TabID) {
+        guard panel(for: tabId) is BrowserPanel else { return }
+        closedBrowserHistoryEligibleDockTabIds.insert(tabId)
+    }
+
+    @discardableResult
+    func closePanelRecordingBrowserHistory(
+        _ panelId: UUID,
+        force: Bool = false
+    ) -> Bool {
+        guard let tabId = surfaceId(forPanelId: panelId) else { return false }
+        markClosedBrowserHistoryEligible(tabId: tabId)
+        let closed = closePanel(panelId, force: force)
+        if !closed, !pendingCloseConfirmDockTabIds.contains(tabId) {
+            clearClosedBrowserHistoryState(for: tabId)
+        }
+        return closed
+    }
+
+    func stageClosedBrowserRestoreSnapshotIfEligible(
+        for tab: Bonsplit.Tab,
+        inPane pane: PaneID
+    ) {
+        guard closedBrowserHistoryEligibleDockTabIds.contains(tab.id),
+              let browserPanel = panel(for: tab.id) as? BrowserPanel,
+              browserPanel.shouldPersistSessionSnapshot(),
+              let tabIndex = bonsplitController.tabs(inPane: pane).firstIndex(
+                  where: { $0.id == tab.id }
+              ) else {
+            pendingClosedBrowserRestoreSnapshots.removeValue(forKey: tab.id)
+            return
+        }
+
+        let fallbackPlan = dockBrowserCloseFallbackPlan(
+            forPaneId: pane.id.uuidString,
+            in: bonsplitController.treeSnapshot()
+        )
+        let resolvedURL = browserPanel.currentURL
+            ?? browserPanel.preferredURLStringForOmnibar().flatMap(URL.init(string:))
+        guard !browserIsTemporaryHistoryURL(resolvedURL) else {
+            pendingClosedBrowserRestoreSnapshots.removeValue(forKey: tab.id)
+            return
+        }
+
+        pendingClosedBrowserRestoreSnapshots[tab.id] =
+            CmuxBrowser.ClosedBrowserPanelRestoreSnapshot(
+                workspaceId: workspaceId,
+                url: resolvedURL,
+                profileID: browserPanel.profileID,
+                originalPaneId: pane.id,
+                originalTabIndex: tabIndex,
+                fallbackSplitOrientation: fallbackPlan?.orientation,
+                fallbackSplitInsertFirst: fallbackPlan?.insertFirst ?? false,
+                fallbackAnchorPaneId: fallbackPlan?.anchorPaneId
+            )
+    }
+
+    func commitClosedBrowserRestoreSnapshot(for tabId: TabID) {
+        let wasEligible = closedBrowserHistoryEligibleDockTabIds.remove(tabId) != nil
+        let snapshot = pendingClosedBrowserRestoreSnapshots.removeValue(forKey: tabId)
+        guard wasEligible, let snapshot else { return }
+        closedBrowserModel.recordClosedBrowserPanel(snapshot)
+    }
+
+    func clearClosedBrowserHistoryState(for tabId: TabID) {
+        closedBrowserHistoryEligibleDockTabIds.remove(tabId)
+        pendingClosedBrowserRestoreSnapshots.removeValue(forKey: tabId)
+    }
+
+    func clearPendingClosedBrowserHistoryState() {
+        closedBrowserHistoryEligibleDockTabIds.removeAll()
+        pendingClosedBrowserRestoreSnapshots.removeAll()
+    }
+
+    @discardableResult
+    func reopenMostRecentlyClosedBrowserPanel() -> Bool {
+        guard isBrowserAvailable() else { return false }
+        while let snapshot = closedBrowserModel.popMostRecentlyClosedBrowserPanel() {
+            if restoreClosedBrowserPanel(snapshot) != nil {
+                return true
+            }
+        }
+        return false
+    }
+
+    private func restoreClosedBrowserPanel(
+        _ snapshot: CmuxBrowser.ClosedBrowserPanelRestoreSnapshot
+    ) -> UUID? {
+        if let originalPane = bonsplitController.allPaneIds.first(
+            where: { $0.id == snapshot.originalPaneId }
+        ), let panelId = newSurface(
+            kind: .browser,
+            inPane: originalPane,
+            url: snapshot.url,
+            focus: true,
+            preferredProfileID: snapshot.profileID
+        ) {
+            if let tabId = surfaceId(forPanelId: panelId) {
+                let tabCount = bonsplitController.tabs(inPane: originalPane).count
+                let targetIndex = min(
+                    max(snapshot.originalTabIndex, 0),
+                    max(0, tabCount - 1)
+                )
+                _ = bonsplitController.reorderTab(tabId, toIndex: targetIndex)
+            }
+            return panelId
+        }
+
+        if let orientation = snapshot.fallbackSplitOrientation,
+           let fallbackAnchorPaneId = snapshot.fallbackAnchorPaneId,
+           let anchorPane = bonsplitController.allPaneIds.first(
+               where: { $0.id == fallbackAnchorPaneId }
+           ), let anchorTab = bonsplitController.selectedTab(inPane: anchorPane)
+               ?? bonsplitController.tabs(inPane: anchorPane).first,
+           let anchorPanelId = surfaceIdToPanelId[anchorTab.id],
+           let panelId = newSplit(
+               kind: .browser,
+               orientation: orientation,
+               insertFirst: snapshot.fallbackSplitInsertFirst,
+               sourcePanelId: anchorPanelId,
+               url: snapshot.url,
+               preferredProfileID: snapshot.profileID,
+               focus: true
+           ) {
+            return panelId
+        }
+
+        guard let pane = resolvePane(requestedPaneID: nil) else { return nil }
+        return newSurface(
+            kind: .browser,
+            inPane: pane,
+            url: snapshot.url,
+            focus: true,
+            preferredProfileID: snapshot.profileID
+        )
+    }
+
+    private func dockBrowserCloseFallbackPlan(
+        forPaneId targetPaneId: String,
+        in node: ExternalTreeNode
+    ) -> DockBrowserCloseFallbackPlan? {
+        switch node {
+        case .pane:
+            return nil
+        case .split(let splitNode):
+            if case .pane(let firstPane) = splitNode.first,
+               firstPane.id == targetPaneId {
+                return DockBrowserCloseFallbackPlan(
+                    orientation: splitNode.orientation.lowercased() == "vertical"
+                        ? .vertical
+                        : .horizontal,
+                    insertFirst: true,
+                    anchorPaneId: dockBrowserNearestPaneId(
+                        in: splitNode.second,
+                        targetCenter: dockBrowserPaneCenter(firstPane)
+                    )
+                )
+            }
+
+            if case .pane(let secondPane) = splitNode.second,
+               secondPane.id == targetPaneId {
+                return DockBrowserCloseFallbackPlan(
+                    orientation: splitNode.orientation.lowercased() == "vertical"
+                        ? .vertical
+                        : .horizontal,
+                    insertFirst: false,
+                    anchorPaneId: dockBrowserNearestPaneId(
+                        in: splitNode.first,
+                        targetCenter: dockBrowserPaneCenter(secondPane)
+                    )
+                )
+            }
+
+            if let nested = dockBrowserCloseFallbackPlan(
+                forPaneId: targetPaneId,
+                in: splitNode.first
+            ) {
+                return nested
+            }
+            return dockBrowserCloseFallbackPlan(
+                forPaneId: targetPaneId,
+                in: splitNode.second
+            )
+        }
+    }
+
+    private func dockBrowserPaneCenter(
+        _ pane: ExternalPaneNode
+    ) -> (x: Double, y: Double) {
+        (
+            x: pane.frame.x + (pane.frame.width * 0.5),
+            y: pane.frame.y + (pane.frame.height * 0.5)
+        )
+    }
+
+    private func dockBrowserNearestPaneId(
+        in node: ExternalTreeNode,
+        targetCenter: (x: Double, y: Double)?
+    ) -> UUID? {
+        var panes: [ExternalPaneNode] = []
+        dockBrowserCollectPaneNodes(node: node, into: &panes)
+        guard !panes.isEmpty else { return nil }
+
+        let bestPane: ExternalPaneNode?
+        if let targetCenter {
+            bestPane = panes.min { lhs, rhs in
+                let lhsCenter = dockBrowserPaneCenter(lhs)
+                let rhsCenter = dockBrowserPaneCenter(rhs)
+                let lhsDistance = pow(lhsCenter.x - targetCenter.x, 2)
+                    + pow(lhsCenter.y - targetCenter.y, 2)
+                let rhsDistance = pow(rhsCenter.x - targetCenter.x, 2)
+                    + pow(rhsCenter.y - targetCenter.y, 2)
+                if lhsDistance != rhsDistance {
+                    return lhsDistance < rhsDistance
+                }
+                return lhs.id < rhs.id
+            }
+        } else {
+            bestPane = panes.first
+        }
+
+        return bestPane.flatMap { UUID(uuidString: $0.id) }
+    }
+
+    private func dockBrowserCollectPaneNodes(
+        node: ExternalTreeNode,
+        into output: inout [ExternalPaneNode]
+    ) {
+        switch node {
+        case .pane(let paneNode):
+            output.append(paneNode)
+        case .split(let splitNode):
+            dockBrowserCollectPaneNodes(node: splitNode.first, into: &output)
+            dockBrowserCollectPaneNodes(node: splitNode.second, into: &output)
+        }
+    }
+}

--- a/Sources/DockSplitStore+Reset.swift
+++ b/Sources/DockSplitStore+Reset.swift
@@ -5,6 +5,7 @@ extension DockSplitStore {
         let tabIds = Set(bonsplitController.allTabIds)
         pendingCloseConfirmDockTabIds.removeAll()
         tabCloseButtonCloseDockTabIds.removeAll()
+        clearPendingClosedBrowserHistoryState()
         forceCloseDockTabIds.formUnion(tabIds)
         defer { forceCloseDockTabIds.subtract(tabIds) }
         for tabId in tabIds { _ = bonsplitController.closeTab(tabId) }

--- a/Sources/DockSplitStore+SurfaceTransfer.swift
+++ b/Sources/DockSplitStore+SurfaceTransfer.swift
@@ -69,6 +69,7 @@ extension DockSplitStore {
     /// `didCloseTab` → `reconcilePanels()` path cannot tear the live panel down.
     func detachSurface(panelId: UUID) -> Workspace.DetachedSurfaceTransfer? {
         guard let tabId = surfaceId(forPanelId: panelId), let panel = panels[panelId] else { return nil }
+        clearClosedBrowserHistoryState(for: tabId)
         if let terminalPanel = panel as? TerminalPanel {
             terminalFontSizeChangeCoordinator?
                 .terminalWillLeaveDock(

--- a/Sources/DockSplitStore.swift
+++ b/Sources/DockSplitStore.swift
@@ -2,6 +2,7 @@ import AppKit
 import Bonsplit
 import Combine
 import CmuxAppKitSupportUI
+import CmuxBrowser
 import CmuxCore
 import CmuxFoundation
 import CmuxSettings
@@ -85,6 +86,9 @@ final class DockSplitStore: BonsplitDelegate {
     @ObservationIgnored var forceCloseDockTabIds: Set<TabID> = []
     @ObservationIgnored var pendingCloseConfirmDockTabIds: Set<TabID> = []
     @ObservationIgnored var tabCloseButtonCloseDockTabIds: Set<TabID> = []
+    @ObservationIgnored let closedBrowserModel = BrowserModel<CmuxBrowser.ClosedBrowserPanelRestoreSnapshot>()
+    @ObservationIgnored var closedBrowserHistoryEligibleDockTabIds: Set<TabID> = []
+    @ObservationIgnored var pendingClosedBrowserRestoreSnapshots: [TabID: CmuxBrowser.ClosedBrowserPanelRestoreSnapshot] = [:]
     @ObservationIgnored var terminalViewReattachCoalescingDepth = 0
     @ObservationIgnored var pendingTerminalViewReattachPanelIds: Set<UUID> = []
     @ObservationIgnored let focusHistoryNavigation: any FocusHistoryNavigating
@@ -266,8 +270,7 @@ final class DockSplitStore: BonsplitDelegate {
         self.sourceLabel = String(localized: "dock.source.title", defaultValue: "Dock")
         self.bonsplitController.delegate = self
         self.bonsplitController.onTabCloseRequest = { [weak self] tabId, _, source in
-            guard source == .closeButton else { return }
-            self?.tabCloseButtonCloseDockTabIds.insert(tabId)
+            self?.markExplicitBrowserCloseFromTabStrip(tabId: tabId, source: source)
         }
         self.bonsplitController.onTabZoomToggleRequest = { [weak self] _, paneId in
             self?.toggleDockPaneZoom(inPane: paneId) ?? false

--- a/Sources/TerminalController+ControlSurfaceContext2.swift
+++ b/Sources/TerminalController+ControlSurfaceContext2.swift
@@ -480,7 +480,7 @@ extension TerminalController {
             if windowDockMismatchesExplicitWindow(routing, dock: windowDock) {
                 return .surfaceNotFound(surfaceId)
             }
-            guard windowDock.closePanel(surfaceId, force: true) else {
+            guard windowDock.closePanelRecordingBrowserHistory(surfaceId, force: true) else {
                 return .closeFailed(surfaceId)
             }
             AppDelegate.shared?.notificationStore?.clearNotifications(
@@ -493,7 +493,10 @@ extension TerminalController {
                 surfaceID: surfaceId
             )
         } else if ws.containsDockPanel(surfaceId) {
-            guard ws.closeDockPanelAndClearNotifications(surfaceId, force: true) else {
+            guard ws.closeDockPanelRecordingBrowserHistoryAndClearNotifications(
+                surfaceId,
+                force: true
+            ) else {
                 return .closeFailed(surfaceId)
             }
             return .closed(

--- a/Sources/TerminalController+ControlSurfaceDock.swift
+++ b/Sources/TerminalController+ControlSurfaceDock.swift
@@ -336,7 +336,7 @@ extension TerminalController {
         guard windowDock.containsPanel(surfaceId) else {
             return .closeFailed(surfaceId)
         }
-        guard windowDock.closePanel(surfaceId, force: true) else {
+        guard windowDock.closePanelRecordingBrowserHistory(surfaceId, force: true) else {
             return .closeFailed(surfaceId)
         }
         AppDelegate.shared?.notificationStore?.clearNotifications(

--- a/Sources/TerminalController+WindowDockBrowserRouting.swift
+++ b/Sources/TerminalController+WindowDockBrowserRouting.swift
@@ -182,12 +182,6 @@ extension TerminalController {
     }
 
     func closeWindowDockBrowserPanel(_ targetId: UUID, in dock: DockSplitStore) -> Bool {
-        guard let tabId = dock.surfaceId(forPanelId: targetId) else { return false }
-        dock.forceCloseDockTabIds.insert(tabId)
-        let closed = dock.bonsplitController.closeTab(tabId)
-        if !closed {
-            dock.forceCloseDockTabIds.remove(tabId)
-        }
-        return closed
+        dock.closePanelRecordingBrowserHistory(targetId, force: true)
     }
 }

--- a/Sources/Workspace+DockBrowserLookup.swift
+++ b/Sources/Workspace+DockBrowserLookup.swift
@@ -40,6 +40,21 @@ extension Workspace {
         return true
     }
 
+    @discardableResult
+    func closeDockPanelRecordingBrowserHistoryAndClearNotifications(
+        _ panelId: UUID,
+        force: Bool = false
+    ) -> Bool {
+        guard _dockSplit?.closePanelRecordingBrowserHistory(panelId, force: force) == true else {
+            return false
+        }
+        AppDelegate.shared?.notificationStore?.clearNotifications(
+            forTabId: id,
+            surfaceId: panelId
+        )
+        return true
+    }
+
     func openDockBrowserLinkInNewTab(panel: BrowserPanel, seed: BrowserNewTabNavigationSeed) -> Bool {
         guard let dock = _dockSplit, let paneId = dock.paneId(forPanelId: panel.id) else { return false }
         return dock.newSurface(
@@ -83,14 +98,17 @@ extension AppDelegate {
         guard context.keyboardFocusCoordinator.activeRightSidebarMode == .dock else { return false }
         if let windowDock = existingWindowDock(forWindowId: context.windowId) {
             guard let panelId = windowDock.focusedPanelId else { return true }
-            if windowDock.closePanel(panelId, force: false) {
+            if windowDock.closePanelRecordingBrowserHistory(panelId, force: false) {
                 notificationStore?.clearNotifications(forTabId: windowDock.workspaceId, surfaceId: panelId)
             }
             return true
         }
         guard let workspace = context.tabManager.selectedWorkspace,
               let panelId = workspace.focusedDockPanelId else { return true }
-        _ = workspace.closeDockPanelAndClearNotifications(panelId, force: false)
+        _ = workspace.closeDockPanelRecordingBrowserHistoryAndClearNotifications(
+            panelId,
+            force: false
+        )
         return true
     }
 }

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -966,6 +966,7 @@ C0DE71B10000000000000001 /* AppDelegate+AgentChatNotifications.swift in Sources 
 		DCDC1000000000000000C020 /* DockScope.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCDC1000000000000000C021 /* DockScope.swift */; };
 		D86840000000000000000001 /* DockSessionPersistenceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D86840000000000000000002 /* DockSessionPersistenceTests.swift */; };
 		D81390010000000000000001 /* DockShortcutRoutingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D81390010000000000000002 /* DockShortcutRoutingTests.swift */; };
+		E6CCC39D98884F26BC43E111 /* DockShortcutRoutingUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 243242DA214F40DCAF44D734 /* DockShortcutRoutingUITests.swift */; };
 		D6212D0C0000000000000001 /* DockSocketLifecycleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6212D0C0000000000000002 /* DockSocketLifecycleTests.swift */; };
 		904090409040904090409043 /* DockSplitContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 904090409040904090409044 /* DockSplitContentView.swift */; };
 		904090409040904090409047 /* DockSplitPanelContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 904090409040904090409048 /* DockSplitPanelContentView.swift */; };
@@ -3574,6 +3575,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 		DCDC1000000000000000C021 /* DockScope.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DockScope.swift; sourceTree = "<group>"; };
 		D86840000000000000000002 /* DockSessionPersistenceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DockSessionPersistenceTests.swift; sourceTree = "<group>"; };
 		D81390010000000000000002 /* DockShortcutRoutingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DockShortcutRoutingTests.swift; sourceTree = "<group>"; };
+		243242DA214F40DCAF44D734 /* DockShortcutRoutingUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DockShortcutRoutingUITests.swift; sourceTree = "<group>"; };
 		D6212D0C0000000000000002 /* DockSocketLifecycleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DockSocketLifecycleTests.swift; sourceTree = "<group>"; };
 		904090409040904090409044 /* DockSplitContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DockSplitContentView.swift; sourceTree = "<group>"; };
 		904090409040904090409048 /* DockSplitPanelContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DockSplitPanelContentView.swift; sourceTree = "<group>"; };
@@ -5415,6 +5417,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				D0E0F0B1A1B2C3D4E5F60718 /* BrowserPaneNavigationKeybindUITests.swift */,
 				CC000001A1B2C3D4E5F60718 /* GotoSplitCycleUITests.swift */,
 				FE00AA11C1B2C3D4E5F60718 /* FocusHistoryShortcutUITests.swift */,
+				243242DA214F40DCAF44D734 /* DockShortcutRoutingUITests.swift */,
 				D0E0F0B5A1B2C3D4E5F60718 /* FindSelectionShortcutUITests.swift */,
 				D0E0F0B3A1B2C3D4E5F60718 /* BrowserOmnibarSuggestionsUITests.swift */,
 				FB100001A1B2C3D4E5F60718 /* BrowserImportProfilesUITests.swift */,
@@ -10263,6 +10266,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				C0DE32470000000000000005 /* CommandPaletteIdentifierClipboardUITests.swift in Sources */,
 				D10000000000000000B00000 /* ControlSocketReadinessUITestSupport.swift in Sources */,
 				B8F266266A1A3D9A45BD840F /* DisplayResolutionRegressionUITests.swift in Sources */,
+				E6CCC39D98884F26BC43E111 /* DockShortcutRoutingUITests.swift in Sources */,
 				FEED0000000000000000F009 /* FeedSidebarUITests.swift in Sources */,
 				D0E0F0B4A1B2C3D4E5F60718 /* FindSelectionShortcutUITests.swift in Sources */,
 				FE00AA10C1B2C3D4E5F60718 /* FocusHistoryShortcutUITests.swift in Sources */,

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -973,6 +973,7 @@ C0DE71B10000000000000001 /* AppDelegate+AgentChatNotifications.swift in Sources 
 		DCDC1000000000000000B011 /* DockSplitStore+Appearance.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCDC1000000000000000B012 /* DockSplitStore+Appearance.swift */; };
 		8777D0038777D0038777D003 /* DockSplitStore+AttentionRouting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8777D0048777D0048777D004 /* DockSplitStore+AttentionRouting.swift */; };
 		DCDC1000000000000000B021 /* DockSplitStore+CloseConfirmation.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCDC1000000000000000B022 /* DockSplitStore+CloseConfirmation.swift */; };
+		D95180000000000000000001 /* DockSplitStore+ClosedBrowserHistory.swift in Sources */ = {isa = PBXBuildFile; fileRef = D95180000000000000000002 /* DockSplitStore+ClosedBrowserHistory.swift */; };
 		DCDC0000000000000000A003 /* DockSplitStore+Config.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCDC0000000000000000A004 /* DockSplitStore+Config.swift */; };
 		DCDC1000000000000000B019 /* DockSplitStore+PaneFocus.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCDC1000000000000000B020 /* DockSplitStore+PaneFocus.swift */; };
 		8997E0038997E0038997E003 /* DockSplitStore+PanelDestruction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8997F0038997F0038997F003 /* DockSplitStore+PanelDestruction.swift */; };
@@ -3582,6 +3583,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 		DCDC1000000000000000B012 /* DockSplitStore+Appearance.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DockSplitStore+Appearance.swift"; sourceTree = "<group>"; };
 		8777D0048777D0048777D004 /* DockSplitStore+AttentionRouting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DockSplitStore+AttentionRouting.swift"; sourceTree = "<group>"; };
 		DCDC1000000000000000B022 /* DockSplitStore+CloseConfirmation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DockSplitStore+CloseConfirmation.swift"; sourceTree = "<group>"; };
+		D95180000000000000000002 /* DockSplitStore+ClosedBrowserHistory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DockSplitStore+ClosedBrowserHistory.swift"; sourceTree = "<group>"; };
 		DCDC0000000000000000A004 /* DockSplitStore+Config.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DockSplitStore+Config.swift"; sourceTree = "<group>"; };
 		DCDC1000000000000000B020 /* DockSplitStore+PaneFocus.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DockSplitStore+PaneFocus.swift"; sourceTree = "<group>"; };
 		8997F0038997F0038997F003 /* DockSplitStore+PanelDestruction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DockSplitStore+PanelDestruction.swift"; sourceTree = "<group>"; };
@@ -7074,6 +7076,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				8777D0048777D0048777D004 /* DockSplitStore+AttentionRouting.swift */,
 				DCDC1000000000000000B012 /* DockSplitStore+Appearance.swift */,
 				DCDC1000000000000000B022 /* DockSplitStore+CloseConfirmation.swift */,
+				D95180000000000000000002 /* DockSplitStore+ClosedBrowserHistory.swift */,
 				DCDC0000000000000000A004 /* DockSplitStore+Config.swift */,
 				DCDC1000000000000000B020 /* DockSplitStore+PaneFocus.swift */,
 				D81390020000000000000002 /* DockSplitStore+ShortcutCommands.swift */,
@@ -8947,6 +8950,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				DCDC1000000000000000B011 /* DockSplitStore+Appearance.swift in Sources */,
 				8777D0038777D0038777D003 /* DockSplitStore+AttentionRouting.swift in Sources */,
 				DCDC1000000000000000B021 /* DockSplitStore+CloseConfirmation.swift in Sources */,
+				D95180000000000000000001 /* DockSplitStore+ClosedBrowserHistory.swift in Sources */,
 				DCDC0000000000000000A003 /* DockSplitStore+Config.swift in Sources */,
 				DCDC1000000000000000B019 /* DockSplitStore+PaneFocus.swift in Sources */,
 				8997E0038997E0038997E003 /* DockSplitStore+PanelDestruction.swift in Sources */,

--- a/cmuxUITests/DockShortcutRoutingUITests.swift
+++ b/cmuxUITests/DockShortcutRoutingUITests.swift
@@ -1,0 +1,429 @@
+import Foundation
+import XCTest
+
+/// End-to-end regression coverage for issue #9518. The control socket builds
+/// real main-area and right-sidebar Dock browser trees, then `simulate_shortcut`
+/// enters the same AppDelegate matcher/dispatcher used by keyboard events. This
+/// keeps the assertions deterministic on headless hosted runners while still
+/// exercising the production focus and closed-panel paths.
+final class DockShortcutRoutingUITests: XCTestCase {
+    private struct CreatedSurface {
+        let id: String
+        let containerID: String
+    }
+
+    private struct BrowserTabState: Equatable {
+        let id: String
+        let url: String
+    }
+
+    private var appProcess: Process?
+    private var isolatedHome: URL!
+    private var appLogPath = ""
+    private var socketPath = ""
+
+    override func setUp() {
+        super.setUp()
+        continueAfterFailure = false
+
+        let token = UUID().uuidString
+        isolatedHome = FileManager.default.temporaryDirectory.appendingPathComponent(
+            "cmux-ui-test-dock-shortcuts-\(token)",
+            isDirectory: true
+        )
+        appLogPath = isolatedHome.appendingPathComponent("app.log").path
+        socketPath = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cmux-dock-\(token.prefix(8)).sock")
+            .path
+        try? FileManager.default.createDirectory(at: isolatedHome, withIntermediateDirectories: true)
+        removeSocketFiles()
+    }
+
+    override func tearDown() {
+        terminateAppProcess()
+        removeSocketFiles()
+        if let isolatedHome {
+            try? FileManager.default.removeItem(at: isolatedHome)
+        }
+        super.tearDown()
+    }
+
+    func testCmdLFocusesDockBrowserAddressBar() throws {
+        try launchIsolatedApp()
+
+        let mainWorkspaceID = try XCTUnwrap(currentWorkspaceID())
+        let mainBrowser = try createBrowserSurface(
+            url: "https://main-address.example/",
+            containerID: mainWorkspaceID
+        )
+        let dockBrowser = try createBrowserSurface(
+            url: "https://dock-address.example/",
+            placement: "dock"
+        )
+        XCTAssertNotEqual(
+            dockBrowser.containerID,
+            mainWorkspaceID,
+            "The regression needs independent main-workspace and window-Dock containers"
+        )
+
+        try focusDockBrowser(dockBrowser)
+        XCTAssertTrue(
+            waitUntil(timeout: 5.0) { self.focusedAddressBarSurfaceID() == nil },
+            "Expected the Dock host, not an address bar, to own focus before Cmd+L"
+        )
+
+        simulateShortcut("cmd+l")
+
+        XCTAssertTrue(
+            waitUntil(timeout: 8.0) { self.focusedAddressBarSurfaceID() != nil },
+            "Cmd+L never focused any browser address bar"
+        )
+        let focusedSurfaceID = focusedAddressBarSurfaceID()
+        XCTAssertEqual(
+            focusedSurfaceID,
+            dockBrowser.id,
+            "Cmd+L should focus the Dock browser address bar, not the main area's. " +
+                "dock=\(dockBrowser.id) main=\(mainBrowser.id) actual=\(focusedSurfaceID ?? "nil")"
+        )
+        XCTAssertNotEqual(
+            focusedSurfaceID,
+            mainBrowser.id,
+            "Cmd+L incorrectly focused the main-area browser address bar"
+        )
+    }
+
+    func testCmdShiftTReopensDockBrowserWithoutChangingMainArea() throws {
+        try launchIsolatedApp()
+
+        let mainWorkspaceID = try XCTUnwrap(currentWorkspaceID())
+        let mainKept = try createBrowserSurface(
+            url: "https://main-kept.example/",
+            containerID: mainWorkspaceID
+        )
+        let mainClosedURL = "https://main-closed.example/"
+        let mainClosed = try createBrowserSurface(
+            url: mainClosedURL,
+            containerID: mainWorkspaceID
+        )
+        try closeSurface(mainClosed)
+
+        let dockClosedURL = "https://dock-closed.example/"
+        let dockClosed = try createBrowserSurface(url: dockClosedURL, placement: "dock")
+        let dockRemaining = try createBrowserSurface(
+            url: "https://dock-remaining.example/",
+            placement: "dock"
+        )
+        XCTAssertEqual(dockClosed.containerID, dockRemaining.containerID)
+        XCTAssertNotEqual(
+            dockRemaining.containerID,
+            mainWorkspaceID,
+            "The regression needs independent main-workspace and window-Dock containers"
+        )
+        try closeSurface(dockClosed)
+        try focusDockBrowser(dockRemaining)
+
+        let mainTabsBefore = try XCTUnwrap(browserTabs(
+            workspaceID: mainWorkspaceID,
+            anchorSurfaceID: mainKept.id
+        ))
+        let dockTabsBefore = try XCTUnwrap(browserTabs(anchorSurfaceID: dockRemaining.id))
+        XCTAssertEqual(mainTabsBefore.map(\.id), [mainKept.id])
+        XCTAssertFalse(mainTabsBefore.contains { urlHost($0.url) == urlHost(mainClosedURL) })
+        XCTAssertEqual(dockTabsBefore.map(\.id), [dockRemaining.id])
+        XCTAssertFalse(dockTabsBefore.contains { urlHost($0.url) == urlHost(dockClosedURL) })
+
+        simulateShortcut("cmd+shift+t")
+
+        XCTAssertTrue(
+            waitUntil(timeout: 10.0) {
+                let mainCount = self.browserTabs(
+                    workspaceID: mainWorkspaceID,
+                    anchorSurfaceID: mainKept.id
+                )?.count
+                let dockCount = self.browserTabs(anchorSurfaceID: dockRemaining.id)?.count
+                return mainCount != mainTabsBefore.count || dockCount != dockTabsBefore.count
+            },
+            "Cmd+Shift+T did not change either browser tree"
+        )
+
+        let mainTabsAfter = try XCTUnwrap(browserTabs(
+            workspaceID: mainWorkspaceID,
+            anchorSurfaceID: mainKept.id
+        ))
+        let dockTabsAfter = try XCTUnwrap(browserTabs(anchorSurfaceID: dockRemaining.id))
+        XCTAssertEqual(
+            mainTabsAfter.map(\.id),
+            mainTabsBefore.map(\.id),
+            "Cmd+Shift+T should leave the main-area browser tabs unchanged. " +
+                "before=\(mainTabsBefore) after=\(mainTabsAfter)"
+        )
+        XCTAssertFalse(
+            mainTabsAfter.contains { urlHost($0.url) == urlHost(mainClosedURL) },
+            "Cmd+Shift+T incorrectly reopened the main area's closed browser"
+        )
+        XCTAssertEqual(dockTabsAfter.count, 2)
+        XCTAssertTrue(dockTabsAfter.contains { $0.id == dockRemaining.id })
+        XCTAssertTrue(
+            dockTabsAfter.contains { urlHost($0.url) == urlHost(dockClosedURL) },
+            "Cmd+Shift+T should restore the closed Dock browser. " +
+                "before=\(dockTabsBefore) after=\(dockTabsAfter)"
+        )
+    }
+
+    // MARK: - App and control socket
+
+    private func launchIsolatedApp() throws {
+        // Socket-driven coverage does not need XCUI accessibility. Launch the
+        // binary directly so headless runners do not abort the test while
+        // XCUIApplication spends 60 seconds trying to foreground the app.
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: try resolveAppBinaryPath())
+        process.arguments = [
+            "-socketControlMode", "allowAll",
+            "-rightSidebar.beta.dock.enabled", "YES",
+            "-browserDisabledOverride", "NO",
+            "-menuBarOnly", "NO",
+            "-NSAppSleepDisabled", "YES",
+            "-AppleLanguages", "(en)",
+            "-AppleLocale", "en_US",
+        ]
+
+        var environment = ProcessInfo.processInfo.environment
+        environment["HOME"] = isolatedHome.path
+        environment["CFFIXED_USER_HOME"] = isolatedHome.path
+        environment["XDG_CONFIG_HOME"] = isolatedHome
+            .appendingPathComponent(".config", isDirectory: true).path
+        environment["CMUX_SOCKET_PATH"] = socketPath
+        environment["CMUX_SOCKET_ENABLE"] = "1"
+        environment["CMUX_SOCKET_MODE"] = "allowAll"
+        environment["CMUX_ALLOW_SOCKET_OVERRIDE"] = "1"
+        environment["CMUX_UI_TEST_MODE"] = "1"
+        environment["CMUX_UI_TEST_PROCESS"] = "1"
+        environment["CMUX_TAG"] = "ui-dock-shortcuts-\(UUID().uuidString.prefix(8))"
+        process.environment = environment
+
+        _ = FileManager.default.createFile(atPath: appLogPath, contents: nil)
+        let logHandle = try FileHandle(forWritingTo: URL(fileURLWithPath: appLogPath))
+        process.standardOutput = logHandle
+        process.standardError = logHandle
+        try process.run()
+        appProcess = process
+
+        XCTAssertTrue(
+            waitForControlSocketReady(
+                socketPath: socketPath,
+                pingTimeout: 20.0,
+                pingReturnsPong: { self.socketCommand("ping") == "PONG" }
+            ),
+            "Control socket never answered ping at \(socketPath). " +
+                "app=\(appProcessDiagnostics()) log=\(appLogTail())"
+        )
+        XCTAssertEqual(socketCommand("activate_app", responseTimeout: 10.0), "OK")
+    }
+
+    private func resolveAppBinaryPath() throws -> String {
+        let testBundle = Bundle(for: Self.self)
+        let productsDirectory = testBundle.bundleURL
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+        let configuration = productsDirectory.lastPathComponent.lowercased()
+        let productNames = configuration.contains("release")
+            ? ["cmux", "cmux DEV"]
+            : ["cmux DEV", "cmux"]
+        let binaryPaths = productNames.map { productName in
+            productsDirectory
+                .appendingPathComponent("\(productName).app")
+                .appendingPathComponent("Contents/MacOS/\(productName)")
+                .path
+        }
+        if let binaryPath = binaryPaths.first(where: FileManager.default.isExecutableFile(atPath:)) {
+            return binaryPath
+        }
+        throw NSError(
+            domain: "DockShortcutRoutingUITests",
+            code: 1,
+            userInfo: [
+                NSLocalizedDescriptionKey: "App binary not found at \(binaryPaths.joined(separator: " or ")). " +
+                    "testBundle=\(testBundle.bundleURL.path)"
+            ]
+        )
+    }
+
+    private func terminateAppProcess() {
+        guard let process = appProcess else { return }
+        appProcess = nil
+        guard process.isRunning else { return }
+        process.terminate()
+        _ = waitUntil(timeout: 5.0) { !process.isRunning }
+        if process.isRunning {
+            process.interrupt()
+        }
+    }
+
+    private func appProcessDiagnostics() -> String {
+        guard let process = appProcess else { return "not-launched" }
+        let status = process.isRunning ? "running" : String(process.terminationStatus)
+        return "pid=\(process.processIdentifier) running=\(process.isRunning) status=\(status)"
+    }
+
+    private func appLogTail() -> String {
+        guard let contents = try? String(contentsOfFile: appLogPath, encoding: .utf8) else {
+            return "<missing>"
+        }
+        return String(contents.suffix(2_000))
+    }
+
+    private func currentWorkspaceID() -> String? {
+        guard let reply = socketCommand("current_workspace"), UUID(uuidString: reply) != nil else {
+            return nil
+        }
+        return reply
+    }
+
+    private func createBrowserSurface(
+        url: String,
+        placement: String? = nil,
+        containerID: String? = nil
+    ) throws -> CreatedSurface {
+        var params: [String: Any] = [
+            "type": "browser",
+            "url": url,
+            "focus": true,
+        ]
+        if let placement { params["placement"] = placement }
+        if let containerID { params["workspace_id"] = containerID }
+
+        let result = try XCTUnwrap(
+            socketResult(method: "surface.create", params: params),
+            "surface.create failed for \(url): \(String(describing: lastSocketEnvelope))"
+        )
+        let isDock = placement == "dock"
+        let idKey = isDock ? "dock_surface_id" : "surface_id"
+        let surfaceID = try XCTUnwrap(result[idKey] as? String)
+        let resolvedContainerID = try XCTUnwrap(result["workspace_id"] as? String)
+        return CreatedSurface(id: surfaceID, containerID: resolvedContainerID)
+    }
+
+    private func closeSurface(_ surface: CreatedSurface) throws {
+        let result = try XCTUnwrap(socketResult(
+            method: "surface.close",
+            params: [
+                "workspace_id": surface.containerID,
+                "surface_id": surface.id,
+            ]
+        ))
+        XCTAssertEqual(result["surface_id"] as? String, surface.id)
+    }
+
+    private func focusDockBrowser(_ surface: CreatedSurface) throws {
+        _ = try XCTUnwrap(socketResult(
+            method: "surface.focus",
+            params: [
+                "workspace_id": surface.containerID,
+                "surface_id": surface.id,
+            ]
+        ))
+        XCTAssertTrue(
+            waitUntil(timeout: 10.0) {
+                self.socketResult(
+                    method: "browser.focus_webview",
+                    params: ["surface_id": surface.id]
+                )?["focused"] as? Bool == true
+            },
+            "Dock browser WebView never became first responder: \(surface.id)"
+        )
+
+        // Leave the selected Dock browser intact, but move AppKit focus to the
+        // Dock host. This is the ownership signal used while first-responder
+        // updates lag or the host itself receives the shortcut.
+        let sidebarResult = try XCTUnwrap(socketResult(
+            method: "debug.right_sidebar.focus",
+            params: [
+                "mode": "dock",
+                "window_id": surface.containerID,
+                "focus_first_item": false,
+            ]
+        ))
+        XCTAssertEqual(sidebarResult["active_mode"] as? String, "dock")
+        XCTAssertEqual(sidebarResult["focus_applied"] as? Bool, true)
+    }
+
+    private func simulateShortcut(_ combo: String) {
+        let reply = socketCommand("simulate_shortcut \(combo)", responseTimeout: 30.0)
+        XCTAssertEqual(reply, "OK", "simulate_shortcut \(combo) failed: \(reply ?? "nil")")
+    }
+
+    // MARK: - State assertions
+
+    private func focusedAddressBarSurfaceID() -> String? {
+        socketResult(method: "debug.browser.address_bar_focused", params: [:])?["focused_surface_id"] as? String
+    }
+
+    private func browserTabs(
+        workspaceID: String? = nil,
+        anchorSurfaceID: String
+    ) -> [BrowserTabState]? {
+        var params: [String: Any] = ["surface_id": anchorSurfaceID]
+        if let workspaceID { params["workspace_id"] = workspaceID }
+        guard let result = socketResult(
+            method: "browser.tab.list",
+            params: params
+        ), let tabs = result["tabs"] as? [[String: Any]] else {
+            return nil
+        }
+        return tabs.compactMap { tab in
+            guard let id = tab["id"] as? String, let url = tab["url"] as? String else {
+                return nil
+            }
+            return BrowserTabState(id: id, url: url)
+        }
+    }
+
+    private func urlHost(_ string: String) -> String? {
+        URL(string: string)?.host
+    }
+
+    // MARK: - Socket plumbing
+
+    private var lastSocketEnvelope: [String: Any]?
+
+    private func socketCommand(_ command: String, responseTimeout: TimeInterval = 5.0) -> String? {
+        controlSocketCommandViaNetcat(
+            command,
+            socketPath: socketPath,
+            responseTimeout: responseTimeout
+        )
+    }
+
+    private func socketResult(method: String, params: [String: Any]) -> [String: Any]? {
+        let request: [String: Any] = [
+            "id": UUID().uuidString,
+            "method": method,
+            "params": params,
+        ]
+        let envelope = controlSocketJSONViaNetcat(
+            request,
+            socketPath: socketPath,
+            responseTimeout: 10.0
+        )
+        lastSocketEnvelope = envelope
+        guard envelope?["ok"] as? Bool == true else { return nil }
+        return envelope?["result"] as? [String: Any]
+    }
+
+    private func waitUntil(timeout: TimeInterval, condition: () -> Bool) -> Bool {
+        let deadline = Date().addingTimeInterval(timeout)
+        repeat {
+            if condition() { return true }
+            RunLoop.current.run(until: Date().addingTimeInterval(0.1))
+        } while Date() < deadline
+        return condition()
+    }
+
+    private func removeSocketFiles() {
+        try? FileManager.default.removeItem(atPath: socketPath)
+        try? FileManager.default.removeItem(atPath: "\(socketPath).lock")
+    }
+}


### PR DESCRIPTION
## Summary

- Route Cmd+L and Cmd+Shift+T through the focused Dock before falling back to the main tab manager.
- Add Dock-local closed-browser history that restores the closed URL, profile, pane, tab index, and split placement.
- Record that history through the shared explicit-close path so shortcut, tab-button, middle-click, and socket closes behave consistently without treating teardown or transfers as user closes.

Fixes #9518

## Testing

- Red regression run at test-only commit `594b4e6d52`: [DockShortcutRoutingUITests](https://github.com/manaflow-ai/cmux/actions/runs/30964218858) executed 2 tests with 2 expected failures (Cmd+L targeted the main browser; Cmd+Shift+T changed main-area state).
- Green regression run at fix commit `3461f51889`: [DockShortcutRoutingUITests](https://github.com/manaflow-ai/cmux/actions/runs/30965207803) executed 2 tests with 0 failures.
- Tagged dev build: `./scripts/reload-cloud.sh --tag sym9518`. The default Blacksmith attempts queued and fell back to two fleet hosts whose Zig preflight failed; no local build was used. A retry on the remote Warp runner succeeded: [reload-build](https://github.com/manaflow-ai/cmux/actions/runs/30966012328), `BUILD_OK`.
- Tagged-socket dogfood on `/tmp/cmux-debug-sym9518.sock`:
  - With distinct main and Dock browsers, Cmd+L changed the focused address-bar surface from none to the exact Dock surface ID, not the main surface ID.
  - After closing one main browser and one Dock browser, Dock-focused Cmd+Shift+T kept the main surface IDs unchanged, increased the Dock tab count from 2 to 3, and restored `https://dock-closed.example/`.
  - Quit the tagged app after verification and confirmed its process, socket, and lock file were absent.
- `./scripts/check-pbxproj.sh`
- `./scripts/lint-pbxproj-test-wiring.sh`
- `python3 scripts/check-package-resolved-policy.py`
- `git diff --check`

Localization audit: no user-facing strings or localization catalogs changed; added string literals are test diagnostics or internal state values.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/9617"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788485597&installation_model_id=21920&pr_number=9617&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F9617&signature=deadc0dfba40f7e20955a7b5a44c582455529ce0c000940b84a9ce38da882d2e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Routes Cmd+L (focus address bar) and Cmd+Shift+T (reopen closed tab) to the focused Dock so Dock actions never change the main area. Adds Dock‑local closed‑browser history to restore tabs with their URL, profile, position, and layout, fixing #9518.

- New Features
  - Cmd+L targets the focused Dock browser; if a non‑browser pane is focused, it creates a Dock browser and focuses its address bar. The shortcut is consumed even when a browser can’t be opened, so the main area isn’t touched.
  - Cmd+Shift+T reopens the most recently closed Dock browser using Dock‑local history. Restores URL, profile, original pane and tab index, and falls back to the correct split orientation/placement when the original pane is gone.

<sup>Written for commit 3461f5188912f45892296183542928a8de732165. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/9617?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Dock-focused browser shortcuts now focus the selected browser address bar or create a browser when needed.
  - Closed Dock browser panels can be reopened in their original location when possible.
  - Browser restoration supports fallback placement when the original pane is unavailable.

- **Bug Fixes**
  - Closing browsers now records restoration history consistently.
  - Failed, canceled, or incomplete close operations no longer leave stale restoration state.

- **Tests**
  - Added end-to-end coverage for Dock shortcut routing and browser restoration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->