### PR TITLE
Lay out standalone quit confirmation before display

### DIFF
--- a/Sources/QuitConfirmationAlertPresenter.swift
+++ b/Sources/QuitConfirmationAlertPresenter.swift
@@ -58,6 +58,8 @@ final class QuitConfirmationAlertPresenter: NSObject, NSWindowDelegate {
     }
 
     private func presentStandalone() {
+        alert.layout()
+
         let buttons = alert.buttons
         if buttons.indices.contains(0) {
             buttons[0].target = self

--- a/cmuxTests/QuitConfirmationAlertPresenterTests.swift
+++ b/cmuxTests/QuitConfirmationAlertPresenterTests.swift
@@ -98,6 +98,13 @@ struct QuitConfirmationAlertPresenterTests {
         #expect(!alert.didRunModal)
         #expect(completedResponse == nil)
 
+        // NSAlert starts with a lazy placeholder layout that stacks full-width
+        // buttons. The standalone presenter must resolve that layout before the
+        // alert becomes visible or the panel renders clipped and washed out.
+        let buttonFrames = alert.buttons.map(\.frame)
+        #expect(buttonFrames.count == 2)
+        #expect(abs(buttonFrames[0].midY - buttonFrames[1].midY) < 0.5)
+
         alert.buttons[0].performClick(nil)
 
         #expect(completedResponse == .alertFirstButtonReturn)


### PR DESCRIPTION
Closes #9595

## Summary

- force `NSAlert` to resolve its lazy layout before the standalone raw window is shown
- preserve the asynchronous presenter and the no-nested-modal-loop invariant from #6461
- add behavior-level coverage for the malformed placeholder button geometry

## Root cause

The no-host-window fallback orders `alert.window` front while `NSAlert` still has its lazy placeholder layout. On macOS 26.4.1 that left the standalone panel at `260×328`, with vertically stacked full-width buttons. `NSAlert.layout()` is the AppKit API that forces immediate layout; using `runModal()` here would reintroduce the nested modal-loop hang that #6461 removed.

The normal host-window path is unchanged and still uses `beginSheetModal(for:)`.

## Regression proof

- Test-only commit `533bbb47e9` adds the standalone button-alignment assertion.
- Local before fix: focused suite reported 4 passes and 1 failure; the two buttons were separated by 80 points vertically.
- CI on the test-only SHA reproduced the failure with a 71-point separation at the new assertion: [run 30969717154](https://github.com/manaflow-ai/cmux/actions/runs/30969717154), [shard job 92191739399](https://github.com/manaflow-ai/cmux/actions/runs/30969717154/job/92191739399). The app-host wrapper currently tolerates ordinary Swift Testing failures and printed `All failures are expected, treating as pass`, so the GitHub job is marked successful despite the recorded test failure.
- Fix commit `c98c6708a0` adds `alert.layout()` before standalone presentation.
- Local after fix: all 5 focused tests pass, including both sheet and standalone assertions that `runModal()` is never called.

## Validation

- Tagged Debug build succeeded on pushed HEAD `c98c6708a0`: [dogfood build](http://127.0.0.1:17320/i9595pre).
- Hidden-host repro: confirmed zero on-screen tagged windows, sent Ctrl+D to the sole terminal, and captured the standalone alert at `260×250`, modal layer `8`, alpha `1.0`.
- Escape dismissed the standalone panel and ran the cancellation recovery path, respawning the sole terminal.
- `git diff --check` passes; the PR contains exactly the presenter and its existing test file.
- `./scripts/lint-pbxproj-test-wiring.sh` passes for all 652 test files.

## Visual evidence

A trustworthy screenshot/video could not be recorded. The cloud Mac run [30968244690](https://github.com/manaflow-ai/cmux-loader/actions/runs/30968244690) reached its SSH hold but never appeared in Tailscale or the Admin API. Local Sky CUA lacks its executable/app-server, the alternate CUA daemon is unavailable, and macOS Screen Recording is denied for the available helper. Runtime geometry and window-layer metadata were captured directly instead.

## Localization

No user-facing strings changed. The changed Swift diff was audited for added English literals; no localization catalog updates are needed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/9620"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788489203&installation_model_id=21920&pr_number=9620&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F9620&signature=fb62c7902c03fdc00677e9bc4c5b3c4502ff43c4f5aa8abcffe6f3ae66eae48f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the standalone quit confirmation dialog on macOS by calling `NSAlert.layout()` before the window is shown. Prevents stacked, full-width buttons and keeps the async presenter (no nested modal loops). Addresses #9595.

- **Bug Fixes**
  - Call `alert.layout()` in the standalone path before ordering the window front to avoid placeholder button geometry.
  - Add a behavior test asserting the two buttons have the same midY (no vertical stack).

<sup>Written for commit c98c6708a047f346b3fc50b76ca80ffe8a7ba477. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/9620?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the quit confirmation alert’s presentation so its buttons are correctly aligned when displayed.
  * Ensured the alert layout is fully resolved before the window becomes visible.

* **Tests**
  * Added coverage confirming the quit confirmation alert’s buttons appear horizontally aligned.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
