### PR TITLE
Preserve workspace titles during session restore

### DIFF
--- a/Packages/macOS/CmuxWorkspaces/Sources/CmuxWorkspaces/Session/RestoredPanelTitleBoundary.swift
+++ b/Packages/macOS/CmuxWorkspaces/Sources/CmuxWorkspaces/Session/RestoredPanelTitleBoundary.swift
@@ -1,0 +1,137 @@
+import Foundation
+
+/// Controls restored terminal title admission.
+///
+/// A terminal rebuilt from a session snapshot may replace its persisted title
+/// only after startup titles become trustworthy. When cmux seeded initial PTY
+/// input, its normalized title is carried as provenance so internal bootstrap
+/// text stays hidden without suppressing titles from the resumed process.
+public struct RestoredPanelTitleBoundary: Sendable {
+    private var phase: RestoredPanelTitlePhase
+    private var pendingTitle: String?
+
+    /// Whether authoritative activity has permanently released this boundary.
+    public var isReleased: Bool {
+        if case .released = phase { return true }
+        return false
+    }
+
+    /// Creates a boundary from cmux-owned startup provenance and current shell state.
+    ///
+    /// - Parameters:
+    ///   - internallySeededInput: Exact input inserted into the restored PTY by
+    ///     cmux, including any surrounding whitespace or newline.
+    ///   - shellState: Latest authoritative shell-activity state for the panel.
+    public init(
+        internallySeededInput: String?,
+        shellState: PanelShellActivityState
+    ) {
+        let normalizedSeededTitle = internallySeededInput?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        let seededTitle = normalizedSeededTitle?.isEmpty == false
+            ? normalizedSeededTitle
+            : nil
+        if let seededTitle, shellState == .commandRunning {
+            phase = .internallySeededBootstrapRunning(expectedTitle: seededTitle)
+        } else if let seededTitle, shellState == .promptIdle {
+            phase = .awaitingInternallySeededBootstrap(expectedTitle: seededTitle)
+        } else if seededTitle == nil, shellState == .commandRunning {
+            phase = .released
+        } else if seededTitle == nil, shellState == .promptIdle {
+            phase = .awaitingUserCommand
+        } else {
+            phase = .awaitingInitialShellPrompt(internallySeededTitle: seededTitle)
+        }
+        pendingTitle = nil
+    }
+
+    /// Evaluates a normalized raw PTY title against the current restore phase.
+    ///
+    /// Rejected preexec titles may be buffered until a matching shell-activity
+    /// transition proves they came from a real command.
+    ///
+    /// - Parameter rawTitle: Non-empty title after whitespace normalization.
+    /// - Returns: `true` when the ordinary title-ownership pipeline may apply it.
+    public mutating func shouldApply(rawTitle: String) -> Bool {
+        switch phase {
+        case .awaitingInitialShellPrompt:
+            // A fresh PTY can publish its generic shell/process name before
+            // the first prompt. It is never meaningful post-restore state.
+            pendingTitle = nil
+            return false
+        case .awaitingUserCommand:
+            // The title callback and shell-state report use independent
+            // ingresses, so retain a preexec title until commandRunning.
+            pendingTitle = rawTitle
+            return false
+        case .awaitingInternallySeededBootstrap(let expectedTitle):
+            pendingTitle = rawTitle == expectedTitle ? nil : rawTitle
+            return false
+        case .internallySeededBootstrapRunning(let expectedTitle):
+            // The restore verb execs the resumed agent and can remain the
+            // foreground command for hours. Suppress only the title proven to
+            // be cmux's exact seeded input; any different title is organic.
+            return rawTitle != expectedTitle
+        case .released:
+            return true
+        }
+    }
+
+    /// Advances the boundary using an authoritative prompt/preexec report.
+    ///
+    /// - Parameter shellState: Newly observed shell-activity state. Callers
+    ///   discard duplicate reports before invoking this method.
+    /// - Returns: A buffered genuine title that became admissible, if any.
+    public mutating func observe(shellState: PanelShellActivityState) -> String? {
+        switch (phase, shellState) {
+        case (.awaitingInitialShellPrompt(let internallySeededTitle), .promptIdle):
+            pendingTitle = nil
+            if let internallySeededTitle {
+                phase = .awaitingInternallySeededBootstrap(
+                    expectedTitle: internallySeededTitle
+                )
+            } else {
+                phase = .awaitingUserCommand
+            }
+        case (.awaitingInitialShellPrompt(let internallySeededTitle), .commandRunning):
+            if let internallySeededTitle {
+                phase = .internallySeededBootstrapRunning(
+                    expectedTitle: internallySeededTitle
+                )
+            } else {
+                // No startup title survived, and commandRunning is the first
+                // demonstrable activity for an unseeded shell.
+                phase = .released
+            }
+        case (.awaitingUserCommand, .promptIdle):
+            pendingTitle = nil
+        case (.awaitingUserCommand, .commandRunning):
+            let title = pendingTitle
+            pendingTitle = nil
+            phase = .released
+            return title
+        case (.awaitingInternallySeededBootstrap(let expectedTitle), .promptIdle):
+            // Initial input is written when the shell becomes ready. This
+            // prompt belongs to startup, not to a completed bootstrap.
+            pendingTitle = nil
+            phase = .awaitingInternallySeededBootstrap(expectedTitle: expectedTitle)
+        case (.awaitingInternallySeededBootstrap(let expectedTitle), .commandRunning):
+            let title = pendingTitle
+            pendingTitle = nil
+            phase = .internallySeededBootstrapRunning(expectedTitle: expectedTitle)
+            return title
+        case (.internallySeededBootstrapRunning, .promptIdle):
+            // The internal command has exited. Preserve its last genuine title
+            // until the next user command establishes new ownership.
+            phase = .awaitingUserCommand
+            pendingTitle = nil
+        case (_, .unknown),
+             (.internallySeededBootstrapRunning, .commandRunning):
+            break
+        case (.released, .promptIdle),
+             (.released, .commandRunning):
+            break
+        }
+        return nil
+    }
+}

--- a/Packages/macOS/CmuxWorkspaces/Sources/CmuxWorkspaces/Session/RestoredPanelTitlePhase.swift
+++ b/Packages/macOS/CmuxWorkspaces/Sources/CmuxWorkspaces/Session/RestoredPanelTitlePhase.swift
@@ -1,0 +1,8 @@
+/// Lifecycle phases for restored terminal title admission.
+enum RestoredPanelTitlePhase: Sendable {
+    case awaitingInitialShellPrompt(internallySeededTitle: String?)
+    case awaitingUserCommand
+    case awaitingInternallySeededBootstrap(expectedTitle: String)
+    case internallySeededBootstrapRunning(expectedTitle: String)
+    case released
+}

--- a/Packages/macOS/CmuxWorkspaces/Tests/CmuxWorkspacesTests/Session/RestoredPanelTitleBoundaryTests.swift
+++ b/Packages/macOS/CmuxWorkspaces/Tests/CmuxWorkspacesTests/Session/RestoredPanelTitleBoundaryTests.swift
@@ -1,0 +1,42 @@
+import Foundation
+import Testing
+@testable import CmuxWorkspaces
+
+@Suite struct RestoredPanelTitleBoundaryTests {
+    @Test func internallySeededTitleStaysInertWhileGenuineAgentTitleApplies() {
+        let seededInput = " internal bootstrap payload\n"
+        let seededTitle = seededInput.trimmingCharacters(in: .whitespacesAndNewlines)
+        var boundary = RestoredPanelTitleBoundary(
+            internallySeededInput: seededInput,
+            shellState: .promptIdle
+        )
+
+        #expect(!boundary.shouldApply(rawTitle: seededTitle))
+        #expect(boundary.observe(shellState: .commandRunning) == nil)
+        #expect(!boundary.shouldApply(rawTitle: seededTitle))
+        #expect(boundary.shouldApply(rawTitle: "Resumed Codex session"))
+        #expect(!boundary.isReleased)
+    }
+
+    @Test func userCommandReleasesBufferedTitle() {
+        var boundary = RestoredPanelTitleBoundary(
+            internallySeededInput: nil,
+            shellState: .promptIdle
+        )
+
+        #expect(!boundary.shouldApply(rawTitle: "cd /tmp/cmux"))
+        #expect(boundary.observe(shellState: .commandRunning) == "cd /tmp/cmux")
+        #expect(boundary.isReleased)
+        #expect(boundary.shouldApply(rawTitle: "/tmp/cmux"))
+    }
+
+    @Test func alreadyRunningUnseededShellStartsReleased() {
+        var boundary = RestoredPanelTitleBoundary(
+            internallySeededInput: nil,
+            shellState: .commandRunning
+        )
+
+        #expect(boundary.isReleased)
+        #expect(boundary.shouldApply(rawTitle: "Genuine running command"))
+    }
+}

--- a/Sources/DockSplitStore+RestoredAgentLifecycle.swift
+++ b/Sources/DockSplitStore+RestoredAgentLifecycle.swift
@@ -19,7 +19,15 @@ extension DockSplitStore {
 
     func updatePanelShellActivityState(panelId: UUID, state: PanelShellActivityState) {
         guard let terminal = panels[panelId] as? TerminalPanel else { return }
+        let previousState = terminal.shellActivity.state
         terminal.updateShellActivityState(state)
+        if previousState != state,
+           let pendingTitle = advanceTransferredRestoredPanelTitleBoundary(
+               panelId: panelId,
+               state: state
+           ) {
+            terminal.updateTitle(pendingTitle)
+        }
         let restoredAgent = restoredAgentLifecycle.snapshotsByPanelId[panelId]
 
         switch (state, restoredAgentLifecycle.resumeStatesByPanelId[panelId]) {
@@ -41,6 +49,22 @@ extension DockSplitStore {
         default:
             break
         }
+    }
+
+    /// Keeps a Workspace-owned restore boundary coherent while its live panel
+    /// temporarily belongs to a Dock.
+    private func advanceTransferredRestoredPanelTitleBoundary(
+        panelId: UUID,
+        state: PanelShellActivityState
+    ) -> String? {
+        guard var transfer = detachedSurfaceTransfersByPanelId[panelId],
+              var boundary = transfer.restoredPanelTitleBoundary else {
+            return nil
+        }
+        let pendingTitle = boundary.observe(shellState: state)
+        transfer.restoredPanelTitleBoundary = boundary.isReleased ? nil : boundary
+        setDetachedSurfaceTransfer(transfer, forPanelID: panelId)
+        return pendingTitle
     }
 
     func adoptSessionRestoreState(from detached: Workspace.DetachedSurfaceTransfer) {

--- a/Sources/DockSplitStore+SurfaceTransfer.swift
+++ b/Sources/DockSplitStore+SurfaceTransfer.swift
@@ -287,6 +287,7 @@ extension DockSplitStore {
             restorableAgentResumeState: transferredResumeState,
             restoredAgentCompletedGeneration: transferredCompletedGeneration,
             shellActivityState: transferredShellActivityState,
+            restoredPanelTitleBoundary: preservedTransfer?.restoredPanelTitleBoundary,
             restoredResumeSessionWorkingDirectory: restoredResumeSessionWorkingDirectory,
             resumeBinding: resumeBinding,
             managedAgentResumeBinding: managedResumeBinding,

--- a/Sources/Workspace+DetachedSurfaceTransfer.swift
+++ b/Sources/Workspace+DetachedSurfaceTransfer.swift
@@ -48,6 +48,7 @@ extension Workspace {
         let restorableAgentResumeState: RestoredAgentResumeState?
         let restoredAgentCompletedGeneration: RestoredAgentCompletedGeneration?
         let shellActivityState: PanelShellActivityState?
+        var restoredPanelTitleBoundary: RestoredPanelTitleBoundary? = nil
         let restoredResumeSessionWorkingDirectory: String?
         let resumeBinding: SurfaceResumeBindingSnapshot?
         /// Authoritative hook identity when `resumeBinding` is an effective
@@ -103,6 +104,7 @@ extension Workspace {
                 restorableAgentResumeState: restorableAgentResumeState,
                 restoredAgentCompletedGeneration: restoredAgentCompletedGeneration,
                 shellActivityState: shellActivityState,
+                restoredPanelTitleBoundary: restoredPanelTitleBoundary,
                 restoredResumeSessionWorkingDirectory: restoredResumeSessionWorkingDirectory,
                 resumeBinding: resumeBinding,
                 managedAgentResumeBinding: managedAgentResumeBinding,

--- a/Sources/Workspace+PanelLifecycle.swift
+++ b/Sources/Workspace+PanelLifecycle.swift
@@ -501,6 +501,7 @@ extension Workspace {
         manualUnreadPanelIds.remove(panelId)
         manualUnreadMarkedAt.removeValue(forKey: panelId)
         panelShellActivityStates.removeValue(forKey: panelId)
+        restoredPanelTitleBoundariesByPanelId.removeValue(forKey: panelId)
         clearAgentLifecycleStates(panelId: panelId)
         surfaceTTYNames.removeValue(forKey: panelId)
         discardRemotePTYSessionID(panelId: panelId)

--- a/Sources/Workspace+RestoredPanelTitleBoundary.swift
+++ b/Sources/Workspace+RestoredPanelTitleBoundary.swift
@@ -2,117 +2,20 @@ import CmuxWorkspaces
 import Foundation
 
 extension Workspace {
-    /// The transient title-admission boundary for a terminal rebuilt from a
-    /// session snapshot. Raw Ghostty titles are untrusted until shell activity
-    /// distinguishes startup noise from a real command. Internally seeded
-    /// input carries its exact title so that cmux-owned bootstrap text never
-    /// becomes user-visible, regardless of the restored agent kind.
-    struct RestoredPanelTitleBoundary {
-        enum Phase {
-            case awaitingInitialShellPrompt(internallySeededTitle: String?)
-            case awaitingUserCommand
-            case awaitingInternallySeededBootstrap(expectedTitle: String)
-            case internallySeededBootstrapRunning(expectedTitle: String)
-        }
-
-        var phase: Phase
-        var pendingTitle: String?
-
-        init(internallySeededInput: String?, shellState: PanelShellActivityState) {
-            let normalizedSeededTitle = internallySeededInput?
-                .trimmingCharacters(in: .whitespacesAndNewlines)
-            let seededTitle = normalizedSeededTitle?.isEmpty == false
-                ? normalizedSeededTitle
-                : nil
-            if let seededTitle, shellState == .commandRunning {
-                phase = .internallySeededBootstrapRunning(expectedTitle: seededTitle)
-            } else if let seededTitle, shellState == .promptIdle {
-                phase = .awaitingInternallySeededBootstrap(expectedTitle: seededTitle)
-            } else if seededTitle == nil, shellState == .promptIdle {
-                phase = .awaitingUserCommand
-            } else {
-                phase = .awaitingInitialShellPrompt(internallySeededTitle: seededTitle)
-            }
-            pendingTitle = nil
-        }
-
-        mutating func shouldApply(rawTitle: String) -> Bool {
-            switch phase {
-            case .awaitingInitialShellPrompt:
-                // A fresh PTY can publish its generic shell/process name before
-                // the first prompt. It is never meaningful post-restore state.
-                pendingTitle = nil
-                return false
-            case .awaitingUserCommand:
-                // The title callback and shell-state report use independent
-                // ingresses, so retain a preexec title until commandRunning.
-                pendingTitle = rawTitle
-                return false
-            case .awaitingInternallySeededBootstrap(let expectedTitle):
-                pendingTitle = rawTitle == expectedTitle ? nil : rawTitle
-                return false
-            case .internallySeededBootstrapRunning(let expectedTitle):
-                // Keep the actual cmux-seeded input inert for the lifetime of
-                // the bootstrap command. Any other title is organic activity
-                // and remains eligible for the normal ownership pipeline.
-                return rawTitle != expectedTitle
-            }
-        }
-
-        mutating func observe(shellState: PanelShellActivityState) -> String? {
-            switch (phase, shellState) {
-            case (.awaitingInitialShellPrompt(let internallySeededTitle), .promptIdle):
-                pendingTitle = nil
-                if let internallySeededTitle {
-                    phase = .awaitingInternallySeededBootstrap(
-                        expectedTitle: internallySeededTitle
-                    )
-                } else {
-                    phase = .awaitingUserCommand
-                }
-            case (.awaitingInitialShellPrompt(let internallySeededTitle), .commandRunning):
-                if let internallySeededTitle {
-                    phase = .internallySeededBootstrapRunning(
-                        expectedTitle: internallySeededTitle
-                    )
-                } else {
-                    // No startup title survived, and commandRunning is the
-                    // first demonstrable activity for an unseeded shell.
-                    phase = .awaitingUserCommand
-                }
-            case (.awaitingUserCommand, .promptIdle):
-                pendingTitle = nil
-            case (.awaitingUserCommand, .commandRunning):
-                return pendingTitle
-            case (.awaitingInternallySeededBootstrap(let expectedTitle), .promptIdle):
-                // Initial input is written when the shell becomes ready. This
-                // prompt belongs to startup, not to a completed bootstrap.
-                pendingTitle = nil
-                phase = .awaitingInternallySeededBootstrap(expectedTitle: expectedTitle)
-            case (.awaitingInternallySeededBootstrap(let expectedTitle), .commandRunning):
-                let title = pendingTitle
-                pendingTitle = nil
-                phase = .internallySeededBootstrapRunning(expectedTitle: expectedTitle)
-                return title
-            case (.internallySeededBootstrapRunning, .promptIdle):
-                // The internal command has exited. Preserve its last genuine
-                // title until the next user command establishes new ownership.
-                phase = .awaitingUserCommand
-                pendingTitle = nil
-            case (_, .unknown),
-                 (.internallySeededBootstrapRunning, .commandRunning):
-                break
-            }
-            return nil
-        }
-    }
-
     /// Starts title admission for a newly rebuilt terminal after persisted metadata lands.
     func armRestoredPanelTitleBoundary(panelId: UUID, internallySeededInput: String?) {
-        restoredPanelTitleBoundariesByPanelId[panelId] = RestoredPanelTitleBoundary(
+        // There is deliberately no timer fallback: elapsed time cannot prove
+        // that PTY startup ended. Raw titles remain untrusted until the managed
+        // shell reports activity; explicit custom-title APIs bypass this path.
+        let boundary = RestoredPanelTitleBoundary(
             internallySeededInput: internallySeededInput,
             shellState: panelShellActivityStates[panelId] ?? .unknown
         )
+        if boundary.isReleased {
+            restoredPanelTitleBoundariesByPanelId.removeValue(forKey: panelId)
+        } else {
+            restoredPanelTitleBoundariesByPanelId[panelId] = boundary
+        }
     }
 
     /// Returns whether a raw PTY title has crossed the restored-title boundary.
@@ -134,10 +37,9 @@ extension Workspace {
             return nil
         }
         let pendingTitle = boundary.observe(shellState: state)
-        switch (boundary.phase, state) {
-        case (.awaitingUserCommand, .commandRunning):
+        if boundary.isReleased {
             restoredPanelTitleBoundariesByPanelId.removeValue(forKey: panelId)
-        default:
+        } else {
             restoredPanelTitleBoundariesByPanelId[panelId] = boundary
         }
         return pendingTitle

--- a/Sources/Workspace+RestoredPanelTitleBoundary.swift
+++ b/Sources/Workspace+RestoredPanelTitleBoundary.swift
@@ -1,0 +1,145 @@
+import CmuxWorkspaces
+import Foundation
+
+extension Workspace {
+    /// The transient title-admission boundary for a terminal rebuilt from a
+    /// session snapshot. Raw Ghostty titles are untrusted until shell activity
+    /// distinguishes startup noise from a real command. Internally seeded
+    /// input carries its exact title so that cmux-owned bootstrap text never
+    /// becomes user-visible, regardless of the restored agent kind.
+    struct RestoredPanelTitleBoundary {
+        enum Phase {
+            case awaitingInitialShellPrompt(internallySeededTitle: String?)
+            case awaitingUserCommand
+            case awaitingInternallySeededBootstrap(expectedTitle: String)
+            case internallySeededBootstrapRunning(expectedTitle: String)
+        }
+
+        var phase: Phase
+        var pendingTitle: String?
+
+        init(internallySeededInput: String?, shellState: PanelShellActivityState) {
+            let normalizedSeededTitle = internallySeededInput?
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+            let seededTitle = normalizedSeededTitle?.isEmpty == false
+                ? normalizedSeededTitle
+                : nil
+            if let seededTitle, shellState == .commandRunning {
+                phase = .internallySeededBootstrapRunning(expectedTitle: seededTitle)
+            } else if let seededTitle, shellState == .promptIdle {
+                phase = .awaitingInternallySeededBootstrap(expectedTitle: seededTitle)
+            } else if seededTitle == nil, shellState == .promptIdle {
+                phase = .awaitingUserCommand
+            } else {
+                phase = .awaitingInitialShellPrompt(internallySeededTitle: seededTitle)
+            }
+            pendingTitle = nil
+        }
+
+        mutating func shouldApply(rawTitle: String) -> Bool {
+            switch phase {
+            case .awaitingInitialShellPrompt:
+                // A fresh PTY can publish its generic shell/process name before
+                // the first prompt. It is never meaningful post-restore state.
+                pendingTitle = nil
+                return false
+            case .awaitingUserCommand:
+                // The title callback and shell-state report use independent
+                // ingresses, so retain a preexec title until commandRunning.
+                pendingTitle = rawTitle
+                return false
+            case .awaitingInternallySeededBootstrap(let expectedTitle):
+                pendingTitle = rawTitle == expectedTitle ? nil : rawTitle
+                return false
+            case .internallySeededBootstrapRunning(let expectedTitle):
+                // Keep the actual cmux-seeded input inert for the lifetime of
+                // the bootstrap command. Any other title is organic activity
+                // and remains eligible for the normal ownership pipeline.
+                return rawTitle != expectedTitle
+            }
+        }
+
+        mutating func observe(shellState: PanelShellActivityState) -> String? {
+            switch (phase, shellState) {
+            case (.awaitingInitialShellPrompt(let internallySeededTitle), .promptIdle):
+                pendingTitle = nil
+                if let internallySeededTitle {
+                    phase = .awaitingInternallySeededBootstrap(
+                        expectedTitle: internallySeededTitle
+                    )
+                } else {
+                    phase = .awaitingUserCommand
+                }
+            case (.awaitingInitialShellPrompt(let internallySeededTitle), .commandRunning):
+                if let internallySeededTitle {
+                    phase = .internallySeededBootstrapRunning(
+                        expectedTitle: internallySeededTitle
+                    )
+                } else {
+                    // No startup title survived, and commandRunning is the
+                    // first demonstrable activity for an unseeded shell.
+                    phase = .awaitingUserCommand
+                }
+            case (.awaitingUserCommand, .promptIdle):
+                pendingTitle = nil
+            case (.awaitingUserCommand, .commandRunning):
+                return pendingTitle
+            case (.awaitingInternallySeededBootstrap(let expectedTitle), .promptIdle):
+                // Initial input is written when the shell becomes ready. This
+                // prompt belongs to startup, not to a completed bootstrap.
+                pendingTitle = nil
+                phase = .awaitingInternallySeededBootstrap(expectedTitle: expectedTitle)
+            case (.awaitingInternallySeededBootstrap(let expectedTitle), .commandRunning):
+                let title = pendingTitle
+                pendingTitle = nil
+                phase = .internallySeededBootstrapRunning(expectedTitle: expectedTitle)
+                return title
+            case (.internallySeededBootstrapRunning, .promptIdle):
+                // The internal command has exited. Preserve its last genuine
+                // title until the next user command establishes new ownership.
+                phase = .awaitingUserCommand
+                pendingTitle = nil
+            case (_, .unknown),
+                 (.internallySeededBootstrapRunning, .commandRunning):
+                break
+            }
+            return nil
+        }
+    }
+
+    /// Starts title admission for a newly rebuilt terminal after persisted metadata lands.
+    func armRestoredPanelTitleBoundary(panelId: UUID, internallySeededInput: String?) {
+        restoredPanelTitleBoundariesByPanelId[panelId] = RestoredPanelTitleBoundary(
+            internallySeededInput: internallySeededInput,
+            shellState: panelShellActivityStates[panelId] ?? .unknown
+        )
+    }
+
+    /// Returns whether a raw PTY title has crossed the restored-title boundary.
+    func shouldApplyRestoredPanelTitle(panelId: UUID, rawTitle: String) -> Bool {
+        guard var boundary = restoredPanelTitleBoundariesByPanelId[panelId] else {
+            return true
+        }
+        let shouldApply = boundary.shouldApply(rawTitle: rawTitle)
+        restoredPanelTitleBoundariesByPanelId[panelId] = boundary
+        return shouldApply
+    }
+
+    /// Advances admission from authoritative shell activity and returns a buffered genuine title.
+    func restoredPanelTitleAfterShellActivity(
+        panelId: UUID,
+        state: PanelShellActivityState
+    ) -> String? {
+        guard var boundary = restoredPanelTitleBoundariesByPanelId[panelId] else {
+            return nil
+        }
+        let pendingTitle = boundary.observe(shellState: state)
+        switch (boundary.phase, state) {
+        case (.awaitingUserCommand, .commandRunning):
+            restoredPanelTitleBoundariesByPanelId.removeValue(forKey: panelId)
+        default:
+            restoredPanelTitleBoundariesByPanelId[panelId] = boundary
+        }
+        return pendingTitle
+    }
+}

--- a/Sources/Workspace+TitleOwnership.swift
+++ b/Sources/Workspace+TitleOwnership.swift
@@ -101,6 +101,9 @@ extension Workspace {
     func updatePanelTitle(panelId: UUID, title: String) -> Bool {
         let trimmed = title.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty, panels[panelId] != nil else { return false }
+        guard shouldApplyRestoredPanelTitle(panelId: panelId, rawTitle: trimmed) else {
+            return false
+        }
         var didMutate = false
         var didMutatePanelTitle = false
         var didMutateWorkspaceTitle = false

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -215,6 +215,8 @@ extension Workspace {
         surfaceResumeBindingsByPanelId.removeAll(keepingCapacity: false)
         restoredGuardedWorkingDirectoriesByPanelId.removeAll(keepingCapacity: false)
         restoredResumeSessionWorkingDirectoriesByPanelId.removeAll(keepingCapacity: false)
+        restoredPanelTitleBoundariesByPanelId.removeAll(keepingCapacity: false)
+        panelShellActivityStates.removeAll(keepingCapacity: false)
 
         let restoredRemoteConfiguration = snapshot.remote?.workspaceConfiguration(
             localSocketPath: TerminalController.shared.currentSocketPathForRemoteRestore()
@@ -1751,6 +1753,10 @@ extension Workspace {
             }
             terminalPanel.restoreSessionTextBoxDraft(snapshot.terminal?.textBoxDraft)
             applySessionPanelMetadata(snapshot, toPanelId: terminalPanel.id)
+            armRestoredPanelTitleBoundary(
+                panelId: terminalPanel.id,
+                internallySeededInput: restoredStartupInput
+            )
             return terminalPanel.id
         case .browser:
             guard let browserPanel = newBrowserSurface(
@@ -2595,6 +2601,9 @@ final class Workspace: Identifiable, ObservableObject {
         get { surfaceRegistry.panelShellActivityStates }
         set { surfaceRegistry.panelShellActivityStates = newValue }
     }
+    /// Per-panel admission state preventing restored PTY startup noise from
+    /// taking ownership of the persisted title.
+    var restoredPanelTitleBoundariesByPanelId: [UUID: RestoredPanelTitleBoundary] = [:]
     /// Agent runtime maps that affect sidebar status visibility.
     let sidebarAgentRuntimeObservation = WorkspaceSidebarAgentRuntimeObservationModel()
     /// Todo lifecycle state: manual status override + persisted checklist (all logic lives in `Workspace+Todos.swift`).
@@ -4990,6 +4999,15 @@ final class Workspace: Identifiable, ObservableObject {
 
     func updatePanelShellActivityState(panelId: UUID, state: PanelShellActivityState) {
         guard panels[panelId] != nil else { return }
+        let pendingRestoredTitle = restoredPanelTitleAfterShellActivity(
+            panelId: panelId,
+            state: state
+        )
+        defer {
+            if let pendingRestoredTitle {
+                _ = updatePanelTitle(panelId: panelId, title: pendingRestoredTitle)
+            }
+        }
         let previousState = panelShellActivityStates[panelId] ?? .unknown
         if previousState == state {
             if let terminalPanel = panels[panelId] as? TerminalPanel {
@@ -5377,6 +5395,9 @@ final class Workspace: Identifiable, ObservableObject {
         pruneRemoteRelaySurfaceAliases(validSurfaceIds: validSurfaceIds)
         remoteDetectedSurfaceIds = remoteDetectedSurfaceIds.filter { validSurfaceIds.contains($0) }
         panelShellActivityStates = panelShellActivityStates.filter { validSurfaceIds.contains($0.key) }
+        restoredPanelTitleBoundariesByPanelId = restoredPanelTitleBoundariesByPanelId.filter {
+            validSurfaceIds.contains($0.key)
+        }
         panelPullRequests = panelPullRequests.filter { validSurfaceIds.contains($0.key) }
         let staleAgentPIDPanelIds = agentPIDKeysByPanelId.keys.filter { !validSurfaceIds.contains($0) }
         var didClearStaleAgentRuntime = false

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -9921,6 +9921,7 @@ final class Workspace: Identifiable, ObservableObject {
             bonsplitController.focusPane(paneId)
             bonsplitController.selectTab(newTabId)
             applyTabSelection(tabId: newTabId, inPane: paneId, focusIntent: focusIntent)
+            applyFocusedPanelTitle(panelId: detached.panelId)
         } else {
             scheduleFocusReconcile()
         }

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -4999,6 +4999,13 @@ final class Workspace: Identifiable, ObservableObject {
 
     func updatePanelShellActivityState(panelId: UUID, state: PanelShellActivityState) {
         guard panels[panelId] != nil else { return }
+        let previousState = panelShellActivityStates[panelId] ?? .unknown
+        if previousState == state {
+            if let terminalPanel = panels[panelId] as? TerminalPanel {
+                terminalPanel.updateShellActivityState(state)
+            }
+            return
+        }
         let pendingRestoredTitle = restoredPanelTitleAfterShellActivity(
             panelId: panelId,
             state: state
@@ -5007,13 +5014,6 @@ final class Workspace: Identifiable, ObservableObject {
             if let pendingRestoredTitle {
                 _ = updatePanelTitle(panelId: panelId, title: pendingRestoredTitle)
             }
-        }
-        let previousState = panelShellActivityStates[panelId] ?? .unknown
-        if previousState == state {
-            if let terminalPanel = panels[panelId] as? TerminalPanel {
-                terminalPanel.updateShellActivityState(state)
-            }
-            return
         }
         panelShellActivityStates[panelId] = state
         if let terminalPanel = panels[panelId] as? TerminalPanel {
@@ -9781,6 +9781,11 @@ final class Workspace: Identifiable, ObservableObject {
 
         bindSurface(newTabId, toPanelId: detached.panelId)
         panels[detached.panelId] = detached.panel
+        if let restoredPanelTitleBoundary = detached.restoredPanelTitleBoundary {
+            restoredPanelTitleBoundariesByPanelId[detached.panelId] = restoredPanelTitleBoundary
+        } else {
+            restoredPanelTitleBoundariesByPanelId.removeValue(forKey: detached.panelId)
+        }
         if let terminalPanel = detached.panel as? TerminalPanel {
             terminalPanel.updateWorkspaceId(id)
             configureTerminalPanel(terminalPanel)
@@ -12600,6 +12605,7 @@ extension Workspace: BonsplitDelegate {
                 restorableAgentResumeState: restorableAgentResumeState,
                 restoredAgentCompletedGeneration: restoredAgentLifecycle.completedGeneration(panelId: panelId),
                 shellActivityState: panelShellActivityStates[panelId],
+                restoredPanelTitleBoundary: restoredPanelTitleBoundariesByPanelId[panelId],
                 restoredResumeSessionWorkingDirectory: restoredResumeSessionWorkingDirectoriesByPanelId[panelId],
                 resumeBinding: resumeBinding,
                 managedAgentResumeBinding: resumeBinding.flatMap {

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -2470,6 +2470,7 @@ C0DE71B10000000000000001 /* AppDelegate+AgentChatNotifications.swift in Sources 
 		906800000000000000000001 /* Workspace+RemoteTerminalLiveness.swift in Sources */ = {isa = PBXBuildFile; fileRef = 906800000000000000000002 /* Workspace+RemoteTerminalLiveness.swift */; };
 		7738C0037738C0037738C003 /* Workspace+RemoteTmuxControlTopology.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7738D0037738D0037738D003 /* Workspace+RemoteTmuxControlTopology.swift */; };
 		D77340010000000000000002 /* Workspace+RemoteTmuxTabOrder.swift in Sources */ = {isa = PBXBuildFile; fileRef = D77340010000000000000001 /* Workspace+RemoteTmuxTabOrder.swift */; };
+		961900000000000000000001 /* Workspace+RestoredPanelTitleBoundary.swift in Sources */ = {isa = PBXBuildFile; fileRef = 961900000000000000000002 /* Workspace+RestoredPanelTitleBoundary.swift */; };
 		9200A0019200A0019200A001 /* Workspace+RestoredWorkingDirectoryGuard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9200A0019200A0019200A002 /* Workspace+RestoredWorkingDirectoryGuard.swift */; };
 		C548600A000000000000001 /* Workspace+SessionRestoreIdentity.swift in Sources */ = {isa = PBXBuildFile; fileRef = C548600A000000000000002 /* Workspace+SessionRestoreIdentity.swift */; };
 		C7268002000000000000001 /* Workspace+SidebarDirectories.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7268002000000000000002 /* Workspace+SidebarDirectories.swift */; };
@@ -5062,6 +5063,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 		906800000000000000000002 /* Workspace+RemoteTerminalLiveness.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Workspace+RemoteTerminalLiveness.swift"; sourceTree = "<group>"; };
 		7738D0037738D0037738D003 /* Workspace+RemoteTmuxControlTopology.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Workspace+RemoteTmuxControlTopology.swift"; sourceTree = "<group>"; };
 		D77340010000000000000001 /* Workspace+RemoteTmuxTabOrder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Workspace+RemoteTmuxTabOrder.swift"; sourceTree = "<group>"; };
+		961900000000000000000002 /* Workspace+RestoredPanelTitleBoundary.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Workspace+RestoredPanelTitleBoundary.swift"; sourceTree = "<group>"; };
 		9200A0019200A0019200A002 /* Workspace+RestoredWorkingDirectoryGuard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Workspace+RestoredWorkingDirectoryGuard.swift"; sourceTree = "<group>"; };
 		C548600A000000000000002 /* Workspace+SessionRestoreIdentity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Workspace+SessionRestoreIdentity.swift"; sourceTree = "<group>"; };
 		C7268002000000000000002 /* Workspace+SidebarDirectories.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Workspace+SidebarDirectories.swift"; sourceTree = "<group>"; };
@@ -6065,6 +6067,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				EE3CB8DEEC6E12B7D04D9B92 /* WorkspaceTodoFeature.swift */,
 				A91C0D0E0000000000000001 /* TerminalTabAgentIcon.swift */,
 				D7AF91981B8F4A2690981D2D /* WorkspaceSidebarProcessTitleObservationModel.swift */,
+				961900000000000000000002 /* Workspace+RestoredPanelTitleBoundary.swift */,
 				D21553D9A12B4EE4974E1943 /* Workspace+TitleOwnership.swift */,
 				C0A1E5CE01C0A1E5CE01A002 /* CoalesceLatestPublisher.swift */,
 				5659A0025659A0025659A002 /* WorkspaceSidebarObservation.swift */,
@@ -10006,6 +10009,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				906800000000000000000001 /* Workspace+RemoteTerminalLiveness.swift in Sources */,
 				7738C0037738C0037738C003 /* Workspace+RemoteTmuxControlTopology.swift in Sources */,
 				D77340010000000000000002 /* Workspace+RemoteTmuxTabOrder.swift in Sources */,
+				961900000000000000000001 /* Workspace+RestoredPanelTitleBoundary.swift in Sources */,
 				9200A0019200A0019200A001 /* Workspace+RestoredWorkingDirectoryGuard.swift in Sources */,
 				C548600A000000000000001 /* Workspace+SessionRestoreIdentity.swift in Sources */,
 				C7268002000000000000001 /* Workspace+SidebarDirectories.swift in Sources */,

--- a/cmuxTests/AgentSessionAutoResumeSwiftTests.swift
+++ b/cmuxTests/AgentSessionAutoResumeSwiftTests.swift
@@ -1,5 +1,6 @@
 import Darwin
 import Foundation
+import CMUXAgentLaunch
 import CmuxCore
 import CmuxSidebar
 import Testing
@@ -12,6 +13,128 @@ import Testing
 
 @Suite(.serialized)
 struct AgentSessionAutoResumeSwiftTests {
+    /// Regression for #9619: cmux-owned restore input is an implementation
+    /// detail, not a user or agent title. Preserve the automatic title captured
+    /// before relaunch through that bootstrap event, then accept the first real
+    /// title reported by the resumed session.
+    @MainActor
+    @Test(arguments: ["codex", "claude"])
+    func restoredAgentBootstrapDoesNotReplacePersistedAutomaticTitle(kind: String) throws {
+        let defaultsName = "cmux-issue-9619-\(kind)-\(UUID().uuidString)"
+        let defaults = try #require(UserDefaults(suiteName: defaultsName))
+        defer { defaults.removePersistentDomain(forName: defaultsName) }
+        defaults.set(true, forKey: AgentSessionAutoResumeSettings.autoResumeAgentSessionsKey)
+
+        let checkpointID = "019fce9e-9619-7a11-8e20-123456789abc"
+        let persistedTitle = "Pre-restore \(kind.capitalized) task"
+        let source = Workspace(agentSessionAutoResumeDefaults: defaults)
+        defer { source.teardownAllPanels() }
+        let sourcePanelID = try #require(source.focusedPanelId)
+        #expect(source.updatePanelTitle(panelId: sourcePanelID, title: persistedTitle))
+        #expect(source.customTitle == nil)
+        #expect(source.panelCustomTitles[sourcePanelID] == nil)
+
+        var snapshot = source.sessionSnapshot(includeScrollback: false)
+        let panelIndex = try #require(snapshot.panels.firstIndex { $0.id == sourcePanelID })
+        var terminalSnapshot = try #require(snapshot.panels[panelIndex].terminal)
+        terminalSnapshot.resumeBinding = SurfaceResumeBindingSnapshot(
+            name: kind.capitalized,
+            kind: kind,
+            command: "\(kind) --resume \(checkpointID)",
+            cwd: source.currentDirectory,
+            checkpointId: checkpointID,
+            source: "agent-hook",
+            autoResume: true,
+            updatedAt: 1_777_777_777
+        )
+        terminalSnapshot.wasAgentRunning = true
+        snapshot.panels[panelIndex].terminal = terminalSnapshot
+
+        let restored = Workspace(agentSessionAutoResumeDefaults: defaults)
+        defer { restored.teardownAllPanels() }
+        let restoredPanelIDs = restored.restoreSessionSnapshot(snapshot)
+        let restoredPanelID = try #require(restoredPanelIDs[sourcePanelID])
+        let restoredPanel = try #require(restored.terminalPanel(for: restoredPanelID))
+        let restoredTabID = try #require(restored.surfaceIdFromPanelId(restoredPanelID))
+        let bootstrapInput =
+            " \(AgentRestoreLaunch.cliStartupExecutableToken) restore \(kind) \(checkpointID)\n"
+        let bootstrapTitle = bootstrapInput.trimmingCharacters(in: .whitespacesAndNewlines)
+
+        #expect(restoredPanel.surface.debugInitialInputForTesting() == bootstrapInput)
+        #expect(restored.panelTitle(panelId: restoredPanelID) == persistedTitle)
+        #expect(restored.title == persistedTitle)
+        #expect(restored.processTitle == persistedTitle)
+        #expect(restored.bonsplitController.tab(restoredTabID)?.title == persistedTitle)
+
+        // Ghostty can deliver the shell's command title before cmux receives the
+        // matching shell-activity transition. The internal event must be inert in
+        // either order.
+        #expect(!restored.updatePanelTitle(panelId: restoredPanelID, title: bootstrapTitle))
+        #expect(restored.panelTitle(panelId: restoredPanelID) == persistedTitle)
+        #expect(restored.title == persistedTitle)
+        #expect(restored.processTitle == persistedTitle)
+        #expect(restored.bonsplitController.tab(restoredTabID)?.title == persistedTitle)
+
+        restored.updatePanelShellActivityState(panelId: restoredPanelID, state: .commandRunning)
+        #expect(restored.panelTitle(panelId: restoredPanelID) == persistedTitle)
+
+        let genuineTitle = "Resumed \(kind.capitalized) session"
+        #expect(restored.updatePanelTitle(panelId: restoredPanelID, title: genuineTitle))
+        #expect(restored.panelTitle(panelId: restoredPanelID) == genuineTitle)
+        #expect(restored.title == genuineTitle)
+        #expect(restored.processTitle == genuineTitle)
+        #expect(restored.bonsplitController.tab(restoredTabID)?.title == genuineTitle)
+    }
+
+    /// The same restore-title boundary applies to an ordinary shell with no
+    /// agent bootstrap. Startup's generic shell title stays hidden until a real
+    /// post-prompt command begins, after which normal title updates resume.
+    @MainActor
+    @Test func restoredPlainShellPreservesTitleUntilUserCommand() throws {
+        let persistedTitle = "Pre-restore shell task"
+        let source = Workspace()
+        defer { source.teardownAllPanels() }
+        let sourcePanelID = try #require(source.focusedPanelId)
+        #expect(source.updatePanelTitle(panelId: sourcePanelID, title: persistedTitle))
+
+        let snapshot = source.sessionSnapshot(includeScrollback: false)
+        let restored = Workspace()
+        defer { restored.teardownAllPanels() }
+        let restoredPanelIDs = restored.restoreSessionSnapshot(snapshot)
+        let restoredPanelID = try #require(restoredPanelIDs[sourcePanelID])
+        let restoredPanel = try #require(restored.terminalPanel(for: restoredPanelID))
+        let restoredTabID = try #require(restored.surfaceIdFromPanelId(restoredPanelID))
+
+        #expect(!restoredPanel.surface.debugInitialInputMetadata().hasInitialInput)
+        #expect(!restored.updatePanelTitle(panelId: restoredPanelID, title: "zsh"))
+        #expect(restored.panelTitle(panelId: restoredPanelID) == persistedTitle)
+        #expect(restored.title == persistedTitle)
+        #expect(restored.processTitle == persistedTitle)
+        #expect(restored.bonsplitController.tab(restoredTabID)?.title == persistedTitle)
+
+        restored.updatePanelShellActivityState(panelId: restoredPanelID, state: .promptIdle)
+        let commandTitle = "cd /tmp/cmux-issue-9619"
+        #expect(!restored.updatePanelTitle(panelId: restoredPanelID, title: commandTitle))
+        #expect(restored.title == persistedTitle)
+
+        // The title event and asynchronous shell-state report may arrive in
+        // either order. A buffered title becomes genuine at the command-running
+        // boundary and normal title ownership resumes from there.
+        restored.updatePanelShellActivityState(panelId: restoredPanelID, state: .commandRunning)
+        #expect(restored.panelTitle(panelId: restoredPanelID) == commandTitle)
+        #expect(restored.title == commandTitle)
+        #expect(restored.processTitle == commandTitle)
+        #expect(restored.bonsplitController.tab(restoredTabID)?.title == commandTitle)
+
+        restored.updatePanelShellActivityState(panelId: restoredPanelID, state: .promptIdle)
+        let directoryTitle = "/tmp/cmux-issue-9619"
+        #expect(restored.updatePanelTitle(panelId: restoredPanelID, title: directoryTitle))
+        #expect(restored.panelTitle(panelId: restoredPanelID) == directoryTitle)
+        #expect(restored.title == directoryTitle)
+        #expect(restored.processTitle == directoryTitle)
+        #expect(restored.bonsplitController.tab(restoredTabID)?.title == directoryTitle)
+    }
+
     /// Regression for #8501: restoring an auto-resumed terminal reapplies the
     /// panel's friendly persisted title before workspace metadata. The
     /// workspace title must follow that restored focused panel instead of the

--- a/cmuxTests/AgentSessionAutoResumeSwiftTests.swift
+++ b/cmuxTests/AgentSessionAutoResumeSwiftTests.swift
@@ -120,6 +120,8 @@ struct AgentSessionAutoResumeSwiftTests {
         // The title event and asynchronous shell-state report may arrive in
         // either order. A buffered title becomes genuine at the command-running
         // boundary and normal title ownership resumes from there.
+        restored.updatePanelShellActivityState(panelId: restoredPanelID, state: .promptIdle)
+        #expect(restored.panelTitle(panelId: restoredPanelID) == persistedTitle)
         restored.updatePanelShellActivityState(panelId: restoredPanelID, state: .commandRunning)
         #expect(restored.panelTitle(panelId: restoredPanelID) == commandTitle)
         #expect(restored.title == commandTitle)
@@ -133,6 +135,72 @@ struct AgentSessionAutoResumeSwiftTests {
         #expect(restored.title == directoryTitle)
         #expect(restored.processTitle == directoryTitle)
         #expect(restored.bonsplitController.tab(restoredTabID)?.title == directoryTitle)
+    }
+
+    /// A restored terminal can move through a detached transfer before its
+    /// startup boundary has admitted a genuine title. The destination must
+    /// continue the same boundary instead of treating the next startup event as
+    /// a fresh, user-owned title.
+    @MainActor
+    @Test func restoredTitleBoundarySurvivesDetachedSurfaceTransfer() throws {
+        let persistedTitle = "Pre-transfer restored title"
+        let snapshotSource = Workspace()
+        defer { snapshotSource.teardownAllPanels() }
+        let snapshotPanelID = try #require(snapshotSource.focusedPanelId)
+        #expect(snapshotSource.updatePanelTitle(panelId: snapshotPanelID, title: persistedTitle))
+
+        let restoredSource = Workspace()
+        defer { restoredSource.teardownAllPanels() }
+        let restoredPanelIDs = restoredSource.restoreSessionSnapshot(
+            snapshotSource.sessionSnapshot(includeScrollback: false)
+        )
+        let restoredPanelID = try #require(restoredPanelIDs[snapshotPanelID])
+        restoredSource.updatePanelShellActivityState(
+            panelId: restoredPanelID,
+            state: .promptIdle
+        )
+
+        let commandTitle = "cd /tmp/cmux-issue-9619-transfer"
+        #expect(!restoredSource.updatePanelTitle(panelId: restoredPanelID, title: commandTitle))
+        let detached = try #require(restoredSource.detachSurface(panelId: restoredPanelID))
+        #expect(detached.restoredPanelTitleBoundary != nil)
+
+        let dock = DockSplitStore(
+            workspaceId: UUID(),
+            baseDirectoryProvider: { nil }
+        )
+        defer { dock.closeAllPanels() }
+        let dockPaneID = try #require(dock.bonsplitController.allPaneIds.first)
+        #expect(
+            dock.attachDetachedSurface(
+                detached,
+                inPane: dockPaneID,
+                focus: false
+            ) == restoredPanelID
+        )
+
+        // The Dock already owns the transferred promptIdle state. A duplicate
+        // report must not discard the pending title before commandRunning.
+        dock.updatePanelShellActivityState(panelId: restoredPanelID, state: .promptIdle)
+        dock.updatePanelShellActivityState(panelId: restoredPanelID, state: .commandRunning)
+        let detachedFromDock = try #require(dock.detachSurface(panelId: restoredPanelID))
+        #expect(detachedFromDock.restoredPanelTitleBoundary == nil)
+
+        let destination = Workspace()
+        defer { destination.teardownAllPanels() }
+        let destinationPaneID = try #require(destination.bonsplitController.allPaneIds.first)
+        #expect(
+            destination.attachDetachedSurface(
+                detachedFromDock,
+                inPane: destinationPaneID,
+                focus: true
+            ) == restoredPanelID
+        )
+        let destinationTabID = try #require(destination.surfaceIdFromPanelId(restoredPanelID))
+        #expect(destination.panelTitle(panelId: restoredPanelID) == commandTitle)
+        #expect(destination.title == commandTitle)
+        #expect(destination.processTitle == commandTitle)
+        #expect(destination.bonsplitController.tab(destinationTabID)?.title == commandTitle)
     }
 
     /// Regression for #8501: restoring an auto-resumed terminal reapplies the


### PR DESCRIPTION
Closes #9619

## Summary
- keep one per-panel restored-title admission boundary in the existing Workspace title path
- model that boundary as a pure explicit phase machine in `CmuxWorkspaces`
- identify cmux-owned bootstrap noise from the exact `initialInput` seeded into the PTY, without matching command prefixes or agent kinds
- preserve restored titles through generic shell startup and the internal bootstrap, while admitting real resumed-agent titles and releasing ordinary shell titles on authoritative command activity
- carry the same boundary across Workspace and Dock detached-surface transfers and ignore duplicate shell-state reports

There is deliberately no timeout or title-count fallback: elapsed time and callback count do not prove that a title came from user or agent activity. Explicit custom-title APIs bypass raw PTY title admission.

## Regression coverage
- Codex and Claude restore input preserve the prior automatic panel, Bonsplit tab, process, and workspace titles
- plain-shell startup cannot replace the restored title with a generic shell name
- a subsequent genuine agent title applies normally
- a subsequent real shell command title is buffered across callback ordering and applies normally
- duplicate prompt reports cannot discard that buffered title
- the boundary and pending title survive Workspace → Dock → Workspace transfer
- the first commit contains the failing regression tests; the second contains the fix

## Validation
- Swift frontend parse for every changed Swift file
- direct Swift 6 typecheck of `PanelShellActivityState` and the extracted phase machine
- `git diff --check`
- `./scripts/check-pbxproj.sh`
- `./scripts/lint-pbxproj-test-wiring.sh` (652 test files)
- `python3 scripts/check-workspace-package-groups.py --check`
- local cmux policy check
- no local `xcodebuild`, XCUITest, reload, or launch, per issue instructions

The lockfile policy checker reports only the unrelated pre-existing `.ruff_cache/.gitignore` violation; this PR changes no package manifest, dependency, lockfile, or ignore rule.

## Localization
- audited changed production and test strings; no user-facing strings changed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved restored panel titles during session startup and panel reattachment.
  * Prevented bootstrap and startup shell activity from incorrectly replacing saved titles.
  * Applied genuine resumed-session titles once user activity begins.
  * Correctly handled shell activity regardless of event order.
  * Preserved pending title updates when panels are detached and reattached.
  * Cleaned up restored title state when panels are closed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->