### PR TITLE
Fix browser eval on strict-CSP pages

### DIFF
--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -385,15 +385,19 @@ jobs:
             case "$NORMALIZED_FILTER" in
               BrowserFixtureInteractionUITests|BrowserFixtureInteractionUITests/*|BrowserReliabilityRegressionUITests|BrowserReliabilityRegressionUITests/*)
                 BROWSER_FIXTURE_SERVER_LOG="$RUNNER_TEMP/cmux-browser-fixture-server.log"
+                BROWSER_FIXTURE_BASE_URL_FILE="$PWD/cmuxUITests/BrowserFixtures/.cmux-ui-test-base-url"
                 rm -f "$BROWSER_FIXTURE_SERVER_LOG"
+                rm -f "$BROWSER_FIXTURE_BASE_URL_FILE"
                 python3 -u scripts/ci/serve-browser-fixtures.py \
                   cmuxUITests/BrowserFixtures \
                   --strict-csp-fixture csp-no-unsafe-eval.html \
+                  --configuration-file "$BROWSER_FIXTURE_BASE_URL_FILE" \
                   >"$BROWSER_FIXTURE_SERVER_LOG" 2>&1 &
                 BROWSER_FIXTURE_SERVER_PID=$!
 
                 for _ in $(seq 1 100); do
-                  if grep -Eq '^READY [0-9]+$' "$BROWSER_FIXTURE_SERVER_LOG" 2>/dev/null; then
+                  if grep -Eq '^READY [0-9]+$' "$BROWSER_FIXTURE_SERVER_LOG" 2>/dev/null && \
+                     [ -s "$BROWSER_FIXTURE_BASE_URL_FILE" ]; then
                     break
                   fi
                   if ! kill -0 "$BROWSER_FIXTURE_SERVER_PID" 2>/dev/null; then
@@ -411,8 +415,6 @@ jobs:
                   exit 1
                 fi
                 BROWSER_FIXTURE_BASE_URL="http://127.0.0.1:$BROWSER_FIXTURE_PORT/"
-                BROWSER_FIXTURE_BASE_URL_FILE="$PWD/cmuxUITests/BrowserFixtures/.cmux-ui-test-base-url"
-                printf '%s\n' "$BROWSER_FIXTURE_BASE_URL" > "$BROWSER_FIXTURE_BASE_URL_FILE"
                 echo "Browser fixture server ready at $BROWSER_FIXTURE_BASE_URL (PID $BROWSER_FIXTURE_SERVER_PID)"
                 ;;
             esac

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -349,18 +349,73 @@ jobs:
           SOURCE_PACKAGES_DIR="$PWD/.ci-source-packages"
           ONLY_TESTING="-only-testing:$TEST_SELECTOR"
           DISPLAY_ENV_PREFIX=()
+          BROWSER_FIXTURE_BASE_URL=""
+          BROWSER_FIXTURE_BASE_URL_FILE=""
+          BROWSER_FIXTURE_SERVER_PID=""
+          BROWSER_FIXTURE_SERVER_LOG=""
+          MANIFEST_PATH=""
+
+          cleanup_test_harnesses() {
+            if [ -n "$BROWSER_FIXTURE_SERVER_PID" ]; then
+              kill "$BROWSER_FIXTURE_SERVER_PID" 2>/dev/null || true
+              wait "$BROWSER_FIXTURE_SERVER_PID" 2>/dev/null || true
+            fi
+            if [ -n "$BROWSER_FIXTURE_BASE_URL_FILE" ]; then
+              rm -f "$BROWSER_FIXTURE_BASE_URL_FILE"
+            fi
+            if [ -n "$MANIFEST_PATH" ]; then
+              rm -f "$MANIFEST_PATH"
+            fi
+          }
+          trap cleanup_test_harnesses EXIT
 
           if [ "$TEST_TARGET" = "cmuxUITests" ] && [ "$NORMALIZED_FILTER" = "DisplayResolutionRegressionUITests" ]; then
             HELPER_PATH="/tmp/create-virtual-display"
             MANIFEST_PATH="/tmp/cmux-ui-test-display-harness.json"
 
             rm -f "$MANIFEST_PATH"
-            trap 'rm -f "$MANIFEST_PATH"' EXIT
 
             clang -framework Foundation -framework CoreGraphics \
               -o "$HELPER_PATH" scripts/create-virtual-display.m
 
             printf '%s\n' "{\"helperBinaryPath\":\"$HELPER_PATH\"}" > "$MANIFEST_PATH"
+          fi
+
+          if [ "$TEST_TARGET" = "cmuxUITests" ]; then
+            case "$NORMALIZED_FILTER" in
+              BrowserFixtureInteractionUITests|BrowserFixtureInteractionUITests/*|BrowserReliabilityRegressionUITests|BrowserReliabilityRegressionUITests/*)
+                BROWSER_FIXTURE_SERVER_LOG="$RUNNER_TEMP/cmux-browser-fixture-server.log"
+                rm -f "$BROWSER_FIXTURE_SERVER_LOG"
+                python3 -u scripts/ci/serve-browser-fixtures.py \
+                  cmuxUITests/BrowserFixtures \
+                  --strict-csp-fixture csp-no-unsafe-eval.html \
+                  >"$BROWSER_FIXTURE_SERVER_LOG" 2>&1 &
+                BROWSER_FIXTURE_SERVER_PID=$!
+
+                for _ in $(seq 1 100); do
+                  if grep -Eq '^READY [0-9]+$' "$BROWSER_FIXTURE_SERVER_LOG" 2>/dev/null; then
+                    break
+                  fi
+                  if ! kill -0 "$BROWSER_FIXTURE_SERVER_PID" 2>/dev/null; then
+                    echo "::error::Browser fixture server exited before readiness"
+                    cat "$BROWSER_FIXTURE_SERVER_LOG"
+                    exit 1
+                  fi
+                  sleep 0.1
+                done
+
+                BROWSER_FIXTURE_PORT="$(awk '/^READY [0-9]+$/ { print $2; exit }' "$BROWSER_FIXTURE_SERVER_LOG")"
+                if [ -z "$BROWSER_FIXTURE_PORT" ]; then
+                  echo "::error::Timed out waiting for browser fixture server readiness"
+                  cat "$BROWSER_FIXTURE_SERVER_LOG"
+                  exit 1
+                fi
+                BROWSER_FIXTURE_BASE_URL="http://127.0.0.1:$BROWSER_FIXTURE_PORT/"
+                BROWSER_FIXTURE_BASE_URL_FILE="$PWD/cmuxUITests/BrowserFixtures/.cmux-ui-test-base-url"
+                printf '%s\n' "$BROWSER_FIXTURE_BASE_URL" > "$BROWSER_FIXTURE_BASE_URL_FILE"
+                echo "Browser fixture server ready at $BROWSER_FIXTURE_BASE_URL (PID $BROWSER_FIXTURE_SERVER_PID)"
+                ;;
+            esac
           fi
 
           # Start recording right before the test (after build/resolve).
@@ -419,7 +474,6 @@ jobs:
           if [ "${#DISPLAY_ENV_PREFIX[@]}" -gt 0 ]; then
             XCODEBUILD_ENV+=("${DISPLAY_ENV_PREFIX[@]}")
           fi
-
           RUN_XCODEBUILD=(env "${XCODEBUILD_ENV[@]}")
           if [ "$TEST_TARGET" = "cmuxUITests" ]; then
             CURRENT_USER="$(id -un)"

--- a/.gitignore
+++ b/.gitignore
@@ -48,6 +48,7 @@ node_modules/
 tests/visual_output/
 tests/visual_report.html
 experiments/*/target/
+cmuxUITests/BrowserFixtures/.cmux-ui-test-base-url
 
 # Stale pre-rebrand Rust TUI dir (renamed to cmux-tui/; old checkouts may
 # still have an untracked mux/target that must never be committed again)

--- a/Packages/macOS/CmuxBrowser/Sources/CmuxBrowser/Control/BrowserControlService.swift
+++ b/Packages/macOS/CmuxBrowser/Sources/CmuxBrowser/Control/BrowserControlService.swift
@@ -88,9 +88,9 @@ public struct BrowserControlService: Sendable {
 
     /// True when a page-world JavaScript failure looks like a Content Security
     /// Policy block of `eval`/`Function` construction (`script-src` without
-    /// `'unsafe-eval'`). Gating the isolated-world retry on this avoids re-running a
-    /// script that already failed for an ordinary reason. Byte-identical to the
-    /// previous `v2BrowserFailureLooksLikeCSPEvalBlock`.
+    /// `'unsafe-eval'`). Gating CSP recovery on this avoids re-running a script that
+    /// already failed for an ordinary reason. Byte-identical to the previous
+    /// `v2BrowserFailureLooksLikeCSPEvalBlock`.
     /// - Parameter message: the failure message.
     /// - Returns: whether the message indicates a CSP eval block.
     public func failureLooksLikeCSPEvalBlock(_ message: String) -> Bool {

--- a/Sources/Panels/BrowserEvalResultMessageHandler.swift
+++ b/Sources/Panels/BrowserEvalResultMessageHandler.swift
@@ -1,0 +1,31 @@
+import Foundation
+import WebKit
+
+/// One-shot page-world bridge used only while a strict-CSP browser expression
+/// is waiting for an asynchronous result.
+final class BrowserEvalResultMessageHandler: NSObject, WKScriptMessageHandler {
+    private let expectedWebViewIdentifier: ObjectIdentifier
+    private let onMessage: @MainActor (Any) -> Void
+
+    init(
+        expectedWebViewIdentifier: ObjectIdentifier,
+        onMessage: @escaping @MainActor (Any) -> Void
+    ) {
+        self.expectedWebViewIdentifier = expectedWebViewIdentifier
+        self.onMessage = onMessage
+    }
+
+    func userContentController(
+        _ userContentController: WKUserContentController,
+        didReceive message: WKScriptMessage
+    ) {
+        // WebKit delivers script messages on the main thread. Keep the one-shot
+        // completion ordered with handler removal and reject subframe reports.
+        MainActor.assumeIsolated {
+            guard message.frameInfo.isMainFrame,
+                  let webView = message.webView,
+                  ObjectIdentifier(webView) == expectedWebViewIdentifier else { return }
+            onMessage(message.body)
+        }
+    }
+}

--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -326,6 +326,16 @@ class TerminalController {
     private nonisolated static let v2BrowserEvalEnvelopeTypeUndefined = "undefined"
     private nonisolated static let v2BrowserEvalEnvelopeTypeValue = "value"
 
+    /// The content-world WebKit APIs expose `Result<Any, Error>`, but bridge a
+    /// JavaScript `undefined` result as an `Optional<Any>.none` boxed inside that
+    /// `Any`. Flatten the box back to nil so the browser eval undefined sentinel
+    /// remains distinguishable from an ordinary Swift value.
+    private nonisolated static func v2UnboxJavaScriptValue(_ value: Any) -> Any? {
+        let mirror = Mirror(reflecting: value)
+        guard mirror.displayStyle == .optional else { return value }
+        return mirror.children.first?.value
+    }
+
     private var v2BrowserNextElementOrdinal: Int = 1
     private var v2BrowserElementRefs: [String: V2BrowserElementRefEntry] = [:]
     private var v2BrowserFrameSelectorBySurface: [UUID: String] = [:]
@@ -6147,11 +6157,10 @@ class TerminalController {
 
     /// True when a page-world JS failure looks like a CSP block of eval/function
     /// construction (script-src without 'unsafe-eval'). That is the only failure
-    /// the isolated-world retry is meant to recover from; gating on it keeps the
-    /// retry from re-running a script that already failed for an ordinary reason
-    /// (a thrown exception, a timeout), which would duplicate any side effect the
-    /// script performed before throwing and could return a value from the wrong
-    /// JS context.
+    /// the CSP recovery path is meant to handle; gating on it keeps the retry from
+    /// re-running a script that already failed for an ordinary reason (a thrown
+    /// exception, a timeout), which would duplicate any side effect the script
+    /// performed before throwing.
     private nonisolated func v2BrowserFailureLooksLikeCSPEvalBlock(_ message: String) -> Bool {
         v2BrowserControl.failureLooksLikeCSPEvalBlock(message)
     }
@@ -6182,7 +6191,16 @@ class TerminalController {
                     webView.callAsyncJavaScript(script, arguments: [:], in: nil, in: contentWorld) { result in
                         switch result {
                         case .success(let value):
-                            finish(value, nil)
+                            finish(Self.v2UnboxJavaScriptValue(value), nil)
+                        case .failure(let error):
+                            finish(nil, browserControl.describeJavaScriptError(error))
+                        }
+                    }
+                } else if #available(macOS 11.0, *) {
+                    webView.evaluateJavaScript(script, in: nil, in: contentWorld) { result in
+                        switch result {
+                        case .success(let value):
+                            finish(Self.v2UnboxJavaScriptValue(value), nil)
                         case .failure(let error):
                             finish(nil, browserControl.describeJavaScriptError(error))
                         }
@@ -6428,8 +6446,7 @@ class TerminalController {
         script: String,
         timeout: TimeInterval = 5.0,
         useEval: Bool = true,
-        requiresPageWorld: Bool = false,
-        onIsolatedWorldFallback: (() -> Void)? = nil
+        requiresPageWorld: Bool = false
     ) -> V2JavaScriptResult {
         guard v2EnsureBrowserDocumentLoaded(
             webView,
@@ -6512,41 +6529,64 @@ class TerminalController {
             rawResult = v2RunJavaScript(webView, script: evaluateFallback, timeout: timeout, world: .page)
         }
 
-        // Retry in the isolated world only when page CSP blocked eval/function construction
-        // (script-src without 'unsafe-eval'). That block applies to callAsyncJavaScript and page
-        // eval() but not to isolated content worlds, which share the DOM, so DOM-only automation
-        // scripts and DOM-reading user evals (document.title) still work there.
+        var usedDirectPageEvaluation = false
+
+        // Page CSP without 'unsafe-eval' can block both callAsyncJavaScript's implicit function
+        // construction and the explicit eval() used to preserve completion values. For eval-wrapped
+        // requests, retry the original source through evaluateJavaScript in the page world. WebKit
+        // injects that source directly, so CSP does not reject it and page-defined globals remain
+        // visible. Nested blocks let user declarations shadow the selected-frame helper bindings
+        // while preserving the source block's JavaScript completion value.
         //
         // Gating on the CSP signature matters: a script can fail in the page world for ordinary
         // reasons (a thrown exception, a timeout) after performing a side effect, and an
-        // unconditional retry would run it a second time and duplicate that side effect, or return
-        // a value from the isolated world that differs from the page world with no visible signal.
+        // unconditional retry would run it a second time and duplicate that side effect.
         //
-        // The isolated world cannot see page-world JS globals (window.reactRoot set by the page's
-        // own scripts). Page-global telemetry and dialog commands therefore set requiresPageWorld
-        // and surface the page-world failure instead of silently reading a different window. For a
-        // user-supplied browser.eval, onIsolatedWorldFallback annotates the result's content world.
-        if !requiresPageWorld,
-           case .failure(let pageMessage) = rawResult,
-           v2BrowserFailureLooksLikeCSPEvalBlock(pageMessage),
-           #available(macOS 11.0, *) {
-            let isolatedResult = v2RunJavaScript(
-                webView,
-                script: asyncFunctionBody,
-                timeout: timeout,
-                preferAsync: true,
-                world: .isolated
-            )
-            switch isolatedResult {
-            case .success:
-                rawResult = isolatedResult
-                onIsolatedWorldFallback?()
-            case .failure(let isolatedMessage):
-                if isolatedMessage != pageMessage {
-                    rawResult = .failure("\(pageMessage) (isolated-world retry: \(isolatedMessage))")
+        // Non-eval automation keeps the existing isolated-world recovery because those scripts are
+        // app-authored DOM operations. Page-global telemetry and dialog commands opt out through
+        // requiresPageWorld because an isolated world cannot see page-authored JavaScript globals.
+        if case .failure(let pageMessage) = rawResult,
+           v2BrowserFailureLooksLikeCSPEvalBlock(pageMessage) {
+            if useEval {
+                let directEvaluationScript = """
+                {
+                  \(framePrelude)
+                  {
+                    const document = __cmuxDoc;
+                    {
+                      \(script)
+                    }
+                  }
                 }
-            case .timedOut:
-                rawResult = .timedOut
+                """
+                let directResult = v2RunJavaScript(
+                    webView,
+                    script: directEvaluationScript,
+                    timeout: timeout,
+                    world: .page
+                )
+                if case .success = directResult {
+                    usedDirectPageEvaluation = true
+                }
+                rawResult = directResult
+            } else if !requiresPageWorld, #available(macOS 11.0, *) {
+                let isolatedResult = v2RunJavaScript(
+                    webView,
+                    script: asyncFunctionBody,
+                    timeout: timeout,
+                    preferAsync: true,
+                    world: .isolated
+                )
+                switch isolatedResult {
+                case .success:
+                    rawResult = isolatedResult
+                case .failure(let isolatedMessage):
+                    if isolatedMessage != pageMessage {
+                        rawResult = .failure("\(pageMessage) (isolated-world retry: \(isolatedMessage))")
+                    }
+                case .timedOut:
+                    rawResult = .timedOut
+                }
             }
         }
 
@@ -6561,6 +6601,9 @@ class TerminalController {
         case .failure(let message):
             return .failure(message)
         case .success(let value):
+            if usedDirectPageEvaluation {
+                return .success(value ?? v2BrowserUndefinedSentinel)
+            }
             guard let dict = value as? [String: Any],
                   let type = dict[Self.v2BrowserEvalEnvelopeTypeKey] as? String else {
                 return .success(value)
@@ -7338,32 +7381,23 @@ class TerminalController {
             return .err(code: "invalid_params", message: "Missing script", data: nil)
         }
         return v2BrowserWithPanelContext(params: params) { ctx in
-            var usedIsolatedWorld = false
             switch v2RunBrowserJavaScript(
                 ctx.webView,
                 browserPanel: ctx.browserPanel,
                 surfaceId: ctx.surfaceId,
                 script: script,
-                timeout: 10.0,
-                onIsolatedWorldFallback: { usedIsolatedWorld = true }
+                timeout: 10.0
             ) {
             case .failure(let message):
                 return .err(code: "js_error", message: message, data: nil)
             case .success(let value):
-                var payload: [String: Any] = [
+                let payload: [String: Any] = [
                     "workspace_id": ctx.workspaceId.uuidString,
                     "workspace_ref": v2Ref(kind: .workspace, uuid: ctx.workspaceId),
                     "surface_id": ctx.surfaceId.uuidString,
                     "surface_ref": v2Ref(kind: .surface, uuid: ctx.surfaceId),
                     "value": v2NormalizeJSValue(value)
                 ]
-                if usedIsolatedWorld {
-                    // Page-world eval was blocked (typically CSP without 'unsafe-eval'); this value
-                    // came from the isolated content world. It shares the DOM but cannot read
-                    // page-world JS globals, so flag it instead of returning silently.
-                    payload["content_world"] = "isolated"
-                    payload["content_world_note"] = "Page-world eval was blocked (likely CSP without 'unsafe-eval'); value came from the isolated content world, which shares the DOM but cannot see page-world JS globals."
-                }
                 return .ok(payload)
             }
         }

--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -6340,7 +6340,7 @@ class TerminalController {
                         complete((.failure(fallbackMessage), false))
                     }
                 }
-                contentController.addScriptMessageHandler(
+                contentController.add(
                     handler,
                     contentWorld: .page,
                     name: handlerName

--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -6736,6 +6736,10 @@ class TerminalController {
                         timeout: timeout,
                         world: .page
                     )
+                    // WebKit rejects Promise completion values from evaluateJavaScript
+                    // with javaScriptResultTypeIsUnsupported.
+                    // A success here is therefore already a settled, bridgeable
+                    // statement completion value; unsupported values stay failures.
                     if case .success = directResult {
                         usedDirectPageEvaluation = true
                     }

--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -6249,6 +6249,160 @@ class TerminalController {
         return .success(outcome.0)
     }
 
+    /// Strict CSP prevents the ordinary `eval` wrapper and WebKit's async-function
+    /// API from compiling user source in the page world. Directly injected source
+    /// is allowed, but `evaluateJavaScript` cannot bridge a Promise result. For a
+    /// source expression, inject an async IIFE and deliver its settled value through
+    /// a random, one-shot page-world message handler instead.
+    private nonisolated func v2RunStrictCSPBrowserExpression(
+        _ webView: WKWebView,
+        script: String,
+        framePrelude: String,
+        timeout: TimeInterval,
+        fallbackMessage: String
+    ) -> (result: BrowserJavaScriptEvaluationResult, statementFallbackRequired: Bool) {
+        let handlerName = "cmuxBrowserEval_" + UUID().uuidString.replacingOccurrences(of: "-", with: "")
+        let token = UUID().uuidString
+        let handlerNameLiteral = v2JSONLiteral(handlerName)
+        let tokenLiteral = v2JSONLiteral(token)
+        let expressionScript = """
+        {
+          \(framePrelude)
+          const __cmuxBridge = window.webkit &&
+            window.webkit.messageHandlers &&
+            window.webkit.messageHandlers[\(handlerNameLiteral)];
+          if (!__cmuxBridge || typeof __cmuxBridge.postMessage !== 'function') {
+            throw new Error('cmux browser eval result bridge is unavailable');
+          }
+
+          const __cmuxPost = (__payload) => {
+            __cmuxBridge.postMessage(Object.assign({ token: \(tokenLiteral) }, __payload));
+          };
+          const __cmuxErrorText = (__error) => {
+            try {
+              return String(__error);
+            } catch (_) {
+              return 'JavaScript evaluation failed';
+            }
+          };
+          const __cmuxPostFailure = (__error) => {
+            try {
+              __cmuxPost({ state: 'failure', message: __cmuxErrorText(__error) });
+            } catch (_) {}
+          };
+
+          void (async () => {
+            const document = __cmuxDoc;
+            const __value = await (\(script));
+            return {
+              __cmux_t: (typeof __value === 'undefined') ? 'undefined' : 'value',
+              __cmux_v: (typeof __value === 'undefined') ? null : __value
+            };
+          })().then(
+            (__result) => {
+              try {
+                __cmuxPost({ state: 'success', result: __result });
+              } catch (__postError) {
+                __cmuxPostFailure(__postError);
+              }
+            },
+            (__error) => __cmuxPostFailure(__error)
+          );
+        }
+        """
+
+        let expectedWebViewIdentifier = ObjectIdentifier(webView)
+        let browserControl = v2BrowserControl
+        let outcome: (BrowserJavaScriptEvaluationResult, Bool)? = v2AwaitCallback(
+            timeout: max(0.01, timeout)
+        ) { finish in
+            v2MainSync {
+                let contentController = webView.configuration.userContentController
+                var didComplete = false
+                let complete: @MainActor ((BrowserJavaScriptEvaluationResult, Bool)) -> Void = { result in
+                    guard !didComplete else { return }
+                    didComplete = true
+                    contentController.removeScriptMessageHandler(forName: handlerName, contentWorld: .page)
+                    finish(result)
+                }
+                let handler = BrowserEvalResultMessageHandler(
+                    expectedWebViewIdentifier: expectedWebViewIdentifier
+                ) { body in
+                    guard let message = body as? [String: Any],
+                          message["token"] as? String == token,
+                          let state = message["state"] as? String else { return }
+                    switch state {
+                    case "success":
+                        complete((.success(message["result"]), false))
+                    case "failure":
+                        complete((.failure(message["message"] as? String ?? fallbackMessage), false))
+                    default:
+                        complete((.failure(fallbackMessage), false))
+                    }
+                }
+                contentController.addScriptMessageHandler(
+                    handler,
+                    contentWorld: .page,
+                    name: handlerName
+                )
+                webView.evaluateJavaScript(expressionScript, in: nil, in: .page) { result in
+                    if case .failure(let error) = result {
+                        let nsError = error as NSError
+                        guard nsError.code == WKError.Code.javaScriptExceptionOccurred.rawValue else {
+                            complete((.failure(browserControl.describeJavaScriptError(error)), false))
+                            return
+                        }
+                        // A source that is not a single expression fails while
+                        // parsing, before the async IIFE or any user code runs.
+                        // The caller can therefore retry it once as a direct
+                        // statement block without duplicating side effects.
+                        complete((.failure(fallbackMessage), true))
+                    }
+                }
+            }
+        }
+
+        // A timed-out page may never post back (for example, after navigating).
+        // Always remove the random handler so the content controller cannot retain
+        // one bridge per timed-out command for the lifetime of the web view.
+        v2MainSync {
+            webView.configuration.userContentController.removeScriptMessageHandler(
+                forName: handlerName,
+                contentWorld: .page
+            )
+        }
+        guard let outcome else { return (result: .timedOut, statementFallbackRequired: false) }
+        return (result: outcome.0, statementFallbackRequired: outcome.1)
+    }
+
+    /// A few JavaScript forms are valid both as expressions and statements but
+    /// have different completion values under `eval` (for example `{ answer: 1 }`
+    /// is a labelled block). Keep those forms on direct statement evaluation;
+    /// ordinary expressions use the async bridge above.
+    private nonisolated func v2StrictCSPSourceRequiresStatementSemantics(_ script: String) -> Bool {
+        let source = script.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !source.isEmpty else { return false }
+        if source.hasPrefix("{") { return true }
+
+        func startsWithKeyword(_ keyword: String, in value: Substring) -> Bool {
+            guard value.hasPrefix(keyword) else { return false }
+            let boundary = value.index(value.startIndex, offsetBy: keyword.count)
+            guard boundary < value.endIndex else { return true }
+            let character = value[boundary]
+            return character.isWhitespace || character == "*" || character == "{"
+        }
+
+        let sourceSlice = source[...]
+        if startsWithKeyword("function", in: sourceSlice) || startsWithKeyword("class", in: sourceSlice) {
+            return true
+        }
+        if startsWithKeyword("async", in: sourceSlice) {
+            let remainder = sourceSlice.dropFirst("async".count).drop(while: { $0.isWhitespace })
+            return startsWithKeyword("function", in: remainder)
+        }
+        return false
+    }
+
     private nonisolated func v2WaitForBrowserCondition(
         _ webView: WKWebView,
         browserPanel: BrowserPanel,
@@ -6533,10 +6687,10 @@ class TerminalController {
 
         // Page CSP without 'unsafe-eval' can block both callAsyncJavaScript's implicit function
         // construction and the explicit eval() used to preserve completion values. For eval-wrapped
-        // requests, retry the original source through evaluateJavaScript in the page world. WebKit
-        // injects that source directly, so CSP does not reject it and page-defined globals remain
-        // visible. Nested blocks let user declarations shadow the selected-frame helper bindings
-        // while preserving the source block's JavaScript completion value.
+        // requests, inject the original source in the page world, where CSP allows WebKit's direct
+        // evaluation and page-defined globals remain visible. Promise-valued expressions settle
+        // through a bounded one-shot message bridge because evaluateJavaScript itself cannot return
+        // a Promise. Sources that require statement completion fall back to a direct nested block.
         //
         // Gating on the CSP signature matters: a script can fail in the page world for ordinary
         // reasons (a thrown exception, a timeout) after performing a side effect, and an
@@ -6548,27 +6702,47 @@ class TerminalController {
         if case .failure(let pageMessage) = rawResult,
            v2BrowserFailureLooksLikeCSPEvalBlock(pageMessage) {
             if useEval {
-                let directEvaluationScript = """
-                {
-                  \(framePrelude)
-                  {
-                    const document = __cmuxDoc;
-                    {
-                      \(script)
-                    }
-                  }
-                }
-                """
-                let directResult = v2RunJavaScript(
-                    webView,
-                    script: directEvaluationScript,
-                    timeout: timeout,
-                    world: .page
+                let expressionOutcome: (
+                    result: BrowserJavaScriptEvaluationResult,
+                    statementFallbackRequired: Bool
                 )
-                if case .success = directResult {
-                    usedDirectPageEvaluation = true
+                if v2StrictCSPSourceRequiresStatementSemantics(script) {
+                    expressionOutcome = (result: .failure(pageMessage), statementFallbackRequired: true)
+                } else {
+                    expressionOutcome = v2RunStrictCSPBrowserExpression(
+                        webView,
+                        script: script,
+                        framePrelude: framePrelude,
+                        timeout: timeout,
+                        fallbackMessage: pageMessage
+                    )
                 }
-                rawResult = directResult
+
+                if expressionOutcome.statementFallbackRequired {
+                    let directEvaluationScript = """
+                    {
+                      \(framePrelude)
+                      {
+                        const document = __cmuxDoc;
+                        {
+                          \(script)
+                        }
+                      }
+                    }
+                    """
+                    let directResult = v2RunJavaScript(
+                        webView,
+                        script: directEvaluationScript,
+                        timeout: timeout,
+                        world: .page
+                    )
+                    if case .success = directResult {
+                        usedDirectPageEvaluation = true
+                    }
+                    rawResult = directResult
+                } else {
+                    rawResult = expressionOutcome.result
+                }
             } else if !requiresPageWorld, #available(macOS 11.0, *) {
                 let isolatedResult = v2RunJavaScript(
                     webView,

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -334,6 +334,7 @@ C0DE71B10000000000000001 /* AppDelegate+AgentChatNotifications.swift in Sources 
 		C2035A010000000000000001 /* BrowserErrorPage.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2035A010000000000000002 /* BrowserErrorPage.swift */; };
 		C2035A020000000000000001 /* BrowserErrorPageContent.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2035A020000000000000002 /* BrowserErrorPageContent.swift */; };
 		C2035A0C000000000000001 /* BrowserErrorPageRetry.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2035A0C000000000000002 /* BrowserErrorPageRetry.swift */; };
+		5158E0015158E0015158E001 /* BrowserEvalResultMessageHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5158E0025158E0025158E002 /* BrowserEvalResultMessageHandler.swift */; };
 		D7632A11A1B2C3D4E5F60718 /* BrowserFileDropNavigationGuard.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7632A12A1B2C3D4E5F60718 /* BrowserFileDropNavigationGuard.swift */; };
 		A5008381 /* BrowserFindJavaScriptTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5008380 /* BrowserFindJavaScriptTests.swift */; };
 		A5008373 /* BrowserFindWebViewEvaluator.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5008372 /* BrowserFindWebViewEvaluator.swift */; };
@@ -3017,6 +3018,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 		C2035A010000000000000002 /* BrowserErrorPage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/BrowserErrorPage.swift; sourceTree = "<group>"; };
 		C2035A020000000000000002 /* BrowserErrorPageContent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/BrowserErrorPageContent.swift; sourceTree = "<group>"; };
 		C2035A0C000000000000002 /* BrowserErrorPageRetry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/BrowserErrorPageRetry.swift; sourceTree = "<group>"; };
+		5158E0025158E0025158E002 /* BrowserEvalResultMessageHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/BrowserEvalResultMessageHandler.swift; sourceTree = "<group>"; };
 		D7632A12A1B2C3D4E5F60718 /* BrowserFileDropNavigationGuard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowserFileDropNavigationGuard.swift; sourceTree = "<group>"; };
 		A5008380 /* BrowserFindJavaScriptTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowserFindJavaScriptTests.swift; sourceTree = "<group>"; };
 		A5008372 /* BrowserFindWebViewEvaluator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Find/BrowserFindWebViewEvaluator.swift; sourceTree = "<group>"; };
@@ -6596,6 +6598,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				C67540100000000000000002 /* BrowserNavigationPopupPolicy.swift */,
 				8054A0060000000000000006 /* BrowserAutomationProbeChannel.swift */,
 				8054A0080000000000000008 /* BrowserAutomationSnapshotResult.swift */,
+				5158E0025158E0025158E002 /* BrowserEvalResultMessageHandler.swift */,
 				8054A00A000000000000000A /* BrowserJavaScriptEvaluationResult.swift */,
 				A5001412 /* BrowserPanel.swift */,
 				B05F00000000000000000001 /* BrowserOffscreenRenderHost.swift */,
@@ -8671,6 +8674,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				C2035A010000000000000001 /* BrowserErrorPage.swift in Sources */,
 				C2035A020000000000000001 /* BrowserErrorPageContent.swift in Sources */,
 				C2035A0C000000000000001 /* BrowserErrorPageRetry.swift in Sources */,
+				5158E0015158E0015158E001 /* BrowserEvalResultMessageHandler.swift in Sources */,
 				D7632A11A1B2C3D4E5F60718 /* BrowserFileDropNavigationGuard.swift in Sources */,
 				A5008373 /* BrowserFindWebViewEvaluator.swift in Sources */,
 				A28B087F0000000000000013 /* BrowserFocusModeKeyDecision.swift in Sources */,

--- a/cmuxUITests/BrowserFixtureInteractionUITests.swift
+++ b/cmuxUITests/BrowserFixtureInteractionUITests.swift
@@ -19,6 +19,10 @@ class BrowserFixtureSocketTestCase: XCTestCase {
     private var appLogPath = ""
     private var launchTag = ""
     private var appProcess: Process?
+    private var appLogHandle: FileHandle?
+    /// Process-launch configuration for the socket-driven app. This helper does
+    /// not launch the `XCUIApplication`; a subclass must call `activate()` before
+    /// using it for UI queries against the independently launched process.
     private(set) var app: XCUIApplication?
 
     override func setUp() {
@@ -54,6 +58,9 @@ class BrowserFixtureSocketTestCase: XCTestCase {
 
     // MARK: - Launch
 
+    /// Launches the built app as a child process and waits for its control socket.
+    /// The returned `XCUIApplication` holds the launch configuration but is not
+    /// attached unless a UI-driven subclass explicitly calls `activate()`.
     @discardableResult
     func launchApp(additionalLaunchArguments: [String] = []) throws -> XCUIApplication {
         let app = XCUIApplication.cmuxTestApplication()
@@ -132,13 +139,23 @@ class BrowserFixtureSocketTestCase: XCTestCase {
         let logHandle = try FileHandle(forWritingTo: URL(fileURLWithPath: appLogPath))
         process.standardOutput = logHandle
         process.standardError = logHandle
-        try process.run()
+        do {
+            try process.run()
+        } catch {
+            try? logHandle.close()
+            throw error
+        }
         appProcess = process
+        appLogHandle = logHandle
     }
 
     private func terminateLaunchedApp() {
+        defer {
+            appProcess = nil
+            try? appLogHandle?.close()
+            appLogHandle = nil
+        }
         guard let process = appProcess else { return }
-        defer { appProcess = nil }
         guard process.isRunning else { return }
 
         process.terminate()
@@ -148,6 +165,7 @@ class BrowserFixtureSocketTestCase: XCTestCase {
         }
         guard process.isRunning else { return }
         _ = kill(process.processIdentifier, SIGKILL)
+        process.waitUntilExit()
     }
 
     private func appProcessDiagnostics() -> String {
@@ -782,8 +800,7 @@ final class BrowserFixtureInteractionUITests: BrowserFixtureSocketTestCase {
         )
         try server.start()
         defer { server.stop() }
-        let baseURL = try XCTUnwrap(URL(string: "http://127.0.0.1:\(server.port)/"))
-        let sid = try openFixture("csp-no-unsafe-eval", baseURL: baseURL)
+        let sid = try openFixture("csp-no-unsafe-eval", baseURL: server.baseURL)
 
         let evalResult = try socketResult(
             method: "browser.eval",

--- a/cmuxUITests/BrowserFixtureInteractionUITests.swift
+++ b/cmuxUITests/BrowserFixtureInteractionUITests.swift
@@ -16,25 +16,38 @@ import Darwin
 class BrowserFixtureSocketTestCase: XCTestCase {
     private(set) var socketPath = ""
     private var diagnosticsPath = ""
+    private var appLogPath = ""
     private var launchTag = ""
+    private var appProcess: Process?
     private(set) var app: XCUIApplication?
 
     override func setUp() {
         super.setUp()
         continueAfterFailure = false
-        socketPath = "/tmp/cmux-debug-\(UUID().uuidString).sock"
-        diagnosticsPath = "/tmp/cmux-ui-test-browser-fixtures-\(UUID().uuidString).json"
-        launchTag = "ui-tests-browser-\(UUID().uuidString.prefix(8))"
+        let token = UUID().uuidString
+        let temporaryDirectory = FileManager.default.temporaryDirectory
+        socketPath = temporaryDirectory
+            .appendingPathComponent("cmux-browser-\(token.prefix(8)).sock")
+            .path
+        diagnosticsPath = temporaryDirectory
+            .appendingPathComponent("cmux-ui-test-browser-fixtures-\(token).json")
+            .path
+        appLogPath = temporaryDirectory
+            .appendingPathComponent("cmux-ui-test-browser-fixtures-\(token).log")
+            .path
+        launchTag = "ui-tests-browser-\(token.prefix(8))"
         try? FileManager.default.removeItem(atPath: socketPath)
         try? FileManager.default.removeItem(atPath: diagnosticsPath)
+        try? FileManager.default.removeItem(atPath: appLogPath)
         try? FileManager.default.removeItem(atPath: taggedSocketPath())
     }
 
     override func tearDown() {
-        app?.terminate()
+        terminateLaunchedApp()
         app = nil
         try? FileManager.default.removeItem(atPath: socketPath)
         try? FileManager.default.removeItem(atPath: diagnosticsPath)
+        try? FileManager.default.removeItem(atPath: appLogPath)
         try? FileManager.default.removeItem(atPath: taggedSocketPath())
         super.tearDown()
     }
@@ -63,27 +76,91 @@ class BrowserFixtureSocketTestCase: XCTestCase {
             app.launchEnvironment["PATH"] = path
         }
         self.app = app
-        // On headless CI runners (no GUI session), XCUIApplication.launch()
-        // blocks ~60s then fails with "Failed to activate application
-        // (current state: Running Background)". Mark this as an expected
-        // failure so the test can continue: these tests are socket-driven and
-        // browser webviews mount in the app windows regardless of activation.
-        let activationOptions = XCTExpectedFailure.Options()
-        activationOptions.isStrict = false
-        XCTExpectFailure("App activation may fail on headless CI runners", options: activationOptions) {
-            app.launch()
-        }
-        if app.state != .runningForeground {
-            XCTAssertTrue(
-                app.state == .runningBackground,
-                "Expected app to be running for browser fixture test. state=\(app.state.rawValue)"
-            )
-        }
+
+        // XCUIApplication.launch() treats foreground activation as mandatory and aborts
+        // the test method when a hosted runner can only run the app in the background.
+        // This base class is exclusively socket-driven, so launch the built binary as a
+        // child process. Inheriting the test runner's sandbox keeps the app and test able
+        // to share the isolated temp-directory socket on hosted runners.
+        try launchBuiltAppProcess(
+            arguments: app.launchArguments,
+            environment: app.launchEnvironment
+        )
+        let socketReady = waitForSocketPong(timeout: 15.0)
         XCTAssertTrue(
-            waitForSocketPong(timeout: 12.0),
-            "Expected socket ping at \(socketPath). diagnostics=\(loadDiagnostics())"
+            socketReady,
+            "Expected socket ping at \(socketPath). app=\(appProcessDiagnostics()) diagnostics=\(loadDiagnostics()) appLog=\(loadAppLogTail())"
         )
         return app
+    }
+
+    private func launchBuiltAppProcess(
+        arguments: [String],
+        environment: [String: String]
+    ) throws {
+        var searchDirectory = Bundle(for: BrowserFixtureSocketTestCase.self).bundleURL
+        var appURL: URL?
+        while searchDirectory.path != "/" {
+            let candidate = searchDirectory.appendingPathComponent("cmux DEV.app", isDirectory: true)
+            if FileManager.default.fileExists(atPath: candidate.path) {
+                appURL = candidate
+                break
+            }
+            searchDirectory.deleteLastPathComponent()
+        }
+
+        let resolvedAppURL = try XCTUnwrap(appURL, "Could not locate the built cmux DEV.app")
+        let executableURL = resolvedAppURL.appendingPathComponent("Contents/MacOS/cmux DEV")
+        guard FileManager.default.isExecutableFile(atPath: executableURL.path) else {
+            throw NSError(
+                domain: "BrowserFixtureSocketTestCase",
+                code: 1,
+                userInfo: [NSLocalizedDescriptionKey: "App binary not found at \(executableURL.path)"]
+            )
+        }
+
+        let process = Process()
+        process.executableURL = executableURL
+        process.arguments = arguments
+        var inheritedEnvironment = ProcessInfo.processInfo.environment
+        for (key, value) in environment {
+            inheritedEnvironment[key] = value
+        }
+        process.environment = inheritedEnvironment
+
+        _ = FileManager.default.createFile(atPath: appLogPath, contents: nil)
+        let logHandle = try FileHandle(forWritingTo: URL(fileURLWithPath: appLogPath))
+        process.standardOutput = logHandle
+        process.standardError = logHandle
+        try process.run()
+        appProcess = process
+    }
+
+    private func terminateLaunchedApp() {
+        guard let process = appProcess else { return }
+        defer { appProcess = nil }
+        guard process.isRunning else { return }
+
+        process.terminate()
+        let deadline = Date().addingTimeInterval(5.0)
+        while process.isRunning && Date() < deadline {
+            RunLoop.current.run(until: Date().addingTimeInterval(0.1))
+        }
+        guard process.isRunning else { return }
+        _ = kill(process.processIdentifier, SIGKILL)
+    }
+
+    private func appProcessDiagnostics() -> String {
+        guard let process = appProcess else { return "not-launched" }
+        let status = process.isRunning ? "running" : String(process.terminationStatus)
+        return "pid=\(process.processIdentifier) running=\(process.isRunning) status=\(status)"
+    }
+
+    private func loadAppLogTail(maximumLength: Int = 2_000) -> String {
+        guard let contents = try? String(contentsOfFile: appLogPath, encoding: .utf8) else {
+            return "<missing>"
+        }
+        return String(contents.suffix(maximumLength))
     }
 
 
@@ -182,17 +259,19 @@ class BrowserFixtureSocketTestCase: XCTestCase {
     /// for `document.readyState === "complete"`.
     func openFixture(
         _ fixtureName: String,
+        baseURL: URL? = nil,
         file: StaticString = #filePath,
         line: UInt = #line
     ) throws -> String {
         let surfaceID = try openBrowserSurface(file: file, line: line)
-        let url = Self.fixtureURL(fixtureName)
+        let fixtureURL = Self.fixtureURL(fixtureName)
         XCTAssertTrue(
-            FileManager.default.fileExists(atPath: url.path),
-            "Missing browser fixture: \(url.path)",
+            FileManager.default.fileExists(atPath: fixtureURL.path),
+            "Missing browser fixture: \(fixtureURL.path)",
             file: file,
             line: line
         )
+        let url = baseURL?.appendingPathComponent("\(fixtureName).html") ?? fixtureURL
         try socketResult(
             method: "browser.navigate",
             params: ["surface_id": surfaceID, "url": url.absoluteString],
@@ -692,15 +771,19 @@ final class BrowserFixtureInteractionUITests: BrowserFixtureSocketTestCase {
         XCTAssertEqual(try statusText(surfaceID: sid), "PASS")
     }
 
-    /// Regression: on a page whose CSP has no 'unsafe-eval', the page-world
-    /// callAsyncJavaScript/eval is blocked; automation must fall back to the
-    /// isolated content world (which shares the DOM). Both eval and the
-    /// interaction methods must keep working. A browser.eval served from the
-    /// isolated world must also flag content_world so the agent knows page-world
-    /// JS globals were not visible (the value came from a different JS context).
+    /// Regression: on a page whose CSP has no 'unsafe-eval', browser.eval must
+    /// execute ordinary expressions directly in the page world. Interaction
+    /// methods must keep working on the same strict-CSP page.
     func testCSPNoUnsafeEval() throws {
         try launchApp()
-        let sid = try openFixture("csp-no-unsafe-eval")
+        let server = try BrowserRecoveryHTTPServer(
+            fixtureDirectory: Self.fixtureURL("csp-no-unsafe-eval").deletingLastPathComponent(),
+            strictCSPFixture: "csp-no-unsafe-eval.html"
+        )
+        try server.start()
+        defer { server.stop() }
+        let baseURL = try XCTUnwrap(URL(string: "http://127.0.0.1:\(server.port)/"))
+        let sid = try openFixture("csp-no-unsafe-eval", baseURL: baseURL)
 
         let evalResult = try socketResult(
             method: "browser.eval",
@@ -710,12 +793,16 @@ final class BrowserFixtureInteractionUITests: BrowserFixtureSocketTestCase {
         XCTAssertEqual(
             evalResult["value"] as? String,
             "csp-no-unsafe-eval",
-            "browser.eval must succeed under CSP without 'unsafe-eval' (isolated-world fallback)"
+            "browser.eval must succeed under CSP without 'unsafe-eval'"
+        )
+        XCTAssertNil(
+            evalResult["content_world"],
+            "ordinary expressions must retain browser.eval's page-world semantics"
         )
         XCTAssertEqual(
-            evalResult["content_world"] as? String,
-            "isolated",
-            "a CSP-blocked browser.eval served from the isolated world must flag content_world"
+            try evalBool("Array.isArray(window.__cmuxLog)", surfaceID: sid),
+            true,
+            "browser.eval must retain access to page-defined globals under strict CSP"
         )
 
         try socketResult(method: "browser.click", params: ["surface_id": sid, "selector": "#csp-btn"])

--- a/cmuxUITests/BrowserFixtures/csp-no-unsafe-eval.html
+++ b/cmuxUITests/BrowserFixtures/csp-no-unsafe-eval.html
@@ -2,7 +2,7 @@
 <html>
 <head>
 <meta charset="utf-8">
-<meta http-equiv="Content-Security-Policy" content="script-src 'unsafe-inline'; object-src 'none'">
+<meta http-equiv="Content-Security-Policy" content="script-src 'nonce-cmux-fixture'; object-src 'none'">
 <title>csp-no-unsafe-eval</title>
 </head>
 <body>
@@ -10,7 +10,13 @@
 <span id="counter">0</span>
 <div id="status">PENDING</div>
 <pre id="event-log"></pre>
-<script>
+<script nonce="cmux-fixture">
+  try {
+    eval('0');
+    document.documentElement.dataset.pageEvalBlocked = 'false';
+  } catch (_) {
+    document.documentElement.dataset.pageEvalBlocked = 'true';
+  }
   window.__cmuxLog = [];
   const logEl = document.getElementById('event-log');
   const statusEl = document.getElementById('status');

--- a/cmuxUITests/BrowserRecoveryHTTPServer.swift
+++ b/cmuxUITests/BrowserRecoveryHTTPServer.swift
@@ -5,7 +5,12 @@ final class BrowserRecoveryHTTPServer {
     let port: UInt16
     let baseURL: URL
 
-    private let serverArguments: [String]
+    private struct ExternalFixtureConfiguration {
+        let baseURL: URL
+        let strictCSPFixture: String
+    }
+
+    private let pythonArguments: [String]
     private let managesProcess: Bool
     private let inputPipe = Pipe()
     private let outputPipe = Pipe()
@@ -15,40 +20,66 @@ final class BrowserRecoveryHTTPServer {
 
     convenience init() throws {
         let port = try Self.availablePort()
-        self.init(port: port, serverArguments: ["recovery"])
+        self.init(
+            port: port,
+            pythonArguments: ["-u", "-c", Self.recoveryServerScript, String(port)]
+        )
     }
 
     convenience init(fixtureDirectory: URL, strictCSPFixture: String) throws {
-        if let externalBaseURL = try Self.externalFixtureBaseURL(fixtureDirectory: fixtureDirectory) {
-            guard let externalPort = externalBaseURL.port else {
-                throw ServerError.invalidExternalFixtureBaseURL(externalBaseURL.absoluteString)
+        try Self.validateStrictCSPFixture(strictCSPFixture, in: fixtureDirectory)
+        if let externalConfiguration = try Self.externalFixtureConfiguration(
+            fixtureDirectory: fixtureDirectory
+        ) {
+            guard externalConfiguration.strictCSPFixture == strictCSPFixture else {
+                throw ServerError.externalStrictCSPFixtureMismatch(
+                    expected: strictCSPFixture,
+                    actual: externalConfiguration.strictCSPFixture
+                )
+            }
+            guard let externalPort = externalConfiguration.baseURL.port else {
+                throw ServerError.invalidExternalFixtureBaseURL(
+                    externalConfiguration.baseURL.absoluteString
+                )
             }
             self.init(
                 port: UInt16(externalPort),
-                baseURL: externalBaseURL,
-                serverArguments: [],
+                baseURL: externalConfiguration.baseURL,
+                pythonArguments: [],
                 managesProcess: false
             )
             return
         }
 
+        let repositoryRoot = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+        let fixtureServerScript = repositoryRoot
+            .appendingPathComponent("scripts/ci/serve-browser-fixtures.py")
+        guard FileManager.default.isReadableFile(atPath: fixtureServerScript.path) else {
+            throw ServerError.fixtureServerScriptMissing(fixtureServerScript.path)
+        }
         let port = try Self.availablePort()
-        self.init(port: port, serverArguments: [
-            "fixtures",
+        self.init(port: port, pythonArguments: [
+            "-u",
+            fixtureServerScript.path,
             fixtureDirectory.path,
+            "--strict-csp-fixture",
             strictCSPFixture,
+            "--port",
+            String(port),
         ])
     }
 
     private init(
         port: UInt16,
         baseURL: URL? = nil,
-        serverArguments: [String],
+        pythonArguments: [String],
         managesProcess: Bool = true
     ) {
         self.port = port
         self.baseURL = baseURL ?? URL(string: "http://127.0.0.1:\(port)/")!
-        self.serverArguments = serverArguments
+        self.pythonArguments = pythonArguments
         self.managesProcess = managesProcess
     }
 
@@ -62,19 +93,15 @@ final class BrowserRecoveryHTTPServer {
 
         let process = Process()
         process.executableURL = URL(fileURLWithPath: "/usr/bin/python3")
-        process.arguments = [
-            "-u",
-            "-c",
-            Self.serverScript,
-            String(port),
-        ] + serverArguments
+        process.arguments = pythonArguments
         process.standardInput = inputPipe
         process.standardOutput = outputPipe
         process.standardError = Pipe()
         try process.run()
         self.process = process
 
-        guard try nextSignal(timeoutMilliseconds: 5_000) == "READY" else {
+        let readySignal = try nextSignal(timeoutMilliseconds: 5_000)
+        guard readySignal == "READY" || readySignal == "READY \(port)" else {
             throw ServerError.unexpectedSignal
         }
     }
@@ -157,22 +184,54 @@ final class BrowserRecoveryHTTPServer {
         return UInt16(bigEndian: resolvedAddress.sin_port)
     }
 
-    private static func externalFixtureBaseURL(fixtureDirectory: URL) throws -> URL? {
-        let key = "CMUX_UI_TEST_BROWSER_FIXTURE_BASE_URL"
-        if let rawValue = ProcessInfo.processInfo.environment[key], !rawValue.isEmpty {
-            return try validateExternalFixtureBaseURL(rawValue)
+    private static func validateStrictCSPFixture(_ fixtureName: String, in fixtureDirectory: URL) throws {
+        guard !fixtureName.isEmpty,
+              !fixtureName.contains("/"),
+              !fixtureName.contains("\\") else {
+            throw ServerError.invalidStrictCSPFixture(fixtureName)
+        }
+        let fixtureURL = fixtureDirectory.appendingPathComponent(fixtureName)
+        guard FileManager.default.isReadableFile(atPath: fixtureURL.path) else {
+            throw ServerError.strictCSPFixtureMissing(fixtureURL.path)
+        }
+    }
+
+    private static func externalFixtureConfiguration(
+        fixtureDirectory: URL
+    ) throws -> ExternalFixtureConfiguration? {
+        let environment = ProcessInfo.processInfo.environment
+        let baseURLKey = "CMUX_UI_TEST_BROWSER_FIXTURE_BASE_URL"
+        let strictFixtureKey = "CMUX_UI_TEST_BROWSER_STRICT_CSP_FIXTURE"
+        if let rawBaseURL = environment[baseURLKey], !rawBaseURL.isEmpty {
+            guard let strictFixture = environment[strictFixtureKey], !strictFixture.isEmpty else {
+                throw ServerError.invalidExternalFixtureConfiguration(
+                    "\(strictFixtureKey) is required when \(baseURLKey) is set"
+                )
+            }
+            return ExternalFixtureConfiguration(
+                baseURL: try validateExternalFixtureBaseURL(rawBaseURL),
+                strictCSPFixture: strictFixture
+            )
         }
 
         // xcodebuild does not pass arbitrary shell environment variables into
-        // its hosted XCTest process. CI writes the same URL beside the fixture
-        // files, which are already readable through their #filePath directory.
+        // its hosted XCTest process. The external server writes its authoritative
+        // URL and strict-CSP fixture beside the source fixtures instead.
         let markerURL = fixtureDirectory.appendingPathComponent(".cmux-ui-test-base-url")
         guard FileManager.default.fileExists(atPath: markerURL.path) else {
             return nil
         }
-        let rawValue = try String(contentsOf: markerURL, encoding: .utf8)
-            .trimmingCharacters(in: .whitespacesAndNewlines)
-        return try validateExternalFixtureBaseURL(rawValue)
+        let data = try Data(contentsOf: markerURL)
+        guard let object = try JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let rawBaseURL = object["base_url"] as? String,
+              let strictFixture = object["strict_csp_fixture"] as? String,
+              !strictFixture.isEmpty else {
+            throw ServerError.invalidExternalFixtureConfiguration(markerURL.path)
+        }
+        return ExternalFixtureConfiguration(
+            baseURL: try validateExternalFixtureBaseURL(rawBaseURL),
+            strictCSPFixture: strictFixture
+        )
     }
 
     private static func validateExternalFixtureBaseURL(_ rawValue: String) throws -> URL {
@@ -180,7 +239,12 @@ final class BrowserRecoveryHTTPServer {
               url.scheme == "http",
               url.host == "127.0.0.1",
               let port = url.port,
-              (1...Int(UInt16.max)).contains(port) else {
+              (1...Int(UInt16.max)).contains(port),
+              url.user == nil,
+              url.password == nil,
+              url.query == nil,
+              url.fragment == nil,
+              url.path == "/" else {
             throw ServerError.invalidExternalFixtureBaseURL(rawValue)
         }
         return url
@@ -188,49 +252,33 @@ final class BrowserRecoveryHTTPServer {
 
     private enum ServerError: Error {
         case couldNotReservePort
+        case externalStrictCSPFixtureMismatch(expected: String, actual: String)
+        case fixtureServerScriptMissing(String)
         case invalidExternalFixtureBaseURL(String)
+        case invalidExternalFixtureConfiguration(String)
+        case invalidStrictCSPFixture(String)
         case signalStreamClosed
         case signalTimedOut
+        case strictCSPFixtureMissing(String)
         case unexpectedSignal
     }
 
-    private static let serverScript = #"""
+    private static let recoveryServerScript = #"""
 import sys
-from pathlib import Path
 from http.server import BaseHTTPRequestHandler, HTTPServer
-from urllib.parse import unquote, urlparse
 
 port = int(sys.argv[1])
-mode = sys.argv[2]
-fixture_root = Path(sys.argv[3]).resolve() if mode == 'fixtures' else None
-strict_csp_fixture = sys.argv[4] if mode == 'fixtures' else None
 
 class Handler(BaseHTTPRequestHandler):
     def do_GET(self):
-        if mode == 'recovery':
-            print('REQUEST', flush=True)
-            if sys.stdin.readline().strip() != 'RELEASE':
-                self.send_error(500)
-                return
-            body = b'<!doctype html><body data-cmux-recovered="true">recovered</body>'
-        else:
-            fixture_name = unquote(urlparse(self.path).path).lstrip('/')
-            if not fixture_name or '/' in fixture_name:
-                self.send_error(404)
-                return
-            fixture_path = (fixture_root / fixture_name).resolve()
-            if fixture_path.parent != fixture_root or not fixture_path.is_file():
-                self.send_error(404)
-                return
-            body = fixture_path.read_bytes()
+        print('REQUEST', flush=True)
+        if sys.stdin.readline().strip() != 'RELEASE':
+            self.send_error(500)
+            return
+        body = b'<!doctype html><body data-cmux-recovered="true">recovered</body>'
 
         self.send_response(200)
         self.send_header('Content-Type', 'text/html; charset=utf-8')
-        if mode == 'fixtures' and fixture_name == strict_csp_fixture:
-            self.send_header(
-                'Content-Security-Policy',
-                "default-src 'none'; script-src 'nonce-cmux-fixture'; object-src 'none'",
-            )
         self.send_header('Content-Length', str(len(body)))
         self.end_headers()
         self.wfile.write(body)

--- a/cmuxUITests/BrowserRecoveryHTTPServer.swift
+++ b/cmuxUITests/BrowserRecoveryHTTPServer.swift
@@ -3,15 +3,53 @@ import Foundation
 
 final class BrowserRecoveryHTTPServer {
     let port: UInt16
+    let baseURL: URL
 
+    private let serverArguments: [String]
+    private let managesProcess: Bool
     private let inputPipe = Pipe()
     private let outputPipe = Pipe()
     private var outputBuffer = Data()
     private var process: Process?
     private var hasHeldRequest = false
 
-    init() throws {
-        self.port = try Self.availablePort()
+    convenience init() throws {
+        let port = try Self.availablePort()
+        self.init(port: port, serverArguments: ["recovery"])
+    }
+
+    convenience init(fixtureDirectory: URL, strictCSPFixture: String) throws {
+        if let externalBaseURL = try Self.externalFixtureBaseURL(fixtureDirectory: fixtureDirectory) {
+            guard let externalPort = externalBaseURL.port else {
+                throw ServerError.invalidExternalFixtureBaseURL(externalBaseURL.absoluteString)
+            }
+            self.init(
+                port: UInt16(externalPort),
+                baseURL: externalBaseURL,
+                serverArguments: [],
+                managesProcess: false
+            )
+            return
+        }
+
+        let port = try Self.availablePort()
+        self.init(port: port, serverArguments: [
+            "fixtures",
+            fixtureDirectory.path,
+            strictCSPFixture,
+        ])
+    }
+
+    private init(
+        port: UInt16,
+        baseURL: URL? = nil,
+        serverArguments: [String],
+        managesProcess: Bool = true
+    ) {
+        self.port = port
+        self.baseURL = baseURL ?? URL(string: "http://127.0.0.1:\(port)/")!
+        self.serverArguments = serverArguments
+        self.managesProcess = managesProcess
     }
 
     deinit {
@@ -19,6 +57,7 @@ final class BrowserRecoveryHTTPServer {
     }
 
     func start() throws {
+        guard managesProcess else { return }
         guard process == nil else { return }
 
         let process = Process()
@@ -28,7 +67,7 @@ final class BrowserRecoveryHTTPServer {
             "-c",
             Self.serverScript,
             String(port),
-        ]
+        ] + serverArguments
         process.standardInput = inputPipe
         process.standardOutput = outputPipe
         process.standardError = Pipe()
@@ -54,6 +93,7 @@ final class BrowserRecoveryHTTPServer {
     }
 
     func stop() {
+        guard managesProcess else { return }
         guard let process else { return }
         self.process = nil
         try? releaseResponse()
@@ -117,8 +157,38 @@ final class BrowserRecoveryHTTPServer {
         return UInt16(bigEndian: resolvedAddress.sin_port)
     }
 
+    private static func externalFixtureBaseURL(fixtureDirectory: URL) throws -> URL? {
+        let key = "CMUX_UI_TEST_BROWSER_FIXTURE_BASE_URL"
+        if let rawValue = ProcessInfo.processInfo.environment[key], !rawValue.isEmpty {
+            return try validateExternalFixtureBaseURL(rawValue)
+        }
+
+        // xcodebuild does not pass arbitrary shell environment variables into
+        // its hosted XCTest process. CI writes the same URL beside the fixture
+        // files, which are already readable through their #filePath directory.
+        let markerURL = fixtureDirectory.appendingPathComponent(".cmux-ui-test-base-url")
+        guard FileManager.default.fileExists(atPath: markerURL.path) else {
+            return nil
+        }
+        let rawValue = try String(contentsOf: markerURL, encoding: .utf8)
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        return try validateExternalFixtureBaseURL(rawValue)
+    }
+
+    private static func validateExternalFixtureBaseURL(_ rawValue: String) throws -> URL {
+        guard let url = URL(string: rawValue),
+              url.scheme == "http",
+              url.host == "127.0.0.1",
+              let port = url.port,
+              (1...Int(UInt16.max)).contains(port) else {
+            throw ServerError.invalidExternalFixtureBaseURL(rawValue)
+        }
+        return url
+    }
+
     private enum ServerError: Error {
         case couldNotReservePort
+        case invalidExternalFixtureBaseURL(String)
         case signalStreamClosed
         case signalTimedOut
         case unexpectedSignal
@@ -126,19 +196,41 @@ final class BrowserRecoveryHTTPServer {
 
     private static let serverScript = #"""
 import sys
+from pathlib import Path
 from http.server import BaseHTTPRequestHandler, HTTPServer
+from urllib.parse import unquote, urlparse
 
 port = int(sys.argv[1])
+mode = sys.argv[2]
+fixture_root = Path(sys.argv[3]).resolve() if mode == 'fixtures' else None
+strict_csp_fixture = sys.argv[4] if mode == 'fixtures' else None
 
 class Handler(BaseHTTPRequestHandler):
     def do_GET(self):
-        print('REQUEST', flush=True)
-        if sys.stdin.readline().strip() != 'RELEASE':
-            self.send_error(500)
-            return
-        body = b'<!doctype html><body data-cmux-recovered="true">recovered</body>'
+        if mode == 'recovery':
+            print('REQUEST', flush=True)
+            if sys.stdin.readline().strip() != 'RELEASE':
+                self.send_error(500)
+                return
+            body = b'<!doctype html><body data-cmux-recovered="true">recovered</body>'
+        else:
+            fixture_name = unquote(urlparse(self.path).path).lstrip('/')
+            if not fixture_name or '/' in fixture_name:
+                self.send_error(404)
+                return
+            fixture_path = (fixture_root / fixture_name).resolve()
+            if fixture_path.parent != fixture_root or not fixture_path.is_file():
+                self.send_error(404)
+                return
+            body = fixture_path.read_bytes()
+
         self.send_response(200)
         self.send_header('Content-Type', 'text/html; charset=utf-8')
+        if mode == 'fixtures' and fixture_name == strict_csp_fixture:
+            self.send_header(
+                'Content-Security-Policy',
+                "default-src 'none'; script-src 'nonce-cmux-fixture'; object-src 'none'",
+            )
         self.send_header('Content-Length', str(len(body)))
         self.end_headers()
         self.wfile.write(body)

--- a/cmuxUITests/BrowserReliabilityRegressionUITests.swift
+++ b/cmuxUITests/BrowserReliabilityRegressionUITests.swift
@@ -154,22 +154,106 @@ final class BrowserReliabilityRegressionUITests: BrowserFixtureSocketTestCase {
         XCTAssertEqual(result["url"] as? String, "about:blank")
     }
 
-    /// Regression: page CSP without 'unsafe-eval' blocks page-world script
-    /// evaluation; browser.eval must fall back to the isolated content world
-    /// and still return a result.
-    func testEvalSucceedsUnderCSPWithoutUnsafeEval() throws {
+    /// Regression: page CSP without 'unsafe-eval' must not block browser.eval
+    /// or force ordinary expressions out of the page's JavaScript world.
+    func testEvalExpressionsPreservePageWorldWithAndWithoutStrictCSP() throws {
         try launchApp()
-        let sid = try openFixture("csp-no-unsafe-eval")
+        let server = try BrowserRecoveryHTTPServer(
+            fixtureDirectory: Self.fixtureURL("csp-no-unsafe-eval").deletingLastPathComponent(),
+            strictCSPFixture: "csp-no-unsafe-eval.html"
+        )
+        try server.start()
+        defer { server.stop() }
+        let strictCSPSurfaceID = try openFixture("csp-no-unsafe-eval", baseURL: server.baseURL)
 
-        let result = try socketResult(
+        let cspEnforcementResult = try socketResult(
             method: "browser.eval",
-            params: ["surface_id": sid, "script": "document.title"],
+            params: [
+                "surface_id": strictCSPSurfaceID,
+                "script": "document.documentElement.dataset.pageEvalBlocked",
+            ],
             responseTimeout: 15.0
         )
         XCTAssertEqual(
-            result["value"] as? String,
+            cspEnforcementResult["value"] as? String,
+            "true",
+            "the fixture must prove its CSP blocks page-authored eval(): \(cspEnforcementResult)"
+        )
+
+        let arithmeticResult = try socketResult(
+            method: "browser.eval",
+            params: ["surface_id": strictCSPSurfaceID, "script": "1+1"],
+            responseTimeout: 15.0
+        )
+        XCTAssertEqual(
+            (arithmeticResult["value"] as? NSNumber)?.intValue,
+            2,
+            "browser.eval 1+1 must succeed under CSP without 'unsafe-eval': \(arithmeticResult)"
+        )
+        XCTAssertNil(
+            arithmeticResult["content_world"],
+            "a simple expression should retain browser.eval's page-world semantics"
+        )
+
+        let titleResult = try socketResult(
+            method: "browser.eval",
+            params: ["surface_id": strictCSPSurfaceID, "script": "document.title"],
+            responseTimeout: 15.0
+        )
+        XCTAssertEqual(
+            titleResult["value"] as? String,
             "csp-no-unsafe-eval",
-            "browser.eval must succeed under CSP without 'unsafe-eval': \(result)"
+            "browser.eval document.title must succeed under CSP without 'unsafe-eval': \(titleResult)"
+        )
+        XCTAssertNil(
+            titleResult["content_world"],
+            "a DOM expression should retain browser.eval's page-world semantics"
+        )
+
+        let pageGlobalResult = try socketResult(
+            method: "browser.eval",
+            params: ["surface_id": strictCSPSurfaceID, "script": "Array.isArray(window.__cmuxLog)"],
+            responseTimeout: 15.0
+        )
+        XCTAssertEqual(
+            pageGlobalResult["value"] as? Bool,
+            true,
+            "browser.eval must retain access to page-defined globals under strict CSP: \(pageGlobalResult)"
+        )
+        XCTAssertNil(
+            pageGlobalResult["content_world"],
+            "page-defined globals cannot be read from an isolated content world"
+        )
+
+        let noCSPSurfaceID = try openFixture("sticky-input", baseURL: server.baseURL)
+        let noCSPArithmeticResult = try socketResult(
+            method: "browser.eval",
+            params: ["surface_id": noCSPSurfaceID, "script": "1+1"],
+            responseTimeout: 15.0
+        )
+        XCTAssertEqual(
+            (noCSPArithmeticResult["value"] as? NSNumber)?.intValue,
+            2,
+            "browser.eval 1+1 must keep working on pages without CSP: \(noCSPArithmeticResult)"
+        )
+        XCTAssertNil(
+            noCSPArithmeticResult["content_world"],
+            "browser.eval must keep using the page world on pages without CSP"
+        )
+
+        let noCSPTitleResult = try socketResult(
+            method: "browser.eval",
+            params: ["surface_id": noCSPSurfaceID, "script": "document.title"],
+            responseTimeout: 15.0
+        )
+        XCTAssertEqual(
+            noCSPTitleResult["value"] as? String,
+            "sticky-input",
+            "browser.eval document.title must keep working on pages without CSP: \(noCSPTitleResult)"
+        )
+        XCTAssertNil(
+            noCSPTitleResult["content_world"],
+            "browser.eval must keep using the page world on pages without CSP"
         )
     }
 

--- a/cmuxUITests/BrowserReliabilityRegressionUITests.swift
+++ b/cmuxUITests/BrowserReliabilityRegressionUITests.swift
@@ -253,6 +253,28 @@ final class BrowserReliabilityRegressionUITests: BrowserFixtureSocketTestCase {
             "strict-CSP recovery must preserve JavaScript statement completion values: \(statementResult)"
         )
 
+        let statementPromiseEnvelope = try XCTUnwrap(
+            socketEnvelope(
+                method: "browser.eval",
+                params: [
+                    "surface_id": strictCSPSurfaceID,
+                    "script": "let statementPromise = Promise.resolve(44); statementPromise",
+                ],
+                responseTimeout: 15.0
+            ),
+            "Expected a socket response for the promise-valued statement completion"
+        )
+        XCTAssertEqual(
+            statementPromiseEnvelope["ok"] as? Bool,
+            false,
+            "strict-CSP statement fallback must not report an unresolved promise as a value: \(statementPromiseEnvelope)"
+        )
+        let statementPromiseError = try XCTUnwrap(
+            statementPromiseEnvelope["error"] as? [String: Any],
+            "Expected js_error for the promise-valued statement completion: \(statementPromiseEnvelope)"
+        )
+        XCTAssertEqual(statementPromiseError["code"] as? String, "js_error")
+
         let undefinedResult = try socketResult(
             method: "browser.eval",
             params: ["surface_id": strictCSPSurfaceID, "script": "void 0"],

--- a/cmuxUITests/BrowserReliabilityRegressionUITests.swift
+++ b/cmuxUITests/BrowserReliabilityRegressionUITests.swift
@@ -225,6 +225,79 @@ final class BrowserReliabilityRegressionUITests: BrowserFixtureSocketTestCase {
             "page-defined globals cannot be read from an isolated content world"
         )
 
+        let promiseResult = try socketResult(
+            method: "browser.eval",
+            params: [
+                "surface_id": strictCSPSurfaceID,
+                "script": "new Promise((resolve) => setTimeout(() => resolve(42), 25))",
+            ],
+            responseTimeout: 15.0
+        )
+        XCTAssertEqual(
+            (promiseResult["value"] as? NSNumber)?.intValue,
+            42,
+            "browser.eval must await promise-valued expressions under strict CSP: \(promiseResult)"
+        )
+
+        let statementResult = try socketResult(
+            method: "browser.eval",
+            params: [
+                "surface_id": strictCSPSurfaceID,
+                "script": "{ const statementValue = 1; statementValue + 1; }",
+            ],
+            responseTimeout: 15.0
+        )
+        XCTAssertEqual(
+            (statementResult["value"] as? NSNumber)?.intValue,
+            2,
+            "strict-CSP recovery must preserve JavaScript statement completion values: \(statementResult)"
+        )
+
+        let undefinedResult = try socketResult(
+            method: "browser.eval",
+            params: ["surface_id": strictCSPSurfaceID, "script": "void 0"],
+            responseTimeout: 15.0
+        )
+        let undefinedEnvelope = try XCTUnwrap(
+            undefinedResult["value"] as? [String: Any],
+            "browser.eval must return the undefined envelope under strict CSP: \(undefinedResult)"
+        )
+        XCTAssertEqual(Set(undefinedEnvelope.keys), Set(["__cmux_t", "__cmux_v"]))
+        XCTAssertEqual(undefinedEnvelope["__cmux_t"] as? String, "undefined")
+        XCTAssertTrue(undefinedEnvelope["__cmux_v"] is NSNull)
+
+        let nullResult = try socketResult(
+            method: "browser.eval",
+            params: ["surface_id": strictCSPSurfaceID, "script": "null"],
+            responseTimeout: 15.0
+        )
+        XCTAssertTrue(
+            nullResult["value"] is NSNull,
+            "browser.eval must keep null distinct from undefined under strict CSP: \(nullResult)"
+        )
+
+        let rejectedPromiseEnvelope = try XCTUnwrap(
+            socketEnvelope(
+                method: "browser.eval",
+                params: [
+                    "surface_id": strictCSPSurfaceID,
+                    "script": "Promise.reject(new Error('strict-csp-expected-rejection'))",
+                ],
+                responseTimeout: 15.0
+            ),
+            "Expected a socket response for the rejected strict-CSP promise"
+        )
+        XCTAssertEqual(rejectedPromiseEnvelope["ok"] as? Bool, false)
+        let rejectedPromiseError = try XCTUnwrap(
+            rejectedPromiseEnvelope["error"] as? [String: Any],
+            "Expected js_error for rejected strict-CSP promise: \(rejectedPromiseEnvelope)"
+        )
+        XCTAssertEqual(rejectedPromiseError["code"] as? String, "js_error")
+        XCTAssertTrue(
+            (rejectedPromiseError["message"] as? String)?.contains("strict-csp-expected-rejection") == true,
+            "Rejected promise must surface its JavaScript error: \(rejectedPromiseEnvelope)"
+        )
+
         let noCSPSurfaceID = try openFixture("sticky-input", baseURL: server.baseURL)
         let noCSPArithmeticResult = try socketResult(
             method: "browser.eval",
@@ -254,6 +327,17 @@ final class BrowserReliabilityRegressionUITests: BrowserFixtureSocketTestCase {
         XCTAssertNil(
             noCSPTitleResult["content_world"],
             "browser.eval must keep using the page world on pages without CSP"
+        )
+
+        let noCSPPromiseResult = try socketResult(
+            method: "browser.eval",
+            params: ["surface_id": noCSPSurfaceID, "script": "Promise.resolve(43)"],
+            responseTimeout: 15.0
+        )
+        XCTAssertEqual(
+            (noCSPPromiseResult["value"] as? NSNumber)?.intValue,
+            43,
+            "browser.eval promise behavior must remain unchanged on pages without CSP: \(noCSPPromiseResult)"
         )
     }
 

--- a/scripts/ci/serve-browser-fixtures.py
+++ b/scripts/ci/serve-browser-fixtures.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import argparse
+import json
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
 from socketserver import TCPServer
@@ -14,7 +15,11 @@ STRICT_CSP = "default-src 'none'; script-src 'nonce-cmux-fixture'; object-src 'n
 
 
 class LoopbackHTTPServer(ThreadingHTTPServer):
+    """HTTP server that binds loopback without a reverse-DNS lookup."""
+
     def server_bind(self) -> None:
+        """Bind directly and retain the numeric host and assigned port."""
+
         # HTTPServer.server_bind() performs a reverse-DNS lookup for server_name.
         # That lookup can hang on hosted macOS runners even though loopback bind
         # already succeeded, so bind directly and keep the numeric host name.
@@ -24,15 +29,25 @@ class LoopbackHTTPServer(ThreadingHTTPServer):
 
 
 def parse_args() -> argparse.Namespace:
+    """Parse fixture-server command-line arguments."""
+
     parser = argparse.ArgumentParser()
     parser.add_argument("fixture_directory", type=Path)
     parser.add_argument("--strict-csp-fixture", required=True)
+    parser.add_argument("--port", type=int, default=0)
+    parser.add_argument("--configuration-file", type=Path)
     return parser.parse_args()
 
 
 def make_handler(fixture_root: Path, strict_csp_fixture: str) -> type[BaseHTTPRequestHandler]:
+    """Create a request handler restricted to flat files under fixture_root."""
+
     class FixtureHandler(BaseHTTPRequestHandler):
+        """Serve one validated HTML fixture per loopback request."""
+
         def do_GET(self) -> None:  # noqa: N802 - BaseHTTPRequestHandler API
+            """Serve a flat fixture and attach strict CSP to the named page."""
+
             fixture_name = unquote(urlparse(self.path).path).lstrip("/")
             if not fixture_name or "/" in fixture_name or "\\" in fixture_name:
                 self.send_error(404)
@@ -52,21 +67,35 @@ def make_handler(fixture_root: Path, strict_csp_fixture: str) -> type[BaseHTTPRe
             self.end_headers()
             self.wfile.write(body)
 
-        def log_message(self, format: str, *args: object) -> None:
+        def log_message(self, format: str, *args: object) -> None:  # noqa: A002 - BaseHTTPRequestHandler API
+            """Suppress per-request stderr noise in hosted test logs."""
+
             pass
 
     return FixtureHandler
 
 
 def main() -> None:
+    """Validate fixtures, start the server, and publish its configuration."""
+
     args = parse_args()
     fixture_root = args.fixture_directory.resolve()
     if not fixture_root.is_dir():
         raise SystemExit(f"fixture directory does not exist: {fixture_root}")
+    strict_csp_path = (fixture_root / args.strict_csp_fixture).resolve()
+    if strict_csp_path.parent != fixture_root or not strict_csp_path.is_file():
+        raise SystemExit(f"strict-CSP fixture does not exist: {strict_csp_path}")
+    if not 0 <= args.port <= 65535:
+        raise SystemExit(f"port is outside 0...65535: {args.port}")
 
     handler = make_handler(fixture_root, args.strict_csp_fixture)
-    print("STARTING", flush=True)
-    server = LoopbackHTTPServer(("127.0.0.1", 0), handler)
+    server = LoopbackHTTPServer(("127.0.0.1", args.port), handler)
+    if args.configuration_file is not None:
+        configuration = {
+            "base_url": f"http://127.0.0.1:{server.server_port}/",
+            "strict_csp_fixture": args.strict_csp_fixture,
+        }
+        args.configuration_file.write_text(json.dumps(configuration) + "\n", encoding="utf-8")
     print(f"READY {server.server_port}", flush=True)
     server.serve_forever()
 

--- a/scripts/ci/serve-browser-fixtures.py
+++ b/scripts/ci/serve-browser-fixtures.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+"""Serve flat browser UI-test fixtures from outside the XCTest sandbox."""
+
+from __future__ import annotations
+
+import argparse
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+from socketserver import TCPServer
+from urllib.parse import unquote, urlparse
+
+
+STRICT_CSP = "default-src 'none'; script-src 'nonce-cmux-fixture'; object-src 'none'"
+
+
+class LoopbackHTTPServer(ThreadingHTTPServer):
+    def server_bind(self) -> None:
+        # HTTPServer.server_bind() performs a reverse-DNS lookup for server_name.
+        # That lookup can hang on hosted macOS runners even though loopback bind
+        # already succeeded, so bind directly and keep the numeric host name.
+        TCPServer.server_bind(self)
+        self.server_name = self.server_address[0]
+        self.server_port = self.server_address[1]
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("fixture_directory", type=Path)
+    parser.add_argument("--strict-csp-fixture", required=True)
+    return parser.parse_args()
+
+
+def make_handler(fixture_root: Path, strict_csp_fixture: str) -> type[BaseHTTPRequestHandler]:
+    class FixtureHandler(BaseHTTPRequestHandler):
+        def do_GET(self) -> None:  # noqa: N802 - BaseHTTPRequestHandler API
+            fixture_name = unquote(urlparse(self.path).path).lstrip("/")
+            if not fixture_name or "/" in fixture_name or "\\" in fixture_name:
+                self.send_error(404)
+                return
+
+            fixture_path = (fixture_root / fixture_name).resolve()
+            if fixture_path.parent != fixture_root or not fixture_path.is_file():
+                self.send_error(404)
+                return
+
+            body = fixture_path.read_bytes()
+            self.send_response(200)
+            self.send_header("Content-Type", "text/html; charset=utf-8")
+            if fixture_name == strict_csp_fixture:
+                self.send_header("Content-Security-Policy", STRICT_CSP)
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+
+        def log_message(self, format: str, *args: object) -> None:
+            pass
+
+    return FixtureHandler
+
+
+def main() -> None:
+    args = parse_args()
+    fixture_root = args.fixture_directory.resolve()
+    if not fixture_root.is_dir():
+        raise SystemExit(f"fixture directory does not exist: {fixture_root}")
+
+    handler = make_handler(fixture_root, args.strict_csp_fixture)
+    print("STARTING", flush=True)
+    server = LoopbackHTTPServer(("127.0.0.1", 0), handler)
+    print(f"READY {server.server_port}", flush=True)
+    server.serve_forever()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- retry CSP-blocked browser eval source directly in WebKit's page world so page globals and JavaScript completion values remain available
- normalize WebKit's boxed `undefined` result while preserving user objects that resemble the internal eval envelope
- add socket-driven strict-CSP and no-CSP browser eval regression coverage using a loopback fixture server

## Testing

- Test-only commit `7fcc2b7125`: [hosted macOS 26 run](https://github.com/manaflow-ai/cmux/actions/runs/30970149492) executed one selected test and failed on the strict-CSP page because eval fell back to the isolated content world
- Fixed commit `8a297701fe`: [hosted macOS 26 run](https://github.com/manaflow-ai/cmux/actions/runs/30970151097) executed the same selected test and passed
- Final tagged build: `reload-cloud` fleet path on `cmuxs-mac-mini-2`, run `sym5158-e0535895576c`; no local build fallback
- Tagged CLI verification against `/tmp/cmux-debug-sym5158.sock`: strict-CSP fixture returned page-world globals, arithmetic, title, `undefined`, `--script`, and JSON values; no-CSP controls were unchanged; the exact issue URL returned its GitHub title and arithmetic result
- The tagged app and fixture server were stopped after verification

Fixes #5158

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/9622"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788490701&installation_model_id=21920&pr_number=9622&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F9622&signature=4b9c8118e69629f0f261684ec696c0d0410618195f9f6ec6a81f072c267bd6ab"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `browser.eval` on strict-CSP pages by evaluating source directly in the page world, preserving page globals, JavaScript completion values, and awaited Promise results (Fixes #5158). The `content_world` response field is removed because strict-CSP evals no longer fall back to the isolated world.

**Bug Fixes**
- On CSP eval/function blocks, inject the original source via page-world `evaluateJavaScript`; keep the isolated-world fallback only for non-eval automation.
- Gate retries on the CSP failure signature so scripts that failed for ordinary reasons are not re-run.
- Await Promise expressions through a one-shot page-world message bridge and use a direct block fallback for statement semantics.
- Treat Promise-valued statements as errors, normalize WebKit's boxed `undefined`, and always remove the message handler on timeout.

**Refactors**
- Add a loopback fixture server wired into CI and expand strict-CSP/no-CSP UI coverage.
- Launch the built app as a child process in UI tests and capture app logs for diagnostics.

<sup>Written for commit 1f250c62a788cfcef0df70c28f9cbe45ce5a3d7b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/9622?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved browser JavaScript evaluation under strict Content Security Policies.
  * Preserved access to page-defined globals and DOM content during evaluation.
  * Correctly distinguishes `undefined`, `null`, promise results, and rejected promises.
  * Improved recovery for scripts affected by CSP restrictions.

* **Tests**
  * Expanded browser reliability coverage across strict and unrestricted CSP environments.
  * Added local fixture serving and improved test-process diagnostics.
  * Added coverage for arithmetic, statements, promises, DOM access, and result handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->