### PR TITLE
Show workspace descriptions in Project Worktrees sidebar

### DIFF
--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -445,7 +445,15 @@ jobs:
             fi
           fi
 
-          if [ "$TEST_TARGET" = "cmuxTests" ]; then
+          if [ "$NORMALIZED_FILTER" = "ProjectWorktreeSidebarTests" ]; then
+            # This package-level provider regression needs a real app snapshot
+            # created through the CLI before it evaluates the render model.
+            XCODEBUILD_CMD=(
+              scripts/ci/run-project-worktree-sidebar-description-e2e.sh
+              "$CMUX_DERIVED_DATA_PATH"
+              "$SOURCE_PACKAGES_DIR"
+            )
+          elif [ "$TEST_TARGET" = "cmuxTests" ]; then
             XCODEBUILD_CMD=(
               scripts/ci/run-in-console-session.sh
               scripts/ci/run-app-host-xcodebuild.sh

--- a/Examples/CmuxExtensionSidebarExamples/Sources/CmuxExtensionSidebarExamples/ProjectWorktreeSidebar.swift
+++ b/Examples/CmuxExtensionSidebarExamples/Sources/CmuxExtensionSidebarExamples/ProjectWorktreeSidebar.swift
@@ -59,6 +59,7 @@ public struct ProjectWorktreeSidebar: CmuxSidebarProvider {
     }
 
     private func branchSubtitle(_ workspace: CmuxSidebarProviderWorkspace) -> CmuxSidebarProviderText? {
-        trimmed(workspace.branchSummary).map(CmuxSidebarProviderText.plain)
+        trimmed(workspace.customDescription).map(CmuxSidebarProviderText.plain)
+            ?? trimmed(workspace.branchSummary).map(CmuxSidebarProviderText.plain)
     }
 }

--- a/Examples/CmuxExtensionSidebarExamples/Tests/CmuxExtensionSidebarExamplesTests/ProjectWorktreeSidebarTests.swift
+++ b/Examples/CmuxExtensionSidebarExamples/Tests/CmuxExtensionSidebarExamplesTests/ProjectWorktreeSidebarTests.swift
@@ -1,0 +1,111 @@
+import CmuxSidebarProviderKit
+@testable import CmuxExtensionSidebarExamples
+import Foundation
+import XCTest
+
+final class ProjectWorktreeSidebarTests: XCTestCase {
+    func testCustomDescriptionReplacesBranchSubtitle() throws {
+        let workspace = CmuxSidebarProviderWorkspace(
+            id: UUID(),
+            title: "Issue 4889",
+            customDescription: "Custom workspace description",
+            isPinned: false,
+            rootPath: "/tmp/issue-4889",
+            projectRootPath: "/tmp/issue-4889",
+            branchSummary: "issue-4889-branch",
+            remoteDisplayTarget: nil,
+            remoteConnectionState: nil,
+            unreadCount: 0,
+            latestNotificationText: nil,
+            listeningPorts: []
+        )
+
+        try assertCustomDescriptionSubtitle(for: workspace)
+    }
+
+    func testLiveSnapshotUsesCustomDescriptionAsSubtitle() throws {
+        let environment = ProcessInfo.processInfo.environment
+        guard let snapshotPath = environment["CMUX_PROJECT_WORKTREE_SNAPSHOT_PATH"] else {
+            throw XCTSkip("Live snapshot fixture is supplied by test-e2e.yml")
+        }
+        let expectedDescription = try XCTUnwrap(
+            environment["CMUX_PROJECT_WORKTREE_EXPECTED_DESCRIPTION"]
+        )
+        let expectedBranch = try XCTUnwrap(
+            environment["CMUX_PROJECT_WORKTREE_EXPECTED_BRANCH"]
+        )
+        let workspace = try liveWorkspace(at: snapshotPath, expectedDescription: expectedDescription)
+
+        XCTAssertEqual(workspace.customDescription, expectedDescription)
+        XCTAssertEqual(workspace.branchSummary, expectedBranch)
+        try assertCustomDescriptionSubtitle(for: workspace)
+    }
+
+    private func assertCustomDescriptionSubtitle(
+        for workspace: CmuxSidebarProviderWorkspace,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) throws {
+        let snapshot = CmuxSidebarProviderSnapshot(
+            sequence: 1,
+            selectedWorkspaceId: workspace.id,
+            workspaces: [workspace]
+        )
+        let model = ProjectWorktreeSidebar().render(snapshot: snapshot)
+        let row = try XCTUnwrap(
+            model.sections.lazy.flatMap(\.rows).first { $0.workspaceId == workspace.id },
+            "Expected the provider render model to contain the workspace",
+            file: file,
+            line: line
+        )
+
+        XCTAssertEqual(
+            row.subtitle,
+            workspace.customDescription.map(CmuxSidebarProviderText.plain),
+            "Expected customDescription to be the rendered workspace subtitle",
+            file: file,
+            line: line
+        )
+        XCTAssertNotEqual(
+            row.subtitle,
+            workspace.branchSummary.map(CmuxSidebarProviderText.plain),
+            "The git branch must only be the fallback subtitle",
+            file: file,
+            line: line
+        )
+    }
+
+    private func liveWorkspace(
+        at path: String,
+        expectedDescription: String
+    ) throws -> CmuxSidebarProviderWorkspace {
+        let data = try Data(contentsOf: URL(fileURLWithPath: path))
+        let root = try XCTUnwrap(
+            try JSONSerialization.jsonObject(with: data) as? [String: Any]
+        )
+        let payload = (root["result"] as? [String: Any]) ?? root
+        let workspaces = try XCTUnwrap(payload["workspaces"] as? [[String: Any]])
+        let value = try XCTUnwrap(
+            workspaces.first { ($0["description"] as? String) == expectedDescription },
+            "Expected the live extension snapshot to contain the described workspace"
+        )
+
+        return CmuxSidebarProviderWorkspace(
+            id: try XCTUnwrap(UUID(uuidString: try XCTUnwrap(value["id"] as? String))),
+            title: try XCTUnwrap(value["title"] as? String),
+            customDescription: value["description"] as? String,
+            isPinned: (value["pinned"] as? Bool) ?? false,
+            rootPath: value["root_path"] as? String,
+            projectRootPath: value["project_root_path"] as? String,
+            branchSummary: value["branch_summary"] as? String,
+            remoteDisplayTarget: value["remote_display_target"] as? String,
+            remoteConnectionState: value["remote_connection_state"] as? String,
+            unreadCount: (value["unread_count"] as? NSNumber)?.intValue ?? 0,
+            latestNotificationText: value["latest_notification_text"] as? String,
+            latestSubmittedMessage: value["latest_submitted_message"] as? String,
+            listeningPorts: (value["listening_ports"] as? [NSNumber])?.map(\.intValue) ?? [],
+            pullRequestURLs: value["pull_request_urls"] as? [String] ?? [],
+            panelDirectories: value["panel_directories"] as? [String] ?? []
+        )
+    }
+}

--- a/scripts/ci/run-project-worktree-sidebar-description-e2e.sh
+++ b/scripts/ci/run-project-worktree-sidebar-description-e2e.sh
@@ -1,0 +1,160 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ "$#" -ne 2 ]; then
+  echo "usage: $0 <derived-data-path> <source-packages-dir>" >&2
+  exit 2
+fi
+
+derived_data_path="$1"
+source_packages_dir="$2"
+token="$(uuidgen | tr '[:upper:]' '[:lower:]')"
+socket_path="/tmp/cmux-ui-test-project-worktree-description-${token}.sock"
+diagnostics_path="/tmp/cmux-ui-test-project-worktree-description-${token}.json"
+app_log_path="/tmp/cmux-ui-test-project-worktree-description-${token}.log"
+snapshot_path="/tmp/cmux-ui-test-project-worktree-description-${token}-snapshot.json"
+launch_tag="ui-tests-project-worktree-description-${token%%-*}"
+repository_path="/tmp/cmux-ui-test-project-worktree-${token}"
+branch="issue-4889-branch"
+custom_description="Custom workspace description"
+workspace_name="Issue 4889 ${token%%-*}"
+app_pid=""
+
+cleanup() {
+  local exit_code=$?
+  if [ -n "$app_pid" ] && kill -0 "$app_pid" 2>/dev/null; then
+    kill -TERM "$app_pid" 2>/dev/null || true
+    for _ in $(seq 1 50); do
+      kill -0 "$app_pid" 2>/dev/null || break
+      sleep 0.1
+    done
+    if kill -0 "$app_pid" 2>/dev/null; then
+      kill -KILL "$app_pid" 2>/dev/null || true
+    fi
+    wait "$app_pid" 2>/dev/null || true
+  fi
+  if [ "$exit_code" -ne 0 ]; then
+    echo "--- Project Worktrees prelaunched app diagnostics ---" >&2
+    tail -80 "$app_log_path" >&2 2>/dev/null || true
+    cat "$diagnostics_path" >&2 2>/dev/null || true
+  fi
+  rm -f "$socket_path" "$diagnostics_path" "$app_log_path" "$snapshot_path"
+  rm -rf -- "$repository_path"
+}
+trap cleanup EXIT
+
+xcodebuild -project cmux.xcodeproj -scheme cmux -configuration Debug \
+  -derivedDataPath "$derived_data_path" \
+  -clonedSourcePackagesDirPath "$source_packages_dir" \
+  -disableAutomaticPackageResolution \
+  -destination "platform=macOS" \
+  CMUX_SKIP_ZIG_BUILD=1 \
+  build
+
+products_path="$derived_data_path/Build/Products/Debug"
+app_bundle="$products_path/cmux DEV.app"
+app_binary="$app_bundle/Contents/MacOS/cmux DEV"
+cli_binary="$app_bundle/Contents/Resources/bin/cmux"
+if [ ! -x "$app_binary" ] || [ ! -x "$cli_binary" ]; then
+  echo "Built app or bundled CLI is missing under $app_bundle" >&2
+  exit 1
+fi
+
+run_cli() {
+  env -u CMUX_SOCKET -u CMUX_SOCKET_PATH -u CMUX_SOCKET_PASSWORD \
+    -u CMUX_WORKSPACE_ID -u CMUX_SURFACE_ID -u CMUX_TAB_ID -u CMUX_PANEL_ID \
+    -u CMUX_WINDOW_ID -u CMUX_TAG -u CMUX_BUNDLE_ID -u CMUX_BUNDLED_CLI_PATH \
+    "$cli_binary" --socket "$socket_path" "$@"
+}
+
+rm -f "$socket_path" "$diagnostics_path" "$app_log_path" "$snapshot_path"
+(
+  unset CMUX_SOCKET CMUX_SOCKET_PASSWORD CMUX_WORKSPACE_ID CMUX_SURFACE_ID
+  unset CMUX_TAB_ID CMUX_PANEL_ID CMUX_WINDOW_ID CMUX_BUNDLE_ID CMUX_BUNDLED_CLI_PATH
+  export CMUX_UI_TEST_MODE=1
+  export CMUX_SOCKET_ENABLE=1
+  export CMUX_SOCKET_MODE=allowAll
+  export CMUX_SOCKET_PATH="$socket_path"
+  export CMUX_ALLOW_SOCKET_OVERRIDE=1
+  export CMUX_UI_TEST_SOCKET_SANITY=1
+  export CMUX_UI_TEST_DIAGNOSTICS_PATH="$diagnostics_path"
+  export CMUX_TAG="$launch_tag"
+  exec "$app_binary" \
+    -socketControlMode allowAll \
+    -AppleLanguages "(en)" \
+    -AppleLocale en_US \
+    -NSAppSleepDisabled YES \
+    -cmuxExtensionSidebar.providerId com.example.cmux.sidebar.project-worktrees
+) >"$app_log_path" 2>&1 &
+app_pid=$!
+echo "Prelaunched app PID: $app_pid"
+echo "Prelaunched app socket: $socket_path"
+
+app_ready=false
+for _ in $(seq 1 120); do
+  if ! kill -0 "$app_pid" 2>/dev/null; then
+    echo "Prelaunched app exited before its socket became ready" >&2
+    break
+  fi
+  if [ -S "$socket_path" ]; then
+    ping_output="$(run_cli ping 2>/dev/null || true)"
+    if [ "$ping_output" = "PONG" ]; then
+      app_ready=true
+      break
+    fi
+  fi
+  sleep 0.25
+done
+
+if [ "$app_ready" != "true" ]; then
+  echo "Prelaunched app did not expose a responsive socket within 30 seconds" >&2
+  exit 1
+fi
+
+mkdir -p "$repository_path"
+git init "$repository_path" >/dev/null
+git -C "$repository_path" checkout -b "$branch" >/dev/null
+git -C "$repository_path" config user.email "cmux-ui-test@example.test"
+git -C "$repository_path" config user.name "cmux UI Test"
+printf 'issue 4889 fixture\n' > "$repository_path/README.md"
+git -C "$repository_path" add README.md
+git -c commit.gpgsign=false -C "$repository_path" commit -m "Initial fixture" >/dev/null
+
+creation_output="$(
+  run_cli new-workspace \
+    --name "$workspace_name" \
+    --description "$custom_description" \
+    --cwd "$repository_path" \
+    --focus true
+)"
+if [[ "$creation_output" != OK\ * ]]; then
+  echo "cmux new-workspace failed: $creation_output" >&2
+  exit 1
+fi
+echo "Created described workspace: $creation_output"
+
+sidebar_snapshot=""
+snapshot_ready=false
+for _ in $(seq 1 80); do
+  sidebar_snapshot="$(run_cli rpc extension.sidebar.snapshot '{}' 2>/dev/null || true)"
+  if [[ "$sidebar_snapshot" == *"$custom_description"* && "$sidebar_snapshot" == *"$branch"* ]]; then
+    snapshot_ready=true
+    break
+  fi
+  sleep 0.25
+done
+if [ "$snapshot_ready" != "true" ]; then
+  echo "Extension sidebar snapshot never contained the described Git workspace: $sidebar_snapshot" >&2
+  exit 1
+fi
+printf '%s\n' "$sidebar_snapshot" > "$snapshot_path"
+echo "Extension sidebar snapshot contains description and branch"
+
+env \
+  CMUX_PROJECT_WORKTREE_SNAPSHOT_PATH="$snapshot_path" \
+  CMUX_PROJECT_WORKTREE_EXPECTED_DESCRIPTION="$custom_description" \
+  CMUX_PROJECT_WORKTREE_EXPECTED_BRANCH="$branch" \
+  swift test \
+    --package-path Examples/CmuxExtensionSidebarExamples \
+    --scratch-path "$derived_data_path/ProjectWorktreeSidebarPackageTests" \
+    --filter ProjectWorktreeSidebarTests/testLiveSnapshotUsesCustomDescriptionAsSubtitle


### PR DESCRIPTION
## Summary

- Prefer a workspace's custom description for the Project Worktrees row subtitle.
- Keep the Git branch as the fallback when no non-empty custom description exists.
- Add a hosted regression harness that creates a described Git workspace through the bundled CLI, captures the live extension snapshot, and evaluates the real provider render output.

Fixes #4889

## Testing

- [Failing regression run on test-only commit `0d301a872e`](https://github.com/manaflow-ai/cmux/actions/runs/30971942189): created `workspace:2`, confirmed the live snapshot contained both values, and executed exactly one test. It failed because the rendered subtitle was `issue-4889-branch` instead of `Custom workspace description`.
- [Passing regression run on fix commit `d2c0f2d745`](https://github.com/manaflow-ai/cmux/actions/runs/30972410295): executed the same one test with zero failures.
- [Tagged cloud build `sym4889`](https://github.com/manaflow-ai/cmux/actions/runs/30972873180): built on the Blacksmith macOS runner and downloaded to this Mac; no local build fallback was used.
- Tagged runtime dogfood against `/tmp/cmux-debug-sym4889.sock`: launched Project Worktrees, created `workspace:2` with `cmux new-workspace --description "Custom workspace description"` in this Git worktree, and confirmed `extension.sidebar.snapshot` contained both the description and branch. A `debug.window.screenshot` showed the row subtitle as `Custom workspace description`, not the branch. The tagged app was then stopped and its isolated socket removed.

## Localization

- Audited the change for user-facing strings. No static copy was added or changed; this only changes precedence between existing dynamic workspace metadata, so localization catalogs do not need updates.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/9625"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788493864&installation_model_id=21920&pr_number=9625&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F9625&signature=6b76b7e9767ca57dabe4c31adc47f6925cb4394edb0dbb04654ff93e1878c2a3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show the workspace description as the Project Worktrees sidebar subtitle, with the Git branch as fallback. Adds an end-to-end test that validates the rendered subtitle from a live extension snapshot. Fixes #4889.

- **Bug Fixes**
  - Sidebar now prefers `customDescription`; falls back to `branchSummary`.
  - Added tests in `CmuxExtensionSidebarExamples` and a CI path that launches the app, creates a described Git workspace via bundled `cmux`, captures `extension.sidebar.snapshot`, and verifies the subtitle. Workflow routes `ProjectWorktreeSidebarTests` to `scripts/ci/run-project-worktree-sidebar-description-e2e.sh`.

<sup>Written for commit d2c0f2d745af9997949757f868b4b94c840267d3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/9625?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Workspace sidebar subtitles now display a custom workspace description when available.
  * Branch information remains available as a fallback when no custom description is set.

* **Bug Fixes**
  * Improved subtitle handling by trimming unnecessary whitespace from workspace descriptions and branch summaries.

* **Tests**
  * Added coverage for subtitle rendering and live sidebar snapshot behavior.
  * Added end-to-end verification for workspace descriptions and branch information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->