### PR TITLE
Fix startup-race crash in v2RefreshKnownRefs against a half-restored session (#2751)

### DIFF
--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -1039,6 +1039,18 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
     private var didPrepareStartupSessionSnapshot = false
     var didAttemptStartupSessionRestore = false
     var isApplyingSessionRestore = false
+    /// True only when it is safe to enumerate the window/tab tree for the v2
+    /// control pre-mint pass (#2751): the initial session-restore decision has
+    /// resolved (`didAttemptStartupSessionRestore`) AND no restore pass is
+    /// currently populating a tab manager in place (`!isApplyingSessionRestore`).
+    /// Deliberately FALSE during the pre-attempt window, the deferred
+    /// signing-secret window (where `didAttemptStartupSessionRestore` stays
+    /// false until the secret arrives), and while `restoreSessionSnapshot` runs
+    /// — the exact windows in which iterating a half-built tree faults. Refs
+    /// mint lazily meanwhile, so skipping the pre-mint is safe.
+    var didCompleteInitialSessionRestore: Bool {
+        didAttemptStartupSessionRestore && !isApplyingSessionRestore
+    }
     /// Durable navigation links that arrived before startup restore registered
     /// their target workspaces.
     var pendingStartupNavigationURLRequests: [CmuxNavigationURLRequest] = []

--- a/Sources/TerminalController+ControlSidebarContext3.swift
+++ b/Sources/TerminalController+ControlSidebarContext3.swift
@@ -110,6 +110,12 @@ extension TerminalController {
         // pre-pass), minting into the same coordinator-owned registry.
         guard let app = AppDelegate.shared else { return }
 
+        // #2751: same guard as the v2 twin. This runs on the
+        // `drag_surface_to_split` v1 path and iterates the same structures, so
+        // skip the pre-mint pass while session restore is pending or in flight
+        // to avoid faulting on a half-built tree; refs mint lazily otherwise.
+        guard app.didCompleteInitialSessionRestore else { return }
+
         let windows = app.listMainWindowSummaries()
         for item in windows {
             _ = controlCommandCoordinator.ensureRef(kind: .window, uuid: item.windowId)

--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -3698,6 +3698,14 @@ class TerminalController {
     func v2RefreshKnownRefs() {
         guard let app = AppDelegate.shared else { return }
 
+        // #2751: skip the pre-mint pass until session restore has settled.
+        // Refreshing here is only an optimization (refs otherwise mint lazily
+        // on the first list/create); iterating the half-built window/tab tree
+        // while restore is pending or in flight faults (EXC_BAD_ACCESS / arm64e
+        // ptrauth). A v2 socket command arriving within ~1s of launch can
+        // re-enter this on the main actor mid-restore, so degrade gracefully.
+        guard app.didCompleteInitialSessionRestore else { return }
+
         let windows = app.listMainWindowSummaries()
         for item in windows {
             _ = v2EnsureHandleRef(kind: .window, uuid: item.windowId)

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -231,6 +231,7 @@ C0DE71B10000000000000001 /* AppDelegate+AgentChatNotifications.swift in Sources 
 		79380000000000000000000A /* AppDelegateOversizedFrameRestoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 793800000000000000000009 /* AppDelegateOversizedFrameRestoreTests.swift */; };
 		D37777050000000000000001 /* AppDelegatePresentPreferencesWindowTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D37777050000000000000002 /* AppDelegatePresentPreferencesWindowTests.swift */; };
 		C34670010000000000000001 /* AppDelegateRenameShortcutContextTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C34670010000000000000002 /* AppDelegateRenameShortcutContextTests.swift */; };
+		89550000000000000000A751 /* AppDelegateSessionRestoreReadinessTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 89550000000000000000A752 /* AppDelegateSessionRestoreReadinessTests.swift */; };
 		D37777040000000000000001 /* AppDelegateSettingsPresentation.swift in Sources */ = {isa = PBXBuildFile; fileRef = D37777040000000000000002 /* AppDelegateSettingsPresentation.swift */; };
 		6419B0016419B0016419B001 /* AppDelegateShortcutRoutingRepairProbe.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6419B0026419B0026419B002 /* AppDelegateShortcutRoutingRepairProbe.swift */; };
 		F6000000A1B2C3D4E5F60718 /* AppDelegateShortcutRoutingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6000001A1B2C3D4E5F60718 /* AppDelegateShortcutRoutingTests.swift */; };
@@ -2912,6 +2913,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 		793800000000000000000009 /* AppDelegateOversizedFrameRestoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegateOversizedFrameRestoreTests.swift; sourceTree = "<group>"; };
 		D37777050000000000000002 /* AppDelegatePresentPreferencesWindowTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegatePresentPreferencesWindowTests.swift; sourceTree = "<group>"; };
 		C34670010000000000000002 /* AppDelegateRenameShortcutContextTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegateRenameShortcutContextTests.swift; sourceTree = "<group>"; };
+		89550000000000000000A752 /* AppDelegateSessionRestoreReadinessTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegateSessionRestoreReadinessTests.swift; sourceTree = "<group>"; };
 		D37777040000000000000002 /* AppDelegateSettingsPresentation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = App/AppDelegateSettingsPresentation.swift; sourceTree = "<group>"; };
 		6419B0026419B0026419B002 /* AppDelegateShortcutRoutingRepairProbe.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegateShortcutRoutingRepairProbe.swift; sourceTree = "<group>"; };
 		F6000001A1B2C3D4E5F60718 /* AppDelegateShortcutRoutingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegateShortcutRoutingTests.swift; sourceTree = "<group>"; };
@@ -7331,6 +7333,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 					F17F00000000000000000002 /* FullWidthTabPersistenceTests.swift */,
 					FD21AD844E5D4D50A6DFC442 /* AppDelegateWindowFrameReconcileTests.swift */,
 					895500000000000000000002 /* AppDelegateFullScreenFrameRestoreTests.swift */,
+					89550000000000000000A752 /* AppDelegateSessionRestoreReadinessTests.swift */,
 					A1B2C3D4E5F600000000CF02 /* AppDelegateDisplayConfigRestoreTests.swift */,
 					793800000000000000000009 /* AppDelegateOversizedFrameRestoreTests.swift */,
 				B35750000000000000000009 /* PiVaultAgentPersistenceTests.swift */,
@@ -10356,6 +10359,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				79380000000000000000000A /* AppDelegateOversizedFrameRestoreTests.swift in Sources */,
 				D37777050000000000000001 /* AppDelegatePresentPreferencesWindowTests.swift in Sources */,
 				C34670010000000000000001 /* AppDelegateRenameShortcutContextTests.swift in Sources */,
+				89550000000000000000A751 /* AppDelegateSessionRestoreReadinessTests.swift in Sources */,
 				6419B0016419B0016419B001 /* AppDelegateShortcutRoutingRepairProbe.swift in Sources */,
 				F6000000A1B2C3D4E5F60718 /* AppDelegateShortcutRoutingTests.swift in Sources */,
 				C6711A030000000000000001 /* AppDelegateSurfaceResumeTerminalIdTests.swift in Sources */,

--- a/cmuxTests/AppDelegateSessionRestoreReadinessTests.swift
+++ b/cmuxTests/AppDelegateSessionRestoreReadinessTests.swift
@@ -1,0 +1,69 @@
+import AppKit
+import Testing
+
+#if canImport(cmux_DEV)
+@testable import cmux_DEV
+#elseif canImport(cmux)
+@testable import cmux
+#endif
+
+// Regression guard for https://github.com/manaflow-ai/cmux/issues/2751.
+//
+// `AppDelegate.didCompleteInitialSessionRestore` is the readiness signal that
+// gates the v2 control pre-mint pass (`TerminalController.v2RefreshKnownRefs()`
+// and its `drag_surface_to_split` twin `controlSidebarRefreshKnownRefs()`):
+// those skip the pre-mint while a session restore is pending or in flight so
+// they never enumerate a half-built window/tab tree (the EXC_BAD_ACCESS the
+// issue reported). The signal is the conjunction of two lifecycle flags:
+//
+//     didAttemptStartupSessionRestore && !isApplyingSessionRestore
+//
+// Draft 1 of the fix gated on a flag that could be TRUE before the primary
+// restore actually ran on the deferred-signing-secret path, reopening the crash
+// window. This test locks the four flag combinations so the signal can only be
+// TRUE when restore has truly settled. It reads two Bools, so no real window or
+// tab tree is needed and the crash itself (which requires a half-built tree) is
+// intentionally not reproduced here.
+@Suite(.serialized)
+@MainActor
+struct AppDelegateSessionRestoreReadinessTests {
+    @Test
+    func signalIsFalseBeforeRestoreIsAttempted() {
+        let appDelegate = AppDelegate()
+        appDelegate.didAttemptStartupSessionRestore = false
+        appDelegate.isApplyingSessionRestore = false
+        // Pre-attempt / deferred-signing-secret window: nothing has decided to
+        // restore yet, so enumerating the tree must be skipped.
+        #expect(appDelegate.didCompleteInitialSessionRestore == false)
+    }
+
+    @Test
+    func signalIsFalseWhileRestoreIsInFlight() {
+        let appDelegate = AppDelegate()
+        appDelegate.didAttemptStartupSessionRestore = true
+        appDelegate.isApplyingSessionRestore = true
+        // restoreSessionSnapshot is mutating a tab manager in place; the tree is
+        // half-built, so the pre-mint pass must be skipped.
+        #expect(appDelegate.didCompleteInitialSessionRestore == false)
+    }
+
+    @Test
+    func signalIsTrueOnceRestoreHasSettled() {
+        let appDelegate = AppDelegate()
+        appDelegate.didAttemptStartupSessionRestore = true
+        appDelegate.isApplyingSessionRestore = false
+        // completeSessionRestoreOperation has cleared the in-flight flag: the
+        // tree is stable and safe to enumerate.
+        #expect(appDelegate.didCompleteInitialSessionRestore == true)
+    }
+
+    @Test
+    func signalIsFalseWhenApplyingWithoutAttemptFlag() {
+        let appDelegate = AppDelegate()
+        appDelegate.didAttemptStartupSessionRestore = false
+        appDelegate.isApplyingSessionRestore = true
+        // Defensive: any restore-in-flight state must read FALSE regardless of
+        // the attempt flag, so the guard can never enumerate a mutating tree.
+        #expect(appDelegate.didCompleteInitialSessionRestore == false)
+    }
+}


### PR DESCRIPTION
Fixes #2751.

## Problem

`EXC_BAD_ACCESS (SIGSEGV)` with an arm64e pointer-authentication failure in `TerminalController.v2RefreshKnownRefs()`, called from the control-command resolution hop (`controlResolveOnMain` → `v2MainSync { v2RefreshKnownRefs() }`). A v2 socket command (e.g. `cmux list-workspaces` from a shell rc) arriving within ~1s of launch runs the handle-ref **pre-mint pass** on the main actor while startup session restore is still building/mutating the window/tab tree, so it enumerates a half-built object and faults. Two users reported the identical signature on macOS 26.4/26.5, and it reproduces on nightly.

## Root cause

`v2RefreshKnownRefs()` (and its `drag_surface_to_split` twin `controlSidebarRefreshKnownRefs()`) iterate `listMainWindowSummaries()` / `tm.tabs` / `tm.workspaceGroups` unconditionally, with no gate on restore completion. Because a v2 command can be serviced during the restore window, the pass can run against a tree that `restoreSessionSnapshot` is populating in place.

The pass is only an **optimization** — it pre-mints handle refs so callers can pass `workspace_group:N` immediately after restore; otherwise refs mint lazily on the first `list`/`create` (as the function's own comment notes). So skipping it until restore settles is behavior-preserving.

## Fix

Gate both functions on a new readiness signal on `AppDelegate`:

```swift
var didCompleteInitialSessionRestore: Bool {
    didAttemptStartupSessionRestore && !isApplyingSessionRestore
}
```

It is **false** during the pre-attempt window, the **deferred-signing-secret** window (cold launch where the Keychain secret isn't ready yet, so `attemptStartupSessionRestore` defers before setting `didAttemptStartupSessionRestore`), and while a restore is applying (`isApplyingSessionRestore` brackets `restoreSessionSnapshot`, including the async additional-windows span and manual reopen). It is **true** only once the tree is stable. Once restore settles the guard is a no-op, so steady-state behavior is unchanged.

The deferred-signing-secret path is the important one: a naive "did we attempt restore" flag flips true too early there and leaves the crash window open (likely why dev builds, which set `environmentSigningSecret()`, never hit it). The composite signal stays false through that whole window.

## Testing

Full Debug build succeeds. Added `cmuxTests/AppDelegateSessionRestoreReadinessTests.swift`, which locks `didCompleteInitialSessionRestore` across the four flag combinations (verified running under the `cmux-unit` scheme). A deterministic red/green crash test isn't feasible — the fault needs a transiently half-built tree that can't be reproduced in a unit test — so the test guards the invariant that governs the skip (this is exactly the invariant an earlier draft got wrong on the deferred-secret path).

---

Used AI assistance on this; I reviewed, built, and tested it.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/9627"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788496866&installation_model_id=21920&pr_number=9627&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F9627&signature=da239aaa2a2e0a81a3b4b37f2887e2826e112c29735fb75c34ec410e1712c877"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents a launch-time crash by skipping the v2 handle-ref pre-mint until session restore finishes. Behavior is unchanged because refs mint lazily. Fixes #2751.

- **Bug Fixes**
  - Added `AppDelegate.didCompleteInitialSessionRestore` (`didAttemptStartupSessionRestore && !isApplyingSessionRestore`) to signal when the tree is stable, including the deferred-signing-secret path.
  - Guarded `TerminalController.v2RefreshKnownRefs()` and `controlSidebarRefreshKnownRefs()` to no-op until the signal is true, avoiding iteration of a half-built window/tab tree.

<sup>Written for commit 5c60ef923da1260447965b95d008e98d4b11a4ee. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/9627?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented reference refreshes from running prematurely during startup session restoration.
  * Reduced unnecessary topology processing while restored sessions are still being applied.
  * Ensured reference refresh behavior resumes once restoration has settled.

* **Tests**
  * Added coverage for session restoration readiness across pre-restore, active restore, and completed states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->