### PR TITLE
Fix beachball: bound every UNUserNotificationCenter call so a wedged usernotificationsd can't deadlock the main thread

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1318,6 +1318,7 @@ jobs:
             CmuxControlSocket
             CmuxFoundation
             CmuxGit
+            CmuxNotifications
             CmuxSettings
             CmuxSettingsUI
             CmuxTerminal

--- a/Packages/macOS/CmuxNotifications/Sources/CmuxNotifications/NotificationDeliveryCoordinator.swift
+++ b/Packages/macOS/CmuxNotifications/Sources/CmuxNotifications/NotificationDeliveryCoordinator.swift
@@ -21,6 +21,10 @@ public final class NotificationDeliveryCoordinator {
     private let terminalIdentifiers: TerminalNotificationDeliveryIdentifiers
     private let actionTitles: NotificationDeliveryActionTitles
 
+    /// The in-flight category installation, retained so reconfiguration can
+    /// cancel and replace a previous install instead of racing it.
+    @ObservationIgnored private var categoryInstallationTask: Task<Void, Never>?
+
     /// Creates a notification delivery coordinator with all OS, terminal, Feed,
     /// and activation side effects supplied through injected seams.
     public init(
@@ -39,11 +43,21 @@ public final class NotificationDeliveryCoordinator {
         self.actionTitles = actionTitles
     }
 
-    /// Installs every terminal and Feed notification category, then assigns the
-    /// `UNUserNotificationCenter` delegate.
+    /// Assigns the `UNUserNotificationCenter` delegate, then installs every
+    /// terminal and Feed notification category.
+    ///
+    /// The delegate is installed synchronously so launch-time notification
+    /// responses are never dropped. Category installation is fire-and-forget
+    /// through the bounded ``UserNotificationCenterConfiguring`` boundary: it
+    /// can touch the notification daemon over XPC, so a wedged daemon must
+    /// degrade to missing categories rather than a blocked main actor.
     public func configureUserNotifications(delegate: any UNUserNotificationCenterDelegate) {
-        center.setNotificationCategories(notificationCategories())
         center.setDelegate(delegate)
+        let categories = notificationCategories()
+        categoryInstallationTask?.cancel()
+        categoryInstallationTask = Task { [center] in
+            _ = await center.setNotificationCategories(categories)
+        }
     }
 
     /// Presentation options for a notification delivered while the app is in

--- a/Packages/macOS/CmuxNotifications/Sources/CmuxNotifications/UserNotificationAuthorizationStatus.swift
+++ b/Packages/macOS/CmuxNotifications/Sources/CmuxNotifications/UserNotificationAuthorizationStatus.swift
@@ -1,0 +1,39 @@
+import UserNotifications
+
+/// A sendable snapshot of the authorization status returned by UserNotifications.
+public enum UserNotificationAuthorizationStatus: Equatable, Sendable {
+    /// The user has not answered the authorization prompt.
+    case notDetermined
+
+    /// The user denied notification authorization.
+    case denied
+
+    /// The app is authorized to post notifications.
+    case authorized
+
+    /// The app has provisional notification authorization.
+    case provisional
+
+    /// The app has ephemeral notification authorization.
+    case ephemeral
+
+    /// The framework returned a status newer than this version of cmux understands.
+    case unknown(Int)
+
+    init(_ status: UNAuthorizationStatus) {
+        switch status {
+        case .notDetermined:
+            self = .notDetermined
+        case .denied:
+            self = .denied
+        case .authorized:
+            self = .authorized
+        case .provisional:
+            self = .provisional
+        case .ephemeral:
+            self = .ephemeral
+        @unknown default:
+            self = .unknown(status.rawValue)
+        }
+    }
+}

--- a/Packages/macOS/CmuxNotifications/Sources/CmuxNotifications/UserNotificationCenterCallGate.swift
+++ b/Packages/macOS/CmuxNotifications/Sources/CmuxNotifications/UserNotificationCenterCallGate.swift
@@ -1,0 +1,59 @@
+import os
+
+/// Settles one callback/deadline race and prevents timed-out queued work from starting.
+final class UserNotificationCenterCallGate<Value: Sendable>: @unchecked Sendable {
+    private struct State {
+        var continuation: CheckedContinuation<
+            Result<Value, UserNotificationCenterFailure>,
+            Never
+        >?
+        var timeoutTask: Task<Void, Never>?
+    }
+
+    // Safety: the lock protects the only mutable state and is held only for
+    // non-blocking compare-and-swap work around continuation settlement.
+    private let state: OSAllocatedUnfairLock<State>
+
+    init(
+        continuation: CheckedContinuation<
+            Result<Value, UserNotificationCenterFailure>,
+            Never
+        >
+    ) {
+        state = OSAllocatedUnfairLock(
+            initialState: State(continuation: continuation, timeoutTask: nil)
+        )
+    }
+
+    func installTimeoutTask(_ task: Task<Void, Never>) {
+        let shouldCancel = state.withLock { state in
+            guard state.continuation != nil else { return true }
+            state.timeoutTask = task
+            return false
+        }
+        if shouldCancel {
+            task.cancel()
+        }
+    }
+
+    func shouldStart() -> Bool {
+        state.withLock { $0.continuation != nil }
+    }
+
+    func resolve(_ result: Result<Value, UserNotificationCenterFailure>) {
+        typealias Settlement = (
+            CheckedContinuation<Result<Value, UserNotificationCenterFailure>, Never>,
+            Task<Void, Never>?
+        )
+        let settlement: Settlement? = state.withLock { state in
+            guard let continuation = state.continuation else { return nil }
+            state.continuation = nil
+            let timeoutTask = state.timeoutTask
+            state.timeoutTask = nil
+            return (continuation, timeoutTask)
+        }
+        guard let settlement else { return }
+        settlement.1?.cancel()
+        settlement.0.resume(returning: result)
+    }
+}

--- a/Packages/macOS/CmuxNotifications/Sources/CmuxNotifications/UserNotificationCenterCalling.swift
+++ b/Packages/macOS/CmuxNotifications/Sources/CmuxNotifications/UserNotificationCenterCalling.swift
@@ -1,0 +1,28 @@
+@preconcurrency import UserNotifications
+
+/// The callback-based framework surface isolated behind ``UserNotificationCenterService``.
+protocol UserNotificationCenterCalling: AnyObject {
+    var delegate: (any UNUserNotificationCenterDelegate)? { get set }
+
+    func setNotificationCategories(_ categories: Set<UNNotificationCategory>)
+
+    func getNotificationSettings(
+        completionHandler: @escaping @Sendable (UNNotificationSettings) -> Void
+    )
+
+    func requestAuthorization(
+        options: UNAuthorizationOptions,
+        completionHandler: @escaping @Sendable (Bool, (any Error)?) -> Void
+    )
+
+    func add(
+        _ request: UNNotificationRequest,
+        withCompletionHandler completionHandler: (@Sendable ((any Error)?) -> Void)?
+    )
+
+    func removeDeliveredNotifications(withIdentifiers identifiers: [String])
+
+    func removePendingNotificationRequests(withIdentifiers identifiers: [String])
+}
+
+extension UNUserNotificationCenter: UserNotificationCenterCalling {}

--- a/Packages/macOS/CmuxNotifications/Sources/CmuxNotifications/UserNotificationCenterConfiguring.swift
+++ b/Packages/macOS/CmuxNotifications/Sources/CmuxNotifications/UserNotificationCenterConfiguring.swift
@@ -1,20 +1,16 @@
 public import UserNotifications
 
-/// A narrow seam over `UNUserNotificationCenter` used by
-/// ``NotificationDeliveryCoordinator`` to install categories and its delegate.
+/// A narrow seam used by ``NotificationDeliveryCoordinator`` to install categories and its delegate.
 @MainActor
-public protocol UserNotificationCenterConfiguring: AnyObject {
-    /// Installs the notification categories the app can deliver or respond to.
-    func setNotificationCategories(_ categories: Set<UNNotificationCategory>)
+public protocol UserNotificationCenterConfiguring: Sendable {
+    /// Installs notification categories without blocking the main actor.
+    /// - Parameter categories: Every category the application can deliver.
+    /// - Returns: Success, a framework error, or a bounded timeout.
+    func setNotificationCategories(
+        _ categories: Set<UNNotificationCategory>
+    ) async -> Result<Void, UserNotificationCenterFailure>
 
     /// Installs the notification-center delegate that receives delivery and
     /// response callbacks.
     func setDelegate(_ delegate: (any UNUserNotificationCenterDelegate)?)
-}
-
-extension UNUserNotificationCenter: UserNotificationCenterConfiguring {
-    /// Installs `delegate` on the underlying `UNUserNotificationCenter`.
-    public func setDelegate(_ delegate: (any UNUserNotificationCenterDelegate)?) {
-        self.delegate = delegate
-    }
 }

--- a/Packages/macOS/CmuxNotifications/Sources/CmuxNotifications/UserNotificationCenterFailure.swift
+++ b/Packages/macOS/CmuxNotifications/Sources/CmuxNotifications/UserNotificationCenterFailure.swift
@@ -1,0 +1,8 @@
+/// A bounded failure returned by the macOS user-notification service boundary.
+public enum UserNotificationCenterFailure: Error, Equatable, Sendable {
+    /// The framework entrypoint or its completion missed the configured deadline.
+    case timedOut
+
+    /// UserNotifications reported a system error after accepting the call.
+    case system(String)
+}

--- a/Packages/macOS/CmuxNotifications/Sources/CmuxNotifications/UserNotificationCenterService.swift
+++ b/Packages/macOS/CmuxNotifications/Sources/CmuxNotifications/UserNotificationCenterService.swift
@@ -1,0 +1,210 @@
+@preconcurrency import Foundation
+@preconcurrency public import UserNotifications
+
+/// Serializes and bounds all UserNotifications framework entrypoints used by cmux.
+///
+/// Every call is funneled through one dedicated serial background queue and a
+/// deadline. UserNotifications methods can block synchronously in XPC to
+/// `usernotificationsd` before their completion handler is even wired up, and
+/// they all barrier onto the app's single
+/// `UNUserNotificationServiceConnection` queue. When the daemon wedges, one
+/// blocked call therefore wedges every later call — so the whole surface must
+/// live behind this boundary: the queue keeps the block off the callers'
+/// executors, and the deadline turns an unbounded wait into a
+/// ``UserNotificationCenterFailure/timedOut`` the caller can degrade on.
+///
+/// Safety: all stored properties are immutable after `init`; the queue and the
+/// per-call ``UserNotificationCenterCallGate`` own every mutable interaction.
+public final class UserNotificationCenterService: @unchecked Sendable {
+    typealias Sleep = @Sendable (_ duration: Duration) async throws -> Void
+
+    private let center: any UserNotificationCenterCalling
+    private let operationQueue: DispatchQueue
+    private let timeout: Duration
+    private let sleep: Sleep
+
+    /// Creates the production service around the current app's notification center.
+    ///
+    /// The serial dispatch queue is a deliberate legacy bridge: UserNotifications
+    /// can block synchronously before returning from an otherwise callback-based
+    /// method. Keeping that entrypoint on a dedicated GCD worker prevents it from
+    /// occupying the main actor or Swift's cooperative executor.
+    ///
+    /// - Parameters:
+    ///   - center: The notification center for the current application.
+    ///   - timeout: Maximum time any queued call or completion may consume.
+    public convenience init(
+        center: UNUserNotificationCenter,
+        timeout: Duration = .seconds(2)
+    ) {
+        let clock = ContinuousClock()
+        self.init(
+            center: center,
+            operationQueue: DispatchQueue(
+                label: "com.cmuxterm.user-notification-center",
+                qos: .utility
+            ),
+            timeout: timeout,
+            sleep: { duration in
+                try await clock.sleep(for: duration)
+            }
+        )
+    }
+
+    init(
+        center: any UserNotificationCenterCalling,
+        operationQueue: DispatchQueue = DispatchQueue(
+            label: "com.cmuxterm.user-notification-center.test",
+            qos: .utility
+        ),
+        timeout: Duration,
+        sleep: @escaping Sleep
+    ) {
+        self.center = center
+        self.operationQueue = operationQueue
+        self.timeout = timeout
+        self.sleep = sleep
+    }
+
+    /// Installs the application delegate synchronously, as required before app launch returns.
+    @MainActor
+    public func setDelegate(_ delegate: (any UNUserNotificationCenterDelegate)?) {
+        center.delegate = delegate
+    }
+
+    /// Installs notification categories through the bounded background boundary.
+    /// - Parameter categories: Every category the application can deliver.
+    /// - Returns: Success, a framework error, or a timeout.
+    @MainActor
+    public func setNotificationCategories(
+        _ categories: Set<UNNotificationCategory>
+    ) async -> Result<Void, UserNotificationCenterFailure> {
+        await perform { [self] completion in
+            center.setNotificationCategories(categories)
+            completion(.success(()))
+        }
+    }
+
+    /// Returns the app's current notification authorization status.
+    public func authorizationStatus() async -> Result<
+        UserNotificationAuthorizationStatus,
+        UserNotificationCenterFailure
+    > {
+        await perform { [self] completion in
+            center.getNotificationSettings { settings in
+                completion(.success(UserNotificationAuthorizationStatus(settings.authorizationStatus)))
+            }
+        }
+    }
+
+    /// Requests notification authorization through the bounded background boundary.
+    /// - Parameter options: The authorization capabilities requested from macOS.
+    /// - Returns: Whether the user granted access, a framework error, or a timeout.
+    public func requestAuthorization(
+        options: UNAuthorizationOptions
+    ) async -> Result<Bool, UserNotificationCenterFailure> {
+        await perform { [self] completion in
+            center.requestAuthorization(options: options) { granted, error in
+                if let error {
+                    completion(.failure(.system(error.localizedDescription)))
+                } else {
+                    completion(.success(granted))
+                }
+            }
+        }
+    }
+
+    /// Adds one notification request through the bounded background boundary.
+    /// - Parameter request: The immutable request to submit to macOS.
+    /// - Returns: Success, a framework error, or a timeout.
+    public func add(
+        _ request: UNNotificationRequest
+    ) async -> Result<Void, UserNotificationCenterFailure> {
+        await add(request) { [self] request, completion in
+            center.add(request, withCompletionHandler: completion)
+        }
+    }
+
+    /// Adds one notification request using an injected low-level entrypoint.
+    ///
+    /// The alternate entrypoint exists for app adapters and behavioral tests;
+    /// it still uses this instance's single queue and deadline.
+    ///
+    /// - Parameters:
+    ///   - request: The immutable request to submit.
+    ///   - operation: The callback-based framework adapter to invoke.
+    /// - Returns: Success, a framework error, or a timeout.
+    public func add(
+        _ request: UNNotificationRequest,
+        using operation: @escaping UserNotificationAddOperation
+    ) async -> Result<Void, UserNotificationCenterFailure> {
+        await perform { completion in
+            operation(request) { error in
+                if let error {
+                    completion(.failure(.system(error.localizedDescription)))
+                } else {
+                    completion(.success(()))
+                }
+            }
+        }
+    }
+
+    /// Removes delivered notifications through the bounded background boundary.
+    /// - Parameter identifiers: Request identifiers to remove.
+    /// - Returns: Success or a timeout if the synchronous framework call wedges.
+    public func removeDeliveredNotifications(
+        withIdentifiers identifiers: [String]
+    ) async -> Result<Void, UserNotificationCenterFailure> {
+        guard !identifiers.isEmpty else { return .success(()) }
+        return await perform { [self] completion in
+            center.removeDeliveredNotifications(withIdentifiers: identifiers)
+            completion(.success(()))
+        }
+    }
+
+    /// Removes pending notification requests through the bounded background boundary.
+    /// - Parameter identifiers: Request identifiers to remove.
+    /// - Returns: Success or a timeout if the synchronous framework call wedges.
+    public func removePendingNotificationRequests(
+        withIdentifiers identifiers: [String]
+    ) async -> Result<Void, UserNotificationCenterFailure> {
+        guard !identifiers.isEmpty else { return .success(()) }
+        return await perform { [self] completion in
+            center.removePendingNotificationRequests(withIdentifiers: identifiers)
+            completion(.success(()))
+        }
+    }
+
+    private func perform<Value: Sendable>(
+        _ operation: @escaping @Sendable (
+            _ completion: @escaping @Sendable (
+                Result<Value, UserNotificationCenterFailure>
+            ) -> Void
+        ) -> Void
+    ) async -> Result<Value, UserNotificationCenterFailure> {
+        await withCheckedContinuation { continuation in
+            let gate = UserNotificationCenterCallGate(continuation: continuation)
+            let timeoutTask = Task { [sleep, timeout] in
+                do {
+                    try await sleep(timeout)
+                    try Task.checkCancellation()
+                } catch {
+                    return
+                }
+                gate.resolve(.failure(.timedOut))
+            }
+            gate.installTimeoutTask(timeoutTask)
+            operationQueue.async {
+                guard gate.shouldStart() else { return }
+                operation { result in
+                    gate.resolve(result)
+                }
+            }
+        }
+    }
+}
+
+// Conformance lives in an extension so the `@MainActor` attribute on
+// `UserNotificationCenterConfiguring` does not infer main-actor isolation for
+// the whole service; only the two configuring witnesses are main-actor bound.
+extension UserNotificationCenterService: UserNotificationCenterServing {}

--- a/Packages/macOS/CmuxNotifications/Sources/CmuxNotifications/UserNotificationCenterServing.swift
+++ b/Packages/macOS/CmuxNotifications/Sources/CmuxNotifications/UserNotificationCenterServing.swift
@@ -1,0 +1,40 @@
+public import UserNotifications
+
+/// A low-level add entrypoint supplied to the serialized notification service.
+public typealias UserNotificationAddOperation = @Sendable (
+    _ request: UNNotificationRequest,
+    _ completion: @escaping @Sendable ((any Error)?) -> Void
+) -> Void
+
+/// Bounded access to every UserNotifications operation used by the macOS app.
+public protocol UserNotificationCenterServing: UserNotificationCenterConfiguring, Sendable {
+    /// Returns the app's current notification authorization status.
+    func authorizationStatus() async -> Result<
+        UserNotificationAuthorizationStatus,
+        UserNotificationCenterFailure
+    >
+
+    /// Requests alert and sound authorization without blocking the caller's executor.
+    /// - Parameter options: The authorization capabilities requested from macOS.
+    func requestAuthorization(
+        options: UNAuthorizationOptions
+    ) async -> Result<Bool, UserNotificationCenterFailure>
+
+    /// Adds one notification request without blocking the caller's executor.
+    /// - Parameter request: The immutable request to submit to macOS.
+    func add(
+        _ request: UNNotificationRequest
+    ) async -> Result<Void, UserNotificationCenterFailure>
+
+    /// Removes delivered notifications matching the supplied identifiers.
+    /// - Parameter identifiers: Request identifiers to remove.
+    func removeDeliveredNotifications(
+        withIdentifiers identifiers: [String]
+    ) async -> Result<Void, UserNotificationCenterFailure>
+
+    /// Removes pending notification requests matching the supplied identifiers.
+    /// - Parameter identifiers: Request identifiers to remove.
+    func removePendingNotificationRequests(
+        withIdentifiers identifiers: [String]
+    ) async -> Result<Void, UserNotificationCenterFailure>
+}

--- a/Packages/macOS/CmuxNotifications/Tests/CmuxNotificationsTests/NotificationDeliveryCoordinatorTests.swift
+++ b/Packages/macOS/CmuxNotifications/Tests/CmuxNotificationsTests/NotificationDeliveryCoordinatorTests.swift
@@ -7,8 +7,12 @@ import UserNotifications
 private final class FakeNotificationCenter: UserNotificationCenterConfiguring {
     private(set) var categories: Set<UNNotificationCategory> = []
     private(set) var delegate: (any UNUserNotificationCenterDelegate)?
+    var synchronousEntryDelay: TimeInterval = 0
 
     func setNotificationCategories(_ categories: Set<UNNotificationCategory>) {
+        if synchronousEntryDelay > 0 {
+            Thread.sleep(forTimeInterval: synchronousEntryDelay)
+        }
         self.categories = categories
     }
 
@@ -132,6 +136,21 @@ struct NotificationDeliveryCoordinatorTests {
         let question = try #require(categories["CMUXFeedQuestion"])
         #expect(question.actions.map(\.identifier) == ["feed.question.open"])
         #expect(question.actions.first?.options.contains(.foreground) == true)
+    }
+
+    @Test("configuration never blocks its caller on notification-center entry")
+    func configureDoesNotBlockCallingExecutor() {
+        let center = FakeNotificationCenter()
+        // Model a finite slice of the framework's otherwise unbounded sync XPC
+        // wait so the red regression fails without wedging the package runner.
+        center.synchronousEntryDelay = 0.25
+        let coordinator = makeCoordinator(center: center)
+        let clock = ContinuousClock()
+        let startedAt = clock.now
+
+        coordinator.configureUserNotifications(delegate: DummyNotificationDelegate())
+
+        #expect(startedAt.duration(to: clock.now) < .milliseconds(100))
     }
 
     @Test("presentation options include sound only when the notification has sound")

--- a/Packages/macOS/CmuxNotifications/Tests/CmuxNotificationsTests/NotificationDeliveryCoordinatorTests.swift
+++ b/Packages/macOS/CmuxNotifications/Tests/CmuxNotificationsTests/NotificationDeliveryCoordinatorTests.swift
@@ -7,17 +7,47 @@ import UserNotifications
 private final class FakeNotificationCenter: UserNotificationCenterConfiguring {
     private(set) var categories: Set<UNNotificationCategory> = []
     private(set) var delegate: (any UNUserNotificationCenterDelegate)?
-    var synchronousEntryDelay: TimeInterval = 0
 
-    func setNotificationCategories(_ categories: Set<UNNotificationCategory>) {
-        if synchronousEntryDelay > 0 {
-            Thread.sleep(forTimeInterval: synchronousEntryDelay)
+    /// When true, category installation suspends until
+    /// ``releaseCategoryInstall()``, modeling the framework's unbounded wait
+    /// on a wedged daemon.
+    var stallCategoryInstall = false
+    private var stallWaiters: [CheckedContinuation<Void, Never>] = []
+    private var categoryInstallWaiters: [CheckedContinuation<Void, Never>] = []
+
+    func setNotificationCategories(
+        _ categories: Set<UNNotificationCategory>
+    ) async -> Result<Void, UserNotificationCenterFailure> {
+        if stallCategoryInstall {
+            await withCheckedContinuation { stallWaiters.append($0) }
         }
         self.categories = categories
+        let waiters = categoryInstallWaiters
+        categoryInstallWaiters.removeAll()
+        for waiter in waiters {
+            waiter.resume()
+        }
+        return .success(())
     }
 
     func setDelegate(_ delegate: (any UNUserNotificationCenterDelegate)?) {
         self.delegate = delegate
+    }
+
+    /// Suspends until the fire-and-forget category install has landed.
+    func waitForCategoryInstall() async {
+        guard categories.isEmpty else { return }
+        await withCheckedContinuation { categoryInstallWaiters.append($0) }
+    }
+
+    /// Lets a stalled category installation proceed.
+    func releaseCategoryInstall() {
+        stallCategoryInstall = false
+        let waiters = stallWaiters
+        stallWaiters.removeAll()
+        for waiter in waiters {
+            waiter.resume()
+        }
     }
 }
 
@@ -100,15 +130,16 @@ private final class DummyNotificationDelegate: NSObject, UNUserNotificationCente
 @MainActor
 struct NotificationDeliveryCoordinatorTests {
     @Test("configure installs terminal and Feed categories and delegate")
-    func configureInstallsCategoriesAndDelegate() throws {
+    func configureInstallsCategoriesAndDelegate() async throws {
         let center = FakeNotificationCenter()
         let delegate = DummyNotificationDelegate()
         let coordinator = makeCoordinator(center: center)
 
         coordinator.configureUserNotifications(delegate: delegate)
+        #expect((center.delegate as AnyObject?) === delegate)
+        await center.waitForCategoryInstall()
 
         let categories = categoriesByIdentifier(center.categories)
-        #expect((center.delegate as AnyObject?) === delegate)
         let terminalCategory = try #require(categories["terminal.category"])
         #expect(terminalCategory.actions.map(\.identifier) == ["terminal.show"])
         #expect(terminalCategory.actions.map(\.title) == ["Show"])
@@ -139,18 +170,23 @@ struct NotificationDeliveryCoordinatorTests {
     }
 
     @Test("configuration never blocks its caller on notification-center entry")
-    func configureDoesNotBlockCallingExecutor() {
+    func configureDoesNotBlockCallingExecutor() async {
         let center = FakeNotificationCenter()
-        // Model a finite slice of the framework's otherwise unbounded sync XPC
-        // wait so the red regression fails without wedging the package runner.
-        center.synchronousEntryDelay = 0.25
+        // Category installation cannot finish until the test releases it, so
+        // the assertion below is causal: it can only pass when configure hands
+        // control back without waiting on the (wedged) center entry.
+        center.stallCategoryInstall = true
         let coordinator = makeCoordinator(center: center)
-        let clock = ContinuousClock()
-        let startedAt = clock.now
 
         coordinator.configureUserNotifications(delegate: DummyNotificationDelegate())
 
-        #expect(startedAt.duration(to: clock.now) < .milliseconds(100))
+        #expect(
+            center.categories.isEmpty,
+            "configure must return before category installation completes"
+        )
+        center.releaseCategoryInstall()
+        await center.waitForCategoryInstall()
+        #expect(!center.categories.isEmpty)
     }
 
     @Test("presentation options include sound only when the notification has sound")

--- a/Packages/macOS/CmuxNotifications/Tests/CmuxNotificationsTests/UserNotificationCenterServiceTests.swift
+++ b/Packages/macOS/CmuxNotifications/Tests/CmuxNotificationsTests/UserNotificationCenterServiceTests.swift
@@ -1,0 +1,358 @@
+import Foundation
+import Testing
+import UserNotifications
+import os
+@testable import CmuxNotifications
+
+/// A controllable stand-in for the framework's callback surface.
+///
+/// The optional entry semaphore models the framework's synchronous XPC wait on
+/// a wedged `usernotificationsd`: the call blocks at method entry, before any
+/// completion handler is wired up. The semaphore is deliberate here — blocking
+/// a thread is the exact behavior under test.
+private final class StubCallingCenter: UserNotificationCenterCalling, @unchecked Sendable {
+    var delegate: (any UNUserNotificationCenterDelegate)?
+
+    private struct State {
+        var startedAdds = 0
+        var finishedAdds = 0
+        var startedRemovals = 0
+    }
+
+    // Safety: the lock guards simple counters written from the service's
+    // worker queue and read from the test.
+    private let state = OSAllocatedUnfairLock(initialState: State())
+    private let addEntryWedge: DispatchSemaphore?
+    private let addCompletionError: (any Error)?
+    private let addCompletes: Bool
+    private let authorizationGrant: (Bool, (any Error)?)?
+
+    /// Invoked as soon as an `add` enters the (possibly wedged) framework call.
+    var onAddStarted: (@Sendable () -> Void)?
+
+    init(
+        addEntryWedge: DispatchSemaphore? = nil,
+        addCompletionError: (any Error)? = nil,
+        addCompletes: Bool = true,
+        authorizationGrant: (Bool, (any Error)?)? = nil
+    ) {
+        self.addEntryWedge = addEntryWedge
+        self.addCompletionError = addCompletionError
+        self.addCompletes = addCompletes
+        self.authorizationGrant = authorizationGrant
+    }
+
+    var startedAdds: Int {
+        state.withLock { $0.startedAdds }
+    }
+
+    var finishedAdds: Int {
+        state.withLock { $0.finishedAdds }
+    }
+
+    var startedRemovals: Int {
+        state.withLock { $0.startedRemovals }
+    }
+
+    func setNotificationCategories(_ categories: Set<UNNotificationCategory>) {}
+
+    func getNotificationSettings(
+        completionHandler: @escaping @Sendable (UNNotificationSettings) -> Void
+    ) {
+        // `UNNotificationSettings` has no public initializer; the settings
+        // path is exercised through its timeout behavior only.
+    }
+
+    func requestAuthorization(
+        options: UNAuthorizationOptions,
+        completionHandler: @escaping @Sendable (Bool, (any Error)?) -> Void
+    ) {
+        guard let authorizationGrant else { return }
+        completionHandler(authorizationGrant.0, authorizationGrant.1)
+    }
+
+    func add(
+        _ request: UNNotificationRequest,
+        withCompletionHandler completionHandler: (@Sendable ((any Error)?) -> Void)?
+    ) {
+        state.withLock { $0.startedAdds += 1 }
+        onAddStarted?()
+        addEntryWedge?.wait()
+        state.withLock { $0.finishedAdds += 1 }
+        guard addCompletes else { return }
+        completionHandler?(addCompletionError)
+    }
+
+    func removeDeliveredNotifications(withIdentifiers identifiers: [String]) {
+        state.withLock { $0.startedRemovals += 1 }
+    }
+
+    func removePendingNotificationRequests(withIdentifiers identifiers: [String]) {
+        state.withLock { $0.startedRemovals += 1 }
+    }
+}
+
+/// Fires the service deadline only when the test asks for it, so timeout
+/// behavior is asserted causally instead of against real elapsed time.
+private final class ManualDeadline: @unchecked Sendable {
+    private struct State {
+        var fired = false
+        var waiters: [CheckedContinuation<Void, Never>] = []
+    }
+
+    // Safety: the lock performs a short compare-and-set around continuation
+    // settlement; waiters installed after `fire()` resume immediately.
+    private let state = OSAllocatedUnfairLock(initialState: State())
+
+    var sleep: UserNotificationCenterService.Sleep {
+        { [self] _ in
+            await withCheckedContinuation { continuation in
+                let alreadyFired = state.withLock { state -> Bool in
+                    if state.fired { return true }
+                    state.waiters.append(continuation)
+                    return false
+                }
+                if alreadyFired {
+                    continuation.resume()
+                }
+            }
+        }
+    }
+
+    func fire() {
+        let waiters = state.withLock { state -> [CheckedContinuation<Void, Never>] in
+            state.fired = true
+            let waiters = state.waiters
+            state.waiters.removeAll()
+            return waiters
+        }
+        for waiter in waiters {
+            waiter.resume()
+        }
+    }
+}
+
+/// A one-shot signal that tolerates signal-before-wait ordering.
+private final class AsyncFlag: @unchecked Sendable {
+    private struct State {
+        var signaled = false
+        var waiter: CheckedContinuation<Void, Never>?
+    }
+
+    // Safety: the lock performs a short compare-and-set around one
+    // continuation settlement.
+    private let state = OSAllocatedUnfairLock(initialState: State())
+
+    func signal() {
+        let waiter = state.withLock { state -> CheckedContinuation<Void, Never>? in
+            state.signaled = true
+            let waiter = state.waiter
+            state.waiter = nil
+            return waiter
+        }
+        waiter?.resume()
+    }
+
+    func wait() async {
+        await withCheckedContinuation { continuation in
+            let alreadySignaled = state.withLock { state -> Bool in
+                if state.signaled { return true }
+                state.waiter = continuation
+                return false
+            }
+            if alreadySignaled {
+                continuation.resume()
+            }
+        }
+    }
+}
+
+struct UserNotificationCenterServiceTests {
+    private static func makeService(
+        center: StubCallingCenter,
+        queue: DispatchQueue,
+        deadline: ManualDeadline? = nil
+    ) -> UserNotificationCenterService {
+        let sleep: UserNotificationCenterService.Sleep
+        if let deadline {
+            sleep = deadline.sleep
+        } else {
+            // Success-path tests: a deadline that never fires on its own. The
+            // call gate cancels this task once the real completion lands,
+            // which throws out of the sleep.
+            sleep = { _ in
+                try await Task.sleep(for: .seconds(600))
+            }
+        }
+        return UserNotificationCenterService(
+            center: center,
+            operationQueue: queue,
+            timeout: .seconds(2),
+            sleep: sleep
+        )
+    }
+
+    private static func makeRequest(identifier: String = "test") -> UNNotificationRequest {
+        UNNotificationRequest(
+            identifier: identifier,
+            content: UNMutableNotificationContent(),
+            trigger: nil
+        )
+    }
+
+    private static func isTimedOut(_ result: Result<Void, UserNotificationCenterFailure>) -> Bool {
+        if case .failure(.timedOut) = result { return true }
+        return false
+    }
+
+    private static func isSuccess(_ result: Result<Void, UserNotificationCenterFailure>) -> Bool {
+        if case .success = result { return true }
+        return false
+    }
+
+    private static func drain(_ queue: DispatchQueue) async {
+        await withCheckedContinuation { continuation in
+            queue.async { continuation.resume() }
+        }
+    }
+
+    @Test("a call whose completion never arrives resolves as a timeout at the deadline")
+    func neverCompletingCallTimesOut() async {
+        let deadline = ManualDeadline()
+        let entered = AsyncFlag()
+        let center = StubCallingCenter(addCompletes: false)
+        center.onAddStarted = { entered.signal() }
+        let queue = DispatchQueue(label: "test.un-service.never-completes")
+        let service = Self.makeService(center: center, queue: queue, deadline: deadline)
+
+        async let pending = service.add(Self.makeRequest())
+        await entered.wait()
+        deadline.fire()
+        let result = await pending
+
+        #expect(Self.isTimedOut(result))
+        #expect(center.startedAdds == 1)
+    }
+
+    @Test("a synchronously wedged framework entry resolves the awaiting caller while still blocked")
+    func wedgedEntryTimesOutWithoutBlockingCaller() async {
+        let wedge = DispatchSemaphore(value: 0)
+        defer { wedge.signal() }
+        let deadline = ManualDeadline()
+        let entered = AsyncFlag()
+        let center = StubCallingCenter(addEntryWedge: wedge)
+        center.onAddStarted = { entered.signal() }
+        let queue = DispatchQueue(label: "test.un-service.wedged-entry")
+        let service = Self.makeService(center: center, queue: queue, deadline: deadline)
+
+        async let pending = service.add(Self.makeRequest())
+        await entered.wait()
+        deadline.fire()
+        let result = await pending
+
+        #expect(Self.isTimedOut(result))
+        // Causal proof the caller resolved while the framework entry was
+        // still blocked: the wedge is only released by the deferred signal.
+        #expect(center.finishedAdds == 0)
+    }
+
+    @Test("a call queued behind a wedged call times out and its framework entry never starts")
+    func queuedCallBehindWedgeNeverStarts() async {
+        let wedge = DispatchSemaphore(value: 0)
+        let deadline = ManualDeadline()
+        let entered = AsyncFlag()
+        let center = StubCallingCenter(addEntryWedge: wedge)
+        center.onAddStarted = { entered.signal() }
+        let queue = DispatchQueue(label: "test.un-service.queued-behind-wedge")
+        let service = Self.makeService(center: center, queue: queue, deadline: deadline)
+
+        async let first = service.add(Self.makeRequest(identifier: "first"))
+        async let second = service.add(Self.makeRequest(identifier: "second"))
+        await entered.wait()
+        deadline.fire()
+        let results = await [first, second]
+
+        #expect(results.allSatisfy(Self.isTimedOut))
+        wedge.signal()
+        await Self.drain(queue)
+        #expect(center.startedAdds == 1)
+    }
+
+    @Test("a completing add passes success and system errors through")
+    func addPassesThroughCompletion() async {
+        let queue = DispatchQueue(label: "test.un-service.add-completes")
+        let succeeding = Self.makeService(center: StubCallingCenter(), queue: queue)
+        #expect(Self.isSuccess(await succeeding.add(Self.makeRequest())))
+
+        let failure = NSError(domain: "cmuxTests.UNService", code: 7)
+        let failing = Self.makeService(
+            center: StubCallingCenter(addCompletionError: failure),
+            queue: queue
+        )
+        let result = await failing.add(Self.makeRequest())
+        guard case .failure(.system(let message)) = result else {
+            Issue.record("expected a system failure, got \(result)")
+            return
+        }
+        #expect(message == failure.localizedDescription)
+    }
+
+    @Test("requestAuthorization maps the framework grant and times out when unresponsive")
+    func requestAuthorizationMapsGrant() async {
+        let queue = DispatchQueue(label: "test.un-service.authorization")
+        let granting = Self.makeService(
+            center: StubCallingCenter(authorizationGrant: (true, nil)),
+            queue: queue
+        )
+        #expect(await granting.requestAuthorization(options: [.alert, .sound]) == .success(true))
+
+        let deadline = ManualDeadline()
+        let unresponsive = Self.makeService(
+            center: StubCallingCenter(),
+            queue: queue,
+            deadline: deadline
+        )
+        deadline.fire()
+        let result = await unresponsive.requestAuthorization(options: [.alert, .sound])
+        #expect(result == .failure(.timedOut))
+    }
+
+    @Test("settings lookups against an unresponsive center resolve as a timeout at the deadline")
+    func authorizationStatusTimesOut() async {
+        let deadline = ManualDeadline()
+        let queue = DispatchQueue(label: "test.un-service.settings")
+        let service = Self.makeService(
+            center: StubCallingCenter(),
+            queue: queue,
+            deadline: deadline
+        )
+
+        deadline.fire()
+        let result = await service.authorizationStatus()
+
+        #expect(result == .failure(.timedOut))
+    }
+
+    @Test("removals with no identifiers succeed without entering the framework")
+    func emptyRemovalsShortCircuit() async {
+        let center = StubCallingCenter()
+        let queue = DispatchQueue(label: "test.un-service.empty-removals")
+        let service = Self.makeService(center: center, queue: queue)
+
+        #expect(Self.isSuccess(await service.removeDeliveredNotifications(withIdentifiers: [])))
+        #expect(Self.isSuccess(await service.removePendingNotificationRequests(withIdentifiers: [])))
+        await Self.drain(queue)
+        #expect(center.startedRemovals == 0)
+    }
+
+    @Test("removals pass through the bounded boundary")
+    func removalsRunOnWorkerQueue() async {
+        let center = StubCallingCenter()
+        let queue = DispatchQueue(label: "test.un-service.removals")
+        let service = Self.makeService(center: center, queue: queue)
+
+        #expect(Self.isSuccess(await service.removeDeliveredNotifications(withIdentifiers: ["a"])))
+        #expect(Self.isSuccess(await service.removePendingNotificationRequests(withIdentifiers: ["b"])))
+        #expect(center.startedRemovals == 2)
+    }
+}

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -705,7 +705,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
     lazy var notificationDeliverySeams = NotificationDeliverySeamAdapter(owner: self)
 
     lazy var notificationDelivery = NotificationDeliveryCoordinator(
-        center: UNUserNotificationCenter.current(),
+        center: TerminalNotificationStore.shared.userNotificationCenter,
         terminalNavigation: notificationNavigation,
         feedReplying: notificationDeliverySeams,
         applicationActivation: notificationDeliverySeams,

--- a/Sources/Feed/FeedCoordinator.swift
+++ b/Sources/Feed/FeedCoordinator.swift
@@ -1,6 +1,7 @@
 import AppKit
 import Bonsplit
 import CMUXAgentLaunch
+import CmuxNotifications
 import Foundation
 @preconcurrency import UserNotifications
 import CmuxSettings
@@ -28,6 +29,13 @@ final class FeedCoordinator: @unchecked Sendable {
     // The store runs on the main actor. The coordinator is not isolated,
     // so it hops to main explicitly when touching the store.
     @MainActor private(set) var store: WorkstreamStore!
+    @MainActor private var userNotificationCenter: (any UserNotificationCenterServing)?
+
+    /// The bounded notification-center boundary. `install(store:)` injects it;
+    /// the shared store's service covers the pre-install window.
+    @MainActor private var resolvedUserNotificationCenter: any UserNotificationCenterServing {
+        userNotificationCenter ?? TerminalNotificationStore.shared.userNotificationCenter
+    }
 
     /// Pending blocking-hook waiters keyed by request id. The waiter owns
     /// a semaphore plus a slot for the resolved decision; the reply
@@ -61,8 +69,15 @@ final class FeedCoordinator: @unchecked Sendable {
 
     /// Must be called once at app launch to install the store.
     @MainActor
-    func install(store: WorkstreamStore) {
+    func install(
+        store: WorkstreamStore,
+        userNotificationCenter: (any UserNotificationCenterServing)? = nil
+    ) {
         self.store = store
+        // Resolved here rather than as a default argument: default-argument
+        // expressions evaluate outside the method's main-actor isolation.
+        self.userNotificationCenter = userNotificationCenter
+            ?? TerminalNotificationStore.shared.userNotificationCenter
         NotificationCenter.default.post(name: Self.storeInstalledNotification, object: self)
         // Catch any pending items that were restored from disk whose
         // agent is already gone. After this, live tracking is
@@ -1141,52 +1156,57 @@ private extension FeedCoordinator {
             trigger: nil
         )
 
-        let center = UNUserNotificationCenter.current()
-        center.getNotificationSettings { settings in
-            Task { @MainActor [weak self] in
-                guard let self, self.isAwaitingDecision(requestId: requestId) else { return }
-                switch settings.authorizationStatus {
-                case .authorized, .provisional:
+        let center = resolvedUserNotificationCenter
+        Task { @MainActor [weak self] in
+            let statusResult = await center.authorizationStatus()
+            guard let self, self.isAwaitingDecision(requestId: requestId) else { return }
+            let status: UserNotificationAuthorizationStatus
+            switch statusResult {
+            case .success(let value):
+                status = value
+            case .failure:
+                // The notification daemon is unresponsive; treat authorization
+                // as unknown and stay audible (fail-open) via local fallback.
+                self.runFallbackEffectsIfStillAwaiting(
+                    requestId: requestId,
+                    title: title,
+                    subtitle: subtitle,
+                    body: body,
+                    effects: TerminalNotificationStore.fallbackEffects(
+                        effects,
+                        authorizationState: .unknown
+                    ),
+                    runCommand: false
+                )
+                return
+            }
+            switch status {
+            case .authorized, .provisional:
+                self.addNotificationIfStillAwaiting(
+                    request: request,
+                    requestId: requestId,
+                    effects: effects
+                )
+            case .notDetermined:
+                let authorization = await center.requestAuthorization(options: [.alert, .sound])
+                guard self.isAwaitingDecision(requestId: requestId) else { return }
+                if case .success(true) = authorization {
                     self.addNotificationIfStillAwaiting(
-                        center: center,
                         request: request,
                         requestId: requestId,
                         effects: effects
                     )
-                case .notDetermined:
-                    var granted = false
-                    var requestFailed = false
-                    do {
-                        granted = try await center.requestAuthorization(options: [.alert, .sound])
-                    } catch {
+                } else {
+                    // A non-grant without an error is the user declining
+                    // the prompt just now: honor the fresh denial on this
+                    // very notification. A request failure is not a user
+                    // decision, so the fallback stays audible (fail-open).
+                    let requestFailed: Bool
+                    if case .failure = authorization {
                         requestFailed = true
-                    }
-                    guard self.isAwaitingDecision(requestId: requestId) else { return }
-                    if granted {
-                        self.addNotificationIfStillAwaiting(
-                            center: center,
-                            request: request,
-                            requestId: requestId,
-                            effects: effects
-                        )
                     } else {
-                        // A non-grant without an error is the user declining
-                        // the prompt just now: honor the fresh denial on this
-                        // very notification. A request error is not a user
-                        // decision, so the fallback stays audible (fail-open).
-                        self.runFallbackEffectsIfStillAwaiting(
-                            requestId: requestId,
-                            title: title,
-                            subtitle: subtitle,
-                            body: body,
-                            effects: TerminalNotificationStore.fallbackEffects(
-                                effects,
-                                authorizationState: requestFailed ? .unknown : .denied
-                            ),
-                            runCommand: false
-                        )
+                        requestFailed = false
                     }
-                default:
                     self.runFallbackEffectsIfStillAwaiting(
                         requestId: requestId,
                         title: title,
@@ -1194,20 +1214,29 @@ private extension FeedCoordinator {
                         body: body,
                         effects: TerminalNotificationStore.fallbackEffects(
                             effects,
-                            authorizationState: TerminalNotificationStore.authorizationState(
-                                from: settings.authorizationStatus
-                            )
+                            authorizationState: requestFailed ? .unknown : .denied
                         ),
                         runCommand: false
                     )
                 }
+            case .denied, .ephemeral, .unknown:
+                self.runFallbackEffectsIfStillAwaiting(
+                    requestId: requestId,
+                    title: title,
+                    subtitle: subtitle,
+                    body: body,
+                    effects: TerminalNotificationStore.fallbackEffects(
+                        effects,
+                        authorizationState: TerminalNotificationStore.authorizationState(from: status)
+                    ),
+                    runCommand: false
+                )
             }
         }
     }
 
     @MainActor
     func addNotificationIfStillAwaiting(
-        center: UNUserNotificationCenter,
         request: UNNotificationRequest,
         requestId: String,
         effects: TerminalNotificationPolicyEffects
@@ -1216,32 +1245,31 @@ private extension FeedCoordinator {
         let title = request.content.title
         let subtitle = request.content.subtitle
         let body = request.content.body
-        center.add(request) { error in
-            let didFail = error != nil
-            Task { @MainActor [weak self] in
-                guard let self else { return }
-                if !self.isAwaitingDecision(requestId: requestId) {
-                    self.cancelNotification(requestId: requestId)
-                    return
-                }
-                if didFail {
-                    self.runFallbackEffectsIfStillAwaiting(
-                        requestId: requestId,
-                        title: title,
-                        subtitle: subtitle,
-                        body: body,
-                        effects: effects,
-                        runCommand: false
-                    )
-                    return
-                }
-                if effects.command {
-                    NotificationSoundSettings.runCustomCommand(
-                        title: title,
-                        subtitle: subtitle,
-                        body: body
-                    )
-                }
+        let center = resolvedUserNotificationCenter
+        Task { @MainActor [weak self] in
+            let result = await center.add(request)
+            guard let self else { return }
+            if !self.isAwaitingDecision(requestId: requestId) {
+                self.cancelNotification(requestId: requestId)
+                return
+            }
+            if case .failure = result {
+                self.runFallbackEffectsIfStillAwaiting(
+                    requestId: requestId,
+                    title: title,
+                    subtitle: subtitle,
+                    body: body,
+                    effects: effects,
+                    runCommand: false
+                )
+                return
+            }
+            if effects.command {
+                NotificationSoundSettings.runCustomCommand(
+                    title: title,
+                    subtitle: subtitle,
+                    body: body
+                )
             }
         }
     }
@@ -1266,9 +1294,12 @@ private extension FeedCoordinator {
 
     func cancelNotification(requestId: String) {
         let identifier = "feed.\(requestId)"
-        let center = UNUserNotificationCenter.current()
-        center.removePendingNotificationRequestsOffMain(withIdentifiers: [identifier])
-        center.removeDeliveredNotificationsOffMain(withIdentifiers: [identifier])
+        Task { @MainActor [weak self] in
+            guard let self else { return }
+            let center = self.resolvedUserNotificationCenter
+            _ = await center.removePendingNotificationRequests(withIdentifiers: [identifier])
+            _ = await center.removeDeliveredNotifications(withIdentifiers: [identifier])
+        }
     }
 }
 

--- a/Sources/NativeNotificationDeliveryHooks.swift
+++ b/Sources/NativeNotificationDeliveryHooks.swift
@@ -1,3 +1,4 @@
+import CmuxNotifications
 import Foundation
 import UserNotifications
 
@@ -7,17 +8,27 @@ struct NativeNotificationDeliveryHooks: Sendable {
     typealias Scheduler = @Sendable (UNNotificationRequest, @escaping @Sendable (Error?) -> Void) -> Void
     typealias CommandRunner = @Sendable (String, String, String) -> Void
 
-    var authorizationHandlerForTesting: AuthorizationHandler?
-    var scheduler: Scheduler = {
-        request,
-        completion in
-        UNUserNotificationCenter.current().add(request, withCompletionHandler: completion)
-    }
-    var commandRunner: CommandRunner = {
+    typealias UnavailableFeedbackPlayer = @Sendable (TerminalNotificationPolicyEffects) -> Void
+
+    static let defaultCommandRunner: CommandRunner = {
         title,
         subtitle,
         body in
         NotificationSoundSettings.runCustomCommand(title: title, subtitle: subtitle, body: body)
+    }
+
+    var authorizationHandlerForTesting: AuthorizationHandler?
+    let userNotificationCenter: UserNotificationCenterService
+    var scheduler: Scheduler?
+    static let defaultUnavailableFeedbackPlayer: UnavailableFeedbackPlayer = { effects in
+        NativeNotificationDeliveryHooks.playNativeUnavailableFeedback(effects: effects)
+    }
+
+    var commandRunner: CommandRunner = defaultCommandRunner
+    var unavailableFeedbackPlayer: UnavailableFeedbackPlayer = defaultUnavailableFeedbackPlayer
+
+    init(userNotificationCenter: UserNotificationCenterService) {
+        self.userNotificationCenter = userNotificationCenter
     }
 
     func authorizeForTesting(_ completion: @escaping AuthorizationCompletion) -> Bool {
@@ -32,11 +43,29 @@ struct NativeNotificationDeliveryHooks: Sendable {
         _ request: UNNotificationRequest,
         completion: @escaping @Sendable (Error?) -> Void
     ) {
-        scheduler(request, completion)
+        let scheduler = scheduler
+        Task {
+            let result: Result<Void, UserNotificationCenterFailure>
+            if let scheduler {
+                result = await userNotificationCenter.add(request, using: scheduler)
+            } else {
+                result = await userNotificationCenter.add(request)
+            }
+            switch result {
+            case .success:
+                completion(nil)
+            case .failure(let error):
+                completion(error)
+            }
+        }
     }
 
     func runCommand(title: String, subtitle: String, body: String) {
         commandRunner(title, subtitle, body)
+    }
+
+    func playUnavailableFeedback(effects: TerminalNotificationPolicyEffects) {
+        unavailableFeedbackPlayer(effects)
     }
 
     func runLocalFeedback(

--- a/Sources/TerminalNotificationStore.swift
+++ b/Sources/TerminalNotificationStore.swift
@@ -22,33 +22,6 @@ extension TerminalNotificationStore {
         phoneForwardingEnabled && categoryAllowsDelivery
     }
 }
-
-// UNUserNotificationCenter.removeDeliveredNotifications(withIdentifiers:) and
-// removePendingNotificationRequests(withIdentifiers:) perform synchronous XPC to
-// usernoted under the hood. When usernoted is slow, this blocks the calling thread
-// indefinitely. These helpers dispatch the calls off the main thread so they never
-// freeze the UI.
-extension UNUserNotificationCenter {
-    private static let removalQueue = DispatchQueue(
-        label: "com.cmuxterm.notification-removal",
-        qos: .utility
-    )
-
-    func removeDeliveredNotificationsOffMain(withIdentifiers ids: [String]) {
-        guard !ids.isEmpty else { return }
-        Self.removalQueue.async {
-            self.removeDeliveredNotifications(withIdentifiers: ids)
-        }
-    }
-
-    func removePendingNotificationRequestsOffMain(withIdentifiers ids: [String]) {
-        guard !ids.isEmpty else { return }
-        Self.removalQueue.async {
-            self.removePendingNotificationRequests(withIdentifiers: ids)
-        }
-    }
-}
-
 enum NotificationBadgeSettings {
     static let dockBadgeEnabledKey = "notificationDockBadgeEnabled"
     static let defaultDockBadgeEnabled = true
@@ -170,7 +143,11 @@ final class TerminalNotificationStore: ObservableObject {
         var latestByTabId: [UUID: TerminalNotification] = [:]
     }
 
-    static let shared = TerminalNotificationStore()
+    static let shared = TerminalNotificationStore(
+        userNotificationCenter: UserNotificationCenterService(
+            center: UNUserNotificationCenter.current()
+        )
+    )
     let notificationHookCache = CmuxNotificationHookCache()
 
     static let authorizationStatusDidChangeNotification = Notification.Name("cmux.terminalNotificationAuthorizationStatusDidChange")
@@ -418,7 +395,7 @@ final class TerminalNotificationStore: ObservableObject {
     }
     private var suppressNotificationDiffPublishing = false
 
-    private let center = UNUserNotificationCenter.current()
+    let userNotificationCenter: UserNotificationCenterService
     private var hasRequestedAutomaticAuthorization = false
     private var hasDeferredAuthorizationRequest = false
     private var hasPromptedForSettings = false
@@ -447,7 +424,7 @@ final class TerminalNotificationStore: ObservableObject {
         effects in
         store.scheduleUserNotification(notification, effects: effects)
     }
-    private var nativeNotificationDeliveryHooks = NativeNotificationDeliveryHooks()
+    private var nativeNotificationDeliveryHooks: NativeNotificationDeliveryHooks
     private var suppressedNotificationFeedbackHandler: (TerminalNotificationStore, TerminalNotification, TerminalNotificationPolicyEffects) -> Void = {
         store,
         notification,
@@ -464,7 +441,11 @@ final class TerminalNotificationStore: ObservableObject {
     var lastNotificationHookFailureDateByKey: [NotificationHookFailureThrottleKey: Date] = [:]
     private var indexes = NotificationIndexes()
     private let inFlightPolicyRequests = TerminalNotificationPolicyInFlightStore()
-    private init() {
+    private init(userNotificationCenter: UserNotificationCenterService) {
+        self.userNotificationCenter = userNotificationCenter
+        nativeNotificationDeliveryHooks = NativeNotificationDeliveryHooks(
+            userNotificationCenter: userNotificationCenter
+        )
         notificationFeedHistory = NotificationFeedHistoryStore(
             fileURL: NotificationFeedHistoryStore.defaultFileURL()
         ) { revision in
@@ -490,6 +471,24 @@ final class TerminalNotificationStore: ObservableObject {
     deinit {
         if let userDefaultsObserver {
             NotificationCenter.default.removeObserver(userDefaultsObserver)
+        }
+    }
+
+    private func removeDeliveredNotifications(withIdentifiers identifiers: [String]) {
+        guard !identifiers.isEmpty else { return }
+        Task { [userNotificationCenter] in
+            _ = await userNotificationCenter.removeDeliveredNotifications(
+                withIdentifiers: identifiers
+            )
+        }
+    }
+
+    private func removePendingNotificationRequests(withIdentifiers identifiers: [String]) {
+        guard !identifiers.isEmpty else { return }
+        Task { [userNotificationCenter] in
+            _ = await userNotificationCenter.removePendingNotificationRequests(
+                withIdentifiers: identifiers
+            )
         }
     }
 
@@ -583,7 +582,9 @@ final class TerminalNotificationStore: ObservableObject {
         terminalNotificationLogger.info("Authorization \(message, privacy: .private)")
     }
 
-    private static func authorizationStatusLabel(_ status: UNAuthorizationStatus) -> String {
+    private static func authorizationStatusLabel(
+        _ status: UserNotificationAuthorizationStatus
+    ) -> String {
         switch status {
         case .notDetermined:
             return "notDetermined"
@@ -595,19 +596,24 @@ final class TerminalNotificationStore: ObservableObject {
             return "provisional"
         case .ephemeral:
             return "ephemeral"
-        @unknown default:
-            return "unknown(\(status.rawValue))"
+        case .unknown(let rawValue):
+            return "unknown(\(rawValue))"
         }
     }
 
     func refreshAuthorizationStatus() {
-        center.getNotificationSettings { [weak self] settings in
-            DispatchQueue.main.async {
-                guard let self else { return }
-                self.authorizationState = Self.authorizationState(from: settings.authorizationStatus)
-                self.logAuthorization(
-                    "refresh status=\(Self.authorizationStatusLabel(settings.authorizationStatus)) mapped=\(self.authorizationState.statusLabel)"
+        Task { @MainActor [weak self, userNotificationCenter] in
+            let result = await userNotificationCenter.authorizationStatus()
+            guard let self else { return }
+            switch result {
+            case .success(let status):
+                authorizationState = Self.authorizationState(from: status)
+                logAuthorization(
+                    "refresh status=\(Self.authorizationStatusLabel(status)) mapped=\(authorizationState.statusLabel)"
                 )
+            case .failure(let error):
+                authorizationState = .unknown
+                logAuthorization("refresh failed error=\(String(describing: error))")
             }
         }
     }
@@ -651,14 +657,18 @@ final class TerminalNotificationStore: ObservableObject {
                 trigger: nil
             )
 
-            self.center.add(request) { error in
-                if let error {
+            Task { @MainActor [weak self, userNotificationCenter] in
+                let result = await userNotificationCenter.add(request)
+                guard let self else { return }
+                switch result {
+                case .failure(let error):
                     terminalNotificationLogger.error(
-                        "Failed to schedule test notification error=\(error.localizedDescription, privacy: .private)"
+                        "Failed to schedule test notification error=\(String(describing: error), privacy: .private)"
                     )
-                    self.logAuthorization("settings test schedule failed error=\(error.localizedDescription)")
-                } else {
-                    self.logAuthorization("settings test schedule succeeded")
+                    logAuthorization("settings test schedule failed error=\(String(describing: error))")
+                    NotificationSoundSettings.playSelectedSound()
+                case .success:
+                    logAuthorization("settings test schedule succeeded")
                     NotificationSoundSettings.runCustomCommand(
                         title: content.title,
                         subtitle: content.subtitle,
@@ -1281,8 +1291,8 @@ final class TerminalNotificationStore: ObservableObject {
         )
 #endif
         if !idsToClear.isEmpty {
-            center.removeDeliveredNotificationsOffMain(withIdentifiers: idsToClear)
-            center.removePendingNotificationRequestsOffMain(withIdentifiers: idsToClear)
+            removeDeliveredNotifications(withIdentifiers: idsToClear)
+            removePendingNotificationRequests(withIdentifiers: idsToClear)
             // Decide replacement admission exactly once in the side-effect
             // chokepoint below. Until then, retain the superseded ids so the
             // actual queue result determines whether dismissal is immediate or
@@ -1397,11 +1407,13 @@ final class TerminalNotificationStore: ObservableObject {
                 content: content,
                 trigger: nil
             )
-            self.center.add(request) { error in
-                if let error {
+            Task { [userNotificationCenter] in
+                let result = await userNotificationCenter.add(request)
+                if case .failure(let error) = result {
                     terminalNotificationLogger.error(
-                        "Failed to schedule notification hook failure alert error=\(error.localizedDescription, privacy: .private)"
+                        "Failed to schedule notification hook failure alert error=\(String(describing: error), privacy: .private)"
                     )
+                    NotificationSoundSettings.playSelectedSound()
                 }
             }
         }
@@ -1432,7 +1444,7 @@ final class TerminalNotificationStore: ObservableObject {
         }
         if !activeIDs.isEmpty {
             notifications = updated
-            center.removeDeliveredNotificationsOffMain(withIdentifiers: activeIDs)
+            removeDeliveredNotifications(withIdentifiers: activeIDs)
             emitNotificationsDismissed(
                 ids: activeIDs,
                 drainedSuperseded: drainedSuperseded
@@ -1492,7 +1504,7 @@ final class TerminalNotificationStore: ObservableObject {
         setPanelDerivedWorkspaceUnread(false, forTabId: tabId)
         setWorkspaceRestoredUnread(false, forTabId: tabId)
         if !idsToClear.isEmpty {
-            center.removeDeliveredNotificationsOffMain(withIdentifiers: idsToClear)
+            removeDeliveredNotifications(withIdentifiers: idsToClear)
             emitNotificationsDismissed(
                 ids: idsToClear,
                 drainedSuperseded: supersededPhoneDismissBuffer.flush(matchingTabId: tabId)
@@ -1536,8 +1548,8 @@ final class TerminalNotificationStore: ObservableObject {
             setWorkspaceRestoredUnread(false, forTabId: tabId)
         }
         if !idsToClear.isEmpty {
-            center.removeDeliveredNotificationsOffMain(withIdentifiers: idsToClear)
-            center.removePendingNotificationRequestsOffMain(withIdentifiers: idsToClear)
+            removeDeliveredNotifications(withIdentifiers: idsToClear)
+            removePendingNotificationRequests(withIdentifiers: idsToClear)
             emitNotificationsDismissed(ids: idsToClear, drainedSuperseded: supersededDrained)
         }
     }
@@ -1616,8 +1628,8 @@ final class TerminalNotificationStore: ObservableObject {
         clearPanelDerivedWorkspaceUnread()
         clearWorkspaceRestoredUnread()
         if !idsToClear.isEmpty {
-            center.removeDeliveredNotificationsOffMain(withIdentifiers: idsToClear)
-            center.removePendingNotificationRequestsOffMain(withIdentifiers: idsToClear)
+            removeDeliveredNotifications(withIdentifiers: idsToClear)
+            removePendingNotificationRequests(withIdentifiers: idsToClear)
             emitNotificationsDismissed(
                 ids: idsToClear,
                 drainedSuperseded: supersededPhoneDismissBuffer.flushAll()
@@ -1636,7 +1648,7 @@ final class TerminalNotificationStore: ObservableObject {
         if let removed {
             clearFocusedReadIndicator(forTabId: removed.tabId, surfaceId: removed.surfaceId)
         }
-        center.removeDeliveredNotificationsOffMain(withIdentifiers: [id.uuidString])
+        removeDeliveredNotifications(withIdentifiers: [id.uuidString])
         let supersededDrained = removed.map { removedNotification in
             supersededPhoneDismissBuffer.flush(
                 forKey: SupersededPhoneDismissBuffer.key(
@@ -1654,7 +1666,7 @@ final class TerminalNotificationStore: ObservableObject {
             $0.tabId == tabId && $0.correlationKey == correlationKey ? $0.id : nil
         }
         ids.forEach(remove)
-        center.removePendingNotificationRequestsOffMain(withIdentifiers: ids.map(\.uuidString))
+        removePendingNotificationRequests(withIdentifiers: ids.map(\.uuidString))
     }
 
     func restoreSessionNotifications(_ restoredNotifications: [TerminalNotification], forTabId tabId: UUID) {
@@ -1683,8 +1695,8 @@ final class TerminalNotificationStore: ObservableObject {
         clearFocusedReadIndicator(forTabId: tabId)
 
         if didChangeNotifications, !removedIds.isEmpty {
-            center.removeDeliveredNotificationsOffMain(withIdentifiers: removedIds)
-            center.removePendingNotificationRequestsOffMain(withIdentifiers: removedIds)
+            removeDeliveredNotifications(withIdentifiers: removedIds)
+            removePendingNotificationRequests(withIdentifiers: removedIds)
         }
     }
 
@@ -1739,8 +1751,8 @@ final class TerminalNotificationStore: ObservableObject {
         clearWorkspaceRestoredUnread()
         focusedReadIndicatorByTabId.removeAll()
         CmuxEventBus.shared.publishNotificationCleared(ids: ids, workspaceId: nil, surfaceId: nil)
-        center.removeDeliveredNotificationsOffMain(withIdentifiers: ids)
-        center.removePendingNotificationRequestsOffMain(withIdentifiers: ids)
+        removeDeliveredNotifications(withIdentifiers: ids)
+        removePendingNotificationRequests(withIdentifiers: ids)
         emitNotificationsDismissed(ids: ids, drainedSuperseded: supersededPhoneDismissBuffer.flushAll())
     }
 
@@ -1785,8 +1797,8 @@ final class TerminalNotificationStore: ObservableObject {
         indicatorTabIds.forEach { clearFocusedReadIndicator(forTabId: $0, surfaceId: surfaceId) }
         if !idsToClear.isEmpty {
             CmuxEventBus.shared.publishNotificationCleared(ids: idsToClear, workspaceId: tabIds.count == 1 ? tabId : nil, surfaceId: surfaceId)
-            center.removeDeliveredNotificationsOffMain(withIdentifiers: idsToClear)
-            center.removePendingNotificationRequestsOffMain(withIdentifiers: idsToClear)
+            removeDeliveredNotifications(withIdentifiers: idsToClear)
+            removePendingNotificationRequests(withIdentifiers: idsToClear)
             emitNotificationsDismissed(ids: idsToClear, drainedSuperseded: supersededDrained)
         }
     }
@@ -1860,8 +1872,8 @@ final class TerminalNotificationStore: ObservableObject {
         clearFocusedReadIndicator(forTabId: tabId)
         if !idsToClear.isEmpty {
             CmuxEventBus.shared.publishNotificationCleared(ids: idsToClear, workspaceId: tabId, surfaceId: nil)
-            center.removeDeliveredNotificationsOffMain(withIdentifiers: idsToClear)
-            center.removePendingNotificationRequestsOffMain(withIdentifiers: idsToClear)
+            removeDeliveredNotifications(withIdentifiers: idsToClear)
+            removePendingNotificationRequests(withIdentifiers: idsToClear)
             emitNotificationsDismissed(
                 ids: idsToClear,
                 drainedSuperseded: supersededPhoneDismissBuffer.flush(matchingTabId: tabId)
@@ -1906,7 +1918,7 @@ final class TerminalNotificationStore: ObservableObject {
             content.subtitle = notificationSubtitle
             content.body = notificationBody
             guard authorized else {
-                NativeNotificationDeliveryHooks.playNativeUnavailableFeedback(
+                nativeDeliveryHooks.playUnavailableFeedback(
                     effects: Self.fallbackEffects(effects, authorizationState: effectiveAuthorizationState)
                 )
                 return
@@ -1938,7 +1950,7 @@ final class TerminalNotificationStore: ObservableObject {
                     terminalNotificationLogger.error(
                         "Failed to schedule notification error=\(error.localizedDescription, privacy: .private)"
                     )
-                    NativeNotificationDeliveryHooks.playNativeUnavailableFeedback(effects: effects)
+                    nativeDeliveryHooks.playUnavailableFeedback(effects: effects)
                 } else if effects.command {
                     nativeDeliveryHooks.runCommand(title: commandTitle, subtitle: commandSubtitle, body: commandBody)
                 }
@@ -1998,42 +2010,47 @@ final class TerminalNotificationStore: ObservableObject {
         }
 
         logAuthorization("ensure start origin=\(origin.rawValue)")
-        center.getNotificationSettings { [weak self] settings in
-            DispatchQueue.main.async {
-                guard let self else {
-                    completion(false, .unknown)
-                    return
-                }
+        Task { @MainActor [weak self, userNotificationCenter] in
+            let result = await userNotificationCenter.authorizationStatus()
+            guard let self else {
+                completion(false, .unknown)
+                return
+            }
+            guard case .success(let status) = result else {
+                authorizationState = .unknown
+                logAuthorization("ensure unavailable origin=\(origin.rawValue) result=\(String(describing: result))")
+                completion(false, .unknown)
+                return
+            }
 
-                self.authorizationState = Self.authorizationState(from: settings.authorizationStatus)
-                self.logAuthorization(
-                    "ensure status origin=\(origin.rawValue) status=\(Self.authorizationStatusLabel(settings.authorizationStatus)) mapped=\(self.authorizationState.statusLabel) appActive=\(AppFocusState.isAppActive())"
-                )
-                switch settings.authorizationStatus {
-                case .authorized, .provisional, .ephemeral:
-                    completion(true, self.authorizationState)
-                case .denied:
-                    if origin != .notificationDelivery {
-                        self.logAuthorization("ensure denied origin=\(origin.rawValue) prompting_settings")
-                        self.promptToEnableNotifications()
-                    }
-                    completion(false, .denied)
-                case .notDetermined:
-                    if Self.shouldDeferAutomaticAuthorizationRequest(
-                        origin: origin,
-                        status: settings.authorizationStatus,
-                        isAppActive: AppFocusState.isAppActive()
-                    ) {
-                        self.logAuthorization("ensure deferred origin=\(origin.rawValue)")
-                        self.hasDeferredAuthorizationRequest = true
-                        completion(false, .notDetermined)
-                    } else {
-                        self.requestAuthorizationIfNeeded(origin: origin, completion)
-                    }
-                @unknown default:
-                    self.logAuthorization("ensure unknown status origin=\(origin.rawValue)")
-                    completion(false, .unknown)
+            authorizationState = Self.authorizationState(from: status)
+            logAuthorization(
+                "ensure status origin=\(origin.rawValue) status=\(Self.authorizationStatusLabel(status)) mapped=\(authorizationState.statusLabel) appActive=\(AppFocusState.isAppActive())"
+            )
+            switch status {
+            case .authorized, .provisional, .ephemeral:
+                completion(true, authorizationState)
+            case .denied:
+                if origin != .notificationDelivery {
+                    logAuthorization("ensure denied origin=\(origin.rawValue) prompting_settings")
+                    promptToEnableNotifications()
                 }
+                completion(false, .denied)
+            case .notDetermined:
+                if Self.shouldDeferAutomaticAuthorizationRequest(
+                    origin: origin,
+                    status: status,
+                    isAppActive: AppFocusState.isAppActive()
+                ) {
+                    logAuthorization("ensure deferred origin=\(origin.rawValue)")
+                    hasDeferredAuthorizationRequest = true
+                    completion(false, .notDetermined)
+                } else {
+                    requestAuthorizationIfNeeded(origin: origin, completion)
+                }
+            case .unknown:
+                logAuthorization("ensure unknown status origin=\(origin.rawValue)")
+                completion(false, .unknown)
             }
         }
     }
@@ -2060,24 +2077,33 @@ final class TerminalNotificationStore: ObservableObject {
         logAuthorization(
             "request starting origin=\(origin.rawValue) automatic=\(isAutomaticRequest) hasRequestedAutomatic=\(hasRequestedAutomaticAuthorization)"
         )
-        center.requestAuthorization(options: [.alert, .sound]) { granted, error in
-            DispatchQueue.main.async {
+        Task { @MainActor [weak self, userNotificationCenter] in
+            let result = await userNotificationCenter.requestAuthorization(
+                options: [.alert, .sound]
+            )
+            guard let self else {
+                completion(false, .unknown)
+                return
+            }
+            switch result {
+            case .success(let granted):
                 if granted {
-                    self.authorizationState = .authorized
+                    authorizationState = .authorized
                 } else {
-                    self.refreshAuthorizationStatus()
+                    refreshAuthorizationStatus()
                 }
-                self.logAuthorization(
-                    "request callback origin=\(origin.rawValue) granted=\(granted) error=\(error?.localizedDescription ?? "nil") mapped=\(self.authorizationState.statusLabel)"
+                logAuthorization(
+                    "request callback origin=\(origin.rawValue) granted=\(granted) error=nil mapped=\(authorizationState.statusLabel)"
                 )
-                // A non-grant without an error is the user answering the
-                // prompt with a live denial, even while authorizationState is
-                // still refreshing. A request error is not a user decision,
-                // so it reports .unknown and the fallback sound stays on
-                // (fail-open).
                 let effectiveState: NotificationAuthorizationState =
-                    granted ? .authorized : (error == nil ? .denied : .unknown)
+                    granted ? .authorized : .denied
                 completion(granted, effectiveState)
+            case .failure(let error):
+                refreshAuthorizationStatus()
+                logAuthorization(
+                    "request callback origin=\(origin.rawValue) granted=false error=\(String(describing: error)) mapped=\(authorizationState.statusLabel)"
+                )
+                completion(false, .unknown)
             }
         }
     }
@@ -2116,7 +2142,9 @@ final class TerminalNotificationStore: ObservableObject {
         }
     }
 
-    static func authorizationState(from status: UNAuthorizationStatus) -> NotificationAuthorizationState {
+    static func authorizationState(
+        from status: UserNotificationAuthorizationStatus
+    ) -> NotificationAuthorizationState {
         switch status {
         case .authorized:
             return .authorized
@@ -2128,7 +2156,7 @@ final class TerminalNotificationStore: ObservableObject {
             return .provisional
         case .ephemeral:
             return .ephemeral
-        @unknown default:
+        case .unknown:
             return .unknown
         }
     }
@@ -2150,11 +2178,11 @@ final class TerminalNotificationStore: ObservableObject {
 
     private static func shouldDeferAutomaticAuthorizationRequest(
         origin: AuthorizationRequestOrigin,
-        status: UNAuthorizationStatus,
+        status: UserNotificationAuthorizationStatus,
         isAppActive: Bool
     ) -> Bool {
         guard origin == .notificationDelivery else { return false }
-        return shouldDeferAutomaticAuthorizationRequest(status: status, isAppActive: isAppActive)
+        return status == .notDetermined && !isAppActive
     }
 
     private static func buildIndexes(for notifications: [TerminalNotification]) -> NotificationIndexes {

--- a/cmuxTests/NativeNotificationFallbackCommandTests.swift
+++ b/cmuxTests/NativeNotificationFallbackCommandTests.swift
@@ -202,3 +202,28 @@ struct NativeNotificationFallbackCommandTests {
         AppFocusState.overrideIsFocused = originalAppFocusOverride
     }
 }
+
+extension AgentNotificationRegressionTests {
+    @Test("An unresponsive notification center never blocks its calling executor")
+    func unresponsiveNativeNotificationCenterDoesNotBlockCallingExecutor() {
+        var hooks = NativeNotificationDeliveryHooks()
+        hooks.scheduler = { _, _ in
+            // Model the framework blocking before it wires up its completion.
+            // The real XPC wait is unbounded; cap the fake so the red test fails
+            // promptly without permanently wedging a test-runner thread.
+            Thread.sleep(forTimeInterval: 0.25)
+        }
+        let content = UNMutableNotificationContent()
+        let request = UNNotificationRequest(
+            identifier: "never-completes",
+            content: content,
+            trigger: nil
+        )
+        let clock = ContinuousClock()
+        let startedAt = clock.now
+
+        hooks.schedule(request) { _ in }
+
+        #expect(startedAt.duration(to: clock.now) < .milliseconds(100))
+    }
+}

--- a/cmuxTests/NativeNotificationFallbackCommandTests.swift
+++ b/cmuxTests/NativeNotificationFallbackCommandTests.swift
@@ -1,3 +1,4 @@
+import CmuxNotifications
 import Foundation
 import os
 import Testing
@@ -106,47 +107,58 @@ struct NativeNotificationFallbackCommandTests {
             commands.append(title: title, subtitle: subtitle, body: body)
         }
 
-        store.addNotification(
-            tabId: UUID(),
-            surfaceId: nil,
-            title: "Real title",
-            subtitle: "",
-            body: "Real message"
-        )
-        await Task.yield()
+        // The failed-scheduling branch plays unavailable feedback instead of
+        // the command fallback; resuming from that seam proves the branch ran
+        // to completion before the absence assertion below.
+        await withCheckedContinuation { continuation in
+            store.configureUnavailableFeedbackPlayerForTesting { _ in
+                continuation.resume()
+            }
+            store.addNotification(
+                tabId: UUID(),
+                surfaceId: nil,
+                title: "Real title",
+                subtitle: "",
+                body: "Real message"
+            )
+        }
 
         #expect(commands.invocations.isEmpty)
     }
 
     @Test
-    func sourceConfinedNativeNotificationSerializesRetargetingProvenance() {
+    func sourceConfinedNativeNotificationSerializesRetargetingProvenance() async {
         let store = TerminalNotificationStore.shared
         let originalAppFocusOverride = AppFocusState.overrideIsFocused
         resetState(originalAppFocusOverride: false)
         defer { resetState(originalAppFocusOverride: originalAppFocusOverride) }
 
-        let retargetingValues = BoolValuesRecorder()
         store.configureNotificationAuthorizationHandlerForTesting { completion in
             completion(true, .authorized)
         }
-        store.configureUserNotificationSchedulerForTesting { request, completion in
-            if let value = request.content.userInfo["retargetsToLiveSurfaceOwner"] as? Bool {
-                retargetingValues.append(value)
-            }
-            completion(nil)
-        }
         store.configureNotificationCommandRunnerForTesting { _, _, _ in }
 
-        store.addNotification(
-            tabId: UUID(),
-            surfaceId: UUID(),
-            title: "Relay",
-            subtitle: "Completed",
-            body: "Must stay confined",
-            retargetsToLiveSurfaceOwner: false
-        )
+        // Delivery now hops through the bounded notification-center service,
+        // so the scheduled request is observed via continuation instead of a
+        // synchronous recorder.
+        let retargetingValue: Bool? = await withCheckedContinuation { continuation in
+            store.configureUserNotificationSchedulerForTesting { request, completion in
+                completion(nil)
+                continuation.resume(
+                    returning: request.content.userInfo["retargetsToLiveSurfaceOwner"] as? Bool
+                )
+            }
+            store.addNotification(
+                tabId: UUID(),
+                surfaceId: UUID(),
+                title: "Relay",
+                subtitle: "Completed",
+                body: "Must stay confined",
+                retargetsToLiveSurfaceOwner: false
+            )
+        }
 
-        #expect(retargetingValues.values == [false])
+        #expect(retargetingValue == false)
     }
 
     @Test
@@ -198,6 +210,7 @@ struct NativeNotificationFallbackCommandTests {
         store.resetNotificationAuthorizationHandlerForTesting()
         store.resetUserNotificationSchedulerForTesting()
         store.resetNotificationCommandRunnerForTesting()
+        store.resetUnavailableFeedbackPlayerForTesting()
         store.resetSuppressedNotificationFeedbackHandlerForTesting()
         AppFocusState.overrideIsFocused = originalAppFocusOverride
     }
@@ -206,12 +219,23 @@ struct NativeNotificationFallbackCommandTests {
 extension AgentNotificationRegressionTests {
     @Test("An unresponsive notification center never blocks its calling executor")
     func unresponsiveNativeNotificationCenterDoesNotBlockCallingExecutor() {
-        var hooks = NativeNotificationDeliveryHooks()
+        var hooks = NativeNotificationDeliveryHooks(
+            userNotificationCenter: UserNotificationCenterService(
+                center: .current()
+            )
+        )
+        let schedulerEntered = DispatchSemaphore(value: 0)
+        let releaseScheduler = DispatchSemaphore(value: 0)
+        // Safety: written by the wedged scheduler thread, read by the test
+        // after schedule() returns.
+        let schedulerFinished = OSAllocatedUnfairLock(initialState: false)
         hooks.scheduler = { _, _ in
-            // Model the framework blocking before it wires up its completion.
-            // The real XPC wait is unbounded; cap the fake so the red test fails
-            // promptly without permanently wedging a test-runner thread.
-            Thread.sleep(forTimeInterval: 0.25)
+            schedulerEntered.signal()
+            // Stand-in for the framework blocking before it wires up its
+            // completion. The deadline exists only so a regression fails the
+            // test instead of wedging a runner thread indefinitely.
+            _ = releaseScheduler.wait(timeout: .now() + 5)
+            schedulerFinished.withLock { $0 = true }
         }
         let content = UNMutableNotificationContent()
         let request = UNNotificationRequest(
@@ -219,11 +243,17 @@ extension AgentNotificationRegressionTests {
             content: content,
             trigger: nil
         )
-        let clock = ContinuousClock()
-        let startedAt = clock.now
 
         hooks.schedule(request) { _ in }
 
-        #expect(startedAt.duration(to: clock.now) < .milliseconds(100))
+        // Causal ordering: schedule() must hand back control while the wedged
+        // framework call still has not finished (it cannot finish until the
+        // release below).
+        #expect(
+            !schedulerFinished.withLock { $0 },
+            "schedule must return before the wedged center call completes"
+        )
+        #expect(schedulerEntered.wait(timeout: .now() + 5) == .success)
+        releaseScheduler.signal()
     }
 }

--- a/cmuxTests/TerminalNotificationStore+NativeNotificationDeliveryTesting.swift
+++ b/cmuxTests/TerminalNotificationStore+NativeNotificationDeliveryTesting.swift
@@ -31,7 +31,23 @@ extension TerminalNotificationStore {
 
     func resetUserNotificationSchedulerForTesting() {
         configureNativeNotificationDeliveryHooksForTesting {
-            $0.scheduler = NativeNotificationDeliveryHooks().scheduler
+            // nil routes scheduling back through the production
+            // notification-center service.
+            $0.scheduler = nil
+        }
+    }
+
+    func configureUnavailableFeedbackPlayerForTesting(
+        _ player: @escaping NativeNotificationDeliveryHooks.UnavailableFeedbackPlayer
+    ) {
+        configureNativeNotificationDeliveryHooksForTesting {
+            $0.unavailableFeedbackPlayer = player
+        }
+    }
+
+    func resetUnavailableFeedbackPlayerForTesting() {
+        configureNativeNotificationDeliveryHooksForTesting {
+            $0.unavailableFeedbackPlayer = NativeNotificationDeliveryHooks.defaultUnavailableFeedbackPlayer
         }
     }
 
@@ -45,7 +61,7 @@ extension TerminalNotificationStore {
 
     func resetNotificationCommandRunnerForTesting() {
         configureNativeNotificationDeliveryHooksForTesting {
-            $0.commandRunner = NativeNotificationDeliveryHooks().commandRunner
+            $0.commandRunner = NativeNotificationDeliveryHooks.defaultCommandRunner
         }
     }
 }


### PR DESCRIPTION
Closes #4133

## Root cause

UserNotifications serializes add, remove, authorization, settings, and category operations onto one internal `UNUserNotificationServiceConnection` queue. The previous removal-only mitigation kept a wedged removal off the main thread, but that removal could still own the framework queue forever. A later `@MainActor` add then synchronously waited for the same queue and beachballed cmux.

## Fix

All macOS `UNUserNotificationCenter` framework entry points now go through one injected `UserNotificationCenterService`:

- A dedicated serial utility queue absorbs the framework's synchronous pre-callback XPC wait away from the main actor and Swift's cooperative executor.
- A two-second deadline starts before queue admission and resolves each caller independently.
- Calls queued behind a permanently wedged framework entry time out without entering UserNotifications later.
- Completion and deadline race through a short documented compare-and-set gate, so each continuation settles exactly once.
- Terminal notifications, Feed notifications, settings/authorization, category installation, and delivered/pending removals all use the same boundary.
- Delegate assignment remains synchronous because it must be installed before launch returns; it is a local property assignment rather than a daemon-backed framework method.

If `usernotificationsd` wedges, native delivery stops, callers receive `.timedOut`, and the existing unavailable-native-delivery feedback policy runs promptly. Sound remains fail-open unless the user explicitly denied notifications. Existing custom-command semantics are unchanged: failed native scheduling does not run the command a second time.

## Regression coverage

The PR contains exactly two commits:

1. A red regression commit proving the existing notification configuration and scheduling paths block their caller when framework entry stalls.
2. The centralized service fix and green behavioral coverage.

The service tests model both failure modes without touching the live daemon:

- framework entry blocks synchronously before a callback can be installed;
- framework entry returns but its callback never arrives;
- a later call queues behind a permanently wedged first call;
- healthy add/authorization/removal paths still complete normally;
- settings and authorization calls time out through the same boundary.

The causal tests use explicit entry signals, release gates, and a manual deadline rather than wall-clock sleeps.

## Validation

- `swift test --package-path Packages/macOS/CmuxNotifications` — 85 tests passed
- Project normalization, test wiring, workspace package grouping, lockfile policy, test determinism, test sharding, stored-work-item, and diff guards passed
- `CMUX_SKIP_ZIG_BUILD=1 ./scripts/reload.sh --tag fix-4133-un-center-main-thread-deadlock` — tagged Debug build passed without launching
- Full macOS call-site audit: the only raw `UNUserNotificationCenter.current()` is the composition root; daemon-backed methods are confined to the package adapter
- No user-facing strings changed; no localization catalog changes required
- The destructive live-desktop `killall -STOP usernotificationsd` repro was intentionally not run locally; the test seam reproduces the XPC-like stall deterministically
