### PR TITLE
Move CodeRouter data plane to Vercel

### DIFF
--- a/web/app/api/cli/config/route.ts
+++ b/web/app/api/cli/config/route.ts
@@ -1,8 +1,3 @@
-import {
-  defaultHostedSubrouterURL,
-  hostedSubrouterBaseURL,
-} from "@/services/subrouter/constants";
-
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
 
@@ -12,24 +7,13 @@ export function GET(request: Request): Response {
   const projectId = process.env.NEXT_PUBLIC_STACK_PROJECT_ID?.trim();
   const publishableClientKey =
     process.env.NEXT_PUBLIC_STACK_PUBLISHABLE_CLIENT_KEY?.trim();
-  const tenantControlToken =
-    process.env.SUBROUTER_STACK_TENANT_DELETE_TOKEN?.trim();
-  if (!projectId || !publishableClientKey || !tenantControlToken) {
-    return unavailableResponse();
-  }
-  let subrouterURL: string;
-  try {
-    subrouterURL = hostedSubrouterBaseURL(
-      process.env.SUBROUTER_HOSTED_URL?.trim() ||
-        defaultHostedSubrouterURL(),
-    );
-  } catch {
+  if (!projectId || !publishableClientKey) {
     return unavailableResponse();
   }
 
   return Response.json(
     {
-      version: 2,
+      version: 3,
       auth: {
         apiUrl:
           process.env.NEXT_PUBLIC_STACK_API_URL?.trim() ||
@@ -40,12 +24,10 @@ export function GET(request: Request): Response {
         // confirmation page uses the Stack project that issued the login code.
         confirmUrl: new URL("/handler/cli-auth-confirm", request.url).toString(),
       },
-      subrouter: {
-        url: subrouterURL,
-        exchangeUrl: new URL(
-          "/api/subrouter/tenant-exchange",
-          request.url,
-        ).toString(),
+      coderouter: {
+        sessionUrl: new URL("/api/coderouter/session", request.url).toString(),
+        accountsUrl: new URL("/api/coderouter/accounts", request.url).toString(),
+        openaiBaseUrl: new URL("/v1", request.url).toString(),
       },
     },
     {

--- a/web/app/api/coderouter/accounts/route.ts
+++ b/web/app/api/coderouter/accounts/route.ts
@@ -1,0 +1,46 @@
+import { addAccount, parseCredential } from "../../../../services/coderouter/accounts";
+import { resolveCodeRouterRequestContext } from "../../../../services/coderouter/requestContext";
+import { accountsWithUsage } from "../../../../services/coderouter/usage";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+const MAX_BODY_BYTES = 128 * 1_024;
+
+export async function GET(request: Request): Promise<Response> {
+  const resolved = await resolveCodeRouterRequestContext(request, "use-or-manage");
+  if (!resolved.ok) return resolved.response;
+  const accounts = await accountsWithUsage(resolved.value.team.teamId);
+  return Response.json(
+    { teamId: resolved.value.team.teamId, accounts },
+    { headers: { "cache-control": "no-store" } },
+  );
+}
+
+export async function POST(request: Request): Promise<Response> {
+  const resolved = await resolveCodeRouterRequestContext(request, "manage");
+  if (!resolved.ok) return resolved.response;
+  const length = Number(request.headers.get("content-length") ?? "0");
+  if (Number.isFinite(length) && length > MAX_BODY_BYTES) {
+    return Response.json({ error: "payload_too_large" }, { status: 413 });
+  }
+  const bytes = new Uint8Array(await request.arrayBuffer());
+  if (bytes.byteLength > MAX_BODY_BYTES) {
+    return Response.json({ error: "payload_too_large" }, { status: 413 });
+  }
+  let value: unknown;
+  try {
+    value = JSON.parse(new TextDecoder().decode(bytes));
+  } catch {
+    return Response.json({ error: "invalid_request" }, { status: 400 });
+  }
+  const credential = parseCredential(value);
+  if (!credential) {
+    return Response.json({ error: "invalid_request" }, { status: 400 });
+  }
+  const result = await addAccount(resolved.value.team.teamId, credential);
+  return Response.json(result, {
+    status: result.alreadyExists ? 200 : 201,
+    headers: { "cache-control": "no-store" },
+  });
+}

--- a/web/app/api/coderouter/opencode/config/route.ts
+++ b/web/app/api/coderouter/opencode/config/route.ts
@@ -1,0 +1,12 @@
+import { openCodeClientConfig } from "../../../../../services/coderouter/opencodeProxy";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+export async function GET(request: Request): Promise<Response> {
+  try {
+    return await openCodeClientConfig(request);
+  } catch {
+    return Response.json({ error: "coderouter_unavailable" }, { status: 503 });
+  }
+}

--- a/web/app/api/coderouter/opencode/proxy/[providerId]/[...path]/route.ts
+++ b/web/app/api/coderouter/opencode/proxy/[providerId]/[...path]/route.ts
@@ -1,0 +1,24 @@
+import { proxyOpenCodeRequest } from "../../../../../../../services/coderouter/opencodeProxy";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+export const maxDuration = 1_800;
+
+type Context = {
+  readonly params: Promise<{
+    readonly providerId: string;
+    readonly path: string[];
+  }>;
+};
+
+async function proxy(request: Request, context: Context): Promise<Response> {
+  try {
+    const params = await context.params;
+    return await proxyOpenCodeRequest(request, params.providerId, params.path);
+  } catch {
+    return Response.json({ error: "coderouter_unavailable" }, { status: 503 });
+  }
+}
+
+export const GET = proxy;
+export const POST = proxy;

--- a/web/app/api/coderouter/session/route.ts
+++ b/web/app/api/coderouter/session/route.ts
@@ -1,0 +1,37 @@
+import {
+  issueRouteToken,
+  revokeRouteToken,
+} from "../../../../services/coderouter/repository";
+import { resolveCodeRouterRequestContext } from "../../../../services/coderouter/requestContext";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+export async function POST(request: Request): Promise<Response> {
+  const resolved = await resolveCodeRouterRequestContext(request, "use");
+  if (!resolved.ok) return resolved.response;
+  const issued = await issueRouteToken(resolved.value.team.teamId);
+  return Response.json(
+    {
+      teamId: resolved.value.team.teamId,
+      token: issued.token,
+      expiresAt: issued.expiresAt.toISOString(),
+      openaiBaseUrl: "https://coderouter.dev/v1",
+    },
+    { headers: { "cache-control": "no-store" } },
+  );
+}
+
+export async function DELETE(request: Request): Promise<Response> {
+  const resolved = await resolveCodeRouterRequestContext(request, "use");
+  if (!resolved.ok) return resolved.response;
+  const routeToken = request.headers.get("x-coderouter-route-token")?.trim();
+  if (!routeToken) {
+    return Response.json({ error: "invalid_request" }, { status: 400 });
+  }
+  await revokeRouteToken(resolved.value.team.teamId, routeToken);
+  return new Response(null, {
+    status: 204,
+    headers: { "cache-control": "no-store" },
+  });
+}

--- a/web/app/v1/responses/route.ts
+++ b/web/app/v1/responses/route.ts
@@ -1,0 +1,16 @@
+import { proxyCodexRequest } from "../../../services/coderouter/codexProxy";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+export const maxDuration = 1_800;
+
+export async function POST(request: Request): Promise<Response> {
+  try {
+    return await proxyCodexRequest(request);
+  } catch {
+    return Response.json(
+      { error: "coderouter_unavailable" },
+      { status: 503, headers: { "cache-control": "no-store" } },
+    );
+  }
+}

--- a/web/db/client.ts
+++ b/web/db/client.ts
@@ -24,15 +24,22 @@ const globalForDb = globalThis as typeof globalThis & {
 };
 
 export function createAwsRdsIamPool(config: CloudDbAwsRdsIamConfig): Pool {
+  // Vercel supplies a short-lived OIDC token in deployed functions. The
+  // operator migration command may instead run under an already-authenticated
+  // AWS identity; in that case let the AWS SDK use its standard credential
+  // chain rather than requiring a synthetic Vercel token.
+  const credentials = process.env.VERCEL_OIDC_TOKEN
+    ? awsCredentialsProvider({
+      roleArn: config.awsRoleArn,
+      clientConfig: { region: config.awsRegion },
+    })
+    : undefined;
   const signer = new Signer({
     hostname: config.host,
     port: config.port,
     username: config.user,
     region: config.awsRegion,
-    credentials: awsCredentialsProvider({
-      roleArn: config.awsRoleArn,
-      clientConfig: { region: config.awsRegion },
-    }),
+    ...(credentials ? { credentials } : {}),
   });
 
   return new Pool({

--- a/web/db/migrations/20260805050000_coderouter_vercel_dataplane/migration.sql
+++ b/web/db/migrations/20260805050000_coderouter_vercel_dataplane/migration.sql
@@ -1,0 +1,53 @@
+CREATE TABLE "coderouter_accounts" (
+  "id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+  "team_id" text NOT NULL,
+  "provider" text NOT NULL,
+  "provider_account_id" text NOT NULL,
+  "label" text NOT NULL,
+  "state" text DEFAULT 'active' NOT NULL,
+  "vault_revision" bigint DEFAULT 1 NOT NULL,
+  "credential_expires_at" timestamp with time zone,
+  "refresh_lease_id" uuid,
+  "refresh_lease_expires_at" timestamp with time zone,
+  "last_used_at" timestamp with time zone,
+  "last_failure_code" text,
+  "created_at" timestamp with time zone DEFAULT now() NOT NULL,
+  "updated_at" timestamp with time zone DEFAULT now() NOT NULL,
+  CONSTRAINT "coderouter_accounts_provider_check"
+    CHECK ("provider" IN ('codex', 'opencode-go')),
+  CONSTRAINT "coderouter_accounts_state_check"
+    CHECK ("state" IN ('active', 'refreshing', 'expired', 'broken')),
+  CONSTRAINT "coderouter_accounts_vault_revision_positive"
+    CHECK ("vault_revision" > 0)
+);
+CREATE UNIQUE INDEX "coderouter_accounts_team_provider_account_unique"
+  ON "coderouter_accounts" ("team_id", "provider", "provider_account_id");
+CREATE INDEX "coderouter_accounts_team_provider_state_idx"
+  ON "coderouter_accounts" ("team_id", "provider", "state");
+CREATE INDEX "coderouter_accounts_refresh_lease_expiry_idx"
+  ON "coderouter_accounts" ("refresh_lease_expires_at");
+
+CREATE TABLE "coderouter_route_tokens" (
+  "id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+  "team_id" text NOT NULL,
+  "token_hash" text NOT NULL,
+  "label" text DEFAULT 'cli' NOT NULL,
+  "expires_at" timestamp with time zone NOT NULL,
+  "last_used_at" timestamp with time zone,
+  "revoked_at" timestamp with time zone,
+  "created_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+CREATE UNIQUE INDEX "coderouter_route_tokens_hash_unique"
+  ON "coderouter_route_tokens" ("token_hash");
+CREATE INDEX "coderouter_route_tokens_team_expiry_idx"
+  ON "coderouter_route_tokens" ("team_id", "expires_at");
+
+CREATE TABLE "coderouter_vault_leases" (
+  "team_id" text PRIMARY KEY NOT NULL,
+  "lease_id" uuid NOT NULL,
+  "expires_at" timestamp with time zone NOT NULL,
+  "created_at" timestamp with time zone DEFAULT now() NOT NULL,
+  "updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+CREATE INDEX "coderouter_vault_leases_expiry_idx"
+  ON "coderouter_vault_leases" ("expires_at");

--- a/web/db/migrations/20260805060000_coderouter_account_cooldown/migration.sql
+++ b/web/db/migrations/20260805060000_coderouter_account_cooldown/migration.sql
@@ -1,0 +1,3 @@
+ALTER TABLE "coderouter_accounts" ADD COLUMN "cooldown_until" timestamp with time zone;
+CREATE INDEX "coderouter_accounts_cooldown_idx"
+  ON "coderouter_accounts" ("cooldown_until");

--- a/web/db/schema.ts
+++ b/web/db/schema.ts
@@ -425,6 +425,81 @@ export const subrouterTenants = pgTable(
   ],
 );
 
+/**
+ * Non-secret routing metadata for CodeRouter accounts. Provider credentials
+ * live only in the Stack team server-metadata vault; Postgres coordinates
+ * selection and rotating refresh-token leases.
+ */
+export const coderouterAccounts = pgTable(
+  "coderouter_accounts",
+  {
+    id: uuid("id").defaultRandom().primaryKey(),
+    teamId: text("team_id").notNull(),
+    provider: text("provider").$type<"codex" | "opencode-go">().notNull(),
+    providerAccountId: text("provider_account_id").notNull(),
+    label: text("label").notNull(),
+    state: text("state")
+      .$type<"active" | "refreshing" | "expired" | "broken">()
+      .notNull()
+      .default("active"),
+    vaultRevision: bigint("vault_revision", { mode: "number" }).notNull().default(1),
+    credentialExpiresAt: timestamp("credential_expires_at", { withTimezone: true }),
+    refreshLeaseId: uuid("refresh_lease_id"),
+    refreshLeaseExpiresAt: timestamp("refresh_lease_expires_at", { withTimezone: true }),
+    lastUsedAt: timestamp("last_used_at", { withTimezone: true }),
+    lastFailureCode: text("last_failure_code"),
+    createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+    updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
+  },
+  (table) => [
+    uniqueIndex("coderouter_accounts_team_provider_account_unique").on(
+      table.teamId,
+      table.provider,
+      table.providerAccountId,
+    ),
+    index("coderouter_accounts_team_provider_state_idx").on(
+      table.teamId,
+      table.provider,
+      table.state,
+    ),
+    index("coderouter_accounts_refresh_lease_expiry_idx").on(
+      table.refreshLeaseExpiresAt,
+    ),
+  ],
+);
+
+export const coderouterRouteTokens = pgTable(
+  "coderouter_route_tokens",
+  {
+    id: uuid("id").defaultRandom().primaryKey(),
+    teamId: text("team_id").notNull(),
+    tokenHash: text("token_hash").notNull(),
+    label: text("label").notNull().default("cli"),
+    expiresAt: timestamp("expires_at", { withTimezone: true }).notNull(),
+    lastUsedAt: timestamp("last_used_at", { withTimezone: true }),
+    revokedAt: timestamp("revoked_at", { withTimezone: true }),
+    createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+  },
+  (table) => [
+    uniqueIndex("coderouter_route_tokens_hash_unique").on(table.tokenHash),
+    index("coderouter_route_tokens_team_expiry_idx").on(table.teamId, table.expiresAt),
+  ],
+);
+
+export const coderouterVaultLeases = pgTable(
+  "coderouter_vault_leases",
+  {
+    teamId: text("team_id").primaryKey(),
+    leaseId: uuid("lease_id").notNull(),
+    expiresAt: timestamp("expires_at", { withTimezone: true }).notNull(),
+    createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+    updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
+  },
+  (table) => [
+    index("coderouter_vault_leases_expiry_idx").on(table.expiresAt),
+  ],
+);
+
 export const stripeCustomers = pgTable(
   "stripe_customers",
   {

--- a/web/db/schema.ts
+++ b/web/db/schema.ts
@@ -446,6 +446,7 @@ export const coderouterAccounts = pgTable(
     credentialExpiresAt: timestamp("credential_expires_at", { withTimezone: true }),
     refreshLeaseId: uuid("refresh_lease_id"),
     refreshLeaseExpiresAt: timestamp("refresh_lease_expires_at", { withTimezone: true }),
+    cooldownUntil: timestamp("cooldown_until", { withTimezone: true }),
     lastUsedAt: timestamp("last_used_at", { withTimezone: true }),
     lastFailureCode: text("last_failure_code"),
     createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
@@ -465,6 +466,7 @@ export const coderouterAccounts = pgTable(
     index("coderouter_accounts_refresh_lease_expiry_idx").on(
       table.refreshLeaseExpiresAt,
     ),
+    index("coderouter_accounts_cooldown_idx").on(table.cooldownUntil),
   ],
 );
 

--- a/web/scripts/migrate-aws-rds-iam.ts
+++ b/web/scripts/migrate-aws-rds-iam.ts
@@ -20,7 +20,15 @@ async function main() {
 }
 
 main().catch((error) => {
-  const message = error instanceof Error ? error.message : String(error);
+  const messages: string[] = [];
+  let current: unknown = error;
+  for (let depth = 0; depth < 4 && current; depth++) {
+    messages.push(current instanceof Error ? current.message : String(current));
+    current = typeof current === "object" && current !== null && "cause" in current
+      ? current.cause
+      : undefined;
+  }
+  const message = messages.join(": ");
   console.error(`aws-rds-iam migration failed: ${message}`);
   process.exit(1);
 });

--- a/web/services/coderouter/accounts.ts
+++ b/web/services/coderouter/accounts.ts
@@ -1,0 +1,106 @@
+import { randomUUID } from "node:crypto";
+import {
+  findAccountByProviderIdentity,
+  listAccounts,
+  upsertAccountMetadata,
+  withVaultLease,
+} from "./repository";
+import { putVaultCredential } from "./vault";
+import type { CodeRouterCredential } from "./types";
+
+export async function addAccount(
+  teamId: string,
+  credential: CodeRouterCredential,
+): Promise<{ accountId: string; alreadyExists: boolean }> {
+  return await withVaultLease(teamId, async () => {
+    const existing = await findAccountByProviderIdentity(
+      teamId,
+      credential.provider,
+      credential.accountId,
+    );
+    if (existing?.state === "active" || existing?.state === "refreshing") {
+      return { accountId: existing.id, alreadyExists: true };
+    }
+
+    const accountId = existing?.id ?? randomUUID();
+    const revision = await putVaultCredential(
+      teamId,
+      accountId,
+      credential,
+      existing?.vaultRevision,
+    );
+    await upsertAccountMetadata({
+      teamId,
+      accountId,
+      credential,
+      vaultRevision: revision,
+    });
+    return { accountId, alreadyExists: false };
+  });
+}
+
+export { listAccounts };
+
+export function parseCredential(value: unknown): CodeRouterCredential | null {
+  if (!isRecord(value)) return null;
+  const provider = value.provider;
+  const accessToken = boundedString(value.accessToken, 32_768);
+  const refreshToken = boundedString(value.refreshToken, 32_768);
+  const accountId = boundedString(value.accountId, 512);
+  const email = boundedString(value.email, 320);
+  const expiresAt = value.expiresAt;
+  if (
+    !accessToken ||
+    !refreshToken ||
+    !accountId ||
+    !email ||
+    typeof expiresAt !== "number" ||
+    !Number.isFinite(expiresAt) ||
+    expiresAt <= Date.now() - 24 * 60 * 60 * 1_000
+  ) {
+    return null;
+  }
+  if (provider === "codex") {
+    const idToken = boundedString(value.idToken, 32_768);
+    return idToken
+      ? {
+        provider,
+        accessToken,
+        refreshToken,
+        idToken,
+        accountId,
+        email,
+        expiresAt,
+      }
+      : null;
+  }
+  if (provider === "opencode-go") {
+    const orgId = optionalBoundedString(value.orgId, 512);
+    const orgName = optionalBoundedString(value.orgName, 512);
+    return {
+      provider,
+      accessToken,
+      refreshToken,
+      accountId,
+      email,
+      expiresAt,
+      ...(orgId ? { orgId } : {}),
+      ...(orgName ? { orgName } : {}),
+    };
+  }
+  return null;
+}
+
+function boundedString(value: unknown, max: number): string | null {
+  return typeof value === "string" && value.length > 0 && value.length <= max
+    ? value
+    : null;
+}
+
+function optionalBoundedString(value: unknown, max: number): string | null {
+  return value === undefined || value === null ? null : boundedString(value, max);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/web/services/coderouter/codexProxy.ts
+++ b/web/services/coderouter/codexProxy.ts
@@ -1,0 +1,105 @@
+import { authenticateRouteToken, selectAccountForRequest } from "./repository";
+import { freshCredential } from "./refresh";
+
+const CODEX_UPSTREAM = "https://chatgpt.com/backend-api/codex/responses";
+const ALLOWED_REQUEST_HEADERS = [
+  "accept",
+  "content-type",
+  "openai-beta",
+  "openai-organization",
+  "session_id",
+  "user-agent",
+] as const;
+
+export async function proxyCodexRequest(request: Request): Promise<Response> {
+  const token = bearerToken(request);
+  if (!token) return jsonError("unauthorized", 401);
+  const identity = await authenticateRouteToken(token);
+  if (!identity) return jsonError("unauthorized", 401);
+
+  const account = await selectAccountForRequest(identity.teamId, "codex");
+  if (!account) return jsonError("no_usable_account", 503);
+
+  let credential;
+  try {
+    credential = await freshCredential({
+      teamId: identity.teamId,
+      accountId: account.id,
+      expectedRevision: account.vaultRevision,
+    });
+  } catch (error) {
+    if (error && typeof error === "object" && "_tag" in error) {
+      const tag = (error as { _tag: string })._tag;
+      if (tag === "CodeRouterRefreshBusy") {
+        return jsonError("credential_refresh_in_progress", 503, {
+          "retry-after": "1",
+        });
+      }
+      if (tag === "CodeRouterCredentialBroken") {
+        return jsonError("no_usable_account", 503);
+      }
+    }
+    throw error;
+  }
+  if (credential.provider !== "codex") {
+    return jsonError("no_usable_account", 503);
+  }
+
+  const headers = new Headers();
+  for (const name of ALLOWED_REQUEST_HEADERS) {
+    const value = request.headers.get(name);
+    if (value) headers.set(name, value);
+  }
+  headers.set("authorization", `Bearer ${credential.accessToken}`);
+  headers.set("chatgpt-account-id", credential.accountId);
+  headers.set("originator", "coderouter");
+
+  const upstream = await fetch(CODEX_UPSTREAM, {
+    method: "POST",
+    headers,
+    body: request.body,
+    // Required by Node fetch for a streaming request body.
+    duplex: "half",
+    cache: "no-store",
+  } as RequestInit & { duplex: "half" });
+  const responseHeaders = new Headers();
+  for (const name of [
+    "content-type",
+    "openai-processing-ms",
+    "x-request-id",
+    "x-ratelimit-limit-requests",
+    "x-ratelimit-remaining-requests",
+    "x-ratelimit-reset-requests",
+  ]) {
+    const value = upstream.headers.get(name);
+    if (value) responseHeaders.set(name, value);
+  }
+  responseHeaders.set("cache-control", "no-store");
+  return new Response(upstream.body, {
+    status: upstream.status,
+    headers: responseHeaders,
+  });
+}
+
+function bearerToken(request: Request): string | null {
+  const authorization = request.headers.get("authorization")?.trim() ?? "";
+  const match = /^Bearer[ \t]+(.+)$/i.exec(authorization);
+  return match?.[1]?.trim() || null;
+}
+
+function jsonError(
+  error: string,
+  status: number,
+  headers?: HeadersInit,
+): Response {
+  return Response.json(
+    { error },
+    {
+      status,
+      headers: {
+        "cache-control": "no-store",
+        ...Object.fromEntries(new Headers(headers)),
+      },
+    },
+  );
+}

--- a/web/services/coderouter/codexProxy.ts
+++ b/web/services/coderouter/codexProxy.ts
@@ -1,4 +1,8 @@
-import { authenticateRouteToken, selectAccountForRequest } from "./repository";
+import {
+  authenticateRouteToken,
+  markAccountCooldown,
+  selectAccountForRequest,
+} from "./repository";
 import { freshCredential } from "./refresh";
 
 const CODEX_UPSTREAM = "https://chatgpt.com/backend-api/codex/responses";
@@ -17,51 +21,60 @@ export async function proxyCodexRequest(request: Request): Promise<Response> {
   const identity = await authenticateRouteToken(token);
   if (!identity) return jsonError("unauthorized", 401);
 
-  const account = await selectAccountForRequest(identity.teamId, "codex");
-  if (!account) return jsonError("no_usable_account", 503);
-
-  let credential;
-  try {
-    credential = await freshCredential({
-      teamId: identity.teamId,
-      accountId: account.id,
-      expectedRevision: account.vaultRevision,
-    });
-  } catch (error) {
-    if (error && typeof error === "object" && "_tag" in error) {
-      const tag = (error as { _tag: string })._tag;
-      if (tag === "CodeRouterRefreshBusy") {
-        return jsonError("credential_refresh_in_progress", 503, {
-          "retry-after": "1",
-        });
-      }
-      if (tag === "CodeRouterCredentialBroken") {
-        return jsonError("no_usable_account", 503);
-      }
-    }
-    throw error;
-  }
-  if (credential.provider !== "codex") {
-    return jsonError("no_usable_account", 503);
-  }
-
-  const headers = new Headers();
+  const forwardedHeaders = new Headers();
   for (const name of ALLOWED_REQUEST_HEADERS) {
     const value = request.headers.get(name);
-    if (value) headers.set(name, value);
+    if (value) forwardedHeaders.set(name, value);
   }
-  headers.set("authorization", `Bearer ${credential.accessToken}`);
-  headers.set("chatgpt-account-id", credential.accountId);
-  headers.set("originator", "coderouter");
-
-  const upstream = await fetch(CODEX_UPSTREAM, {
-    method: "POST",
-    headers,
-    body: request.body,
-    // Required by Node fetch for a streaming request body.
-    duplex: "half",
-    cache: "no-store",
-  } as RequestInit & { duplex: "half" });
+  const attempted: string[] = [];
+  let upstream: Response | null = null;
+  for (let attempt = 0; attempt < 8; attempt++) {
+    const account = await selectAccountForRequest(
+      identity.teamId,
+      "codex",
+      attempted,
+    );
+    if (!account) break;
+    attempted.push(account.id);
+    let credential;
+    try {
+      credential = await freshCredential({
+        teamId: identity.teamId,
+        accountId: account.id,
+        expectedRevision: account.vaultRevision,
+      });
+    } catch (error) {
+      if (error && typeof error === "object" && "_tag" in error) {
+        const tag = (error as { _tag: string })._tag;
+        if (tag === "CodeRouterRefreshBusy") continue;
+        if (tag === "CodeRouterCredentialBroken") continue;
+      }
+      throw error;
+    }
+    if (credential.provider !== "codex") continue;
+    upstream = await sendCodex(request.clone(), forwardedHeaders, credential);
+    if (upstream.status === 401) {
+      try {
+        const refreshed = await freshCredential({
+          teamId: identity.teamId,
+          accountId: account.id,
+          expectedRevision: account.vaultRevision,
+          force: true,
+        });
+        if (refreshed.provider === "codex") {
+          upstream = await sendCodex(request.clone(), forwardedHeaders, refreshed);
+        }
+      } catch {
+        continue;
+      }
+    }
+    if (upstream.status === 429) {
+      await markAccountCooldown(account.id, rateLimitDelay(upstream.headers));
+      continue;
+    }
+    break;
+  }
+  if (!upstream) return jsonError("no_usable_account", 503);
   const responseHeaders = new Headers();
   for (const name of [
     "content-type",
@@ -79,6 +92,41 @@ export async function proxyCodexRequest(request: Request): Promise<Response> {
     status: upstream.status,
     headers: responseHeaders,
   });
+}
+
+async function sendCodex(
+  request: Request,
+  forwardedHeaders: Headers,
+  credential: { accessToken: string; accountId: string },
+): Promise<Response> {
+  const headers = new Headers(forwardedHeaders);
+  headers.set("authorization", `Bearer ${credential.accessToken}`);
+  headers.set("chatgpt-account-id", credential.accountId);
+  headers.set("originator", "coderouter");
+  return await fetch(CODEX_UPSTREAM, {
+    method: "POST",
+    headers,
+    body: request.body,
+    duplex: "half",
+    cache: "no-store",
+  } as RequestInit & { duplex: "half" });
+}
+
+function rateLimitDelay(headers: Headers): number {
+  const retryAfter = headers.get("retry-after");
+  if (retryAfter && /^\d+$/.test(retryAfter)) {
+    return Number(retryAfter) * 1_000;
+  }
+  for (const name of [
+    "x-ratelimit-reset-requests",
+    "x-ratelimit-reset-tokens",
+  ]) {
+    const raw = headers.get(name);
+    if (!raw) continue;
+    const seconds = /^(\d+(?:\.\d+)?)s$/.exec(raw)?.[1] ?? (/^\d+$/.test(raw) ? raw : null);
+    if (seconds) return Math.ceil(Number(seconds) * 1_000);
+  }
+  return 60_000;
 }
 
 function bearerToken(request: Request): string | null {

--- a/web/services/coderouter/opencodeProxy.ts
+++ b/web/services/coderouter/opencodeProxy.ts
@@ -1,0 +1,180 @@
+import { authenticateRouteToken, selectAccountForRequest } from "./repository";
+import { freshCredential } from "./refresh";
+
+const OPENCODE_CONSOLE = "https://console.opencode.ai";
+
+export async function openCodeClientConfig(request: Request): Promise<Response> {
+  const auth = await routeIdentity(request);
+  if (!auth) return Response.json({ error: "unauthorized" }, { status: 401 });
+  const resolved = await openCodeAccount(auth.teamId);
+  if (!resolved) return Response.json({ error: "no_usable_account" }, { status: 503 });
+  const remote = await remoteConfig(resolved.credential.accessToken);
+  const provider = rewriteProviders(remote, auth.token);
+  return Response.json({ provider }, {
+    headers: { "cache-control": "no-store" },
+  });
+}
+
+export async function proxyOpenCodeRequest(
+  request: Request,
+  providerId: string,
+  path: readonly string[],
+): Promise<Response> {
+  const auth = await routeIdentity(request);
+  if (!auth) return Response.json({ error: "unauthorized" }, { status: 401 });
+  const resolved = await openCodeAccount(auth.teamId);
+  if (!resolved) return Response.json({ error: "no_usable_account" }, { status: 503 });
+  const config = await remoteConfig(resolved.credential.accessToken);
+  const provider = config[providerId];
+  if (!isRecord(provider)) {
+    return Response.json({ error: "unknown_provider" }, { status: 404 });
+  }
+  const api = provider.api;
+  const base = isRecord(api) ? api.url : undefined;
+  if (typeof base !== "string" || !safeProviderURL(base)) {
+    return Response.json({ error: "invalid_provider" }, { status: 502 });
+  }
+  const target = new URL(base);
+  target.pathname = `${target.pathname.replace(/\/+$/, "")}/${path
+    .map(encodeURIComponent)
+    .join("/")}`;
+  target.search = new URL(request.url).search;
+
+  const headers = new Headers();
+  for (const name of ["accept", "content-type", "user-agent"]) {
+    const value = request.headers.get(name);
+    if (value) headers.set(name, value);
+  }
+  headers.set("authorization", `Bearer ${resolved.credential.accessToken}`);
+  const upstream = await fetch(target, {
+    method: request.method,
+    headers,
+    body: request.method === "GET" || request.method === "HEAD"
+      ? undefined
+      : request.body,
+    duplex: "half",
+    cache: "no-store",
+  } as RequestInit & { duplex: "half" });
+  return new Response(upstream.body, {
+    status: upstream.status,
+    headers: filteredResponseHeaders(upstream.headers),
+  });
+}
+
+async function openCodeAccount(teamId: string) {
+  const account = await selectAccountForRequest(teamId, "opencode-go");
+  if (!account) return null;
+  const credential = await freshCredential({
+    teamId,
+    accountId: account.id,
+    expectedRevision: account.vaultRevision,
+  });
+  return credential.provider === "opencode-go" ? { account, credential } : null;
+}
+
+async function remoteConfig(accessToken: string): Promise<Record<string, unknown>> {
+  const response = await fetch(`${OPENCODE_CONSOLE}/api/config`, {
+    headers: { authorization: `Bearer ${accessToken}` },
+    cache: "no-store",
+    signal: AbortSignal.timeout(5_000),
+  });
+  if (!response.ok) throw new Error(`OpenCode config failed: ${response.status}`);
+  const value: unknown = await response.json();
+  if (!isRecord(value) || !isRecord(value.config) || !isRecord(value.config.provider)) {
+    throw new Error("OpenCode returned an invalid provider catalog");
+  }
+  return value.config.provider;
+}
+
+function rewriteProviders(
+  providers: Record<string, unknown>,
+  routeToken: string,
+): Record<string, unknown> {
+  return Object.fromEntries(Object.entries(providers).flatMap(([id, value]) => {
+    if (!isRecord(value)) return [];
+    const api = value.api;
+    const npm = isRecord(api) && typeof api.package === "string"
+      ? api.package
+      : typeof value.npm === "string"
+      ? value.npm
+      : undefined;
+    const models = isRecord(value.models)
+      ? Object.fromEntries(Object.entries(value.models).map(([modelId, model]) => {
+        if (!isRecord(model)) return [modelId, model];
+        const nestedProvider = isRecord(model.provider) ? model.provider : undefined;
+        return [modelId, {
+          ...model,
+          ...(nestedProvider
+            ? {
+              provider: {
+                ...nestedProvider,
+                api: `https://coderouter.dev/api/coderouter/opencode/proxy/${encodeURIComponent(id)}`,
+              },
+            }
+            : {}),
+        }];
+      }))
+      : value.models;
+    return [[id, {
+      ...value,
+      ...(npm ? { npm } : {}),
+      api: undefined,
+      models,
+      options: {
+        ...(isRecord(value.options) ? withoutSecrets(value.options) : {}),
+        baseURL: `https://coderouter.dev/api/coderouter/opencode/proxy/${encodeURIComponent(id)}`,
+        apiKey: routeToken,
+      },
+    }]];
+  }));
+}
+
+function withoutSecrets(value: Record<string, unknown>): Record<string, unknown> {
+  return Object.fromEntries(
+    Object.entries(value).filter(([key]) =>
+      !["apiKey", "token", "accessToken", "refreshToken", "headers"].includes(key)
+    ),
+  );
+}
+
+async function routeIdentity(
+  request: Request,
+): Promise<{ teamId: string; token: string } | null> {
+  const header = request.headers.get("authorization")?.trim() ?? "";
+  const token = /^Bearer[ \t]+(.+)$/i.exec(header)?.[1]?.trim();
+  if (!token) return null;
+  const identity = await authenticateRouteToken(token);
+  return identity ? { ...identity, token } : null;
+}
+
+function safeProviderURL(value: string): boolean {
+  try {
+    const url = new URL(value);
+    if (url.protocol !== "https:" || url.username || url.password) return false;
+    const hostname = url.hostname.toLowerCase();
+    return hostname !== "localhost" &&
+      hostname !== "0.0.0.0" &&
+      hostname !== "::1" &&
+      !/^127\./.test(hostname) &&
+      !/^10\./.test(hostname) &&
+      !/^192\.168\./.test(hostname) &&
+      !/^172\.(1[6-9]|2[0-9]|3[01])\./.test(hostname);
+  } catch {
+    return false;
+  }
+}
+
+function filteredResponseHeaders(input: Headers): Headers {
+  const headers = new Headers({ "cache-control": "no-store" });
+  for (const name of ["content-type", "x-request-id"]) {
+    const value = input.get(name);
+    if (value) headers.set(name, value);
+  }
+  return headers;
+}
+
+function isRecord(value: unknown): value is Record<string, any> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+export const __test = { rewriteProviders, safeProviderURL };

--- a/web/services/coderouter/refresh.ts
+++ b/web/services/coderouter/refresh.ts
@@ -1,0 +1,220 @@
+import {
+  claimRefreshLease,
+  completeRefreshLease,
+  failRefreshLease,
+  withVaultLease,
+} from "./repository";
+import {
+  putVaultCredential,
+  readTeamVault,
+} from "./vault";
+import type { CodeRouterCredential } from "./types";
+
+const CODEX_CLIENT_ID = "app_EMoamEEZ73f0CkXaXp7hrann";
+const OPENCODE_CLIENT_ID = "opencode-cli";
+const REFRESH_SKEW_MS = 60_000;
+
+export class CodeRouterRefreshBusy extends Error {
+  readonly _tag = "CodeRouterRefreshBusy";
+}
+
+export class CodeRouterCredentialBroken extends Error {
+  readonly _tag = "CodeRouterCredentialBroken";
+}
+
+export async function freshCredential(input: {
+  readonly teamId: string;
+  readonly accountId: string;
+  readonly expectedRevision: number;
+  readonly force?: boolean;
+}): Promise<CodeRouterCredential> {
+  const before = await readCredential(input.teamId, input.accountId);
+  if (!input.force && before.credential.expiresAt > Date.now() + REFRESH_SKEW_MS) {
+    return before.credential;
+  }
+
+  const leaseId = await claimRefreshLease(input.accountId);
+  if (!leaseId) throw new CodeRouterRefreshBusy("credential refresh already in progress");
+  try {
+    // The lease winner must re-read Stack after claiming. Another request may
+    // have refreshed and rotated the token immediately before this lease.
+    const current = await readCredential(input.teamId, input.accountId);
+    if (
+      !input.force &&
+      current.credential.expiresAt > Date.now() + REFRESH_SKEW_MS
+    ) {
+      await completeRefreshLease({
+        accountId: input.accountId,
+        leaseId,
+        vaultRevision: current.revision,
+        credentialExpiresAt: new Date(current.credential.expiresAt),
+      });
+      return current.credential;
+    }
+
+    const refreshed = await refreshProviderCredential(current.credential);
+    const revision = await withVaultLease(input.teamId, async () => {
+      let lastError: unknown;
+      for (let attempt = 0; attempt < 3; attempt++) {
+        try {
+          return await putVaultCredential(
+            input.teamId,
+            input.accountId,
+            refreshed,
+            current.revision,
+          );
+        } catch (error) {
+          lastError = error;
+          if (attempt < 2) {
+            await new Promise((resolve) => setTimeout(resolve, 50 * (attempt + 1)));
+          }
+        }
+      }
+      throw lastError;
+    });
+    await completeRefreshLease({
+      accountId: input.accountId,
+      leaseId,
+      vaultRevision: revision,
+      credentialExpiresAt: new Date(refreshed.expiresAt),
+    });
+    return refreshed;
+  } catch (error) {
+    const terminal = isTerminalRefreshError(error);
+    await failRefreshLease(
+      input.accountId,
+      leaseId,
+      terminal,
+      refreshFailureCode(error),
+    ).catch(() => undefined);
+    if (terminal) {
+      throw new CodeRouterCredentialBroken("provider refresh token is no longer usable");
+    }
+    throw error;
+  }
+}
+
+async function readCredential(teamId: string, accountId: string) {
+  const account = (await readTeamVault(teamId)).accounts[accountId];
+  if (!account) throw new CodeRouterCredentialBroken("vault credential not found");
+  return account;
+}
+
+async function refreshProviderCredential(
+  credential: CodeRouterCredential,
+): Promise<CodeRouterCredential> {
+  if (credential.provider === "codex") {
+    const token = await postForm("https://auth.openai.com/oauth/token", {
+      grant_type: "refresh_token",
+      refresh_token: credential.refreshToken,
+      client_id: CODEX_CLIENT_ID,
+    });
+    return {
+      ...credential,
+      accessToken: requiredString(token, "access_token"),
+      refreshToken: optionalString(token, "refresh_token") ?? credential.refreshToken,
+      idToken: optionalString(token, "id_token") ?? credential.idToken,
+      expiresAt: Date.now() + optionalPositiveNumber(token, "expires_in", 3_600) * 1_000,
+    };
+  }
+
+  const token = await postJson("https://console.opencode.ai/auth/device/token", {
+    grant_type: "refresh_token",
+    refresh_token: credential.refreshToken,
+    client_id: OPENCODE_CLIENT_ID,
+  });
+  return {
+    ...credential,
+    accessToken: requiredString(token, "access_token"),
+    refreshToken: optionalString(token, "refresh_token") ?? credential.refreshToken,
+    expiresAt: Date.now() + optionalPositiveNumber(token, "expires_in", 3_600) * 1_000,
+  };
+}
+
+class ProviderRefreshError extends Error {
+  constructor(
+    readonly status: number,
+    readonly code: string,
+  ) {
+    super(`provider refresh failed: ${status} ${code}`);
+  }
+}
+
+async function postForm(
+  url: string,
+  body: Record<string, string>,
+): Promise<Record<string, unknown>> {
+  const response = await fetch(url, {
+    method: "POST",
+    headers: { "content-type": "application/x-www-form-urlencoded" },
+    body: new URLSearchParams(body),
+    cache: "no-store",
+  });
+  return await providerJson(response);
+}
+
+async function postJson(
+  url: string,
+  body: Record<string, string>,
+): Promise<Record<string, unknown>> {
+  const response = await fetch(url, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+    cache: "no-store",
+  });
+  return await providerJson(response);
+}
+
+async function providerJson(response: Response): Promise<Record<string, unknown>> {
+  const value: unknown = await response.json().catch(() => ({}));
+  const record = isRecord(value) ? value : {};
+  if (!response.ok) {
+    throw new ProviderRefreshError(
+      response.status,
+      optionalString(record, "code") ??
+        optionalString(record, "error") ??
+        "refresh_failed",
+    );
+  }
+  return record;
+}
+
+function isTerminalRefreshError(error: unknown): boolean {
+  return error instanceof ProviderRefreshError &&
+    (error.status === 400 || error.status === 401) &&
+    /invalid|expired|reused|revoked|not_found/i.test(error.code);
+}
+
+function refreshFailureCode(error: unknown): string {
+  return error instanceof ProviderRefreshError ? error.code : "refresh_unavailable";
+}
+
+function requiredString(record: Record<string, unknown>, key: string): string {
+  const value = optionalString(record, key);
+  if (!value) throw new Error(`provider response missing ${key}`);
+  return value;
+}
+
+function optionalString(
+  record: Record<string, unknown>,
+  key: string,
+): string | undefined {
+  const value = record[key];
+  return typeof value === "string" && value ? value : undefined;
+}
+
+function optionalPositiveNumber(
+  record: Record<string, unknown>,
+  key: string,
+  fallback: number,
+): number {
+  const value = record[key];
+  return typeof value === "number" && Number.isFinite(value) && value > 0
+    ? value
+    : fallback;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/web/services/coderouter/refresh.ts
+++ b/web/services/coderouter/refresh.ts
@@ -173,11 +173,19 @@ async function providerJson(response: Response): Promise<Record<string, unknown>
     throw new ProviderRefreshError(
       response.status,
       optionalString(record, "code") ??
-        optionalString(record, "error") ??
+        providerErrorCode(record.error) ??
         "refresh_failed",
     );
   }
   return record;
+}
+
+function providerErrorCode(value: unknown): string | undefined {
+  if (typeof value === "string") return value;
+  if (!isRecord(value)) return undefined;
+  return optionalString(value, "code") ??
+    optionalString(value, "type") ??
+    optionalString(value, "error");
 }
 
 function isTerminalRefreshError(error: unknown): boolean {

--- a/web/services/coderouter/repository.ts
+++ b/web/services/coderouter/repository.ts
@@ -1,0 +1,304 @@
+import { createHash, randomBytes, randomUUID } from "node:crypto";
+import { and, eq, gt, isNull, lte, or, sql } from "drizzle-orm";
+import { cloudDb } from "../../db/client";
+import {
+  coderouterAccounts,
+  coderouterRouteTokens,
+  coderouterVaultLeases,
+} from "../../db/schema";
+import type {
+  CodeRouterAccountSummary,
+  CodeRouterCredential,
+  CodeRouterProvider,
+} from "./types";
+
+const ROUTE_TOKEN_LIFETIME_MS = 30 * 24 * 60 * 60 * 1_000;
+const VAULT_LEASE_MS = 30_000;
+const REFRESH_LEASE_MS = 30_000;
+
+export class CodeRouterLeaseBusy extends Error {
+  readonly _tag = "CodeRouterLeaseBusy";
+}
+
+export function routeTokenHash(token: string): string {
+  return createHash("sha256").update(token, "utf8").digest("hex");
+}
+
+export async function issueRouteToken(
+  teamId: string,
+  label = "cli",
+): Promise<{ token: string; expiresAt: Date }> {
+  const token = `crt_${randomBytes(32).toString("base64url")}`;
+  const expiresAt = new Date(Date.now() + ROUTE_TOKEN_LIFETIME_MS);
+  await cloudDb().insert(coderouterRouteTokens).values({
+    teamId,
+    tokenHash: routeTokenHash(token),
+    label,
+    expiresAt,
+  });
+  return { token, expiresAt };
+}
+
+export async function authenticateRouteToken(
+  token: string,
+  now = new Date(),
+): Promise<{ teamId: string } | null> {
+  if (!/^crt_[A-Za-z0-9_-]{40,}$/.test(token)) return null;
+  const [row] = await cloudDb()
+    .select({ id: coderouterRouteTokens.id, teamId: coderouterRouteTokens.teamId })
+    .from(coderouterRouteTokens)
+    .where(and(
+      eq(coderouterRouteTokens.tokenHash, routeTokenHash(token)),
+      gt(coderouterRouteTokens.expiresAt, now),
+      isNull(coderouterRouteTokens.revokedAt),
+    ))
+    .limit(1);
+  if (!row) return null;
+  await cloudDb()
+    .update(coderouterRouteTokens)
+    .set({ lastUsedAt: now })
+    .where(eq(coderouterRouteTokens.id, row.id));
+  return { teamId: row.teamId };
+}
+
+export async function revokeRouteToken(
+  teamId: string,
+  token: string,
+  now = new Date(),
+): Promise<void> {
+  if (!/^crt_[A-Za-z0-9_-]{40,}$/.test(token)) return;
+  await cloudDb()
+    .update(coderouterRouteTokens)
+    .set({ revokedAt: now })
+    .where(and(
+      eq(coderouterRouteTokens.teamId, teamId),
+      eq(coderouterRouteTokens.tokenHash, routeTokenHash(token)),
+      isNull(coderouterRouteTokens.revokedAt),
+    ));
+}
+
+export async function listAccounts(
+  teamId: string,
+): Promise<readonly CodeRouterAccountSummary[]> {
+  return await cloudDb()
+    .select({
+      id: coderouterAccounts.id,
+      provider: coderouterAccounts.provider,
+      providerAccountId: coderouterAccounts.providerAccountId,
+      label: coderouterAccounts.label,
+      state: coderouterAccounts.state,
+      credentialExpiresAt: coderouterAccounts.credentialExpiresAt,
+      lastFailureCode: coderouterAccounts.lastFailureCode,
+    })
+    .from(coderouterAccounts)
+    .where(eq(coderouterAccounts.teamId, teamId))
+    .then((rows) => rows.map((row) => ({
+      ...row,
+      credentialExpiresAt: row.credentialExpiresAt?.toISOString() ?? null,
+    })));
+}
+
+export async function upsertAccountMetadata(input: {
+  readonly teamId: string;
+  readonly accountId: string;
+  readonly credential: CodeRouterCredential;
+  readonly vaultRevision: number;
+}): Promise<void> {
+  const providerAccountId = input.credential.accountId;
+  const label = input.credential.email ||
+    (input.credential.provider === "opencode-go"
+      ? input.credential.orgName
+      : undefined) ||
+    providerAccountId;
+  await cloudDb()
+    .insert(coderouterAccounts)
+    .values({
+      id: input.accountId,
+      teamId: input.teamId,
+      provider: input.credential.provider,
+      providerAccountId,
+      label,
+      state: "active",
+      vaultRevision: input.vaultRevision,
+      credentialExpiresAt: new Date(input.credential.expiresAt),
+      updatedAt: new Date(),
+    })
+    .onConflictDoUpdate({
+      target: [
+        coderouterAccounts.teamId,
+        coderouterAccounts.provider,
+        coderouterAccounts.providerAccountId,
+      ],
+      set: {
+        label,
+        state: "active",
+        vaultRevision: input.vaultRevision,
+        credentialExpiresAt: new Date(input.credential.expiresAt),
+        lastFailureCode: null,
+        updatedAt: new Date(),
+      },
+    });
+}
+
+export async function findAccountByProviderIdentity(
+  teamId: string,
+  provider: CodeRouterProvider,
+  providerAccountId: string,
+): Promise<{ id: string; state: string; vaultRevision: number } | null> {
+  const [row] = await cloudDb()
+    .select({
+      id: coderouterAccounts.id,
+      state: coderouterAccounts.state,
+      vaultRevision: coderouterAccounts.vaultRevision,
+    })
+    .from(coderouterAccounts)
+    .where(and(
+      eq(coderouterAccounts.teamId, teamId),
+      eq(coderouterAccounts.provider, provider),
+      eq(coderouterAccounts.providerAccountId, providerAccountId),
+    ))
+    .limit(1);
+  return row ?? null;
+}
+
+export async function selectAccountForRequest(
+  teamId: string,
+  provider: CodeRouterProvider,
+): Promise<{
+  id: string;
+  vaultRevision: number;
+  credentialExpiresAt: Date | null;
+} | null> {
+  const [row] = await cloudDb()
+    .select({
+      id: coderouterAccounts.id,
+      vaultRevision: coderouterAccounts.vaultRevision,
+      credentialExpiresAt: coderouterAccounts.credentialExpiresAt,
+    })
+    .from(coderouterAccounts)
+    .where(and(
+      eq(coderouterAccounts.teamId, teamId),
+      eq(coderouterAccounts.provider, provider),
+      eq(coderouterAccounts.state, "active"),
+    ))
+    .orderBy(sql`${coderouterAccounts.lastUsedAt} asc nulls first`, coderouterAccounts.createdAt)
+    .limit(1);
+  if (!row) return null;
+  await cloudDb()
+    .update(coderouterAccounts)
+    .set({ lastUsedAt: new Date() })
+    .where(eq(coderouterAccounts.id, row.id));
+  return row;
+}
+
+export async function claimRefreshLease(
+  accountId: string,
+  now = new Date(),
+): Promise<string | null> {
+  const leaseId = randomUUID();
+  const [claimed] = await cloudDb()
+    .update(coderouterAccounts)
+    .set({
+      state: "refreshing",
+      refreshLeaseId: leaseId,
+      refreshLeaseExpiresAt: new Date(now.getTime() + REFRESH_LEASE_MS),
+      updatedAt: now,
+    })
+    .where(and(
+      eq(coderouterAccounts.id, accountId),
+      or(
+        isNull(coderouterAccounts.refreshLeaseExpiresAt),
+        lte(coderouterAccounts.refreshLeaseExpiresAt, now),
+      ),
+    ))
+    .returning({ id: coderouterAccounts.id });
+  return claimed ? leaseId : null;
+}
+
+export async function completeRefreshLease(input: {
+  readonly accountId: string;
+  readonly leaseId: string;
+  readonly vaultRevision: number;
+  readonly credentialExpiresAt: Date;
+}): Promise<void> {
+  await cloudDb()
+    .update(coderouterAccounts)
+    .set({
+      state: "active",
+      vaultRevision: input.vaultRevision,
+      credentialExpiresAt: input.credentialExpiresAt,
+      refreshLeaseId: null,
+      refreshLeaseExpiresAt: null,
+      lastFailureCode: null,
+      updatedAt: new Date(),
+    })
+    .where(and(
+      eq(coderouterAccounts.id, input.accountId),
+      eq(coderouterAccounts.refreshLeaseId, input.leaseId),
+    ));
+}
+
+export async function failRefreshLease(
+  accountId: string,
+  leaseId: string,
+  terminal: boolean,
+  code: string,
+): Promise<void> {
+  await cloudDb()
+    .update(coderouterAccounts)
+    .set({
+      state: terminal ? "broken" : "active",
+      refreshLeaseId: null,
+      refreshLeaseExpiresAt: null,
+      lastFailureCode: code.slice(0, 128),
+      updatedAt: new Date(),
+    })
+    .where(and(
+      eq(coderouterAccounts.id, accountId),
+      eq(coderouterAccounts.refreshLeaseId, leaseId),
+    ));
+}
+
+export async function withVaultLease<T>(
+  teamId: string,
+  operation: () => Promise<T>,
+  now = () => new Date(),
+): Promise<T> {
+  const leaseId = randomUUID();
+  const db = cloudDb();
+  await db.transaction(async (tx) => {
+    await tx.execute(
+      sql`select pg_advisory_xact_lock(hashtextextended(${"coderouter-vault:" + teamId}, 0))`,
+    );
+    const reservedAt = now();
+    await tx
+      .delete(coderouterVaultLeases)
+      .where(and(
+        eq(coderouterVaultLeases.teamId, teamId),
+        lte(coderouterVaultLeases.expiresAt, reservedAt),
+      ));
+    const [active] = await tx
+      .select({ leaseId: coderouterVaultLeases.leaseId })
+      .from(coderouterVaultLeases)
+      .where(eq(coderouterVaultLeases.teamId, teamId))
+      .limit(1);
+    if (active) throw new CodeRouterLeaseBusy("Stack vault is busy");
+    await tx.insert(coderouterVaultLeases).values({
+      teamId,
+      leaseId,
+      expiresAt: new Date(reservedAt.getTime() + VAULT_LEASE_MS),
+      updatedAt: reservedAt,
+    });
+  });
+  try {
+    return await operation();
+  } finally {
+    await db
+      .delete(coderouterVaultLeases)
+      .where(and(
+        eq(coderouterVaultLeases.teamId, teamId),
+        eq(coderouterVaultLeases.leaseId, leaseId),
+      ))
+      .catch(() => undefined);
+  }
+}

--- a/web/services/coderouter/repository.ts
+++ b/web/services/coderouter/repository.ts
@@ -1,5 +1,5 @@
 import { createHash, randomBytes, randomUUID } from "node:crypto";
-import { and, eq, gt, isNull, lte, or, sql } from "drizzle-orm";
+import { and, eq, gt, isNull, lte, notInArray, or, sql } from "drizzle-orm";
 import { cloudDb } from "../../db/client";
 import {
   coderouterAccounts,
@@ -164,11 +164,26 @@ export async function findAccountByProviderIdentity(
 export async function selectAccountForRequest(
   teamId: string,
   provider: CodeRouterProvider,
+  excludedAccountIds: readonly string[] = [],
 ): Promise<{
   id: string;
   vaultRevision: number;
   credentialExpiresAt: Date | null;
 } | null> {
+  const now = new Date();
+  await cloudDb()
+    .update(coderouterAccounts)
+    .set({
+      state: "active",
+      refreshLeaseId: null,
+      refreshLeaseExpiresAt: null,
+      updatedAt: now,
+    })
+    .where(and(
+      eq(coderouterAccounts.teamId, teamId),
+      eq(coderouterAccounts.state, "refreshing"),
+      lte(coderouterAccounts.refreshLeaseExpiresAt, now),
+    ));
   const [row] = await cloudDb()
     .select({
       id: coderouterAccounts.id,
@@ -180,6 +195,13 @@ export async function selectAccountForRequest(
       eq(coderouterAccounts.teamId, teamId),
       eq(coderouterAccounts.provider, provider),
       eq(coderouterAccounts.state, "active"),
+      or(
+        isNull(coderouterAccounts.cooldownUntil),
+        lte(coderouterAccounts.cooldownUntil, now),
+      ),
+      excludedAccountIds.length === 0
+        ? sql`true`
+        : notInArray(coderouterAccounts.id, [...excludedAccountIds]),
     ))
     .orderBy(sql`${coderouterAccounts.lastUsedAt} asc nulls first`, coderouterAccounts.createdAt)
     .limit(1);
@@ -189,6 +211,21 @@ export async function selectAccountForRequest(
     .set({ lastUsedAt: new Date() })
     .where(eq(coderouterAccounts.id, row.id));
   return row;
+}
+
+export async function markAccountCooldown(
+  accountId: string,
+  durationMs: number,
+): Promise<void> {
+  const bounded = Math.min(Math.max(durationMs, 1_000), 7 * 24 * 60 * 60 * 1_000);
+  await cloudDb()
+    .update(coderouterAccounts)
+    .set({
+      cooldownUntil: new Date(Date.now() + bounded),
+      lastFailureCode: "rate_limited",
+      updatedAt: new Date(),
+    })
+    .where(eq(coderouterAccounts.id, accountId));
 }
 
 export async function claimRefreshLease(

--- a/web/services/coderouter/requestContext.ts
+++ b/web/services/coderouter/requestContext.ts
@@ -1,0 +1,66 @@
+import {
+  browserMutationOriginAllowed,
+  jsonResponse,
+  parseBearer,
+  requestedVmTeamIdFromRequest,
+  requiresBrowserMutationProtection,
+} from "../vms/routeHelpers";
+import {
+  parseNativeStackTokens,
+  unauthorized,
+  verifySubrouterRequest,
+  withSubrouterAuthorizationDeadline,
+  type AuthedUser,
+} from "../vms/auth";
+import { resolveTeam } from "../subrouter/routeHelpers";
+
+export type CodeRouterRequestContext = {
+  readonly user: AuthedUser;
+  readonly team: {
+    readonly teamId: string;
+    readonly teamName: string;
+    readonly use: boolean;
+    readonly manageAccounts: boolean;
+  };
+};
+
+export async function resolveCodeRouterRequestContext(
+  request: Request,
+  permission: "use" | "manage" | "use-or-manage" = "use",
+): Promise<
+  | { readonly ok: true; readonly value: CodeRouterRequestContext }
+  | { readonly ok: false; readonly response: Response }
+> {
+  return await withSubrouterAuthorizationDeadline(async (signal) => {
+    const requestedTeamId = requestedVmTeamIdFromRequest(request);
+    const user = await verifySubrouterRequest(request, signal, {
+      requestedTeamId,
+      allowCookie: true,
+    });
+    if (!user) return { ok: false, response: unauthorized() };
+
+    const bearer = parseBearer(request);
+    if (
+      requiresBrowserMutationProtection(request.method, bearer) &&
+      !browserMutationOriginAllowed(request)
+    ) {
+      return { ok: false, response: jsonResponse({ error: "forbidden" }, 403) };
+    }
+
+    const team = await resolveTeam(request, user);
+    if (!team.ok) return team;
+    const permitted = permission === "manage"
+      ? team.manageAccounts
+      : permission === "use-or-manage"
+      ? team.use || team.manageAccounts
+      : team.use;
+    if (!permitted) {
+      return { ok: false, response: jsonResponse({ error: "forbidden" }, 403) };
+    }
+
+    // Parse native tokens so malformed mixed auth never falls through as a
+    // browser-cookie request. Verification above remains authoritative.
+    parseNativeStackTokens(request);
+    return { ok: true, value: { user, team } };
+  });
+}

--- a/web/services/coderouter/types.ts
+++ b/web/services/coderouter/types.ts
@@ -1,0 +1,44 @@
+export type CodeRouterProvider = "codex" | "opencode-go";
+
+export type CodexCredential = {
+  readonly provider: "codex";
+  readonly accessToken: string;
+  readonly refreshToken: string;
+  readonly idToken: string;
+  readonly accountId: string;
+  readonly email: string;
+  readonly expiresAt: number;
+};
+
+export type OpenCodeGoCredential = {
+  readonly provider: "opencode-go";
+  readonly accessToken: string;
+  readonly refreshToken: string;
+  readonly accountId: string;
+  readonly email: string;
+  readonly orgId?: string;
+  readonly orgName?: string;
+  readonly expiresAt: number;
+};
+
+export type CodeRouterCredential = CodexCredential | OpenCodeGoCredential;
+
+export type VaultAccount = {
+  readonly revision: number;
+  readonly credential: CodeRouterCredential;
+};
+
+export type CodeRouterVault = {
+  readonly version: 1;
+  readonly accounts: Readonly<Record<string, VaultAccount>>;
+};
+
+export type CodeRouterAccountSummary = {
+  readonly id: string;
+  readonly provider: CodeRouterProvider;
+  readonly providerAccountId: string;
+  readonly label: string;
+  readonly state: "active" | "refreshing" | "expired" | "broken";
+  readonly credentialExpiresAt: string | null;
+  readonly lastFailureCode: string | null;
+};

--- a/web/services/coderouter/usage.ts
+++ b/web/services/coderouter/usage.ts
@@ -1,0 +1,37 @@
+import { listAccounts } from "./repository";
+import { freshCredential } from "./refresh";
+
+const CODEX_USAGE_URL = "https://chatgpt.com/backend-api/wham/usage";
+
+export async function accountsWithUsage(teamId: string) {
+  const accounts = await listAccounts(teamId);
+  return await Promise.all(accounts.map(async (account) => {
+    if (account.provider !== "codex" || account.state !== "active") {
+      return account;
+    }
+    try {
+      const credential = await freshCredential({
+        teamId,
+        accountId: account.id,
+        expectedRevision: 0,
+      });
+      if (credential.provider !== "codex") return account;
+      const response = await fetch(CODEX_USAGE_URL, {
+        headers: {
+          authorization: `Bearer ${credential.accessToken}`,
+          "chatgpt-account-id": credential.accountId,
+          "user-agent": "coderouter/0.2",
+        },
+        cache: "no-store",
+        signal: AbortSignal.timeout(5_000),
+      });
+      if (!response.ok) {
+        return { ...account, usageError: `HTTP ${response.status}` };
+      }
+      const usage: unknown = await response.json();
+      return { ...account, usage };
+    } catch {
+      return { ...account, usageError: "unavailable" };
+    }
+  }));
+}

--- a/web/services/coderouter/usage.ts
+++ b/web/services/coderouter/usage.ts
@@ -1,4 +1,4 @@
-import { listAccounts } from "./repository";
+import { listAccounts, markAccountCooldown } from "./repository";
 import { freshCredential } from "./refresh";
 
 const CODEX_USAGE_URL = "https://chatgpt.com/backend-api/wham/usage";
@@ -29,9 +29,30 @@ export async function accountsWithUsage(teamId: string) {
         return { ...account, usageError: `HTTP ${response.status}` };
       }
       const usage: unknown = await response.json();
+      const cooldownMs = usageCooldown(usage);
+      if (cooldownMs !== null) {
+        await markAccountCooldown(account.id, cooldownMs);
+      }
       return { ...account, usage };
     } catch {
       return { ...account, usageError: "unavailable" };
     }
   }));
+}
+
+function usageCooldown(value: unknown): number | null {
+  if (!isRecord(value) || !isRecord(value.rate_limit)) return null;
+  const rate = value.rate_limit;
+  if (rate.limit_reached !== true && rate.allowed !== false) return null;
+  const windows = [rate.primary_window, rate.secondary_window].filter(isRecord);
+  const resetSeconds = windows
+    .map((window) => window.reset_after_seconds)
+    .filter((seconds): seconds is number =>
+      typeof seconds === "number" && Number.isFinite(seconds) && seconds > 0
+    );
+  return (resetSeconds.length > 0 ? Math.min(...resetSeconds) : 60) * 1_000;
+}
+
+function isRecord(value: unknown): value is Record<string, any> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
 }

--- a/web/services/coderouter/vault.ts
+++ b/web/services/coderouter/vault.ts
@@ -1,0 +1,123 @@
+import { getStackServerApp } from "../../app/lib/stack";
+import type {
+  CodeRouterCredential,
+  CodeRouterVault,
+  VaultAccount,
+} from "./types";
+
+const METADATA_KEY = "coderouterVaultV1";
+
+export class CodeRouterVaultUnavailable extends Error {
+  readonly _tag = "CodeRouterVaultUnavailable";
+}
+
+export class CodeRouterVaultCorrupt extends Error {
+  readonly _tag = "CodeRouterVaultCorrupt";
+}
+
+export async function readTeamVault(teamId: string): Promise<CodeRouterVault> {
+  const team = await getStackServerApp().getTeam(teamId);
+  if (!team) throw new CodeRouterVaultUnavailable("Stack team not found");
+  return parseVault(team.serverMetadata?.[METADATA_KEY]);
+}
+
+export async function writeTeamVault(
+  teamId: string,
+  vault: CodeRouterVault,
+): Promise<void> {
+  const team = await getStackServerApp().getTeam(teamId);
+  if (!team) throw new CodeRouterVaultUnavailable("Stack team not found");
+  const metadata = isRecord(team.serverMetadata)
+    ? { ...team.serverMetadata }
+    : {};
+  await team.update({
+    serverMetadata: {
+      ...metadata,
+      [METADATA_KEY]: vault,
+    },
+  });
+}
+
+export async function putVaultCredential(
+  teamId: string,
+  accountId: string,
+  credential: CodeRouterCredential,
+  expectedRevision?: number,
+): Promise<number> {
+  const vault = await readTeamVault(teamId);
+  const current = vault.accounts[accountId];
+  if (
+    expectedRevision !== undefined &&
+    current?.revision !== expectedRevision
+  ) {
+    throw new CodeRouterVaultUnavailable("vault revision changed");
+  }
+  const revision = (current?.revision ?? 0) + 1;
+  await writeTeamVault(teamId, {
+    version: 1,
+    accounts: {
+      ...vault.accounts,
+      [accountId]: { revision, credential },
+    },
+  });
+  return revision;
+}
+
+export async function deleteVaultCredential(
+  teamId: string,
+  accountId: string,
+): Promise<void> {
+  const vault = await readTeamVault(teamId);
+  if (!(accountId in vault.accounts)) return;
+  const accounts = { ...vault.accounts };
+  delete accounts[accountId];
+  await writeTeamVault(teamId, { version: 1, accounts });
+}
+
+export function parseVault(value: unknown): CodeRouterVault {
+  if (value === undefined || value === null) {
+    return { version: 1, accounts: {} };
+  }
+  if (!isRecord(value) || value.version !== 1 || !isRecord(value.accounts)) {
+    throw new CodeRouterVaultCorrupt("invalid Stack CodeRouter vault");
+  }
+  const accounts: Record<string, VaultAccount> = {};
+  for (const [accountId, candidate] of Object.entries(value.accounts)) {
+    if (
+      !isRecord(candidate) ||
+      !Number.isSafeInteger(candidate.revision) ||
+      (candidate.revision as number) < 1 ||
+      !isCredential(candidate.credential)
+    ) {
+      throw new CodeRouterVaultCorrupt("invalid Stack CodeRouter vault account");
+    }
+    accounts[accountId] = {
+      revision: candidate.revision as number,
+      credential: candidate.credential,
+    };
+  }
+  return { version: 1, accounts };
+}
+
+function isCredential(value: unknown): value is CodeRouterCredential {
+  if (!isRecord(value)) return false;
+  const common =
+    nonEmptyString(value.accessToken) &&
+    nonEmptyString(value.refreshToken) &&
+    nonEmptyString(value.accountId) &&
+    nonEmptyString(value.email) &&
+    typeof value.expiresAt === "number";
+  if (!common) return false;
+  if (value.provider === "codex") return nonEmptyString(value.idToken);
+  return value.provider === "opencode-go" &&
+    (value.orgId === undefined || typeof value.orgId === "string") &&
+    (value.orgName === undefined || typeof value.orgName === "string");
+}
+
+function nonEmptyString(value: unknown): value is string {
+  return typeof value === "string" && value.length > 0;
+}
+
+function isRecord(value: unknown): value is Record<string, any> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/web/tests/cli-config-route.test.ts
+++ b/web/tests/cli-config-route.test.ts
@@ -5,17 +5,12 @@ type CliConfigEnvKey =
   | "NEXT_PUBLIC_STACK_API_URL"
   | "NEXT_PUBLIC_STACK_PROJECT_ID"
   | "NEXT_PUBLIC_STACK_PUBLISHABLE_CLIENT_KEY"
-  | "SUBROUTER_HOSTED_URL"
-  | "SUBROUTER_STACK_TENANT_DELETE_TOKEN"
   | "VERCEL_ENV";
 
 const testEnvironment = {
   NEXT_PUBLIC_STACK_API_URL: "https://stack.example.test/api/v1",
   NEXT_PUBLIC_STACK_PROJECT_ID: "test-stack-project-id",
   NEXT_PUBLIC_STACK_PUBLISHABLE_CLIENT_KEY: "test-stack-publishable-key",
-  SUBROUTER_HOSTED_URL: "https://subrouter.example.test",
-  SUBROUTER_STACK_TENANT_DELETE_TOKEN:
-    "0123456789abcdef0123456789abcdef-test",
   VERCEL_ENV: "preview",
 } satisfies Record<CliConfigEnvKey, string>;
 
@@ -51,13 +46,13 @@ async function withCliConfigEnvironment(
 }
 
 describe("CLI config route", () => {
-  test("publishes native Stack Auth and hosted Subrouter configuration", async () => {
+  test("publishes native Stack Auth and the Vercel CodeRouter data plane", async () => {
     await withCliConfigEnvironment(testEnvironment, async () => {
       const response = GET(new Request("https://cmux.com/api/cli/config"));
       expect(response.status).toBe(200);
       expect(response.headers.get("cache-control")).toBe("no-store");
       expect(await response.json()).toEqual({
-        version: 2,
+        version: 3,
         auth: {
           apiUrl: testEnvironment.NEXT_PUBLIC_STACK_API_URL,
           projectId: testEnvironment.NEXT_PUBLIC_STACK_PROJECT_ID,
@@ -65,9 +60,10 @@ describe("CLI config route", () => {
             testEnvironment.NEXT_PUBLIC_STACK_PUBLISHABLE_CLIENT_KEY,
           confirmUrl: "https://cmux.com/handler/cli-auth-confirm",
         },
-        subrouter: {
-          url: testEnvironment.SUBROUTER_HOSTED_URL,
-          exchangeUrl: "https://cmux.com/api/subrouter/tenant-exchange",
+        coderouter: {
+          sessionUrl: "https://cmux.com/api/coderouter/session",
+          accountsUrl: "https://cmux.com/api/coderouter/accounts",
+          openaiBaseUrl: "https://cmux.com/v1",
         },
       });
     });
@@ -84,46 +80,10 @@ describe("CLI config route", () => {
       expect(body.auth.confirmUrl).toBe(
         "http://127.0.0.1:4152/handler/cli-auth-confirm",
       );
-      expect(body.subrouter.exchangeUrl).toBe(
-        "http://127.0.0.1:4152/api/subrouter/tenant-exchange",
+      expect(body.coderouter.sessionUrl).toBe(
+        "http://127.0.0.1:4152/api/coderouter/session",
       );
     });
-  });
-
-  test("defaults non-production deployments to staging Subrouter", async () => {
-    for (const deploymentEnvironment of [undefined, "development", "preview"]) {
-      await withCliConfigEnvironment(
-        {
-          ...testEnvironment,
-          SUBROUTER_HOSTED_URL: undefined,
-          VERCEL_ENV: deploymentEnvironment,
-        },
-        async () => {
-          const response = GET(new Request("https://preview.example/api/cli/config"));
-          expect(response.status).toBe(200);
-          expect((await response.json()).subrouter.url).toBe(
-            "https://staging.sr.cmux.com",
-          );
-        },
-      );
-    }
-  });
-
-  test("defaults production deployments to production Subrouter", async () => {
-    await withCliConfigEnvironment(
-      {
-        ...testEnvironment,
-        SUBROUTER_HOSTED_URL: undefined,
-        VERCEL_ENV: "production",
-      },
-      async () => {
-        const response = GET(new Request("https://cmux.com/api/cli/config"));
-        expect(response.status).toBe(200);
-        expect((await response.json()).subrouter.url).toBe(
-          "https://sr.cmux.com",
-        );
-      },
-    );
   });
 
   test("returns 503 instead of advertising incomplete Stack configuration", async () => {
@@ -132,7 +92,6 @@ describe("CLI config route", () => {
         ...testEnvironment,
         NEXT_PUBLIC_STACK_PROJECT_ID: undefined,
         NEXT_PUBLIC_STACK_PUBLISHABLE_CLIENT_KEY: undefined,
-        SUBROUTER_STACK_TENANT_DELETE_TOKEN: undefined,
       },
       async () => {
         const response = GET(new Request("https://cmux.com/api/cli/config"));
@@ -144,19 +103,4 @@ describe("CLI config route", () => {
     );
   });
 
-  test("returns 503 instead of advertising an insecure hosted Subrouter", async () => {
-    await withCliConfigEnvironment(
-      {
-        ...testEnvironment,
-        SUBROUTER_HOSTED_URL: "http://subrouter.example.test",
-      },
-      async () => {
-        const response = GET(new Request("https://cmux.com/api/cli/config"));
-        expect(response.status).toBe(503);
-        expect(await response.json()).toEqual({
-          error: "cli_auth_unavailable",
-        });
-      },
-    );
-  });
 });

--- a/web/tests/coderouter-opencode-proxy.test.ts
+++ b/web/tests/coderouter-opencode-proxy.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, test } from "bun:test";
+import { __test } from "../services/coderouter/opencodeProxy";
+
+describe("CodeRouter OpenCode Go proxy", () => {
+  test("rewrites provider traffic through coderouter.dev without upstream secrets", () => {
+    const rewritten = __test.rewriteProviders({
+      go: {
+        name: "OpenCode Go",
+        npm: "@ai-sdk/openai-compatible",
+        api: { url: "https://models.example.test/v1", package: "@ai-sdk/openai-compatible" },
+        options: { apiKey: "upstream-secret", headers: { secret: "value" }, mode: "go" },
+        models: { "model-1": { name: "Model One" } },
+      },
+    }, "route-token") as Record<string, any>;
+    expect(rewritten.go.options).toEqual({
+      mode: "go",
+      baseURL: "https://coderouter.dev/api/coderouter/opencode/proxy/go",
+      apiKey: "route-token",
+    });
+    expect(JSON.stringify(rewritten)).not.toContain("upstream-secret");
+    expect(JSON.stringify(rewritten)).not.toContain("models.example.test");
+  });
+
+  test("rejects loopback and private provider targets", () => {
+    expect(__test.safeProviderURL("https://api.example.com/v1")).toBe(true);
+    expect(__test.safeProviderURL("http://api.example.com/v1")).toBe(false);
+    expect(__test.safeProviderURL("https://127.0.0.1/v1")).toBe(false);
+    expect(__test.safeProviderURL("https://10.0.0.1/v1")).toBe(false);
+    expect(__test.safeProviderURL("https://192.168.1.4/v1")).toBe(false);
+  });
+});

--- a/web/tests/coderouter-vault.test.ts
+++ b/web/tests/coderouter-vault.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, test } from "bun:test";
+import { parseCredential } from "../services/coderouter/accounts";
+import { parseVault } from "../services/coderouter/vault";
+
+const codex = {
+  provider: "codex",
+  accessToken: "access",
+  refreshToken: "refresh",
+  idToken: "id",
+  accountId: "account-1",
+  email: "person@example.com",
+  expiresAt: Date.now() + 3_600_000,
+};
+
+describe("CodeRouter Stack vault", () => {
+  test("accepts complete Codex and OpenCode Go credentials", () => {
+    expect(parseCredential(codex)).toEqual(codex);
+    expect(parseCredential({
+      provider: "opencode-go",
+      accessToken: "access",
+      refreshToken: "refresh",
+      accountId: "user-1",
+      email: "person@example.com",
+      orgId: "org-1",
+      orgName: "Personal",
+      expiresAt: Date.now() + 3_600_000,
+    })?.provider).toBe("opencode-go");
+  });
+
+  test("rejects incomplete secrets before they reach Stack", () => {
+    expect(parseCredential({ ...codex, refreshToken: "" })).toBeNull();
+    expect(parseCredential({ ...codex, expiresAt: "soon" })).toBeNull();
+    expect(parseCredential({ ...codex, provider: "claude" })).toBeNull();
+  });
+
+  test("fails closed on malformed Stack server metadata", () => {
+    expect(() => parseVault({
+      version: 1,
+      accounts: {
+        "account-1": { revision: 1, credential: { ...codex, refreshToken: "" } },
+      },
+    })).toThrow("invalid Stack CodeRouter vault account");
+  });
+
+  test("treats an absent vault as an empty versioned vault", () => {
+    expect(parseVault(undefined)).toEqual({ version: 1, accounts: {} });
+  });
+});


### PR DESCRIPTION
Replaces the GCP/Go CodeRouter request path with Vercel-native streaming routes at coderouter.dev. Provider credentials live in Stack team server metadata; Postgres stores only account metadata, route-token hashes, and bounded vault/refresh leases. Includes direct Codex routing, OpenCode Go catalog rewriting/proxying, rotating refresh-token locks, a v3 CLI contract, migrations, and regression coverage. Claude is intentionally unsupported.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/9633"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788506250&installation_model_id=21920&pr_number=9633&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F9633&signature=8339ed9b2e301574b637e1cb990f10378e7516a9e035fc18fde94129ce66529d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moves the CodeRouter data plane to Vercel with streaming routes at coderouter.dev, replacing the GCP/Go path. Ships a v3 CLI config, route-token auth, and Stack-managed provider credentials with serialized refresh and failover.

- New Features
  - Vercel endpoints: POST /v1/responses (Codex), GET/POST /api/coderouter/accounts, POST/DELETE /api/coderouter/session, and OpenCode proxy/config under /api/coderouter/opencode.
  - CLI config v3: returns coderouter session/accounts URLs and OpenAI base URL; removes Subrouter config.
  - Provider secrets live only in Stack team server metadata; Postgres tracks account metadata, route-token hashes, and vault/refresh leases.
  - Serialized credential refresh with short leases, retry-on-401, cooldowns on 429, automatic failover when tokens are cooked; Codex usage shown when listing accounts and can trigger cooldowns.
  - OpenCode provider catalog is rewritten to route through coderouter.dev, strips upstream secrets, and blocks private/loopback targets.
  - Claude is not supported.

- Migration
  - Run migrations: 20260805050000_coderouter_vercel_dataplane and 20260805060000_coderouter_account_cooldown.
  - Ensure the Stack team server metadata vault key exists (created on first write).
  - Update clients to CLI config v3: obtain a `crt_` route token via `sessionUrl` and use it as Bearer auth against the data plane.
  - Remove `SUBROUTER_*` env usage.
  - RDS IAM migration supports ambient AWS credentials when `VERCEL_OIDC_TOKEN` is absent; improved error chaining.

<sup>Written for commit 7ad2c42de4f2d08b18681932aed2931a4ef93d76. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/9633?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added CodeRouter support for managing provider accounts and viewing usage.
  * Added secure session token creation, revocation, credential storage, and automatic refresh.
  * Added proxy support for Codex and OpenCode requests, including streaming responses.
  * Updated CLI configuration to use CodeRouter endpoints and session settings.
  * Added validation and safeguards for credentials and provider connections.

* **Bug Fixes**
  * Improved handling of unavailable accounts, expired credentials, rate limits, and failed provider requests.

* **Tests**
  * Added coverage for configuration, vault credentials, provider proxying, and URL security validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->