### PR TITLE
Fix CodeRouter responses middleware routing

### DIFF
--- a/web/proxy.ts
+++ b/web/proxy.ts
@@ -28,6 +28,13 @@ export default function middleware(request: NextRequest) {
 
   const { pathname } = request.nextUrl;
 
+  // OpenAI-compatible CodeRouter traffic is a machine endpoint, never a
+  // localized page. Keep this explicit in addition to the matcher exclusion
+  // so direct middleware tests and future matcher edits fail safely.
+  if (pathname === "/v1/responses") {
+    return NextResponse.next();
+  }
+
   // cmux consumes this marker before navigation. If an ordinary browser
   // reaches the server, canonicalize the URL while preserving every public
   // query parameter.
@@ -349,6 +356,6 @@ function legacyOpenGraphImageRewritePath(pathname: string): string | undefined {
 
 export const config = {
   matcher: [
-    "/((?!api|_next|_vercel|agent-page-variant|authorize|handler).*)",
+    "/((?!api|v1|_next|_vercel|agent-page-variant|authorize|handler).*)",
   ],
 };

--- a/web/tests/coderouter-middleware.test.ts
+++ b/web/tests/coderouter-middleware.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, test } from "bun:test";
+import { NextRequest } from "next/server";
+import middleware from "../proxy";
+
+describe("CodeRouter middleware", () => {
+  test("does not localize the OpenAI-compatible data-plane route", () => {
+    const response = middleware(
+      new NextRequest("https://coderouter.dev/v1/responses", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+      }),
+    );
+
+    expect(response.headers.get("x-middleware-rewrite")).toBeNull();
+    expect(response.headers.get("x-middleware-next")).toBe("1");
+  });
+});


### PR DESCRIPTION
## Summary
- exclude `/v1` from localization middleware
- preserve an explicit fail-safe bypass for `/v1/responses`
- add a regression test reproducing the production rewrite to `/en/v1/responses`

## Test plan
- `bun test tests/coderouter-middleware.test.ts tests/cli-config-route.test.ts tests/coderouter-vault.test.ts tests/coderouter-opencode-proxy.test.ts`
- `bun run typecheck`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/9636"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788509292&installation_model_id=21920&pr_number=9636&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F9636&signature=fb17fbf1244ef44d9c5b44f3311ad7b2386553720c85f6ce85b1184becd3bbc1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent the localization middleware from rewriting the OpenAI-compatible CodeRouter endpoint. `/v1/responses` now bypasses middleware to avoid accidental rewrites like `/en/v1/responses`.

- **Bug Fixes**
  - Exclude `/v1` from the middleware matcher and add an explicit bypass for `/v1/responses` as a fail-safe.
  - Add a regression test to ensure `/v1/responses` is not rewritten and proceeds with `x-middleware-next`.

<sup>Written for commit d62dc185b00c9f796fd69e6a94f9da262426217f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/9636?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - OpenAI-compatible `/v1/responses` requests now bypass localization and continue without unexpected rewrites.
  - Requests under the `/v1` path are no longer processed by localization middleware.

- **Tests**
  - Added coverage confirming `/v1/responses` POST requests proceed normally without localization headers or rewrites.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->