### PR TITLE
Restore Vercel OIDC credentials for RDS access

### DIFF
--- a/web/db/client.ts
+++ b/web/db/client.ts
@@ -24,22 +24,15 @@ const globalForDb = globalThis as typeof globalThis & {
 };
 
 export function createAwsRdsIamPool(config: CloudDbAwsRdsIamConfig): Pool {
-  // Vercel supplies a short-lived OIDC token in deployed functions. The
-  // operator migration command may instead run under an already-authenticated
-  // AWS identity; in that case let the AWS SDK use its standard credential
-  // chain rather than requiring a synthetic Vercel token.
-  const credentials = process.env.VERCEL_OIDC_TOKEN
-    ? awsCredentialsProvider({
-      roleArn: config.awsRoleArn,
-      clientConfig: { region: config.awsRegion },
-    })
-    : undefined;
   const signer = new Signer({
     hostname: config.host,
     port: config.port,
     username: config.user,
     region: config.awsRegion,
-    ...(credentials ? { credentials } : {}),
+    credentials: awsCredentialsProvider({
+      roleArn: config.awsRoleArn,
+      clientConfig: { region: config.awsRegion },
+    }),
   });
 
   return new Pool({

--- a/web/tests/db-client-oidc.test.ts
+++ b/web/tests/db-client-oidc.test.ts
@@ -1,4 +1,4 @@
-import { afterAll, describe, expect, mock, test } from "bun:test";
+import { describe, expect, mock, test } from "bun:test";
 
 let oidcProviderCalls = 0;
 mock.module("@vercel/oidc-aws-credentials-provider", () => ({
@@ -33,8 +33,4 @@ describe("Vercel RDS IAM credentials", () => {
     expect(oidcProviderCalls).toBe(1);
     await pool.end();
   });
-});
-
-afterAll(() => {
-  mock.restore();
 });

--- a/web/tests/db-client-oidc.test.ts
+++ b/web/tests/db-client-oidc.test.ts
@@ -1,0 +1,40 @@
+import { afterAll, describe, expect, mock, test } from "bun:test";
+
+let oidcProviderCalls = 0;
+mock.module("@vercel/oidc-aws-credentials-provider", () => ({
+  awsCredentialsProvider: () => {
+    oidcProviderCalls += 1;
+    return async () => ({
+      accessKeyId: "test",
+      secretAccessKey: "test",
+    });
+  },
+}));
+
+const { createAwsRdsIamPool } = await import("../db/client");
+
+describe("Vercel RDS IAM credentials", () => {
+  test("always configures the Vercel OIDC provider for AWS RDS pools", async () => {
+    const previous = process.env.VERCEL_OIDC_TOKEN;
+    delete process.env.VERCEL_OIDC_TOKEN;
+    const pool = createAwsRdsIamPool({
+      driver: "aws-rds-iam",
+      awsRegion: "us-west-2",
+      awsRoleArn: "arn:aws:iam::123456789012:role/vercel",
+      host: "db.example.com",
+      port: 5432,
+      user: "postgres",
+      database: "postgres",
+      poolMax: 1,
+      sslRejectUnauthorized: true,
+    });
+    if (previous) process.env.VERCEL_OIDC_TOKEN = previous;
+
+    expect(oidcProviderCalls).toBe(1);
+    await pool.end();
+  });
+});
+
+afterAll(() => {
+  mock.restore();
+});


### PR DESCRIPTION
## Summary
- always configure the Vercel OIDC AWS credential provider for RDS IAM pools
- fix production database access for CodeRouter and existing cmux routes
- add regression coverage for runtimes where `VERCEL_OIDC_TOKEN` is not visible during module initialization

## Test plan
- `bun test tests/db-client-oidc.test.ts tests/coderouter-middleware.test.ts tests/cli-config-route.test.ts tests/coderouter-vault.test.ts tests/coderouter-opencode-proxy.test.ts`
- `bun run typecheck`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/9637"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788510507&installation_model_id=21920&pr_number=9637&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F9637&signature=f42269becc89e5b17ece288358a6127c03ce5159dec883a990e9c3320486655f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Always use Vercel OIDC-based AWS credentials for RDS IAM pools to restore production database access in Vercel. This fixes CodeRouter and existing cmux routes that rely on RDS IAM auth.

- **Bug Fixes**
  - In `createAwsRdsIamPool`, always configure credentials from `@vercel/oidc-aws-credentials-provider` instead of checking `VERCEL_OIDC_TOKEN`.
  - Added `web/tests/db-client-oidc.test.ts` to ensure the provider initializes even when `VERCEL_OIDC_TOKEN` is not set.

<sup>Written for commit a4090695032b767064fedf5a773300f8ff8ad359. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/9637?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved AWS RDS IAM authentication to consistently use the configured AWS credentials provider.
  - Prevented authentication issues when a Vercel OIDC token is unavailable.

- **Tests**
  - Added coverage verifying credential provider configuration and connection cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->