### PR TITLE
Restore hosted Subrouter CLI configuration

### DIFF
--- a/web/app/api/cli/config/route.ts
+++ b/web/app/api/cli/config/route.ts
@@ -1,3 +1,8 @@
+import {
+  defaultHostedSubrouterURL,
+  hostedSubrouterBaseURL,
+} from "@/services/subrouter/constants";
+
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
 
@@ -8,6 +13,15 @@ export function GET(request: Request): Response {
   const publishableClientKey =
     process.env.NEXT_PUBLIC_STACK_PUBLISHABLE_CLIENT_KEY?.trim();
   if (!projectId || !publishableClientKey) {
+    return unavailableResponse();
+  }
+  let subrouterUrl: string;
+  try {
+    subrouterUrl = hostedSubrouterBaseURL(
+      process.env.SUBROUTER_HOSTED_URL?.trim() ||
+        defaultHostedSubrouterURL(),
+    );
+  } catch {
     return unavailableResponse();
   }
 
@@ -28,6 +42,15 @@ export function GET(request: Request): Response {
         sessionUrl: new URL("/api/coderouter/session", request.url).toString(),
         accountsUrl: new URL("/api/coderouter/accounts", request.url).toString(),
         openaiBaseUrl: new URL("/v1", request.url).toString(),
+      },
+      // Keep the hosted Subrouter fields for released sr clients while cmux
+      // migrates its CodeRouter data plane to Vercel.
+      subrouter: {
+        url: subrouterUrl,
+        exchangeUrl: new URL(
+          "/api/subrouter/tenant-exchange",
+          request.url,
+        ).toString(),
       },
     },
     {

--- a/web/tests/cli-config-route.test.ts
+++ b/web/tests/cli-config-route.test.ts
@@ -5,12 +5,14 @@ type CliConfigEnvKey =
   | "NEXT_PUBLIC_STACK_API_URL"
   | "NEXT_PUBLIC_STACK_PROJECT_ID"
   | "NEXT_PUBLIC_STACK_PUBLISHABLE_CLIENT_KEY"
+  | "SUBROUTER_HOSTED_URL"
   | "VERCEL_ENV";
 
 const testEnvironment = {
   NEXT_PUBLIC_STACK_API_URL: "https://stack.example.test/api/v1",
   NEXT_PUBLIC_STACK_PROJECT_ID: "test-stack-project-id",
   NEXT_PUBLIC_STACK_PUBLISHABLE_CLIENT_KEY: "test-stack-publishable-key",
+  SUBROUTER_HOSTED_URL: "https://subrouter.example.test",
   VERCEL_ENV: "preview",
 } satisfies Record<CliConfigEnvKey, string>;
 
@@ -46,7 +48,7 @@ async function withCliConfigEnvironment(
 }
 
 describe("CLI config route", () => {
-  test("publishes native Stack Auth and the Vercel CodeRouter data plane", async () => {
+  test("publishes CodeRouter and the hosted Subrouter POST contract", async () => {
     await withCliConfigEnvironment(testEnvironment, async () => {
       const response = GET(new Request("https://cmux.com/api/cli/config"));
       expect(response.status).toBe(200);
@@ -64,6 +66,10 @@ describe("CLI config route", () => {
           sessionUrl: "https://cmux.com/api/coderouter/session",
           accountsUrl: "https://cmux.com/api/coderouter/accounts",
           openaiBaseUrl: "https://cmux.com/v1",
+        },
+        subrouter: {
+          url: testEnvironment.SUBROUTER_HOSTED_URL,
+          exchangeUrl: "https://cmux.com/api/subrouter/tenant-exchange",
         },
       });
     });


### PR DESCRIPTION
Restores the `subrouter` block in `/api/cli/config` alongside the Vercel-native `coderouter` block. Released `sr` clients require this block to exchange Stack auth and POST hosted credentials.

Regression coverage was committed before the fix and fails on current main.

Related: https://github.com/manaflow-ai/subrouter/pull/164
Related: https://github.com/manaflow-ai/subrouter/pull/165

Tests:
- `SKIP_ENV_VALIDATION=1 bun test tests/cli-config-route.test.ts`
- `SKIP_ENV_VALIDATION=1 bun run typecheck`
- `bunx eslint app/api/cli/config/route.ts tests/cli-config-route.test.ts`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/9638"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788511006&installation_model_id=21920&pr_number=9638&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F9638&signature=0fc73cf6c0b38c07f10351cc43117271a964e14155ba6c535a011c8ee3d54970"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restore the `subrouter` block in `/api/cli/config` alongside `coderouter` to keep released `sr` clients working for hosted creds POST and Stack auth exchange. Adds URL derivation from `SUBROUTER_HOSTED_URL` with a safe default and updates tests to cover the contract.

- **Bug Fixes**
  - Build `subrouter.url` via `hostedSubrouterBaseURL` using `SUBROUTER_HOSTED_URL` or `defaultHostedSubrouterURL()`; return 503 if invalid.
  - Expose `subrouter.exchangeUrl` at `/api/subrouter/tenant-exchange` and extend tests to assert both `coderouter` and `subrouter` fields.

<sup>Written for commit 46ab06b650ec462eb326ae084d405e88dd3426f1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/9638?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * CLI configuration responses now include the hosted Subrouter URL and tenant-exchange endpoint.
* **Bug Fixes**
  * CLI configuration requests now return a clear `503 cli_auth_unavailable` response when the hosted Subrouter URL cannot be resolved.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->