### PR TITLE
Fix unread badge optical centering

### DIFF
--- a/Sources/Sidebar/AppKitList/Cells/SidebarGroupHeaderRowView.swift
+++ b/Sources/Sidebar/AppKitList/Cells/SidebarGroupHeaderRowView.swift
@@ -20,7 +20,7 @@ final class SidebarGroupHeaderTableCellView: NSTableCellView {
     // Direct-draw badge (shared with workspace rows): NSTextField's
     // intrinsic insets shift single digits off the circle's optical center.
     private let unreadBadgeView = SidebarRowUnreadBadgeView()
-    private var unreadBadgeFont: NSFont = .systemFont(ofSize: 10, weight: .semibold)
+    private var unreadBadgeFont: NSFont = .systemFont(ofSize: 10, weight: .medium)
     private let plusButton = SidebarHeaderGlyphButton()
     private let topDropIndicator = NSView()
     private let bottomDropIndicator = NSView()
@@ -185,7 +185,7 @@ final class SidebarGroupHeaderTableCellView: NSTableCellView {
         if showsBadge {
             unreadBadgeFont = .systemFont(
                 ofSize: GlobalFontMagnification.scaledSize(metrics.unreadFontSize, percent: percent),
-                weight: .semibold
+                weight: .medium
             )
             unreadBadgeView.configure(
                 count: model.anchorUnreadCount,
@@ -385,11 +385,12 @@ final class SidebarGroupHeaderTableCellView: NSTableCellView {
 
         var badgeSize = NSSize.zero
         if !unreadBadgeView.isHidden {
-            let textSize = NSString(string: "\(model.anchorUnreadCount)")
-                .size(withAttributes: [.font: unreadBadgeFont])
-            badgeSize = NSSize(
-                width: ceil(textSize.width) + metrics.unreadHorizontalPadding * 2,
-                height: ceil(textSize.height) + metrics.unreadVerticalPadding * 2
+            badgeSize = unreadBadgeView.fittingSize(
+                horizontalPadding: metrics.unreadHorizontalPadding,
+                minimumHeight: GlobalFontMagnification.scaledSize(
+                    14 * model.fontScale,
+                    percent: model.globalFontMagnificationPercent
+                )
             )
         }
 

--- a/Sources/Sidebar/AppKitList/Cells/SidebarWorkspaceRowCellView.swift
+++ b/Sources/Sidebar/AppKitList/Cells/SidebarWorkspaceRowCellView.swift
@@ -607,7 +607,7 @@ final class SidebarWorkspaceRowTableCellView: NSTableCellView {
             return model.isActive ? palette.primaryText.withAlphaComponent(0.25) : cmuxAccentNSColor()
         }()
         let badgeText: NSColor = model.isActive ? palette.primaryText : .white
-        let badgeFont = NSFont.systemFont(ofSize: model.scaled(9), weight: .semibold)
+        let badgeFont = NSFont.systemFont(ofSize: model.scaled(8.5), weight: .medium)
 
         let leadingBadgeVisible = badgeVisible && model.settings.notificationBadgePosition == .leading
         let trailingBadgeVisible = badgeVisible && model.settings.notificationBadgePosition == .trailing
@@ -1075,7 +1075,14 @@ final class SidebarWorkspaceRowTableCellView: NSTableCellView {
         let titleRowSpacing: CGFloat = (model.settings.loadingSpinnerPosition == .leading
             && model.showsAgentActivity && model.snapshot.activeCodingAgentCount > 0) ? 6 : 8
         var x = leading
-        let badgeSide = 16 * model.fontScale
+        let badgeSize = leadingBadge.fittingSize(
+            horizontalPadding: model.scaled(4),
+            minimumHeight: model.scaled(14)
+        )
+        let trailingBadgeSize = trailingBadge.fittingSize(
+            horizontalPadding: model.scaled(4),
+            minimumHeight: model.scaled(14)
+        )
         let spinnerSide = max(10, 12 * model.fontScale)
         let firstLineCenter = model.scaled(12.5) * 0.6 + y
 
@@ -1089,14 +1096,16 @@ final class SidebarWorkspaceRowTableCellView: NSTableCellView {
 
         let leadingSlotActive = (!leadingBadge.isHidden) || (leadingSpinner?.isHidden == false)
         if leadingSlotActive {
-            let side = !leadingBadge.isHidden ? badgeSide : spinnerSide
+            let size = !leadingBadge.isHidden
+                ? badgeSize
+                : NSSize(width: spinnerSide, height: spinnerSide)
             if !leadingBadge.isHidden {
-                place(leadingBadge, size: NSSize(width: side, height: side), centerY: firstLineCenter)
+                place(leadingBadge, size: size, centerY: firstLineCenter)
             }
             if let spinner = leadingSpinner, !spinner.isHidden {
                 place(spinner, size: NSSize(width: spinnerSide, height: spinnerSide), centerY: firstLineCenter)
             }
-            x += side + titleRowSpacing
+            x += size.width + titleRowSpacing
         }
         if !pinImageView.isHidden {
             let side = model.scaled(9) + 4
@@ -1118,7 +1127,20 @@ final class SidebarWorkspaceRowTableCellView: NSTableCellView {
         let closeHit = max(16, 16 * model.fontScale)
         let closeWidth = max(16, closeHit)
         let trailingSlotActive = !trailingBadge.isHidden || (trailingSpinner?.isHidden == false) || model.canCloseWorkspace
-        let titleMaxX = trailingSlotActive ? (trailing - closeWidth - titleRowSpacing) : trailing
+        let trailingSlotWidth: CGFloat = {
+            var width: CGFloat = 0
+            if !trailingBadge.isHidden {
+                width = max(width, trailingBadgeSize.width)
+            }
+            if trailingSpinner?.isHidden == false {
+                width = max(width, spinnerSide)
+            }
+            if model.canCloseWorkspace {
+                width = max(width, closeWidth)
+            }
+            return width
+        }()
+        let titleMaxX = trailingSlotActive ? (trailing - trailingSlotWidth - titleRowSpacing) : trailing
         let titleWidth = max(10, titleMaxX - x)
         let titleHeight = isEditing
             ? ceil(renameField.intrinsicContentSize.height)
@@ -1137,8 +1159,10 @@ final class SidebarWorkspaceRowTableCellView: NSTableCellView {
                 )
                 if !trailingBadge.isHidden {
                     trailingBadge.frame = NSRect(
-                        x: trailing - badgeSide, y: firstLineCenter - badgeSide / 2,
-                        width: badgeSide, height: badgeSide
+                        x: trailing - trailingBadgeSize.width,
+                        y: firstLineCenter - trailingBadgeSize.height / 2,
+                        width: trailingBadgeSize.width,
+                        height: trailingBadgeSize.height
                     )
                 }
                 if let spinner = trailingSpinner, !spinner.isHidden {
@@ -1149,7 +1173,11 @@ final class SidebarWorkspaceRowTableCellView: NSTableCellView {
                 }
             }
         }
-        y += max(titleHeight, leadingSlotActive ? badgeSide : 0)
+        let leadingSlotHeight = leadingSlotActive
+            ? (!leadingBadge.isHidden ? badgeSize.height : spinnerSide)
+            : 0
+        let trailingSlotHeight = !trailingBadge.isHidden ? trailingBadgeSize.height : 0
+        y += max(titleHeight, leadingSlotHeight, trailingSlotHeight)
 
         func placeBlock(_ view: SidebarRowTextView) {
             guard !view.isHidden else { return }

--- a/Sources/Sidebar/AppKitList/Cells/SidebarWorkspaceRowSlotViews.swift
+++ b/Sources/Sidebar/AppKitList/Cells/SidebarWorkspaceRowSlotViews.swift
@@ -1,6 +1,7 @@
 import AppKit
 import CmuxFoundation
 import CmuxSidebar
+import CoreText
 
 /// Leaf AppKit views for the pure-AppKit workspace row: unread badge,
 /// pull-request status icons, progress bar. Each is configured with values
@@ -22,13 +23,21 @@ extension NSTextField {
     }
 }
 
-/// Circle unread-count badge (parity with SidebarWorkspaceUnreadBadge).
-/// Draws the count directly so the glyph is optically centered — NSTextField
-/// intrinsic sizing carries asymmetric insets that shift small digits.
+/// Adaptive unread-count badge shared by workspace and group rows.
+/// Draws directly so the glyph is optically centered without NSTextField's
+/// asymmetric cell insets.
 @MainActor
 final class SidebarRowUnreadBadgeView: NSView {
-    private var text: NSString = ""
-    private var textAttributes: [NSAttributedString.Key: Any] = [:]
+    private var textOutline: CGPath?
+    private var textInkBounds: CGRect = .zero
+    private var textHorizontalOpticalCenter: CGFloat = 0
+    private var textAdvance: CGFloat = 0
+    private var textLineHeight: CGFloat = 0
+    private var drawsCircularBadge = true
+    private var fillColor: NSColor = .clear
+    private var textColor: NSColor = .clear
+
+    override var isFlipped: Bool { false }
 
     override init(frame frameRect: NSRect) {
         super.init(frame: frameRect)
@@ -40,29 +49,166 @@ final class SidebarRowUnreadBadgeView: NSView {
     }
 
     func configure(count: Int, fillColor: NSColor, textColor: NSColor, font: NSFont) {
-        text = NSString(string: "\(count)")
-        textAttributes = [.font: font, .foregroundColor: textColor]
-        layer?.backgroundColor = fillColor.cgColor
+        let text = count > 99 ? "99+" : "\(max(0, count))"
+        drawsCircularBadge = text.count == 1
+        let attributedText = NSAttributedString(
+            string: text,
+            attributes: [.font: font, .foregroundColor: textColor]
+        )
+        let line = CTLineCreateWithAttributedString(attributedText)
+        var ascent: CGFloat = 0
+        var descent: CGFloat = 0
+        var leading: CGFloat = 0
+        textAdvance = CGFloat(CTLineGetTypographicBounds(line, &ascent, &descent, &leading))
+        textLineHeight = ascent + descent + leading
+        textOutline = Self.makeTextOutline(line: line, font: font as CTFont)
+        textInkBounds = textOutline?.boundingBoxOfPath ?? .zero
+        textHorizontalOpticalCenter = textOutline
+            .flatMap { Self.horizontalInkCentroid(of: $0, in: textInkBounds) }
+            ?? textInkBounds.midX
+        self.fillColor = fillColor
+        self.textColor = textColor
         needsDisplay = true
     }
 
-    override func layout() {
-        super.layout()
-        layer?.cornerRadius = min(bounds.width, bounds.height) / 2
+    private static func makeTextOutline(line: CTLine, font: CTFont) -> CGPath? {
+        let outline = CGMutablePath()
+        var appendedGlyph = false
+
+        for case let run as CTRun in CTLineGetGlyphRuns(line) as NSArray {
+            let glyphCount = CTRunGetGlyphCount(run)
+            var glyphs = Array(repeating: CGGlyph(), count: glyphCount)
+            var positions = Array(repeating: CGPoint.zero, count: glyphCount)
+            glyphs.withUnsafeMutableBufferPointer { buffer in
+                CTRunGetGlyphs(run, CFRange(location: 0, length: 0), buffer.baseAddress!)
+            }
+            positions.withUnsafeMutableBufferPointer { buffer in
+                CTRunGetPositions(run, CFRange(location: 0, length: 0), buffer.baseAddress!)
+            }
+
+            for index in 0..<glyphCount {
+                guard let glyphPath = CTFontCreatePathForGlyph(font, glyphs[index], nil) else {
+                    continue
+                }
+                outline.addPath(
+                    glyphPath,
+                    transform: CGAffineTransform(
+                        translationX: positions[index].x,
+                        y: positions[index].y
+                    )
+                )
+                appendedGlyph = true
+            }
+        }
+
+        return appendedGlyph ? outline : nil
+    }
+
+    private static func horizontalInkCentroid(
+        of outline: CGPath,
+        in inkBounds: CGRect,
+        renderingScale: CGFloat = 2
+    ) -> CGFloat? {
+        guard inkBounds.width.isFinite,
+              inkBounds.height.isFinite,
+              inkBounds.width > 0,
+              inkBounds.height > 0,
+              renderingScale > 0 else {
+            return nil
+        }
+
+        let sampleRect = inkBounds.insetBy(dx: -1, dy: -1)
+        let pixelsWide = max(1, Int(ceil(sampleRect.width * renderingScale)))
+        let pixelsHigh = max(1, Int(ceil(sampleRect.height * renderingScale)))
+        let bytesPerRow = pixelsWide
+        var bitmap = [UInt8](repeating: 0, count: pixelsHigh * bytesPerRow)
+
+        let totalWeight = bitmap.withUnsafeMutableBytes { buffer -> (weight: CGFloat, weightedX: CGFloat) in
+            let pixels = buffer.bindMemory(to: UInt8.self)
+            guard let context = CGContext(
+                data: pixels.baseAddress,
+                width: pixelsWide,
+                height: pixelsHigh,
+                bitsPerComponent: 8,
+                bytesPerRow: bytesPerRow,
+                space: CGColorSpaceCreateDeviceGray(),
+                bitmapInfo: CGImageAlphaInfo.none.rawValue
+            ) else {
+                return (0, 0)
+            }
+
+            context.setAllowsAntialiasing(true)
+            context.setShouldAntialias(true)
+            context.setFillColor(gray: 1, alpha: 1)
+            context.scaleBy(x: renderingScale, y: renderingScale)
+            context.translateBy(x: -sampleRect.minX, y: -sampleRect.minY)
+            context.addPath(outline)
+            context.fillPath()
+
+            var weight: CGFloat = 0
+            var weightedX: CGFloat = 0
+            for y in 0..<pixelsHigh {
+                let rowOffset = y * bytesPerRow
+                for x in 0..<pixelsWide {
+                    let pixelWeight = CGFloat(pixels[rowOffset + x])
+                    guard pixelWeight > 0 else { continue }
+                    let glyphX = sampleRect.minX + (CGFloat(x) + 0.5) / renderingScale
+                    weight += pixelWeight
+                    weightedX += glyphX * pixelWeight
+                }
+            }
+            return (weight, weightedX)
+        }
+
+        guard totalWeight.weight > 0 else { return nil }
+        return totalWeight.weightedX / totalWeight.weight
+    }
+
+    func fittingSize(horizontalPadding: CGFloat, minimumHeight: CGFloat) -> NSSize {
+        let height = ceil(max(minimumHeight, textLineHeight + 2))
+        if drawsCircularBadge {
+            return NSSize(width: height, height: height)
+        }
+        return NSSize(
+            width: ceil(max(height, textAdvance + horizontalPadding * 2)),
+            height: height
+        )
+    }
+
+    override func viewDidChangeEffectiveAppearance() {
+        super.viewDidChangeEffectiveAppearance()
+        needsDisplay = true
     }
 
     override func draw(_ dirtyRect: NSRect) {
         super.draw(dirtyRect)
-        guard text.length > 0, let font = textAttributes[.font] as? NSFont else { return }
-        let size = text.size(withAttributes: textAttributes)
-        // Center on the digit's cap-height band, not the full line box, so
-        // single digits sit optically centered in the circle.
-        let capCenterOffset = (font.ascender + font.descender) / 2
-        let y = bounds.midY - size.height / 2 + (size.height / 2 - font.ascender + capCenterOffset)
-        text.draw(
-            at: NSPoint(x: bounds.midX - size.width / 2, y: y),
-            withAttributes: textAttributes
+        guard let textOutline, let context = NSGraphicsContext.current?.cgContext else { return }
+
+        // Single digits occupy a square and therefore render as circles.
+        // Wider counts expand horizontally into capsules without changing
+        // their height or optical glyph centering.
+        let badgeRect = bounds
+        fillColor.setFill()
+        NSBezierPath(
+            roundedRect: badgeRect,
+            xRadius: badgeRect.height / 2,
+            yRadius: badgeRect.height / 2
+        ).fill()
+
+        // Measure and fill the same outline. Drawing the separately hinted
+        // CTLine can snap a narrow digit to a different Retina pixel than the
+        // outline used here. Horizontally, center the rendered ink mass rather
+        // than its bounds so digits with asymmetric strokes do not read off
+        // center inside a circular badge.
+        context.saveGState()
+        context.translateBy(
+            x: badgeRect.midX - textHorizontalOpticalCenter,
+            y: badgeRect.midY - textInkBounds.midY
         )
+        textColor.setFill()
+        context.addPath(textOutline)
+        context.fillPath()
+        context.restoreGState()
     }
 }
 

--- a/cmuxTests/SidebarAppKitRowCellTests.swift
+++ b/cmuxTests/SidebarAppKitRowCellTests.swift
@@ -457,7 +457,7 @@ struct SidebarAppKitRowCellTests {
     }
 
     @Test
-    func unreadBadgesUseCircularRegularCountRendering() throws {
+    func unreadBadgesUseCircularMediumCountRendering() throws {
         let workspace = Self.configuredCell(
             model: Self.makeModel(canClose: false, unreadCount: 2)
         )
@@ -485,14 +485,14 @@ struct SidebarAppKitRowCellTests {
                 "workspace",
                 workspaceBadge,
                 cmuxAccentNSColor(),
-                .systemFont(ofSize: 8.5, weight: .regular),
+                .systemFont(ofSize: 8.5, weight: .medium),
                 .systemFont(ofSize: 9, weight: .semibold)
             ),
             (
                 "group",
                 groupBadge,
                 NSColor.controlAccentColor,
-                .systemFont(ofSize: 10, weight: .regular),
+                .systemFont(ofSize: 10, weight: .medium),
                 .systemFont(ofSize: 10, weight: .semibold)
             ),
         ]
@@ -526,7 +526,7 @@ struct SidebarAppKitRowCellTests {
             #expect(
                 abs(actualInk.pixelCount - expectedInk.pixelCount)
                     < abs(actualInk.pixelCount - oversizedInk.pixelCount),
-                "\(label) unread badge count should render closer to regular-size text than semibold oversized text"
+                "\(label) unread badge count should render closer to medium-weight text than semibold oversized text"
             )
             #expect(
                 abs(actualInk.bounds.midY - badge.bounds.midY) <= 0.25,

--- a/cmuxTests/SidebarAppKitRowCellTests.swift
+++ b/cmuxTests/SidebarAppKitRowCellTests.swift
@@ -61,7 +61,8 @@ struct SidebarAppKitRowCellTests {
         settings: SidebarTabItemSettingsSnapshot? = nil,
         customDescription: String? = nil,
         metadataEntries: [SidebarStatusEntry] = [],
-        shortcutHintText: String? = nil
+        shortcutHintText: String? = nil,
+        unreadCount: Int = 0
     ) -> SidebarWorkspaceRowModel {
         let resolvedSettings = settings
             ?? SidebarTabItemSettingsSnapshot(defaults: UserDefaults(suiteName: UUID().uuidString)!)
@@ -78,7 +79,7 @@ struct SidebarAppKitRowCellTests {
             isMultiSelected: false,
             canCloseWorkspace: canClose,
             accessibilityWorkspaceCount: 1,
-            unreadCount: 0,
+            unreadCount: unreadCount,
             latestNotificationText: nil,
             showsAgentActivity: resolvedSettings.details.showAgentActivity,
             rowSpacing: 8,
@@ -240,6 +241,132 @@ struct SidebarAppKitRowCellTests {
         view.subviews + view.subviews.flatMap { descendants(of: $0) }
     }
 
+    private static func makeGroupModel(
+        name: String = "Group",
+        isPinned: Bool = false,
+        unreadCount: Int = 0
+    ) -> SidebarGroupHeaderRowModel {
+        SidebarGroupHeaderRowModel(
+            groupId: UUID(),
+            anchorWorkspaceId: UUID(),
+            name: name,
+            iconSymbol: "folder",
+            tintHex: nil,
+            isCollapsed: false,
+            isPinned: isPinned,
+            isAnchorActive: false,
+            isMultiSelected: false,
+            multiSelectionBackgroundStyle: .clear,
+            memberCount: 1,
+            anchorUnreadCount: unreadCount,
+            canMarkRead: unreadCount > 0,
+            canMarkUnread: unreadCount == 0,
+            hasLatestNotifications: unreadCount > 0,
+            canMarkAllRead: unreadCount > 0,
+            canMarkAllUnread: unreadCount == 0,
+            shortcutHintText: nil,
+            shortcutHintXOffset: 0,
+            shortcutHintYOffset: 0,
+            fontScale: 1,
+            globalFontMagnificationPercent: 100,
+            cwdContextMenuItems: [],
+            rowSpacing: 1,
+            isFirstRow: true,
+            isBeingDragged: false,
+            topDropIndicatorVisible: false,
+            bottomDropIndicatorVisible: false
+        )
+    }
+
+    private struct BrightInkMetrics {
+        let bounds: NSRect
+        let luminanceWeightedCentroid: NSPoint
+        let pixelCount: Int
+    }
+
+    private static func brightInkMetrics(
+        in view: NSView,
+        renderingScale: CGFloat = 4
+    ) throws -> BrightInkMetrics {
+        view.layoutSubtreeIfNeeded()
+        view.displayIfNeeded()
+        let bounds = view.bounds.integral
+        let pixelsWide = max(1, Int(ceil(bounds.width * renderingScale)))
+        let pixelsHigh = max(1, Int(ceil(bounds.height * renderingScale)))
+        let colorSpace = try #require(CGColorSpace(name: CGColorSpace.sRGB))
+        let context = try #require(CGContext(
+            data: nil,
+            width: pixelsWide,
+            height: pixelsHigh,
+            bitsPerComponent: 8,
+            bytesPerRow: pixelsWide * 4,
+            space: colorSpace,
+            bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
+        ))
+        context.scaleBy(x: renderingScale, y: renderingScale)
+        context.translateBy(x: -bounds.minX, y: -bounds.minY)
+        let graphicsContext = NSGraphicsContext(cgContext: context, flipped: false)
+        NSGraphicsContext.saveGraphicsState()
+        NSGraphicsContext.current = graphicsContext
+        view.draw(bounds)
+        graphicsContext.flushGraphics()
+        NSGraphicsContext.restoreGraphicsState()
+        let bitmap = NSBitmapImageRep(cgImage: try #require(context.makeImage()))
+
+        let scaleX = CGFloat(bitmap.pixelsWide) / bounds.width
+        let scaleY = CGFloat(bitmap.pixelsHigh) / bounds.height
+        var minimumX = bitmap.pixelsWide
+        var minimumY = bitmap.pixelsHigh
+        var maximumX = -1
+        var maximumY = -1
+        var brightPixelCount = 0
+        var weightedCentroidX: CGFloat = 0
+        var weightedCentroidY: CGFloat = 0
+        var totalWeight: CGFloat = 0
+
+        for x in 0..<bitmap.pixelsWide {
+            for y in 0..<bitmap.pixelsHigh {
+                guard let color = bitmap.colorAt(x: x, y: y)?.usingColorSpace(.sRGB),
+                      color.alphaComponent > 0.5,
+                      min(color.redComponent, color.greenComponent, color.blueComponent) > 0.72 else {
+                    continue
+                }
+                minimumX = min(minimumX, x)
+                minimumY = min(minimumY, y)
+                maximumX = max(maximumX, x)
+                maximumY = max(maximumY, y)
+                brightPixelCount += 1
+                let viewX = bounds.minX + (CGFloat(x) + 0.5) / scaleX
+                let viewY = bounds.minY + (CGFloat(y) + 0.5) / scaleY
+                let weight = (
+                    0.2126 * color.redComponent
+                    + 0.7152 * color.greenComponent
+                    + 0.0722 * color.blueComponent
+                ) * color.alphaComponent
+                weightedCentroidX += viewX * weight
+                weightedCentroidY += viewY * weight
+                totalWeight += weight
+            }
+        }
+
+        try #require(maximumX >= minimumX && maximumY >= minimumY)
+        try #require(brightPixelCount > 0)
+        try #require(totalWeight > 0)
+        return BrightInkMetrics(
+            bounds: NSRect(
+                x: bounds.minX + CGFloat(minimumX) / scaleX,
+                y: bounds.minY + CGFloat(minimumY) / scaleY,
+                width: CGFloat(maximumX - minimumX + 1) / scaleX,
+                height: CGFloat(maximumY - minimumY + 1) / scaleY
+            ),
+            luminanceWeightedCentroid: NSPoint(
+                x: weightedCentroidX / totalWeight,
+                y: weightedCentroidY / totalWeight
+            ),
+            pixelCount: brightPixelCount
+        )
+    }
+
     private static func textView(in cell: SidebarWorkspaceRowTableCellView, linkedTo url: URL) -> SidebarRowTextView? {
         descendants(of: cell)
             .compactMap { $0 as? SidebarRowTextView }
@@ -327,6 +454,119 @@ struct SidebarAppKitRowCellTests {
         window.sendEvent(down)
         window.sendEvent(up)
         return hitView
+    }
+
+    @Test
+    func unreadBadgesUseCircularRegularCountRendering() throws {
+        let workspace = Self.configuredCell(
+            model: Self.makeModel(canClose: false, unreadCount: 2)
+        )
+        workspace.frame = NSRect(x: 0, y: 0, width: 320, height: 44)
+        workspace.layoutSubtreeIfNeeded()
+        let workspaceBadge = try #require(
+            Self.descendants(of: workspace)
+                .compactMap { $0 as? SidebarRowUnreadBadgeView }
+                .first { !$0.isHidden }
+        )
+
+        let group = SidebarGroupHeaderTableCellView(
+            frame: NSRect(x: 0, y: 0, width: 320, height: 32)
+        )
+        group.configurePresentation(model: Self.makeGroupModel(name: "Core", unreadCount: 2))
+        group.layoutSubtreeIfNeeded()
+        let groupBadge = try #require(
+            Self.descendants(of: group)
+                .compactMap { $0 as? SidebarRowUnreadBadgeView }
+                .first { !$0.isHidden }
+        )
+
+        let cases: [(String, SidebarRowUnreadBadgeView, NSColor, NSFont, NSFont)] = [
+            (
+                "workspace",
+                workspaceBadge,
+                cmuxAccentNSColor(),
+                .systemFont(ofSize: 8.5, weight: .regular),
+                .systemFont(ofSize: 9, weight: .semibold)
+            ),
+            (
+                "group",
+                groupBadge,
+                NSColor.controlAccentColor,
+                .systemFont(ofSize: 10, weight: .regular),
+                .systemFont(ofSize: 10, weight: .semibold)
+            ),
+        ]
+
+        for (label, badge, fillColor, expectedFont, oversizedFont) in cases {
+            let actualInk = try Self.brightInkMetrics(in: badge)
+            let expectedReference = SidebarRowUnreadBadgeView()
+            expectedReference.configure(
+                count: 2,
+                fillColor: fillColor,
+                textColor: .white,
+                font: expectedFont
+            )
+            expectedReference.frame = NSRect(origin: .zero, size: badge.bounds.size)
+            let expectedInk = try Self.brightInkMetrics(in: expectedReference)
+
+            let oversizedReference = SidebarRowUnreadBadgeView()
+            oversizedReference.configure(
+                count: 2,
+                fillColor: fillColor,
+                textColor: .white,
+                font: oversizedFont
+            )
+            oversizedReference.frame = NSRect(origin: .zero, size: badge.bounds.size)
+            let oversizedInk = try Self.brightInkMetrics(in: oversizedReference)
+
+            #expect(
+                abs(badge.bounds.width - badge.bounds.height) < 0.001,
+                "\(label) single-digit unread badge should stay circular"
+            )
+            #expect(
+                abs(actualInk.pixelCount - expectedInk.pixelCount)
+                    < abs(actualInk.pixelCount - oversizedInk.pixelCount),
+                "\(label) unread badge count should render closer to regular-size text than semibold oversized text"
+            )
+            #expect(
+                abs(actualInk.bounds.midY - badge.bounds.midY) <= 0.25,
+                "\(label) unread badge count should stay vertically centered"
+            )
+        }
+    }
+
+    @Test
+    func unreadBadgesOpticallyCenterSingleDigitBrightInkAtRetinaScale() throws {
+        let workspace = Self.configuredCell(
+            model: Self.makeModel(canClose: false, unreadCount: 1)
+        )
+        workspace.frame = NSRect(x: 0, y: 0, width: 320, height: 44)
+        workspace.layoutSubtreeIfNeeded()
+        let workspaceBadge = try #require(
+            Self.descendants(of: workspace)
+                .compactMap { $0 as? SidebarRowUnreadBadgeView }
+                .first { !$0.isHidden }
+        )
+
+        let group = SidebarGroupHeaderTableCellView(
+            frame: NSRect(x: 0, y: 0, width: 320, height: 32)
+        )
+        group.configurePresentation(model: Self.makeGroupModel(name: "Core", unreadCount: 1))
+        group.layoutSubtreeIfNeeded()
+        let groupBadge = try #require(
+            Self.descendants(of: group)
+                .compactMap { $0 as? SidebarRowUnreadBadgeView }
+                .first { !$0.isHidden }
+        )
+
+        for (label, badge) in [("workspace", workspaceBadge), ("group", groupBadge)] {
+            let ink = try Self.brightInkMetrics(in: badge, renderingScale: 2)
+            let opticalDrift = ink.luminanceWeightedCentroid.x - badge.bounds.midX
+            #expect(
+                abs(opticalDrift) <= 0.25,
+                "\(label) unread badge bright-ink centroid drifted \(opticalDrift) pt"
+            )
+        }
     }
 
     private static let linkedMetadataMarkdown =


### PR DESCRIPTION
## Summary
- add a behavior-level AppKit regression for circular regular unread badges and Retina bright-ink centering
- render unread badge text from CoreText glyph outlines and center by measured ink mass
- use regular-size unread badge fonts and renderer-driven badge sizing for workspace rows and group headers

## Scope
Isolated from #9446: this PR only touches unread badge rendering/tests. No merge until user verification.

## Checks
- pending: focused hosted unit check
- pending: tagged reload + sidebar screenshot proof

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/9639"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788512199&installation_model_id=21920&pr_number=9639&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F9639&signature=34e0e19122ee0d5a75e2fee22ec540e34ad6c385492cc0dff743c983827f18a4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes unread badge centering and shape across workspace and group rows. Badges now render from CoreText outlines, size to content with a fixed-height circle/capsule, clamp at 99+, and keep digits optically centered on Retina.

- **Bug Fixes**
  - Draw from CoreText glyph outlines and center by luminance-weighted ink centroid; fixed-height circle/capsule background with 99+ clamp.
  - Use medium-weight fonts and compute sizes via `fittingSize(...)` with a scaled 14pt minimum; applied to workspace and group headers.
  - Lay out using measured badge widths/heights; compute trailing-slot width across badge/spinner/close and adjust title width/row height.
  - Add tests for circular single-digit rendering and Retina bright-ink optical centering (≤0.25 pt) across both row types.

<sup>Written for commit 8e42776e3951b23df2f5568f9804bc35ccab6c71. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/9639?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **UI Improvements**
  * Refined sidebar unread and notification badge sizing, typography, and alignment for a more consistent appearance.
  * Improved badge rendering and optical centering, including on Retina displays.
  * Reduced unnecessary spacing around badges, spinners, and close controls.
  * Added adaptive badge shapes and sizing for larger counts, including `99+`.

* **Tests**
  * Expanded sidebar tests to verify badge shape, sizing, centering, and pixel positioning.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->