### PR TITLE
Fix SDK registry bootstrap verification

### DIFF
--- a/.github/workflows/sdk-bootstrap-crates.yml
+++ b/.github/workflows/sdk-bootstrap-crates.yml
@@ -609,12 +609,16 @@ jobs:
             echo "expected one tested crate, found ${#artifacts[@]}" >&2
             exit 1
           }
+          retry_missing_project=()
+          if [[ "$PACKAGE" == "cmux-sidebar" ]]; then
+            retry_missing_project=(--retry-missing-project)
+          fi
           python3 cmux-tui/bindings/reconcile_registry_artifact.py check \
             --registry crates \
             --package "$PACKAGE" \
             --version "$BOOTSTRAP_VERSION" \
             --artifact "${artifacts[0]}" \
-            --retry-missing-project \
+            "${retry_missing_project[@]}" \
             --wait-seconds 300 \
             --require-match
           sleep 1

--- a/.github/workflows/sdk-bootstrap-npm.yml
+++ b/.github/workflows/sdk-bootstrap-npm.yml
@@ -258,7 +258,7 @@ jobs:
             exit 1
           }
           echo "npm lifecycle scripts are disabled in the credentialed publisher"
-          npm publish "${packages[0]}" \
+          npm publish "$(realpath "${packages[0]}")" \
             --ignore-scripts \
             --tag bootstrap \
             --provenance \

--- a/cmux-tui/bindings/tests/test_verify_pypi_provenance.py
+++ b/cmux-tui/bindings/tests/test_verify_pypi_provenance.py
@@ -272,6 +272,42 @@ class VerifyPyPIProvenanceTests(unittest.TestCase):
             )
         run.assert_not_called()
 
+    def test_accepts_publisher_when_optional_claims_are_omitted(self) -> None:
+        metadata = self.metadata(self.filenames)
+        provenance_payload = self.provenance_payload()
+        bundles = provenance_payload["attestation_bundles"]
+        assert isinstance(bundles, list)
+        publisher = bundles[0]["publisher"]
+        assert isinstance(publisher, dict)
+        del publisher["claims"]
+
+        def response(request: object, **_kwargs: object) -> io.BytesIO:
+            url = str(getattr(request, "full_url", ""))
+            return self.response(
+                provenance_payload if "/integrity/" in url else metadata
+            )
+
+        with mock.patch.object(
+            provenance,
+            "urlopen",
+            side_effect=response,
+        ), mock.patch.object(
+            provenance.subprocess,
+            "run",
+            return_value=subprocess.CompletedProcess([], 0),
+        ) as run:
+            provenance.verify(
+                self.package,
+                self.version,
+                self.filenames,
+                self.repository,
+                self.owners,
+                self.workflow,
+                self.environment,
+            )
+
+        self.assertEqual(run.call_count, 2)
+
     def test_binds_verified_stable_claims_to_the_release_commit_and_ref(self) -> None:
         with mock.patch.object(
             provenance,

--- a/cmux-tui/bindings/verify_pypi_provenance.py
+++ b/cmux-tui/bindings/verify_pypi_provenance.py
@@ -162,9 +162,7 @@ def _verify_publisher(
     ):
         raise ProvenanceError("PyPI trusted publisher identity does not match")
     claims = publisher.get("claims")
-    if "claims" not in publisher or not (
-        claims is None or isinstance(claims, dict)
-    ):
+    if claims is not None and not isinstance(claims, dict):
         raise ProvenanceError("PyPI trusted publisher claims are malformed")
     attestations = bundle.get("attestations")
     if not isinstance(attestations, list) or not attestations:

--- a/tests/test_tui_publish_workflow_security.py
+++ b/tests/test_tui_publish_workflow_security.py
@@ -130,7 +130,7 @@ def test_npm_bootstrap_preserves_the_first_stable_version() -> None:
     assert "npm test" in bootstrap
     assert "npm pack --pack-destination" in bootstrap
     assert "CMUX_NPM_PACKAGE" in bootstrap
-    assert 'npm publish "${packages[0]}"' in bootstrap
+    assert 'npm publish "$(realpath "${packages[0]}")"' in bootstrap
     assert "--tag bootstrap" in bootstrap
     assert "--provenance" in bootstrap
     assert "--access public" in bootstrap


### PR DESCRIPTION
Summary:
- Publish the npm bootstrap from an absolute tarball path so npm does not parse it as a GitHub shorthand.
- Accept PyPI provenance when the optional publisher claims field is omitted.
- Retry missing crates.io project propagation only for cmux-sidebar.

Evidence:
- npm failure: https://github.com/manaflow-ai/cmux/actions/runs/30990671733
- PyPI verifier failure: https://github.com/manaflow-ai/cmux/actions/runs/30990671709
- crates.io verifier failure: https://github.com/manaflow-ai/cmux/actions/runs/30990672607

Tests:
- python3 -m unittest cmux-tui/bindings/tests/test_verify_pypi_provenance.py cmux-tui/bindings/tests/test_reconcile_registry_artifact.py
- python3 -m pytest -q tests/test_tui_publish_workflow_security.py
- actionlint -shellcheck= -pyflakes= .github/workflows/sdk-bootstrap-npm.yml .github/workflows/sdk-bootstrap-pypi.yml .github/workflows/sdk-bootstrap-crates.yml
- Live authority-only verification of cmux-sdk==0.0.0a0 on PyPI

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/9640"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788512605&installation_model_id=21920&pr_number=9640&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F9640&signature=4d141a7f6d0d87f8184e6bf49db9a6df87e58cd1223080dec426956863b858e3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes SDK bootstrap verification across `npm`, `PyPI`, and crates.io. Publishes the `npm` tarball with an absolute path, accepts omitted PyPI publisher claims, and limits crates retries to `cmux-sidebar`.

- **Bug Fixes**
  - `npm`: publish the tarball via `$(realpath "${packages[0]}")` so `npm` doesn’t misparse it as a GitHub shorthand.
  - `PyPI` provenance: treat `publisher.claims` as optional; added a test to cover omitted claims.
  - crates.io: retry “missing project” propagation only for `cmux-sidebar` to avoid unnecessary waits.

<sup>Written for commit 94bfbf8017b3f8dba5a0df22c61209dc1d30e4e0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/9640?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

