### PR TITLE
Proxy Codex model discovery through CodeRouter

### DIFF
--- a/web/app/v1/models/route.ts
+++ b/web/app/v1/models/route.ts
@@ -1,0 +1,8 @@
+import { proxyCodexModels } from "@/services/coderouter/codexProxy";
+
+export const dynamic = "force-dynamic";
+export const maxDuration = 60;
+
+export async function GET(request: Request): Promise<Response> {
+  return await proxyCodexModels(request);
+}

--- a/web/services/coderouter/codexProxy.ts
+++ b/web/services/coderouter/codexProxy.ts
@@ -6,6 +6,7 @@ import {
 import { freshCredential } from "./refresh";
 
 const CODEX_UPSTREAM = "https://chatgpt.com/backend-api/codex/responses";
+const CODEX_MODELS_UPSTREAM = "https://chatgpt.com/backend-api/codex/models";
 const ALLOWED_REQUEST_HEADERS = [
   "accept",
   "content-type",
@@ -91,6 +92,60 @@ export async function proxyCodexRequest(request: Request): Promise<Response> {
   return new Response(upstream.body, {
     status: upstream.status,
     headers: responseHeaders,
+  });
+}
+
+export async function proxyCodexModels(request: Request): Promise<Response> {
+  const token = bearerToken(request);
+  if (!token) return jsonError("unauthorized", 401);
+  const identity = await authenticateRouteToken(token);
+  if (!identity) return jsonError("unauthorized", 401);
+
+  const attempted: string[] = [];
+  let upstream: Response | null = null;
+  for (let attempt = 0; attempt < 8; attempt++) {
+    const account = await selectAccountForRequest(
+      identity.teamId,
+      "codex",
+      attempted,
+    );
+    if (!account) break;
+    attempted.push(account.id);
+    let credential;
+    try {
+      credential = await freshCredential({
+        teamId: identity.teamId,
+        accountId: account.id,
+        expectedRevision: account.vaultRevision,
+      });
+    } catch {
+      continue;
+    }
+    if (credential.provider !== "codex") continue;
+    const upstreamUrl = new URL(CODEX_MODELS_UPSTREAM);
+    upstreamUrl.search = new URL(request.url).search;
+    upstream = await fetch(upstreamUrl, {
+      headers: {
+        authorization: `Bearer ${credential.accessToken}`,
+        "chatgpt-account-id": credential.accountId,
+        originator: "codex_cli_rs",
+        "user-agent": request.headers.get("user-agent") ?? "coderouter",
+      },
+      cache: "no-store",
+    });
+    if (upstream.status === 429) {
+      await markAccountCooldown(account.id, rateLimitDelay(upstream.headers));
+      continue;
+    }
+    break;
+  }
+  if (!upstream) return jsonError("no_usable_account", 503);
+  return new Response(upstream.body, {
+    status: upstream.status,
+    headers: {
+      "cache-control": "no-store",
+      "content-type": upstream.headers.get("content-type") ?? "application/json",
+    },
   });
 }
 

--- a/web/tests/coderouter-models-proxy.test.ts
+++ b/web/tests/coderouter-models-proxy.test.ts
@@ -10,6 +10,11 @@ mock.module("../services/coderouter/repository", () => ({
     vaultRevision: 1,
   }),
   markAccountCooldown: async () => {},
+  listAccounts: async () => [],
+  findAccountByProviderIdentity: async () => null,
+  upsertAccountMetadata: async () => {},
+  withVaultLease: async (_teamId: string, operation: () => unknown) =>
+    await operation(),
 }));
 mock.module("../services/coderouter/refresh", () => ({
   freshCredential: async () => ({
@@ -22,7 +27,8 @@ mock.module("../services/coderouter/refresh", () => ({
 const originalFetch = globalThis.fetch;
 let upstreamUrl = "";
 beforeAll(() => {
-  globalThis.fetch = mock(async (input: string | URL | Request) => {
+  globalThis.fetch = mock(async (...args: unknown[]) => {
+    const input = args[0] as string | URL | Request;
     upstreamUrl = String(input);
     return Response.json({ models: [{ slug: "gpt-test" }] });
   }) as typeof fetch;

--- a/web/tests/coderouter-models-proxy.test.ts
+++ b/web/tests/coderouter-models-proxy.test.ts
@@ -1,0 +1,52 @@
+import { afterAll, beforeAll, describe, expect, mock, test } from "bun:test";
+
+mock.module("../services/coderouter/repository", () => ({
+  authenticateRouteToken: async () => ({
+    teamId: "team-1",
+    routeTokenId: "route-1",
+  }),
+  selectAccountForRequest: async () => ({
+    id: "account-1",
+    vaultRevision: 1,
+  }),
+  markAccountCooldown: async () => {},
+}));
+mock.module("../services/coderouter/refresh", () => ({
+  freshCredential: async () => ({
+    provider: "codex",
+    accessToken: "provider-access",
+    accountId: "chatgpt-account",
+  }),
+}));
+
+const originalFetch = globalThis.fetch;
+let upstreamUrl = "";
+beforeAll(() => {
+  globalThis.fetch = mock(async (input: string | URL | Request) => {
+    upstreamUrl = String(input);
+    return Response.json({ models: [{ slug: "gpt-test" }] });
+  }) as typeof fetch;
+});
+afterAll(() => {
+  globalThis.fetch = originalFetch;
+});
+
+const { proxyCodexModels } = await import("../services/coderouter/codexProxy");
+
+describe("CodeRouter models proxy", () => {
+  test("forwards Codex model discovery through the authenticated account", async () => {
+    const response = await proxyCodexModels(
+      new Request("https://coderouter.dev/v1/models?client_version=0.146.0", {
+        headers: { authorization: "Bearer crt_route" },
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(upstreamUrl).toBe(
+      "https://chatgpt.com/backend-api/codex/models?client_version=0.146.0",
+    );
+    expect(await response.json()).toEqual({
+      models: [{ slug: "gpt-test" }],
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add authenticated `/v1/models` support for Codex model discovery
- forward through the selected Stack-vault account
- preserve account cooldown/failover behavior
- prevent Codex startup from logging a Next.js HTML 404

## Test plan
- focused CodeRouter suite: 12 passed
- `bun run typecheck`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/9641"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788513723&installation_model_id=21920&pr_number=9641&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F9641&signature=21c2f8a78bf76b0c75aa52873a0bfa118a9227da75d6f2983c4cda269cc59517"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expose an authenticated `/v1/models` endpoint in CodeRouter that proxies Codex model discovery through the selected vault-backed Codex account. Preserves cooldown/failover behavior and stops the Codex startup 404 log.

- **New Features**
  - Proxies to https://chatgpt.com/backend-api/codex/models, forwarding query params and using the account’s `accessToken`.
  - Retries on 429s and marks account cooldown before failing over to the next account.
  - Adds a focused test for the models proxy.

- **Bug Fixes**
  - Serve the models route dynamically to prevent a Next.js HTML 404 during Codex startup.

<sup>Written for commit cfe00a508e032ed344cebc4065360d35e7395ae2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/9641?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

