### PR TITLE
Fix fake Pi tool approval notifications

### DIFF
--- a/CLI/CMUXCLI+PiExtensionSourcePart2.swift
+++ b/CLI/CMUXCLI+PiExtensionSourcePart2.swift
@@ -260,7 +260,6 @@ async function clearResumeBinding(
 }
 
 type PiFeedEventName =
-  | "PreToolUse"
   | "PostToolUse"
   | "PreCompact"
   | "PostCompact"
@@ -443,7 +442,11 @@ export default function cmuxPiSessionExtension(pi: ExtensionAPI) {
   };
 
   pi.on("tool_execution_start", (event, ctx) => {
-    enqueueFeed(isSubagentTool(event) ? "SubagentStart" : "PreToolUse", event, ctx);
+    // Pi executes ordinary tools without an approval contract. Older cmux
+    // releases treated an unregistered agent's PreToolUse event as an
+    // approval request, so reserve start telemetry for subagents, which have
+    // their own non-approval event. PostToolUse still reports ordinary tools.
+    if (isSubagentTool(event)) enqueueFeed("SubagentStart", event, ctx);
   });
 
   pi.on("tool_execution_end", (event, ctx) => {

--- a/tests/test_pi_extension_dispatch.py
+++ b/tests/test_pi_extension_dispatch.py
@@ -328,8 +328,8 @@ await handlers.get("session_shutdown")({ reason: "hot path test complete" }, ctx
 if (projectedSynchronously) {
   throw new Error("tool payload was traversed before the Pi event handler returned");
 }
-if (projectionCount !== 1) {
-  throw new Error(`expected one deferred payload projection, got ${projectionCount}`);
+if (projectionCount !== 0) {
+  throw new Error(`ordinary Pi tool starts must not project Feed payloads, got ${projectionCount}`);
 }
 """
     projection = run_extension(
@@ -663,10 +663,11 @@ const ctx = {
   sessionManager: { getSessionId() { return "pi-feed-backlog-session"; } }
 };
 for (let index = 0; index < 10; index += 1) {
-  handlers.get("tool_execution_start")({
+  handlers.get("tool_execution_end")({
     toolCallId: `tool-${index}`,
     toolName: "bash",
-    args: { command: `echo ${index}` }
+    result: { content: [{ type: "text", text: `result ${index}` }] },
+    isError: false
   }, ctx);
 }
 handlers.get("tool_execution_end")({
@@ -1456,7 +1457,7 @@ if "hooks feed" in args and "PostToolUse" in args and lock_path:
             raise SystemExit(91)
         time.sleep(0.1)
 
-if "hooks feed" in args and "PreToolUse" in args:
+if "hooks feed" in args and "PostToolUse" in args and not lock_path:
     def handle_term(_signum, _frame):
         time.sleep(1.0)
         raise SystemExit(88)
@@ -1484,10 +1485,11 @@ const ctx = {
   sessionManager: { getSessionId() { return "pi-cancellation-session"; } }
 };
 for (let index = 0; index < 10; index += 1) {
-  handlers.get("tool_execution_start")({
+  handlers.get("tool_execution_end")({
     toolCallId: `cancel-tool-${index}`,
     toolName: "bash",
-    args: { command: `echo ${index}` }
+    result: { content: [{ type: "text", text: `result ${index}` }] },
+    isError: false
   }, ctx);
 }
 const logPath = process.env.CMUX_TEST_PI_CANCELLATION_LOG;
@@ -1546,9 +1548,6 @@ async function readLog() {
     return "";
   }
 }
-while (!(await readLog()).includes("hooks feed")) {
-  await new Promise((resolve) => setTimeout(resolve, 10));
-}
 for (const index of [3, 1, 2, 0]) {
   handlers.get("tool_execution_end")({
     toolCallId: `completion-tool-${index}`,
@@ -1590,7 +1589,7 @@ while (performance.now() < completionDeadline) {
     completion_feed_indexes = [index for index, line in enumerate(completion_calls) if "hooks feed" in line]
     notification_indexes = [index for index, line in enumerate(completion_calls) if "hooks pi notification" in line]
     stop_indexes = [index for index, line in enumerate(completion_calls) if "hooks pi stop" in line]
-    if len(completion_feed_indexes) != 5:
+    if len(completion_feed_indexes) != 4:
         print(f"FAIL: terminal lifecycle did not cancel feed backlog: {completion_calls!r}")
         return 1
     if sum("PostToolUse" in line for line in completion_calls) != 4:

--- a/tests/test_pi_extension_install.py
+++ b/tests/test_pi_extension_install.py
@@ -575,7 +575,6 @@ await handlers.get("tool_execution_start")({
   toolName: "task",
   args: { task: "ordinary tool" }
 }, ctx);
-await waitForFeedEvent("PreToolUse", 2);
 await handlers.get("tool_execution_end")({
   toolCallId: "lowercase-task-call",
   toolName: "task",
@@ -995,11 +994,11 @@ await waitForCompletionHookCount(completionCount);
         bash_feed_events = [
             payload for payload in feed_events if payload.get("tool_name") == "bash"
         ]
-        if [payload.get("hook_event_name") for payload in bash_feed_events] != [
-            "PreToolUse",
-            "PostToolUse",
-        ]:
-            print(f"FAIL: Pi Feed bridge payloads were incomplete: {bash_feed_events!r}")
+        if [payload.get("hook_event_name") for payload in bash_feed_events] != ["PostToolUse"]:
+            print(
+                "FAIL: Pi ordinary tools must publish completion telemetry without "
+                f"approval-shaped PreToolUse events: {bash_feed_events!r}"
+            )
             return 1
         if {payload.get("turn_id") for payload in feed_events} != {prompt_turn_id}:
             print(f"FAIL: Pi Feed bridge did not use the active prompt turn id: {feed_events!r}")
@@ -1067,7 +1066,6 @@ await waitForCompletionHookCount(completionCount);
             if payload.get("tool_name") == "task"
         ]
         if [payload.get("hook_event_name") for payload in lowercase_task_events] != [
-            "PreToolUse",
             "PostToolUse",
         ]:
             print(f"FAIL: lowercase task was misclassified as a subagent: {lowercase_task_events!r}")


### PR DESCRIPTION
## Summary
- stop generated Pi extensions from publishing ordinary tool starts as approval-capable `PreToolUse` events
- retain `PostToolUse` completion telemetry and dedicated subagent lifecycle events
- add regression coverage for `apply_patch`-style ordinary tools and adapt dispatch/backlog tests

## Verification
- `python3 tests/test_pi_extension_install.py` (PASS, tagged CLI)
- `python3 tests/test_pi_extension_dispatch.py` (PASS, tagged CLI)
- tagged Xcode build reached `** BUILD SUCCEEDED **` with Xcode 26.3; reload post-processing was terminated after an unrelated recursive dev-shim hang
- live installed extension smoke test: `apply_patch` emitted no Feed start event while cmux lifecycle hooks remained active
- synced patched extension to `ssh cmux-lawrence`

## Regression commits
1. `test: reject approval-shaped Pi tool starts`
2. `fix: keep Pi tool starts out of approval feed`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/9642"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788516934&installation_model_id=21920&pr_number=9642&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F9642&signature=a1aa01eb688d444a3af7d42893b8cc95763f3e594fcbb416909adb390c300905"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop emitting approval-shaped start events for ordinary Pi tools to prevent fake approval notifications. Ordinary tools now only send "PostToolUse"; subagent starts still use "SubagentStart".

- **Bug Fixes**
  - Enqueue only "SubagentStart" on `tool_execution_start`; removed "PreToolUse" from feed events.
  - Updated dispatch/install tests to expect no start events for ordinary tools; backlog/cancellation driven by completion events.
  - Added regression coverage for `apply_patch` and lowercase `task` to verify only "PostToolUse" is emitted.

<sup>Written for commit a284399db21b898d78713cb294b8de6633cd5f0c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/9642?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Ordinary tool executions no longer generate start-event telemetry.
  * Subagent executions continue to report start events.
  * Tool completion telemetry remains unchanged.
  * Updated lifecycle handling for more accurate feed activity and completion behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->