### PR TITLE
Dim inactive browser panes like terminal splits

### DIFF
--- a/Sources/BrowserWindowPortal.swift
+++ b/Sources/BrowserWindowPortal.swift
@@ -1140,6 +1140,24 @@ private final class BrowserDropZoneOverlayView: NSView {
     }
 }
 
+/// Click-through overlay that paints the unfocused-split dim over a browser
+/// pane's web content. Internal (not file-private) so tests can locate it in
+/// the slot's subviews by type.
+final class BrowserInactiveDimOverlayView: NSView {
+    override var acceptsFirstResponder: Bool { false }
+
+    override func hitTest(_ point: NSPoint) -> NSView? {
+        nil
+    }
+}
+
+/// The unfocused-split dim painted over an inactive browser pane's web content,
+/// mirroring the terminal's `unfocused-split-opacity` overlay.
+struct BrowserPortalInactiveDimConfiguration: Equatable {
+    let color: NSColor
+    let opacity: Double
+}
+
 struct BrowserPortalSearchOverlayConfiguration {
     let panelId: UUID
     let searchState: BrowserSearchState
@@ -1172,6 +1190,7 @@ final class WindowBrowserSlotView: NSView {
     }
     private let paneDropTargetView = BrowserPaneDropTargetView(frame: .zero)
     private let dropZoneOverlayView = BrowserDropZoneOverlayView(frame: .zero)
+    private let inactiveDimOverlayView = BrowserInactiveDimOverlayView(frame: .zero)
     private var searchOverlayHostingView: NSHostingView<BrowserSearchOverlay>?
     private var designComposerHostingView: BrowserDesignModeComposerHostingView?
     private var designComposerPanelId: UUID?
@@ -1207,6 +1226,12 @@ final class WindowBrowserSlotView: NSView {
         dropZoneOverlayView.layer?.borderWidth = 2
         dropZoneOverlayView.layer?.cornerRadius = 8
         dropZoneOverlayView.isHidden = true
+
+        inactiveDimOverlayView.wantsLayer = true
+        inactiveDimOverlayView.isHidden = true
+        inactiveDimOverlayView.autoresizingMask = [.width, .height]
+        addSubview(inactiveDimOverlayView, positioned: .above, relativeTo: nil)
+
         addSubview(paneDropTargetView, positioned: .above, relativeTo: nil)
     }
 
@@ -1225,6 +1250,8 @@ final class WindowBrowserSlotView: NSView {
     override func layout() {
         super.layout()
         paneDropTargetView.frame = bounds
+        inactiveDimOverlayView.frame = bounds
+        liftInactiveDimAboveHostedContentIfNeeded()
         applyResolvedDropZoneOverlay()
         if let hostedWebView,
            hostedWebView.cmuxBrowserViewportUsesHost,
@@ -1308,6 +1335,35 @@ final class WindowBrowserSlotView: NSView {
         guard abs(paneTopChromeHeight - resolvedHeight) > 0.5 else { return }
         paneTopChromeHeight = resolvedHeight
         applyResolvedDropZoneOverlay()
+    }
+
+    /// Shows, updates, or hides the unfocused-split dim over this slot's content.
+    func setInactiveDim(_ configuration: BrowserPortalInactiveDimConfiguration?) {
+        let clampedOpacity = min(max(configuration?.opacity ?? 0, 0), 1)
+        guard let configuration, clampedOpacity > 0.0001 else {
+            inactiveDimOverlayView.isHidden = true
+            return
+        }
+        inactiveDimOverlayView.layer?.backgroundColor =
+            configuration.color.withAlphaComponent(clampedOpacity).cgColor
+        if inactiveDimOverlayView.isHidden {
+            inactiveDimOverlayView.frame = bounds
+            inactiveDimOverlayView.isHidden = false
+        }
+        liftInactiveDimAboveHostedContentIfNeeded()
+    }
+
+    /// Re-lifts the visible dim above hosted content. sortSubviews is silently
+    /// ignored while a subview insertion is in flight (didAddSubview), so a web
+    /// view attached after the dim would cover it; layout runs once attach
+    /// churn settles and restores the order here.
+    private func liftInactiveDimAboveHostedContentIfNeeded() {
+        guard !inactiveDimOverlayView.isHidden,
+              let dimIndex = subviews.firstIndex(of: inactiveDimOverlayView),
+              let topContent = subviews.last(where: { interactionLayerPriority(of: $0) == 0 }),
+              let topContentIndex = subviews.firstIndex(of: topContent),
+              topContentIndex > dimIndex else { return }
+        addSubview(inactiveDimOverlayView, positioned: .above, relativeTo: topContent)
     }
 
     private func logSearchOverlayEvent(_ action: String, panelId: UUID?) {
@@ -1731,10 +1787,12 @@ final class WindowBrowserSlotView: NSView {
     }
 
     private func interactionLayerPriority(of view: NSView) -> Int {
-        if view === paneDropTargetView { return 4 }
-        if view === omnibarSuggestionsHostingView { return 3 }
-        if view === searchOverlayHostingView { return 2 }
-        if view === designComposerHostingView { return 1 }
+        if view === dropZoneOverlayView { return 6 }
+        if view === paneDropTargetView { return 5 }
+        if view === omnibarSuggestionsHostingView { return 4 }
+        if view === searchOverlayHostingView { return 3 }
+        if view === designComposerHostingView { return 2 }
+        if view === inactiveDimOverlayView { return 1 }
         return 0
     }
 
@@ -1824,6 +1882,7 @@ final class WindowBrowserPortal: NSObject {
         var searchOverlay: BrowserPortalSearchOverlayConfiguration?
         var designComposer: BrowserPortalDesignComposerConfiguration?
         var omnibarSuggestions: BrowserPortalOmnibarSuggestionsConfiguration?
+        var inactiveDim: BrowserPortalInactiveDimConfiguration?
         var paneTopChromeHeight: CGFloat
         var transientRecoveryReason: String?
         var transientRecoveryRetriesRemaining: Int
@@ -2402,6 +2461,7 @@ final class WindowBrowserPortal: NSObject {
             existing.setSearchOverlay(entry.searchOverlay)
             existing.setDesignComposer(entry.designComposer)
             existing.setOmnibarSuggestions(entry.omnibarSuggestions)
+            existing.setInactiveDim(entry.inactiveDim)
             existing.setPaneTopChromeHeight(entry.paneTopChromeHeight)
             return existing
         }
@@ -2410,6 +2470,7 @@ final class WindowBrowserPortal: NSObject {
         created.setSearchOverlay(entry.searchOverlay)
         created.setDesignComposer(entry.designComposer)
         created.setOmnibarSuggestions(entry.omnibarSuggestions)
+        created.setInactiveDim(entry.inactiveDim)
         created.setPaneTopChromeHeight(entry.paneTopChromeHeight)
 #if DEBUG
         cmuxDebugLog(
@@ -2858,6 +2919,18 @@ final class WindowBrowserPortal: NSObject {
         entry.containerView?.setOmnibarSuggestions(configuration)
     }
 
+    /// Stores and applies the unfocused-split dim for the given web view's slot.
+    func updateInactiveDim(
+        forWebViewId webViewId: ObjectIdentifier,
+        configuration: BrowserPortalInactiveDimConfiguration?
+    ) {
+        guard var entry = entriesByWebViewId[webViewId] else { return }
+        guard entry.inactiveDim != configuration else { return }
+        entry.inactiveDim = configuration
+        entriesByWebViewId[webViewId] = entry
+        entry.containerView?.setInactiveDim(configuration)
+    }
+
     func searchOverlayPanelId(for responder: NSResponder) -> UUID? {
         // Drive the lookup off the live slot view hierarchy rather than copying
         // Entry structs out of entriesByWebViewId. Each Entry copy performs 3
@@ -2942,6 +3015,7 @@ final class WindowBrowserPortal: NSObject {
                 searchOverlay: nil,
                 designComposer: nil,
                 omnibarSuggestions: nil,
+                inactiveDim: nil,
                 paneTopChromeHeight: 0,
                 transientRecoveryReason: nil,
                 transientRecoveryRetriesRemaining: 0
@@ -2982,6 +3056,7 @@ final class WindowBrowserPortal: NSObject {
             searchOverlay: previousEntry?.searchOverlay,
             designComposer: previousEntry?.designComposer,
             omnibarSuggestions: previousEntry?.omnibarSuggestions,
+            inactiveDim: previousEntry?.inactiveDim,
             paneTopChromeHeight: previousEntry?.paneTopChromeHeight ?? 0,
             transientRecoveryReason: previousEntry?.transientRecoveryReason,
             transientRecoveryRetriesRemaining: previousEntry?.transientRecoveryRetriesRemaining ?? 0
@@ -4017,6 +4092,17 @@ enum BrowserWindowPortalRegistry {
         guard let windowId = webViewToWindowId[webViewId],
               let portal = portalsByWindowId[windowId] else { return }
         portal.updateOmnibarSuggestions(forWebViewId: webViewId, configuration: configuration)
+    }
+
+    /// Routes an unfocused-split dim update to the web view's window portal.
+    static func updateInactiveDim(
+        for webView: WKWebView,
+        configuration: BrowserPortalInactiveDimConfiguration?
+    ) {
+        let webViewId = ObjectIdentifier(webView)
+        guard let windowId = webViewToWindowId[webViewId],
+              let portal = portalsByWindowId[windowId] else { return }
+        portal.updateInactiveDim(forWebViewId: webViewId, configuration: configuration)
     }
 
     static func searchOverlayPanelId(for responder: NSResponder, in window: NSWindow) -> UUID? {

--- a/Sources/Canvas/CanvasHostedPanelContentView.swift
+++ b/Sources/Canvas/CanvasHostedPanelContentView.swift
@@ -15,7 +15,6 @@ struct CanvasHostedPanelContentView: View {
     let paneId: PaneID
     let isVisibleInUI: Bool
     let portalPriority: Int
-    let appearance: PanelAppearance
     let windowAppearance: WindowAppearanceSnapshot
     let customSidebarTabManager: TabManager?
     let onRequestPanelFocus: () -> Void
@@ -31,8 +30,8 @@ struct CanvasHostedPanelContentView: View {
             allowsPointerInput: presentation.allowsPointerInput,
             pointerEntryEventFilter: presentation.acceptsPointerEntryEvent,
             portalPriority: portalPriority,
-            isSplit: false,
-            appearance: appearance,
+            isSplit: presentation.isSplit,
+            appearance: presentation.appearance,
             windowAppearance: windowAppearance,
             customSidebarTabManager: customSidebarTabManager,
             hasUnreadNotification: false,

--- a/Sources/Canvas/CanvasHostedPanelPresentation.swift
+++ b/Sources/Canvas/CanvasHostedPanelPresentation.swift
@@ -5,11 +5,24 @@ import Observation
 @Observable
 final class CanvasHostedPanelPresentation {
     private(set) var isFocused: Bool
+    /// Whether the canvas shows multiple panes; drives the unfocused-split dim.
+    private(set) var isSplit: Bool
+    /// Panel appearance, refreshed on every host update so retained mounts
+    /// track ghostty config reloads instead of the value captured at mount.
+    private(set) var appearance: PanelAppearance
     private(set) var allowsPointerInput: Bool
     @ObservationIgnored private weak var pointerInputOwner: NSView?
 
-    init(isFocused: Bool, allowsPointerInput: Bool, pointerInputOwner: NSView) {
+    init(
+        isFocused: Bool,
+        isSplit: Bool,
+        appearance: PanelAppearance,
+        allowsPointerInput: Bool,
+        pointerInputOwner: NSView
+    ) {
         self.isFocused = isFocused
+        self.isSplit = isSplit
+        self.appearance = appearance
         self.allowsPointerInput = allowsPointerInput
         self.pointerInputOwner = pointerInputOwner
     }
@@ -17,6 +30,18 @@ final class CanvasHostedPanelPresentation {
     func setFocused(_ isFocused: Bool) {
         guard self.isFocused != isFocused else { return }
         self.isFocused = isFocused
+    }
+
+    /// Updates the split state when panes are added to or removed from the canvas.
+    func setSplit(_ isSplit: Bool) {
+        guard self.isSplit != isSplit else { return }
+        self.isSplit = isSplit
+    }
+
+    /// Refreshes the appearance after a ghostty config reload.
+    func setAppearance(_ appearance: PanelAppearance) {
+        guard self.appearance != appearance else { return }
+        self.appearance = appearance
     }
 
     func setAllowsPointerInput(_ allowsPointerInput: Bool) {

--- a/Sources/Canvas/CanvasPaneContent.swift
+++ b/Sources/Canvas/CanvasPaneContent.swift
@@ -121,6 +121,8 @@ final class CanvasPaneContentMount: CanvasPaneContentMounting {
     /// terminal stays mounted.
     func updatePresentation(
         isFocused: Bool,
+        isSplit: Bool,
+        appearance: PanelAppearance,
         allowsPointerInput: Bool,
         showsInactiveOverlay: Bool,
         inactiveOverlayColor: NSColor,
@@ -139,6 +141,8 @@ final class CanvasPaneContentMount: CanvasPaneContentMounting {
             )
         case .hosted(_, _, let presentation):
             presentation.setFocused(isFocused)
+            presentation.setSplit(isSplit)
+            presentation.setAppearance(appearance)
             presentation.setAllowsPointerInput(allowsPointerInput)
         }
     }

--- a/Sources/Canvas/WorkspaceCanvasHostView.swift
+++ b/Sources/Canvas/WorkspaceCanvasHostView.swift
@@ -63,6 +63,7 @@ struct WorkspaceCanvasHostView: View {
                             workspace: workspace,
                             pointerInputOwner: container,
                             isFocused: isFocused,
+                            isSplit: isSplit,
                             isWorkspaceVisible: isWorkspaceVisible,
                             allowsPointerInput: isWorkspaceVisible && isWorkspaceInputActive,
                             portalPriority: portalPriority,
@@ -82,6 +83,8 @@ struct WorkspaceCanvasHostView: View {
                     guard let mount = mount as? CanvasPaneContentMount else { return }
                     mount.updatePresentation(
                         isFocused: isFocused,
+                        isSplit: isSplit,
+                        appearance: appearance,
                         allowsPointerInput: isWorkspaceVisible && isWorkspaceInputActive,
                         showsInactiveOverlay: isSplit && !isFocused,
                         inactiveOverlayColor: appearance.unfocusedOverlayNSColor,
@@ -118,6 +121,7 @@ struct WorkspaceCanvasHostView: View {
         workspace: Workspace?,
         pointerInputOwner: NSView,
         isFocused: Bool,
+        isSplit: Bool,
         isWorkspaceVisible: Bool,
         allowsPointerInput: Bool,
         portalPriority: Int,
@@ -133,6 +137,8 @@ struct WorkspaceCanvasHostView: View {
         let paneId = workspace?.bonsplitPaneId(forPanelId: panel.id) ?? PaneID()
         let presentation = CanvasHostedPanelPresentation(
             isFocused: isFocused,
+            isSplit: isSplit,
+            appearance: appearance,
             allowsPointerInput: allowsPointerInput,
             pointerInputOwner: pointerInputOwner
         )
@@ -143,7 +149,6 @@ struct WorkspaceCanvasHostView: View {
             paneId: paneId,
             isVisibleInUI: isWorkspaceVisible,
             portalPriority: portalPriority,
-            appearance: appearance,
             windowAppearance: windowAppearance,
             customSidebarTabManager: workspace?.owningTabManager,
             onRequestPanelFocus: { [weak workspace] in

--- a/Sources/Panels/BrowserPanelView.swift
+++ b/Sources/Panels/BrowserPanelView.swift
@@ -249,6 +249,11 @@ struct BrowserPanelView: View {
     let isFocused: Bool
     let isVisibleInUI: Bool
     let portalPriority: Int
+    /// Whether the pane shares its container with other panes; unfocused split
+    /// panes get the unfocused-split dim.
+    let isSplit: Bool
+    /// Resolved panel appearance supplying the dim color and opacity.
+    let appearance: PanelAppearance
     let onRequestPanelFocus: () -> Void
     /// Explicit pane-ownership signal for hosts whose panels are not registered
     /// in the main `Workspace` tree (e.g. the right-sidebar Dock, which owns its
@@ -347,6 +352,8 @@ struct BrowserPanelView: View {
         isFocused: Bool,
         isVisibleInUI: Bool,
         portalPriority: Int,
+        isSplit: Bool,
+        appearance: PanelAppearance,
         paneOwnershipOverride: Bool? = nil,
         onRequestPanelFocus: @escaping () -> Void
     ) {
@@ -355,6 +362,8 @@ struct BrowserPanelView: View {
         self.isFocused = isFocused
         self.isVisibleInUI = isVisibleInUI
         self.portalPriority = portalPriority
+        self.isSplit = isSplit
+        self.appearance = appearance
         self.paneOwnershipOverride = paneOwnershipOverride
         self.onRequestPanelFocus = onRequestPanelFocus
         self._browserChromeStyle = State(initialValue: BrowserChromeStyle.resolve(
@@ -362,6 +371,16 @@ struct BrowserPanelView: View {
             themeBackgroundColor: GhosttyBackgroundTheme.currentColor(),
             drawsBackground: panel.drawsConfiguredWebViewBackgroundForCurrentPage()
         ))
+    }
+
+    /// The unfocused-split dim to apply, or `nil` when the pane should not dim.
+    private var inactiveDim: BrowserPortalInactiveDimConfiguration? {
+        isSplit && !isFocused
+            ? BrowserPortalInactiveDimConfiguration(
+                color: appearance.unfocusedOverlayNSColor,
+                opacity: appearance.unfocusedOverlayOpacity
+            )
+            : nil
     }
 
     private var searchConfiguration: BrowserSearchConfiguration {
@@ -1723,6 +1742,7 @@ struct BrowserPanelView: View {
                         controller: panel.designModeController
                     ),
                     omnibarSuggestions: portalOmnibarSuggestions,
+                    inactiveDim: inactiveDim,
                     paneTopChromeHeight: panel.isOmnibarVisible ? addressBarHeight : 0
                 )
                 .accessibilityIdentifier("BrowserWebViewSurface")
@@ -1762,6 +1782,13 @@ struct BrowserPanelView: View {
                         if shouldShowEmptyStateImportOverlay,
                            browserImportHintPresentation.blankTabPlacement == .floatingCard {
                             emptyBrowserStateCardOverlay
+                        }
+                    }
+                    .overlay {
+                        if let inactiveDim {
+                            Color(nsColor: inactiveDim.color)
+                                .opacity(inactiveDim.opacity)
+                                .allowsHitTesting(false)
                         }
                     }
             }
@@ -5322,6 +5349,8 @@ struct WebViewRepresentable: NSViewRepresentable {
     let searchOverlay: BrowserPortalSearchOverlayConfiguration?
     let designComposer: BrowserPortalDesignComposerConfiguration?
     let omnibarSuggestions: BrowserPortalOmnibarSuggestionsConfiguration?
+    /// The unfocused-split dim for the hosted web content, or `nil` for none.
+    let inactiveDim: BrowserPortalInactiveDimConfiguration?
     let paneTopChromeHeight: CGFloat
 
     final class Coordinator {
@@ -7198,6 +7227,7 @@ struct WebViewRepresentable: NSViewRepresentable {
         guard let host = nsView as? HostContainerView else { return false }
         let slotView = host.ensureLocalInlineSlotView()
         slotView.setDesignComposer(designComposer)
+        slotView.setInactiveDim(inactiveDim)
         let isAlreadyInLocalHost = host.containsManagedLocalInlineContent(webView)
         let shouldPreserveExternalFullscreenHost = Self.shouldPreserveExternalFullscreenHost(
             for: webView,
@@ -7416,6 +7446,7 @@ struct WebViewRepresentable: NSViewRepresentable {
         let activePaneDropContext = coordinator.desiredPortalVisibleInUI ? paneDropContext : nil
         let activeSearchOverlay = coordinator.desiredPortalVisibleInUI ? searchOverlay : nil
         let activeDesignComposer = coordinator.desiredPortalVisibleInUI ? designComposer : nil
+        let activeInactiveDim = coordinator.desiredPortalVisibleInUI ? inactiveDim : nil
         let portalAnchorView = panel.portalAnchorView
         let portalHideReason = !isCurrentPaneOwner ? "lostPaneOwnership" : "hidden"
         let didReleasePortalHost: Bool
@@ -7503,6 +7534,7 @@ struct WebViewRepresentable: NSViewRepresentable {
             BrowserWindowPortalRegistry.updateSearchOverlay(for: webView, configuration: activeSearchOverlay)
             BrowserWindowPortalRegistry.updateDesignComposer(for: webView, configuration: activeDesignComposer)
             BrowserWindowPortalRegistry.updateOmnibarSuggestions(for: webView, configuration: activeOmnibarSuggestions)
+            BrowserWindowPortalRegistry.updateInactiveDim(for: webView, configuration: activeInactiveDim)
             coordinator.lastPortalHostId = ObjectIdentifier(host)
             coordinator.lastSynchronizedHostGeometryRevision = host.geometryRevision
         }
@@ -7540,6 +7572,7 @@ struct WebViewRepresentable: NSViewRepresentable {
                 BrowserWindowPortalRegistry.updateSearchOverlay(for: webView, configuration: activeSearchOverlay)
                 BrowserWindowPortalRegistry.updateDesignComposer(for: webView, configuration: activeDesignComposer)
                 BrowserWindowPortalRegistry.updateOmnibarSuggestions(for: webView, configuration: activeOmnibarSuggestions)
+                BrowserWindowPortalRegistry.updateInactiveDim(for: webView, configuration: activeInactiveDim)
                 coordinator.lastPortalHostId = hostId
             }
             BrowserWindowPortalRegistry.synchronizeForAnchor(portalAnchorView)
@@ -7589,6 +7622,7 @@ struct WebViewRepresentable: NSViewRepresentable {
             BrowserWindowPortalRegistry.updateSearchOverlay(for: webView, configuration: activeSearchOverlay)
             BrowserWindowPortalRegistry.updateDesignComposer(for: webView, configuration: activeDesignComposer)
             BrowserWindowPortalRegistry.updateOmnibarSuggestions(for: webView, configuration: activeOmnibarSuggestions)
+            BrowserWindowPortalRegistry.updateInactiveDim(for: webView, configuration: activeInactiveDim)
             if !shouldBindNow,
                coordinator.lastSynchronizedHostGeometryRevision != geometryRevision {
                 BrowserWindowPortalRegistry.synchronizeForAnchor(portalAnchorView)
@@ -7621,6 +7655,7 @@ struct WebViewRepresentable: NSViewRepresentable {
             BrowserWindowPortalRegistry.updateSearchOverlay(for: webView, configuration: activeSearchOverlay)
             BrowserWindowPortalRegistry.updateDesignComposer(for: webView, configuration: activeDesignComposer)
             BrowserWindowPortalRegistry.updateOmnibarSuggestions(for: webView, configuration: activeOmnibarSuggestions)
+            BrowserWindowPortalRegistry.updateInactiveDim(for: webView, configuration: activeInactiveDim)
         }
 
         panel.restoreDeveloperToolsAfterAttachIfNeeded()

--- a/Sources/Panels/PanelContentView.swift
+++ b/Sources/Panels/PanelContentView.swift
@@ -74,6 +74,8 @@ struct PanelContentView: View {
                     isFocused: isFocused,
                     isVisibleInUI: isVisibleInUI,
                     portalPriority: portalPriority,
+                    isSplit: isSplit,
+                    appearance: appearance,
                     paneOwnershipOverride: paneOwnershipOverride,
                     onRequestPanelFocus: onRequestPanelFocus
                 )

--- a/Sources/Panels/TerminalPanelView.swift
+++ b/Sources/Panels/TerminalPanelView.swift
@@ -420,7 +420,7 @@ private func terminalViewportFormat(_ value: CGFloat) -> String {
 #endif
 
 /// Shared appearance settings for panels
-struct PanelAppearance {
+struct PanelAppearance: Equatable {
     let backgroundColor: NSColor
     let foregroundColor: NSColor
     let dividerColor: Color

--- a/cmuxTests/BrowserConfigTests.swift
+++ b/cmuxTests/BrowserConfigTests.swift
@@ -4112,6 +4112,7 @@ final class BrowserDeveloperToolsVisibilityPersistenceTests: XCTestCase {
             searchOverlay: nil,
             designComposer: nil,
             omnibarSuggestions: nil,
+            inactiveDim: nil,
             paneTopChromeHeight: 0
         )
         let coordinator = representable.makeCoordinator()
@@ -4157,6 +4158,7 @@ final class BrowserDeveloperToolsVisibilityPersistenceTests: XCTestCase {
             searchOverlay: nil,
             designComposer: nil,
             omnibarSuggestions: nil,
+            inactiveDim: nil,
             paneTopChromeHeight: 0
         )
         let coordinator = representable.makeCoordinator()
@@ -4334,6 +4336,7 @@ final class BrowserDeveloperToolsVisibilityPersistenceTests: XCTestCase {
             searchOverlay: nil,
             designComposer: nil,
             omnibarSuggestions: nil,
+            inactiveDim: nil,
             paneTopChromeHeight: 0
         )
 
@@ -4431,6 +4434,7 @@ final class BrowserDeveloperToolsVisibilityPersistenceTests: XCTestCase {
             searchOverlay: nil,
             designComposer: nil,
             omnibarSuggestions: nil,
+            inactiveDim: nil,
             paneTopChromeHeight: 0
         )
 

--- a/cmuxTests/BrowserPanelTests.swift
+++ b/cmuxTests/BrowserPanelTests.swift
@@ -2949,6 +2949,63 @@ final class WindowBrowserSlotViewTests: XCTestCase {
         advanceAnimations()
         XCTAssertEqual(slot.layer?.masksToBounds, true)
     }
+
+    private func inactiveDimOverlayView(in slot: WindowBrowserSlotView) throws -> NSView {
+        try XCTUnwrap(
+            slot.subviews.first { $0 is BrowserInactiveDimOverlayView },
+            "Expected the slot to contain the inactive-dim overlay"
+        )
+    }
+
+    func testInactiveDimOverlayTracksConfiguration() throws {
+        let slot = WindowBrowserSlotView(frame: NSRect(x: 0, y: 0, width: 200, height: 120))
+        let dimView = try inactiveDimOverlayView(in: slot)
+
+        XCTAssertTrue(dimView.isHidden, "No dim before a configuration is applied")
+
+        slot.setInactiveDim(BrowserPortalInactiveDimConfiguration(color: .black, opacity: 0.6))
+        XCTAssertFalse(dimView.isHidden)
+        let alpha = dimView.layer?.backgroundColor
+            .flatMap { NSColor(cgColor: $0)?.alphaComponent } ?? 0
+        XCTAssertEqual(alpha, 0.6, accuracy: 0.001)
+
+        slot.setInactiveDim(BrowserPortalInactiveDimConfiguration(color: .black, opacity: 0))
+        XCTAssertTrue(dimView.isHidden, "Zero opacity must not paint a dim")
+
+        slot.setInactiveDim(BrowserPortalInactiveDimConfiguration(color: .black, opacity: -0.2))
+        XCTAssertTrue(dimView.isHidden, "Negative opacity clamps to zero and must not paint a dim")
+
+        slot.setInactiveDim(BrowserPortalInactiveDimConfiguration(color: .black, opacity: 1.2))
+        XCTAssertFalse(dimView.isHidden)
+        let clampedAlpha = dimView.layer?.backgroundColor
+            .flatMap { NSColor(cgColor: $0)?.alphaComponent } ?? 0
+        XCTAssertEqual(clampedAlpha, 1.0, accuracy: 0.001, "Opacity above 1 clamps to fully opaque")
+
+        slot.setInactiveDim(nil)
+        XCTAssertTrue(dimView.isHidden, "Clearing the configuration must clear the dim")
+    }
+
+    // The dim is only visible if it stays above the hosted web view, which is
+    // (re)attached to the slot after the dim view (and sortSubviews is ignored
+    // during didAddSubview). Layout is where the ordering is enforced, matching
+    // the production attach path, which ends in layoutSubtreeIfNeeded().
+    func testInactiveDimOverlayStaysAboveLaterAttachedContent() throws {
+        let slot = WindowBrowserSlotView(frame: NSRect(x: 0, y: 0, width: 200, height: 120))
+        slot.setInactiveDim(BrowserPortalInactiveDimConfiguration(color: .black, opacity: 0.6))
+
+        let hostedContent = NSView(frame: slot.bounds)
+        slot.addSubview(hostedContent, positioned: .above, relativeTo: nil)
+        slot.needsLayout = true
+        slot.layoutSubtreeIfNeeded()
+
+        let dimView = try inactiveDimOverlayView(in: slot)
+        guard let dimIndex = slot.subviews.firstIndex(of: dimView),
+              let contentIndex = slot.subviews.firstIndex(of: hostedContent) else {
+            XCTFail("Expected both the dim overlay and hosted content in the slot")
+            return
+        }
+        XCTAssertGreaterThan(dimIndex, contentIndex, "Dim overlay must remain above hosted content")
+    }
 }
 
 

--- a/cmuxTests/SimulatorPanelThemeTests.swift
+++ b/cmuxTests/SimulatorPanelThemeTests.swift
@@ -208,6 +208,8 @@ struct CanvasSimulatorPointerOwnershipTests {
         let owner = NSView(frame: .zero)
         let presentation = CanvasHostedPanelPresentation(
             isFocused: false,
+            isSplit: false,
+            appearance: makeHostedPresentationAppearance(),
             allowsPointerInput: true,
             pointerInputOwner: owner
         )
@@ -215,6 +217,10 @@ struct CanvasSimulatorPointerOwnershipTests {
         #expect(!presentation.isFocused)
         presentation.setFocused(true)
         #expect(presentation.isFocused)
+
+        #expect(!presentation.isSplit)
+        presentation.setSplit(true)
+        #expect(presentation.isSplit)
     }
 
     @Test("An overlapping pointer entry belongs only to the frontmost pane")
@@ -236,11 +242,15 @@ struct CanvasSimulatorPointerOwnershipTests {
         defer { window.orderOut(nil) }
         let obscured = CanvasHostedPanelPresentation(
             isFocused: false,
+            isSplit: false,
+            appearance: makeHostedPresentationAppearance(),
             allowsPointerInput: true,
             pointerInputOwner: obscuredOwner
         )
         let frontmost = CanvasHostedPanelPresentation(
             isFocused: true,
+            isSplit: false,
+            appearance: makeHostedPresentationAppearance(),
             allowsPointerInput: true,
             pointerInputOwner: frontmostOwner
         )
@@ -293,4 +303,16 @@ private actor SimulatorThemePaneClient: SimulatorPaneClient {
     func emit(_ message: SimulatorWorkerOutbound) async {
         _ = await events.continuation.yield(.message(message))
     }
+}
+
+@MainActor
+private func makeHostedPresentationAppearance() -> PanelAppearance {
+    PanelAppearance(
+        backgroundColor: .black,
+        foregroundColor: .white,
+        dividerColor: Color(nsColor: .separatorColor),
+        unfocusedOverlayNSColor: .black,
+        unfocusedOverlayOpacity: 0.3,
+        usesClearContentBackground: false
+    )
 }


### PR DESCRIPTION
## Summary

- What changed? Unfocused browser panes in a split now dim, the same way unfocused terminal panes already do. Uses the existing `unfocused-split-opacity` / `unfocused-split-fill` settings — no new config.
- Why? In a terminal/browser split, only the terminal dims when unfocused. When the terminal has focus, both panes look equally bright and it's hard to tell which one is active — especially on dark themes.

How: the dim is a click-through overlay on the browser pane's content view, shown when the pane is in a split and not focused. It reuses the same color/opacity the terminal overlay gets, and is wired through the same update path as the browser find bar so it works in every hosting mode.

## Testing

- New unit tests: the overlay follows its configuration (shown with the right opacity, hidden when cleared or zero), and stays above web content that attaches after it.
- Updated existing tests for the new parameter.
- Manual check (demo video): split terminal + browser, focus each side, the unfocused side dims both ways.

## Demo Video

https://github.com/user-attachments/assets/4895d466-6508-4989-aa33-e4c9ec459c0e




## Review Trigger (Copy/Paste as PR comment)

```text
@codex review
@coderabbitai review
@greptile-apps review
@cubic-dev-ai review
```

## Checklist

- [x] I tested the change locally
- [x] I added or updated tests for behavior changes
- [x] I updated docs/changelog if needed
- [x] I requested bot reviews after my latest commit (copy/paste block above or equivalent)
- [x] All code review bot comments are resolved
- [ ] All human review comments are resolved


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Inactive split browser panes are now dimmed to make the focused pane easier to identify.
  * Dimming color and opacity adjust automatically based on panel appearance.
  * Interactive controls and hosted content remain accessible above the dimming layer.

* **Bug Fixes**
  * Dimming state now remains consistent when panes are reused, moved, or resized.

* **Tests**
  * Added coverage for dimming visibility, opacity behavior, clearing, and content layering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

