### PR TITLE
Fix ControlHandleRegistry data race (SIGSEGV/SIGABRT in ensureRef under concurrent socket access)

### DIFF
--- a/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Wire/ControlHandleRegistry.swift
+++ b/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Wire/ControlHandleRegistry.swift
@@ -5,9 +5,12 @@ public import Foundation
 /// dictionaries + `v2EnsureHandleRef`/`v2ResolveHandleRef` on
 /// `TerminalController`).
 ///
-/// A plain value type; the owner provides isolation (legacy: main-actor
-/// state on the controller).
-public struct ControlHandleRegistry: Sendable {
+/// A shared reference type. Callers reach it from more than one lane (the
+/// main-actor dispatch path and the socket worker's resolution hop) under an
+/// unenforced "owner provides isolation" invariant; a missed hop races the
+/// three dictionaries and corrupts their buffers (SIGSEGV/SIGABRT in
+/// `ensureRef`).
+public final class ControlHandleRegistry: @unchecked Sendable {
     private var nextOrdinal: [ControlHandleKind: Int]
     private var refByUUID: [ControlHandleKind: [UUID: String]]
     private var uuidByRef: [ControlHandleKind: [String: UUID]]
@@ -34,7 +37,7 @@ public struct ControlHandleRegistry: Sendable {
     ///   - kind: The handle kind.
     ///   - uuid: The object identity.
     /// - Returns: The stable ref string.
-    public mutating func ensureRef(kind: ControlHandleKind, uuid: UUID) -> String {
+    public func ensureRef(kind: ControlHandleKind, uuid: UUID) -> String {
         if let existing = refByUUID[kind]?[uuid] {
             return existing
         }
@@ -54,7 +57,7 @@ public struct ControlHandleRegistry: Sendable {
     /// - Parameters:
     ///   - kind: The handle kind.
     ///   - uuid: The object identity to forget.
-    public mutating func removeRef(kind: ControlHandleKind, uuid: UUID) {
+    public func removeRef(kind: ControlHandleKind, uuid: UUID) {
         if let ref = refByUUID[kind]?[uuid] {
             uuidByRef[kind]?.removeValue(forKey: ref)
         }

--- a/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Wire/ControlHandleRegistry.swift
+++ b/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Wire/ControlHandleRegistry.swift
@@ -12,9 +12,26 @@ public import Foundation
 /// `ensureRef`).
 public final class ControlHandleRegistry: @unchecked Sendable {
     /// Serializes all access to the three dictionaries so concurrent callers
-    /// (a missed main-actor hop from the socket worker) can never corrupt a
-    /// dictionary buffer mid-mutation. This is the enforcement the old
-    /// "owner provides isolation" invariant relied on by convention.
+    /// can never corrupt a dictionary buffer mid-mutation.
+    ///
+    /// A lock, not an actor or `@MainActor`, is deliberate here — two concrete
+    /// reasons, neither of which is "simpler":
+    ///
+    /// 1. `ensureRef` / `removeRef` / `uuid(forRef:)` are **synchronous** and
+    ///    called from synchronous, non-`async` contexts: the coordinator mints
+    ///    refs inline while building socket responses (`ref()` runs on nearly
+    ///    every response), and the legacy path reaches them through
+    ///    `v2MainSync`. An `actor` exposes only `async` members to outside
+    ///    callers, so adopting one would force `await` across the entire
+    ///    synchronous socket-dispatch chain. This is a non-`async` low-level
+    ///    access point, the case the blocking-runtime policy allows a lock for.
+    ///
+    /// 2. `@MainActor` isolation is the design that just failed. This state was
+    ///    already "owned" on the main actor by convention; the crash is a
+    ///    caller reaching it *without* the hop (the socket worker's resolution
+    ///    lane). A lock makes the type safe regardless of a missed hop;
+    ///    re-asserting `@MainActor` only reinstates the same unenforced
+    ///    invariant that corrupted the dictionaries in the first place.
     private let lock = NSLock()
     private var nextOrdinal: [ControlHandleKind: Int]
     private var refByUUID: [ControlHandleKind: [UUID: String]]

--- a/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Wire/ControlHandleRegistry.swift
+++ b/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Wire/ControlHandleRegistry.swift
@@ -11,6 +11,11 @@ public import Foundation
 /// three dictionaries and corrupts their buffers (SIGSEGV/SIGABRT in
 /// `ensureRef`).
 public final class ControlHandleRegistry: @unchecked Sendable {
+    /// Serializes all access to the three dictionaries so concurrent callers
+    /// (a missed main-actor hop from the socket worker) can never corrupt a
+    /// dictionary buffer mid-mutation. This is the enforcement the old
+    /// "owner provides isolation" invariant relied on by convention.
+    private let lock = NSLock()
     private var nextOrdinal: [ControlHandleKind: Int]
     private var refByUUID: [ControlHandleKind: [UUID: String]]
     private var uuidByRef: [ControlHandleKind: [String: UUID]]
@@ -38,15 +43,17 @@ public final class ControlHandleRegistry: @unchecked Sendable {
     ///   - uuid: The object identity.
     /// - Returns: The stable ref string.
     public func ensureRef(kind: ControlHandleKind, uuid: UUID) -> String {
-        if let existing = refByUUID[kind]?[uuid] {
-            return existing
+        lock.withLock {
+            if let existing = refByUUID[kind]?[uuid] {
+                return existing
+            }
+            let next = nextOrdinal[kind] ?? 1
+            let ref = "\(kind.rawValue):\(next)"
+            refByUUID[kind, default: [:]][uuid] = ref
+            uuidByRef[kind, default: [:]][ref] = uuid
+            nextOrdinal[kind] = next + 1
+            return ref
         }
-        let next = nextOrdinal[kind] ?? 1
-        let ref = "\(kind.rawValue):\(next)"
-        refByUUID[kind, default: [:]][uuid] = ref
-        uuidByRef[kind, default: [:]][ref] = uuid
-        nextOrdinal[kind] = next + 1
-        return ref
     }
 
     /// Forgets the ref minted for an object (e.g. when a surface closes).
@@ -58,10 +65,12 @@ public final class ControlHandleRegistry: @unchecked Sendable {
     ///   - kind: The handle kind.
     ///   - uuid: The object identity to forget.
     public func removeRef(kind: ControlHandleKind, uuid: UUID) {
-        if let ref = refByUUID[kind]?[uuid] {
-            uuidByRef[kind]?.removeValue(forKey: ref)
+        lock.withLock {
+            if let ref = refByUUID[kind]?[uuid] {
+                uuidByRef[kind]?.removeValue(forKey: ref)
+            }
+            refByUUID[kind]?.removeValue(forKey: uuid)
         }
-        refByUUID[kind]?.removeValue(forKey: uuid)
     }
 
     /// Resolves a ref back to the object identity it was minted for.
@@ -72,18 +81,20 @@ public final class ControlHandleRegistry: @unchecked Sendable {
     /// - Parameter ref: The handle ref to resolve.
     /// - Returns: The object identity, or `nil` for an unknown ref.
     public func uuid(forRef ref: String) -> UUID? {
-        for kind in ControlHandleKind.allCases {
-            if let id = uuidByRef[kind]?[ref] {
+        lock.withLock {
+            for kind in ControlHandleKind.allCases {
+                if let id = uuidByRef[kind]?[ref] {
+                    return id
+                }
+            }
+            // Tab refs are aliases for surface refs in tab-facing APIs.
+            let trimmed = ref.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+            if trimmed.hasPrefix("tab:"),
+               let ordinal = Int(trimmed.replacingOccurrences(of: "tab:", with: "")),
+               let id = uuidByRef[.surface]?["surface:\(ordinal)"] {
                 return id
             }
+            return nil
         }
-        // Tab refs are aliases for surface refs in tab-facing APIs.
-        let trimmed = ref.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
-        if trimmed.hasPrefix("tab:"),
-           let ordinal = Int(trimmed.replacingOccurrences(of: "tab:", with: "")),
-           let id = uuidByRef[.surface]?["surface:\(ordinal)"] {
-            return id
-        }
-        return nil
     }
 }

--- a/Packages/macOS/CmuxControlSocket/Tests/CmuxControlSocketTests/ControlHandleRegistryTests.swift
+++ b/Packages/macOS/CmuxControlSocket/Tests/CmuxControlSocketTests/ControlHandleRegistryTests.swift
@@ -5,7 +5,7 @@ import Testing
 @Suite("ControlHandleRegistry")
 struct ControlHandleRegistryTests {
     @Test func mintsSequentialRefsPerKind() {
-        var registry = ControlHandleRegistry()
+        let registry = ControlHandleRegistry()
         let a = UUID()
         let b = UUID()
         #expect(registry.ensureRef(kind: .workspace, uuid: a) == "workspace:1")
@@ -16,7 +16,7 @@ struct ControlHandleRegistryTests {
     }
 
     @Test func ensureRefIsIdempotentPerIdentity() {
-        var registry = ControlHandleRegistry()
+        let registry = ControlHandleRegistry()
         let id = UUID()
         let first = registry.ensureRef(kind: .pane, uuid: id)
         #expect(registry.ensureRef(kind: .pane, uuid: id) == first)
@@ -24,12 +24,12 @@ struct ControlHandleRegistryTests {
     }
 
     @Test func workspaceGroupRefsUseTheWireRawValue() {
-        var registry = ControlHandleRegistry()
+        let registry = ControlHandleRegistry()
         #expect(registry.ensureRef(kind: .workspaceGroup, uuid: UUID()) == "workspace_group:1")
     }
 
     @Test func resolvesMintedRefsBack() {
-        var registry = ControlHandleRegistry()
+        let registry = ControlHandleRegistry()
         let id = UUID()
         let ref = registry.ensureRef(kind: .surface, uuid: id)
         #expect(registry.uuid(forRef: ref) == id)
@@ -38,7 +38,7 @@ struct ControlHandleRegistryTests {
     }
 
     @Test func removeRefForgetsBothDirectionsWithoutReusingOrdinals() {
-        var registry = ControlHandleRegistry()
+        let registry = ControlHandleRegistry()
         let id = UUID()
         let ref = registry.ensureRef(kind: .surface, uuid: id)
         registry.removeRef(kind: .surface, uuid: id)
@@ -50,12 +50,54 @@ struct ControlHandleRegistryTests {
     }
 
     @Test func tabRefsAliasSurfaceRefs() {
-        var registry = ControlHandleRegistry()
+        let registry = ControlHandleRegistry()
         let id = UUID()
         _ = registry.ensureRef(kind: .surface, uuid: id)
         #expect(registry.uuid(forRef: "tab:1") == id)
         #expect(registry.uuid(forRef: "  TAB:1  ") == id)
         #expect(registry.uuid(forRef: "tab:2") == nil)
         #expect(registry.uuid(forRef: "tab:x") == nil)
+    }
+
+    // A single identity, minted concurrently from many threads, must resolve to
+    // exactly one ref. Without synchronization the check-then-mint in
+    // `ensureRef` races: several threads miss the existing entry and each mint a
+    // fresh ordinal, so the identity ends up with multiple refs.
+    @Test func concurrentEnsureRefForSameIdentityMintsExactlyOneRef() {
+        let registry = ControlHandleRegistry()
+        let id = UUID()
+        let seenLock = NSLock()
+        var seen = Set<String>()
+
+        DispatchQueue.concurrentPerform(iterations: 4_000) { _ in
+            let ref = registry.ensureRef(kind: .surface, uuid: id)
+            seenLock.lock()
+            seen.insert(ref)
+            seenLock.unlock()
+        }
+
+        #expect(seen == ["surface:1"])
+    }
+
+    // Distinct identities minted concurrently must each keep a unique,
+    // round-tripping ref. Without synchronization concurrent mutation corrupts
+    // the backing dictionaries — lost inserts, colliding ordinals, or a crash.
+    @Test func concurrentEnsureRefForDistinctIdentitiesStaysConsistent() {
+        let registry = ControlHandleRegistry()
+        let count = 2_000
+        let ids = (0..<count).map { _ in UUID() }
+
+        DispatchQueue.concurrentPerform(iterations: count) { i in
+            _ = registry.ensureRef(kind: .surface, uuid: ids[i])
+        }
+
+        var refs = Set<String>()
+        for id in ids {
+            let ref = registry.ensureRef(kind: .surface, uuid: id)
+            refs.insert(ref)
+            #expect(registry.uuid(forRef: ref) == id)
+        }
+        // One distinct ref per distinct identity: no lost or colliding inserts.
+        #expect(refs.count == count)
     }
 }


### PR DESCRIPTION
## Summary

**What:** Fix a data race in `ControlHandleRegistry` (the `kind:N` handle-ref mint behind the v2 control socket) that corrupts its backing dictionaries and crashes the app with `SIGSEGV`/`SIGABRT` inside `ensureRef`.

**Why:** The registry holds three `Dictionary`s guarded only by an unenforced "owner provides isolation" convention (documented in its own header). Callers reach it from two lanes — the main-actor dispatch path and the socket worker's resolution hop (`v2MainSync { v2RefreshKnownRefs() }`). When a caller mutates it without the main-actor hop, two threads mutate the same dictionary concurrently and corrupt its buffer. A dictionary undergoing a concurrent `insert` mid-resize hands back a freed/half-written bucket → crash in `ensureRef`.

This reproduces under load: an external poller walking the tree every few seconds (repeated `system.tree` / ref-minting) races the main lane and takes the app down.

## Root cause

`ensureRef` is check-then-mint on shared, unsynchronized state:

```swift
if let existing = refByUUID[kind]?[uuid] { return existing }   // read
let next = nextOrdinal[kind] ?? 1
refByUUID[kind, default: [:]][uuid] = ref                      // write
uuidByRef[kind, default: [:]][ref] = uuid                      // write
nextOrdinal[kind] = next + 1                                   // write
```

Two threads here either (a) mutate the same `Dictionary` storage concurrently → buffer corruption → `SIGSEGV`/`SIGABRT`, or (b) both miss the `existing` entry and mint two different ordinals for one identity → duplicate/colliding refs.

## Fix

- Make `ControlHandleRegistry` a shared reference type (`final class`, was a `struct`).
- Serialize all three access points (`ensureRef`, `removeRef`, `uuid(forRef:)`) behind a single `NSLock`.

The lock is the enforcement the old convention relied on by hand. This is defensive at the type level, so it holds regardless of which lane forgets to hop — no need to chase every call site. The public API and the `kind:N` ref semantics are unchanged.

## Scope / risk

- **App target is unaffected by the struct→class change.** Every app-target use goes through `controlCommandCoordinator.ensureRef / removeRef / resolveRef` (11 sites in `Sources/`); nothing in the app references the `ControlHandleRegistry` type or a `handles` value directly. The coordinator (the only direct user) lives in this package and its method signatures are unchanged.
- **Hot path:** `ensureRef` runs on nearly every socket response. An uncontended `NSLock` is a few ns; contention here is rare and short. No measurable cost expected.

## Testing

Two commits, so CI proves the test catches the bug (per the repo's regression policy):

1. `test:` — registry made shareable, two concurrency tests added, **no lock** → CI red (crash).
2. `fix:` — add the lock → CI green.

Run locally:

```bash
cd Packages/macOS/CmuxControlSocket

# On commit 1 (no lock): aborts with signal 11/6 — the bug, reproduced.
swift test --filter concurrentEnsureRefForDistinctIdentities

# On commit 2 (lock): passes, repeatedly and under Thread Sanitizer.
swift test --filter ControlHandleRegistry
swift test --filter ControlHandleRegistry --sanitize=thread
```

Verified locally on the fix commit: 6/6 plain runs green, and all 8 registry tests pass under `--sanitize=thread` (no data race reported). Full `CmuxControlSocket` suite green.

### Scenarios covered

| Test | Without lock | With lock |
|---|---|---|
| `concurrentEnsureRefForSameIdentityMintsExactlyOneRef` — 4,000 threads mint the *same* identity | can mint multiple refs for one identity | resolves to exactly one ref (`surface:1`) |
| `concurrentEnsureRefForDistinctIdentitiesStaysConsistent` — 2,000 threads mint *distinct* identities | corrupts the dictionaries → `SIGSEGV`/`SIGABRT` | every identity keeps a unique, round-tripping ref |

## Demo Video

N/A — non-visual crash fix. Evidence is the RED→GREEN test split above (the Commits tab shows the test failing without the fix).

## Review Trigger (Copy/Paste as PR comment)

```text
@codex review
@coderabbitai review
@greptile-apps review
@cubic-dev-ai review
```

## Checklist

- [x] I tested the change locally
- [x] I added or updated tests for behavior changes
- [ ] I updated docs/changelog if needed (n/a)
- [ ] I requested bot reviews after my latest commit (copy/paste block above or equivalent)
- [ ] All code review bot comments are resolved
- [ ] All human review comments are resolved

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/9650"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788536598&installation_model_id=21920&pr_number=9650&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F9650&signature=fb125b5b08f217f2fdbc189a84f26165aed5a89e4452b3d394bb643c3527877c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a data race in `ControlHandleRegistry` that corrupted its dictionaries and crashed with SIGSEGV/SIGABRT under concurrent v2 control socket access. The registry is now synchronized without changing public behavior or `kind:N` ref semantics.

- **Bug Fixes**
  - Serialized access with a single `NSLock` across `ensureRef`, `removeRef`, and `uuid(forRef:)` to prevent concurrent dictionary mutation; added inline docs explaining why a lock is used over an actor/`@MainActor` for these synchronous call sites.
  - Converted `ControlHandleRegistry` from a `struct` to a `final class` (`@unchecked Sendable`) so it can be safely shared across the main-actor path and the socket worker, eliminating duplicate refs and crashes in `ensureRef`.

<sup>Written for commit 66215744cc37c5fe1dd663344a94fa33e79638b1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/9650?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved control-handle registry reliability during concurrent operations.
  - Prevented duplicate references and lost or colliding entries when handles are registered simultaneously.
  - Preserved accurate reference removal and alias resolution.

- **Tests**
  - Added coverage for concurrent registration and round-trip reference handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->