### PR TITLE
feat(sidebar): let PR links open at Graphite or a custom review URL

### DIFF
--- a/Packages/macOS/CmuxSettings/Sources/CmuxSettings/Keys/SidebarCatalogSection.swift
+++ b/Packages/macOS/CmuxSettings/Sources/CmuxSettings/Keys/SidebarCatalogSection.swift
@@ -102,6 +102,18 @@ public struct SidebarCatalogSection: SettingCatalogSection {
         userDefaultsKey: "browserOpenSidebarPullRequestLinksInCmuxBrowser"
     )
 
+    public let pullRequestLinkDestination = DefaultsKey<PullRequestLinkDestination>(
+        id: "sidebar.pullRequestLinkDestination",
+        defaultValue: PullRequestLinkConfiguration.defaultDestination,
+        userDefaultsKey: "sidebarPullRequestLinkDestination"
+    )
+
+    public let customPullRequestLinkURLTemplate = DefaultsKey<String>(
+        id: "sidebar.customPullRequestLinkURLTemplate",
+        defaultValue: PullRequestLinkConfiguration.defaultCustomURLTemplate,
+        userDefaultsKey: "sidebarCustomPullRequestLinkURLTemplate"
+    )
+
     public let openPortLinksInCmuxBrowser = DefaultsKey<Bool>(
         id: "sidebar.openPortLinksInCmuxBrowser",
         defaultValue: true,

--- a/Packages/macOS/CmuxSettings/Sources/CmuxSettings/Stores/PullRequestLinkSettingsStore.swift
+++ b/Packages/macOS/CmuxSettings/Sources/CmuxSettings/Stores/PullRequestLinkSettingsStore.swift
@@ -1,0 +1,35 @@
+import Foundation
+
+/// Repository for the pull request link destination persisted in `UserDefaults`.
+///
+/// Isolation: a stateless `Sendable` struct, not an actor. Every reader is a
+/// synchronous call path — a sidebar row click, an open-all-pull-requests
+/// command, a settings projection — the struct holds no mutable state, and
+/// `UserDefaults` is documented thread-safe.
+///
+/// ```swift
+/// let configuration = PullRequestLinkSettingsStore(defaults: defaults).currentConfiguration
+/// NSWorkspace.shared.open(configuration.resolvedURL(for: pullRequest.url))
+/// ```
+public struct PullRequestLinkSettingsStore: Sendable {
+    private let sidebar = SidebarCatalogSection()
+
+    // UserDefaults is documented thread-safe and the reference is immutable.
+    private nonisolated(unsafe) let defaults: UserDefaults
+
+    /// Creates a store reading the given defaults suite.
+    ///
+    /// - Parameter defaults: The defaults suite holding sidebar settings.
+    public init(defaults: UserDefaults = .standard) {
+        self.defaults = defaults
+    }
+
+    /// The stored destination and custom template, resolved against their defaults.
+    public var currentConfiguration: PullRequestLinkConfiguration {
+        let settings = UserDefaultsSettingsClient(defaults: defaults)
+        return PullRequestLinkConfiguration(
+            destination: settings.value(for: sidebar.pullRequestLinkDestination),
+            customURLTemplate: settings.value(for: sidebar.customPullRequestLinkURLTemplate)
+        )
+    }
+}

--- a/Packages/macOS/CmuxSettings/Sources/CmuxSettings/Values/PullRequestLinkConfiguration.swift
+++ b/Packages/macOS/CmuxSettings/Sources/CmuxSettings/Values/PullRequestLinkConfiguration.swift
@@ -1,0 +1,107 @@
+import Foundation
+
+/// Resolved pull request link settings used wherever cmux opens a sidebar
+/// pull request.
+///
+/// Sidebar state keeps the canonical URL the review host reported; this type is
+/// the single seam that rewrites it at open time, so polling, deduplication, and
+/// staleness comparisons keep working on the canonical value.
+///
+/// ```swift
+/// let configuration = PullRequestLinkConfiguration(destination: .graphite, customURLTemplate: "")
+/// configuration.resolvedURL(for: URL(string: "https://github.com/manaflow-ai/cmux/pull/9641")!)
+/// // https://app.graphite.com/github/pr/manaflow-ai/cmux/9641
+/// ```
+public struct PullRequestLinkConfiguration: Equatable, Sendable {
+    /// Destination applied when no preference is stored.
+    public static let defaultDestination: PullRequestLinkDestination = .github
+
+    /// Custom template applied when no preference is stored. Empty means links
+    /// open unchanged, matching ``PullRequestLinkDestination/github``.
+    public static let defaultCustomURLTemplate = ""
+
+    /// The selected destination.
+    public let destination: PullRequestLinkDestination
+
+    /// The stored custom URL template, used only when ``destination`` is
+    /// ``PullRequestLinkDestination/custom``.
+    public let customURLTemplate: String
+
+    /// Creates a resolved pull request link configuration.
+    ///
+    /// - Parameters:
+    ///   - destination: The selected destination.
+    ///   - customURLTemplate: The custom URL template.
+    public init(destination: PullRequestLinkDestination, customURLTemplate: String) {
+        self.destination = destination
+        self.customURLTemplate = customURLTemplate
+    }
+
+    /// The template this configuration renders, or `nil` when links open unchanged.
+    public var urlTemplate: String? {
+        guard destination == .custom else { return destination.urlTemplate }
+        let trimmed = customURLTemplate.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? nil : trimmed
+    }
+
+    /// Rewrites a canonical pull request URL for the configured destination.
+    ///
+    /// - Parameter canonicalURL: The URL the review host reported for the pull request.
+    /// - Returns: The rewritten URL, or `canonicalURL` unchanged when the
+    ///   destination does not rewrite links, the URL is not a recognizable pull
+    ///   request URL (an enterprise path shape, a permalink to a comment), or the
+    ///   configured template cannot produce an `http`/`https` URL.
+    public func resolvedURL(for canonicalURL: URL) -> URL {
+        guard let template = urlTemplate,
+              let reference = PullRequestLinkReference(pullRequestURL: canonicalURL),
+              let rendered = Self.url(fromTemplate: template, reference: reference) else {
+            return canonicalURL
+        }
+        return rendered
+    }
+
+    /// Whether a template renders an allowed URL, for validating settings input.
+    ///
+    /// - Parameter rawTemplate: The template to check. Empty templates are valid
+    ///   and mean links open unchanged.
+    /// - Returns: `true` when the template is empty or renders an `http`/`https` URL.
+    public static func isValidURLTemplate(_ rawTemplate: String) -> Bool {
+        let trimmed = rawTemplate.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return true }
+        return url(
+            fromTemplate: trimmed,
+            reference: PullRequestLinkReference(owner: "manaflow-ai", repo: "cmux", number: 1)
+        ) != nil
+    }
+
+    /// Renders a pull request URL from a template.
+    ///
+    /// - Parameters:
+    ///   - rawTemplate: A template containing `{owner}`, `{repo}`, and `{number}`
+    ///     placeholders. A template with no placeholder cannot address a specific
+    ///     pull request and is rejected.
+    ///   - reference: The pull request to render.
+    /// - Returns: An allowed `http` or `https` URL, or `nil` when the template
+    ///   cannot produce one.
+    public static func url(fromTemplate rawTemplate: String, reference: PullRequestLinkReference) -> URL? {
+        let template = rawTemplate.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard template.contains("{number}") else { return nil }
+        let rendered = template
+            .replacingOccurrences(of: "{owner}", with: percentEncoded(reference.owner))
+            .replacingOccurrences(of: "{repo}", with: percentEncoded(reference.repo))
+            .replacingOccurrences(of: "{number}", with: String(reference.number))
+        guard let url = URL(string: rendered),
+              let scheme = url.scheme?.lowercased(),
+              scheme == "https" || scheme == "http",
+              url.host?.isEmpty == false else {
+            return nil
+        }
+        return url
+    }
+
+    private static func percentEncoded(_ segment: String) -> String {
+        var allowed = CharacterSet.alphanumerics
+        allowed.insert(charactersIn: "-._~")
+        return segment.addingPercentEncoding(withAllowedCharacters: allowed) ?? segment
+    }
+}

--- a/Packages/macOS/CmuxSettings/Sources/CmuxSettings/Values/PullRequestLinkDestination.swift
+++ b/Packages/macOS/CmuxSettings/Sources/CmuxSettings/Values/PullRequestLinkDestination.swift
@@ -1,0 +1,51 @@
+import Foundation
+
+/// Where a sidebar pull request link opens.
+///
+/// Sidebar pull request state always stores the canonical review-host URL the
+/// probe reported; this selects what a click does with it. ``github`` keeps that
+/// URL untouched, which is also what enterprise and non-GitHub hosts need.
+///
+/// ```swift
+/// let configuration = PullRequestLinkConfiguration(destination: .graphite, customURLTemplate: "")
+/// configuration.resolvedURL(for: canonicalURL)
+/// ```
+public enum PullRequestLinkDestination: String, CaseIterable, Identifiable, Sendable, SettingCodable {
+    /// The pull request's own page on the host that reported it.
+    case github
+
+    /// The pull request in Graphite's review UI.
+    case graphite
+
+    /// A destination rendered from ``PullRequestLinkConfiguration/customURLTemplate``.
+    case custom
+
+    /// Stable identifier matching the stored raw value.
+    public var id: String { rawValue }
+
+    /// Localized display name shown in settings UI.
+    public var displayName: String {
+        switch self {
+        case .github:
+            return String(localized: "settings.sidebar.pullRequestLinkDestination.github", defaultValue: "GitHub")
+        case .graphite:
+            return String(localized: "settings.sidebar.pullRequestLinkDestination.graphite", defaultValue: "Graphite")
+        case .custom:
+            return String(localized: "settings.sidebar.pullRequestLinkDestination.custom", defaultValue: "Custom")
+        }
+    }
+
+    /// URL template used to render links for this destination, or `nil` when the
+    /// destination does not rewrite the canonical URL (``github``) or takes its
+    /// template from settings (``custom``).
+    public var urlTemplate: String? {
+        switch self {
+        case .github:
+            return nil
+        case .graphite:
+            return "https://app.graphite.com/github/pr/{owner}/{repo}/{number}"
+        case .custom:
+            return nil
+        }
+    }
+}

--- a/Packages/macOS/CmuxSettings/Sources/CmuxSettings/Values/PullRequestLinkReference.swift
+++ b/Packages/macOS/CmuxSettings/Sources/CmuxSettings/Values/PullRequestLinkReference.swift
@@ -34,15 +34,19 @@ public struct PullRequestLinkReference: Equatable, Sendable {
 
     /// Parses a reference out of a pull request URL.
     ///
-    /// - Parameter pullRequestURL: An `http` or `https` URL whose path is exactly
-    ///   `/{owner}/{repo}/pull/{number}`. GitHub's `html_url` has this shape.
+    /// - Parameter pullRequestURL: An `http` or `https` URL with a host whose path
+    ///   is exactly `/{owner}/{repo}/pull/{number}`. GitHub's `html_url` has this
+    ///   shape. An empty authority (`https:///owner/repo/pull/1`) parses as that
+    ///   path with a `nil` host, so the host is checked explicitly.
     /// - Returns: `nil` when the scheme or path shape does not match, in which
     ///   case callers keep the original URL rather than rewriting it. Deeper
     ///   paths (`/pull/42/files`) and fragments (`#issuecomment-1`) are rejected
     ///   on purpose: they address something more specific than the pull request,
     ///   and no rewrite can carry that target across hosts.
     public init?(pullRequestURL: URL) {
-        guard let scheme = pullRequestURL.scheme?.lowercased(), scheme == "https" || scheme == "http" else {
+        guard let scheme = pullRequestURL.scheme?.lowercased(),
+              scheme == "https" || scheme == "http",
+              pullRequestURL.host?.isEmpty == false else {
             return nil
         }
         let segments = pullRequestURL.pathComponents.filter { $0 != "/" }

--- a/Packages/macOS/CmuxSettings/Sources/CmuxSettings/Values/PullRequestLinkReference.swift
+++ b/Packages/macOS/CmuxSettings/Sources/CmuxSettings/Values/PullRequestLinkReference.swift
@@ -1,0 +1,56 @@
+import Foundation
+
+/// The repository coordinates of a pull request, parsed out of its review URL.
+///
+/// Used to render the same pull request at another review host. Parsing is
+/// host-agnostic so that enterprise hosts still resolve against a custom
+/// template; only the `/{owner}/{repo}/pull/{number}` path shape is required.
+///
+/// ```swift
+/// PullRequestLinkReference(pullRequestURL: URL(string: "https://github.com/manaflow-ai/cmux/pull/9641")!)
+/// // owner: "manaflow-ai", repo: "cmux", number: 9641
+/// ```
+public struct PullRequestLinkReference: Equatable, Sendable {
+    /// The repository owner (user or organization).
+    public let owner: String
+
+    /// The repository name.
+    public let repo: String
+
+    /// The pull request number.
+    public let number: Int
+
+    /// Creates a reference from explicit coordinates.
+    ///
+    /// - Parameters:
+    ///   - owner: The repository owner.
+    ///   - repo: The repository name.
+    ///   - number: The pull request number.
+    public init(owner: String, repo: String, number: Int) {
+        self.owner = owner
+        self.repo = repo
+        self.number = number
+    }
+
+    /// Parses a reference out of a pull request URL.
+    ///
+    /// - Parameter pullRequestURL: An `http` or `https` URL whose path is
+    ///   `/{owner}/{repo}/pull/{number}`. GitHub's `html_url` has this shape.
+    /// - Returns: `nil` when the scheme or path shape does not match, in which
+    ///   case callers keep the original URL rather than rewriting it.
+    public init?(pullRequestURL: URL) {
+        guard let scheme = pullRequestURL.scheme?.lowercased(), scheme == "https" || scheme == "http" else {
+            return nil
+        }
+        let segments = pullRequestURL.pathComponents.filter { $0 != "/" }
+        guard segments.count >= 4,
+              segments[2].lowercased() == "pull",
+              let number = Int(segments[3]),
+              number > 0,
+              !segments[0].isEmpty,
+              !segments[1].isEmpty else {
+            return nil
+        }
+        self.init(owner: segments[0], repo: segments[1], number: number)
+    }
+}

--- a/Packages/macOS/CmuxSettings/Sources/CmuxSettings/Values/PullRequestLinkReference.swift
+++ b/Packages/macOS/CmuxSettings/Sources/CmuxSettings/Values/PullRequestLinkReference.swift
@@ -34,16 +34,20 @@ public struct PullRequestLinkReference: Equatable, Sendable {
 
     /// Parses a reference out of a pull request URL.
     ///
-    /// - Parameter pullRequestURL: An `http` or `https` URL whose path is
+    /// - Parameter pullRequestURL: An `http` or `https` URL whose path is exactly
     ///   `/{owner}/{repo}/pull/{number}`. GitHub's `html_url` has this shape.
     /// - Returns: `nil` when the scheme or path shape does not match, in which
-    ///   case callers keep the original URL rather than rewriting it.
+    ///   case callers keep the original URL rather than rewriting it. Deeper
+    ///   paths (`/pull/42/files`) and fragments (`#issuecomment-1`) are rejected
+    ///   on purpose: they address something more specific than the pull request,
+    ///   and no rewrite can carry that target across hosts.
     public init?(pullRequestURL: URL) {
         guard let scheme = pullRequestURL.scheme?.lowercased(), scheme == "https" || scheme == "http" else {
             return nil
         }
         let segments = pullRequestURL.pathComponents.filter { $0 != "/" }
-        guard segments.count >= 4,
+        guard pullRequestURL.fragment == nil,
+              segments.count == 4,
               segments[2].lowercased() == "pull",
               let number = Int(segments[3]),
               number > 0,

--- a/Packages/macOS/CmuxSettings/Tests/CmuxSettingsTests/PullRequestLinkConfigurationTests.swift
+++ b/Packages/macOS/CmuxSettings/Tests/CmuxSettingsTests/PullRequestLinkConfigurationTests.swift
@@ -1,0 +1,107 @@
+import Foundation
+import Testing
+@testable import CmuxSettings
+
+@Suite("PullRequestLinkConfiguration")
+struct PullRequestLinkConfigurationTests {
+    private let canonical = URL(string: "https://github.com/manaflow-ai/cmux/pull/9641")!
+
+    @Test func githubDestinationLeavesCanonicalURLUntouched() {
+        let configuration = PullRequestLinkConfiguration(destination: .github, customURLTemplate: "")
+
+        #expect(configuration.resolvedURL(for: canonical) == canonical)
+    }
+
+    @Test func graphiteDestinationRewritesToGraphiteReviewURL() {
+        let configuration = PullRequestLinkConfiguration(destination: .graphite, customURLTemplate: "")
+
+        #expect(
+            configuration.resolvedURL(for: canonical).absoluteString
+                == "https://app.graphite.com/github/pr/manaflow-ai/cmux/9641"
+        )
+    }
+
+    @Test func customTemplateRendersEveryPlaceholder() {
+        let configuration = PullRequestLinkConfiguration(
+            destination: .custom,
+            customURLTemplate: "https://review.example.com/{owner}/{repo}/changes/{number}?tab=diff"
+        )
+
+        #expect(
+            configuration.resolvedURL(for: canonical).absoluteString
+                == "https://review.example.com/manaflow-ai/cmux/changes/9641?tab=diff"
+        )
+    }
+
+    @Test func customDestinationWithEmptyTemplateLeavesLinksUntouched() {
+        let configuration = PullRequestLinkConfiguration(destination: .custom, customURLTemplate: "   ")
+
+        #expect(configuration.resolvedURL(for: canonical) == canonical)
+    }
+
+    /// A template without `{number}` cannot address a specific pull request, so
+    /// the click must still land on the real PR rather than a repository root.
+    @Test func templateWithoutNumberPlaceholderLeavesLinksUntouched() {
+        let configuration = PullRequestLinkConfiguration(
+            destination: .custom,
+            customURLTemplate: "https://review.example.com/{owner}/{repo}"
+        )
+
+        #expect(configuration.resolvedURL(for: canonical) == canonical)
+        #expect(!PullRequestLinkConfiguration.isValidURLTemplate("https://review.example.com/{owner}/{repo}"))
+    }
+
+    @Test(arguments: [
+        "app.graphite.com/github/pr/{owner}/{repo}/{number}",
+        "javascript:alert({number})",
+        "file:///tmp/{number}",
+    ])
+    func nonWebTemplatesLeaveLinksUntouched(template: String) {
+        let configuration = PullRequestLinkConfiguration(destination: .custom, customURLTemplate: template)
+
+        #expect(configuration.resolvedURL(for: canonical) == canonical)
+        #expect(!PullRequestLinkConfiguration.isValidURLTemplate(template))
+    }
+
+    @Test func emptyTemplateIsValidBecauseItMeansNoRewrite() {
+        #expect(PullRequestLinkConfiguration.isValidURLTemplate(""))
+    }
+
+    /// Enterprise hosts keep the `/{owner}/{repo}/pull/{number}` shape, so a
+    /// custom template can retarget them even though Graphite cannot.
+    @Test func enterpriseHostResolvesAgainstCustomTemplate() throws {
+        let enterprise = try #require(URL(string: "https://github.acme.example/platform/api/pull/412"))
+        let configuration = PullRequestLinkConfiguration(
+            destination: .custom,
+            customURLTemplate: "https://review.acme.example/{owner}/{repo}/{number}"
+        )
+
+        #expect(
+            configuration.resolvedURL(for: enterprise).absoluteString
+                == "https://review.acme.example/platform/api/412"
+        )
+    }
+
+    @Test(arguments: [
+        "https://github.com/manaflow-ai/cmux",
+        "https://github.com/manaflow-ai/cmux/issues/9641",
+        "https://github.com/manaflow-ai/cmux/pull/not-a-number",
+        "https://github.com/manaflow-ai/cmux/pull/0",
+        "https://app.graphite.com/github/pr/manaflow-ai/cmux/9641",
+    ])
+    func unrecognizedPullRequestURLsAreNotRewritten(rawURL: String) throws {
+        let url = try #require(URL(string: rawURL))
+        let configuration = PullRequestLinkConfiguration(destination: .graphite, customURLTemplate: "")
+
+        #expect(configuration.resolvedURL(for: url) == url)
+    }
+
+    @Test func referenceParsesTrailingPathSegments() throws {
+        let withTab = try #require(URL(string: "https://github.com/manaflow-ai/cmux/pull/9641/files"))
+        let reference = try #require(PullRequestLinkReference(pullRequestURL: withTab))
+
+        #expect(reference.owner == "manaflow-ai")
+        #expect(reference.repo == "cmux")
+        #expect(reference.number == 9641)
+    }
+}

--- a/Packages/macOS/CmuxSettings/Tests/CmuxSettingsTests/PullRequestLinkConfigurationTests.swift
+++ b/Packages/macOS/CmuxSettings/Tests/CmuxSettingsTests/PullRequestLinkConfigurationTests.swift
@@ -88,6 +88,8 @@ struct PullRequestLinkConfigurationTests {
         "https://github.com/manaflow-ai/cmux/pull/not-a-number",
         "https://github.com/manaflow-ai/cmux/pull/0",
         "https://app.graphite.com/github/pr/manaflow-ai/cmux/9641",
+        "https://github.com/manaflow-ai/cmux/pull/9641/files",
+        "https://github.com/manaflow-ai/cmux/pull/9641#issuecomment-1",
     ])
     func unrecognizedPullRequestURLsAreNotRewritten(rawURL: String) throws {
         let url = try #require(URL(string: rawURL))
@@ -96,12 +98,26 @@ struct PullRequestLinkConfigurationTests {
         #expect(configuration.resolvedURL(for: url) == url)
     }
 
-    @Test func referenceParsesTrailingPathSegments() throws {
-        let withTab = try #require(URL(string: "https://github.com/manaflow-ai/cmux/pull/9641/files"))
-        let reference = try #require(PullRequestLinkReference(pullRequestURL: withTab))
+    @Test func referenceParsesCanonicalPullRequestURL() throws {
+        let reference = try #require(PullRequestLinkReference(pullRequestURL: canonical))
 
         #expect(reference.owner == "manaflow-ai")
         #expect(reference.repo == "cmux")
         #expect(reference.number == 9641)
+    }
+
+    /// A deeper path or a fragment addresses something more specific than the
+    /// pull request — a diff tab, a review comment — and no rewrite can carry
+    /// that target to another host, so those URLs are left alone.
+    @Test(arguments: [
+        "https://github.com/manaflow-ai/cmux/pull/9641/files",
+        "https://github.com/manaflow-ai/cmux/pull/9641/commits/abc123",
+        "https://github.com/manaflow-ai/cmux/pull/9641#issuecomment-1",
+        "https://github.com/manaflow-ai/cmux/pull/9641#discussion_r1",
+    ])
+    func referenceRejectsMoreSpecificTargets(rawURL: String) throws {
+        let url = try #require(URL(string: rawURL))
+
+        #expect(PullRequestLinkReference(pullRequestURL: url) == nil)
     }
 }

--- a/Packages/macOS/CmuxSettings/Tests/CmuxSettingsTests/PullRequestLinkConfigurationTests.swift
+++ b/Packages/macOS/CmuxSettings/Tests/CmuxSettingsTests/PullRequestLinkConfigurationTests.swift
@@ -98,6 +98,20 @@ struct PullRequestLinkConfigurationTests {
         #expect(configuration.resolvedURL(for: url) == url)
     }
 
+    /// An empty authority parses as `/{owner}/{repo}/pull/{number}` with a `nil`
+    /// host, which would otherwise satisfy the path check.
+    @Test(arguments: [
+        "https:///manaflow-ai/cmux/pull/9641",
+        "http:///manaflow-ai/cmux/pull/9641",
+    ])
+    func referenceRejectsURLsWithoutAHost(rawURL: String) throws {
+        let url = try #require(URL(string: rawURL))
+        let configuration = PullRequestLinkConfiguration(destination: .graphite, customURLTemplate: "")
+
+        #expect(PullRequestLinkReference(pullRequestURL: url) == nil)
+        #expect(configuration.resolvedURL(for: url) == url)
+    }
+
     @Test func referenceParsesCanonicalPullRequestURL() throws {
         let reference = try #require(PullRequestLinkReference(pullRequestURL: canonical))
 

--- a/Packages/macOS/CmuxSettingsUI/Sources/CmuxSettingsUI/Navigation/CuratedSettingEntry+Default.swift
+++ b/Packages/macOS/CmuxSettingsUI/Sources/CmuxSettingsUI/Navigation/CuratedSettingEntry+Default.swift
@@ -170,7 +170,15 @@ extension Array where Element == CuratedSettingEntry {
             .init(section: .sidebarAppearance, id: "watch-git-status", title: "Watch Git Status in Sidebar", synonyms: "sidebar.watchGitStatus git status branch watcher index lock"),
             .init(section: .sidebarAppearance, id: "make-pr-clickable", title: "Make Sidebar PR Clickable", synonyms: "sidebar.makePullRequestsClickable clickable pull requests pr mr reviews links select workspace row"),
             .init(section: .sidebarAppearance, id: "open-pr-links", title: "Open Sidebar PR Links in cmux Browser", synonyms: "sidebar.openPullRequestLinksInCmuxBrowser pr links github browser default external embedded"),
-            .init(section: .sidebarAppearance, id: "pr-link-destination", title: "Open PR Links At", synonyms: "sidebar.pullRequestLinkDestination sidebar.customPullRequestLinkURLTemplate pr links destination github graphite stacked review host custom url template where"),
+            .init(
+                section: .sidebarAppearance,
+                id: "pr-link-destination",
+                title: String(localized: "settings.app.pullRequestLinkDestination", defaultValue: "Open PR Links At"),
+                synonyms: String(
+                    localized: "settings.search.alias.setting.sidebarAppearance.pr-link-destination",
+                    defaultValue: "sidebar.pullRequestLinkDestination sidebar.customPullRequestLinkURLTemplate pr links destination github graphite stacked review host custom url template where"
+                )
+            ),
             .init(section: .sidebarAppearance, id: "open-port-links", title: "Open Sidebar Port Links in cmux Browser", synonyms: "sidebar.openPortLinksInCmuxBrowser ports localhost links browser default external embedded"),
             .init(section: .sidebarAppearance, id: "show-ssh", title: "Show SSH in Sidebar", synonyms: "sidebar.showSSH remote host target ssh server"),
             .init(section: .sidebarAppearance, id: "show-ports", title: "Show Listening Ports in Sidebar", synonyms: "sidebar.showPorts localhost port listener dev server url"),

--- a/Packages/macOS/CmuxSettingsUI/Sources/CmuxSettingsUI/Navigation/CuratedSettingEntry+Default.swift
+++ b/Packages/macOS/CmuxSettingsUI/Sources/CmuxSettingsUI/Navigation/CuratedSettingEntry+Default.swift
@@ -170,6 +170,7 @@ extension Array where Element == CuratedSettingEntry {
             .init(section: .sidebarAppearance, id: "watch-git-status", title: "Watch Git Status in Sidebar", synonyms: "sidebar.watchGitStatus git status branch watcher index lock"),
             .init(section: .sidebarAppearance, id: "make-pr-clickable", title: "Make Sidebar PR Clickable", synonyms: "sidebar.makePullRequestsClickable clickable pull requests pr mr reviews links select workspace row"),
             .init(section: .sidebarAppearance, id: "open-pr-links", title: "Open Sidebar PR Links in cmux Browser", synonyms: "sidebar.openPullRequestLinksInCmuxBrowser pr links github browser default external embedded"),
+            .init(section: .sidebarAppearance, id: "pr-link-destination", title: "Open PR Links At", synonyms: "sidebar.pullRequestLinkDestination sidebar.customPullRequestLinkURLTemplate pr links destination github graphite stacked review host custom url template where"),
             .init(section: .sidebarAppearance, id: "open-port-links", title: "Open Sidebar Port Links in cmux Browser", synonyms: "sidebar.openPortLinksInCmuxBrowser ports localhost links browser default external embedded"),
             .init(section: .sidebarAppearance, id: "show-ssh", title: "Show SSH in Sidebar", synonyms: "sidebar.showSSH remote host target ssh server"),
             .init(section: .sidebarAppearance, id: "show-ports", title: "Show Listening Ports in Sidebar", synonyms: "sidebar.showPorts localhost port listener dev server url"),

--- a/Packages/macOS/CmuxSettingsUI/Sources/CmuxSettingsUI/Sections/SidebarSection.swift
+++ b/Packages/macOS/CmuxSettingsUI/Sources/CmuxSettingsUI/Sections/SidebarSection.swift
@@ -23,6 +23,8 @@ public struct SidebarSection: View {
     @State private var watchGit: DefaultsValueModel<Bool>
     @State private var prClickable: DefaultsValueModel<Bool>
     @State private var prLinks: DefaultsValueModel<Bool>
+    @State private var prLinkDestination: DefaultsValueModel<PullRequestLinkDestination>
+    @State private var prLinkTemplate: DefaultsValueModel<String>
     @State private var portLinks: DefaultsValueModel<Bool>
     @State private var showSSH: DefaultsValueModel<Bool>
     @State private var showPorts: DefaultsValueModel<Bool>
@@ -52,6 +54,8 @@ public struct SidebarSection: View {
         _watchGit = State(initialValue: DefaultsValueModel(store: defaultsStore, key: catalog.sidebar.watchGitStatus))
         _prClickable = State(initialValue: DefaultsValueModel(store: defaultsStore, key: catalog.sidebar.makePullRequestsClickable))
         _prLinks = State(initialValue: DefaultsValueModel(store: defaultsStore, key: catalog.sidebar.openPullRequestLinksInCmuxBrowser))
+        _prLinkDestination = State(initialValue: DefaultsValueModel(store: defaultsStore, key: catalog.sidebar.pullRequestLinkDestination))
+        _prLinkTemplate = State(initialValue: DefaultsValueModel(store: defaultsStore, key: catalog.sidebar.customPullRequestLinkURLTemplate))
         _portLinks = State(initialValue: DefaultsValueModel(store: defaultsStore, key: catalog.sidebar.openPortLinksInCmuxBrowser))
         _showSSH = State(initialValue: DefaultsValueModel(store: defaultsStore, key: catalog.sidebar.showSSH))
         _showPorts = State(initialValue: DefaultsValueModel(store: defaultsStore, key: catalog.sidebar.showPorts))
@@ -86,6 +90,8 @@ public struct SidebarSection: View {
             watchGit,
             prClickable,
             prLinks,
+            prLinkDestination,
+            prLinkTemplate,
             portLinks,
             showSSH,
             showPorts,
@@ -409,6 +415,43 @@ public struct SidebarSection: View {
             SettingsCardDivider()
 
             SettingsCardRow(
+                configurationReview: .json("sidebar.pullRequestLinkDestination"),
+                String(localized: "settings.app.pullRequestLinkDestination", defaultValue: "Open PR Links At"),
+                subtitle: prLinkDestinationSubtitle(prVisible: showPR.current, destination: prLinkDestination.current),
+                controlWidth: 250
+            ) {
+                Picker("", selection: Binding(get: { prLinkDestination.current }, set: { prLinkDestination.set($0) })) {
+                    ForEach(PullRequestLinkDestination.allCases) { value in
+                        Text(value.displayName).tag(value)
+                    }
+                }
+                .labelsHidden()
+                .pickerStyle(.menu)
+                .accessibilityIdentifier("SettingsSidebarPullRequestLinkDestinationPicker")
+            }
+            .disabled(hideAll.current || !showPR.current)
+            SettingsCardDivider()
+
+            if prLinkDestination.current == .custom {
+                SettingsCardRow(
+                    configurationReview: .json("sidebar.customPullRequestLinkURLTemplate"),
+                    String(localized: "settings.app.customPullRequestLinkURLTemplate", defaultValue: "Custom PR URL"),
+                    subtitle: String(localized: "settings.app.customPullRequestLinkURLTemplate.subtitle", defaultValue: "Use {owner}, {repo}, and {number} for the pull request. Leave empty to open the PR's own page."),
+                    controlWidth: 330
+                ) {
+                    TextField(
+                        "",
+                        text: Binding(get: { prLinkTemplate.current }, set: { prLinkTemplate.set($0) }),
+                        prompt: Text(verbatim: "https://app.graphite.com/github/pr/{owner}/{repo}/{number}")
+                    )
+                    .textFieldStyle(.roundedBorder)
+                    .accessibilityIdentifier("SettingsSidebarCustomPullRequestLinkURLTemplateField")
+                }
+                .disabled(hideAll.current || !showPR.current)
+                SettingsCardDivider()
+            }
+
+            SettingsCardRow(
                 configurationReview: .json("sidebar.openPortLinksInCmuxBrowser"),
                 String(localized: "settings.app.openSidebarPortLinks", defaultValue: "Open Sidebar Port Links in cmux Browser"),
                 subtitle: portLinks.current
@@ -482,6 +525,20 @@ public struct SidebarSection: View {
                     .controlSize(.small)
             }
             .disabled(hideAll.current)
+        }
+    }
+
+    private func prLinkDestinationSubtitle(prVisible: Bool, destination: PullRequestLinkDestination) -> String {
+        if !prVisible {
+            return String(localized: "settings.app.pullRequestLinkDestination.subtitleHidden", defaultValue: "Enable sidebar PR visibility to choose where PR links go.")
+        }
+        switch destination {
+        case .github:
+            return String(localized: "settings.app.pullRequestLinkDestination.subtitleGitHub", defaultValue: "PR links go to the pull request's own page.")
+        case .graphite:
+            return String(localized: "settings.app.pullRequestLinkDestination.subtitleGraphite", defaultValue: "PR links go to Graphite's review UI.")
+        case .custom:
+            return String(localized: "settings.app.pullRequestLinkDestination.subtitleCustom", defaultValue: "PR links go to your own review URL.")
         }
     }
 

--- a/Packages/macOS/CmuxSettingsUI/Sources/CmuxSettingsUI/Sections/SidebarSection.swift
+++ b/Packages/macOS/CmuxSettingsUI/Sources/CmuxSettingsUI/Sections/SidebarSection.swift
@@ -442,7 +442,10 @@ public struct SidebarSection: View {
                     TextField(
                         "",
                         text: Binding(get: { prLinkTemplate.current }, set: { prLinkTemplate.set($0) }),
-                        prompt: Text(verbatim: "https://app.graphite.com/github/pr/{owner}/{repo}/{number}")
+                        prompt: Text(String(
+                            localized: "settings.app.customPullRequestLinkURLTemplate.prompt",
+                            defaultValue: "https://app.graphite.com/github/pr/{owner}/{repo}/{number}"
+                        ))
                     )
                     .textFieldStyle(.roundedBorder)
                     .accessibilityIdentifier("SettingsSidebarCustomPullRequestLinkURLTemplateField")

--- a/Packages/macOS/CmuxSettingsUI/Tests/CmuxSettingsUITests/SettingsRowAnchorResolutionTests.swift
+++ b/Packages/macOS/CmuxSettingsUI/Tests/CmuxSettingsUITests/SettingsRowAnchorResolutionTests.swift
@@ -98,6 +98,7 @@ struct SettingsRowAnchorResolutionTests {
         "sidebar.openPortLinksInCmuxBrowser",
         "sidebar.openPullRequestLinksInCmuxBrowser",
         "sidebar.pathLastSegmentOnly",
+        "sidebar.pullRequestLinkDestination",
         "sidebar.rightMaxWidth",
         "sidebar.showBranchDirectory",
         "sidebar.showCustomMetadata",

--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -148733,6 +148733,40 @@
         }
       }
     },
+    "settings.app.customPullRequestLinkURLTemplate": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Custom PR URL"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "カスタムPR URL"
+          }
+        }
+      }
+    },
+    "settings.app.customPullRequestLinkURLTemplate.subtitle": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Use {owner}, {repo}, and {number} for the pull request. Leave empty to open the PR's own page."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "プルリクエストの指定には {owner}、{repo}、{number} を使います。空欄の場合はPR本来のページを開きます。"
+          }
+        }
+      }
+    },
     "settings.app.defaultTerminal": {
       "extractionState": "manual",
       "localizations": {
@@ -154039,6 +154073,91 @@
           "stringUnit": {
             "state": "translated",
             "value": "Cmd+クリックのファイルプレビューが無効な場合、またはファイルが未対応の場合に使うコマンドです。空欄のままにするとシステムの既定で開きます。"
+          }
+        }
+      }
+    },
+    "settings.app.pullRequestLinkDestination": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Open PR Links At"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "PRリンクの遷移先"
+          }
+        }
+      }
+    },
+    "settings.app.pullRequestLinkDestination.subtitleCustom": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "PR links go to your own review URL."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "PRリンクは指定したレビューURLを開きます。"
+          }
+        }
+      }
+    },
+    "settings.app.pullRequestLinkDestination.subtitleGitHub": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "PR links go to the pull request's own page."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "PRリンクはプルリクエスト本来のページを開きます。"
+          }
+        }
+      }
+    },
+    "settings.app.pullRequestLinkDestination.subtitleGraphite": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "PR links go to Graphite's review UI."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "PRリンクはGraphiteのレビュー画面を開きます。"
+          }
+        }
+      }
+    },
+    "settings.app.pullRequestLinkDestination.subtitleHidden": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enable sidebar PR visibility to choose where PR links go."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "PRリンクの遷移先を選ぶには、サイドバーのPR表示を有効にしてください。"
           }
         }
       }
@@ -191356,6 +191475,23 @@
         }
       }
     },
+    "settings.search.alias.setting.sidebarAppearance.pr-link-destination": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "sidebar.pullRequestLinkDestination sidebar.customPullRequestLinkURLTemplate pr links destination github graphite stacked review host custom url template where"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "sidebar.pullRequestLinkDestination sidebar.customPullRequestLinkURLTemplate pr links destination github graphite stacked review host custom url template where PRリンク 遷移先 プルリクエスト レビュー カスタム URL テンプレート"
+          }
+        }
+      }
+    },
     "settings.search.alias.setting.sidebarAppearance.reset-tint": {
       "extractionState": "manual",
       "localizations": {
@@ -194633,6 +194769,57 @@
           "stringUnit": {
             "state": "translated",
             "value": "Cmd または Control を押し続けるとショートカットヒントのチップを表示します。"
+          }
+        }
+      }
+    },
+    "settings.sidebar.pullRequestLinkDestination.custom": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Custom"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "カスタム"
+          }
+        }
+      }
+    },
+    "settings.sidebar.pullRequestLinkDestination.github": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "GitHub"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "GitHub"
+          }
+        }
+      }
+    },
+    "settings.sidebar.pullRequestLinkDestination.graphite": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Graphite"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Graphite"
           }
         }
       }

--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -148736,10 +148736,52 @@
     "settings.app.customPullRequestLinkURLTemplate": {
       "extractionState": "manual",
       "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "عنوان URL مخصص لطلب السحب"
+          }
+        },
+        "bs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Prilagođeni PR URL"
+          }
+        },
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tilpasset PR-URL"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Eigene PR-URL"
+          }
+        },
         "en": {
           "stringUnit": {
             "state": "translated",
             "value": "Custom PR URL"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "URL de PR personalizada"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "URL de PR personnalisée"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "URL PR personalizzato"
           }
         },
         "ja": {
@@ -148747,22 +148789,321 @@
             "state": "translated",
             "value": "カスタムPR URL"
           }
+        },
+        "km": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "URL PR ផ្ទាល់ខ្លួន"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "사용자 지정 PR URL"
+          }
+        },
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tilpasset PR-URL"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Niestandardowy adres URL PR"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "URL de PR personalizada"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Собственный URL для PR"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "URL ของ PR ที่กำหนดเอง"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Özel PR URL'si"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Власна URL-адреса PR"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "自定义 PR URL"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "自訂 PR URL"
+          }
+        }
+      }
+    },
+    "settings.app.customPullRequestLinkURLTemplate.prompt": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "https://app.graphite.com/github/pr/{owner}/{repo}/{number}"
+          }
+        },
+        "bs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "https://app.graphite.com/github/pr/{owner}/{repo}/{number}"
+          }
+        },
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "https://app.graphite.com/github/pr/{owner}/{repo}/{number}"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "https://app.graphite.com/github/pr/{owner}/{repo}/{number}"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "https://app.graphite.com/github/pr/{owner}/{repo}/{number}"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "https://app.graphite.com/github/pr/{owner}/{repo}/{number}"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "https://app.graphite.com/github/pr/{owner}/{repo}/{number}"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "https://app.graphite.com/github/pr/{owner}/{repo}/{number}"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "https://app.graphite.com/github/pr/{owner}/{repo}/{number}"
+          }
+        },
+        "km": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "https://app.graphite.com/github/pr/{owner}/{repo}/{number}"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "https://app.graphite.com/github/pr/{owner}/{repo}/{number}"
+          }
+        },
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "https://app.graphite.com/github/pr/{owner}/{repo}/{number}"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "https://app.graphite.com/github/pr/{owner}/{repo}/{number}"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "https://app.graphite.com/github/pr/{owner}/{repo}/{number}"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "https://app.graphite.com/github/pr/{owner}/{repo}/{number}"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "https://app.graphite.com/github/pr/{owner}/{repo}/{number}"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "https://app.graphite.com/github/pr/{owner}/{repo}/{number}"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "https://app.graphite.com/github/pr/{owner}/{repo}/{number}"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "https://app.graphite.com/github/pr/{owner}/{repo}/{number}"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "https://app.graphite.com/github/pr/{owner}/{repo}/{number}"
+          }
         }
       }
     },
     "settings.app.customPullRequestLinkURLTemplate.subtitle": {
       "extractionState": "manual",
       "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "استخدم {owner} و{repo} و{number} لتحديد طلب السحب. اتركه فارغًا لفتح صفحة طلب السحب الأصلية."
+          }
+        },
+        "bs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Koristite {owner}, {repo} i {number} za pull request. Ostavite prazno da se otvori vlastita stranica PR-a."
+          }
+        },
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Brug {owner}, {repo} og {number} til pull requesten. Lad feltet være tomt for at åbne PR'ens egen side."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Verwenden Sie {owner}, {repo} und {number} für den Pull Request. Leer lassen, um die eigene Seite des PR zu öffnen."
+          }
+        },
         "en": {
           "stringUnit": {
             "state": "translated",
             "value": "Use {owner}, {repo}, and {number} for the pull request. Leave empty to open the PR's own page."
           }
         },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Usa {owner}, {repo} y {number} para el pull request. Déjalo vacío para abrir la página propia del PR."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Utilisez {owner}, {repo} et {number} pour la pull request. Laissez vide pour ouvrir la page propre à la PR."
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Usa {owner}, {repo} e {number} per la pull request. Lascia vuoto per aprire la pagina della PR."
+          }
+        },
         "ja": {
           "stringUnit": {
             "state": "translated",
             "value": "プルリクエストの指定には {owner}、{repo}、{number} を使います。空欄の場合はPR本来のページを開きます。"
+          }
+        },
+        "km": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ប្រើ {owner}, {repo} និង {number} សម្រាប់សំណើទាញ។ ទុកឲ្យទំនេរ ដើម្បីបើកទំព័រដើមរបស់ PR។"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "풀 리퀘스트를 지정하려면 {owner}, {repo}, {number}를 사용하세요. 비워 두면 PR 자체 페이지가 열립니다."
+          }
+        },
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bruk {owner}, {repo} og {number} for pull requesten. La feltet stå tomt for å åpne PR-ens egen side."
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Użyj {owner}, {repo} i {number} dla pull requesta. Pozostaw puste, aby otwierać własną stronę PR."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Use {owner}, {repo} e {number} para o pull request. Deixe vazio para abrir a página do próprio PR."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Используйте {owner}, {repo} и {number} для пул-реквеста. Оставьте пустым, чтобы открывать собственную страницу PR."
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ใส่ {owner} {repo} และ {number} เพื่อระบุ pull request เว้นว่างไว้เพื่อเปิดหน้าของ PR เอง"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pull request için {owner}, {repo} ve {number} kullanın. PR'ın kendi sayfasını açmak için boş bırakın."
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Використовуйте {owner}, {repo} і {number} для пул-реквесту. Залиште порожнім, щоб відкривати власну сторінку PR."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "使用 {owner}、{repo} 和 {number} 指定拉取请求。留空则打开 PR 自身的页面。"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "使用 {owner}、{repo} 與 {number} 指定拉取請求。留空則開啟 PR 本身的頁面。"
           }
         }
       }
@@ -154080,10 +154421,52 @@
     "settings.app.pullRequestLinkDestination": {
       "extractionState": "manual",
       "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "فتح روابط طلبات السحب في"
+          }
+        },
+        "bs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Otvori PR linkove na"
+          }
+        },
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Åbn PR-links i"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "PR-Links öffnen in"
+          }
+        },
         "en": {
           "stringUnit": {
             "state": "translated",
             "value": "Open PR Links At"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Abrir enlaces de PR en"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ouvrir les liens de PR dans"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Apri i link delle PR in"
           }
         },
         "ja": {
@@ -154091,16 +154474,124 @@
             "state": "translated",
             "value": "PRリンクの遷移先"
           }
+        },
+        "km": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "បើកតំណ PR នៅ"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "PR 링크 이동 위치"
+          }
+        },
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Åpne PR-lenker i"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Otwieraj linki PR w"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Abrir links de PR em"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Открывать ссылки PR в"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "เปิดลิงก์ PR ที่"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "PR bağlantılarını şurada aç"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Куди ведуть посилання PR"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "PR 链接打开位置"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "PR 連結開啟位置"
+          }
         }
       }
     },
     "settings.app.pullRequestLinkDestination.subtitleCustom": {
       "extractionState": "manual",
       "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "روابط طلبات السحب تفتح عنوان URL الخاص بمراجعتك."
+          }
+        },
+        "bs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "PR linkovi vode na vaš vlastiti URL za pregled."
+          }
+        },
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "PR-links fører til din egen review-URL."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "PR-Links führen zu Ihrer eigenen Review-URL."
+          }
+        },
         "en": {
           "stringUnit": {
             "state": "translated",
             "value": "PR links go to your own review URL."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Los enlaces de PR llevan a tu propia URL de revisión."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Les liens de PR mènent à votre propre URL de revue."
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "I link delle PR portano al tuo URL di revisione."
           }
         },
         "ja": {
@@ -154108,16 +154599,124 @@
             "state": "translated",
             "value": "PRリンクは指定したレビューURLを開きます。"
           }
+        },
+        "km": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "តំណ PR នាំទៅ URL ត្រួតពិនិត្យផ្ទាល់ខ្លួនរបស់អ្នក។"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "PR 링크가 직접 지정한 리뷰 URL로 이동합니다."
+          }
+        },
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "PR-lenker fører til din egen gjennomgangs-URL."
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Linki PR prowadzą do Twojego własnego adresu URL przeglądu."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Os links de PR levam à sua própria URL de revisão."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ссылки PR ведут на ваш собственный URL для ревью."
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ลิงก์ PR จะเปิด URL ตรวจทานที่คุณกำหนด"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "PR bağlantıları kendi inceleme URL'nize gider."
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Посилання PR ведуть на вашу власну URL-адресу рецензування."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "PR 链接打开你自定义的审查 URL。"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "PR 連結會開啟你自訂的審查 URL。"
+          }
         }
       }
     },
     "settings.app.pullRequestLinkDestination.subtitleGitHub": {
       "extractionState": "manual",
       "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "روابط طلبات السحب تفتح صفحة طلب السحب الأصلية."
+          }
+        },
+        "bs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "PR linkovi vode na vlastitu stranicu pull requesta."
+          }
+        },
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "PR-links fører til pull requestens egen side."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "PR-Links führen zur eigenen Seite des Pull Requests."
+          }
+        },
         "en": {
           "stringUnit": {
             "state": "translated",
             "value": "PR links go to the pull request's own page."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Los enlaces de PR llevan a la página propia del pull request."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Les liens de PR mènent à la page propre à la pull request."
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "I link delle PR portano alla pagina della pull request."
           }
         },
         "ja": {
@@ -154125,16 +154724,124 @@
             "state": "translated",
             "value": "PRリンクはプルリクエスト本来のページを開きます。"
           }
+        },
+        "km": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "តំណ PR នាំទៅទំព័រដើមរបស់សំណើទាញ។"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "PR 링크가 풀 리퀘스트 자체 페이지로 이동합니다."
+          }
+        },
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "PR-lenker fører til pull requestens egen side."
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Linki PR prowadzą do własnej strony pull requesta."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Os links de PR levam à página do próprio pull request."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ссылки PR ведут на собственную страницу пул-реквеста."
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ลิงก์ PR จะเปิดหน้าของ pull request เอง"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "PR bağlantıları pull request'in kendi sayfasına gider."
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Посилання PR ведуть на власну сторінку пул-реквесту."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "PR 链接打开拉取请求自身的页面。"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "PR 連結會開啟拉取請求本身的頁面。"
+          }
         }
       }
     },
     "settings.app.pullRequestLinkDestination.subtitleGraphite": {
       "extractionState": "manual",
       "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "روابط طلبات السحب تفتح واجهة المراجعة في Graphite."
+          }
+        },
+        "bs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "PR linkovi vode na Graphite sučelje za pregled."
+          }
+        },
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "PR-links fører til Graphites review-grænseflade."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "PR-Links führen zur Review-Oberfläche von Graphite."
+          }
+        },
         "en": {
           "stringUnit": {
             "state": "translated",
             "value": "PR links go to Graphite's review UI."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Los enlaces de PR llevan a la interfaz de revisión de Graphite."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Les liens de PR mènent à l'interface de revue de Graphite."
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "I link delle PR portano all'interfaccia di revisione di Graphite."
           }
         },
         "ja": {
@@ -154142,22 +154849,196 @@
             "state": "translated",
             "value": "PRリンクはGraphiteのレビュー画面を開きます。"
           }
+        },
+        "km": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "តំណ PR នាំទៅផ្ទាំងត្រួតពិនិត្យរបស់ Graphite។"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "PR 링크가 Graphite 리뷰 화면으로 이동합니다."
+          }
+        },
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "PR-lenker fører til Graphites gjennomgangsgrensesnitt."
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Linki PR prowadzą do interfejsu przeglądu Graphite."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Os links de PR levam à interface de revisão do Graphite."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ссылки PR ведут в интерфейс ревью Graphite."
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ลิงก์ PR จะเปิดหน้าตรวจทานของ Graphite"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "PR bağlantıları Graphite'in inceleme arayüzüne gider."
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Посилання PR ведуть до інтерфейсу рецензування Graphite."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "PR 链接打开 Graphite 的审查界面。"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "PR 連結會開啟 Graphite 的審查介面。"
+          }
         }
       }
     },
     "settings.app.pullRequestLinkDestination.subtitleHidden": {
       "extractionState": "manual",
       "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "مكّن عرض طلبات السحب في الشريط الجانبي لاختيار وجهة الروابط."
+          }
+        },
+        "bs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Uključite prikaz PR-ova u bočnoj traci da odaberete gdje vode linkovi."
+          }
+        },
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aktivér visning af PR i sidebjælken for at vælge, hvor links fører til."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aktivieren Sie die PR-Anzeige in der Seitenleiste, um das Ziel von PR-Links zu wählen."
+          }
+        },
         "en": {
           "stringUnit": {
             "state": "translated",
             "value": "Enable sidebar PR visibility to choose where PR links go."
           }
         },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Activa la visibilidad de PR en la barra lateral para elegir adónde llevan los enlaces."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Activez l'affichage des PR dans la barre latérale pour choisir la destination des liens."
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Attiva la visibilità delle PR nella barra laterale per scegliere dove portano i link."
+          }
+        },
         "ja": {
           "stringUnit": {
             "state": "translated",
             "value": "PRリンクの遷移先を選ぶには、サイドバーのPR表示を有効にしてください。"
+          }
+        },
+        "km": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "បើកការបង្ហាញ PR នៅរបារចំហៀង ដើម្បីជ្រើសទីតាំងដែលតំណនាំទៅ។"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "PR 링크가 열리는 위치를 선택하려면 사이드바 PR 표시를 켜세요."
+          }
+        },
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Slå på visning av PR i sidepanelet for å velge hvor lenkene fører."
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Włącz widoczność PR na pasku bocznym, aby wybrać, gdzie prowadzą linki."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ative a exibição de PR na barra lateral para escolher para onde os links levam."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Включите отображение PR в боковой панели, чтобы выбрать, куда ведут ссылки."
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "เปิดการแสดง PR ในแถบด้านข้างเพื่อเลือกปลายทางของลิงก์"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bağlantıların nereye gideceğini seçmek için kenar çubuğunda PR görünürlüğünü açın."
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Увімкніть показ PR у боковій панелі, щоб вибрати, куди ведуть посилання."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "启用侧边栏 PR 显示后即可选择 PR 链接的打开位置。"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "啟用側邊欄 PR 顯示後即可選擇 PR 連結的開啟位置。"
           }
         }
       }
@@ -191478,16 +192359,124 @@
     "settings.search.alias.setting.sidebarAppearance.pr-link-destination": {
       "extractionState": "manual",
       "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "sidebar.pullRequestLinkDestination sidebar.customPullRequestLinkURLTemplate github graphite روابط طلب السحب وجهة مراجعة مخصص قالب"
+          }
+        },
+        "bs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "sidebar.pullRequestLinkDestination sidebar.customPullRequestLinkURLTemplate github graphite PR linkovi odredište pull request pregled prilagođeno URL šablon"
+          }
+        },
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "sidebar.pullRequestLinkDestination sidebar.customPullRequestLinkURLTemplate github graphite PR-links destination pull request review tilpasset URL skabelon"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "sidebar.pullRequestLinkDestination sidebar.customPullRequestLinkURLTemplate github graphite PR-Links Ziel Pull Request Review benutzerdefiniert URL Vorlage"
+          }
+        },
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "sidebar.pullRequestLinkDestination sidebar.customPullRequestLinkURLTemplate pr links destination github graphite stacked review host custom url template where"
+            "value": "sidebar.pullRequestLinkDestination sidebar.customPullRequestLinkURLTemplate github graphite pr links destination pull request review custom url template"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "sidebar.pullRequestLinkDestination sidebar.customPullRequestLinkURLTemplate github graphite enlaces PR destino pull request revisión personalizado URL plantilla"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "sidebar.pullRequestLinkDestination sidebar.customPullRequestLinkURLTemplate github graphite liens PR destination pull request revue personnalisé URL modèle"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "sidebar.pullRequestLinkDestination sidebar.customPullRequestLinkURLTemplate github graphite link PR destinazione pull request revisione personalizzato URL modello"
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "sidebar.pullRequestLinkDestination sidebar.customPullRequestLinkURLTemplate pr links destination github graphite stacked review host custom url template where PRリンク 遷移先 プルリクエスト レビュー カスタム URL テンプレート"
+            "value": "sidebar.pullRequestLinkDestination sidebar.customPullRequestLinkURLTemplate github graphite PRリンク 遷移先 プルリクエスト レビュー カスタム URL テンプレート"
+          }
+        },
+        "km": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "sidebar.pullRequestLinkDestination sidebar.customPullRequestLinkURLTemplate github graphite តំណ PR ទីតាំង សំណើទាញ ត្រួតពិនិត្យ ផ្ទាល់ខ្លួន URL ទម្រង់"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "sidebar.pullRequestLinkDestination sidebar.customPullRequestLinkURLTemplate github graphite PR 링크 이동 위치 풀리퀘스트 리뷰 사용자 지정 URL 템플릿"
+          }
+        },
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "sidebar.pullRequestLinkDestination sidebar.customPullRequestLinkURLTemplate github graphite PR-lenker destinasjon pull request gjennomgang tilpasset URL mal"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "sidebar.pullRequestLinkDestination sidebar.customPullRequestLinkURLTemplate github graphite linki PR miejsce docelowe pull request przegląd niestandardowy URL szablon"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "sidebar.pullRequestLinkDestination sidebar.customPullRequestLinkURLTemplate github graphite links de PR destino pull request revisão personalizado URL modelo"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "sidebar.pullRequestLinkDestination sidebar.customPullRequestLinkURLTemplate github graphite ссылки PR назначение пул-реквест ревью пользовательский URL шаблон"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "sidebar.pullRequestLinkDestination sidebar.customPullRequestLinkURLTemplate github graphite ลิงก์ PR ปลายทาง pull request ตรวจทาน กำหนดเอง URL เทมเพลต"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "sidebar.pullRequestLinkDestination sidebar.customPullRequestLinkURLTemplate github graphite PR bağlantıları hedef pull request inceleme özel URL şablon"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "sidebar.pullRequestLinkDestination sidebar.customPullRequestLinkURLTemplate github graphite PR посилання призначення пул-реквест рецензування власний URL шаблон"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "sidebar.pullRequestLinkDestination sidebar.customPullRequestLinkURLTemplate github graphite PR 链接 打开位置 拉取请求 审查 自定义 URL 模板"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "sidebar.pullRequestLinkDestination sidebar.customPullRequestLinkURLTemplate github graphite PR 連結 開啟位置 拉取請求 審查 自訂 URL 範本"
           }
         }
       }
@@ -194776,10 +195765,52 @@
     "settings.sidebar.pullRequestLinkDestination.custom": {
       "extractionState": "manual",
       "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "مخصص"
+          }
+        },
+        "bs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Prilagođeno"
+          }
+        },
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tilpasset"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Benutzerdefiniert"
+          }
+        },
         "en": {
           "stringUnit": {
             "state": "translated",
             "value": "Custom"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Personalizado"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Personnalisé"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Personalizzato"
           }
         },
         "ja": {
@@ -194787,19 +195818,193 @@
             "state": "translated",
             "value": "カスタム"
           }
+        },
+        "km": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ផ្ទាល់ខ្លួន"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "사용자 지정"
+          }
+        },
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tilpasset"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Niestandardowe"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Personalizado"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Пользовательский"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "กำหนดเอง"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Özel"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Користувацький"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "自定义"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "自訂"
+          }
         }
       }
     },
     "settings.sidebar.pullRequestLinkDestination.github": {
       "extractionState": "manual",
       "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "GitHub"
+          }
+        },
+        "bs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "GitHub"
+          }
+        },
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "GitHub"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "GitHub"
+          }
+        },
         "en": {
           "stringUnit": {
             "state": "translated",
             "value": "GitHub"
           }
         },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "GitHub"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "GitHub"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "GitHub"
+          }
+        },
         "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "GitHub"
+          }
+        },
+        "km": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "GitHub"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "GitHub"
+          }
+        },
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "GitHub"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "GitHub"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "GitHub"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "GitHub"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "GitHub"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "GitHub"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "GitHub"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "GitHub"
+          }
+        },
+        "zh-Hant": {
           "stringUnit": {
             "state": "translated",
             "value": "GitHub"
@@ -194810,13 +196015,121 @@
     "settings.sidebar.pullRequestLinkDestination.graphite": {
       "extractionState": "manual",
       "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Graphite"
+          }
+        },
+        "bs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Graphite"
+          }
+        },
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Graphite"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Graphite"
+          }
+        },
         "en": {
           "stringUnit": {
             "state": "translated",
             "value": "Graphite"
           }
         },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Graphite"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Graphite"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Graphite"
+          }
+        },
         "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Graphite"
+          }
+        },
+        "km": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Graphite"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Graphite"
+          }
+        },
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Graphite"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Graphite"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Graphite"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Graphite"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Graphite"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Graphite"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Graphite"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Graphite"
+          }
+        },
+        "zh-Hant": {
           "stringUnit": {
             "state": "translated",
             "value": "Graphite"

--- a/Sources/CmuxSettingsJSONPathSupport.swift
+++ b/Sources/CmuxSettingsJSONPathSupport.swift
@@ -286,14 +286,6 @@ enum SidebarSettingsFileMapping {
             defaultsKey: BrowserLinkOpenSettings.openSidebarPullRequestLinksInCmuxBrowserKey
         ),
         .init(
-            jsonKey: "pullRequestLinkDestination",
-            defaultsKey: sidebar.pullRequestLinkDestination.userDefaultsKey
-        ),
-        .init(
-            jsonKey: "customPullRequestLinkURLTemplate",
-            defaultsKey: sidebar.customPullRequestLinkURLTemplate.userDefaultsKey
-        ),
-        .init(
             jsonKey: "openPortLinksInCmuxBrowser",
             defaultsKey: BrowserLinkOpenSettings.openSidebarPortLinksInCmuxBrowserKey
         ),
@@ -323,6 +315,17 @@ enum SidebarSettingsFileMapping {
         default:
             return nil
         }
+    }
+
+    static let pullRequestLinkDestinationKey = sidebar.pullRequestLinkDestination.userDefaultsKey
+    static let customPullRequestLinkURLTemplateKey = sidebar.customPullRequestLinkURLTemplate.userDefaultsKey
+
+    static func pullRequestLinkDestinationStoredValue(_ rawValue: String) -> String? {
+        PullRequestLinkDestination(rawValue: rawValue)?.rawValue
+    }
+
+    static func customPullRequestLinkURLTemplateStoredValue(_ rawValue: String) -> String? {
+        PullRequestLinkConfiguration.isValidURLTemplate(rawValue) ? rawValue : nil
     }
 }
 

--- a/Sources/CmuxSettingsJSONPathSupport.swift
+++ b/Sources/CmuxSettingsJSONPathSupport.swift
@@ -286,6 +286,14 @@ enum SidebarSettingsFileMapping {
             defaultsKey: BrowserLinkOpenSettings.openSidebarPullRequestLinksInCmuxBrowserKey
         ),
         .init(
+            jsonKey: "pullRequestLinkDestination",
+            defaultsKey: sidebar.pullRequestLinkDestination.userDefaultsKey
+        ),
+        .init(
+            jsonKey: "customPullRequestLinkURLTemplate",
+            defaultsKey: sidebar.customPullRequestLinkURLTemplate.userDefaultsKey
+        ),
+        .init(
             jsonKey: "openPortLinksInCmuxBrowser",
             defaultsKey: BrowserLinkOpenSettings.openSidebarPortLinksInCmuxBrowserKey
         ),
@@ -461,6 +469,8 @@ extension CmuxSettingsFileStore {
         "sidebar.watchGitStatus",
         "sidebar.makePullRequestsClickable",
         "sidebar.openPullRequestLinksInCmuxBrowser",
+        "sidebar.pullRequestLinkDestination",
+        "sidebar.customPullRequestLinkURLTemplate",
         "sidebar.openPortLinksInCmuxBrowser",
         "sidebar.showSSH",
         "sidebar.showPorts",

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -10035,20 +10035,23 @@ struct ContentView: View {
         let pullRequests = workspace.sidebarPullRequestsInDisplayOrder()
         guard !pullRequests.isEmpty else { return false }
 
+        let linkConfiguration = PullRequestLinkSettingsStore().currentConfiguration
+        let urls = pullRequests.map { linkConfiguration.resolvedURL(for: $0.url) }
+
         var openedCount = 0
         if BrowserLinkOpenSettings.openSidebarPullRequestLinksInCmuxBrowser() {
-            for pullRequest in pullRequests {
-                if tabManager.openBrowser(url: pullRequest.url, insertAtEnd: true) != nil {
+            for url in urls {
+                if tabManager.openBrowser(url: url, insertAtEnd: true) != nil {
                     openedCount += 1
-                } else if NSWorkspace.shared.open(pullRequest.url) {
+                } else if NSWorkspace.shared.open(url) {
                     openedCount += 1
                 }
             }
             return openedCount > 0
         }
 
-        for pullRequest in pullRequests {
-            if NSWorkspace.shared.open(pullRequest.url) {
+        for url in urls {
+            if NSWorkspace.shared.open(url) {
                 openedCount += 1
             }
         }
@@ -11861,8 +11864,11 @@ struct VerticalTabsSidebar: View, Equatable {
             onOpenWorkspaceDescriptionURL: { url in
                 NSWorkspace.shared.open(url)
             },
-            onOpenPullRequest: { [prefer = input.settings.openPullRequestLinksInCmuxBrowser] url in
-                openInBrowser(url, prefer)
+            onOpenPullRequest: { [
+                prefer = input.settings.openPullRequestLinksInCmuxBrowser,
+                linkConfiguration = input.settings.pullRequestLinkConfiguration
+            ] url in
+                openInBrowser(linkConfiguration.resolvedURL(for: url), prefer)
             },
             onOpenPort: { [prefer = input.settings.openPortLinksInCmuxBrowser] port in
                 guard let url = URL(string: "http://localhost:\(port)") else { return }

--- a/Sources/ExtensionSidebarWorkspaceRowView.swift
+++ b/Sources/ExtensionSidebarWorkspaceRowView.swift
@@ -1,5 +1,6 @@
 import CmuxFoundation
 import AppKit
+import CmuxSettings
 import CmuxSidebarProviderKit
 import SwiftUI
 import WebKit
@@ -132,13 +133,19 @@ struct CmuxExtensionWorkspaceInspectorDraft: Equatable {
         workspace: CmuxSidebarProviderWorkspace,
         selectedTab: CmuxSidebarProviderWorkspacePopoverTab = .notes
     ) -> CmuxExtensionWorkspaceInspectorDraft {
-        let initialAddress = workspace.pullRequestURLs.first ?? "https://github.com/"
+        let initialAddress = Self.initialAddress(for: workspace)
         return CmuxExtensionWorkspaceInspectorDraft(
             selectedTab: selectedTab,
             notes: "",
             address: initialAddress,
             committedAddress: initialAddress
         )
+    }
+
+    private static func initialAddress(for workspace: CmuxSidebarProviderWorkspace) -> String {
+        guard let rawURL = workspace.pullRequestURLs.first else { return "https://github.com/" }
+        guard let url = URL(string: rawURL) else { return rawURL }
+        return PullRequestLinkSettingsStore().currentConfiguration.resolvedURL(for: url).absoluteString
     }
 }
 

--- a/Sources/KeyboardShortcutSettingsFileStore+Template.swift
+++ b/Sources/KeyboardShortcutSettingsFileStore+Template.swift
@@ -150,6 +150,8 @@ extension CmuxSettingsFileStore {
                     "watchGitStatus": SidebarWorkspaceDetailDefaults.watchGitStatus,
                     "makePullRequestsClickable": SettingCatalog().sidebar.makePullRequestsClickable.defaultValue,
                     "openPullRequestLinksInCmuxBrowser": BrowserLinkOpenSettings.defaultOpenSidebarPullRequestLinksInCmuxBrowser,
+                    "pullRequestLinkDestination": SettingCatalog().sidebar.pullRequestLinkDestination.defaultValue.rawValue,
+                    "customPullRequestLinkURLTemplate": SettingCatalog().sidebar.customPullRequestLinkURLTemplate.defaultValue,
                     "openPortLinksInCmuxBrowser": BrowserLinkOpenSettings.defaultOpenSidebarPortLinksInCmuxBrowser,
                     "showSSH": SidebarWorkspaceDetailDefaults.showSSH,
                     "showPorts": SidebarWorkspaceDetailDefaults.showPorts,

--- a/Sources/KeyboardShortcutSettingsFileStore.swift
+++ b/Sources/KeyboardShortcutSettingsFileStore.swift
@@ -671,6 +671,24 @@ final class CmuxSettingsFileStore {
                 logInvalid("sidebar.branchLayout", sourcePath: sourcePath)
             }
         }
+        if let raw = jsonString(section["pullRequestLinkDestination"]) {
+            if let value = SidebarSettingsFileMapping.pullRequestLinkDestinationStoredValue(raw) {
+                snapshot.managedUserDefaults[SidebarSettingsFileMapping.pullRequestLinkDestinationKey] = .string(value)
+            } else {
+                logInvalid("sidebar.pullRequestLinkDestination", sourcePath: sourcePath)
+            }
+        } else if section.keys.contains("pullRequestLinkDestination") {
+            logInvalid("sidebar.pullRequestLinkDestination", sourcePath: sourcePath)
+        }
+        if let raw = jsonString(section["customPullRequestLinkURLTemplate"]) {
+            if let value = SidebarSettingsFileMapping.customPullRequestLinkURLTemplateStoredValue(raw) {
+                snapshot.managedUserDefaults[SidebarSettingsFileMapping.customPullRequestLinkURLTemplateKey] = .string(value)
+            } else {
+                logInvalid("sidebar.customPullRequestLinkURLTemplate", sourcePath: sourcePath)
+            }
+        } else if section.keys.contains("customPullRequestLinkURLTemplate") {
+            logInvalid("sidebar.customPullRequestLinkURLTemplate", sourcePath: sourcePath)
+        }
         if let rawBeta = section["beta"], let beta = rawBeta as? [String: Any] {
             parseSidebarWorkspaceTodosBeta(beta, sourcePath: sourcePath, snapshot: &snapshot)
         } else if section.keys.contains("beta") { logInvalid("sidebar.beta", sourcePath: sourcePath) }

--- a/Sources/SettingsNavigation.swift
+++ b/Sources/SettingsNavigation.swift
@@ -540,6 +540,8 @@ enum SettingsSearchIndex {
         "sidebar.watchGitStatus": settingID(for: .sidebarAppearance, idSuffix: "watch-git-status"),
         "sidebar.makePullRequestsClickable": settingID(for: .sidebarAppearance, idSuffix: "make-pr-clickable"),
         "sidebar.openPullRequestLinksInCmuxBrowser": settingID(for: .sidebarAppearance, idSuffix: "open-pr-links"),
+        "sidebar.pullRequestLinkDestination": settingID(for: .sidebarAppearance, idSuffix: "pr-link-destination"),
+        "sidebar.customPullRequestLinkURLTemplate": settingID(for: .sidebarAppearance, idSuffix: "pr-link-destination"),
         "sidebar.openPortLinksInCmuxBrowser": settingID(for: .sidebarAppearance, idSuffix: "open-port-links"),
         "sidebar.showSSH": settingID(for: .sidebarAppearance, idSuffix: "show-ssh"),
         "sidebar.showPorts": settingID(for: .sidebarAppearance, idSuffix: "show-ports"),

--- a/Sources/SettingsNavigation.swift
+++ b/Sources/SettingsNavigation.swift
@@ -406,6 +406,7 @@ enum SettingsSearchIndex {
         setting(.sidebarAppearance, "watch-git-status", String(localized: "settings.app.watchGitStatus", defaultValue: "Watch Git Status in Sidebar"), "git status branch watcher index lock"),
         setting(.sidebarAppearance, "make-pr-clickable", String(localized: "settings.app.makeSidebarPullRequestClickable", defaultValue: "Make Sidebar PR Clickable"), "pull requests pull request pr mr review clickable links select workspace row"),
         setting(.sidebarAppearance, "open-pr-links", String(localized: "settings.app.openSidebarPRLinks", defaultValue: "Open Sidebar PR Links in cmux Browser"), "pull request link browser"),
+        setting(.sidebarAppearance, "pr-link-destination", String(localized: "settings.app.pullRequestLinkDestination", defaultValue: "Open PR Links At"), "pull request link destination github graphite review host custom url template"),
         setting(.sidebarAppearance, "open-port-links", String(localized: "settings.app.openSidebarPortLinks", defaultValue: "Open Sidebar Port Links in cmux Browser"), "port link browser"),
         setting(.sidebarAppearance, "show-ssh", String(localized: "settings.app.showSSH", defaultValue: "Show SSH in Sidebar"), "remote target"),
         setting(.sidebarAppearance, "show-ports", String(localized: "settings.app.showPorts", defaultValue: "Show Listening Ports in Sidebar"), "localhost port"),

--- a/Sources/SettingsSearchAliases.swift
+++ b/Sources/SettingsSearchAliases.swift
@@ -122,6 +122,7 @@ enum SettingsSearchAliasIndex {
         "sidebarAppearance:watch-git-status": localized("settings.search.alias.setting.app.watch-git-status", defaultValue: "sidebar.watchGitStatus git status branch watcher index lock"),
         "sidebarAppearance:make-pr-clickable": localized("settings.search.alias.setting.sidebarAppearance.make-pr-clickable", defaultValue: "sidebar.makePullRequestsClickable clickable pull requests pr mr reviews links select workspace row"),
         "sidebarAppearance:open-pr-links": localized("settings.search.alias.setting.app.open-pr-links", defaultValue: "sidebar.openPullRequestLinksInCmuxBrowser pr links github browser default external embedded"),
+        "sidebarAppearance:pr-link-destination": localized("settings.search.alias.setting.sidebarAppearance.pr-link-destination", defaultValue: "sidebar.pullRequestLinkDestination sidebar.customPullRequestLinkURLTemplate pr links destination github graphite stacked review host custom url template where"),
         "sidebarAppearance:open-port-links": localized("settings.search.alias.setting.app.open-port-links", defaultValue: "sidebar.openPortLinksInCmuxBrowser ports localhost links browser default external embedded"),
         "sidebarAppearance:show-ssh": localized("settings.search.alias.setting.app.show-ssh", defaultValue: "sidebar.showSSH remote host target ssh server"),
         "sidebarAppearance:show-ports": localized("settings.search.alias.setting.app.show-ports", defaultValue: "sidebar.showPorts localhost port listener dev server url"),

--- a/Sources/SidebarTabItemSettingsSnapshot.swift
+++ b/Sources/SidebarTabItemSettingsSnapshot.swift
@@ -19,6 +19,7 @@ struct SidebarTabItemSettingsSnapshot: Equatable {
     let showsGitBranchIcon: Bool
     let makesPullRequestsClickable: Bool
     let openPullRequestLinksInCmuxBrowser: Bool
+    let pullRequestLinkConfiguration: PullRequestLinkConfiguration
     let openPortLinksInCmuxBrowser: Bool
     let showsNotificationMessage: Bool
     let notificationMessageLineLimit: Int
@@ -55,6 +56,7 @@ struct SidebarTabItemSettingsSnapshot: Equatable {
         openPullRequestLinksInCmuxBrowser = BrowserLinkOpenSettings.openSidebarPullRequestLinksInCmuxBrowser(
             defaults: defaults
         )
+        pullRequestLinkConfiguration = PullRequestLinkSettingsStore(defaults: defaults).currentConfiguration
         openPortLinksInCmuxBrowser = BrowserLinkOpenSettings.openSidebarPortLinksInCmuxBrowser(
             defaults: defaults
         )

--- a/cmuxTests/SidebarAppKitRowCellTests.swift
+++ b/cmuxTests/SidebarAppKitRowCellTests.swift
@@ -1,4 +1,5 @@
 import AppKit
+import CmuxSettings
 import CmuxSidebar
 import Testing
 @testable import cmux_DEV
@@ -970,6 +971,27 @@ struct SidebarAppKitRowCellTests {
         #expect(!settings.wrapsWorkspaceTitles)
         #expect(swiftUIRow.settings.branchDirectory == settings.branchDirectory)
         #expect(appKitRow.settings.branchDirectory == settings.branchDirectory)
+    }
+
+    @Test
+    func defaultSettingsLeavePullRequestLinksOnTheirOwnHost() {
+        let settings = SidebarTabItemSettingsSnapshot(defaults: Self.makeDefaults())
+        let canonical = URL(string: "https://github.com/manaflow-ai/cmux/pull/9641")!
+
+        #expect(settings.pullRequestLinkConfiguration.destination == .github)
+        #expect(settings.pullRequestLinkConfiguration.resolvedURL(for: canonical) == canonical)
+    }
+
+    @Test
+    func storedPullRequestLinkDestinationReachesBothRows() {
+        let defaults = Self.makeDefaults()
+        defaults.set(PullRequestLinkDestination.graphite.rawValue, forKey: "sidebarPullRequestLinkDestination")
+        let settings = SidebarTabItemSettingsSnapshot(defaults: defaults)
+        let expected = PullRequestLinkConfiguration(destination: .graphite, customURLTemplate: "")
+
+        #expect(settings.pullRequestLinkConfiguration == expected)
+        #expect(Self.makeSwiftUIRow(settings: settings).settings.pullRequestLinkConfiguration == expected)
+        #expect(Self.makeModel(settings: settings).settings.pullRequestLinkConfiguration == expected)
     }
 
     @Test(arguments: [false, true])

--- a/cmuxTests/WorkspaceUnitTests.swift
+++ b/cmuxTests/WorkspaceUnitTests.swift
@@ -1327,6 +1327,118 @@ final class KeyboardShortcutSettingsFileStoreTests: XCTestCase {
         XCTAssertEqual(defaults.object(forKey: SidebarWorkspaceTitleWrapSettings.key) as? Bool, true)
     }
 
+    /// `sidebar.pullRequestLinkDestination` is a string enum, so it must not be
+    /// read through the Boolean mapping — that silently dropped the value and
+    /// left PR links on GitHub for anyone configuring it from cmux.json.
+    func testSettingsFileStoreParsesSidebarPullRequestLinkDestination() throws {
+        let defaults = UserDefaults.standard
+        let destinationKey = SidebarSettingsFileMapping.pullRequestLinkDestinationKey
+        let templateKey = SidebarSettingsFileMapping.customPullRequestLinkURLTemplateKey
+        let previousDestination = defaults.object(forKey: destinationKey)
+        let previousTemplate = defaults.object(forKey: templateKey)
+        let previousBackups = defaults.data(forKey: settingsFileBackupsDefaultsKey)
+        defer {
+            if let previousDestination {
+                defaults.set(previousDestination, forKey: destinationKey)
+            } else {
+                defaults.removeObject(forKey: destinationKey)
+            }
+
+            if let previousTemplate {
+                defaults.set(previousTemplate, forKey: templateKey)
+            } else {
+                defaults.removeObject(forKey: templateKey)
+            }
+
+            if let previousBackups {
+                defaults.set(previousBackups, forKey: settingsFileBackupsDefaultsKey)
+            } else {
+                defaults.removeObject(forKey: settingsFileBackupsDefaultsKey)
+            }
+        }
+
+        defaults.removeObject(forKey: destinationKey)
+        defaults.removeObject(forKey: templateKey)
+        defaults.removeObject(forKey: settingsFileBackupsDefaultsKey)
+
+        let directoryURL = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directoryURL) }
+
+        let settingsFileURL = directoryURL.appendingPathComponent("cmux.json", isDirectory: false)
+        try writeSettingsFile(
+            """
+            {
+              "sidebar": {
+                "pullRequestLinkDestination": "custom",
+                "customPullRequestLinkURLTemplate": "https://review.example.com/{owner}/{repo}/{number}"
+              }
+            }
+            """,
+            to: settingsFileURL
+        )
+
+        _ = KeyboardShortcutSettingsFileStore(
+            primaryPath: settingsFileURL.path,
+            fallbackPath: nil,
+            startWatching: false
+        )
+
+        let configuration = PullRequestLinkSettingsStore(defaults: defaults).currentConfiguration
+        XCTAssertEqual(configuration.destination, .custom)
+        XCTAssertEqual(
+            configuration.resolvedURL(for: URL(string: "https://github.com/manaflow-ai/cmux/pull/9641")!)
+                .absoluteString,
+            "https://review.example.com/manaflow-ai/cmux/9641"
+        )
+    }
+
+    func testSettingsFileStoreRejectsInvalidSidebarPullRequestLinkDestination() throws {
+        let defaults = UserDefaults.standard
+        let destinationKey = SidebarSettingsFileMapping.pullRequestLinkDestinationKey
+        let previousDestination = defaults.object(forKey: destinationKey)
+        let previousBackups = defaults.data(forKey: settingsFileBackupsDefaultsKey)
+        defer {
+            if let previousDestination {
+                defaults.set(previousDestination, forKey: destinationKey)
+            } else {
+                defaults.removeObject(forKey: destinationKey)
+            }
+
+            if let previousBackups {
+                defaults.set(previousBackups, forKey: settingsFileBackupsDefaultsKey)
+            } else {
+                defaults.removeObject(forKey: settingsFileBackupsDefaultsKey)
+            }
+        }
+
+        defaults.removeObject(forKey: destinationKey)
+        defaults.removeObject(forKey: settingsFileBackupsDefaultsKey)
+
+        let directoryURL = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directoryURL) }
+
+        let settingsFileURL = directoryURL.appendingPathComponent("cmux.json", isDirectory: false)
+        try writeSettingsFile(
+            """
+            {
+              "sidebar": {
+                "pullRequestLinkDestination": "gitlab"
+              }
+            }
+            """,
+            to: settingsFileURL
+        )
+
+        _ = KeyboardShortcutSettingsFileStore(
+            primaryPath: settingsFileURL.path,
+            fallbackPath: nil,
+            startWatching: false
+        )
+
+        XCTAssertNil(defaults.object(forKey: destinationKey))
+        XCTAssertEqual(PullRequestLinkSettingsStore(defaults: defaults).currentConfiguration.destination, .github)
+    }
+
     func testSettingsFileStoreParsesWorkspaceTodoControlsBetaSetting() throws {
         let defaults = UserDefaults.standard
         let managedKey = SettingCatalog().betaFeatures.workspaceTodoControls.userDefaultsKey

--- a/skills/cmux-settings/references/all-keys.md
+++ b/skills/cmux-settings/references/all-keys.md
@@ -68,7 +68,7 @@ Sidebar content and metadata visibility from Settings > Sidebar.
 | `sidebar.makePullRequestsClickable` | boolean | `true` | Allow sidebar pull request metadata to open links when clicked. |
 | `sidebar.openPullRequestLinksInCmuxBrowser` | boolean | `true` | Open sidebar pull request links in the embedded cmux browser. |
 | `sidebar.pullRequestLinkDestination` | `"github"` or `"graphite"` or `"custom"` | `"github"` | Where sidebar pull request links go. github keeps the pull request's own URL, graphite opens it in Graphite's review UI, and custom renders customPullRequestLinkURLTemplate. |
-| `sidebar.customPullRequestLinkURLTemplate` | string | `""` | Pull request URL used when pullRequestLinkDestination is custom. Include {owner}, {repo}, and {number}; {number} is required. Leave empty to open the pull request's own page. |
+| `sidebar.customPullRequestLinkURLTemplate` | string | `""` | Pull request URL used when pullRequestLinkDestination is custom. Include {owner}, {repo}, and {number}; {number} is required. An empty or invalid template falls back to the pull request's own page. |
 | `sidebar.openPortLinksInCmuxBrowser` | boolean | `true` | Open sidebar port links in the embedded cmux browser. |
 | `sidebar.showSSH` | boolean | `true` | Show SSH connection details. |
 | `sidebar.showPorts` | boolean | `true` | Show listening ports. |

--- a/skills/cmux-settings/references/all-keys.md
+++ b/skills/cmux-settings/references/all-keys.md
@@ -67,6 +67,8 @@ Sidebar content and metadata visibility from Settings > Sidebar.
 | `sidebar.showPullRequests` | boolean | `true` | Show pull request metadata in the sidebar. |
 | `sidebar.makePullRequestsClickable` | boolean | `true` | Allow sidebar pull request metadata to open links when clicked. |
 | `sidebar.openPullRequestLinksInCmuxBrowser` | boolean | `true` | Open sidebar pull request links in the embedded cmux browser. |
+| `sidebar.pullRequestLinkDestination` | `"github"` or `"graphite"` or `"custom"` | `"github"` | Where sidebar pull request links go. github keeps the pull request's own URL, graphite opens it in Graphite's review UI, and custom renders customPullRequestLinkURLTemplate. |
+| `sidebar.customPullRequestLinkURLTemplate` | string | `""` | Pull request URL used when pullRequestLinkDestination is custom. Include {owner}, {repo}, and {number}; {number} is required. Leave empty to open the pull request's own page. |
 | `sidebar.openPortLinksInCmuxBrowser` | boolean | `true` | Open sidebar port links in the embedded cmux browser. |
 | `sidebar.showSSH` | boolean | `true` | Show SSH connection details. |
 | `sidebar.showPorts` | boolean | `true` | Show listening ports. |

--- a/web/data/cmux.schema.json
+++ b/web/data/cmux.schema.json
@@ -1073,12 +1073,14 @@
           "type": "string",
           "enum": ["github", "graphite", "custom"],
           "default": "github",
-          "description": "Where sidebar pull request links go. github keeps the pull request's own URL, graphite opens it in Graphite's review UI, and custom renders customPullRequestLinkURLTemplate."
+          "description": "Where sidebar pull request links go. github keeps the pull request's own URL, graphite opens it in Graphite's review UI, and custom renders customPullRequestLinkURLTemplate.",
+          "descriptionKey": "schemaDescriptions.sidebar.pullRequestLinkDestination"
         },
         "customPullRequestLinkURLTemplate": {
           "type": "string",
           "default": "",
-          "description": "Pull request URL used when pullRequestLinkDestination is custom. Include {owner}, {repo}, and {number}; {number} is required. Leave empty to open the pull request's own page."
+          "description": "Pull request URL used when pullRequestLinkDestination is custom. Include {owner}, {repo}, and {number}; {number} is required. An empty or invalid template falls back to the pull request's own page.",
+          "descriptionKey": "schemaDescriptions.sidebar.customPullRequestLinkURLTemplate"
         },
         "openPortLinksInCmuxBrowser": {
           "type": "boolean",

--- a/web/data/cmux.schema.json
+++ b/web/data/cmux.schema.json
@@ -1069,6 +1069,17 @@
           "default": true,
           "description": "Open sidebar pull request links in the embedded cmux browser."
         },
+        "pullRequestLinkDestination": {
+          "type": "string",
+          "enum": ["github", "graphite", "custom"],
+          "default": "github",
+          "description": "Where sidebar pull request links go. github keeps the pull request's own URL, graphite opens it in Graphite's review UI, and custom renders customPullRequestLinkURLTemplate."
+        },
+        "customPullRequestLinkURLTemplate": {
+          "type": "string",
+          "default": "",
+          "description": "Pull request URL used when pullRequestLinkDestination is custom. Include {owner}, {repo}, and {number}; {number} is required. Leave empty to open the pull request's own page."
+        },
         "openPortLinksInCmuxBrowser": {
           "type": "boolean",
           "default": true,

--- a/web/messages/ar.json
+++ b/web/messages/ar.json
@@ -984,6 +984,8 @@
           "maxWidth": "Default maximum reading column width, in CSS pixels, for newly opened markdown viewers."
         },
         "sidebar": {
+          "pullRequestLinkDestination": "إلى أين تؤدي روابط طلبات السحب في الشريط الجانبي. تُبقي github على عنوان URL الخاص بطلب السحب، ويفتحه graphite في واجهة المراجعة في Graphite، ويستخدم custom القيمة customPullRequestLinkURLTemplate.",
+          "customPullRequestLinkURLTemplate": "عنوان URL لطلب السحب المستخدم عندما تكون قيمة pullRequestLinkDestination هي custom. أدرج {owner} و{repo} و{number}؛ الرمز {number} مطلوب. إذا كان القالب فارغًا أو غير صالح، يُفتح طلب السحب في صفحته الأصلية.",
           "notificationMessageLineLimit": "الحد الأقصى لعدد الأسطر المعروضة لأحدث إشعار أسفل عنوان كل مساحة عمل.",
           "rightMaxWidth": "أقصى عرض بالنقاط للشريط الجانبي الأيمن. عند تركه فارغًا، يُطبّق الحد الديناميكي المضمن."
         },

--- a/web/messages/bs.json
+++ b/web/messages/bs.json
@@ -984,6 +984,8 @@
           "maxWidth": "Default maximum reading column width, in CSS pixels, for newly opened markdown viewers."
         },
         "sidebar": {
+          "pullRequestLinkDestination": "Gdje vode linkovi pull requestova u bočnoj traci. github zadržava vlastiti URL pull requesta, graphite ga otvara u Graphite sučelju za pregled, a custom primjenjuje customPullRequestLinkURLTemplate.",
+          "customPullRequestLinkURLTemplate": "URL pull requesta koji se koristi kada je pullRequestLinkDestination custom. Koristite {owner}, {repo} i {number}; {number} je obavezan. Prazan ili nevažeći šablon vraća na vlastitu stranicu pull requesta.",
           "notificationMessageLineLimit": "Maksimalan broj redova prikazanih za najnoviju obavijest ispod naslova svakog radnog prostora.",
           "rightMaxWidth": "Maksimalna širina desne bočne trake u tačkama. Ako se izostavi, primjenjuje se ugrađeno dinamičko ograničenje."
         },

--- a/web/messages/da.json
+++ b/web/messages/da.json
@@ -984,6 +984,8 @@
           "maxWidth": "Default maximum reading column width, in CSS pixels, for newly opened markdown viewers."
         },
         "sidebar": {
+          "pullRequestLinkDestination": "Hvor pull request-links i sidebjælken fører til. github beholder pull requestens egen URL, graphite åbner den i Graphites review-grænseflade, og custom bruger customPullRequestLinkURLTemplate.",
+          "customPullRequestLinkURLTemplate": "Pull request-URL, der bruges, når pullRequestLinkDestination er custom. Brug {owner}, {repo} og {number}; {number} er påkrævet. En tom eller ugyldig skabelon falder tilbage til pull requestens egen side.",
           "notificationMessageLineLimit": "Det maksimale antal linjer, der vises for den seneste notifikation under hver arbejdsområdetitel.",
           "rightMaxWidth": "Maksimal bredde i punkter for højre sidepanel. Hvis den udelades, bruges den indbyggede dynamiske grænse."
         },

--- a/web/messages/de.json
+++ b/web/messages/de.json
@@ -984,6 +984,8 @@
           "maxWidth": "Default maximum reading column width, in CSS pixels, for newly opened markdown viewers."
         },
         "sidebar": {
+          "pullRequestLinkDestination": "Wohin Pull-Request-Links in der Seitenleiste führen. github behält die eigene URL des Pull Requests, graphite öffnet ihn in der Review-Oberfläche von Graphite, und custom verwendet customPullRequestLinkURLTemplate.",
+          "customPullRequestLinkURLTemplate": "Pull-Request-URL, die verwendet wird, wenn pullRequestLinkDestination custom ist. Verwenden Sie {owner}, {repo} und {number}; {number} ist erforderlich. Bei einer leeren oder ungültigen Vorlage wird die eigene Seite des Pull Requests geöffnet.",
           "notificationMessageLineLimit": "Maximale Anzahl der Zeilen, die für die neueste Benachrichtigung unter jedem Workspace-Titel angezeigt werden.",
           "rightMaxWidth": "Maximale Breite der rechten Seitenleiste in Punkten. Wenn weggelassen, gilt die integrierte dynamische Obergrenze."
         },

--- a/web/messages/en.json
+++ b/web/messages/en.json
@@ -1876,6 +1876,8 @@
           "wordWrap": "Wrap long lines at the editor's right edge instead of scrolling horizontally."
         },
         "sidebar": {
+          "pullRequestLinkDestination": "Where sidebar pull request links go. github keeps the pull request's own URL, graphite opens it in Graphite's review UI, and custom renders customPullRequestLinkURLTemplate.",
+          "customPullRequestLinkURLTemplate": "Pull request URL used when pullRequestLinkDestination is custom. Include {owner}, {repo}, and {number}; {number} is required. An empty or invalid template falls back to the pull request's own page.",
           "notificationMessageLineLimit": "Maximum lines shown for the latest notification below each workspace title.",
           "rightMaxWidth": "Maximum width in points for the right sidebar. When omitted, the built-in dynamic cap applies."
         },

--- a/web/messages/es.json
+++ b/web/messages/es.json
@@ -984,6 +984,8 @@
           "maxWidth": "Default maximum reading column width, in CSS pixels, for newly opened markdown viewers."
         },
         "sidebar": {
+          "pullRequestLinkDestination": "Adónde llevan los enlaces de pull request de la barra lateral. github conserva la URL propia del pull request, graphite lo abre en la interfaz de revisión de Graphite y custom aplica customPullRequestLinkURLTemplate.",
+          "customPullRequestLinkURLTemplate": "URL de pull request que se usa cuando pullRequestLinkDestination es custom. Incluye {owner}, {repo} y {number}; {number} es obligatorio. Si la plantilla está vacía o no es válida, se abre la página propia del pull request.",
           "notificationMessageLineLimit": "Número máximo de líneas que se muestran para la notificación más reciente debajo del título de cada espacio de trabajo.",
           "rightMaxWidth": "Ancho máximo en puntos para la barra lateral derecha. Si se omite, se aplica el límite dinámico integrado."
         },

--- a/web/messages/fr.json
+++ b/web/messages/fr.json
@@ -984,6 +984,8 @@
           "maxWidth": "Default maximum reading column width, in CSS pixels, for newly opened markdown viewers."
         },
         "sidebar": {
+          "pullRequestLinkDestination": "Destination des liens de pull request de la barre latérale. github conserve l'URL propre à la pull request, graphite l'ouvre dans l'interface de revue de Graphite et custom utilise customPullRequestLinkURLTemplate.",
+          "customPullRequestLinkURLTemplate": "URL de pull request utilisée lorsque pullRequestLinkDestination vaut custom. Incluez {owner}, {repo} et {number} ; {number} est obligatoire. Si le modèle est vide ou invalide, la page propre à la pull request est ouverte.",
           "notificationMessageLineLimit": "Nombre maximal de lignes affichées pour la notification la plus récente sous le titre de chaque espace de travail.",
           "rightMaxWidth": "Largeur maximale en points de la barre latérale droite. Si elle est omise, la limite dynamique intégrée s’applique."
         },

--- a/web/messages/it.json
+++ b/web/messages/it.json
@@ -984,6 +984,8 @@
           "maxWidth": "Default maximum reading column width, in CSS pixels, for newly opened markdown viewers."
         },
         "sidebar": {
+          "pullRequestLinkDestination": "Dove portano i link alle pull request nella barra laterale. github mantiene l'URL della pull request, graphite la apre nell'interfaccia di revisione di Graphite e custom usa customPullRequestLinkURLTemplate.",
+          "customPullRequestLinkURLTemplate": "URL della pull request usato quando pullRequestLinkDestination è custom. Includi {owner}, {repo} e {number}; {number} è obbligatorio. Se il modello è vuoto o non valido, viene aperta la pagina della pull request.",
           "notificationMessageLineLimit": "Numero massimo di righe mostrate per la notifica più recente sotto il titolo di ogni area di lavoro.",
           "rightMaxWidth": "Larghezza massima in punti della barra laterale destra. Se omessa, si applica il limite dinamico integrato."
         },

--- a/web/messages/ja.json
+++ b/web/messages/ja.json
@@ -1799,6 +1799,8 @@
           "wordWrap": "横スクロールする代わりに、エディタの右端で長い行を折り返します。"
         },
         "sidebar": {
+          "pullRequestLinkDestination": "サイドバーのプルリクエストリンクの遷移先です。github はプルリクエスト本来のURLを使い、graphite は Graphite のレビュー画面で開き、custom は customPullRequestLinkURLTemplate を使用します。",
+          "customPullRequestLinkURLTemplate": "pullRequestLinkDestination が custom のときに使うプルリクエストURLです。{owner}、{repo}、{number} を指定でき、{number} は必須です。空欄または無効なテンプレートの場合はプルリクエスト本来のページに戻ります。",
           "notificationMessageLineLimit": "各ワークスペースタイトルの下に表示する最新通知の最大行数です。",
           "rightMaxWidth": "右サイドバーの最大幅（ポイント）。省略すると、組み込みの動的上限が適用されます。"
         },

--- a/web/messages/km.json
+++ b/web/messages/km.json
@@ -984,6 +984,8 @@
           "maxWidth": "Default maximum reading column width, in CSS pixels, for newly opened markdown viewers."
         },
         "sidebar": {
+          "pullRequestLinkDestination": "ទីតាំងដែលតំណសំណើទាញនៅរបារចំហៀងនាំទៅ។ github រក្សា URL ដើមរបស់សំណើទាញ, graphite បើកវានៅក្នុងផ្ទាំងត្រួតពិនិត្យរបស់ Graphite, ហើយ custom ប្រើ customPullRequestLinkURLTemplate។",
+          "customPullRequestLinkURLTemplate": "URL សំណើទាញដែលប្រើនៅពេល pullRequestLinkDestination ជា custom។ ដាក់ {owner}, {repo} និង {number}; {number} ត្រូវបានទាមទារ។ ទម្រង់ទំនេរ ឬមិនត្រឹមត្រូវ នឹងត្រឡប់ទៅទំព័រដើមរបស់សំណើទាញ។",
           "notificationMessageLineLimit": "ចំនួនបន្ទាត់អតិបរមាដែលបង្ហាញសម្រាប់ការជូនដំណឹងចុងក្រោយនៅខាងក្រោមចំណងជើងកន្លែងធ្វើការនីមួយៗ។",
           "rightMaxWidth": "ទទឹងអតិបរមាជាពិន្ទុសម្រាប់របារចំហៀងខាងស្តាំ។ បើមិនបញ្ជាក់ នឹងប្រើដែនកំណត់ថាមវន្តដែលមានស្រាប់។"
         },

--- a/web/messages/ko.json
+++ b/web/messages/ko.json
@@ -984,6 +984,8 @@
           "maxWidth": "Default maximum reading column width, in CSS pixels, for newly opened markdown viewers."
         },
         "sidebar": {
+          "pullRequestLinkDestination": "사이드바 풀 리퀘스트 링크가 열리는 위치입니다. github는 풀 리퀘스트 자체 URL을 유지하고, graphite는 Graphite 리뷰 화면에서 열며, custom은 customPullRequestLinkURLTemplate을 사용합니다.",
+          "customPullRequestLinkURLTemplate": "pullRequestLinkDestination이 custom일 때 사용하는 풀 리퀘스트 URL입니다. {owner}, {repo}, {number}를 사용할 수 있으며 {number}는 필수입니다. 템플릿이 비어 있거나 유효하지 않으면 풀 리퀘스트 자체 페이지로 돌아갑니다.",
           "notificationMessageLineLimit": "각 작업 공간 제목 아래에 표시되는 최신 알림의 최대 줄 수입니다.",
           "rightMaxWidth": "오른쪽 사이드바의 최대 너비(포인트). 생략하면 내장 동적 상한이 적용됩니다."
         },

--- a/web/messages/no.json
+++ b/web/messages/no.json
@@ -984,6 +984,8 @@
           "maxWidth": "Default maximum reading column width, in CSS pixels, for newly opened markdown viewers."
         },
         "sidebar": {
+          "pullRequestLinkDestination": "Hvor pull request-lenker i sidepanelet fører. github beholder pull requestens egen URL, graphite åpner den i Graphites gjennomgangsgrensesnitt, og custom bruker customPullRequestLinkURLTemplate.",
+          "customPullRequestLinkURLTemplate": "Pull request-URL som brukes når pullRequestLinkDestination er custom. Bruk {owner}, {repo} og {number}; {number} er påkrevd. En tom eller ugyldig mal faller tilbake til pull requestens egen side.",
           "notificationMessageLineLimit": "Maksimalt antall linjer som vises for det nyeste varselet under tittelen til hvert arbeidsområde.",
           "rightMaxWidth": "Maksimal bredde i punkter for høyre sidepanel. Hvis den utelates, brukes den innebygde dynamiske grensen."
         },

--- a/web/messages/pl.json
+++ b/web/messages/pl.json
@@ -985,6 +985,8 @@
           "maxWidth": "Default maximum reading column width, in CSS pixels, for newly opened markdown viewers."
         },
         "sidebar": {
+          "pullRequestLinkDestination": "Gdzie prowadzą linki do pull requestów na pasku bocznym. github zachowuje własny adres URL pull requesta, graphite otwiera go w interfejsie przeglądu Graphite, a custom stosuje customPullRequestLinkURLTemplate.",
+          "customPullRequestLinkURLTemplate": "Adres URL pull requesta używany, gdy pullRequestLinkDestination ma wartość custom. Użyj {owner}, {repo} i {number}; {number} jest wymagany. Pusty lub nieprawidłowy szablon powoduje powrót do własnej strony pull requesta.",
           "notificationMessageLineLimit": "Maksymalna liczba wierszy wyświetlanych dla najnowszego powiadomienia pod tytułem każdego obszaru roboczego.",
           "rightMaxWidth": "Maksymalna szerokość prawego paska bocznego w punktach. Jeśli pominięta, obowiązuje wbudowany limit dynamiczny."
         },

--- a/web/messages/pt-BR.json
+++ b/web/messages/pt-BR.json
@@ -984,6 +984,8 @@
           "maxWidth": "Default maximum reading column width, in CSS pixels, for newly opened markdown viewers."
         },
         "sidebar": {
+          "pullRequestLinkDestination": "Para onde os links de pull request da barra lateral levam. github mantém a URL do próprio pull request, graphite o abre na interface de revisão do Graphite e custom usa customPullRequestLinkURLTemplate.",
+          "customPullRequestLinkURLTemplate": "URL de pull request usada quando pullRequestLinkDestination é custom. Inclua {owner}, {repo} e {number}; {number} é obrigatório. Um modelo vazio ou inválido volta para a página do próprio pull request.",
           "notificationMessageLineLimit": "Número máximo de linhas exibidas para a notificação mais recente abaixo do título de cada espaço de trabalho.",
           "rightMaxWidth": "Largura máxima em pontos para a barra lateral direita. Quando omitida, o limite dinâmico integrado se aplica."
         },

--- a/web/messages/ru.json
+++ b/web/messages/ru.json
@@ -984,6 +984,8 @@
           "maxWidth": "Default maximum reading column width, in CSS pixels, for newly opened markdown viewers."
         },
         "sidebar": {
+          "pullRequestLinkDestination": "Куда ведут ссылки на пул-реквесты в боковой панели. github сохраняет собственный URL пул-реквеста, graphite открывает его в интерфейсе ревью Graphite, а custom использует customPullRequestLinkURLTemplate.",
+          "customPullRequestLinkURLTemplate": "URL пул-реквеста, используемый, когда pullRequestLinkDestination равен custom. Укажите {owner}, {repo} и {number}; {number} обязателен. Пустой или недопустимый шаблон возвращает к собственной странице пул-реквеста.",
           "notificationMessageLineLimit": "Максимальное количество строк последнего уведомления, отображаемых под заголовком каждого рабочего пространства.",
           "rightMaxWidth": "Максимальная ширина правой боковой панели в пунктах. Если не указано, применяется встроенное динамическое ограничение."
         },

--- a/web/messages/th.json
+++ b/web/messages/th.json
@@ -985,6 +985,8 @@
           "maxWidth": "Default maximum reading column width, in CSS pixels, for newly opened markdown viewers."
         },
         "sidebar": {
+          "pullRequestLinkDestination": "ปลายทางของลิงก์ pull request ในแถบด้านข้าง github จะใช้ URL ของ pull request เอง graphite จะเปิดในหน้าตรวจทานของ Graphite และ custom จะใช้ customPullRequestLinkURLTemplate",
+          "customPullRequestLinkURLTemplate": "URL ของ pull request ที่ใช้เมื่อ pullRequestLinkDestination เป็น custom ใส่ {owner} {repo} และ {number} โดย {number} จำเป็นต้องมี หากเทมเพลตว่างหรือไม่ถูกต้อง จะย้อนกลับไปใช้หน้าของ pull request เอง",
           "notificationMessageLineLimit": "จำนวนบรรทัดสูงสุดที่แสดงสำหรับการแจ้งเตือนล่าสุดใต้ชื่อของแต่ละพื้นที่ทำงาน",
           "rightMaxWidth": "ความกว้างสูงสุดเป็นพอยต์สำหรับแถบด้านขวา หากเว้นไว้ จะใช้ขีดจำกัดแบบไดนามิกในตัว"
         },

--- a/web/messages/tr.json
+++ b/web/messages/tr.json
@@ -984,6 +984,8 @@
           "maxWidth": "Default maximum reading column width, in CSS pixels, for newly opened markdown viewers."
         },
         "sidebar": {
+          "pullRequestLinkDestination": "Kenar çubuğundaki pull request bağlantılarının nereye gideceği. github pull request'in kendi URL'sini korur, graphite onu Graphite'in inceleme arayüzünde açar ve custom, customPullRequestLinkURLTemplate değerini kullanır.",
+          "customPullRequestLinkURLTemplate": "pullRequestLinkDestination değeri custom olduğunda kullanılan pull request URL'si. {owner}, {repo} ve {number} kullanın; {number} zorunludur. Boş veya geçersiz şablon, pull request'in kendi sayfasına geri döner.",
           "notificationMessageLineLimit": "Her çalışma alanı başlığının altında en son bildirim için gösterilen en fazla satır sayısı.",
           "rightMaxWidth": "Sağ kenar çubuğu için puan cinsinden en fazla genişlik. Atlanırsa yerleşik dinamik sınır uygulanır."
         },

--- a/web/messages/uk.json
+++ b/web/messages/uk.json
@@ -984,6 +984,8 @@
           "maxWidth": "Default maximum reading column width, in CSS pixels, for newly opened markdown viewers."
         },
         "sidebar": {
+          "pullRequestLinkDestination": "Куди ведуть посилання на пул-реквести на боковій панелі. github зберігає власну URL-адресу пул-реквесту, graphite відкриває його в інтерфейсі рецензування Graphite, а custom застосовує customPullRequestLinkURLTemplate.",
+          "customPullRequestLinkURLTemplate": "URL-адреса пул-реквесту, яка використовується, коли pullRequestLinkDestination має значення custom. Вкажіть {owner}, {repo} і {number}; {number} обов'язковий. Порожній або некоректний шаблон повертає до власної сторінки пул-реквесту.",
           "notificationMessageLineLimit": "Максимальна кількість рядків останнього сповіщення, що відображаються під заголовком кожного робочого простору.",
           "rightMaxWidth": "Максимальна ширина правої бічної панелі в пунктах. Якщо пропущено, застосовується вбудоване динамічне обмеження."
         },

--- a/web/messages/zh-CN.json
+++ b/web/messages/zh-CN.json
@@ -984,6 +984,8 @@
           "maxWidth": "Default maximum reading column width, in CSS pixels, for newly opened markdown viewers."
         },
         "sidebar": {
+          "pullRequestLinkDestination": "侧边栏拉取请求链接的跳转位置。github 使用拉取请求自身的 URL，graphite 在 Graphite 的审查界面中打开，custom 则渲染 customPullRequestLinkURLTemplate。",
+          "customPullRequestLinkURLTemplate": "当 pullRequestLinkDestination 为 custom 时使用的拉取请求 URL。可包含 {owner}、{repo} 和 {number}，其中 {number} 为必填。模板为空或无效时，将回退到拉取请求自身的页面。",
           "notificationMessageLineLimit": "每个工作区标题下方显示的最新通知的最大行数。",
           "rightMaxWidth": "右侧边栏的最大宽度（点）。省略时使用内置动态上限。"
         },

--- a/web/messages/zh-TW.json
+++ b/web/messages/zh-TW.json
@@ -984,6 +984,8 @@
           "maxWidth": "Default maximum reading column width, in CSS pixels, for newly opened markdown viewers."
         },
         "sidebar": {
+          "pullRequestLinkDestination": "側邊欄拉取請求連結的前往位置。github 使用拉取請求本身的 URL，graphite 會在 Graphite 的審查介面開啟，custom 則會套用 customPullRequestLinkURLTemplate。",
+          "customPullRequestLinkURLTemplate": "當 pullRequestLinkDestination 為 custom 時使用的拉取請求 URL。可包含 {owner}、{repo} 與 {number}，其中 {number} 為必填。範本為空或無效時，會回復為拉取請求本身的頁面。",
           "notificationMessageLineLimit": "每個工作區標題下方顯示的最新通知最大行數。",
           "rightMaxWidth": "右側邊欄的最大寬度（點）。省略時使用內建動態上限。"
         },


### PR DESCRIPTION
## Problem

Sidebar PR links always go to the pull request's own GitHub page. Teams that review on Graphite (or any other review host) have to re-navigate on every click.

## What this adds

Two settings under `sidebar.*`, following the existing `browser.defaultSearchEngine` + `browser.customSearchEngineURLTemplate` pattern:

| Key | Type | Default |
|---|---|---|
| `sidebar.pullRequestLinkDestination` | `"github"` \| `"graphite"` \| `"custom"` | `"github"` |
| `sidebar.customPullRequestLinkURLTemplate` | string, `{owner}`/`{repo}`/`{number}` | `""` |

```json
{
  "sidebar": { "pullRequestLinkDestination": "graphite" }
}
```

Also in Settings › Sidebar as **Open PR Links At**, with the custom URL field appearing only when Custom is selected.

## Design

Sidebar state keeps storing the canonical URL the probe reported. One seam — `PullRequestLinkConfiguration.resolvedURL(for:)` — rewrites it at open time, so PR polling, deduplication, and staleness comparisons keep comparing canonical values. Per the shared-behaviour policy, every user-facing open goes through it:

- the sidebar PR row click (`onOpenPullRequest`)
- the open-all-pull-requests command
- the extension sidebar browser seed

Links are deliberately left **untouched** when the destination is `github`, when the URL isn't a recognizable `/{owner}/{repo}/pull/{number}` URL, or when the template can't render an `http(s)` URL — a malformed template can never swallow a click. Parsing is host-agnostic, so enterprise hosts can retarget via a custom template even though Graphite can't serve them.

The conditional custom-URL row follows the same convention as `browser.customSearchEngineURLTemplate`: no curated search entry of its own, its terms folded into the always-visible parent, and it's kept out of `rowConfigPaths` so it isn't a dead search hit when hidden.

## Tests

- 10 new cases in `PullRequestLinkConfigurationTests`: graphite/custom rendering, empty and `{number}`-less templates, non-http schemes, enterprise hosts, idempotence on an already-Graphite URL, and trailing-segment PR URLs.
- 2 new cases in `SidebarAppKitRowCellTests` covering the settings projection that feeds both sidebar row implementations.

`CmuxSettings` and `CmuxSettingsUI` package suites are green (153 tests, including the settings-row anchor contract). `cmuxTests/SidebarAppKitRowCellTests` passes apart from `shortcutHintPillUsesExplicitOpacityAnimationInsideDisabledTransaction`, which fails identically on a clean tree at the same commit on this machine — pre-existing and unrelated (CoreAnimation `animationKeys()` on the shortcut-hint pill).

## Docs

`web/data/cmux.schema.json`, `skills/cmux-settings/references/all-keys.md`, and 11 new `Localizable.xcstrings` entries (en + ja). The configuration docs page renders from the schema, so it picks the keys up automatically.

## Verification

Dogfooded in a tagged debug build: switching to Graphite sends row clicks to `app.graphite.com/github/pr/<owner>/<repo>/<number>`; Custom with an empty template falls back to the PR's own page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/9651"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788536846&installation_model_id=21920&pr_number=9651&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F9651&signature=659a0ce00a7049f9905c544bb3dec5527c826175364280feb8d950ef5a049e7c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Let users choose where sidebar PR links open: GitHub, Graphite, or a custom URL template. All PR opens resolve at click time; settings work via `cmux.json`, and UI/docs are fully localized.

- **New Features**
  - Added `sidebar.pullRequestLinkDestination` (`"github"` | `"graphite"` | `"custom"`, default `"github"`) and `sidebar.customPullRequestLinkURLTemplate` (supports `{owner}`, `{repo}`, `{number}`; empty = no rewrite).
  - Settings UI adds “Open PR Links At” with a conditional Custom URL field.
  - Central resolver `PullRequestLinkConfiguration.resolvedURL(for:)` is used by row clicks, open-all-PRs, and the extension sidebar browser seed.
  - Safe defaults: no rewrite for GitHub destination, non-PR URLs, PR URLs with extra segments/fragments, or templates that don’t render an http(s) URL; host-agnostic parsing enables enterprise retargeting via Custom.

- **Bug Fixes**
  - `cmux.json` now correctly parses and validates `sidebar.pullRequestLinkDestination` and `sidebar.customPullRequestLinkURLTemplate`; invalid values are rejected with `logInvalid` instead of being dropped.
  - Added a curated Settings entry and anchor so search can navigate to the new row.
  - Completed localization and schema `descriptionKey` coverage for both settings across all supported locales.
  - Require a host when parsing PR URLs to avoid rewriting malformed values (e.g., `https:///owner/repo/pull/1`), keeping such links unchanged.

<sup>Written for commit 8a4526908444e27df5921c372855075b176c5f5b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/9651?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added sidebar options to open pull request links through GitHub, Graphite, or a custom URL template.
  * Custom templates support `{owner}`, `{repo}`, and `{number}` placeholders.
  * Added localized labels, search support, and configuration-file support for these settings.

* **Bug Fixes**
  * Pull request links now consistently use the selected destination across supported opening methods.
  * Invalid or empty custom templates safely fall back to the pull request’s original URL.
  * Settings remain synchronized across sidebar and workspace views.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->