### PR TITLE
fix: use weak var instead of weak let for macOS 26 / Swift 6 compat

### DIFF
--- a/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/MobileMacConnectionPoolTests.swift
+++ b/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/MobileMacConnectionPoolTests.swift
@@ -2872,7 +2872,7 @@ import Testing
             runtime: runtime,
             isSignedIn: true
         )
-        weak let weakShell = shell
+        weak var weakShell = shell
         shell?.secondaryMacSubscriptions["mac-retain".pairingKey] = subscription
         shell?.startSecondaryEventConsumer(subscription, displayName: "Retain Mac")
 

--- a/Packages/macOS/CmuxCommandPalette/Tests/CmuxCommandPaletteTests/CommandPaletteInteractionMonitorTests.swift
+++ b/Packages/macOS/CmuxCommandPalette/Tests/CmuxCommandPaletteTests/CommandPaletteInteractionMonitorTests.swift
@@ -229,7 +229,7 @@ struct CommandPaletteInteractionMonitorTests {
             onDismiss: { _ in }
         )
 
-        weak let weakMonitor = monitor
+        weak var weakMonitor = monitor
         monitor = nil
 
         #expect(weakMonitor == nil)

--- a/Packages/macOS/CmuxSimulator/Tests/CmuxSimulatorTests/SimulatorWorkerClientContainmentTests.swift
+++ b/Packages/macOS/CmuxSimulator/Tests/CmuxSimulatorTests/SimulatorWorkerClientContainmentTests.swift
@@ -192,7 +192,7 @@ extension SimulatorWorkerClientTests {
             ),
             sleeper: ContinuousSimulatorWorkerSleeper()
         )
-        weak let weakClient = client
+        weak var weakClient = client
         await client?.send(.releaseInputs)
         for _ in 0..<10_000 where !FileManager.default.fileExists(atPath: marker.path) {
             await Task.yield()

--- a/cmuxTests/AppDelegateEqualizeSplitsShortcutTests.swift
+++ b/cmuxTests/AppDelegateEqualizeSplitsShortcutTests.swift
@@ -4919,7 +4919,7 @@ final class AppDelegateEqualizeSplitsShortcutTests {
             XCTFail("Expected an unvisited terminal")
             return
         }
-        weak let weakRemovablePanel = removablePanel
+        weak var weakRemovablePanel = removablePanel
         workspace.panels.removeValue(forKey: removablePanelId)
         removablePanel = nil
 


### PR DESCRIPTION
Closes #9652

## Summary

`weak let` is rejected by the Swift compiler on newer toolchains (e.g. the macOS 26 SDK): a `weak` reference can become `nil` at runtime when the referenced object is deallocated, so its storage must be mutable. The compiler error is

```
error: 'weak' must be a mutable variable, because it may change at runtime
```

CI runs on macOS 15.7.4 where these still compile, so this is latent there — it only surfaces on macOS 26, where it blocks the test-target compile (e.g. `cmuxTests/AppDelegateEqualizeSplitsShortcutTests.swift:4922` fails first and aborts the whole `cmux-unit` build).

## Changes

Replaces `weak let` with `weak var` at the four remaining sites. None of the variables are reassigned, so the change is purely a compile-time correctness fix with no behavioral difference:

| File | Variable |
|------|----------|
| `cmuxTests/AppDelegateEqualizeSplitsShortcutTests.swift` | `weakRemovablePanel` |
| `Packages/macOS/CmuxCommandPalette/Tests/.../CommandPaletteInteractionMonitorTests.swift` | `weakMonitor` |
| `Packages/macOS/CmuxSimulator/Tests/.../SimulatorWorkerClientContainmentTests.swift` | `weakClient` |
| `Packages/iOS/CmuxMobileShell/Tests/.../MobileMacConnectionPoolTests.swift` | `weakShell` |

The fifth site originally reported (`Packages/iOS/CmuxMobileSupport/Sources/.../ComposerDictationController.swift`) was already fixed on `main` (now `weak var`), so this PR covers the remainder.

## Why no regression test

Compile-time fix only. On CI's macOS 15.7.4 the code already compiles, so there is no observable runtime behavior to assert; a "test" would just duplicate a compile that already passes. Per the project's test-quality policy, no fake regression test is added.

## Test plan

- [x] `swift build --build-tests` for `CmuxCommandPalette` on macOS 26 — its test target (containing one of the `weak var` sites) compiles clean.
- [x] Mechanical correctness: every site is a direct `weak let` → `weak var`, the exact form the compiler error mandates; none of the variables are reassigned.
- [ ] CI (macOS 15.7.4) — confirms no regression; the change is a no-op there (macOS 15 still accepts `weak let`).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Corrected weak-reference test declarations across iOS and macOS test suites.
  * Improved reliability of deallocation and cleanup assertions for shells, monitors, simulator clients, and panels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->