### PR TITLE
Stop reporting recovered remote reconnects as errors

### DIFF
--- a/CLI/CMUXCLI+SSHPTYAttachBridge.swift
+++ b/CLI/CMUXCLI+SSHPTYAttachBridge.swift
@@ -35,6 +35,20 @@ extension CMUXCLI {
         return exitCode.isWrapperRetryable
     }
 
+    /// True when the persistent attach wrapper will retry this failure itself.
+    ///
+    /// The wrapper prints its own "reattaching (attempt n/limit)" notice, so
+    /// also printing `Error: ...` renders a recovered reconnect as a hard
+    /// failure in the user's terminal. Failures the wrapper will not retry
+    /// still print normally, and so does every non-attach command.
+    func attachWrapperReportsFailureItself(_ error: Error) -> Bool {
+        guard let cliError = error as? CLIError,
+              let exitCode = SSHPTYAttachExitCode(rawValue: cliError.exitCode) else {
+            return false
+        }
+        return sshPTYAttachWrapperWillRetry(exitCode)
+    }
+
     func sshPTYAttachBridgeClosedExitCode(
         receivedLiveOutput: Bool,
         readyUptime: TimeInterval

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -36367,7 +36367,9 @@ struct CMUXTermMain {
         do {
             try cli.run()
         } catch {
-            CMUXCLIOutput.writeStandardError("Error: \(error)\n")
+            if !cli.attachWrapperReportsFailureItself(error) {
+                CMUXCLIOutput.writeStandardError("Error: \(error)\n")
+            }
             let exitCode = (error as? CLIError)?.exitCode ?? 1
             exit(exitCode)
         }

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -2757,6 +2757,12 @@ final class Workspace: Identifiable, ObservableObject {
     /// since healed, so keeping it would leave a red sidebar entry as the last
     /// word on a working workspace.
     func clearResolvedRemoteDaemonSidebarArtifacts() {
+        // A ready daemon only proves the management lane recovered. When the
+        // workspace has no remote terminal session, its terminal has fallen
+        // back to a local shell while the row still reads "Connected", and
+        // retracting here would erase the only sign that anything went wrong.
+        // Keep the errors visible until a remote terminal is actually alive.
+        guard hasActiveRemoteTerminalSessions else { return }
         logEntries.removeAll { entry in
             entry.source == "remote-daemon" && entry.level == .error
         }

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -2750,6 +2750,18 @@ final class Workspace: Identifiable, ObservableObject {
         }
     }
 
+    /// Retracts daemon errors that a later ready daemon resolved.
+    ///
+    /// Call only once the daemon reports `.ready`: every daemon error recorded
+    /// before that point describes an outage the reconnect state machine has
+    /// since healed, so keeping it would leave a red sidebar entry as the last
+    /// word on a working workspace.
+    func clearResolvedRemoteDaemonSidebarArtifacts() {
+        logEntries.removeAll { entry in
+            entry.source == "remote-daemon" && entry.level == .error
+        }
+    }
+
     private func remoteNotificationCooldownKey(target: String) -> String? {
         let rawTarget = (remoteConfiguration?.destination ?? target)
             .trimmingCharacters(in: .whitespacesAndNewlines)
@@ -6955,7 +6967,15 @@ final class Workspace: Identifiable, ObservableObject {
                 // #8917: a transport bounce that re-bootstrapped successfully is
                 // not a workspace failure, so retract its sidebar error the same
                 // way the connection-state path retracts on `.connected`.
-                clearProxyOnlyRemoteDaemonSidebarArtifacts()
+                //
+                // A ready daemon has resolved every daemon error recorded before
+                // it, so retract all of them rather than only the proxy-only
+                // subset. Relay bounces publish `.error` details that already say
+                // "retrying in 2 seconds" and always schedule a reconnect; leaving
+                // those behind made a fully recovered reconnect read as a red
+                // failure in the sidebar. Errors the daemon never recovers from
+                // still persist, because this only runs on `.ready`.
+                clearResolvedRemoteDaemonSidebarArtifacts()
             }
             return
         }

--- a/cmuxTests/WorkspaceRemoteDaemonRecoveryTests.swift
+++ b/cmuxTests/WorkspaceRemoteDaemonRecoveryTests.swift
@@ -9,6 +9,9 @@ import Testing
 @testable import cmux
 #endif
 
+/// Covers which remote-daemon errors survive on a workspace's sidebar row:
+/// errors a recovered daemon resolved are retracted, errors that are still
+/// true are not.
 @MainActor
 struct WorkspaceRemoteDaemonRecoveryTests {
     /// https://github.com/manaflow-ai/cmux/issues/8917: a daemon transport

--- a/cmuxTests/WorkspaceRemoteDaemonRecoveryTests.swift
+++ b/cmuxTests/WorkspaceRemoteDaemonRecoveryTests.swift
@@ -16,22 +16,7 @@ struct WorkspaceRemoteDaemonRecoveryTests {
     /// on the workspace's sidebar row.
     @Test
     func recoveredDaemonTransportBounceClearsSidebarDaemonError() {
-        let workspace = Workspace()
-        let config = WorkspaceRemoteConfiguration(
-            destination: "dev@example.com",
-            port: 22,
-            identityFile: nil,
-            sshOptions: [],
-            localProxyPort: nil,
-            relayPort: 64_021,
-            relayID: String(repeating: "c", count: 16),
-            relayToken: String(repeating: "d", count: 64),
-            localSocketPath: "/tmp/cmux-debug-test.sock",
-            terminalStartupCommand: "ssh dev@example.com",
-            preserveAfterTerminalExit: true,
-            skipDaemonBootstrap: true
-        )
-        workspace.configureRemoteConnection(config, autoConnect: false)
+        let workspace = makeRemoteWorkspace()
 
         workspace.applyRemoteDaemonStatusUpdate(
             WorkspaceRemoteDaemonStatus(state: .ready),
@@ -120,7 +105,40 @@ struct WorkspaceRemoteDaemonRecoveryTests {
         )
     }
 
-    private func makeRemoteWorkspace() -> Workspace {
+    /// Retraction must not paper over a workspace whose remote terminal died:
+    /// the daemon can be ready while the surface has fallen back to a local
+    /// shell and the row still reads "Connected". The daemon error is then the
+    /// only visible sign that the workspace is not really remote.
+    @Test
+    func daemonReadyWithoutRemoteTerminalKeepsSidebarDaemonError() {
+        let workspace = makeRemoteWorkspace(withRemoteTerminal: false)
+
+        workspace.applyRemoteDaemonStatusUpdate(
+            WorkspaceRemoteDaemonStatus(
+                state: .error,
+                detail: "Remote SSH relay unavailable; retrying in 2 seconds"
+            ),
+            target: "dev@example.com"
+        )
+        workspace.applyRemoteDaemonStatusUpdate(
+            WorkspaceRemoteDaemonStatus(state: .ready),
+            target: "dev@example.com"
+        )
+
+        #expect(
+            workspace.hasActiveRemoteTerminalSessions == false,
+            "This case is about a workspace with no live remote terminal"
+        )
+        #expect(
+            workspace.logEntries.contains { $0.source == "remote-daemon" && $0.level == .error },
+            "A ready daemon with no remote terminal session must not clear the error"
+        )
+    }
+
+    /// Builds a remote workspace. `withRemoteTerminal` mirrors a workspace whose
+    /// surface is actually attached to the remote host; without it the workspace
+    /// models the fallback case where the terminal is no longer remote.
+    private func makeRemoteWorkspace(withRemoteTerminal: Bool = true) -> Workspace {
         let workspace = Workspace()
         let config = WorkspaceRemoteConfiguration(
             destination: "dev@example.com",
@@ -137,6 +155,9 @@ struct WorkspaceRemoteDaemonRecoveryTests {
             skipDaemonBootstrap: true
         )
         workspace.configureRemoteConnection(config, autoConnect: false)
+        if withRemoteTerminal {
+            workspace.trackRemoteTerminalSurface(UUID())
+        }
         return workspace
     }
 }

--- a/cmuxTests/WorkspaceRemoteDaemonRecoveryTests.swift
+++ b/cmuxTests/WorkspaceRemoteDaemonRecoveryTests.swift
@@ -61,4 +61,82 @@ struct WorkspaceRemoteDaemonRecoveryTests {
             "The workspace row must not keep rendering the recovered daemon error"
         )
     }
+
+    /// A reverse-relay bounce publishes a daemon error whose own detail says it
+    /// is retrying, and the reconnect state machine always schedules that retry.
+    /// Once the daemon reports ready again the workspace is healthy, so the
+    /// sidebar must not keep a red row for the outage that already healed.
+    @Test
+    func recoveredRelayBounceClearsSidebarDaemonError() {
+        let workspace = makeRemoteWorkspace()
+
+        for detail in [
+            "Remote SSH relay unavailable; retrying in 2 seconds",
+            "Remote SSH relay port unavailable; retrying in 2 seconds",
+        ] {
+            workspace.applyRemoteDaemonStatusUpdate(
+                WorkspaceRemoteDaemonStatus(state: .error, detail: detail),
+                target: "dev@example.com"
+            )
+        }
+
+        #expect(
+            workspace.logEntries.contains { $0.source == "remote-daemon" && $0.level == .error },
+            "The relay bounce should be recorded while the daemon is still down"
+        )
+
+        workspace.applyRemoteDaemonStatusUpdate(
+            WorkspaceRemoteDaemonStatus(state: .ready),
+            target: "dev@example.com"
+        )
+
+        #expect(
+            workspace.logEntries.contains { $0.source == "remote-daemon" && $0.level == .error } == false,
+            "A relay bounce the daemon recovered from must not stay a sidebar error"
+        )
+    }
+
+    /// The retraction is tied to the daemon actually recovering, so an outage
+    /// that never reaches ready keeps its sidebar error.
+    @Test
+    func daemonErrorWithoutRecoveryKeepsSidebarEntry() {
+        let workspace = makeRemoteWorkspace()
+
+        workspace.applyRemoteDaemonStatusUpdate(
+            WorkspaceRemoteDaemonStatus(
+                state: .error,
+                detail: "Remote SSH relay unavailable; retrying in 2 seconds"
+            ),
+            target: "dev@example.com"
+        )
+        workspace.applyRemoteDaemonStatusUpdate(
+            WorkspaceRemoteDaemonStatus(state: .bootstrapping, detail: "Reconnecting"),
+            target: "dev@example.com"
+        )
+
+        #expect(
+            workspace.logEntries.contains { $0.source == "remote-daemon" && $0.level == .error },
+            "An unrecovered daemon outage must keep reporting itself"
+        )
+    }
+
+    private func makeRemoteWorkspace() -> Workspace {
+        let workspace = Workspace()
+        let config = WorkspaceRemoteConfiguration(
+            destination: "dev@example.com",
+            port: 22,
+            identityFile: nil,
+            sshOptions: [],
+            localProxyPort: nil,
+            relayPort: 64_021,
+            relayID: String(repeating: "c", count: 16),
+            relayToken: String(repeating: "d", count: 64),
+            localSocketPath: "/tmp/cmux-debug-test.sock",
+            terminalStartupCommand: "ssh dev@example.com",
+            preserveAfterTerminalExit: true,
+            skipDaemonBootstrap: true
+        )
+        workspace.configureRemoteConnection(config, autoConnect: false)
+        return workspace
+    }
 }


### PR DESCRIPTION
## Summary
Restarting cmux while a remote workspace is attached reported two failures for an outage that had already healed.

- **Terminal:** `cmux ssh-pty-attach` exits with a *retryable* status when its bridge closes, and the CLI's top-level handler printed `Error: ssh-pty-attach: bridge closed before remote PTY exit could be confirmed: remote daemon is not ready` even though the persistent attach wrapper immediately retried and printed its own yellow "reattaching (attempt n/∞)" notice. The CLI now leaves reporting to the wrapper whenever the wrapper will retry the failure itself. Failures the wrapper will not retry, and every non-attach command, still print normally.
- **Sidebar:** relay bounces publish daemon `.error` with details like `Remote SSH relay unavailable; retrying in 2 seconds` and always schedule a reconnect, but retraction-on-recovery only matched the "proxy-only" substrings, so those entries stayed red forever on a workspace that was `Connected` and working. Retraction now covers every daemon error once the daemon reports `.ready` — a ready daemon has by definition resolved the errors recorded before it. Outages the daemon never recovers from still persist, because retraction only runs on `.ready`.

## Testing
- `cmuxTests/WorkspaceRemoteDaemonRecoveryTests.swift`: a recovered relay bounce retracts its sidebar error (fails before this change); an outage that never reaches `.ready` keeps its entry. The pre-existing #8917 proxy-bounce test still passes.
- Live A/B on a real host (`cmux-mac-mini`), identical protocol on both builds — one fresh remote session, one app restart, no other cmux instance running:
  - **Before (build without this change):** sidebar keeps `[remote-daemon] [error] Remote daemon error (cmux-mac-mini): Remote SSH relay unavailable; retrying in 2 seconds`.
  - **After (this branch):** `No log entries`, daemon `ready`, workspace `connected`.
  - The duplicate red `Error:` line no longer appears in the terminal on a bridge close the wrapper retries.

## Known gap (pre-existing, not from this change)
Reattaching a remote PTY after an app restart is itself unreliable, and reproduces on a build **without** this change: the control build ended the restored session with `^D`, and the fixed build reported `ssh-pty-attach: remote PTY attach failed`. That is a separate defect in the reattach path; this PR only stops a *recovered* reconnect from being reported as a failure. Filed separately.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/9664"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788552497&installation_model_id=21920&pr_number=9664&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F9664&signature=e5ed6d0532c449eae5c621721dd0d004a914c80256f9db962cfefeeea1e5148f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops showing errors for remote reconnects that recover on their own. The CLI suppresses duplicate errors for retryable `ssh-pty-attach` disconnects, and the sidebar clears resolved daemon errors once the daemon is ready and a remote terminal is active.

- **Bug Fixes**
  - CLI: Skip the top-level error line when the attach wrapper will retry; other failures still print.
  - Sidebar: On `.ready` with an active remote terminal, retract all prior `remote-daemon` errors (including relay bounces); outages that never reach ready or lack a remote terminal keep their entries.

<sup>Written for commit d3ebc23775f1777eded6216308e9354ef9642c01. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/9664?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented duplicate error messages when SSH PTY attachment failures have already been reported.
  - Improved remote daemon recovery handling by removing resolved error indicators once the daemon is ready and active remote sessions are restored.
  - Preserved error reporting for unresolved connection, startup, and non-retryable failures.
  - Added recovery validation to ensure relay errors appear during outages, remain visible when recovery is incomplete, and clear after successful recovery.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->