### PR TITLE
iOS: unbreak MobileInjectedAttachStartupTests so the xctestplan compiles

### DIFF
--- a/Packages/iOS/CmuxMobileShellUI/Tests/CmuxMobileShellUITests/MobileInjectedAttachStartupTests.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Tests/CmuxMobileShellUITests/MobileInjectedAttachStartupTests.swift
@@ -48,6 +48,21 @@ struct MobileInjectedAttachStartupTests {
 
     @Test
     @MainActor
+    func awaitingUserApprovalConsumesStartupWithoutFallback() throws {
+        let coordinator = MobileStartupConnectionCoordinator()
+        let attempt = try #require(coordinator.claimInjectedAttach())
+
+        let shouldFallBack = coordinator.finishInjectedAttach(attempt, outcome: .awaitingUserApproval)
+
+        #expect(!shouldFallBack)
+        #expect(!coordinator.shouldFallBackFromInjectedAttach)
+        // Approval is pending on the user, not on startup: the saved-Mac
+        // reconnect must not dial underneath the pending dialog.
+        #expect(coordinator.claimStoredReconnect() == nil)
+    }
+
+    @Test
+    @MainActor
     func failedInjectedAttachReleasesStartupToStoredReconnect() throws {
         let coordinator = MobileStartupConnectionCoordinator()
         let attempt = try #require(coordinator.claimInjectedAttach())

--- a/Packages/iOS/CmuxMobileShellUI/Tests/CmuxMobileShellUITests/MobileInjectedAttachStartupTests.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Tests/CmuxMobileShellUITests/MobileInjectedAttachStartupTests.swift
@@ -30,6 +30,24 @@ struct MobileInjectedAttachStartupTests {
 
     @Test
     @MainActor
+    func approvalGatedInjectedAttachConsumesStartupWithoutFallback() throws {
+        let coordinator = MobileStartupConnectionCoordinator()
+        let attempt = try #require(coordinator.claimInjectedAttach())
+
+        let shouldFallBack = coordinator.finishInjectedAttach(
+            attempt, outcome: .awaitingUserApproval
+        )
+
+        #expect(!shouldFallBack)
+        #expect(!coordinator.shouldFallBackFromInjectedAttach)
+        // An attach parked on the Mac-side approval prompt still owns startup:
+        // the saved-Mac reconnect dialing underneath it would race the very
+        // connection the user is approving.
+        #expect(coordinator.claimStoredReconnect() == nil)
+    }
+
+    @Test
+    @MainActor
     func failedInjectedAttachReleasesStartupToStoredReconnect() throws {
         let coordinator = MobileStartupConnectionCoordinator()
         let attempt = try #require(coordinator.claimInjectedAttach())

--- a/Packages/iOS/CmuxMobileShellUI/Tests/CmuxMobileShellUITests/MobileInjectedAttachStartupTests.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Tests/CmuxMobileShellUITests/MobileInjectedAttachStartupTests.swift
@@ -1,41 +1,55 @@
-import CmuxMobileShellModel
 import Testing
 @testable import CmuxMobileShellUI
 
+/// Startup admission contract for an explicitly injected attach URL.
+///
+/// The original version of this suite was written against a
+/// `connectInjectedAttach(_:attachURL:_:)` coordinator API that was reworked
+/// before it merged, so the file has not compiled since it landed — and a
+/// compile-broken test target blocks every `cmux.xctestplan` run (the plan
+/// builds all of its targets even under `-only-testing`). These tests assert
+/// the same admission contract against the coordinator API that shipped; the
+/// URL-connect side effects live in `CMUXMobileRootView`, which claims and
+/// finishes attempts through exactly these entry points.
 @Suite
 struct MobileInjectedAttachStartupTests {
     @Test
     @MainActor
-    func beginsRouteAdmissionWithoutAnExternalTransportReadinessBarrier() async throws {
+    func connectedInjectedAttachConsumesStartupWithoutFallback() throws {
         let coordinator = MobileStartupConnectionCoordinator()
         let attempt = try #require(coordinator.claimInjectedAttach())
-        let recorder = MobileInjectedAttachURLRecorder()
-        let attachURL = "cmux-ios://attach?v=2&payload=iroh-route"
 
-        let completion = await coordinator.connectInjectedAttach(
-            attempt,
-            attachURL: attachURL
-        ) { rawURL in
-            await recorder.record(rawURL)
-            return MobilePairingURLConnectionResult.connected
-        }
+        let shouldFallBack = coordinator.finishInjectedAttach(attempt, outcome: .connected)
 
-        let completedAttempt = try #require(completion)
-        #expect(await recorder.values() == [attachURL])
-        #expect(completedAttempt.result == .connected)
-        #expect(!completedAttempt.shouldReconnectStoredMac)
+        #expect(!shouldFallBack)
+        #expect(!coordinator.shouldFallBackFromInjectedAttach)
+        // A consumed explicit route keeps owning startup: the saved-Mac
+        // reconnect must not also dial.
         #expect(coordinator.claimStoredReconnect() == nil)
     }
-}
 
-private actor MobileInjectedAttachURLRecorder {
-    private var urls: [String] = []
+    @Test
+    @MainActor
+    func failedInjectedAttachReleasesStartupToStoredReconnect() throws {
+        let coordinator = MobileStartupConnectionCoordinator()
+        let attempt = try #require(coordinator.claimInjectedAttach())
 
-    func record(_ url: String) {
-        urls.append(url)
+        let shouldFallBack = coordinator.finishInjectedAttach(attempt, outcome: .failed)
+
+        #expect(shouldFallBack)
+        #expect(coordinator.shouldFallBackFromInjectedAttach)
+        // A failed explicit route releases startup so the authenticated shell
+        // is not stranded disconnected.
+        #expect(coordinator.claimStoredReconnect() != nil)
     }
 
-    func values() -> [String] {
-        urls
+    @Test
+    @MainActor
+    func onlyOneStartupSourceCanClaimAdmission() throws {
+        let coordinator = MobileStartupConnectionCoordinator()
+
+        #expect(coordinator.claimInjectedAttach() != nil)
+        #expect(coordinator.claimInjectedAttach() == nil)
+        #expect(coordinator.claimStoredReconnect() == nil)
     }
 }

--- a/Packages/iOS/CmuxMobileShellUI/Tests/CmuxMobileShellUITests/MobileInjectedAttachStartupTests.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Tests/CmuxMobileShellUITests/MobileInjectedAttachStartupTests.swift
@@ -48,21 +48,6 @@ struct MobileInjectedAttachStartupTests {
 
     @Test
     @MainActor
-    func awaitingUserApprovalConsumesStartupWithoutFallback() throws {
-        let coordinator = MobileStartupConnectionCoordinator()
-        let attempt = try #require(coordinator.claimInjectedAttach())
-
-        let shouldFallBack = coordinator.finishInjectedAttach(attempt, outcome: .awaitingUserApproval)
-
-        #expect(!shouldFallBack)
-        #expect(!coordinator.shouldFallBackFromInjectedAttach)
-        // Approval is pending on the user, not on startup: the saved-Mac
-        // reconnect must not dial underneath the pending dialog.
-        #expect(coordinator.claimStoredReconnect() == nil)
-    }
-
-    @Test
-    @MainActor
     func failedInjectedAttachReleasesStartupToStoredReconnect() throws {
         let coordinator = MobileStartupConnectionCoordinator()
         let attempt = try #require(coordinator.claimInjectedAttach())


### PR DESCRIPTION
`CmuxMobileShellUITests/MobileInjectedAttachStartupTests.swift` references `connectInjectedAttach(_:attachURL:_:)`, an API that was reworked before https://github.com/manaflow-ai/cmux/pull/9252 merged, so the file has never compiled. `cmux.xctestplan` builds every member test target even under `-only-testing`, so this single broken target fails the whole **iOS simulator tests (iphone)** lane for every dispatch — e.g. https://github.com/manaflow-ai/cmux/actions/runs/31045548482 ("value of type 'MobileStartupConnectionCoordinator' has no member 'connectInjectedAttach'").

This rewrites the suite against the coordinator API that shipped, preserving the admission contract: a connected injected attach consumes startup and blocks the saved-Mac reconnect, a failed one releases startup to it, and only one startup source can claim admission. The original's URL-connect side-effect assertion lives in `CMUXMobileRootView`'s path and was never compilable in this target.

Two other pre-existing failures in the same workflow are NOT addressed here and still fail independently of this fix: `package-conventions-lint` (free-function `secondaryControlAttemptIsTransient` in `Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/SecondaryControlAttemptPolicy.swift`) and `mobile-core-package` (`MobilePairingFailureTests/gatedConnectAttemptIsNotPresentedAsATimeout` and `MobileMacConnectionPoolTests/sameMacRedialWaitsForLeaseHandoffButNotPhysicalClose`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/9668"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788556376&installation_model_id=21920&pr_number=9668&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F9668&signature=ef7fe071a2805700695fcb8de00484a40dd81e510f8382e8432fb749e7a8116a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Rewrites `MobileInjectedAttachStartupTests` to the shipped coordinator API to restore `cmux.xctestplan` compilation and unblock the iOS simulator tests lane. Adds coverage for approval-gated injected attach (`.awaitingUserApproval`) and removes duplicate coverage to ensure startup stays consumed with no fallback dial.

- **Bug Fixes**
  - Switched to coordinator claim/finish APIs instead of `connectInjectedAttach(_:attachURL:_:)`.
  - Enforced admission: connected and `.awaitingUserApproval` consume startup and block stored reconnect; failed attach falls back; only one source may claim.
  - Removed duplicate `.awaitingUserApproval` test; suite compiles and unblocks the lane (other known workflow failures unchanged).

<sup>Written for commit 65c8b9565ec8e4f0e7b514b62bde5e84498bd259. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/9668?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded coverage for startup admission when already connected or awaiting approval.
  * Added validation that failed startup attempts can proceed appropriately.
  * Confirmed competing startup paths cannot claim admission simultaneously.
  * Documented expected startup admission behavior across connection and approval states.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->