### PR TITLE
Fix red main: read hosted tenant delete token lazily from process.env

### DIFF
--- a/web/services/subrouter/hostedClient.ts
+++ b/web/services/subrouter/hostedClient.ts
@@ -74,9 +74,13 @@ export function createHostedSubrouterClient(options: {
     options.baseUrl ?? env.SUBROUTER_HOSTED_URL ?? defaultHostedSubrouterURL(),
   );
   const fetchImpl = options.fetch ?? fetch;
+  // Read lazily from process.env, not the validated `env` object: t3-env
+  // freezes values at first import, but tenant-control configuration must be
+  // observable per client construction (env.ts still validates presence on
+  // Vercel non-preview deployments).
   const tenantDeleteToken = (
     options.tenantDeleteToken ??
-    env.SUBROUTER_STACK_TENANT_DELETE_TOKEN ??
+    process.env.SUBROUTER_STACK_TENANT_DELETE_TOKEN ??
     ""
   ).trim();
   const assertTenantControlConfigured = (): void => {


### PR DESCRIPTION
Main has been red on web tests since https://github.com/manaflow-ai/cmux/commit/0eecd5afea17c75b145670c3cf9ad442ecb634b5 (https://github.com/manaflow-ai/cmux/pull/9607, "Read hosted credentials through validated runtime env"): 2 failures in `web/tests/account-route.test.ts` and 1 in `web/tests/hosted-subrouter-routes.test.ts`. CI is paused, so it landed unnoticed; it currently blocks the merge gate for https://github.com/manaflow-ai/cmux/pull/9319 (and any other PR gated on `web-typecheck`).

Mechanism: t3-env's `env` object freezes values at first import. `SUBROUTER_STACK_TENANT_DELETE_TOKEN` gates hosted tenant control per client construction, and the tests toggle it per-case via `process.env`, so the frozen read makes the client permanently "configured": the exchange route returns 200 instead of 503 when unconfigured, and account deletion fires hosted tenant deletes for accounts that never enabled Subrouter.

Fix restores the lazy `process.env` read (parent-commit behavior) with a comment stating the constraint. Deploy-time validation is unchanged: `env.ts` still requires the value on Vercel non-preview.

Verified on this branch: `tests/hosted-subrouter-routes.test.ts` 18/18, `tests/account-route.test.ts` 65/65, `bun run typecheck` clean. Both files fail identically on `origin/main`, pass at `0eecd5afea~1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/9669"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788558622&installation_model_id=21920&pr_number=9669&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F9669&signature=85e8417f737db084c8a960e39d87db9994d2da1189410223673b560582dce902"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Read the hosted tenant delete token lazily from `process.env` to avoid `t3-env` freezing the value at import time. This restores per-client configuration, returns 503 when unconfigured, and prevents unintended hosted tenant deletes.

- **Bug Fixes**
  - Read `SUBROUTER_STACK_TENANT_DELETE_TOKEN` via `process.env` instead of the validated `env` object from `t3-env`.
  - Keep deploy-time validation in `env.ts` for Vercel non-preview deployments.

<sup>Written for commit f2c2b6fb2899aeedec666f7cdccf5f0748313af0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/9669?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tenant deletion token handling when creating hosted clients.
  * Explicit token overrides and whitespace trimming continue to work as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->