### PR TITLE
Scope pairing scanner guidance copy onto MobilePairingScannerSheet

### DIFF
--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MobilePairingScannerPreview.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MobilePairingScannerPreview.swift
@@ -26,7 +26,7 @@ struct MobilePairingScannerPreview: View {
                 .frame(maxWidth: 280, maxHeight: 280)
                 .aspectRatio(1, contentMode: .fit)
 
-                Text(MobilePairingScannerGuidanceCopy.text)
+                Text(MobilePairingScannerSheet.guidanceText)
                 .font(.headline)
                 .multilineTextAlignment(.center)
                 .foregroundStyle(.white)

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MobilePairingScannerSheet.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MobilePairingScannerSheet.swift
@@ -50,7 +50,7 @@ struct MobilePairingScannerSheet: View {
                             }
                             .ignoresSafeArea(edges: .bottom)
 
-                            Text(MobilePairingScannerGuidanceCopy.text)
+                            Text(Self.guidanceText)
                                 .font(.footnote.weight(.medium))
                                 .multilineTextAlignment(.center)
                                 .foregroundStyle(.white)
@@ -181,8 +181,8 @@ struct MobilePairingScannerSheet: View {
 }
 #endif
 
-enum MobilePairingScannerGuidanceCopy {
-    static var text: String {
+extension MobilePairingScannerSheet {
+    static var guidanceText: String {
         L10n.string(
             "mobile.pairing.scannerInstruction",
             defaultValue: """


### PR DESCRIPTION
The caseless `MobilePairingScannerGuidanceCopy` enum from https://github.com/manaflow-ai/cmux/pull/9493 trips the `namespace-enum` rule in `scripts/lint-ios-package-conventions.sh`. Because that job lints the whole repo whenever `Packages/` changes, every Packages-touching branch cut from current main fails `package-conventions-lint` (e.g. https://github.com/manaflow-ai/cmux/actions/runs/31055337211). This moves the guidance string onto the owning type as `MobilePairingScannerSheet.guidanceText` and updates both call sites. `./scripts/lint-ios-package-conventions.sh` now exits 0.

Note: `mobile-core-package` remains red on main from the unrelated `gatedConnectAttemptIsNotPresentedAsATimeout` failure; a fix for that is in flight on `feat-fix-gated-attempt-classifier`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/9672"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788565159&installation_model_id=21920&pr_number=9672&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F9672&signature=6a1d564e87ff3ef24a6ba58404e803e735c5690e8b5ad4ec65b111a6a29db2c9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Scoped the pairing scanner guidance copy to `MobilePairingScannerSheet.guidanceText`, replacing the caseless `MobilePairingScannerGuidanceCopy` enum and updating both call sites. This fixes the `namespace-enum` violation in `scripts/lint-ios-package-conventions.sh`, so the package conventions lint passes for branches that touch `Packages/`.

<sup>Written for commit a556cfc58f125d82a5cf24fa544ab202182b6b83. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/9672?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated mobile pairing scanner guidance to consistently use the current scanner sheet text.
  * Improved consistency between the scanner preview and pairing screen instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->