### PR TITLE
iOS: Connection Method picker is a determinant — Tailscale means Tailscale only

### DIFF
--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobilePairingFailure.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobilePairingFailure.swift
@@ -447,7 +447,7 @@ extension MobilePairingFailureCategory {
 
         if let connectionError = error as? MobileShellConnectionError {
             switch connectionError {
-            case .requestTimedOut, .connectAttemptGated:
+            case .requestTimedOut:
                 return .handshakeTimedOut(host: host, port: port)
             case .connectAttemptGated:
                 // Another attempt owns this route: the Mac did not time out,

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobilePairingFailure.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobilePairingFailure.swift
@@ -88,6 +88,11 @@ public enum MobilePairingFailureCategory: Equatable, Sendable {
     /// The pairing code carried no route kind this device build can dial (for
     /// example an iroh-only ticket on a build without the iroh transport).
     case noSupportedRoute
+    /// The connection method is Tailscale-only, and this computer has no
+    /// Tailscale destination authorized by a user-entered pairing code, so
+    /// there is nothing the method allows dialing. Distinct from
+    /// ``noSupportedRoute``: routes exist, the user's method forbids them.
+    case tailscalePairingRequired
     /// Two cancellation-ignoring route cleanups are still alive. Retrying in
     /// this process cannot start another transport without exceeding the cap.
     case routeCleanupBlocked
@@ -126,6 +131,7 @@ extension MobilePairingFailureCategory {
         case .macUpdateRequired: return "mac_update_required"
         case .unsupportedRoute: return "unsupported_route"
         case .noSupportedRoute: return "no_supported_route"
+        case .tailscalePairingRequired: return "tailscale_pairing_required"
         case .routeCleanupBlocked: return "route_cleanup_blocked"
         case .connectAttemptGated: return "connect_attempt_gated"
         case .cancelled: return "cancelled"
@@ -287,6 +293,11 @@ extension MobilePairingFailureCategory {
                 "mobile.pairing.unsupportedRoute",
                 defaultValue: "This pairing code is not supported."
             )
+        case .tailscalePairingRequired:
+            return L10n.string(
+                "mobile.pairing.tailscalePairingRequired",
+                defaultValue: "Connection Method is set to Tailscale, but this computer has no Tailscale pairing code authorization yet."
+            )
         case .routeCleanupBlocked:
             return L10n.string(
                 "mobile.pairing.routeCleanupBlocked",
@@ -360,6 +371,11 @@ extension MobilePairingFailureCategory {
             return L10n.string(
                 "mobile.pairing.guidance.rescanFresh",
                 defaultValue: "Open Tailscale Pairing on your Mac and scan a fresh QR or link."
+            )
+        case .tailscalePairingRequired:
+            return L10n.string(
+                "mobile.pairing.guidance.tailscalePairingRequired",
+                defaultValue: "Open Tailscale Pairing on your Mac and scan its code here, or switch Connection Method back to Auto-Connect."
             )
         case .unrecognizedVersion:
             return L10n.string(

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+ConnectionRecovery.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+ConnectionRecovery.swift
@@ -622,7 +622,17 @@ extension MobileShellComposite {
                 )
                 : nil
         )
-        guard let firstRoute = pinnedRoutes.first else { return .failed(.unsupportedRoute) }
+        guard let firstRoute = pinnedRoutes.first else {
+            if connectionMethodStore?.method == .tailscale {
+                // Tailscale-only with no granted route: fail closed with the
+                // actionable pairing-code requirement instead of a generic
+                // unsupported-route message.
+                applyTailscalePairingRequiredFailure(
+                    disconnect: !hasActiveMacConnection
+                )
+            }
+            return .failed(.unsupportedRoute)
+        }
 
         var outcome: StoredMacReconnectOutcome = .failed(.unknown)
 
@@ -648,7 +658,8 @@ extension MobileShellComposite {
                     ifStillCurrent: ifStillCurrent
                 )
                 guard ifStillCurrent?() ?? true else { return .superseded }
-                if noThrowFailure == .noSupportedRoute {
+                if noThrowFailure == .noSupportedRoute
+                    || noThrowFailure == .tailscalePairingRequired {
                     outcome = .failed(.unsupportedRoute)
                 }
             } catch {
@@ -821,12 +832,34 @@ extension MobileShellComposite {
     ) async {
         let scope = await currentScopeSnapshot()
         let supportedKinds = runtime?.supportedRouteKinds ?? []
+        // Under the Tailscale-only method a registry tap may dial only routes
+        // covered by this device's stored grant for that Mac; a fresh registry
+        // route can never mint authorization by itself.
+        let tailscalePreference: MobileShellComposite.TailscaleRoutePreference? =
+            connectionMethodStore?.method == .tailscale
+                ? Self.TailscaleRoutePreference(
+                    macDeviceID: device.deviceId,
+                    grantRoutes: pairedMacs.first {
+                        cmxCanonicalDeviceID($0.macDeviceID)
+                            == cmxCanonicalDeviceID(device.deviceId)
+                            && $0.legacyTailscaleRoutes?.isEmpty == false
+                    }?.legacyTailscaleRoutes ?? []
+                )
+                : nil
         let candidateRoutes = Self.storedReconnectRoutes(
             instance.routes,
             supportedKinds: supportedKinds,
-            preferNonLoopback: Self.prefersNonLoopbackRoutes
+            preferNonLoopback: Self.prefersNonLoopbackRoutes,
+            tailscalePreference: tailscalePreference
         )
         guard !candidateRoutes.isEmpty else {
+            if tailscalePreference != nil {
+                // A user tap needs feedback: explain the missing pairing-code
+                // authorization rather than failing silently.
+                applyTailscalePairingRequiredFailure(
+                    disconnect: !hasActiveMacConnection
+                )
+            }
             mobileShellLog.error(
                 "connectToRegistryInstance: no reconnectable route device=\(device.deviceId, privacy: .public) tag=\(instance.tag, privacy: .public)"
             )
@@ -868,6 +901,9 @@ extension MobileShellComposite {
         accountID: String,
         ifStillCurrent: (() -> Bool)? = nil
     ) async -> Bool {
+        // Zero-touch discovery connects new Macs over Iroh; the Tailscale-only
+        // method forbids that transport entirely.
+        guard connectionMethodStore?.method != .tailscale else { return false }
         let supportedKinds = runtime?.supportedRouteKinds ?? []
         let candidateRoutes = Self.storedReconnectRoutes(
             mac.routes,

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+ReconnectRoutes.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+ReconnectRoutes.swift
@@ -110,8 +110,9 @@ extension MobileShellComposite {
         return nil
     }
 
-    /// The Tailscale ordering preference for one paired Mac: which grant routes
-    /// may promote an exact stored Tailscale route ahead of the Iroh pin.
+    /// The Tailscale-only constraint for one paired Mac: which grant routes
+    /// make an exact stored Tailscale route dialable while the user's
+    /// connection method is Tailscale.
     struct TailscaleRoutePreference {
         let macDeviceID: String
         let grantRoutes: [CmxAttachRoute]
@@ -128,10 +129,12 @@ extension MobileShellComposite {
     /// grant. Pairings without an authenticated Iroh identity remain fail-closed.
     ///
     /// `tailscalePreference` (the user's explicit Tailscale connection-method
-    /// choice) relaxes only the ORDER of that pin: stored Tailscale routes that
-    /// carry a device-local grant dial first, and the Iroh routes stay as the
-    /// fallback instead of being exclusive. Unauthorized Tailscale routes are
-    /// still never dialable, so a preference flip alone grants nothing.
+    /// choice) is a determinant, not an ordering hint: only stored Tailscale
+    /// routes that carry a device-local grant are dialable, and Iroh is never
+    /// dialed as a fallback. With no granted route the result is EMPTY, so the
+    /// caller fails closed and surfaces the pairing-code requirement instead
+    /// of silently riding another transport. Unauthorized Tailscale routes are
+    /// still never dialable, so a method flip alone grants nothing.
     static func storedReconnectRoutes(
         _ routes: [CmxAttachRoute],
         supportedKinds: [CmxAttachTransportKind],
@@ -148,22 +151,16 @@ extension MobileShellComposite {
         if preferNonLoopback {
             ordered.removeAll { $0.kind == .debugLoopback }
         }
-        let irohRoutes = ordered.filter { $0.kind == .iroh }
         if let tailscalePreference {
-            let authorizedTailscale = ordered.filter { route in
+            return ordered.filter { route in
                 legacyTailscaleAuthorizationEvidence(
                     for: route,
                     macDeviceID: tailscalePreference.macDeviceID,
                     persistedRoutes: tailscalePreference.grantRoutes
                 ) != nil
             }
-            if !authorizedTailscale.isEmpty {
-                let rest = ordered.filter { route in
-                    route.kind != .iroh && route.kind != .tailscale
-                }
-                return authorizedTailscale + irohRoutes + rest
-            }
         }
+        let irohRoutes = ordered.filter { $0.kind == .iroh }
         if !irohRoutes.isEmpty {
             return irohRoutes
         }
@@ -430,6 +427,14 @@ extension MobileShellComposite {
         scope: MobileShellScopeSnapshot,
         snapshot: ReconnectRefreshSnapshot?
     ) async -> ReconnectRouteRefreshOutcome {
+        // This rescue exists to recover an Iroh dial from fresh registry
+        // routes, which is exactly the fallback the Tailscale-only method
+        // forbids. Stay inconclusive so the failure surfaces as the
+        // pairing-code requirement, not an Iroh rescue or a misleading
+        // mac-update diagnosis.
+        guard connectionMethodStore?.method != .tailscale else {
+            return .inconclusive
+        }
         let supportedKinds = runtime?.supportedRouteKinds ?? []
         guard let snapshot,
               await isScopeCurrent(scope),

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
@@ -2468,6 +2468,11 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         var firstCandidateNeedingMacUpdate: MobilePairedMac?
         var attemptedAutomaticIroh = false
         var lastDialOutcome: StoredMacReconnectOutcome = .failed(.noRoute)
+        // A candidate whose stored routes were all blocked by the
+        // Tailscale-only method (no granted destination). Lets the sweep fail
+        // closed with the actionable pairing-code error when no dial set a
+        // more specific one.
+        var tailscaleOnlyBlockedACandidate = false
         // Try each candidate until one connects, so a single offline Mac never
         // blocks the others.
         for (candidateIndex, mac) in candidates.enumerated() {
@@ -2497,6 +2502,11 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
             let isLegacyPrivateNetworkPairing = !mac.routes.contains { $0.kind == .iroh }
                 && mac.routes.contains { $0.kind == .tailscale }
 
+            if connectionMethodStore?.method == .tailscale,
+               localRoutes.isEmpty,
+               !mac.routes.isEmpty {
+                tailscaleOnlyBlockedACandidate = true
+            }
             // Raw Tailscale/TCP is bearer-capable only for an exact local route
             // grandfathered during the v7-to-v8 migration. Every fresh, changed,
             // restored, or registry route remains a hint for discovering Iroh.
@@ -2553,7 +2563,11 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         // saved candidate failed. This keeps a healthy saved Mac from sitting
         // behind an unrelated account-wide discovery request.
         var zeroTouchCandidates: [MobilePairedMac] = []
+        // Zero-touch candidates are Iroh-only rows by construction; the
+        // Tailscale-only method forbids dialing them, so skip the broker
+        // discovery request entirely.
         if connectionState != .connected,
+           connectionMethodStore?.method != .tailscale,
            !automaticIrohReconnectIsBlocked(accountID: scope.userID) {
             zeroTouchCandidates = await discoverZeroTouchIrohCandidates(
                 scope: scope,
@@ -2632,6 +2646,17 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
                 applyStoredMacUpdateRequiredFailure(disconnect: true)
                 lastDialOutcome = .failed(.unsupportedRoute)
             }
+        }
+        if connectionState != .connected,
+           !connectionRequiresReauth,
+           connectionError == nil,
+           connectionMethodStore?.method == .tailscale,
+           tailscaleOnlyBlockedACandidate {
+            // Every stored candidate was blocked by the Tailscale-only method
+            // and nothing set a more specific dial error: explain the missing
+            // pairing-code authorization instead of staying silently offline.
+            applyTailscalePairingRequiredFailure(disconnect: true)
+            lastDialOutcome = .failed(.unsupportedRoute)
         }
         if connectionState != .connected,
            !connectionRequiresReauth,
@@ -4185,10 +4210,19 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
     ) async -> SecondaryClientAttempt {
         guard let runtime else { return .permanentFailure }
         let supportedKinds = runtime.supportedRouteKinds
+        // The Tailscale-only method applies to background aggregation too: a
+        // secondary Mac without a granted Tailscale route is unreachable
+        // rather than silently pooled over Iroh.
         let pinnedRoutes = Self.storedReconnectRoutes(
             mac.routes,
             supportedKinds: supportedKinds,
-            preferNonLoopback: Self.prefersNonLoopbackRoutes
+            preferNonLoopback: Self.prefersNonLoopbackRoutes,
+            tailscalePreference: connectionMethodStore?.method == .tailscale
+                ? Self.TailscaleRoutePreference(
+                    macDeviceID: mac.macDeviceID,
+                    grantRoutes: mac.legacyTailscaleRoutes ?? []
+                )
+                : nil
         )
         guard let firstRoute = pinnedRoutes.first else {
             return .permanentFailure
@@ -7713,7 +7747,8 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
     /// Establishes the live connection for `ticket`. Returns `nil` on success
     /// (and superseded-generation early exits), or the failure category it applied
     /// when it returned without connecting and without throwing
-    /// (`.noSupportedRoute`), so callers record the matching analytics reason.
+    /// (`.noSupportedRoute` / `.tailscalePairingRequired`), so callers record
+    /// the matching analytics reason.
     @discardableResult
     func connect(
         ticket: CmxAttachTicket,
@@ -7763,10 +7798,16 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
             userTailscalePairingAuthorizations: userTailscalePairingAuthorizations
         )
         guard let firstRoute = supportedRoutes.first else {
-            // No route kind this build can dial: set the specific category;
+            // No dialable route: either no route kind this build supports, or
+            // the Tailscale-only method filtered every route because this Mac
+            // has no pairing-code authorization. Set the specific category;
             // the caller records the matching analytics reason from it.
-            connectionError = MobilePairingFailureCategory.noSupportedRoute.message
-            connectionErrorGuidance = MobilePairingFailureCategory.noSupportedRoute.guidance
+            let category: MobilePairingFailureCategory =
+                connectionMethodStore?.method == .tailscale
+                    ? .tailscalePairingRequired
+                    : .noSupportedRoute
+            connectionError = category.message
+            connectionErrorGuidance = category.guidance
             connectionState = .disconnected
             macConnectionStatus = .unavailable
             diagnosticLog?.record(DiagnosticEvent(
@@ -7775,7 +7816,7 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
                 b: DiagnosticFailureKind.unsupportedRoute.rawValue
             ))
             clearRemoteConnectionContext()
-            return .noSupportedRoute
+            return category
         }
         let targetsCurrentLogicalMac =
             currentFocusedConnection.map { connection in
@@ -8420,15 +8461,14 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
                 supportedKinds.contains(route.kind)
             }
         }
-        let irohRoutes = supportedRoutes.filter { route in
-            route.kind == .iroh
-        }
-        // The user's explicit Tailscale method relaxes only the Iroh pin's
-        // ORDER: authorized Tailscale routes dial first and Iroh remains the
-        // fallback. Routes without a grant or a user-entered code stay
-        // undialable regardless of the preference.
+        // The user's explicit Tailscale method is a determinant: only routes
+        // authorized by a device-local grant or a user-entered pairing code
+        // are dialable, and Iroh is never dialed as a fallback. An empty
+        // result fails closed; ``connect(ticket:)`` surfaces the pairing-code
+        // requirement. Routes without a grant or a user-entered code stay
+        // undialable regardless of the method.
         if connectionMethodStore?.method == .tailscale {
-            let authorizedTailscale = supportedRoutes.filter { route in
+            return supportedRoutes.filter { route in
                 Self.legacyTailscaleAuthorizationEvidence(
                     for: route,
                     macDeviceID: ticket.macDeviceID,
@@ -8439,12 +8479,9 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
                         authorizations: userTailscalePairingAuthorizations
                     ) != nil
             }
-            if !authorizedTailscale.isEmpty {
-                let rest = supportedRoutes.filter { route in
-                    route.kind != .iroh && route.kind != .tailscale
-                }
-                return authorizedTailscale + irohRoutes + rest
-            }
+        }
+        let irohRoutes = supportedRoutes.filter { route in
+            route.kind == .iroh
         }
         return irohRoutes.isEmpty ? supportedRoutes : irohRoutes
     }
@@ -9190,6 +9227,20 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
     /// as the Mac updates and republishes through the authenticated registry.
     private func applyStoredMacUpdateRequiredFailure(disconnect: Bool) {
         applyPairingFailure(.macUpdateRequired, phase: "migration")
+        connectionRequiresReauth = false
+        guard disconnect else { return }
+        connectionState = .disconnected
+        macConnectionStatus = .unavailable
+        clearRemoteConnectionContext()
+    }
+
+    /// The Tailscale-only method blocked every route to this Mac because no
+    /// stored Tailscale destination carries a pairing-code authorization.
+    /// Deliberately not an auth failure: the remedy is scanning the Mac's
+    /// Tailscale pairing code (or switching back to Auto-Connect), never
+    /// signing out or deleting the pairing.
+    func applyTailscalePairingRequiredFailure(disconnect: Bool) {
+        applyPairingFailure(.tailscalePairingRequired, phase: "route-selection")
         connectionRequiresReauth = false
         guard disconnect else { return }
         connectionState = .disconnected

--- a/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/IrohReconnectRouteSelectionTests.swift
+++ b/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/IrohReconnectRouteSelectionTests.swift
@@ -111,6 +111,87 @@ extension ReconnectRouteSelectionTests {
         #expect(factory.attemptedKinds() == [.iroh])
     }
 
+    @Test func tailscaleOnlyMethodConnectsOverTheGrantedRoute() async throws {
+        let clock = TestClock()
+        let router = LivenessHostRouter()
+        let box = TransportBox()
+        let factory = KindRecordingTransportFactory(router: router, box: box)
+        let granted = try tailscale()
+        let store = try await makeReconnectStore(
+            routes: [granted, try iroh()],
+            runtime: LivenessTestRuntime(
+                transportFactory: factory,
+                now: { clock.now },
+                supportedRouteKinds: [.iroh, .tailscale]
+            ),
+            connectionMethod: .tailscale,
+            userAuthorizedTailscaleRoutes: [granted]
+        )
+
+        #expect(await store.reconnectActiveMacIfAvailable(stackUserID: "user-1"))
+        #expect(store.connectionState == .connected)
+        #expect(factory.attemptedKinds() == [.tailscale])
+        #expect(store.activeRoute?.kind == .tailscale)
+    }
+
+    @Test func tailscaleOnlyMethodNeverFallsBackToIrohAfterAFailedDial() async throws {
+        let clock = TestClock()
+        let router = LivenessHostRouter()
+        let box = TransportBox()
+        let factory = KindRecordingTransportFactory(
+            router: router,
+            box: box,
+            failingKinds: [.tailscale]
+        )
+        let granted = try tailscale()
+        let store = try await makeReconnectStore(
+            routes: [granted, try iroh()],
+            runtime: LivenessTestRuntime(
+                transportFactory: factory,
+                now: { clock.now },
+                supportedRouteKinds: [.iroh, .tailscale]
+            ),
+            connectionMethod: .tailscale,
+            userAuthorizedTailscaleRoutes: [granted]
+        )
+
+        #expect(!(await store.reconnectActiveMacIfAvailable(stackUserID: "user-1")))
+        #expect(store.connectionState == .disconnected)
+        // The granted Tailscale dial failed; the Tailscale-only method must
+        // never dial the stored Iroh route as a fallback.
+        #expect(factory.attemptedKinds() == [.tailscale])
+    }
+
+    @Test func tailscaleOnlyMethodWithoutGrantFailsClosedWithPairingGuidance() async throws {
+        let clock = TestClock()
+        let router = LivenessHostRouter()
+        let box = TransportBox()
+        let factory = KindRecordingTransportFactory(router: router, box: box)
+        let store = try await makeReconnectStore(
+            routes: [try tailscale(), try iroh()],
+            runtime: LivenessTestRuntime(
+                transportFactory: factory,
+                now: { clock.now },
+                supportedRouteKinds: [.iroh, .tailscale]
+            ),
+            connectionMethod: .tailscale
+        )
+
+        #expect(!(await store.reconnectActiveMacIfAvailable(stackUserID: "user-1")))
+        #expect(store.connectionState == .disconnected)
+        // Nothing is dialable without a pairing-code grant, and the failure
+        // explains the missing authorization instead of staying silent.
+        #expect(factory.attemptedKinds().isEmpty)
+        #expect(
+            store.connectionError
+                == MobilePairingFailureCategory.tailscalePairingRequired.message
+        )
+        #expect(
+            store.connectionErrorGuidance
+                == MobilePairingFailureCategory.tailscalePairingRequired.guidance
+        )
+    }
+
     @Test func legacyMacWithoutIrohFailsClosedInsteadOfSendingBearerOverTCP() async throws {
         let clock = TestClock()
         let router = LivenessHostRouter()

--- a/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/ReconnectRouteSelectionTests.swift
+++ b/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/ReconnectRouteSelectionTests.swift
@@ -1,6 +1,7 @@
 import CMUXMobileCore
 import CmuxMobilePairedMac
 import CmuxMobileRPC
+import CmuxMobileShellModel
 import Foundation
 import Testing
 @testable import CmuxMobileShell
@@ -516,7 +517,9 @@ import Testing
 
     func makeReconnectStore(
         routes: [CmxAttachRoute],
-        runtime: any MobileSyncRuntime
+        runtime: any MobileSyncRuntime,
+        connectionMethod: MobileConnectionMethod? = nil,
+        userAuthorizedTailscaleRoutes: [CmxAttachRoute] = []
     ) async throws -> MobileShellComposite {
         let (pairedStore, _) = try makePairedMacStore()
         try await pairedStore.upsert(
@@ -528,10 +531,30 @@ import Testing
             teamID: nil,
             now: Date()
         )
+        if !userAuthorizedTailscaleRoutes.isEmpty {
+            try await pairedStore.authorizeUserTailscaleRoutes(
+                macDeviceID: "test-mac",
+                instanceTag: nil,
+                stackUserID: "user-1",
+                teamID: nil,
+                routes: userAuthorizedTailscaleRoutes
+            )
+        }
+        var connectionMethodStore: MobileConnectionMethodStore?
+        if let connectionMethod {
+            let methodStore = MobileConnectionMethodStore(
+                defaults: UserDefaults(
+                    suiteName: "connection-method-\(UUID().uuidString)"
+                )!
+            )
+            methodStore.method = connectionMethod
+            connectionMethodStore = methodStore
+        }
         let store = MobileShellComposite(
             runtime: runtime,
             isSignedIn: true,
             pairedMacStore: pairedStore,
+            connectionMethodStore: connectionMethodStore,
             identityProvider: StaticIdentityProvider(userID: "user-1"),
             reachability: AlwaysOnlineReachability(),
             pairingHintDefaults: UserDefaults(suiteName: "reconnect-routes-\(UUID().uuidString)")!,
@@ -541,7 +564,7 @@ import Testing
         return store
     }
 
-    @Test func tailscalePreferencePromotesGrantedRouteAheadOfIrohPin() throws {
+    @Test func tailscaleMethodDialsOnlyTheGrantedTailscaleRoute() throws {
         let tailscale = try tailscale()
         let routes = MobileShellComposite.storedReconnectRoutes(
             [tailscale, try iroh()],
@@ -553,14 +576,15 @@ import Testing
             )
         )
 
-        // The granted Tailscale destination dials first; Iroh stays as the
-        // fallback instead of being exclusive.
-        #expect(routes.map(\.kind) == [.tailscale, .iroh])
+        // The Tailscale method is a determinant: the granted destination is
+        // the only dialable route, with no Iroh fallback.
+        #expect(routes.map(\.kind) == [.tailscale])
     }
 
-    @Test func tailscalePreferenceWithoutGrantKeepsIrohExclusivePin() throws {
-        // A preference flip alone grants nothing: without a device-local grant
-        // the Iroh pin still drops every raw host/port fallback.
+    @Test func tailscaleMethodWithoutGrantFailsClosed() throws {
+        // A method flip alone grants nothing: without a device-local grant
+        // there is nothing the method allows dialing. The result is empty,
+        // never a silent Iroh fallback.
         let routes = MobileShellComposite.storedReconnectRoutes(
             [try tailscale(), try iroh()],
             supportedKinds: [.iroh, .tailscale],
@@ -571,10 +595,10 @@ import Testing
             )
         )
 
-        #expect(routes.map(\.kind) == [.iroh])
+        #expect(routes.isEmpty)
     }
 
-    @Test func tailscalePreferenceIgnoresGrantForDifferentDestination() throws {
+    @Test func tailscaleMethodIgnoresGrantForDifferentDestination() throws {
         let otherDestination = try tailscale(50907)
         let routes = MobileShellComposite.storedReconnectRoutes(
             [try tailscale(), try iroh()],
@@ -586,6 +610,6 @@ import Testing
             )
         )
 
-        #expect(routes.map(\.kind) == [.iroh])
+        #expect(routes.isEmpty)
     }
 }

--- a/Packages/iOS/CmuxMobileShellModel/Sources/CmuxMobileShellModel/MobileConnectionMethodStore.swift
+++ b/Packages/iOS/CmuxMobileShellModel/Sources/CmuxMobileShellModel/MobileConnectionMethodStore.swift
@@ -6,18 +6,19 @@ public enum MobileConnectionMethod: String, CaseIterable, Sendable {
     /// Dial the built-in encrypted peer-to-peer transport (direct paths with
     /// managed relays as fallback). The default; no setup required.
     case automatic
-    /// Prefer the user's Tailscale network. Requires entering the Tailscale
-    /// pairing code shown on the Mac once, which authorizes that exact peer.
+    /// Use ONLY the user's Tailscale network. Requires entering the Tailscale
+    /// pairing code shown on the Mac once, which authorizes that exact peer;
+    /// Macs without a scanned code are unreachable while this is selected.
     case tailscale
 }
 
 /// Persists the user's connection-method choice.
 ///
-/// The preference only reorders dialing: `tailscale` puts authorized Tailscale
-/// routes ahead of the automatic transport instead of the default pin that
-/// dials the automatic transport exclusively. It never manufactures Tailscale
-/// authorization by itself; a pairing code entry remains the authorization
-/// event for each Mac.
+/// The choice is a determinant: `tailscale` dials only Tailscale destinations
+/// authorized by a user-entered pairing code and never falls back to the
+/// automatic transport, while `automatic` keeps the default Iroh pin. It
+/// never manufactures Tailscale authorization by itself; a pairing code entry
+/// remains the authorization event for each Mac.
 ///
 /// The backing `UserDefaults` is injected so the store is testable without
 /// touching `.standard`; the app constructs it at the composition root.

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MobileConnectionMethodSection.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MobileConnectionMethodSection.swift
@@ -62,8 +62,10 @@ struct MobileConnectionMethodSection: View {
             L10n.string(
                 "mobile.settings.connectionMethod.tailscaleFooter",
                 defaultValue: """
-                Install Tailscale on this iPhone and your Mac, then connect both to the same Tailscale network. \
-                On your Mac, open Tailscale Pairing in cmux to show the QR, then scan it here once.
+                Connects only over your Tailscale network, with no automatic fallback. \
+                Install Tailscale on this iPhone and your Mac, connect both to the same Tailscale network, \
+                then open Tailscale Pairing in cmux on the Mac and scan the QR here once. \
+                Computers without a scanned code stay unreachable while this is selected.
                 """
             )
         }

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/OnboardingConnectionMethodPicker.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/OnboardingConnectionMethodPicker.swift
@@ -33,7 +33,7 @@ struct OnboardingConnectionMethodPicker: View {
                 ),
                 subtitle: L10n.string(
                     "mobile.onboarding.connect.method.tailscaleDetail",
-                    defaultValue: "Uses your Tailscale network. Scan the pairing code on your Mac."
+                    defaultValue: "Uses only your Tailscale network. Scan the pairing code on your Mac."
                 ),
                 systemImage: "qrcode",
                 accessibilityIdentifier: "MobileOnboardingConnectionMethodTailscale"

--- a/ios/cmux/Resources/Localizable.xcstrings
+++ b/ios/cmux/Resources/Localizable.xcstrings
@@ -4291,13 +4291,13 @@
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "Uses your Tailscale network. Scan the pairing code on your Mac."
+            "value": "Uses only your Tailscale network. Scan the pairing code on your Mac."
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "Tailscaleネットワークを使用します。Macに表示されるペアリングコードをスキャンしてください。"
+            "value": "Tailscaleネットワークのみを使用します。Macに表示されるペアリングコードをスキャンしてください。"
           }
         }
       }
@@ -4444,13 +4444,13 @@
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "Install Tailscale on this iPhone and your Mac, then connect both to the same Tailscale network. On your Mac, open Tailscale Pairing in cmux to show the QR, then scan it here once."
+            "value": "Connects only over your Tailscale network, with no automatic fallback. Install Tailscale on this iPhone and your Mac, connect both to the same Tailscale network, then open Tailscale Pairing in cmux on the Mac and scan the QR here once. Computers without a scanned code stay unreachable while this is selected."
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "このiPhoneとMacの両方にTailscaleをインストールし、同じTailscaleネットワークに接続してください。Macのcmuxで「Tailscaleペアリング」を開いてQRコードを表示し、ここで一度スキャンします。"
+            "value": "Tailscaleネットワーク経由でのみ接続し、自動フォールバックはありません。このiPhoneとMacの両方にTailscaleをインストールし、同じTailscaleネットワークに接続してから、Macのcmuxで「Tailscaleペアリング」を開いてQRコードをここで一度スキャンしてください。コードをスキャンしていないコンピュータには、この設定の間は接続できません。"
           }
         }
       }
@@ -5424,6 +5424,23 @@
         }
       }
     },
+    "mobile.pairing.guidance.tailscalePairingRequired": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Open Tailscale Pairing on your Mac and scan its code here, or switch Connection Method back to Auto-Connect."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Macで「Tailscaleペアリング」を開いてコードをスキャンするか、接続方法を「自動接続」に戻してください。"
+          }
+        }
+      }
+    },
     "mobile.pairing.guidance.sameAccount": {
       "extractionState": "manual",
       "localizations": {
@@ -5777,6 +5794,23 @@
           "stringUnit": {
             "state": "translated",
             "value": "このペアリングコードには対応していません。"
+          }
+        }
+      }
+    },
+    "mobile.pairing.tailscalePairingRequired": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Connection Method is set to Tailscale, but this computer has no Tailscale pairing code authorization yet."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "接続方法がTailscaleに設定されていますが、このコンピュータはTailscaleペアリングコードでまだ承認されていません。"
           }
         }
       }


### PR DESCRIPTION
The Tailscale connection method used to be a dial-order preference: authorized Tailscale routes went first, Iroh stayed as a silent fallback, and with no scanned pairing code the picker did nothing at all. Aziz hit exactly that while verifying transports ("the Connection Method picker doesn't seem to work") and asked for strict semantics.

Setting Connection Method to Tailscale now means only Tailscale is dialed:

- `storedReconnectRoutes` and connect-time `supportedRoutes` return only Tailscale routes covered by a pairing-code authorization; with no grant the result is empty and dialing fails closed instead of riding Iroh.
- A new failure category `tailscalePairingRequired` (localized en+ja) explains the missing pairing-code authorization at every surface that can hit it: stored-Mac dials, ticket connects, registry-instance taps, and the startup reconnect sweep.
- Iroh side doors now respect the method: the registry-refresh rescue, zero-touch Iroh discovery, account-discovered Iroh dials, and the background multi-Mac pool (a secondary Mac without a grant shows unreachable rather than being silently pooled over Iroh).
- Settings footer, onboarding copy, and the store's docs state the strict semantics.

The authorization model is unchanged: flipping the method still grants nothing; scanning the Mac's Tailscale pairing code remains the only authorization event, so this change only removes dialing power.

Second commit is a drive-by fix: `classify` listed `.connectAttemptGated` in the timeout arm, making the dedicated arm below unreachable, so gated attempts showed "No response" timeout copy. The existing test `gatedConnectAttemptIsNotPresentedAsATimeout` asserts the intended mapping and passes again.

Tests: rewrote the three route-ordering tests for strict semantics and added three behavior tests (grant present connects over Tailscale only; failed Tailscale dial never falls back to Iroh; no grant attempts nothing and surfaces the pairing-required error). Localization audit: `mobile.settings.connectionMethod.tailscaleFooter` and `mobile.onboarding.connect.method.tailscaleDetail` updated, `mobile.pairing.tailscalePairingRequired` and `mobile.pairing.guidance.tailscalePairingRequired` added, all with en and ja.

Follow-up candidates (not in this PR): a per-computer "needs pairing code" row indicator, and a live "connected via Tailscale/Auto" transport indicator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/9674"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788565916&installation_model_id=21920&pr_number=9674&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F9674&signature=72b8fc60ab33b12f96ae4c62f389c970d8ae67cdd6ee48ea6d0ed10cf4650ce5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Setting Connection Method to Tailscale now dials only Tailscale routes authorized by a scanned pairing code, with no Iroh fallback. If no grant exists, we fail closed and show a clear “Tailscale pairing required” error.

- **New Features**
  - Tailscale method is strict: only granted Tailscale routes are dialed; otherwise no routes are attempted.
  - New failure category: tailscalePairingRequired (with guidance), shown on stored-Mac dials, ticket connects, registry taps, and the reconnect sweep.
  - Iroh paths respect the method: disable registry-refresh rescue, zero-touch Iroh discovery, account-discovered Iroh dials, and background multi-Mac pooling for ungranted Macs.
  - Updated copy in Settings and Onboarding; added en/ja localizations.
  - Tests updated for strict semantics; added coverage for grant-only dialing and fail-closed behavior.

- **Bug Fixes**
  - Fixed connectAttemptGated misclassified as a timeout; now mapped to its own category and shows accurate messaging.

<sup>Written for commit bda41e96e2228e13715de5ac3a3371554b403892. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/9674?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Tailscale-only connections now use exclusively authorized Tailscale routes.
  - Added clear pairing-required guidance when no authorized route is available.
  - Pairing guidance is available in English and Japanese.

- **Bug Fixes**
  - Prevented unintended fallback to Iroh or other transports when Tailscale is selected.
  - Improved reconnect behavior and connection-error classification.

- **Documentation**
  - Clarified setup, QR pairing, and Auto-Connect fallback information throughout onboarding and connection settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->