### PR TITLE
Parallelize coderouter usage and add dedicated landing

### DIFF
--- a/web/app/api/coderouter/accounts/route.ts
+++ b/web/app/api/coderouter/accounts/route.ts
@@ -1,5 +1,8 @@
 import { addAccount, parseCredential } from "../../../../services/coderouter/accounts";
-import { resolveCodeRouterRequestContext } from "../../../../services/coderouter/requestContext";
+import {
+  resolveCoderouterUsageTeam,
+  resolveCodeRouterRequestContext,
+} from "../../../../services/coderouter/requestContext";
 import { accountsWithUsage } from "../../../../services/coderouter/usage";
 
 export const runtime = "nodejs";
@@ -8,11 +11,11 @@ export const dynamic = "force-dynamic";
 const MAX_BODY_BYTES = 128 * 1_024;
 
 export async function GET(request: Request): Promise<Response> {
-  const resolved = await resolveCodeRouterRequestContext(request, "use-or-manage");
+  const resolved = await resolveCoderouterUsageTeam(request);
   if (!resolved.ok) return resolved.response;
-  const accounts = await accountsWithUsage(resolved.value.team.teamId);
+  const accounts = await accountsWithUsage(resolved.teamId);
   return Response.json(
-    { teamId: resolved.value.team.teamId, accounts },
+    { teamId: resolved.teamId, accounts },
     { headers: { "cache-control": "no-store" } },
   );
 }

--- a/web/app/coderouter/page.tsx
+++ b/web/app/coderouter/page.tsx
@@ -1,0 +1,63 @@
+import type { Metadata } from "next";
+
+const tagline =
+  "coderouter - route Codex/Claude Code traffic across multiple ChatGPT Pro/Claude Max/OpenCode subscriptions and API keys.";
+
+export const metadata: Metadata = {
+  title: "coderouter",
+  description: tagline,
+  alternates: { canonical: "https://coderouter.dev" },
+};
+
+export default function CoderouterLandingPage() {
+  return (
+    <main className="min-h-screen bg-[#fafafa] text-[#111]">
+      <nav className="mx-auto flex h-16 max-w-6xl items-center justify-between px-6">
+        <span className="font-mono text-sm font-medium tracking-[-0.02em]">
+          coderouter
+        </span>
+        <span className="rounded-full border border-black/10 bg-white px-3 py-1 font-mono text-[11px] text-black/50">
+          private beta
+        </span>
+      </nav>
+
+      <section className="mx-auto flex min-h-[calc(100vh-8rem)] max-w-6xl items-center px-6 py-20">
+        <div className="max-w-4xl">
+          <p className="mb-6 font-mono text-xs uppercase tracking-[0.14em] text-black/40">
+            one endpoint. every subscription.
+          </p>
+          <h1 className="max-w-4xl text-balance text-4xl font-medium leading-[1.08] tracking-[-0.045em] sm:text-6xl lg:text-7xl">
+            {tagline}
+          </h1>
+
+          <div className="mt-12 inline-flex items-center gap-5 rounded-xl border border-black/10 bg-white p-2 pl-5 shadow-[0_1px_2px_rgba(0,0,0,0.04)]">
+            <code className="font-mono text-sm text-black/70">
+              cr codex
+            </code>
+            <span className="select-none rounded-lg bg-black px-4 py-2 font-mono text-xs text-white">
+              coming soon
+            </span>
+          </div>
+
+          <div className="mt-20 grid max-w-3xl gap-px overflow-hidden rounded-xl border border-black/10 bg-black/10 sm:grid-cols-3">
+            {[
+              ["01", "connect", "Add subscriptions with provider-native authorization."],
+              ["02", "route", "Use one OpenAI-compatible endpoint from any agent."],
+              ["03", "continue", "Move to healthy capacity without changing your workflow."],
+            ].map(([number, title, description]) => (
+              <div key={number} className="bg-[#fafafa] p-6">
+                <p className="font-mono text-[11px] text-black/30">{number}</p>
+                <h2 className="mt-8 text-sm font-medium">{title}</h2>
+                <p className="mt-2 text-sm leading-6 text-black/50">{description}</p>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      <footer className="mx-auto flex h-16 max-w-6xl items-center px-6 font-mono text-[11px] text-black/30">
+        coderouter.dev
+      </footer>
+    </main>
+  );
+}

--- a/web/proxy.ts
+++ b/web/proxy.ts
@@ -28,7 +28,16 @@ export default function middleware(request: NextRequest) {
 
   const { pathname } = request.nextUrl;
 
-  // OpenAI-compatible CodeRouter traffic is a machine endpoint, never a
+  if (
+    (host === "coderouter.dev" || host === "www.coderouter.dev") &&
+    (pathname === "/" || pathname === "/en" || pathname === "/en/")
+  ) {
+    const url = request.nextUrl.clone();
+    url.pathname = "/coderouter";
+    return NextResponse.rewrite(url);
+  }
+
+  // OpenAI-compatible coderouter traffic is a machine endpoint, never a
   // localized page. Keep this explicit in addition to the matcher exclusion
   // so direct middleware tests and future matcher edits fail safely.
   if (pathname === "/v1/responses") {

--- a/web/services/coderouter/refresh.ts
+++ b/web/services/coderouter/refresh.ts
@@ -9,6 +9,7 @@ import {
   readTeamVault,
 } from "./vault";
 import type { CodeRouterCredential } from "./types";
+import type { VaultAccount } from "./types";
 
 const CODEX_CLIENT_ID = "app_EMoamEEZ73f0CkXaXp7hrann";
 const OPENCODE_CLIENT_ID = "opencode-cli";
@@ -27,8 +28,10 @@ export async function freshCredential(input: {
   readonly accountId: string;
   readonly expectedRevision: number;
   readonly force?: boolean;
+  readonly known?: VaultAccount;
 }): Promise<CodeRouterCredential> {
-  const before = await readCredential(input.teamId, input.accountId);
+  const before = input.known ??
+    await readCredential(input.teamId, input.accountId);
   if (!input.force && before.credential.expiresAt > Date.now() + REFRESH_SKEW_MS) {
     return before.credential;
   }

--- a/web/services/coderouter/repository.ts
+++ b/web/services/coderouter/repository.ts
@@ -319,7 +319,7 @@ export async function withVaultLease<T>(
       .from(coderouterVaultLeases)
       .where(eq(coderouterVaultLeases.teamId, teamId))
       .limit(1);
-    if (active) throw new CodeRouterLeaseBusy("Stack vault is busy");
+    if (active) throw new CodeRouterLeaseBusy("coderouter vault is busy");
     await tx.insert(coderouterVaultLeases).values({
       teamId,
       leaseId,

--- a/web/services/coderouter/requestContext.ts
+++ b/web/services/coderouter/requestContext.ts
@@ -13,6 +13,7 @@ import {
   type AuthedUser,
 } from "../vms/auth";
 import { resolveTeam } from "../subrouter/routeHelpers";
+import { authenticateRouteToken } from "./repository";
 
 export type CodeRouterRequestContext = {
   readonly user: AuthedUser;
@@ -23,6 +24,24 @@ export type CodeRouterRequestContext = {
     readonly manageAccounts: boolean;
   };
 };
+
+export async function resolveCoderouterUsageTeam(
+  request: Request,
+): Promise<
+  | { readonly ok: true; readonly teamId: string }
+  | { readonly ok: false; readonly response: Response }
+> {
+  const authorization = request.headers.get("authorization");
+  const token = authorization?.match(/^Bearer\s+(\S+)$/i)?.[1];
+  if (token?.startsWith("crt_")) {
+    const routed = await authenticateRouteToken(token);
+    if (routed) return { ok: true, teamId: routed.teamId };
+  }
+  const resolved = await resolveCodeRouterRequestContext(request, "use-or-manage");
+  return resolved.ok
+    ? { ok: true, teamId: resolved.value.team.teamId }
+    : resolved;
+}
 
 export async function resolveCodeRouterRequestContext(
   request: Request,

--- a/web/services/coderouter/usage.ts
+++ b/web/services/coderouter/usage.ts
@@ -1,10 +1,16 @@
 import { listAccounts, markAccountCooldown } from "./repository";
 import { freshCredential } from "./refresh";
+import { readTeamVault } from "./vault";
 
 const CODEX_USAGE_URL = "https://chatgpt.com/backend-api/wham/usage";
 
 export async function accountsWithUsage(teamId: string) {
-  const accounts = await listAccounts(teamId);
+  // The account list and encrypted credential snapshot are independent.
+  // Fetch each exactly once and overlap their network round trips.
+  const [accounts, vault] = await Promise.all([
+    listAccounts(teamId),
+    readTeamVault(teamId).catch(() => null),
+  ]);
   return await Promise.all(accounts.map(async (account) => {
     if (account.provider !== "codex" || account.state !== "active") {
       return account;
@@ -14,6 +20,7 @@ export async function accountsWithUsage(teamId: string) {
         teamId,
         accountId: account.id,
         expectedRevision: 0,
+        known: vault?.accounts[account.id],
       });
       if (credential.provider !== "codex") return account;
       const response = await fetch(CODEX_USAGE_URL, {

--- a/web/services/coderouter/vault.ts
+++ b/web/services/coderouter/vault.ts
@@ -17,7 +17,7 @@ export class CodeRouterVaultCorrupt extends Error {
 
 export async function readTeamVault(teamId: string): Promise<CodeRouterVault> {
   const team = await getStackServerApp().getTeam(teamId);
-  if (!team) throw new CodeRouterVaultUnavailable("Stack team not found");
+  if (!team) throw new CodeRouterVaultUnavailable("coderouter team not found");
   return parseVault(team.serverMetadata?.[METADATA_KEY]);
 }
 
@@ -26,7 +26,7 @@ export async function writeTeamVault(
   vault: CodeRouterVault,
 ): Promise<void> {
   const team = await getStackServerApp().getTeam(teamId);
-  if (!team) throw new CodeRouterVaultUnavailable("Stack team not found");
+  if (!team) throw new CodeRouterVaultUnavailable("coderouter team not found");
   const metadata = isRecord(team.serverMetadata)
     ? { ...team.serverMetadata }
     : {};
@@ -79,7 +79,7 @@ export function parseVault(value: unknown): CodeRouterVault {
     return { version: 1, accounts: {} };
   }
   if (!isRecord(value) || value.version !== 1 || !isRecord(value.accounts)) {
-    throw new CodeRouterVaultCorrupt("invalid Stack CodeRouter vault");
+    throw new CodeRouterVaultCorrupt("invalid coderouter vault");
   }
   const accounts: Record<string, VaultAccount> = {};
   for (const [accountId, candidate] of Object.entries(value.accounts)) {
@@ -89,7 +89,7 @@ export function parseVault(value: unknown): CodeRouterVault {
       (candidate.revision as number) < 1 ||
       !isCredential(candidate.credential)
     ) {
-      throw new CodeRouterVaultCorrupt("invalid Stack CodeRouter vault account");
+      throw new CodeRouterVaultCorrupt("invalid coderouter vault account");
     }
     accounts[accountId] = {
       revision: candidate.revision as number,

--- a/web/tests/coderouter-middleware.test.ts
+++ b/web/tests/coderouter-middleware.test.ts
@@ -2,7 +2,19 @@ import { describe, expect, test } from "bun:test";
 import { NextRequest } from "next/server";
 import middleware from "../proxy";
 
-describe("CodeRouter middleware", () => {
+describe("coderouter middleware", () => {
+  test("serves a dedicated landing page on coderouter.dev", () => {
+    const response = middleware(
+      new NextRequest("https://coderouter.dev/", {
+        headers: { host: "coderouter.dev" },
+      }),
+    );
+
+    expect(response.headers.get("x-middleware-rewrite")).toBe(
+      "https://coderouter.dev/coderouter",
+    );
+  });
+
   test("does not localize the OpenAI-compatible data-plane route", () => {
     const response = middleware(
       new NextRequest("https://coderouter.dev/v1/responses", {

--- a/web/tests/coderouter-models-proxy.test.ts
+++ b/web/tests/coderouter-models-proxy.test.ts
@@ -39,7 +39,7 @@ afterAll(() => {
 
 const { proxyCodexModels } = await import("../services/coderouter/codexProxy");
 
-describe("CodeRouter models proxy", () => {
+describe("coderouter models proxy", () => {
   test("forwards Codex model discovery through the authenticated account", async () => {
     const response = await proxyCodexModels(
       new Request("https://coderouter.dev/v1/models?client_version=0.146.0", {

--- a/web/tests/coderouter-opencode-proxy.test.ts
+++ b/web/tests/coderouter-opencode-proxy.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import { __test } from "../services/coderouter/opencodeProxy";
 
-describe("CodeRouter OpenCode Go proxy", () => {
+describe("coderouter OpenCode Go proxy", () => {
   test("rewrites provider traffic through coderouter.dev without upstream secrets", () => {
     const rewritten = __test.rewriteProviders({
       go: {

--- a/web/tests/coderouter-vault.test.ts
+++ b/web/tests/coderouter-vault.test.ts
@@ -12,7 +12,7 @@ const codex = {
   expiresAt: Date.now() + 3_600_000,
 };
 
-describe("CodeRouter Stack vault", () => {
+describe("coderouter vault", () => {
   test("accepts complete Codex and OpenCode Go credentials", () => {
     expect(parseCredential(codex)).toEqual(codex);
     expect(parseCredential({
@@ -39,7 +39,7 @@ describe("CodeRouter Stack vault", () => {
       accounts: {
         "account-1": { revision: 1, credential: { ...codex, refreshToken: "" } },
       },
-    })).toThrow("invalid Stack CodeRouter vault account");
+    })).toThrow("invalid coderouter vault account");
   });
 
   test("treats an absent vault as an empty versioned vault", () => {


### PR DESCRIPTION
## Summary
- authenticate read-only usage requests with scoped coderouter route tokens instead of interactive auth
- fetch the account list and one encrypted credential snapshot concurrently
- fan out all provider usage requests with `Promise.all`
- avoid one vault read per account by passing the shared snapshot into refresh logic
- serve a dedicated minimal landing page on coderouter.dev
- style user-visible coderouter branding lowercase

## Verification
- targeted coderouter route, proxy, and vault tests pass
- TypeScript typecheck passes
- production deployment is tested separately against coderouter.dev

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/9675"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788566990&installation_model_id=21920&pr_number=9675&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F9675&signature=1fb4382a3e09c66824a71dca4dab744d8c86bcd0553c297bfc3ca3c48da380a5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Parallelized coderouter usage fetching and added a dedicated landing page at coderouter.dev. Also enabled route-token auth for read-only usage requests and standardized lowercase branding.

- **New Features**
  - Serve a minimal landing page at `/coderouter` with host rewrite for `coderouter.dev` and `www.coderouter.dev`.
  - Support `crt_` route tokens to authenticate usage requests without interactive auth.
  - Lowercase user-facing “coderouter” branding.

- **Performance**
  - Fetch the account list and encrypted vault snapshot concurrently.
  - Fan out provider usage requests with `Promise.all`.
  - Pass the shared vault snapshot into credential refresh to avoid per-account vault reads.

<sup>Written for commit 01957c381bb19855c175204f6171c12dcb14108a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/9675?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a dedicated Coderouter landing page with private-beta branding, SEO metadata, feature highlights, subscription-routing messaging, and a “coming soon” Codex command.
  * Requests to `coderouter.dev` and `www.coderouter.dev` now open the Coderouter landing page.
  * Improved account access and usage handling for supported route-based authentication.

* **Bug Fixes**
  * Improved credential refresh reliability and handling when vault access is unavailable.
  * Updated vault and availability messages to consistently use Coderouter terminology.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->