### PR TITLE
Cache coderouter usage and collapse token auth query

### DIFF
--- a/web/services/coderouter/repository.ts
+++ b/web/services/coderouter/repository.ts
@@ -45,20 +45,15 @@ export async function authenticateRouteToken(
 ): Promise<{ teamId: string } | null> {
   if (!/^crt_[A-Za-z0-9_-]{40,}$/.test(token)) return null;
   const [row] = await cloudDb()
-    .select({ id: coderouterRouteTokens.id, teamId: coderouterRouteTokens.teamId })
-    .from(coderouterRouteTokens)
+    .update(coderouterRouteTokens)
+    .set({ lastUsedAt: now })
     .where(and(
       eq(coderouterRouteTokens.tokenHash, routeTokenHash(token)),
       gt(coderouterRouteTokens.expiresAt, now),
       isNull(coderouterRouteTokens.revokedAt),
     ))
-    .limit(1);
-  if (!row) return null;
-  await cloudDb()
-    .update(coderouterRouteTokens)
-    .set({ lastUsedAt: now })
-    .where(eq(coderouterRouteTokens.id, row.id));
-  return { teamId: row.teamId };
+    .returning({ teamId: coderouterRouteTokens.teamId });
+  return row ?? null;
 }
 
 export async function revokeRouteToken(

--- a/web/services/coderouter/usage.ts
+++ b/web/services/coderouter/usage.ts
@@ -3,8 +3,43 @@ import { freshCredential } from "./refresh";
 import { readTeamVault } from "./vault";
 
 const CODEX_USAGE_URL = "https://chatgpt.com/backend-api/wham/usage";
+const USAGE_CACHE_MS = 15_000;
+const MAX_CACHED_TEAMS = 256;
+const usageCache = new Map<string, {
+  readonly expiresAt: number;
+  readonly accounts: Awaited<ReturnType<typeof loadAccountsWithUsage>>;
+}>();
+const usageRequests = new Map<
+  string,
+  Promise<Awaited<ReturnType<typeof loadAccountsWithUsage>>>
+>();
 
 export async function accountsWithUsage(teamId: string) {
+  const cached = usageCache.get(teamId);
+  if (cached && cached.expiresAt > Date.now()) return cached.accounts;
+  const pending = usageRequests.get(teamId);
+  if (pending) return await pending;
+
+  const request = loadAccountsWithUsage(teamId);
+  usageRequests.set(teamId, request);
+  try {
+    const accounts = await request;
+    if (usageCache.size >= MAX_CACHED_TEAMS && !usageCache.has(teamId)) {
+      const oldest = usageCache.keys().next().value;
+      if (oldest !== undefined) usageCache.delete(oldest);
+    }
+    usageCache.delete(teamId);
+    usageCache.set(teamId, {
+      expiresAt: Date.now() + USAGE_CACHE_MS,
+      accounts,
+    });
+    return accounts;
+  } finally {
+    usageRequests.delete(teamId);
+  }
+}
+
+async function loadAccountsWithUsage(teamId: string) {
   // The account list and encrypted credential snapshot are independent.
   // Fetch each exactly once and overlap their network round trips.
   const [accounts, vault] = await Promise.all([


### PR DESCRIPTION
## Summary
- cache non-secret usage summaries for 15 seconds per team
- coalesce concurrent usage requests so one provider fanout serves all callers
- cap the warm-instance cache at 256 teams
- authenticate route tokens with one atomic update-returning query instead of a select followed by an update

Provider requests remain parallel; the cache only holds account labels and usage responses, never credentials.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/9676"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788567381&installation_model_id=21920&pr_number=9676&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F9676&signature=c325c65ca7e9479060685932200b841eb813ee23a1ca67c3698b57235932986b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Caches coderouter usage per team for 15s and coalesces concurrent requests to cut provider fanout. Also replaces the select+update token auth with a single atomic update-returning query.

- **New Features**
  - 15s in-memory usage cache per team, capped at 256 teams.
  - Coalesces concurrent usage calls; one provider fanout serves all callers.
  - Cache holds only account labels and usage; never credentials. Provider calls stay parallel.

- **Refactors**
  - Token auth now uses a single update-returning to set lastUsedAt and return teamId.

<sup>Written for commit 0851fc62504d6a6b7da21091fdf0764852ec441f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/9676?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Improved usage loading by caching team usage data for up to 15 seconds.
  * Reduced duplicate requests when multiple usage checks occur simultaneously.
  * Added automatic cache limits and cleanup for reliable performance.

* **Bug Fixes**
  * Improved route token validation and activity tracking.
  * Ensured temporary usage-loading state is cleared when requests fail.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->