### PR TITLE
Add discoverable cmux Browser download page

### DIFF
--- a/web/app/[locale]/(landing)/browser/browser-download-card-action.tsx
+++ b/web/app/[locale]/(landing)/browser/browser-download-card-action.tsx
@@ -1,0 +1,53 @@
+import {
+  ctaButtonBase,
+  ctaButtonDefaultSize,
+  ctaButtonStyle,
+} from "@/app/[locale]/components/cta-styles";
+import {
+  PlatformDownloadLink,
+  type BrowserDownloadPlatform,
+} from "@/app/[locale]/components/platform-download-link";
+
+interface BrowserDownloadCardActionProps {
+  readonly platform: BrowserDownloadPlatform;
+  readonly artifact: string;
+  readonly href: string;
+  readonly available: boolean;
+  readonly children: React.ReactNode;
+}
+
+/** Keeps download telemetry and disabled-card semantics consistent. */
+export function BrowserDownloadCardAction({
+  platform,
+  artifact,
+  href,
+  available,
+  children,
+}: BrowserDownloadCardActionProps) {
+  const className = `${ctaButtonBase} ${ctaButtonDefaultSize} w-full justify-center`;
+
+  if (available) {
+    return (
+      <PlatformDownloadLink
+        href={href}
+        platform={platform}
+        artifact={artifact}
+        location="browser-landing"
+        className={className}
+        style={ctaButtonStyle}
+      >
+        {children}
+      </PlatformDownloadLink>
+    );
+  }
+
+  return (
+    <span
+      aria-disabled="true"
+      className={`${className} cursor-not-allowed opacity-45`}
+      style={ctaButtonStyle}
+    >
+      {children}
+    </span>
+  );
+}

--- a/web/app/[locale]/(landing)/browser/page.tsx
+++ b/web/app/[locale]/(landing)/browser/page.tsx
@@ -1,11 +1,6 @@
 import Image from "next/image";
 import { getTranslations } from "next-intl/server";
 import { BrandLogoLink } from "@/app/[locale]/components/brand-logo-link";
-import {
-  ctaButtonBase,
-  ctaButtonDefaultSize,
-  ctaButtonStyle,
-} from "@/app/[locale]/components/cta-styles";
 import { PlatformIcon } from "@/app/[locale]/components/platform-icons";
 import { SiteHeader } from "@/app/[locale]/components/site-header";
 import {
@@ -17,6 +12,7 @@ import {
   PLATFORM_DOWNLOADS,
 } from "@/app/lib/download";
 import { buildAlternates, openGraphDefaults, twitterSummary } from "@/i18n/seo";
+import { BrowserDownloadCardAction } from "./browser-download-card-action";
 
 export async function generateMetadata({
   params,
@@ -61,6 +57,7 @@ export default async function BrowserPage() {
       name: platforms("macos"),
       cta: common("downloadForMac"),
       href: BROWSER_MACOS_NIGHTLY_DOWNLOAD.primary.url,
+      artifact: BROWSER_MACOS_NIGHTLY_DOWNLOAD.primary.artifact,
       available: BROWSER_MACOS_NIGHTLY_AVAILABLE,
       requirements: null,
     },
@@ -69,6 +66,7 @@ export default async function BrowserPage() {
       name: t("windows.name"),
       cta: t("windows.primaryCta"),
       href: PLATFORM_DOWNLOADS.windows.primary.url,
+      artifact: PLATFORM_DOWNLOADS.windows.primary.artifact,
       available: PLATFORM_DOWNLOAD_AVAILABILITY.windows,
       requirements: t("windows.requirements"),
     },
@@ -77,6 +75,7 @@ export default async function BrowserPage() {
       name: t("linux.name"),
       cta: t("linux.primaryCta"),
       href: PLATFORM_DOWNLOADS.linux.primary.url,
+      artifact: PLATFORM_DOWNLOADS.linux.primary.artifact,
       available: PLATFORM_DOWNLOAD_AVAILABILITY.linux,
       requirements: t("linux.requirements"),
     },
@@ -130,23 +129,14 @@ export default async function BrowserPage() {
                 </p>
               )}
               <div className="mt-auto pt-6">
-                {card.available ? (
-                  <a
-                    href={card.href}
-                    className={`${ctaButtonBase} ${ctaButtonDefaultSize} w-full justify-center`}
-                    style={ctaButtonStyle}
-                  >
-                    {card.cta}
-                  </a>
-                ) : (
-                  <span
-                    aria-disabled="true"
-                    className={`${ctaButtonBase} ${ctaButtonDefaultSize} w-full cursor-not-allowed justify-center opacity-45`}
-                    style={ctaButtonStyle}
-                  >
-                    {card.cta}
-                  </span>
-                )}
+                <BrowserDownloadCardAction
+                  platform={card.platform}
+                  artifact={card.artifact}
+                  href={card.href}
+                  available={card.available}
+                >
+                  {card.cta}
+                </BrowserDownloadCardAction>
               </div>
             </section>
           ))}

--- a/web/app/[locale]/(landing)/browser/page.tsx
+++ b/web/app/[locale]/(landing)/browser/page.tsx
@@ -24,9 +24,12 @@ export async function generateMetadata({
   params: Promise<{ locale: string }>;
 }) {
   const { locale } = await params;
-  const t = await getTranslations({ locale, namespace: "browserDownloads" });
+  const [t, footer] = await Promise.all([
+    getTranslations({ locale, namespace: "browserDownloads" }),
+    getTranslations({ locale, namespace: "footer" }),
+  ]);
   const alternates = buildAlternates(locale, "/browser");
-  const title = `${t("eyebrow")} — ${t("releaseTitle")}`;
+  const title = `${t("eyebrow")} ${footer("nightly")}`;
   const description = t("tagline");
 
   return {
@@ -44,12 +47,14 @@ export async function generateMetadata({
 }
 
 export default async function BrowserPage() {
-  const [t, common, platforms, unavailable] = await Promise.all([
+  const [t, common, platforms, unavailable, footer] = await Promise.all([
     getTranslations("browserDownloads"),
     getTranslations("common"),
     getTranslations("platforms"),
     getTranslations("vault.detail"),
+    getTranslations("footer"),
   ]);
+  const title = `${t("eyebrow")} ${footer("nightly")}`;
   const cards = [
     {
       platform: "macos" as const,
@@ -96,7 +101,7 @@ export default async function BrowserPage() {
               {t("releaseTitle")}
             </p>
             <h1 className="text-2xl font-semibold tracking-tight">
-              {t("eyebrow")}
+              {title}
             </h1>
           </div>
         </div>

--- a/web/app/[locale]/(landing)/browser/page.tsx
+++ b/web/app/[locale]/(landing)/browser/page.tsx
@@ -62,7 +62,7 @@ export default async function BrowserPage() {
       cta: common("downloadForMac"),
       href: BROWSER_MACOS_NIGHTLY_DOWNLOAD.primary.url,
       available: BROWSER_MACOS_NIGHTLY_AVAILABLE,
-      requirements: "macOS · Universal 2",
+      requirements: null,
     },
     {
       platform: "windows" as const,
@@ -121,7 +121,9 @@ export default async function BrowserPage() {
                 <PlatformIcon name={card.platform} size={20} />
                 <h2 className="text-base font-medium">{card.name}</h2>
               </div>
-              <p className="mt-3 text-sm text-muted">{card.requirements}</p>
+              {card.requirements && (
+                <p className="mt-3 text-sm text-muted">{card.requirements}</p>
+              )}
               {!card.available && (
                 <p className="mt-4 text-xs text-muted">
                   {waitlist("calloutText")}

--- a/web/app/[locale]/(landing)/browser/page.tsx
+++ b/web/app/[locale]/(landing)/browser/page.tsx
@@ -1,0 +1,177 @@
+import Image from "next/image";
+import { getTranslations } from "next-intl/server";
+import { BrandLogoLink } from "@/app/[locale]/components/brand-logo-link";
+import {
+  ctaButtonBase,
+  ctaButtonDefaultSize,
+  ctaButtonStyle,
+} from "@/app/[locale]/components/cta-styles";
+import { PlatformIcon } from "@/app/[locale]/components/platform-icons";
+import { SiteHeader } from "@/app/[locale]/components/site-header";
+import {
+  BROWSER_MACOS_NIGHTLY_AVAILABLE,
+  BROWSER_MACOS_NIGHTLY_DOWNLOAD,
+  BROWSER_NIGHTLY_RELEASE_URL,
+  BROWSER_RELEASE_REPOSITORY_URL,
+  PLATFORM_DOWNLOAD_AVAILABILITY,
+  PLATFORM_DOWNLOADS,
+} from "@/app/lib/download";
+import { buildAlternates, openGraphDefaults, twitterSummary } from "@/i18n/seo";
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ locale: string }>;
+}) {
+  const { locale } = await params;
+  const t = await getTranslations({ locale, namespace: "browserDownloads" });
+  const alternates = buildAlternates(locale, "/browser");
+  const title = `${t("eyebrow")} — ${t("releaseTitle")}`;
+  const description = t("tagline");
+
+  return {
+    title,
+    description,
+    alternates,
+    openGraph: {
+      ...openGraphDefaults(locale, "website"),
+      title,
+      description,
+      url: alternates.canonical,
+    },
+    twitter: twitterSummary(locale, title, description),
+  };
+}
+
+export default async function BrowserPage() {
+  const [t, common, platforms, unavailable] = await Promise.all([
+    getTranslations("browserDownloads"),
+    getTranslations("common"),
+    getTranslations("platforms"),
+    getTranslations("vault.detail"),
+  ]);
+  const cards = [
+    {
+      platform: "macos" as const,
+      name: platforms("macos"),
+      cta: common("downloadForMac"),
+      href: BROWSER_MACOS_NIGHTLY_DOWNLOAD.primary.url,
+      available: BROWSER_MACOS_NIGHTLY_AVAILABLE,
+      requirements: "macOS · Universal 2",
+    },
+    {
+      platform: "windows" as const,
+      name: t("windows.name"),
+      cta: t("windows.primaryCta"),
+      href: PLATFORM_DOWNLOADS.windows.primary.url,
+      available: PLATFORM_DOWNLOAD_AVAILABILITY.windows,
+      requirements: t("windows.requirements"),
+    },
+    {
+      platform: "linux" as const,
+      name: t("linux.name"),
+      cta: t("linux.primaryCta"),
+      href: PLATFORM_DOWNLOADS.linux.primary.url,
+      available: PLATFORM_DOWNLOAD_AVAILABILITY.linux,
+      requirements: t("linux.requirements"),
+    },
+  ];
+
+  return (
+    <div className="min-h-screen">
+      <SiteHeader hideLogo />
+      <main className="mx-auto w-full max-w-4xl px-6 py-16 sm:py-24">
+        <div className="mb-10 flex items-center gap-4">
+          <BrandLogoLink className="shrink-0">
+            <Image
+              src="/logo.png"
+              alt={t("logoAlt")}
+              width={48}
+              height={48}
+              className="rounded-xl"
+            />
+          </BrandLogoLink>
+          <div>
+            <p className="mb-1 text-xs font-medium text-muted">
+              {t("releaseTitle")}
+            </p>
+            <h1 className="text-2xl font-semibold tracking-tight">
+              {t("eyebrow")}
+            </h1>
+          </div>
+        </div>
+
+        <p className="max-w-2xl text-lg leading-relaxed text-foreground">
+          {t("tagline")}
+        </p>
+
+        <div className="mt-10 grid gap-4 md:grid-cols-3">
+          {cards.map((card) => (
+            <section
+              key={card.platform}
+              className="flex min-h-64 flex-col rounded-2xl border border-border p-5"
+              data-dev={`browser-${card.platform}`}
+            >
+              <div className="flex items-center gap-2.5">
+                <PlatformIcon name={card.platform} size={20} />
+                <h2 className="text-base font-medium">{card.name}</h2>
+              </div>
+              <p className="mt-3 text-sm text-muted">{card.requirements}</p>
+              {!card.available && (
+                <p className="mt-4 text-xs text-muted">
+                  {unavailable("downloadUnavailable")}
+                </p>
+              )}
+              <div className="mt-auto pt-6">
+                {card.available ? (
+                  <a
+                    href={card.href}
+                    className={`${ctaButtonBase} ${ctaButtonDefaultSize} w-full justify-center`}
+                    style={ctaButtonStyle}
+                  >
+                    {card.cta}
+                  </a>
+                ) : (
+                  <span
+                    aria-disabled="true"
+                    className={`${ctaButtonBase} ${ctaButtonDefaultSize} w-full cursor-not-allowed justify-center opacity-45`}
+                    style={ctaButtonStyle}
+                  >
+                    {card.cta}
+                  </span>
+                )}
+              </div>
+            </section>
+          ))}
+        </div>
+
+        <section className="mt-12 rounded-2xl border border-border bg-code-bg/40 p-6">
+          <h2 className="text-sm font-medium text-foreground">
+            {t("releaseTitle")}
+          </h2>
+          <p className="mt-2 text-[15px] text-muted" style={{ lineHeight: 1.5 }}>
+            {t.rich("releaseBody", {
+              github: (chunks) => (
+                <a
+                  href={BROWSER_NIGHTLY_RELEASE_URL}
+                  className="underline decoration-link-underline underline-offset-2 transition-colors hover:decoration-foreground"
+                >
+                  {chunks}
+                </a>
+              ),
+            })}
+          </p>
+        </section>
+
+        <div className="mt-8 text-sm">
+          <a
+            href={BROWSER_RELEASE_REPOSITORY_URL}
+            className="text-muted underline decoration-link-underline underline-offset-2 transition-colors hover:text-foreground hover:decoration-foreground"
+          >
+            {t("sourceLink")}
+          </a>
+        </div>
+      </main>
+    </div>
+  );
+}

--- a/web/app/[locale]/(landing)/browser/page.tsx
+++ b/web/app/[locale]/(landing)/browser/page.tsx
@@ -47,11 +47,11 @@ export async function generateMetadata({
 }
 
 export default async function BrowserPage() {
-  const [t, common, platforms, unavailable, footer] = await Promise.all([
+  const [t, common, platforms, waitlist, footer] = await Promise.all([
     getTranslations("browserDownloads"),
     getTranslations("common"),
     getTranslations("platforms"),
-    getTranslations("vault.detail"),
+    getTranslations("waitlist"),
     getTranslations("footer"),
   ]);
   const title = `${t("eyebrow")} ${footer("nightly")}`;
@@ -124,7 +124,7 @@ export default async function BrowserPage() {
               <p className="mt-3 text-sm text-muted">{card.requirements}</p>
               {!card.available && (
                 <p className="mt-4 text-xs text-muted">
-                  {unavailable("downloadUnavailable")}
+                  {waitlist("calloutText")}
                 </p>
               )}
               <div className="mt-auto pt-6">

--- a/web/app/[locale]/components/download-button.tsx
+++ b/web/app/[locale]/components/download-button.tsx
@@ -6,6 +6,7 @@ import posthog from "posthog-js";
 import { useState } from "react";
 import { Link, usePathname } from "../../../i18n/navigation";
 import {
+  BROWSER_NIGHTLY_PAGE,
   DOWNLOAD_CONFIRMATION_HREF,
   DOWNLOAD_CONFIRMATION_PATH,
   DOWNLOAD_PLATFORMS,
@@ -39,6 +40,7 @@ export function DownloadButton({
 }) {
   const t = useTranslations("common");
   const tp = useTranslations("platforms");
+  const tb = useTranslations("browserDownloads");
   const tw = useTranslations("waitlist");
   const pathname = usePathname();
   const isSmall = size === "sm";
@@ -212,6 +214,18 @@ export function DownloadButton({
                   <span className="flex-1 text-left">{tp("ios")}</span>
                   <ExternalLinkIcon />
                 </Menu.Item>
+                <Menu.Item
+                  render={<Link href={BROWSER_NIGHTLY_PAGE} />}
+                  onClick={() =>
+                    posthog.capture("cmux_browser_nightly_page_clicked", {
+                      location,
+                    })
+                  }
+                  className={menuItemClass}
+                >
+                  <BrowserIcon />
+                  <span className="flex-1 text-left">{tb("eyebrow")}</span>
+                </Menu.Item>
                 {DOWNLOAD_PLATFORMS.map((platform) => (
                   <Menu.Item
                     key={platform}
@@ -288,6 +302,26 @@ function ExternalLinkIcon() {
       <path d="M6 3.5H3.5v9h9V10" />
       <path d="M9.5 3.5h3v3" />
       <path d="m12.5 3.5-5 5" />
+    </svg>
+  );
+}
+
+function BrowserIcon() {
+  return (
+    <svg
+      width="16"
+      height="16"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.8"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <rect x="3" y="4" width="18" height="16" rx="2" />
+      <path d="M3 9h18" />
+      <path d="M7 6.5h.01M10 6.5h.01" />
     </svg>
   );
 }

--- a/web/app/[locale]/components/download-button.tsx
+++ b/web/app/[locale]/components/download-button.tsx
@@ -41,6 +41,7 @@ export function DownloadButton({
   const t = useTranslations("common");
   const tp = useTranslations("platforms");
   const tb = useTranslations("browserDownloads");
+  const tf = useTranslations("footer");
   const tw = useTranslations("waitlist");
   const pathname = usePathname();
   const isSmall = size === "sm";
@@ -224,7 +225,9 @@ export function DownloadButton({
                   className={menuItemClass}
                 >
                   <BrowserIcon />
-                  <span className="flex-1 text-left">{tb("eyebrow")}</span>
+                  <span className="flex-1 text-left">
+                    {tb("eyebrow")} {tf("nightly")}
+                  </span>
                 </Menu.Item>
                 {DOWNLOAD_PLATFORMS.map((platform) => (
                   <Menu.Item

--- a/web/app/[locale]/components/platform-download-link.tsx
+++ b/web/app/[locale]/components/platform-download-link.tsx
@@ -3,6 +3,8 @@
 import posthog from "posthog-js";
 import type { DownloadPlatform } from "@/app/lib/download";
 
+export type BrowserDownloadPlatform = DownloadPlatform | "macos";
+
 /** Emits download intent telemetry before following an artifact link. */
 export function PlatformDownloadLink({
   href,
@@ -14,7 +16,7 @@ export function PlatformDownloadLink({
   children,
 }: {
   href: string;
-  platform: DownloadPlatform;
+  platform: BrowserDownloadPlatform;
   artifact: string;
   location: string;
   className?: string;

--- a/web/app/lib/agent-page-paths.ts
+++ b/web/app/lib/agent-page-paths.ts
@@ -128,6 +128,7 @@ const agentReadableDownloadPages = DOWNLOAD_PLATFORMS.map((platform) => ({
 export const agentReadablePages = [
   { path: "/", title: "Home" },
   { path: "/ios", title: "cmux iOS" },
+  { path: "/browser", title: "cmux Browser" },
   ...agentReadableDownloadPages,
   { path: "/pricing", title: "Pricing", locales: fallbackContentLocales },
   { path: "/enterprise", title: "Enterprise" },

--- a/web/app/lib/download.ts
+++ b/web/app/lib/download.ts
@@ -38,7 +38,25 @@ export const BROWSER_RELEASE_REPOSITORY_URL =
 export const BROWSER_NIGHTLY_RELEASE_URL =
   `${BROWSER_RELEASE_REPOSITORY_URL}/releases/tag/nightly`;
 
+/** Discoverable landing page for the cross-platform cmux Browser nightly. */
+export const BROWSER_NIGHTLY_PAGE = "/browser";
+
 const BROWSER_NIGHTLY_DOWNLOAD_PATH = "/api/download/browser-nightly";
+
+/** Universal 2 macOS artifacts resolved through the signed public feed. */
+export const BROWSER_MACOS_NIGHTLY_DOWNLOAD = {
+  primary: {
+    artifact: "dmg",
+    url: `${BROWSER_NIGHTLY_DOWNLOAD_PATH}/mac-arm64/dmg`,
+  },
+  secondary: {
+    artifact: "update-zip",
+    url: `${BROWSER_NIGHTLY_DOWNLOAD_PATH}/mac-arm64/zip`,
+  },
+} as const;
+
+/** Flip only after the signed public feed and Universal 2 DMG are live. */
+export const BROWSER_MACOS_NIGHTLY_AVAILABLE = false;
 
 /**
  * Stable cross-platform cmux Browser download endpoints. The browser never

--- a/web/app/sitemap.ts
+++ b/web/app/sitemap.ts
@@ -33,6 +33,7 @@ export default function sitemap(): MetadataRoute.Sitemap {
   }> = [
     { path: "", lastModified: "2026-03-18", changeFrequency: "weekly" as const, priority: 1 },
     { path: "/ios", lastModified: "2026-06-22", changeFrequency: "monthly" as const, priority: 0.8 },
+    { path: "/browser", lastModified: "2026-08-05", changeFrequency: "weekly" as const, priority: 0.9 },
     ...DOWNLOAD_PLATFORMS.map((platform) => ({
       path: PLATFORM_DOWNLOADS[platform].page,
       lastModified: "2026-08-04",

--- a/web/tests/browser-download-card-action.test.tsx
+++ b/web/tests/browser-download-card-action.test.tsx
@@ -1,13 +1,13 @@
-import { describe, expect, spyOn, test } from "bun:test";
+import { describe, expect, mock, test } from "bun:test";
 import posthog from "posthog-js";
 import { BrowserDownloadCardAction } from "../app/[locale]/(landing)/browser/browser-download-card-action";
 import { PlatformDownloadLink } from "../app/[locale]/components/platform-download-link";
 
 describe("Browser download card action", () => {
   test("tracks enabled landing-page downloads for current and future platforms", () => {
-    const capture = spyOn(posthog, "capture").mockImplementation(
-      () => undefined,
-    );
+    const originalCapture = posthog.capture;
+    const capture = mock(() => undefined);
+    posthog.capture = capture as unknown as typeof posthog.capture;
 
     try {
       const scenarios = [
@@ -59,7 +59,7 @@ describe("Browser download card action", () => {
         );
       }
     } finally {
-      capture.mockRestore();
+      posthog.capture = originalCapture;
     }
   });
 

--- a/web/tests/browser-download-card-action.test.tsx
+++ b/web/tests/browser-download-card-action.test.tsx
@@ -1,0 +1,80 @@
+import { describe, expect, spyOn, test } from "bun:test";
+import posthog from "posthog-js";
+import { BrowserDownloadCardAction } from "../app/[locale]/(landing)/browser/browser-download-card-action";
+import { PlatformDownloadLink } from "../app/[locale]/components/platform-download-link";
+
+describe("Browser download card action", () => {
+  test("tracks enabled landing-page downloads for current and future platforms", () => {
+    const capture = spyOn(posthog, "capture").mockImplementation(
+      () => undefined,
+    );
+
+    try {
+      const scenarios = [
+        {
+          platform: "linux",
+          artifact: "run-installer",
+          href: "/api/download/browser-nightly/linux-x64/run",
+        },
+        {
+          platform: "macos",
+          artifact: "dmg",
+          href: "/api/download/browser-nightly/mac-arm64/dmg",
+        },
+      ] as const;
+
+      for (const scenario of scenarios) {
+        const action = BrowserDownloadCardAction({
+          ...scenario,
+          available: true,
+          children: `Download for ${scenario.platform}`,
+        });
+
+        expect(action.type).toBe(PlatformDownloadLink);
+        if (action.type !== PlatformDownloadLink) {
+          throw new Error("available download did not render a tracked link");
+        }
+
+        const anchor = PlatformDownloadLink(action.props);
+        expect(anchor.type).toBe("a");
+        expect(anchor.props.href).toBe(scenario.href);
+        anchor.props.onClick();
+      }
+
+      expect(capture).toHaveBeenCalledTimes(2);
+      for (const [index, scenario] of scenarios.entries()) {
+        expect(capture).toHaveBeenNthCalledWith(
+          index + 1,
+          "cmux_browser_download_clicked",
+          {
+            platform: scenario.platform,
+            artifact: scenario.artifact,
+            location: "browser-landing",
+            target: scenario.href,
+          },
+          {
+            transport: "sendBeacon",
+            send_instantly: true,
+          },
+        );
+      }
+    } finally {
+      capture.mockRestore();
+    }
+  });
+
+  test("keeps unavailable landing-page downloads non-interactive", () => {
+    const action = BrowserDownloadCardAction({
+      platform: "windows",
+      artifact: "installer",
+      href: "/api/download/browser-nightly/windows-x64/installer",
+      available: false,
+      children: "Download installer (.exe)",
+    });
+
+    expect(action.type).toBe("span");
+    expect(action.props["aria-disabled"]).toBe("true");
+    expect(action.props.href).toBeUndefined();
+    expect(action.props.onClick).toBeUndefined();
+  });
+});

--- a/web/tests/platform-downloads.test.ts
+++ b/web/tests/platform-downloads.test.ts
@@ -168,6 +168,8 @@ describe("Windows and Linux downloads", () => {
     expect(browserPage).toContain("BROWSER_MACOS_NIGHTLY_AVAILABLE");
     expect(browserPage).toContain("PLATFORM_DOWNLOAD_AVAILABILITY.windows");
     expect(browserPage).toContain("PLATFORM_DOWNLOAD_AVAILABILITY.linux");
+    expect(browserPage).toContain('getTranslations("waitlist")');
+    expect(browserPage).not.toContain('getTranslations("vault.detail")');
     expect(downloadButton).toContain("BROWSER_NIGHTLY_PAGE");
     expect(downloadButton).toContain("cmux_browser_nightly_page_clicked");
   });

--- a/web/tests/platform-downloads.test.ts
+++ b/web/tests/platform-downloads.test.ts
@@ -3,6 +3,9 @@ import { readFile } from "node:fs/promises";
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
 import {
+  BROWSER_MACOS_NIGHTLY_AVAILABLE,
+  BROWSER_MACOS_NIGHTLY_DOWNLOAD,
+  BROWSER_NIGHTLY_PAGE,
   BROWSER_NIGHTLY_RELEASE_URL,
   BROWSER_RELEASE_REPOSITORY_URL,
   DOWNLOAD_PLATFORMS,
@@ -23,6 +26,12 @@ const PLATFORM_PAGE_SOURCE = fileURLToPath(
     import.meta.url,
   ),
 );
+const BROWSER_PAGE_SOURCE = fileURLToPath(
+  new URL("../app/[locale]/(landing)/browser/page.tsx", import.meta.url),
+);
+const DOWNLOAD_BUTTON_SOURCE = fileURLToPath(
+  new URL("../app/[locale]/components/download-button.tsx", import.meta.url),
+);
 
 describe("Windows and Linux downloads", () => {
   test("publishes Linux without leaking the private product repository", () => {
@@ -41,6 +50,14 @@ describe("Windows and Linux downloads", () => {
     expect(PLATFORM_DOWNLOADS.linux.secondary.url).toBe(
       "/api/download/browser-nightly/linux-x64/deb",
     );
+    expect(BROWSER_NIGHTLY_PAGE).toBe("/browser");
+    expect(BROWSER_MACOS_NIGHTLY_AVAILABLE).toBe(false);
+    expect(BROWSER_MACOS_NIGHTLY_DOWNLOAD.primary.url).toBe(
+      "/api/download/browser-nightly/mac-arm64/dmg",
+    );
+    expect(BROWSER_MACOS_NIGHTLY_DOWNLOAD.secondary.url).toBe(
+      "/api/download/browser-nightly/mac-arm64/zip",
+    );
     expect(BROWSER_RELEASE_REPOSITORY_URL).toBe(
       "https://github.com/manaflow-ai/cmux-v2",
     );
@@ -48,6 +65,9 @@ describe("Windows and Linux downloads", () => {
       "https://github.com/manaflow-ai/cmux-v2/releases/tag/nightly",
     );
     expect(JSON.stringify(PLATFORM_DOWNLOADS)).not.toContain("cmux-browser");
+    expect(JSON.stringify(BROWSER_MACOS_NIGHTLY_DOWNLOAD)).not.toContain(
+      "cmux-browser",
+    );
   });
 
   test("keeps direct links and waitlists coherent for every release state", () => {
@@ -124,6 +144,11 @@ describe("Windows and Linux downloads", () => {
   test("publishes Linux and keeps unavailable Windows out of the sitemap", () => {
     expect(
       sitemap().filter((entry) =>
+        new URL(entry.url).pathname.endsWith(BROWSER_NIGHTLY_PAGE),
+      ),
+    ).toHaveLength(locales.length);
+    expect(
+      sitemap().filter((entry) =>
         new URL(entry.url).pathname.endsWith("/windows"),
       ),
     ).toEqual([]);
@@ -132,6 +157,19 @@ describe("Windows and Linux downloads", () => {
         new URL(entry.url).pathname.endsWith("/linux"),
       ),
     ).toHaveLength(locales.length);
+  });
+
+  test("makes Browser downloads discoverable without enabling unsigned platforms", async () => {
+    const [browserPage, downloadButton] = await Promise.all([
+      readFile(BROWSER_PAGE_SOURCE, "utf8"),
+      readFile(DOWNLOAD_BUTTON_SOURCE, "utf8"),
+    ]);
+
+    expect(browserPage).toContain("BROWSER_MACOS_NIGHTLY_AVAILABLE");
+    expect(browserPage).toContain("PLATFORM_DOWNLOAD_AVAILABILITY.windows");
+    expect(browserPage).toContain("PLATFORM_DOWNLOAD_AVAILABILITY.linux");
+    expect(downloadButton).toContain("BROWSER_NIGHTLY_PAGE");
+    expect(downloadButton).toContain("cmux_browser_nightly_page_clicked");
   });
 
   test("wraps long localized installer labels on narrow screens", async () => {


### PR DESCRIPTION
## Summary
- add a localized `/browser` landing page without changing native cmux `/nightly`
- expose the existing signed-feed download routes and keep unsigned Mac/Windows controls disabled
- add the page to the Download menu, sitemap, and agent-readable navigation

This replaces the approach in stale PR #9206: it uses the current signed-feed API contract and Universal 2 artifact names instead of hard-coded moving release assets.

## Tests
- `bun test tests/platform-downloads.test.ts tests/browser-nightly-download-route.test.ts` (16 passed)
- `bun run typecheck`
- scoped ESLint on all changed TypeScript/TSX files
- `git diff origin/main...HEAD --check`

## Pending before merge
- visual review in Google Chrome; the installed extension is currently not responding, so no substitute browser was used

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/9678"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788567475&installation_model_id=21920&pr_number=9678&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F9678&signature=d6bf8604ae6c42bc1d548684e81b7000edf1fd0f26fd1c29c2fabe63e8bdaca4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a localized `/browser` landing page for the cmux Browser nightly with clear macOS, Windows, and Linux downloads, linked from the Download menu, sitemap, and agent-readable navigation. Tracks landing-page download clicks; macOS stays gated and unsigned installers remain disabled.

- **New Features**
  - New `/browser` page with i18n, SEO, platform cards, and release/source links, plus localized waitlist messaging.
  - macOS downloads use signed public feed endpoints (Universal 2 DMG and update ZIP) behind a flag; Windows/Linux reuse existing nightly endpoints.
  - Added a Browser menu item with an icon and i18n “nightly” label, plus a menu click analytics event.

- **Bug Fixes**
  - Fixed analytics for `/browser` download actions and added tests; unavailable cards render non-interactive.

<sup>Written for commit 404f0108f1275143d70f804acb21cf2dcd00a6a4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/9678?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a localized cmux Browser downloads page with SEO metadata.
  - Added platform-specific download information for macOS, Windows, and Linux, including release details and source repository access.
  - Added a Browser option to the download menu with download analytics.
  - Added the Browser page to site discoverability tools.

- **Availability**
  - Download actions now reflect platform availability, with unavailable options shown as disabled.
  - macOS nightly downloads are not yet enabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->