### PR TITLE
Share coderouter usage cache across Vercel instances

### DIFF
--- a/web/services/coderouter/usage.ts
+++ b/web/services/coderouter/usage.ts
@@ -1,3 +1,4 @@
+import { unstable_cache } from "next/cache";
 import { listAccounts, markAccountCooldown } from "./repository";
 import { freshCredential } from "./refresh";
 import { readTeamVault } from "./vault";
@@ -13,6 +14,11 @@ const usageRequests = new Map<
   string,
   Promise<Awaited<ReturnType<typeof loadAccountsWithUsage>>>
 >();
+const sharedAccountsWithUsage = unstable_cache(
+  loadAccountsWithUsage,
+  ["coderouter-usage-v1"],
+  { revalidate: USAGE_CACHE_MS / 1_000 },
+);
 
 export async function accountsWithUsage(teamId: string) {
   const cached = usageCache.get(teamId);
@@ -20,7 +26,9 @@ export async function accountsWithUsage(teamId: string) {
   const pending = usageRequests.get(teamId);
   if (pending) return await pending;
 
-  const request = loadAccountsWithUsage(teamId);
+  // Vercel's encrypted data cache is shared across function instances. It
+  // stores only account summaries and provider usage, never credentials.
+  const request = sharedAccountsWithUsage(teamId);
   usageRequests.set(teamId, request);
   try {
     const accounts = await request;


### PR DESCRIPTION
Uses Vercel encrypted Data Cache for the 15-second non-secret usage snapshot so requests remain fast when traffic lands on different function instances. Credentials and tokens are never cached.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/9679"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788568271&installation_model_id=21920&pr_number=9679&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F9679&signature=f59dca52531d53d2b4c51c3893a34ead31950f135d479b3c006b655bf4b30fe3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Share coderouter usage data across Vercel function instances using Next.js `unstable_cache` to keep requests fast under cross-instance traffic. The cache only stores non-secret account summaries and provider usage for ~15 seconds; credentials and tokens are never cached.

<sup>Written for commit 507a1eb0ca24a75e4ba712de5b7eda24e9e8507d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/9679?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved account usage loading speed and consistency through short-lived caching.
  * Reduced repeated loading during closely timed requests while keeping usage data refreshed regularly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->