### PR TITLE
Move coderouter credentials to KMS-encrypted RDS

### DIFF
--- a/web/bun.lock
+++ b/web/bun.lock
@@ -5,6 +5,7 @@
     "": {
       "name": "web",
       "dependencies": {
+        "@aws-sdk/client-kms": "^3.1045.0",
         "@aws-sdk/client-s3": "^3.1045.0",
         "@aws-sdk/rds-signer": "^3.1045.0",
         "@aws-sdk/s3-request-presigner": "^3.1045.0",

--- a/web/db/migrations/20260806010000_coderouter_encrypted_credentials/migration.sql
+++ b/web/db/migrations/20260806010000_coderouter_encrypted_credentials/migration.sql
@@ -1,0 +1,24 @@
+CREATE TABLE "coderouter_credentials" (
+  "account_id" uuid PRIMARY KEY NOT NULL
+    REFERENCES "coderouter_accounts" ("id") ON DELETE CASCADE,
+  "team_id" text NOT NULL,
+  "provider" text NOT NULL,
+  "credential_revision" bigint NOT NULL,
+  "algorithm" text DEFAULT 'aes-256-gcm' NOT NULL,
+  "ciphertext" text NOT NULL,
+  "nonce" text NOT NULL,
+  "auth_tag" text NOT NULL,
+  "encrypted_data_key" text NOT NULL,
+  "kms_key_id" text NOT NULL,
+  "created_at" timestamp with time zone DEFAULT now() NOT NULL,
+  "updated_at" timestamp with time zone DEFAULT now() NOT NULL,
+  CONSTRAINT "coderouter_credentials_provider_check"
+    CHECK ("provider" IN ('codex', 'opencode-go')),
+  CONSTRAINT "coderouter_credentials_revision_positive"
+    CHECK ("credential_revision" > 0),
+  CONSTRAINT "coderouter_credentials_algorithm_check"
+    CHECK ("algorithm" = 'aes-256-gcm')
+);
+
+CREATE INDEX "coderouter_credentials_team_idx"
+  ON "coderouter_credentials" ("team_id");

--- a/web/db/schema.ts
+++ b/web/db/schema.ts
@@ -522,6 +522,42 @@ export const coderouterRouteTokens = pgTable(
   ],
 );
 
+/**
+ * Envelope-encrypted provider credentials. Every secret-bearing field is
+ * ciphertext; the plaintext data key exists only briefly in Vercel memory.
+ */
+export const coderouterCredentials = pgTable(
+  "coderouter_credentials",
+  {
+    accountId: uuid("account_id")
+      .primaryKey()
+      .references(() => coderouterAccounts.id, { onDelete: "cascade" }),
+    teamId: text("team_id").notNull(),
+    provider: text("provider").$type<"codex" | "opencode-go">().notNull(),
+    credentialRevision: bigint("credential_revision", { mode: "number" })
+      .notNull(),
+    algorithm: text("algorithm").notNull().default("aes-256-gcm"),
+    ciphertext: text("ciphertext").notNull(),
+    nonce: text("nonce").notNull(),
+    authTag: text("auth_tag").notNull(),
+    encryptedDataKey: text("encrypted_data_key").notNull(),
+    kmsKeyId: text("kms_key_id").notNull(),
+    createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+    updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
+  },
+  (table) => [
+    check(
+      "coderouter_credentials_revision_positive",
+      sql`${table.credentialRevision} > 0`,
+    ),
+    check(
+      "coderouter_credentials_algorithm_check",
+      sql`${table.algorithm} = 'aes-256-gcm'`,
+    ),
+    index("coderouter_credentials_team_idx").on(table.teamId),
+  ],
+);
+
 export const coderouterVaultLeases = pgTable(
   "coderouter_vault_leases",
   {

--- a/web/package.json
+++ b/web/package.json
@@ -9,6 +9,7 @@
     "vercel-build": "bun tools/generate-managed-iroh-relay-catalog.ts --check && bun tools/build-docs-search.mjs && VERCEL_PREVIEW_COMMENTS_ENABLED=0 next build",
     "search:index": "bun tools/build-docs-search.mjs",
     "subrouter:migrate-legacy": "bun scripts/subrouter/migrate-legacy-tenants.ts",
+    "coderouter:migrate-encrypted-credentials": "bun scripts/coderouter/migrate-encrypted-credentials.ts",
     "testflight:backfill-legacy-ownership": "bun scripts/stripe/backfill-pro-testflight-legacy-ownership.ts",
     "cloud-vm:env:audit": "bun scripts/cloud-vm/audit-vercel-env.mjs",
     "cloud-vm:migrate": "bun scripts/cloud-vm/migrate-vercel-aurora-iam.mjs",
@@ -34,6 +35,7 @@
     "lint": "eslint"
   },
   "dependencies": {
+    "@aws-sdk/client-kms": "^3.1045.0",
     "@aws-sdk/client-s3": "^3.1045.0",
     "@aws-sdk/rds-signer": "^3.1045.0",
     "@aws-sdk/s3-request-presigner": "^3.1045.0",

--- a/web/scripts/coderouter/migrate-encrypted-credentials.ts
+++ b/web/scripts/coderouter/migrate-encrypted-credentials.ts
@@ -1,0 +1,76 @@
+import {
+  decryptCredential,
+  encryptCredential,
+} from "../../services/coderouter/encryption";
+import {
+  importEncryptedCredential,
+  listCoderouterTeamIds,
+  listEncryptedCredentials,
+} from "../../services/coderouter/repository";
+import { clearTeamVault, readTeamVault } from "../../services/coderouter/vault";
+import { closeCloudDbForTests } from "../../db/client";
+
+const deleteSource = process.argv.includes("--delete-source");
+const verifyOnly = process.argv.includes("--verify-only");
+if (deleteSource && verifyOnly) {
+  throw new Error("--delete-source and --verify-only are mutually exclusive");
+}
+if (deleteSource && process.env.CODEROUTER_CONFIRM_DELETE_SOURCE !== "yes") {
+  throw new Error(
+    "CODEROUTER_CONFIRM_DELETE_SOURCE=yes is required with --delete-source",
+  );
+}
+
+const teams = await listCoderouterTeamIds();
+let migrated = 0;
+let verified = 0;
+
+for (const teamId of teams) {
+  if (deleteSource) {
+    const encrypted = await listEncryptedCredentials(teamId);
+    for (const envelope of encrypted) {
+      await decryptCredential(envelope);
+      verified += 1;
+    }
+    const source = await readTeamVault(teamId);
+    if (Object.keys(source.accounts).length !== encrypted.length) {
+      throw new Error(
+        `refusing to delete source for team ${teamId}: account counts differ`,
+      );
+    }
+    await clearTeamVault(teamId);
+    continue;
+  }
+
+  if (!verifyOnly) {
+    const source = await readTeamVault(teamId);
+    for (const [accountId, account] of Object.entries(source.accounts)) {
+      const encrypted = await encryptCredential({
+        teamId,
+        accountId,
+        provider: account.credential.provider,
+        credentialRevision: account.revision,
+        credential: account.credential,
+      });
+      await importEncryptedCredential({
+        credential: account.credential,
+        encrypted,
+      });
+      migrated += 1;
+    }
+  }
+
+  const encrypted = await listEncryptedCredentials(teamId);
+  for (const envelope of encrypted) {
+    await decryptCredential(envelope);
+    verified += 1;
+  }
+}
+
+console.log(JSON.stringify({
+  teams: teams.length,
+  migrated,
+  verified,
+  sourceDeleted: deleteSource,
+}));
+await closeCloudDbForTests();

--- a/web/services/coderouter/accounts.ts
+++ b/web/services/coderouter/accounts.ts
@@ -1,42 +1,57 @@
 import { randomUUID } from "node:crypto";
 import {
   findAccountByProviderIdentity,
+  insertAccountWithCredential,
   listAccounts,
-  upsertAccountMetadata,
-  withVaultLease,
+  replaceAccountCredential,
 } from "./repository";
-import { putVaultCredential } from "./vault";
+import { encryptCredential } from "./encryption";
 import type { CodeRouterCredential } from "./types";
 
 export async function addAccount(
   teamId: string,
   credential: CodeRouterCredential,
 ): Promise<{ accountId: string; alreadyExists: boolean }> {
-  return await withVaultLease(teamId, async () => {
-    const existing = await findAccountByProviderIdentity(
-      teamId,
-      credential.provider,
-      credential.accountId,
-    );
-    if (existing?.state === "active" || existing?.state === "refreshing") {
-      return { accountId: existing.id, alreadyExists: true };
-    }
+  const existing = await findAccountByProviderIdentity(
+    teamId,
+    credential.provider,
+    credential.accountId,
+  );
+  if (existing?.state === "active" || existing?.state === "refreshing") {
+    return { accountId: existing.id, alreadyExists: true };
+  }
 
-    const accountId = existing?.id ?? randomUUID();
-    const revision = await putVaultCredential(
-      teamId,
-      accountId,
-      credential,
-      existing?.vaultRevision,
-    );
-    await upsertAccountMetadata({
-      teamId,
-      accountId,
-      credential,
-      vaultRevision: revision,
-    });
-    return { accountId, alreadyExists: false };
+  const accountId = existing?.id ?? randomUUID();
+  const expectedRevision = existing?.vaultRevision ?? 0;
+  const encrypted = await encryptCredential({
+    teamId,
+    accountId,
+    provider: credential.provider,
+    credentialRevision: expectedRevision + 1,
+    credential,
   });
+  if (!existing) {
+    const inserted = await insertAccountWithCredential({
+      credential,
+      encrypted,
+    });
+    if (!inserted) {
+      const raced = await findAccountByProviderIdentity(
+        teamId,
+        credential.provider,
+        credential.accountId,
+      );
+      if (raced) return { accountId: raced.id, alreadyExists: true };
+      throw new Error("coderouter account insert lost a uniqueness race");
+    }
+  } else {
+    await replaceAccountCredential({
+      credential,
+      encrypted,
+      expectedRevision,
+    });
+  }
+  return { accountId, alreadyExists: false };
 }
 
 export { listAccounts };

--- a/web/services/coderouter/encryption.ts
+++ b/web/services/coderouter/encryption.ts
@@ -1,0 +1,335 @@
+import {
+  createCipheriv,
+  createDecipheriv,
+  randomBytes,
+  timingSafeEqual,
+} from "node:crypto";
+import {
+  DecryptCommand,
+  GenerateDataKeyCommand,
+  KMSClient,
+} from "@aws-sdk/client-kms";
+import { awsCredentialsProvider } from "@vercel/oidc-aws-credentials-provider";
+import type {
+  CodeRouterCredential,
+  CodeRouterProvider,
+} from "./types";
+
+const ALGORITHM = "aes-256-gcm" as const;
+const DATA_KEY_BYTES = 32;
+const NONCE_BYTES = 12;
+const AUTH_TAG_BYTES = 16;
+
+export type EncryptedCredential = {
+  readonly accountId: string;
+  readonly teamId: string;
+  readonly provider: CodeRouterProvider;
+  readonly credentialRevision: number;
+  readonly algorithm: typeof ALGORITHM;
+  readonly ciphertext: string;
+  readonly nonce: string;
+  readonly authTag: string;
+  readonly encryptedDataKey: string;
+  readonly kmsKeyId: string;
+};
+
+export type CredentialKeyService = {
+  generateDataKey(input: {
+    readonly keyId: string;
+    readonly encryptionContext: Readonly<Record<string, string>>;
+  }): Promise<{ readonly plaintext: Uint8Array; readonly encrypted: Uint8Array }>;
+  decryptDataKey(input: {
+    readonly keyId: string;
+    readonly encrypted: Uint8Array;
+    readonly encryptionContext: Readonly<Record<string, string>>;
+  }): Promise<Uint8Array>;
+};
+
+export async function encryptCredential(input: {
+  readonly accountId: string;
+  readonly teamId: string;
+  readonly provider: CodeRouterProvider;
+  readonly credentialRevision: number;
+  readonly credential: CodeRouterCredential;
+  readonly keyId?: string;
+  readonly keys?: CredentialKeyService;
+}): Promise<EncryptedCredential> {
+  assertIdentity(input);
+  if (input.credential.provider !== input.provider) {
+    throw new Error("credential provider does not match its account");
+  }
+  const keyId = input.keyId ?? requiredEnv("CODEROUTER_KMS_KEY_ID");
+  const keys = input.keys ?? kmsKeyService();
+  const aad = credentialAad(input);
+  const context = credentialEncryptionContext(input);
+  const generated = await keys.generateDataKey({
+    keyId,
+    encryptionContext: context,
+  });
+  const plaintextKey = Buffer.from(generated.plaintext);
+  if (plaintextKey.byteLength !== DATA_KEY_BYTES) {
+    plaintextKey.fill(0);
+    throw new Error("KMS returned an invalid coderouter data key");
+  }
+
+  const nonce = randomBytes(NONCE_BYTES);
+  const plaintext = Buffer.from(JSON.stringify(input.credential), "utf8");
+  try {
+    const cipher = createCipheriv(ALGORITHM, plaintextKey, nonce, {
+      authTagLength: AUTH_TAG_BYTES,
+    });
+    cipher.setAAD(aad);
+    const ciphertext = Buffer.concat([cipher.update(plaintext), cipher.final()]);
+    const authTag = cipher.getAuthTag();
+    return {
+      accountId: input.accountId,
+      teamId: input.teamId,
+      provider: input.provider,
+      credentialRevision: input.credentialRevision,
+      algorithm: ALGORITHM,
+      ciphertext: ciphertext.toString("base64"),
+      nonce: nonce.toString("base64"),
+      authTag: authTag.toString("base64"),
+      encryptedDataKey: Buffer.from(generated.encrypted).toString("base64"),
+      kmsKeyId: keyId,
+    };
+  } finally {
+    plaintext.fill(0);
+    plaintextKey.fill(0);
+  }
+}
+
+export async function decryptCredential(
+  encrypted: EncryptedCredential,
+  keys: CredentialKeyService = kmsKeyService(),
+): Promise<CodeRouterCredential> {
+  assertIdentity(encrypted);
+  if (encrypted.algorithm !== ALGORITHM) {
+    throw new Error("unsupported coderouter credential encryption algorithm");
+  }
+  const nonce = strictBase64(encrypted.nonce, "nonce");
+  const authTag = strictBase64(encrypted.authTag, "authentication tag");
+  const ciphertext = strictBase64(encrypted.ciphertext, "ciphertext");
+  const wrappedKey = strictBase64(encrypted.encryptedDataKey, "encrypted data key");
+  if (nonce.byteLength !== NONCE_BYTES || authTag.byteLength !== AUTH_TAG_BYTES) {
+    throw new Error("invalid coderouter credential envelope");
+  }
+  const plaintextKey = Buffer.from(await keys.decryptDataKey({
+    keyId: encrypted.kmsKeyId,
+    encrypted: wrappedKey,
+    encryptionContext: credentialEncryptionContext(encrypted),
+  }));
+  if (plaintextKey.byteLength !== DATA_KEY_BYTES) {
+    plaintextKey.fill(0);
+    throw new Error("KMS returned an invalid coderouter data key");
+  }
+
+  let plaintext: Buffer | undefined;
+  try {
+    const decipher = createDecipheriv(ALGORITHM, plaintextKey, nonce, {
+      authTagLength: AUTH_TAG_BYTES,
+    });
+    decipher.setAAD(credentialAad(encrypted));
+    decipher.setAuthTag(authTag);
+    plaintext = Buffer.concat([
+      decipher.update(ciphertext),
+      decipher.final(),
+    ]);
+    const value: unknown = JSON.parse(plaintext.toString("utf8"));
+    const credential = parseCredential(value);
+    if (!credential || credential.provider !== encrypted.provider) {
+      throw new Error("decrypted coderouter credential is invalid");
+    }
+    return credential;
+  } catch (error) {
+    if (error instanceof SyntaxError) {
+      throw new Error("decrypted coderouter credential is invalid");
+    }
+    throw error;
+  } finally {
+    plaintext?.fill(0);
+    plaintextKey.fill(0);
+  }
+}
+
+function credentialAad(input: {
+  readonly accountId: string;
+  readonly teamId: string;
+  readonly provider: CodeRouterProvider;
+  readonly credentialRevision: number;
+}): Buffer {
+  return Buffer.from(JSON.stringify([
+    "coderouter",
+    1,
+    input.teamId,
+    input.accountId,
+    input.provider,
+    input.credentialRevision,
+  ]), "utf8");
+}
+
+function credentialEncryptionContext(input: {
+  readonly accountId: string;
+  readonly teamId: string;
+  readonly provider: CodeRouterProvider;
+  readonly credentialRevision: number;
+}): Readonly<Record<string, string>> {
+  return {
+    service: "coderouter",
+    version: "1",
+    team: input.teamId,
+    account: input.accountId,
+    provider: input.provider,
+    revision: String(input.credentialRevision),
+  };
+}
+
+function assertIdentity(input: {
+  readonly accountId: string;
+  readonly teamId: string;
+  readonly provider: CodeRouterProvider;
+  readonly credentialRevision: number;
+}): void {
+  if (
+    !input.accountId ||
+    !input.teamId ||
+    !["codex", "opencode-go"].includes(input.provider) ||
+    !Number.isSafeInteger(input.credentialRevision) ||
+    input.credentialRevision < 1
+  ) {
+    throw new Error("invalid coderouter credential identity");
+  }
+}
+
+function strictBase64(value: string, label: string): Buffer {
+  if (
+    !value ||
+    !/^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$/.test(value)
+  ) {
+    throw new Error(`invalid coderouter credential ${label}`);
+  }
+  const decoded = Buffer.from(value, "base64");
+  const canonical = decoded.toString("base64");
+  if (
+    canonical.length !== value.length ||
+    !timingSafeEqual(Buffer.from(canonical), Buffer.from(value))
+  ) {
+    throw new Error(`invalid coderouter credential ${label}`);
+  }
+  return decoded;
+}
+
+function parseCredential(value: unknown): CodeRouterCredential | null {
+  if (!isRecord(value)) return null;
+  const {
+    accessToken,
+    refreshToken,
+    accountId,
+    email,
+    expiresAt,
+  } = value;
+  if (
+    !string(accessToken) ||
+    !string(refreshToken) ||
+    !string(accountId) ||
+    !string(email) ||
+    !positiveNumber(expiresAt)
+  ) {
+    return null;
+  }
+  if (value.provider === "codex" && string(value.idToken)) {
+    return {
+      provider: "codex",
+      accessToken,
+      refreshToken,
+      idToken: value.idToken,
+      accountId,
+      email,
+      expiresAt,
+    };
+  }
+  if (value.provider === "opencode-go") {
+    if (
+      value.orgId !== undefined && typeof value.orgId !== "string" ||
+      value.orgName !== undefined && typeof value.orgName !== "string"
+    ) {
+      return null;
+    }
+    return {
+      provider: "opencode-go",
+      accessToken,
+      refreshToken,
+      accountId,
+      email,
+      expiresAt,
+      ...(value.orgId ? { orgId: value.orgId } : {}),
+      ...(value.orgName ? { orgName: value.orgName } : {}),
+    };
+  }
+  return null;
+}
+
+function string(value: unknown): value is string {
+  return typeof value === "string" && value.length > 0;
+}
+
+function positiveNumber(value: unknown): value is number {
+  return typeof value === "number" && Number.isFinite(value) && value > 0;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+let defaultKeyService: CredentialKeyService | undefined;
+
+function kmsKeyService(): CredentialKeyService {
+  if (defaultKeyService) return defaultKeyService;
+  const region = requiredEnv("AWS_REGION");
+  const roleArn = process.env.AWS_ROLE_ARN?.trim();
+  const client = new KMSClient({
+    region,
+    ...(process.env.VERCEL_OIDC_TOKEN && roleArn
+      ? {
+        credentials: awsCredentialsProvider({
+          roleArn,
+          clientConfig: { region },
+        }),
+      }
+      : {}),
+  });
+  defaultKeyService = {
+    async generateDataKey(input) {
+      const output = await client.send(new GenerateDataKeyCommand({
+        KeyId: input.keyId,
+        KeySpec: "AES_256",
+        EncryptionContext: { ...input.encryptionContext },
+      }));
+      if (!output.Plaintext || !output.CiphertextBlob) {
+        throw new Error("KMS did not return a coderouter data key");
+      }
+      return {
+        plaintext: output.Plaintext,
+        encrypted: output.CiphertextBlob,
+      };
+    },
+    async decryptDataKey(input) {
+      const output = await client.send(new DecryptCommand({
+        KeyId: input.keyId,
+        CiphertextBlob: input.encrypted,
+        EncryptionContext: { ...input.encryptionContext },
+      }));
+      if (!output.Plaintext) {
+        throw new Error("KMS did not decrypt the coderouter data key");
+      }
+      return output.Plaintext;
+    },
+  };
+  return defaultKeyService;
+}
+
+function requiredEnv(key: string): string {
+  const value = process.env[key]?.trim();
+  if (!value) throw new Error(`${key} is required`);
+  return value;
+}

--- a/web/services/coderouter/refresh.ts
+++ b/web/services/coderouter/refresh.ts
@@ -1,15 +1,16 @@
 import {
   claimRefreshLease,
   completeRefreshLease,
+  encryptedCredentialForAccount,
   failRefreshLease,
-  withVaultLease,
+  releaseRefreshLease,
 } from "./repository";
 import {
-  putVaultCredential,
-  readTeamVault,
-} from "./vault";
+  decryptCredential,
+  encryptCredential,
+  type EncryptedCredential,
+} from "./encryption";
 import type { CodeRouterCredential } from "./types";
-import type { VaultAccount } from "./types";
 
 const CODEX_CLIENT_ID = "app_EMoamEEZ73f0CkXaXp7hrann";
 const OPENCODE_CLIENT_ID = "opencode-cli";
@@ -28,9 +29,21 @@ export async function freshCredential(input: {
   readonly accountId: string;
   readonly expectedRevision: number;
   readonly force?: boolean;
-  readonly known?: VaultAccount;
+  readonly known?: EncryptedCredential;
 }): Promise<CodeRouterCredential> {
-  const before = input.known ??
+  if (
+    input.known &&
+    input.expectedRevision > 0 &&
+    input.known.credentialRevision !== input.expectedRevision
+  ) {
+    throw new CodeRouterRefreshBusy("credential revision changed");
+  }
+  const before = input.known
+    ? {
+      envelope: input.known,
+      credential: await decryptCredential(input.known),
+    }
+    :
     await readCredential(input.teamId, input.accountId);
   if (!input.force && before.credential.expiresAt > Date.now() + REFRESH_SKEW_MS) {
     return before.credential;
@@ -39,47 +52,31 @@ export async function freshCredential(input: {
   const leaseId = await claimRefreshLease(input.accountId);
   if (!leaseId) throw new CodeRouterRefreshBusy("credential refresh already in progress");
   try {
-    // The lease winner must re-read Stack after claiming. Another request may
-    // have refreshed and rotated the token immediately before this lease.
+    // The lease winner must re-read after claiming. Another request may have
+    // refreshed and rotated the token immediately before this lease.
     const current = await readCredential(input.teamId, input.accountId);
     if (
       !input.force &&
       current.credential.expiresAt > Date.now() + REFRESH_SKEW_MS
     ) {
-      await completeRefreshLease({
-        accountId: input.accountId,
-        leaseId,
-        vaultRevision: current.revision,
-        credentialExpiresAt: new Date(current.credential.expiresAt),
-      });
+      await releaseRefreshLease(input.accountId, leaseId);
       return current.credential;
     }
 
     const refreshed = await refreshProviderCredential(current.credential);
-    const revision = await withVaultLease(input.teamId, async () => {
-      let lastError: unknown;
-      for (let attempt = 0; attempt < 3; attempt++) {
-        try {
-          return await putVaultCredential(
-            input.teamId,
-            input.accountId,
-            refreshed,
-            current.revision,
-          );
-        } catch (error) {
-          lastError = error;
-          if (attempt < 2) {
-            await new Promise((resolve) => setTimeout(resolve, 50 * (attempt + 1)));
-          }
-        }
-      }
-      throw lastError;
+    const encrypted = await encryptCredential({
+      teamId: input.teamId,
+      accountId: input.accountId,
+      provider: refreshed.provider,
+      credentialRevision: current.envelope.credentialRevision + 1,
+      credential: refreshed,
     });
     await completeRefreshLease({
       accountId: input.accountId,
       leaseId,
-      vaultRevision: revision,
-      credentialExpiresAt: new Date(refreshed.expiresAt),
+      expectedRevision: current.envelope.credentialRevision,
+      credential: refreshed,
+      encrypted,
     });
     return refreshed;
   } catch (error) {
@@ -98,9 +95,14 @@ export async function freshCredential(input: {
 }
 
 async function readCredential(teamId: string, accountId: string) {
-  const account = (await readTeamVault(teamId)).accounts[accountId];
-  if (!account) throw new CodeRouterCredentialBroken("vault credential not found");
-  return account;
+  const envelope = await encryptedCredentialForAccount(teamId, accountId);
+  if (!envelope) {
+    throw new CodeRouterCredentialBroken("encrypted credential not found");
+  }
+  return {
+    envelope,
+    credential: await decryptCredential(envelope),
+  };
 }
 
 async function refreshProviderCredential(

--- a/web/services/coderouter/repository.ts
+++ b/web/services/coderouter/repository.ts
@@ -3,9 +3,11 @@ import { and, eq, gt, isNull, lte, notInArray, or, sql } from "drizzle-orm";
 import { cloudDb } from "../../db/client";
 import {
   coderouterAccounts,
+  coderouterCredentials,
   coderouterRouteTokens,
   coderouterVaultLeases,
 } from "../../db/schema";
+import type { EncryptedCredential } from "./encryption";
 import type {
   CodeRouterAccountSummary,
   CodeRouterCredential,
@@ -18,6 +20,10 @@ const REFRESH_LEASE_MS = 30_000;
 
 export class CodeRouterLeaseBusy extends Error {
   readonly _tag = "CodeRouterLeaseBusy";
+}
+
+export class CodeRouterCredentialRace extends Error {
+  readonly _tag = "CodeRouterCredentialRace";
 }
 
 export function routeTokenHash(token: string): string {
@@ -91,6 +97,169 @@ export async function listAccounts(
       ...row,
       credentialExpiresAt: row.credentialExpiresAt?.toISOString() ?? null,
     })));
+}
+
+export async function listCoderouterTeamIds(): Promise<readonly string[]> {
+  return await cloudDb()
+    .selectDistinct({ teamId: coderouterAccounts.teamId })
+    .from(coderouterAccounts)
+    .then((rows) => rows.map((row) => row.teamId));
+}
+
+export async function listEncryptedCredentials(
+  teamId: string,
+): Promise<readonly EncryptedCredential[]> {
+  return await cloudDb()
+    .select({
+      accountId: coderouterCredentials.accountId,
+      teamId: coderouterCredentials.teamId,
+      provider: coderouterCredentials.provider,
+      credentialRevision: coderouterCredentials.credentialRevision,
+      algorithm: coderouterCredentials.algorithm,
+      ciphertext: coderouterCredentials.ciphertext,
+      nonce: coderouterCredentials.nonce,
+      authTag: coderouterCredentials.authTag,
+      encryptedDataKey: coderouterCredentials.encryptedDataKey,
+      kmsKeyId: coderouterCredentials.kmsKeyId,
+    })
+    .from(coderouterCredentials)
+    .where(eq(coderouterCredentials.teamId, teamId))
+    .then((rows) => rows.map(encryptedCredentialRow));
+}
+
+export async function encryptedCredentialForAccount(
+  teamId: string,
+  accountId: string,
+): Promise<EncryptedCredential | null> {
+  const [row] = await cloudDb()
+    .select({
+      accountId: coderouterCredentials.accountId,
+      teamId: coderouterCredentials.teamId,
+      provider: coderouterCredentials.provider,
+      credentialRevision: coderouterCredentials.credentialRevision,
+      algorithm: coderouterCredentials.algorithm,
+      ciphertext: coderouterCredentials.ciphertext,
+      nonce: coderouterCredentials.nonce,
+      authTag: coderouterCredentials.authTag,
+      encryptedDataKey: coderouterCredentials.encryptedDataKey,
+      kmsKeyId: coderouterCredentials.kmsKeyId,
+    })
+    .from(coderouterCredentials)
+    .where(and(
+      eq(coderouterCredentials.teamId, teamId),
+      eq(coderouterCredentials.accountId, accountId),
+    ))
+    .limit(1);
+  return row ? encryptedCredentialRow(row) : null;
+}
+
+export async function insertAccountWithCredential(input: {
+  readonly credential: CodeRouterCredential;
+  readonly encrypted: EncryptedCredential;
+}): Promise<boolean> {
+  const db = cloudDb();
+  return await db.transaction(async (tx) => {
+    const label = credentialLabel(input.credential);
+    const [inserted] = await tx
+      .insert(coderouterAccounts)
+      .values({
+        id: input.encrypted.accountId,
+        teamId: input.encrypted.teamId,
+        provider: input.credential.provider,
+        providerAccountId: input.credential.accountId,
+        label,
+        state: "active",
+        vaultRevision: input.encrypted.credentialRevision,
+        credentialExpiresAt: new Date(input.credential.expiresAt),
+        updatedAt: new Date(),
+      })
+      .onConflictDoNothing({
+        target: [
+          coderouterAccounts.teamId,
+          coderouterAccounts.provider,
+          coderouterAccounts.providerAccountId,
+        ],
+      })
+      .returning({ id: coderouterAccounts.id });
+    if (!inserted) return false;
+    await tx.insert(coderouterCredentials).values(encryptedValues(input.encrypted));
+    return true;
+  });
+}
+
+export async function replaceAccountCredential(input: {
+  readonly credential: CodeRouterCredential;
+  readonly encrypted: EncryptedCredential;
+  readonly expectedRevision: number;
+}): Promise<void> {
+  await cloudDb().transaction(async (tx) => {
+    const [updatedCredential] = await tx
+      .update(coderouterCredentials)
+      .set({
+        ...encryptedValues(input.encrypted),
+        updatedAt: new Date(),
+      })
+      .where(and(
+        eq(coderouterCredentials.accountId, input.encrypted.accountId),
+        eq(coderouterCredentials.teamId, input.encrypted.teamId),
+        eq(coderouterCredentials.credentialRevision, input.expectedRevision),
+      ))
+      .returning({ accountId: coderouterCredentials.accountId });
+    if (!updatedCredential) {
+      throw new CodeRouterCredentialRace("credential revision changed");
+    }
+    const [updatedAccount] = await tx
+      .update(coderouterAccounts)
+      .set({
+        label: credentialLabel(input.credential),
+        state: "active",
+        vaultRevision: input.encrypted.credentialRevision,
+        credentialExpiresAt: new Date(input.credential.expiresAt),
+        refreshLeaseId: null,
+        refreshLeaseExpiresAt: null,
+        lastFailureCode: null,
+        updatedAt: new Date(),
+      })
+      .where(and(
+        eq(coderouterAccounts.id, input.encrypted.accountId),
+        eq(coderouterAccounts.teamId, input.encrypted.teamId),
+        eq(coderouterAccounts.vaultRevision, input.expectedRevision),
+      ))
+      .returning({ id: coderouterAccounts.id });
+    if (!updatedAccount) {
+      throw new CodeRouterCredentialRace("account revision changed");
+    }
+  });
+}
+
+export async function importEncryptedCredential(input: {
+  readonly credential: CodeRouterCredential;
+  readonly encrypted: EncryptedCredential;
+}): Promise<void> {
+  await cloudDb().transaction(async (tx) => {
+    await tx
+      .insert(coderouterCredentials)
+      .values(encryptedValues(input.encrypted))
+      .onConflictDoUpdate({
+        target: coderouterCredentials.accountId,
+        set: {
+          ...encryptedValues(input.encrypted),
+          updatedAt: new Date(),
+        },
+      });
+    await tx
+      .update(coderouterAccounts)
+      .set({
+        label: credentialLabel(input.credential),
+        vaultRevision: input.encrypted.credentialRevision,
+        credentialExpiresAt: new Date(input.credential.expiresAt),
+        updatedAt: new Date(),
+      })
+      .where(and(
+        eq(coderouterAccounts.id, input.encrypted.accountId),
+        eq(coderouterAccounts.teamId, input.encrypted.teamId),
+      ));
+  });
 }
 
 export async function upsertAccountMetadata(input: {
@@ -250,23 +419,64 @@ export async function claimRefreshLease(
 export async function completeRefreshLease(input: {
   readonly accountId: string;
   readonly leaseId: string;
-  readonly vaultRevision: number;
-  readonly credentialExpiresAt: Date;
+  readonly expectedRevision: number;
+  readonly credential: CodeRouterCredential;
+  readonly encrypted: EncryptedCredential;
 }): Promise<void> {
+  await cloudDb().transaction(async (tx) => {
+    const [updatedCredential] = await tx
+      .update(coderouterCredentials)
+      .set({
+        ...encryptedValues(input.encrypted),
+        updatedAt: new Date(),
+      })
+      .where(and(
+        eq(coderouterCredentials.accountId, input.accountId),
+        eq(coderouterCredentials.credentialRevision, input.expectedRevision),
+      ))
+      .returning({ accountId: coderouterCredentials.accountId });
+    if (!updatedCredential) {
+      throw new CodeRouterCredentialRace("credential refresh lost revision race");
+    }
+    const [completed] = await tx
+      .update(coderouterAccounts)
+      .set({
+        state: "active",
+        vaultRevision: input.encrypted.credentialRevision,
+        credentialExpiresAt: new Date(input.credential.expiresAt),
+        refreshLeaseId: null,
+        refreshLeaseExpiresAt: null,
+        lastFailureCode: null,
+        updatedAt: new Date(),
+      })
+      .where(and(
+        eq(coderouterAccounts.id, input.accountId),
+        eq(coderouterAccounts.refreshLeaseId, input.leaseId),
+        eq(coderouterAccounts.vaultRevision, input.expectedRevision),
+      ))
+      .returning({ id: coderouterAccounts.id });
+    if (!completed) {
+      throw new CodeRouterCredentialRace("credential refresh lost lease");
+    }
+  });
+}
+
+export async function releaseRefreshLease(
+  accountId: string,
+  leaseId: string,
+): Promise<void> {
   await cloudDb()
     .update(coderouterAccounts)
     .set({
       state: "active",
-      vaultRevision: input.vaultRevision,
-      credentialExpiresAt: input.credentialExpiresAt,
       refreshLeaseId: null,
       refreshLeaseExpiresAt: null,
       lastFailureCode: null,
       updatedAt: new Date(),
     })
     .where(and(
-      eq(coderouterAccounts.id, input.accountId),
-      eq(coderouterAccounts.refreshLeaseId, input.leaseId),
+      eq(coderouterAccounts.id, accountId),
+      eq(coderouterAccounts.refreshLeaseId, leaseId),
     ));
 }
 
@@ -333,4 +543,46 @@ export async function withVaultLease<T>(
       ))
       .catch(() => undefined);
   }
+}
+
+function credentialLabel(credential: CodeRouterCredential): string {
+  return credential.email ||
+    (credential.provider === "opencode-go" ? credential.orgName : undefined) ||
+    credential.accountId;
+}
+
+function encryptedValues(encrypted: EncryptedCredential) {
+  return {
+    accountId: encrypted.accountId,
+    teamId: encrypted.teamId,
+    provider: encrypted.provider,
+    credentialRevision: encrypted.credentialRevision,
+    algorithm: encrypted.algorithm,
+    ciphertext: encrypted.ciphertext,
+    nonce: encrypted.nonce,
+    authTag: encrypted.authTag,
+    encryptedDataKey: encrypted.encryptedDataKey,
+    kmsKeyId: encrypted.kmsKeyId,
+  };
+}
+
+function encryptedCredentialRow(row: {
+  accountId: string;
+  teamId: string;
+  provider: CodeRouterProvider;
+  credentialRevision: number;
+  algorithm: string;
+  ciphertext: string;
+  nonce: string;
+  authTag: string;
+  encryptedDataKey: string;
+  kmsKeyId: string;
+}): EncryptedCredential {
+  if (row.algorithm !== "aes-256-gcm") {
+    throw new Error("unsupported coderouter credential encryption algorithm");
+  }
+  return {
+    ...row,
+    algorithm: "aes-256-gcm",
+  };
 }

--- a/web/services/coderouter/usage.ts
+++ b/web/services/coderouter/usage.ts
@@ -1,7 +1,10 @@
 import { unstable_cache } from "next/cache";
-import { listAccounts, markAccountCooldown } from "./repository";
+import {
+  listAccounts,
+  listEncryptedCredentials,
+  markAccountCooldown,
+} from "./repository";
 import { freshCredential } from "./refresh";
-import { readTeamVault } from "./vault";
 
 const CODEX_USAGE_URL = "https://chatgpt.com/backend-api/wham/usage";
 const USAGE_CACHE_MS = 15_000;
@@ -48,12 +51,14 @@ export async function accountsWithUsage(teamId: string) {
 }
 
 async function loadAccountsWithUsage(teamId: string) {
-  // The account list and encrypted credential snapshot are independent.
-  // Fetch each exactly once and overlap their network round trips.
-  const [accounts, vault] = await Promise.all([
+  // Account metadata and encrypted envelopes are independent RDS reads.
+  const [accounts, credentials] = await Promise.all([
     listAccounts(teamId),
-    readTeamVault(teamId).catch(() => null),
+    listEncryptedCredentials(teamId),
   ]);
+  const credentialsByAccount = new Map(
+    credentials.map((credential) => [credential.accountId, credential]),
+  );
   return await Promise.all(accounts.map(async (account) => {
     if (account.provider !== "codex" || account.state !== "active") {
       return account;
@@ -62,8 +67,8 @@ async function loadAccountsWithUsage(teamId: string) {
       const credential = await freshCredential({
         teamId,
         accountId: account.id,
-        expectedRevision: 0,
-        known: vault?.accounts[account.id],
+        expectedRevision: credentialsByAccount.get(account.id)?.credentialRevision ?? 0,
+        known: credentialsByAccount.get(account.id),
       });
       if (credential.provider !== "codex") return account;
       const response = await fetch(CODEX_USAGE_URL, {
@@ -103,6 +108,6 @@ function usageCooldown(value: unknown): number | null {
   return (resetSeconds.length > 0 ? Math.min(...resetSeconds) : 60) * 1_000;
 }
 
-function isRecord(value: unknown): value is Record<string, any> {
+function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }

--- a/web/services/coderouter/vault.ts
+++ b/web/services/coderouter/vault.ts
@@ -38,6 +38,16 @@ export async function writeTeamVault(
   });
 }
 
+export async function clearTeamVault(teamId: string): Promise<void> {
+  const team = await getStackServerApp().getTeam(teamId);
+  if (!team) throw new CodeRouterVaultUnavailable("coderouter team not found");
+  const metadata = isRecord(team.serverMetadata)
+    ? { ...team.serverMetadata }
+    : {};
+  delete metadata[METADATA_KEY];
+  await team.update({ serverMetadata: metadata });
+}
+
 export async function putVaultCredential(
   teamId: string,
   accountId: string,

--- a/web/tests/coderouter-encryption.test.ts
+++ b/web/tests/coderouter-encryption.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, test } from "bun:test";
+import { randomBytes } from "node:crypto";
+import {
+  decryptCredential,
+  encryptCredential,
+  type CredentialKeyService,
+  type EncryptedCredential,
+} from "../services/coderouter/encryption";
+import type { CodeRouterCredential } from "../services/coderouter/types";
+
+const credential: CodeRouterCredential = {
+  provider: "codex",
+  accessToken: "access-secret-value",
+  refreshToken: "refresh-secret-value",
+  idToken: "id-secret-value",
+  accountId: "provider-account",
+  email: "person@example.com",
+  expiresAt: 1_900_000_000_000,
+};
+
+describe("coderouter credential envelope encryption", () => {
+  test("round trips without exposing provider secrets", async () => {
+    const keys = fakeKeys();
+    const encrypted = await encrypt(keys);
+
+    expect(await decryptCredential(encrypted, keys)).toEqual(credential);
+    const serialized = JSON.stringify(encrypted);
+    expect(serialized).not.toContain(credential.accessToken);
+    expect(serialized).not.toContain(credential.refreshToken);
+    expect(serialized).not.toContain(credential.idToken);
+  });
+
+  test("rejects tampered ciphertext", async () => {
+    const keys = fakeKeys();
+    const encrypted = await encrypt(keys);
+    const bytes = Buffer.from(encrypted.ciphertext, "base64");
+    bytes[0] ^= 1;
+
+    await expect(
+      decryptCredential({
+        ...encrypted,
+        ciphertext: bytes.toString("base64"),
+      }, keys),
+    ).rejects.toThrow();
+  });
+
+  test("binds ciphertext to tenant and revision through AAD", async () => {
+    const keys = fakeKeys();
+    const encrypted = await encrypt(keys);
+
+    await expect(
+      decryptCredential({ ...encrypted, teamId: "other-team" }, keys),
+    ).rejects.toThrow();
+    await expect(
+      decryptCredential({
+        ...encrypted,
+        credentialRevision: encrypted.credentialRevision + 1,
+      }, keys),
+    ).rejects.toThrow();
+  });
+
+  test("rejects a data key from the wrong KMS envelope", async () => {
+    const encrypted = await encrypt(fakeKeys());
+    await expect(
+      decryptCredential(encrypted, fakeKeys()),
+    ).rejects.toThrow();
+  });
+
+  test("does not include provider secrets in KMS failures", async () => {
+    const denied: CredentialKeyService = {
+      async generateDataKey() {
+        throw new Error("KMS access denied");
+      },
+      async decryptDataKey() {
+        throw new Error("KMS access denied");
+      },
+    };
+    let message = "";
+    try {
+      await encrypt(denied);
+    } catch (error) {
+      message = error instanceof Error ? error.message : String(error);
+    }
+    expect(message).toContain("KMS access denied");
+    expect(message).not.toContain(credential.accessToken);
+    expect(message).not.toContain(credential.refreshToken);
+    expect(message).not.toContain(credential.idToken);
+  });
+});
+
+async function encrypt(keys: CredentialKeyService): Promise<EncryptedCredential> {
+  return await encryptCredential({
+    accountId: "00000000-0000-4000-8000-000000000001",
+    teamId: "team-1",
+    provider: "codex",
+    credentialRevision: 1,
+    credential,
+    keyId: "test-key",
+    keys,
+  });
+}
+
+function fakeKeys(): CredentialKeyService {
+  const dataKey = randomBytes(32);
+  return {
+    async generateDataKey() {
+      return {
+        plaintext: Buffer.from(dataKey),
+        encrypted: Buffer.from(dataKey),
+      };
+    },
+    async decryptDataKey({ encrypted }) {
+      if (!Buffer.from(encrypted).equals(dataKey)) {
+        throw new Error("wrong test key");
+      }
+      return Buffer.from(dataKey);
+    },
+  };
+}

--- a/web/tests/coderouter-models-proxy.test.ts
+++ b/web/tests/coderouter-models-proxy.test.ts
@@ -11,7 +11,11 @@ mock.module("../services/coderouter/repository", () => ({
   }),
   markAccountCooldown: async () => {},
   listAccounts: async () => [],
+  listEncryptedCredentials: async () => [],
+  encryptedCredentialForAccount: async () => null,
   findAccountByProviderIdentity: async () => null,
+  insertAccountWithCredential: async () => true,
+  replaceAccountCredential: async () => {},
   upsertAccountMetadata: async () => {},
   withVaultLease: async (_teamId: string, operation: () => unknown) =>
     await operation(),


### PR DESCRIPTION
## Summary
- store provider credentials in a dedicated RDS table using per-record AES-256-GCM data keys wrapped by AWS KMS
- bind ciphertext to team, account, provider, and revision through both AES AAD and KMS encryption context
- access KMS from Vercel through the existing OIDC role with a dedicated least-privilege policy
- replace remote team-metadata reads with RDS envelope reads
- make refresh rotation atomic with per-account leases and revision CAS, without holding a transaction during provider calls
- add migration/verification/source-cleanup tooling

## Production preparation already completed
- created and rotation-enabled `alias/coderouter-prod-credentials` in us-west-2
- attached `kms:GenerateDataKey`, `kms:Decrypt`, and `kms:DescribeKey` only to the production Vercel role
- added the production KMS key ID to Vercel
- applied the schema migration
- migrated and successfully decrypted all 3 production credential records
- confirmed there are no account rows missing an encrypted credential

## Verification
- TypeScript typecheck
- targeted ESLint
- 14 coderouter tests, including round-trip, ciphertext tampering, wrong tenant/revision AAD, wrong key, and secret-redaction failure behavior

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/9686"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788579207&installation_model_id=21920&pr_number=9686&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F9686&signature=a678b213eecf7f9a45127fefa55e16f832cce5ca0d300e81ea3dc07b9bd1993e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Move CodeRouter provider credentials from Stack team metadata to a KMS-encrypted RDS table with per-record AES-256-GCM envelopes. This hardens secret storage, enables atomic rotation, and reduces cross-service reads.

- **New Features**
  - Store credentials in `coderouter_credentials` using AES‑256‑GCM per record with KMS data keys; bind to team/account/provider/revision via AAD and KMS encryption context.
  - Access KMS from Vercel using the existing OIDC role with a least‑privilege policy.
  - Atomic refresh with per-account leases and revision CAS; repository/services now encrypt/decrypt on write/read without holding long transactions.
  - Added tests for round‑trip, tampering, wrong tenant/revision, wrong key, and redaction behavior.
  - Added dependency `@aws-sdk/client-kms`.

- **Migration**
  - Run: `bun run coderouter:migrate-encrypted-credentials` to import and verify envelopes.
  - To verify only: add `--verify-only`. To delete the legacy source after verification: add `--delete-source` and set `CODEROUTER_CONFIRM_DELETE_SOURCE=yes`.
  - Script checks counts and decrypts each record before allowing source cleanup.

<sup>Written for commit e11018472f38911e6b3e13069822244950b909de. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/9686?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * CodeRouter credentials are now protected with authenticated encryption and securely managed key encryption.
  * Credential updates and refreshes now use revision tracking to prevent conflicting changes.
  * Added migration support to transfer existing credentials into encrypted storage, with verification and guarded source cleanup options.
  * Added support for clearing obsolete CodeRouter vault entries.

* **Security**
  * Added validation, tamper detection, provider consistency checks, and protection against exposing credential secrets.

* **Tests**
  * Added coverage for encryption, tampering, key failures, and credential isolation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->