### PR TITLE
Limit transient Actions artifact retention

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1232,6 +1232,7 @@ jobs:
           name: cmux-ghostty-cli-helper
           path: ghostty-cli-helper/ghostty
           if-no-files-found: error
+          retention-days: 1
 
       - name: Retry universal Ghostty CLI helper upload
         if: steps.upload-ghostty-cli-helper.outcome == 'failure'
@@ -1240,6 +1241,7 @@ jobs:
           name: cmux-ghostty-cli-helper
           path: ghostty-cli-helper/ghostty
           if-no-files-found: error
+          retention-days: 1
           overwrite: true
 
       - name: Select Xcode

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,6 +59,7 @@ jobs:
           name: cmux-ghostty-cli-helper
           path: ghostty-cli-helper/ghostty
           if-no-files-found: error
+          retention-days: 3
 
   build-sign-notarize:
     needs: build-ghostty-cli-helper

--- a/.github/workflows/reload-build.yml
+++ b/.github/workflows/reload-build.yml
@@ -246,5 +246,5 @@ jobs:
         with:
           name: reload-${{ inputs.tag }}-${{ inputs.platform }}
           path: artifact/
-          retention-days: 3
+          retention-days: 1
           if-no-files-found: error


### PR DESCRIPTION
## Summary

- retain CI Ghostty helper handoffs for one day instead of the 90-day repository default
- retain reload-build artifacts for one day instead of three
- retain stable-release helper handoffs for three days to preserve a rerun cushion
- leave nightly and published release assets unchanged

## Why

These artifacts transfer build outputs between jobs or to the immediate reload caller. They are not durable distribution assets, so long retention creates unnecessary Actions artifact storage.

## Validation

- actionlint v1.7.12 on all three changed workflows
- ./tests/test_ci_self_hosted_guard.sh
- ./tests/test_ci_release_sdk_lane.sh
- Python Ghostty workflow guard tests and full workflow scan
- focused retention placement assertions
- git diff --check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/9687"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788579227&installation_model_id=21920&pr_number=9687&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F9687&signature=026e63726de39af932bfbe6be22829aea1fc429743c583e2b5cfa8b0b86e24f1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Shorten retention for transient GitHub Actions artifacts to reduce storage. CI and reload-build handoffs now keep artifacts for 1 day; release handoffs keep them for 3 days to allow reruns.

- **Changes**
  - `ci.yml`: `cmux-ghostty-cli-helper` retention set to 1 day.
  - `reload-build.yml`: reload artifact retention changed from 3 days to 1 day.
  - `release.yml`: `cmux-ghostty-cli-helper` retention set to 3 days (nightly/published assets unchanged).

<sup>Written for commit 400dfdc642de726563859cb00f0632f4da11c8f2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/9687?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated retention periods for build and release artifacts.
  * CI helper artifacts are retained for one day.
  * Release artifacts are retained for three days.
  * Reload-build artifacts are retained for one day.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->