### PR TITLE
Allow coderouter legacy cleanup after new accounts

### DIFF
--- a/web/scripts/coderouter/migrate-encrypted-credentials.ts
+++ b/web/scripts/coderouter/migrate-encrypted-credentials.ts
@@ -33,9 +33,12 @@ for (const teamId of teams) {
       verified += 1;
     }
     const source = await readTeamVault(teamId);
-    if (Object.keys(source.accounts).length !== encrypted.length) {
+    const encryptedIds = new Set(encrypted.map((value) => value.accountId));
+    const missing = Object.keys(source.accounts)
+      .filter((accountId) => !encryptedIds.has(accountId));
+    if (missing.length > 0) {
       throw new Error(
-        `refusing to delete source for team ${teamId}: account counts differ`,
+        `refusing to delete source for team ${teamId}: ${missing.length} source accounts are not encrypted`,
       );
     }
     await clearTeamVault(teamId);

--- a/web/services/coderouter/repository.ts
+++ b/web/services/coderouter/repository.ts
@@ -1,5 +1,5 @@
 import { createHash, randomBytes, randomUUID } from "node:crypto";
-import { and, eq, gt, isNull, lte, notInArray, or, sql } from "drizzle-orm";
+import { and, eq, gt, isNull, lt, lte, notInArray, or, sql } from "drizzle-orm";
 import { cloudDb } from "../../db/client";
 import {
   coderouterAccounts,
@@ -237,16 +237,28 @@ export async function importEncryptedCredential(input: {
   readonly encrypted: EncryptedCredential;
 }): Promise<void> {
   await cloudDb().transaction(async (tx) => {
-    await tx
+    const [inserted] = await tx
       .insert(coderouterCredentials)
       .values(encryptedValues(input.encrypted))
-      .onConflictDoUpdate({
+      .onConflictDoNothing({
         target: coderouterCredentials.accountId,
-        set: {
+      })
+      .returning({ accountId: coderouterCredentials.accountId });
+    if (!inserted) {
+      await tx
+        .update(coderouterCredentials)
+        .set({
           ...encryptedValues(input.encrypted),
           updatedAt: new Date(),
-        },
-      });
+        })
+        .where(and(
+          eq(coderouterCredentials.accountId, input.encrypted.accountId),
+          lt(
+            coderouterCredentials.credentialRevision,
+            input.encrypted.credentialRevision,
+          ),
+        ));
+    }
     await tx
       .update(coderouterAccounts)
       .set({
@@ -258,6 +270,7 @@ export async function importEncryptedCredential(input: {
       .where(and(
         eq(coderouterAccounts.id, input.encrypted.accountId),
         eq(coderouterAccounts.teamId, input.encrypted.teamId),
+        lt(coderouterAccounts.vaultRevision, input.encrypted.credentialRevision),
       ));
   });
 }


### PR DESCRIPTION
The rollback source only needs to be a subset of encrypted RDS. Requiring equal counts would permanently block cleanup if a new account were added after cutover. Cleanup still refuses deletion if any legacy source account lacks an encrypted destination.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/9689"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788580487&installation_model_id=21920&pr_number=9689&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F9689&signature=9f65c64a039b2432c64520e9505d14d0f9318d52c1d6dac95fc7d93d30b14055"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Allow legacy credential cleanup when new encrypted accounts exist, and ensure migration only advances credential revisions.

- **Bug Fixes**
  - Replaced count equality check with an ID-based subset check of encrypted accounts; cleanup blocks only when source accounts lack encrypted counterparts (error shows missing count).
  - Made migration monotonic: insert-or-ignore, and update credentials and vault only when the incoming `credentialRevision` is higher.

<sup>Written for commit 6e85fbad030c73d27c6e0445963af8178bad1fb6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/9689?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation when deleting source accounts.
  * Deletion is now prevented if any source account lacks a matching encrypted credential.
  * Prevented older imported credentials and account details from overwriting newer information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->