### PR TITLE
Sidebar: request an authoritative apply when a deferred row click parks

### DIFF
--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -10612,6 +10612,13 @@ struct VerticalTabsSidebar: View, Equatable {
     /// notifications) would otherwise stay unrendered until the next
     /// unrelated sidebar change. The bump forces one fresh rebuild.
     @State private var appKitPostResizeRefreshToken: UInt64 = 0
+    // Bumped when a completed row click parks in the table controller
+    // awaiting live actions. The park mutates no other tracked state and
+    // this view is Equatable-gated, so without this token nothing would
+    // re-evaluate the body, no authoritative apply would re-arm the rows,
+    // and the parked click would wait on unrelated invalidation
+    // (issue #9690: taps only landed after an app focus cycle).
+    @State private var appKitTableApplyRequestToken: UInt64 = 0
     @State private var workspaceScrollContentMinHeight: CGFloat = 0
     @State private var checklistPopoverWorkspaceId: UUID?
     // Pending keyed refresh ids are intentionally non-observed. Workspace
@@ -11444,6 +11451,7 @@ struct VerticalTabsSidebar: View, Equatable {
     private func appKitWorkspaceScrollArea(renderContext: WorkspaceListRenderContext) -> some View {
         let _ = anchorCwdRevision
         let _ = appKitPostResizeRefreshToken
+        let _ = appKitTableApplyRequestToken
         let tableRows: [SidebarWorkspaceTableRowConfiguration]
         let isDividerDragActive = isPresented
             && TerminalWindowPortalRegistry.isInteractiveGeometryResizeActive(in: observedWindow)
@@ -11476,7 +11484,8 @@ struct VerticalTabsSidebar: View, Equatable {
             selectedWorkspaceId: selectedWorkspaceId,
             selectedScrollTargetWorkspaceId: selectedScrollTargetWorkspaceId,
             isPresented: isPresented,
-            unreadSource: sidebarUnread
+            unreadSource: sidebarUnread,
+            onDeferredClickAwaitingApply: { appKitTableApplyRequestToken &+= 1 }
         )
             .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
             .mask(

--- a/Sources/Sidebar/AppKitList/SidebarWorkspaceTableController.swift
+++ b/Sources/Sidebar/AppKitList/SidebarWorkspaceTableController.swift
@@ -573,6 +573,13 @@ final class SidebarWorkspaceTableController: NSObject, NSTableViewDataSource, NS
             // so preserve the completed click by stable row identity.
             previewSelection(row: row, modifiers: modifiers, hitView: nil)
             deferredRowClick = click
+            // Request the apply the replay depends on. Fired only from a
+            // physical click (never from a replay re-park), so a request per
+            // click is the ceiling and a pathological apply cannot loop.
+#if DEBUG
+            cmuxDebugLog("sidebar.table.applyRequest row=\(row)")
+#endif
+            onDeferredRowClickAwaitingApply?()
         case .invalid:
             deferredRowClick = nil
         }

--- a/Sources/Sidebar/AppKitList/SidebarWorkspaceTableController.swift
+++ b/Sources/Sidebar/AppKitList/SidebarWorkspaceTableController.swift
@@ -24,6 +24,14 @@ final class SidebarWorkspaceTableController: NSObject, NSTableViewDataSource, NS
     private var rows: [SidebarWorkspaceTableRowConfiguration] = []
     private var actions: SidebarWorkspaceTableActions?
     private var deferredRowClick: DeferredRowClick?
+    /// SwiftUI-side wake-up for a parked click. A deferred click only lands
+    /// through the next authoritative apply, and applies only happen when
+    /// the deliberately Equatable-gated sidebar body re-evaluates. The park
+    /// itself mutates no SwiftUI-tracked state, so without requesting an
+    /// apply an idle app never re-arms the rows and the click waits on
+    /// unrelated invalidation — historically an app deactivate/reactivate
+    /// (issue #9690).
+    var onDeferredRowClickAwaitingApply: (() -> Void)?
     private var hoveredRowId: SidebarWorkspaceRenderItemID?
     private var contextMenuRowId: SidebarWorkspaceRenderItemID?
     private var workspaceIds: [UUID] = []

--- a/Sources/Sidebar/AppKitList/SidebarWorkspaceTableView.swift
+++ b/Sources/Sidebar/AppKitList/SidebarWorkspaceTableView.swift
@@ -10,6 +10,9 @@ struct SidebarWorkspaceTableView: NSViewRepresentable {
     let selectedScrollTargetWorkspaceId: UUID?
     let isPresented: Bool
     let unreadSource: SidebarUnreadModel
+    /// Invoked when a completed row click parks awaiting live actions; the
+    /// owner must invalidate itself so this view re-applies (issue #9690).
+    let onDeferredClickAwaitingApply: () -> Void
 
 #if DEBUG
     @Environment(\.sidebarLazyContractProbe) private var sidebarLazyContractProbe
@@ -28,6 +31,7 @@ struct SidebarWorkspaceTableView: NSViewRepresentable {
         context.coordinator.reconfigurationProbe = sidebarLazyContractProbe.tableRootViewReconfigure
 #endif
         context.coordinator.setUnreadSource(unreadSource)
+        context.coordinator.onDeferredRowClickAwaitingApply = onDeferredClickAwaitingApply
         context.coordinator.setPresentationActive(isPresented, workspaceIds: workspaceIds)
         guard isPresented else { return }
         context.coordinator.apply(

--- a/cmuxTests/SidebarWorkspaceTableSuspensionTests.swift
+++ b/cmuxTests/SidebarWorkspaceTableSuspensionTests.swift
@@ -182,6 +182,94 @@ struct SidebarWorkspaceTableSuspensionTests {
     }
 
     @Test
+    func visibleRowClickWhileRevealApplyIsPendingRequestsAuthoritativeApply() async throws {
+        let tabManager = TabManager(autoWelcomeIfNeeded: false)
+        let initiallySelectedWorkspace = try #require(tabManager.selectedWorkspace)
+        let clickedWorkspace = tabManager.addWorkspace(
+            select: false,
+            autoWelcomeIfNeeded: false,
+            autoRefreshMetadata: false
+        )
+        let model = SidebarWorkspaceRowSuspensionTests.makeModel(
+            workspaceId: clickedWorkspace.id
+        )
+        let row = SidebarWorkspaceTableRowConfiguration(
+            workspaceRowModel: model,
+            actions: SidebarWorkspaceRowSuspensionTests.makeActions(
+                model: model,
+                workspace: clickedWorkspace,
+                tabManager: tabManager
+            ),
+            groupId: nil,
+            isPinned: false,
+            environment: SidebarWorkspaceTableEnvironmentSnapshot(
+                colorScheme: .light,
+                globalFontMagnificationPercent: 100,
+                lazyContractProbe: SidebarLazyContractProbe()
+            )
+        )
+        let controller = SidebarWorkspaceTableController()
+        let container = controller.makeContainerView()
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 320, height: 240),
+            styleMask: [.borderless],
+            backing: .buffered,
+            defer: false
+        )
+        window.contentView = container
+        defer {
+            window.contentView = nil
+            window.close()
+        }
+        var applyRequests = 0
+        controller.onDeferredRowClickAwaitingApply = { applyRequests += 1 }
+
+        controller.apply(
+            rows: [row],
+            actions: makeTableActions(),
+            workspaceIds: [clickedWorkspace.id],
+            selectedWorkspaceId: initiallySelectedWorkspace.id,
+            selectedScrollTargetWorkspaceId: nil
+        )
+        await flushStagedTableMutations()
+        container.layoutSubtreeIfNeeded()
+        container.tableView.layoutSubtreeIfNeeded()
+
+        controller.setPresentationActive(false, workspaceIds: [clickedWorkspace.id])
+        controller.setPresentationActive(true, workspaceIds: [clickedWorkspace.id])
+
+        let table = container.tableView
+        let action = try #require(table.action)
+        let target = try #require(table.target)
+        table.setValue(0, forKey: "clickedRow")
+        defer { table.setValue(-1, forKey: "clickedRow") }
+        #expect(table.sendAction(action, to: target))
+
+        #expect(
+            applyRequests == 1,
+            """
+            A click parked on a reveal-time row must request an authoritative \
+            apply: the park mutates no SwiftUI-tracked state, so nothing else \
+            re-evaluates the Equatable-gated sidebar and the click stays \
+            parked until unrelated invalidation (issue #9690: taps only \
+            landed after an app focus cycle).
+            """
+        )
+
+        // Respond to the request the way production SwiftUI does — with a
+        // fresh authoritative apply — and confirm the parked click lands.
+        controller.apply(
+            rows: [row],
+            actions: makeTableActions(),
+            workspaceIds: [clickedWorkspace.id],
+            selectedWorkspaceId: initiallySelectedWorkspace.id,
+            selectedScrollTargetWorkspaceId: nil
+        )
+        await flushStagedTableMutations()
+        #expect(tabManager.selectedTabId == clickedWorkspace.id)
+    }
+
+    @Test
     func hidingRetiresNativeReorderSession() async {
         let controller = SidebarWorkspaceTableController()
         let container = controller.makeContainerView()


### PR DESCRIPTION
Fixes https://github.com/manaflow-ai/cmux/issues/9690.

Infrequently, sidebar row taps did nothing until an app deactivate/reactivate cycle. https://github.com/manaflow-ai/cmux/pull/9225 made a click that lands on a presentation-snapshot row (live action captures released) survive as `deferredRowClick`, replayed from the next authoritative apply. The replay was passive: applies only happen when the Equatable-gated `VerticalTabsSidebar` body re-evaluates, and the park itself mutates no SwiftUI-tracked state, so an idle app never re-armed the rows. The parked click waited on unrelated invalidation, which a focus cycle eventually provided via window-key row repaints.

The controller now fires `onDeferredRowClickAwaitingApply` when it parks a click. `SidebarWorkspaceTableView` forwards it to `VerticalTabsSidebar`, which bumps a `@State` token read by `appKitWorkspaceScrollArea` (the `appKitPostResizeRefreshToken` pattern), so the body re-evaluates, `updateNSView` re-applies fresh action-carrying rows, and the parked click replays immediately. The request fires only from a physical click, never from a replay re-park, so one request per click is the ceiling and it cannot loop; a fresh apply always carries live actions (`appKitRowSnapshotCache` caches display snapshots only).

Two commits: the first adds the regression test against an inert seam (red), the second wires the seam (green). The test drives the exact reveal gap (suspend, reveal, no apply), sends the row click, asserts the apply request fires once, then answers it like production and asserts the parked selection lands.

Localization audit: no user-facing strings added or changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/9691"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788582627&installation_model_id=21920&pr_number=9691&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F9691&signature=64ce022fd2d9272f8093b7933c8baeaae7a54ee5ba7d023ee0a6f7ab4c3a602b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes sidebar row clicks that sometimes did nothing until app refocus by requesting an authoritative apply when a deferred click parks, so the click replays immediately. Fixes #9690.

- **Bug Fixes**
  - Added `onDeferredRowClickAwaitingApply` in `SidebarWorkspaceTableController`, fired when a click is deferred on snapshot rows.
  - Forwarded via `SidebarWorkspaceTableView` to `VerticalTabsSidebar`, which bumps `appKitTableApplyRequestToken` to re-evaluate and re-apply rows.
  - Fires only for physical clicks (no loops); at most one request per click.
  - Added test to assert a single apply request and that the parked selection lands; no user-facing strings changed.

<sup>Written for commit df21c4d44cb0f3fe257a4f9dae16d79d0d681fa7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/9691?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sidebar row selection when presentation reactivation is pending.
  * Deferred clicks are now applied reliably after the interface becomes available.
  * Prevented duplicate click handling and inconsistent selection updates.

* **Tests**
  * Added regression coverage for suspended and reactivated sidebar interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->