### PR TITLE
Complete coderouter private-beta routing reliability

### DIFF
--- a/web/app/api/coderouter/accounts/[accountId]/route.ts
+++ b/web/app/api/coderouter/accounts/[accountId]/route.ts
@@ -1,0 +1,43 @@
+import { removeAccount } from "../../../../../services/coderouter/accounts";
+import { resolveCodeRouterRequestContext } from "../../../../../services/coderouter/requestContext";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+const UUID = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+export function createDeleteAccountHandler(dependencies: {
+  readonly resolve: typeof resolveCodeRouterRequestContext;
+  readonly remove: (input: {
+    readonly teamId: string;
+    readonly accountId: string;
+  }) => ReturnType<typeof removeAccount>;
+}) {
+  return async (
+    request: Request,
+    context: { params: Promise<{ accountId: string }> },
+  ): Promise<Response> => {
+    const resolved = await dependencies.resolve(request, "manage");
+    if (!resolved.ok) return resolved.response;
+    const { accountId } = await context.params;
+    if (!UUID.test(accountId)) {
+      return Response.json({ error: "invalid_request" }, { status: 400 });
+    }
+    const result = await dependencies.remove({
+      teamId: resolved.value.team.teamId,
+      accountId,
+    });
+    if (!result.removed) {
+      return Response.json({ error: "not_found" }, { status: 404 });
+    }
+    return Response.json(result, {
+      headers: { "cache-control": "no-store" },
+    });
+  };
+}
+
+export const DELETE = createDeleteAccountHandler({
+  resolve: resolveCodeRouterRequestContext,
+  remove: async ({ teamId, accountId }) =>
+    await removeAccount(teamId, accountId),
+});

--- a/web/app/api/coderouter/accounts/route.ts
+++ b/web/app/api/coderouter/accounts/route.ts
@@ -11,13 +11,41 @@ export const dynamic = "force-dynamic";
 const MAX_BODY_BYTES = 128 * 1_024;
 
 export async function GET(request: Request): Promise<Response> {
+  const startedAt = performance.now();
+  const authStartedAt = performance.now();
   const resolved = await resolveCoderouterUsageTeam(request);
   if (!resolved.ok) return resolved.response;
-  const accounts = await accountsWithUsage(resolved.teamId);
-  return Response.json(
-    { teamId: resolved.teamId, accounts },
-    { headers: { "cache-control": "no-store" } },
-  );
+  const authMs = performance.now() - authStartedAt;
+  const result = await accountsWithUsage(resolved.teamId);
+  const serializeStartedAt = performance.now();
+  const body = JSON.stringify({
+    teamId: resolved.teamId,
+    accounts: result.accounts,
+    usageAsOf: result.usageAsOf,
+    usageAgeSeconds: Math.max(
+      0,
+      Math.floor((Date.now() - result.usageGeneratedAtMs) / 1_000),
+    ),
+    cacheMaxAgeSeconds: result.cacheMaxAgeSeconds,
+  });
+  const serializeMs = performance.now() - serializeStartedAt;
+  const serverTiming = [
+    timing("auth", authMs),
+    timing("rds", result.timing.rdsMs),
+    timing("provider", result.timing.providerMs),
+    timing("serialize", serializeMs),
+    timing("total", performance.now() - startedAt),
+  ].join(", ");
+  return new Response(body, {
+    headers: {
+      "cache-control": "no-store",
+      "content-type": "application/json",
+      "server-timing": serverTiming,
+      // Vercel may reserve/strip Server-Timing at the edge. Keep the same
+      // standards-formatted value observable under a product header.
+      "x-coderouter-server-timing": serverTiming,
+    },
+  });
 }
 
 export async function POST(request: Request): Promise<Response> {
@@ -46,4 +74,8 @@ export async function POST(request: Request): Promise<Response> {
     status: result.alreadyExists ? 200 : 201,
     headers: { "cache-control": "no-store" },
   });
+}
+
+function timing(name: string, duration: number): string {
+  return `${name};dur=${Math.max(0, duration).toFixed(1)}`;
 }

--- a/web/app/coderouter/page.tsx
+++ b/web/app/coderouter/page.tsx
@@ -35,9 +35,14 @@ export default function CoderouterLandingPage() {
               cr codex
             </code>
             <span className="select-none rounded-lg bg-black px-4 py-2 font-mono text-xs text-white">
-              coming soon
+              private beta
             </span>
           </div>
+
+          <p className="mt-5 max-w-xl font-mono text-[11px] leading-5 text-black/40">
+            Codex and OpenCode Go are available now. Pi support is experimental.
+            Claude Max and API-key routing are coming soon.
+          </p>
 
           <div className="mt-20 grid max-w-3xl gap-px overflow-hidden rounded-xl border border-black/10 bg-black/10 sm:grid-cols-3">
             {[

--- a/web/db/schema.ts
+++ b/web/db/schema.ts
@@ -460,9 +460,9 @@ export const subrouterTenants = pgTable(
 );
 
 /**
- * Non-secret routing metadata for CodeRouter accounts. Provider credentials
- * live only in the Stack team server-metadata vault; Postgres coordinates
- * selection and rotating refresh-token leases.
+ * Non-secret routing metadata for coderouter accounts. Provider credentials
+ * live in the envelope-encrypted coderouterCredentials table; this table
+ * coordinates selection and rotating refresh-token leases.
  */
 export const coderouterAccounts = pgTable(
   "coderouter_accounts",

--- a/web/services/coderouter/accounts.ts
+++ b/web/services/coderouter/accounts.ts
@@ -1,12 +1,16 @@
 import { randomUUID } from "node:crypto";
 import {
   findAccountByProviderIdentity,
+  deleteAccount,
   insertAccountWithCredential,
   listAccounts,
   replaceAccountCredential,
+  withVaultLease,
 } from "./repository";
 import { encryptCredential } from "./encryption";
 import type { CodeRouterCredential } from "./types";
+import { deleteVaultCredential } from "./vault";
+import { reportCoderouterFailure } from "./observability";
 
 export async function addAccount(
   teamId: string,
@@ -55,6 +59,43 @@ export async function addAccount(
 }
 
 export { listAccounts };
+
+type RemoveAccountResult = {
+  removed: boolean;
+  lastAccount: boolean;
+  legacyCleanupPending: boolean;
+};
+
+export function createAccountRemover(dependencies: {
+  readonly deleteRuntime: typeof deleteAccount;
+  readonly deleteLegacy: typeof deleteVaultCredential;
+  readonly withLease: typeof withVaultLease;
+  readonly report: typeof reportCoderouterFailure;
+}): (teamId: string, accountId: string) => Promise<RemoveAccountResult> {
+  return async (teamId, accountId) => {
+    const result = await dependencies.deleteRuntime({ teamId, accountId });
+    if (!result.removed) return { ...result, legacyCleanupPending: false };
+    try {
+      // Temporary rollback copy only. This call disappears after the migration
+      // cleanup window; failure cannot restore runtime access to the credential.
+      await dependencies.withLease(
+        teamId,
+        async () => await dependencies.deleteLegacy(teamId, accountId),
+      );
+      return { ...result, legacyCleanupPending: false };
+    } catch (error) {
+      dependencies.report("legacy_cleanup", error);
+      return { ...result, legacyCleanupPending: true };
+    }
+  };
+}
+
+export const removeAccount = createAccountRemover({
+  deleteRuntime: deleteAccount,
+  deleteLegacy: deleteVaultCredential,
+  withLease: withVaultLease,
+  report: reportCoderouterFailure,
+});
 
 export function parseCredential(value: unknown): CodeRouterCredential | null {
   if (!isRecord(value)) return null;

--- a/web/services/coderouter/codexProxy.ts
+++ b/web/services/coderouter/codexProxy.ts
@@ -4,6 +4,8 @@ import {
   selectAccountForRequest,
 } from "./repository";
 import { freshCredential } from "./refresh";
+import { fetchProviderRead } from "./providerFetch";
+import { reportCoderouterFailure } from "./observability";
 
 const CODEX_UPSTREAM = "https://chatgpt.com/backend-api/codex/responses";
 const CODEX_MODELS_UPSTREAM = "https://chatgpt.com/backend-api/codex/models";
@@ -70,6 +72,10 @@ export async function proxyCodexRequest(request: Request): Promise<Response> {
       }
     }
     if (upstream.status === 429) {
+      reportCoderouterFailure("provider_rate_limit", new Error("rate limited"), {
+        provider: "codex",
+        status: 429,
+      });
       await markAccountCooldown(account.id, rateLimitDelay(upstream.headers));
       continue;
     }
@@ -95,59 +101,81 @@ export async function proxyCodexRequest(request: Request): Promise<Response> {
   });
 }
 
-export async function proxyCodexModels(request: Request): Promise<Response> {
-  const token = bearerToken(request);
-  if (!token) return jsonError("unauthorized", 401);
-  const identity = await authenticateRouteToken(token);
-  if (!identity) return jsonError("unauthorized", 401);
+type CodexModelsDependencies = {
+  readonly authenticate: typeof authenticateRouteToken;
+  readonly select: typeof selectAccountForRequest;
+  readonly credential: typeof freshCredential;
+  readonly cooldown: typeof markAccountCooldown;
+  readonly providerRead: typeof fetchProviderRead;
+};
 
-  const attempted: string[] = [];
-  let upstream: Response | null = null;
-  for (let attempt = 0; attempt < 8; attempt++) {
-    const account = await selectAccountForRequest(
-      identity.teamId,
-      "codex",
-      attempted,
-    );
-    if (!account) break;
-    attempted.push(account.id);
-    let credential;
-    try {
-      credential = await freshCredential({
-        teamId: identity.teamId,
-        accountId: account.id,
-        expectedRevision: account.vaultRevision,
-      });
-    } catch {
-      continue;
+export function createCodexModelsProxy(dependencies: CodexModelsDependencies) {
+  return async (request: Request): Promise<Response> => {
+    const token = bearerToken(request);
+    if (!token) return jsonError("unauthorized", 401);
+    const identity = await dependencies.authenticate(token);
+    if (!identity) return jsonError("unauthorized", 401);
+
+    const attempted: string[] = [];
+    let upstream: Response | null = null;
+    for (let attempt = 0; attempt < 8; attempt++) {
+      const account = await dependencies.select(
+        identity.teamId,
+        "codex",
+        attempted,
+      );
+      if (!account) break;
+      attempted.push(account.id);
+      let credential;
+      try {
+        credential = await dependencies.credential({
+          teamId: identity.teamId,
+          accountId: account.id,
+          expectedRevision: account.vaultRevision,
+        });
+      } catch {
+        continue;
+      }
+      if (credential.provider !== "codex") continue;
+      const upstreamUrl = new URL(CODEX_MODELS_UPSTREAM);
+      upstreamUrl.search = new URL(request.url).search;
+      upstream = await dependencies.providerRead(() => fetch(upstreamUrl, {
+        headers: {
+          authorization: `Bearer ${credential.accessToken}`,
+          "chatgpt-account-id": credential.accountId,
+          originator: "codex_cli_rs",
+          "user-agent": request.headers.get("user-agent") ?? "coderouter",
+        },
+        cache: "no-store",
+      }));
+      if (upstream.status === 429) {
+        reportCoderouterFailure("provider_rate_limit", new Error("rate limited"), {
+          provider: "codex",
+          status: 429,
+        });
+        await dependencies.cooldown(account.id, rateLimitDelay(upstream.headers));
+        continue;
+      }
+      break;
     }
-    if (credential.provider !== "codex") continue;
-    const upstreamUrl = new URL(CODEX_MODELS_UPSTREAM);
-    upstreamUrl.search = new URL(request.url).search;
-    upstream = await fetch(upstreamUrl, {
+    if (!upstream) return jsonError("no_usable_account", 503);
+    return new Response(upstream.body, {
+      status: upstream.status,
       headers: {
-        authorization: `Bearer ${credential.accessToken}`,
-        "chatgpt-account-id": credential.accountId,
-        originator: "codex_cli_rs",
-        "user-agent": request.headers.get("user-agent") ?? "coderouter",
+        "cache-control": "no-store",
+        "content-type": upstream.headers.get("content-type") ?? "application/json",
       },
-      cache: "no-store",
     });
-    if (upstream.status === 429) {
-      await markAccountCooldown(account.id, rateLimitDelay(upstream.headers));
-      continue;
-    }
-    break;
-  }
-  if (!upstream) return jsonError("no_usable_account", 503);
-  return new Response(upstream.body, {
-    status: upstream.status,
-    headers: {
-      "cache-control": "no-store",
-      "content-type": upstream.headers.get("content-type") ?? "application/json",
-    },
-  });
+  };
 }
+
+export const proxyCodexModels = createCodexModelsProxy({
+  authenticate: authenticateRouteToken,
+  select: selectAccountForRequest,
+  credential: freshCredential,
+  cooldown: markAccountCooldown,
+  providerRead: fetchProviderRead,
+});
 
 async function sendCodex(
   request: Request,

--- a/web/services/coderouter/encryption.ts
+++ b/web/services/coderouter/encryption.ts
@@ -19,6 +19,7 @@ const ALGORITHM = "aes-256-gcm" as const;
 const DATA_KEY_BYTES = 32;
 const NONCE_BYTES = 12;
 const AUTH_TAG_BYTES = 16;
+const CREDENTIAL_REFRESH_SKEW_MS = 5 * 60 * 1_000;
 
 export type EncryptedCredential = {
   readonly accountId: string;
@@ -283,18 +284,57 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 
 let defaultKeyService: CredentialKeyService | undefined;
 
+type AwsCredentials = {
+  readonly accessKeyId: string;
+  readonly secretAccessKey: string;
+  readonly sessionToken?: string;
+  readonly expiration?: Date;
+};
+
+export function coalescingCredentialsProvider(
+  provider: () => Promise<AwsCredentials>,
+  now: () => number = Date.now,
+): () => Promise<AwsCredentials> {
+  let current: AwsCredentials | undefined;
+  let pending: Promise<AwsCredentials> | undefined;
+  return async () => {
+    if (
+      current &&
+      (!current.expiration ||
+        current.expiration.getTime() > now() + CREDENTIAL_REFRESH_SKEW_MS)
+    ) {
+      return current;
+    }
+    if (pending) return await pending;
+    pending = provider().then((credentials) => {
+      current = credentials;
+      return credentials;
+    });
+    try {
+      return await pending;
+    } finally {
+      pending = undefined;
+    }
+  };
+}
+
 function kmsKeyService(): CredentialKeyService {
   if (defaultKeyService) return defaultKeyService;
   const region = requiredEnv("AWS_REGION");
-  const roleArn = process.env.AWS_ROLE_ARN?.trim();
+  const runningOnVercel = Boolean(process.env.VERCEL);
+  const roleArn = runningOnVercel
+    ? requiredEnv("CODEROUTER_KMS_ROLE_ARN")
+    : undefined;
   const client = new KMSClient({
     region,
-    ...(process.env.VERCEL_OIDC_TOKEN && roleArn
+    ...(runningOnVercel && roleArn
       ? {
-        credentials: awsCredentialsProvider({
-          roleArn,
-          clientConfig: { region },
-        }),
+        credentials: coalescingCredentialsProvider(
+          awsCredentialsProvider({
+            roleArn,
+            clientConfig: { region },
+          }),
+        ),
       }
       : {}),
   });

--- a/web/services/coderouter/observability.ts
+++ b/web/services/coderouter/observability.ts
@@ -1,0 +1,27 @@
+import { reportError } from "../observability/report";
+
+type CodeRouterFailure =
+  | "credential_decrypt"
+  | "provider_usage"
+  | "provider_refresh"
+  | "provider_rate_limit"
+  | "legacy_cleanup"
+  | "rds";
+
+/**
+ * Emit an alertable error without ever forwarding a provider error message,
+ * response body, credential, tenant ID, or account ID to logs/Sentry.
+ */
+export function reportCoderouterFailure(
+  failure: CodeRouterFailure,
+  error: unknown,
+  context: Readonly<Record<string, string | number | boolean>> = {},
+): void {
+  const errorType = error instanceof Error ? error.name : typeof error;
+  reportError(new Error(`coderouter.${failure}`), {
+    service: "coderouter",
+    failure,
+    errorType,
+    ...context,
+  });
+}

--- a/web/services/coderouter/opencodeProxy.ts
+++ b/web/services/coderouter/opencodeProxy.ts
@@ -1,5 +1,6 @@
 import { authenticateRouteToken, selectAccountForRequest } from "./repository";
 import { freshCredential } from "./refresh";
+import { fetchProviderRead } from "./providerFetch";
 
 const OPENCODE_CONSOLE = "https://console.opencode.ai";
 
@@ -61,23 +62,44 @@ export async function proxyOpenCodeRequest(
   });
 }
 
-async function openCodeAccount(teamId: string) {
-  const account = await selectAccountForRequest(teamId, "opencode-go");
-  if (!account) return null;
-  const credential = await freshCredential({
-    teamId,
-    accountId: account.id,
-    expectedRevision: account.vaultRevision,
-  });
-  return credential.provider === "opencode-go" ? { account, credential } : null;
+async function openCodeAccount(
+  teamId: string,
+  dependencies = {
+    select: selectAccountForRequest,
+    credential: freshCredential,
+  },
+) {
+  const attempted: string[] = [];
+  for (let attempt = 0; attempt < 8; attempt++) {
+    const account = await dependencies.select(
+      teamId,
+      "opencode-go",
+      attempted,
+    );
+    if (!account) return null;
+    attempted.push(account.id);
+    try {
+      const credential = await dependencies.credential({
+        teamId,
+        accountId: account.id,
+        expectedRevision: account.vaultRevision,
+      });
+      if (credential.provider === "opencode-go") {
+        return { account, credential };
+      }
+    } catch {
+      // Broken, refreshing, and transiently unavailable accounts are skipped.
+    }
+  }
+  return null;
 }
 
 async function remoteConfig(accessToken: string): Promise<Record<string, unknown>> {
-  const response = await fetch(`${OPENCODE_CONSOLE}/api/config`, {
+  const response = await fetchProviderRead(() => fetch(`${OPENCODE_CONSOLE}/api/config`, {
     headers: { authorization: `Bearer ${accessToken}` },
     cache: "no-store",
     signal: AbortSignal.timeout(5_000),
-  });
+  }));
   if (!response.ok) throw new Error(`OpenCode config failed: ${response.status}`);
   const value: unknown = await response.json();
   if (!isRecord(value) || !isRecord(value.config) || !isRecord(value.config.provider)) {
@@ -173,8 +195,8 @@ function filteredResponseHeaders(input: Headers): Headers {
   return headers;
 }
 
-function isRecord(value: unknown): value is Record<string, any> {
+function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
-export const __test = { rewriteProviders, safeProviderURL };
+export const __test = { rewriteProviders, safeProviderURL, openCodeAccount };

--- a/web/services/coderouter/providerFetch.ts
+++ b/web/services/coderouter/providerFetch.ts
@@ -1,0 +1,13 @@
+const RETRYABLE_STATUS = new Set([408, 425, 500, 502, 503, 504]);
+
+/** Retry one safe, replayable provider read. Mutating requests must not use this. */
+export async function fetchProviderRead(
+  request: () => Promise<Response>,
+): Promise<Response> {
+  try {
+    const first = await request();
+    return RETRYABLE_STATUS.has(first.status) ? await request() : first;
+  } catch {
+    return await request();
+  }
+}

--- a/web/services/coderouter/refresh.ts
+++ b/web/services/coderouter/refresh.ts
@@ -11,6 +11,7 @@ import {
   type EncryptedCredential,
 } from "./encryption";
 import type { CodeRouterCredential } from "./types";
+import { reportCoderouterFailure } from "./observability";
 
 const CODEX_CLIENT_ID = "app_EMoamEEZ73f0CkXaXp7hrann";
 const OPENCODE_CLIENT_ID = "opencode-cli";
@@ -24,13 +25,31 @@ export class CodeRouterCredentialBroken extends Error {
   readonly _tag = "CodeRouterCredentialBroken";
 }
 
-export async function freshCredential(input: {
+export type FreshCredentialInput = {
   readonly teamId: string;
   readonly accountId: string;
   readonly expectedRevision: number;
   readonly force?: boolean;
   readonly known?: EncryptedCredential;
-}): Promise<CodeRouterCredential> {
+};
+
+export type CredentialRefreshDependencies = {
+  readonly read: typeof readCredential;
+  readonly decrypt: typeof decryptCredential;
+  readonly claim: typeof claimRefreshLease;
+  readonly release: typeof releaseRefreshLease;
+  readonly refresh: typeof refreshProviderCredential;
+  readonly encrypt: typeof encryptCredential;
+  readonly complete: typeof completeRefreshLease;
+  readonly fail: typeof failRefreshLease;
+  readonly isTerminal: typeof isTerminalRefreshError;
+  readonly failureCode: typeof refreshFailureCode;
+};
+
+export function createCredentialRefresher(
+  dependencies: CredentialRefreshDependencies,
+): (input: FreshCredentialInput) => Promise<CodeRouterCredential> {
+  return async (input) => {
   if (
     input.known &&
     input.expectedRevision > 0 &&
@@ -38,40 +57,46 @@ export async function freshCredential(input: {
   ) {
     throw new CodeRouterRefreshBusy("credential revision changed");
   }
-  const before = input.known
-    ? {
-      envelope: input.known,
-      credential: await decryptCredential(input.known),
-    }
-    :
-    await readCredential(input.teamId, input.accountId);
+  let before;
+  try {
+    before = input.known
+      ? {
+        envelope: input.known,
+        credential: await dependencies.decrypt(input.known),
+      }
+      :
+      await dependencies.read(input.teamId, input.accountId);
+  } catch (error) {
+    reportCoderouterFailure("credential_decrypt", error);
+    throw error;
+  }
   if (!input.force && before.credential.expiresAt > Date.now() + REFRESH_SKEW_MS) {
     return before.credential;
   }
 
-  const leaseId = await claimRefreshLease(input.accountId);
+  const leaseId = await dependencies.claim(input.accountId);
   if (!leaseId) throw new CodeRouterRefreshBusy("credential refresh already in progress");
   try {
     // The lease winner must re-read after claiming. Another request may have
     // refreshed and rotated the token immediately before this lease.
-    const current = await readCredential(input.teamId, input.accountId);
+    const current = await dependencies.read(input.teamId, input.accountId);
     if (
       !input.force &&
       current.credential.expiresAt > Date.now() + REFRESH_SKEW_MS
     ) {
-      await releaseRefreshLease(input.accountId, leaseId);
+      await dependencies.release(input.accountId, leaseId);
       return current.credential;
     }
 
-    const refreshed = await refreshProviderCredential(current.credential);
-    const encrypted = await encryptCredential({
+    const refreshed = await dependencies.refresh(current.credential);
+    const encrypted = await dependencies.encrypt({
       teamId: input.teamId,
       accountId: input.accountId,
       provider: refreshed.provider,
       credentialRevision: current.envelope.credentialRevision + 1,
       credential: refreshed,
     });
-    await completeRefreshLease({
+    await dependencies.complete({
       accountId: input.accountId,
       leaseId,
       expectedRevision: current.envelope.credentialRevision,
@@ -80,19 +105,41 @@ export async function freshCredential(input: {
     });
     return refreshed;
   } catch (error) {
-    const terminal = isTerminalRefreshError(error);
-    await failRefreshLease(
+    const terminal = dependencies.isTerminal(error);
+    reportCoderouterFailure("provider_refresh", error, {
+      provider: currentProvider(before.credential),
+      terminal,
+    });
+    await dependencies.fail(
       input.accountId,
       leaseId,
       terminal,
-      refreshFailureCode(error),
+      dependencies.failureCode(error),
     ).catch(() => undefined);
     if (terminal) {
       throw new CodeRouterCredentialBroken("provider refresh token is no longer usable");
     }
     throw error;
   }
+  };
 }
+
+function currentProvider(credential: CodeRouterCredential): string {
+  return credential.provider;
+}
+
+export const freshCredential = createCredentialRefresher({
+  read: readCredential,
+  decrypt: decryptCredential,
+  claim: claimRefreshLease,
+  release: releaseRefreshLease,
+  refresh: refreshProviderCredential,
+  encrypt: encryptCredential,
+  complete: completeRefreshLease,
+  fail: failRefreshLease,
+  isTerminal: isTerminalRefreshError,
+  failureCode: refreshFailureCode,
+});
 
 async function readCredential(teamId: string, accountId: string) {
   const envelope = await encryptedCredentialForAccount(teamId, accountId);
@@ -105,7 +152,7 @@ async function readCredential(teamId: string, accountId: string) {
   };
 }
 
-async function refreshProviderCredential(
+export async function refreshProviderCredential(
   credential: CodeRouterCredential,
 ): Promise<CodeRouterCredential> {
   if (credential.provider === "codex") {
@@ -193,7 +240,7 @@ function providerErrorCode(value: unknown): string | undefined {
     optionalString(value, "error");
 }
 
-function isTerminalRefreshError(error: unknown): boolean {
+export function isTerminalRefreshError(error: unknown): boolean {
   return error instanceof ProviderRefreshError &&
     (error.status === 400 || error.status === 401) &&
     /invalid|expired|reused|revoked|not_found/i.test(error.code);

--- a/web/services/coderouter/repository.ts
+++ b/web/services/coderouter/repository.ts
@@ -78,6 +78,43 @@ export async function revokeRouteToken(
     ));
 }
 
+export async function deleteAccount(input: {
+  readonly teamId: string;
+  readonly accountId: string;
+  readonly now?: Date;
+}): Promise<{ removed: boolean; lastAccount: boolean }> {
+  const now = input.now ?? new Date();
+  return await cloudDb().transaction(async (tx) => {
+    const [removed] = await tx
+      .delete(coderouterAccounts)
+      .where(and(
+        eq(coderouterAccounts.id, input.accountId),
+        eq(coderouterAccounts.teamId, input.teamId),
+      ))
+      .returning({ id: coderouterAccounts.id });
+    if (!removed) return { removed: false, lastAccount: false };
+
+    // coderouterCredentials is deleted by its account FK. If the workspace no
+    // longer has an account, route tokens have no useful authority and should
+    // not remain live.
+    const [remaining] = await tx
+      .select({ id: coderouterAccounts.id })
+      .from(coderouterAccounts)
+      .where(eq(coderouterAccounts.teamId, input.teamId))
+      .limit(1);
+    if (!remaining) {
+      await tx
+        .update(coderouterRouteTokens)
+        .set({ revokedAt: now })
+        .where(and(
+          eq(coderouterRouteTokens.teamId, input.teamId),
+          isNull(coderouterRouteTokens.revokedAt),
+        ));
+    }
+    return { removed: true, lastAccount: !remaining };
+  });
+}
+
 export async function listAccounts(
   teamId: string,
 ): Promise<readonly CodeRouterAccountSummary[]> {

--- a/web/services/coderouter/usage.ts
+++ b/web/services/coderouter/usage.ts
@@ -5,6 +5,8 @@ import {
   markAccountCooldown,
 } from "./repository";
 import { freshCredential } from "./refresh";
+import { fetchProviderRead } from "./providerFetch";
+import { reportCoderouterFailure } from "./observability";
 
 const CODEX_USAGE_URL = "https://chatgpt.com/backend-api/wham/usage";
 const USAGE_CACHE_MS = 15_000;
@@ -51,15 +53,19 @@ export async function accountsWithUsage(teamId: string) {
 }
 
 async function loadAccountsWithUsage(teamId: string) {
+  const startedAt = performance.now();
   // Account metadata and encrypted envelopes are independent RDS reads.
+  const rdsStartedAt = performance.now();
   const [accounts, credentials] = await Promise.all([
     listAccounts(teamId),
     listEncryptedCredentials(teamId),
   ]);
+  const rdsMs = performance.now() - rdsStartedAt;
   const credentialsByAccount = new Map(
     credentials.map((credential) => [credential.accountId, credential]),
   );
-  return await Promise.all(accounts.map(async (account) => {
+  const providerStartedAt = performance.now();
+  const withUsage = await Promise.all(accounts.map(async (account) => {
     if (account.provider !== "codex" || account.state !== "active") {
       return account;
     }
@@ -71,7 +77,7 @@ async function loadAccountsWithUsage(teamId: string) {
         known: credentialsByAccount.get(account.id),
       });
       if (credential.provider !== "codex") return account;
-      const response = await fetch(CODEX_USAGE_URL, {
+      const response = await fetchProviderRead(() => fetch(CODEX_USAGE_URL, {
         headers: {
           authorization: `Bearer ${credential.accessToken}`,
           "chatgpt-account-id": credential.accountId,
@@ -79,8 +85,13 @@ async function loadAccountsWithUsage(teamId: string) {
         },
         cache: "no-store",
         signal: AbortSignal.timeout(5_000),
-      });
+      }));
       if (!response.ok) {
+        reportCoderouterFailure(
+          response.status === 429 ? "provider_rate_limit" : "provider_usage",
+          new Error("provider usage request failed"),
+          { provider: account.provider, status: response.status },
+        );
         return { ...account, usageError: `HTTP ${response.status}` };
       }
       const usage: unknown = await response.json();
@@ -89,10 +100,24 @@ async function loadAccountsWithUsage(teamId: string) {
         await markAccountCooldown(account.id, cooldownMs);
       }
       return { ...account, usage };
-    } catch {
+    } catch (error) {
+      reportCoderouterFailure("provider_usage", error, {
+        provider: account.provider,
+      });
       return { ...account, usageError: "unavailable" };
     }
   }));
+  return {
+    accounts: withUsage,
+    usageAsOf: new Date().toISOString(),
+    usageGeneratedAtMs: Date.now(),
+    cacheMaxAgeSeconds: USAGE_CACHE_MS / 1_000,
+    timing: {
+      rdsMs,
+      providerMs: performance.now() - providerStartedAt,
+      totalMs: performance.now() - startedAt,
+    },
+  };
 }
 
 function usageCooldown(value: unknown): number | null {

--- a/web/tests/coderouter-account-removal.test.ts
+++ b/web/tests/coderouter-account-removal.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, test } from "bun:test";
+import { createDeleteAccountHandler } from "../app/api/coderouter/accounts/[accountId]/route";
+import { createAccountRemover } from "../services/coderouter/accounts";
+
+const accountId = "00000000-0000-4000-8000-000000000001";
+
+describe("coderouter account removal", () => {
+  test("requires manage permission and scopes deletion to the resolved team", async () => {
+    let removed: { teamId: string; accountId: string } | undefined;
+    const handler = createDeleteAccountHandler({
+      resolve: async (_request, permission) => {
+        expect(permission).toBe("manage");
+        return {
+          ok: true as const,
+          value: {
+            user: {} as never,
+            team: {
+              teamId: "team-1",
+              teamName: "Team",
+              use: true,
+              manageAccounts: true,
+            },
+          },
+        };
+      },
+      remove: async (input) => {
+        removed = input;
+        return {
+          removed: true,
+          lastAccount: true,
+          legacyCleanupPending: false,
+        };
+      },
+    });
+    const response = await handler(
+      new Request("https://coderouter.dev/api/coderouter/accounts/" + accountId, {
+        method: "DELETE",
+      }),
+      { params: Promise.resolve({ accountId }) },
+    );
+    expect(response.status).toBe(200);
+    expect(removed).toEqual({ teamId: "team-1", accountId });
+    expect(await response.json()).toEqual({
+      removed: true,
+      lastAccount: true,
+      legacyCleanupPending: false,
+    });
+  });
+
+  test("rejects malformed IDs before touching storage", async () => {
+    let called = false;
+    const handler = createDeleteAccountHandler({
+      resolve: async () => ({
+        ok: true as const,
+        value: {
+          user: {} as never,
+          team: {
+            teamId: "team-1",
+            teamName: "Team",
+            use: true,
+            manageAccounts: true,
+          },
+        },
+      }),
+      remove: async () => {
+        called = true;
+        return {
+          removed: true,
+          lastAccount: false,
+          legacyCleanupPending: false,
+        };
+      },
+    });
+    const response = await handler(
+      new Request("https://coderouter.dev", { method: "DELETE" }),
+      { params: Promise.resolve({ accountId: "../other-team" }) },
+    );
+    expect(response.status).toBe(400);
+    expect(called).toBe(false);
+  });
+});
+
+describe("coderouter account-removal storage semantics", () => {
+  test("deletes runtime ciphertext before the temporary rollback copy", async () => {
+    const order: string[] = [];
+    const remove = createAccountRemover({
+      deleteRuntime: async () => {
+        order.push("runtime");
+        return { removed: true, lastAccount: false };
+      },
+      deleteLegacy: async () => {
+        order.push("legacy");
+      },
+      withLease: async (_teamId, operation) => await operation(),
+      report: () => {},
+    });
+    expect(await remove("team-1", accountId)).toEqual({
+      removed: true,
+      lastAccount: false,
+      legacyCleanupPending: false,
+    });
+    expect(order).toEqual(["runtime", "legacy"]);
+  });
+
+  test("keeps runtime deletion successful when rollback-copy cleanup is unavailable", async () => {
+    let reported = false;
+    const remove = createAccountRemover({
+      deleteRuntime: async () => ({ removed: true, lastAccount: true }),
+      deleteLegacy: async () => {
+        throw new Error("Stack unavailable");
+      },
+      withLease: async (_teamId, operation) => await operation(),
+      report: (failure) => {
+        reported = failure === "legacy_cleanup";
+      },
+    });
+    expect(await remove("team-1", accountId)).toEqual({
+      removed: true,
+      lastAccount: true,
+      legacyCleanupPending: true,
+    });
+    expect(reported).toBe(true);
+  });
+});

--- a/web/tests/coderouter-encryption.test.ts
+++ b/web/tests/coderouter-encryption.test.ts
@@ -3,6 +3,7 @@ import { randomBytes } from "node:crypto";
 import {
   decryptCredential,
   encryptCredential,
+  coalescingCredentialsProvider,
   type CredentialKeyService,
   type EncryptedCredential,
 } from "../services/coderouter/encryption";
@@ -67,24 +68,56 @@ describe("coderouter credential envelope encryption", () => {
   });
 
   test("does not include provider secrets in KMS failures", async () => {
-    const denied: CredentialKeyService = {
-      async generateDataKey() {
-        throw new Error("KMS access denied");
-      },
-      async decryptDataKey() {
-        throw new Error("KMS access denied");
-      },
-    };
-    let message = "";
-    try {
-      await encrypt(denied);
-    } catch (error) {
-      message = error instanceof Error ? error.message : String(error);
+    for (const failure of [
+      "KMS access denied",
+      "KMS request timed out",
+      "KMS throttling exception",
+    ]) {
+      const unavailable: CredentialKeyService = {
+        async generateDataKey() {
+          throw new Error(failure);
+        },
+        async decryptDataKey() {
+          throw new Error(failure);
+        },
+      };
+      let message = "";
+      try {
+        await encrypt(unavailable);
+      } catch (error) {
+        message = error instanceof Error ? error.message : String(error);
+      }
+      expect(message).toContain(failure);
+      expect(message).not.toContain(credential.accessToken);
+      expect(message).not.toContain(credential.refreshToken);
+      expect(message).not.toContain(credential.idToken);
     }
-    expect(message).toContain("KMS access denied");
-    expect(message).not.toContain(credential.accessToken);
-    expect(message).not.toContain(credential.refreshToken);
-    expect(message).not.toContain(credential.idToken);
+  });
+});
+
+describe("coderouter Vercel OIDC credentials", () => {
+  test("coalesces parallel AWS role exchanges and refreshes before expiry", async () => {
+    let calls = 0;
+    let now = 1_000;
+    const provider = coalescingCredentialsProvider(async () => {
+      calls++;
+      await Promise.resolve();
+      return {
+        accessKeyId: `access-${calls}`,
+        secretAccessKey: "secret",
+        expiration: new Date(now + 10 * 60 * 1_000),
+      };
+    }, () => now);
+    const first = await Promise.all([provider(), provider(), provider()]);
+    expect(calls).toBe(1);
+    expect(first.map((value) => value.accessKeyId)).toEqual([
+      "access-1",
+      "access-1",
+      "access-1",
+    ]);
+    now += 6 * 60 * 1_000;
+    expect((await provider()).accessKeyId).toBe("access-2");
+    expect(calls).toBe(2);
   });
 });
 

--- a/web/tests/coderouter-models-proxy.test.ts
+++ b/web/tests/coderouter-models-proxy.test.ts
@@ -1,32 +1,7 @@
-import { afterAll, beforeAll, describe, expect, mock, test } from "bun:test";
+import { afterAll, beforeAll, beforeEach, describe, expect, mock, test } from "bun:test";
 
-mock.module("../services/coderouter/repository", () => ({
-  authenticateRouteToken: async () => ({
-    teamId: "team-1",
-    routeTokenId: "route-1",
-  }),
-  selectAccountForRequest: async () => ({
-    id: "account-1",
-    vaultRevision: 1,
-  }),
-  markAccountCooldown: async () => {},
-  listAccounts: async () => [],
-  listEncryptedCredentials: async () => [],
-  encryptedCredentialForAccount: async () => null,
-  findAccountByProviderIdentity: async () => null,
-  insertAccountWithCredential: async () => true,
-  replaceAccountCredential: async () => {},
-  upsertAccountMetadata: async () => {},
-  withVaultLease: async (_teamId: string, operation: () => unknown) =>
-    await operation(),
-}));
-mock.module("../services/coderouter/refresh", () => ({
-  freshCredential: async () => ({
-    provider: "codex",
-    accessToken: "provider-access",
-    accountId: "chatgpt-account",
-  }),
-}));
+let selectedAccounts = ["account-1"];
+let unusableAccounts = new Set<string>();
 
 const originalFetch = globalThis.fetch;
 let upstreamUrl = "";
@@ -41,9 +16,39 @@ afterAll(() => {
   globalThis.fetch = originalFetch;
 });
 
-const { proxyCodexModels } = await import("../services/coderouter/codexProxy");
+const { createCodexModelsProxy } = await import("../services/coderouter/codexProxy");
+const proxyCodexModels = createCodexModelsProxy({
+  authenticate: async () => ({ teamId: "team-1" }),
+  select: async () => {
+    const id = selectedAccounts.shift();
+    return id
+      ? { id, vaultRevision: 1, credentialExpiresAt: new Date() }
+      : null;
+  },
+  credential: async ({ accountId }) => {
+    if (unusableAccounts.has(accountId)) {
+      throw Object.assign(new Error("busy"), { _tag: "CodeRouterRefreshBusy" });
+    }
+    return {
+      provider: "codex",
+      accessToken: "provider-access",
+      refreshToken: "provider-refresh",
+      idToken: "provider-id",
+      accountId: "chatgpt-account",
+      email: "person@example.com",
+      expiresAt: Date.now() + 60_000,
+    };
+  },
+  cooldown: async () => {},
+  providerRead: async (request) => await request(),
+});
 
 describe("coderouter models proxy", () => {
+  beforeEach(() => {
+    selectedAccounts = ["account-1"];
+    unusableAccounts = new Set();
+  });
+
   test("forwards Codex model discovery through the authenticated account", async () => {
     const response = await proxyCodexModels(
       new Request("https://coderouter.dev/v1/models?client_version=0.146.0", {
@@ -55,6 +60,20 @@ describe("coderouter models proxy", () => {
     expect(upstreamUrl).toBe(
       "https://chatgpt.com/backend-api/codex/models?client_version=0.146.0",
     );
+    expect(await response.json()).toEqual({
+      models: [{ slug: "gpt-test" }],
+    });
+  });
+
+  test("routes around a refreshing or broken account", async () => {
+    selectedAccounts = ["refreshing-account", "healthy-account"];
+    unusableAccounts.add("refreshing-account");
+    const response = await proxyCodexModels(
+      new Request("https://coderouter.dev/v1/models?client_version=0.146.0", {
+        headers: { authorization: "Bearer crt_route" },
+      }),
+    );
+    expect(response.status).toBe(200);
     expect(await response.json()).toEqual({
       models: [{ slug: "gpt-test" }],
     });

--- a/web/tests/coderouter-opencode-proxy.test.ts
+++ b/web/tests/coderouter-opencode-proxy.test.ts
@@ -11,7 +11,9 @@ describe("coderouter OpenCode Go proxy", () => {
         options: { apiKey: "upstream-secret", headers: { secret: "value" }, mode: "go" },
         models: { "model-1": { name: "Model One" } },
       },
-    }, "route-token") as Record<string, any>;
+    }, "route-token") as {
+      go: { options: Record<string, unknown> };
+    };
     expect(rewritten.go.options).toEqual({
       mode: "go",
       baseURL: "https://coderouter.dev/api/coderouter/opencode/proxy/go",
@@ -27,5 +29,32 @@ describe("coderouter OpenCode Go proxy", () => {
     expect(__test.safeProviderURL("https://127.0.0.1/v1")).toBe(false);
     expect(__test.safeProviderURL("https://10.0.0.1/v1")).toBe(false);
     expect(__test.safeProviderURL("https://192.168.1.4/v1")).toBe(false);
+  });
+
+  test("routes around an unavailable OpenCode account", async () => {
+    const ids = ["busy", "healthy"];
+    const selected: string[] = [];
+    const result = await __test.openCodeAccount("team-1", {
+      select: async (_teamId, _provider, excluded) => {
+        selected.push(...(excluded ?? []));
+        const id = ids.shift();
+        return id
+          ? { id, vaultRevision: 1, credentialExpiresAt: new Date() }
+          : null;
+      },
+      credential: async ({ accountId }) => {
+        if (accountId === "busy") throw new Error("refreshing");
+        return {
+          provider: "opencode-go" as const,
+          accessToken: "access",
+          refreshToken: "refresh",
+          accountId: "provider-account",
+          email: "person@example.com",
+          expiresAt: Date.now() + 60_000,
+        };
+      },
+    });
+    expect(result?.account.id).toBe("healthy");
+    expect(selected).toContain("busy");
   });
 });

--- a/web/tests/coderouter-provider-fetch.test.ts
+++ b/web/tests/coderouter-provider-fetch.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, test } from "bun:test";
+import { fetchProviderRead } from "../services/coderouter/providerFetch";
+
+describe("coderouter safe provider retries", () => {
+  test("retries a transient read exactly once", async () => {
+    let calls = 0;
+    const response = await fetchProviderRead(async () => {
+      calls++;
+      return new Response(null, { status: calls === 1 ? 503 : 200 });
+    });
+    expect(response.status).toBe(200);
+    expect(calls).toBe(2);
+  });
+
+  test("retries a network failure exactly once", async () => {
+    let calls = 0;
+    const response = await fetchProviderRead(async () => {
+      calls++;
+      if (calls === 1) throw new Error("network unavailable");
+      return new Response(null, { status: 200 });
+    });
+    expect(response.status).toBe(200);
+    expect(calls).toBe(2);
+  });
+
+  test("does not retry terminal responses or rate limits", async () => {
+    for (const status of [400, 401, 403, 404, 429]) {
+      let calls = 0;
+      const response = await fetchProviderRead(async () => {
+        calls++;
+        return new Response(null, { status });
+      });
+      expect(response.status).toBe(status);
+      expect(calls).toBe(1);
+    }
+  });
+});

--- a/web/tests/coderouter-refresh.test.ts
+++ b/web/tests/coderouter-refresh.test.ts
@@ -1,0 +1,207 @@
+import { describe, expect, test } from "bun:test";
+import {
+  CodeRouterCredentialBroken,
+  CodeRouterRefreshBusy,
+  createCredentialRefresher,
+  isTerminalRefreshError,
+  refreshProviderCredential,
+  type CredentialRefreshDependencies,
+} from "../services/coderouter/refresh";
+import type { EncryptedCredential } from "../services/coderouter/encryption";
+import type { CodexCredential } from "../services/coderouter/types";
+
+const expired: CodexCredential = {
+  provider: "codex",
+  accessToken: "old-access",
+  refreshToken: "old-refresh",
+  idToken: "old-id",
+  accountId: "provider-account",
+  email: "person@example.com",
+  expiresAt: 1,
+};
+const envelope: EncryptedCredential = {
+  accountId: "00000000-0000-4000-8000-000000000001",
+  teamId: "team-1",
+  provider: "codex",
+  credentialRevision: 1,
+  algorithm: "aes-256-gcm",
+  ciphertext: "ciphertext",
+  nonce: "nonce",
+  authTag: "tag",
+  encryptedDataKey: "key",
+  kmsKeyId: "kms-key",
+};
+
+describe("coderouter credential refresh coordination", () => {
+  test("only one simultaneous refresh claims an account", async () => {
+    let leaseAvailable = true;
+    let releaseProvider!: () => void;
+    const providerGate = new Promise<void>((resolve) => {
+      releaseProvider = resolve;
+    });
+    let claimed!: () => void;
+    const didClaim = new Promise<void>((resolve) => {
+      claimed = resolve;
+    });
+    const dependencies = fakeDependencies({
+      claim: async () => {
+        if (!leaseAvailable) return null;
+        leaseAvailable = false;
+        claimed();
+        return "lease-1";
+      },
+      refresh: async () => {
+        await providerGate;
+        return refreshed();
+      },
+    });
+    const refresh = createCredentialRefresher(dependencies);
+    const first = refresh(input());
+    await didClaim;
+    await expect(refresh(input())).rejects.toBeInstanceOf(CodeRouterRefreshBusy);
+    releaseProvider();
+    expect((await first).refreshToken).toBe("new-refresh");
+  });
+
+  test("an abandoned lease becomes claimable after expiry", async () => {
+    let now = 0;
+    let leaseExpiresAt = 1_000;
+    const dependencies = fakeDependencies({
+      claim: async () => {
+        if (leaseExpiresAt > now) return null;
+        leaseExpiresAt = now + 30_000;
+        return "replacement-lease";
+      },
+    });
+    const refresh = createCredentialRefresher(dependencies);
+    await expect(refresh(input())).rejects.toBeInstanceOf(CodeRouterRefreshBusy);
+    now = 1_001;
+    expect((await refresh(input())).accessToken).toBe("new-access");
+  });
+
+  test("persists a rotated provider refresh token at the next revision", async () => {
+    let completed:
+      | Parameters<CredentialRefreshDependencies["complete"]>[0]
+      | undefined;
+    const refresh = createCredentialRefresher(fakeDependencies({
+      complete: async (value) => {
+        completed = value;
+      },
+    }));
+    const result = await refresh(input());
+    expect(result.refreshToken).toBe("new-refresh");
+    expect(completed?.credential.refreshToken).toBe("new-refresh");
+    expect(completed?.encrypted.credentialRevision).toBe(2);
+  });
+
+  test("marks invalid provider refresh tokens broken without returning them", async () => {
+    let terminalFailure = false;
+    const refresh = createCredentialRefresher(fakeDependencies({
+      refresh: async () => {
+        throw new Error("invalid_grant");
+      },
+      isTerminal: () => true,
+      failureCode: () => "invalid_grant",
+      fail: async (_account, _lease, terminal, code) => {
+        terminalFailure = terminal && code === "invalid_grant";
+      },
+    }));
+    await expect(refresh(input())).rejects.toBeInstanceOf(CodeRouterCredentialBroken);
+    expect(terminalFailure).toBe(true);
+  });
+
+  test("does not return a refreshed token when the RDS CAS fails", async () => {
+    let failedLease = false;
+    const refresh = createCredentialRefresher(fakeDependencies({
+      complete: async () => {
+        throw new Error("database unavailable");
+      },
+      fail: async () => {
+        failedLease = true;
+      },
+    }));
+    await expect(refresh(input())).rejects.toThrow("database unavailable");
+    expect(failedLease).toBe(true);
+  });
+});
+
+describe("coderouter provider refresh responses", () => {
+  test("accepts and uses provider refresh-token rotation", async () => {
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = (async () =>
+      Response.json({
+        access_token: "rotated-access",
+        refresh_token: "rotated-refresh",
+        id_token: "rotated-id",
+        expires_in: 3600,
+      })) as typeof fetch;
+    try {
+      const result = await refreshProviderCredential(expired);
+      if (result.provider !== "codex") throw new Error("unexpected provider");
+      expect(result.accessToken).toBe("rotated-access");
+      expect(result.refreshToken).toBe("rotated-refresh");
+      expect(result.idToken).toBe("rotated-id");
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  test("classifies an invalidated refresh token as terminal", async () => {
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = (async () =>
+      Response.json(
+        { error: { code: "invalid_grant" } },
+        { status: 400 },
+      )) as typeof fetch;
+    try {
+      let failure: unknown;
+      try {
+        await refreshProviderCredential(expired);
+      } catch (error) {
+        failure = error;
+      }
+      expect(isTerminalRefreshError(failure)).toBe(true);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+});
+
+function input() {
+  return {
+    teamId: "team-1",
+    accountId: envelope.accountId,
+    expectedRevision: 1,
+  };
+}
+
+function refreshed(): CodexCredential {
+  return {
+    ...expired,
+    accessToken: "new-access",
+    refreshToken: "new-refresh",
+    idToken: "new-id",
+    expiresAt: Date.now() + 3_600_000,
+  };
+}
+
+function fakeDependencies(
+  overrides: Partial<CredentialRefreshDependencies> = {},
+): CredentialRefreshDependencies {
+  return {
+    read: async () => ({ envelope, credential: expired }),
+    decrypt: async () => expired,
+    claim: async () => "lease-1",
+    release: async () => {},
+    refresh: async () => refreshed(),
+    encrypt: async (value) => ({
+      ...envelope,
+      credentialRevision: value.credentialRevision,
+    }),
+    complete: async () => {},
+    fail: async () => {},
+    isTerminal: () => false,
+    failureCode: () => "refresh_unavailable",
+    ...overrides,
+  };
+}


### PR DESCRIPTION
Adds manager-scoped account removal with encrypted-credential cascade and final-account route-token revocation, transient-safe provider reads, multi-account failure routing, refresh/KMS/RDS race tests, scrubbed alert signals, usage freshness metadata, Server-Timing, and accurate landing-page support states. Also includes the production backend needed by experimental `cr pi`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/9692"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788583568&installation_model_id=21920&pr_number=9692&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F9692&signature=e21fb65ac78e074ab95af17c14bb4d86c5e25b48360f4cc7367adc6979a7fbb4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improves CodeRouter private beta reliability with safe, retried provider reads, multi-account failover, and secure manager-scoped deletion that cascades encrypted credentials and revokes route tokens when a team loses its last account. Adds usage freshness fields with `Server-Timing` mirrored in headers, rate-limit telemetry, and updates the landing page to reflect private beta and experimental `cr pi`.

- **New Features**
  - DELETE `api/coderouter/accounts/[accountId]` (manage scope, team-scoped) with encrypted-credential cascade and final route-token revocation; returns `legacyCleanupPending` when rollback cleanup fails.
  - Account listing now returns `usageAsOf`, `usageAgeSeconds`, `cacheMaxAgeSeconds`, and `Server-Timing`; mirrors timing in `x-coderouter-server-timing`. Landing page clarifies: Codex and OpenCode Go available, Pi experimental, Claude Max and API-key routing coming soon.

- **Bug Fixes**
  - Adds `fetchProviderRead` for one safe retry of read-only provider calls; used in Codex models, usage reads, and OpenCode config; reports rate limits and applies cooldowns; routes around refreshing/broken accounts.
  - Hardens refresh with lease coordination, rotated-token persistence via CAS, terminal error classification, and scrubbed error reporting via `reportCoderouterFailure`; coalesces Vercel AWS role exchanges for KMS.

<sup>Written for commit db6cc105346d1ed13db298fe02ec30f93e1db85e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/9692?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added permission- and team-scoped CodeRouter account removal with cleanup status reporting.
  - Account listings now include usage metadata, cache age, request timing, and improved cache handling.
  - Improved provider routing with transient-failure retries and fallback to healthy accounts.
  - Added shared credential refresh handling for more reliable encrypted provider access.

- **Bug Fixes**
  - Improved credential refresh recovery and temporary provider failure handling.
  - Enhanced error reporting while protecting sensitive credentials.

- **Documentation**
  - Updated CodeRouter messaging to reflect private beta availability and supported providers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->