### PR TITLE
Stop caching coderouter quota usage

### DIFF
--- a/web/services/coderouter/usage.ts
+++ b/web/services/coderouter/usage.ts
@@ -1,4 +1,3 @@
-import { unstable_cache } from "next/cache";
 import {
   listAccounts,
   listEncryptedCredentials,
@@ -9,44 +8,21 @@ import { fetchProviderRead } from "./providerFetch";
 import { reportCoderouterFailure } from "./observability";
 
 const CODEX_USAGE_URL = "https://chatgpt.com/backend-api/wham/usage";
-const USAGE_CACHE_MS = 15_000;
-const MAX_CACHED_TEAMS = 256;
-const usageCache = new Map<string, {
-  readonly expiresAt: number;
-  readonly accounts: Awaited<ReturnType<typeof loadAccountsWithUsage>>;
-}>();
 const usageRequests = new Map<
   string,
   Promise<Awaited<ReturnType<typeof loadAccountsWithUsage>>>
 >();
-const sharedAccountsWithUsage = unstable_cache(
-  loadAccountsWithUsage,
-  ["coderouter-usage-v1"],
-  { revalidate: USAGE_CACHE_MS / 1_000 },
-);
 
 export async function accountsWithUsage(teamId: string) {
-  const cached = usageCache.get(teamId);
-  if (cached && cached.expiresAt > Date.now()) return cached.accounts;
   const pending = usageRequests.get(teamId);
   if (pending) return await pending;
 
-  // Vercel's encrypted data cache is shared across function instances. It
-  // stores only account summaries and provider usage, never credentials.
-  const request = sharedAccountsWithUsage(teamId);
+  // Provider reads fan out in parallel. Coalesce only requests that are
+  // concurrently in flight; completed quota data is never served from cache.
+  const request = loadAccountsWithUsage(teamId);
   usageRequests.set(teamId, request);
   try {
-    const accounts = await request;
-    if (usageCache.size >= MAX_CACHED_TEAMS && !usageCache.has(teamId)) {
-      const oldest = usageCache.keys().next().value;
-      if (oldest !== undefined) usageCache.delete(oldest);
-    }
-    usageCache.delete(teamId);
-    usageCache.set(teamId, {
-      expiresAt: Date.now() + USAGE_CACHE_MS,
-      accounts,
-    });
-    return accounts;
+    return await request;
   } finally {
     usageRequests.delete(teamId);
   }
@@ -111,7 +87,7 @@ async function loadAccountsWithUsage(teamId: string) {
     accounts: withUsage,
     usageAsOf: new Date().toISOString(),
     usageGeneratedAtMs: Date.now(),
-    cacheMaxAgeSeconds: USAGE_CACHE_MS / 1_000,
+    cacheMaxAgeSeconds: 0,
     timing: {
       rdsMs,
       providerMs: performance.now() - providerStartedAt,


### PR DESCRIPTION
Removes Vercel stale-while-revalidate and completed in-memory usage caches. Usage still fans out in parallel and concurrent requests are coalesced, but every later `cr` invocation gets a fresh provider snapshot. This prevents stale data from exceeding the advertised refresh target.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/9694"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788586134&installation_model_id=21920&pr_number=9694&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F9694&signature=648a3971312fa0b2167a0cfd7d091eeebb240ce712aade91c15da5f19714ff6b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop caching coderouter quota usage so every `cr` call reads a fresh provider snapshot and avoids stale overages. Concurrent requests are still coalesced, and provider reads fan out in parallel.

- **Bug Fixes**
  - Removed `unstable_cache` from `next/cache` and the in-memory usage cache; quota data is no longer served from cache.
  - Set `cacheMaxAgeSeconds` to 0 so responses are treated as non-cacheable.

<sup>Written for commit 1b5f60c3287fa0f83994e2162116601950d208a3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/9694?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

