### PR TITLE
Support private Pi route authentication

### DIFF
--- a/web/app/v1/codex/responses/route.ts
+++ b/web/app/v1/codex/responses/route.ts
@@ -1,0 +1,9 @@
+import { POST as handleResponsesRequest } from "../../responses/route";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+export const maxDuration = 1_800;
+
+export async function POST(request: Request): Promise<Response> {
+  return await handleResponsesRequest(request);
+}

--- a/web/proxy.ts
+++ b/web/proxy.ts
@@ -40,7 +40,10 @@ export default function middleware(request: NextRequest) {
   // OpenAI-compatible coderouter traffic is a machine endpoint, never a
   // localized page. Keep this explicit in addition to the matcher exclusion
   // so direct middleware tests and future matcher edits fail safely.
-  if (pathname === "/v1/responses") {
+  if (
+    pathname === "/v1/responses" ||
+    pathname === "/v1/codex/responses"
+  ) {
     return NextResponse.next();
   }
 

--- a/web/services/coderouter/codexProxy.ts
+++ b/web/services/coderouter/codexProxy.ts
@@ -11,6 +11,7 @@ const CODEX_UPSTREAM = "https://chatgpt.com/backend-api/codex/responses";
 const CODEX_MODELS_UPSTREAM = "https://chatgpt.com/backend-api/codex/models";
 const ALLOWED_REQUEST_HEADERS = [
   "accept",
+  "content-encoding",
   "content-type",
   "openai-beta",
   "openai-organization",
@@ -93,6 +94,9 @@ export async function proxyCodexRequest(request: Request): Promise<Response> {
   ]) {
     const value = upstream.headers.get(name);
     if (value) responseHeaders.set(name, value);
+  }
+  if (!responseHeaders.has("content-type")) {
+    responseHeaders.set("content-type", "text/event-stream; charset=utf-8");
   }
   responseHeaders.set("cache-control", "no-store");
   return new Response(upstream.body, {
@@ -213,6 +217,8 @@ function rateLimitDelay(headers: Headers): number {
 }
 
 function bearerToken(request: Request): string | null {
+  const routed = request.headers.get("x-coderouter-route-token")?.trim();
+  if (routed) return routed;
   const authorization = request.headers.get("authorization")?.trim() ?? "";
   const match = /^Bearer[ \t]+(.+)$/i.exec(authorization);
   return match?.[1]?.trim() || null;

--- a/web/tests/coderouter-middleware.test.ts
+++ b/web/tests/coderouter-middleware.test.ts
@@ -26,4 +26,16 @@ describe("coderouter middleware", () => {
     expect(response.headers.get("x-middleware-rewrite")).toBeNull();
     expect(response.headers.get("x-middleware-next")).toBe("1");
   });
+
+  test("does not localize Pi's Codex-compatible data-plane route", () => {
+    const response = middleware(
+      new NextRequest("https://coderouter.dev/v1/codex/responses", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+      }),
+    );
+
+    expect(response.headers.get("x-middleware-rewrite")).toBeNull();
+    expect(response.headers.get("x-middleware-next")).toBe("1");
+  });
 });

--- a/web/tests/coderouter-models-proxy.test.ts
+++ b/web/tests/coderouter-models-proxy.test.ts
@@ -78,4 +78,13 @@ describe("coderouter models proxy", () => {
       models: [{ slug: "gpt-test" }],
     });
   });
+
+  test("accepts the private Pi route-token header", async () => {
+    const response = await proxyCodexModels(
+      new Request("https://coderouter.dev/v1/models?client_version=0.146.0", {
+        headers: { "x-coderouter-route-token": "crt_route" },
+      }),
+    );
+    expect(response.status).toBe(200);
+  });
 });


### PR DESCRIPTION
Allows the ephemeral `cr pi` provider to authenticate with its route token in a private header while using Pi’s Codex-compatible Responses serializer with a non-secret local placeholder JWT. The proxy never forwards the route header upstream and still replaces upstream authorization/account headers.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/9695"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788586930&installation_model_id=21920&pr_number=9695&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F9695&signature=e1b72f6987a05b09db11d80e977eff4c131625f5c37266b31ddadc1976b9f03e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Support private Pi route authentication by accepting the `x-coderouter-route-token` header as the bearer token (trimmed), letting the ephemeral `cr pi` provider use a local placeholder JWT while the proxy handles upstream auth and never forwards the private header. Also expose `POST /v1/codex/responses` as a machine endpoint (not localized), default Codex proxy responses to `text/event-stream; charset=utf-8` when upstream omits `content-type`, and forward `content-encoding`.

<sup>Written for commit 48b26e50ba2f457911196337d1e20ab1f6208335. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/9695?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for authenticating Codex requests with a private route-token header.
  * Added support for the Codex-compatible responses endpoint.
  * Route tokens are trimmed automatically before validation.

* **Bug Fixes**
  * Improved authentication compatibility for Codex model proxy access.
  * Preserved upstream content encoding in proxied responses.
  * Ensured responses use the expected event-stream format when the upstream omits a content type.
  * Prevented localization from interfering with machine-readable API responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->