### PR TITLE
Fix main window refit after display disconnect

### DIFF
--- a/Sources/App/CmuxMainWindow.swift
+++ b/Sources/App/CmuxMainWindow.swift
@@ -284,6 +284,8 @@ final class CmuxMainWindow: NSWindow {
         }
         return Self.recoveredOffscreenFrame(
             frameRect,
+            styleMask: styleMask,
+            windowMinSize: minSize,
             mouseLocation: NSEvent.mouseLocation
         ) ?? super.constrainFrameRect(frameRect, to: screen)
     }
@@ -400,7 +402,12 @@ extension CmuxMainWindow {
             return
         }
 
-        guard let recovered = recoveredOffscreenFrame(window.frame, mouseLocation: mouseLocation) else {
+        guard let recovered = recoveredOffscreenFrame(
+            window.frame,
+            styleMask: window.styleMask,
+            windowMinSize: window.minSize,
+            mouseLocation: mouseLocation
+        ) else {
             return
         }
         guard recovered != window.frame else { return }
@@ -409,13 +416,15 @@ extension CmuxMainWindow {
 
     static func recoveredOffscreenFrame(
         _ frame: NSRect,
+        styleMask: NSWindow.StyleMask,
+        windowMinSize: NSSize = .zero,
         mouseLocation: NSPoint?
     ) -> NSRect? {
         let screens = NSScreen.screens.map { (frame: $0.frame, visibleFrame: $0.visibleFrame) }
         let fallbackVisibleFrame = (NSScreen.main ?? NSScreen.screens.first)?.visibleFrame
-        let minimumFrameSize = NSSize(
-            width: minimumContentSize.width,
-            height: minimumContentSize.height
+        let minimumFrameSize = minimumFrameSize(
+            for: styleMask,
+            windowMinSize: windowMinSize
         )
         return MultiMonitorWindowGeometry.recoveredFrame(
             frame,
@@ -424,6 +433,21 @@ extension CmuxMainWindow {
             mouseLocation: mouseLocation,
             fallbackVisibleFrame: fallbackVisibleFrame,
             inset: 0
+        )
+    }
+
+    private static func minimumFrameSize(
+        for styleMask: NSWindow.StyleMask,
+        windowMinSize: NSSize
+    ) -> NSSize {
+        let contentMinimum = NSRect(origin: .zero, size: minimumContentSize)
+        let convertedMinimum = NSWindow.frameRect(
+            forContentRect: contentMinimum,
+            styleMask: styleMask
+        ).size
+        return NSSize(
+            width: max(windowMinSize.width, convertedMinimum.width),
+            height: max(windowMinSize.height, convertedMinimum.height)
         )
     }
 }

--- a/Sources/App/CmuxMainWindow.swift
+++ b/Sources/App/CmuxMainWindow.swift
@@ -282,7 +282,10 @@ final class CmuxMainWindow: NSWindow {
         ) {
             return frameRect
         }
-        return super.constrainFrameRect(frameRect, to: screen)
+        return Self.recoveredOffscreenFrame(
+            frameRect,
+            mouseLocation: NSEvent.mouseLocation
+        ) ?? super.constrainFrameRect(frameRect, to: screen)
     }
 
     /// Whether `proposedFrame` is reachable enough across `visibleFrames` that
@@ -385,10 +388,9 @@ extension CmuxMainWindow {
 
     /// Move a main window back onto a connected display when its frame would be
     /// stranded off-screen (e.g. the display it lived on was disconnected).
-    /// Uses the same target-screen selection as Settings multi-monitor recovery
-    /// (#5770). No-op when the frame already has a grabbable on-screen slice.
+    /// No-op when the frame already has a grabbable on-screen slice.
     static func applyOffscreenRecoveryIfNeeded(
-        _ window: NSWindow,
+        _ window: CmuxMainWindow,
         mouseLocation: NSPoint? = NSEvent.mouseLocation
     ) {
         guard !window.styleMask.contains(.fullScreen) else { return }
@@ -398,26 +400,30 @@ extension CmuxMainWindow {
             return
         }
 
-        let screens = NSScreen.screens.map { (frame: $0.frame, visibleFrame: $0.visibleFrame) }
-        let fallbackVisibleFrame = (NSScreen.main ?? NSScreen.screens.first)?.visibleFrame
-        guard let targetVisibleFrame = SettingsWindowPresenter.targetVisibleFrame(
-            windowFrame: window.frame,
-            screens: screens,
-            mouseLocation: mouseLocation,
-            fallbackVisibleFrame: fallbackVisibleFrame
-        ) else { return }
-
-        let minimumFrameSize = NSSize(
-            width: max(window.minSize.width, minimumContentSize.width),
-            height: max(window.minSize.height, minimumContentSize.height)
-        )
-        let recovered = SettingsWindowPresenter.clampedFrame(
-            window.frame,
-            minimumSize: minimumFrameSize,
-            into: targetVisibleFrame,
-            inset: 0
-        )
+        guard let recovered = recoveredOffscreenFrame(window.frame, mouseLocation: mouseLocation) else {
+            return
+        }
         guard recovered != window.frame else { return }
         window.setFrame(recovered, display: true, animate: false)
+    }
+
+    static func recoveredOffscreenFrame(
+        _ frame: NSRect,
+        mouseLocation: NSPoint?
+    ) -> NSRect? {
+        let screens = NSScreen.screens.map { (frame: $0.frame, visibleFrame: $0.visibleFrame) }
+        let fallbackVisibleFrame = (NSScreen.main ?? NSScreen.screens.first)?.visibleFrame
+        let minimumFrameSize = NSSize(
+            width: minimumContentSize.width,
+            height: minimumContentSize.height
+        )
+        return MultiMonitorWindowGeometry.recoveredFrame(
+            frame,
+            minimumSize: minimumFrameSize,
+            screens: screens,
+            mouseLocation: mouseLocation,
+            fallbackVisibleFrame: fallbackVisibleFrame,
+            inset: 0
+        )
     }
 }

--- a/Sources/App/CmuxMainWindow.swift
+++ b/Sources/App/CmuxMainWindow.swift
@@ -272,22 +272,29 @@ final class CmuxMainWindow: NSWindow {
     /// whatever the re-constrain produced sticks and accumulates.
     ///
     /// Fix: refuse the re-constrain for any frame that is already reachable on
-    /// some screen, and defer to AppKit's default only when the frame would
-    /// otherwise be stranded off-screen (e.g. a display was disconnected), so a
-    /// genuinely lost window can still be pulled back into view.
+    /// some screen and already fits the connected displays. Defer to shared
+    /// recovery when the frame would otherwise be stranded off-screen or must be
+    /// shrunk after a display disconnect.
     override func constrainFrameRect(_ frameRect: NSRect, to screen: NSScreen?) -> NSRect {
-        if Self.shouldPreserveFrameDuringConstrain(
-            frameRect,
-            visibleFrames: NSScreen.screens.map(\.visibleFrame)
-        ) {
-            return frameRect
-        }
-        return Self.recoveredOffscreenFrame(
+        let screens = NSScreen.screens.map { (frame: $0.frame, visibleFrame: $0.visibleFrame) }
+        let recovered = Self.recoveredFrameAfterDisplayChange(
             frameRect,
             styleMask: styleMask,
             windowMinSize: minSize,
-            mouseLocation: NSEvent.mouseLocation
-        ) ?? super.constrainFrameRect(frameRect, to: screen)
+            screens: screens,
+            mouseLocation: NSEvent.mouseLocation,
+            fallbackVisibleFrame: (NSScreen.main ?? NSScreen.screens.first)?.visibleFrame
+        )
+        let recoveredShrinksFrame = (recovered?.width ?? frameRect.width) < frameRect.width
+            || (recovered?.height ?? frameRect.height) < frameRect.height
+        if !recoveredShrinksFrame,
+           Self.shouldPreserveFrameDuringConstrain(
+               frameRect,
+               visibleFrames: screens.map(\.visibleFrame)
+           ) {
+            return frameRect
+        }
+        return recovered ?? super.constrainFrameRect(frameRect, to: screen)
     }
 
     /// Whether `proposedFrame` is reachable enough across `visibleFrames` that
@@ -389,8 +396,9 @@ extension CmuxMainWindow {
     }
 
     /// Move a main window back onto a connected display when its frame would be
-    /// stranded off-screen (e.g. the display it lived on was disconnected).
-    /// No-op when the frame already has a grabbable on-screen slice.
+    /// stranded off-screen or too large for the remaining display (e.g. the
+    /// display it lived on was disconnected). Reachable frames that already fit
+    /// remain user-owned so ordinary side-parking is preserved.
     static func applyOffscreenRecoveryIfNeeded(
         _ window: CmuxMainWindow,
         mouseLocation: NSPoint? = NSEvent.mouseLocation
@@ -398,30 +406,37 @@ extension CmuxMainWindow {
         guard !window.styleMask.contains(.fullScreen) else { return }
 
         let visibleFrames = NSScreen.screens.map(\.visibleFrame)
-        guard !shouldPreserveFrameDuringConstrain(window.frame, visibleFrames: visibleFrames) else {
-            return
-        }
-
-        guard let recovered = recoveredOffscreenFrame(
+        guard let recovered = recoveredFrameAfterDisplayChange(
             window.frame,
             styleMask: window.styleMask,
             windowMinSize: window.minSize,
-            mouseLocation: mouseLocation
+            screens: NSScreen.screens.map { (frame: $0.frame, visibleFrame: $0.visibleFrame) },
+            mouseLocation: mouseLocation,
+            fallbackVisibleFrame: (NSScreen.main ?? NSScreen.screens.first)?.visibleFrame
         ) else {
             return
         }
         guard recovered != window.frame else { return }
+
+        let hasReachableTitlebar = shouldPreserveFrameDuringConstrain(
+            window.frame,
+            visibleFrames: visibleFrames
+        )
+        let recoveredShrinksFrame = recovered.width < window.frame.width
+            || recovered.height < window.frame.height
+        guard !hasReachableTitlebar || recoveredShrinksFrame else { return }
+
         window.setFrame(recovered, display: true, animate: false)
     }
 
-    static func recoveredOffscreenFrame(
+    static func recoveredFrameAfterDisplayChange(
         _ frame: NSRect,
         styleMask: NSWindow.StyleMask,
         windowMinSize: NSSize = .zero,
-        mouseLocation: NSPoint?
+        screens: [(frame: NSRect, visibleFrame: NSRect)],
+        mouseLocation: NSPoint?,
+        fallbackVisibleFrame: NSRect?
     ) -> NSRect? {
-        let screens = NSScreen.screens.map { (frame: $0.frame, visibleFrame: $0.visibleFrame) }
-        let fallbackVisibleFrame = (NSScreen.main ?? NSScreen.screens.first)?.visibleFrame
         let minimumFrameSize = minimumFrameSize(
             for: styleMask,
             windowMinSize: windowMinSize

--- a/Sources/App/CmuxMainWindow.swift
+++ b/Sources/App/CmuxMainWindow.swift
@@ -382,4 +382,42 @@ extension CmuxMainWindow {
             height: height
         )
     }
+
+    /// Move a main window back onto a connected display when its frame would be
+    /// stranded off-screen (e.g. the display it lived on was disconnected).
+    /// Uses the same target-screen selection as Settings multi-monitor recovery
+    /// (#5770). No-op when the frame already has a grabbable on-screen slice.
+    static func applyOffscreenRecoveryIfNeeded(
+        _ window: NSWindow,
+        mouseLocation: NSPoint? = NSEvent.mouseLocation
+    ) {
+        guard !window.styleMask.contains(.fullScreen) else { return }
+
+        let visibleFrames = NSScreen.screens.map(\.visibleFrame)
+        guard !shouldPreserveFrameDuringConstrain(window.frame, visibleFrames: visibleFrames) else {
+            return
+        }
+
+        let screens = NSScreen.screens.map { (frame: $0.frame, visibleFrame: $0.visibleFrame) }
+        let fallbackVisibleFrame = (NSScreen.main ?? NSScreen.screens.first)?.visibleFrame
+        guard let targetVisibleFrame = SettingsWindowPresenter.targetVisibleFrame(
+            windowFrame: window.frame,
+            screens: screens,
+            mouseLocation: mouseLocation,
+            fallbackVisibleFrame: fallbackVisibleFrame
+        ) else { return }
+
+        let minimumFrameSize = NSSize(
+            width: max(window.minSize.width, minimumContentSize.width),
+            height: max(window.minSize.height, minimumContentSize.height)
+        )
+        let recovered = SettingsWindowPresenter.clampedFrame(
+            window.frame,
+            minimumSize: minimumFrameSize,
+            into: targetVisibleFrame,
+            inset: 0
+        )
+        guard recovered != window.frame else { return }
+        window.setFrame(recovered, display: true, animate: false)
+    }
 }

--- a/Sources/App/MultiMonitorWindowGeometry.swift
+++ b/Sources/App/MultiMonitorWindowGeometry.swift
@@ -1,0 +1,96 @@
+import AppKit
+
+/// Shared multi-monitor window placement geometry used by main windows,
+/// settings recovery, and other AppKit presenters that clamp frames onto a
+/// connected display.
+enum MultiMonitorWindowGeometry {
+    /// Pure selection of the visible-screen frame a window should be clamped
+    /// into. When the window's saved frame is off every active screen (e.g.
+    /// restored onto a now-disconnected display) it recovers onto the screen
+    /// under the cursor, then the main/first screen. Cursor hit-testing uses
+    /// each screen's *full* frame: `visibleFrame` excludes the menu bar and
+    /// Dock strips, and the cursor sits exactly there when a window is opened
+    /// from the menu bar, which would misroute recovery to the main screen.
+    static func targetVisibleFrame(
+        windowFrame: NSRect,
+        screens: [(frame: NSRect, visibleFrame: NSRect)],
+        mouseLocation: NSPoint?,
+        fallbackVisibleFrame: NSRect?
+    ) -> NSRect? {
+        guard !screens.isEmpty else { return fallbackVisibleFrame }
+
+        // Prefer the screen the window already overlaps the most so a window
+        // that is mostly visible stays where the user put it.
+        var bestFrame: NSRect?
+        var bestArea: CGFloat = 0
+        for screen in screens {
+            let intersection = screen.visibleFrame.intersection(windowFrame)
+            let area = intersection.isNull ? 0 : intersection.width * intersection.height
+            if area > bestArea {
+                bestArea = area
+                bestFrame = screen.visibleFrame
+            }
+        }
+        if let bestFrame, bestArea > 0 {
+            return bestFrame
+        }
+
+        // The window is off every active screen. Recover onto the screen under
+        // the cursor when possible so the window appears where the user is looking.
+        if let mouseLocation,
+           let mouseScreen = screens.first(where: { $0.frame.contains(mouseLocation) }) {
+            return mouseScreen.visibleFrame
+        }
+        return fallbackVisibleFrame ?? screens.first?.visibleFrame
+    }
+
+    /// Pure clamp geometry: fit `frame` within `visibleFrame` (honoring `inset`
+    /// and a minimum size).
+    static func clampedFrame(
+        _ frame: NSRect,
+        minimumSize: NSSize,
+        into visibleFrame: NSRect,
+        inset: CGFloat
+    ) -> NSRect {
+        var result = frame
+        let maxVisibleSize = NSSize(
+            width: max(minimumSize.width, visibleFrame.width - 2 * inset),
+            height: max(minimumSize.height, visibleFrame.height - 2 * inset)
+        )
+        result.size.width = min(result.size.width, maxVisibleSize.width)
+        result.size.height = min(result.size.height, maxVisibleSize.height)
+        let minX = visibleFrame.minX + inset
+        let minY = visibleFrame.minY + inset
+        let maxX = max(minX, visibleFrame.maxX - inset - result.width)
+        let maxY = max(minY, visibleFrame.maxY - inset - result.height)
+        result.origin = NSPoint(
+            x: min(max(result.origin.x, minX), maxX),
+            y: min(max(result.origin.y, minY), maxY)
+        )
+        return result
+    }
+
+    /// Clamp `frame` onto a connected display using the shared target-screen
+    /// selection and clamp geometry. Returns `nil` when no screen is available.
+    static func recoveredFrame(
+        _ frame: NSRect,
+        minimumSize: NSSize,
+        screens: [(frame: NSRect, visibleFrame: NSRect)],
+        mouseLocation: NSPoint?,
+        fallbackVisibleFrame: NSRect?,
+        inset: CGFloat
+    ) -> NSRect? {
+        guard let targetVisibleFrame = targetVisibleFrame(
+            windowFrame: frame,
+            screens: screens,
+            mouseLocation: mouseLocation,
+            fallbackVisibleFrame: fallbackVisibleFrame
+        ) else { return nil }
+        return clampedFrame(
+            frame,
+            minimumSize: minimumSize,
+            into: targetVisibleFrame,
+            inset: inset
+        )
+    }
+}

--- a/Sources/App/SettingsWindowGeometry.swift
+++ b/Sources/App/SettingsWindowGeometry.swift
@@ -1,33 +1,28 @@
 import AppKit
 
-/// Pure multi-monitor recovery geometry and window-usability policy for the
-/// Settings window, split out of `SettingsWindowPresenter` (which stays under
-/// the Swift file-length budget) and kept as extensions so call sites and
-/// tests address one type.
+/// Settings window recovery and window-usability policy, split out of
+/// `SettingsWindowPresenter` so the presenter stays under the Swift
+/// file-length budget. Multi-display clamp math lives in
+/// `MultiMonitorWindowGeometry` and is shared with main-window recovery.
 extension SettingsWindowPresenter {
     static let visibleAreaInset: CGFloat = 18
 
     func clampToVisibleAreaIfNeeded(_ window: NSWindow) {
         let screens = NSScreen.screens.map { (frame: $0.frame, visibleFrame: $0.visibleFrame) }
         let fallbackVisibleFrame = (NSScreen.main ?? NSScreen.screens.first)?.visibleFrame
-        guard let visibleFrame = Self.targetVisibleFrame(
-            windowFrame: window.frame,
-            screens: screens,
-            mouseLocation: NSEvent.mouseLocation,
-            fallbackVisibleFrame: fallbackVisibleFrame
-        ) else { return }
-
+        let originalFrame = window.frame
         let minimumFrameSize = NSSize(
             width: max(window.minSize.width, window.contentMinSize.width),
             height: max(window.minSize.height, window.contentMinSize.height)
         )
-        let originalFrame = window.frame
-        let clamped = Self.clampedFrame(
+        guard let clamped = MultiMonitorWindowGeometry.recoveredFrame(
             originalFrame,
             minimumSize: minimumFrameSize,
-            into: visibleFrame,
+            screens: screens,
+            mouseLocation: NSEvent.mouseLocation,
+            fallbackVisibleFrame: fallbackVisibleFrame,
             inset: Self.visibleAreaInset
-        )
+        ) else { return }
         guard clamped != originalFrame else { return }
 
         let wasOffAllScreens = window.screen == nil
@@ -85,74 +80,5 @@ extension SettingsWindowPresenter {
             return "window frame is degenerate (\(Int(frame.width))x\(Int(frame.height)))"
         }
         return nil
-    }
-
-    /// Pure selection of the visible-screen frame the settings window should be
-    /// clamped into. When the window's saved frame is off every active screen
-    /// (e.g. restored onto a now-disconnected display in a multi-monitor setup)
-    /// it recovers onto the screen under the cursor, then the main/first screen.
-    /// Cursor hit-testing uses each screen's *full* frame: `visibleFrame`
-    /// excludes the menu bar and Dock strips, and the cursor sits exactly there
-    /// when Settings is opened from the menu bar, which would misroute the
-    /// recovery to the main screen. The returned rect is always a visible
-    /// frame. Factored out so multi-monitor recovery is unit-testable.
-    static func targetVisibleFrame(
-        windowFrame: NSRect,
-        screens: [(frame: NSRect, visibleFrame: NSRect)],
-        mouseLocation: NSPoint?,
-        fallbackVisibleFrame: NSRect?
-    ) -> NSRect? {
-        guard !screens.isEmpty else { return fallbackVisibleFrame }
-
-        // Prefer the screen the window already overlaps the most so a window
-        // that is mostly visible stays where the user put it.
-        var bestFrame: NSRect?
-        var bestArea: CGFloat = 0
-        for screen in screens {
-            let intersection = screen.visibleFrame.intersection(windowFrame)
-            let area = intersection.isNull ? 0 : intersection.width * intersection.height
-            if area > bestArea {
-                bestArea = area
-                bestFrame = screen.visibleFrame
-            }
-        }
-        if let bestFrame, bestArea > 0 {
-            return bestFrame
-        }
-
-        // The window is off every active screen. Recover onto the screen under
-        // the cursor when possible so Settings appears where the user is looking.
-        if let mouseLocation,
-           let mouseScreen = screens.first(where: { $0.frame.contains(mouseLocation) }) {
-            return mouseScreen.visibleFrame
-        }
-        return fallbackVisibleFrame ?? screens.first?.visibleFrame
-    }
-
-    /// Pure clamp geometry: fit `frame` within `visibleFrame` (honoring `inset`
-    /// and a minimum size). Factored out of `clampToVisibleAreaIfNeeded` so the
-    /// geometry is unit-testable independent of `NSWindow`/`NSScreen`.
-    static func clampedFrame(
-        _ frame: NSRect,
-        minimumSize: NSSize,
-        into visibleFrame: NSRect,
-        inset: CGFloat
-    ) -> NSRect {
-        var result = frame
-        let maxVisibleSize = NSSize(
-            width: max(minimumSize.width, visibleFrame.width - 2 * inset),
-            height: max(minimumSize.height, visibleFrame.height - 2 * inset)
-        )
-        result.size.width = min(result.size.width, maxVisibleSize.width)
-        result.size.height = min(result.size.height, maxVisibleSize.height)
-        let minX = visibleFrame.minX + inset
-        let minY = visibleFrame.minY + inset
-        let maxX = max(minX, visibleFrame.maxX - inset - result.width)
-        let maxY = max(minY, visibleFrame.maxY - inset - result.height)
-        result.origin = NSPoint(
-            x: min(max(result.origin.x, minX), maxX),
-            y: min(max(result.origin.y, minY), maxY)
-        )
-        return result
     }
 }

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -792,6 +792,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
     private var shortcutDefaultsObserver: NSObjectProtocol?
     private var menuBarVisibilityObserver: NSObjectProtocol?
     private var mobileHostSettingsObserver: NSObjectProtocol?
+    private var screenParametersObserver: NSObjectProtocol?
     private var reloadConfigurationMenuItemRefreshScheduled = false
     /// Orchestrates per-window cmux config-store reloads + window-title refresh.
     /// Holds `self` weakly through the environment seam to avoid a retain cycle.
@@ -1410,6 +1411,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
             name: .feedRequestSendText,
             object: nil
         )
+        installMainWindowScreenParametersObserver()
 
 #if DEBUG
         // UI tests run on a shared VM user profile, so persisted shortcuts can drift and make
@@ -18535,6 +18537,29 @@ extension AppDelegate: UpdateActionDelegate, UpdateActionsHost {
 
     var updateLogPath: String {
         updateLog.logPath()
+    }
+}
+
+// MARK: - Main-window display recovery
+
+extension AppDelegate {
+    private func installMainWindowScreenParametersObserver() {
+        guard screenParametersObserver == nil else { return }
+        screenParametersObserver = NotificationCenter.default.addObserver(
+            forName: NSApplication.didChangeScreenParametersNotification,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            MainActor.assumeIsolated {
+                self?.recoverMainWindowsAfterDisplayChange()
+            }
+        }
+    }
+
+    private func recoverMainWindowsAfterDisplayChange() {
+        for window in mainWindowsForVisibilityController() where window.isVisible {
+            CmuxMainWindow.applyOffscreenRecoveryIfNeeded(window)
+        }
     }
 }
 

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -18558,7 +18558,8 @@ extension AppDelegate {
 
     private func recoverMainWindowsAfterDisplayChange() {
         for window in mainWindowsForVisibilityController() where window.isVisible {
-            CmuxMainWindow.applyOffscreenRecoveryIfNeeded(window)
+            guard let mainWindow = window as? CmuxMainWindow else { continue }
+            CmuxMainWindow.applyOffscreenRecoveryIfNeeded(mainWindow)
         }
     }
 }

--- a/Sources/TerminalController+DebugMethodNames.swift
+++ b/Sources/TerminalController+DebugMethodNames.swift
@@ -43,6 +43,7 @@ extension TerminalController {
         "debug.panel_snapshot.reset",
         "debug.session_snapshot_benchmark",
         "debug.session_snapshot_seed_scrollback",
+        "debug.window.recover_after_display_change",
         "debug.window.screenshot",
         "debug.terminal.simulate_file_drop",
         "debug.sidebar.simulate_drag",

--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -2474,6 +2474,10 @@ class TerminalController {
         // on the socket worker (see ControlCommandExecutionPolicy + the worker
         // switch in processCommand) so its inter-tick Thread.sleep never blocks
         // the main actor.
+#if DEBUG
+        case "debug.window.recover_after_display_change":
+            return v2Result(id: id, self.v2DebugWindowRecoverAfterDisplayChange(params: params))
+#endif
 
             default:
                 return v2Error(id: id, code: "method_not_found", message: "Unknown method")
@@ -10653,6 +10657,85 @@ class TerminalController {
 #endif
 
 #if DEBUG
+    private func v2DebugWindowRecoverAfterDisplayChange(params: [String: Any]) -> V2CallResult {
+        guard let windowId = v2UUID(params, "window_id") else {
+            return .err(code: "invalid_params", message: "Missing or invalid window_id", data: nil)
+        }
+        guard let window = AppDelegate.shared?.windowForMainWindowId(windowId) as? CmuxMainWindow else {
+            return .err(
+                code: "not_found",
+                message: "No CmuxMainWindow for window_id",
+                data: ["window_id": windowId.uuidString]
+            )
+        }
+
+        func number(_ key: String, in object: [String: Any]) -> CGFloat? {
+            if let value = object[key] as? Double { return CGFloat(value) }
+            if let value = object[key] as? Int { return CGFloat(value) }
+            if let value = object[key] as? NSNumber { return CGFloat(value.doubleValue) }
+            return nil
+        }
+
+        func framePayload(_ object: Any?) -> NSRect? {
+            guard let object = object as? [String: Any],
+                  let x = number("x", in: object),
+                  let y = number("y", in: object),
+                  let width = number("width", in: object),
+                  let height = number("height", in: object),
+                  width > 1,
+                  height > 1 else {
+                return nil
+            }
+            return NSRect(x: x, y: y, width: width, height: height)
+        }
+
+        func rectPayload(_ rect: NSRect) -> [String: Double] {
+            [
+                "x": Double(rect.origin.x),
+                "y": Double(rect.origin.y),
+                "width": Double(rect.width),
+                "height": Double(rect.height),
+            ]
+        }
+
+        let before = framePayload(params["frame"]) ?? window.frame
+        let visibleFrames = NSScreen.screens.map(\.visibleFrame)
+        let recovered = CmuxMainWindow.recoveredFrameAfterDisplayChange(
+            before,
+            styleMask: window.styleMask,
+            windowMinSize: window.minSize,
+            screens: NSScreen.screens.map { (frame: $0.frame, visibleFrame: $0.visibleFrame) },
+            mouseLocation: nil,
+            fallbackVisibleFrame: (NSScreen.main ?? NSScreen.screens.first)?.visibleFrame
+        )
+        let recoveredShrinksFrame = (recovered?.width ?? before.width) < before.width
+            || (recovered?.height ?? before.height) < before.height
+        let hasReachableTitlebar = CmuxMainWindow.shouldPreserveFrameDuringConstrain(
+            before,
+            visibleFrames: visibleFrames
+        )
+        let shouldRecover = recovered.map {
+            $0 != before && (!hasReachableTitlebar || recoveredShrinksFrame)
+        } ?? false
+        let after = shouldRecover ? recovered ?? before : before
+        if after != window.frame {
+            window.setFrame(after, display: true, animate: false)
+        }
+
+        let recoveredPayload: Any
+        if let recovered {
+            recoveredPayload = rectPayload(recovered)
+        } else {
+            recoveredPayload = NSNull()
+        }
+        return .ok([
+            "changed": !before.equalTo(after),
+            "recovered": recoveredPayload,
+            "before": rectPayload(before),
+            "after": rectPayload(after),
+            "actual": rectPayload(window.frame),
+        ])
+    }
 
     /// Drives `SidebarDragState.draggedTabId` and `dropIndicator` mutations
     /// across N steps from a starting workspace toward a target neighbor.

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -1413,6 +1413,7 @@ C0DE71B10000000000000001 /* AppDelegate+AgentChatNotifications.swift in Sources 
 		D75280030000000000000001 /* MobileWorkspaceObserverSignposts.swift in Sources */ = {isa = PBXBuildFile; fileRef = D75280030000000000000002 /* MobileWorkspaceObserverSignposts.swift */; };
 		13AB1A2E5DA6AD02DCAE971D /* MockBridgeInputCapture.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD3B5F249DECAB446CC71D32 /* MockBridgeInputCapture.swift */; };
 		C75740020000000000000001 /* MouseDownMenuItemView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C75740020000000000000002 /* MouseDownMenuItemView.swift */; };
+		D36090040000000000000001 /* MultiMonitorWindowGeometry.swift in Sources */ = {isa = PBXBuildFile; fileRef = D36090040000000000000002 /* MultiMonitorWindowGeometry.swift */; };
 		B9000015A1B2C3D4E5F60719 /* MultiWindowNotificationsUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9000016A1B2C3D4E5F60719 /* MultiWindowNotificationsUITests.swift */; };
 		D77690000000000000000005 /* MultiWindowNotificationsWorkspaceHeadlineUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D77690000000000000000006 /* MultiWindowNotificationsWorkspaceHeadlineUITests.swift */; };
 		596100000000000000000003 /* NativeNotificationDeliveryHooks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 596100000000000000000004 /* NativeNotificationDeliveryHooks.swift */; };
@@ -4031,6 +4032,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 		D75280030000000000000002 /* MobileWorkspaceObserverSignposts.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MobileWorkspaceObserverSignposts.swift; sourceTree = "<group>"; };
 		CD3B5F249DECAB446CC71D32 /* MockBridgeInputCapture.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockBridgeInputCapture.swift; sourceTree = "<group>"; };
 		C75740020000000000000002 /* MouseDownMenuItemView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Update/MouseDownMenuItemView.swift; sourceTree = "<group>"; };
+		D36090040000000000000002 /* MultiMonitorWindowGeometry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = App/MultiMonitorWindowGeometry.swift; sourceTree = "<group>"; };
 		B9000016A1B2C3D4E5F60719 /* MultiWindowNotificationsUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MultiWindowNotificationsUITests.swift; sourceTree = "<group>"; };
 		D77690000000000000000006 /* MultiWindowNotificationsWorkspaceHeadlineUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MultiWindowNotificationsWorkspaceHeadlineUITests.swift; sourceTree = "<group>"; };
 		596100000000000000000004 /* NativeNotificationDeliveryHooks.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NativeNotificationDeliveryHooks.swift; sourceTree = "<group>"; };
@@ -5676,6 +5678,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				D3610C010000000000000002 /* CmuxSettingsJSONPathSupport.swift */,
 				D36090030000000000000002 /* SettingsWindowFactory.swift */,
 				D37777030000000000000002 /* SettingsWindowGeometry.swift */,
+				D36090040000000000000002 /* MultiMonitorWindowGeometry.swift */,
 				D37777070000000000000002 /* SettingsWindowNavigationDelivery.swift */,
 				D37777040000000000000002 /* AppDelegateSettingsPresentation.swift */,
 				D36090010000000000000002 /* SettingsWindowPresenter.swift */,
@@ -9568,6 +9571,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				A50019B0 /* SettingsSearchAliases.swift in Sources */,
 				D36090030000000000000001 /* SettingsWindowFactory.swift in Sources */,
 				D37777030000000000000001 /* SettingsWindowGeometry.swift in Sources */,
+				D36090040000000000000001 /* MultiMonitorWindowGeometry.swift in Sources */,
 				D37777070000000000000001 /* SettingsWindowNavigationDelivery.swift in Sources */,
 				D36090010000000000000001 /* SettingsWindowPresenter.swift in Sources */,
 				F0ACC0DE0000000000000011 /* SharedLiveAgentIndex.swift in Sources */,

--- a/cmuxTests/CmuxMainWindowConstrainFrameTests.swift
+++ b/cmuxTests/CmuxMainWindowConstrainFrameTests.swift
@@ -161,6 +161,32 @@ final class CmuxMainWindowConstrainFrameTests: XCTestCase {
         XCTAssertTrue(
             CmuxMainWindow.shouldPreserveFrameDuringConstrain(flushTop, visibleFrames: [visible])
         )
+    func testOffscreenRecoveryMovesWindowOntoConnectedDisplay() throws {
+        let window = CmuxMainWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 800, height: 600),
+            styleMask: [.titled, .closable, .miniaturizable, .resizable, .fullSizeContentView],
+            backing: .buffered,
+            defer: false
+        )
+        window.isReleasedWhenClosed = false
+        defer {
+            window.orderOut(nil)
+            window.close()
+        }
+
+        // Frame on a now-disconnected external display to the right.
+        window.setFrame(NSRect(x: 5000, y: 200, width: 800, height: 600), display: false)
+
+        CmuxMainWindow.applyOffscreenRecoveryIfNeeded(window, mouseLocation: NSPoint(x: 400, y: 400))
+
+        guard let screen = NSScreen.main ?? NSScreen.screens.first else {
+            throw XCTSkip("No screen available for offscreen recovery regression")
+        }
+        let visible = screen.visibleFrame
+        let intersection = window.frame.intersection(visible)
+        XCTAssertFalse(intersection.isNull)
+        XCTAssertGreaterThanOrEqual(intersection.width, 60)
+        XCTAssertGreaterThanOrEqual(intersection.height, 60)
     }
 }
 #endif

--- a/cmuxTests/CmuxMainWindowConstrainFrameTests.swift
+++ b/cmuxTests/CmuxMainWindowConstrainFrameTests.swift
@@ -174,8 +174,9 @@ final class CmuxMainWindowConstrainFrameTests: XCTestCase {
             window.close()
         }
 
-        // Frame on a now-disconnected external display to the right.
-        window.setFrame(NSRect(x: 5000, y: 200, width: 800, height: 600), display: false)
+        let size = NSSize(width: 800, height: 600)
+        let offscreenFrame = try guaranteedOffscreenFrame(size: size)
+        window.setFrame(offscreenFrame, display: false)
 
         CmuxMainWindow.applyOffscreenRecoveryIfNeeded(window, mouseLocation: NSPoint(x: 400, y: 400))
 
@@ -187,6 +188,22 @@ final class CmuxMainWindowConstrainFrameTests: XCTestCase {
         XCTAssertFalse(intersection.isNull)
         XCTAssertGreaterThanOrEqual(intersection.width, 60)
         XCTAssertGreaterThanOrEqual(intersection.height, 60)
+    }
+
+    private func guaranteedOffscreenFrame(size: NSSize) throws -> NSRect {
+        let screens = NSScreen.screens
+        guard !screens.isEmpty else {
+            throw XCTSkip("No screen available for offscreen recovery regression")
+        }
+
+        let maxX = screens.map(\.frame.maxX).max() ?? 0
+        let maxY = screens.map(\.frame.maxY).max() ?? 0
+        let offscreen = NSRect(x: maxX + 1_000, y: maxY / 2, width: size.width, height: size.height)
+        let visibleFrames = screens.map(\.visibleFrame)
+        guard !CmuxMainWindow.shouldPreserveFrameDuringConstrain(offscreen, visibleFrames: visibleFrames) else {
+            throw XCTSkip("Could not construct a guaranteed off-screen frame on this display layout")
+        }
+        return offscreen
     }
 }
 #endif

--- a/cmuxTests/CmuxMainWindowConstrainFrameTests.swift
+++ b/cmuxTests/CmuxMainWindowConstrainFrameTests.swift
@@ -161,6 +161,85 @@ final class CmuxMainWindowConstrainFrameTests: XCTestCase {
         XCTAssertTrue(
             CmuxMainWindow.shouldPreserveFrameDuringConstrain(flushTop, visibleFrames: [visible])
         )
+    }
+
+    func testDisplayRecoveryShrinksExternalMonitorSizedFrameToBuiltInVisibleArea() {
+        let builtInScreen = (
+            frame: NSRect(x: 0, y: 0, width: 1512, height: 982),
+            visibleFrame: NSRect(x: 0, y: 0, width: 1512, height: 944)
+        )
+        let externalMonitorSizedFrame = NSRect(x: 0, y: 0, width: 2560, height: 980)
+        XCTAssertTrue(
+            CmuxMainWindow.shouldPreserveFrameDuringConstrain(
+                externalMonitorSizedFrame,
+                visibleFrames: [builtInScreen.visibleFrame]
+            )
+        )
+
+        let recovered = CmuxMainWindow.recoveredFrameAfterDisplayChange(
+            externalMonitorSizedFrame,
+            styleMask: [.titled, .closable, .miniaturizable, .resizable, .fullSizeContentView],
+            screens: [builtInScreen],
+            mouseLocation: NSPoint(x: builtInScreen.visibleFrame.midX, y: builtInScreen.visibleFrame.midY),
+            fallbackVisibleFrame: builtInScreen.visibleFrame
+        )
+
+        guard let recovered else {
+            XCTFail("Expected oversized frame to recover onto the built-in display")
+            return
+        }
+        XCTAssertLessThanOrEqual(recovered.width, builtInScreen.visibleFrame.width)
+        XCTAssertLessThanOrEqual(recovered.height, builtInScreen.visibleFrame.height)
+        XCTAssertGreaterThanOrEqual(recovered.minX, builtInScreen.visibleFrame.minX)
+        XCTAssertGreaterThanOrEqual(recovered.minY, builtInScreen.visibleFrame.minY)
+        XCTAssertLessThanOrEqual(recovered.maxX, builtInScreen.visibleFrame.maxX)
+        XCTAssertLessThanOrEqual(recovered.maxY, builtInScreen.visibleFrame.maxY)
+        XCTAssertLessThan(recovered.width, externalMonitorSizedFrame.width)
+        XCTAssertLessThan(recovered.height, externalMonitorSizedFrame.height)
+    }
+
+    func testConstrainShrinksReachableFrameTooLargeForCurrentDisplay() throws {
+        guard let screen = NSScreen.main else {
+            throw XCTSkip("No screen available for oversized-frame constrain regression")
+        }
+        let window = CmuxMainWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 800, height: 600),
+            styleMask: [.titled, .closable, .miniaturizable, .resizable, .fullSizeContentView],
+            backing: .buffered,
+            defer: false
+        )
+        window.isReleasedWhenClosed = false
+        defer {
+            window.orderOut(nil)
+            window.close()
+        }
+
+        let visible = screen.visibleFrame
+        let proposed = NSRect(
+            x: visible.minX,
+            y: visible.minY,
+            width: visible.width + 400,
+            height: visible.height + 36
+        )
+        XCTAssertTrue(
+            CmuxMainWindow.shouldPreserveFrameDuringConstrain(
+                proposed,
+                visibleFrames: [visible]
+            )
+        )
+
+        let constrained = window.constrainFrameRect(proposed, to: screen)
+
+        XCTAssertLessThan(constrained.width, proposed.width)
+        XCTAssertLessThan(constrained.height, proposed.height)
+        XCTAssertLessThanOrEqual(constrained.width, visible.width)
+        XCTAssertLessThanOrEqual(constrained.height, visible.height)
+        XCTAssertGreaterThanOrEqual(constrained.minX, visible.minX)
+        XCTAssertGreaterThanOrEqual(constrained.minY, visible.minY)
+        XCTAssertLessThanOrEqual(constrained.maxX, visible.maxX)
+        XCTAssertLessThanOrEqual(constrained.maxY, visible.maxY)
+    }
+
     func testOffscreenRecoveryMovesWindowOntoConnectedDisplay() throws {
         let window = CmuxMainWindow(
             contentRect: NSRect(x: 0, y: 0, width: 800, height: 600),

--- a/cmuxTests/SettingsWindowPresenterTests.swift
+++ b/cmuxTests/SettingsWindowPresenterTests.swift
@@ -371,7 +371,7 @@ extension SettingsWindowSharedStateSuites {
             // Saved on a third display to the far left that is no longer connected.
             let orphanFrame = NSRect(x: -2400, y: 400, width: 980, height: 680)
 
-            let target = SettingsWindowPresenter.targetVisibleFrame(
+            let target = MultiMonitorWindowGeometry.targetVisibleFrame(
                 windowFrame: orphanFrame,
                 screens: [Self.primaryScreen, Self.secondaryScreen],
                 mouseLocation: NSPoint(x: 2000, y: 450), // cursor is on the secondary screen
@@ -391,7 +391,7 @@ extension SettingsWindowSharedStateSuites {
             #expect(!Self.secondaryScreen.visibleFrame.contains(menuBarCursor))
             #expect(Self.secondaryScreen.frame.contains(menuBarCursor))
 
-            let target = SettingsWindowPresenter.targetVisibleFrame(
+            let target = MultiMonitorWindowGeometry.targetVisibleFrame(
                 windowFrame: orphanFrame,
                 screens: [Self.primaryScreen, Self.secondaryScreen],
                 mouseLocation: menuBarCursor,
@@ -405,7 +405,7 @@ extension SettingsWindowSharedStateSuites {
         @Test func targetVisibleFrameFallsBackWhenOffscreenAndCursorElsewhere() {
             let orphanFrame = NSRect(x: -2400, y: 400, width: 980, height: 680)
 
-            let target = SettingsWindowPresenter.targetVisibleFrame(
+            let target = MultiMonitorWindowGeometry.targetVisibleFrame(
                 windowFrame: orphanFrame,
                 screens: [Self.primaryScreen],
                 mouseLocation: NSPoint(x: -3000, y: 9000), // cursor off all screens too
@@ -419,7 +419,7 @@ extension SettingsWindowSharedStateSuites {
         @Test func targetVisibleFramePrefersScreenWithMostOverlap() {
             let mostlyOnSecondary = NSRect(x: 1900, y: 100, width: 980, height: 680)
 
-            let target = SettingsWindowPresenter.targetVisibleFrame(
+            let target = MultiMonitorWindowGeometry.targetVisibleFrame(
                 windowFrame: mostlyOnSecondary,
                 screens: [Self.primaryScreen, Self.secondaryScreen],
                 mouseLocation: NSPoint(x: 10, y: 10), // cursor on primary, but window is on secondary
@@ -435,7 +435,7 @@ extension SettingsWindowSharedStateSuites {
             // Origin far to the left/below the target screen.
             let offscreen = NSRect(x: -5000, y: -5000, width: 980, height: 680)
 
-            let clamped = SettingsWindowPresenter.clampedFrame(
+            let clamped = MultiMonitorWindowGeometry.clampedFrame(
                 offscreen,
                 minimumSize: SettingsWindowPresenter.minimumSize,
                 into: visible,
@@ -454,7 +454,7 @@ extension SettingsWindowSharedStateSuites {
             let inset: CGFloat = 18
             let oversized = NSRect(x: 0, y: 0, width: 4000, height: 4000)
 
-            let clamped = SettingsWindowPresenter.clampedFrame(
+            let clamped = MultiMonitorWindowGeometry.clampedFrame(
                 oversized,
                 minimumSize: SettingsWindowPresenter.minimumSize,
                 into: visible,


### PR DESCRIPTION
## Summary
- Salvages https://github.com/manaflow-ai/cmux/pull/7127 onto current `main`; https://github.com/manaflow-ai/cmux/pull/7127 was from an external fork, so this PR supersedes it from an in-org branch.
- Adds shared `MultiMonitorWindowGeometry` recovery/clamp math and uses it for main windows and Settings.
- Recovers visible main windows on `NSApplication.didChangeScreenParametersNotification` and from `CmuxMainWindow.constrainFrameRect`.
- Fixes the https://github.com/manaflow-ai/cmux/issues/9696 clipped-content case by shrinking reachable but oversized external-monitor frames to the remaining display's visible frame, not just moving fully off-screen windows.
- Adds a DEBUG-only `debug.window.recover_after_display_change` socket hook for tagged preflight proof.

## Validation
- `git diff --check`
- `./scripts/lint-pbxproj-test-wiring.sh`
- `./scripts/run-e2e.sh cmuxTests/CmuxMainWindowConstrainFrameTests --ref issue-9696-display-disconnect-refit --wait --timeout 240`, passed: https://github.com/manaflow-ai/cmux/actions/runs/31077876857, artifact: https://github.com/manaflow-ai/cmux-dev-artifacts/issues/9225
- `./scripts/reload.sh --tag drefit`, passed, cloud shim was absent in this worktree.
- Tagged socket proof on `/tmp/cmux-debug-drefit.sock`: synthetic pre-disconnect frame `2560x980 @ 0,0` recovered to `1512x949 @ 0,0`; the actual tagged window matched `1512x949 @ 0,0` afterward.
- Tagged screenshot captured at `/var/folders/w6/6yv5pn9d57q7nhmjglj8w5wh0000gn/T/cmux-screenshots/issue-9696-after_2026-08-06T06-39-13Z_33C5D689.png`.

## Issues
- Closes https://github.com/manaflow-ai/cmux/issues/9696
- Closes https://github.com/manaflow-ai/cmux/issues/7600
- Closes https://github.com/manaflow-ai/cmux/issues/7852
- Closes https://github.com/manaflow-ai/cmux/issues/2824
- Supersedes https://github.com/manaflow-ai/cmux/pull/7127
- Supersedes https://github.com/manaflow-ai/cmux/pull/5193
