### PR TITLE
Gate hosted coderouter on Pro

### DIFF
--- a/web/app/api/coderouter/session/route.ts
+++ b/web/app/api/coderouter/session/route.ts
@@ -1,25 +1,99 @@
+import { env } from "../../../env";
+import { hasActiveStripeProSubscription } from "../../../../services/billing/pro";
 import {
+  authenticateRouteToken,
   issueRouteToken,
   revokeRouteToken,
 } from "../../../../services/coderouter/repository";
 import { resolveCodeRouterRequestContext } from "../../../../services/coderouter/requestContext";
+import { captureCoderouterError } from "../../../../services/errors";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
 
-export async function POST(request: Request): Promise<Response> {
-  const resolved = await resolveCodeRouterRequestContext(request, "use");
-  if (!resolved.ok) return resolved.response;
-  const issued = await issueRouteToken(resolved.value.team.teamId);
-  return Response.json(
-    {
-      teamId: resolved.value.team.teamId,
-      token: issued.token,
-      expiresAt: issued.expiresAt.toISOString(),
-      openaiBaseUrl: "https://coderouter.dev/v1",
-    },
-    { headers: { "cache-control": "no-store" } },
-  );
+type SessionDependencies = {
+  readonly resolveContext: typeof resolveCodeRouterRequestContext;
+  readonly hasActivePro: typeof hasActiveStripeProSubscription;
+  readonly issueToken: typeof issueRouteToken;
+  readonly hostedProRequired: () => boolean;
+};
+
+const defaultDependencies: SessionDependencies = {
+  resolveContext: resolveCodeRouterRequestContext,
+  hasActivePro: hasActiveStripeProSubscription,
+  issueToken: issueRouteToken,
+  hostedProRequired: () => env.CODEROUTER_HOSTED_PRO_REQUIRED === "1",
+};
+
+export const POST = makeCoderouterSessionPostHandler();
+
+export const GET = makeCoderouterSessionGetHandler();
+
+export function makeCoderouterSessionGetHandler(
+  authenticate: typeof authenticateRouteToken = authenticateRouteToken,
+) {
+  return async function GET(request: Request): Promise<Response> {
+    const authorization = request.headers.get("authorization")?.trim() ?? "";
+    const token = /^Bearer[ \t]+(.+)$/i.exec(authorization)?.[1]?.trim();
+    if (!token || !await authenticate(token)) {
+      return Response.json(
+        { error: "unauthorized" },
+        { status: 401, headers: { "cache-control": "no-store" } },
+      );
+    }
+    return new Response(null, {
+      status: 204,
+      headers: { "cache-control": "no-store" },
+    });
+  };
+}
+
+export function makeCoderouterSessionPostHandler(
+  dependencies: SessionDependencies = defaultDependencies,
+) {
+  return async function POST(request: Request): Promise<Response> {
+    const resolved = await dependencies.resolveContext(request, "use");
+    if (!resolved.ok) return resolved.response;
+    const userId = resolved.value.user.id;
+    if (dependencies.hostedProRequired()) {
+      try {
+        if (!await dependencies.hasActivePro(userId)) {
+          return Response.json(
+            { error: "pro_required" },
+            {
+              status: 402,
+              headers: { "cache-control": "no-store" },
+            },
+          );
+        }
+      } catch (error) {
+        captureCoderouterError(error, {
+          operation: "resolve_hosted_entitlement",
+          route: "/api/coderouter/session",
+        });
+        return Response.json(
+          { error: "entitlement_unavailable" },
+          {
+            status: 503,
+            headers: { "cache-control": "no-store" },
+          },
+        );
+      }
+    }
+    const issued = await dependencies.issueToken(
+      resolved.value.team.teamId,
+      userId,
+    );
+    return Response.json(
+      {
+        teamId: resolved.value.team.teamId,
+        token: issued.token,
+        expiresAt: issued.expiresAt.toISOString(),
+        openaiBaseUrl: new URL("/v1", request.url).toString().replace(/\/$/, ""),
+      },
+      { headers: { "cache-control": "no-store" } },
+    );
+  };
 }
 
 export async function DELETE(request: Request): Promise<Response> {

--- a/web/app/api/stripe/webhook/route.ts
+++ b/web/app/api/stripe/webhook/route.ts
@@ -14,6 +14,7 @@ import {
   recordCheckoutCompletion as recordCheckoutCompletionDefault,
 } from "../../../../services/billing/purchase";
 import { sendProSignupWelcome as sendProSignupWelcomeDefault } from "../../../../services/billing/proFulfillment";
+import { revokeRouteTokensForUser as revokeRouteTokensForUserDefault } from "../../../../services/coderouter/repository";
 import { isStripeBillingConfigured, stripe } from "../../../../services/billing/stripe";
 import {
   recordSpanError,
@@ -32,6 +33,7 @@ type StripeWebhookDependencies = {
   recordCheckoutCompletion: typeof recordCheckoutCompletionDefault;
   applySubscriptionUpdate: typeof applySubscriptionUpdateDefault;
   sendProSignupWelcome: typeof sendProSignupWelcomeDefault;
+  revokeCoderouterRouteTokens: typeof revokeRouteTokensForUserDefault;
 };
 
 const defaultDependencies: StripeWebhookDependencies = {
@@ -42,6 +44,7 @@ const defaultDependencies: StripeWebhookDependencies = {
   recordCheckoutCompletion: recordCheckoutCompletionDefault,
   applySubscriptionUpdate: applySubscriptionUpdateDefault,
   sendProSignupWelcome: sendProSignupWelcomeDefault,
+  revokeCoderouterRouteTokens: revokeRouteTokensForUserDefault,
 };
 
 export const POST = makeStripeWebhookHandler();
@@ -159,7 +162,10 @@ async function processStripeEvent(
     case "customer.subscription.created":
     case "customer.subscription.updated":
     case "customer.subscription.deleted": {
-      const result = await dependencies.applySubscriptionUpdate(event.data.object);
+      const result = await applySubscriptionEntitlementUpdate(
+        event.data.object,
+        dependencies,
+      );
       return "skipped" in result
         ? { skipped: "subscription_unmapped" }
         : { processed: event.type };
@@ -169,7 +175,10 @@ async function processStripeEvent(
       const subscriptionId = invoiceSubscriptionId(event.data.object);
       if (!subscriptionId) return { skipped: "invoice_without_subscription" };
       const subscription = await dependencies.stripe().subscriptions.retrieve(subscriptionId);
-      const result = await dependencies.applySubscriptionUpdate(subscription);
+      const result = await applySubscriptionEntitlementUpdate(
+        subscription,
+        dependencies,
+      );
       return "skipped" in result
         ? { skipped: "invoice_subscription_unmapped" }
         : { processed: event.type };
@@ -177,6 +186,21 @@ async function processStripeEvent(
     default:
       return { skipped: "event_type" };
   }
+}
+
+async function applySubscriptionEntitlementUpdate(
+  subscription: Stripe.Subscription,
+  dependencies: StripeWebhookDependencies,
+) {
+  const result = await dependencies.applySubscriptionUpdate(subscription);
+  if (
+    !("skipped" in result)
+    && result.scope === "user"
+    && !result.isActive
+  ) {
+    await dependencies.revokeCoderouterRouteTokens(result.stackUserId);
+  }
+  return result;
 }
 
 function isPersonalProCheckout(session: Stripe.Checkout.Session): boolean {

--- a/web/app/env.ts
+++ b/web/app/env.ts
@@ -50,6 +50,18 @@ const requireVercelNonPreviewValue = (
       });
     }
   });
+const requireVercelProductionValue = (
+  name: string,
+  schema: z.ZodType<string> = z.string().min(1),
+): z.ZodType<string | undefined> =>
+  schema.optional().superRefine((value, context) => {
+    if (isVercelProductionDeployment && !value) {
+      context.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: `${name} is required for deployed production runtimes`,
+      });
+    }
+  });
 const requireVercelRelayValue = (
   schema: z.ZodString = z.string().min(1),
 ): z.ZodType<string | undefined> =>
@@ -201,6 +213,12 @@ export const env = createEnv({
     CMUX_TESTFLIGHT_APP_ID: z.string().min(1).optional(),
     CMUX_PRO_TESTFLIGHT_GROUP_ID: z.string().min(1).optional(),
     SENTRY_DSN: z.string().url().optional(),
+    // Hosted coderouter requires an active personal cmux Pro subscription.
+    // Self-hosted deployments leave this unset (or set it to "0").
+    CODEROUTER_HOSTED_PRO_REQUIRED: requireVercelProductionValue(
+      "CODEROUTER_HOSTED_PRO_REQUIRED",
+      z.enum(["0", "1"]),
+    ),
     CRON_SECRET: z.string().min(1).optional(),
     CMUX_ALERTS_SLACK_WEBHOOK_URL: z.string().url().optional(),
     CMUX_VM_ALERT_CREATE_FAILURES_15M: z.string().regex(/^\d+$/).optional(),
@@ -344,6 +362,9 @@ export const env = createEnv({
     CMUX_TESTFLIGHT_APP_ID: trimEnv(process.env.CMUX_TESTFLIGHT_APP_ID),
     CMUX_PRO_TESTFLIGHT_GROUP_ID: trimEnv(process.env.CMUX_PRO_TESTFLIGHT_GROUP_ID),
     SENTRY_DSN: trimEnv(process.env.SENTRY_DSN),
+    CODEROUTER_HOSTED_PRO_REQUIRED: trimEnv(
+      process.env.CODEROUTER_HOSTED_PRO_REQUIRED,
+    ),
     CRON_SECRET: trimEnv(process.env.CRON_SECRET),
     CMUX_ALERTS_SLACK_WEBHOOK_URL: trimEnv(process.env.CMUX_ALERTS_SLACK_WEBHOOK_URL),
     CMUX_VM_ALERT_CREATE_FAILURES_15M: trimEnv(process.env.CMUX_VM_ALERT_CREATE_FAILURES_15M),

--- a/web/db/migrations/20260806020000_coderouter_hosted_entitlements/migration.sql
+++ b/web/db/migrations/20260806020000_coderouter_hosted_entitlements/migration.sql
@@ -1,0 +1,7 @@
+-- Expand first. The application rejects unscoped rows after deployment; a
+-- follow-up migration removes them and makes this column NOT NULL.
+ALTER TABLE "coderouter_route_tokens"
+  ADD COLUMN IF NOT EXISTS "stack_user_id" text;
+
+CREATE INDEX IF NOT EXISTS "coderouter_route_tokens_user_expiry_idx"
+  ON "coderouter_route_tokens" ("stack_user_id", "expires_at");

--- a/web/db/migrations/20260806021000_coderouter_route_token_principals/migration.sql
+++ b/web/db/migrations/20260806021000_coderouter_route_token_principals/migration.sql
@@ -1,0 +1,17 @@
+-- Contract after the principal-aware application is live. Unscoped tokens are
+-- intentionally not transferable to a guessed user.
+DELETE FROM "coderouter_route_tokens"
+WHERE "stack_user_id" IS NULL;
+
+ALTER TABLE "coderouter_route_tokens"
+  ADD CONSTRAINT "coderouter_route_tokens_stack_user_id_not_null"
+  CHECK ("stack_user_id" IS NOT NULL) NOT VALID;
+
+ALTER TABLE "coderouter_route_tokens"
+  VALIDATE CONSTRAINT "coderouter_route_tokens_stack_user_id_not_null";
+
+ALTER TABLE "coderouter_route_tokens"
+  ALTER COLUMN "stack_user_id" SET NOT NULL;
+
+ALTER TABLE "coderouter_route_tokens"
+  DROP CONSTRAINT "coderouter_route_tokens_stack_user_id_not_null";

--- a/web/db/schema.ts
+++ b/web/db/schema.ts
@@ -509,6 +509,7 @@ export const coderouterRouteTokens = pgTable(
   {
     id: uuid("id").defaultRandom().primaryKey(),
     teamId: text("team_id").notNull(),
+    stackUserId: text("stack_user_id").notNull(),
     tokenHash: text("token_hash").notNull(),
     label: text("label").notNull().default("cli"),
     expiresAt: timestamp("expires_at", { withTimezone: true }).notNull(),
@@ -519,6 +520,10 @@ export const coderouterRouteTokens = pgTable(
   (table) => [
     uniqueIndex("coderouter_route_tokens_hash_unique").on(table.tokenHash),
     index("coderouter_route_tokens_team_expiry_idx").on(table.teamId, table.expiresAt),
+    index("coderouter_route_tokens_user_expiry_idx").on(
+      table.stackUserId,
+      table.expiresAt,
+    ),
   ],
 );
 

--- a/web/instrumentation.ts
+++ b/web/instrumentation.ts
@@ -1,4 +1,8 @@
 import { registerOTel } from "@vercel/otel";
+import {
+  scrubSentryEvent,
+  shouldSendCoderouterSentryEvent,
+} from "./services/sentry";
 
 export async function register() {
   registerOTel({ serviceName: process.env.OTEL_SERVICE_NAME ?? "cmux-web" });
@@ -6,6 +10,14 @@ export async function register() {
     const Sentry = await import("@sentry/nextjs");
     Sentry.init({
       dsn: process.env.SENTRY_DSN,
+      environment: process.env.VERCEL_ENV ?? process.env.NODE_ENV,
+      release: process.env.VERCEL_GIT_COMMIT_SHA,
+      sendDefaultPii: false,
+      // Vercel OpenTelemetry owns tracing. This project is intentionally only
+      // for coderouter errors, not every request served by the shared cmux app.
+      tracesSampleRate: 0,
+      beforeSend: (event) =>
+        shouldSendCoderouterSentryEvent(event) ? scrubSentryEvent(event) : null,
     });
   }
 }

--- a/web/next.config.ts
+++ b/web/next.config.ts
@@ -1,6 +1,7 @@
 import "./app/env";
 import type { NextConfig } from "next";
 import createNextIntlPlugin from "next-intl/plugin";
+import { withSentryConfig } from "@sentry/nextjs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { poweredByHeader, securityHeaderRules } from "./security-headers";
@@ -185,4 +186,16 @@ const nextConfig: NextConfig = {
   },
 };
 
-export default withNextIntl(nextConfig);
+const configuredNext = withNextIntl(nextConfig);
+
+export default process.env.SENTRY_AUTH_TOKEN
+  ? withSentryConfig(configuredNext, {
+      org: process.env.SENTRY_ORG,
+      project: process.env.SENTRY_PROJECT,
+      authToken: process.env.SENTRY_AUTH_TOKEN,
+      silent: true,
+      telemetry: false,
+      widenClientFileUpload: true,
+      disableLogger: true,
+    })
+  : configuredNext;

--- a/web/services/coderouter/repository.ts
+++ b/web/services/coderouter/repository.ts
@@ -1,5 +1,5 @@
 import { createHash, randomBytes, randomUUID } from "node:crypto";
-import { and, eq, gt, isNull, lt, lte, notInArray, or, sql } from "drizzle-orm";
+import { and, eq, gt, isNotNull, isNull, lt, lte, notInArray, or, sql } from "drizzle-orm";
 import { cloudDb } from "../../db/client";
 import {
   coderouterAccounts,
@@ -32,17 +32,32 @@ export function routeTokenHash(token: string): string {
 
 export async function issueRouteToken(
   teamId: string,
+  stackUserId: string,
   label = "cli",
 ): Promise<{ token: string; expiresAt: Date }> {
   const token = `crt_${randomBytes(32).toString("base64url")}`;
   const expiresAt = new Date(Date.now() + ROUTE_TOKEN_LIFETIME_MS);
   await cloudDb().insert(coderouterRouteTokens).values({
     teamId,
+    stackUserId,
     tokenHash: routeTokenHash(token),
     label,
     expiresAt,
   });
   return { token, expiresAt };
+}
+
+export async function revokeRouteTokensForUser(
+  stackUserId: string,
+  now = new Date(),
+): Promise<void> {
+  await cloudDb()
+    .update(coderouterRouteTokens)
+    .set({ revokedAt: now })
+    .where(and(
+      eq(coderouterRouteTokens.stackUserId, stackUserId),
+      isNull(coderouterRouteTokens.revokedAt),
+    ));
 }
 
 export async function authenticateRouteToken(
@@ -55,6 +70,7 @@ export async function authenticateRouteToken(
     .set({ lastUsedAt: now })
     .where(and(
       eq(coderouterRouteTokens.tokenHash, routeTokenHash(token)),
+      isNotNull(coderouterRouteTokens.stackUserId),
       gt(coderouterRouteTokens.expiresAt, now),
       isNull(coderouterRouteTokens.revokedAt),
     ))

--- a/web/services/errors.ts
+++ b/web/services/errors.ts
@@ -28,6 +28,21 @@ export function captureAscError(
   });
 }
 
+export function captureCoderouterError(
+  error: unknown,
+  context: Record<string, string | number | boolean | null | undefined> = {},
+): void {
+  if (!env.SENTRY_DSN) return;
+  Sentry.captureException(error, {
+    tags: {
+      subsystem: "coderouter",
+    },
+    // Never pass request bodies, headers, route tokens, provider credentials,
+    // account labels, or email addresses into this context.
+    extra: cleanContext(context),
+  });
+}
+
 function cleanContext(
   context: Record<string, string | number | boolean | null | undefined>,
 ): Record<string, string | number | boolean> {

--- a/web/services/sentry.ts
+++ b/web/services/sentry.ts
@@ -1,0 +1,60 @@
+import type { Event } from "@sentry/nextjs";
+
+const SECRET_KEY =
+  /^(authorization|cookie|set-cookie|x-coderouter-route-token|x-stack-access-token|x-stack-refresh-token|access_token|refresh_token|id_token|credential|ciphertext|encryptedDataKey)$/i;
+const ROUTE_TOKEN = /\bcrt_[A-Za-z0-9_-]{32,}\b/g;
+const BEARER_TOKEN = /\bBearer\s+[A-Za-z0-9._~+/=-]{16,}\b/gi;
+const JWT = /\beyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]*\b/g;
+const API_KEY = /\b(?:sk|srt)_[A-Za-z0-9_-]{8,}\b/g;
+
+/**
+ * Defense in depth for telemetry. Product code must still avoid attaching
+ * request bodies, auth headers, credentials, email addresses, or account
+ * labels to Sentry events.
+ */
+export function scrubSentryEvent<T extends Event>(event: T): T {
+  scrubValue(event);
+  if (event.request) {
+    delete event.request.data;
+    delete event.request.cookies;
+    delete event.request.headers;
+  }
+  delete event.user;
+  return event;
+}
+
+export function shouldSendCoderouterSentryEvent(event: Event): boolean {
+  if (event.tags?.subsystem === "coderouter") return true;
+  const cmux = event.contexts?.cmux as Record<string, unknown> | undefined;
+  if (cmux?.service === "coderouter") return true;
+  const message = event.message
+    ?? event.exception?.values?.map((value) => value.value ?? "").join(" ")
+    ?? "";
+  if (message.startsWith("coderouter.")) return true;
+  const url = event.request?.url;
+  if (!url) return false;
+  try {
+    return new URL(url).hostname.toLowerCase() === "coderouter.dev";
+  } catch {
+    return false;
+  }
+}
+
+function scrubValue(value: unknown): void {
+  if (!value || typeof value !== "object") return;
+  for (const [childKey, child] of Object.entries(value)) {
+    if (SECRET_KEY.test(childKey)) {
+      (value as Record<string, unknown>)[childKey] = "[Filtered]";
+      continue;
+    }
+    if (typeof child === "string") {
+      (value as Record<string, unknown>)[childKey] = child
+        .replace(ROUTE_TOKEN, "[Filtered route token]")
+        .replace(BEARER_TOKEN, "Bearer [Filtered]")
+        .replace(JWT, "[Filtered JWT]")
+        .replace(API_KEY, "[Filtered API key]");
+    } else {
+      scrubValue(child);
+    }
+  }
+}

--- a/web/tests/coderouter-sentry.test.ts
+++ b/web/tests/coderouter-sentry.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, test } from "bun:test";
+import type { Event } from "@sentry/nextjs";
+
+import {
+  scrubSentryEvent,
+  shouldSendCoderouterSentryEvent,
+} from "../services/sentry";
+
+describe("coderouter Sentry privacy", () => {
+  test("isolates the shared cmux deployment to coderouter events", () => {
+    expect(shouldSendCoderouterSentryEvent({
+      request: { url: "https://coderouter.dev/v1/responses" },
+    })).toBe(true);
+    expect(shouldSendCoderouterSentryEvent({
+      tags: { subsystem: "coderouter" },
+    })).toBe(true);
+    expect(shouldSendCoderouterSentryEvent({
+      contexts: { cmux: { service: "coderouter" } },
+    })).toBe(true);
+    expect(shouldSendCoderouterSentryEvent({
+      request: { url: "https://cmux.com/api/devices" },
+    })).toBe(false);
+  });
+
+  test("removes request bodies, auth headers, route tokens, JWTs, and PII", () => {
+    const event = scrubSentryEvent({
+      message:
+        "Bearer secret-bearer-token-123 crt_abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMN eyJabcdefghijk.payload.signature",
+      request: {
+        data: { refresh_token: "refresh-secret" },
+        cookies: { session: "secret" },
+        headers: {
+          authorization: "Bearer secret",
+          cookie: "session=secret",
+          "x-coderouter-route-token": "crt_secret",
+          "x-api-key": "opaque-secret",
+          accept: "application/json",
+        },
+      },
+      user: {
+        id: "user-id",
+        email: "private@example.com",
+        ip_address: "127.0.0.1",
+      },
+      extra: {
+        credential: "secret",
+        nested: { refresh_token: "also-secret" },
+      },
+    } as Event);
+
+    expect(event.request?.data).toBeUndefined();
+    expect(event.request?.cookies).toBeUndefined();
+    expect(event.request?.headers).toBeUndefined();
+    expect(event.user).toBeUndefined();
+    expect(event.extra).toEqual({
+      credential: "[Filtered]",
+      nested: { refresh_token: "[Filtered]" },
+    });
+    expect(event.message).not.toContain("secret-bearer");
+    expect(event.message).not.toContain("crt_");
+    expect(event.message).not.toContain("eyJabcdefghijk");
+  });
+});

--- a/web/tests/coderouter-session-route.test.ts
+++ b/web/tests/coderouter-session-route.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, mock, test } from "bun:test";
+
+import {
+  makeCoderouterSessionGetHandler,
+  makeCoderouterSessionPostHandler,
+} from "../app/api/coderouter/session/route";
+
+const context = {
+  ok: true as const,
+  value: {
+    user: { id: "user_1" },
+    team: {
+      teamId: "team_1",
+      teamName: "Team",
+      use: true,
+      manageAccounts: true,
+    },
+  },
+};
+
+describe("coderouter hosted entitlement", () => {
+  test("validates an existing principal-scoped route session cheaply", async () => {
+    const authenticate = async (token: string) =>
+      token === "crt_valid" ? { teamId: "team_1" } : null;
+    const GET = makeCoderouterSessionGetHandler(authenticate);
+
+    const valid = await GET(new Request(
+      "https://coderouter.dev/api/coderouter/session",
+      { headers: { authorization: "Bearer crt_valid" } },
+    ));
+    const invalid = await GET(new Request(
+      "https://coderouter.dev/api/coderouter/session",
+      { headers: { authorization: "Bearer crt_invalid" } },
+    ));
+
+    expect(valid.status).toBe(204);
+    expect(invalid.status).toBe(401);
+  });
+
+  test("requires Pro before issuing a hosted route token", async () => {
+    const issueToken = mock(async () => ({
+      token: "crt_test",
+      expiresAt: new Date("2026-09-01T00:00:00Z"),
+    }));
+    const POST = makeCoderouterSessionPostHandler({
+      resolveContext: mock(async () => context) as never,
+      hasActivePro: mock(async () => false),
+      issueToken,
+      hostedProRequired: () => true,
+    });
+
+    const response = await POST(
+      new Request("https://coderouter.dev/api/coderouter/session", {
+        method: "POST",
+      }),
+    );
+
+    expect(response.status).toBe(402);
+    await expect(response.json()).resolves.toMatchObject({
+      error: "pro_required",
+    });
+    expect(issueToken).not.toHaveBeenCalled();
+  });
+
+  test("keeps self-hosted servers independent from hosted billing", async () => {
+    const issueToken = mock(async () => ({
+      token: "crt_test",
+      expiresAt: new Date("2026-09-01T00:00:00Z"),
+    }));
+    const hasActivePro = mock(async () => false);
+    const POST = makeCoderouterSessionPostHandler({
+      resolveContext: mock(async () => context) as never,
+      hasActivePro,
+      issueToken,
+      hostedProRequired: () => false,
+    });
+
+    const response = await POST(
+      new Request("https://router.example.com/api/coderouter/session", {
+        method: "POST",
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({
+      token: "crt_test",
+      openaiBaseUrl: "https://router.example.com/v1",
+    });
+    expect(hasActivePro).not.toHaveBeenCalled();
+    expect(issueToken).toHaveBeenCalledWith("team_1", "user_1");
+  });
+
+  test("fails closed when hosted entitlement storage is unavailable", async () => {
+    const POST = makeCoderouterSessionPostHandler({
+      resolveContext: mock(async () => context) as never,
+      hasActivePro: mock(async () => {
+        throw new Error("database unavailable");
+      }),
+      issueToken: mock(async () => {
+        throw new Error("must not issue");
+      }),
+      hostedProRequired: () => true,
+    });
+
+    const response = await POST(
+      new Request("https://coderouter.dev/api/coderouter/session", {
+        method: "POST",
+      }),
+    );
+
+    expect(response.status).toBe(503);
+    expect(response.headers.get("retry-after")).toBeNull();
+  });
+});

--- a/web/tests/stripe-webhook-route.test.ts
+++ b/web/tests/stripe-webhook-route.test.ts
@@ -18,7 +18,13 @@ const recordCheckoutCompletion = mock(async () => {
   if (recordCheckoutShouldFail) throw new Error("db down");
   return recordCheckoutCompletionResult;
 });
-const applySubscriptionUpdate = mock(async () => ({ stackUserId: "user_1", isActive: true }));
+let applySubscriptionUpdateResult: unknown = {
+  scope: "user",
+  stackUserId: "user_1",
+  isActive: true,
+};
+const applySubscriptionUpdate = mock(async () => applySubscriptionUpdateResult);
+const revokeCoderouterRouteTokens = mock(async () => {});
 const sendProSignupWelcome = mock(async () => {
   if (proWelcomeShouldFail) throw new Error("email provider unavailable");
 });
@@ -89,6 +95,7 @@ const POST = makeStripeWebhookHandler({
   recordCheckoutCompletion: recordCheckoutCompletion as never,
   applySubscriptionUpdate: applySubscriptionUpdate as never,
   sendProSignupWelcome,
+  revokeCoderouterRouteTokens,
 });
 
 describe("Stripe billing webhook route", () => {
@@ -115,9 +122,15 @@ describe("Stripe billing webhook route", () => {
       stackUserId: "user_1",
       subscriptionId: "sub_1",
     };
+    applySubscriptionUpdateResult = {
+      scope: "user",
+      stackUserId: "user_1",
+      isActive: true,
+    };
     retrievedCheckoutSession = paidCheckoutSession;
     recordCheckoutCompletion.mockClear();
     applySubscriptionUpdate.mockClear();
+    revokeCoderouterRouteTokens.mockClear();
     sendProSignupWelcome.mockClear();
     retrieveSession.mockClear();
     retrieveSubscription.mockClear();
@@ -268,6 +281,11 @@ describe("Stripe billing webhook route", () => {
   });
 
   test("applies deleted subscription updates", async () => {
+    applySubscriptionUpdateResult = {
+      scope: "user",
+      stackUserId: "user_1",
+      isActive: false,
+    };
     currentEvent = {
       id: "evt_1",
       type: "customer.subscription.deleted",
@@ -287,6 +305,31 @@ describe("Stripe billing webhook route", () => {
     expect(applySubscriptionUpdate).toHaveBeenCalledWith(
       (currentEvent.data as { object: unknown }).object,
     );
+    expect(revokeCoderouterRouteTokens).toHaveBeenCalledWith("user_1");
+  });
+
+  test("revokes coderouter tokens for an inactive invoice subscription update", async () => {
+    currentEvent = {
+      id: "evt_invoice_failed",
+      type: "invoice.payment_failed",
+      data: {
+        object: {
+          id: "in_1",
+          subscription: "sub_1",
+        },
+      },
+    };
+    applySubscriptionUpdateResult = {
+      scope: "user",
+      stackUserId: "user_1",
+      isActive: false,
+    };
+
+    const response = await POST(webhookRequest());
+
+    expect(response.status).toBe(200);
+    expect(retrieveSubscription).toHaveBeenCalledWith("sub_1");
+    expect(revokeCoderouterRouteTokens).toHaveBeenCalledWith("user_1");
   });
 
   test("marks the event and returns 500 when processing fails", async () => {


### PR DESCRIPTION
## Summary
- gates hosted coderouter session issuance on local authoritative cmux Pro state
- principal-scopes route tokens and revokes them on all inactive subscription update paths
- leaves self-hosted deployments explicitly billing-independent
- adds coderouter-only, privacy-scrubbed Sentry with manaflow source-map uploads

## Testing
- `bun run typecheck`
- `bun run db:check`
- 47 focused billing/coderouter/Sentry tests
- production free-user rejection and self-host integration coverage
- production Sentry ingest, grouping, environment/release tags, and 2,796 uploaded source-map files

## Demo
- Ratatui Ctrl-C flow and production CLI were verified in cmux; no video is needed for this backend-focused change.

## Review trigger
@coderabbitai review

## Checklist
- [x] No Stripe query on model traffic hot path
- [x] Billing/storage failures fail closed
- [x] Secrets and PII are excluded from Sentry
- [x] Migrations applied using expand/deploy/contract ordering
- [x] Living architecture document updated