### PR TITLE
Fix npm bootstrap latest-tag verification

### DIFF
--- a/.github/workflows/sdk-bootstrap-npm.yml
+++ b/.github/workflows/sdk-bootstrap-npm.yml
@@ -319,7 +319,8 @@ jobs:
             typeof tags.latest !== "string" ||
             tags.latest.length === 0
           ) {
-            throw new Error(`unexpected cmux-sdk dist-tags: ${JSON.stringify(tags)}`);
+            console.error("cmux-sdk dist-tag validation failed.");
+            process.exit(1);
           }
           NODE
 

--- a/.github/workflows/sdk-bootstrap-npm.yml
+++ b/.github/workflows/sdk-bootstrap-npm.yml
@@ -167,6 +167,7 @@ jobs:
             --workflow .github/workflows/sdk-bootstrap-npm.yml \
             --workflow-ref refs/heads/main \
             --dist-tag bootstrap \
+            --require-dist-tag latest \
             --publisher owner \
             --artifact "${packages[0]}"
 
@@ -297,7 +298,7 @@ jobs:
       - name: Install pinned npm
         run: npm install --global --ignore-scripts npm@11.5.1
 
-      - name: Verify the prerelease did not claim latest
+      - name: Verify npm-required bootstrap tags
         run: |
           set -euo pipefail
           tags="$RUNNER_TEMP/cmux-sdk-bootstrap-tags.json"
@@ -313,7 +314,11 @@ jobs:
           const fs = require("node:fs");
           const [path, expected] = process.argv.slice(2);
           const tags = JSON.parse(fs.readFileSync(path, "utf8"));
-          if (tags.bootstrap !== expected || Object.hasOwn(tags, "latest")) {
+          if (
+            tags.bootstrap !== expected ||
+            typeof tags.latest !== "string" ||
+            tags.latest.length === 0
+          ) {
             throw new Error(`unexpected cmux-sdk dist-tags: ${JSON.stringify(tags)}`);
           }
           NODE
@@ -336,5 +341,6 @@ jobs:
             --workflow .github/workflows/sdk-bootstrap-npm.yml \
             --workflow-ref refs/heads/main \
             --dist-tag bootstrap \
+            --require-dist-tag latest \
             --publisher owner \
             --artifact "${packages[0]}"

--- a/cmux-tui/bindings/tests/test_verify_npm_provenance.py
+++ b/cmux-tui/bindings/tests/test_verify_npm_provenance.py
@@ -233,7 +233,7 @@ class VerifyNpmProvenanceTests(unittest.TestCase):
         for name in environment:
             self.assertNotIn("TOKEN", name.upper())
 
-    def test_accepts_all_required_bootstrap_dist_tags(self) -> None:
+    def test_accepts_npm_latest_for_the_sole_bootstrap_release(self) -> None:
         metadata = self.metadata()
         metadata["dist-tags"]["latest"] = self.version
         completed = (
@@ -267,6 +267,9 @@ class VerifyNpmProvenanceTests(unittest.TestCase):
     def test_accepts_a_stable_latest_tag_after_bootstrap(self) -> None:
         metadata = self.metadata()
         metadata["dist-tags"]["latest"] = "1.0.0"
+        stable_release = dict(metadata["versions"][self.version])
+        stable_release["version"] = "1.0.0"
+        metadata["versions"]["1.0.0"] = stable_release
         completed = (
             subprocess.CompletedProcess([], 0, stdout="", stderr=""),
             subprocess.CompletedProcess(
@@ -294,6 +297,29 @@ class VerifyNpmProvenanceTests(unittest.TestCase):
                 required_dist_tags=("latest",),
                 **self.verification_options(),
             )
+
+    def test_rejects_bootstrap_latest_after_a_stable_release_exists(self) -> None:
+        metadata = self.metadata()
+        metadata["dist-tags"]["latest"] = self.version
+        stable_release = dict(metadata["versions"][self.version])
+        stable_release["version"] = "1.0.0"
+        metadata["versions"]["1.0.0"] = stable_release
+        with mock.patch.object(
+            provenance,
+            "urlopen",
+            side_effect=self.registry_response(metadata=metadata),
+        ), mock.patch.object(provenance.subprocess, "run") as run, \
+            self.assertRaisesRegex(provenance.ProvenanceError, "prerelease"):
+            provenance.verify(
+                self.package,
+                self.version,
+                self.repository_url,
+                self.repository_directory,
+                self.artifact,
+                required_dist_tags=("latest",),
+                **self.verification_options(),
+            )
+        run.assert_not_called()
 
     def test_rejects_a_missing_required_bootstrap_dist_tag(self) -> None:
         with mock.patch.object(

--- a/cmux-tui/bindings/tests/test_verify_npm_provenance.py
+++ b/cmux-tui/bindings/tests/test_verify_npm_provenance.py
@@ -266,10 +266,10 @@ class VerifyNpmProvenanceTests(unittest.TestCase):
 
     def test_accepts_a_stable_latest_tag_after_bootstrap(self) -> None:
         metadata = self.metadata()
-        metadata["dist-tags"]["latest"] = "1.0.0"
+        metadata["dist-tags"]["latest"] = "1.0.0+build-1"
         stable_release = dict(metadata["versions"][self.version])
-        stable_release["version"] = "1.0.0"
-        metadata["versions"]["1.0.0"] = stable_release
+        stable_release["version"] = "1.0.0+build-1"
+        metadata["versions"]["1.0.0+build-1"] = stable_release
         completed = (
             subprocess.CompletedProcess([], 0, stdout="", stderr=""),
             subprocess.CompletedProcess(

--- a/cmux-tui/bindings/tests/test_verify_npm_provenance.py
+++ b/cmux-tui/bindings/tests/test_verify_npm_provenance.py
@@ -233,6 +233,86 @@ class VerifyNpmProvenanceTests(unittest.TestCase):
         for name in environment:
             self.assertNotIn("TOKEN", name.upper())
 
+    def test_accepts_all_required_bootstrap_dist_tags(self) -> None:
+        metadata = self.metadata()
+        metadata["dist-tags"]["latest"] = self.version
+        completed = (
+            subprocess.CompletedProcess([], 0, stdout="", stderr=""),
+            subprocess.CompletedProcess(
+                [],
+                0,
+                stdout=json.dumps({"invalid": [], "missing": []}),
+                stderr="",
+            ),
+        )
+        with mock.patch.object(
+            provenance,
+            "urlopen",
+            side_effect=self.registry_response(metadata=metadata),
+        ), mock.patch.object(
+            provenance.subprocess,
+            "run",
+            side_effect=completed,
+        ):
+            provenance.verify(
+                self.package,
+                self.version,
+                self.repository_url,
+                self.repository_directory,
+                self.artifact,
+                required_dist_tags=("latest",),
+                **self.verification_options(),
+            )
+
+    def test_accepts_a_stable_latest_tag_after_bootstrap(self) -> None:
+        metadata = self.metadata()
+        metadata["dist-tags"]["latest"] = "1.0.0"
+        completed = (
+            subprocess.CompletedProcess([], 0, stdout="", stderr=""),
+            subprocess.CompletedProcess(
+                [],
+                0,
+                stdout=json.dumps({"invalid": [], "missing": []}),
+                stderr="",
+            ),
+        )
+        with mock.patch.object(
+            provenance,
+            "urlopen",
+            side_effect=self.registry_response(metadata=metadata),
+        ), mock.patch.object(
+            provenance.subprocess,
+            "run",
+            side_effect=completed,
+        ):
+            provenance.verify(
+                self.package,
+                self.version,
+                self.repository_url,
+                self.repository_directory,
+                self.artifact,
+                required_dist_tags=("latest",),
+                **self.verification_options(),
+            )
+
+    def test_rejects_a_missing_required_bootstrap_dist_tag(self) -> None:
+        with mock.patch.object(
+            provenance,
+            "urlopen",
+            side_effect=self.registry_response(),
+        ), mock.patch.object(provenance.subprocess, "run") as run, \
+            self.assertRaisesRegex(provenance.ProvenanceError, "dist-tag"):
+            provenance.verify(
+                self.package,
+                self.version,
+                self.repository_url,
+                self.repository_directory,
+                self.artifact,
+                required_dist_tags=("latest",),
+                **self.verification_options(),
+            )
+        run.assert_not_called()
+
     def test_accepts_matching_sha512_in_multi_entry_sri(self) -> None:
         metadata = self.metadata()
         metadata["versions"][self.version]["dist"]["integrity"] = (

--- a/cmux-tui/bindings/verify_npm_provenance.py
+++ b/cmux-tui/bindings/verify_npm_provenance.py
@@ -111,6 +111,15 @@ def _validate_metadata(
         for required_tag in required_dist_tags
     ):
         raise ProvenanceError("npm required dist-tag is missing")
+    for required_tag in required_dist_tags:
+        tagged_version = tags[required_tag]
+        if not isinstance(versions.get(tagged_version), dict):
+            raise ProvenanceError("npm required dist-tag names an unknown release")
+        if required_tag == "latest" and "-" in tagged_version:
+            # npm requires a latest tag even when the ownership bootstrap is
+            # the project's sole release. A later release must replace it.
+            if tagged_version != version or len(versions) != 1:
+                raise ProvenanceError("npm latest dist-tag names a prerelease")
 
     repository = release.get("repository")
     if not isinstance(repository, dict) or repository != {

--- a/cmux-tui/bindings/verify_npm_provenance.py
+++ b/cmux-tui/bindings/verify_npm_provenance.py
@@ -115,7 +115,8 @@ def _validate_metadata(
         tagged_version = tags[required_tag]
         if not isinstance(versions.get(tagged_version), dict):
             raise ProvenanceError("npm required dist-tag names an unknown release")
-        if required_tag == "latest" and "-" in tagged_version:
+        version_without_build = tagged_version.split("+", 1)[0]
+        if required_tag == "latest" and "-" in version_without_build:
             # npm requires a latest tag even when the ownership bootstrap is
             # the project's sole release. A later release must replace it.
             if tagged_version != version or len(versions) != 1:

--- a/cmux-tui/bindings/verify_npm_provenance.py
+++ b/cmux-tui/bindings/verify_npm_provenance.py
@@ -90,6 +90,7 @@ def _validate_metadata(
     artifact: Optional[Path],
     owner: str,
     dist_tag: str,
+    required_dist_tags: Sequence[str],
     publisher_type: str,
 ) -> tuple[str, str]:
     if metadata.get("name") != package:
@@ -104,6 +105,12 @@ def _validate_metadata(
     tags = metadata.get("dist-tags")
     if not isinstance(tags, dict) or tags.get(dist_tag) != version:
         raise ProvenanceError("npm dist-tag does not name the expected release")
+    if any(
+        not isinstance(tags.get(required_tag), str)
+        or not tags[required_tag]
+        for required_tag in required_dist_tags
+    ):
+        raise ProvenanceError("npm required dist-tag is missing")
 
     repository = release.get("repository")
     if not isinstance(repository, dict) or repository != {
@@ -382,6 +389,7 @@ def verify(
     workflow_ref: str,
     dist_tag: str,
     publisher: str,
+    required_dist_tags: Sequence[str] = (),
     expected_commit: Optional[str] = None,
     npm: str = "npm",
 ) -> None:
@@ -395,6 +403,7 @@ def verify(
             workflow,
             workflow_ref,
             dist_tag,
+            *required_dist_tags,
             publisher,
             npm,
         )
@@ -417,6 +426,7 @@ def verify(
         artifact,
         owner,
         dist_tag,
+        required_dist_tags,
         publisher,
     )
     attestation = _json(
@@ -448,6 +458,12 @@ def _parser() -> argparse.ArgumentParser:
     parser.add_argument("--expected-commit")
     parser.add_argument("--dist-tag", required=True)
     parser.add_argument(
+        "--require-dist-tag",
+        action="append",
+        default=[],
+        dest="required_dist_tags",
+    )
+    parser.add_argument(
         "--publisher",
         choices=("owner", "github-actions"),
         required=True,
@@ -470,6 +486,7 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
             workflow_ref=args.workflow_ref,
             expected_commit=args.expected_commit,
             dist_tag=args.dist_tag,
+            required_dist_tags=args.required_dist_tags,
             publisher=args.publisher,
             npm=args.npm,
         )


### PR DESCRIPTION
npm requires every package to retain a `latest` dist-tag. The bootstrap verifier incorrectly treated its presence as a failure, so the first ownership bootstrap could never finish green.

This change requires `bootstrap` to name the bootstrap artifact while accepting npm's mandatory non-empty `latest` tag. It also keeps reruns valid after a stable release replaces `latest`.

Tests:
- `python3 -m unittest cmux-tui/bindings/tests/test_verify_npm_provenance.py`
- `python3 -m py_compile cmux-tui/bindings/verify_npm_provenance.py`
- `actionlint .github/workflows/sdk-bootstrap-npm.yml`

The first commit adds the failing regression coverage; the second implements the fix.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/9700"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788596127&installation_model_id=21920&pr_number=9700&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F9700&signature=cb4f5279c84fb9a9a047fbe4c2ff464538492a90d164de4cefac99f31e42c046"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `npm` bootstrap verification by accepting the mandatory non-empty `latest` dist-tag and constraining when `latest` can point to a prerelease. Adds safe prerelease parsing and redacts tag validation errors.

- **Bug Fixes**
  - Verifier enforces required `dist-tags` via `--require-dist-tag` (including non-empty `latest`), rejects missing/unknown tags, safely parses prerelease (ignores build metadata), and only allows prerelease `latest` when it’s the sole bootstrap release.
  - Workflow passes `--require-dist-tag latest` and validates tags without echoing registry data; tests cover sole-bootstrap acceptance, stable-after-bootstrap behavior, missing-tag failure, and prerelease parsing.

<sup>Written for commit ff7b59a7f505fa4d7ca62ef644f6c226959f580e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/9700?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * NPM provenance verification now supports checking multiple required distribution tags.
  * Verification requires the `latest` tag to be present and non-empty, while continuing to validate the `bootstrap` tag.
  * The command-line verification tool now accepts repeatable options for specifying required tags.
  * Verification supports valid `latest` references for both the initial bootstrap release and subsequent stable releases.

* **Bug Fixes**
  * Prevented verification from proceeding when a required NPM tag is missing, invalid, or points to an inappropriate release.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->