### PR TITLE
Polish pricing CTAs and annual default

### DIFF
--- a/web/app/[locale]/pricing/page.tsx
+++ b/web/app/[locale]/pricing/page.tsx
@@ -100,7 +100,7 @@ export default async function PricingPage({
   const query = searchParams ? await searchParams : {};
   const t = await getTranslations({ locale, namespace: "pricing" });
   const snapshot = await currentPlanSnapshot();
-  const interval = proBillingInterval(firstParam(query.interval));
+  const interval = proBillingInterval(firstParam(query.interval) ?? "year");
   const proCheckoutHrefs = {
     month: withCheckoutInterval(PRO_CHECKOUT_URL, "month"),
     year: withCheckoutInterval(PRO_CHECKOUT_URL, "year"),
@@ -204,7 +204,7 @@ export default async function PricingPage({
                   </SecondaryLink>
                 </div>
               ) : (
-                <ProCtaLink checkoutHrefs={proCheckoutHrefs}>
+                <ProCtaLink checkoutHrefs={proCheckoutHrefs} size="compact">
                   {t("pro.cta")}
                 </ProCtaLink>
               )}
@@ -232,6 +232,7 @@ export default async function PricingPage({
                 hrefs={teamCheckoutHrefs}
                 location="pricing_page"
                 plan="team"
+                size="compact"
               >
                 {t("team.cta")}
               </PricingCheckoutButton>

--- a/web/tests/pricing-page.test.tsx
+++ b/web/tests/pricing-page.test.tsx
@@ -73,7 +73,7 @@ describe("localized pricing page", () => {
     proUser.update.mockClear();
   });
 
-  test("does not render Manage billing for non-Pro snapshots", async () => {
+  test("defaults public pricing to annual billing with compact paid-plan CTAs", async () => {
     const element = await PricingPage({ params: Promise.resolve({ locale: "en" }) });
     const html = renderToStaticMarkup(element);
 
@@ -82,9 +82,15 @@ describe("localized pricing page", () => {
     expect(html).toContain("/mo");
     expect(html).toContain("/user/mo");
     expect(html).not.toContain("/mo.");
-    expect(html).toContain("$35/user/mo");
+    expect(html).toContain("$28/user/mo");
     expect(html).toContain(
-      "/api/billing/checkout?plan=team&amp;cmux_external_browser=1&amp;interval=month",
+      "/api/billing/checkout?plan=team&amp;cmux_external_browser=1&amp;interval=year",
+    );
+    expect(html).toContain(
+      "/api/billing/checkout?plan=pro&amp;cmux_external_browser=1&amp;interval=year",
+    );
+    expect(html).toContain(
+      'px-3 py-1.5 text-xs bg-foreground transition-opacity hover:opacity-85',
     );
     expect(html).toContain('<p class="mt-5 text-sm font-medium">Includes:</p>');
     expect(html).not.toContain('style="min-height:4rem"');

--- a/web/tests/pricing-page.test.tsx
+++ b/web/tests/pricing-page.test.tsx
@@ -89,8 +89,11 @@ describe("localized pricing page", () => {
     expect(html).toContain(
       "/api/billing/checkout?plan=pro&amp;cmux_external_browser=1&amp;interval=year",
     );
-    expect(html).toContain(
-      'px-3 py-1.5 text-xs bg-foreground transition-opacity hover:opacity-85',
+    expect(html).toMatch(
+      /href="\/api\/billing\/checkout\?plan=pro[^"]*interval=year"[^>]*class="[^"]*px-3 py-1\.5 text-xs[^"]*"[^>]*><span>Get Pro/,
+    );
+    expect(html).toMatch(
+      /href="\/api\/billing\/checkout\?plan=team[^"]*interval=year"[^>]*class="[^"]*px-3 py-1\.5 text-xs[^"]*"[^>]*><span>Get Teams/,
     );
     expect(html).toContain('<p class="mt-5 text-sm font-medium">Includes:</p>');
     expect(html).not.toContain('style="min-height:4rem"');
@@ -150,6 +153,26 @@ describe("localized pricing page", () => {
     expect(html).toContain('<button type="button" role="radio" aria-checked="true"');
     expect(html).not.toContain('href="?interval=');
     expect(html).toContain("mx-auto mt-6 flex w-fit");
+  });
+
+  test("honors an explicit monthly billing interval", async () => {
+    const element = await PricingPage({
+      params: Promise.resolve({ locale: "en" }),
+      searchParams: Promise.resolve({ interval: "month" }),
+    });
+    const html = renderToStaticMarkup(element);
+
+    expect(html).toContain("$30");
+    expect(html).toContain("$35");
+    expect(html).toContain(
+      "/api/billing/checkout?plan=pro&amp;cmux_external_browser=1&amp;interval=month",
+    );
+    expect(html).toContain(
+      "/api/billing/checkout?plan=team&amp;cmux_external_browser=1&amp;interval=month",
+    );
+    expect(html).toContain(
+      '<button type="button" role="radio" aria-checked="true" tabindex="0" class="bg-foreground px-3 py-1.5 font-medium text-background">Monthly</button>',
+    );
   });
 });
 


### PR DESCRIPTION
## Summary
- default public pricing to annual billing while preserving explicit monthly links
- reduce the Get Pro and Get Teams card CTA height
- cover both billing defaults and explicit interval selection

## Testing
- `cd web && bun test tests/pricing-page.test.tsx tests/pro-pricing.test.ts tests/pro-cta-link.test.tsx`
- `cd web && bun run typecheck`
- `cd web && bunx eslint "app/[locale]/pricing/page.tsx" tests/pricing-page.test.tsx`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/9701"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788600018&installation_model_id=21920&pr_number=9701&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F9701&signature=bb0c79ecacea698429d5bcef0da0b206289a6f17a2230ec75d1f44bbfa45fd22"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Default the public pricing page to annual billing and make the Pro and Teams CTAs compact. Keeps explicit monthly selection via `?interval=month`, and updates checkout links to match the selected interval.

<sup>Written for commit a446c0fe1bc5a3b00b0e1cbf162095c261666449. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/9701?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Pricing now defaults to annual billing when no billing interval is selected.
  * Monthly billing remains available through the billing toggle.
  * Paid-plan checkout buttons now use a more compact layout.
  * Updated team-plan pricing is reflected in the pricing page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->