### PR TITLE
Test Stripe entitlement lifecycle states

### DIFF
--- a/web/tests/billing-purchase.test.ts
+++ b/web/tests/billing-purchase.test.ts
@@ -16,7 +16,11 @@ process.env.STACK_SECRET_SERVER_KEY ??= "test-stack-secret";
 process.env.NEXT_PUBLIC_STACK_PROJECT_ID ??= "00000000-0000-4000-8000-000000000000";
 process.env.NEXT_PUBLIC_STACK_PUBLISHABLE_CLIENT_KEY ??= "test-stack-publishable";
 
-const { applySubscriptionUpdate, recordCheckoutCompletion } = await import(
+const {
+  applySubscriptionUpdate,
+  isActiveStripeSubscriptionStatus,
+  recordCheckoutCompletion,
+} = await import(
   "../services/billing/purchase"
 );
 
@@ -184,6 +188,26 @@ function teamCheckoutInput(customerId = "cus_team", stackUserId?: string) {
     },
   };
 }
+
+describe("Stripe subscription entitlement states", () => {
+  for (const status of ["active", "trialing", "past_due"]) {
+    test(`${status} retains Pro access`, () => {
+      expect(isActiveStripeSubscriptionStatus(status)).toBe(true);
+    });
+  }
+
+  for (const status of [
+    "canceled",
+    "incomplete",
+    "incomplete_expired",
+    "paused",
+    "unpaid",
+  ]) {
+    test(`${status} revokes Pro access`, () => {
+      expect(isActiveStripeSubscriptionStatus(status)).toBe(false);
+    });
+  }
+});
 
 describe("recordCheckoutCompletion", () => {
   beforeEach(() => {

--- a/web/tests/stripe-webhook-route.test.ts
+++ b/web/tests/stripe-webhook-route.test.ts
@@ -251,6 +251,19 @@ describe("Stripe billing webhook route", () => {
     expect(sendProSignupWelcome).toHaveBeenCalledTimes(1);
   });
 
+  test("records a fully discounted checkout that requires no payment", async () => {
+    retrievedCheckoutSession = {
+      ...paidCheckoutSession,
+      payment_status: "no_payment_required",
+    };
+
+    const response = await POST(webhookRequest());
+
+    expect(response.status).toBe(200);
+    expect(recordCheckoutCompletion).toHaveBeenCalledTimes(1);
+    expect(sendProSignupWelcome).toHaveBeenCalledTimes(1);
+  });
+
   test("does not run personal Pro fulfillment for a team checkout", async () => {
     recordCheckoutCompletionResult = {
       scope: "team",
@@ -330,6 +343,53 @@ describe("Stripe billing webhook route", () => {
     expect(response.status).toBe(200);
     expect(retrieveSubscription).toHaveBeenCalledWith("sub_1");
     expect(revokeCoderouterRouteTokens).toHaveBeenCalledWith("user_1");
+  });
+
+  test("restores entitlement without revoking tokens after invoice recovery", async () => {
+    currentEvent = {
+      id: "evt_invoice_paid",
+      type: "invoice.paid",
+      data: {
+        object: {
+          id: "in_1",
+          subscription: "sub_1",
+        },
+      },
+    };
+    applySubscriptionUpdateResult = {
+      scope: "user",
+      stackUserId: "user_1",
+      isActive: true,
+    };
+
+    const response = await POST(webhookRequest());
+
+    expect(response.status).toBe(200);
+    expect(retrieveSubscription).toHaveBeenCalledWith("sub_1");
+    expect(applySubscriptionUpdate).toHaveBeenCalledTimes(1);
+    expect(revokeCoderouterRouteTokens).not.toHaveBeenCalled();
+  });
+
+  test("does not revoke tokens when an invoice subscription is unmapped", async () => {
+    currentEvent = {
+      id: "evt_invoice_unmapped",
+      type: "invoice.payment_failed",
+      data: {
+        object: {
+          id: "in_1",
+          subscription: "sub_foreign",
+        },
+      },
+    };
+    applySubscriptionUpdateResult = { skipped: "subscription_unmapped" };
+
+    const response = await POST(webhookRequest());
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({
+      skipped: "invoice_subscription_unmapped",
+    });
+    expect(revokeCoderouterRouteTokens).not.toHaveBeenCalled();
   });
 
   test("marks the event and returns 500 when processing fails", async () => {


### PR DESCRIPTION
## Summary
- cover active, trialing, past-due, and terminal Stripe entitlement states
- cover fully discounted Checkout fulfillment
- cover invoice recovery and unmapped invoice behavior

## External E2E evidence
- completed a real Stripe test-mode $30 Checkout against isolated Postgres and the dev Stack project
- advanced a Stripe Test Clock through renewal, recurring payment failure, past_due, recovery, and cancellation
- verified past_due retains a route token and cancellation revokes it
- replayed a signed webhook after an intentional account-lease race and verified convergence

## Testing
- `bun test tests/billing-purchase.test.ts tests/stripe-webhook-route.test.ts tests/coderouter-session-route.test.ts`
- `bun run typecheck`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/9707"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788604881&installation_model_id=21920&pr_number=9707&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F9707&signature=67c3e83c482466f7fe9f53235ea1fed832a6d7cf2f912d70f4a3e9842fea6f59"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds principal-scoped coderouter route tokens gated by hosted Pro entitlement, with automatic revocation when a Stripe subscription is not active. Expands webhook handling (active/trialing/past_due mapping, invoice recovery, fully discounted checkouts, unmapped invoices) and isolates coderouter Sentry with aggressive scrubbing.

- **New Features**
  - Hosted only: POST `/api/coderouter/session` requires active Pro; returns 402 `pro_required` or 503 on entitlement errors; self‑hosted unaffected.
  - Adds GET `/api/coderouter/session` for cheap Bearer token validation; session responses return a host-aware `openaiBaseUrl`.
  - Webhooks revoke tokens only when a user’s subscription is inactive; respect invoice recovery, fully discounted checkouts, and ignore unmapped invoice events.
  - Route tokens are scoped to a principal (`stack_user_id`); adds user/expiry index and user revocation API.
  - Adds `@sentry/nextjs` with coderouter-only event filtering and aggressive secret/PII scrubbing.

- **Migration**
  - Apply DB migrations to add `stack_user_id` and then enforce NOT NULL; the second migration deletes legacy unscoped tokens.
  - Set CODEROUTER_HOSTED_PRO_REQUIRED=1 in hosted production; leave unset or 0 for self‑hosted.
  - Optional Sentry build config: set `SENTRY_DSN` (runtime) and `SENTRY_AUTH_TOKEN`, `SENTRY_ORG`, `SENTRY_PROJECT` (build) to enable uploads.

<sup>Written for commit 35d1d0c5e4de51e1947a1fefdf1aa4d313d6099b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/9707?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded billing coverage for subscription statuses that grant or revoke Pro access.
  * Added webhook scenarios for discounted checkouts, subscription failures, token revocation, invoice recovery, and unmapped subscriptions.
  * Improved test isolation for subscription update results and token revocation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->