### PR TITLE
Terminate SSH descendants after cleanup deadline

### DIFF
--- a/Packages/macOS/CmuxFoundation/Sources/CmuxFoundation/SSHForegroundAuthenticationRetryPolicy.swift
+++ b/Packages/macOS/CmuxFoundation/Sources/CmuxFoundation/SSHForegroundAuthenticationRetryPolicy.swift
@@ -70,8 +70,10 @@ public struct SSHForegroundAuthenticationRetryPolicy: Sendable {
     /// period. Survivors are revalidated against that parent, frozen, rescanned,
     /// and force-killed. Process-group boundaries are recorded before TERM so a
     /// handler cannot escape by forking a replacement and exiting before the next
-    /// scan. Every recursive grace check shares one two-second deadline, while an
-    /// isolated child process group is terminated as one unit before recursion.
+    /// scan. Every recursive grace check shares one two-second deadline. Once it
+    /// expires, the helper still walks the frozen remaining subtree without any
+    /// further waits and force-kills each identity-checked descendant. An isolated
+    /// child process group is terminated as one unit before recursion.
     /// The caller supplies the authentication root's known wrapper PID so root
     /// validation is not inferred from a potentially reused candidate PID.
     ///
@@ -108,6 +110,73 @@ public struct SSHForegroundAuthenticationRetryPolicy: Sendable {
             /bin/kill -0 "$cmux_ssh_auth_process_pid" >/dev/null 2>&1
           )
 
+          cmux_ssh_force_terminate_auth_process() (
+            cmux_ssh_auth_tree_pid="$1"
+            cmux_ssh_auth_tree_parent_pid="$2"
+            cmux_ssh_auth_tree_freeze_attempt=0
+            cmux_ssh_auth_tree_members=
+            while [ "$cmux_ssh_auth_tree_freeze_attempt" -lt 8 ]; do
+              # Freeze parent-first, then resnapshot to catch children spawned before STOP landed.
+              cmux_ssh_auth_tree_snapshot=$(/bin/ps -axo pid=,ppid=,state= 2>/dev/null) || exit 0
+              cmux_ssh_auth_tree_members=$(printf '%s\n' "$cmux_ssh_auth_tree_snapshot" | /usr/bin/awk \
+                -v cmux_root="$cmux_ssh_auth_tree_pid" \
+                -v cmux_root_parent="$cmux_ssh_auth_tree_parent_pid" '
+                  {
+                    cmux_parent[$1] = $2
+                    cmux_state[$1] = $3
+                    cmux_process[$1] = 1
+                  }
+                  END {
+                    if (!(cmux_root in cmux_process) ||
+                        cmux_parent[cmux_root] != cmux_root_parent ||
+                        cmux_state[cmux_root] ~ /Z/) {
+                      exit
+                    }
+                    cmux_depth[cmux_root] = 0
+                    cmux_discovered = 1
+                    while (cmux_discovered) {
+                      cmux_discovered = 0
+                      for (cmux_candidate in cmux_process) {
+                        if (cmux_candidate in cmux_depth || cmux_state[cmux_candidate] ~ /Z/) {
+                          continue
+                        }
+                        cmux_candidate_parent = cmux_parent[cmux_candidate]
+                        if (cmux_candidate_parent in cmux_depth) {
+                          cmux_depth[cmux_candidate] = cmux_depth[cmux_candidate_parent] + 1
+                          cmux_discovered = 1
+                        }
+                      }
+                    }
+                    for (cmux_candidate in cmux_depth) {
+                      print cmux_depth[cmux_candidate], cmux_candidate, cmux_state[cmux_candidate]
+                    }
+                  }
+                ' | /usr/bin/sort -n -k1,1 -k2,2n)
+              if [ -z "$cmux_ssh_auth_tree_members" ]; then exit 0; fi
+
+              cmux_ssh_auth_tree_all_stopped=1
+              set -- $cmux_ssh_auth_tree_members
+              while [ "$#" -ge 3 ]; do
+                cmux_ssh_auth_tree_member_pid="$2"
+                cmux_ssh_auth_tree_member_state="$3"
+                shift 3
+                case "$cmux_ssh_auth_tree_member_state" in *T*) ;; *) cmux_ssh_auth_tree_all_stopped= ;; esac
+                kill -STOP "$cmux_ssh_auth_tree_member_pid" >/dev/null 2>&1 || true
+              done
+              if [ -n "$cmux_ssh_auth_tree_all_stopped" ]; then break; fi
+              cmux_ssh_auth_tree_freeze_attempt=$((cmux_ssh_auth_tree_freeze_attempt + 1))
+            done
+
+            cmux_ssh_auth_tree_members=$(printf '%s\n' "$cmux_ssh_auth_tree_members" | /usr/bin/sort -nr -k1,1 -k2,2nr)
+            set -- $cmux_ssh_auth_tree_members
+            while [ "$#" -ge 3 ]; do
+              cmux_ssh_auth_tree_member_pid="$2"
+              shift 3
+              kill -KILL "$cmux_ssh_auth_tree_member_pid" >/dev/null 2>&1 || true
+              kill -CONT "$cmux_ssh_auth_tree_member_pid" >/dev/null 2>&1 || true
+            done
+          )
+
           cmux_ssh_terminate_auth_process() (
             cmux_ssh_auth_tree_pid="$1"
             cmux_ssh_auth_tree_parent_pid="$2"
@@ -115,8 +184,7 @@ public struct SSHForegroundAuthenticationRetryPolicy: Sendable {
               exit 0
             fi
             if ! cmux_ssh_auth_cleanup_has_time; then
-              /bin/kill -KILL "$cmux_ssh_auth_tree_pid" >/dev/null 2>&1 || true
-              exit 0
+              exit "$cmux_ssh_auth_cleanup_expired_status"
             fi
             if ! /bin/kill -STOP "$cmux_ssh_auth_tree_pid" >/dev/null 2>&1; then exit 0; fi
             if ! cmux_ssh_auth_process_is_original "$cmux_ssh_auth_tree_pid" "$cmux_ssh_auth_tree_parent_pid"; then
@@ -145,12 +213,15 @@ public struct SSHForegroundAuthenticationRetryPolicy: Sendable {
               exit 0
             fi
             for cmux_ssh_auth_tree_child in $(/usr/bin/pgrep -P "$cmux_ssh_auth_tree_pid" . 2>/dev/null || true); do
-              cmux_ssh_terminate_auth_process "$cmux_ssh_auth_tree_child" "$cmux_ssh_auth_tree_pid"
+              cmux_ssh_terminate_auth_process "$cmux_ssh_auth_tree_child" "$cmux_ssh_auth_tree_pid" || {
+                cmux_ssh_auth_tree_child_status=$?
+                if [ "$cmux_ssh_auth_tree_child_status" -eq "$cmux_ssh_auth_cleanup_expired_status" ]; then
+                  exit "$cmux_ssh_auth_cleanup_expired_status"
+                fi
+              }
             done
             if ! cmux_ssh_auth_cleanup_has_time; then
-              /bin/kill -KILL "$cmux_ssh_auth_tree_pid" >/dev/null 2>&1 || true
-              /bin/kill -CONT "$cmux_ssh_auth_tree_pid" >/dev/null 2>&1 || true
-              exit 0
+              exit "$cmux_ssh_auth_cleanup_expired_status"
             fi
 
             /bin/kill -TERM "$cmux_ssh_auth_tree_pid" >/dev/null 2>&1 || true
@@ -163,8 +234,7 @@ public struct SSHForegroundAuthenticationRetryPolicy: Sendable {
               exit 0
             fi
             if ! cmux_ssh_auth_cleanup_has_time; then
-              /bin/kill -KILL "$cmux_ssh_auth_tree_pid" >/dev/null 2>&1 || true
-              exit 0
+              exit "$cmux_ssh_auth_cleanup_expired_status"
             fi
 
             if ! /bin/kill -STOP "$cmux_ssh_auth_tree_pid" >/dev/null 2>&1; then
@@ -175,7 +245,12 @@ public struct SSHForegroundAuthenticationRetryPolicy: Sendable {
               exit 0
             fi
             for cmux_ssh_auth_tree_child in $(/usr/bin/pgrep -P "$cmux_ssh_auth_tree_pid" . 2>/dev/null || true); do
-              cmux_ssh_terminate_auth_process "$cmux_ssh_auth_tree_child" "$cmux_ssh_auth_tree_pid"
+              cmux_ssh_terminate_auth_process "$cmux_ssh_auth_tree_child" "$cmux_ssh_auth_tree_pid" || {
+                cmux_ssh_auth_tree_child_status=$?
+                if [ "$cmux_ssh_auth_tree_child_status" -eq "$cmux_ssh_auth_cleanup_expired_status" ]; then
+                  exit "$cmux_ssh_auth_cleanup_expired_status"
+                fi
+              }
             done
             if cmux_ssh_auth_process_is_original "$cmux_ssh_auth_tree_pid" "$cmux_ssh_auth_tree_parent_pid"; then
               /bin/kill -KILL "$cmux_ssh_auth_tree_pid" >/dev/null 2>&1 || true
@@ -193,7 +268,14 @@ public struct SSHForegroundAuthenticationRetryPolicy: Sendable {
           cmux_ssh_auth_cleanup_started_at=$(/bin/date +%s 2>/dev/null) || exit 0
           case "$cmux_ssh_auth_cleanup_started_at" in ''|*[!0-9]*) exit 0 ;; esac
           cmux_ssh_auth_cleanup_deadline=$((cmux_ssh_auth_cleanup_started_at + 2))
-          cmux_ssh_terminate_auth_process "$cmux_ssh_auth_tree_root_pid" "$cmux_ssh_auth_tree_root_parent"
+          # Unwind stopped ancestors before one root-level force scan of the remaining subtree.
+          cmux_ssh_auth_cleanup_expired_status=90
+          cmux_ssh_auth_tree_status=0
+          cmux_ssh_terminate_auth_process "$cmux_ssh_auth_tree_root_pid" "$cmux_ssh_auth_tree_root_parent" || \
+            cmux_ssh_auth_tree_status=$?
+          if [ "$cmux_ssh_auth_tree_status" -eq "$cmux_ssh_auth_cleanup_expired_status" ]; then
+            cmux_ssh_force_terminate_auth_process "$cmux_ssh_auth_tree_root_pid" "$cmux_ssh_auth_tree_root_parent"
+          fi
         )
         """
     }

--- a/Packages/macOS/CmuxFoundation/Sources/CmuxFoundation/SSHForegroundAuthenticationRetryPolicy.swift
+++ b/Packages/macOS/CmuxFoundation/Sources/CmuxFoundation/SSHForegroundAuthenticationRetryPolicy.swift
@@ -104,10 +104,43 @@ public struct SSHForegroundAuthenticationRetryPolicy: Sendable {
             cmux_ssh_auth_process_pid="$1"
             cmux_ssh_auth_process_parent_pid="$2"
             cmux_ssh_auth_process_snapshot=$(/bin/ps -o ppid= -o state= -p "$cmux_ssh_auth_process_pid" 2>/dev/null) || exit 1
-            set -- $cmux_ssh_auth_process_snapshot
-            if [ "$#" -lt 2 ] || [ "$1" != "$cmux_ssh_auth_process_parent_pid" ]; then exit 1; fi
-            case "$2" in *Z*) exit 1 ;; esac
+            if ! printf '%s\n' "$cmux_ssh_auth_process_snapshot" | (
+              IFS=' ' read -r cmux_ssh_auth_process_observed_parent cmux_ssh_auth_process_state
+              if [ "$cmux_ssh_auth_process_observed_parent" != "$cmux_ssh_auth_process_parent_pid" ]; then exit 1; fi
+              case "$cmux_ssh_auth_process_state" in ''|*Z*) exit 1 ;; esac
+            ); then
+              exit 1
+            fi
             /bin/kill -0 "$cmux_ssh_auth_process_pid" >/dev/null 2>&1
+          )
+
+          cmux_ssh_stop_auth_tree_members() (
+            printf '%s\n' "$1" | (
+              cmux_ssh_auth_tree_all_stopped=1
+              while IFS=' ' read -r cmux_ssh_auth_tree_member_depth cmux_ssh_auth_tree_member_pid cmux_ssh_auth_tree_member_state; do
+                if [ -z "$cmux_ssh_auth_tree_member_pid" ]; then continue; fi
+                case "$cmux_ssh_auth_tree_member_state" in *T*) ;; *) cmux_ssh_auth_tree_all_stopped= ;; esac
+                kill -STOP "$cmux_ssh_auth_tree_member_pid" >/dev/null 2>&1 || true
+              done
+              [ -n "$cmux_ssh_auth_tree_all_stopped" ]
+            )
+          )
+
+          cmux_ssh_resume_auth_tree_members() (
+            printf '%s\n' "$1" | while IFS=' ' read -r cmux_ssh_auth_tree_member_depth cmux_ssh_auth_tree_member_pid cmux_ssh_auth_tree_member_state; do
+              if [ -n "$cmux_ssh_auth_tree_member_pid" ]; then
+                kill -CONT "$cmux_ssh_auth_tree_member_pid" >/dev/null 2>&1 || true
+              fi
+            done
+          )
+
+          cmux_ssh_kill_auth_tree_members() (
+            printf '%s\n' "$1" | while IFS=' ' read -r cmux_ssh_auth_tree_member_depth cmux_ssh_auth_tree_member_pid cmux_ssh_auth_tree_member_state; do
+              if [ -n "$cmux_ssh_auth_tree_member_pid" ]; then
+                kill -KILL "$cmux_ssh_auth_tree_member_pid" >/dev/null 2>&1 || true
+                kill -CONT "$cmux_ssh_auth_tree_member_pid" >/dev/null 2>&1 || true
+              fi
+            done
           )
 
           cmux_ssh_force_terminate_auth_process() (
@@ -115,10 +148,14 @@ public struct SSHForegroundAuthenticationRetryPolicy: Sendable {
             cmux_ssh_auth_tree_parent_pid="$2"
             cmux_ssh_auth_tree_freeze_attempt=0
             cmux_ssh_auth_tree_members=
+            cmux_ssh_auth_tree_frozen_members=
             while [ "$cmux_ssh_auth_tree_freeze_attempt" -lt 8 ]; do
               # Freeze parent-first, then resnapshot to catch children spawned before STOP landed.
-              cmux_ssh_auth_tree_snapshot=$(/bin/ps -axo pid=,ppid=,state= 2>/dev/null) || exit 0
-              cmux_ssh_auth_tree_members=$(printf '%s\n' "$cmux_ssh_auth_tree_snapshot" | /usr/bin/awk \
+              cmux_ssh_auth_tree_snapshot=$(/bin/ps -axo pid=,ppid=,state= 2>/dev/null) || {
+                cmux_ssh_resume_auth_tree_members "$cmux_ssh_auth_tree_frozen_members"
+                exit 0
+              }
+              cmux_ssh_auth_tree_next_members=$(printf '%s\n' "$cmux_ssh_auth_tree_snapshot" | /usr/bin/awk \
                 -v cmux_root="$cmux_ssh_auth_tree_pid" \
                 -v cmux_root_parent="$cmux_ssh_auth_tree_parent_pid" '
                   {
@@ -152,29 +189,25 @@ public struct SSHForegroundAuthenticationRetryPolicy: Sendable {
                     }
                   }
                 ' | /usr/bin/sort -n -k1,1 -k2,2n)
-              if [ -z "$cmux_ssh_auth_tree_members" ]; then exit 0; fi
-
-              cmux_ssh_auth_tree_all_stopped=1
-              set -- $cmux_ssh_auth_tree_members
-              while [ "$#" -ge 3 ]; do
-                cmux_ssh_auth_tree_member_pid="$2"
-                cmux_ssh_auth_tree_member_state="$3"
-                shift 3
-                case "$cmux_ssh_auth_tree_member_state" in *T*) ;; *) cmux_ssh_auth_tree_all_stopped= ;; esac
-                kill -STOP "$cmux_ssh_auth_tree_member_pid" >/dev/null 2>&1 || true
-              done
-              if [ -n "$cmux_ssh_auth_tree_all_stopped" ]; then break; fi
+              if [ -z "$cmux_ssh_auth_tree_next_members" ]; then
+                cmux_ssh_resume_auth_tree_members "$cmux_ssh_auth_tree_frozen_members"
+                exit 0
+              fi
+              cmux_ssh_auth_tree_members="$cmux_ssh_auth_tree_next_members"
+              cmux_ssh_auth_tree_frozen_members="$cmux_ssh_auth_tree_members"
+              if cmux_ssh_stop_auth_tree_members "$cmux_ssh_auth_tree_members"; then break; fi
               cmux_ssh_auth_tree_freeze_attempt=$((cmux_ssh_auth_tree_freeze_attempt + 1))
             done
 
-            cmux_ssh_auth_tree_members=$(printf '%s\n' "$cmux_ssh_auth_tree_members" | /usr/bin/sort -nr -k1,1 -k2,2nr)
-            set -- $cmux_ssh_auth_tree_members
-            while [ "$#" -ge 3 ]; do
-              cmux_ssh_auth_tree_member_pid="$2"
-              shift 3
-              kill -KILL "$cmux_ssh_auth_tree_member_pid" >/dev/null 2>&1 || true
-              kill -CONT "$cmux_ssh_auth_tree_member_pid" >/dev/null 2>&1 || true
-            done
+            cmux_ssh_auth_tree_kill_order=$(printf '%s\n' "$cmux_ssh_auth_tree_members" | /usr/bin/sort -nr -k1,1 -k2,2nr) || {
+              cmux_ssh_resume_auth_tree_members "$cmux_ssh_auth_tree_frozen_members"
+              exit 0
+            }
+            if [ -z "$cmux_ssh_auth_tree_kill_order" ]; then
+              cmux_ssh_resume_auth_tree_members "$cmux_ssh_auth_tree_frozen_members"
+              exit 0
+            fi
+            cmux_ssh_kill_auth_tree_members "$cmux_ssh_auth_tree_kill_order"
           )
 
           cmux_ssh_terminate_auth_process() (
@@ -216,11 +249,13 @@ public struct SSHForegroundAuthenticationRetryPolicy: Sendable {
               cmux_ssh_terminate_auth_process "$cmux_ssh_auth_tree_child" "$cmux_ssh_auth_tree_pid" || {
                 cmux_ssh_auth_tree_child_status=$?
                 if [ "$cmux_ssh_auth_tree_child_status" -eq "$cmux_ssh_auth_cleanup_expired_status" ]; then
+                  /bin/kill -CONT "$cmux_ssh_auth_tree_pid" >/dev/null 2>&1 || true
                   exit "$cmux_ssh_auth_cleanup_expired_status"
                 fi
               }
             done
             if ! cmux_ssh_auth_cleanup_has_time; then
+              /bin/kill -CONT "$cmux_ssh_auth_tree_pid" >/dev/null 2>&1 || true
               exit "$cmux_ssh_auth_cleanup_expired_status"
             fi
 
@@ -248,6 +283,7 @@ public struct SSHForegroundAuthenticationRetryPolicy: Sendable {
               cmux_ssh_terminate_auth_process "$cmux_ssh_auth_tree_child" "$cmux_ssh_auth_tree_pid" || {
                 cmux_ssh_auth_tree_child_status=$?
                 if [ "$cmux_ssh_auth_tree_child_status" -eq "$cmux_ssh_auth_cleanup_expired_status" ]; then
+                  /bin/kill -CONT "$cmux_ssh_auth_tree_pid" >/dev/null 2>&1 || true
                   exit "$cmux_ssh_auth_cleanup_expired_status"
                 fi
               }

--- a/Packages/macOS/CmuxFoundation/Tests/CmuxFoundationTests/SSHForegroundAuthenticationRetryPolicyTests.swift
+++ b/Packages/macOS/CmuxFoundation/Tests/CmuxFoundationTests/SSHForegroundAuthenticationRetryPolicyTests.swift
@@ -343,7 +343,8 @@ struct SSHForegroundAuthenticationRetryPolicyTests {
         #expect(process.terminationStatus == 0)
     }
 
-    @Test func processTreeTerminationUsesOneOverallDeadline() throws {
+    @Test(arguments: ["/bin/sh", "/bin/zsh"])
+    func processTreeTerminationUsesOneOverallDeadline(shellPath: String) throws {
         let fileManager = FileManager.default
         let root = fileManager.temporaryDirectory
             .appendingPathComponent("cmux-ssh-auth-deadline-\(UUID().uuidString)", isDirectory: true)
@@ -390,7 +391,7 @@ struct SSHForegroundAuthenticationRetryPolicyTests {
         """
 
         let process = Process()
-        process.executableURL = URL(fileURLWithPath: "/bin/sh")
+        process.executableURL = URL(fileURLWithPath: shellPath)
         process.arguments = ["-c", command]
         process.environment = ProcessInfo.processInfo.environment.merging([
             "CMUX_TEST_CHAIN_SCRIPT": chainScript.path,

--- a/Packages/macOS/CmuxFoundation/Tests/CmuxFoundationTests/SSHForegroundAuthenticationRetryPolicyTests.swift
+++ b/Packages/macOS/CmuxFoundation/Tests/CmuxFoundationTests/SSHForegroundAuthenticationRetryPolicyTests.swift
@@ -422,7 +422,11 @@ struct SSHForegroundAuthenticationRetryPolicyTests {
             elapsed < 3,
             "Foreground authentication cleanup took \(elapsed) seconds instead of one bounded deadline"
         )
-        #expect(!processIDs.contains(where: { Darwin.kill($0, 0) == 0 }))
+        let survivingProcessIDs = processIDs.filter { Darwin.kill($0, 0) == 0 }
+        #expect(
+            survivingProcessIDs.isEmpty,
+            "Foreground authentication cleanup left descendants alive: \(survivingProcessIDs)"
+        )
     }
 
     @Test func terminatesReplacementSpawnedByAuthenticationTermHandler() throws {


### PR DESCRIPTION
## Summary

- unwind deadline expiry to the authentication root
- freeze and identity-check the remaining subtree from one process snapshot loop
- kill the verified descendants bottom-up without additional grace waits

## Why

The shared grace deadline previously killed only the current PID. Descendants that recursion had not reached remained alive, and repeated per-node rescans would exceed the cleanup time bound.

## Tests

- `swift test --package-path Packages/macOS/CmuxFoundation --filter processTreeTerminationUsesOneOverallDeadline` (three consecutive focused passes)
- `swift test --package-path Packages/macOS/CmuxFoundation --filter SSHForegroundAuthenticationRetryPolicyTests` (23 tests)
- `swift test --package-path Packages/macOS/CmuxFoundation` (171 tests)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/9710"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788610491&installation_model_id=21920&pr_number=9710&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F9710&signature=2b6a185ddbb14afa263d9e601fa5f9c42ae20c10ee0dd92b6a62d444f4543e2f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops leaving SSH authentication descendants alive after the 2s cleanup deadline and makes the termination logic cross‑shell safe. On expiry, we freeze the remaining subtree and kill verified descendants bottom‑up in one pass to keep cleanup bounded.

- **Bug Fixes**
  - Share one cleanup deadline across recursion and unwind to the auth root before the final pass.
  - On deadline expiry, snapshot the tree, STOP it, then KILL descendants bottom‑up without extra waits.
  - Make process identity checks and parsing shell‑agnostic; works under `/bin/sh` and `/bin/zsh`.
  - Extend tests to run under both shells and report any surviving PIDs while enforcing the 2s bound.

<sup>Written for commit a970e8a4d54caa7228a39f4cb3d5aaf15be4ee6c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/9710?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cleanup of foreground SSH processes and their descendants.
  * Ensured cleanup respects a shared deadline and force-terminates remaining processes when needed.
  * Improved termination of deeply nested process trees.
  * Preserved handling for isolated process groups.
  * Improved recovery when stopped processes are encountered during cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->