### PR TITLE
Sync restore help contract probe

### DIFF
--- a/docs/cli-contract.md
+++ b/docs/cli-contract.md
@@ -560,7 +560,7 @@ the expected text without connecting to a cmux socket.
 - `cmux enable-browser --help` -> `Usage: cmux enable-browser [--json]`
 - `cmux browser-status --help` -> `Usage: cmux browser-status [--json]`
 - `cmux agent-hibernation --help` -> `Usage: cmux agent-hibernation <on|off> [--json]`
-- `cmux restore --help` -> `Usage: cmux restore <kind> <checkpoint-id>`
+- `cmux restore --help` -> `Usage: cmux restore [--surface <id|ref>] <kind> <checkpoint-id>`
 - `cmux restore-session --help` -> `Usage: cmux restore-session`
 - `cmux open --help` -> `Usage: cmux open <path-or-url>...`
 - `cmux feedback --help` -> `Usage: cmux feedback`


### PR DESCRIPTION
## Summary
- update the executable CLI help probe to match the existing surface-aware restore usage
- unblock app-host validation on current main and stacked terminal work

## Testing
- CMUX_CLI_BIN=<current tagged CLI> python3 tests/test_cli_contract_help.py, 150 probes and 1 negative probe passed
- git diff --check
- localization audit: no new CLI text or locale keys; the contributor contract now mirrors the existing localized help output

## Issues
- Related: https://github.com/manaflow-ai/cmux/pull/9387

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/9714"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788619238&installation_model_id=21920&pr_number=9714&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F9714&signature=5e51c7838a280e0c4ecfbad3238e34bae11cc8ac62b409d9d3a7c746ac51a2ec"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated the CLI help contract to match the current restore usage: `cmux restore [--surface <id|ref>] <kind> <checkpoint-id>`. Aligns docs with localized help output and unblocks app-host validation and terminal work.

<sup>Written for commit baf76259e51c1d7b9a1e1600e1a42cfb14023a16. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/9714?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the `cmux restore --help` documentation to include the optional `--surface <id|ref>` argument.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->