### PR TITLE
Fix Swift Testing zero-test guard false positives

### DIFF
--- a/scripts/ci/require_selected_test_execution.sh
+++ b/scripts/ci/require_selected_test_execution.sh
@@ -20,8 +20,8 @@ fi
 
 summary_kind="$(
   awk '
-    /Executed [0-9]+ tests?,/ || /Test run with [0-9]+ tests? (passed|failed)/ {
-      if ($0 ~ /Executed 0 tests?,/ || $0 ~ /Test run with 0 tests? (passed|failed)/) {
+    /Executed [0-9]+ tests?,/ || /Test run with [0-9]+ tests? (passed|failed)/ || /Test run with [0-9]+ tests? in [0-9]+ suites? (passed|failed)/ {
+      if ($0 ~ /Executed 0 tests?,/ || $0 ~ /Test run with 0 tests? (passed|failed)/ || $0 ~ /Test run with 0 tests? in [0-9]+ suites? (passed|failed)/) {
         zero = 1
       } else {
         positive = 1

--- a/tests/test_ios_selected_test_execution.py
+++ b/tests/test_ios_selected_test_execution.py
@@ -39,6 +39,25 @@ class SelectedIOSTestExecutionGuardTests(unittest.TestCase):
         )
         self.assertEqual(result.returncode, 0, result.stderr)
 
+    def test_accepts_swift_testing_suite_summary(self) -> None:
+        result = self.run_guard(
+            "Test run with 11 tests in 1 suite passed after 12.819 seconds.",
+            "cmuxFeatureTests/MobileIrohRuntimeCompositionCooldownTests",
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+
+    def test_rejects_swift_testing_zero_suite_summary(self) -> None:
+        result = self.run_guard(
+            "Test run with 0 tests in 1 suite passed after 0.012 seconds.",
+            "cmuxFeatureTests/MissingSuite",
+        )
+        self.assertNotEqual(result.returncode, 0)
+        self.assertEqual(
+            result.stderr,
+            "selected iOS test filter matched zero tests; "
+            "use target/class or target/class/method syntax\n",
+        )
+
     def test_rejects_zero_tests_for_requested_filter(self) -> None:
         test_filter = "cmuxUITests/testMissingMethod\n::error::injected"
         result = self.run_guard(


### PR DESCRIPTION
## Summary

- Update the selected iOS test execution guard to recognize Swift Testing summaries that include suite counts.
- Prevent successful Swift Testing package filters from being reported as zero-test failures.
- Fixes #9671.

## Testing

- `python3 tests/test_ios_selected_test_execution.py` — 9 tests passed.
- `bash -n scripts/ci/require_selected_test_execution.sh` — passed.
- Verified positive and zero XCTest summaries, positive and zero Swift Testing suite summaries, missing summaries, and mixed nested summaries.
- Full iOS workflow was not run locally.

## Demo Video

- Not needed — this is a CI parser and regression-test change.

## Review Trigger (Copy/Paste as PR comment)

```text
@codex review
@coderabbitai review
@greptile-apps review
@cubic-dev-ai review
```

## Checklist

- [x] I tested the change locally
- [x] I added or updated tests for behavior changes
- [x] I updated docs/changelog if needed
- [ ] I requested bot reviews after my latest commit
- [ ] All code review bot comments are resolved
- [ ] All human review comments are resolved

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/9715"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788627701&installation_model_id=21920&pr_number=9715&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F9715&signature=2a34eedb4cd00432ff378d4837d64526eb02dcde41b23ecfe416c5f884fad4f0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix false positives in the iOS selected test execution guard when parsing Swift Testing output with suite summaries. Valid filters no longer fail as zero-test runs.

- **Bug Fixes**
  - Recognize Swift Testing summaries with suite counts and correctly classify zero vs nonzero runs.
  - Add tests covering positive and zero suite summaries.

<sup>Written for commit bc71ef2a0b8868002726c99f8e297cb2d002c9a2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/9715?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved selected-test validation to recognize suite-level test run summaries, including runs with multiple suites.
  * Preserved existing handling for executions and errors.
  * Correctly rejects summaries reporting zero executed tests.

* **Tests**
  * Added coverage for Swift Testing suite-level execution summaries, including valid and zero-test scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->