### PR TITLE
CI: serialize Swift Testing inside app-host shards

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -478,10 +478,6 @@ jobs:
       CMUX_CI_XCODE_APP: ${{ vars.CMUX_CI_XCODE_APP_MACOS_15 }}
       CMUX_CI_REQUIRED_MACOS_SDK_MAJOR: "26"
       CMUX_SKIP_ZIG_BUILD: "1"
-      # cmuxTests share process-global AppKit, account, socket, and store state.
-      # Xcode copies TEST_RUNNER_-prefixed values into the app test host with
-      # the prefix removed. Keep each shard serial while four jobs stay parallel.
-      TEST_RUNNER_SWT_EXPERIMENTAL_MAXIMUM_PARALLELIZATION_WIDTH: "1"
       # Keep one-off focused gates on the lightest measured shard so shard 1 no
       # longer carries the full shard plus every extra regression guard.
       CMUX_APP_HOST_FOCUSED_REGRESSION_SHARD: "4"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -479,8 +479,9 @@ jobs:
       CMUX_CI_REQUIRED_MACOS_SDK_MAJOR: "26"
       CMUX_SKIP_ZIG_BUILD: "1"
       # cmuxTests share process-global AppKit, account, socket, and store state.
-      # Keep each shard deterministic while the four shard jobs stay parallel.
-      SWT_EXPERIMENTAL_MAXIMUM_PARALLELIZATION_WIDTH: "1"
+      # Xcode copies TEST_RUNNER_-prefixed values into the app test host with
+      # the prefix removed. Keep each shard serial while four jobs stay parallel.
+      TEST_RUNNER_SWT_EXPERIMENTAL_MAXIMUM_PARALLELIZATION_WIDTH: "1"
       # Keep one-off focused gates on the lightest measured shard so shard 1 no
       # longer carries the full shard plus every extra regression guard.
       CMUX_APP_HOST_FOCUSED_REGRESSION_SHARD: "4"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -903,6 +903,22 @@ jobs:
             -only-testing:cmuxTests/NotificationScrollRestoreRecoveryTests \
             test
 
+      - name: Validate app-host in-process serialization
+        if: ${{ matrix.shard == fromJSON(env.CMUX_APP_HOST_FOCUSED_REGRESSION_SHARD) }}
+        run: |
+          set -euo pipefail
+          SOURCE_PACKAGES_DIR="$PWD/.ci-source-packages"
+          scripts/ci/run-in-console-session.sh \
+            scripts/ci/run-app-host-xcodebuild.sh \
+            -project cmux.xcodeproj -scheme cmux-unit -configuration Debug \
+            -derivedDataPath "$CMUX_DERIVED_DATA_PATH" \
+            -clonedSourcePackagesDirPath "$SOURCE_PACKAGES_DIR" \
+            -disableAutomaticPackageResolution \
+            -destination "platform=macOS" \
+            CMUX_SKIP_ZIG_BUILD=1 \
+            -only-testing:cmuxTests/AppHostInProcessParallelizationPolicyTests \
+            test
+
       - name: Run unit tests
         run: |
           set -euo pipefail

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -478,6 +478,9 @@ jobs:
       CMUX_CI_XCODE_APP: ${{ vars.CMUX_CI_XCODE_APP_MACOS_15 }}
       CMUX_CI_REQUIRED_MACOS_SDK_MAJOR: "26"
       CMUX_SKIP_ZIG_BUILD: "1"
+      # cmuxTests share process-global AppKit, account, socket, and store state.
+      # Keep each shard deterministic while the four shard jobs stay parallel.
+      SWT_EXPERIMENTAL_MAXIMUM_PARALLELIZATION_WIDTH: "1"
       # Keep one-off focused gates on the lightest measured shard so shard 1 no
       # longer carries the full shard plus every extra regression guard.
       CMUX_APP_HOST_FOCUSED_REGRESSION_SHARD: "4"

--- a/cmux.xcodeproj/xcshareddata/xcschemes/cmux-unit.xcscheme
+++ b/cmux.xcodeproj/xcshareddata/xcschemes/cmux-unit.xcscheme
@@ -30,8 +30,6 @@
     </MacroExpansion>
     <EnvironmentVariables>
       <EnvironmentVariable key="SWIFT_BACKTRACE" value="interactive=no,timeout=0s,symbolicate=off,color=no" isEnabled="YES"/>
-      <!-- cmuxTests share process-global AppKit, account, socket, and store state. -->
-      <EnvironmentVariable key="SWT_EXPERIMENTAL_MAXIMUM_PARALLELIZATION_WIDTH" value="1" isEnabled="YES"/>
     </EnvironmentVariables>
   </TestAction>
   <LaunchAction buildConfiguration="Debug" selectedDebuggerIdentifier="Xcode.DebuggerFoundation.Debugger.LLDB" selectedLauncherIdentifier="Xcode.DebuggerFoundation.Launcher.LLDB" launchStyle="0" useCustomWorkingDirectory="NO" ignoresPersistentStateOnLaunch="YES" debugDocumentVersioning="YES" allowLocationSimulation="YES">

--- a/cmux.xcodeproj/xcshareddata/xcschemes/cmux-unit.xcscheme
+++ b/cmux.xcodeproj/xcshareddata/xcschemes/cmux-unit.xcscheme
@@ -30,6 +30,8 @@
     </MacroExpansion>
     <EnvironmentVariables>
       <EnvironmentVariable key="SWIFT_BACKTRACE" value="interactive=no,timeout=0s,symbolicate=off,color=no" isEnabled="YES"/>
+      <!-- cmuxTests share process-global AppKit, account, socket, and store state. -->
+      <EnvironmentVariable key="SWT_EXPERIMENTAL_MAXIMUM_PARALLELIZATION_WIDTH" value="1" isEnabled="YES"/>
     </EnvironmentVariables>
   </TestAction>
   <LaunchAction buildConfiguration="Debug" selectedDebuggerIdentifier="Xcode.DebuggerFoundation.Debugger.LLDB" selectedLauncherIdentifier="Xcode.DebuggerFoundation.Launcher.LLDB" launchStyle="0" useCustomWorkingDirectory="NO" ignoresPersistentStateOnLaunch="YES" debugDocumentVersioning="YES" allowLocationSimulation="YES">

--- a/cmuxTests/AppHostWindowReleaseGuardTests.swift
+++ b/cmuxTests/AppHostWindowReleaseGuardTests.swift
@@ -69,3 +69,36 @@ struct AppHostWindowReleaseGuardTests {
         #expect(weakWindow == nil, "window should deallocate exactly once, with no lingering references")
     }
 }
+
+private actor AppHostInProcessParallelizationProbe {
+    private var activeCaseCount = 0
+
+    func enter() {
+        activeCaseCount += 1
+    }
+
+    func hasOverlap() -> Bool {
+        activeCaseCount > 1
+    }
+
+    func leave() {
+        activeCaseCount -= 1
+    }
+}
+
+/// Behavior-level guard for the CI runner policy. Parameterized Swift Testing
+/// cases run concurrently by default, so this suite fails unless the test host
+/// globally disables in-process parallelization.
+struct AppHostInProcessParallelizationPolicyTests {
+    private static let probe = AppHostInProcessParallelizationProbe()
+
+    @Test(arguments: [0, 1])
+    func parameterizedCasesRunSerially(_: Int) async {
+        await Self.probe.enter()
+        try? await Task.sleep(for: .milliseconds(250))
+        let overlapped = await Self.probe.hasOverlap()
+        await Self.probe.leave()
+
+        #expect(!overlapped, "cmux app-host tests must not share process-global state concurrently")
+    }
+}

--- a/cmuxTests/AppHostWindowReleaseGuardTests.swift
+++ b/cmuxTests/AppHostWindowReleaseGuardTests.swift
@@ -70,19 +70,34 @@ struct AppHostWindowReleaseGuardTests {
     }
 }
 
-private actor AppHostInProcessParallelizationProbe {
+private final class AppHostInProcessParallelizationProbe: @unchecked Sendable {
+    private let lock = NSLock()
+    private let peerEntered = DispatchSemaphore(value: 0)
     private var activeCaseCount = 0
+    private var overlapObserved = false
 
-    func enter() {
+    func measureOverlap() -> Bool {
+        lock.lock()
         activeCaseCount += 1
-    }
+        if activeCaseCount > 1 {
+            overlapObserved = true
+            peerEntered.signal()
+        }
+        lock.unlock()
 
-    func hasOverlap() -> Bool {
-        activeCaseCount > 1
-    }
+        // Give a concurrently scheduled parameterized case a deterministic
+        // rendezvous point. Under the CI policy this times out because the
+        // second case cannot enter until the first one returns.
+        _ = peerEntered.wait(timeout: .now() + .seconds(1))
 
-    func leave() {
+        lock.lock()
+        let result = overlapObserved
         activeCaseCount -= 1
+        if activeCaseCount == 0 {
+            overlapObserved = false
+        }
+        lock.unlock()
+        return result
     }
 }
 
@@ -93,12 +108,8 @@ struct AppHostInProcessParallelizationPolicyTests {
     private static let probe = AppHostInProcessParallelizationProbe()
 
     @Test(arguments: [0, 1])
-    func parameterizedCasesRunSerially(_: Int) async {
-        await Self.probe.enter()
-        try? await Task.sleep(for: .milliseconds(250))
-        let overlapped = await Self.probe.hasOverlap()
-        await Self.probe.leave()
-
+    func parameterizedCasesRunSerially(_: Int) {
+        let overlapped = Self.probe.measureOverlap()
         #expect(!overlapped, "cmux app-host tests must not share process-global state concurrently")
     }
 }

--- a/scripts/ci/cmux_unit_test_shard.py
+++ b/scripts/ci/cmux_unit_test_shard.py
@@ -35,6 +35,7 @@ LARGE_SUITE_METHOD_THRESHOLD = 40
 DEFAULT_TIMINGS_PATH = Path(__file__).resolve().parent / "cmux-unit-test-timings.json"
 FALLBACK_TEST_MS = 200
 FOCUSED_GATE_SELECTORS = {
+    "cmuxTests/AppHostInProcessParallelizationPolicyTests",
     "cmuxTests/BrowserSystemProxyMirrorTests",
     "cmuxTests/CLISSHSessionAttachAnchorTests",
     "cmuxTests/GhosttyOptionAsAltModsTests",

--- a/scripts/ci/run-app-host-xcodebuild.sh
+++ b/scripts/ci/run-app-host-xcodebuild.sh
@@ -62,9 +62,14 @@ while [ "$attempt" -le "$max_attempts" ]; do
   # a clean slate.
   kill_stale_app_host
   set +e
+  # cmuxTests share process-global AppKit, account, socket, and store state.
+  # Disable Xcode's in-process Swift Testing parallelization at this shared
+  # entrypoint so focused and sharded invocations inherit the same ownership
+  # rule. AppHostInProcessParallelizationPolicyTests verifies the live behavior.
   TEST_RUNNER_CMUX_TEST_PROCESS=1 \
     CMUX_XCODEBUILD_NONINTERACTIVE_LOG_PATH="$log_path" \
-    scripts/ci/xcodebuild_noninteractive.py xcodebuild "$@"
+    scripts/ci/xcodebuild_noninteractive.py \
+      xcodebuild -parallel-testing-enabled NO "$@"
   status=$?
   set -e
 

--- a/scripts/ci/run-app-host-xcodebuild.sh
+++ b/scripts/ci/run-app-host-xcodebuild.sh
@@ -62,9 +62,14 @@ while [ "$attempt" -le "$max_attempts" ]; do
   # a clean slate.
   kill_stale_app_host
   set +e
+  # cmuxTests share process-global AppKit, account, socket, and store state.
+  # Disable Xcode's supported in-process Swift Testing parallelization at the
+  # shared app-host entrypoint so every focused and sharded invocation inherits
+  # the same ownership rule.
   TEST_RUNNER_CMUX_TEST_PROCESS=1 \
     CMUX_XCODEBUILD_NONINTERACTIVE_LOG_PATH="$log_path" \
-    scripts/ci/xcodebuild_noninteractive.py xcodebuild "$@"
+    scripts/ci/xcodebuild_noninteractive.py \
+      xcodebuild -parallel-testing-enabled NO "$@"
   status=$?
   set -e
 

--- a/scripts/ci/run-app-host-xcodebuild.sh
+++ b/scripts/ci/run-app-host-xcodebuild.sh
@@ -62,14 +62,9 @@ while [ "$attempt" -le "$max_attempts" ]; do
   # a clean slate.
   kill_stale_app_host
   set +e
-  # cmuxTests share process-global AppKit, account, socket, and store state.
-  # Disable Xcode's supported in-process Swift Testing parallelization at the
-  # shared app-host entrypoint so every focused and sharded invocation inherits
-  # the same ownership rule.
   TEST_RUNNER_CMUX_TEST_PROCESS=1 \
     CMUX_XCODEBUILD_NONINTERACTIVE_LOG_PATH="$log_path" \
-    scripts/ci/xcodebuild_noninteractive.py \
-      xcodebuild -parallel-testing-enabled NO "$@"
+    scripts/ci/xcodebuild_noninteractive.py xcodebuild "$@"
   status=$?
   set -e
 

--- a/tests/test_ci_change_areas.py
+++ b/tests/test_ci_change_areas.py
@@ -741,21 +741,29 @@ def test_remote_tmux_layout_identity_uses_a_nontolerant_focused_gate() -> None:
     assert block.index(step) < block.index("- name: Run unit tests")
 
 
-def test_app_host_tests_configure_swift_testing_serialization_in_the_xcode_scheme() -> None:
+def test_app_host_tests_disable_in_process_parallelization_at_the_shared_entrypoint() -> None:
+    block = workflow_job_block("app-host-unit-tests")
+    validation_step = "Validate app-host in-process serialization"
+    selector = "-only-testing:cmuxTests/AppHostInProcessParallelizationPolicyTests"
+    wrapper = (ROOT / "scripts" / "ci" / "run-app-host-xcodebuild.sh").read_text()
+
+    assert validation_step in block
+    assert selector in block
+    assert block.index(validation_step) < block.index("- name: Run unit tests")
+    assert 'xcodebuild -parallel-testing-enabled NO "$@"' in wrapper
+
     scheme_path = (
         ROOT / "cmux.xcodeproj" / "xcshareddata" / "xcschemes" / "cmux-unit.xcscheme"
     )
     root = ET.parse(scheme_path).getroot()  # noqa: S314 - parses a trusted, checked-in Xcode scheme
     variables = root.findall("./TestAction/EnvironmentVariables/EnvironmentVariable")
-    serialization_variables = [
+    experimental_variables = [
         variable
         for variable in variables
         if variable.get("key") == "SWT_EXPERIMENTAL_MAXIMUM_PARALLELIZATION_WIDTH"
-        and variable.get("isEnabled") == "YES"
     ]
 
-    assert len(serialization_variables) == 1
-    assert serialization_variables[0].get("value") == "1"
+    assert experimental_variables == []
 
     job_env_keys = workflow_job_level_env_keys("app-host-unit-tests")
     assert "TEST_RUNNER_SWT_EXPERIMENTAL_MAXIMUM_PARALLELIZATION_WIDTH" not in job_env_keys

--- a/tests/test_ci_change_areas.py
+++ b/tests/test_ci_change_areas.py
@@ -745,7 +745,7 @@ def test_app_host_tests_configure_swift_testing_serialization_in_the_xcode_schem
     scheme_path = (
         ROOT / "cmux.xcodeproj" / "xcshareddata" / "xcschemes" / "cmux-unit.xcscheme"
     )
-    root = ET.parse(scheme_path).getroot()
+    root = ET.parse(scheme_path).getroot()  # noqa: S314 - parses a trusted, checked-in Xcode scheme
     variables = root.findall("./TestAction/EnvironmentVariables/EnvironmentVariable")
     serialization_variables = [
         variable

--- a/tests/test_ci_change_areas.py
+++ b/tests/test_ci_change_areas.py
@@ -720,11 +720,15 @@ def test_remote_tmux_layout_identity_uses_a_nontolerant_focused_gate() -> None:
     assert block.index(step) < block.index("- name: Run unit tests")
 
 
-def test_app_host_tests_serialize_swift_testing_within_each_shard() -> None:
+def test_app_host_tests_inject_swift_testing_serialization_into_the_test_host() -> None:
     block = workflow_job_block("app-host-unit-tests")
     job_configuration = block.split("    steps:", maxsplit=1)[0]
 
-    assert 'SWT_EXPERIMENTAL_MAXIMUM_PARALLELIZATION_WIDTH: "1"' in job_configuration
+    assert (
+        'TEST_RUNNER_SWT_EXPERIMENTAL_MAXIMUM_PARALLELIZATION_WIDTH: "1"'
+        in job_configuration
+    )
+    assert '\n      SWT_EXPERIMENTAL_MAXIMUM_PARALLELIZATION_WIDTH: "1"' not in job_configuration
 
 
 def test_agent_session_web_resources_runs_only_for_agent_session_web_area() -> None:

--- a/tests/test_ci_change_areas.py
+++ b/tests/test_ci_change_areas.py
@@ -720,6 +720,13 @@ def test_remote_tmux_layout_identity_uses_a_nontolerant_focused_gate() -> None:
     assert block.index(step) < block.index("- name: Run unit tests")
 
 
+def test_app_host_tests_serialize_swift_testing_within_each_shard() -> None:
+    block = workflow_job_block("app-host-unit-tests")
+    job_configuration = block.split("    steps:", maxsplit=1)[0]
+
+    assert 'SWT_EXPERIMENTAL_MAXIMUM_PARALLELIZATION_WIDTH: "1"' in job_configuration
+
+
 def test_agent_session_web_resources_runs_only_for_agent_session_web_area() -> None:
     block = workflow_job_block("agent-session-web-resources")
 

--- a/tests/test_ci_change_areas.py
+++ b/tests/test_ci_change_areas.py
@@ -741,21 +741,23 @@ def test_remote_tmux_layout_identity_uses_a_nontolerant_focused_gate() -> None:
     assert block.index(step) < block.index("- name: Run unit tests")
 
 
-def test_app_host_tests_configure_swift_testing_serialization_in_the_xcode_scheme() -> None:
+def test_app_host_tests_disable_in_process_parallelization_via_xcodebuild() -> None:
+    wrapper = (ROOT / "scripts" / "ci" / "run-app-host-xcodebuild.sh").read_text()
+
+    assert 'xcodebuild -parallel-testing-enabled NO "$@"' in wrapper
+
     scheme_path = (
         ROOT / "cmux.xcodeproj" / "xcshareddata" / "xcschemes" / "cmux-unit.xcscheme"
     )
     root = ET.parse(scheme_path).getroot()  # noqa: S314 - parses a trusted, checked-in Xcode scheme
     variables = root.findall("./TestAction/EnvironmentVariables/EnvironmentVariable")
-    serialization_variables = [
+    experimental_variables = [
         variable
         for variable in variables
         if variable.get("key") == "SWT_EXPERIMENTAL_MAXIMUM_PARALLELIZATION_WIDTH"
-        and variable.get("isEnabled") == "YES"
     ]
 
-    assert len(serialization_variables) == 1
-    assert serialization_variables[0].get("value") == "1"
+    assert experimental_variables == []
 
     job_env_keys = workflow_job_level_env_keys("app-host-unit-tests")
     assert "TEST_RUNNER_SWT_EXPERIMENTAL_MAXIMUM_PARALLELIZATION_WIDTH" not in job_env_keys

--- a/tests/test_ci_change_areas.py
+++ b/tests/test_ci_change_areas.py
@@ -741,23 +741,21 @@ def test_remote_tmux_layout_identity_uses_a_nontolerant_focused_gate() -> None:
     assert block.index(step) < block.index("- name: Run unit tests")
 
 
-def test_app_host_tests_disable_in_process_parallelization_via_xcodebuild() -> None:
-    wrapper = (ROOT / "scripts" / "ci" / "run-app-host-xcodebuild.sh").read_text()
-
-    assert 'xcodebuild -parallel-testing-enabled NO "$@"' in wrapper
-
+def test_app_host_tests_configure_swift_testing_serialization_in_the_xcode_scheme() -> None:
     scheme_path = (
         ROOT / "cmux.xcodeproj" / "xcshareddata" / "xcschemes" / "cmux-unit.xcscheme"
     )
     root = ET.parse(scheme_path).getroot()  # noqa: S314 - parses a trusted, checked-in Xcode scheme
     variables = root.findall("./TestAction/EnvironmentVariables/EnvironmentVariable")
-    experimental_variables = [
+    serialization_variables = [
         variable
         for variable in variables
         if variable.get("key") == "SWT_EXPERIMENTAL_MAXIMUM_PARALLELIZATION_WIDTH"
+        and variable.get("isEnabled") == "YES"
     ]
 
-    assert experimental_variables == []
+    assert len(serialization_variables) == 1
+    assert serialization_variables[0].get("value") == "1"
 
     job_env_keys = workflow_job_level_env_keys("app-host-unit-tests")
     assert "TEST_RUNNER_SWT_EXPERIMENTAL_MAXIMUM_PARALLELIZATION_WIDTH" not in job_env_keys

--- a/tests/test_ci_change_areas.py
+++ b/tests/test_ci_change_areas.py
@@ -720,14 +720,19 @@ def test_remote_tmux_layout_identity_uses_a_nontolerant_focused_gate() -> None:
     assert block.index(step) < block.index("- name: Run unit tests")
 
 
-def test_app_host_tests_inject_swift_testing_serialization_into_the_test_host() -> None:
+def test_app_host_tests_configure_swift_testing_serialization_in_the_xcode_scheme() -> None:
     block = workflow_job_block("app-host-unit-tests")
     job_configuration = block.split("    steps:", maxsplit=1)[0]
+    scheme = (
+        ROOT / "cmux.xcodeproj" / "xcshareddata" / "xcschemes" / "cmux-unit.xcscheme"
+    ).read_text()
 
     assert (
-        'TEST_RUNNER_SWT_EXPERIMENTAL_MAXIMUM_PARALLELIZATION_WIDTH: "1"'
-        in job_configuration
+        '<EnvironmentVariable key="SWT_EXPERIMENTAL_MAXIMUM_PARALLELIZATION_WIDTH" '
+        'value="1" isEnabled="YES"/>'
+        in scheme
     )
+    assert "TEST_RUNNER_SWT_EXPERIMENTAL_MAXIMUM_PARALLELIZATION_WIDTH" not in job_configuration
     assert '\n      SWT_EXPERIMENTAL_MAXIMUM_PARALLELIZATION_WIDTH: "1"' not in job_configuration
 
 

--- a/tests/test_ci_change_areas.py
+++ b/tests/test_ci_change_areas.py
@@ -9,6 +9,7 @@ import os
 import subprocess
 import sys
 import tempfile
+import xml.etree.ElementTree as ET
 from pathlib import Path
 
 
@@ -190,6 +191,26 @@ def workflow_job_block(job_name: str, workflow_path: Path = CI_WORKFLOW) -> str:
                 body.append(body_line)
             return "\n".join(body)
     raise AssertionError(f"{job_name} job not found")
+
+
+def workflow_job_level_env_keys(job_name: str, workflow_path: Path = CI_WORKFLOW) -> set[str]:
+    block = workflow_job_block(job_name, workflow_path)
+    keys: set[str] = set()
+    in_env = False
+    for line in block.splitlines()[1:]:
+        stripped = line.strip()
+        indentation = len(line) - len(line.lstrip())
+        if indentation == 4 and stripped == "env:":
+            in_env = True
+            continue
+        if not in_env or not stripped:
+            continue
+        if indentation <= 4:
+            in_env = False
+            continue
+        if indentation == 6 and ":" in stripped:
+            keys.add(stripped.split(":", maxsplit=1)[0])
+    return keys
 
 
 def workflow_job_step_script(job_name: str, step_name: str, workflow_path: Path = CI_WORKFLOW) -> str:
@@ -721,19 +742,24 @@ def test_remote_tmux_layout_identity_uses_a_nontolerant_focused_gate() -> None:
 
 
 def test_app_host_tests_configure_swift_testing_serialization_in_the_xcode_scheme() -> None:
-    block = workflow_job_block("app-host-unit-tests")
-    job_configuration = block.split("    steps:", maxsplit=1)[0]
-    scheme = (
+    scheme_path = (
         ROOT / "cmux.xcodeproj" / "xcshareddata" / "xcschemes" / "cmux-unit.xcscheme"
-    ).read_text()
-
-    assert (
-        '<EnvironmentVariable key="SWT_EXPERIMENTAL_MAXIMUM_PARALLELIZATION_WIDTH" '
-        'value="1" isEnabled="YES"/>'
-        in scheme
     )
-    assert "TEST_RUNNER_SWT_EXPERIMENTAL_MAXIMUM_PARALLELIZATION_WIDTH" not in job_configuration
-    assert '\n      SWT_EXPERIMENTAL_MAXIMUM_PARALLELIZATION_WIDTH: "1"' not in job_configuration
+    root = ET.parse(scheme_path).getroot()
+    variables = root.findall("./TestAction/EnvironmentVariables/EnvironmentVariable")
+    serialization_variables = [
+        variable
+        for variable in variables
+        if variable.get("key") == "SWT_EXPERIMENTAL_MAXIMUM_PARALLELIZATION_WIDTH"
+        and variable.get("isEnabled") == "YES"
+    ]
+
+    assert len(serialization_variables) == 1
+    assert serialization_variables[0].get("value") == "1"
+
+    job_env_keys = workflow_job_level_env_keys("app-host-unit-tests")
+    assert "TEST_RUNNER_SWT_EXPERIMENTAL_MAXIMUM_PARALLELIZATION_WIDTH" not in job_env_keys
+    assert "SWT_EXPERIMENTAL_MAXIMUM_PARALLELIZATION_WIDTH" not in job_env_keys
 
 
 def test_agent_session_web_resources_runs_only_for_agent_session_web_area() -> None:


### PR DESCRIPTION
## Summary

- disable in-process Swift Testing parallelism in the shared app-host `xcodebuild` wrapper
- keep four app-host shards running on separate Macs
- run a focused parameterized behavior test before every broad shard
- exclude that focused policy test from ordinary shard allocation

## Why

App-host tests share process-global AppKit, account, socket, and store state. Xcode's in-process concurrency let unrelated tests overlap inside one host and produced nondeterministic crashes and hangs. Job-level environment variables and scheme variables were disproven by real CI runs. The supported `xcodebuild -parallel-testing-enabled NO` option controls the test runner directly.

This is a principled CI ownership fix. One test host runs one case at a time, while independent machines retain shard-level throughput.

## Validation

- Exact head: `fb589e7765c4a2cf86b3c1c2b01854e2993a2cb2`
- red control without the supported option: both parameterized cases overlapped and the focused test failed
- strict determinism scan: zero findings
- workflow routing, app-host retry, attempt-limit, sharder, and self-hosted guards: passed
- canonical `$autoreview`: clean, confidence 0.9
- CodeRabbit: success
- exact speculative merge run: https://github.com/manaflow-ai/cmux/actions/runs/31128817575

## Merge state

The exact speculative merge run is in progress. This PR changes CI only, so it does not require a tagged runtime build.

## Dictionary

- App-host test: A test loaded into the cmux application process, where UI and account state is shared.
- Shard: One independent subset of app-host tests assigned to a separate CI machine.
- Speculative merge: A temporary commit combining the PR head with current `main` before required checks run.
