### PR TITLE
Warm up the billing success page

### DIFF
--- a/web/app/billing/success/page.tsx
+++ b/web/app/billing/success/page.tsx
@@ -18,7 +18,10 @@ import {
   latestStripeSubscriptionForSession,
 } from "../../../services/billing/purchase";
 import { captureBillingError } from "../../../services/errors";
-import { isStripeBillingConfigured, stripe } from "../../../services/billing/stripe";
+import {
+  isStripeBillingConfigured,
+  stripe,
+} from "../../../services/billing/stripe";
 
 type BillingSuccessMessages = {
   metaTitle: string;
@@ -33,10 +36,7 @@ type BillingSuccessMessages = {
 };
 
 type BillingSuccessFeatureKey =
-  | "cloudAgents"
-  | "modelGateway"
-  | "aiAccounts"
-  | "iosApp";
+  "cloudAgents" | "modelGateway" | "aiAccounts" | "iosApp";
 
 type BillingSuccessFeatureMessage = {
   title: string;
@@ -86,7 +86,9 @@ export default async function BillingSuccessPage({
     trustedNativeCallbackScheme(session.metadata?.nativeCallbackScheme) ??
     requestedScheme;
   const subscription = expandedSubscription(session);
-  let recordedSubscription: Awaited<ReturnType<typeof latestStripeSubscriptionForSession>> = null;
+  let recordedSubscription: Awaited<
+    ReturnType<typeof latestStripeSubscriptionForSession>
+  > = null;
   try {
     recordedSubscription = await latestStripeSubscriptionForSession(session);
   } catch (error) {
@@ -98,7 +100,8 @@ export default async function BillingSuccessPage({
   }
   const active =
     (subscription && isActiveStripeSubscriptionStatus(subscription.status)) ||
-    (recordedSubscription && isActiveStripeSubscriptionStatus(recordedSubscription.status));
+    (recordedSubscription &&
+      isActiveStripeSubscriptionStatus(recordedSubscription.status));
   if (!active) redirect("/pricing?welcome=pending");
 
   const email = purchaseEmail(session) ?? "";
@@ -119,58 +122,93 @@ export default async function BillingSuccessPage({
   ];
 
   return (
-    <main className="min-h-screen bg-[#fafafa] px-4 py-10 text-[#171717] sm:px-6 sm:py-16">
-      <div className="mx-auto max-w-5xl" lang={locale}>
-        <section className="border-b border-black/10 pb-8">
-          <p className="mb-3 text-sm font-medium text-[#5f6368]">{messages.emailLabel}</p>
-          <p className="mb-8 break-words text-base">{email}</p>
-          <h1 className="text-3xl font-medium tracking-tight">{messages.title}</h1>
-          <p className="mt-4 max-w-2xl text-base leading-7 text-[#4b5563]">
-            {messages.body.replace("{email}", email)}
-          </p>
-          <a
-            className="mt-8 inline-flex rounded-md bg-[#171717] px-4 py-2 text-sm font-medium text-white"
-            href={openCmuxHref.toString()}
-          >
-            {messages.openCmux}
-          </a>
-        </section>
+    <main className="min-h-screen bg-[#f4f0e7] px-4 py-8 text-[#241f1a] sm:px-6 sm:py-14">
+      <div className="mx-auto max-w-4xl" lang={locale}>
+        <section className="border border-[#d6ccbc] bg-[#fffdf8]">
+          <div className="grid border-b border-[#d6ccbc] sm:grid-cols-[1fr_auto]">
+            <div className="p-6 sm:p-10">
+              <div className="mb-8 flex items-center gap-3 text-sm font-medium text-[#7b5839]">
+                <span className="grid size-7 place-items-center bg-[#e8a15b] text-base text-[#241f1a]">
+                  ✓
+                </span>
+                <span>{messages.emailLabel}</span>
+              </div>
+              <h1 className="max-w-2xl text-3xl font-medium tracking-[-0.035em] sm:text-4xl">
+                {messages.title}
+              </h1>
+              <p className="mt-4 max-w-2xl text-base leading-7 text-[#655c52]">
+                {messages.body.replace("{email}", email)}
+              </p>
+              <a
+                className="mt-8 inline-flex min-h-11 items-center bg-[#241f1a] px-5 py-2 text-sm font-medium text-[#fffaf1] transition-colors hover:bg-[#47382b]"
+                href={openCmuxHref.toString()}
+              >
+                {messages.openCmux}
+                <span aria-hidden="true" className="ml-3">
+                  →
+                </span>
+              </a>
+            </div>
+            <div className="border-t border-[#d6ccbc] bg-[#f9e9d2] p-6 sm:w-64 sm:border-l sm:border-t-0 sm:p-8">
+              <p className="text-xs font-medium uppercase tracking-[0.14em] text-[#8b6848]">
+                {messages.emailLabel}
+              </p>
+              <p className="mt-3 break-words text-sm leading-6">{email}</p>
+              <div className="mt-8 h-1 w-12 bg-[#e2813f]" />
+            </div>
+          </div>
 
-        <section className="py-8">
-          <h2 className="text-xl font-medium tracking-tight">{messages.whatUnlockedTitle}</h2>
-          <div className="mt-5 grid gap-4 md:grid-cols-2">
-            {featureCards.map((card) => {
-              const feature = messages.features[card.key];
-              return (
-                <article
-                  key={card.key}
-                  className="flex min-h-48 flex-col justify-between rounded-lg border border-black/10 bg-white p-5 shadow-sm"
-                >
-                  <div>
-                    <h3 className="text-base font-medium">{feature.title}</h3>
-                    <p className="mt-3 text-sm leading-6 text-[#4b5563]">{feature.body}</p>
-                  </div>
-                  <a
-                    className="mt-5 inline-flex w-fit rounded-md bg-[#171717] px-3 py-2 text-sm font-medium text-white"
-                    href={card.href}
+          <div className="p-6 sm:p-10">
+            <div className="flex items-end justify-between gap-6">
+              <h2 className="text-xl font-medium tracking-tight">
+                {messages.whatUnlockedTitle}
+              </h2>
+              <span className="hidden text-xs uppercase tracking-[0.14em] text-[#8b8176] sm:block">
+                Pro
+              </span>
+            </div>
+            <div className="mt-6 grid border-l border-t border-[#d6ccbc] md:grid-cols-2">
+              {featureCards.map((card) => {
+                const feature = messages.features[card.key];
+                return (
+                  <article
+                    key={card.key}
+                    className="group flex min-h-44 flex-col justify-between border-b border-r border-[#d6ccbc] bg-[#fffdf8] p-5 transition-colors hover:bg-[#fbf3e7]"
                   >
-                    {feature.action}
-                  </a>
-                </article>
-              );
-            })}
+                    <div>
+                      <h3 className="text-base font-medium">{feature.title}</h3>
+                      <p className="mt-3 text-sm leading-6 text-[#655c52]">
+                        {feature.body}
+                      </p>
+                    </div>
+                    <a
+                      className="mt-5 inline-flex w-fit items-center border-b border-[#8b6848] pb-1 text-sm font-medium text-[#6e4a2d]"
+                      href={card.href}
+                    >
+                      {feature.action}
+                      <span
+                        aria-hidden="true"
+                        className="ml-2 transition-transform group-hover:translate-x-0.5"
+                      >
+                        →
+                      </span>
+                    </a>
+                  </article>
+                );
+              })}
+            </div>
           </div>
         </section>
 
-        <div className="flex flex-wrap gap-3 border-t border-black/10 pt-6">
+        <div className="flex flex-wrap gap-x-6 gap-y-3 border-x border-b border-[#d6ccbc] bg-[#ebe4d8] px-6 py-4 sm:px-10">
           <a
-            className="inline-flex rounded-md border border-black/15 px-4 py-2 text-sm font-medium text-[#171717]"
+            className="inline-flex py-1 text-sm font-medium text-[#655c52] underline decoration-[#b7a895] underline-offset-4 hover:text-[#241f1a]"
             href="/api/billing/portal"
           >
             {messages.manageBilling}
           </a>
           <a
-            className="inline-flex rounded-md border border-black/15 px-4 py-2 text-sm font-medium text-[#171717]"
+            className="inline-flex py-1 text-sm font-medium text-[#655c52] underline decoration-[#b7a895] underline-offset-4 hover:text-[#241f1a]"
             href="/handler/account-settings"
           >
             {messages.manageSignInMethods}
@@ -185,7 +223,8 @@ async function billingSuccessMessages(
   headersList: Headers,
 ): Promise<{ locale: Locale; messages: BillingSuccessMessages }> {
   const locale = preferredLocale(headersList);
-  const messages = (await import(`../../../messages/${locale}.json`)).default as {
+  const messages = (await import(`../../../messages/${locale}.json`))
+    .default as {
     billingSuccess?: BillingSuccessMessages;
   };
   if (messages.billingSuccess) {
@@ -211,23 +250,40 @@ function preferredLocale(headersList: Headers): Locale {
     .map((part) => part.split(";")[0]?.trim())
     .filter(Boolean);
   for (const language of requested) {
-    const exact = locales.find((locale) => locale.toLowerCase() === language.toLowerCase());
+    const exact = locales.find(
+      (locale) => locale.toLowerCase() === language.toLowerCase(),
+    );
     if (exact) return exact;
     const base = language.split("-")[0]?.toLowerCase();
-    const baseMatch = locales.find((locale) => locale.toLowerCase().split("-")[0] === base);
+    const baseMatch = locales.find(
+      (locale) => locale.toLowerCase().split("-")[0] === base,
+    );
     if (baseMatch) return baseMatch;
   }
   return routing.defaultLocale;
 }
 
-function requestFromHeaders(headersList: Headers, pathname: string): NextRequest {
-  const host = headersList.get("x-forwarded-host") ?? headersList.get("host") ?? "cmux.com";
-  const proto = headersList.get("x-forwarded-proto") ?? (host.startsWith("localhost") ? "http" : "https");
-  return new NextRequest(`${proto}://${host}${pathname}`, { headers: headersList });
+function requestFromHeaders(
+  headersList: Headers,
+  pathname: string,
+): NextRequest {
+  const host =
+    headersList.get("x-forwarded-host") ??
+    headersList.get("host") ??
+    "cmux.com";
+  const proto =
+    headersList.get("x-forwarded-proto") ??
+    (host.startsWith("localhost") ? "http" : "https");
+  return new NextRequest(`${proto}://${host}${pathname}`, {
+    headers: headersList,
+  });
 }
 
-function expandedSubscription(session: Stripe.Checkout.Session): Stripe.Subscription | null {
-  return typeof session.subscription === "object" && session.subscription !== null
+function expandedSubscription(
+  session: Stripe.Checkout.Session,
+): Stripe.Subscription | null {
+  return typeof session.subscription === "object" &&
+    session.subscription !== null
     ? session.subscription
     : null;
 }


### PR DESCRIPTION
Makes the post-purchase experience more square, warm, and welcoming while preserving the existing localized content and trusted native return flow.

Validation:
- `bun test tests/billing-success-page.test.tsx tests/billing-purchase.test.ts tests/stripe-webhook-route.test.ts`
- `bun run typecheck`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/9718"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788640484&installation_model_id=21920&pr_number=9718&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F9718&signature=bdd428e6641ae78b35201c82b54918e9f79ff9fd21c46f47c272379022a89bf5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Redesigned the billing success page with a warmer, more welcoming UI while preserving localized content and the trusted native return flow. Improves readability and CTAs without changing billing or session logic.

- **Refactors**
  - Reworked layout with card-like sections, grid, and a warm color palette.
  - Clear email panel and “What you unlocked” grid with subtle hover states.
  - CTAs updated for better accessibility and clarity with arrow indicators.
  - Locale detection, content strings, redirects, and open-app link preserved.
  - No changes to `stripe` subscription validation or session handling.

<sup>Written for commit bf97f30e0dbfcbbb5ce84ff8665fca6459b75f26. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/9718?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

