### PR TITLE
Open Notifications as a pane tab

### DIFF
--- a/Packages/macOS/CmuxWorkspaces/Sources/CmuxWorkspaces/Core/Values/SurfaceKind.swift
+++ b/Packages/macOS/CmuxWorkspaces/Sources/CmuxWorkspaces/Core/Values/SurfaceKind.swift
@@ -37,6 +37,8 @@ public struct SurfaceKind: RawRepresentable, Hashable, Sendable {
     public static let extensionBrowser = SurfaceKind(rawValue: "extensionBrowser")
     /// A workspace todo pane.
     public static let todo = SurfaceKind(rawValue: "todo")
+    /// A notifications pane.
+    public static let notifications = SurfaceKind(rawValue: "notifications")
     /// A transient Cloud VM loading pane.
     public static let cloudVMLoading = SurfaceKind(rawValue: "cloudVMLoading")
     /// A transient iPhone pairing pane.

--- a/Sources/Canvas/WorkspaceCanvasHostView.swift
+++ b/Sources/Canvas/WorkspaceCanvasHostView.swift
@@ -106,6 +106,7 @@ struct WorkspaceCanvasHostView: View {
         case .project: return "folder"
         case .extensionBrowser: return "puzzlepiece.extension"
         case .workspaceTodo: return "checklist"
+        case .notifications: return "bell"
         case .cloudVMLoading: return "cloud.fill"
         case .mobilePairing: return "iphone"
         case .accountSignIn: return "person.crop.circle"

--- a/Sources/ClosedItemHistory+PanelTitle.swift
+++ b/Sources/ClosedItemHistory+PanelTitle.swift
@@ -37,6 +37,8 @@ extension ClosedItemHistoryStore {
             return String(localized: "sidebar.extensions.browser.title", defaultValue: "Sidebar Extensions")
         case .workspaceTodo:
             return String(localized: "workspaceTodoPane.title", defaultValue: "Todos")
+        case .notifications:
+            return String(localized: "notifications.title", defaultValue: "Notifications")
         case .cloudVMLoading:
             return String(localized: "menu.history.recentlyClosed.panel.cloudVM", defaultValue: "Cloud VM")
         case .mobilePairing:

--- a/Sources/CmuxLifecycleEventPublishing.swift
+++ b/Sources/CmuxLifecycleEventPublishing.swift
@@ -227,6 +227,8 @@ extension Workspace {
             return "extension_browser"
         case .workspaceTodo:
             return "workspace_todo"
+        case .notifications:
+            return "notifications"
         case .cloudVMLoading:
             return "cloud_vm_loading"
         case .mobilePairing:

--- a/Sources/ContentView+CommandPaletteSurfaceMetadata.swift
+++ b/Sources/ContentView+CommandPaletteSurfaceMetadata.swift
@@ -24,6 +24,8 @@ extension ContentView {
             return String(localized: "sidebar.extensions.browser.title", defaultValue: "Sidebar Extensions")
         case .workspaceTodo:
             return String(localized: "commandPalette.kind.workspaceTodo", defaultValue: "Todos")
+        case .notifications:
+            return String(localized: "notifications.title", defaultValue: "Notifications")
         case .cloudVMLoading:
             return String(localized: "commandPalette.kind.cloudVMLoading", defaultValue: "Cloud VM")
         case .mobilePairing:
@@ -55,6 +57,8 @@ extension ContentView {
             return ["sidebar", "extensions", "extensionkit", "browser"]
         case .workspaceTodo:
             return ["todo", "todos", "checklist", "task", "status"]
+        case .notifications:
+            return ["notifications", "alerts", "feed"]
         case .cloudVMLoading:
             return ["cloud", "vm", "loading"]
         case .mobilePairing:

--- a/Sources/ContentView+SidebarSurfaceKind.swift
+++ b/Sources/ContentView+SidebarSurfaceKind.swift
@@ -13,7 +13,7 @@ extension VerticalTabsSidebar {
             return .filePreview
         case .rightSidebarTool:
             return .rightSidebarTool
-        case .customSidebar, .simulator, .extensionBrowser, .workspaceTodo, .cloudVMLoading,
+        case .customSidebar, .simulator, .extensionBrowser, .workspaceTodo, .notifications, .cloudVMLoading,
              .mobilePairing, .accountSignIn:
             return .unknown
         case .agentSession:

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -1814,19 +1814,6 @@ struct ContentView: View {
         return max(titlebarLeadingInset, visibleSidebarTitleInset)
     }
 
-    nonisolated static func workspaceContentIsVisible(
-        mountedWorkspaceIsVisible: Bool,
-        sidebarSelection: SidebarSelection
-    ) -> Bool {
-        guard mountedWorkspaceIsVisible else { return false }
-        switch sidebarSelection {
-        case .tabs:
-            return true
-        case .notifications:
-            return false
-        }
-    }
-
     /// Where the always-visible fullscreen titlebar controls (sidebar toggle,
     /// history, new tab, notifications) are anchored inside the titlebar band.
     struct FullscreenControlsPlacement: Equatable {
@@ -1865,19 +1852,15 @@ struct ContentView: View {
                         isSelectedWorkspace: isSelectedWorkspace,
                         isRetiringWorkspace: isRetiringWorkspace
                     )
-                    let isWorkspaceVisible = Self.workspaceContentIsVisible(
-                        mountedWorkspaceIsVisible: presentation.isPanelVisible,
-                        sidebarSelection: sidebarSelectionState.selection
-                    )
                     // Keep the retiring workspace visible during handoff, but never input-active.
                     // Allowing both selected+retiring workspaces to be input-active lets the
                     // old workspace steal first responder (notably with WKWebView), which can
                     // delay handoff completion and make browser returns feel laggy.
-                    let isInputActive = isSelectedWorkspace && isWorkspaceVisible
+                    let isInputActive = isSelectedWorkspace
                     let portalPriority = isSelectedWorkspace ? 2 : (isRetiringWorkspace ? 1 : 0)
                     WorkspaceContentView(
                         workspace: tab,
-                        isWorkspaceVisible: isWorkspaceVisible,
+                        isWorkspaceVisible: presentation.isPanelVisible,
                         isWorkspaceInputActive: isInputActive,
                         rightSidebarOwnsInputFocus: fileExplorerState.rightSidebarOwnsInputFocus,
                         isFullScreen: isFullScreen,
@@ -1902,11 +1885,6 @@ struct ContentView: View {
             .opacity(sidebarSelectionState.selection == .tabs ? 1 : 0)
             .allowsHitTesting(sidebarSelectionState.selection == .tabs)
             .accessibilityHidden(sidebarSelectionState.selection != .tabs)
-
-            NotificationsPage(selection: $sidebarSelectionState.selection)
-                .opacity(sidebarSelectionState.selection == .notifications ? 1 : 0)
-                .allowsHitTesting(sidebarSelectionState.selection == .notifications)
-                .accessibilityHidden(sidebarSelectionState.selection != .notifications)
         }
         .modifier(WorkspacePresentationModeContentTopPaddingModifier(
             isFullScreen: isFullScreen,

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -1814,6 +1814,19 @@ struct ContentView: View {
         return max(titlebarLeadingInset, visibleSidebarTitleInset)
     }
 
+    nonisolated static func workspaceContentIsVisible(
+        mountedWorkspaceIsVisible: Bool,
+        sidebarSelection: SidebarSelection
+    ) -> Bool {
+        guard mountedWorkspaceIsVisible else { return false }
+        switch sidebarSelection {
+        case .tabs:
+            return true
+        case .notifications:
+            return false
+        }
+    }
+
     /// Where the always-visible fullscreen titlebar controls (sidebar toggle,
     /// history, new tab, notifications) are anchored inside the titlebar band.
     struct FullscreenControlsPlacement: Equatable {
@@ -1852,15 +1865,19 @@ struct ContentView: View {
                         isSelectedWorkspace: isSelectedWorkspace,
                         isRetiringWorkspace: isRetiringWorkspace
                     )
+                    let isWorkspaceVisible = Self.workspaceContentIsVisible(
+                        mountedWorkspaceIsVisible: presentation.isPanelVisible,
+                        sidebarSelection: sidebarSelectionState.selection
+                    )
                     // Keep the retiring workspace visible during handoff, but never input-active.
                     // Allowing both selected+retiring workspaces to be input-active lets the
                     // old workspace steal first responder (notably with WKWebView), which can
                     // delay handoff completion and make browser returns feel laggy.
-                    let isInputActive = isSelectedWorkspace
+                    let isInputActive = isSelectedWorkspace && isWorkspaceVisible
                     let portalPriority = isSelectedWorkspace ? 2 : (isRetiringWorkspace ? 1 : 0)
                     WorkspaceContentView(
                         workspace: tab,
-                        isWorkspaceVisible: presentation.isPanelVisible,
+                        isWorkspaceVisible: isWorkspaceVisible,
                         isWorkspaceInputActive: isInputActive,
                         rightSidebarOwnsInputFocus: fileExplorerState.rightSidebarOwnsInputFocus,
                         isFullScreen: isFullScreen,

--- a/Sources/NotificationsPage.swift
+++ b/Sources/NotificationsPage.swift
@@ -5,7 +5,6 @@ import SwiftUI
 struct NotificationsPage: View {
     @EnvironmentObject var notificationStore: TerminalNotificationStore
     @EnvironmentObject var tabManager: TabManager
-    @Binding var selection: SidebarSelection
     @FocusState private var focusedNotificationId: UUID?
     @State private var keyboardShortcutSettingsObserver = KeyboardShortcutSettingsObserver.shared
     @State private var phonePushConfigurationState =
@@ -56,9 +55,6 @@ struct NotificationsPage: View {
                             // isolated; hop to the main actor for window focus + tab selection.
                             Task { @MainActor in
                                 _ = AppDelegate.shared?.openTerminalNotification(notification)
-                                if notification.clickAction == nil {
-                                    selection = .tabs
-                                }
                             }
                         },
                         onClear: {
@@ -81,7 +77,6 @@ struct NotificationsPage: View {
     private func setInitialFocus() {
         // Only set focus when the notifications page is visible
         // to avoid stealing focus from the terminal when notifications arrive
-        guard selection == .notifications else { return }
         guard let firstId = notificationStore.notifications.first?.id else {
             focusedNotificationId = nil
             return

--- a/Sources/NotificationsPage.swift
+++ b/Sources/NotificationsPage.swift
@@ -3,6 +3,9 @@ import Bonsplit
 import SwiftUI
 
 struct NotificationsPage: View {
+    let isFocused: Bool
+    let isVisibleInUI: Bool
+
     @EnvironmentObject var notificationStore: TerminalNotificationStore
     @EnvironmentObject var tabManager: TabManager
     @FocusState private var focusedNotificationId: UUID?
@@ -33,6 +36,12 @@ struct NotificationsPage: View {
         .background(Color(nsColor: .windowBackgroundColor))
         .onAppear(perform: setInitialFocus)
         .onChange(of: notificationStore.notifications.first?.id) { _ in
+            setInitialFocus()
+        }
+        .onChange(of: isFocused) { _ in
+            setInitialFocus()
+        }
+        .onChange(of: isVisibleInUI) { _ in
             setInitialFocus()
         }
     }
@@ -75,9 +84,10 @@ struct NotificationsPage: View {
     }
 
     private func setInitialFocus() {
-        // Only set focus when the notifications page is visible
-        // to avoid stealing focus from the terminal when notifications arrive
-        guard let firstId = notificationStore.notifications.first?.id else {
+        // Background-mounted pane tabs must not claim focus when their feed changes.
+        guard isFocused,
+              isVisibleInUI,
+              let firstId = notificationStore.notifications.first?.id else {
             focusedNotificationId = nil
             return
         }

--- a/Sources/NotificationsPage.swift
+++ b/Sources/NotificationsPage.swift
@@ -91,9 +91,7 @@ struct NotificationsPage: View {
             focusedNotificationId = nil
             return
         }
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.05) {
-            focusedNotificationId = firstId
-        }
+        focusedNotificationId = firstId
     }
 
     private var header: some View {

--- a/Sources/PaneDropTargetView+FileDropTextDestination.swift
+++ b/Sources/PaneDropTargetView+FileDropTextDestination.swift
@@ -18,7 +18,7 @@ extension PaneDropTargetView {
                   filePreviewPanel.previewMode == .text else { return nil }
             return .editor
         case .browser, .markdown, .rightSidebarTool, .customSidebar, .simulator,
-             .agentSession, .project, .extensionBrowser, .workspaceTodo, .cloudVMLoading,
+             .agentSession, .project, .extensionBrowser, .workspaceTodo, .notifications, .cloudVMLoading,
              .mobilePairing, .accountSignIn:
             return nil
         }

--- a/Sources/Panels/NotificationsPanel.swift
+++ b/Sources/Panels/NotificationsPanel.swift
@@ -1,0 +1,28 @@
+import AppKit
+import Combine
+import Foundation
+
+/// A pane tab that hosts the notification feed and forwarding controls.
+@MainActor
+final class NotificationsPanel: Panel {
+    let id: UUID
+    let stableSurfaceIdentity = PanelStableSurfaceIdentity()
+    let panelType: PanelType = .notifications
+
+    var displayTitle: String {
+        String(localized: "notifications.title", defaultValue: "Notifications")
+    }
+
+    var displayIcon: String? { "bell" }
+
+    init(id: UUID = UUID()) {
+        self.id = id
+    }
+
+    func close() {}
+    func focus() {}
+    func unfocus() {}
+    func triggerFlash(reason: WorkspaceAttentionFlashReason) {
+        _ = reason
+    }
+}

--- a/Sources/Panels/Panel.swift
+++ b/Sources/Panels/Panel.swift
@@ -15,6 +15,7 @@ public enum PanelType: String, Codable, Sendable {
     case project
     case extensionBrowser
     case workspaceTodo
+    case notifications
     case cloudVMLoading
     case mobilePairing
     case accountSignIn
@@ -44,6 +45,10 @@ public enum PanelType: String, Codable, Sendable {
         }
         if rawValue.lowercased() == Self.workspaceTodo.rawValue.lowercased() {
             self = .workspaceTodo
+            return
+        }
+        if rawValue.lowercased() == Self.notifications.rawValue.lowercased() {
+            self = .notifications
             return
         }
         if rawValue.lowercased() == Self.cloudVMLoading.rawValue.lowercased() {

--- a/Sources/Panels/PanelContentView.swift
+++ b/Sources/Panels/PanelContentView.swift
@@ -184,6 +184,12 @@ struct PanelContentView: View {
                     onRequestPanelFocus: onRequestPanelFocus
                 )
             }
+        case .notifications:
+            if panel is NotificationsPanel {
+                NotificationsPage()
+                    .contentShape(Rectangle())
+                    .onTapGesture { onRequestPanelFocus() }
+            }
         case .cloudVMLoading:
             if let loadingPanel = panel as? CloudVMLoadingPanel {
                 CloudVMLoadingPanelView(panel: loadingPanel)
@@ -221,7 +227,7 @@ struct PanelContentView: View {
     private var shouldInstallPaneDropTarget: Bool {
         guard isVisibleInUI else { return false }
         switch panel.panelType {
-        case .markdown, .filePreview, .rightSidebarTool, .customSidebar, .simulator, .agentSession, .project, .extensionBrowser, .workspaceTodo, .cloudVMLoading, .mobilePairing, .accountSignIn:
+        case .markdown, .filePreview, .rightSidebarTool, .customSidebar, .simulator, .agentSession, .project, .extensionBrowser, .workspaceTodo, .notifications, .cloudVMLoading, .mobilePairing, .accountSignIn:
             return true
         case .terminal, .browser:
             return false

--- a/Sources/Panels/PanelContentView.swift
+++ b/Sources/Panels/PanelContentView.swift
@@ -186,7 +186,10 @@ struct PanelContentView: View {
             }
         case .notifications:
             if panel is NotificationsPanel {
-                NotificationsPage()
+                NotificationsPage(
+                    isFocused: isFocused,
+                    isVisibleInUI: isVisibleInUI
+                )
                     .contentShape(Rectangle())
                     .onTapGesture { onRequestPanelFocus() }
             }

--- a/Sources/Search/GlobalSearchDocuments.swift
+++ b/Sources/Search/GlobalSearchDocuments.swift
@@ -35,7 +35,7 @@ enum GlobalSearchDocuments {
         case .markdown:
             kind = .markdown
         case .terminal, .filePreview, .rightSidebarTool, .customSidebar, .agentSession, .project,
-             .extensionBrowser, .simulator, .workspaceTodo, .cloudVMLoading, .mobilePairing, .accountSignIn:
+             .extensionBrowser, .simulator, .workspaceTodo, .notifications, .cloudVMLoading, .mobilePairing, .accountSignIn:
             kind = .title
         }
 

--- a/Sources/SessionPersistence.swift
+++ b/Sources/SessionPersistence.swift
@@ -1643,6 +1643,8 @@ struct SessionFilePreviewPanelSnapshot: Codable, Sendable {
 /// Marker for a workspace todo pane; the pane has no content of its own (the checklist
 /// persists on the workspace), so the panel `type` plus this empty marker is enough to restore it.
 struct SessionWorkspaceTodoPanelSnapshot: Codable, Sendable {}
+/// Marker for the global notifications pane; its feed lives in the notification store.
+struct SessionNotificationsPanelSnapshot: Codable, Sendable {}
 struct SessionProjectPanelSnapshot: Codable, Sendable {
     var projectPath: String
     var selectedNodePath: String?
@@ -1694,6 +1696,7 @@ struct SessionPanelSnapshot: Codable, Sendable {
     var agentSession: SessionAgentSessionPanelSnapshot? = nil
     var project: SessionProjectPanelSnapshot?
     var workspaceTodo: SessionWorkspaceTodoPanelSnapshot? = nil
+    var notificationsPanel: SessionNotificationsPanelSnapshot? = nil
 }
 extension SessionPanelSnapshot: WorkspaceSessionRemoteRestorePanelSnapshot {}
 

--- a/Sources/SessionPersistence.swift
+++ b/Sources/SessionPersistence.swift
@@ -206,10 +206,10 @@ enum SessionSidebarSelection: String, Codable, Sendable, Equatable {
 
     init(selection: SidebarSelection) {
         switch selection {
-        case .tabs:
+        case .tabs, .notifications:
+            // Notifications moved from a window-level overlay to a pane tab.
+            // Never persist the retired overlay selection.
             self = .tabs
-        case .notifications:
-            self = .notifications
         }
     }
 
@@ -218,7 +218,8 @@ enum SessionSidebarSelection: String, Codable, Sendable, Equatable {
         case .tabs:
             return .tabs
         case .notifications:
-            return .notifications
+            // Migrate snapshots written by builds that used the overlay.
+            return .tabs
         }
     }
 }

--- a/Sources/Update/UpdateTitlebarAccessory.swift
+++ b/Sources/Update/UpdateTitlebarAccessory.swift
@@ -2302,11 +2302,15 @@ final class TitlebarControlsAccessoryViewController: NSTitlebarAccessoryViewCont
 private func openPhoneForwardingSettings(in window: NSWindow?) {
     guard let window,
           let appDelegate = AppDelegate.shared,
-          let context = appDelegate.contextForMainTerminalWindow(window) else {
+          let context = appDelegate.contextForMainTerminalWindow(window),
+          let workspace = context.tabManager.selectedWorkspace,
+          let paneId = workspace.bonsplitController.focusedPaneId
+            ?? workspace.bonsplitController.allPaneIds.first else {
         NSSound.beep()
         return
     }
-    context.sidebarSelectionState.selection = .notifications
+    context.sidebarSelectionState.selection = .tabs
+    _ = workspace.openOrFocusNotificationsSurface(inPane: paneId)
 }
 
 private struct NotificationsPopoverView: View {

--- a/Sources/Workspace+LayoutCapture.swift
+++ b/Sources/Workspace+LayoutCapture.swift
@@ -152,7 +152,7 @@ extension Workspace {
                     focus: nil
                 )
             }
-        case .markdown, .filePreview, .rightSidebarTool, .customSidebar, .simulator, .agentSession, .extensionBrowser, .workspaceTodo, .cloudVMLoading, .mobilePairing, .accountSignIn:
+        case .markdown, .filePreview, .rightSidebarTool, .customSidebar, .simulator, .agentSession, .extensionBrowser, .workspaceTodo, .notifications, .cloudVMLoading, .mobilePairing, .accountSignIn:
             unsupportedSurfaceCount += 1
             definition = CmuxSurfaceDefinition(type: .terminal)
         }

--- a/Sources/Workspace+NotificationsPane.swift
+++ b/Sources/Workspace+NotificationsPane.swift
@@ -1,0 +1,76 @@
+import Bonsplit
+import CmuxWorkspaces
+import Foundation
+
+/// Notification-pane creation and the shared one-per-workspace open path.
+extension Workspace {
+    @discardableResult
+    func newNotificationsSurface(
+        inPane paneId: PaneID,
+        focus: Bool? = nil,
+        targetIndex: Int? = nil
+    ) -> NotificationsPanel? {
+        let shouldFocusNewTab = focus ?? (bonsplitController.focusedPaneId == paneId)
+        let previousFocusedPanelId = focusedPanelId
+        let previousHostedView = focusedTerminalInputTarget()?.panel.hostedView
+
+        let notificationsPanel = NotificationsPanel()
+        panels[notificationsPanel.id] = notificationsPanel
+        panelTitles[notificationsPanel.id] = notificationsPanel.displayTitle
+
+        guard let newTabId = bonsplitController.createTab(
+            title: notificationsPanel.displayTitle,
+            icon: notificationsPanel.displayIcon,
+            kind: SurfaceKind.notifications.rawValue,
+            isDirty: false,
+            isLoading: false,
+            isPinned: false,
+            inPane: paneId
+        ) else {
+            panels.removeValue(forKey: notificationsPanel.id)
+            panelTitles.removeValue(forKey: notificationsPanel.id)
+            return nil
+        }
+
+        bindSurface(newTabId, toPanelId: notificationsPanel.id)
+        if let targetIndex {
+            _ = bonsplitController.reorderTab(newTabId, toIndex: targetIndex)
+        }
+        publishCmuxSurfaceCreated(
+            notificationsPanel.id,
+            paneId: paneId,
+            kind: SurfaceKind.notifications.rawValue,
+            origin: "notifications_tab",
+            focused: shouldFocusNewTab
+        )
+        if shouldFocusNewTab {
+            bonsplitController.focusPane(paneId)
+            bonsplitController.selectTab(newTabId)
+            applyTabSelection(tabId: newTabId, inPane: paneId)
+        } else {
+            preserveFocusAfterNonFocusSplit(
+                preferredPanelId: previousFocusedPanelId,
+                splitPanelId: notificationsPanel.id,
+                previousHostedView: previousHostedView
+            )
+        }
+
+        return notificationsPanel
+    }
+
+    /// Focuses the workspace's notification tab or creates it in `paneId`.
+    @discardableResult
+    func openOrFocusNotificationsSurface(
+        inPane paneId: PaneID,
+        focus: Bool = true
+    ) -> NotificationsPanel? {
+        for (existingId, panel) in panels {
+            guard let notificationsPanel = panel as? NotificationsPanel else { continue }
+            if focus {
+                focusPanel(existingId)
+            }
+            return notificationsPanel
+        }
+        return newNotificationsSurface(inPane: paneId, focus: focus)
+    }
+}

--- a/Sources/Workspace+SurfaceNavigation.swift
+++ b/Sources/Workspace+SurfaceNavigation.swift
@@ -199,6 +199,8 @@ extension Workspace {
             return SurfaceKind.extensionBrowser.rawValue
         case .workspaceTodo:
             return SurfaceKind.todo.rawValue
+        case .notifications:
+            return SurfaceKind.notifications.rawValue
         case .cloudVMLoading:
             return SurfaceKind.cloudVMLoading.rawValue
         case .mobilePairing:

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -466,6 +466,7 @@ extension Workspace {
         var simulatorSnapshot: SessionSimulatorPanelSnapshot? = nil
         let agentSessionSnapshot: SessionAgentSessionPanelSnapshot?
         let projectSnapshot: SessionProjectPanelSnapshot?; var workspaceTodoSnapshot: SessionWorkspaceTodoPanelSnapshot? = nil
+        var notificationsPanelSnapshot: SessionNotificationsPanelSnapshot? = nil
         switch panel.panelType {
         case .terminal:
             guard let terminalPanel = panel as? TerminalPanel else { return nil }
@@ -705,6 +706,10 @@ extension Workspace {
             terminalSnapshot = nil; browserSnapshot = nil; markdownSnapshot = nil; filePreviewSnapshot = nil
             rightSidebarToolSnapshot = nil; agentSessionSnapshot = nil; projectSnapshot = nil
             workspaceTodoSnapshot = SessionWorkspaceTodoPanelSnapshot()
+        case .notifications:
+            terminalSnapshot = nil; browserSnapshot = nil; markdownSnapshot = nil; filePreviewSnapshot = nil
+            rightSidebarToolSnapshot = nil; agentSessionSnapshot = nil; projectSnapshot = nil
+            notificationsPanelSnapshot = SessionNotificationsPanelSnapshot()
         case .extensionBrowser:
             return nil
         case .cloudVMLoading:
@@ -740,7 +745,9 @@ extension Workspace {
             customSidebar: customSidebarSnapshot,
             simulator: simulatorSnapshot,
             agentSession: agentSessionSnapshot,
-            project: projectSnapshot, workspaceTodo: workspaceTodoSnapshot
+            project: projectSnapshot,
+            workspaceTodo: workspaceTodoSnapshot,
+            notificationsPanel: notificationsPanelSnapshot
         )
     }
     private func closedPanelHistoryEntry(panelId: UUID, tabId: TabID, pane: PaneID) -> ClosedPanelHistoryEntry? {
@@ -1835,6 +1842,11 @@ extension Workspace {
             guard let todoPanel = newWorkspaceTodoSurface(inPane: paneId, focus: false) else { return nil }
             applySessionPanelMetadata(snapshot, toPanelId: todoPanel.id)
             return todoPanel.id
+        case .notifications:
+            guard snapshot.notificationsPanel != nil,
+                  let notificationsPanel = newNotificationsSurface(inPane: paneId, focus: false) else { return nil }
+            applySessionPanelMetadata(snapshot, toPanelId: notificationsPanel.id)
+            return notificationsPanel.id
         case .extensionBrowser:
             return nil
         case .cloudVMLoading:

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -1456,6 +1456,7 @@ C0DE71B10000000000000001 /* AppDelegate+AgentChatNotifications.swift in Sources 
 		B7F00002 /* NotificationSoundSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7F00001 /* NotificationSoundSettings.swift */; };
 		4E5F60720000000000000001 /* NotificationSoundSettingsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E5F60720000000000000002 /* NotificationSoundSettingsTests.swift */; };
 		A5001094 /* NotificationsPage.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001091 /* NotificationsPage.swift */; };
+		733B576F46794C01A2195B9A /* NotificationsPanel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB29060C585943CD96C77929 /* NotificationsPanel.swift */; };
 		D7769000000000000000000F /* NotificationsPopoverMetrics.swift in Sources */ = {isa = PBXBuildFile; fileRef = D77690000000000000000010 /* NotificationsPopoverMetrics.swift */; };
 		D77690000000000000000007 /* NotificationsPopoverResizeHandle.swift in Sources */ = {isa = PBXBuildFile; fileRef = D77690000000000000000008 /* NotificationsPopoverResizeHandle.swift */; };
 		D77690000000000000000009 /* NotificationsPopoverResizeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7769000000000000000000A /* NotificationsPopoverResizeView.swift */; };
@@ -2472,6 +2473,7 @@ C0DE71B10000000000000001 /* AppDelegate+AgentChatNotifications.swift in Sources 
 		F0ACC0DE0000000000000003 /* Workspace+ForkConversationContextMenu.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0ACC0DE0000000000000004 /* Workspace+ForkConversationContextMenu.swift */; };
 		F17F00000000000000000005 /* Workspace+FullWidthTab.swift in Sources */ = {isa = PBXBuildFile; fileRef = F17F00000000000000000006 /* Workspace+FullWidthTab.swift */; };
 		C0DE1A050000000000000001 /* Workspace+LayoutCapture.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE1A050000000000000002 /* Workspace+LayoutCapture.swift */; };
+		8B45A4329C234E6FB261E635 /* Workspace+NotificationsPane.swift in Sources */ = {isa = PBXBuildFile; fileRef = 688C3F45DAA548B3B57DE780 /* Workspace+NotificationsPane.swift */; };
 		C3744E010000000000000001 /* Workspace+PanelLifecycle.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3744E020000000000000001 /* Workspace+PanelLifecycle.swift */; };
 		797800030000000000000001 /* Workspace+PersistentRemotePTYReattach.swift in Sources */ = {isa = PBXBuildFile; fileRef = 797800030000000000000002 /* Workspace+PersistentRemotePTYReattach.swift */; };
 		791100010000000000000001 /* Workspace+RemoteDisconnectPlaceholder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 791100020000000000000001 /* Workspace+RemoteDisconnectPlaceholder.swift */; };
@@ -4074,6 +4076,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 		B7F00001 /* NotificationSoundSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationSoundSettings.swift; sourceTree = "<group>"; };
 		4E5F60720000000000000002 /* NotificationSoundSettingsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationSoundSettingsTests.swift; sourceTree = "<group>"; };
 		A5001091 /* NotificationsPage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationsPage.swift; sourceTree = "<group>"; };
+		CB29060C585943CD96C77929 /* NotificationsPanel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/NotificationsPanel.swift; sourceTree = "<group>"; };
 		D77690000000000000000010 /* NotificationsPopoverMetrics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Update/NotificationsPopoverMetrics.swift; sourceTree = "<group>"; };
 		D77690000000000000000008 /* NotificationsPopoverResizeHandle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Update/NotificationsPopoverResizeHandle.swift; sourceTree = "<group>"; };
 		D7769000000000000000000A /* NotificationsPopoverResizeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Update/NotificationsPopoverResizeView.swift; sourceTree = "<group>"; };
@@ -5076,6 +5079,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 		F0ACC0DE0000000000000004 /* Workspace+ForkConversationContextMenu.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Workspace+ForkConversationContextMenu.swift"; sourceTree = "<group>"; };
 		F17F00000000000000000006 /* Workspace+FullWidthTab.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Workspace+FullWidthTab.swift"; sourceTree = "<group>"; };
 		C0DE1A050000000000000002 /* Workspace+LayoutCapture.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Workspace+LayoutCapture.swift"; sourceTree = "<group>"; };
+		688C3F45DAA548B3B57DE780 /* Workspace+NotificationsPane.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Workspace+NotificationsPane.swift"; sourceTree = "<group>"; };
 		C3744E020000000000000001 /* Workspace+PanelLifecycle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Workspace+PanelLifecycle.swift"; sourceTree = "<group>"; };
 		797800030000000000000002 /* Workspace+PersistentRemotePTYReattach.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Workspace+PersistentRemotePTYReattach.swift"; sourceTree = "<group>"; };
 		791100020000000000000001 /* Workspace+RemoteDisconnectPlaceholder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Workspace+RemoteDisconnectPlaceholder.swift"; sourceTree = "<group>"; };
@@ -6088,6 +6092,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				56EA28B32C38ED8C753C82D3 /* TabItemView+WorkspaceTodo.swift */,
 				E9E7BB6EF7C9F8D2C681999D /* SidebarWorkspaceChecklistView.swift */,
 				C30350CE2602EEAFBD873DC9 /* Workspace+TodoPane.swift */,
+				688C3F45DAA548B3B57DE780 /* Workspace+NotificationsPane.swift */,
 				BAC8DE2AF74EC2C272681A75 /* SidebarWorkspaceChecklistPopover.swift */,
 				3896D9D4AD4D31A54882813E /* SidebarWorkspaceStatusPopover.swift */,
 				4AEAD128139F57CB0E5BD39E /* SidebarWorkspaceTodoPopoverHost.swift */,
@@ -6785,6 +6790,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				A5001418 /* MarkdownPanel.swift */,
 				8311EFDE1BC83CBAB1F21B6F /* WorkspaceTodoPanelView.swift */,
 				28F2A069A4931E9403474975 /* WorkspaceTodoPanel.swift */,
+				CB29060C585943CD96C77929 /* NotificationsPanel.swift */,
 				A50014F0 /* MarkdownPanelFileLinkResolver.swift */,
 				F5168A030000000000000002 /* MarkdownFontSizeSettings.swift */,
 				F5168A040000000000000002 /* MarkdownFontFamily.swift */,
@@ -9321,6 +9327,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				D78970000000000000000001 /* NotificationScrollRestoreState.swift in Sources */,
 				B7F00002 /* NotificationSoundSettings.swift in Sources */,
 				A5001094 /* NotificationsPage.swift in Sources */,
+				733B576F46794C01A2195B9A /* NotificationsPanel.swift in Sources */,
 				D7769000000000000000000F /* NotificationsPopoverMetrics.swift in Sources */,
 				D77690000000000000000007 /* NotificationsPopoverResizeHandle.swift in Sources */,
 				D77690000000000000000009 /* NotificationsPopoverResizeView.swift in Sources */,
@@ -10043,6 +10050,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				F0ACC0DE0000000000000003 /* Workspace+ForkConversationContextMenu.swift in Sources */,
 				F17F00000000000000000005 /* Workspace+FullWidthTab.swift in Sources */,
 				C0DE1A050000000000000001 /* Workspace+LayoutCapture.swift in Sources */,
+				8B45A4329C234E6FB261E635 /* Workspace+NotificationsPane.swift in Sources */,
 				C3744E010000000000000001 /* Workspace+PanelLifecycle.swift in Sources */,
 				797800030000000000000001 /* Workspace+PersistentRemotePTYReattach.swift in Sources */,
 				791100010000000000000001 /* Workspace+RemoteDisconnectPlaceholder.swift in Sources */,

--- a/cmuxTests/SessionPersistenceTests.swift
+++ b/cmuxTests/SessionPersistenceTests.swift
@@ -13,6 +13,14 @@ import CmuxTerminal
 #endif
 
 final class SessionPersistenceTests: XCTestCase {
+    func testLegacyNotificationsSidebarSelectionRestoresTabs() {
+        XCTAssertEqual(SessionSidebarSelection.notifications.sidebarSelection, .tabs)
+    }
+
+    func testNotificationsSidebarSelectionPersistsAsTabs() {
+        XCTAssertEqual(SessionSidebarSelection(selection: .notifications), .tabs)
+    }
+
     private struct LegacyPersistedWindowGeometry: Codable {
         let frame: SessionRectSnapshot
         let display: SessionDisplaySnapshot?

--- a/cmuxTests/WorkspaceContentViewVisibilityTests.swift
+++ b/cmuxTests/WorkspaceContentViewVisibilityTests.swift
@@ -607,29 +607,6 @@ final class WorkspaceContentViewVisibilityTests {
     }
 
     @Test
-    func notificationsPageHidesPortalHostedWorkspaceContent() {
-        #expect(
-            ContentView.workspaceContentIsVisible(
-                mountedWorkspaceIsVisible: true,
-                sidebarSelection: .tabs
-            )
-        )
-        #expect(
-            !ContentView.workspaceContentIsVisible(
-                mountedWorkspaceIsVisible: true,
-                sidebarSelection: .notifications
-            ),
-            "The notifications page must hide portal-hosted terminals and browsers"
-        )
-        #expect(
-            !ContentView.workspaceContentIsVisible(
-                mountedWorkspaceIsVisible: false,
-                sidebarSelection: .tabs
-            )
-        )
-    }
-
-    @Test
     func testRenderedVisiblePanelPolicyPrefersSelectedTabOverStaleFocusedPanel() {
         let paneId = UUID()
         let selectedPanelId = UUID()

--- a/cmuxTests/WorkspaceContentViewVisibilityTests.swift
+++ b/cmuxTests/WorkspaceContentViewVisibilityTests.swift
@@ -607,6 +607,29 @@ final class WorkspaceContentViewVisibilityTests {
     }
 
     @Test
+    func notificationsPageHidesPortalHostedWorkspaceContent() {
+        #expect(
+            ContentView.workspaceContentIsVisible(
+                mountedWorkspaceIsVisible: true,
+                sidebarSelection: .tabs
+            )
+        )
+        #expect(
+            !ContentView.workspaceContentIsVisible(
+                mountedWorkspaceIsVisible: true,
+                sidebarSelection: .notifications
+            ),
+            "The notifications page must hide portal-hosted terminals and browsers"
+        )
+        #expect(
+            !ContentView.workspaceContentIsVisible(
+                mountedWorkspaceIsVisible: false,
+                sidebarSelection: .tabs
+            )
+        )
+    }
+
+    @Test
     func testRenderedVisiblePanelPolicyPrefersSelectedTabOverStaleFocusedPanel() {
         let paneId = UUID()
         let selectedPanelId = UUID()

--- a/cmuxUITests/MultiWindowNotificationsUITests.swift
+++ b/cmuxUITests/MultiWindowNotificationsUITests.swift
@@ -217,6 +217,11 @@ final class MultiWindowNotificationsUITests: XCTestCase {
             forwardingToggle.waitForExistence(timeout: 9.0),
             "Expected the popover entrypoint to reveal the actual phone-forwarding controls"
         )
+        let notificationsTab = app.buttons["Notifications"]
+        XCTAssertTrue(
+            notificationsTab.waitForExistence(timeout: 3.0) && notificationsTab.isHittable,
+            "Expected Notifications to open as a selectable pane tab"
+        )
     }
 
     func testEmptyNotificationsPopoverBlocksTerminalTyping() throws {


### PR DESCRIPTION
Notifications now opens through the workspace pane system instead of replacing the workspace content layer. The quick titlebar popover remains lightweight; its forwarding entry opens or focuses one Notifications tab per workspace.

The new panel participates in tab binding, focus, close history, session restore, surface metadata, and accessibility. Regression coverage requires the forwarding path to produce a hittable Notifications tab. The failing test and implementation are separate commits.

Verified with tagged cloud build `npbg`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/9721"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788662811&installation_model_id=21920&pr_number=9721&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F9721&signature=f5f2b32f47a369961ae034c4fa5275dd92df3ea3b0179db2d6d1682c54bb0792"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate UI and navigation refactor with session migration and focus behavior changes across workspace layout, but no security or data-layer changes.
> 
> **Overview**
> **Notifications** is no longer a full-window sidebar overlay; it is a **pane tab** in the workspace split system, alongside todos and other special surfaces.
> 
> A new **`NotificationsPanel`** hosts the existing **`NotificationsPage`** inside **`PanelContentView`**, with **`openOrFocusNotificationsSurface`** / **`newNotificationsSurface`** on **`Workspace`** (one notifications tab per workspace, reused when already open). **`SurfaceKind.notifications`** and **`PanelType.notifications`** are wired through icons, command palette labels, closed-tab history, lifecycle events, and global search.
> 
> The main content area no longer stacks a separate **`NotificationsPage`** when the sidebar picks notifications. **`SessionSidebarSelection`** now maps legacy **`.notifications`** sidebar state to **`.tabs`**, and session snapshots can restore a notifications pane via **`SessionNotificationsPanelSnapshot`**.
> 
> **Phone forwarding** from the titlebar popover switches the sidebar to tabs and opens or focuses the notifications pane in the current split instead of selecting the retired overlay. **`NotificationsPage`** focus logic uses pane **`isFocused`** / **`isVisibleInUI`** so background tabs do not steal keyboard focus from terminals.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 78520a4e2fb94a8bac3c64d39ccd6810122cc965. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Notifications as a dedicated pane that can be opened, focused, and selected.
  * Notifications panes display a bell icon and localized “Notifications” label.
  * Notifications can be discovered through command palette search.
  * Notification panes are preserved when saving and restoring sessions.
  * Phone-forwarding controls now open or focus the Notifications pane.

* **Bug Fixes**
  * Improved notification opening and focus behavior regardless of sidebar selection.
  * Migrated legacy Notifications sidebar selections to the Tabs view.
  * Prevented unsupported file-drop actions in Notifications panes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->