### PR TITLE
Show iOS terminal send progress and failures

### DIFF
--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
@@ -515,6 +515,11 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
                 b: terminalInputText.isEmpty ? 1 : 0
             ))
             #endif
+            if !terminalInputText.isEmpty,
+               terminalInputText != oldValue,
+               let terminalID = selectedTerminalID?.rawValue {
+                clearSettledTerminalSendStatus(forTerminalID: terminalID)
+            }
             // Persist the live edit under the CURRENT terminal so it survives a
             // terminal switch. Skipped while a draft is being loaded (the load is
             // the saved value, re-saving it is redundant and would race the
@@ -595,11 +600,65 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
     /// this spans the entire image-then-text run. Not observed: it gates an
     /// async flow, not view state.
     @ObservationIgnored private var isSubmittingComposer = false
+    /// The last user-visible send settlement for each terminal. Unlike the
+    /// re-entrancy flags above, this is observed by both the composer button and
+    /// terminal command status pill.
+    private var terminalSendStatusesByTerminalID: [String: MobileTerminalSendStatus] = [:]
+    /// Latest operation identity per terminal. A late result from an older send
+    /// cannot overwrite the state of a newer retry.
+    @ObservationIgnored private var terminalSendOperationIDsByTerminalID: [String: UUID] = [:]
+    /// Raw-command operations are tracked separately so a focus/connection
+    /// pipeline clear can settle only those sends without disturbing an
+    /// independently in-flight composer paste pinned to the same terminal.
+    @ObservationIgnored private var rawTerminalSendOperationIDsByTerminalID: [String: UUID] = [:]
     /// Pending image attachments per terminal, keyed by terminal id so switching
     /// terminals keeps each draft's own attachments (mirroring how the text draft
     /// is keyed). Observed so the composer's chip row re-renders on add/remove.
     /// Sent in order on the next submit and then cleared for that terminal.
     private var pendingAttachmentsByTerminalID: [String: [MobilePendingAttachment]] = [:]
+
+    public func terminalSendStatus(forTerminalID terminalID: String) -> MobileTerminalSendStatus {
+        terminalSendStatusesByTerminalID[terminalID] ?? .idle
+    }
+
+    @discardableResult
+    private func beginTerminalSend(forTerminalID terminalID: String) -> UUID {
+        let operationID = UUID()
+        terminalSendOperationIDsByTerminalID[terminalID] = operationID
+        terminalSendStatusesByTerminalID[terminalID] = .sending
+        return operationID
+    }
+
+    private func finishTerminalSend(
+        _ operationID: UUID?,
+        forTerminalID terminalID: String,
+        succeeded: Bool
+    ) {
+        guard let operationID,
+              terminalSendOperationIDsByTerminalID[terminalID] == operationID else { return }
+        terminalSendStatusesByTerminalID[terminalID] = succeeded ? .sent : .failed
+    }
+
+    private func clearSettledTerminalSendStatus(forTerminalID terminalID: String) {
+        guard terminalSendStatusesByTerminalID[terminalID] != .sending else { return }
+        terminalSendStatusesByTerminalID[terminalID] = nil
+        terminalSendOperationIDsByTerminalID[terminalID] = nil
+    }
+
+    private func finishRawTerminalSend(
+        _ operationID: UUID?,
+        forTerminalID terminalID: String,
+        succeeded: Bool
+    ) {
+        guard let operationID,
+              rawTerminalSendOperationIDsByTerminalID[terminalID] == operationID else { return }
+        rawTerminalSendOperationIDsByTerminalID[terminalID] = nil
+        finishTerminalSend(
+            operationID,
+            forTerminalID: terminalID,
+            succeeded: succeeded
+        )
+    }
 
     /// Max number of staged attachments per terminal. Enforced in
     /// ``addPendingAttachment(_:format:forTerminalID:)`` against the CURRENT
@@ -7397,22 +7456,33 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
     /// attachments staged AND keeps the text unsent, so the user can retry
     /// instead of silently losing photos (matching the text-keep-on-failure
     /// semantics of ``submitComposerInput()``).
-    public func submitComposer() async {
+    @discardableResult
+    public func submitComposer() async -> Bool {
         // Reject a re-entrant submit (e.g. a double tap on Send): the button
         // stays enabled while the first image RPC awaits, and a second submit
         // would capture the same still-staged attachments and re-upload them.
         // Set/cleared on the main actor around the awaits, so no second call can
         // slip past. A failed send keeps the attachments staged (below), so the
         // user can retry once this flag clears.
-        guard !isSubmittingComposer else { return }
+        guard !isSubmittingComposer else { return false }
         isSubmittingComposer = true
         defer { isSubmittingComposer = false }
         guard let workspaceID = selectedWorkspace?.id,
               let submittedTerminalID = selectedTerminalID else {
             // No target: fall back to the text-only path, which is itself a no-op
             // without a selected terminal.
-            await submitComposerInput()
-            return
+            return await submitComposerInput()
+        }
+        let sendOperationID = beginTerminalSend(
+            forTerminalID: submittedTerminalID.rawValue
+        )
+        var sendSucceeded = false
+        defer {
+            finishTerminalSend(
+                sendOperationID,
+                forTerminalID: submittedTerminalID.rawValue,
+                succeeded: sendSucceeded
+            )
         }
         // Snapshot the text BEFORE any await (the image sends below). Threaded
         // through the text submit + the post-send reconcile so a terminal switch
@@ -7452,7 +7522,7 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
                 signIn: submitSignInGeneration,
                 connection: submitConnectionGeneration,
                 client: submitClient
-            ) else { return }
+            ) else { return false }
             // Re-check the attachment is still staged for the captured terminal
             // before uploading it. The user can delete a not-yet-acked chip while
             // an earlier image's send is in flight; that removes it from
@@ -7469,7 +7539,7 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
                 workspaceID: workspaceID,
                 terminalID: submittedTerminalID
             )
-            guard sent else { return }
+            guard sent else { return false }
             removePendingAttachment(id: attachment.id, forTerminalID: submittedTerminalID.rawValue)
         }
         // Re-check the captured identity one last time before the text send. The
@@ -7481,16 +7551,17 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
             signIn: submitSignInGeneration,
             connection: submitConnectionGeneration,
             client: submitClient
-        ) else { return }
+        ) else { return false }
         // Submit the captured text to the captured terminal (a no-op when empty,
         // e.g. an images-only send). All images acked by here, so the text
         // follows. Passing the snapshot (not the live field) keeps this immune to
         // a switch/edit that happened during the image awaits above.
-        await submitComposerInput(
+        sendSucceeded = await submitComposerInput(
             workspaceID: workspaceID,
             terminalID: submittedTerminalID,
             capturedText: submittedText
         )
+        return sendSucceeded
     }
 
     /// Whether the session + connection identity captured at the start of a
@@ -7572,11 +7643,22 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
             #endif
             return
         }
+        prepareTerminalSendStatusForRawInput(
+            text,
+            terminalID: terminalID.rawValue
+        )
         let enqueueResult = rawTerminalInputBuffer.enqueue(
             text,
             workspaceID: workspaceID,
             terminalID: terminalID
         )
+        if enqueueResult == .rejected, Self.containsTerminalSubmission(text) {
+            finishRawTerminalSend(
+                terminalSendOperationIDsByTerminalID[terminalID.rawValue],
+                forTerminalID: terminalID.rawValue,
+                succeeded: false
+            )
+        }
         handleSynchronousRawTerminalInputEnqueueResult(enqueueResult)
     }
 
@@ -7586,11 +7668,19 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
             return
         }
         guard let workspaceID = workspaceID(forTerminalID: surfaceID) else { return }
+        prepareTerminalSendStatusForRawInput(text, terminalID: surfaceID)
         let enqueueResult = rawTerminalInputBuffer.enqueue(
             text,
             workspaceID: workspaceID,
             terminalID: MobileTerminalPreview.ID(rawValue: surfaceID)
         )
+        if enqueueResult == .rejected, Self.containsTerminalSubmission(text) {
+            finishRawTerminalSend(
+                terminalSendOperationIDsByTerminalID[surfaceID],
+                forTerminalID: surfaceID,
+                succeeded: false
+            )
+        }
         handleSynchronousRawTerminalInputEnqueueResult(enqueueResult)
     }
 
@@ -7606,6 +7696,25 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
             return
         case .rejected:
             handleRawTerminalInputOverflow()
+        }
+    }
+
+    private func prepareTerminalSendStatusForRawInput(
+        _ text: String,
+        terminalID: String
+    ) {
+        if Self.containsTerminalSubmission(text) {
+            rawTerminalSendOperationIDsByTerminalID[terminalID] = beginTerminalSend(
+                forTerminalID: terminalID
+            )
+        } else {
+            clearSettledTerminalSendStatus(forTerminalID: terminalID)
+        }
+    }
+
+    private nonisolated static func containsTerminalSubmission(_ text: String) -> Bool {
+        text.unicodeScalars.contains { scalar in
+            scalar.value == 0x0D || scalar.value == 0x0A
         }
     }
 
@@ -7699,7 +7808,10 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
                 chunk.text,
                 workspaceID: chunk.workspaceID,
                 terminalID: chunk.terminalID,
-                latencyBatchNumber: latencyBatchNumberForSend
+                latencyBatchNumber: latencyBatchNumberForSend,
+                sendStatusOperationID: Self.containsTerminalSubmission(chunk.text)
+                    ? rawTerminalSendOperationIDsByTerminalID[chunk.terminalID.rawValue]
+                    : nil
             )
         }
     }
@@ -7714,6 +7826,14 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
     func clearPendingTerminalInputForFocusChange() {
         rawTerminalInputBuffer.clear()
         terminalInputRPCPipeline.clear()
+        let pendingRawSends = rawTerminalSendOperationIDsByTerminalID
+        for (terminalID, operationID) in pendingRawSends {
+            finishRawTerminalSend(
+                operationID,
+                forTerminalID: terminalID,
+                succeeded: false
+            )
+        }
         resumeRawTerminalInputDrainWaiters()
     }
 
@@ -9662,13 +9782,19 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         _ text: String,
         workspaceID: MobileWorkspacePreview.ID,
         terminalID: MobileTerminalPreview.ID,
-        latencyBatchNumber: UInt64? = nil
+        latencyBatchNumber: UInt64? = nil,
+        sendStatusOperationID: UUID? = nil
     ) async {
         guard let client = remoteClient else {
             #if DEBUG
             mobileShellLog.info("skip remote terminal input remoteClient=0")
             #endif
             Self.stampTerminalInputSettlement(latencyBatchNumber, succeeded: false)
+            finishRawTerminalSend(
+                sendStatusOperationID,
+                forTerminalID: terminalID.rawValue,
+                succeeded: false
+            )
             return
         }
         let generation = connectionGeneration
@@ -9703,6 +9829,11 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
                             latencyBatchNumber,
                             succeeded: false
                         )
+                        finishRawTerminalSend(
+                            sendStatusOperationID,
+                            forTerminalID: terminalID.rawValue,
+                            succeeded: false
+                        )
                         return
                     }
                     if terminalInputRPCPipeline.hasAmbiguousFailure(
@@ -9729,12 +9860,22 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
             switch laneResult {
             case .sent:
                 Self.stampTerminalInputSettlement(latencyBatchNumber, succeeded: true)
+                finishRawTerminalSend(
+                    sendStatusOperationID,
+                    forTerminalID: terminalID.rawValue,
+                    succeeded: true
+                )
                 return
             case .failed:
                 mobileShellLog.error(
                     "independent terminal input failed surface=\(terminalID.rawValue, privacy: .public)"
                 )
                 Self.stampTerminalInputSettlement(latencyBatchNumber, succeeded: false)
+                finishRawTerminalSend(
+                    sendStatusOperationID,
+                    forTerminalID: terminalID.rawValue,
+                    succeeded: false
+                )
                 return
             case .unavailable:
                 break
@@ -9767,6 +9908,11 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
                                 latencyBatchNumber,
                                 succeeded: true
                             )
+                            self?.finishRawTerminalSend(
+                                sendStatusOperationID,
+                                forTerminalID: terminalID.rawValue,
+                                succeeded: true
+                            )
                             guard let self, let client else { return }
                             guard self.isCurrentRemoteOperation(
                                 client: client,
@@ -9779,6 +9925,11 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
                         case let .failure(error):
                             Self.stampTerminalInputSettlement(
                                 latencyBatchNumber,
+                                succeeded: false
+                            )
+                            self?.finishRawTerminalSend(
+                                sendStatusOperationID,
+                                forTerminalID: terminalID.rawValue,
                                 succeeded: false
                             )
                             guard let self, let client else { return }
@@ -9797,6 +9948,11 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
                 // operational failure, regardless of whether the caller also
                 // rotated connectionGeneration.
                 Self.stampTerminalInputSettlement(latencyBatchNumber, succeeded: false)
+                finishRawTerminalSend(
+                    sendStatusOperationID,
+                    forTerminalID: terminalID.rawValue,
+                    succeeded: false
+                )
                 if error is CancellationError { return }
                 handleTerminalInputFailure(
                     error,
@@ -9818,12 +9974,27 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
             )
             guard isCurrentRemoteOperation(client: client, generation: generation) else {
                 Self.stampTerminalInputSettlement(latencyBatchNumber, succeeded: false)
+                finishRawTerminalSend(
+                    sendStatusOperationID,
+                    forTerminalID: terminalID.rawValue,
+                    succeeded: false
+                )
                 return
             }
             handleTerminalInputResponse(responseData, surfaceID: terminalID.rawValue)
             Self.stampTerminalInputSettlement(latencyBatchNumber, succeeded: true)
+            finishRawTerminalSend(
+                sendStatusOperationID,
+                forTerminalID: terminalID.rawValue,
+                succeeded: true
+            )
         } catch {
             Self.stampTerminalInputSettlement(latencyBatchNumber, succeeded: false)
+            finishRawTerminalSend(
+                sendStatusOperationID,
+                forTerminalID: terminalID.rawValue,
+                succeeded: false
+            )
             handleTerminalInputFailure(
                 error,
                 client: client,

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
@@ -515,7 +515,8 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
                 b: terminalInputText.isEmpty ? 1 : 0
             ))
             #endif
-            if !terminalInputText.isEmpty,
+            if !isLoadingDraft,
+               !terminalInputText.isEmpty,
                terminalInputText != oldValue,
                let terminalID = selectedTerminalID?.rawValue {
                 clearSettledTerminalSendStatus(forTerminalID: terminalID)

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
@@ -7381,10 +7381,14 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
     /// send fails (no connection, or an older host that does not implement
     /// `terminal.paste` and answers `method_not_found`), the composed text is
     /// kept so the user can retry instead of silently losing the message.
-    public func submitComposerInput() async {
+    @discardableResult
+    public func submitComposerInput() async -> Bool {
         guard let workspaceID = selectedWorkspace?.id,
-              let terminalID = selectedTerminalID else { return }
-        await submitComposerInput(workspaceID: workspaceID, terminalID: terminalID)
+              let terminalID = selectedTerminalID else { return false }
+        return await submitComposerInput(
+            workspaceID: workspaceID,
+            terminalID: terminalID
+        )
     }
 
     /// Submit the composer's text to an explicitly captured terminal. Used by
@@ -7643,18 +7647,19 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
             #endif
             return
         }
-        prepareTerminalSendStatusForRawInput(
+        let sendStatusOperationID = prepareTerminalSendStatusForRawInput(
             text,
             terminalID: terminalID.rawValue
         )
         let enqueueResult = rawTerminalInputBuffer.enqueue(
             text,
             workspaceID: workspaceID,
-            terminalID: terminalID
+            terminalID: terminalID,
+            sendStatusOperationID: sendStatusOperationID
         )
-        if enqueueResult == .rejected, Self.containsTerminalSubmission(text) {
+        if enqueueResult == .rejected {
             finishRawTerminalSend(
-                terminalSendOperationIDsByTerminalID[terminalID.rawValue],
+                sendStatusOperationID,
                 forTerminalID: terminalID.rawValue,
                 succeeded: false
             )
@@ -7668,15 +7673,19 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
             return
         }
         guard let workspaceID = workspaceID(forTerminalID: surfaceID) else { return }
-        prepareTerminalSendStatusForRawInput(text, terminalID: surfaceID)
+        let sendStatusOperationID = prepareTerminalSendStatusForRawInput(
+            text,
+            terminalID: surfaceID
+        )
         let enqueueResult = rawTerminalInputBuffer.enqueue(
             text,
             workspaceID: workspaceID,
-            terminalID: MobileTerminalPreview.ID(rawValue: surfaceID)
+            terminalID: MobileTerminalPreview.ID(rawValue: surfaceID),
+            sendStatusOperationID: sendStatusOperationID
         )
-        if enqueueResult == .rejected, Self.containsTerminalSubmission(text) {
+        if enqueueResult == .rejected {
             finishRawTerminalSend(
-                terminalSendOperationIDsByTerminalID[surfaceID],
+                sendStatusOperationID,
                 forTerminalID: surfaceID,
                 succeeded: false
             )
@@ -7702,13 +7711,16 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
     private func prepareTerminalSendStatusForRawInput(
         _ text: String,
         terminalID: String
-    ) {
+    ) -> UUID? {
         if Self.containsTerminalSubmission(text) {
-            rawTerminalSendOperationIDsByTerminalID[terminalID] = beginTerminalSend(
+            let operationID = beginTerminalSend(
                 forTerminalID: terminalID
             )
+            rawTerminalSendOperationIDsByTerminalID[terminalID] = operationID
+            return operationID
         } else {
             clearSettledTerminalSendStatus(forTerminalID: terminalID)
+            return nil
         }
     }
 
@@ -7809,9 +7821,7 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
                 workspaceID: chunk.workspaceID,
                 terminalID: chunk.terminalID,
                 latencyBatchNumber: latencyBatchNumberForSend,
-                sendStatusOperationID: Self.containsTerminalSubmission(chunk.text)
-                    ? rawTerminalSendOperationIDsByTerminalID[chunk.terminalID.rawValue]
-                    : nil
+                sendStatusOperationID: chunk.sendStatusOperationID
             )
         }
     }

--- a/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/ComposerSubmitRoutingStoreBuilders.swift
+++ b/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/ComposerSubmitRoutingStoreBuilders.swift
@@ -28,6 +28,7 @@ func makeRoutingConnectedStore(
     pairedMacStore: (any MobilePairedMacStoring)? = nil,
     routeKind: CmxAttachTransportKind = .debugLoopback,
     terminalLaneProvider: MobileTerminalLaneProvider? = nil,
+    draftStore: (any TerminalDraftStoring)? = nil,
     rpcRequestTimeoutNanoseconds: UInt64 = 30 * 1_000_000_000
 ) async throws -> MobileShellComposite {
     let runtime = RoutingTestRuntime(
@@ -53,7 +54,8 @@ func makeRoutingConnectedStore(
         ],
         pairedMacStore: pairedMacStore,
         identityProvider: StaticIdentityProvider(userID: "routing-user"),
-        pendingDismissQueue: pendingDismissQueue
+        pendingDismissQueue: pendingDismissQueue,
+        draftStore: draftStore
     )
     // 127.0.0.1 is a Stack-auth-trusted route, so authorized requests carry the
     // Stack token and do not throw insecureManualRoute before reaching the

--- a/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/ComposerSubmitRoutingTests.swift
+++ b/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/ComposerSubmitRoutingTests.swift
@@ -45,6 +45,30 @@ import Testing
         #expect(store.terminalSendStatus(forTerminalID: terminalID) == .failed)
     }
 
+    @Test func restoredFailedDraftKeepsFailureSettlement() async throws {
+        let router = RoutingHostRouter()
+        let drafts = InMemoryTerminalDraftStore()
+        let store = try await makeRoutingConnectedStore(router: router, draftStore: drafts)
+        let termA = RoutingHostRouter.terminalA
+        let termB = RoutingHostRouter.terminalB
+        store.selectTerminal(MobileTerminalPreview.ID(rawValue: termA))
+        await store.drainDraftOperationsForTesting()
+        store.terminalInputText = "retry me"
+        store.addPendingAttachment(Self.bytes("rejected"), format: "png", forTerminalID: termA)
+
+        await router.setRejectPasteImage(true)
+        await store.submitComposer()
+        #expect(store.terminalSendStatus(forTerminalID: termA) == .failed)
+
+        store.selectTerminal(MobileTerminalPreview.ID(rawValue: termB))
+        await store.drainDraftOperationsForTesting()
+        store.selectTerminal(MobileTerminalPreview.ID(rawValue: termA))
+        await store.drainDraftOperationsForTesting()
+
+        #expect(store.terminalInputText == "retry me")
+        #expect(store.terminalSendStatus(forTerminalID: termA) == .failed)
+    }
+
     /// Images and text both go to the selected terminal when nothing switches.
     @Test func sendsAttachmentsAndTextToSelectedTerminal() async throws {
         let router = RoutingHostRouter()

--- a/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/ComposerSubmitRoutingTests.swift
+++ b/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/ComposerSubmitRoutingTests.swift
@@ -12,6 +12,39 @@ import Testing
 @Suite struct ComposerSubmitRoutingTests {
     private static func bytes(_ s: String) -> Data { Data(s.utf8) }
 
+    @Test func exposesComposerSendProgressAndSettlement() async throws {
+        let router = RoutingHostRouter()
+        let store = try await makeRoutingConnectedStore(router: router)
+        let terminalID = RoutingHostRouter.terminalA
+        store.selectTerminal(MobileTerminalPreview.ID(rawValue: terminalID))
+        store.addPendingAttachment(Self.bytes("held"), format: "png", forTerminalID: terminalID)
+        store.terminalInputText = "hello"
+
+        await router.setHoldFirstPasteImage(true)
+        let submit = Task { await store.submitComposer() }
+        await router.awaitFirstPasteImageReached()
+
+        #expect(store.terminalSendStatus(forTerminalID: terminalID) == .sending)
+
+        await router.releaseFirstPasteImage()
+        await submit.value
+
+        #expect(store.terminalSendStatus(forTerminalID: terminalID) == .sent)
+    }
+
+    @Test func exposesComposerSendFailure() async throws {
+        let router = RoutingHostRouter()
+        let store = try await makeRoutingConnectedStore(router: router)
+        let terminalID = RoutingHostRouter.terminalA
+        store.selectTerminal(MobileTerminalPreview.ID(rawValue: terminalID))
+        store.addPendingAttachment(Self.bytes("rejected"), format: "png", forTerminalID: terminalID)
+
+        await router.setRejectPasteImage(true)
+        await store.submitComposer()
+
+        #expect(store.terminalSendStatus(forTerminalID: terminalID) == .failed)
+    }
+
     /// Images and text both go to the selected terminal when nothing switches.
     @Test func sendsAttachmentsAndTextToSelectedTerminal() async throws {
         let router = RoutingHostRouter()

--- a/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/TerminalRawInputOrderingTests.swift
+++ b/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/TerminalRawInputOrderingTests.swift
@@ -1,10 +1,54 @@
 import CmuxMobileRPC
+import CmuxMobileShellModel
 import Foundation
 import Testing
 
 @testable import CmuxMobileShell
 
 @Suite struct TerminalRawInputOrderingTests {
+    @MainActor
+    @Test func returnKeyExposesCommandSendProgressAndSettlement() async throws {
+        let router = RoutingHostRouter()
+        await router.setHoldFirstTerminalInput(true)
+        let store = try await makeRoutingConnectedStore(router: router)
+
+        store.sendTerminalRawInput(
+            Data("\r".utf8),
+            surfaceID: RoutingHostRouter.terminalA
+        )
+        await router.awaitFirstTerminalInputReached()
+
+        #expect(
+            store.terminalSendStatus(forTerminalID: RoutingHostRouter.terminalA)
+                == .sending
+        )
+
+        await router.releaseFirstTerminalInput()
+        #expect(await waitForTerminalSendStatus(
+            .sent,
+            store: store,
+            terminalID: RoutingHostRouter.terminalA
+        ))
+    }
+
+    @MainActor
+    @Test func rejectedReturnKeyExposesCommandSendFailure() async throws {
+        let router = RoutingHostRouter()
+        await router.setRejectTerminalInput(at: 0)
+        let store = try await makeRoutingConnectedStore(router: router)
+
+        store.sendTerminalRawInput(
+            Data("\r".utf8),
+            surfaceID: RoutingHostRouter.terminalA
+        )
+
+        #expect(await waitForTerminalSendStatus(
+            .failed,
+            store: store,
+            terminalID: RoutingHostRouter.terminalA
+        ))
+    }
+
     @MainActor
     @Test func orderedIrohFallbackPipelinesAtMostFourRequests() async throws {
         let router = RoutingHostRouter()
@@ -473,6 +517,21 @@ import Testing
         }
         return false
     }
+}
+
+@MainActor
+private func waitForTerminalSendStatus(
+    _ expected: MobileTerminalSendStatus,
+    store: MobileShellComposite,
+    terminalID: String
+) async -> Bool {
+    for _ in 0..<200 {
+        if store.terminalSendStatus(forTerminalID: terminalID) == expected {
+            return true
+        }
+        await Task.yield()
+    }
+    return false
 }
 
 private actor RawInputBarrierTerminalLane: MobileTerminalLaneConnection {

--- a/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/TerminalRawInputOrderingTests.swift
+++ b/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/TerminalRawInputOrderingTests.swift
@@ -50,6 +50,35 @@ import Testing
     }
 
     @MainActor
+    @Test func secondQueuedReturnOwnsItsFailureSettlement() async throws {
+        let router = RoutingHostRouter()
+        await router.setHoldFirstTerminalInput(true)
+        await router.setRejectTerminalInput(at: 1)
+        let store = try await makeRoutingConnectedStore(router: router)
+
+        store.sendTerminalRawInput(
+            Data("first\r".utf8),
+            surfaceID: RoutingHostRouter.terminalA
+        )
+        await router.awaitFirstTerminalInputReached()
+        store.sendTerminalRawInput(
+            Data("second\r".utf8),
+            surfaceID: RoutingHostRouter.terminalA
+        )
+
+        await router.releaseFirstTerminalInput()
+        #expect(await waitForTerminalSendStatus(
+            .failed,
+            store: store,
+            terminalID: RoutingHostRouter.terminalA
+        ))
+        #expect(
+            await router.recordedTerminalInputs().map(\.text)
+                == ["first\r", "second\r"]
+        )
+    }
+
+    @MainActor
     @Test func orderedIrohFallbackPipelinesAtMostFourRequests() async throws {
         let router = RoutingHostRouter()
         await router.setHoldAllTerminalInputs(true)
@@ -525,7 +554,9 @@ private func waitForTerminalSendStatus(
     store: MobileShellComposite,
     terminalID: String
 ) async -> Bool {
-    for _ in 0..<200 {
+    let clock = ContinuousClock()
+    let deadline = clock.now.advanced(by: .seconds(2))
+    while clock.now < deadline {
         if store.terminalSendStatus(forTerminalID: terminalID) == expected {
             return true
         }

--- a/Packages/iOS/CmuxMobileShellModel/Sources/CmuxMobileShellModel/MobileTerminalInputSendBuffer.swift
+++ b/Packages/iOS/CmuxMobileShellModel/Sources/CmuxMobileShellModel/MobileTerminalInputSendBuffer.swift
@@ -1,4 +1,4 @@
-import Foundation
+public import Foundation
 
 /// A coalescing, back-pressured queue of pending terminal input.
 ///
@@ -19,6 +19,8 @@ public struct MobileTerminalInputSendBuffer: Equatable, Sendable {
         public var terminalID: MobileTerminalPreview.ID
         /// The accumulated text for this chunk.
         public var text: String
+        /// The newest Return-terminated send represented by this chunk.
+        public var sendStatusOperationID: UUID?
 
         /// Creates a pending-input chunk.
         /// - Parameters:
@@ -28,11 +30,13 @@ public struct MobileTerminalInputSendBuffer: Equatable, Sendable {
         public init(
             workspaceID: MobileWorkspacePreview.ID,
             terminalID: MobileTerminalPreview.ID,
-            text: String
+            text: String,
+            sendStatusOperationID: UUID? = nil
         ) {
             self.workspaceID = workspaceID
             self.terminalID = terminalID
             self.text = text
+            self.sendStatusOperationID = sendStatusOperationID
         }
     }
 
@@ -56,7 +60,8 @@ public struct MobileTerminalInputSendBuffer: Equatable, Sendable {
     public mutating func enqueue(
         _ text: String,
         workspaceID: MobileWorkspacePreview.ID,
-        terminalID: MobileTerminalPreview.ID
+        terminalID: MobileTerminalPreview.ID,
+        sendStatusOperationID: UUID? = nil
     ) -> MobileTerminalInputEnqueueResult {
         guard !text.isEmpty else { return .queued }
         let byteCount = text.utf8.count
@@ -67,13 +72,17 @@ public struct MobileTerminalInputSendBuffer: Equatable, Sendable {
            last.workspaceID == workspaceID,
            last.terminalID == terminalID {
             last.text += text
+            if let sendStatusOperationID {
+                last.sendStatusOperationID = sendStatusOperationID
+            }
             pendingChunks[pendingChunks.count - 1] = last
         } else {
             pendingChunks.append(
                 Chunk(
                     workspaceID: workspaceID,
                     terminalID: terminalID,
-                    text: text
+                    text: text,
+                    sendStatusOperationID: sendStatusOperationID
                 )
             )
         }
@@ -120,7 +129,10 @@ public struct MobileTerminalInputSendBuffer: Equatable, Sendable {
             return Chunk(
                 workspaceID: pendingChunks[0].workspaceID,
                 terminalID: pendingChunks[0].terminalID,
-                text: prefix
+                text: prefix,
+                // Settle only after the final piece of a split chunk has been
+                // handed to the transport.
+                sendStatusOperationID: nil
             )
         }
         let chunk = pendingChunks.removeFirst()

--- a/Packages/iOS/CmuxMobileShellModel/Sources/CmuxMobileShellModel/MobileTerminalSendStatus.swift
+++ b/Packages/iOS/CmuxMobileShellModel/Sources/CmuxMobileShellModel/MobileTerminalSendStatus.swift
@@ -1,0 +1,11 @@
+/// User-visible settlement state for a terminal submission.
+///
+/// The state is scoped per terminal and covers both the composer paste path and
+/// Return-terminated raw terminal commands. Ordinary keystrokes are excluded so
+/// typing does not flash transport chrome for every character.
+public enum MobileTerminalSendStatus: Equatable, Sendable {
+    case idle
+    case sending
+    case sent
+    case failed
+}

--- a/Packages/iOS/CmuxMobileShellModel/Tests/CmuxMobileShellModelTests/MobileTerminalInputSendBufferTests.swift
+++ b/Packages/iOS/CmuxMobileShellModel/Tests/CmuxMobileShellModelTests/MobileTerminalInputSendBufferTests.swift
@@ -1,3 +1,4 @@
+import Foundation
 import Testing
 
 @testable import CmuxMobileShellModel
@@ -104,5 +105,30 @@ import Testing
         #expect(buffer.nextBatch(maximumByteCount: 4)?.text == "漢")
         #expect(buffer.pendingByteCount == 0)
         #expect(buffer.nextBatch(maximumByteCount: 4) == nil)
+    }
+
+    @Test func coalescedChunkRetainsNewestSendOperation() {
+        var buffer = MobileTerminalInputSendBuffer()
+        let workspaceID = MobileWorkspacePreview.ID(rawValue: "workspace-a")
+        let terminalID = MobileTerminalPreview.ID(rawValue: "terminal-a")
+        let firstOperationID = UUID()
+        let secondOperationID = UUID()
+
+        #expect(buffer.enqueue(
+            "first\r",
+            workspaceID: workspaceID,
+            terminalID: terminalID,
+            sendStatusOperationID: firstOperationID
+        ) == .startDraining)
+        #expect(buffer.enqueue(
+            "second\r",
+            workspaceID: workspaceID,
+            terminalID: terminalID,
+            sendStatusOperationID: secondOperationID
+        ) == .queued)
+
+        let batch = buffer.nextBatch()
+        #expect(batch?.text == "first\rsecond\r")
+        #expect(batch?.sendStatusOperationID == secondOperationID)
     }
 }

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TerminalComposerView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TerminalComposerView.swift
@@ -131,6 +131,14 @@ struct TerminalComposerView: View {
         store.composerCanSend(forTerminalID: terminalID)
     }
 
+    private var sendStatus: MobileTerminalSendStatus {
+        store.terminalSendStatus(forTerminalID: terminalID)
+    }
+
+    private var isSending: Bool {
+        sendStatus == .sending
+    }
+
     /// This terminal's staged image attachments, shown as the chip row above the
     /// field and sent (in order) ahead of the text on submit.
     private var pendingAttachments: [MobilePendingAttachment] {
@@ -182,6 +190,9 @@ struct TerminalComposerView: View {
         // runs after SwiftUI commits the change, so the host measures the collapsed
         // (chip-less) layout rather than the stale tall one.
         .onChange(of: pendingAttachments.isEmpty) { _, _ in
+            requestHeightRemeasure()
+        }
+        .onChange(of: sendStatus) { _, _ in
             requestHeightRemeasure()
         }
         .onAppear {
@@ -292,6 +303,20 @@ struct TerminalComposerView: View {
                 attachmentChipRow
             }
 
+            if sendStatus == .failed {
+                Label(
+                    L10n.string(
+                        "mobile.terminal.sendFailed",
+                        defaultValue: "Couldn’t send. Check the connection and try again."
+                    ),
+                    systemImage: "exclamationmark.circle.fill"
+                )
+                .font(.caption.weight(.medium))
+                .foregroundStyle(.red)
+                .padding(.leading, controlHeight + 8)
+                .accessibilityIdentifier("MobileComposerSendFailure")
+            }
+
             HStack(alignment: .bottom, spacing: 8) {
                 MobileComposerIconButton(
                     systemImage: "paperclip",
@@ -354,28 +379,12 @@ struct TerminalComposerView: View {
                     Button {
                         send()
                     } label: {
-                        Image(systemName: "arrow.up")
-                            .font(.system(size: 15, weight: .bold))
-                            .foregroundStyle(
-                                canSend
-                                    ? .white
-                                    : store.activeTerminalTheme.terminalForegroundColor.opacity(0.35)
-                            )
-                            .frame(width: inlineSendDiameter, height: inlineSendDiameter)
-                            .background(
-                                Circle().fill(
-                                    canSend
-                                        ? AnyShapeStyle(Color.accentColor)
-                                        : AnyShapeStyle(
-                                            store.activeTerminalTheme.terminalForegroundColor.opacity(0.12)
-                                        )
-                                )
-                            )
+                        composerSendButtonLabel
                     }
                     .buttonStyle(.plain)
-                    .disabled(!canSend)
+                    .disabled(isSending || !canSend)
                     .accessibilityIdentifier("MobileComposerSend")
-                    .accessibilityLabel(L10n.string("mobile.composer.send", defaultValue: "Send"))
+                    .accessibilityLabel(composerSendAccessibilityLabel)
                 }
             }
         }
@@ -401,6 +410,73 @@ struct TerminalComposerView: View {
             } else {
                 photoPickerDidDismiss()
             }
+        }
+    }
+
+    @ViewBuilder
+    private var composerSendButtonLabel: some View {
+        Group {
+            if isSending {
+                ProgressView()
+                    .controlSize(.small)
+                    .tint(.white)
+            } else {
+                Image(systemName: composerSendSystemImage)
+                    .font(.system(size: 15, weight: .bold))
+            }
+        }
+        .foregroundStyle(composerSendForegroundStyle)
+        .frame(width: inlineSendDiameter, height: inlineSendDiameter)
+        .background(Circle().fill(composerSendBackgroundStyle))
+    }
+
+    private var composerSendSystemImage: String {
+        switch sendStatus {
+        case .sent:
+            return "checkmark"
+        case .failed:
+            return "exclamationmark"
+        case .idle, .sending:
+            return "arrow.up"
+        }
+    }
+
+    private var composerSendForegroundStyle: AnyShapeStyle {
+        if isSending || sendStatus == .sent || sendStatus == .failed || canSend {
+            return AnyShapeStyle(Color.white)
+        }
+        return AnyShapeStyle(
+            store.activeTerminalTheme.terminalForegroundColor.opacity(0.35)
+        )
+    }
+
+    private var composerSendBackgroundStyle: AnyShapeStyle {
+        switch sendStatus {
+        case .sending:
+            return AnyShapeStyle(Color.accentColor)
+        case .sent:
+            return AnyShapeStyle(Color.green)
+        case .failed:
+            return AnyShapeStyle(Color.red)
+        case .idle:
+            return canSend
+                ? AnyShapeStyle(Color.accentColor)
+                : AnyShapeStyle(
+                    store.activeTerminalTheme.terminalForegroundColor.opacity(0.12)
+                )
+        }
+    }
+
+    private var composerSendAccessibilityLabel: String {
+        switch sendStatus {
+        case .sending:
+            return L10n.string("mobile.terminal.sending", defaultValue: "Sending")
+        case .sent:
+            return L10n.string("mobile.terminal.sent", defaultValue: "Sent")
+        case .failed:
+            return L10n.string("mobile.terminal.sendFailed.short", defaultValue: "Send failed")
+        case .idle:
+            return L10n.string("mobile.composer.send", defaultValue: "Send")
         }
     }
 

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TerminalComposerView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TerminalComposerView.swift
@@ -432,17 +432,15 @@ struct TerminalComposerView: View {
 
     private var composerSendSystemImage: String {
         switch sendStatus {
-        case .sent:
-            return "checkmark"
         case .failed:
             return "exclamationmark"
-        case .idle, .sending:
+        case .idle, .sending, .sent:
             return "arrow.up"
         }
     }
 
     private var composerSendForegroundStyle: AnyShapeStyle {
-        if isSending || sendStatus == .sent || sendStatus == .failed || canSend {
+        if isSending || sendStatus == .failed || canSend {
             return AnyShapeStyle(Color.white)
         }
         return AnyShapeStyle(
@@ -454,11 +452,9 @@ struct TerminalComposerView: View {
         switch sendStatus {
         case .sending:
             return AnyShapeStyle(Color.accentColor)
-        case .sent:
-            return AnyShapeStyle(Color.green)
         case .failed:
             return AnyShapeStyle(Color.red)
-        case .idle:
+        case .idle, .sent:
             return canSend
                 ? AnyShapeStyle(Color.accentColor)
                 : AnyShapeStyle(
@@ -472,7 +468,7 @@ struct TerminalComposerView: View {
         case .sending:
             return L10n.string("mobile.terminal.sending", defaultValue: "Sending")
         case .sent:
-            return L10n.string("mobile.terminal.sent", defaultValue: "Sent")
+            return L10n.string("mobile.composer.send", defaultValue: "Send")
         case .failed:
             return L10n.string("mobile.terminal.sendFailed.short", defaultValue: "Send failed")
         case .idle:

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TerminalSendStatusPill.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TerminalSendStatusPill.swift
@@ -1,0 +1,44 @@
+#if os(iOS)
+import CmuxMobileShellModel
+import CmuxMobileSupport
+import SwiftUI
+
+struct TerminalSendStatusPill: View {
+    let status: MobileTerminalSendStatus
+
+    var body: some View {
+        if status != .idle {
+            HStack(spacing: 7) {
+                if status == .sending {
+                    ProgressView()
+                        .controlSize(.small)
+                } else {
+                    Image(systemName: status == .sent ? "checkmark.circle.fill" : "xmark.circle.fill")
+                        .foregroundStyle(status == .sent ? Color.green : Color.red)
+                }
+
+                Text(title)
+                    .font(.caption.weight(.semibold))
+            }
+            .padding(.horizontal, 10)
+            .padding(.vertical, 7)
+            .background(.ultraThinMaterial, in: Capsule())
+            .accessibilityElement(children: .combine)
+            .accessibilityIdentifier("MobileTerminalSendStatus")
+        }
+    }
+
+    private var title: String {
+        switch status {
+        case .idle:
+            return ""
+        case .sending:
+            return L10n.string("mobile.terminal.sending", defaultValue: "Sending")
+        case .sent:
+            return L10n.string("mobile.terminal.sent", defaultValue: "Sent")
+        case .failed:
+            return L10n.string("mobile.terminal.sendFailed.short", defaultValue: "Send failed")
+        }
+    }
+}
+#endif

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TerminalSendStatusPill.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TerminalSendStatusPill.swift
@@ -7,14 +7,14 @@ struct TerminalSendStatusPill: View {
     let status: MobileTerminalSendStatus
 
     var body: some View {
-        if status != .idle {
+        if status == .sending || status == .failed {
             HStack(spacing: 7) {
                 if status == .sending {
                     ProgressView()
                         .controlSize(.small)
                 } else {
-                    Image(systemName: status == .sent ? "checkmark.circle.fill" : "xmark.circle.fill")
-                        .foregroundStyle(status == .sent ? Color.green : Color.red)
+                    Image(systemName: "xmark.circle.fill")
+                        .foregroundStyle(Color.red)
                 }
 
                 Text(title)
@@ -35,7 +35,7 @@ struct TerminalSendStatusPill: View {
         case .sending:
             return L10n.string("mobile.terminal.sending", defaultValue: "Sending")
         case .sent:
-            return L10n.string("mobile.terminal.sent", defaultValue: "Sent")
+            return ""
         case .failed:
             return L10n.string("mobile.terminal.sendFailed.short", defaultValue: "Send failed")
         }

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceDetailView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceDetailView.swift
@@ -365,6 +365,19 @@ struct WorkspaceDetailView: View {
                 .padding(.top, 10)
                 .padding(.leading, 10)
         }
+        #if os(iOS)
+        .overlay(alignment: .topTrailing) {
+            if let terminalID = selectedTerminal?.id.rawValue,
+               !store.isComposerPresented {
+                TerminalSendStatusPill(
+                    status: store.terminalSendStatus(forTerminalID: terminalID)
+                )
+                .allowsHitTesting(false)
+                .padding(.top, 10)
+                .padding(.trailing, 10)
+            }
+        }
+        #endif
         #if os(iOS) && DEBUG
         // DEBUG/UI-test-only store-side composer probe.
         .overlay {

--- a/ios/cmux/Resources/Localizable.xcstrings
+++ b/ios/cmux/Resources/Localizable.xcstrings
@@ -9776,6 +9776,74 @@
         }
       }
     },
+    "mobile.terminal.sendFailed": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Couldn’t send. Check the connection and try again."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "送信できませんでした。接続を確認して、もう一度お試しください。"
+          }
+        }
+      }
+    },
+    "mobile.terminal.sendFailed.short": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Send failed"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "送信に失敗しました"
+          }
+        }
+      }
+    },
+    "mobile.terminal.sending": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sending"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "送信中"
+          }
+        }
+      }
+    },
+    "mobile.terminal.sent": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sent"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "送信済み"
+          }
+        }
+      }
+    },
     "mobile.terminal.surfaceNotReady": {
       "extractionState": "manual",
       "localizations": {

--- a/ios/cmux/Resources/Localizable.xcstrings
+++ b/ios/cmux/Resources/Localizable.xcstrings
@@ -9827,23 +9827,6 @@
         }
       }
     },
-    "mobile.terminal.sent": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Sent"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "送信済み"
-          }
-        }
-      }
-    },
     "mobile.terminal.surfaceNotReady": {
       "extractionState": "manual",
       "localizations": {

--- a/ios/cmuxUITests/cmuxUITests.swift
+++ b/ios/cmuxUITests/cmuxUITests.swift
@@ -2838,7 +2838,11 @@ final class cmuxUITests: XCTestCase {
         XCTAssertTrue(send.waitForExistence(timeout: 3))
         send.tap()
         await server.awaitTerminalPasteRequestReached()
-        XCTAssertEqual(send.label, "Sending")
+        let sending = XCTNSPredicateExpectation(
+            predicate: NSPredicate(format: "label == %@", "Sending"),
+            object: send
+        )
+        XCTAssertEqual(XCTWaiter.wait(for: [sending], timeout: 2), .completed)
 
         server.releaseTerminalPasteResponse()
         let normalSend = XCTNSPredicateExpectation(

--- a/ios/cmuxUITests/cmuxUITests.swift
+++ b/ios/cmuxUITests/cmuxUITests.swift
@@ -2789,7 +2789,7 @@ final class cmuxUITests: XCTestCase {
     @MainActor
     func testTerminalComposerShowsSendingAndFailureSettlement() async throws {
         let server = try MobileSyncMockHostServer(
-            terminalSendResponseDelay: 1,
+            holdsTerminalPasteResponse: true,
             rejectsTerminalPaste: true
         )
         let port = try await server.start()
@@ -2804,14 +2804,16 @@ final class cmuxUITests: XCTestCase {
         let send = app.buttons["MobileComposerSend"]
         XCTAssertTrue(send.waitForExistence(timeout: 3))
         send.tap()
+        await server.awaitTerminalPasteRequestReached()
 
         let sending = XCTNSPredicateExpectation(
             predicate: NSPredicate(format: "label == %@", "Sending"),
             object: send
         )
-        XCTAssertEqual(XCTWaiter.wait(for: [sending], timeout: 0.8), .completed)
+        XCTAssertEqual(XCTWaiter.wait(for: [sending], timeout: 2), .completed)
         XCTAssertFalse(send.isEnabled)
 
+        server.releaseTerminalPasteResponse()
         let failure = app.staticTexts["MobileComposerSendFailure"]
         XCTAssertTrue(failure.waitForExistence(timeout: 4))
         XCTAssertEqual(send.label, "Send failed")
@@ -7216,7 +7218,7 @@ private final class MobileSyncMockHostServer: @unchecked Sendable {
     private let createdWorkspaceTerminalDelay: TimeInterval?
     private let supportsManualAttachTicket: Bool
     private let workspaceCreateSelectsCreatedWorkspace: Bool
-    private let terminalSendResponseDelay: TimeInterval?
+    private let holdsTerminalPasteResponse: Bool
     private let rejectsTerminalPaste: Bool
     private let macInstanceTag: String
     private var readyContinuation: CheckedContinuation<UInt16, Error>?
@@ -7227,6 +7229,9 @@ private final class MobileSyncMockHostServer: @unchecked Sendable {
     private var replayCounts: [String: Int] = [:]
     private var terminalScrollRequestsReceived = 0
     private var streamOffset: UInt64 = 1
+    private var terminalPasteRequestReached = false
+    private var terminalPasteRequestReachedWaiters: [CheckedContinuation<Void, Never>] = []
+    private var heldTerminalPasteResponse: (() -> Void)?
     private var workspaces: [Workspace] = [
         Workspace(
             id: "workspace-main",
@@ -7282,7 +7287,7 @@ private final class MobileSyncMockHostServer: @unchecked Sendable {
         createdWorkspaceTerminalDelay: TimeInterval? = nil,
         supportsManualAttachTicket: Bool = false,
         workspaceCreateSelectsCreatedWorkspace: Bool = true,
-        terminalSendResponseDelay: TimeInterval? = nil,
+        holdsTerminalPasteResponse: Bool = false,
         rejectsTerminalPaste: Bool = false,
         macInstanceTag: String = mockHostInstanceTag()
     ) throws {
@@ -7290,7 +7295,7 @@ private final class MobileSyncMockHostServer: @unchecked Sendable {
         self.createdWorkspaceTerminalDelay = createdWorkspaceTerminalDelay
         self.supportsManualAttachTicket = supportsManualAttachTicket
         self.workspaceCreateSelectsCreatedWorkspace = workspaceCreateSelectsCreatedWorkspace
-        self.terminalSendResponseDelay = terminalSendResponseDelay
+        self.holdsTerminalPasteResponse = holdsTerminalPasteResponse
         self.rejectsTerminalPaste = rejectsTerminalPaste
         self.macInstanceTag = macInstanceTag
         appendMainTerminals(count: additionalMainTerminalCount)
@@ -7531,8 +7536,12 @@ private final class MobileSyncMockHostServer: @unchecked Sendable {
         do {
             let responseFrame = try makeResponseFrame(for: payload)
             if Self.requestMethod(in: payload) == "terminal.paste",
-               let terminalSendResponseDelay {
-                queue.asyncAfter(deadline: .now() + terminalSendResponseDelay) { [weak self, weak connection] in
+               holdsTerminalPasteResponse {
+                terminalPasteRequestReached = true
+                let waiters = terminalPasteRequestReachedWaiters
+                terminalPasteRequestReachedWaiters = []
+                for waiter in waiters { waiter.resume() }
+                heldTerminalPasteResponse = { [weak self, weak connection] in
                     guard let self, let connection else { return }
                     self.sendResponse(
                         responseFrame,
@@ -7549,6 +7558,30 @@ private final class MobileSyncMockHostServer: @unchecked Sendable {
             }
         } catch {
             connection.cancel()
+        }
+    }
+
+    func awaitTerminalPasteRequestReached() async {
+        await withCheckedContinuation { continuation in
+            queue.async { [weak self] in
+                guard let self else {
+                    continuation.resume()
+                    return
+                }
+                if terminalPasteRequestReached {
+                    continuation.resume()
+                } else {
+                    terminalPasteRequestReachedWaiters.append(continuation)
+                }
+            }
+        }
+    }
+
+    func releaseTerminalPasteResponse() {
+        queue.async { [weak self] in
+            let response = self?.heldTerminalPasteResponse
+            self?.heldTerminalPasteResponse = nil
+            response?()
         }
     }
 

--- a/ios/cmuxUITests/cmuxUITests.swift
+++ b/ios/cmuxUITests/cmuxUITests.swift
@@ -2820,6 +2820,34 @@ final class cmuxUITests: XCTestCase {
         XCTAssertEqual(field.value as? String, "Preserve this prompt")
     }
 
+    /// A successful acknowledgement removes the in-flight treatment instead of
+    /// replacing Send with a persistent success glyph.
+    @MainActor
+    func testTerminalComposerReturnsToSendAfterAcknowledgement() async throws {
+        let server = try MobileSyncMockHostServer(holdsTerminalPasteResponse: true)
+        let port = try await server.start()
+        defer { server.stop() }
+
+        let app = try launchConnectedApp(port: port)
+        let field = app.textFields[Composer.field]
+        XCTAssertTrue(field.waitForExistence(timeout: 4))
+        field.tap()
+        field.typeText("Acknowledge this prompt")
+
+        let send = app.buttons["MobileComposerSend"]
+        XCTAssertTrue(send.waitForExistence(timeout: 3))
+        send.tap()
+        await server.awaitTerminalPasteRequestReached()
+        XCTAssertEqual(send.label, "Sending")
+
+        server.releaseTerminalPasteResponse()
+        let normalSend = XCTNSPredicateExpectation(
+            predicate: NSPredicate(format: "label == %@", "Send"),
+            object: send
+        )
+        XCTAssertEqual(XCTWaiter.wait(for: [normalSend], timeout: 4), .completed)
+    }
+
     /// Freeze fuzzing for the keyboard + layout interactions, modeled on
     /// `testFastPinchZoomDoesNotHangOrCorrupt`. The user report: "Sometimes the
     /// terminal on iOS freezes; we should do some fuzzing around here." The

--- a/ios/cmuxUITests/cmuxUITests.swift
+++ b/ios/cmuxUITests/cmuxUITests.swift
@@ -2784,6 +2784,40 @@ final class cmuxUITests: XCTestCase {
         assertTerminalRow(1, label: "Mobile Core: connected", in: app)
     }
 
+    /// A composer submission stays visibly in progress until the Mac responds,
+    /// then exposes a durable failure while preserving the draft for retry.
+    @MainActor
+    func testTerminalComposerShowsSendingAndFailureSettlement() async throws {
+        let server = try MobileSyncMockHostServer(
+            terminalSendResponseDelay: 1,
+            rejectsTerminalPaste: true
+        )
+        let port = try await server.start()
+        defer { server.stop() }
+
+        let app = try launchConnectedApp(port: port)
+        let field = app.textFields[Composer.field]
+        XCTAssertTrue(field.waitForExistence(timeout: 4))
+        field.tap()
+        field.typeText("Preserve this prompt")
+
+        let send = app.buttons["MobileComposerSend"]
+        XCTAssertTrue(send.waitForExistence(timeout: 3))
+        send.tap()
+
+        let sending = XCTNSPredicateExpectation(
+            predicate: NSPredicate(format: "label == %@", "Sending"),
+            object: send
+        )
+        XCTAssertEqual(XCTWaiter.wait(for: [sending], timeout: 0.8), .completed)
+        XCTAssertFalse(send.isEnabled)
+
+        let failure = app.staticTexts["MobileComposerSendFailure"]
+        XCTAssertTrue(failure.waitForExistence(timeout: 4))
+        XCTAssertEqual(send.label, "Send failed")
+        XCTAssertEqual(field.value as? String, "Preserve this prompt")
+    }
+
     /// Freeze fuzzing for the keyboard + layout interactions, modeled on
     /// `testFastPinchZoomDoesNotHangOrCorrupt`. The user report: "Sometimes the
     /// terminal on iOS freezes; we should do some fuzzing around here." The
@@ -7182,6 +7216,8 @@ private final class MobileSyncMockHostServer: @unchecked Sendable {
     private let createdWorkspaceTerminalDelay: TimeInterval?
     private let supportsManualAttachTicket: Bool
     private let workspaceCreateSelectsCreatedWorkspace: Bool
+    private let terminalSendResponseDelay: TimeInterval?
+    private let rejectsTerminalPaste: Bool
     private let macInstanceTag: String
     private var readyContinuation: CheckedContinuation<UInt16, Error>?
     private var connections: [NWConnection] = []
@@ -7246,12 +7282,16 @@ private final class MobileSyncMockHostServer: @unchecked Sendable {
         createdWorkspaceTerminalDelay: TimeInterval? = nil,
         supportsManualAttachTicket: Bool = false,
         workspaceCreateSelectsCreatedWorkspace: Bool = true,
+        terminalSendResponseDelay: TimeInterval? = nil,
+        rejectsTerminalPaste: Bool = false,
         macInstanceTag: String = mockHostInstanceTag()
     ) throws {
         listener = try NWListener(using: .tcp, on: .any)
         self.createdWorkspaceTerminalDelay = createdWorkspaceTerminalDelay
         self.supportsManualAttachTicket = supportsManualAttachTicket
         self.workspaceCreateSelectsCreatedWorkspace = workspaceCreateSelectsCreatedWorkspace
+        self.terminalSendResponseDelay = terminalSendResponseDelay
+        self.rejectsTerminalPaste = rejectsTerminalPaste
         self.macInstanceTag = macInstanceTag
         appendMainTerminals(count: additionalMainTerminalCount)
         // Optionally replace the selected terminal's content (used by the
@@ -7490,23 +7530,52 @@ private final class MobileSyncMockHostServer: @unchecked Sendable {
     private func respond(to payload: Data, on connection: NWConnection, remainingBuffer: Data) {
         do {
             let responseFrame = try makeResponseFrame(for: payload)
-            connection.send(
-                content: responseFrame,
-                contentContext: .defaultMessage,
-                isComplete: false,
-                completion: .contentProcessed { [weak self, weak connection] error in
-                    guard error == nil,
-                          let self,
-                          let connection else {
-                        connection?.cancel()
-                        return
-                    }
-                    self.receiveRequest(on: connection, buffer: remainingBuffer)
+            if Self.requestMethod(in: payload) == "terminal.paste",
+               let terminalSendResponseDelay {
+                queue.asyncAfter(deadline: .now() + terminalSendResponseDelay) { [weak self, weak connection] in
+                    guard let self, let connection else { return }
+                    self.sendResponse(
+                        responseFrame,
+                        on: connection,
+                        remainingBuffer: remainingBuffer
+                    )
                 }
-            )
+            } else {
+                sendResponse(
+                    responseFrame,
+                    on: connection,
+                    remainingBuffer: remainingBuffer
+                )
+            }
         } catch {
             connection.cancel()
         }
+    }
+
+    private func sendResponse(
+        _ responseFrame: Data,
+        on connection: NWConnection,
+        remainingBuffer: Data
+    ) {
+        connection.send(
+            content: responseFrame,
+            contentContext: .defaultMessage,
+            isComplete: false,
+            completion: .contentProcessed { [weak self, weak connection] error in
+                guard error == nil,
+                      let self,
+                      let connection else {
+                    connection?.cancel()
+                    return
+                }
+                self.receiveRequest(on: connection, buffer: remainingBuffer)
+            }
+        )
+    }
+
+    private static func requestMethod(in payload: Data) -> String? {
+        let request = try? JSONSerialization.jsonObject(with: payload) as? [String: Any]
+        return request?["method"] as? String
     }
 
     private func makeResponseFrame(for payload: Data) throws -> Data {
@@ -7524,6 +7593,18 @@ private final class MobileSyncMockHostServer: @unchecked Sendable {
                 "error": [
                     "code": "method_not_found",
                     "message": "Unknown method",
+                ],
+            ]
+            let responsePayload = try JSONSerialization.data(withJSONObject: envelope)
+            return Self.frame(responsePayload)
+        }
+        if method == "terminal.paste", rejectsTerminalPaste {
+            let envelope: [String: Any] = [
+                "id": id,
+                "ok": false,
+                "error": [
+                    "code": "send_failed",
+                    "message": "Rejected terminal paste",
                 ],
             ]
             let responsePayload = try JSONSerialization.data(withJSONObject: envelope)


### PR DESCRIPTION
## Summary

- show an in-progress spinner while iOS prompt and terminal-command sends await the Mac
- clear the spinner back to the normal Send control after acknowledgement, with no success checkmark or Sent state
- show an explicit failure state, preserve failed drafts, and bind settlement to the newest queued send

## Verification

- `swift test --package-path Packages/iOS/CmuxMobileShellModel`
- focused composer, Return-command, failure, and queued-send race tests
- UI regression asserts acknowledgement returns the button label to `Send`
- current tagged macOS cloud build: https://github.com/manaflow-ai/cmux/actions/runs/31142723538
- `sndios` installed and launched on Aziz at commit `46aad061a6`

The selected hosted iOS workflow could not execute its UI test because unrelated existing package tests and a repository-wide pairing lint fail to compile or pass on this branch. The focused send-status tests pass, and the device archive compiles successfully.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the terminal input send pipeline and composer UX across store, buffer, and RPC settlement paths, but behavior is scoped to user-visible status and preserves existing retry/staging semantics with added race guards.
> 
> **Overview**
> Adds **per-terminal send settlement** for iOS composer submits and Return-terminated raw commands, so users see in-flight progress and explicit failures instead of silent hangs or lost drafts.
> 
> The shell store tracks `MobileTerminalSendStatus` (`sending` / `sent` / `failed`) with operation IDs so a late RPC from an older send cannot overwrite a newer retry. Composer `submitComposer` wraps the full image+text run; raw input only enters this path when the buffered text contains a line break or carriage return. Non-submit keystrokes do not flash chrome; editing the draft clears a settled failure state. Focus/connection teardown fails pending raw sends without disturbing an in-flight composer paste on the same terminal.
> 
> **UI:** The composer Send button shows a spinner while sending, disables double-tap, surfaces a failure caption and red styling on error, and returns to the normal Send affordance after success (no persistent “sent” checkmark). When the composer is hidden, a **status pill** overlays the terminal surface for sending/failed.
> 
> The raw input send buffer carries the newest operation ID through coalesced chunks. Tests cover routing, queued Return races, draft restore after failure, and UI tests hold/release `terminal.paste` on the mock host.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9a887b9bc128ac3b133bb38081ac0e281a1451cf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added send-status feedback for terminal submissions: Sending, Sent, and Failed.
  * Send controls are disabled while a submission is in progress.
  * Failed submissions show an inline error and preserve the draft for retry.
  * Status indicators appear in the composer and terminal workspace views.
  * Added English and Japanese localized status messages.

* **Bug Fixes**
  * Improved handling of queued, rejected, delayed, and stale terminal submissions to prevent incorrect status updates.

* **Tests**
  * Added coverage for submission status transitions, failure recovery, draft restoration, and queued input ordering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->