### PR TITLE
Instrument coderouter usage and failures

### DIFF
--- a/web/app/api/coderouter/accounts/[accountId]/route.ts
+++ b/web/app/api/coderouter/accounts/[accountId]/route.ts
@@ -1,10 +1,16 @@
 import { removeAccount } from "../../../../../services/coderouter/accounts";
 import { resolveCodeRouterRequestContext } from "../../../../../services/coderouter/requestContext";
+import { captureCoderouterEvent } from "../../../../../services/coderouter/analytics";
+import {
+  addCoderouterBreadcrumb,
+  reportCoderouterFailure,
+} from "../../../../../services/coderouter/observability";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
 
-const UUID = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+const UUID =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 
 export function createDeleteAccountHandler(dependencies: {
   readonly resolve: typeof resolveCodeRouterRequestContext;
@@ -23,13 +29,51 @@ export function createDeleteAccountHandler(dependencies: {
     if (!UUID.test(accountId)) {
       return Response.json({ error: "invalid_request" }, { status: 400 });
     }
-    const result = await dependencies.remove({
-      teamId: resolved.value.team.teamId,
-      accountId,
-    });
-    if (!result.removed) {
-      return Response.json({ error: "not_found" }, { status: 404 });
+    let result;
+    try {
+      result = await dependencies.remove({
+        teamId: resolved.value.team.teamId,
+        accountId,
+      });
+    } catch (error) {
+      reportCoderouterFailure("rds", error, { operation: "remove_account" });
+      return Response.json(
+        {
+          error: "account_remove_unavailable",
+          message:
+            "coderouter could not remove this account. Nothing was partially removed; retry shortly.",
+          retryable: true,
+        },
+        {
+          status: 503,
+          headers: { "cache-control": "no-store", "retry-after": "5" },
+        },
+      );
     }
+    if (!result.removed) {
+      return Response.json(
+        {
+          error: "not_found",
+          message:
+            "That coderouter account no longer exists. Refresh with `cr` and retry if needed.",
+          retryable: false,
+        },
+        { status: 404 },
+      );
+    }
+    captureCoderouterEvent({
+      event: "coderouter_account_removed",
+      userId: resolved.value.user.id,
+      teamId: resolved.value.team.teamId,
+      properties: {
+        last_account: result.lastAccount,
+        legacy_cleanup_pending: result.legacyCleanupPending,
+      },
+    });
+    addCoderouterBreadcrumb("account", "Provider account removed", {
+      last_account: result.lastAccount,
+      legacy_cleanup_pending: result.legacyCleanupPending,
+    });
     return Response.json(result, {
       headers: { "cache-control": "no-store" },
     });

--- a/web/app/api/coderouter/accounts/route.ts
+++ b/web/app/api/coderouter/accounts/route.ts
@@ -1,9 +1,17 @@
-import { addAccount, parseCredential } from "../../../../services/coderouter/accounts";
+import {
+  addAccount,
+  parseCredential,
+} from "../../../../services/coderouter/accounts";
 import {
   resolveCoderouterUsageTeam,
   resolveCodeRouterRequestContext,
 } from "../../../../services/coderouter/requestContext";
 import { accountsWithUsage } from "../../../../services/coderouter/usage";
+import { captureCoderouterEvent } from "../../../../services/coderouter/analytics";
+import {
+  addCoderouterBreadcrumb,
+  reportCoderouterFailure,
+} from "../../../../services/coderouter/observability";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
@@ -36,6 +44,22 @@ export async function GET(request: Request): Promise<Response> {
     timing("serialize", serializeMs),
     timing("total", performance.now() - startedAt),
   ].join(", ");
+  captureCoderouterEvent({
+    event: "coderouter_account_status_viewed",
+    userId: resolved.stackUserId,
+    teamId: resolved.teamId,
+    properties: {
+      account_count: result.accounts.length,
+      account_error_count: result.accounts.filter(
+        (account) => "usageError" in account && Boolean(account.usageError),
+      ).length,
+      duration_ms: Math.round(performance.now() - startedAt),
+    },
+  });
+  addCoderouterBreadcrumb("status", "Account status loaded", {
+    account_count: result.accounts.length,
+    duration_ms: Math.round(performance.now() - startedAt),
+  });
   return new Response(body, {
     headers: {
       "cache-control": "no-store",
@@ -69,11 +93,43 @@ export async function POST(request: Request): Promise<Response> {
   if (!credential) {
     return Response.json({ error: "invalid_request" }, { status: 400 });
   }
-  const result = await addAccount(resolved.value.team.teamId, credential);
-  return Response.json(result, {
-    status: result.alreadyExists ? 200 : 201,
-    headers: { "cache-control": "no-store" },
-  });
+  try {
+    const result = await addAccount(resolved.value.team.teamId, credential);
+    captureCoderouterEvent({
+      event: "coderouter_account_added",
+      userId: resolved.value.user.id,
+      teamId: resolved.value.team.teamId,
+      properties: {
+        provider: credential.provider,
+        already_exists: result.alreadyExists,
+      },
+    });
+    addCoderouterBreadcrumb("account", "Provider account stored", {
+      provider: credential.provider,
+      already_exists: result.alreadyExists,
+    });
+    return Response.json(result, {
+      status: result.alreadyExists ? 200 : 201,
+      headers: { "cache-control": "no-store" },
+    });
+  } catch (error) {
+    reportCoderouterFailure("rds", error, { operation: "add_account" });
+    return Response.json(
+      {
+        error: "account_store_unavailable",
+        message:
+          "coderouter could not store this account. Your local provider sign-in was not removed; retry `cr add` shortly.",
+        retryable: true,
+      },
+      {
+        status: 503,
+        headers: {
+          "cache-control": "no-store",
+          "retry-after": "5",
+        },
+      },
+    );
+  }
 }
 
 function timing(name: string, duration: number): string {

--- a/web/app/api/coderouter/session/route.ts
+++ b/web/app/api/coderouter/session/route.ts
@@ -7,6 +7,11 @@ import {
 } from "../../../../services/coderouter/repository";
 import { resolveCodeRouterRequestContext } from "../../../../services/coderouter/requestContext";
 import { captureCoderouterError } from "../../../../services/errors";
+import { captureCoderouterEvent } from "../../../../services/coderouter/analytics";
+import {
+  addCoderouterBreadcrumb,
+  reportCoderouterFailure,
+} from "../../../../services/coderouter/observability";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
@@ -35,9 +40,20 @@ export function makeCoderouterSessionGetHandler(
   return async function GET(request: Request): Promise<Response> {
     const authorization = request.headers.get("authorization")?.trim() ?? "";
     const token = /^Bearer[ \t]+(.+)$/i.exec(authorization)?.[1]?.trim();
-    if (!token || !await authenticate(token)) {
+    if (!token || !(await authenticate(token))) {
+      addCoderouterBreadcrumb(
+        "auth",
+        "Route session validation rejected",
+        {},
+        "warning",
+      );
       return Response.json(
-        { error: "unauthorized" },
+        {
+          error: "unauthorized",
+          message:
+            "Your coderouter session expired or was revoked. Run `cr login` and retry.",
+          retryable: false,
+        },
         { status: 401, headers: { "cache-control": "no-store" } },
       );
     }
@@ -57,9 +73,14 @@ export function makeCoderouterSessionPostHandler(
     const userId = resolved.value.user.id;
     if (dependencies.hostedProRequired()) {
       try {
-        if (!await dependencies.hasActivePro(userId)) {
+        if (!(await dependencies.hasActivePro(userId))) {
           return Response.json(
-            { error: "pro_required" },
+            {
+              error: "pro_required",
+              message:
+                "Hosted coderouter requires cmux Pro. Upgrade or connect a self-hosted server.",
+              retryable: false,
+            },
             {
               status: 402,
               headers: { "cache-control": "no-store" },
@@ -72,7 +93,12 @@ export function makeCoderouterSessionPostHandler(
           route: "/api/coderouter/session",
         });
         return Response.json(
-          { error: "entitlement_unavailable" },
+          {
+            error: "entitlement_unavailable",
+            message:
+              "coderouter could not verify your Pro entitlement. Nothing was charged or changed; retry shortly.",
+            retryable: true,
+          },
           {
             status: 503,
             headers: { "cache-control": "no-store" },
@@ -80,16 +106,44 @@ export function makeCoderouterSessionPostHandler(
         );
       }
     }
-    const issued = await dependencies.issueToken(
-      resolved.value.team.teamId,
+    let issued;
+    try {
+      issued = await dependencies.issueToken(
+        resolved.value.team.teamId,
+        userId,
+      );
+    } catch (error) {
+      reportCoderouterFailure("rds", error, {
+        operation: "issue_route_session",
+      });
+      return Response.json(
+        {
+          error: "session_unavailable",
+          message:
+            "coderouter could not create a route session. Retry shortly; no account credentials were changed.",
+          retryable: true,
+        },
+        {
+          status: 503,
+          headers: { "cache-control": "no-store", "retry-after": "5" },
+        },
+      );
+    }
+    captureCoderouterEvent({
+      event: "coderouter_route_session_issued",
       userId,
-    );
+      teamId: resolved.value.team.teamId,
+      properties: { hosted_pro_required: dependencies.hostedProRequired() },
+    });
+    addCoderouterBreadcrumb("session", "Route session issued");
     return Response.json(
       {
         teamId: resolved.value.team.teamId,
         token: issued.token,
         expiresAt: issued.expiresAt.toISOString(),
-        openaiBaseUrl: new URL("/v1", request.url).toString().replace(/\/$/, ""),
+        openaiBaseUrl: new URL("/v1", request.url)
+          .toString()
+          .replace(/\/$/, ""),
       },
       { headers: { "cache-control": "no-store" } },
     );
@@ -104,6 +158,12 @@ export async function DELETE(request: Request): Promise<Response> {
     return Response.json({ error: "invalid_request" }, { status: 400 });
   }
   await revokeRouteToken(resolved.value.team.teamId, routeToken);
+  captureCoderouterEvent({
+    event: "coderouter_route_session_revoked",
+    userId: resolved.value.user.id,
+    teamId: resolved.value.team.teamId,
+  });
+  addCoderouterBreadcrumb("session", "Route session revoked");
   return new Response(null, {
     status: 204,
     headers: { "cache-control": "no-store" },

--- a/web/services/coderouter/analytics.ts
+++ b/web/services/coderouter/analytics.ts
@@ -1,0 +1,143 @@
+import { randomUUID } from "node:crypto";
+import { after } from "next/server";
+
+import { POSTHOG_HOST, POSTHOG_PROJECT_KEY } from "../analytics/iosEventPolicy";
+import {
+  addCoderouterBreadcrumb,
+  reportCoderouterFailure,
+} from "./observability";
+
+export type CoderouterAnalyticsEvent =
+  | "coderouter_account_added"
+  | "coderouter_account_removed"
+  | "coderouter_account_status_viewed"
+  | "coderouter_auth_rejected"
+  | "coderouter_route_session_issued"
+  | "coderouter_route_session_revoked"
+  | "coderouter_model_request_completed";
+
+type AnalyticsScalar = string | number | boolean;
+
+type CaptureInput = {
+  readonly event: CoderouterAnalyticsEvent;
+  readonly userId: string;
+  readonly teamId?: string;
+  readonly properties?: Readonly<
+    Record<string, AnalyticsScalar | null | undefined>
+  >;
+};
+
+type AnalyticsDependencies = {
+  readonly fetch: typeof fetch;
+  readonly defer: (task: Promise<unknown>) => void;
+  readonly enabled: () => boolean;
+};
+
+const RETRYABLE_STATUS = new Set([408, 425, 429, 500, 502, 503, 504]);
+const SENSITIVE_PROPERTY =
+  /account.?id|authorization|body|content|cookie|credential|email|header|key|prompt|response|secret|session|token/i;
+const CAPTURE_TIMEOUT_MS = 2_000;
+
+const defaultDependencies: AnalyticsDependencies = {
+  fetch,
+  defer: (task) => {
+    try {
+      after(task);
+    } catch {
+      // Unit tests and non-request scripts do not have a Next request scope.
+      // The promise is already running; always absorb rejection.
+      void task.catch(() => undefined);
+    }
+  },
+  enabled: () =>
+    process.env.VERCEL_ENV === "production" ||
+    process.env.CODEROUTER_ANALYTICS_FORCE === "1",
+};
+
+/**
+ * Best-effort product analytics. It never blocks the response and accepts only
+ * an intentionally small scalar property surface. Prompts, output, provider
+ * account IDs, credentials, route tokens, headers, and email are rejected.
+ */
+export function captureCoderouterEvent(
+  input: CaptureInput,
+  dependencies: AnalyticsDependencies = defaultDependencies,
+): void {
+  if (!dependencies.enabled()) return;
+  const properties = safeProperties(input.properties ?? {});
+  if (input.teamId) {
+    properties.$groups = { coderouter_team: input.teamId };
+  }
+  const body = JSON.stringify({
+    api_key: POSTHOG_PROJECT_KEY,
+    batch: [
+      {
+        event: input.event,
+        distinct_id: input.userId,
+        properties: {
+          ...properties,
+          $insert_id: randomUUID(),
+          product: "coderouter",
+          schema_version: 1,
+        },
+        timestamp: new Date().toISOString(),
+      },
+    ],
+  });
+  const task = deliver(body, dependencies.fetch).catch((error) => {
+    reportCoderouterFailure("analytics_delivery", error);
+  });
+  dependencies.defer(task);
+}
+
+async function deliver(
+  body: string,
+  posthogFetch: typeof fetch,
+): Promise<void> {
+  for (let attempt = 0; attempt < 2; attempt++) {
+    try {
+      const response = await posthogFetch(`${POSTHOG_HOST}/batch/`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body,
+        signal: AbortSignal.timeout(CAPTURE_TIMEOUT_MS),
+      });
+      if (response.ok) {
+        addCoderouterBreadcrumb("analytics", "PostHog event accepted", {
+          attempt: attempt + 1,
+        });
+        return;
+      }
+      if (!RETRYABLE_STATUS.has(response.status) || attempt === 1) {
+        throw new Error(
+          `PostHog capture failed with status ${response.status}`,
+        );
+      }
+    } catch (error) {
+      if (attempt === 1) throw error;
+    }
+  }
+}
+
+function safeProperties(
+  input: Readonly<Record<string, AnalyticsScalar | null | undefined>>,
+): Record<string, AnalyticsScalar | { coderouter_team: string }> {
+  const output: Record<string, AnalyticsScalar | { coderouter_team: string }> =
+    {};
+  for (const [key, value] of Object.entries(input)) {
+    const safeTokenCount = /^(?:input|cached_input|output|total)_tokens$/.test(
+      key,
+    );
+    if (SENSITIVE_PROPERTY.test(key) && !safeTokenCount) continue;
+    if (
+      typeof value === "string" ||
+      typeof value === "number" ||
+      typeof value === "boolean"
+    ) {
+      output[key] = value;
+    }
+  }
+  return output;
+}
+
+export const __test = { safeProperties, deliver };

--- a/web/services/coderouter/codexProxy.ts
+++ b/web/services/coderouter/codexProxy.ts
@@ -5,7 +5,12 @@ import {
 } from "./repository";
 import { freshCredential } from "./refresh";
 import { fetchProviderRead } from "./providerFetch";
-import { reportCoderouterFailure } from "./observability";
+import { captureCoderouterEvent } from "./analytics";
+import {
+  addCoderouterBreadcrumb,
+  reportCoderouterFailure,
+} from "./observability";
+import { observeModelUsage, type ModelUsage } from "./responseUsage";
 
 const CODEX_UPSTREAM = "https://chatgpt.com/backend-api/codex/responses";
 const CODEX_MODELS_UPSTREAM = "https://chatgpt.com/backend-api/codex/models";
@@ -20,10 +25,37 @@ const ALLOWED_REQUEST_HEADERS = [
 ] as const;
 
 export async function proxyCodexRequest(request: Request): Promise<Response> {
+  const startedAt = performance.now();
   const token = bearerToken(request);
-  if (!token) return jsonError("unauthorized", 401);
+  if (!token) {
+    addCoderouterBreadcrumb("auth", "Route token missing", {}, "warning");
+    return jsonError(
+      "unauthorized",
+      401,
+      undefined,
+      "Sign in with `cr login` and retry.",
+      false,
+    );
+  }
   const identity = await authenticateRouteToken(token);
-  if (!identity) return jsonError("unauthorized", 401);
+  if (!identity) {
+    addCoderouterBreadcrumb("auth", "Route token rejected", {}, "warning");
+    captureCoderouterEvent({
+      event: "coderouter_auth_rejected",
+      userId: "coderouter:anonymous",
+      properties: { path: "responses", reason: "invalid_route_token" },
+    });
+    return jsonError(
+      "unauthorized",
+      401,
+      undefined,
+      "Your coderouter session expired or was revoked. Run `cr login` and retry.",
+      false,
+    );
+  }
+  addCoderouterBreadcrumb("auth", "Route token accepted", {
+    path: "responses",
+  });
 
   const forwardedHeaders = new Headers();
   for (const name of ALLOWED_REQUEST_HEADERS) {
@@ -31,6 +63,7 @@ export async function proxyCodexRequest(request: Request): Promise<Response> {
     if (value) forwardedHeaders.set(name, value);
   }
   const attempted: string[] = [];
+  let refreshRetries = 0;
   let upstream: Response | null = null;
   for (let attempt = 0; attempt < 8; attempt++) {
     const account = await selectAccountForRequest(
@@ -40,6 +73,10 @@ export async function proxyCodexRequest(request: Request): Promise<Response> {
     );
     if (!account) break;
     attempted.push(account.id);
+    addCoderouterBreadcrumb("routing", "Selected provider account", {
+      provider: "codex",
+      attempt: attempt + 1,
+    });
     let credential;
     try {
       credential = await freshCredential({
@@ -56,8 +93,26 @@ export async function proxyCodexRequest(request: Request): Promise<Response> {
       throw error;
     }
     if (credential.provider !== "codex") continue;
-    upstream = await sendCodex(request.clone(), forwardedHeaders, credential);
+    try {
+      upstream = await sendCodex(request.clone(), forwardedHeaders, credential);
+    } catch (error) {
+      reportCoderouterFailure("upstream_transport", error, {
+        provider: "codex",
+        attempt: attempt + 1,
+      });
+      continue;
+    }
     if (upstream.status === 401) {
+      refreshRetries++;
+      addCoderouterBreadcrumb(
+        "refresh",
+        "Refreshing rejected credential",
+        {
+          provider: "codex",
+          attempt: attempt + 1,
+        },
+        "warning",
+      );
       try {
         const refreshed = await freshCredential({
           teamId: identity.teamId,
@@ -66,23 +121,53 @@ export async function proxyCodexRequest(request: Request): Promise<Response> {
           force: true,
         });
         if (refreshed.provider === "codex") {
-          upstream = await sendCodex(request.clone(), forwardedHeaders, refreshed);
+          upstream = await sendCodex(
+            request.clone(),
+            forwardedHeaders,
+            refreshed,
+          );
         }
-      } catch {
+      } catch (error) {
+        reportCoderouterFailure("provider_refresh", error, {
+          provider: "codex",
+          forced: true,
+        });
         continue;
       }
     }
     if (upstream.status === 429) {
-      reportCoderouterFailure("provider_rate_limit", new Error("rate limited"), {
-        provider: "codex",
-        status: 429,
-      });
+      reportCoderouterFailure(
+        "provider_rate_limit",
+        new Error("rate limited"),
+        {
+          provider: "codex",
+          status: 429,
+        },
+      );
       await markAccountCooldown(account.id, rateLimitDelay(upstream.headers));
       continue;
     }
     break;
   }
-  if (!upstream) return jsonError("no_usable_account", 503);
+  if (!upstream) {
+    captureModelRequest({
+      identity,
+      request,
+      startedAt,
+      status: 503,
+      attempted: attempted.length,
+      refreshRetries,
+      outcome: "no_usable_account",
+      usage: null,
+    });
+    return jsonError(
+      "no_usable_account",
+      503,
+      { "retry-after": "15" },
+      "No healthy Codex subscription is currently available. Check `cr`, add an account with `cr add`, or retry shortly.",
+      true,
+    );
+  }
   const responseHeaders = new Headers();
   for (const name of [
     "content-type",
@@ -99,7 +184,20 @@ export async function proxyCodexRequest(request: Request): Promise<Response> {
     responseHeaders.set("content-type", "text/event-stream; charset=utf-8");
   }
   responseHeaders.set("cache-control", "no-store");
-  return new Response(upstream.body, {
+  const status = upstream.status;
+  const observedBody = observeModelUsage(upstream.body, (usage) => {
+    captureModelRequest({
+      identity,
+      request,
+      startedAt,
+      status,
+      attempted: attempted.length,
+      refreshRetries,
+      outcome: status >= 200 && status < 300 ? "success" : "upstream_error",
+      usage,
+    });
+  });
+  return new Response(observedBody, {
     status: upstream.status,
     headers: responseHeaders,
   });
@@ -143,21 +241,40 @@ export function createCodexModelsProxy(dependencies: CodexModelsDependencies) {
       if (credential.provider !== "codex") continue;
       const upstreamUrl = new URL(CODEX_MODELS_UPSTREAM);
       upstreamUrl.search = new URL(request.url).search;
-      upstream = await dependencies.providerRead(() => fetch(upstreamUrl, {
-        headers: {
-          authorization: `Bearer ${credential.accessToken}`,
-          "chatgpt-account-id": credential.accountId,
-          originator: "codex_cli_rs",
-          "user-agent": request.headers.get("user-agent") ?? "coderouter",
-        },
-        cache: "no-store",
-      }));
-      if (upstream.status === 429) {
-        reportCoderouterFailure("provider_rate_limit", new Error("rate limited"), {
+      try {
+        upstream = await dependencies.providerRead(() =>
+          fetch(upstreamUrl, {
+            headers: {
+              authorization: `Bearer ${credential.accessToken}`,
+              "chatgpt-account-id": credential.accountId,
+              originator: "codex_cli_rs",
+              "user-agent": request.headers.get("user-agent") ?? "coderouter",
+            },
+            cache: "no-store",
+            signal: AbortSignal.timeout(5_000),
+          }),
+        );
+      } catch (error) {
+        reportCoderouterFailure("upstream_transport", error, {
           provider: "codex",
-          status: 429,
+          operation: "models",
+          attempt: attempt + 1,
         });
-        await dependencies.cooldown(account.id, rateLimitDelay(upstream.headers));
+        continue;
+      }
+      if (upstream.status === 429) {
+        reportCoderouterFailure(
+          "provider_rate_limit",
+          new Error("rate limited"),
+          {
+            provider: "codex",
+            status: 429,
+          },
+        );
+        await dependencies.cooldown(
+          account.id,
+          rateLimitDelay(upstream.headers),
+        );
         continue;
       }
       break;
@@ -167,7 +284,8 @@ export function createCodexModelsProxy(dependencies: CodexModelsDependencies) {
       status: upstream.status,
       headers: {
         "cache-control": "no-store",
-        "content-type": upstream.headers.get("content-type") ?? "application/json",
+        "content-type":
+          upstream.headers.get("content-type") ?? "application/json",
       },
     });
   };
@@ -210,7 +328,8 @@ function rateLimitDelay(headers: Headers): number {
   ]) {
     const raw = headers.get(name);
     if (!raw) continue;
-    const seconds = /^(\d+(?:\.\d+)?)s$/.exec(raw)?.[1] ?? (/^\d+$/.test(raw) ? raw : null);
+    const seconds =
+      /^(\d+(?:\.\d+)?)s$/.exec(raw)?.[1] ?? (/^\d+$/.test(raw) ? raw : null);
     if (seconds) return Math.ceil(Number(seconds) * 1_000);
   }
   return 60_000;
@@ -228,9 +347,11 @@ function jsonError(
   error: string,
   status: number,
   headers?: HeadersInit,
+  message?: string,
+  retryable = false,
 ): Response {
   return Response.json(
-    { error },
+    { error, message: message ?? error, retryable },
     {
       status,
       headers: {
@@ -239,4 +360,57 @@ function jsonError(
       },
     },
   );
+}
+
+function captureModelRequest(input: {
+  readonly identity: { readonly teamId: string; readonly stackUserId: string };
+  readonly request: Request;
+  readonly startedAt: number;
+  readonly status: number;
+  readonly attempted: number;
+  readonly refreshRetries: number;
+  readonly outcome: string;
+  readonly usage: ModelUsage | null;
+}): void {
+  addCoderouterBreadcrumb(
+    "request",
+    "Model request completed",
+    {
+      provider: "codex",
+      status: input.status,
+      outcome: input.outcome,
+      attempts: input.attempted,
+      duration_ms: Math.round(performance.now() - input.startedAt),
+    },
+    input.status >= 500 ? "error" : input.status >= 400 ? "warning" : "info",
+  );
+  captureCoderouterEvent({
+    event: "coderouter_model_request_completed",
+    userId: input.identity.stackUserId,
+    teamId: input.identity.teamId,
+    properties: {
+      provider: "codex",
+      agent: agentFromUserAgent(input.request.headers.get("user-agent")),
+      outcome: input.outcome,
+      status: input.status,
+      attempt_count: input.attempted,
+      refresh_retry_count: input.refreshRetries,
+      duration_ms: Math.round(performance.now() - input.startedAt),
+      model: input.usage?.model ?? "unknown",
+      input_tokens: input.usage?.inputTokens ?? 0,
+      cached_input_tokens: input.usage?.cachedInputTokens ?? 0,
+      output_tokens: input.usage?.outputTokens ?? 0,
+      total_tokens: input.usage?.totalTokens ?? 0,
+      actual_cost_usd: 0,
+      cost_basis: "subscription_included",
+    },
+  });
+}
+
+function agentFromUserAgent(value: string | null): string {
+  const normalized = value?.toLowerCase() ?? "";
+  if (normalized.includes("codex")) return "codex";
+  if (normalized.includes("pi")) return "pi";
+  if (normalized.includes("opencode")) return "opencode";
+  return "other";
 }

--- a/web/services/coderouter/observability.ts
+++ b/web/services/coderouter/observability.ts
@@ -6,7 +6,34 @@ type CodeRouterFailure =
   | "provider_refresh"
   | "provider_rate_limit"
   | "legacy_cleanup"
-  | "rds";
+  | "rds"
+  | "analytics_delivery"
+  | "upstream_transport";
+
+const SENSITIVE_CONTEXT_KEY = /account.?id|authorization|body|content|cookie|credential|email|header|key|prompt|response|secret|session|team.?id|token/i;
+
+export function addCoderouterBreadcrumb(
+  category: string,
+  message: string,
+  data: Readonly<Record<string, string | number | boolean>> = {},
+  level: "debug" | "info" | "warning" | "error" = "info",
+): void {
+  const safeData = Object.fromEntries(
+    Object.entries(data).filter(([key]) => !SENSITIVE_CONTEXT_KEY.test(key)),
+  );
+  void import("@sentry/nextjs")
+    .then((Sentry) => {
+      Sentry.addBreadcrumb({
+        category: `coderouter.${category}`,
+        message,
+        level,
+        data: safeData,
+      });
+    })
+    .catch(() => {
+      // Observability must never alter product control flow.
+    });
+}
 
 /**
  * Emit an alertable error without ever forwarding a provider error message,
@@ -18,6 +45,12 @@ export function reportCoderouterFailure(
   context: Readonly<Record<string, string | number | boolean>> = {},
 ): void {
   const errorType = error instanceof Error ? error.name : typeof error;
+  addCoderouterBreadcrumb(
+    "error",
+    `coderouter.${failure}`,
+    { failure, errorType, ...context },
+    "error",
+  );
   reportError(new Error(`coderouter.${failure}`), {
     service: "coderouter",
     failure,

--- a/web/services/coderouter/opencodeProxy.ts
+++ b/web/services/coderouter/opencodeProxy.ts
@@ -1,19 +1,31 @@
 import { authenticateRouteToken, selectAccountForRequest } from "./repository";
 import { freshCredential } from "./refresh";
 import { fetchProviderRead } from "./providerFetch";
+import { captureCoderouterEvent } from "./analytics";
+import {
+  addCoderouterBreadcrumb,
+  reportCoderouterFailure,
+} from "./observability";
+import { observeModelUsage } from "./responseUsage";
 
 const OPENCODE_CONSOLE = "https://console.opencode.ai";
 
-export async function openCodeClientConfig(request: Request): Promise<Response> {
+export async function openCodeClientConfig(
+  request: Request,
+): Promise<Response> {
   const auth = await routeIdentity(request);
   if (!auth) return Response.json({ error: "unauthorized" }, { status: 401 });
   const resolved = await openCodeAccount(auth.teamId);
-  if (!resolved) return Response.json({ error: "no_usable_account" }, { status: 503 });
+  if (!resolved)
+    return Response.json({ error: "no_usable_account" }, { status: 503 });
   const remote = await remoteConfig(resolved.credential.accessToken);
   const provider = rewriteProviders(remote, auth.token);
-  return Response.json({ provider }, {
-    headers: { "cache-control": "no-store" },
-  });
+  return Response.json(
+    { provider },
+    {
+      headers: { "cache-control": "no-store" },
+    },
+  );
 }
 
 export async function proxyOpenCodeRequest(
@@ -21,19 +33,58 @@ export async function proxyOpenCodeRequest(
   providerId: string,
   path: readonly string[],
 ): Promise<Response> {
+  const startedAt = performance.now();
   const auth = await routeIdentity(request);
-  if (!auth) return Response.json({ error: "unauthorized" }, { status: 401 });
+  if (!auth) {
+    return apiError(
+      "unauthorized",
+      "Your coderouter session expired or was revoked. Run `cr login` and retry.",
+      401,
+      false,
+    );
+  }
   const resolved = await openCodeAccount(auth.teamId);
-  if (!resolved) return Response.json({ error: "no_usable_account" }, { status: 503 });
-  const config = await remoteConfig(resolved.credential.accessToken);
+  if (!resolved) {
+    return apiError(
+      "no_usable_account",
+      "No healthy OpenCode subscription is available. Check `cr`, add an account with `cr add`, or retry shortly.",
+      503,
+      true,
+    );
+  }
+  let config: Record<string, unknown>;
+  try {
+    config = await remoteConfig(resolved.credential.accessToken);
+  } catch (error) {
+    reportCoderouterFailure("provider_usage", error, {
+      provider: "opencode-go",
+      operation: "config",
+    });
+    return apiError(
+      "provider_unavailable",
+      "OpenCode configuration is temporarily unavailable. Retry shortly.",
+      502,
+      true,
+    );
+  }
   const provider = config[providerId];
   if (!isRecord(provider)) {
-    return Response.json({ error: "unknown_provider" }, { status: 404 });
+    return apiError(
+      "unknown_provider",
+      "This OpenCode provider is no longer available. Refresh OpenCode's provider list and retry.",
+      404,
+      false,
+    );
   }
   const api = provider.api;
   const base = isRecord(api) ? api.url : undefined;
   if (typeof base !== "string" || !safeProviderURL(base)) {
-    return Response.json({ error: "invalid_provider" }, { status: 502 });
+    return apiError(
+      "invalid_provider",
+      "OpenCode returned an unsafe or invalid provider endpoint.",
+      502,
+      false,
+    );
   }
   const target = new URL(base);
   target.pathname = `${target.pathname.replace(/\/+$/, "")}/${path
@@ -47,16 +98,56 @@ export async function proxyOpenCodeRequest(
     if (value) headers.set(name, value);
   }
   headers.set("authorization", `Bearer ${resolved.credential.accessToken}`);
-  const upstream = await fetch(target, {
-    method: request.method,
-    headers,
-    body: request.method === "GET" || request.method === "HEAD"
-      ? undefined
-      : request.body,
-    duplex: "half",
-    cache: "no-store",
-  } as RequestInit & { duplex: "half" });
-  return new Response(upstream.body, {
+  let upstream: Response;
+  try {
+    upstream = await fetch(target, {
+      method: request.method,
+      headers,
+      body:
+        request.method === "GET" || request.method === "HEAD"
+          ? undefined
+          : request.body,
+      duplex: "half",
+      cache: "no-store",
+    } as RequestInit & { duplex: "half" });
+  } catch (error) {
+    reportCoderouterFailure("upstream_transport", error, {
+      provider: "opencode-go",
+    });
+    return apiError(
+      "provider_unavailable",
+      "The selected OpenCode provider could not be reached. Retry shortly.",
+      502,
+      true,
+    );
+  }
+  const body = observeModelUsage(upstream.body, (usage) => {
+    addCoderouterBreadcrumb("request", "Model request completed", {
+      provider: "opencode-go",
+      status: upstream.status,
+      duration_ms: Math.round(performance.now() - startedAt),
+    });
+    captureCoderouterEvent({
+      event: "coderouter_model_request_completed",
+      userId: auth.stackUserId,
+      teamId: auth.teamId,
+      properties: {
+        provider: "opencode-go",
+        agent: "opencode",
+        outcome: upstream.ok ? "success" : "upstream_error",
+        status: upstream.status,
+        duration_ms: Math.round(performance.now() - startedAt),
+        model: usage?.model ?? "unknown",
+        input_tokens: usage?.inputTokens ?? 0,
+        cached_input_tokens: usage?.cachedInputTokens ?? 0,
+        output_tokens: usage?.outputTokens ?? 0,
+        total_tokens: usage?.totalTokens ?? 0,
+        actual_cost_usd: 0,
+        cost_basis: "subscription_included",
+      },
+    });
+  });
+  return new Response(body, {
     status: upstream.status,
     headers: filteredResponseHeaders(upstream.headers),
   });
@@ -71,11 +162,7 @@ async function openCodeAccount(
 ) {
   const attempted: string[] = [];
   for (let attempt = 0; attempt < 8; attempt++) {
-    const account = await dependencies.select(
-      teamId,
-      "opencode-go",
-      attempted,
-    );
+    const account = await dependencies.select(teamId, "opencode-go", attempted);
     if (!account) return null;
     attempted.push(account.id);
     try {
@@ -94,15 +181,24 @@ async function openCodeAccount(
   return null;
 }
 
-async function remoteConfig(accessToken: string): Promise<Record<string, unknown>> {
-  const response = await fetchProviderRead(() => fetch(`${OPENCODE_CONSOLE}/api/config`, {
-    headers: { authorization: `Bearer ${accessToken}` },
-    cache: "no-store",
-    signal: AbortSignal.timeout(5_000),
-  }));
-  if (!response.ok) throw new Error(`OpenCode config failed: ${response.status}`);
+async function remoteConfig(
+  accessToken: string,
+): Promise<Record<string, unknown>> {
+  const response = await fetchProviderRead(() =>
+    fetch(`${OPENCODE_CONSOLE}/api/config`, {
+      headers: { authorization: `Bearer ${accessToken}` },
+      cache: "no-store",
+      signal: AbortSignal.timeout(5_000),
+    }),
+  );
+  if (!response.ok)
+    throw new Error(`OpenCode config failed: ${response.status}`);
   const value: unknown = await response.json();
-  if (!isRecord(value) || !isRecord(value.config) || !isRecord(value.config.provider)) {
+  if (
+    !isRecord(value) ||
+    !isRecord(value.config) ||
+    !isRecord(value.config.provider)
+  ) {
     throw new Error("OpenCode returned an invalid provider catalog");
   }
   return value.config.provider;
@@ -112,56 +208,89 @@ function rewriteProviders(
   providers: Record<string, unknown>,
   routeToken: string,
 ): Record<string, unknown> {
-  return Object.fromEntries(Object.entries(providers).flatMap(([id, value]) => {
-    if (!isRecord(value)) return [];
-    const api = value.api;
-    const npm = isRecord(api) && typeof api.package === "string"
-      ? api.package
-      : typeof value.npm === "string"
-      ? value.npm
-      : undefined;
-    const models = isRecord(value.models)
-      ? Object.fromEntries(Object.entries(value.models).map(([modelId, model]) => {
-        if (!isRecord(model)) return [modelId, model];
-        const nestedProvider = isRecord(model.provider) ? model.provider : undefined;
-        return [modelId, {
-          ...model,
+  return Object.fromEntries(
+    Object.entries(providers).flatMap(([id, value]) => {
+      if (!isRecord(value)) return [];
+      const api = value.api;
+      const npm =
+        isRecord(api) && typeof api.package === "string"
+          ? api.package
+          : typeof value.npm === "string"
+            ? value.npm
+            : undefined;
+      const models = isRecord(value.models)
+        ? Object.fromEntries(
+            Object.entries(value.models).map(([modelId, model]) => {
+              if (!isRecord(model)) return [modelId, model];
+              const nestedProvider = isRecord(model.provider)
+                ? model.provider
+                : undefined;
+              return [
+                modelId,
+                {
+                  ...model,
           ...(nestedProvider
             ? {
               provider: {
-                ...nestedProvider,
+                ...publicNestedProvider(nestedProvider),
                 api: `https://coderouter.dev/api/coderouter/opencode/proxy/${encodeURIComponent(id)}`,
               },
-            }
-            : {}),
-        }];
-      }))
-      : value.models;
-    return [[id, {
-      ...value,
-      ...(npm ? { npm } : {}),
-      api: undefined,
-      models,
-      options: {
-        ...(isRecord(value.options) ? withoutSecrets(value.options) : {}),
-        baseURL: `https://coderouter.dev/api/coderouter/opencode/proxy/${encodeURIComponent(id)}`,
-        apiKey: routeToken,
-      },
-    }]];
-  }));
+                      }
+                    : {}),
+                },
+              ];
+            }),
+          )
+        : value.models;
+      return [
+        [
+          id,
+          {
+            ...value,
+            ...(npm ? { npm } : {}),
+            api: undefined,
+            models,
+            options: {
+              ...(isRecord(value.options) ? withoutSecrets(value.options) : {}),
+              baseURL: `https://coderouter.dev/api/coderouter/opencode/proxy/${encodeURIComponent(id)}`,
+              apiKey: routeToken,
+            },
+          },
+        ],
+      ];
+    }),
+  );
 }
 
-function withoutSecrets(value: Record<string, unknown>): Record<string, unknown> {
+function publicNestedProvider(
+  value: Record<string, unknown>,
+): Record<string, string> {
+  const output: Record<string, string> = {};
+  for (const key of ["id", "name", "npm"]) {
+    const candidate = value[key];
+    if (typeof candidate === "string" && candidate.length <= 512) {
+      output[key] = candidate;
+    }
+  }
+  return output;
+}
+
+function withoutSecrets(
+  value: Record<string, unknown>,
+): Record<string, unknown> {
   return Object.fromEntries(
-    Object.entries(value).filter(([key]) =>
-      !["apiKey", "token", "accessToken", "refreshToken", "headers"].includes(key)
+    Object.entries(value).filter(
+      ([key]) =>
+        !["apiKey", "token", "accessToken", "refreshToken", "headers"].includes(
+          key,
+        ),
     ),
   );
 }
 
 async function routeIdentity(
   request: Request,
-): Promise<{ teamId: string; token: string } | null> {
+): Promise<{ teamId: string; stackUserId: string; token: string } | null> {
   const header = request.headers.get("authorization")?.trim() ?? "";
   const token = /^Bearer[ \t]+(.+)$/i.exec(header)?.[1]?.trim();
   if (!token) return null;
@@ -169,18 +298,38 @@ async function routeIdentity(
   return identity ? { ...identity, token } : null;
 }
 
+function apiError(
+  error: string,
+  message: string,
+  status: number,
+  retryable: boolean,
+): Response {
+  return Response.json(
+    { error, message, retryable },
+    {
+      status,
+      headers: {
+        "cache-control": "no-store",
+        ...(retryable ? { "retry-after": "5" } : {}),
+      },
+    },
+  );
+}
+
 function safeProviderURL(value: string): boolean {
   try {
     const url = new URL(value);
     if (url.protocol !== "https:" || url.username || url.password) return false;
     const hostname = url.hostname.toLowerCase();
-    return hostname !== "localhost" &&
+    return (
+      hostname !== "localhost" &&
       hostname !== "0.0.0.0" &&
       hostname !== "::1" &&
       !/^127\./.test(hostname) &&
       !/^10\./.test(hostname) &&
       !/^192\.168\./.test(hostname) &&
-      !/^172\.(1[6-9]|2[0-9]|3[01])\./.test(hostname);
+      !/^172\.(1[6-9]|2[0-9]|3[01])\./.test(hostname)
+    );
   } catch {
     return false;
   }

--- a/web/services/coderouter/providerFetch.ts
+++ b/web/services/coderouter/providerFetch.ts
@@ -1,13 +1,24 @@
+import { addCoderouterBreadcrumb } from "./observability";
+
 const RETRYABLE_STATUS = new Set([408, 425, 500, 502, 503, 504]);
 
 /** Retry one safe, replayable provider read. Mutating requests must not use this. */
 export async function fetchProviderRead(
   request: () => Promise<Response>,
 ): Promise<Response> {
+  let first: Response;
   try {
-    const first = await request();
-    return RETRYABLE_STATUS.has(first.status) ? await request() : first;
+    first = await request();
   } catch {
+    addCoderouterBreadcrumb("retry", "Retrying provider read after transport failure", {
+      attempt: 2,
+    }, "warning");
     return await request();
   }
+  if (!RETRYABLE_STATUS.has(first.status)) return first;
+  addCoderouterBreadcrumb("retry", "Retrying safe provider read", {
+    status: first.status,
+    attempt: 2,
+  }, "warning");
+  return await request();
 }

--- a/web/services/coderouter/refresh.ts
+++ b/web/services/coderouter/refresh.ts
@@ -11,7 +11,7 @@ import {
   type EncryptedCredential,
 } from "./encryption";
 import type { CodeRouterCredential } from "./types";
-import { reportCoderouterFailure } from "./observability";
+import { addCoderouterBreadcrumb, reportCoderouterFailure } from "./observability";
 
 const CODEX_CLIENT_ID = "app_EMoamEEZ73f0CkXaXp7hrann";
 const OPENCODE_CLIENT_ID = "opencode-cli";
@@ -75,7 +75,16 @@ export function createCredentialRefresher(
   }
 
   const leaseId = await dependencies.claim(input.accountId);
-  if (!leaseId) throw new CodeRouterRefreshBusy("credential refresh already in progress");
+  if (!leaseId) {
+    addCoderouterBreadcrumb("refresh", "Credential refresh already in progress", {
+      provider: currentProvider(before.credential),
+    }, "warning");
+    throw new CodeRouterRefreshBusy("credential refresh already in progress");
+  }
+  addCoderouterBreadcrumb("refresh", "Credential refresh lease acquired", {
+    provider: currentProvider(before.credential),
+    forced: input.force === true,
+  });
   try {
     // The lease winner must re-read after claiming. Another request may have
     // refreshed and rotated the token immediately before this lease.
@@ -102,6 +111,9 @@ export function createCredentialRefresher(
       expectedRevision: current.envelope.credentialRevision,
       credential: refreshed,
       encrypted,
+    });
+    addCoderouterBreadcrumb("refresh", "Credential refresh completed", {
+      provider: refreshed.provider,
     });
     return refreshed;
   } catch (error) {
@@ -201,6 +213,7 @@ async function postForm(
     headers: { "content-type": "application/x-www-form-urlencoded" },
     body: new URLSearchParams(body),
     cache: "no-store",
+    signal: AbortSignal.timeout(10_000),
   });
   return await providerJson(response);
 }
@@ -214,6 +227,7 @@ async function postJson(
     headers: { "content-type": "application/json" },
     body: JSON.stringify(body),
     cache: "no-store",
+    signal: AbortSignal.timeout(10_000),
   });
   return await providerJson(response);
 }

--- a/web/services/coderouter/repository.ts
+++ b/web/services/coderouter/repository.ts
@@ -63,7 +63,7 @@ export async function revokeRouteTokensForUser(
 export async function authenticateRouteToken(
   token: string,
   now = new Date(),
-): Promise<{ teamId: string } | null> {
+): Promise<{ teamId: string; stackUserId: string } | null> {
   if (!/^crt_[A-Za-z0-9_-]{40,}$/.test(token)) return null;
   const [row] = await cloudDb()
     .update(coderouterRouteTokens)
@@ -74,7 +74,10 @@ export async function authenticateRouteToken(
       gt(coderouterRouteTokens.expiresAt, now),
       isNull(coderouterRouteTokens.revokedAt),
     ))
-    .returning({ teamId: coderouterRouteTokens.teamId });
+    .returning({
+      teamId: coderouterRouteTokens.teamId,
+      stackUserId: coderouterRouteTokens.stackUserId,
+    });
   return row ?? null;
 }
 

--- a/web/services/coderouter/requestContext.ts
+++ b/web/services/coderouter/requestContext.ts
@@ -28,18 +28,24 @@ export type CodeRouterRequestContext = {
 export async function resolveCoderouterUsageTeam(
   request: Request,
 ): Promise<
-  | { readonly ok: true; readonly teamId: string }
+  | { readonly ok: true; readonly teamId: string; readonly stackUserId: string }
   | { readonly ok: false; readonly response: Response }
 > {
   const authorization = request.headers.get("authorization");
   const token = authorization?.match(/^Bearer\s+(\S+)$/i)?.[1];
   if (token?.startsWith("crt_")) {
     const routed = await authenticateRouteToken(token);
-    if (routed) return { ok: true, teamId: routed.teamId };
+    if (routed) {
+      return { ok: true, teamId: routed.teamId, stackUserId: routed.stackUserId };
+    }
   }
   const resolved = await resolveCodeRouterRequestContext(request, "use-or-manage");
   return resolved.ok
-    ? { ok: true, teamId: resolved.value.team.teamId }
+    ? {
+      ok: true,
+      teamId: resolved.value.team.teamId,
+      stackUserId: resolved.value.user.id,
+    }
     : resolved;
 }
 

--- a/web/services/coderouter/responseUsage.ts
+++ b/web/services/coderouter/responseUsage.ts
@@ -1,0 +1,114 @@
+export type ModelUsage = {
+  readonly model?: string;
+  readonly inputTokens: number;
+  readonly cachedInputTokens: number;
+  readonly outputTokens: number;
+  readonly totalTokens: number;
+};
+
+const MAX_TAIL_CHARS = 256 * 1024;
+
+/**
+ * Passes upstream bytes through immediately while retaining only a bounded
+ * rolling tail and a model identifier. No prompt or model output is logged,
+ * persisted, or sent to analytics.
+ */
+export function observeModelUsage(
+  body: ReadableStream<Uint8Array> | null,
+  onComplete: (usage: ModelUsage | null) => void,
+): ReadableStream<Uint8Array> | null {
+  if (!body) {
+    onComplete(null);
+    return null;
+  }
+  const decoder = new TextDecoder();
+  let tail = "";
+  let model: string | undefined;
+  return body.pipeThrough(
+    new TransformStream<Uint8Array, Uint8Array>({
+      transform(chunk, controller) {
+        controller.enqueue(chunk);
+        const text = decoder.decode(chunk, { stream: true });
+        const combined = `${tail.slice(-256)}${text}`;
+        model ??= stringField(combined, "model");
+        tail = `${tail}${text}`.slice(-MAX_TAIL_CHARS);
+      },
+      flush() {
+        tail = `${tail}${decoder.decode()}`.slice(-MAX_TAIL_CHARS);
+        onComplete(usageFromTail(tail, model));
+      },
+    }),
+  );
+}
+
+function usageFromTail(tail: string, model?: string): ModelUsage | null {
+  const marker = tail.lastIndexOf('"usage"');
+  if (marker < 0) return null;
+  const start = tail.indexOf("{", marker);
+  if (start < 0) return null;
+  const raw = balancedObject(tail, start);
+  if (!raw) return null;
+  try {
+    const value: unknown = JSON.parse(raw);
+    if (!isRecord(value)) return null;
+    const inputTokens = finiteInteger(value.input_tokens);
+    const outputTokens = finiteInteger(value.output_tokens);
+    if (inputTokens === null || outputTokens === null) return null;
+    const details = isRecord(value.input_tokens_details)
+      ? value.input_tokens_details
+      : null;
+    const cachedInputTokens = finiteInteger(details?.cached_tokens) ?? 0;
+    return {
+      ...(model ? { model } : {}),
+      inputTokens,
+      cachedInputTokens,
+      outputTokens,
+      totalTokens:
+        finiteInteger(value.total_tokens) ?? inputTokens + outputTokens,
+    };
+  } catch {
+    return null;
+  }
+}
+
+function balancedObject(value: string, start: number): string | null {
+  let depth = 0;
+  let quoted = false;
+  let escaped = false;
+  for (let index = start; index < value.length; index++) {
+    const character = value[index];
+    if (quoted) {
+      if (escaped) escaped = false;
+      else if (character === "\\") escaped = true;
+      else if (character === '"') quoted = false;
+      continue;
+    }
+    if (character === '"') quoted = true;
+    else if (character === "{") depth++;
+    else if (character === "}" && --depth === 0)
+      return value.slice(start, index + 1);
+  }
+  return null;
+}
+
+function stringField(value: string, field: string): string | undefined {
+  const match = new RegExp(`"${field}"\\s*:\\s*"([^"\\\\]{1,200})"`).exec(
+    value,
+  );
+  return match?.[1];
+}
+
+function finiteInteger(value: unknown): number | null {
+  return typeof value === "number" &&
+    Number.isFinite(value) &&
+    Number.isInteger(value) &&
+    value >= 0
+    ? value
+    : null;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+export const __test = { usageFromTail };

--- a/web/services/coderouter/usage.ts
+++ b/web/services/coderouter/usage.ts
@@ -5,7 +5,7 @@ import {
 } from "./repository";
 import { freshCredential } from "./refresh";
 import { fetchProviderRead } from "./providerFetch";
-import { reportCoderouterFailure } from "./observability";
+import { addCoderouterBreadcrumb, reportCoderouterFailure } from "./observability";
 
 const CODEX_USAGE_URL = "https://chatgpt.com/backend-api/wham/usage";
 const usageRequests = new Map<
@@ -30,6 +30,7 @@ export async function accountsWithUsage(teamId: string) {
 
 async function loadAccountsWithUsage(teamId: string) {
   const startedAt = performance.now();
+  addCoderouterBreadcrumb("status", "Loading account usage");
   // Account metadata and encrypted envelopes are independent RDS reads.
   const rdsStartedAt = performance.now();
   const [accounts, credentials] = await Promise.all([
@@ -83,6 +84,10 @@ async function loadAccountsWithUsage(teamId: string) {
       return { ...account, usageError: "unavailable" };
     }
   }));
+  addCoderouterBreadcrumb("status", "Provider usage fanout completed", {
+    account_count: accounts.length,
+    provider_ms: Math.round(performance.now() - providerStartedAt),
+  });
   return {
     accounts: withUsage,
     usageAsOf: new Date().toISOString(),

--- a/web/services/sentry.ts
+++ b/web/services/sentry.ts
@@ -1,7 +1,7 @@
 import type { Event } from "@sentry/nextjs";
 
 const SECRET_KEY =
-  /^(authorization|cookie|set-cookie|x-coderouter-route-token|x-stack-access-token|x-stack-refresh-token|access_token|refresh_token|id_token|credential|ciphertext|encryptedDataKey)$/i;
+  /^(authorization|body|completion|content|cookie|email|output|prompt|provider_?account_?id|response|set-cookie|x-coderouter-route-token|x-stack-access-token|x-stack-refresh-token|access_token|refresh_token|id_token|credential|ciphertext|encryptedDataKey)$/i;
 const ROUTE_TOKEN = /\bcrt_[A-Za-z0-9_-]{32,}\b/g;
 const BEARER_TOKEN = /\bBearer\s+[A-Za-z0-9._~+/=-]{16,}\b/gi;
 const JWT = /\beyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]*\b/g;
@@ -27,9 +27,10 @@ export function shouldSendCoderouterSentryEvent(event: Event): boolean {
   if (event.tags?.subsystem === "coderouter") return true;
   const cmux = event.contexts?.cmux as Record<string, unknown> | undefined;
   if (cmux?.service === "coderouter") return true;
-  const message = event.message
-    ?? event.exception?.values?.map((value) => value.value ?? "").join(" ")
-    ?? "";
+  const message =
+    event.message ??
+    event.exception?.values?.map((value) => value.value ?? "").join(" ") ??
+    "";
   if (message.startsWith("coderouter.")) return true;
   const url = event.request?.url;
   if (!url) return false;

--- a/web/tests/coderouter-analytics.test.ts
+++ b/web/tests/coderouter-analytics.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, mock, test } from "bun:test";
+
+import {
+  __test as analyticsTest,
+  captureCoderouterEvent,
+} from "../services/coderouter/analytics";
+import { __test as usageTest } from "../services/coderouter/responseUsage";
+
+describe("coderouter analytics", () => {
+  test("keeps aggregate usage while dropping sensitive properties", () => {
+    expect(
+      analyticsTest.safeProperties({
+        provider: "codex",
+        input_tokens: 123,
+        cached_input_tokens: 20,
+        output_tokens: 45,
+        total_tokens: 168,
+        actual_cost_usd: 0,
+        prompt: "secret prompt",
+        response_body: "secret output",
+        route_token: "crt_secret",
+        email: "buyer@example.com",
+        provider_account_id: "acct_secret",
+      }),
+    ).toEqual({
+      provider: "codex",
+      input_tokens: 123,
+      cached_input_tokens: 20,
+      output_tokens: 45,
+      total_tokens: 168,
+      actual_cost_usd: 0,
+    });
+  });
+
+  test("is deferred and retries one transient PostHog failure with one insert id", async () => {
+    const bodies: string[] = [];
+    const posthogFetch = mock(async (...args: unknown[]) => {
+      const init = args[1] as RequestInit | undefined;
+      bodies.push(String(init?.body));
+      return new Response(null, { status: bodies.length === 1 ? 503 : 200 });
+    });
+    let deferred: Promise<unknown> | null = null;
+
+    captureCoderouterEvent(
+      {
+        event: "coderouter_model_request_completed",
+        userId: "stack-user-1",
+        teamId: "team-1",
+        properties: { provider: "codex", total_tokens: 10 },
+      },
+      {
+        fetch: posthogFetch as typeof fetch,
+        defer: (task) => {
+          deferred = task;
+        },
+        enabled: () => true,
+      },
+    );
+
+    expect(deferred).not.toBeNull();
+    await deferred;
+    expect(posthogFetch).toHaveBeenCalledTimes(2);
+    expect(bodies[0]).toBe(bodies[1]);
+    const payload = JSON.parse(bodies[0]!) as {
+      batch: Array<{
+        distinct_id: string;
+        properties: Record<string, unknown>;
+      }>;
+    };
+    expect(payload.batch[0]?.distinct_id).toBe("stack-user-1");
+    expect(payload.batch[0]?.properties.$groups).toEqual({
+      coderouter_team: "team-1",
+    });
+    expect(payload.batch[0]?.properties.$insert_id).toBeString();
+  });
+});
+
+describe("streaming model usage extraction", () => {
+  test("extracts token counts without retaining prompt or output properties", () => {
+    const usage = usageTest.usageFromTail(
+      [
+        'data: {"type":"response.completed","response":{',
+        '"output":[{"content":[{"text":"private output"}]}],',
+        '"usage":{"input_tokens":120,"input_tokens_details":{"cached_tokens":80},',
+        '"output_tokens":30,"total_tokens":150}}}',
+      ].join(""),
+      "gpt-test",
+    );
+    expect(usage).toEqual({
+      model: "gpt-test",
+      inputTokens: 120,
+      cachedInputTokens: 80,
+      outputTokens: 30,
+      totalTokens: 150,
+    });
+    expect(usage).not.toHaveProperty("output");
+  });
+
+  test("fails closed on missing or malformed usage", () => {
+    expect(usageTest.usageFromTail('{"output":"private"}')).toBeNull();
+    expect(
+      usageTest.usageFromTail('{"usage":{"input_tokens":"many"}}'),
+    ).toBeNull();
+  });
+});

--- a/web/tests/coderouter-models-proxy.test.ts
+++ b/web/tests/coderouter-models-proxy.test.ts
@@ -18,7 +18,7 @@ afterAll(() => {
 
 const { createCodexModelsProxy } = await import("../services/coderouter/codexProxy");
 const proxyCodexModels = createCodexModelsProxy({
-  authenticate: async () => ({ teamId: "team-1" }),
+  authenticate: async () => ({ teamId: "team-1", stackUserId: "stack-user-1" }),
   select: async () => {
     const id = selectedAccounts.shift();
     return id

--- a/web/tests/coderouter-opencode-proxy.test.ts
+++ b/web/tests/coderouter-opencode-proxy.test.ts
@@ -9,7 +9,18 @@ describe("coderouter OpenCode Go proxy", () => {
         npm: "@ai-sdk/openai-compatible",
         api: { url: "https://models.example.test/v1", package: "@ai-sdk/openai-compatible" },
         options: { apiKey: "upstream-secret", headers: { secret: "value" }, mode: "go" },
-        models: { "model-1": { name: "Model One" } },
+        models: {
+          "model-1": {
+            name: "Model One",
+            provider: {
+              id: "go",
+              name: "OpenCode Go",
+              npm: "@ai-sdk/openai-compatible",
+              apiKey: "nested-upstream-secret",
+              headers: { authorization: "nested-secret" },
+            },
+          },
+        },
       },
     }, "route-token") as {
       go: { options: Record<string, unknown> };
@@ -20,6 +31,7 @@ describe("coderouter OpenCode Go proxy", () => {
       apiKey: "route-token",
     });
     expect(JSON.stringify(rewritten)).not.toContain("upstream-secret");
+    expect(JSON.stringify(rewritten)).not.toContain("nested-secret");
     expect(JSON.stringify(rewritten)).not.toContain("models.example.test");
   });
 

--- a/web/tests/coderouter-sentry.test.ts
+++ b/web/tests/coderouter-sentry.test.ts
@@ -8,18 +8,26 @@ import {
 
 describe("coderouter Sentry privacy", () => {
   test("isolates the shared cmux deployment to coderouter events", () => {
-    expect(shouldSendCoderouterSentryEvent({
-      request: { url: "https://coderouter.dev/v1/responses" },
-    })).toBe(true);
-    expect(shouldSendCoderouterSentryEvent({
-      tags: { subsystem: "coderouter" },
-    })).toBe(true);
-    expect(shouldSendCoderouterSentryEvent({
-      contexts: { cmux: { service: "coderouter" } },
-    })).toBe(true);
-    expect(shouldSendCoderouterSentryEvent({
-      request: { url: "https://cmux.com/api/devices" },
-    })).toBe(false);
+    expect(
+      shouldSendCoderouterSentryEvent({
+        request: { url: "https://coderouter.dev/v1/responses" },
+      }),
+    ).toBe(true);
+    expect(
+      shouldSendCoderouterSentryEvent({
+        tags: { subsystem: "coderouter" },
+      }),
+    ).toBe(true);
+    expect(
+      shouldSendCoderouterSentryEvent({
+        contexts: { cmux: { service: "coderouter" } },
+      }),
+    ).toBe(true);
+    expect(
+      shouldSendCoderouterSentryEvent({
+        request: { url: "https://cmux.com/api/devices" },
+      }),
+    ).toBe(false);
   });
 
   test("removes request bodies, auth headers, route tokens, JWTs, and PII", () => {
@@ -44,8 +52,21 @@ describe("coderouter Sentry privacy", () => {
       },
       extra: {
         credential: "secret",
+        prompt: "private prompt",
+        provider_account_id: "provider-secret",
         nested: { refresh_token: "also-secret" },
       },
+      breadcrumbs: [
+        {
+          message: "safe lifecycle step",
+          data: {
+            provider: "codex",
+            prompt: "private prompt",
+            output: "private output",
+            total_tokens: 42,
+          },
+        },
+      ],
     } as Event);
 
     expect(event.request?.data).toBeUndefined();
@@ -54,7 +75,15 @@ describe("coderouter Sentry privacy", () => {
     expect(event.user).toBeUndefined();
     expect(event.extra).toEqual({
       credential: "[Filtered]",
+      prompt: "[Filtered]",
+      provider_account_id: "[Filtered]",
       nested: { refresh_token: "[Filtered]" },
+    });
+    expect(event.breadcrumbs?.[0]?.data).toEqual({
+      provider: "codex",
+      prompt: "[Filtered]",
+      output: "[Filtered]",
+      total_tokens: 42,
     });
     expect(event.message).not.toContain("secret-bearer");
     expect(event.message).not.toContain("crt_");

--- a/web/tests/coderouter-session-route.test.ts
+++ b/web/tests/coderouter-session-route.test.ts
@@ -21,7 +21,9 @@ const context = {
 describe("coderouter hosted entitlement", () => {
   test("validates an existing principal-scoped route session cheaply", async () => {
     const authenticate = async (token: string) =>
-      token === "crt_valid" ? { teamId: "team_1" } : null;
+      token === "crt_valid"
+        ? { teamId: "team_1", stackUserId: "stack-user-1" }
+        : null;
     const GET = makeCoderouterSessionGetHandler(authenticate);
 
     const valid = await GET(new Request(


### PR DESCRIPTION
Adds privacy-bounded, non-blocking PostHog events for coderouter account/session/model lifecycles; per-user/team streaming token totals and subscription cost basis; Sentry lifecycle breadcrumbs with stronger scrubbing; actionable API errors; and bounded safe-read retries.

Privacy:
- no prompt/output, email, provider account ID, credential, token, header, or body properties
- streaming response remains pass-through with only a bounded rolling tail used to extract aggregate usage
- PostHog delivery uses post-response work, a 2s timeout, and one deduplicated retry

Validation:
- `bun run typecheck`
- `bun test tests/coderouter*.test.ts` (43 pass)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/9725"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788648449&installation_model_id=21920&pr_number=9725&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F9725&signature=56e6e159f00c9c8aab778a8725bd4c1f8ecf89ec1e71df26dd328f418dfcf5cd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Instruments coderouter requests, accounts, and sessions with privacy-safe analytics and Sentry breadcrumbs, and extracts streaming token usage without retaining prompts or outputs. Improves reliability and clarity with safer retries/timeouts and actionable API errors across Codex and OpenCode routing.

- **New Features**
  - Added PostHog events for account add/remove/status, session issue/revoke, auth rejects, and per-request model completion (grouped by `coderouter_team`).
  - Extracted usage via `observeModelUsage` for Codex and OpenCode (model + token counts only; bodies remain pass-through).
  - Returned clearer API errors with human messages, `retryable` hints, and `retry-after` where applicable.

- **Refactors**
  - Introduced `addCoderouterBreadcrumb` and expanded breadcrumbs across auth, routing, refresh leasing, retries, requests, and analytics delivery with strict scrubbing.
  - Hardened provider interactions: transport failure handling, safe-read retry with breadcrumbs, 5–10s timeouts, and cooldowns on 429.
  - Improved OpenCode proxy: safe provider URL checks, nested model provider rewrite without secrets, and resilient config fetch.
  - Centralized analytics capture with bounded, deferred delivery and one deduplicated retry.
  - Extended route token auth and request context to include `stackUserId`.

<sup>Written for commit 547313673c004acf3c40102ea13c7a3472765d03. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/9725?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added model and token usage tracking for routed requests.
  - Added clearer request status details, including retry guidance for temporary failures.
  - Improved provider routing for nested model APIs.

- **Bug Fixes**
  - Added timeouts and retry handling for account, provider, credential, and session operations.
  - Improved account and session error responses.
  - Strengthened protection of sensitive request, response, credential, and prompt data.

- **Observability**
  - Added richer activity and request diagnostics for account, session, provider, and routing operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->