### PR TITLE
Replace iOS Mac hide swipes with row toggles

### DIFF
--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+HiddenMacs.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+HiddenMacs.swift
@@ -404,10 +404,45 @@ extension MobileShellComposite {
         }
     }
 
-    /// Unhides one stored pairing immediately without requiring network access.
+    /// Unhides one stored pairing without requiring network access.
     public func unhideMacDeviceID(
         _ macDeviceID: String,
         instanceTag: String? = nil
+    ) async {
+        await enqueueUnhideMacDeviceID(
+            macDeviceID,
+            instanceTag: instanceTag
+        ).value
+    }
+
+    /// Starts an owned unhide operation for a row visibility switch.
+    public func requestUnhideMacDeviceID(
+        _ macDeviceID: String,
+        instanceTag: String? = nil
+    ) {
+        _ = enqueueUnhideMacDeviceID(macDeviceID, instanceTag: instanceTag)
+    }
+
+    private func enqueueUnhideMacDeviceID(
+        _ macDeviceID: String,
+        instanceTag: String?
+    ) -> Task<Void, Never> {
+        enqueueComputerVisibilityMutation(
+            computerID: MobilePairedMac.pairingID(
+                macDeviceID: macDeviceID,
+                instanceTag: instanceTag
+            )
+        ) { store in
+            await store.performUnhideMacDeviceID(
+                macDeviceID,
+                instanceTag: instanceTag
+            )
+        }
+    }
+
+    private func performUnhideMacDeviceID(
+        _ macDeviceID: String,
+        instanceTag: String?
     ) async {
         guard let scope = await currentScopeSnapshot() else { return }
         await clearHiddenMacDeviceID(
@@ -458,6 +493,45 @@ extension MobileShellComposite {
         representativeID: String,
         aliasIDs: [String]
     ) async {
+        await enqueueHideStoredPairedMacEntries(
+            representativeID: representativeID,
+            aliasIDs: aliasIDs,
+            refreshRegistry: false
+        ).value
+    }
+
+    /// Starts an owned hide operation for a row visibility switch.
+    public func requestHideStoredPairedMacEntries(
+        representativeID: String,
+        aliasIDs: [String]
+    ) {
+        _ = enqueueHideStoredPairedMacEntries(
+            representativeID: representativeID,
+            aliasIDs: aliasIDs,
+            refreshRegistry: true
+        )
+    }
+
+    private func enqueueHideStoredPairedMacEntries(
+        representativeID: String,
+        aliasIDs: [String],
+        refreshRegistry: Bool
+    ) -> Task<Void, Never> {
+        enqueueComputerVisibilityMutation(computerID: representativeID) { store in
+            await store.performHideStoredPairedMacEntries(
+                representativeID: representativeID,
+                aliasIDs: aliasIDs
+            )
+            if refreshRegistry {
+                await store.loadRegistryDevices()
+            }
+        }
+    }
+
+    private func performHideStoredPairedMacEntries(
+        representativeID: String,
+        aliasIDs: [String]
+    ) async {
         guard !representativeID.isEmpty,
               let scope = await currentScopeSnapshot() else { return }
         let representative = MobilePairedMac.pairingIdentity(from: representativeID)
@@ -476,6 +550,43 @@ extension MobileShellComposite {
         }
         guard !targets.isEmpty else { return }
         await hideStoredPairedMacs(targets, scope: scope)
+    }
+
+    private func enqueueComputerVisibilityMutation(
+        computerID: String,
+        operation: @escaping @MainActor (MobileShellComposite) async -> Void
+    ) -> Task<Void, Never> {
+        let previousTask = computerVisibilityMutationTasksByID[computerID]
+        let operationID = UUID()
+        computerVisibilityMutationOperationIDsByID[computerID] = operationID
+        computerVisibilityMutationIDs.insert(computerID)
+
+        let task = Task { @MainActor [weak self] in
+            await previousTask?.value
+            guard let self else { return }
+            defer {
+                self.finishComputerVisibilityMutation(
+                    computerID: computerID,
+                    operationID: operationID
+                )
+            }
+            guard !Task.isCancelled else { return }
+            await operation(self)
+        }
+        computerVisibilityMutationTasksByID[computerID] = task
+        return task
+    }
+
+    private func finishComputerVisibilityMutation(
+        computerID: String,
+        operationID: UUID
+    ) {
+        guard computerVisibilityMutationOperationIDsByID[computerID] == operationID else {
+            return
+        }
+        computerVisibilityMutationTasksByID[computerID] = nil
+        computerVisibilityMutationOperationIDsByID[computerID] = nil
+        computerVisibilityMutationIDs.remove(computerID)
     }
 
     /// Hides exactly one stored paired-Mac row.

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+HiddenMacs.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+HiddenMacs.swift
@@ -582,12 +582,13 @@ extension MobileShellComposite {
 
     func cancelComputerVisibilityMutations() {
         let tasks = Array(computerVisibilityMutationTasksByID.values)
-        computerVisibilityMutationTasksByID = [:]
-        computerVisibilityMutationOperationIDsByID = [:]
         computerVisibilityMutationIDs = []
         for task in tasks {
             task.cancel()
         }
+        // Keep each cancelled task as the serial tail until its rollback ends.
+        // A request in the next account/team scope must await that cleanup before
+        // writing a newer durable visibility preference for the same computer.
     }
 
     private func finishComputerVisibilityMutation(

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+HiddenMacs.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+HiddenMacs.swift
@@ -638,8 +638,9 @@ extension MobileShellComposite {
                 includeUserWideScope: teamlessLegacyIDs.contains(mac.id)
             )
         }
-        guard !Task.isCancelled else { return }
-        guard await isScopeCurrent(scope), !Task.isCancelled else {
+        guard !Task.isCancelled,
+              await isScopeCurrent(scope),
+              !Task.isCancelled else {
             for pairingID in targetPairingIDs {
                 await clearHiddenMacDeviceID(pairingID, scope: scope)
             }

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+HiddenMacs.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+HiddenMacs.swift
@@ -450,8 +450,11 @@ extension MobileShellComposite {
             instanceTag: instanceTag,
             scope: scope
         )
-        guard await isScopeCurrent(scope) else { return }
+        guard !Task.isCancelled,
+              await isScopeCurrent(scope),
+              !Task.isCancelled else { return }
         await loadPairedMacs()
+        guard !Task.isCancelled else { return }
         await loadRegistryDevices()
     }
 
@@ -522,7 +525,7 @@ extension MobileShellComposite {
                 representativeID: representativeID,
                 aliasIDs: aliasIDs
             )
-            if refreshRegistry {
+            if refreshRegistry, !Task.isCancelled {
                 await store.loadRegistryDevices()
             }
         }
@@ -577,6 +580,16 @@ extension MobileShellComposite {
         return task
     }
 
+    func cancelComputerVisibilityMutations() {
+        let tasks = Array(computerVisibilityMutationTasksByID.values)
+        computerVisibilityMutationTasksByID = [:]
+        computerVisibilityMutationOperationIDsByID = [:]
+        computerVisibilityMutationIDs = []
+        for task in tasks {
+            task.cancel()
+        }
+    }
+
     private func finishComputerVisibilityMutation(
         computerID: String,
         operationID: UUID
@@ -625,7 +638,8 @@ extension MobileShellComposite {
                 includeUserWideScope: teamlessLegacyIDs.contains(mac.id)
             )
         }
-        guard await isScopeCurrent(scope) else {
+        guard !Task.isCancelled else { return }
+        guard await isScopeCurrent(scope), !Task.isCancelled else {
             for pairingID in targetPairingIDs {
                 await clearHiddenMacDeviceID(pairingID, scope: scope)
             }
@@ -682,7 +696,9 @@ extension MobileShellComposite {
             removeNotificationFeedSnapshot(macDeviceID: id)
         }
 
-        guard await isScopeCurrent(scope) else { return }
+        guard !Task.isCancelled,
+              await isScopeCurrent(scope),
+              !Task.isCancelled else { return }
         await loadPairedMacs()
         clearSavedMacHintWhenNoStoredMacsRemainIfNeeded()
     }

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
@@ -1558,6 +1558,9 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         workspaceChangesSummaryTrailingTask?.cancel()
         pullToRefreshTask?.cancel()
         foregroundWorkspaceMutationRefreshTask?.cancel()
+        for task in computerVisibilityMutationTasksByID.values {
+            task.cancel()
+        }
         foregroundWorkspaceMutationRefreshPending = false
         foregroundWorkspaceMutationRefreshGeneration = UUID()
         notificationFeedOpenTask?.cancel()
@@ -2713,6 +2716,10 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
     public internal(set) var hiddenComputers: [MobileHiddenComputer] = []
     /// True when the current account/team scope has at least one hidden computer.
     public internal(set) var hasHiddenComputers = false
+    /// Computer identities whose visibility preference is being persisted.
+    public internal(set) var computerVisibilityMutationIDs: Set<String> = []
+    @ObservationIgnored var computerVisibilityMutationTasksByID: [String: Task<Void, Never>] = [:]
+    @ObservationIgnored var computerVisibilityMutationOperationIDsByID: [String: UUID] = [:]
 
     var pairedMacsForIdentityMatching: [MobilePairedMac] {
         storedPairedMacs.isEmpty ? pairedMacs : storedPairedMacs

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
@@ -1606,6 +1606,7 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
     }
 
     public func signOut() {
+        cancelComputerVisibilityMutations()
         // Reset analytics identity to anonymous on the signed-in→signed-out edge
         // only (this is called on every unauthenticated auth-state sync).
         if isSignedIn {
@@ -1762,6 +1763,7 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
     /// never drops the terminal the user is in (the chosen "keep session, re-scope
     /// lists" behavior).
     public func currentTeamDidChange() {
+        cancelComputerVisibilityMutations()
         secondaryAggregationScopeGeneration &+= 1
         let teamScopeGeneration = secondaryAggregationScopeGeneration
         // Presence: cancel + re-subscribe so the online dots reflect the new team

--- a/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/DelayedFirstHidePairedMacHiddenStore.swift
+++ b/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/DelayedFirstHidePairedMacHiddenStore.swift
@@ -1,0 +1,64 @@
+@testable import CmuxMobileShell
+
+actor DelayedFirstHidePairedMacHiddenStore: PairedMacHiddenStoring {
+    private var idsByScope: [String: Set<String>] = [:]
+    private var didDelayHideSave = false
+    private var hideSaveStarted = false
+    private var hideSaveStartWaiters: [CheckedContinuation<Void, Never>] = []
+    private var hideSaveRelease: CheckedContinuation<Void, Never>?
+    private var didSaveEmpty = false
+    private var emptySaveWaiters: [CheckedContinuation<Void, Never>] = []
+
+    func load(scope: String) async -> Set<String> {
+        idsByScope[scope] ?? []
+    }
+
+    func save(_ ids: Set<String>, scope: String) async {
+        if !didDelayHideSave, !ids.isEmpty {
+            didDelayHideSave = true
+            hideSaveStarted = true
+            let waiters = hideSaveStartWaiters
+            hideSaveStartWaiters = []
+            for waiter in waiters {
+                waiter.resume()
+            }
+            await withCheckedContinuation { continuation in
+                hideSaveRelease = continuation
+            }
+        }
+        if ids.isEmpty {
+            idsByScope.removeValue(forKey: scope)
+            didSaveEmpty = true
+            let waiters = emptySaveWaiters
+            emptySaveWaiters = []
+            for waiter in waiters {
+                waiter.resume()
+            }
+        } else {
+            idsByScope[scope] = ids
+        }
+    }
+
+    func removeAll() async {
+        idsByScope.removeAll()
+    }
+
+    func waitForDelayedHideSave() async {
+        guard !hideSaveStarted else { return }
+        await withCheckedContinuation { continuation in
+            hideSaveStartWaiters.append(continuation)
+        }
+    }
+
+    func releaseDelayedHideSave() {
+        hideSaveRelease?.resume()
+        hideSaveRelease = nil
+    }
+
+    func waitForEmptySave() async {
+        guard !didSaveEmpty else { return }
+        await withCheckedContinuation { continuation in
+            emptySaveWaiters.append(continuation)
+        }
+    }
+}

--- a/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/MobileShellCompositeHideMacTests.swift
+++ b/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/MobileShellCompositeHideMacTests.swift
@@ -158,10 +158,12 @@ import Testing
 
         #expect(task.isCancelled)
         #expect(store.computerVisibilityMutationIDs.isEmpty)
-        #expect(store.computerVisibilityMutationTasksByID.isEmpty)
-        #expect(store.computerVisibilityMutationOperationIDsByID.isEmpty)
+        #expect(store.computerVisibilityMutationTasksByID[computer.id] != nil)
+        #expect(store.computerVisibilityMutationOperationIDsByID[computer.id] != nil)
         await hiddenStore.releaseDelayedHideSave()
         await task.value
+        #expect(store.computerVisibilityMutationTasksByID.isEmpty)
+        #expect(store.computerVisibilityMutationOperationIDsByID.isEmpty)
         #expect(store.hiddenComputers.isEmpty)
         #expect(await hiddenStore.load(scope: scopeKey).isEmpty)
     }
@@ -208,10 +210,12 @@ import Testing
 
         #expect(task.isCancelled)
         #expect(store.computerVisibilityMutationIDs.isEmpty)
-        #expect(store.computerVisibilityMutationTasksByID.isEmpty)
-        #expect(store.computerVisibilityMutationOperationIDsByID.isEmpty)
+        #expect(store.computerVisibilityMutationTasksByID[computer.id] != nil)
+        #expect(store.computerVisibilityMutationOperationIDsByID[computer.id] != nil)
         await hiddenStore.releaseDelayedHideSave()
         await task.value
+        #expect(store.computerVisibilityMutationTasksByID.isEmpty)
+        #expect(store.computerVisibilityMutationOperationIDsByID.isEmpty)
         #expect(store.hiddenComputers.isEmpty)
         #expect(await hiddenStore.load(scope: scopeKey).isEmpty)
     }

--- a/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/MobileShellCompositeHideMacTests.swift
+++ b/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/MobileShellCompositeHideMacTests.swift
@@ -69,6 +69,55 @@ import Testing
         #expect(store.workspaceListConnectionStatus == .connected)
     }
 
+    @Test func laterUnhideWinsWhenEarlierHidePersistenceFinishesLast() async throws {
+        let hiddenStore = DelayedFirstHidePairedMacHiddenStore()
+        let pairedStore = DelayedTeamPairedMacStore(
+            recordsByTeam: [
+                "team-a": [
+                    try Self.pairedMac(
+                        id: "mac-a",
+                        displayName: "Desk Mac",
+                        host: "100.82.214.112",
+                        lastSeenAt: Date(timeIntervalSince1970: 10),
+                        isActive: false
+                    ),
+                ],
+            ],
+            blockedTeams: []
+        )
+        let store = MobileShellComposite(
+            isSignedIn: true,
+            pairedMacStore: pairedStore,
+            identityProvider: StaticIdentityProvider(userID: "user-1"),
+            teamIDProvider: { "team-a" },
+            hiddenMacStore: hiddenStore
+        )
+        await store.loadPairedMacs()
+        let computer = try #require(store.pairedMacs.first)
+        let scope = try #require(await store.currentScopeSnapshot())
+        let scopeKey = store.pairedMacScopeKey(scope)
+
+        let hideTask = Task { @MainActor in
+            await store.hideStoredPairedMacEntries(
+                representativeID: computer.id,
+                aliasIDs: [computer.id]
+            )
+        }
+        await hiddenStore.waitForDelayedHideSave()
+
+        await store.unhideMacDeviceID(
+            computer.macDeviceID,
+            instanceTag: computer.instanceTag
+        )
+        await hiddenStore.releaseDelayedHideSave()
+        await hideTask.value
+
+        #expect(
+            await hiddenStore.load(scope: scopeKey).isEmpty,
+            "The later show request must remain durable after relaunch."
+        )
+    }
+
     @Test func rawDeviceIDMarkerMatchingExistingRowSurvivesMigration() async throws {
         let defaultsSuiteName = "hidden-marker-hint-migration-\(UUID().uuidString)"
         let defaults = try #require(UserDefaults(suiteName: defaultsSuiteName))
@@ -895,5 +944,53 @@ import Testing
         try MobileNotificationFeedListResponse.decode(Data(
             #"{"revision":\#(revision),"notifications":[{"id":"\#(id)","workspace_id":"workspace","title":"Title","body":"Body","created_at":100,"is_read":false}]}"#.utf8
         ))
+    }
+}
+
+private actor DelayedFirstHidePairedMacHiddenStore: PairedMacHiddenStoring {
+    private var idsByScope: [String: Set<String>] = [:]
+    private var didDelayHideSave = false
+    private var hideSaveStarted = false
+    private var hideSaveStartWaiters: [CheckedContinuation<Void, Never>] = []
+    private var hideSaveRelease: CheckedContinuation<Void, Never>?
+
+    func load(scope: String) async -> Set<String> {
+        idsByScope[scope] ?? []
+    }
+
+    func save(_ ids: Set<String>, scope: String) async {
+        if !didDelayHideSave, !ids.isEmpty {
+            didDelayHideSave = true
+            hideSaveStarted = true
+            let waiters = hideSaveStartWaiters
+            hideSaveStartWaiters = []
+            for waiter in waiters {
+                waiter.resume()
+            }
+            await withCheckedContinuation { continuation in
+                hideSaveRelease = continuation
+            }
+        }
+        if ids.isEmpty {
+            idsByScope.removeValue(forKey: scope)
+        } else {
+            idsByScope[scope] = ids
+        }
+    }
+
+    func removeAll() async {
+        idsByScope.removeAll()
+    }
+
+    func waitForDelayedHideSave() async {
+        guard !hideSaveStarted else { return }
+        await withCheckedContinuation { continuation in
+            hideSaveStartWaiters.append(continuation)
+        }
+    }
+
+    func releaseDelayedHideSave() {
+        hideSaveRelease?.resume()
+        hideSaveRelease = nil
     }
 }

--- a/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/MobileShellCompositeHideMacTests.swift
+++ b/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/MobileShellCompositeHideMacTests.swift
@@ -144,6 +144,8 @@ import Testing
         )
         await store.loadPairedMacs()
         let computer = try #require(store.pairedMacs.first)
+        let scope = try #require(await store.currentScopeSnapshot())
+        let scopeKey = store.pairedMacScopeKey(scope)
 
         store.requestHideStoredPairedMacEntries(
             representativeID: computer.id,
@@ -161,6 +163,7 @@ import Testing
         await hiddenStore.releaseDelayedHideSave()
         await task.value
         #expect(store.hiddenComputers.isEmpty)
+        #expect(await hiddenStore.load(scope: scopeKey).isEmpty)
     }
 
     @Test func teamChangeCancelsInFlightComputerVisibilityMutation() async throws {
@@ -190,6 +193,8 @@ import Testing
         )
         await store.loadPairedMacs()
         let computer = try #require(store.pairedMacs.first)
+        let scope = try #require(await store.currentScopeSnapshot())
+        let scopeKey = store.pairedMacScopeKey(scope)
 
         store.requestHideStoredPairedMacEntries(
             representativeID: computer.id,
@@ -208,6 +213,7 @@ import Testing
         await hiddenStore.releaseDelayedHideSave()
         await task.value
         #expect(store.hiddenComputers.isEmpty)
+        #expect(await hiddenStore.load(scope: scopeKey).isEmpty)
     }
 
     @Test func rawDeviceIDMarkerMatchingExistingRowSurvivesMigration() async throws {

--- a/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/MobileShellCompositeHideMacTests.swift
+++ b/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/MobileShellCompositeHideMacTests.swift
@@ -105,11 +105,12 @@ import Testing
         }
         await hiddenStore.waitForDelayedHideSave()
 
-        await store.unhideMacDeviceID(
+        store.requestUnhideMacDeviceID(
             computer.macDeviceID,
             instanceTag: computer.instanceTag
         )
         await hiddenStore.releaseDelayedHideSave()
+        await hiddenStore.waitForEmptySave()
         await hideTask.value
 
         #expect(
@@ -944,53 +945,5 @@ import Testing
         try MobileNotificationFeedListResponse.decode(Data(
             #"{"revision":\#(revision),"notifications":[{"id":"\#(id)","workspace_id":"workspace","title":"Title","body":"Body","created_at":100,"is_read":false}]}"#.utf8
         ))
-    }
-}
-
-private actor DelayedFirstHidePairedMacHiddenStore: PairedMacHiddenStoring {
-    private var idsByScope: [String: Set<String>] = [:]
-    private var didDelayHideSave = false
-    private var hideSaveStarted = false
-    private var hideSaveStartWaiters: [CheckedContinuation<Void, Never>] = []
-    private var hideSaveRelease: CheckedContinuation<Void, Never>?
-
-    func load(scope: String) async -> Set<String> {
-        idsByScope[scope] ?? []
-    }
-
-    func save(_ ids: Set<String>, scope: String) async {
-        if !didDelayHideSave, !ids.isEmpty {
-            didDelayHideSave = true
-            hideSaveStarted = true
-            let waiters = hideSaveStartWaiters
-            hideSaveStartWaiters = []
-            for waiter in waiters {
-                waiter.resume()
-            }
-            await withCheckedContinuation { continuation in
-                hideSaveRelease = continuation
-            }
-        }
-        if ids.isEmpty {
-            idsByScope.removeValue(forKey: scope)
-        } else {
-            idsByScope[scope] = ids
-        }
-    }
-
-    func removeAll() async {
-        idsByScope.removeAll()
-    }
-
-    func waitForDelayedHideSave() async {
-        guard !hideSaveStarted else { return }
-        await withCheckedContinuation { continuation in
-            hideSaveStartWaiters.append(continuation)
-        }
-    }
-
-    func releaseDelayedHideSave() {
-        hideSaveRelease?.resume()
-        hideSaveRelease = nil
     }
 }

--- a/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/MobileShellCompositeHideMacTests.swift
+++ b/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/MobileShellCompositeHideMacTests.swift
@@ -119,6 +119,97 @@ import Testing
         )
     }
 
+    @Test func signOutCancelsInFlightComputerVisibilityMutation() async throws {
+        let hiddenStore = DelayedFirstHidePairedMacHiddenStore()
+        let pairedStore = DelayedTeamPairedMacStore(
+            recordsByTeam: [
+                "team-a": [
+                    try Self.pairedMac(
+                        id: "mac-a",
+                        displayName: "Desk Mac",
+                        host: "100.82.214.112",
+                        lastSeenAt: Date(timeIntervalSince1970: 10),
+                        isActive: false
+                    ),
+                ],
+            ],
+            blockedTeams: []
+        )
+        let store = MobileShellComposite(
+            isSignedIn: true,
+            pairedMacStore: pairedStore,
+            identityProvider: StaticIdentityProvider(userID: "user-1"),
+            teamIDProvider: { "team-a" },
+            hiddenMacStore: hiddenStore
+        )
+        await store.loadPairedMacs()
+        let computer = try #require(store.pairedMacs.first)
+
+        store.requestHideStoredPairedMacEntries(
+            representativeID: computer.id,
+            aliasIDs: [computer.id]
+        )
+        await hiddenStore.waitForDelayedHideSave()
+        let task = try #require(store.computerVisibilityMutationTasksByID[computer.id])
+
+        store.signOut()
+
+        #expect(task.isCancelled)
+        #expect(store.computerVisibilityMutationIDs.isEmpty)
+        #expect(store.computerVisibilityMutationTasksByID.isEmpty)
+        #expect(store.computerVisibilityMutationOperationIDsByID.isEmpty)
+        await hiddenStore.releaseDelayedHideSave()
+        await task.value
+        #expect(store.hiddenComputers.isEmpty)
+    }
+
+    @Test func teamChangeCancelsInFlightComputerVisibilityMutation() async throws {
+        let hiddenStore = DelayedFirstHidePairedMacHiddenStore()
+        let pairedStore = DelayedTeamPairedMacStore(
+            recordsByTeam: [
+                "team-a": [
+                    try Self.pairedMac(
+                        id: "mac-a",
+                        displayName: "Desk Mac",
+                        host: "100.82.214.112",
+                        lastSeenAt: Date(timeIntervalSince1970: 10),
+                        isActive: false
+                    ),
+                ],
+            ],
+            blockedTeams: []
+        )
+        let selectedTeam = MutableTeamID("team-a")
+        let store = MobileShellComposite(
+            isSignedIn: true,
+            connectionState: .connected,
+            pairedMacStore: pairedStore,
+            identityProvider: StaticIdentityProvider(userID: "user-1"),
+            teamIDProvider: { await selectedTeam.value },
+            hiddenMacStore: hiddenStore
+        )
+        await store.loadPairedMacs()
+        let computer = try #require(store.pairedMacs.first)
+
+        store.requestHideStoredPairedMacEntries(
+            representativeID: computer.id,
+            aliasIDs: [computer.id]
+        )
+        await hiddenStore.waitForDelayedHideSave()
+        let task = try #require(store.computerVisibilityMutationTasksByID[computer.id])
+
+        await selectedTeam.set("team-b")
+        store.currentTeamDidChange()
+
+        #expect(task.isCancelled)
+        #expect(store.computerVisibilityMutationIDs.isEmpty)
+        #expect(store.computerVisibilityMutationTasksByID.isEmpty)
+        #expect(store.computerVisibilityMutationOperationIDsByID.isEmpty)
+        await hiddenStore.releaseDelayedHideSave()
+        await task.value
+        #expect(store.hiddenComputers.isEmpty)
+    }
+
     @Test func rawDeviceIDMarkerMatchingExistingRowSurvivesMigration() async throws {
         let defaultsSuiteName = "hidden-marker-hint-migration-\(UUID().uuidString)"
         let defaults = try #require(UserDefaults(suiteName: defaultsSuiteName))

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/ComputerVisibilityToggle.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/ComputerVisibilityToggle.swift
@@ -10,6 +10,7 @@ struct ComputerVisibilityToggle: View {
     let computerID: String
     let computerName: String
     let isVisible: Bool
+    var isDisabled = false
     let setVisible: (Bool) -> Void
 
     var body: some View {
@@ -25,15 +26,13 @@ struct ComputerVisibilityToggle: View {
         )
         .labelsHidden()
         .accessibilityLabel(
-            String(
-                format: L10n.string(
-                    "mobile.computers.visibilityToggle.named",
-                    defaultValue: "Show %@ on this iPhone"
-                ),
-                computerName
+            L10n.string(
+                "mobile.computers.visibilityToggle.named",
+                defaultValue: "Show \(computerName) on this iPhone"
             )
         )
         .accessibilityIdentifier("MobileComputerVisibilityToggle-\(computerID)")
+        .disabled(isDisabled)
     }
 }
 #endif

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/ComputerVisibilityToggle.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/ComputerVisibilityToggle.swift
@@ -4,19 +4,13 @@ import SwiftUI
 
 /// A row-local switch for whether one computer appears on this iPhone.
 ///
-/// The pending value moves immediately with the user's gesture while the
-/// durable hide marker updates. If the mutation cannot be applied, the switch
-/// returns to the authoritative value supplied by the parent row.
+/// The owning row performs the asynchronous mutation. This leaf view only
+/// reports the requested value and renders the authoritative row state.
 struct ComputerVisibilityToggle: View {
     let computerID: String
     let computerName: String
     let isVisible: Bool
-    let setVisible: @MainActor (Bool) async -> Void
-
-    @State private var pendingValue: Bool?
-    @State private var isMutating = false
-
-    private var displayedValue: Bool { pendingValue ?? isVisible }
+    let setVisible: (Bool) -> Void
 
     var body: some View {
         Toggle(
@@ -25,12 +19,11 @@ struct ComputerVisibilityToggle: View {
                 defaultValue: "Show this computer on this iPhone"
             ),
             isOn: Binding(
-                get: { displayedValue },
-                set: beginMutation
+                get: { isVisible },
+                set: setVisible
             )
         )
         .labelsHidden()
-        .disabled(isMutating)
         .accessibilityLabel(
             String(
                 format: L10n.string(
@@ -41,21 +34,6 @@ struct ComputerVisibilityToggle: View {
             )
         )
         .accessibilityIdentifier("MobileComputerVisibilityToggle-\(computerID)")
-        .onChange(of: isVisible) { _, newValue in
-            guard !isMutating else { return }
-            pendingValue = newValue
-        }
-    }
-
-    private func beginMutation(_ newValue: Bool) {
-        guard !isMutating, newValue != displayedValue else { return }
-        pendingValue = newValue
-        isMutating = true
-        Task { @MainActor in
-            await setVisible(newValue)
-            pendingValue = nil
-            isMutating = false
-        }
     }
 }
 #endif

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/ComputerVisibilityToggle.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/ComputerVisibilityToggle.swift
@@ -14,7 +14,7 @@ struct ComputerVisibilityToggle: View {
     let setVisible: @MainActor (Bool) async -> Void
 
     @State private var pendingValue: Bool?
-    @State private var actionTask: Task<Void, Never>?
+    @State private var isMutating = false
 
     private var displayedValue: Bool { pendingValue ?? isVisible }
 
@@ -30,7 +30,7 @@ struct ComputerVisibilityToggle: View {
             )
         )
         .labelsHidden()
-        .disabled(actionTask != nil)
+        .disabled(isMutating)
         .accessibilityLabel(
             String(
                 format: L10n.string(
@@ -42,18 +42,19 @@ struct ComputerVisibilityToggle: View {
         )
         .accessibilityIdentifier("MobileComputerVisibilityToggle-\(computerID)")
         .onChange(of: isVisible) { _, newValue in
-            guard actionTask == nil else { return }
+            guard !isMutating else { return }
             pendingValue = newValue
         }
     }
 
     private func beginMutation(_ newValue: Bool) {
-        guard actionTask == nil, newValue != displayedValue else { return }
+        guard !isMutating, newValue != displayedValue else { return }
         pendingValue = newValue
-        actionTask = Task { @MainActor in
+        isMutating = true
+        Task { @MainActor in
             await setVisible(newValue)
             pendingValue = nil
-            actionTask = nil
+            isMutating = false
         }
     }
 }

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/ComputerVisibilityToggle.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/ComputerVisibilityToggle.swift
@@ -21,7 +21,11 @@ struct ComputerVisibilityToggle: View {
             ),
             isOn: Binding(
                 get: { isVisible },
-                set: { newValue in setVisible(newValue) }
+                set: { newValue, transaction in
+                    withTransaction(transaction) {
+                        setVisible(newValue)
+                    }
+                }
             )
         )
         .labelsHidden()

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/ComputerVisibilityToggle.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/ComputerVisibilityToggle.swift
@@ -1,0 +1,60 @@
+#if os(iOS)
+import CmuxMobileSupport
+import SwiftUI
+
+/// A row-local switch for whether one computer appears on this iPhone.
+///
+/// The pending value moves immediately with the user's gesture while the
+/// durable hide marker updates. If the mutation cannot be applied, the switch
+/// returns to the authoritative value supplied by the parent row.
+struct ComputerVisibilityToggle: View {
+    let computerID: String
+    let computerName: String
+    let isVisible: Bool
+    let setVisible: @MainActor (Bool) async -> Void
+
+    @State private var pendingValue: Bool?
+    @State private var actionTask: Task<Void, Never>?
+
+    private var displayedValue: Bool { pendingValue ?? isVisible }
+
+    var body: some View {
+        Toggle(
+            L10n.string(
+                "mobile.computers.visibilityToggle",
+                defaultValue: "Show this computer on this iPhone"
+            ),
+            isOn: Binding(
+                get: { displayedValue },
+                set: beginMutation
+            )
+        )
+        .labelsHidden()
+        .disabled(actionTask != nil)
+        .accessibilityLabel(
+            String(
+                format: L10n.string(
+                    "mobile.computers.visibilityToggle.named",
+                    defaultValue: "Show %@ on this iPhone"
+                ),
+                computerName
+            )
+        )
+        .accessibilityIdentifier("MobileComputerVisibilityToggle-\(computerID)")
+        .onChange(of: isVisible) { _, newValue in
+            guard actionTask == nil else { return }
+            pendingValue = newValue
+        }
+    }
+
+    private func beginMutation(_ newValue: Bool) {
+        guard actionTask == nil, newValue != displayedValue else { return }
+        pendingValue = newValue
+        actionTask = Task { @MainActor in
+            await setVisible(newValue)
+            pendingValue = nil
+            actionTask = nil
+        }
+    }
+}
+#endif

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/ComputerVisibilityToggle.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/ComputerVisibilityToggle.swift
@@ -20,7 +20,7 @@ struct ComputerVisibilityToggle: View {
             ),
             isOn: Binding(
                 get: { isVisible },
-                set: setVisible
+                set: { newValue in setVisible(newValue) }
             )
         )
         .labelsHidden()

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DeviceTreeView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DeviceTreeView.swift
@@ -52,6 +52,7 @@ struct DeviceTreeView: View {
                         ComputerVisibilityRows(
                             visibleComputers: computers,
                             hiddenComputers: store.hiddenComputers,
+                            mutatingComputerIDs: store.computerVisibilityMutationIDs,
                             hide: hideComputer,
                             unhide: unhideComputer,
                             forget: forgetComputer
@@ -167,16 +168,15 @@ struct DeviceTreeView: View {
         }
     }
 
-    private func hideComputer(_ computer: MacComputerSnapshot) async {
-        await store.hideStoredPairedMacEntries(
+    private func hideComputer(_ computer: MacComputerSnapshot) {
+        store.requestHideStoredPairedMacEntries(
             representativeID: computer.id,
             aliasIDs: computer.aliasIDs
         )
-        await reload()
     }
 
-    private func unhideComputer(_ computer: MobileHiddenComputer) async {
-        await store.unhideMacDeviceID(
+    private func unhideComputer(_ computer: MobileHiddenComputer) {
+        store.requestUnhideMacDeviceID(
             computer.macDeviceID,
             instanceTag: computer.instanceTag
         )

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DeviceTreeView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DeviceTreeView.swift
@@ -9,7 +9,8 @@ import SwiftUI
 /// The Computers screen: the Macs signed in to the user's account, each shown
 /// with its name, live/last-seen status, and workspace count. The main workspace
 /// list owns the Mac picker; this screen manages the saved computer set and lets
-/// users inspect or hide one. The data is the durable-object–backed device
+/// users inspect one or choose whether it appears on this iPhone. The data is
+/// the durable-object–backed device
 /// registry (with a paired-Mac fallback) plus live presence.
 ///
 /// Snapshot boundary (see AGENTS.md): every row below the `List` takes an
@@ -33,7 +34,8 @@ struct DeviceTreeView: View {
     /// backup (`pairedMacs`) — this feature's source of truth, the same set that
     /// feeds the workspace aggregation, and the one ``CMUXMobileShellStore/hideMac``
     /// filters locally. Each is enriched with presence, live status, and how
-    /// many aggregated workspaces it contributes. Built by the shared
+    /// many aggregated workspaces it contributes. Hidden Macs remain in the
+    /// same section with their switches off. Built by the shared
     /// ``MacComputerSnapshot/snapshots(from:)`` so the disconnected reconnect
     /// list shows exactly the same computer set.
     private var computers: [MacComputerSnapshot] {
@@ -43,28 +45,26 @@ struct DeviceTreeView: View {
     var body: some View {
         NavigationStack {
             List {
-                if computers.isEmpty {
+                if computers.isEmpty && store.hiddenComputers.isEmpty {
                     emptySection
                 } else {
                     Section {
-                        ForEach(computers) { computer in
-                            MacComputerRow(
-                                computer: computer,
-                                hide: { _ in hideComputer(computer) }
-                            )
-                        }
+                        ComputerVisibilityRows(
+                            visibleComputers: computers,
+                            hiddenComputers: store.hiddenComputers,
+                            hide: hideComputer,
+                            unhide: unhideComputer,
+                            forget: forgetComputer
+                        )
                         if showAddDevice != nil {
                             addComputerRow
                         }
                     } footer: {
                         Text(L10n.string(
                             "mobile.computers.footer",
-                            defaultValue: "The computers signed in to your account. Use the workspace title picker to focus one computer or show All Computers."
+                            defaultValue: "Turn a computer off to hide its workspaces on this iPhone. It stays signed in to your account."
                         ))
                     }
-                }
-                if store.hasHiddenComputers {
-                    hiddenComputersSection
                 }
             }
             .listStyle(.insetGrouped)
@@ -157,28 +157,6 @@ struct DeviceTreeView: View {
     }
 
     @ViewBuilder
-    private var hiddenComputersSection: some View {
-        HiddenComputersSection(
-            computers: store.hiddenComputers,
-            unhide: { computer in
-                await store.unhideMacDeviceID(
-                    computer.macDeviceID,
-                    instanceTag: computer.instanceTag
-                )
-            },
-            forget: { computer in
-                let forgot = await store.forgetHiddenComputer(computer)
-                if !forgot {
-                    forgetFailureMessage = L10n.string(
-                        "mobile.computers.forget.failureMessage",
-                        defaultValue: "It's still signed in. Check your connection and try again."
-                    )
-                }
-            }
-        )
-    }
-
-    @ViewBuilder
     private var emptySection: some View {
         Section {
             Text(L10n.string(
@@ -189,13 +167,28 @@ struct DeviceTreeView: View {
         }
     }
 
-    private func hideComputer(_ computer: MacComputerSnapshot) {
-        Task {
-            await store.hideStoredPairedMacEntries(
-                representativeID: computer.id,
-                aliasIDs: computer.aliasIDs
+    private func hideComputer(_ computer: MacComputerSnapshot) async {
+        await store.hideStoredPairedMacEntries(
+            representativeID: computer.id,
+            aliasIDs: computer.aliasIDs
+        )
+        await reload()
+    }
+
+    private func unhideComputer(_ computer: MobileHiddenComputer) async {
+        await store.unhideMacDeviceID(
+            computer.macDeviceID,
+            instanceTag: computer.instanceTag
+        )
+    }
+
+    private func forgetComputer(_ computer: MobileHiddenComputer) async {
+        let forgot = await store.forgetHiddenComputer(computer)
+        if !forgot {
+            forgetFailureMessage = L10n.string(
+                "mobile.computers.forget.failureMessage",
+                defaultValue: "It's still signed in. Check your connection and try again."
             )
-            await reload()
         }
     }
 

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DisconnectedWorkspaceShellView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DisconnectedWorkspaceShellView.swift
@@ -156,6 +156,7 @@ struct DisconnectedWorkspaceShellView: View {
                     style: .reconnect,
                     connect: connect,
                     connectingComputerID: connectingMacID,
+                    mutatingComputerIDs: store?.computerVisibilityMutationIDs ?? [],
                     hide: hideComputer,
                     unhide: unhideComputer
                 )
@@ -275,15 +276,15 @@ struct DisconnectedWorkspaceShellView: View {
         )
     }
 
-    private func hideComputer(_ computer: MacComputerSnapshot) async {
-        await store?.hideStoredPairedMacEntries(
+    private func hideComputer(_ computer: MacComputerSnapshot) {
+        store?.requestHideStoredPairedMacEntries(
             representativeID: computer.id,
             aliasIDs: computer.aliasIDs
         )
     }
 
-    private func unhideComputer(_ computer: MobileHiddenComputer) async {
-        await store?.unhideMacDeviceID(
+    private func unhideComputer(_ computer: MobileHiddenComputer) {
+        store?.requestUnhideMacDeviceID(
             computer.macDeviceID,
             instanceTag: computer.instanceTag
         )

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DisconnectedWorkspaceShellView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DisconnectedWorkspaceShellView.swift
@@ -135,7 +135,7 @@ struct DisconnectedWorkspaceShellView: View {
 
     @ViewBuilder
     private var content: some View {
-        if !savedComputers.isEmpty {
+        if !savedComputers.isEmpty || !(store?.hiddenComputers.isEmpty ?? true) {
             savedComputersList(savedComputers)
         } else {
             emptyState
@@ -143,28 +143,28 @@ struct DisconnectedWorkspaceShellView: View {
     }
 
     /// The returning-user state: a real list of the saved computers, one row per
-    /// logical Mac, with presence, last-seen, tap-to-reconnect, and
-    /// swipe-to-hide — the same row component as the Computers screen.
+    /// logical Mac, with presence, last-seen, tap-to-reconnect, and an inline
+    /// visibility switch. Hidden Macs stay in the same section with switches off.
     /// Snapshot boundary (see AGENTS.md): rows receive immutable
     /// ``MacComputerSnapshot`` values and closures only, never the store.
     private func savedComputersList(_ computers: [MacComputerSnapshot]) -> some View {
         List {
             Section {
-                ForEach(computers) { computer in
-                    MacComputerRow(
-                        computer: computer,
-                        hide: { _ in hideComputer(computer) },
-                        style: .reconnect,
-                        connect: { _ in connect(to: computer) },
-                        isConnecting: connectingMacID == computer.id
-                    )
-                }
+                ComputerVisibilityRows(
+                    visibleComputers: computers,
+                    hiddenComputers: store?.hiddenComputers ?? [],
+                    style: .reconnect,
+                    connect: connect,
+                    connectingComputerID: connectingMacID,
+                    hide: hideComputer,
+                    unhide: unhideComputer
+                )
             } header: {
                 Text(L10n.string("mobile.devices.savedTitle", defaultValue: "Your Computers"))
             } footer: {
                 Text(L10n.string(
                     "mobile.disconnected.listFooter",
-                    defaultValue: "Tap a computer to reconnect. Swipe left to hide one."
+                    defaultValue: "Tap a shown computer to reconnect. Use its switch to show or hide it on this iPhone."
                 ))
             }
             Section {
@@ -275,13 +275,18 @@ struct DisconnectedWorkspaceShellView: View {
         )
     }
 
-    private func hideComputer(_ computer: MacComputerSnapshot) {
-        Task {
-            await store?.hideStoredPairedMacEntries(
-                representativeID: computer.id,
-                aliasIDs: computer.aliasIDs
-            )
-        }
+    private func hideComputer(_ computer: MacComputerSnapshot) async {
+        await store?.hideStoredPairedMacEntries(
+            representativeID: computer.id,
+            aliasIDs: computer.aliasIDs
+        )
+    }
+
+    private func unhideComputer(_ computer: MobileHiddenComputer) async {
+        await store?.unhideMacDeviceID(
+            computer.macDeviceID,
+            instanceTag: computer.instanceTag
+        )
     }
     #else
     /// Saved Macs restored/known on this device (macOS fallback shell).

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/HiddenComputerRow.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/HiddenComputerRow.swift
@@ -14,6 +14,7 @@ import SwiftUI
 struct HiddenComputerRow: View {
     let computer: MobileHiddenComputer
     let setVisible: (Bool) -> Void
+    let isVisibilityMutating: Bool
     /// Revokes this Mac's binding for the account (via the store, which resolves
     /// the binding id from a fresh discovery). Presenting any failure feedback is
     /// the caller's job so the row stays a pure snapshot.
@@ -22,7 +23,7 @@ struct HiddenComputerRow: View {
     @State private var forgetTask: Task<Void, Never>?
     @State private var showForgetConfirm = false
 
-    private var isBusy: Bool { forgetTask != nil }
+    private var isBusy: Bool { forgetTask != nil || isVisibilityMutating }
 
     var body: some View {
         HStack(spacing: 12) {
@@ -44,9 +45,9 @@ struct HiddenComputerRow: View {
                 computerID: computer.id,
                 computerName: computer.displayName,
                 isVisible: false,
+                isDisabled: isBusy,
                 setVisible: setVisible
             )
-            .disabled(isBusy)
         }
         .padding(.vertical, 4)
         .contextMenu {
@@ -166,8 +167,9 @@ struct ComputerVisibilityRows: View {
     var style: MacComputerRow.Style = .computers
     var connect: @MainActor (MacComputerSnapshot) -> Void = { _ in }
     var connectingComputerID: String?
-    let hide: @MainActor (MacComputerSnapshot) async -> Void
-    let unhide: @MainActor (MobileHiddenComputer) async -> Void
+    var mutatingComputerIDs: Set<String> = []
+    let hide: @MainActor (MacComputerSnapshot) -> Void
+    let unhide: @MainActor (MobileHiddenComputer) -> Void
     var forget: (@MainActor (MobileHiddenComputer) async -> Void)? = nil
 
     var body: some View {
@@ -176,8 +178,9 @@ struct ComputerVisibilityRows: View {
                 computer: computer,
                 setVisible: { visible in
                     guard !visible else { return }
-                    Task { await hide(computer) }
+                    hide(computer)
                 },
+                isVisibilityMutating: mutatingComputerIDs.contains(computer.id),
                 style: style,
                 connect: { _ in connect(computer) },
                 isConnecting: connectingComputerID == computer.id
@@ -188,8 +191,9 @@ struct ComputerVisibilityRows: View {
                 computer: computer,
                 setVisible: { visible in
                     guard visible else { return }
-                    Task { await unhide(computer) }
+                    unhide(computer)
                 },
+                isVisibilityMutating: mutatingComputerIDs.contains(computer.id),
                 forget: forgetAction(for: computer)
             )
         }

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/HiddenComputerRow.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/HiddenComputerRow.swift
@@ -13,7 +13,7 @@ import SwiftUI
 /// No first tap commits the revoke; the dialog's `.destructive` button does.
 struct HiddenComputerRow: View {
     let computer: MobileHiddenComputer
-    let setVisible: @MainActor (Bool) async -> Void
+    let setVisible: (Bool) -> Void
     /// Revokes this Mac's binding for the account (via the store, which resolves
     /// the binding id from a fresh discovery). Presenting any failure feedback is
     /// the caller's job so the row stays a pure snapshot.
@@ -176,7 +176,7 @@ struct ComputerVisibilityRows: View {
                 computer: computer,
                 setVisible: { visible in
                     guard !visible else { return }
-                    await hide(computer)
+                    Task { await hide(computer) }
                 },
                 style: style,
                 connect: { _ in connect(computer) },
@@ -188,7 +188,7 @@ struct ComputerVisibilityRows: View {
                 computer: computer,
                 setVisible: { visible in
                     guard visible else { return }
-                    await unhide(computer)
+                    Task { await unhide(computer) }
                 },
                 forget: forgetAction(for: computer)
             )

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/HiddenComputerRow.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/HiddenComputerRow.swift
@@ -3,28 +3,26 @@ import CmuxMobileShell
 import CmuxMobileSupport
 import SwiftUI
 
-/// Immutable hidden-computer row with an offline unhide action and a destructive
-/// "Forget" action.
+/// Immutable hidden-computer row with an offline visibility switch and a
+/// destructive "Forget" action.
 ///
-/// Unhide is the primary, reversible action (it only clears this iPhone's local
-/// hide marker), so it stays as the inline trailing button. Forget is the
-/// destructive one: it revokes the Mac's iroh binding for the whole account, so
-/// it lives behind a swipe/context-menu plus a confirmation dialog, mirroring the
-/// swipe+menu pattern `MacComputerRow` uses for Hide. No first tap commits the
-/// revoke; the dialog's `.destructive` button does.
+/// Showing the Mac is the primary, reversible action (it only clears this
+/// iPhone's local hide marker), so it stays as the inline trailing switch.
+/// Forget is destructive: it revokes the Mac's iroh binding for the whole
+/// account, so it lives behind a swipe/context-menu plus a confirmation dialog.
+/// No first tap commits the revoke; the dialog's `.destructive` button does.
 struct HiddenComputerRow: View {
     let computer: MobileHiddenComputer
-    let unhide: @MainActor () async -> Void
+    let setVisible: @MainActor (Bool) async -> Void
     /// Revokes this Mac's binding for the account (via the store, which resolves
     /// the binding id from a fresh discovery). Presenting any failure feedback is
     /// the caller's job so the row stays a pure snapshot.
-    let forget: @MainActor () async -> Void
+    let forget: (@MainActor () async -> Void)?
 
-    @State private var actionTask: Task<Void, Never>?
     @State private var forgetTask: Task<Void, Never>?
     @State private var showForgetConfirm = false
 
-    private var isBusy: Bool { actionTask != nil || forgetTask != nil }
+    private var isBusy: Bool { forgetTask != nil }
 
     var body: some View {
         HStack(spacing: 12) {
@@ -42,24 +40,24 @@ struct HiddenComputerRow: View {
                 }
             }
             Spacer(minLength: 8)
-            Button(action: performUnhide) {
-                if actionTask != nil {
-                    ProgressView().controlSize(.small)
-                } else {
-                    Text(L10n.string(
-                        "mobile.computers.unhide",
-                        defaultValue: "Unhide"
-                    ))
-                }
-            }
+            ComputerVisibilityToggle(
+                computerID: computer.id,
+                computerName: computer.displayName,
+                isVisible: false,
+                setVisible: setVisible
+            )
             .disabled(isBusy)
-            .buttonStyle(.borderless)
-            .accessibilityIdentifier("MobileComputerUnhide-\(computer.id)")
         }
         .padding(.vertical, 4)
-        .contextMenu { forgetMenuButton }
+        .contextMenu {
+            if forget != nil {
+                forgetMenuButton
+            }
+        }
         .swipeActions(edge: .trailing, allowsFullSwipe: false) {
-            forgetSwipeButton
+            if forget != nil {
+                forgetSwipeButton
+            }
         }
         .confirmationDialog(
             L10n.string(
@@ -86,8 +84,6 @@ struct HiddenComputerRow: View {
             ))
         }
         .onDisappear {
-            actionTask?.cancel()
-            actionTask = nil
             forgetTask?.cancel()
             forgetTask = nil
         }
@@ -152,16 +148,8 @@ struct HiddenComputerRow: View {
         .accessibilityIdentifier("MobileComputerForgetMenuButton-\(computer.id)")
     }
 
-    private func performUnhide() {
-        guard !isBusy else { return }
-        actionTask = Task { @MainActor in
-            defer { actionTask = nil }
-            await unhide()
-        }
-    }
-
     private func performForget() {
-        guard !isBusy else { return }
+        guard !isBusy, let forget else { return }
         forgetTask = Task { @MainActor in
             defer { forgetTask = nil }
             await forget()
@@ -169,59 +157,49 @@ struct HiddenComputerRow: View {
     }
 }
 
-/// Shared localized copy for every Hidden Computers surface so the strings
-/// cannot drift between the Computers screen, the disconnected shell, and its
-/// empty state.
-enum HiddenComputersCopy {
-    static var title: String {
-        L10n.string("mobile.computers.hidden.title", defaultValue: "Hidden Computers")
-    }
-
-    static var footer: String {
-        L10n.string(
-            "mobile.computers.hidden.footer",
-            defaultValue: "Hidden computers stay signed in to your account and are only hidden on this iPhone."
-        )
-    }
-}
-
-/// Shared per-computer row wiring for Hidden Computers lists. Takes immutable
-/// snapshots plus closures only; the store stays at the caller's boundary.
-struct HiddenComputersRows: View {
-    let computers: [MobileHiddenComputer]
+/// Shared row wiring for the visible and hidden computers in one section.
+/// Takes immutable snapshots plus closures only; the store stays at the
+/// caller's list boundary.
+struct ComputerVisibilityRows: View {
+    let visibleComputers: [MacComputerSnapshot]
+    let hiddenComputers: [MobileHiddenComputer]
+    var style: MacComputerRow.Style = .computers
+    var connect: @MainActor (MacComputerSnapshot) -> Void = { _ in }
+    var connectingComputerID: String?
+    let hide: @MainActor (MacComputerSnapshot) async -> Void
     let unhide: @MainActor (MobileHiddenComputer) async -> Void
-    let forget: @MainActor (MobileHiddenComputer) async -> Void
+    var forget: (@MainActor (MobileHiddenComputer) async -> Void)? = nil
 
     var body: some View {
-        ForEach(computers) { computer in
+        ForEach(visibleComputers) { computer in
+            MacComputerRow(
+                computer: computer,
+                setVisible: { visible in
+                    guard !visible else { return }
+                    await hide(computer)
+                },
+                style: style,
+                connect: { _ in connect(computer) },
+                isConnecting: connectingComputerID == computer.id
+            )
+        }
+        ForEach(hiddenComputers) { computer in
             HiddenComputerRow(
                 computer: computer,
-                unhide: { await unhide(computer) },
-                forget: { await forget(computer) }
+                setVisible: { visible in
+                    guard visible else { return }
+                    await unhide(computer)
+                },
+                forget: forgetAction(for: computer)
             )
         }
     }
-}
 
-/// The list-style Hidden Computers section shared by the Computers screen and
-/// the disconnected shell.
-struct HiddenComputersSection: View {
-    let computers: [MobileHiddenComputer]
-    let unhide: @MainActor (MobileHiddenComputer) async -> Void
-    let forget: @MainActor (MobileHiddenComputer) async -> Void
-
-    var body: some View {
-        Section {
-            HiddenComputersRows(
-                computers: computers,
-                unhide: unhide,
-                forget: forget
-            )
-        } header: {
-            Text(HiddenComputersCopy.title)
-        } footer: {
-            Text(HiddenComputersCopy.footer)
-        }
+    private func forgetAction(
+        for computer: MobileHiddenComputer
+    ) -> (@MainActor () async -> Void)? {
+        guard let forget else { return nil }
+        return { await forget(computer) }
     }
 }
 #endif

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/HiddenComputerRow.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/HiddenComputerRow.swift
@@ -3,21 +3,53 @@ import CmuxMobileShell
 import CmuxMobileSupport
 import SwiftUI
 
-/// Immutable hidden-computer row with an offline visibility switch and a
-/// destructive "Forget" action.
+private enum ComputerVisibilityRowItem: Identifiable {
+    case visible(MacComputerSnapshot)
+    case hidden(MobileHiddenComputer)
+
+    var id: String {
+        switch self {
+        case .visible(let computer): computer.id
+        case .hidden(let computer): computer.id
+        }
+    }
+
+    var name: String {
+        switch self {
+        case .visible(let computer): computer.title
+        case .hidden(let computer): computer.displayName
+        }
+    }
+
+    var isVisible: Bool {
+        if case .visible = self { return true }
+        return false
+    }
+
+    var visibleComputer: MacComputerSnapshot? {
+        guard case .visible(let computer) = self else { return nil }
+        return computer
+    }
+
+    var hiddenComputer: MobileHiddenComputer? {
+        guard case .hidden(let computer) = self else { return nil }
+        return computer
+    }
+}
+
+/// A stable computer row whose trailing visibility switch survives transitions
+/// between visible and hidden content.
 ///
-/// Showing the Mac is the primary, reversible action (it only clears this
-/// iPhone's local hide marker), so it stays as the inline trailing switch.
-/// Forget is destructive: it revokes the Mac's iroh binding for the whole
-/// account, so it lives behind a swipe/context-menu plus a confirmation dialog.
-/// No first tap commits the revoke; the dialog's `.destructive` button does.
-struct HiddenComputerRow: View {
-    let computer: MobileHiddenComputer
+/// Keeping one row identity and one `Toggle` instance lets SwiftUI carry the
+/// native switch transaction through the model update. Forget remains available
+/// only while the computer is hidden.
+private struct ComputerVisibilityRow: View {
+    let item: ComputerVisibilityRowItem
     let setVisible: (Bool) -> Void
     let isVisibilityMutating: Bool
-    /// Revokes this Mac's binding for the account (via the store, which resolves
-    /// the binding id from a fresh discovery). Presenting any failure feedback is
-    /// the caller's job so the row stays a pure snapshot.
+    var style: MacComputerRow.Style
+    let connect: @MainActor (MacComputerSnapshot) -> Void
+    let isConnecting: Bool
     let forget: (@MainActor () async -> Void)?
 
     @State private var forgetTask: Task<Void, Never>?
@@ -26,37 +58,24 @@ struct HiddenComputerRow: View {
     private var isBusy: Bool { forgetTask != nil || isVisibilityMutating }
 
     var body: some View {
-        HStack(spacing: 12) {
-            avatar
-            HStack(spacing: 6) {
-                Text(computer.displayName)
-                    .font(.headline)
-                    .lineLimit(1)
-                if computer.instanceTag != nil,
-                   let buildLabel = MacBuildChannel().label(
-                       bundleID: nil,
-                       tag: computer.instanceTag
-                   ) {
-                    ComputerBuildBadge(label: buildLabel)
-                }
-            }
-            Spacer(minLength: 8)
+        HStack(spacing: item.isVisible ? 8 : 12) {
+            leadingContent
             ComputerVisibilityToggle(
-                computerID: computer.id,
-                computerName: computer.displayName,
-                isVisible: false,
+                computerID: item.id,
+                computerName: item.name,
+                isVisible: item.isVisible,
                 isDisabled: isBusy,
                 setVisible: setVisible
             )
         }
-        .padding(.vertical, 4)
+        .padding(.vertical, item.isVisible ? 0 : 4)
         .contextMenu {
-            if forget != nil {
+            if item.hiddenComputer != nil, forget != nil {
                 forgetMenuButton
             }
         }
         .swipeActions(edge: .trailing, allowsFullSwipe: false) {
-            if forget != nil {
+            if item.hiddenComputer != nil, forget != nil {
                 forgetSwipeButton
             }
         }
@@ -73,7 +92,7 @@ struct HiddenComputerRow: View {
                 role: .destructive,
                 action: performForget
             )
-            .accessibilityIdentifier("MobileComputerForgetConfirmButton-\(computer.id)")
+            .accessibilityIdentifier("MobileComputerForgetConfirmButton-\(item.id)")
             Button(
                 L10n.string("mobile.common.cancel", defaultValue: "Cancel"),
                 role: .cancel
@@ -90,7 +109,40 @@ struct HiddenComputerRow: View {
         }
     }
 
-    private var avatar: some View {
+    @ViewBuilder
+    private var leadingContent: some View {
+        if let computer = item.visibleComputer {
+            MacComputerRow(
+                computer: computer,
+                style: style,
+                connect: { _ in connect(computer) },
+                isConnecting: isConnecting
+            )
+        } else if let computer = item.hiddenComputer {
+            hiddenLabel(computer)
+        }
+    }
+
+    private func hiddenLabel(_ computer: MobileHiddenComputer) -> some View {
+        HStack(spacing: 12) {
+            hiddenAvatar(computer)
+            HStack(spacing: 6) {
+                Text(computer.displayName)
+                    .font(.headline)
+                    .lineLimit(1)
+                if computer.instanceTag != nil,
+                   let buildLabel = MacBuildChannel().label(
+                       bundleID: nil,
+                       tag: computer.instanceTag
+                   ) {
+                    ComputerBuildBadge(label: buildLabel)
+                }
+            }
+            Spacer(minLength: 8)
+        }
+    }
+
+    private func hiddenAvatar(_ computer: MobileHiddenComputer) -> some View {
         ZStack {
             Circle()
                 .fill(MachineAvatarColors.gradient(
@@ -133,7 +185,7 @@ struct HiddenComputerRow: View {
         }
         .tint(.red)
         .disabled(isBusy)
-        .accessibilityIdentifier("MobileComputerForgetSwipeButton-\(computer.id)")
+        .accessibilityIdentifier("MobileComputerForgetSwipeButton-\(item.id)")
     }
 
     private var forgetMenuButton: some View {
@@ -146,7 +198,7 @@ struct HiddenComputerRow: View {
             )
         }
         .disabled(isBusy)
-        .accessibilityIdentifier("MobileComputerForgetMenuButton-\(computer.id)")
+        .accessibilityIdentifier("MobileComputerForgetMenuButton-\(item.id)")
     }
 
     private func performForget() {
@@ -158,9 +210,7 @@ struct HiddenComputerRow: View {
     }
 }
 
-/// Shared row wiring for the visible and hidden computers in one section.
-/// Takes immutable snapshots plus closures only; the store stays at the
-/// caller's list boundary.
+/// Shared row wiring for visible and hidden computers in one stable `ForEach`.
 struct ComputerVisibilityRows: View {
     let visibleComputers: [MacComputerSnapshot]
     let hiddenComputers: [MobileHiddenComputer]
@@ -172,37 +222,40 @@ struct ComputerVisibilityRows: View {
     let unhide: @MainActor (MobileHiddenComputer) -> Void
     var forget: (@MainActor (MobileHiddenComputer) async -> Void)? = nil
 
+    private var items: [ComputerVisibilityRowItem] {
+        visibleComputers.map(ComputerVisibilityRowItem.visible)
+            + hiddenComputers.map(ComputerVisibilityRowItem.hidden)
+    }
+
     var body: some View {
-        ForEach(visibleComputers) { computer in
-            MacComputerRow(
-                computer: computer,
-                setVisible: { visible in
-                    guard !visible else { return }
-                    hide(computer)
-                },
-                isVisibilityMutating: mutatingComputerIDs.contains(computer.id),
+        ForEach(items) { item in
+            ComputerVisibilityRow(
+                item: item,
+                setVisible: { visible in setVisibility(visible, for: item) },
+                isVisibilityMutating: mutatingComputerIDs.contains(item.id),
                 style: style,
-                connect: { _ in connect(computer) },
-                isConnecting: connectingComputerID == computer.id
-            )
-        }
-        ForEach(hiddenComputers) { computer in
-            HiddenComputerRow(
-                computer: computer,
-                setVisible: { visible in
-                    guard visible else { return }
-                    unhide(computer)
-                },
-                isVisibilityMutating: mutatingComputerIDs.contains(computer.id),
-                forget: forgetAction(for: computer)
+                connect: connect,
+                isConnecting: connectingComputerID == item.id,
+                forget: forgetAction(for: item.hiddenComputer)
             )
         }
     }
 
+    private func setVisibility(_ visible: Bool, for item: ComputerVisibilityRowItem) {
+        switch item {
+        case .visible(let computer):
+            guard !visible else { return }
+            hide(computer)
+        case .hidden(let computer):
+            guard visible else { return }
+            unhide(computer)
+        }
+    }
+
     private func forgetAction(
-        for computer: MobileHiddenComputer
+        for computer: MobileHiddenComputer?
     ) -> (@MainActor () async -> Void)? {
-        guard let forget else { return nil }
+        guard let computer, let forget else { return nil }
         return { await forget(computer) }
     }
 }

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/HiddenComputersPreviewView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/HiddenComputersPreviewView.swift
@@ -1,50 +1,99 @@
 #if canImport(UIKit) && DEBUG
 import CmuxMobileShell
+import CmuxMobileSupport
+import Foundation
 import SwiftUI
 
-/// DEBUG fixture list for the Hidden Computers rows
+/// DEBUG fixture list for unified computer visibility rows
 /// (`CMUX_UITEST_HIDDEN_COMPUTERS_PREVIEW=1`), so UI tests can exercise the
-/// rows' swipe actions without sign-in or Mac pairing.
+/// switches and hidden-row Forget action without sign-in or Mac pairing.
 ///
 /// The closures mirror production semantics exactly: a Forget swipe tap only
-/// presents the row's confirmation dialog (no synchronous model mutation —
-/// the regression surface for the destructive-role swipe crash), the dialog's
-/// confirm removes the row, and Unhide removes it immediately.
+/// presents the row's confirmation dialog (no synchronous model mutation, the
+/// regression surface for the destructive-role swipe crash), and the dialog's
+/// confirm removes the row.
 struct HiddenComputersPreviewView: View {
-    @State private var computers: [MobileHiddenComputer] = [
-        MobileHiddenComputer(
-            id: "preview-mac-1",
-            macDeviceID: "preview-mac-1",
-            instanceTag: nil,
-            displayName: "Preview Mac",
-            customColor: nil,
-            customIcon: nil
-        ),
-        MobileHiddenComputer(
-            id: "preview-mac-2",
-            macDeviceID: "preview-mac-2",
-            instanceTag: nil,
-            displayName: "Studio Mac",
-            customColor: nil,
-            customIcon: nil
-        ),
+    @State private var visibleIDs: Set<String> = ["preview-mac-2"]
+    @State private var forgottenIDs: Set<String> = []
+
+    private let fixtures = [
+        Fixture(id: "preview-mac-1", name: "Preview Mac"),
+        Fixture(id: "preview-mac-2", name: "Studio Mac"),
     ]
 
     var body: some View {
         NavigationStack {
             List {
-                HiddenComputersSection(
-                    computers: computers,
-                    unhide: { computer in remove(computer.id) },
-                    forget: { computer in remove(computer.id) }
-                )
+                Section {
+                    ComputerVisibilityRows(
+                        visibleComputers: visibleComputers,
+                        hiddenComputers: hiddenComputers,
+                        hide: { computer in setVisible(false, id: computer.id) },
+                        unhide: { computer in setVisible(true, id: computer.id) },
+                        forget: { computer in forgottenIDs.insert(computer.id) }
+                    )
+                } footer: {
+                    Text(L10n.string(
+                        "mobile.computers.footer",
+                        defaultValue: "Turn a computer off to hide its workspaces on this iPhone. It stays signed in to your account."
+                    ))
+                }
             }
-            .navigationTitle(HiddenComputersCopy.title)
+            .navigationTitle(L10n.string("mobile.computers.title", defaultValue: "Computers"))
         }
     }
 
-    private func remove(_ id: String) {
-        computers.removeAll { $0.id == id }
+    private var visibleComputers: [MacComputerSnapshot] {
+        fixtures.compactMap { fixture in
+            guard visibleIDs.contains(fixture.id), !forgottenIDs.contains(fixture.id) else {
+                return nil
+            }
+            return MacComputerSnapshot(
+                deviceId: fixture.id,
+                instanceTag: nil,
+                title: fixture.name,
+                platform: "mac",
+                colorIndex: nil,
+                customColor: nil,
+                customIcon: nil,
+                connectionStatus: nil,
+                presence: nil,
+                buildLabel: nil,
+                routeDescription: nil,
+                lastSeenAt: .now,
+                workspaceCount: 0,
+                aliasIDs: [fixture.id]
+            )
+        }
+    }
+
+    private var hiddenComputers: [MobileHiddenComputer] {
+        fixtures.compactMap { fixture in
+            guard !visibleIDs.contains(fixture.id), !forgottenIDs.contains(fixture.id) else {
+                return nil
+            }
+            return MobileHiddenComputer(
+                id: fixture.id,
+                macDeviceID: fixture.id,
+                instanceTag: nil,
+                displayName: fixture.name,
+                customColor: nil,
+                customIcon: nil
+            )
+        }
+    }
+
+    private func setVisible(_ visible: Bool, id: String) {
+        if visible {
+            visibleIDs.insert(id)
+        } else {
+            visibleIDs.remove(id)
+        }
+    }
+
+    private struct Fixture {
+        let id: String
+        let name: String
     }
 }
 #endif

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/HiddenComputersPreviewView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/HiddenComputersPreviewView.swift
@@ -41,6 +41,24 @@ struct HiddenComputersPreviewView: View {
             }
             .navigationTitle(L10n.string("mobile.computers.title", defaultValue: "Computers"))
         }
+        .overlay(alignment: .topLeading) {
+            visibilityPersistenceMarkers
+        }
+    }
+
+    /// Accessibility-only completion markers for deterministic UI tests. Each
+    /// label changes only after the fixture's authoritative state mutates.
+    private var visibilityPersistenceMarkers: some View {
+        VStack {
+            ForEach(fixtures, id: \.id) { fixture in
+                Text(visibleIDs.contains(fixture.id) ? "shown" : "hidden")
+                    .accessibilityIdentifier(
+                        "MobileComputerVisibilityPersisted-\(fixture.id)"
+                    )
+            }
+        }
+        .frame(width: 1, height: 1)
+        .opacity(0.01)
     }
 
     private var visibleComputers: [MacComputerSnapshot] {

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MacComputerDetailView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MacComputerDetailView.swift
@@ -439,23 +439,6 @@ struct MacComputerDetailView: View {
             } label: {
                 Label(L10n.string("mobile.workspace.reconnect", defaultValue: "Reconnect"), systemImage: "arrow.clockwise")
             }
-            Button {
-                let id = macDeviceID
-                let tag = instanceTag
-                Task {
-                    // Scope the hide to this exact pairing; the alias-based
-                    // overload would also hide sibling app instances (e.g. DEV
-                    // vs. stable) the user is not viewing here.
-                    await store.hideMac(macDeviceID: id, instanceTag: tag)
-                }
-                dismiss()
-            } label: {
-                Label(
-                    L10n.string("mobile.computers.hide", defaultValue: "Hide"),
-                    systemImage: "eye.slash"
-                )
-            }
-            .accessibilityIdentifier("MobileComputerDetailHide")
         }
     }
 

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MacComputerRow.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MacComputerRow.swift
@@ -25,7 +25,7 @@ struct MacComputerRow: View {
     let computer: MacComputerSnapshot
     /// Changes whether this computer appears on the current iPhone. When `nil`,
     /// the visibility switch is omitted.
-    var setVisible: (@MainActor (Bool) async -> Void)? = nil
+    var setVisible: ((Bool) -> Void)? = nil
     var style: Style = .computers
     /// Reconnect action for `.reconnect` rows; tapping the row calls this with
     /// the device id instead of navigating.

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MacComputerRow.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MacComputerRow.swift
@@ -26,6 +26,7 @@ struct MacComputerRow: View {
     /// Changes whether this computer appears on the current iPhone. When `nil`,
     /// the visibility switch is omitted.
     var setVisible: ((Bool) -> Void)? = nil
+    var isVisibilityMutating = false
     var style: Style = .computers
     /// Reconnect action for `.reconnect` rows; tapping the row calls this with
     /// the device id instead of navigating.
@@ -43,6 +44,7 @@ struct MacComputerRow: View {
                     computerID: computer.id,
                     computerName: computer.title,
                     isVisible: true,
+                    isDisabled: isVisibilityMutating,
                     setVisible: setVisible
                 )
             }

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MacComputerRow.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MacComputerRow.swift
@@ -23,9 +23,9 @@ struct MacComputerRow: View {
     }
 
     let computer: MacComputerSnapshot
-    /// Hides this computer on the current iPhone. When `nil`, hide affordances
-    /// are omitted.
-    var hide: ((String) -> Void)? = nil
+    /// Changes whether this computer appears on the current iPhone. When `nil`,
+    /// the visibility switch is omitted.
+    var setVisible: (@MainActor (Bool) async -> Void)? = nil
     var style: Style = .computers
     /// Reconnect action for `.reconnect` rows; tapping the row calls this with
     /// the device id instead of navigating.
@@ -36,12 +36,18 @@ struct MacComputerRow: View {
     var isConnecting: Bool = false
 
     var body: some View {
-        rowContainer
-        .contextMenu { hideMenuButton }
-        .swipeActions(edge: .trailing, allowsFullSwipe: true) {
-            hideSwipeButton
+        HStack(spacing: 8) {
+            rowContainer
+            if let setVisible {
+                ComputerVisibilityToggle(
+                    computerID: computer.id,
+                    computerName: computer.title,
+                    isVisible: true,
+                    setVisible: setVisible
+                )
+            }
         }
-        .accessibilityElement(children: .combine)
+        .accessibilityElement(children: .contain)
         .accessibilityIdentifier("MobileComputerRow-\(computer.id)")
     }
 
@@ -52,6 +58,7 @@ struct MacComputerRow: View {
             NavigationLink(value: computer.id) {
                 rowLabel
             }
+            .accessibilityElement(children: .combine)
         case .reconnect:
             Button {
                 connect?(computer.id)
@@ -59,6 +66,7 @@ struct MacComputerRow: View {
                 rowLabel
             }
             .buttonStyle(.plain)
+            .accessibilityElement(children: .combine)
         }
     }
 
@@ -102,36 +110,6 @@ struct MacComputerRow: View {
         }
         .padding(.vertical, 4)
         .contentShape(Rectangle())
-    }
-
-    @ViewBuilder
-    private var hideSwipeButton: some View {
-        if let hide {
-            Button {
-                hide(computer.id)
-            } label: {
-                Label(
-                    L10n.string("mobile.computers.hide", defaultValue: "Hide"),
-                    systemImage: "eye.slash"
-                )
-            }
-            .accessibilityIdentifier("MobileComputerHideSwipeButton-\(computer.id)")
-        }
-    }
-
-    @ViewBuilder
-    private var hideMenuButton: some View {
-        if let hide {
-            Button {
-                hide(computer.id)
-            } label: {
-                Label(
-                    L10n.string("mobile.computers.hide", defaultValue: "Hide"),
-                    systemImage: "eye.slash"
-                )
-            }
-            .accessibilityIdentifier("MobileComputerHideMenuButton-\(computer.id)")
-        }
     }
 
     /// The connection dot: green only when the PHONE is actually connected to this

--- a/ios/cmux/Resources/Localizable.xcstrings
+++ b/ios/cmux/Resources/Localizable.xcstrings
@@ -1826,13 +1826,13 @@
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "The computers signed in to your account. Use the workspace title picker to focus one computer or show All Computers."
+            "value": "Turn a computer off to hide its workspaces on this iPhone. It stays signed in to your account."
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "アカウントにサインインしているコンピュータ。ワークスペースのタイトルピッカーで 1 台のコンピュータに絞り込むか、すべてのコンピュータを表示できます。"
+            "value": "コンピュータをオフにすると、このiPhoneでそのワークスペースを非表示にできます。コンピュータはアカウントにサインインしたままです。"
           }
         }
       }
@@ -2088,6 +2088,40 @@
           "stringUnit": {
             "state": "translated",
             "value": "再表示"
+          }
+        }
+      }
+    },
+    "mobile.computers.visibilityToggle": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Show this computer on this iPhone"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "このiPhoneにこのコンピュータを表示"
+          }
+        }
+      }
+    },
+    "mobile.computers.visibilityToggle.named": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Show %@ on this iPhone"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "このiPhoneに%@を表示"
           }
         }
       }
@@ -2999,13 +3033,13 @@
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "Tap a computer to reconnect. Swipe left to hide one."
+            "value": "Tap a shown computer to reconnect. Use its switch to show or hide it on this iPhone."
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "コンピュータをタップすると再接続します。左にスワイプすると非表示にできます。"
+            "value": "表示中のコンピュータをタップすると再接続します。スイッチでこのiPhoneでの表示と非表示を切り替えられます。"
           }
         }
       }

--- a/ios/cmuxUITests/cmuxUITests.swift
+++ b/ios/cmuxUITests/cmuxUITests.swift
@@ -584,6 +584,49 @@ final class cmuxUITests: XCTestCase {
     }
 
     @MainActor
+    func testComputerVisibilitySwitchesKeepShownAndHiddenMacsInOneSection() throws {
+        let app = launchApp(mockData: false, environment: [
+            "CMUX_UITEST_HIDDEN_COMPUTERS_PREVIEW": "1",
+        ])
+        defer { app.terminate() }
+
+        func waitForValue(_ value: String, on toggle: XCUIElement) {
+            let expectation = XCTNSPredicateExpectation(
+                predicate: NSPredicate(format: "value == %@", value),
+                object: toggle
+            )
+            XCTAssertEqual(XCTWaiter.wait(for: [expectation], timeout: 3), .completed)
+        }
+
+        let shownToggle = app.switches["MobileComputerVisibilityToggle-preview-mac-2"]
+        let hiddenToggle = app.switches["MobileComputerVisibilityToggle-preview-mac-1"]
+        XCTAssertTrue(shownToggle.waitForExistence(timeout: 8))
+        XCTAssertTrue(hiddenToggle.waitForExistence(timeout: 3))
+        waitForValue("1", on: shownToggle)
+        waitForValue("0", on: hiddenToggle)
+        XCTAssertFalse(app.staticTexts["Hidden Computers"].exists)
+
+        shownToggle.tap()
+        waitForValue("0", on: shownToggle)
+        XCTAssertTrue(
+            app.staticTexts["Studio Mac"].exists,
+            "Turning a computer off must keep it in the same list."
+        )
+
+        hiddenToggle.tap()
+        waitForValue("1", on: hiddenToggle)
+        XCTAssertTrue(
+            app.staticTexts["Preview Mac"].exists,
+            "Turning a computer on must update its switch without moving it to another section."
+        )
+
+        let attachment = XCTAttachment(screenshot: app.screenshot())
+        attachment.name = "computer-visibility-switches-unified-section"
+        attachment.lifetime = .keepAlways
+        add(attachment)
+    }
+
+    @MainActor
     func testHiddenComputersForgetSwipeConfirmsWithoutRemovingRow() throws {
         let app = launchApp(mockData: false, environment: [
             "CMUX_UITEST_HIDDEN_COMPUTERS_PREVIEW": "1",

--- a/ios/cmuxUITests/cmuxUITests.swift
+++ b/ios/cmuxUITests/cmuxUITests.swift
@@ -598,27 +598,48 @@ final class cmuxUITests: XCTestCase {
             XCTAssertEqual(XCTWaiter.wait(for: [expectation], timeout: 3), .completed)
         }
 
+        func waitForLabel(_ label: String, on element: XCUIElement) {
+            let expectation = XCTNSPredicateExpectation(
+                predicate: NSPredicate(format: "label == %@", label),
+                object: element
+            )
+            XCTAssertEqual(XCTWaiter.wait(for: [expectation], timeout: 3), .completed)
+        }
+
+        func assertUnifiedRowsRemainVisible() {
+            XCTAssertTrue(app.navigationBars["Computers"].exists)
+            XCTAssertTrue(app.staticTexts["Studio Mac"].exists)
+            XCTAssertTrue(app.staticTexts["Preview Mac"].exists)
+            XCTAssertFalse(app.staticTexts["Hidden Computers"].exists)
+        }
+
         let shownToggle = app.switches["MobileComputerVisibilityToggle-preview-mac-2"]
         let hiddenToggle = app.switches["MobileComputerVisibilityToggle-preview-mac-1"]
+        let shownPersistence = app.staticTexts[
+            "MobileComputerVisibilityPersisted-preview-mac-2"
+        ]
+        let hiddenPersistence = app.staticTexts[
+            "MobileComputerVisibilityPersisted-preview-mac-1"
+        ]
         XCTAssertTrue(shownToggle.waitForExistence(timeout: 8))
         XCTAssertTrue(hiddenToggle.waitForExistence(timeout: 3))
+        XCTAssertTrue(shownPersistence.waitForExistence(timeout: 3))
+        XCTAssertTrue(hiddenPersistence.waitForExistence(timeout: 3))
+        waitForLabel("shown", on: shownPersistence)
+        waitForLabel("hidden", on: hiddenPersistence)
         waitForValue("1", on: shownToggle)
         waitForValue("0", on: hiddenToggle)
-        XCTAssertFalse(app.staticTexts["Hidden Computers"].exists)
+        assertUnifiedRowsRemainVisible()
 
         shownToggle.tap()
+        waitForLabel("hidden", on: shownPersistence)
         waitForValue("0", on: shownToggle)
-        XCTAssertTrue(
-            app.staticTexts["Studio Mac"].exists,
-            "Turning a computer off must keep it in the same list."
-        )
+        assertUnifiedRowsRemainVisible()
 
         hiddenToggle.tap()
+        waitForLabel("shown", on: hiddenPersistence)
         waitForValue("1", on: hiddenToggle)
-        XCTAssertTrue(
-            app.staticTexts["Preview Mac"].exists,
-            "Turning a computer on must update its switch without moving it to another section."
-        )
+        assertUnifiedRowsRemainVisible()
 
         let attachment = XCTAttachment(screenshot: app.screenshot())
         attachment.name = "computer-visibility-switches-unified-section"


### PR DESCRIPTION
## Summary

- replace hide/unhide swipe actions with a visibility toggle on every Mac row
- keep shown and hidden Macs in one Computers section
- cover visible and hidden toggle behavior in the iOS UI fixture

## Verification

- `swift build --package-path Packages/iOS/CmuxMobileShellUI`
- changed Swift files parse with `swiftc -parse`
- localization catalog parses and includes English and Japanese entries
- focused iOS simulator workflow running: https://github.com/manaflow-ai/cmux/actions/runs/31129392640

## Runner notes

- package conventions currently fails on pre-existing `MobilePairingScannerGuidanceCopy` in untouched `MobilePairingScannerSheet.swift`
- mobile shell package job hit unrelated existing timing failures in connection and terminal suites

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/9727"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788649398&installation_model_id=21920&pr_number=9727&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F9727&signature=91f0f7efdb5bd1192ea00a3cdcd1bc8e2489d0f051da38890b548fe5334118bd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replace hide swipes with per-row visibility switches and keep shown and hidden Macs in one unified list on Computers and Disconnected screens. Switches animate in place, persist per computer so the latest intent wins, disable while saving, and serialization survives sign‑out/team changes so new requests wait for cleanup.

- **New Features**
  - Added `ComputerVisibilityToggle` and unified `ComputerVisibilityRows`; removed hide swipes, the Hidden Computers section, and the detail view Hide action; `MacComputerRow` now shows a switch.
  - Updated EN/JA guidance and DEBUG preview; added UI tests for a unified section and switch persistence.

- **Refactors**
  - Serialized hide/unhide per computer with queued tasks and operation IDs (`computerVisibilityMutationIDs`), plus `requestHideStoredPairedMacEntries` and `requestUnhideMacDeviceID`; cancelled mutations on teardown/sign‑out/team change, keeping cancelled tasks as serial tails until rollback finishes.
  - Added tests that the latest intent persists when an earlier save completes later and that queue tails preserve correctness across account/team scope changes.

<sup>Written for commit de2799a2df50d8ca9f26f194bb6d9b417e989960. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/9727?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Manage visible and hidden computers together in one unified list.
  * Hide or show computers with responsive visibility toggles.
  * Hidden computers remain signed in and can be restored anytime.
  * Forget computers directly from supported computer entries.
  * Added localized visibility guidance and accessibility labels.

* **Bug Fixes**
  * Visibility changes now update in place without moving computers between sections.
  * Improved empty-state handling and action failure behavior.
  * Removed the hide action from computer detail views.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes durable per-device visibility persistence and hide/unhide ordering across account/team switches; incorrect rollback or race handling could leave Macs wrongly hidden or visible after relaunch.
> 
> **Overview**
> Replaces hide/unhide swipe actions with a **per-row visibility toggle** on the Computers and disconnected shells. Shown and hidden Macs now share **one list section**; hidden rows stay in place with the switch off instead of moving to a separate “Hidden Computers” section.
> 
> **`MobileShellComposite`** serializes hide/unhide per computer via `enqueueComputerVisibilityMutation`, exposes `requestHideStoredPairedMacEntries` / `requestUnhideMacDeviceID` for the UI, tracks in-flight work in `computerVisibilityMutationIDs`, and rolls back or cancels on scope loss (`Task.isCancelled`, sign-out, team change, teardown). Tests cover “later unhide wins” over a slow hide save and cancellation rollback.
> 
> UI adds `ComputerVisibilityToggle` and unified `ComputerVisibilityRows`; removes hide swipes, the hidden section, and the computer detail Hide action. EN/JA copy and a UI test exercise switch persistence in the DEBUG preview fixture.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit de2799a2df50d8ca9f26f194bb6d9b417e989960. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->