### PR TITLE
Clarify coderouter model errors

### DIFF
--- a/web/services/coderouter/codexProxy.ts
+++ b/web/services/coderouter/codexProxy.ts
@@ -214,9 +214,25 @@ type CodexModelsDependencies = {
 export function createCodexModelsProxy(dependencies: CodexModelsDependencies) {
   return async (request: Request): Promise<Response> => {
     const token = bearerToken(request);
-    if (!token) return jsonError("unauthorized", 401);
+    if (!token) {
+      return jsonError(
+        "unauthorized",
+        401,
+        undefined,
+        "Sign in with `cr login` and retry.",
+        false,
+      );
+    }
     const identity = await dependencies.authenticate(token);
-    if (!identity) return jsonError("unauthorized", 401);
+    if (!identity) {
+      return jsonError(
+        "unauthorized",
+        401,
+        undefined,
+        "Your coderouter session expired or was revoked. Run `cr login` and retry.",
+        false,
+      );
+    }
 
     const attempted: string[] = [];
     let upstream: Response | null = null;
@@ -279,7 +295,15 @@ export function createCodexModelsProxy(dependencies: CodexModelsDependencies) {
       }
       break;
     }
-    if (!upstream) return jsonError("no_usable_account", 503);
+    if (!upstream) {
+      return jsonError(
+        "no_usable_account",
+        503,
+        { "retry-after": "15" },
+        "No healthy Codex subscription is currently available. Check `cr`, add an account with `cr add`, or retry shortly.",
+        true,
+      );
+    }
     return new Response(upstream.body, {
       status: upstream.status,
       headers: {


### PR DESCRIPTION
Adds explicit actionable model-catalog auth and no-account messages while retaining stable error codes and retry metadata.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/9728"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788649910&installation_model_id=21920&pr_number=9728&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F9728&signature=0242e978c2a279ae07b00db96f8bbe8e9ec3c92f6b1b2f56c543d49285cd7a2c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improved coderouter model proxy errors with clear, actionable messages for auth and account availability, while preserving stable error codes and retry metadata.

- **Bug Fixes**
  - Unauthorized responses now guide users to run `cr login` and clarify expired/revoked sessions.
  - `no_usable_account` (503) now includes `retry-after: 15` and a message to check `cr`, add an account with `cr add`, or retry soon; marked as retriable.

<sup>Written for commit 25dcd414ef9ac28d727c9f21796a08a6288e38b2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/9728?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error messages when route authentication is missing or invalid, including guidance for signing in.
  * Added clearer status information for errors that cannot be resolved by retrying.
  * Added recovery guidance and retry timing when no usable account is available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->