### PR TITLE
iOS browser stream: focus editables under replayed taps, suppress stray backspace, verbose diagnostics

### DIFF
--- a/Packages/Shared/CMUXMobileCore/Sources/CMUXMobileCore/DiagnosticEventCode.swift
+++ b/Packages/Shared/CMUXMobileCore/Sources/CMUXMobileCore/DiagnosticEventCode.swift
@@ -193,6 +193,27 @@ public enum DiagnosticEventCode: UInt16, Sendable, Codable, CaseIterable {
     /// `b` is ``DiagnosticPathKind`` for the affected path, and `c` is the
     /// matching positive, process-local session correlation ID.
     case transportPathEvent = 55
+    /// A phone-driven browser stream session changed lifecycle state on the
+    /// Mac. `a` is the stage (1 started, 2 replaced an existing session,
+    /// 3 stopped, 4 first frame emitted), and `c` is the positive browser
+    /// panel correlation ID derived from the panel UUID.
+    case browserStreamLifecycle = 56
+    /// Replayed phone input reached a streamed browser panel. `a` is the
+    /// input kind (1 pointer, 2 key, 3 text), `b` is the click count for
+    /// pointers, 1 for a suppressed no-editable backspace (else 0) for keys,
+    /// or the inserted character count for text, and `c` is the panel
+    /// correlation ID.
+    case browserInputReplayed = 57
+    /// The streamed page's editable-focus state changed or a replayed click's
+    /// focus assist resolved. `a` is 1 when an editable has focus (else 0),
+    /// `b` is the focus-assist outcome (0 no editable at the point, 1 focus
+    /// moved, 2 already focused, 3 beacon-reported transition), and `c` is
+    /// the panel correlation ID.
+    case browserEditableFocus = 58
+    /// A phone-initiated `mobile.browser.create` request resolved on the Mac.
+    /// `a` is 1 on success else 0, and `c` is the panel correlation ID of the
+    /// created panel (absent on failure).
+    case browserPanelCreateResolved = 59
 }
 
 /// Scene phase carried by ``DiagnosticEventCode/appLifecycleChanged``.

--- a/Packages/Shared/CMUXMobileCore/Sources/CMUXMobileCore/DiagnosticEventCode.swift
+++ b/Packages/Shared/CMUXMobileCore/Sources/CMUXMobileCore/DiagnosticEventCode.swift
@@ -199,10 +199,9 @@ public enum DiagnosticEventCode: UInt16, Sendable, Codable, CaseIterable {
     /// panel correlation ID derived from the panel UUID.
     case browserStreamLifecycle = 56
     /// Replayed phone input reached a streamed browser panel. `a` is the
-    /// input kind (1 pointer, 2 key, 3 text), `b` is the click count for
-    /// pointers, 1 for a suppressed no-editable backspace (else 0) for keys,
-    /// or the inserted character count for text, and `c` is the panel
-    /// correlation ID.
+    /// input kind (1 pointer, 2 key, 3 text, 4 suppressed no-editable
+    /// backspace), `b` is the click count for pointers, 1 for keys, or the
+    /// inserted character count for text, and `c` is the panel correlation ID.
     case browserInputReplayed = 57
     /// The streamed page's editable-focus state changed or a replayed click's
     /// focus assist resolved. `a` is 1 when an editable has focus (else 0),

--- a/Packages/Shared/CMUXMobileCore/Sources/CMUXMobileCore/DiagnosticEventPresentation.swift
+++ b/Packages/Shared/CMUXMobileCore/Sources/CMUXMobileCore/DiagnosticEventPresentation.swift
@@ -395,6 +395,14 @@ public struct DiagnosticEventPresentation: Sendable {
             return Field(key: "composer_active", value: booleanName(raw))
         case .composerKeyboardToggleWhilePresented:
             return Field(key: "terminal_input_focused", value: booleanName(raw))
+        case .browserStreamLifecycle:
+            return Field(key: "stage", value: browserStreamStageName(raw))
+        case .browserInputReplayed:
+            return Field(key: "input", value: browserInputKindName(raw))
+        case .browserEditableFocus:
+            return Field(key: "editable_focused", value: booleanName(raw))
+        case .browserPanelCreateResolved:
+            return Field(key: "created", value: booleanName(raw))
         default:
             return Field(key: "detail_1", value: String(raw))
         }
@@ -419,6 +427,10 @@ public struct DiagnosticEventPresentation: Sendable {
             return Field(key: "draft_empty", value: booleanName(raw))
         case .composerActiveTransition, .composerKeyboardToggleWhilePresented:
             return Field(key: "first_responder", value: responderName(raw))
+        case .browserInputReplayed:
+            return Field(key: "count", value: String(raw))
+        case .browserEditableFocus:
+            return Field(key: "outcome", value: browserFocusOutcomeName(raw))
         default:
             return Field(key: "detail_2", value: String(raw))
         }
@@ -453,6 +465,9 @@ public struct DiagnosticEventPresentation: Sendable {
             return Field(key: "session", value: String(raw))
         case .composerActiveTransition:
             return Field(key: "terminal_input_focused", value: booleanName(raw))
+        case .browserStreamLifecycle, .browserInputReplayed,
+             .browserEditableFocus, .browserPanelCreateResolved:
+            return Field(key: "panel", value: String(raw))
         default:
             return Field(key: "detail_3", value: String(raw))
         }
@@ -606,6 +621,48 @@ public struct DiagnosticEventPresentation: Sendable {
         }
     }
 
+    private func browserStreamStageName(_ raw: Int) -> String {
+        switch raw {
+        case 1: localized("diagnostics.browserStage.started", defaultValue: "Started")
+        case 2: localized("diagnostics.browserStage.replaced", defaultValue: "Replaced existing session")
+        case 3: localized("diagnostics.browserStage.stopped", defaultValue: "Stopped")
+        case 4: localized("diagnostics.browserStage.firstFrame", defaultValue: "First frame delivered")
+        default:
+            localized(
+                "diagnostics.unknown.browserStage",
+                defaultValue: "Unknown stage (\(raw))"
+            )
+        }
+    }
+
+    private func browserInputKindName(_ raw: Int) -> String {
+        switch raw {
+        case 1: localized("diagnostics.browserInput.pointer", defaultValue: "Pointer")
+        case 2: localized("diagnostics.browserInput.key", defaultValue: "Key")
+        case 3: localized("diagnostics.browserInput.text", defaultValue: "Text")
+        case 4: localized("diagnostics.browserInput.keySuppressed", defaultValue: "Key suppressed")
+        default:
+            localized(
+                "diagnostics.unknown.browserInput",
+                defaultValue: "Unknown input (\(raw))"
+            )
+        }
+    }
+
+    private func browserFocusOutcomeName(_ raw: Int) -> String {
+        switch raw {
+        case 0: localized("diagnostics.browserFocus.none", defaultValue: "No editable at point")
+        case 1: localized("diagnostics.browserFocus.moved", defaultValue: "Focus moved")
+        case 2: localized("diagnostics.browserFocus.already", defaultValue: "Already focused")
+        case 3: localized("diagnostics.browserFocus.beacon", defaultValue: "Beacon transition")
+        default:
+            localized(
+                "diagnostics.unknown.browserFocus",
+                defaultValue: "Unknown outcome (\(raw))"
+            )
+        }
+    }
+
     private func pathEventName(_ raw: Int) -> String {
         switch raw {
         case 1: localized("diagnostics.pathOperation.opened", defaultValue: "Opened")
@@ -698,6 +755,13 @@ public struct DiagnosticEventPresentation: Sendable {
         case "remote_sequence": localized("diagnostics.field.remoteSequence", defaultValue: "Remote sequence")
         case "delivered_sequence": localized("diagnostics.field.deliveredSequence", defaultValue: "Delivered sequence")
         case "next_sequence": localized("diagnostics.field.nextSequence", defaultValue: "Next sequence")
+        case "stage": localized("diagnostics.field.stage", defaultValue: "Stage")
+        case "input": localized("diagnostics.field.input", defaultValue: "Input")
+        case "count": localized("diagnostics.field.count", defaultValue: "Count")
+        case "outcome": localized("diagnostics.field.outcome", defaultValue: "Outcome")
+        case "editable_focused": localized("diagnostics.field.editableFocused", defaultValue: "Editable focused")
+        case "created": localized("diagnostics.field.created", defaultValue: "Created")
+        case "panel": localized("diagnostics.field.panel", defaultValue: "Panel")
         case "detail_1": localized("diagnostics.field.detail1", defaultValue: "Detail 1")
         case "detail_2": localized("diagnostics.field.detail2", defaultValue: "Detail 2")
         case "detail_3": localized("diagnostics.field.detail3", defaultValue: "Detail 3")

--- a/Packages/Shared/CMUXMobileCore/Sources/CMUXMobileCore/DiagnosticEventPresentation.swift
+++ b/Packages/Shared/CMUXMobileCore/Sources/CMUXMobileCore/DiagnosticEventPresentation.swift
@@ -353,6 +353,14 @@ public struct DiagnosticEventPresentation: Sendable {
             localized("diagnostics.event.transportCloseAttribution", defaultValue: "Transport close attributed")
         case .transportPathEvent:
             localized("diagnostics.event.transportPathEvent", defaultValue: "Transport path changed")
+        case .browserStreamLifecycle:
+            localized("diagnostics.event.browserStreamLifecycle", defaultValue: "Browser stream lifecycle")
+        case .browserInputReplayed:
+            localized("diagnostics.event.browserInputReplayed", defaultValue: "Browser input replayed")
+        case .browserEditableFocus:
+            localized("diagnostics.event.browserEditableFocus", defaultValue: "Browser editable focus")
+        case .browserPanelCreateResolved:
+            localized("diagnostics.event.browserPanelCreateResolved", defaultValue: "Browser panel create resolved")
         }
     }
 

--- a/Packages/Shared/CMUXMobileCore/Tests/CMUXMobileCoreTests/DiagnosticEventPresentationTests.swift
+++ b/Packages/Shared/CMUXMobileCore/Tests/CMUXMobileCoreTests/DiagnosticEventPresentationTests.swift
@@ -239,6 +239,54 @@ import Testing
             .init(key: "remote_sequence", value: "20"),
         ])
 
+        let browserLifecycle = englishPresentation.describe(DiagnosticEvent(
+            code: .browserStreamLifecycle,
+            tNanos: 1,
+            a: 4,
+            c: 987
+        ))
+        #expect(browserLifecycle.fields == [
+            .init(key: "stage", value: "First frame delivered"),
+            .init(key: "panel", value: "987"),
+        ])
+
+        let browserInput = englishPresentation.describe(DiagnosticEvent(
+            code: .browserInputReplayed,
+            tNanos: 1,
+            a: 4,
+            b: 1,
+            c: 987
+        ))
+        #expect(browserInput.fields == [
+            .init(key: "input", value: "Key suppressed"),
+            .init(key: "count", value: "1"),
+            .init(key: "panel", value: "987"),
+        ])
+
+        let browserFocus = englishPresentation.describe(DiagnosticEvent(
+            code: .browserEditableFocus,
+            tNanos: 1,
+            a: 1,
+            b: 2,
+            c: 987
+        ))
+        #expect(browserFocus.fields == [
+            .init(key: "editable_focused", value: "Yes"),
+            .init(key: "outcome", value: "Already focused"),
+            .init(key: "panel", value: "987"),
+        ])
+
+        let browserCreate = englishPresentation.describe(DiagnosticEvent(
+            code: .browserPanelCreateResolved,
+            tNanos: 1,
+            a: 1,
+            c: 987
+        ))
+        #expect(browserCreate.fields == [
+            .init(key: "created", value: "Yes"),
+            .init(key: "panel", value: "987"),
+        ])
+
         for described in [recovery, endpoint, session, composer, input] {
             #expect(!described.fields.contains { ["a", "b", "c", "ms"].contains($0.key) })
         }

--- a/Packages/Shared/CMUXMobileCore/Tests/CMUXMobileCoreTests/DiagnosticEventPresentationTests.swift
+++ b/Packages/Shared/CMUXMobileCore/Tests/CMUXMobileCoreTests/DiagnosticEventPresentationTests.swift
@@ -159,6 +159,10 @@ import Testing
             .reachabilityChanged: "Network reachability changed",
             .transportCloseAttribution: "Transport close attributed",
             .transportPathEvent: "Transport path changed",
+            .browserStreamLifecycle: "Browser stream lifecycle",
+            .browserInputReplayed: "Browser input replayed",
+            .browserEditableFocus: "Browser editable focus",
+            .browserPanelCreateResolved: "Browser panel create resolved",
         ]
 
         #expect(Set(expected.keys) == Set(DiagnosticEventCode.allCases))

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+BrowserStream.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+BrowserStream.swift
@@ -1,5 +1,6 @@
 public import CMUXMobileCore
 import CmuxMobileBrowserStream
+import CmuxMobileDiagnostics
 import CmuxMobileRPC
 import Foundation
 
@@ -25,16 +26,23 @@ extension MobileShellComposite {
     public func createMobileBrowserPanel(workspaceID: String) async -> MobileBrowserPanelDescriptor? {
         guard connectionState == .connected,
               supportsBrowserStreamCreate,
-              let client = remoteClient else { return nil }
+              let client = remoteClient else {
+            MobileDebugLog.anchormux(
+                "browser.create skipped connected=\(connectionState == .connected ? 1 : 0) supported=\(supportsBrowserStreamCreate ? 1 : 0)"
+            )
+            return nil
+        }
         guard let descriptor = try? await client.createMobileBrowserPanel(workspaceID: workspaceID),
               remoteClient === client else {
             // The Mac may have committed the panel even though the outcome was
             // lost (timeout, decode failure, or a client swap mid-flight).
             // Reconcile discovery so a committed panel surfaces in the picker
             // instead of becoming an orphan the phone never learns about.
+            MobileDebugLog.anchormux("browser.create uncertain-failure ws=\(workspaceID.prefix(8)) reconciling")
             await refreshMobileBrowserPanels(workspaceID: workspaceID)
             return nil
         }
+        MobileDebugLog.anchormux("browser.create ok panel=\(descriptor.panelID.prefix(8))")
         browserStreamEvents?.browserPanelCreated(descriptor)
         return descriptor
     }
@@ -55,7 +63,10 @@ extension MobileShellComposite {
         let viewport = supportsBrowserStreamViewport
             ? browserStreamEvents?.browserStreamViewport(for: panelID)
             : nil
-        guard !supportsBrowserStreamViewport || viewport != nil else { return }
+        guard !supportsBrowserStreamViewport || viewport != nil else {
+            MobileDebugLog.anchormux("browser.stream start-deferred panel=\(panelID.prefix(8)) awaiting-viewport")
+            return
+        }
         await browserStreamEvents?.browserStreamWillStart(panelID: panelID)
         guard connectionState == .connected,
               supportsBrowserStream,
@@ -65,8 +76,12 @@ extension MobileShellComposite {
             viewport: viewport
         ),
               connectionState == .connected,
-              remoteClient === client else { return }
+              remoteClient === client else {
+            MobileDebugLog.anchormux("browser.stream start-failed panel=\(panelID.prefix(8))")
+            return
+        }
         startedMobileBrowserPanelIDs.insert(panelID)
+        MobileDebugLog.anchormux("browser.stream started panel=\(panelID.prefix(8))")
         browserStreamEvents?.browserStreamDidStart(descriptor)
     }
 
@@ -184,6 +199,7 @@ extension MobileShellComposite {
     func handleMobileBrowserClosedEvent(_ event: MobileEventEnvelope) {
         guard let payload = event.payloadJSON else { return }
         if let panelID = browserStreamEvents?.receiveBrowserClosedPayload(payload) {
+            MobileDebugLog.anchormux("browser.stream closed-by-mac panel=\(panelID.prefix(8))")
             startedMobileBrowserPanelIDs.remove(panelID)
         }
     }
@@ -219,6 +235,7 @@ extension MobileShellComposite {
     /// started-dedupe set must not suppress the re-arm in that case, or the
     /// mirror freezes with no path back short of closing the surface.
     func forceRestartMobileBrowserStream(panelID: String) async {
+        MobileDebugLog.anchormux("browser.stream force-restart panel=\(panelID.prefix(8))")
         startedMobileBrowserPanelIDs.remove(panelID)
         await startMobileBrowserStream(panelID: panelID)
     }
@@ -237,6 +254,7 @@ extension MobileShellComposite {
 
     private func performStopMobileBrowserStream(panelID: String) async {
         startedMobileBrowserPanelIDs.remove(panelID)
+        MobileDebugLog.anchormux("browser.stream stop panel=\(panelID.prefix(8))")
         guard let client = remoteClient else { return }
         _ = try? await client.stopMobileBrowserStream(panelID: panelID)
     }

--- a/Sources/Mobile/MobileBrowserStreamCoordinator.swift
+++ b/Sources/Mobile/MobileBrowserStreamCoordinator.swift
@@ -19,6 +19,7 @@ final class MobileBrowserStreamCoordinator {
             return nil
         }
         let key = SessionKey(connectionID: connectionID, panelID: panel.id)
+        let replacedExisting = sessions[key] != nil
         if let previous = sessions.removeValue(forKey: key) {
             await previous.stop(sendClosed: false)
         }
@@ -39,6 +40,11 @@ final class MobileBrowserStreamCoordinator {
         }
         sessions[key] = session
         session.start()
+        MobileHostIrohRuntime.hostDiagnosticLog.record(DiagnosticEvent(
+            .browserStreamLifecycle,
+            a: replacedExisting ? 2 : 1,
+            c: TerminalController.mobileBrowserPanelCorrelation(panel.id)
+        ))
         return MobileBrowserWireEncoder().descriptor(panel: panel)
     }
 
@@ -65,6 +71,11 @@ final class MobileBrowserStreamCoordinator {
         let key = SessionKey(connectionID: connectionID, panelID: panelID)
         guard let session = sessions.removeValue(forKey: key) else { return false }
         await session.stop(sendClosed: false)
+        MobileHostIrohRuntime.hostDiagnosticLog.record(DiagnosticEvent(
+            .browserStreamLifecycle,
+            a: 3,
+            c: TerminalController.mobileBrowserPanelCorrelation(panelID)
+        ))
         return true
     }
 

--- a/Sources/Mobile/MobileBrowserStreamSession.swift
+++ b/Sources/Mobile/MobileBrowserStreamSession.swift
@@ -36,6 +36,7 @@ final class MobileBrowserStreamSession {
     /// committed render, because an unsynchronized snapshot of a freshly
     /// (re)hosted or still-loading web view is a blank white bitmap.
     private var hasCapturedCommittedFrame = false
+    private var hasRecordedFirstDeliveredFrame = false
     private var synchronizedFirstCaptureFailures = 0
 
     /// Bound on the synchronized first capture so an occluded render host
@@ -261,11 +262,6 @@ final class MobileBrowserStreamSession {
             if waitForScreenUpdate, panel.webView === capturedWebView {
                 hasCapturedCommittedFrame = true
                 synchronizedFirstCaptureFailures = 0
-                MobileHostIrohRuntime.hostDiagnosticLog.record(DiagnosticEvent(
-                    .browserStreamLifecycle,
-                    a: 4,
-                    c: TerminalController.mobileBrowserPanelCorrelation(panelID)
-                ))
             }
             panel.updateMobileBrowserStreamMirror(image)
             #if DEBUG
@@ -308,6 +304,16 @@ final class MobileBrowserStreamSession {
             if !delivered {
                 pacing.acknowledge(sequence: sequence)
                 pacing.noteDirty(at: clock.now)
+            } else if !hasRecordedFirstDeliveredFrame {
+                // The first-frame stage means the phone actually received a
+                // frame: record it once per session, after delivery succeeds,
+                // never for the capture alone.
+                hasRecordedFirstDeliveredFrame = true
+                MobileHostIrohRuntime.hostDiagnosticLog.record(DiagnosticEvent(
+                    .browserStreamLifecycle,
+                    a: 4,
+                    c: TerminalController.mobileBrowserPanelCorrelation(panelID)
+                ))
             }
             return delivered
         } catch is CancellationError {

--- a/Sources/Mobile/MobileBrowserStreamSession.swift
+++ b/Sources/Mobile/MobileBrowserStreamSession.swift
@@ -110,6 +110,12 @@ final class MobileBrowserStreamSession {
         case let .dirty(focused):
             if let focused, editableFocused != focused {
                 editableFocused = focused
+                MobileHostIrohRuntime.hostDiagnosticLog.record(DiagnosticEvent(
+                    .browserEditableFocus,
+                    a: focused ? 1 : 0,
+                    b: 3,
+                    c: TerminalController.mobileBrowserPanelCorrelation(panelID)
+                ))
                 scheduleStateEmission()
             }
             noteDirty()
@@ -255,6 +261,11 @@ final class MobileBrowserStreamSession {
             if waitForScreenUpdate, panel.webView === capturedWebView {
                 hasCapturedCommittedFrame = true
                 synchronizedFirstCaptureFailures = 0
+                MobileHostIrohRuntime.hostDiagnosticLog.record(DiagnosticEvent(
+                    .browserStreamLifecycle,
+                    a: 4,
+                    c: TerminalController.mobileBrowserPanelCorrelation(panelID)
+                ))
             }
             panel.updateMobileBrowserStreamMirror(image)
             #if DEBUG

--- a/Sources/Panels/BrowserPanel+MobileBrowserStreaming.swift
+++ b/Sources/Panels/BrowserPanel+MobileBrowserStreaming.swift
@@ -120,6 +120,22 @@ extension BrowserPanel {
     })()
     """
 
+    /// Replays one phone pointer input on the streamed panel.
+    /// - Parameter input: Page-point pointer input from the phone.
+    /// - Returns: The focus-assist outcome for clicks (0 when none ran).
+    func replayMobileBrowserPointer(_ input: MobileBrowserPointerInput) async throws -> Int {
+        try MobileBrowserInputReplayer().replayPointer(input, in: webView)
+        return 0
+    }
+
+    /// Replays one phone key input on the streamed panel.
+    /// - Parameter input: A key token and modifiers from the phone.
+    /// - Returns: `true` when the key was delivered.
+    func replayMobileBrowserKey(_ input: MobileBrowserKeyInput) async throws -> Bool {
+        try MobileBrowserInputReplayer().replayKey(input, in: webView)
+        return true
+    }
+
     func addMobileBrowserStreamSignalHandler(
         id handlerID: UUID,
         handler: @escaping (MobileBrowserPanelNativeSignal) -> Void

--- a/Sources/Panels/BrowserPanel+MobileBrowserStreaming.swift
+++ b/Sources/Panels/BrowserPanel+MobileBrowserStreaming.swift
@@ -120,20 +120,98 @@ extension BrowserPanel {
     })()
     """
 
-    /// Replays one phone pointer input on the streamed panel.
+    /// Replays one phone pointer input and, for clicks, moves page focus into
+    /// the editable under the tap.
+    ///
+    /// Replayed clicks reach the page as DOM events, but WebKit refuses to
+    /// move field focus for clicks in a window that is never key (the
+    /// offscreen render host), so a tapped text field never focuses, the
+    /// phone keyboard never rises, and backspace falls through as a
+    /// page-level history-back. Programmatic JS focus is exempt from the
+    /// key-window rule, so hit-test the click point and focus explicitly.
     /// - Parameter input: Page-point pointer input from the phone.
-    /// - Returns: The focus-assist outcome for clicks (0 when none ran).
+    /// - Returns: The focus-assist outcome (0 no editable, 1 focus moved,
+    ///   2 already focused); 0 for non-click kinds.
     func replayMobileBrowserPointer(_ input: MobileBrowserPointerInput) async throws -> Int {
         try MobileBrowserInputReplayer().replayPointer(input, in: webView)
-        return 0
+        guard input.kind == .click else { return 0 }
+        return await assistMobileBrowserEditableFocus(atPageX: input.x, pageY: input.y)
     }
 
-    /// Replays one phone key input on the streamed panel.
+    /// Replays one phone key input unless it is a bare backspace outside an
+    /// editable, which WebKit would interpret as history back-navigation.
+    ///
+    /// The phone keyboard's backspace is a text-editing key: with no focused
+    /// editable it must be dropped, or deleting "highlighted" text navigates
+    /// the page away and loses state. Modified combinations pass through.
     /// - Parameter input: A key token and modifiers from the phone.
-    /// - Returns: `true` when the key was delivered.
+    /// - Returns: `true` when the key was delivered, `false` when suppressed.
     func replayMobileBrowserKey(_ input: MobileBrowserKeyInput) async throws -> Bool {
+        let isBareBackspace = (input.key == "delete" || input.key == "backspace")
+            && input.modifiers.isEmpty
+        if isBareBackspace, await mobileBrowserEditableHasFocus() == false {
+            return false
+        }
         try MobileBrowserInputReplayer().replayKey(input, in: webView)
         return true
+    }
+
+    /// Whether the streamed page currently focuses an editable element.
+    func mobileBrowserEditableHasFocus() async -> Bool {
+        let script = """
+        (() => {
+          const el = document.activeElement;
+          if (!el) return false;
+          if (el.isContentEditable) return true;
+          const tag = el.tagName;
+          if (tag === 'TEXTAREA' || tag === 'SELECT') return true;
+          if (tag !== 'INPUT') return false;
+          const type = String(el.type || 'text').toLowerCase();
+          return !['button','checkbox','color','file','hidden','image','radio','range','reset','submit'].includes(type);
+        })()
+        """
+        let result = try? await webView.evaluateJavaScript(script, contentWorld: .page)
+        return (result as? Bool) ?? false
+    }
+
+    /// Focuses the editable element under a replayed click point.
+    /// - Parameters:
+    ///   - x: Click X in page viewport points.
+    ///   - y: Click Y in page viewport points.
+    /// - Returns: 0 when no editable is at the point, 1 when focus moved,
+    ///   2 when the editable was already focused.
+    func assistMobileBrowserEditableFocus(atPageX x: Double, pageY y: Double) async -> Int {
+        guard x.isFinite, y.isFinite else { return 0 }
+        let script = """
+        (() => {
+          const isEditable = (el) => {
+            if (!el || el.nodeType !== 1) return false;
+            if (el.isContentEditable) return true;
+            const tag = el.tagName;
+            if (tag === 'TEXTAREA' || tag === 'SELECT') return true;
+            if (tag !== 'INPUT') return false;
+            const type = String(el.type || 'text').toLowerCase();
+            return !['button','checkbox','color','file','hidden','image','radio','range','reset','submit'].includes(type);
+          };
+          let el = document.elementFromPoint(\(x), \(y));
+          // Widgets often wrap their input in a shadow root; descend one level
+          // so the hit test can reach the real editable.
+          if (el && el.shadowRoot) {
+            const inner = el.shadowRoot.elementFromPoint(\(x), \(y));
+            if (inner) el = inner;
+          }
+          while (el && !isEditable(el)) el = el.parentElement || (el.getRootNode && el.getRootNode().host) || null;
+          if (!el) return 0;
+          const root = el.getRootNode ? el.getRootNode() : document;
+          const active = root.activeElement || document.activeElement;
+          if (active === el) return 2;
+          try { el.focus({ preventScroll: true }); } catch (_) { return 0; }
+          const focusedRoot = el.getRootNode ? el.getRootNode() : document;
+          return (focusedRoot.activeElement || document.activeElement) === el ? 1 : 0;
+        })()
+        """
+        let result = try? await webView.evaluateJavaScript(script, contentWorld: .page)
+        return (result as? Int) ?? 0
     }
 
     func addMobileBrowserStreamSignalHandler(

--- a/Sources/Panels/BrowserPanel+MobileBrowserStreaming.swift
+++ b/Sources/Panels/BrowserPanel+MobileBrowserStreaming.swift
@@ -9,7 +9,10 @@ extension BrowserPanel {
     (() => {
       const handlerName = 'cmuxMobileBrowserStream';
       const editableFocused = () => {
-        const el = document.activeElement;
+        // Descend shadow roots: document.activeElement reports the shadow
+        // host, and the phone keyboard must rise for widget-wrapped inputs.
+        let el = document.activeElement;
+        while (el && el.shadowRoot && el.shadowRoot.activeElement) el = el.shadowRoot.activeElement;
         if (!el) return false;
         const tag = String(el.tagName || '').toLowerCase();
         return !!el.isContentEditable || tag === 'textarea' ||
@@ -157,17 +160,26 @@ extension BrowserPanel {
     }
 
     /// Whether the streamed page currently focuses an editable element.
+    ///
+    /// `document.activeElement` reports the shadow HOST when focus sits inside
+    /// a shadow root, so the check descends shadow roots to the real focused
+    /// element; otherwise backspace into a widget-wrapped input would be
+    /// suppressed as no-editable.
     func mobileBrowserEditableHasFocus() async -> Bool {
         let script = """
         (() => {
-          const el = document.activeElement;
-          if (!el) return false;
-          if (el.isContentEditable) return true;
-          const tag = el.tagName;
-          if (tag === 'TEXTAREA' || tag === 'SELECT') return true;
-          if (tag !== 'INPUT') return false;
-          const type = String(el.type || 'text').toLowerCase();
-          return !['button','checkbox','color','file','hidden','image','radio','range','reset','submit'].includes(type);
+          const isEditable = (el) => {
+            if (!el || el.nodeType !== 1) return false;
+            if (el.isContentEditable) return true;
+            const tag = el.tagName;
+            if (tag === 'TEXTAREA' || tag === 'SELECT') return true;
+            if (tag !== 'INPUT') return false;
+            const type = String(el.type || 'text').toLowerCase();
+            return !['button','checkbox','color','file','hidden','image','radio','range','reset','submit'].includes(type);
+          };
+          let el = document.activeElement;
+          while (el && el.shadowRoot && el.shadowRoot.activeElement) el = el.shadowRoot.activeElement;
+          return isEditable(el);
         })()
         """
         let result = try? await webView.evaluateJavaScript(script, contentWorld: .page)
@@ -202,12 +214,14 @@ extension BrowserPanel {
           }
           while (el && !isEditable(el)) el = el.parentElement || (el.getRootNode && el.getRootNode().host) || null;
           if (!el) return 0;
-          const root = el.getRootNode ? el.getRootNode() : document;
-          const active = root.activeElement || document.activeElement;
-          if (active === el) return 2;
+          const deepActive = () => {
+            let active = document.activeElement;
+            while (active && active.shadowRoot && active.shadowRoot.activeElement) active = active.shadowRoot.activeElement;
+            return active;
+          };
+          if (deepActive() === el) return 2;
           try { el.focus({ preventScroll: true }); } catch (_) { return 0; }
-          const focusedRoot = el.getRootNode ? el.getRootNode() : document;
-          return (focusedRoot.activeElement || document.activeElement) === el ? 1 : 0;
+          return deepActive() === el ? 1 : 0;
         })()
         """
         let result = try? await webView.evaluateJavaScript(script, contentWorld: .page)

--- a/Sources/TerminalController+MobileBrowser.swift
+++ b/Sources/TerminalController+MobileBrowser.swift
@@ -119,11 +119,11 @@ extension TerminalController {
                 "dialog_id": response.dialogID,
             ])
         case "mobile.browser.input.pointer":
-            return v2MobileBrowserPointerInput(params: params, connectionID: connectionID)
+            return await v2MobileBrowserPointerInput(params: params, connectionID: connectionID)
         case "mobile.browser.input.scroll":
             return v2MobileBrowserScrollInput(params: params, connectionID: connectionID)
         case "mobile.browser.input.key":
-            return v2MobileBrowserKeyInput(params: params, connectionID: connectionID)
+            return await v2MobileBrowserKeyInput(params: params, connectionID: connectionID)
         case "mobile.browser.input.text":
             return await v2MobileBrowserTextInput(params: params, connectionID: connectionID)
         case "mobile.browser.navigate":
@@ -187,19 +187,22 @@ extension TerminalController {
             return .err(code: "not_found", message: "Pane not found", data: nil)
         }
         guard let panel = workspace.newBrowserSurface(inPane: paneId, focus: false) else {
+            mobileBrowserRecordDiagnostic(.browserPanelCreateResolved, panel: nil, a: 0)
             return .err(code: "unavailable", message: "Browser creation is unavailable", data: nil)
         }
         let encoder = MobileBrowserWireEncoder()
         guard let payload = encoder.object(encoder.descriptor(panel: panel)) else {
+            mobileBrowserRecordDiagnostic(.browserPanelCreateResolved, panel: panel, a: 0)
             return .err(code: "internal_error", message: "Browser creation is unavailable", data: nil)
         }
+        mobileBrowserRecordDiagnostic(.browserPanelCreateResolved, panel: panel, a: 1)
         return .ok(payload)
     }
 
     private func v2MobileBrowserPointerInput(
         params: [String: Any],
         connectionID: UUID?
-    ) -> V2CallResult {
+    ) async -> V2CallResult {
         guard let input = mobileBrowserDecode(MobileBrowserPointerInput.self, params: params) else {
             return .err(code: "invalid_params", message: "Invalid browser pointer input", data: nil)
         }
@@ -207,12 +210,47 @@ extension TerminalController {
             return .err(code: "not_found", message: "Browser panel not found", data: ["panel_id": input.panelID])
         }
         do {
-            try MobileBrowserInputReplayer().replayPointer(input, in: panel.webView)
+            let focusAssist = try await panel.replayMobileBrowserPointer(input)
             mobileBrowserInputDidReplay(connectionID: connectionID, panelID: panel.id)
+            mobileBrowserRecordDiagnostic(
+                .browserInputReplayed, panel: panel, a: 1, b: input.clickCount
+            )
+            if input.kind == .click {
+                mobileBrowserRecordDiagnostic(
+                    .browserEditableFocus,
+                    panel: panel,
+                    a: focusAssist == 0 ? 0 : 1,
+                    b: focusAssist
+                )
+            }
             return .ok(["ok": true, "panel_id": input.panelID])
         } catch {
             return .err(code: "invalid_params", message: "Invalid browser pointer input", data: nil)
         }
+    }
+
+    /// Records one browser-stream diagnostic into the host ring so user bug
+    /// reports carry the stream's input, focus, and lifecycle history.
+    func mobileBrowserRecordDiagnostic(
+        _ code: DiagnosticEventCode,
+        panel: BrowserPanel?,
+        a: Int? = nil,
+        b: Int? = nil
+    ) {
+        MobileHostIrohRuntime.hostDiagnosticLog.record(DiagnosticEvent(
+            code,
+            a: a,
+            b: b,
+            c: panel.map { Self.mobileBrowserPanelCorrelation($0.id) }
+        ))
+    }
+
+    /// Stable positive correlation ID for one browser panel, derived from the
+    /// panel UUID so ring events group without carrying the full identifier.
+    static func mobileBrowserPanelCorrelation(_ id: UUID) -> Int {
+        let bytes = id.uuid
+        let value = (UInt32(bytes.0) << 24) | (UInt32(bytes.1) << 16) | (UInt32(bytes.2) << 8) | UInt32(bytes.3)
+        return Int(value & 0x7FFF_FFFF)
     }
 
     private func v2MobileBrowserScrollInput(
@@ -237,7 +275,7 @@ extension TerminalController {
     private func v2MobileBrowserKeyInput(
         params: [String: Any],
         connectionID: UUID?
-    ) -> V2CallResult {
+    ) async -> V2CallResult {
         guard let input = mobileBrowserDecode(MobileBrowserKeyInput.self, params: params) else {
             return .err(code: "invalid_params", message: "Invalid browser key input", data: nil)
         }
@@ -245,9 +283,14 @@ extension TerminalController {
             return .err(code: "not_found", message: "Browser panel not found", data: ["panel_id": input.panelID])
         }
         do {
-            try MobileBrowserInputReplayer().replayKey(input, in: panel.webView)
-            mobileBrowserInputDidReplay(connectionID: connectionID, panelID: panel.id)
-            return .ok(["ok": true, "panel_id": input.panelID])
+            let delivered = try await panel.replayMobileBrowserKey(input)
+            if delivered {
+                mobileBrowserInputDidReplay(connectionID: connectionID, panelID: panel.id)
+            }
+            mobileBrowserRecordDiagnostic(
+                .browserInputReplayed, panel: panel, a: 2, b: delivered ? 0 : 1
+            )
+            return .ok(["ok": true, "panel_id": input.panelID, "delivered": delivered])
         } catch {
             return .err(code: "invalid_params", message: "Invalid browser key input", data: nil)
         }
@@ -266,8 +309,12 @@ extension TerminalController {
         do {
             try await MobileBrowserInputReplayer().replayText(input, in: panel.webView)
             mobileBrowserInputDidReplay(connectionID: connectionID, panelID: panel.id)
+            mobileBrowserRecordDiagnostic(
+                .browserInputReplayed, panel: panel, a: 3, b: input.text.count
+            )
             return .ok(["ok": true, "panel_id": input.panelID])
         } catch {
+            mobileBrowserRecordDiagnostic(.browserInputReplayed, panel: panel, a: 3, b: -1)
             return .err(code: "invalid_params", message: "Browser text could not be inserted", data: nil)
         }
     }

--- a/Sources/TerminalController+MobileBrowser.swift
+++ b/Sources/TerminalController+MobileBrowser.swift
@@ -288,7 +288,7 @@ extension TerminalController {
                 mobileBrowserInputDidReplay(connectionID: connectionID, panelID: panel.id)
             }
             mobileBrowserRecordDiagnostic(
-                .browserInputReplayed, panel: panel, a: 2, b: delivered ? 0 : 1
+                .browserInputReplayed, panel: panel, a: delivered ? 2 : 4, b: 1
             )
             return .ok(["ok": true, "panel_id": input.panelID, "delivered": delivered])
         } catch {

--- a/cmuxTests/BrowserPanelTests.swift
+++ b/cmuxTests/BrowserPanelTests.swift
@@ -4553,3 +4553,32 @@ final class MobileBrowserStreamInputFocusTests: XCTestCase {
         XCTAssertEqual(active, "field", "A replayed click on a text field must focus it")
     }
 }
+
+extension MobileBrowserStreamInputFocusTests {
+    func testBareBackspaceOutsideEditableIsSuppressed() async throws {
+        let panel = try await loadInputTestPanel()
+        defer { panel.close() }
+        let backspace = MobileBrowserKeyInput(
+            panelID: panel.id.uuidString,
+            key: "delete",
+            modifiers: []
+        )
+        let deliveredWithoutFocus = try await panel.replayMobileBrowserKey(backspace)
+        XCTAssertFalse(
+            deliveredWithoutFocus,
+            "A bare backspace with no focused editable must be suppressed, not navigate history"
+        )
+
+        let click = MobileBrowserPointerInput(
+            panelID: panel.id.uuidString,
+            kind: .click,
+            x: 100,
+            y: 30,
+            clickCount: 1,
+            button: .left
+        )
+        _ = try await panel.replayMobileBrowserPointer(click)
+        let deliveredWhileEditing = try await panel.replayMobileBrowserKey(backspace)
+        XCTAssertTrue(deliveredWhileEditing, "Backspace while editing must reach the field")
+    }
+}

--- a/cmuxTests/BrowserPanelTests.swift
+++ b/cmuxTests/BrowserPanelTests.swift
@@ -8,6 +8,7 @@ import Bonsplit
 import UserNotifications
 import Darwin
 import Testing
+import CMUXMobileCore
 import CmuxBrowser
 
 #if canImport(cmux_DEV)
@@ -4495,5 +4496,60 @@ final class OmnibarNativeTextFieldCaretTests: XCTestCase {
             NSRange(location: 0, length: textLength),
             "Explicit omnibar focus requests such as Cmd+L must still select the whole URL"
         )
+    }
+}
+
+@MainActor
+final class MobileBrowserStreamInputFocusTests: XCTestCase {
+    /// Loads a panel whose page is one fixed-position text field at the origin.
+    private func loadInputTestPanel() async throws -> BrowserPanel {
+        let panel = BrowserPanel(workspaceId: UUID())
+        panel.webView.frame = CGRect(x: 0, y: 0, width: 400, height: 300)
+        let baseURL = try XCTUnwrap(URL(string: "https://example.test/mobile-focus"))
+        let loaded = expectation(description: "input test page loaded")
+        let previousDelegate = panel.webView.navigationDelegate
+        let loadDelegate = BrowserPanelTestNavigationDelegate(expectation: loaded)
+        panel.webView.navigationDelegate = loadDelegate
+        defer { panel.webView.navigationDelegate = previousDelegate }
+        panel.webView.loadHTMLString(
+            """
+            <!doctype html><html><body style="margin:0">
+            <input id="field" style="position:fixed;left:0;top:0;width:200px;height:60px">
+            </body></html>
+            """,
+            baseURL: baseURL
+        )
+        await fulfillment(of: [loaded], timeout: 5)
+        if let error = loadDelegate.error { throw error }
+        return panel
+    }
+
+    private func activeElementID(_ panel: BrowserPanel) async -> String {
+        let value = try? await panel.webView.evaluateJavaScript(
+            "document.activeElement ? (document.activeElement.id || document.activeElement.tagName) : 'none'",
+            contentWorld: .page
+        )
+        return (value as? String) ?? "none"
+    }
+
+    func testReplayedClickFocusesEditableUnderTap() async throws {
+        // RED: replayed phone clicks reach the page as DOM events, but WebKit
+        // refuses to move field focus for clicks in a window that is never key
+        // (the offscreen render host), so a tapped text field never focuses,
+        // the phone keyboard never rises, and backspace falls through as
+        // page-level history back-navigation.
+        let panel = try await loadInputTestPanel()
+        defer { panel.close() }
+        let click = MobileBrowserPointerInput(
+            panelID: panel.id.uuidString,
+            kind: .click,
+            x: 100,
+            y: 30,
+            clickCount: 1,
+            button: .left
+        )
+        _ = try await panel.replayMobileBrowserPointer(click)
+        let active = await activeElementID(panel)
+        XCTAssertEqual(active, "field", "A replayed click on a text field must focus it")
     }
 }

--- a/cmuxTests/BrowserPanelTests.swift
+++ b/cmuxTests/BrowserPanelTests.swift
@@ -4581,4 +4581,46 @@ extension MobileBrowserStreamInputFocusTests {
         let deliveredWhileEditing = try await panel.replayMobileBrowserKey(backspace)
         XCTAssertTrue(deliveredWhileEditing, "Backspace while editing must reach the field")
     }
+
+    func testBackspaceDeliversToShadowRootInput() async throws {
+        // document.activeElement reports the shadow HOST when focus sits in a
+        // shadow root; the suppression check must descend to the real focused
+        // element or widget-wrapped inputs never receive backspace.
+        let panel = BrowserPanel(workspaceId: UUID())
+        panel.webView.frame = CGRect(x: 0, y: 0, width: 400, height: 300)
+        let baseURL = try XCTUnwrap(URL(string: "https://example.test/shadow-focus"))
+        let loaded = expectation(description: "shadow test page loaded")
+        let previousDelegate = panel.webView.navigationDelegate
+        let loadDelegate = BrowserPanelTestNavigationDelegate(expectation: loaded)
+        panel.webView.navigationDelegate = loadDelegate
+        defer { panel.webView.navigationDelegate = previousDelegate }
+        panel.webView.loadHTMLString(
+            """
+            <!doctype html><html><body style="margin:0"><div id="host"></div>
+            <script>
+              const root = document.getElementById('host').attachShadow({ mode: 'open' });
+              const field = document.createElement('input');
+              field.id = 'shadow-field';
+              root.appendChild(field);
+            </script>
+            </body></html>
+            """,
+            baseURL: baseURL
+        )
+        await fulfillment(of: [loaded], timeout: 5)
+        if let error = loadDelegate.error { throw error }
+        defer { panel.close() }
+
+        _ = try await panel.webView.evaluateJavaScript(
+            "document.getElementById('host').shadowRoot.getElementById('shadow-field').focus()",
+            contentWorld: .page
+        )
+        let backspace = MobileBrowserKeyInput(
+            panelID: panel.id.uuidString,
+            key: "delete",
+            modifiers: []
+        )
+        let delivered = try await panel.replayMobileBrowserKey(backspace)
+        XCTAssertTrue(delivered, "Backspace must reach an input focused inside a shadow root")
+    }
 }


### PR DESCRIPTION
## Summary

Fixes the streamed-browser input bugs Aziz hit dogfooding https://github.com/manaflow-ai/cmux/pull/9577, and adds the verbose browser-stream diagnostics he asked for.

**Symptoms (all one root cause):** tapping a page text field does nothing (no caret, no keyboard); typed text lands nowhere on most pages; backspace with "highlighted" text navigates the page back in history instead of deleting. Diagnosis: replayed phone clicks reach the page as DOM events (verified: `mousedown`/`click` with correct coordinates and target), but WebKit refuses to move field focus for clicks in a window that is never key, and the streamed webview lives in the offscreen render host whose window is deliberately non-key. With `document.activeElement` stuck on `BODY`, `editable_focused` never fires (no phone keyboard), text insertion has no target, and backspace falls through as WebKit's page-level history back-navigation.

## Fix

- `BrowserPanel.replayMobileBrowserPointer` replays the click and then runs a focus assist: programmatic JS focus is exempt from the key-window rule, so it hit-tests the tap point (`elementFromPoint`, descending one shadow-root level for widget-wrapped inputs, then walking ancestors) and calls `focus({preventScroll: true})` on the editable it finds. The existing `editable_focused` beacon then raises the phone keyboard, and both text-insertion paths (key events and JS insertion) have a real target.
- `BrowserPanel.replayMobileBrowserKey` suppresses a bare backspace when no editable has focus: the phone keyboard's backspace is a text-editing key, and letting it through navigated history and lost page state. Modified combinations pass through unchanged.
- Red/green commit pair: `testReplayedClickFocusesEditableUnderTap` (red on the bare replay seam) then the assist; `testBareBackspaceOutsideEditableIsSuppressed` covers the suppression plus delivery-while-editing.

## Verbose browser-stream diagnostics

Mac host ring (Sentry-attached via the existing diagnostics tap): new `DiagnosticEventCode`s record stream lifecycle (start / replace / stop / first committed frame), input replay outcomes (kind, click count, suppressed backspace, text length), focus-assist results, beacon editable-focus transitions, and `mobile.browser.create` resolutions, all correlated by a stable panel ID. Phone debug log (`Copy Debug Logs`, feedback bundles): `browser.create` outcomes and `browser.stream` start / start-deferred / start-failed / stop / force-restart / closed-by-mac lines.

Localization audit: no user-facing UI strings changed; the four new diagnostics titles follow the package's existing `localized(_:defaultValue:)` pattern used by all 55 prior event codes.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/9729"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788651493&installation_model_id=21920&pr_number=9729&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F9729&signature=5aa886df9b140f0b3719eec72d7c026820c231ac3a118bc853ac03f28a12a181"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes iOS browser stream input so tapped fields focus, typing goes into the page, and bare backspace no longer navigates history. Adds shadow‑root‑aware focus detection and richer, semantic diagnostics (including first delivered frame) to debug lifecycle, input, and focus.

- **Bug Fixes**
  - After a replayed click, hit-test the tap (`elementFromPoint`, descend one shadow root) and focus the editable via JS to bypass WebKit’s key-window rule.
  - Suppress bare backspace when no editable is focused; focus checks descend shadow roots. Modified combos still pass.
  - Tests added: `testReplayedClickFocusesEditableUnderTap`, `testBareBackspaceOutsideEditableIsSuppressed`, `testBackspaceDeliversToShadowRootInput`.

- **New Features**
  - New diagnostics with semantic fields: `browserStreamLifecycle`, `browserInputReplayed` (now includes a distinct “suppressed backspace” kind), `browserEditableFocus`, `browserPanelCreateResolved` — with stage/input/count/focus-outcome and a stable panel correlation ID.
  - Record “first delivered frame” once per session after a successfully delivered frame.
  - Mac host ring logs lifecycle, input outcomes, focus-assist results, and beacon transitions; phone debug logs emit `browser.create` outcomes and `browser.stream` start/start-deferred/start-failed/stop/force-restart/closed-by-mac.

<sup>Written for commit b584cc97f2d84051ef282f9ffff24f2621723b63. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/9729?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Mac-side WebKit input replay and RPC key handling (async, `delivered` flag); user-visible browser streaming behavior but confined to the mobile browser stream path with new test coverage.
> 
> **Overview**
> Fixes **iOS streamed-browser input** when the Mac web view lives in a non-key offscreen host: replayed taps did not focus fields (no keyboard, typing went nowhere), and bare backspace could trigger history navigation.
> 
> **Input behavior:** After pointer replay, **click focus assist** hit-tests the tap (`elementFromPoint`, shadow-root descent) and calls programmatic `focus()` so editables can receive keys. **Bare backspace** is dropped when no editable is focused; shadow-root–aware checks align the dirty beacon and suppression logic with widget-wrapped inputs.
> 
> **Diagnostics:** Four new `DiagnosticEventCode` values (56–59) with presentation/decoding record stream lifecycle, input replay outcomes, editable focus, and `mobile.browser.create` results on the Mac host ring (panel correlation IDs). The phone shell adds `MobileDebugLog.anchormux` lines for browser create and stream start/stop/restart paths.
> 
> **Tests:** `MobileBrowserStreamInputFocusTests` covers click-to-focus, backspace suppression, and shadow-root backspace delivery.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b584cc97f2d84051ef282f9ffff24f2621723b63. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added detailed diagnostics for browser streaming, panel creation, input replay, editable focus, and stream lifecycle events.
  * Added support for focusing editable controls inside shadow roots during mobile browser interaction.
  * Added clearer reporting for browser stream and input delivery outcomes.

* **Bug Fixes**
  * Prevented unmodified Backspace/Delete inputs from being sent when no editable field is focused.
  * Improved mobile click and keyboard replay reliability for editable controls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->