### PR TITLE
Fix Claude Teams teammate respawn environment

### DIFF
--- a/CLI/CMUXCLI+ExecutableResolution.swift
+++ b/CLI/CMUXCLI+ExecutableResolution.swift
@@ -296,6 +296,7 @@ extension CMUXCLI {
             unsetenv(key)
         }
         unsetenv(ClaudeTeamsRespawnEnvironmentTransport.environmentKey)
+        unsetenv("CMUX_CLAUDE_TEAMS_WRAPPER_LAUNCH")
     }
 
     private func providerExecutableSearchDirectories(searchPath: String?) -> [String] {

--- a/CLI/CMUXCLI+ExecutableResolution.swift
+++ b/CLI/CMUXCLI+ExecutableResolution.swift
@@ -295,7 +295,7 @@ extension CMUXCLI {
         for key in ClaudeSessionEnvironmentPolicy().inheritedIndependentLaunchKeys {
             unsetenv(key)
         }
-        unsetenv(Self.claudeTeamsRespawnEnvironmentTransportKey)
+        unsetenv(ClaudeTeamsRespawnEnvironmentTransport.environmentKey)
     }
 
     private func providerExecutableSearchDirectories(searchPath: String?) -> [String] {

--- a/CLI/CMUXCLI+ExecutableResolution.swift
+++ b/CLI/CMUXCLI+ExecutableResolution.swift
@@ -295,6 +295,7 @@ extension CMUXCLI {
         for key in ClaudeSessionEnvironmentPolicy().inheritedIndependentLaunchKeys {
             unsetenv(key)
         }
+        unsetenv(Self.claudeTeamsRespawnEnvironmentTransportKey)
     }
 
     private func providerExecutableSearchDirectories(searchPath: String?) -> [String] {

--- a/CLI/CMUXCLI+TmuxCompatLaunchContext.swift
+++ b/CLI/CMUXCLI+TmuxCompatLaunchContext.swift
@@ -11,6 +11,11 @@ extension CMUXCLI {
         let surfaceId: String?
     }
 
+    struct ClaudeTeamsShimPlan {
+        let directory: URL
+        let managedClaudeWrapperURL: URL?
+    }
+
     func tmuxCompatResolvedSocketPath(processEnvironment: [String: String]) throws -> String {
         let envSocketPath = try CLISocketEnvironment.socketPath(in: processEnvironment)
         let bundleIdentifier = CLISocketPathResolver.currentAppBundleIdentifier()
@@ -199,11 +204,11 @@ extension CMUXCLI {
         return environment
     }
 
-    func createClaudeTeamsShimDirectory(
+    func createClaudeTeamsShimPlan(
         processEnvironment: [String: String],
         commandArgs: [String],
         launchContext: TmuxCompatLaunchContext?
-    ) throws -> URL {
+    ) throws -> ClaudeTeamsShimPlan {
         let downstreamTmuxMissing = String(
             localized: "cli.tmux-compat.error.downstreamTmuxMissing",
             defaultValue: "cmux tmux shim: no downstream tmux executable found"
@@ -259,7 +264,11 @@ extension CMUXCLI {
                     script,
                     to: managedRoot.appendingPathComponent("tmux", isDirectory: false)
                 )
-                return managedRoot
+                return ClaudeTeamsShimPlan(
+                    directory: managedRoot,
+                    managedClaudeWrapperURL: managedRoot
+                        .appendingPathComponent("claude", isDirectory: false)
+                )
             } catch {
                 // Informational launches do not create teammates, so they may use the
                 // launcher-only compatibility directory below. Real Teams sessions must
@@ -270,9 +279,12 @@ extension CMUXCLI {
         guard claudeTeamsIsNonLaunchInvocation(commandArgs: commandArgs) else {
             throw CLIError(message: managedTerminalRequiredMessage(displayName: "Claude Teams"))
         }
-        return try createTmuxCompatShimDirectory(
-            directoryName: "claude-teams-bin",
-            tmuxShimScript: script
+        return ClaudeTeamsShimPlan(
+            directory: try createTmuxCompatShimDirectory(
+                directoryName: "claude-teams-bin",
+                tmuxShimScript: script
+            ),
+            managedClaudeWrapperURL: nil
         )
     }
 

--- a/CLI/CMUXCLI+TmuxCompatSupport.swift
+++ b/CLI/CMUXCLI+TmuxCompatSupport.swift
@@ -2,8 +2,6 @@ import CMUXAgentLaunch
 import Foundation
 
 extension CMUXCLI {
-    static let claudeTeamsRespawnEnvironmentTransportKey = "CMUX_CLAUDE_TEAMS_RESPAWN_ENV_B64"
-
     func tmuxEnrichContextWithGeometry(
         _ context: inout [String: String],
         pane: [String: Any],
@@ -121,52 +119,13 @@ extension CMUXCLI {
         return tmuxShellInvokedStartCommand("\(exports); \(trimmed)")
     }
 
-    /// Encodes the launcher's non-secret environment for same-launch teammate respawns.
-    ///
-    /// ``AgentLaunchEnvironmentPolicy`` is the repository's shared replay-safe
-    /// allowlist. `PATH` is added explicitly because executable discovery is the
-    /// capability teammate panes lose when the app's GUI environment owns the
-    /// respawn. The consumer applies the same allowlist again, so a forged marker
-    /// cannot promote arbitrary variables or credentials into the pane command.
-    func claudeTeamsRespawnEnvironmentTransportValue(
-        from launcherEnvironment: [String: String]
-    ) -> String? {
-        var selected = AgentLaunchEnvironmentPolicy().selectedEnvironment(
-            from: launcherEnvironment,
-            kind: "claude"
-        )
-        if let path = launcherEnvironment["PATH"] {
-            selected["PATH"] = path
-        }
-        guard let data = try? JSONEncoder().encode(selected) else { return nil }
-        return data.base64EncodedString()
-    }
-
-    /// Decodes and revalidates the same-launch teammate environment transport.
-    func tmuxClaudeTeamsTransportedRespawnEnvironment(
-        processEnvironment: [String: String]
-    ) -> [String: String] {
-        guard let encoded = processEnvironment[Self.claudeTeamsRespawnEnvironmentTransportKey],
-              let data = Data(base64Encoded: encoded),
-              let transported = try? JSONDecoder().decode([String: String].self, from: data) else {
-            return [:]
-        }
-        var selected = AgentLaunchEnvironmentPolicy().selectedEnvironment(
-            from: transported,
-            kind: "claude"
-        )
-        if let path = transported["PATH"] {
-            selected["PATH"] = path
-        }
-        return selected
-    }
-
     /// Environment that a claude-teams teammate pane must start with.
     ///
     /// Teammate panes are respawned by cmux's surface layer, not by `cmux
     /// claude-teams`, so they do NOT inherit the launcher environment the lead
     /// got from `configureClaudeTeamsEnvironment`. The launcher records a
-    /// replay-safe snapshot in ``claudeTeamsRespawnEnvironmentTransportKey``;
+    /// replay-safe snapshot in
+    /// ``ClaudeTeamsRespawnEnvironmentTransport/environmentKey``;
     /// re-supply that snapshot so PATH-based tools and allowlisted Claude
     /// configuration match the lead without copying secrets or surface identity.
     /// `CLAUDE_CODE_SANDBOXED` is handled alongside it: Claude Code short-circuits
@@ -192,8 +151,9 @@ extension CMUXCLI {
     /// the trust boundary outside an explicit opt-in.
     func tmuxClaudeTeamsRespawnEnvironment() -> [(key: String, value: String)] {
         let processEnvironment = ProcessInfo.processInfo.environment
-        var environment = tmuxClaudeTeamsTransportedRespawnEnvironment(
-            processEnvironment: processEnvironment
+        let transport = ClaudeTeamsRespawnEnvironmentTransport()
+        var environment = transport.decodedEnvironment(
+            from: processEnvironment[ClaudeTeamsRespawnEnvironmentTransport.environmentKey]
         )
         if processEnvironment["CMUX_CLAUDE_TEAMS_SANDBOXED"] == "1" {
             environment["CLAUDE_CODE_SANDBOXED"] = "1"

--- a/CLI/CMUXCLI+TmuxCompatSupport.swift
+++ b/CLI/CMUXCLI+TmuxCompatSupport.swift
@@ -1,6 +1,9 @@
+import CMUXAgentLaunch
 import Foundation
 
 extension CMUXCLI {
+    static let claudeTeamsRespawnEnvironmentTransportKey = "CMUX_CLAUDE_TEAMS_RESPAWN_ENV_B64"
+
     func tmuxEnrichContextWithGeometry(
         _ context: inout [String: String],
         pane: [String: Any],
@@ -118,15 +121,57 @@ extension CMUXCLI {
         return tmuxShellInvokedStartCommand("\(exports); \(trimmed)")
     }
 
+    /// Encodes the launcher's non-secret environment for same-launch teammate respawns.
+    ///
+    /// ``AgentLaunchEnvironmentPolicy`` is the repository's shared replay-safe
+    /// allowlist. `PATH` is added explicitly because executable discovery is the
+    /// capability teammate panes lose when the app's GUI environment owns the
+    /// respawn. The consumer applies the same allowlist again, so a forged marker
+    /// cannot promote arbitrary variables or credentials into the pane command.
+    func claudeTeamsRespawnEnvironmentTransportValue(
+        from launcherEnvironment: [String: String]
+    ) -> String? {
+        var selected = AgentLaunchEnvironmentPolicy().selectedEnvironment(
+            from: launcherEnvironment,
+            kind: "claude"
+        )
+        if let path = launcherEnvironment["PATH"] {
+            selected["PATH"] = path
+        }
+        guard let data = try? JSONEncoder().encode(selected) else { return nil }
+        return data.base64EncodedString()
+    }
+
+    /// Decodes and revalidates the same-launch teammate environment transport.
+    func tmuxClaudeTeamsTransportedRespawnEnvironment(
+        processEnvironment: [String: String]
+    ) -> [String: String] {
+        guard let encoded = processEnvironment[Self.claudeTeamsRespawnEnvironmentTransportKey],
+              let data = Data(base64Encoded: encoded),
+              let transported = try? JSONDecoder().decode([String: String].self, from: data) else {
+            return [:]
+        }
+        var selected = AgentLaunchEnvironmentPolicy().selectedEnvironment(
+            from: transported,
+            kind: "claude"
+        )
+        if let path = transported["PATH"] {
+            selected["PATH"] = path
+        }
+        return selected
+    }
+
     /// Environment that a claude-teams teammate pane must start with.
     ///
     /// Teammate panes are respawned by cmux's surface layer, not by `cmux
     /// claude-teams`, so they do NOT inherit the launcher environment the lead
-    /// got from `configureClaudeTeamsEnvironment`. The one variable that matters
-    /// for startup is `CLAUDE_CODE_SANDBOXED`: Claude Code short-circuits its
-    /// interactive "Do you trust this folder?" gate on it, and a teammate that
-    /// hits that gate hangs forever (its pane opens but it never checks in —
-    /// issue #6447). Re-supply it so teammates start the same way the lead does.
+    /// got from `configureClaudeTeamsEnvironment`. The launcher records a
+    /// replay-safe snapshot in ``claudeTeamsRespawnEnvironmentTransportKey``;
+    /// re-supply that snapshot so PATH-based tools and allowlisted Claude
+    /// configuration match the lead without copying secrets or surface identity.
+    /// `CLAUDE_CODE_SANDBOXED` is handled alongside it: Claude Code short-circuits
+    /// its interactive "Do you trust this folder?" gate on that variable, and a
+    /// teammate that hits the gate hangs forever (issue #6447).
     ///
     /// That trust gate is a real safety boundary, so it is only waived when the
     /// user already opted into skipping safety prompts. The opt-in is NOT inferred
@@ -146,10 +191,16 @@ extension CMUXCLI {
     /// it correctly falls back to Claude's trust prompt rather than silently bypassing
     /// the trust boundary outside an explicit opt-in.
     func tmuxClaudeTeamsRespawnEnvironment() -> [(key: String, value: String)] {
-        guard ProcessInfo.processInfo.environment["CMUX_CLAUDE_TEAMS_SANDBOXED"] == "1" else {
-            return []
+        let processEnvironment = ProcessInfo.processInfo.environment
+        var environment = tmuxClaudeTeamsTransportedRespawnEnvironment(
+            processEnvironment: processEnvironment
+        )
+        if processEnvironment["CMUX_CLAUDE_TEAMS_SANDBOXED"] == "1" {
+            environment["CLAUDE_CODE_SANDBOXED"] = "1"
         }
-        return [(key: "CLAUDE_CODE_SANDBOXED", value: "1")]
+        return environment.keys.sorted().compactMap { key in
+            environment[key].map { (key: key, value: $0) }
+        }
     }
 
     func tmuxShellWords(_ commandText: String) -> [String] {

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -20573,10 +20573,11 @@ struct CMUXCLI {
         clearInheritedClaudeLaunchEnvironment()
         defer {
             let launcherEnvironment = ProcessInfo.processInfo.environment
-            if let encoded = claudeTeamsRespawnEnvironmentTransportValue(from: launcherEnvironment) {
-                setenv(Self.claudeTeamsRespawnEnvironmentTransportKey, encoded, 1)
+            let transport = ClaudeTeamsRespawnEnvironmentTransport()
+            if let encoded = transport.encodedValue(from: launcherEnvironment) {
+                setenv(ClaudeTeamsRespawnEnvironmentTransport.environmentKey, encoded, 1)
             } else {
-                unsetenv(Self.claudeTeamsRespawnEnvironmentTransportKey)
+                unsetenv(ClaudeTeamsRespawnEnvironmentTransport.environmentKey)
             }
         }
         configureTmuxCompatEnvironment(

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -20664,15 +20664,17 @@ struct CMUXCLI {
             processEnvironment: launcherEnvironment,
             explicitPassword: explicitPassword
         )
-        if !claudeTeamsIsNonLaunchInvocation(commandArgs: commandArgs),
+        let launchesAgentSession = !claudeTeamsIsNonLaunchInvocation(commandArgs: commandArgs)
+        if launchesAgentSession,
            normalizedTmuxTarget(launchContext?.surfaceId) == nil {
             throw CLIError(message: managedTerminalRequiredMessage(displayName: "Claude Teams"))
         }
-        let shimDirectory = try createClaudeTeamsShimDirectory(
+        let shimPlan = try createClaudeTeamsShimPlan(
             processEnvironment: launcherEnvironment,
             commandArgs: commandArgs,
             launchContext: launchContext
         )
+        let shimDirectory = shimPlan.directory
         // Check custom path from Settings > Automation > Claude Code first.
         // Never fall back to a cmux-bundled provider binary.
         guard let claudeExecutablePath = resolveClaudeExecutable(
@@ -20700,7 +20702,10 @@ struct CMUXCLI {
             launchContext: launchContext, commandArgs: commandArgs
         )
 
-        let launchPath = claudeExecutablePath
+        let managedClaudeWrapperURL = launchesAgentSession
+            ? shimPlan.managedClaudeWrapperURL
+            : nil
+        let launchPath = managedClaudeWrapperURL?.path ?? claudeExecutablePath
         let launchArguments = claudeTeamsLaunchArguments(commandArgs: commandArgs)
         exportAgentLaunchCommandEnvironment(
             launcher: "claudeTeams",
@@ -20708,6 +20713,15 @@ struct CMUXCLI {
             arguments: [executablePath, "claude-teams"] + launchArguments,
             workingDirectory: launcherEnvironment["PWD"]
         )
+        if managedClaudeWrapperURL != nil {
+            // The validated per-surface wrapper injects hooks/session identity.
+            // It consumes this one-shot marker while preserving the Teams launch
+            // capture above; teammate wrappers do not inherit the marker and
+            // therefore record ordinary Claude launches.
+            setenv("CMUX_CLAUDE_TEAMS_WRAPPER_LAUNCH", "1", 1)
+        } else {
+            unsetenv("CMUX_CLAUDE_TEAMS_WRAPPER_LAUNCH")
+        }
         var argv = ([launchPath] + claudeTeamsExecArguments(commandArgs: commandArgs)).map { strdup($0) }
         defer {
             for item in argv {

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -20571,6 +20571,14 @@ struct CMUXCLI {
         launchContext: TmuxCompatLaunchContext?, commandArgs: [String]
     ) {
         clearInheritedClaudeLaunchEnvironment()
+        defer {
+            let launcherEnvironment = ProcessInfo.processInfo.environment
+            if let encoded = claudeTeamsRespawnEnvironmentTransportValue(from: launcherEnvironment) {
+                setenv(Self.claudeTeamsRespawnEnvironmentTransportKey, encoded, 1)
+            } else {
+                unsetenv(Self.claudeTeamsRespawnEnvironmentTransportKey)
+            }
+        }
         configureTmuxCompatEnvironment(
             processEnvironment: processEnvironment,
             shimDirectory: shimDirectory,

--- a/Packages/macOS/CMUXAgentLaunch/README.md
+++ b/Packages/macOS/CMUXAgentLaunch/README.md
@@ -1,0 +1,23 @@
+# CMUXAgentLaunch
+
+`CMUXAgentLaunch` owns launch, restore, and environment policy for coding
+agents. New value-level policy APIs accept captured inputs directly, while
+executable targets keep process mutation at their own seams.
+
+## Testing Claude Teams respawn transport
+
+Construct a transport with an explicit environment dictionary, then inspect the
+decoded value without launching cmux or mutating the test process:
+
+```swift
+let transport = ClaudeTeamsRespawnEnvironmentTransport()
+let encoded = transport.encodedValue(from: [
+    "PATH": "/opt/homebrew/bin:/usr/bin:/bin",
+    "CLAUDE_CONFIG_DIR": "/tmp/claude-config",
+])
+let decoded = transport.decodedEnvironment(from: encoded)
+```
+
+The transport applies `AgentLaunchEnvironmentPolicy` while encoding and again
+while decoding, so tests can also prove that credentials and process identity
+fail closed at the transport boundary.

--- a/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/ClaudeTeamsRespawnEnvironmentTransport.swift
+++ b/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/ClaudeTeamsRespawnEnvironmentTransport.swift
@@ -1,0 +1,64 @@
+import Foundation
+
+/// Carries replay-safe launcher environment values into Claude Teams teammate respawns.
+///
+/// Teammate panes are created by the cmux app process rather than the `cmux
+/// claude-teams` launcher, so they cannot inherit the launcher's environment
+/// directly. This transport preserves executable discovery through `PATH` and
+/// delegates every other value to ``AgentLaunchEnvironmentPolicy`` so secrets
+/// and process identity do not cross the respawn boundary.
+public struct ClaudeTeamsRespawnEnvironmentTransport: Sendable {
+    /// The process-environment key used to carry the encoded launch snapshot.
+    public static let environmentKey = "CMUX_CLAUDE_TEAMS_RESPAWN_ENV_B64"
+
+    private let environmentPolicy: AgentLaunchEnvironmentPolicy
+
+    /// Creates a Claude Teams respawn environment transport.
+    ///
+    /// - Parameter environmentPolicy: The policy that selects replay-safe
+    ///   environment values. The shared agent-launch policy is used by default.
+    public init(
+        environmentPolicy: AgentLaunchEnvironmentPolicy = AgentLaunchEnvironmentPolicy()
+    ) {
+        self.environmentPolicy = environmentPolicy
+    }
+
+    /// Encodes a launcher's replay-safe environment as a base64 JSON value.
+    ///
+    /// - Parameter launcherEnvironment: The final environment configured for the
+    ///   Claude Teams lead process.
+    /// - Returns: The encoded transport value, or `nil` if encoding fails.
+    public func encodedValue(from launcherEnvironment: [String: String]) -> String? {
+        let selected = selectedEnvironment(from: launcherEnvironment)
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys]
+        guard let data = try? encoder.encode(selected) else { return nil }
+        return data.base64EncodedString()
+    }
+
+    /// Decodes and revalidates a launch-scoped environment transport value.
+    ///
+    /// Invalid data fails closed. Reapplying the allowlist during decoding means
+    /// a forged or modified transport value cannot promote credentials or process
+    /// identity into a teammate pane.
+    ///
+    /// - Parameter encodedValue: The base64 JSON value read from
+    ///   ``environmentKey``.
+    /// - Returns: Replay-safe environment values for the teammate process.
+    public func decodedEnvironment(from encodedValue: String?) -> [String: String] {
+        guard let encodedValue,
+              let data = Data(base64Encoded: encodedValue),
+              let transported = try? JSONDecoder().decode([String: String].self, from: data) else {
+            return [:]
+        }
+        return selectedEnvironment(from: transported)
+    }
+
+    private func selectedEnvironment(from environment: [String: String]) -> [String: String] {
+        var selected = environmentPolicy.selectedEnvironment(from: environment, kind: "claude")
+        if let path = environment["PATH"] {
+            selected["PATH"] = path
+        }
+        return selected
+    }
+}

--- a/Packages/macOS/CMUXAgentLaunch/Tests/CMUXAgentLaunchTests/ClaudeTeamsRespawnEnvironmentTransportTests.swift
+++ b/Packages/macOS/CMUXAgentLaunch/Tests/CMUXAgentLaunchTests/ClaudeTeamsRespawnEnvironmentTransportTests.swift
@@ -1,0 +1,55 @@
+import Foundation
+import Testing
+@testable import CMUXAgentLaunch
+
+@Suite("Claude Teams respawn environment transport")
+struct ClaudeTeamsRespawnEnvironmentTransportTests {
+    private let transport = ClaudeTeamsRespawnEnvironmentTransport()
+
+    @Test("Round trip preserves PATH and replay-safe Claude configuration")
+    func roundTripPreservesReplaySafeEnvironment() throws {
+        let encoded = try #require(transport.encodedValue(from: [
+            "PATH": "/opt/homebrew/bin:/Users/test/.local/share/mise/shims:/usr/bin:/bin",
+            "CLAUDE_CONFIG_DIR": "/Users/test/Library/Application Support/Claude",
+            "ANTHROPIC_MODEL": "claude-sonnet",
+            "ANTHROPIC_API_KEY": "sk-ant-must-not-cross-respawn-transport",
+            "CMUX_SURFACE_ID": "surface-must-not-cross-respawn-transport",
+        ]))
+
+        #expect(transport.decodedEnvironment(from: encoded) == [
+            "PATH": "/opt/homebrew/bin:/Users/test/.local/share/mise/shims:/usr/bin:/bin",
+            "CLAUDE_CONFIG_DIR": "/Users/test/Library/Application Support/Claude",
+            "ANTHROPIC_MODEL": "claude-sonnet",
+        ])
+    }
+
+    @Test("Decoder revalidates a forged transport value")
+    func decoderRevalidatesTransport() throws {
+        let forgedData = try JSONEncoder().encode([
+            "PATH": "/custom/bin:/usr/bin",
+            "CLAUDE_CONFIG_DIR": "/Users/test/.claude",
+            "ANTHROPIC_API_KEY": "secret",
+            "CMUX_WORKSPACE_ID": "workspace-id",
+        ])
+
+        #expect(
+            transport.decodedEnvironment(from: forgedData.base64EncodedString()) == [
+                "PATH": "/custom/bin:/usr/bin",
+                "CLAUDE_CONFIG_DIR": "/Users/test/.claude",
+            ]
+        )
+    }
+
+    @Test("Malformed values fail closed")
+    func malformedValuesFailClosed() {
+        let invalidValues: [String?] = [
+            nil,
+            "",
+            "not-base64",
+            Data("[]".utf8).base64EncodedString(),
+        ]
+        for encodedValue in invalidValues {
+            #expect(transport.decodedEnvironment(from: encodedValue).isEmpty)
+        }
+    }
+}

--- a/Resources/bin/cmux-claude-wrapper
+++ b/Resources/bin/cmux-claude-wrapper
@@ -157,6 +157,7 @@ cmux_claude_wrapper_exec_resolved_claude() {
         # Clear the shim-bounce guard so real Claude children that invoke
         # `claude` later begin a fresh wrapper resolution.
         unset CMUX_AGENT_RESTORE_LAUNCH
+        unset CMUX_CLAUDE_TEAMS_WRAPPER_LAUNCH
         unset cmux_claude_wrapper_reexec_guard
         unset cmux_claude_wrapper_reexec_targets
         exec "$target" "$@"
@@ -184,10 +185,30 @@ cmux_claude_wrapper_exec_resolved_claude() {
         # authorization for that pass; the next wrapper consumes it immediately.
         export CMUX_AGENT_RESTORE_LAUNCH="$cmux_claude_app_restore_launch"
     fi
+    if [[ "${cmux_claude_teams_wrapper_launch:-0}" == "1" ]]; then
+        # Keep the one-shot launch signal across finite version-manager shim
+        # hops. The final real-Claude boundary above consumes it.
+        export CMUX_CLAUDE_TEAMS_WRAPPER_LAUNCH=1
+    fi
     exec "$target" "$@"
 }
 
 cmux_claude_wrapper_init_reexec_guard
+
+# `cmux claude-teams` resolves the real provider itself, then deliberately
+# enters this app-owned wrapper so hooks can bind the lead session. Preserve its
+# structured launcher capture for that one process only. The marker is consumed
+# before Claude starts, so teammate `claude` commands inherit no launch signal
+# and receive their own ordinary Claude capture below.
+cmux_claude_teams_wrapper_launch=0
+if [[ "${CMUX_CLAUDE_TEAMS_WRAPPER_LAUNCH:-}" == "1" &&
+      "${CMUX_AGENT_LAUNCH_KIND:-}" == "claudeTeams" &&
+      -n "${CMUX_AGENT_LAUNCH_EXECUTABLE:-}" &&
+      "${CMUX_AGENT_LAUNCH_EXECUTABLE:-}" == "${CMUX_CLAUDE_TEAMS_CMUX_BIN:-}" &&
+      -n "${CMUX_AGENT_LAUNCH_ARGV_B64:-}" ]]; then
+    cmux_claude_teams_wrapper_launch=1
+fi
+unset CMUX_CLAUDE_TEAMS_WRAPPER_LAUNCH
 
 # Find the real claude binary, skipping cmux's wrapper and temp shell shims.
 find_real_claude() {
@@ -862,9 +883,11 @@ if (( cmux_claude_wrapper_reexec_hops > 0 )); then
     clear_inherited_claude_auth_selection_env
     export CMUX_CLAUDE_PID=$$
     export CMUX_CLAUDE_HOOK_CMUX_BIN="$(resolve_hook_cmux_bin)"
-    export CMUX_AGENT_LAUNCH_KIND="claude"
-    export CMUX_AGENT_LAUNCH_EXECUTABLE="$REAL_CLAUDE"
-    export CMUX_AGENT_LAUNCH_CWD="$PWD"
+    if [[ "$cmux_claude_teams_wrapper_launch" != "1" ]]; then
+        export CMUX_AGENT_LAUNCH_KIND="claude"
+        export CMUX_AGENT_LAUNCH_EXECUTABLE="$REAL_CLAUDE"
+        export CMUX_AGENT_LAUNCH_CWD="$PWD"
+    fi
     install_cmux_node_options
     cmux_claude_wrapper_exec_resolved_claude "$REAL_CLAUDE" "$@"
 fi
@@ -902,10 +925,12 @@ fi
 # the actual claude process PID, which hooks use for stale-session detection.
 export CMUX_CLAUDE_PID=$$
 export CMUX_CLAUDE_HOOK_CMUX_BIN="$(resolve_hook_cmux_bin)"
-export CMUX_AGENT_LAUNCH_KIND="claude"
-export CMUX_AGENT_LAUNCH_EXECUTABLE="$REAL_CLAUDE"
-export CMUX_AGENT_LAUNCH_ARGV_B64="$(encode_launch_argv "$@")"
-export CMUX_AGENT_LAUNCH_CWD="$PWD"
+if [[ "$cmux_claude_teams_wrapper_launch" != "1" ]]; then
+    export CMUX_AGENT_LAUNCH_KIND="claude"
+    export CMUX_AGENT_LAUNCH_EXECUTABLE="$REAL_CLAUDE"
+    export CMUX_AGENT_LAUNCH_ARGV_B64="$(encode_launch_argv "$@")"
+    export CMUX_AGENT_LAUNCH_CWD="$PWD"
+fi
 install_cmux_node_options
 
 # Build Claude settings JSON.

--- a/Sources/SurfaceResumeCommandCanonicalizer+PortableAgentExecutable.swift
+++ b/Sources/SurfaceResumeCommandCanonicalizer+PortableAgentExecutable.swift
@@ -75,7 +75,7 @@ extension SurfaceResumeBindingSnapshot {
               !value.isEmpty else {
             return nil
         }
-        AgentRestoreCLIArgument(rawValue: value)?.rawValue
+        return AgentRestoreCLIArgument(rawValue: value)?.rawValue
     }
 
     private func resolvedStartupCommand(repairPortableAgentExecutable: Bool) -> String {

--- a/cmuxTests/CLITmuxCompatRemoteSplitTests.swift
+++ b/cmuxTests/CLITmuxCompatRemoteSplitTests.swift
@@ -96,12 +96,18 @@ import Testing
         }
     }
 
+    private enum RespawnInvocation {
+        case tmuxCompatibility
+        case publicCLI
+    }
+
     /// Drives `__tmux-compat respawn-pane -k -- <command>` against a mock socket
     /// and returns the `command` / `tmux_start_command` forwarded to
     /// `surface.respawn`.
     private func respawnPaneForwardedCommand(
         _ command: String,
-        extraEnvironment: [String: String] = [:]
+        extraEnvironment: [String: String] = [:],
+        invocation: RespawnInvocation = .tmuxCompatibility
     ) throws -> (command: String, startCommand: String) {
         let cliPath = try BundledCLITestSupport.bundledCLIPath(for: CLITmuxCompatRemoteSplitBundleToken.self)
         let tmpDir = FileManager.default.temporaryDirectory
@@ -154,9 +160,21 @@ import Testing
         for (key, value) in extraEnvironment {
             environment[key] = value
         }
+        let arguments: [String]
+        switch invocation {
+        case .tmuxCompatibility:
+            arguments = ["__tmux-compat", "respawn-pane", "-k", "--", command]
+        case .publicCLI:
+            arguments = [
+                "respawn-pane",
+                "--workspace", workspaceId,
+                "--surface", surfaceId,
+                "--command", command,
+            ]
+        }
         let result = Self.runProcess(
             executablePath: cliPath,
-            arguments: ["__tmux-compat", "respawn-pane", "-k", "--", command],
+            arguments: arguments,
             environment: environment,
             timeout: 30
         )
@@ -286,6 +304,70 @@ import Testing
             !outsideTeams.command.contains("CLAUDE_CODE_SANDBOXED"),
             "without the opt-in marker, respawn must not inject CLAUDE_CODE_SANDBOXED, got: \(outsideTeams.command)"
         )
+    }
+
+    /// Regression for #9150: `surface.respawn` creates teammate processes from
+    /// the app's GUI environment, not from the `cmux claude-teams` launcher. The
+    /// launcher must therefore carry a per-launch, non-secret environment snapshot
+    /// through the tmux shim and compose it into the teammate command. PATH is the
+    /// executable-discovery capability that fixes Homebrew/mise/nvm tools; other
+    /// replay-safe Claude configuration follows the shared launch policy. OMO has
+    /// no claude-teams marker, and the public command does not consume it even when
+    /// invoked from inside a claude-teams process tree.
+    @Test func respawnPaneInjectsAllowlistedClaudeTeamsLauncherEnvironment() throws {
+        let teammate = "cd /tmp/work && env CLAUDECODE=1 /opt/claude --agent-id alice@team --agent-name alice"
+        let launcherPath = "/opt/homebrew/bin:/Users/test/.local/share/mise/shims:/usr/bin:/bin"
+        let claudeConfigDirectory = "/Users/test/Library/Application Support/Claude"
+        let secret = "sk-ant-must-not-cross-respawn-transport"
+        let transport = try JSONEncoder().encode([
+            "PATH": launcherPath,
+            "CLAUDE_CONFIG_DIR": claudeConfigDirectory,
+            "ANTHROPIC_API_KEY": secret,
+        ])
+        let markerEnvironment = [
+            "CMUX_CLAUDE_TEAMS_RESPAWN_ENV_B64": transport.base64EncodedString(),
+        ]
+
+        let inTeams = try respawnPaneForwardedCommand(
+            teammate,
+            extraEnvironment: markerEnvironment
+        )
+        #expect(
+            inTeams.command.contains("export PATH=") && inTeams.command.contains(launcherPath),
+            "claude-teams respawn must export the launcher's PATH, got: \(inTeams.command)"
+        )
+        #expect(
+            inTeams.command.contains("export CLAUDE_CONFIG_DIR=")
+                && inTeams.command.contains(claudeConfigDirectory),
+            "claude-teams respawn must retain allowlisted Claude configuration, got: \(inTeams.command)"
+        )
+        #expect(
+            !inTeams.command.contains("ANTHROPIC_API_KEY") && !inTeams.command.contains(secret),
+            "claude-teams respawn must reject secrets from its transport, got: \(inTeams.command)"
+        )
+        #expect(
+            !inTeams.command.contains("CLAUDE_CODE_SANDBOXED"),
+            "launcher environment transport must not imply the separate trust-bypass opt-in, got: \(inTeams.command)"
+        )
+        #expect(inTeams.startCommand == teammate)
+
+        let unchangedCommand = "/bin/sh -c '\(teammate)'"
+        let inOMO = try respawnPaneForwardedCommand(teammate)
+        #expect(
+            inOMO.command == unchangedCommand,
+            "OMO tmux compatibility respawn must remain byte-identical, got: \(inOMO.command)"
+        )
+
+        let publicRespawn = try respawnPaneForwardedCommand(
+            teammate,
+            extraEnvironment: markerEnvironment,
+            invocation: .publicCLI
+        )
+        #expect(
+            publicRespawn.command == unchangedCommand,
+            "public respawn-pane must ignore claude-teams transport state, got: \(publicRespawn.command)"
+        )
+        #expect(publicRespawn.startCommand == teammate)
     }
 
     private enum CLITmuxCompatRespawnTestError: Error {

--- a/tests/claude_teams_test_utils.py
+++ b/tests/claude_teams_test_utils.py
@@ -49,6 +49,15 @@ class _FocusedCmuxHandler(socketserver.StreamRequestHandler):
     def handle(self) -> None:
         while line := self.rfile.readline():
             decoded_line = line.decode("utf-8").rstrip("\r\n")
+            capability_prefix = "_cmux_capability_v1 "
+            if decoded_line.startswith(capability_prefix):
+                envelope_parts = decoded_line.split(" ", 2)
+                if len(envelope_parts) != 3 or not envelope_parts[1] or not envelope_parts[2]:
+                    self.wfile.write(b"ERROR: malformed capability envelope\n")
+                    self.wfile.flush()
+                    continue
+                decoded_line = envelope_parts[2]
+
             if decoded_line.startswith("auth "):
                 self.server.requests.append("auth")  # type: ignore[attr-defined]
                 self.wfile.write(b"OK\n")

--- a/tests/test_cli_claude_teams_env.py
+++ b/tests/test_cli_claude_teams_env.py
@@ -5,6 +5,8 @@ Regression test: `cmux claude-teams` injects the tmux-style auto-mode env.
 
 from __future__ import annotations
 
+import base64
+import json
 import os
 import subprocess
 import tempfile
@@ -50,6 +52,7 @@ def run_claude_teams(
         env_log = tmp / "agent-teams.log"
         sandboxed_log = tmp / "sandboxed.log"
         marker_log = tmp / "sandboxed-marker.log"
+        respawn_environment_log = tmp / "respawn-environment.log"
         tmux_log = tmp / "tmux-path.log"
         tmux_shim_log = tmp / "tmux-shim.log"
         cmux_bin_log = tmp / "cmux-bin.log"
@@ -78,6 +81,7 @@ set -euo pipefail
 printf '%s\\n' "${CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS-__UNSET__}" > "$FAKE_AGENT_TEAMS_LOG"
 printf '%s\\n' "${CLAUDE_CODE_SANDBOXED-__UNSET__}" > "$FAKE_SANDBOXED_LOG"
 printf '%s\\n' "${CMUX_CLAUDE_TEAMS_SANDBOXED-__UNSET__}" > "$FAKE_SANDBOXED_MARKER_LOG"
+printf '%s\\n' "${CMUX_CLAUDE_TEAMS_RESPAWN_ENV_B64-__UNSET__}" > "$FAKE_RESPAWN_ENVIRONMENT_LOG"
 # Claude Code restores a shell snapshot before invoking tmux. The snapshot's
 # full PATH assignment can discard the launcher-only claude-teams-bin entry,
 # while cmux's managed per-surface wrapper root remains available.
@@ -142,6 +146,7 @@ fs.writeFileSync(
         env["FAKE_AGENT_TEAMS_LOG"] = str(env_log)
         env["FAKE_SANDBOXED_LOG"] = str(sandboxed_log)
         env["FAKE_SANDBOXED_MARKER_LOG"] = str(marker_log)
+        env["FAKE_RESPAWN_ENVIRONMENT_LOG"] = str(respawn_environment_log)
         env["FAKE_TMUX_PATH_LOG"] = str(tmux_log)
         env["FAKE_TMUX_SHIM_LOG"] = str(tmux_shim_log)
         env["FAKE_CMUX_BIN_LOG"] = str(cmux_bin_log)
@@ -166,6 +171,8 @@ fs.writeFileSync(
         env["TERM"] = "xterm-256color"
         env["TERM_PROGRAM"] = "__HOST_TERM_PROGRAM__"
         env["NODE_OPTIONS"] = node_options
+        env["CLAUDE_CONFIG_DIR"] = str(fake_home / "claude-config")
+        env["ANTHROPIC_API_KEY"] = "sk-ant-must-not-cross-respawn-transport"
         expect_managed_tmux_shim = True
         env["TMPDIR"] = str(tmp) if tmpdir is None else tmpdir
         explicit_socket_path_hint = tmp / "explicit-cmux.sock"
@@ -229,6 +236,39 @@ fs.writeFileSync(
         marker_value = read_text(marker_log)
         if marker_value != "1":
             print(f"FAIL: expected CMUX_CLAUDE_TEAMS_SANDBOXED=1 opt-in marker, got {marker_value!r}")
+            raise SystemExit(1)
+
+        encoded_respawn_environment = read_text(respawn_environment_log)
+        try:
+            respawn_environment = json.loads(
+                base64.b64decode(encoded_respawn_environment, validate=True).decode("utf-8")
+            )
+        except (ValueError, UnicodeDecodeError, json.JSONDecodeError) as exc:
+            print(
+                "FAIL: expected CMUX_CLAUDE_TEAMS_RESPAWN_ENV_B64 to contain a base64 JSON object, "
+                f"got {encoded_respawn_environment!r}: {exc}"
+            )
+            raise SystemExit(1) from exc
+
+        transported_path = respawn_environment.get("PATH", "")
+        expected_shim_prefix = f"{wrapper_shim_bin}:"
+        if not transported_path.startswith(expected_shim_prefix) or str(real_bin) not in transported_path.split(":"):
+            print(
+                "FAIL: expected the respawn transport to carry the final launcher PATH "
+                f"(managed shim first, invoking tool path retained), got {transported_path!r}"
+            )
+            raise SystemExit(1)
+
+        expected_config_directory = str(fake_home / "claude-config")
+        if respawn_environment.get("CLAUDE_CONFIG_DIR") != expected_config_directory:
+            print(
+                "FAIL: expected the respawn transport to retain allowlisted Claude configuration, "
+                f"got {respawn_environment!r}"
+            )
+            raise SystemExit(1)
+
+        if "ANTHROPIC_API_KEY" in respawn_environment:
+            print(f"FAIL: respawn transport must reject secrets, got {respawn_environment!r}")
             raise SystemExit(1)
 
         tmux_path = read_text(tmux_log)

--- a/tests/test_cli_claude_teams_existing_shim.py
+++ b/tests/test_cli_claude_teams_existing_shim.py
@@ -110,6 +110,7 @@ printf '%s\\n' "$@" > "$FAKE_CLAUDE_ARGV_LOG"
         env["CMUX_WORKSPACE_ID"] = FOCUSED_WORKSPACE_ID
         env["CMUX_SURFACE_ID"] = surface_id
         env["CMUX_BUNDLED_CLI_PATH"] = cli_path
+        env["CMUX_SOCKET_CAPABILITY"] = "claude-teams-test-capability"
         env["FAKE_TMUX_PATH_LOG"] = str(tmux_path_log)
         env["FAKE_LAUNCH_KIND_LOG"] = str(launch_kind_log)
         env["FAKE_LAUNCH_ARGV_LOG"] = str(launch_argv_log)

--- a/tests/test_cli_claude_teams_existing_shim.py
+++ b/tests/test_cli_claude_teams_existing_shim.py
@@ -1,12 +1,18 @@
 #!/usr/bin/env python3
 """
-Regression test: `cmux claude-teams` prefers the managed per-surface shim root.
+Regression test: `cmux claude-teams` launches through the managed Claude wrapper.
+
+The wrapper is what injects Claude hooks/session identity while preserving the
+`claudeTeams` launch capture used to build a structured restore command. A
+direct launch of the resolved Claude binary appears to work until cmux restarts,
+when every team pane restores as an unbound shell.
 """
 
 from __future__ import annotations
 
+import base64
 import os
-import stat
+import shutil
 import subprocess
 import tempfile
 from pathlib import Path
@@ -22,6 +28,10 @@ from claude_teams_test_utils import (
 def make_executable(path: Path, content: str) -> None:
     path.write_text(content, encoding="utf-8")
     path.chmod(0o755)
+
+
+def read_text(path: Path) -> str:
+    return path.read_text(encoding="utf-8").strip() if path.exists() else ""
 
 
 def main() -> int:
@@ -43,6 +53,12 @@ def main() -> int:
         second_cmux_shim_bin.mkdir(parents=True, exist_ok=True)
         real_bin.mkdir(parents=True, exist_ok=True)
 
+        tmux_path_log = tmp / "tmux-path.log"
+        launch_kind_log = tmp / "launch-kind.log"
+        launch_argv_log = tmp / "launch-argv.log"
+        wrapper_marker_log = tmp / "wrapper-marker.log"
+        claude_argv_log = tmp / "claude-argv.log"
+
         shim_dir = home / ".cmuxterm" / "claude-teams-bin"
         shim_dir.mkdir(parents=True, exist_ok=True)
         shim_path = shim_dir / "tmux"
@@ -55,19 +71,23 @@ def main() -> int:
         shim_path.chmod(0o555)
         shim_dir.chmod(0o555)
 
-        make_executable(
-            cmux_shim_bin / "claude",
-            """#!/usr/bin/env bash
-set -euo pipefail
-echo cmux-claude-command-shim-should-not-run
-exit 42
-""",
+        wrapper_source = (
+            Path(__file__).resolve().parents[1]
+            / "Resources"
+            / "bin"
+            / "cmux-claude-wrapper"
         )
+        shutil.copyfile(wrapper_source, cmux_shim_bin / "claude")
+        (cmux_shim_bin / "claude").chmod(0o755)
         make_executable(
             real_bin / "claude",
             """#!/usr/bin/env bash
 set -euo pipefail
-printf 'shim=%s\\n' "$(command -v tmux)"
+printf '%s\\n' "$(command -v tmux)" > "$FAKE_TMUX_PATH_LOG"
+printf '%s\\n' "${CMUX_AGENT_LAUNCH_KIND-__UNSET__}" > "$FAKE_LAUNCH_KIND_LOG"
+printf '%s\\n' "${CMUX_AGENT_LAUNCH_ARGV_B64-__UNSET__}" > "$FAKE_LAUNCH_ARGV_LOG"
+printf '%s\\n' "${CMUX_CLAUDE_TEAMS_WRAPPER_LAUNCH-__UNSET__}" > "$FAKE_WRAPPER_MARKER_LOG"
+printf '%s\\n' "$@" > "$FAKE_CLAUDE_ARGV_LOG"
 """,
         )
         make_executable(
@@ -85,6 +105,12 @@ printf 'shim=%s\\n' "$(command -v tmux)"
         env["CMUX_CLAUDE_WRAPPER_SHIM_ROOT"] = str(cmux_shim_bin)
         env["CMUX_WORKSPACE_ID"] = FOCUSED_WORKSPACE_ID
         env["CMUX_SURFACE_ID"] = surface_id
+        env["CMUX_BUNDLED_CLI_PATH"] = cli_path
+        env["FAKE_TMUX_PATH_LOG"] = str(tmux_path_log)
+        env["FAKE_LAUNCH_KIND_LOG"] = str(launch_kind_log)
+        env["FAKE_LAUNCH_ARGV_LOG"] = str(launch_argv_log)
+        env["FAKE_WRAPPER_MARKER_LOG"] = str(wrapper_marker_log)
+        env["FAKE_CLAUDE_ARGV_LOG"] = str(claude_argv_log)
         socket_path = tmp / "cmux.sock"
 
         with focused_cmux_server(socket_path, surface_id=surface_id) as (
@@ -93,7 +119,7 @@ printf 'shim=%s\\n' "$(command -v tmux)"
         ):
             env["CMUX_SOCKET_PATH"] = live_socket_path
             proc = subprocess.run(
-                [cli_path, "claude-teams", "--version"],
+                [cli_path, "claude-teams", "restore wrapper capture"],
                 capture_output=True,
                 text=True,
                 check=False,
@@ -105,16 +131,57 @@ printf 'shim=%s\\n' "$(command -v tmux)"
         shim_path.chmod(0o755)
 
         if proc.returncode != 0:
-            print("FAIL: `cmux claude-teams --version` failed with an existing shim")
+            print("FAIL: `cmux claude-teams` failed with an existing managed wrapper")
             print(f"exit={proc.returncode}")
             print(f"stdout={proc.stdout.strip()}")
             print(f"stderr={proc.stderr.strip()}")
             return 1
 
         expected = str(cmux_shim_bin / "tmux")
-        actual = proc.stdout.strip()
-        if actual != f"shim={expected}":
+        actual = read_text(tmux_path_log)
+        if actual != expected:
             print(f"FAIL: expected managed shim path {expected!r}, got {actual!r}")
+            return 1
+
+        claude_argv = read_text(claude_argv_log).splitlines()
+        if "--session-id" not in claude_argv or "--settings" not in claude_argv:
+            print(
+                "FAIL: managed Claude wrapper did not inject session identity and hooks; "
+                f"argv={claude_argv!r}"
+            )
+            return 1
+
+        launch_kind = read_text(launch_kind_log)
+        if launch_kind != "claudeTeams":
+            print(
+                "FAIL: wrapper did not preserve the Claude Teams restore capture; "
+                f"CMUX_AGENT_LAUNCH_KIND={launch_kind!r}"
+            )
+            return 1
+
+        try:
+            launch_argv = (
+                base64.b64decode(read_text(launch_argv_log), validate=True)
+                .decode("utf-8")
+                .split("\0")
+            )
+        except (ValueError, UnicodeDecodeError) as exc:
+            print(f"FAIL: invalid Claude Teams restore argv capture: {exc}")
+            return 1
+        if launch_argv and launch_argv[-1] == "":
+            launch_argv.pop()
+        if (
+            len(launch_argv) < 3
+            or Path(launch_argv[0]).resolve() != Path(cli_path).resolve()
+            or launch_argv[1] != "claude-teams"
+            or "restore wrapper capture" not in launch_argv
+        ):
+            print(f"FAIL: unexpected Claude Teams restore argv capture: {launch_argv!r}")
+            return 1
+
+        wrapper_marker = read_text(wrapper_marker_log)
+        if wrapper_marker != "__UNSET__":
+            print(f"FAIL: one-shot wrapper marker leaked into Claude: {wrapper_marker!r}")
             return 1
 
         managed_shim = cmux_shim_bin / "tmux"
@@ -148,7 +215,10 @@ printf 'shim=%s\\n' "$(command -v tmux)"
             )
             return 1
 
-    print("PASS: managed teams shim routes only marked launches and delegates ordinary tmux")
+    print(
+        "PASS: managed Claude wrapper captures a restorable Teams session and "
+        "ordinary tmux still delegates"
+    )
     return 0
 
 

--- a/tests/test_cli_claude_teams_existing_shim.py
+++ b/tests/test_cli_claude_teams_existing_shim.py
@@ -79,6 +79,10 @@ def main() -> int:
         )
         shutil.copyfile(wrapper_source, cmux_shim_bin / "claude")
         (cmux_shim_bin / "claude").chmod(0o755)
+        # The production wrapper lives beside the bundled cmux CLI and uses it
+        # for its bounded socket-ownership probe. This fixture copies the wrapper
+        # into the per-surface directory, so provide the equivalent sibling seam.
+        make_executable(cmux_shim_bin / "cmux", "#!/usr/bin/env bash\nexit 0\n")
         make_executable(
             real_bin / "claude",
             """#!/usr/bin/env bash


### PR DESCRIPTION
## Summary

- Preserve the invoking terminal's replay-safe environment (including `PATH`) when Claude Teams respawns teammate panes from the GUI app process.
- Encode/decode that environment through the shared `CMUXAgentLaunch` package with allowlist revalidation, while keeping secrets and surface identity out of the transport.
- Launch real Teams sessions through cmux's validated per-surface Claude wrapper so the lead and teammates retain hook/session bindings and can resume after cmux relaunch.
- Keep informational/management invocations direct, and leave OMO plus public `respawn-pane` behavior unchanged.

## Testing

- Test-first regression commit: `699769615c` failed in the CLI no-socket shard before the implementation.
- Focused package, Swift CLI, and Python socket regressions cover environment round trips, forged-secret rejection, wrapper routing, launch capture, and capability-authenticated socket fixtures.
- `tests/test_cli_claude_teams_existing_shim.py`, `tests/test_cli_claude_teams_env.py`, and `tests/test_cli_claude_teams_skips_wrapper_claude.py` pass against the tagged bundled CLI.
- Tagged Debug build completed remotely without reported Swift warnings and launched locally.
- Real dogfood: launched a one-teammate team, observed two restorable records and two persisted agent snapshots, gracefully relaunched the tagged app, and verified both panes resumed into Claude with active bindings and no resume error or shell fallback.
- Local `xcodebuild test` / XCUITests were not run, per repository policy.

## Demo Video

Not applicable: this changes CLI process-environment/session-restoration behavior and has no new UI.

## Review Trigger

Configured GitHub checks and review bots run on each pushed HEAD. cubic previously reported its workspace quota exhausted and supplied no code finding.

## Checklist

- [x] Added behavior-level regression coverage.
- [x] Added public package documentation for the new transport.
- [x] Added no user-facing strings and changed no localization catalogs.
- [x] Changed neither Swift warning/file-length budget.
- [ ] Required checks and latest-HEAD bot reviews complete.

## Issue

https://github.com/manaflow-ai/cmux/issues/9150

Closes #9150
