### PR TITLE
Finish coderouter billing operations and telemetry

### DIFF
--- a/docs/coderouter-operations.md
+++ b/docs/coderouter-operations.md
@@ -1,0 +1,78 @@
+# coderouter operations
+
+This is the private-beta runbook for billing convergence, webhook replay,
+latency evidence, and privacy-safe observability. Never paste route tokens,
+OAuth credentials, request bodies, email addresses, or provider-account IDs
+into tickets, logs, Sentry, or PostHog.
+
+## Stripe webhook replay
+
+1. Identify the failed Stripe event and the production `cmux.com` webhook
+   endpoint in Stripe Workbench. Verify the event belongs to `app=cmux`.
+2. Inspect without printing the complete payload:
+
+   ```sh
+   stripe events retrieve "$EVENT_ID" --live |
+     jq '{id,type,created,pending_webhooks,livemode}'
+   stripe webhook_endpoints list --live |
+     jq '.data[] | {id,url,status}'
+   ```
+
+3. Redeliver the immutable signed event:
+
+   ```sh
+   stripe events resend "$EVENT_ID" \
+     --webhook-endpoint "$CMUX_WEBHOOK_ENDPOINT_ID" \
+     --live --confirm
+   ```
+
+4. Confirm `pending_webhooks=0`, the corresponding
+   `stripe_webhook_events.error` is null, RDS matches Stripe, and an existing
+   coderouter route token is accepted or rejected according to the resulting
+   entitlement.
+
+Webhook event IDs are idempotency keys. Never fabricate an event, manually
+edit entitlement rows, or retry a different mutation as a substitute.
+
+## Stripe/RDS reconciliation
+
+The Vercel cron calls `/api/cron/billing-reconcile` at minute 23 every hour.
+It requires `Authorization: Bearer $CRON_SECRET`, checks Stripe subscriptions
+with bounded concurrency, and reuses the webhook's principal lock,
+entitlement update, Stack metadata update, and route-token revocation path.
+Stripe is authoritative.
+
+For an operator run from a production-configured shell:
+
+```sh
+bun run coderouter:reconcile-billing --dry-run
+bun run coderouter:reconcile-billing
+```
+
+The command prints counts only. Any failed or truncated run exits nonzero and
+must be investigated. Do not expose the cron endpoint publicly or place
+`CRON_SECRET` in command history.
+
+## Latency evidence
+
+```sh
+bun run coderouter:benchmark --samples 30 > coderouter-benchmark.json
+CODEROUTER_ROUTE_TOKEN=... \
+  bun run coderouter:benchmark --samples 30 > coderouter-auth-benchmark.json
+```
+
+The checked-in harness drains responses, records status counts, reports
+p50/p95/p99 client-to-edge latency, and parses every `Server-Timing` phase. A
+route token belongs in an ephemeral environment variable only; never commit
+the authenticated output if it contains a principal identifier.
+
+## Observability
+
+- Sentry project: `coderouter-web`; alert on new coderouter errors,
+  reconciliation failure, refresh failure, and sustained provider failure.
+- PostHog dashboard: `coderouter private beta`; internal only.
+- PostHog may contain aggregate token counts, outcomes, durations, user/team
+  identity, and actual subscription cost basis.
+- PostHog must never contain prompts, outputs, bodies, credentials, route
+  tokens, email, payment-method details, or provider-account identifiers.
+

--- a/web/app/api/billing/checkout/route.ts
+++ b/web/app/api/billing/checkout/route.ts
@@ -1,5 +1,5 @@
 import type { StackServerApp } from "@stackframe/stack";
-import { NextRequest, NextResponse } from "next/server";
+import { after, NextRequest, NextResponse } from "next/server";
 import { eq } from "drizzle-orm";
 
 import { validatedNativeCallbackScheme } from "../../../lib/native-callback";
@@ -26,6 +26,7 @@ import {
   billingInterval,
   type BillingInterval,
 } from "../../../../services/billing/plans";
+import { captureBillingCheckoutStarted } from "../../../../services/analytics/stripeBilling";
 
 export const dynamic = "force-dynamic";
 
@@ -178,6 +179,12 @@ async function stripeProCheckout(
       cancel_url: cancelUrl.toString(),
     });
     if (!session.url) throw new Error("Stripe Checkout Session did not include a URL");
+    deferCheckoutAnalytics(() => captureBillingCheckoutStarted({
+      sessionId: session.id,
+      subject: { scope: "user", stackUserId: user.id },
+      plan: "pro",
+      billingInterval: interval,
+    }));
     return NextResponse.redirect(session.url);
   } catch (error) {
     captureBillingError(error, {
@@ -243,6 +250,12 @@ async function stripeTeamCheckout(
       cancel_url: cancelUrl.toString(),
     });
     if (!session.url) throw new Error("Stripe Checkout Session did not include a URL");
+    deferCheckoutAnalytics(() => captureBillingCheckoutStarted({
+      sessionId: session.id,
+      subject: { scope: "team", stackTeamId: teamId },
+      plan: "team",
+      billingInterval: interval,
+    }));
     return NextResponse.redirect(session.url);
   } catch (error) {
     captureBillingError(error, {
@@ -259,6 +272,16 @@ function accountDeletionCheckoutRedirect(request: NextRequest) {
   return NextResponse.redirect(
     new URL("/pricing?billing=account_deletion_in_progress", request.url),
   );
+}
+
+function deferCheckoutAnalytics(task: () => Promise<void>): void {
+  try {
+    after(task);
+  } catch {
+    // Unit tests and non-Next callers have no request work store. Analytics is
+    // best effort and must never turn a valid Checkout session into an error.
+    void task();
+  }
 }
 
 function isAccountDeletionInProgress(user: { readonly clientReadOnlyMetadata?: unknown }): boolean {

--- a/web/app/api/cron/billing-reconcile/route.ts
+++ b/web/app/api/cron/billing-reconcile/route.ts
@@ -1,0 +1,36 @@
+import { reconcileStripeSubscriptions } from "../../../../services/billing/reconcile";
+import { captureCoderouterError } from "../../../../services/errors";
+
+export const dynamic = "force-dynamic";
+export const maxDuration = 60;
+
+export async function GET(request: Request): Promise<Response> {
+  const secret = process.env.CRON_SECRET?.trim();
+  if (!secret || request.headers.get("authorization") !== `Bearer ${secret}`) {
+    return Response.json({ error: "unauthorized" }, { status: 401 });
+  }
+
+  try {
+    const result = await reconcileStripeSubscriptions();
+    return Response.json({
+      ok: result.failed === 0,
+      ...result,
+    }, { status: result.failed === 0 ? 200 : 503 });
+  } catch (error) {
+    captureCoderouterError(error, {
+      operation: "stripe_subscription_reconcile_cron",
+      recoverable: true,
+    });
+    return Response.json(
+      {
+        error: "billing_reconcile_failed",
+        message: "Billing reconciliation failed; retry the cron run.",
+        retryable: true,
+      },
+      {
+        status: 503,
+        headers: { "Retry-After": "60" },
+      },
+    );
+  }
+}

--- a/web/app/api/stripe/webhook/route.ts
+++ b/web/app/api/stripe/webhook/route.ts
@@ -186,8 +186,14 @@ async function processStripeEvent(
     case "customer.subscription.created":
     case "customer.subscription.updated":
     case "customer.subscription.deleted": {
+      // Stripe can deliver events late or out of order. Always reconcile the
+      // provider's current object rather than allowing an older event payload
+      // to overwrite a newer entitlement state.
+      const subscription = await dependencies.stripe().subscriptions.retrieve(
+        event.data.object.id,
+      );
       const result = await applySubscriptionEntitlementUpdate(
-        event.data.object,
+        subscription,
         dependencies,
       );
       return "skipped" in result
@@ -196,7 +202,7 @@ async function processStripeEvent(
             processed: event.type,
             analytics: () => dependencies.captureStripeBillingEvent(
               event,
-              analyticsSubject(result, result.isActive, event.data.object.status),
+              analyticsSubject(result, result.isActive, subscription.status),
             ),
           };
     }
@@ -211,6 +217,35 @@ async function processStripeEvent(
       );
       return "skipped" in result
         ? { skipped: "invoice_subscription_unmapped" }
+        : {
+            processed: event.type,
+            analytics: () => dependencies.captureStripeBillingEvent(
+              event,
+              analyticsSubject(result, result.isActive, subscription.status),
+            ),
+          };
+    }
+    case "charge.refunded": {
+      const charge = event.data.object as Stripe.Charge & {
+        invoice?: string | Stripe.Invoice | null;
+      };
+      const invoiceId = stringId(charge.invoice);
+      if (!invoiceId) return { skipped: "refund_without_invoice" };
+      const invoice = await dependencies.stripe().invoices.retrieve(invoiceId);
+      const subscriptionId = invoiceSubscriptionId(invoice);
+      if (!subscriptionId) return { skipped: "refund_without_subscription" };
+      const subscription = await dependencies.stripe().subscriptions.retrieve(
+        subscriptionId,
+      );
+      // Refunds do not inherently revoke a subscription. Re-applying Stripe's
+      // current subscription state preserves that policy while mapping the
+      // event to the correct privacy-safe analytics principal.
+      const result = await applySubscriptionEntitlementUpdate(
+        subscription,
+        dependencies,
+      );
+      return "skipped" in result
+        ? { skipped: "refund_subscription_unmapped" }
         : {
             processed: event.type,
             analytics: () => dependencies.captureStripeBillingEvent(

--- a/web/db/migrations/20260807010000_stripe_reconcile_cursor/migration.sql
+++ b/web/db/migrations/20260807010000_stripe_reconcile_cursor/migration.sql
@@ -1,0 +1,5 @@
+ALTER TABLE "stripe_subscriptions"
+  ADD COLUMN "last_reconciled_at" timestamp with time zone;
+
+CREATE INDEX "stripe_subscriptions_reconcile_cursor_idx"
+  ON "stripe_subscriptions" ("last_reconciled_at", "id");

--- a/web/db/migrations/20260807010000_stripe_reconcile_cursor/migration.sql
+++ b/web/db/migrations/20260807010000_stripe_reconcile_cursor/migration.sql
@@ -2,4 +2,5 @@ ALTER TABLE "stripe_subscriptions"
   ADD COLUMN "last_reconciled_at" timestamp with time zone;
 
 CREATE INDEX "stripe_subscriptions_reconcile_cursor_idx"
-  ON "stripe_subscriptions" ("last_reconciled_at", "id");
+  ON "stripe_subscriptions"
+  ("last_reconciled_at" ASC NULLS FIRST, "id" ASC);

--- a/web/db/schema.ts
+++ b/web/db/schema.ts
@@ -616,11 +616,16 @@ export const stripeSubscriptions = pgTable(
     raw: jsonb("raw").$type<Record<string, unknown>>(),
     createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
     updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
+    lastReconciledAt: timestamp("last_reconciled_at", { withTimezone: true }),
   },
   (table) => [
     index("stripe_subscriptions_customer_id_idx").on(table.customerId),
     index("stripe_subscriptions_stack_user_id_idx").on(table.stackUserId),
     index("stripe_subscriptions_stack_team_id_idx").on(table.stackTeamId),
+    index("stripe_subscriptions_reconcile_cursor_idx").on(
+      table.lastReconciledAt,
+      table.id,
+    ),
   ],
 );
 

--- a/web/db/schema.ts
+++ b/web/db/schema.ts
@@ -623,8 +623,8 @@ export const stripeSubscriptions = pgTable(
     index("stripe_subscriptions_stack_user_id_idx").on(table.stackUserId),
     index("stripe_subscriptions_stack_team_id_idx").on(table.stackTeamId),
     index("stripe_subscriptions_reconcile_cursor_idx").on(
-      table.lastReconciledAt,
-      table.id,
+      table.lastReconciledAt.asc().nullsFirst(),
+      table.id.asc(),
     ),
   ],
 );

--- a/web/package.json
+++ b/web/package.json
@@ -10,6 +10,8 @@
     "search:index": "bun tools/build-docs-search.mjs",
     "subrouter:migrate-legacy": "bun scripts/subrouter/migrate-legacy-tenants.ts",
     "coderouter:migrate-encrypted-credentials": "bun scripts/coderouter/migrate-encrypted-credentials.ts",
+    "coderouter:benchmark": "bun scripts/coderouter/benchmark.ts",
+    "coderouter:reconcile-billing": "bun scripts/coderouter/reconcile-billing.ts",
     "testflight:backfill-legacy-ownership": "bun scripts/stripe/backfill-pro-testflight-legacy-ownership.ts",
     "cloud-vm:env:audit": "bun scripts/cloud-vm/audit-vercel-env.mjs",
     "cloud-vm:migrate": "bun scripts/cloud-vm/migrate-vercel-aurora-iam.mjs",

--- a/web/scripts/coderouter/benchmark.ts
+++ b/web/scripts/coderouter/benchmark.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env bun
 
-export {};
+import { pathToFileURL } from "node:url";
 
 type Sample = {
   readonly durationMs: number;
@@ -26,48 +26,67 @@ type Percentiles = {
   readonly max: number;
 };
 
-const args = parseArgs(process.argv.slice(2));
-const origin = args.origin ?? "https://coderouter.dev";
-const samples = positiveInteger(args.samples ?? "30", "samples");
-const timeoutMs = positiveInteger(args.timeout ?? "15000", "timeout");
-const routeToken = args.token ?? process.env.CODEROUTER_ROUTE_TOKEN;
-const targets = [
-  { name: "landing", path: "/", expected: [200] },
-  { name: "cli_config", path: "/api/cli/config", expected: [200] },
-  {
-    name: "models_unauthenticated",
-    path: "/v1/models",
-    expected: routeToken ? [200, 503] : [401],
-    authorization: routeToken,
-  },
-];
+if (
+  process.argv[1] &&
+  import.meta.url === pathToFileURL(process.argv[1]).href
+) await main();
 
-const output: BenchmarkResult[] = [];
-for (const target of targets) {
-  const url = new URL(target.path, origin).toString();
-  const collected: Sample[] = [];
-  // Warm DNS, TLS, CDN, and function artifacts before retaining measurements.
-  await requestSample(url, target.authorization, timeoutMs).catch(() => null);
-  for (let index = 0; index < samples; index += 1) {
-    collected.push(await requestSample(url, target.authorization, timeoutMs));
-  }
-  const result = summarize(target.name, url, collected);
-  output.push(result);
-  if (!collected.every((sample) => target.expected.includes(sample.status))) {
-    console.error(
-      `${target.name}: unexpected status; expected ${target.expected.join("/ ")}`,
+async function main(): Promise<void> {
+  const args = parseArgs(process.argv.slice(2));
+  const origin = normalizeOrigin(args.origin ?? "https://coderouter.dev");
+  const samples = positiveInteger(args.samples ?? "30", "samples");
+  const timeoutMs = positiveInteger(args.timeout ?? "15000", "timeout");
+  const routeToken = args.token ??
+    (isApprovedTokenOrigin(origin)
+      ? process.env.CODEROUTER_ROUTE_TOKEN
+      : undefined);
+  if (
+    process.env.CODEROUTER_ROUTE_TOKEN &&
+    !args.token &&
+    !isApprovedTokenOrigin(origin)
+  ) {
+    throw new Error(
+      "Refusing to send the environment route token to an unapproved origin.",
     );
-    process.exitCode = 1;
   }
-}
+  const targets = [
+    { name: "landing", path: "/", expected: [200] },
+    { name: "cli_config", path: "/api/cli/config", expected: [200] },
+    {
+      name: "models_unauthenticated",
+      path: "/v1/models",
+      expected: routeToken ? [200, 503] : [401],
+      authorization: routeToken,
+    },
+  ];
 
-console.log(JSON.stringify({
-  schemaVersion: 1,
-  measuredAt: new Date().toISOString(),
-  origin,
-  network: "client_to_edge",
-  results: output,
-}, null, 2));
+  const output: BenchmarkResult[] = [];
+  for (const target of targets) {
+    const url = new URL(target.path, origin).toString();
+    const collected: Sample[] = [];
+    // Warm DNS, TLS, CDN, and function artifacts before retaining measurements.
+    await requestSample(url, target.authorization, timeoutMs).catch(() => null);
+    for (let index = 0; index < samples; index += 1) {
+      collected.push(await requestSample(url, target.authorization, timeoutMs));
+    }
+    const result = summarize(target.name, url, collected);
+    output.push(result);
+    if (!collected.every((sample) => target.expected.includes(sample.status))) {
+      console.error(
+        `${target.name}: unexpected status; expected ${target.expected.join("/ ")}`,
+      );
+      process.exitCode = 1;
+    }
+  }
+
+  console.log(JSON.stringify({
+    schemaVersion: 1,
+    measuredAt: new Date().toISOString(),
+    origin,
+    network: "client_to_edge",
+    results: output,
+  }, null, 2));
+}
 
 async function requestSample(
   url: string,
@@ -92,45 +111,51 @@ async function requestSample(
   };
 }
 
-function summarize(
+export function summarize(
   name: string,
   url: string,
   samples: readonly Sample[],
 ): BenchmarkResult {
-  const timingNames = new Set(
-    samples.flatMap((sample) => Object.keys(sample.serverTiming)),
-  );
+  const statusCounts = new Map<number, number>();
+  const timingValues = new Map<string, number[]>();
+  const durations: number[] = [];
+  let successful = 0;
+  for (const sample of samples) {
+    durations.push(sample.durationMs);
+    if (sample.status < 500) successful += 1;
+    statusCounts.set(sample.status, (statusCounts.get(sample.status) ?? 0) + 1);
+    for (const [name, value] of Object.entries(sample.serverTiming)) {
+      const values = timingValues.get(name) ?? [];
+      values.push(value);
+      timingValues.set(name, values);
+    }
+  }
   return {
     name,
     url,
     samples: samples.length,
-    successful: samples.filter((sample) => sample.status < 500).length,
+    successful,
     statusCounts: Object.fromEntries(
-      [...new Set(samples.map((sample) => sample.status))]
-        .sort()
-        .map((status) => [
-          String(status),
-          samples.filter((sample) => sample.status === status).length,
-        ]),
+      [...statusCounts.entries()]
+        .sort(([left], [right]) => left - right)
+        .map(([status, count]) => [String(status), count]),
     ),
-    latencyMs: percentiles(samples.map((sample) => sample.durationMs)),
+    latencyMs: percentiles(durations),
     serverTimingMs: Object.fromEntries(
-      [...timingNames].sort().map((timing) => [
+      [...timingValues.entries()].sort(([left], [right]) =>
+        left.localeCompare(right)
+      ).map(([timing, values]) => [
         timing,
-        percentiles(
-          samples
-            .map((sample) => sample.serverTiming[timing])
-            .filter((value): value is number => value !== undefined),
-        ),
+        percentiles(values),
       ]),
     ),
   };
 }
 
-function parseServerTiming(value: string | null): Record<string, number> {
+export function parseServerTiming(value: string | null): Record<string, number> {
   if (!value) return {};
   const parsed: Record<string, number> = {};
-  for (const entry of value.split(",")) {
+  for (const entry of splitOutsideQuotes(value)) {
     const [name, ...parameters] = entry.trim().split(";");
     if (!name) continue;
     const duration = parameters
@@ -139,6 +164,32 @@ function parseServerTiming(value: string | null): Record<string, number> {
     if (duration) parsed[name] = Number(duration);
   }
   return parsed;
+}
+
+function splitOutsideQuotes(value: string): string[] {
+  const entries: string[] = [];
+  let current = "";
+  let quoted = false;
+  let escaped = false;
+  for (const character of value) {
+    if (escaped) {
+      current += character;
+      escaped = false;
+    } else if (character === "\\" && quoted) {
+      current += character;
+      escaped = true;
+    } else if (character === "\"") {
+      current += character;
+      quoted = !quoted;
+    } else if (character === "," && !quoted) {
+      entries.push(current);
+      current = "";
+    } else {
+      current += character;
+    }
+  }
+  entries.push(current);
+  return entries;
 }
 
 function percentiles(values: readonly number[]): Percentiles {
@@ -167,12 +218,17 @@ function round(value: number): number {
   return Math.round(value * 100) / 100;
 }
 
-function parseArgs(values: readonly string[]): Record<string, string> {
+export function parseArgs(values: readonly string[]): Record<string, string> {
   const parsed: Record<string, string> = {};
+  const supported = new Set(["origin", "samples", "timeout", "token"]);
   for (let index = 0; index < values.length; index += 1) {
     const value = values[index]!;
     if (!value.startsWith("--")) throw new Error(`Unexpected argument: ${value}`);
     const [inlineKey, inlineValue] = value.slice(2).split("=", 2);
+    if (!inlineKey || !supported.has(inlineKey)) {
+      throw new Error("Unsupported benchmark option.");
+    }
+    if (inlineKey in parsed) throw new Error("Duplicate benchmark option.");
     const next = values[index + 1];
     if (inlineValue !== undefined) {
       parsed[inlineKey!] = inlineValue;
@@ -184,6 +240,29 @@ function parseArgs(values: readonly string[]): Record<string, string> {
     }
   }
   return parsed;
+}
+
+export function normalizeOrigin(value: string): string {
+  const parsed = new URL(value);
+  const loopback = parsed.hostname === "localhost" ||
+    parsed.hostname === "127.0.0.1" ||
+    parsed.hostname === "::1";
+  if (parsed.protocol !== "https:" && !(parsed.protocol === "http:" && loopback)) {
+    throw new Error("Benchmark origin must use HTTPS except on loopback.");
+  }
+  if (
+    parsed.username || parsed.password || parsed.search || parsed.hash ||
+    parsed.pathname !== "/"
+  ) {
+    throw new Error(
+      "Benchmark origin cannot contain credentials, a path, query, or fragment.",
+    );
+  }
+  return parsed.origin;
+}
+
+function isApprovedTokenOrigin(origin: string): boolean {
+  return origin === "https://coderouter.dev";
 }
 
 function positiveInteger(value: string, name: string): number {

--- a/web/scripts/coderouter/benchmark.ts
+++ b/web/scripts/coderouter/benchmark.ts
@@ -1,0 +1,195 @@
+#!/usr/bin/env bun
+
+export {};
+
+type Sample = {
+  readonly durationMs: number;
+  readonly status: number;
+  readonly serverTiming: Record<string, number>;
+};
+
+type BenchmarkResult = {
+  readonly name: string;
+  readonly url: string;
+  readonly samples: number;
+  readonly successful: number;
+  readonly statusCounts: Record<string, number>;
+  readonly latencyMs: Percentiles;
+  readonly serverTimingMs: Record<string, Percentiles>;
+};
+
+type Percentiles = {
+  readonly p50: number;
+  readonly p95: number;
+  readonly p99: number;
+  readonly min: number;
+  readonly max: number;
+};
+
+const args = parseArgs(process.argv.slice(2));
+const origin = args.origin ?? "https://coderouter.dev";
+const samples = positiveInteger(args.samples ?? "30", "samples");
+const timeoutMs = positiveInteger(args.timeout ?? "15000", "timeout");
+const routeToken = args.token ?? process.env.CODEROUTER_ROUTE_TOKEN;
+const targets = [
+  { name: "landing", path: "/", expected: [200] },
+  { name: "cli_config", path: "/api/cli/config", expected: [200] },
+  {
+    name: "models_unauthenticated",
+    path: "/v1/models",
+    expected: routeToken ? [200, 503] : [401],
+    authorization: routeToken,
+  },
+];
+
+const output: BenchmarkResult[] = [];
+for (const target of targets) {
+  const url = new URL(target.path, origin).toString();
+  const collected: Sample[] = [];
+  // Warm DNS, TLS, CDN, and function artifacts before retaining measurements.
+  await requestSample(url, target.authorization, timeoutMs).catch(() => null);
+  for (let index = 0; index < samples; index += 1) {
+    collected.push(await requestSample(url, target.authorization, timeoutMs));
+  }
+  const result = summarize(target.name, url, collected);
+  output.push(result);
+  if (!collected.every((sample) => target.expected.includes(sample.status))) {
+    console.error(
+      `${target.name}: unexpected status; expected ${target.expected.join("/ ")}`,
+    );
+    process.exitCode = 1;
+  }
+}
+
+console.log(JSON.stringify({
+  schemaVersion: 1,
+  measuredAt: new Date().toISOString(),
+  origin,
+  network: "client_to_edge",
+  results: output,
+}, null, 2));
+
+async function requestSample(
+  url: string,
+  authorization: string | undefined,
+  timeoutMs: number,
+): Promise<Sample> {
+  const started = performance.now();
+  const response = await fetch(url, {
+    redirect: "manual",
+    headers: {
+      ...(authorization ? { authorization: `Bearer ${authorization}` } : {}),
+      "user-agent": "coderouter-benchmark/1",
+    },
+    signal: AbortSignal.timeout(timeoutMs),
+  });
+  // Drain the response so connection reuse and total duration are comparable.
+  await response.arrayBuffer();
+  return {
+    durationMs: round(performance.now() - started),
+    status: response.status,
+    serverTiming: parseServerTiming(response.headers.get("server-timing")),
+  };
+}
+
+function summarize(
+  name: string,
+  url: string,
+  samples: readonly Sample[],
+): BenchmarkResult {
+  const timingNames = new Set(
+    samples.flatMap((sample) => Object.keys(sample.serverTiming)),
+  );
+  return {
+    name,
+    url,
+    samples: samples.length,
+    successful: samples.filter((sample) => sample.status < 500).length,
+    statusCounts: Object.fromEntries(
+      [...new Set(samples.map((sample) => sample.status))]
+        .sort()
+        .map((status) => [
+          String(status),
+          samples.filter((sample) => sample.status === status).length,
+        ]),
+    ),
+    latencyMs: percentiles(samples.map((sample) => sample.durationMs)),
+    serverTimingMs: Object.fromEntries(
+      [...timingNames].sort().map((timing) => [
+        timing,
+        percentiles(
+          samples
+            .map((sample) => sample.serverTiming[timing])
+            .filter((value): value is number => value !== undefined),
+        ),
+      ]),
+    ),
+  };
+}
+
+function parseServerTiming(value: string | null): Record<string, number> {
+  if (!value) return {};
+  const parsed: Record<string, number> = {};
+  for (const entry of value.split(",")) {
+    const [name, ...parameters] = entry.trim().split(";");
+    if (!name) continue;
+    const duration = parameters
+      .map((parameter) => parameter.trim().match(/^dur=([0-9.]+)$/)?.[1])
+      .find(Boolean);
+    if (duration) parsed[name] = Number(duration);
+  }
+  return parsed;
+}
+
+function percentiles(values: readonly number[]): Percentiles {
+  if (values.length === 0) {
+    return { p50: 0, p95: 0, p99: 0, min: 0, max: 0 };
+  }
+  const sorted = [...values].sort((left, right) => left - right);
+  return {
+    p50: quantile(sorted, 0.50),
+    p95: quantile(sorted, 0.95),
+    p99: quantile(sorted, 0.99),
+    min: sorted[0]!,
+    max: sorted.at(-1)!,
+  };
+}
+
+function quantile(sorted: readonly number[], fraction: number): number {
+  const index = Math.min(
+    sorted.length - 1,
+    Math.max(0, Math.ceil(sorted.length * fraction) - 1),
+  );
+  return round(sorted[index]!);
+}
+
+function round(value: number): number {
+  return Math.round(value * 100) / 100;
+}
+
+function parseArgs(values: readonly string[]): Record<string, string> {
+  const parsed: Record<string, string> = {};
+  for (let index = 0; index < values.length; index += 1) {
+    const value = values[index]!;
+    if (!value.startsWith("--")) throw new Error(`Unexpected argument: ${value}`);
+    const [inlineKey, inlineValue] = value.slice(2).split("=", 2);
+    const next = values[index + 1];
+    if (inlineValue !== undefined) {
+      parsed[inlineKey!] = inlineValue;
+    } else if (next && !next.startsWith("--")) {
+      parsed[inlineKey!] = next;
+      index += 1;
+    } else {
+      throw new Error(`Missing value for --${inlineKey}`);
+    }
+  }
+  return parsed;
+}
+
+function positiveInteger(value: string, name: string): number {
+  const parsed = Number(value);
+  if (!Number.isSafeInteger(parsed) || parsed < 1 || parsed > 60_000) {
+    throw new Error(`--${name} must be an integer from 1 to 60000`);
+  }
+  return parsed;
+}

--- a/web/scripts/coderouter/benchmark.ts
+++ b/web/scripts/coderouter/benchmark.ts
@@ -223,7 +223,9 @@ export function parseArgs(values: readonly string[]): Record<string, string> {
   const supported = new Set(["origin", "samples", "timeout", "token"]);
   for (let index = 0; index < values.length; index += 1) {
     const value = values[index]!;
-    if (!value.startsWith("--")) throw new Error(`Unexpected argument: ${value}`);
+    if (!value.startsWith("--")) {
+      throw new Error("Unexpected benchmark argument.");
+    }
     const [inlineKey, inlineValue] = value.slice(2).split("=", 2);
     if (!inlineKey || !supported.has(inlineKey)) {
       throw new Error("Unsupported benchmark option.");

--- a/web/scripts/coderouter/reconcile-billing.ts
+++ b/web/scripts/coderouter/reconcile-billing.ts
@@ -1,0 +1,14 @@
+#!/usr/bin/env bun
+
+import { reconcileStripeSubscriptions } from "../../services/billing/reconcile";
+
+const dryRun = process.argv.includes("--dry-run");
+const unknown = process.argv.slice(2).filter((value) => value !== "--dry-run");
+if (unknown.length > 0) {
+  throw new Error(`Unknown arguments: ${unknown.join(", ")}`);
+}
+
+const result = await reconcileStripeSubscriptions({ dryRun });
+console.log(JSON.stringify({ dryRun, ...result }, null, 2));
+if (result.failed > 0 || result.truncated) process.exitCode = 1;
+

--- a/web/scripts/coderouter/reconcile-billing.ts
+++ b/web/scripts/coderouter/reconcile-billing.ts
@@ -1,14 +1,26 @@
 #!/usr/bin/env bun
 
 import { reconcileStripeSubscriptions } from "../../services/billing/reconcile";
+import { captureCoderouterError } from "../../services/errors";
 
 const dryRun = process.argv.includes("--dry-run");
 const unknown = process.argv.slice(2).filter((value) => value !== "--dry-run");
 if (unknown.length > 0) {
-  throw new Error(`Unknown arguments: ${unknown.join(", ")}`);
+  console.error("Unknown arguments. Use --dry-run or no arguments.");
+  process.exit(2);
 }
 
-const result = await reconcileStripeSubscriptions({ dryRun });
-console.log(JSON.stringify({ dryRun, ...result }, null, 2));
-if (result.failed > 0 || result.truncated) process.exitCode = 1;
-
+try {
+  const result = await reconcileStripeSubscriptions({ dryRun });
+  console.log(JSON.stringify({ dryRun, ...result }, null, 2));
+  if (result.failed > 0 || result.truncated) process.exitCode = 1;
+} catch (error) {
+  captureCoderouterError(error, {
+    operation: "stripe_subscription_reconcile_command",
+    recoverable: true,
+  });
+  console.error(
+    "Billing reconciliation did not complete. Check internal telemetry and retry.",
+  );
+  process.exitCode = 1;
+}

--- a/web/scripts/stripe/dev-stack.sh
+++ b/web/scripts/stripe/dev-stack.sh
@@ -158,7 +158,7 @@ if [[ -z "$slug" ]]; then
 fi
 db_container="${CMUX_DB_CONTAINER_NAME:-cmux-postgres-${slug}-dev-${PORT}}"
 
-events="checkout.session.completed,checkout.session.async_payment_succeeded,customer.subscription.created,customer.subscription.updated,customer.subscription.deleted,invoice.paid,invoice.payment_failed"
+events="checkout.session.completed,checkout.session.async_payment_succeeded,customer.subscription.created,customer.subscription.updated,customer.subscription.deleted,invoice.paid,invoice.payment_failed,charge.refunded"
 
 echo "cmux Stripe dev stack"
 echo "  Web log: $web_log"

--- a/web/scripts/stripe/provision-catalog.sh
+++ b/web/scripts/stripe/provision-catalog.sh
@@ -30,6 +30,7 @@ EVENTS=(
   "customer.subscription.deleted"
   "invoice.paid"
   "invoice.payment_failed"
+  "charge.refunded"
 )
 
 if [[ ! -f "$SECRET_FILE" ]]; then
@@ -73,14 +74,16 @@ stripe_get() {
   local path="$1"
   shift
   printf 'Authorization: Bearer %s\n' "$STRIPE_PROVISION_KEY" |
-    curl -fsS --header @- --get "$@" "${STRIPE_API_BASE}${path}"
+    curl -fsS --connect-timeout 5 --max-time 30 --retry 2 --retry-all-errors \
+      --header @- --get "$@" "${STRIPE_API_BASE}${path}"
 }
 
 stripe_post() {
   local path="$1"
   shift
   printf 'Authorization: Bearer %s\n' "$STRIPE_PROVISION_KEY" |
-    curl -fsS --header @- -X POST "$@" "${STRIPE_API_BASE}${path}"
+    curl -fsS --connect-timeout 5 --max-time 30 --retry 2 --retry-all-errors \
+      --header @- -X POST "$@" "${STRIPE_API_BASE}${path}"
 }
 
 product_matches_catalog_identity() {
@@ -101,29 +104,43 @@ product_matches_catalog_identity() {
 ensure_product() {
   local name="$1"
   local plan="$2"
-  local response product_json product_id starting_after
+  local response product_id next_page page_product_ids
   local -a matching_product_ids=()
   local -a page_args=(--data-urlencode "limit=100")
 
-  starting_after=""
+  next_page=""
   while :; do
-    page_args=(--data-urlencode "limit=100")
-    if [[ -n "$starting_after" ]]; then
-      page_args+=(--data-urlencode "starting_after=${starting_after}")
+    page_args=(
+      --data-urlencode "limit=100"
+      --data-urlencode "query=active:'true' AND metadata['app']:'cmux' AND metadata['plan']:'${plan}'"
+    )
+    if [[ -n "$next_page" ]]; then
+      page_args+=(--data-urlencode "page=${next_page}")
     fi
     response="$(
-      stripe_get "/products" "${page_args[@]}"
+      stripe_get "/products/search" "${page_args[@]}"
     )"
-    while IFS= read -r product_json; do
-      if product_matches_catalog_identity "$product_json" "$name" "$plan"; then
-        matching_product_ids+=("$(jq -er '.id' <<<"$product_json")")
-      fi
-    done < <(jq -c '.data[]' <<<"$response")
+    echo "Scanned Stripe products for ${plan}." >&2
+    page_product_ids="$(
+      jq -r --arg name "$name" --arg plan "$plan" '
+        .data[]
+        | select(
+            .name == $name
+            and .active == true
+            and .metadata.app == "cmux"
+            and .metadata.plan == $plan
+          )
+        | .id
+      ' <<<"$response"
+    )"
+    while IFS= read -r product_id; do
+      [[ -n "$product_id" ]] && matching_product_ids+=("$product_id")
+    done <<<"$page_product_ids"
 
     if [[ "$(jq -r '.has_more // false' <<<"$response")" != "true" ]]; then
       break
     fi
-    starting_after="$(jq -er '.data[-1].id' <<<"$response")"
+    next_page="$(jq -er '.next_page' <<<"$response")"
   done
 
   if (( ${#matching_product_ids[@]} > 1 )); then
@@ -159,6 +176,7 @@ canonical_product() {
       --data-urlencode "expand[]=data.product" \
       --data-urlencode "limit=1"
   )"
+  echo "Checked Stripe price ${monthly_lookup_key}." >&2
   product_id="$(jq -r '.data[0].product.id // empty' <<<"$response")"
   if [[ -z "$product_id" ]]; then
     ensure_product "$name" "$plan"
@@ -227,8 +245,11 @@ ensure_price() {
   echo "Created price ${lookup_key}: ${price_id}"
 }
 
+echo "Resolving ${MODE} Stripe catalog…" >&2
 pro_product_id="$(canonical_product "cmux-pro-monthly" "cmux Pro" "pro")"
+echo "Resolved Pro product." >&2
 team_product_id="$(canonical_product "cmux-team-monthly" "cmux Team" "team")"
+echo "Resolved Team product." >&2
 
 ensure_price "$pro_product_id" "cmux-pro-monthly" "3000" "month" "cmux Pro Monthly"
 # Keep the original $240 annual Price active for existing subscribers. Stripe

--- a/web/scripts/stripe/provision-catalog.sh
+++ b/web/scripts/stripe/provision-catalog.sh
@@ -81,8 +81,11 @@ stripe_get() {
 stripe_post() {
   local path="$1"
   shift
+  # POST mutations are not automatically retried without a stable Stripe
+  # idempotency key. A failed operator run safely re-discovers completed
+  # catalog objects before attempting a new mutation.
   printf 'Authorization: Bearer %s\n' "$STRIPE_PROVISION_KEY" |
-    curl -fsS --connect-timeout 5 --max-time 30 --retry 2 --retry-all-errors \
+    curl -fsS --connect-timeout 5 --max-time 30 \
       --header @- -X POST "$@" "${STRIPE_API_BASE}${path}"
 }
 

--- a/web/services/analytics/stripeBilling.ts
+++ b/web/services/analytics/stripeBilling.ts
@@ -34,25 +34,34 @@ export async function captureStripeBillingEvent(
   const mapped = mappedBillingEvent(event, subject);
   if (!mapped) return;
 
-  try {
-    await postHogFetch(`${POSTHOG_HOST}/capture/`, {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({
-        api_key: POSTHOG_PROJECT_KEY,
-        event: mapped.name,
-        properties: {
-          distinct_id: subjectDistinctId(subject),
-          // Stripe redeliveries and route retries keep one PostHog event.
-          $insert_id: event.id,
-          ...mapped.properties,
-        },
-      }),
-      signal: AbortSignal.timeout(CAPTURE_TIMEOUT_MS),
-    });
-  } catch {
-    // Analytics is deliberately non-authoritative.
-  }
+  await captureBillingPayload({
+    name: mapped.name,
+    insertId: event.id,
+    subject,
+    properties: mapped.properties,
+  }, postHogFetch);
+}
+
+export async function captureBillingCheckoutStarted(
+  input: {
+    readonly sessionId: string;
+    readonly subject: StripeBillingAnalyticsSubject;
+    readonly plan: "pro" | "team";
+    readonly billingInterval: "month" | "year";
+  },
+  postHogFetch: typeof fetch = fetch,
+): Promise<void> {
+  await captureBillingPayload({
+    name: "cmux_billing_checkout_started",
+    insertId: `checkout-started:${input.sessionId}`,
+    subject: input.subject,
+    properties: {
+      source: "checkout_route",
+      billing_scope: input.subject.scope,
+      plan: input.plan,
+      billing_interval: input.billingInterval,
+    },
+  }, postHogFetch);
 }
 
 function mappedBillingEvent(
@@ -131,6 +140,21 @@ function mappedBillingEvent(
         },
       };
     }
+    case "charge.refunded": {
+      const charge = event.data.object;
+      return {
+        name: "cmux_billing_charge_refunded",
+        properties: {
+          ...common,
+          amount: charge.amount,
+          amount_refunded: charge.amount_refunded,
+          currency: charge.currency,
+          fully_refunded: charge.refunded,
+          stripe_charge_id: charge.id,
+          stripe_customer_id: stringId(charge.customer),
+        },
+      };
+    }
     default:
       return null;
   }
@@ -140,6 +164,42 @@ function subjectDistinctId(subject: StripeBillingAnalyticsSubject): string {
   return subject.scope === "user"
     ? subject.stackUserId
     : `stack-team:${subject.stackTeamId}`;
+}
+
+async function captureBillingPayload(
+  input: {
+    readonly name: string;
+    readonly insertId: string;
+    readonly subject: StripeBillingAnalyticsSubject;
+    readonly properties: Record<string, unknown>;
+  },
+  postHogFetch: typeof fetch,
+): Promise<void> {
+  const body = JSON.stringify({
+    api_key: POSTHOG_PROJECT_KEY,
+    event: input.name,
+    properties: {
+      distinct_id: subjectDistinctId(input.subject),
+      $insert_id: input.insertId,
+      ...(input.subject.scope === "team"
+        ? { $groups: { stack_team: input.subject.stackTeamId } }
+        : {}),
+      ...input.properties,
+    },
+  });
+  for (let attempt = 0; attempt < 2; attempt += 1) {
+    try {
+      const response = await postHogFetch(`${POSTHOG_HOST}/capture/`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body,
+        signal: AbortSignal.timeout(CAPTURE_TIMEOUT_MS),
+      });
+      if (response.ok || response.status < 500) return;
+    } catch {
+      // Retry once with the same insert id; never fail billing traffic.
+    }
+  }
 }
 
 function subscriptionEventAction(

--- a/web/services/billing/reconcile.ts
+++ b/web/services/billing/reconcile.ts
@@ -36,6 +36,7 @@ type BillingReconcileDependencies = {
     context: Record<string, string | number | boolean>,
   ) => void;
   readonly concurrency?: number;
+  readonly withLease?: <T>(task: () => Promise<T>) => Promise<T>;
 };
 
 /**
@@ -52,6 +53,17 @@ export async function reconcileStripeSubscriptions(
     readonly dryRun?: boolean;
   } = {},
   dependencies: BillingReconcileDependencies = {},
+): Promise<BillingReconcileResult> {
+  const withLease = dependencies.withLease ?? withReconciliationLease;
+  return withLease(() => reconcileStripeSubscriptionsLocked(options, dependencies));
+}
+
+async function reconcileStripeSubscriptionsLocked(
+  options: {
+    readonly limit?: number;
+    readonly dryRun?: boolean;
+  },
+  dependencies: BillingReconcileDependencies,
 ): Promise<BillingReconcileResult> {
   const limit = clampInteger(options.limit ?? DEFAULT_LIMIT, 1, DEFAULT_LIMIT);
   const list = dependencies.list ?? listSubscriptionSnapshots;
@@ -91,7 +103,7 @@ export async function reconcileStripeSubscriptions(
       }
     },
   );
-  if (snapshots.length > 0) {
+  if (!options.dryRun && snapshots.length > 0) {
     await markChecked(snapshots.map((snapshot) => snapshot.id));
   }
 
@@ -109,6 +121,17 @@ export async function reconcileStripeSubscriptions(
     data: result,
   });
   return result;
+}
+
+async function withReconciliationLease<T>(
+  task: () => Promise<T>,
+): Promise<T> {
+  return cloudDb().transaction(async (tx) => {
+    await tx.execute(
+      sql`select pg_advisory_xact_lock(hashtextextended(${"coderouter:billing-reconcile"}, 0))`,
+    );
+    return task();
+  });
 }
 
 async function listSubscriptionSnapshots(

--- a/web/services/billing/reconcile.ts
+++ b/web/services/billing/reconcile.ts
@@ -1,5 +1,5 @@
 import * as Sentry from "@sentry/nextjs";
-import { asc } from "drizzle-orm";
+import { asc, inArray, sql } from "drizzle-orm";
 import type Stripe from "stripe";
 
 import { cloudDb } from "../../db/client";
@@ -30,6 +30,7 @@ type BillingReconcileDependencies = {
   readonly list?: (limit: number) => Promise<readonly SubscriptionSnapshot[]>;
   readonly retrieve?: (id: string) => Promise<Stripe.Subscription>;
   readonly apply?: (subscription: Stripe.Subscription) => Promise<unknown>;
+  readonly markChecked?: (ids: readonly string[]) => Promise<void>;
   readonly captureError?: (
     error: unknown,
     context: Record<string, string | number | boolean>,
@@ -58,6 +59,7 @@ export async function reconcileStripeSubscriptions(
     ((id) => stripe().subscriptions.retrieve(id));
   const apply = dependencies.apply ?? ((subscription) =>
     applySubscriptionUpdate(subscription));
+  const markChecked = dependencies.markChecked ?? markSubscriptionsChecked;
   const captureError = dependencies.captureError ?? captureCoderouterError;
   const rows = await list(limit + 1);
   const snapshots = rows.slice(0, limit);
@@ -89,6 +91,9 @@ export async function reconcileStripeSubscriptions(
       }
     },
   );
+  if (snapshots.length > 0) {
+    await markChecked(snapshots.map((snapshot) => snapshot.id));
+  }
 
   const result = {
     checked: snapshots.length,
@@ -117,8 +122,19 @@ async function listSubscriptionSnapshots(
       currentPeriodEnd: stripeSubscriptions.currentPeriodEnd,
     })
     .from(stripeSubscriptions)
-    .orderBy(asc(stripeSubscriptions.updatedAt))
+    .orderBy(
+      sql`${stripeSubscriptions.lastReconciledAt} asc nulls first`,
+      asc(stripeSubscriptions.id),
+    )
     .limit(limit);
+}
+
+async function markSubscriptionsChecked(ids: readonly string[]): Promise<void> {
+  if (ids.length === 0) return;
+  await cloudDb()
+    .update(stripeSubscriptions)
+    .set({ lastReconciledAt: sql`now()` })
+    .where(inArray(stripeSubscriptions.id, [...ids]));
 }
 
 function hasDrift(

--- a/web/services/billing/reconcile.ts
+++ b/web/services/billing/reconcile.ts
@@ -1,0 +1,162 @@
+import * as Sentry from "@sentry/nextjs";
+import { asc } from "drizzle-orm";
+import type Stripe from "stripe";
+
+import { cloudDb } from "../../db/client";
+import { stripeSubscriptions } from "../../db/schema";
+import { captureCoderouterError } from "../errors";
+import { applySubscriptionUpdate } from "./purchase";
+import { stripe } from "./stripe";
+
+const DEFAULT_LIMIT = 1_000;
+const DEFAULT_CONCURRENCY = 8;
+
+type SubscriptionSnapshot = {
+  readonly id: string;
+  readonly status: string;
+  readonly cancelAtPeriodEnd: boolean;
+  readonly currentPeriodEnd: Date | null;
+};
+
+export type BillingReconcileResult = {
+  readonly checked: number;
+  readonly drifted: number;
+  readonly repaired: number;
+  readonly failed: number;
+  readonly truncated: boolean;
+};
+
+type BillingReconcileDependencies = {
+  readonly list?: (limit: number) => Promise<readonly SubscriptionSnapshot[]>;
+  readonly retrieve?: (id: string) => Promise<Stripe.Subscription>;
+  readonly apply?: (subscription: Stripe.Subscription) => Promise<unknown>;
+  readonly captureError?: (
+    error: unknown,
+    context: Record<string, string | number | boolean>,
+  ) => void;
+  readonly concurrency?: number;
+};
+
+/**
+ * Repairs Stripe/RDS entitlement drift outside request traffic.
+ *
+ * Stripe remains authoritative. Re-applying a subscription is idempotent and
+ * goes through the same per-principal advisory lock, Stack metadata update,
+ * and route-token revocation path as a signed webhook. Retrievals fan out with
+ * bounded concurrency; mutations retain their existing principal locks.
+ */
+export async function reconcileStripeSubscriptions(
+  options: {
+    readonly limit?: number;
+    readonly dryRun?: boolean;
+  } = {},
+  dependencies: BillingReconcileDependencies = {},
+): Promise<BillingReconcileResult> {
+  const limit = clampInteger(options.limit ?? DEFAULT_LIMIT, 1, DEFAULT_LIMIT);
+  const list = dependencies.list ?? listSubscriptionSnapshots;
+  const retrieve = dependencies.retrieve ??
+    ((id) => stripe().subscriptions.retrieve(id));
+  const apply = dependencies.apply ?? ((subscription) =>
+    applySubscriptionUpdate(subscription));
+  const captureError = dependencies.captureError ?? captureCoderouterError;
+  const rows = await list(limit + 1);
+  const snapshots = rows.slice(0, limit);
+
+  let drifted = 0;
+  let repaired = 0;
+  let failed = 0;
+  await mapConcurrent(
+    snapshots,
+    dependencies.concurrency ?? DEFAULT_CONCURRENCY,
+    async (snapshot) => {
+      try {
+        const remote = await retrieve(snapshot.id);
+        if (!hasDrift(snapshot, remote)) return;
+        drifted += 1;
+        if (options.dryRun) return;
+        const result = await apply(remote);
+        if (isSkipped(result)) {
+          throw new Error("Stripe subscription could not be mapped to a billing principal");
+        }
+        repaired += 1;
+      } catch (error) {
+        failed += 1;
+        captureError(error, {
+          operation: "stripe_subscription_reconcile",
+          // Deliberately omit subscription/customer/principal identifiers.
+          recoverable: true,
+        });
+      }
+    },
+  );
+
+  const result = {
+    checked: snapshots.length,
+    drifted,
+    repaired,
+    failed,
+    truncated: rows.length > limit,
+  };
+  Sentry.addBreadcrumb({
+    category: "billing.reconcile",
+    level: failed > 0 ? "warning" : "info",
+    message: "Stripe subscription reconciliation completed",
+    data: result,
+  });
+  return result;
+}
+
+async function listSubscriptionSnapshots(
+  limit: number,
+): Promise<readonly SubscriptionSnapshot[]> {
+  return cloudDb()
+    .select({
+      id: stripeSubscriptions.id,
+      status: stripeSubscriptions.status,
+      cancelAtPeriodEnd: stripeSubscriptions.cancelAtPeriodEnd,
+      currentPeriodEnd: stripeSubscriptions.currentPeriodEnd,
+    })
+    .from(stripeSubscriptions)
+    .orderBy(asc(stripeSubscriptions.updatedAt))
+    .limit(limit);
+}
+
+function hasDrift(
+  local: SubscriptionSnapshot,
+  remote: Stripe.Subscription,
+): boolean {
+  return local.status !== remote.status ||
+    local.cancelAtPeriodEnd !== remote.cancel_at_period_end ||
+    epochSeconds(local.currentPeriodEnd) !==
+      (remote.items.data[0]?.current_period_end ?? null);
+}
+
+function epochSeconds(value: Date | null): number | null {
+  return value ? Math.floor(value.getTime() / 1_000) : null;
+}
+
+function isSkipped(result: unknown): boolean {
+  return typeof result === "object" && result !== null && "skipped" in result;
+}
+
+async function mapConcurrent<T>(
+  values: readonly T[],
+  concurrency: number,
+  visit: (value: T) => Promise<void>,
+): Promise<void> {
+  const bounded = clampInteger(concurrency, 1, 32);
+  let next = 0;
+  await Promise.all(
+    Array.from({ length: Math.min(bounded, values.length) }, async () => {
+      while (next < values.length) {
+        const index = next;
+        next += 1;
+        await visit(values[index]!);
+      }
+    }),
+  );
+}
+
+function clampInteger(value: number, minimum: number, maximum: number): number {
+  return Math.max(minimum, Math.min(maximum, Math.floor(value)));
+}

--- a/web/tests/billing-reconcile-route.test.ts
+++ b/web/tests/billing-reconcile-route.test.ts
@@ -1,0 +1,73 @@
+import { afterEach, describe, expect, mock, test } from "bun:test";
+
+let reconcileError: Error | null = null;
+const reconcileStripeSubscriptions = mock(async () => {
+  if (reconcileError) throw reconcileError;
+  return {
+    checked: 2,
+    drifted: 1,
+    repaired: 1,
+    failed: 0,
+    truncated: false,
+  };
+});
+const captureCoderouterError = mock(() => {});
+
+mock.module("../services/billing/reconcile", () => ({
+  reconcileStripeSubscriptions,
+}));
+mock.module("../services/errors", () => ({ captureCoderouterError }));
+
+const { GET } = await import("../app/api/cron/billing-reconcile/route");
+const originalSecret = process.env.CRON_SECRET;
+
+afterEach(() => {
+  reconcileStripeSubscriptions.mockClear();
+  reconcileError = null;
+  captureCoderouterError.mockClear();
+  if (originalSecret === undefined) delete process.env.CRON_SECRET;
+  else process.env.CRON_SECRET = originalSecret;
+});
+
+describe("billing reconciliation cron", () => {
+  test("fails closed without configured bearer authentication", async () => {
+    delete process.env.CRON_SECRET;
+    expect((await GET(new Request("https://cmux.test/api/cron/billing-reconcile"))).status)
+      .toBe(401);
+    expect(reconcileStripeSubscriptions).not.toHaveBeenCalled();
+  });
+
+  test("runs reconciliation with a valid cron secret", async () => {
+    process.env.CRON_SECRET = "expected";
+    const response = await GET(new Request(
+      "https://cmux.test/api/cron/billing-reconcile",
+      { headers: { authorization: "Bearer expected" } },
+    ));
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({
+      ok: true,
+      checked: 2,
+      drifted: 1,
+      repaired: 1,
+      failed: 0,
+      truncated: false,
+    });
+  });
+
+  test("returns retry guidance when reconciliation cannot start", async () => {
+    process.env.CRON_SECRET = "expected";
+    reconcileError = new Error("database unavailable");
+    const response = await GET(new Request(
+      "https://cmux.test/api/cron/billing-reconcile",
+      { headers: { authorization: "Bearer expected" } },
+    ));
+    expect(response.status).toBe(503);
+    expect(response.headers.get("retry-after")).toBe("60");
+    expect(await response.json()).toEqual({
+      error: "billing_reconcile_failed",
+      message: "Billing reconciliation failed; retry the cron run.",
+      retryable: true,
+    });
+    expect(captureCoderouterError).toHaveBeenCalledTimes(1);
+  });
+});

--- a/web/tests/billing-reconcile.test.ts
+++ b/web/tests/billing-reconcile.test.ts
@@ -33,6 +33,11 @@ describe("Stripe subscription reconciliation", () => {
   test("checks remote subscriptions concurrently and repairs only drift", async () => {
     let inFlight = 0;
     let peak = 0;
+    let started = 0;
+    let releaseBoth!: () => void;
+    const bothStarted = new Promise<void>((resolve) => {
+      releaseBoth = resolve;
+    });
     const applied: string[] = [];
     const result = await reconcileStripeSubscriptions({}, {
       list: async () => [
@@ -53,7 +58,9 @@ describe("Stripe subscription reconciliation", () => {
       retrieve: async (id) => {
         inFlight += 1;
         peak = Math.max(peak, inFlight);
-        await new Promise((resolve) => setTimeout(resolve, 5));
+        started += 1;
+        if (started === 2) releaseBoth();
+        await bothStarted;
         inFlight -= 1;
         return id === "sub_drift"
           ? subscription(id, "canceled")
@@ -63,6 +70,7 @@ describe("Stripe subscription reconciliation", () => {
         applied.push(remote.id);
         return { scope: "user", stackUserId: "ignored", isActive: false };
       },
+      markChecked: async () => {},
     });
 
     expect(peak).toBe(2);
@@ -89,6 +97,7 @@ describe("Stripe subscription reconciliation", () => {
       apply: async () => {
         applied = true;
       },
+      markChecked: async () => {},
     });
     expect(applied).toBe(false);
     expect(result.drifted).toBe(1);
@@ -108,6 +117,7 @@ describe("Stripe subscription reconciliation", () => {
         throw new Error("provider unavailable");
       },
       captureError: (_error, context) => contexts.push(context),
+      markChecked: async () => {},
     });
     expect(result.failed).toBe(1);
     expect(contexts).toEqual([{
@@ -134,8 +144,36 @@ describe("Stripe subscription reconciliation", () => {
         },
       ],
       retrieve: async (id) => subscription(id),
+      markChecked: async () => {},
     });
     expect(result.checked).toBe(1);
     expect(result.truncated).toBe(true);
+  });
+
+  test("advances every checked row so a later batch can rotate in", async () => {
+    const remaining = ["sub_one", "sub_two"];
+    const checked: string[] = [];
+    const list = async (limit: number) =>
+      remaining.slice(0, limit).map((id) => ({
+        id,
+        status: "active",
+        cancelAtPeriodEnd: false,
+        currentPeriodEnd: new Date(1_800_000_000_000),
+      }));
+    const markChecked = async (ids: readonly string[]) => {
+      checked.push(...ids);
+      for (const id of ids) remaining.splice(remaining.indexOf(id), 1);
+    };
+    const dependencies = {
+      list,
+      retrieve: async (id: string) => subscription(id),
+      markChecked,
+    };
+
+    expect((await reconcileStripeSubscriptions({ limit: 1 }, dependencies)).truncated)
+      .toBe(true);
+    expect((await reconcileStripeSubscriptions({ limit: 1 }, dependencies)).truncated)
+      .toBe(false);
+    expect(checked).toEqual(["sub_one", "sub_two"]);
   });
 });

--- a/web/tests/billing-reconcile.test.ts
+++ b/web/tests/billing-reconcile.test.ts
@@ -1,0 +1,141 @@
+import { describe, expect, test } from "bun:test";
+import type Stripe from "stripe";
+
+import { reconcileStripeSubscriptions } from "../services/billing/reconcile";
+
+function subscription(
+  id: string,
+  status: Stripe.Subscription.Status = "active",
+  overrides: Partial<Stripe.Subscription> = {},
+): Stripe.Subscription {
+  return {
+    id,
+    object: "subscription",
+    status,
+    cancel_at_period_end: false,
+    items: {
+      object: "list",
+      data: [{
+        id: "si_test",
+        object: "subscription_item",
+        current_period_end: 1_800_000_000,
+        price: { id: "price_test" },
+      }],
+      has_more: false,
+      url: "/v1/subscription_items",
+    },
+    metadata: { app: "cmux", stackUserId: "redacted", plan: "pro" },
+    ...overrides,
+  } as Stripe.Subscription;
+}
+
+describe("Stripe subscription reconciliation", () => {
+  test("checks remote subscriptions concurrently and repairs only drift", async () => {
+    let inFlight = 0;
+    let peak = 0;
+    const applied: string[] = [];
+    const result = await reconcileStripeSubscriptions({}, {
+      list: async () => [
+        {
+          id: "sub_equal",
+          status: "active",
+          cancelAtPeriodEnd: false,
+          currentPeriodEnd: new Date(1_800_000_000_000),
+        },
+        {
+          id: "sub_drift",
+          status: "active",
+          cancelAtPeriodEnd: false,
+          currentPeriodEnd: new Date(1_800_000_000_000),
+        },
+      ],
+      concurrency: 2,
+      retrieve: async (id) => {
+        inFlight += 1;
+        peak = Math.max(peak, inFlight);
+        await new Promise((resolve) => setTimeout(resolve, 5));
+        inFlight -= 1;
+        return id === "sub_drift"
+          ? subscription(id, "canceled")
+          : subscription(id);
+      },
+      apply: async (remote) => {
+        applied.push(remote.id);
+        return { scope: "user", stackUserId: "ignored", isActive: false };
+      },
+    });
+
+    expect(peak).toBe(2);
+    expect(applied).toEqual(["sub_drift"]);
+    expect(result).toEqual({
+      checked: 2,
+      drifted: 1,
+      repaired: 1,
+      failed: 0,
+      truncated: false,
+    });
+  });
+
+  test("dry-run reports drift without mutation", async () => {
+    let applied = false;
+    const result = await reconcileStripeSubscriptions({ dryRun: true }, {
+      list: async () => [{
+        id: "sub_drift",
+        status: "active",
+        cancelAtPeriodEnd: false,
+        currentPeriodEnd: null,
+      }],
+      retrieve: async () => subscription("sub_drift", "canceled"),
+      apply: async () => {
+        applied = true;
+      },
+    });
+    expect(applied).toBe(false);
+    expect(result.drifted).toBe(1);
+    expect(result.repaired).toBe(0);
+  });
+
+  test("isolates failures and never includes identifiers in error context", async () => {
+    const contexts: Record<string, unknown>[] = [];
+    const result = await reconcileStripeSubscriptions({}, {
+      list: async () => [{
+        id: "sub_secret",
+        status: "active",
+        cancelAtPeriodEnd: false,
+        currentPeriodEnd: null,
+      }],
+      retrieve: async () => {
+        throw new Error("provider unavailable");
+      },
+      captureError: (_error, context) => contexts.push(context),
+    });
+    expect(result.failed).toBe(1);
+    expect(contexts).toEqual([{
+      operation: "stripe_subscription_reconcile",
+      recoverable: true,
+    }]);
+    expect(JSON.stringify(contexts)).not.toContain("sub_secret");
+  });
+
+  test("bounds each run and reports truncation", async () => {
+    const result = await reconcileStripeSubscriptions({ limit: 1 }, {
+      list: async () => [
+        {
+          id: "sub_one",
+          status: "active",
+          cancelAtPeriodEnd: false,
+          currentPeriodEnd: new Date(1_800_000_000_000),
+        },
+        {
+          id: "sub_two",
+          status: "active",
+          cancelAtPeriodEnd: false,
+          currentPeriodEnd: new Date(1_800_000_000_000),
+        },
+      ],
+      retrieve: async (id) => subscription(id),
+    });
+    expect(result.checked).toBe(1);
+    expect(result.truncated).toBe(true);
+  });
+});

--- a/web/tests/billing-reconcile.test.ts
+++ b/web/tests/billing-reconcile.test.ts
@@ -3,6 +3,8 @@ import type Stripe from "stripe";
 
 import { reconcileStripeSubscriptions } from "../services/billing/reconcile";
 
+const withoutLease = async <T>(task: () => Promise<T>): Promise<T> => task();
+
 function subscription(
   id: string,
   status: Stripe.Subscription.Status = "active",
@@ -40,6 +42,7 @@ describe("Stripe subscription reconciliation", () => {
     });
     const applied: string[] = [];
     const result = await reconcileStripeSubscriptions({}, {
+      withLease: withoutLease,
       list: async () => [
         {
           id: "sub_equal",
@@ -86,7 +89,9 @@ describe("Stripe subscription reconciliation", () => {
 
   test("dry-run reports drift without mutation", async () => {
     let applied = false;
+    let marked = false;
     const result = await reconcileStripeSubscriptions({ dryRun: true }, {
+      withLease: withoutLease,
       list: async () => [{
         id: "sub_drift",
         status: "active",
@@ -97,9 +102,12 @@ describe("Stripe subscription reconciliation", () => {
       apply: async () => {
         applied = true;
       },
-      markChecked: async () => {},
+      markChecked: async () => {
+        marked = true;
+      },
     });
     expect(applied).toBe(false);
+    expect(marked).toBe(false);
     expect(result.drifted).toBe(1);
     expect(result.repaired).toBe(0);
   });
@@ -107,6 +115,7 @@ describe("Stripe subscription reconciliation", () => {
   test("isolates failures and never includes identifiers in error context", async () => {
     const contexts: Record<string, unknown>[] = [];
     const result = await reconcileStripeSubscriptions({}, {
+      withLease: withoutLease,
       list: async () => [{
         id: "sub_secret",
         status: "active",
@@ -129,6 +138,7 @@ describe("Stripe subscription reconciliation", () => {
 
   test("bounds each run and reports truncation", async () => {
     const result = await reconcileStripeSubscriptions({ limit: 1 }, {
+      withLease: withoutLease,
       list: async () => [
         {
           id: "sub_one",
@@ -165,6 +175,7 @@ describe("Stripe subscription reconciliation", () => {
       for (const id of ids) remaining.splice(remaining.indexOf(id), 1);
     };
     const dependencies = {
+      withLease: withoutLease,
       list,
       retrieve: async (id: string) => subscription(id),
       markChecked,
@@ -175,5 +186,56 @@ describe("Stripe subscription reconciliation", () => {
     expect((await reconcileStripeSubscriptions({ limit: 1 }, dependencies)).truncated)
       .toBe(false);
     expect(checked).toEqual(["sub_one", "sub_two"]);
+  });
+
+  test("serializes concurrent cron and operator runs with one shared lease", async () => {
+    let releaseFirst!: () => void;
+    let signalFirstStarted!: () => void;
+    const firstMayFinish = new Promise<void>((resolve) => {
+      releaseFirst = resolve;
+    });
+    const firstStarted = new Promise<void>((resolve) => {
+      signalFirstStarted = resolve;
+    });
+    let leaseTail = Promise.resolve();
+    let activeLeases = 0;
+    let peakLeases = 0;
+    const withLease = async <T>(task: () => Promise<T>): Promise<T> => {
+      const previous = leaseTail;
+      let release!: () => void;
+      leaseTail = new Promise<void>((resolve) => {
+        release = resolve;
+      });
+      await previous;
+      activeLeases += 1;
+      peakLeases = Math.max(peakLeases, activeLeases);
+      try {
+        return await task();
+      } finally {
+        activeLeases -= 1;
+        release();
+      }
+    };
+    let listCalls = 0;
+    const dependencies = {
+      withLease,
+      list: async () => {
+        listCalls += 1;
+        if (listCalls === 1) {
+          signalFirstStarted();
+          await firstMayFinish;
+        }
+        return [];
+      },
+      markChecked: async () => {},
+    };
+    const first = reconcileStripeSubscriptions({}, dependencies);
+    const second = reconcileStripeSubscriptions({}, dependencies);
+    await firstStarted;
+    expect(listCalls).toBe(1);
+    releaseFirst();
+    await Promise.all([first, second]);
+    expect(listCalls).toBe(2);
+    expect(peakLeases).toBe(1);
   });
 });

--- a/web/tests/coderouter-benchmark.test.ts
+++ b/web/tests/coderouter-benchmark.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  normalizeOrigin,
+  parseArgs,
+  parseServerTiming,
+  summarize,
+} from "../scripts/coderouter/benchmark";
+
+describe("coderouter benchmark harness", () => {
+  test("parses quoted Server-Timing descriptions containing commas", () => {
+    expect(parseServerTiming(
+      'cache;desc="edge, cache";dur=12.5, db;dur=4',
+    )).toEqual({ cache: 12.5, db: 4 });
+  });
+
+  test("rejects unsupported and duplicate options", () => {
+    expect(() => parseArgs(["--orign", "https://example.com"])).toThrow();
+    expect(() => parseArgs(["--samples", "1", "--samples=2"])).toThrow();
+  });
+
+  test("normalizes safe origins and rejects credential-bearing origins", () => {
+    expect(normalizeOrigin("https://coderouter.dev/")).toBe(
+      "https://coderouter.dev",
+    );
+    expect(normalizeOrigin("http://localhost:3000")).toBe(
+      "http://localhost:3000",
+    );
+    expect(() => normalizeOrigin("https://token@example.com")).toThrow();
+    expect(() => normalizeOrigin("https://example.com/?token=secret")).toThrow();
+  });
+
+  test("aggregates status and timing samples without changing output", () => {
+    expect(summarize("status", "https://example.com", [
+      {
+        durationMs: 10,
+        status: 200,
+        serverTiming: { auth: 2 },
+      },
+      {
+        durationMs: 20,
+        status: 503,
+        serverTiming: { auth: 4, db: 3 },
+      },
+    ])).toMatchObject({
+      samples: 2,
+      successful: 1,
+      statusCounts: { "200": 1, "503": 1 },
+      latencyMs: { p50: 10, p95: 20 },
+      serverTimingMs: {
+        auth: { p50: 2, p95: 4 },
+        db: { p50: 3, p95: 3 },
+      },
+    });
+  });
+});

--- a/web/tests/coderouter-benchmark.test.ts
+++ b/web/tests/coderouter-benchmark.test.ts
@@ -17,6 +17,13 @@ describe("coderouter benchmark harness", () => {
   test("rejects unsupported and duplicate options", () => {
     expect(() => parseArgs(["--orign", "https://example.com"])).toThrow();
     expect(() => parseArgs(["--samples", "1", "--samples=2"])).toThrow();
+    const secret = "crt_must_not_be_printed";
+    expect(() => parseArgs([secret])).toThrow("Unexpected benchmark argument.");
+    try {
+      parseArgs([secret]);
+    } catch (error) {
+      expect(String(error)).not.toContain(secret);
+    }
   });
 
   test("normalizes safe origins and rejects credential-bearing origins", () => {

--- a/web/tests/stripe-billing-analytics.test.ts
+++ b/web/tests/stripe-billing-analytics.test.ts
@@ -1,7 +1,10 @@
 import { describe, expect, test } from "bun:test";
 import type Stripe from "stripe";
 
-import { captureStripeBillingEvent } from "../services/analytics/stripeBilling";
+import {
+  captureBillingCheckoutStarted,
+  captureStripeBillingEvent,
+} from "../services/analytics/stripeBilling";
 
 describe("Stripe billing analytics", () => {
   test("joins paid checkout events to the Stack PostHog identity", async () => {
@@ -97,7 +100,9 @@ describe("Stripe billing analytics", () => {
   });
 
   test("does not make billing fail when PostHog is unavailable", async () => {
+    let attempts = 0;
     const postHogFetch = (async () => {
+      attempts += 1;
       throw new Error("offline");
     }) as typeof fetch;
     const event = {
@@ -119,5 +124,66 @@ describe("Stripe billing analytics", () => {
       { scope: "user", stackUserId: "stack-user-1", isActive: false },
       postHogFetch,
     )).resolves.toBeUndefined();
+    expect(attempts).toBe(2);
+  });
+
+  test("captures checkout start with a stable deduplication id and no email", async () => {
+    let payload: Record<string, unknown> = {};
+    await captureBillingCheckoutStarted({
+      sessionId: "cs_started",
+      subject: { scope: "user", stackUserId: "stack-user-1" },
+      plan: "pro",
+      billingInterval: "year",
+    }, (async (_input, init) => {
+      payload = JSON.parse(String(init?.body));
+      return new Response(null, { status: 200 });
+    }) as typeof fetch);
+
+    expect(payload).toMatchObject({
+      event: "cmux_billing_checkout_started",
+      properties: {
+        distinct_id: "stack-user-1",
+        $insert_id: "checkout-started:cs_started",
+        plan: "pro",
+        billing_interval: "year",
+      },
+    });
+    expect(JSON.stringify(payload)).not.toContain("email");
+  });
+
+  test("captures refunds without payment method details", async () => {
+    let payload: Record<string, unknown> = {};
+    await captureStripeBillingEvent({
+      id: "evt_refund",
+      type: "charge.refunded",
+      data: {
+        object: {
+          id: "ch_1",
+          amount: 3000,
+          amount_refunded: 3000,
+          currency: "usd",
+          refunded: true,
+          customer: "cus_1",
+        },
+      },
+    } as unknown as Stripe.Event, {
+      scope: "user",
+      stackUserId: "stack-user-1",
+      isActive: false,
+      status: "canceled",
+    }, (async (_input, init) => {
+      payload = JSON.parse(String(init?.body));
+      return new Response(null, { status: 200 });
+    }) as typeof fetch);
+
+    expect(payload).toMatchObject({
+      event: "cmux_billing_charge_refunded",
+      properties: {
+        distinct_id: "stack-user-1",
+        amount_refunded: 3000,
+        fully_refunded: true,
+      },
+    });
+    expect(JSON.stringify(payload)).not.toMatch(/card|payment_method|receipt_url/);
   });
 });

--- a/web/tests/stripe-provision-catalog.test.ts
+++ b/web/tests/stripe-provision-catalog.test.ts
@@ -86,18 +86,13 @@ describe("Stripe catalog provisioning", () => {
     ).toBe(true);
   });
 
-  test("finds a canonical product on a later product-list page", async () => {
+  test("finds a canonical product on a later product-search page", async () => {
     const result = await runProvision("test", "canonical-product-second-page");
 
     expect(result.exitCode).toBe(0);
     expect(
-      result.calls.some((call) => call.args.includes("starting_after=prod_attacker")),
+      result.calls.some((call) => call.args.includes("page=page_two")),
     ).toBe(true);
-    expect(
-      result.calls.some((call) =>
-        call.args.includes("https://api.stripe.com/v1/products/search")
-      ),
-    ).toBe(false);
     expect(
       result.calls.some(
         (call) =>
@@ -271,6 +266,7 @@ const valueFor = (prefix) => {
 };
 const lookupKey = valueFor("lookup_keys[]=");
 const startingAfter = valueFor("starting_after=");
+const searchPage = valueFor("page=");
 const expandedProduct = args.includes("expand[]=data.product");
 const dataValue = valueFor("name=");
 const respond = (value) => {
@@ -369,18 +365,18 @@ if (url.endsWith("/prices") && !isPost) {
   } else {
     respond({ data: [] });
   }
-} else if (url.endsWith("/products") && !isPost) {
+} else if (url.endsWith("/products/search") && !isPost) {
   const attacker = {
     id: "prod_attacker",
     name: "cmux Pro",
     active: true,
     metadata: { app: "other", plan: "pro" },
   };
-  if (scenario === "canonical-product-second-page" && !startingAfter) {
-    respond({ data: [attacker], has_more: true });
+  if (scenario === "canonical-product-second-page" && !searchPage) {
+    respond({ data: [attacker], has_more: true, next_page: "page_two" });
   } else if (
     scenario === "canonical-product-second-page" &&
-    startingAfter === "prod_attacker"
+    searchPage === "page_two"
   ) {
     respond({ data: [products.pro], has_more: false });
   } else {

--- a/web/tests/stripe-webhook-route.test.ts
+++ b/web/tests/stripe-webhook-route.test.ts
@@ -40,14 +40,20 @@ const paidCheckoutSession = {
 };
 let retrievedCheckoutSession: Record<string, unknown> = paidCheckoutSession;
 const retrieveSession = mock(async () => retrievedCheckoutSession);
-const retrieveSubscription = mock(async () => ({
+let retrievedSubscription: Record<string, unknown> = {
   id: "sub_1",
   customer: "cus_1",
   status: "active",
   metadata: { stackUserId: "user_1", app: "cmux" },
   cancel_at_period_end: false,
   items: { data: [{ current_period_end: 1_800_000_000, price: { id: "price_1" } }] },
-}));
+};
+const retrieveSubscription = mock(async () => retrievedSubscription);
+let retrievedInvoice: Record<string, unknown> = {
+  id: "in_1",
+  subscription: "sub_1",
+};
+const retrieveInvoice = mock(async () => retrievedInvoice);
 
 const POST = makeStripeWebhookHandler({
   webhookSecret: () => "whsec_test",
@@ -67,6 +73,9 @@ const POST = makeStripeWebhookHandler({
       },
       subscriptions: {
         retrieve: retrieveSubscription,
+      },
+      invoices: {
+        retrieve: retrieveInvoice,
       },
     }) as never,
   db: () =>
@@ -132,6 +141,20 @@ describe("Stripe billing webhook route", () => {
       isActive: true,
     };
     retrievedCheckoutSession = paidCheckoutSession;
+    retrievedSubscription = {
+      id: "sub_1",
+      customer: "cus_1",
+      status: "active",
+      metadata: { stackUserId: "user_1", app: "cmux" },
+      cancel_at_period_end: false,
+      items: {
+        data: [{
+          current_period_end: 1_800_000_000,
+          price: { id: "price_1" },
+        }],
+      },
+    };
+    retrievedInvoice = { id: "in_1", subscription: "sub_1" };
     recordCheckoutCompletion.mockClear();
     applySubscriptionUpdate.mockClear();
     revokeCoderouterRouteTokens.mockClear();
@@ -140,6 +163,7 @@ describe("Stripe billing webhook route", () => {
     sendProSignupWelcome.mockClear();
     retrieveSession.mockClear();
     retrieveSubscription.mockClear();
+    retrieveInvoice.mockClear();
   });
 
   test("rejects invalid Stripe signatures", async () => {
@@ -348,12 +372,17 @@ describe("Stripe billing webhook route", () => {
         },
       },
     };
+    retrievedSubscription = {
+      ...(currentEvent.data as { object: Record<string, unknown> }).object,
+      cancel_at_period_end: false,
+      items: { data: [] },
+    };
 
     const response = await POST(webhookRequest());
 
     expect(response.status).toBe(200);
     expect(applySubscriptionUpdate).toHaveBeenCalledWith(
-      (currentEvent.data as { object: unknown }).object,
+      retrievedSubscription,
     );
     expect(revokeCoderouterRouteTokens).toHaveBeenCalledWith("user_1");
     expect(captureStripeBillingEvent).not.toHaveBeenCalled();
@@ -368,6 +397,47 @@ describe("Stripe billing webhook route", () => {
         status: "canceled",
       },
     );
+  });
+
+  test("repairs delayed subscription events from Stripe's current state", async () => {
+    currentEvent = {
+      id: "evt_stale_deleted",
+      type: "customer.subscription.deleted",
+      data: {
+        object: {
+          id: "sub_1",
+          status: "canceled",
+          metadata: { stackUserId: "user_1", app: "cmux" },
+        },
+      },
+    };
+    retrievedSubscription = {
+      id: "sub_1",
+      customer: "cus_1",
+      status: "active",
+      metadata: { stackUserId: "user_1", app: "cmux" },
+      cancel_at_period_end: false,
+      items: { data: [] },
+    };
+    applySubscriptionUpdateResult = {
+      scope: "user",
+      stackUserId: "user_1",
+      isActive: true,
+    };
+
+    const response = await POST(webhookRequest());
+
+    expect(response.status).toBe(200);
+    expect(retrieveSubscription).toHaveBeenCalledWith("sub_1");
+    expect(applySubscriptionUpdate).toHaveBeenCalledWith(retrievedSubscription);
+    expect(revokeCoderouterRouteTokens).not.toHaveBeenCalled();
+    await deferredTasks[0]();
+    expect(captureStripeBillingEvent).toHaveBeenCalledWith(currentEvent, {
+      scope: "user",
+      stackUserId: "user_1",
+      isActive: true,
+      status: "active",
+    });
   });
 
   test("revokes coderouter tokens for an inactive invoice subscription update", async () => {
@@ -439,6 +509,42 @@ describe("Stripe billing webhook route", () => {
       skipped: "invoice_subscription_unmapped",
     });
     expect(revokeCoderouterRouteTokens).not.toHaveBeenCalled();
+  });
+
+  test("records refunds without revoking an otherwise active subscription", async () => {
+    currentEvent = {
+      id: "evt_refunded",
+      type: "charge.refunded",
+      data: {
+        object: {
+          id: "ch_1",
+          invoice: "in_1",
+          amount: 3000,
+          amount_refunded: 3000,
+          currency: "usd",
+          refunded: true,
+        },
+      },
+    };
+    applySubscriptionUpdateResult = {
+      scope: "user",
+      stackUserId: "user_1",
+      isActive: true,
+    };
+
+    const response = await POST(webhookRequest());
+
+    expect(response.status).toBe(200);
+    expect(retrieveInvoice).toHaveBeenCalledWith("in_1");
+    expect(retrieveSubscription).toHaveBeenCalledWith("sub_1");
+    expect(revokeCoderouterRouteTokens).not.toHaveBeenCalled();
+    await deferredTasks[0]();
+    expect(captureStripeBillingEvent).toHaveBeenCalledWith(currentEvent, {
+      scope: "user",
+      stackUserId: "user_1",
+      isActive: true,
+      status: "active",
+    });
   });
 
   test("marks the event and returns 500 when processing fails", async () => {

--- a/web/vercel.json
+++ b/web/vercel.json
@@ -19,6 +19,10 @@
       "schedule": "*/5 * * * *"
     },
     {
+      "path": "/api/cron/billing-reconcile",
+      "schedule": "23 * * * *"
+    },
+    {
       "path": "/api/internal/vm/leases/revoke-expired",
       "schedule": "*/10 * * * *"
     },


### PR DESCRIPTION
Adds hourly Stripe/RDS reconciliation, delayed-event repair, refund and checkout-start analytics, internal runbooks and benchmark tooling, bounded retries/concurrency, privacy-safe Sentry breadcrumbs, and deterministic coverage.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/9732"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788654429&installation_model_id=21920&pr_number=9732&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F9732&signature=8d001e2d6f3af1fa90d707bb8f42cd439042552ab882fd628aac1b4e3880907d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Completes coderouter billing operations and telemetry for the private beta. Adds serialized hourly Stripe↔RDS reconciliation, hardened webhooks (including refunds), privacy‑safe checkout/refund analytics, and lightweight ops tooling.

- **New Features**
  - Hourly reconciliation cron `/api/cron/billing-reconcile` (Bearer `CRON_SECRET`) runs under a global advisory lock to serialize cron/operator runs, uses per-subscription cursor `last_reconciled_at`, bounded concurrency, and CLI `bun coderouter:reconcile-billing` with `--dry-run`; exits nonzero on failures/truncation; returns 503 with `Retry-After`; scheduled at minute 23 in `vercel.json`.
  - Webhook always re-fetches the current Stripe subscription; handles `charge.refunded` by joining invoice→subscription, records analytics, and does not revoke active access.
  - Checkout-start analytics from checkout routes are deferred via Next.js `after()` with a safe fallback; unified capture adds stable `$insert_id`, team grouping via `$groups`, and a single retry on 5xx only.
  - Benchmark harness `bun coderouter:benchmark` reports status counts, p50/p95/p99, and `Server-Timing`, and refuses to send route tokens to unapproved origins; runbook `docs/coderouter-operations.md` covers replay, reconciliation, latency evidence, and observability.

- **Bug Fixes**
  - Prevents stale Stripe payloads from overwriting newer entitlements; Stripe is authoritative.
  - Stripe catalog provisioning uses `/products/search` with `next_page` and `curl` timeouts/retries; dev stack listens for `charge.refunded`.
  - Adds privacy-safe Sentry breadcrumb for reconciliation runs; analytics failures never affect billing paths.

<sup>Written for commit 10351a50732aab8957ca14a1381e811e565fb02a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/9732?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Billing**
  * Added automated Stripe subscription reconciliation with drift detection, repair, dry-run support, and failure reporting.
  * Scheduled recurring reconciliation with secure access controls.
  * Improved handling of refunded charges and stale subscription events to keep entitlements accurate.
  * Improved Stripe catalog provisioning and webhook configuration.

* **Observability**
  * Added checkout-start and refund analytics with retries, deduplication, and privacy-safe event data.

* **Operations**
  * Added benchmarking and billing-reconciliation command-line tools.
  * Added an operations runbook covering billing recovery, performance checks, and observability practices.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->