### PR TITLE
Fix literal tildes in terminal-inserted paths

### DIFF
--- a/Packages/macOS/CmuxTerminal/Sources/CmuxTerminal/Services/Pasteboard/String+TerminalShellEscaping.swift
+++ b/Packages/macOS/CmuxTerminal/Sources/CmuxTerminal/Services/Pasteboard/String+TerminalShellEscaping.swift
@@ -3,7 +3,7 @@ internal import Foundation
 extension String {
     /// The characters terminal paste paths escape with a backslash before
     /// injecting a path or URL as shell input.
-    private static let terminalShellEscapeCharacters = "\\ ()[]{}<>\"'`!#$&;|*?\t"
+    private static let terminalShellEscapeCharacters = "\\ ()[]{}<>\"'`!#$&;|*?~\t"
 
     /// This string escaped for safe injection as terminal shell input.
     ///

--- a/Packages/macOS/CmuxTerminal/Tests/CmuxTerminalTests/Services/TerminalPasteboardServiceTests.swift
+++ b/Packages/macOS/CmuxTerminal/Tests/CmuxTerminalTests/Services/TerminalPasteboardServiceTests.swift
@@ -46,6 +46,46 @@ struct TerminalShellEscapingTests {
         #expect("a$b;c|d".terminalShellEscaped == "a\\$b\\;c\\|d")
     }
 
+    @Test func escapesLeadingTildeForZshPathInsertion() throws {
+        let root = try makeScratchDirectory()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let target = root
+            .appendingPathComponent("~md", isDirectory: true)
+            .appendingPathComponent("Mobile Documents", isDirectory: true)
+            .appendingPathComponent("invest", isDirectory: true)
+        try FileManager.default.createDirectory(at: target, withIntermediateDirectories: true)
+
+        let process = Process()
+        let standardOutput = Pipe()
+        let standardError = Pipe()
+        process.executableURL = URL(fileURLWithPath: "/bin/zsh")
+        process.arguments = [
+            "-f",
+            "-c",
+            "cd -- \("~md/Mobile Documents/invest".terminalShellEscaped) && pwd -P",
+        ]
+        process.currentDirectoryURL = root
+        process.standardOutput = standardOutput
+        process.standardError = standardError
+
+        try process.run()
+        process.waitUntilExit()
+        let output = String(
+            decoding: standardOutput.fileHandleForReading.readDataToEndOfFile(),
+            as: UTF8.self
+        ).trimmingCharacters(in: .whitespacesAndNewlines)
+        let error = String(
+            decoding: standardError.fileHandleForReading.readDataToEndOfFile(),
+            as: UTF8.self
+        ).trimmingCharacters(in: .whitespacesAndNewlines)
+
+        try #require(process.terminationStatus == 0, "zsh failed to enter the inserted path: \(error)")
+        #expect(
+            URL(fileURLWithPath: output).resolvingSymlinksInPath()
+                == target.resolvingSymlinksInPath()
+        )
+    }
+
     @Test func singleQuotesValuesContainingNewlines() {
         #expect("a\nb".terminalShellEscaped == "'a\nb'")
         #expect("it's\r".terminalShellEscaped == "'it'\\''s\r'")


### PR DESCRIPTION
## Summary

- Escape literal `~` characters in the shared terminal shell escaper used by paste, drag and drop, file explorer insertion, image transfer, and upload fallback paths.
- Add a behavior-level regression that creates `~md/Mobile Documents/invest`, passes the cmux-escaped relative path to a clean `/bin/zsh -f`, and verifies that zsh enters the literal directory.
- Preserve the required red/green history: commit 1 adds the failing test; commit 2 fixes the shared escaper.

Refs #9680.

## Issue analysis

The exact command in #9680 contains an unescaped space:

`cd /Users/ren/Library/Mobile Documents/iCloud~md~obsidian/Documents/invest`

That command is split into two arguments by zsh, which selects the documented `cd old new` form. Bare zsh and zsh with cmux integration sourced both emit the same `string not in pwd` error. Quoting the path or escaping the space succeeds. The mid-token `iCloud~md~obsidian` segment is not treated as named-directory syntax.

The investigation did uncover a related cmux-owned edge case: the shared app insertion escaper did not escape a literal tilde at the start of a token, so a relative path such as `~md/Mobile Documents/invest` was interpreted by zsh as a named directory. This PR fixes that shared boundary and does not claim the cwd integration emitted the original error.

## Testing

- Confirmed the new test fails before the fix with `zsh:1: no such user or named directory: md`.
- `swift test --package-path Packages/macOS/CmuxTerminal --filter TerminalShellEscapingTests`
- `swift test --package-path Packages/macOS/CmuxTerminal` (178 Swift Testing tests and 11 XCTest tests passed)
- `./scripts/reload.sh --tag issue-9680-cd-space-tilde-path`
- Manually compared the reported unquoted command under bare zsh and cmux-integrated zsh; both returned status 1 with identical output. The quoted path returned status 0 and preserved spaces and mid-path tildes.

## Demo Video

Not applicable: this is deterministic non-visual shell escaping behavior.

## Checklist

- [x] Tested locally
- [x] Added behavior-level regression coverage
- [x] No documentation or changelog update is needed
- [x] Localization audit complete; no user-facing strings changed

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/9734"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788655450&installation_model_id=21920&pr_number=9734&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F9734&signature=f0d29539f468b996d7668fc26fa30d0c4bf63d40c0a6e88b4ae971d851bc19a5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Escape literal `~` in terminal-inserted paths so zsh doesn’t treat them as home or named directories. Adds a regression test to cover `~md/...` paths; addresses an edge case found while investigating #9680.

- **Bug Fixes**
  - Escape `~` in the shared terminal shell escaper used by paste, drag-and-drop, file explorer insertion, image transfer, and upload fallback.
  - Add a behavior test that creates `~md/Mobile Documents/invest`, runs `/bin/zsh -f`, and verifies `cd` enters the literal directory.

<sup>Written for commit 4bfa6df57b3ca05da5cd11492369a7ae1d6136ba. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/9734?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

