### PR TITLE
Fix cmux-tui startup config latency

### DIFF
--- a/cmux-tui/Cargo.lock
+++ b/cmux-tui/Cargo.lock
@@ -676,6 +676,7 @@ dependencies = [
  "unicode-width",
  "url",
  "uuid",
+ "wait-timeout",
  "zeroize",
 ]
 
@@ -5202,6 +5203,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d9b2acfb050df409c972a37d3b8e08cdea3bddb0c09db9d53137e504cfabed0"
 dependencies = [
  "utf8parse",
+]
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
+dependencies = [
+ "libc",
 ]
 
 [[package]]

--- a/cmux-tui/Cargo.toml
+++ b/cmux-tui/Cargo.toml
@@ -106,6 +106,7 @@ hyper-util = { version = "0.1", features = ["service", "tokio"] }
 iroh = { version = "1.0.3", default-features = false, features = ["fast-apple-datapath", "portmapper", "tls-ring"] }
 subtle = "2.6.1"
 parking_lot = "0.12"
+wait-timeout = "0.2"
 # rusqlite 0.40's libsqlite3-sys build script requires Rust 1.95 without
 # declaring that MSRV. Keep the workspace's advertised Rust 1.91 support.
 rusqlite = { version = "=0.39.0", default-features = false, features = ["bundled"] }

--- a/cmux-tui/crates/cmux-tui/Cargo.toml
+++ b/cmux-tui/crates/cmux-tui/Cargo.toml
@@ -37,6 +37,7 @@ terminput-crossterm.workspace = true
 parking_lot.workspace = true
 sha2.workspace = true
 uuid.workspace = true
+wait-timeout.workspace = true
 
 [target.'cfg(unix)'.dependencies]
 cmux-remote.workspace = true

--- a/cmux-tui/crates/cmux-tui/src/config.rs
+++ b/cmux-tui/crates/cmux-tui/src/config.rs
@@ -2929,6 +2929,78 @@ fn platform_appearance_theme_mode() -> Option<GhosttyThemeMode> {
 
 #[cfg(not(target_os = "macos"))]
 fn platform_appearance_theme_mode() -> Option<GhosttyThemeMode> {
+    non_macos_appearance_theme_mode()
+}
+
+#[cfg(not(target_os = "macos"))]
+fn non_macos_appearance_theme_mode() -> Option<GhosttyThemeMode> {
+    if let Some(mode) = std::env::var_os("GTK_THEME")
+        .as_deref()
+        .and_then(|value| gtk_theme_name_theme_mode(&value.to_string_lossy()))
+    {
+        return Some(mode);
+    }
+    gtk_settings_paths().into_iter().find_map(|path| {
+        let text = read_ghostty_regular_file(&path, 64 * 1024)?;
+        gtk_settings_theme_mode(&text)
+    })
+}
+
+#[cfg(not(target_os = "macos"))]
+fn gtk_settings_paths() -> Vec<PathBuf> {
+    let mut roots = Vec::new();
+    if let Some(config_home) = std::env::var_os("XDG_CONFIG_HOME").map(PathBuf::from) {
+        roots.push(config_home);
+    }
+    if let Some(home) = platform::home_dir() {
+        roots.push(home.join(".config"));
+    }
+
+    let mut paths = Vec::new();
+    for root in roots {
+        for version in ["gtk-4.0", "gtk-3.0"] {
+            let path = root.join(version).join("settings.ini");
+            if !paths.contains(&path) {
+                paths.push(path);
+            }
+        }
+    }
+    paths
+}
+
+#[cfg(any(test, not(target_os = "macos")))]
+fn gtk_settings_theme_mode(text: &str) -> Option<GhosttyThemeMode> {
+    let mut theme_name = None;
+    for line in text.lines() {
+        let line = line.trim();
+        if line.is_empty() || line.starts_with('#') || line.starts_with(';') {
+            continue;
+        }
+        let Some((key, value)) = line.split_once('=') else { continue };
+        let key = key.trim();
+        let value = value.trim().trim_matches('"');
+        match key {
+            "gtk-application-prefer-dark-theme" => match value.to_ascii_lowercase().as_str() {
+                "1" | "true" | "yes" => return Some(GhosttyThemeMode::Dark),
+                "0" | "false" | "no" => return Some(GhosttyThemeMode::Light),
+                _ => {}
+            },
+            "gtk-theme-name" => theme_name = gtk_theme_name_theme_mode(value),
+            _ => {}
+        }
+    }
+    theme_name
+}
+
+#[cfg(any(test, not(target_os = "macos")))]
+fn gtk_theme_name_theme_mode(value: &str) -> Option<GhosttyThemeMode> {
+    let value = value.to_ascii_lowercase();
+    if value.split([':', '-', '_']).any(|part| part == "dark") {
+        return Some(GhosttyThemeMode::Dark);
+    }
+    if value.split([':', '-', '_']).any(|part| part == "light") {
+        return Some(GhosttyThemeMode::Light);
+    }
     None
 }
 
@@ -4396,6 +4468,24 @@ mod tests {
         restore_env_var("COLORFGBG", old_colorfgbg);
 
         assert_eq!(mode, GhosttyThemeMode::Light);
+    }
+
+    #[test]
+    fn ghostty_non_macos_gtk_sources_detect_system_theme_mode() {
+        assert_eq!(
+            gtk_settings_theme_mode("[Settings]\ngtk-application-prefer-dark-theme=1\n"),
+            Some(GhosttyThemeMode::Dark)
+        );
+        assert_eq!(
+            gtk_settings_theme_mode("[Settings]\ngtk-application-prefer-dark-theme=false\n"),
+            Some(GhosttyThemeMode::Light)
+        );
+        assert_eq!(
+            gtk_settings_theme_mode("[Settings]\ngtk-theme-name=Adwaita-dark\n"),
+            Some(GhosttyThemeMode::Dark)
+        );
+        assert_eq!(gtk_theme_name_theme_mode("Adwaita:dark"), Some(GhosttyThemeMode::Dark));
+        assert_eq!(gtk_theme_name_theme_mode("Yaru-light"), Some(GhosttyThemeMode::Light));
     }
 
     #[test]

--- a/cmux-tui/crates/cmux-tui/src/config.rs
+++ b/cmux-tui/crates/cmux-tui/src/config.rs
@@ -118,11 +118,11 @@
 //! keys.
 
 use std::collections::{HashMap, HashSet};
-#[cfg(not(test))]
-use std::io::Read;
-use std::io::Write;
+use std::io::{Read, Write};
+#[cfg(all(unix, not(test)))]
+use std::os::unix::process::CommandExt;
 use std::path::{Path, PathBuf};
-#[cfg(any(not(test), all(test, unix)))]
+use std::process::Child;
 use std::process::Command;
 #[cfg(not(test))]
 use std::process::Stdio as ProcessStdio;
@@ -140,7 +140,6 @@ use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 use ratatui::style::Color;
 use serde::{Deserialize, Deserializer};
 use serde_json::{Value, json};
-#[cfg(not(test))]
 use wait_timeout::ChildExt;
 
 use crate::localization::catalog;
@@ -2658,11 +2657,16 @@ fn ghostty_defaults_from_sources(
     theme_dirs: Vec<PathBuf>,
     helper_defaults: GhosttyHelperDefaults,
 ) -> DefaultColors {
+    #[cfg(not(test))]
+    let _ = (&config_paths, &theme_dirs);
     let parsed = match helper_defaults {
         GhosttyHelperDefaults::Resolved(defaults) => defaults,
+        #[cfg(test)]
         GhosttyHelperDefaults::Unavailable => {
             parse_ghostty_defaults_from_paths(config_paths, theme_dirs).unwrap_or_default()
         }
+        #[cfg(not(test))]
+        GhosttyHelperDefaults::Unavailable => DefaultColors::default(),
         GhosttyHelperDefaults::TimedOut => DefaultColors::default(),
     };
     resolve_ghostty_application_defaults(parsed)
@@ -2723,13 +2727,17 @@ pub(crate) fn is_ghostty_config_helper_invocation(args: &[String]) -> bool {
 }
 
 pub(crate) fn run_ghostty_config_helper() -> i32 {
-    let defaults = parse_ghostty_defaults_from_paths(
+    match parse_ghostty_defaults_from_paths_result(
         platform::ghostty_config_paths(),
         platform::ghostty_theme_dirs(),
-    )
-    .unwrap_or_default();
-    print!("{}", serialize_ghostty_defaults(defaults));
-    0
+    ) {
+        GhosttyConfigParseOutcome::Parsed(defaults) => {
+            print!("{}", serialize_ghostty_defaults(defaults));
+            0
+        }
+        GhosttyConfigParseOutcome::Missing => 1,
+        GhosttyConfigParseOutcome::TimedOut => 2,
+    }
 }
 
 #[cfg(not(test))]
@@ -2743,35 +2751,70 @@ fn ghostty_defaults_from_helper() -> GhosttyHelperDefaults {
         .stdin(ProcessStdio::null())
         .stdout(ProcessStdio::piped())
         .stderr(ProcessStdio::null());
+    #[cfg(unix)]
+    command.process_group(0);
     scrub_ghostty_helper_secret_environment(&mut command);
     let Ok(mut child) = command.spawn() else {
         return GhosttyHelperDefaults::Unavailable;
     };
-    let Some(mut stdout) = child.stdout.take() else {
-        let _ = child.kill();
-        let _ = child.wait();
+    let Some(stdout) = child.stdout.take() else {
+        terminate_ghostty_helper_child(child);
+        return GhosttyHelperDefaults::Unavailable;
+    };
+    let Some(output_reader) = read_ghostty_helper_output_async(stdout) else {
+        terminate_ghostty_helper_child(child);
         return GhosttyHelperDefaults::Unavailable;
     };
     let status = match child.wait_timeout(GHOSTTY_CONFIG_PARSE_DEADLINE) {
         Ok(status) => status,
-        Err(_) => return GhosttyHelperDefaults::Unavailable,
+        Err(_) => {
+            terminate_ghostty_helper_child(child);
+            return GhosttyHelperDefaults::Unavailable;
+        }
     };
     let status = match status {
         Some(status) => status,
         None => {
-            let _ = child.kill();
-            let _ = child.wait();
+            terminate_ghostty_helper_child(child);
             return GhosttyHelperDefaults::TimedOut;
         }
     };
     if !status.success() {
+        if status.code() == Some(2) {
+            return GhosttyHelperDefaults::TimedOut;
+        }
         return GhosttyHelperDefaults::Unavailable;
     }
-    let mut output = String::new();
-    if stdout.read_to_string(&mut output).is_err() {
-        return GhosttyHelperDefaults::Unavailable;
+    match output_reader.join().ok().flatten() {
+        Some(output) => GhosttyHelperDefaults::Resolved(parse_resolved_ghostty_defaults(&output)),
+        None => GhosttyHelperDefaults::Unavailable,
     }
-    GhosttyHelperDefaults::Resolved(parse_resolved_ghostty_defaults(&output))
+}
+
+fn read_ghostty_helper_output_async(
+    stdout: impl Read + Send + 'static,
+) -> Option<std::thread::JoinHandle<Option<String>>> {
+    std::thread::Builder::new()
+        .name("cmux-tui-ghostty-helper-output".to_string())
+        .spawn(move || read_ghostty_limited_string(stdout, GHOSTTY_HELPER_OUTPUT_MAX_BYTES))
+        .ok()
+}
+
+fn terminate_ghostty_helper_child(mut child: Child) {
+    #[cfg(unix)]
+    unsafe {
+        // SAFETY: killpg only sends SIGKILL to the helper-owned process group.
+        libc::killpg(child.id() as libc::pid_t, libc::SIGKILL);
+    }
+    let _ = child.kill();
+    if matches!(child.wait_timeout(Duration::from_millis(10)), Ok(Some(_))) {
+        return;
+    }
+    let _ = std::thread::Builder::new().name("cmux-tui-ghostty-helper-reaper".to_string()).spawn(
+        move || {
+            let _ = child.wait();
+        },
+    );
 }
 
 #[cfg(any(not(test), all(test, unix)))]
@@ -2781,37 +2824,80 @@ fn scrub_ghostty_helper_secret_environment(command: &mut Command) {
     }
 }
 
+#[cfg(test)]
 fn parse_ghostty_defaults_from_paths(
     config_paths: Vec<PathBuf>,
     theme_dirs: Vec<PathBuf>,
 ) -> Option<DefaultColors> {
-    config_paths.iter().find_map(|path| parse_ghostty_defaults_from_path(path, &theme_dirs))
+    match parse_ghostty_defaults_from_paths_result(config_paths, theme_dirs) {
+        GhosttyConfigParseOutcome::Parsed(defaults) => Some(defaults),
+        GhosttyConfigParseOutcome::Missing | GhosttyConfigParseOutcome::TimedOut => None,
+    }
+}
+
+enum GhosttyConfigParseOutcome {
+    Parsed(DefaultColors),
+    Missing,
+    TimedOut,
+}
+
+fn parse_ghostty_defaults_from_paths_result(
+    config_paths: Vec<PathBuf>,
+    theme_dirs: Vec<PathBuf>,
+) -> GhosttyConfigParseOutcome {
+    for path in config_paths {
+        match parse_ghostty_defaults_from_path_result(&path, &theme_dirs) {
+            GhosttyConfigParseOutcome::Missing => {}
+            outcome => return outcome,
+        }
+    }
+    GhosttyConfigParseOutcome::Missing
 }
 
 #[cfg(test)]
 fn parse_ghostty_defaults_with_theme_dirs(text: &str, theme_dirs: &[PathBuf]) -> DefaultColors {
-    let mut theme_selection = GhosttyThemeSelection::System;
+    let mut theme_selection = auto_ghostty_theme_selection();
     let mut theme_candidates = Vec::new();
     let parsed = parse_ghostty_config_text(text, None, &mut theme_selection, &mut theme_candidates);
-    let mut defaults =
-        resolve_ghostty_theme_defaults(&theme_candidates, theme_dirs, theme_selection);
+    let mut defaults = resolve_ghostty_theme_defaults(
+        &theme_candidates,
+        theme_dirs,
+        theme_selection,
+        &parsed.overrides,
+    );
     overlay_ghostty_defaults(&mut defaults, parsed.overrides);
     defaults
 }
 
+#[cfg(test)]
 fn parse_ghostty_defaults_from_path(path: &Path, theme_dirs: &[PathBuf]) -> Option<DefaultColors> {
-    let mut theme_selection = GhosttyThemeSelection::System;
+    match parse_ghostty_defaults_from_path_result(path, theme_dirs) {
+        GhosttyConfigParseOutcome::Parsed(defaults) => Some(defaults),
+        GhosttyConfigParseOutcome::Missing | GhosttyConfigParseOutcome::TimedOut => None,
+    }
+}
+
+fn parse_ghostty_defaults_from_path_result(
+    path: &Path,
+    theme_dirs: &[PathBuf],
+) -> GhosttyConfigParseOutcome {
+    let mut theme_selection = auto_ghostty_theme_selection();
     let mut theme_candidates = Vec::new();
-    let overrides = parse_ghostty_config_file(path, &mut theme_selection, &mut theme_candidates)?;
+    let overrides =
+        match parse_ghostty_config_file(path, &mut theme_selection, &mut theme_candidates) {
+            GhosttyConfigParseOutcome::Parsed(overrides) => overrides,
+            outcome => return outcome,
+        };
     let mut defaults =
-        resolve_ghostty_theme_defaults(&theme_candidates, theme_dirs, theme_selection);
+        resolve_ghostty_theme_defaults(&theme_candidates, theme_dirs, theme_selection, &overrides);
     overlay_ghostty_defaults(&mut defaults, overrides);
-    Some(defaults)
+    GhosttyConfigParseOutcome::Parsed(defaults)
 }
 
 const GHOSTTY_CONFIG_MAX_FILES: usize = 64;
 const GHOSTTY_CONFIG_MAX_DEPTH: usize = 16;
 const GHOSTTY_CONFIG_MAX_BYTES: u64 = 1024 * 1024;
+const GHOSTTY_HELPER_OUTPUT_MAX_BYTES: u64 = 64 * 1024;
 const GHOSTTY_CONFIG_PARSE_DEADLINE: Duration = Duration::from_millis(250);
 
 struct PendingGhosttyConfig {
@@ -2823,7 +2909,21 @@ fn parse_ghostty_config_file(
     path: &Path,
     theme_selection: &mut GhosttyThemeSelection,
     theme_candidates: &mut Vec<GhosttyThemeCandidate>,
-) -> Option<DefaultColors> {
+) -> GhosttyConfigParseOutcome {
+    parse_ghostty_config_file_with_deadline(
+        path,
+        theme_selection,
+        theme_candidates,
+        GHOSTTY_CONFIG_PARSE_DEADLINE,
+    )
+}
+
+fn parse_ghostty_config_file_with_deadline(
+    path: &Path,
+    theme_selection: &mut GhosttyThemeSelection,
+    theme_candidates: &mut Vec<GhosttyThemeCandidate>,
+    deadline: Duration,
+) -> GhosttyConfigParseOutcome {
     let started_at = Instant::now();
     let mut stack = vec![PendingGhosttyConfig { path: path.to_path_buf(), depth: 0 }];
     let mut loaded = HashSet::new();
@@ -2833,8 +2933,8 @@ fn parse_ghostty_config_file(
     let mut overrides = DefaultColors::default();
 
     while let Some(pending) = stack.pop() {
-        if started_at.elapsed() > GHOSTTY_CONFIG_PARSE_DEADLINE {
-            break;
+        if files_loaded > 0 && started_at.elapsed() > deadline {
+            return GhosttyConfigParseOutcome::TimedOut;
         }
         if pending.depth > GHOSTTY_CONFIG_MAX_DEPTH || files_loaded >= GHOSTTY_CONFIG_MAX_FILES {
             continue;
@@ -2846,7 +2946,9 @@ fn parse_ghostty_config_file(
         let remaining_bytes = GHOSTTY_CONFIG_MAX_BYTES.saturating_sub(bytes_loaded);
         let text = match read_ghostty_regular_file(&pending.path, remaining_bytes) {
             Some(text) => text,
-            None if pending.depth == 0 && files_loaded == 0 => return None,
+            None if pending.depth == 0 && files_loaded == 0 => {
+                return GhosttyConfigParseOutcome::Missing;
+            }
             None => continue,
         };
         bytes_loaded = bytes_loaded.saturating_add(text.len() as u64);
@@ -2864,9 +2966,16 @@ fn parse_ghostty_config_file(
         {
             stack.push(PendingGhosttyConfig { path: include, depth: pending.depth + 1 });
         }
+        if started_at.elapsed() > deadline {
+            return GhosttyConfigParseOutcome::TimedOut;
+        }
     }
 
-    loaded_root.then_some(overrides)
+    if loaded_root {
+        GhosttyConfigParseOutcome::Parsed(overrides)
+    } else {
+        GhosttyConfigParseOutcome::Missing
+    }
 }
 
 struct ParsedGhosttyConfig {
@@ -2915,12 +3024,29 @@ enum GhosttyThemeSelection {
     Ghostty,
 }
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum ResolvedGhosttyThemeSelection {
+    Mode(GhosttyThemeMode),
+    Ghostty,
+}
+
 impl GhosttyThemeSelection {
-    fn resolve(self) -> GhosttyThemeMode {
+    fn resolve_for_parse(self) -> ResolvedGhosttyThemeSelection {
+        match self {
+            Self::Mode(mode) => ResolvedGhosttyThemeSelection::Mode(mode),
+            Self::System => ResolvedGhosttyThemeSelection::Mode(system_ghostty_theme_mode(
+                platform_appearance_theme_mode(),
+            )),
+            Self::Ghostty => ResolvedGhosttyThemeSelection::Ghostty,
+        }
+    }
+}
+
+impl ResolvedGhosttyThemeSelection {
+    fn resolve(self, ghostty_background: Option<Rgb>) -> GhosttyThemeMode {
         match self {
             Self::Mode(mode) => mode,
-            Self::System => system_ghostty_theme_mode(platform_appearance_theme_mode()),
-            Self::Ghostty => ghostty_background_theme_mode(platform_appearance_theme_mode()),
+            Self::Ghostty => ghostty_background_theme_mode(ghostty_background),
         }
     }
 }
@@ -2948,11 +3074,13 @@ fn system_ghostty_theme_mode(platform_appearance: Option<GhosttyThemeMode>) -> G
     GhosttyThemeMode::Light
 }
 
-fn ghostty_background_theme_mode(
-    platform_appearance: Option<GhosttyThemeMode>,
-) -> GhosttyThemeMode {
-    terminal_background_theme_mode()
-        .unwrap_or_else(|| system_ghostty_theme_mode(platform_appearance))
+fn ghostty_background_theme_mode(background: Option<Rgb>) -> GhosttyThemeMode {
+    let background = background.unwrap_or(Rgb { r: 0x28, g: 0x2c, b: 0x34 });
+    if ghostty_background_is_light(background) {
+        GhosttyThemeMode::Light
+    } else {
+        GhosttyThemeMode::Dark
+    }
 }
 
 #[cfg(target_os = "macos")]
@@ -2967,16 +3095,140 @@ fn platform_appearance_theme_mode() -> Option<GhosttyThemeMode> {
 
 #[cfg(not(target_os = "macos"))]
 fn non_macos_appearance_theme_mode() -> Option<GhosttyThemeMode> {
+    if let Some(mode) = freedesktop_portal_theme_mode() {
+        return Some(mode);
+    }
+    if let Some(mode) = gnome_color_scheme_theme_mode() {
+        return Some(mode);
+    }
     if let Some(mode) = std::env::var_os("GTK_THEME")
         .as_deref()
         .and_then(|value| gtk_theme_name_theme_mode(&value.to_string_lossy()))
     {
         return Some(mode);
     }
-    gtk_settings_paths().into_iter().find_map(|path| {
+    gtk_settings_paths()
+        .into_iter()
+        .find_map(|path| {
+            let text = read_ghostty_regular_file(&path, 64 * 1024)?;
+            gtk_settings_theme_mode(&text)
+        })
+        .or_else(kde_globals_theme_mode)
+}
+
+#[cfg(not(target_os = "macos"))]
+fn freedesktop_portal_theme_mode() -> Option<GhosttyThemeMode> {
+    let output = desktop_theme_command_output(
+        "gdbus",
+        &[
+            "call",
+            "--session",
+            "--dest",
+            "org.freedesktop.portal.Desktop",
+            "--object-path",
+            "/org/freedesktop/portal/desktop",
+            "--method",
+            "org.freedesktop.portal.Settings.Read",
+            "org.freedesktop.appearance",
+            "color-scheme",
+        ],
+    )?;
+    freedesktop_portal_color_scheme_theme_mode(&output)
+}
+
+#[cfg(not(target_os = "macos"))]
+fn gnome_color_scheme_theme_mode() -> Option<GhosttyThemeMode> {
+    let output = desktop_theme_command_output(
+        "gsettings",
+        &["get", "org.gnome.desktop.interface", "color-scheme"],
+    )?;
+    gnome_color_scheme_output_theme_mode(&output)
+}
+
+#[cfg(not(target_os = "macos"))]
+fn desktop_theme_command_output(program: &str, args: &[&str]) -> Option<String> {
+    let mut child = Command::new(program)
+        .args(args)
+        .stdin(std::process::Stdio::null())
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::null())
+        .spawn()
+        .ok()?;
+    let Some(stdout) = child.stdout.take() else {
+        terminate_ghostty_helper_child(child);
+        return None;
+    };
+    let Some(output_reader) = read_ghostty_helper_output_async(stdout) else {
+        terminate_ghostty_helper_child(child);
+        return None;
+    };
+    let status = match child.wait_timeout(Duration::from_millis(75)) {
+        Ok(Some(status)) => status,
+        Ok(None) | Err(_) => {
+            terminate_ghostty_helper_child(child);
+            return None;
+        }
+    };
+    if !status.success() {
+        return None;
+    }
+    output_reader.join().ok().flatten()
+}
+
+#[cfg(any(test, not(target_os = "macos")))]
+fn freedesktop_portal_color_scheme_theme_mode(text: &str) -> Option<GhosttyThemeMode> {
+    if text.contains("uint32 1") || text.contains("<1>") {
+        return Some(GhosttyThemeMode::Dark);
+    }
+    if text.contains("uint32 2") || text.contains("<2>") {
+        return Some(GhosttyThemeMode::Light);
+    }
+    None
+}
+
+#[cfg(any(test, not(target_os = "macos")))]
+fn gnome_color_scheme_output_theme_mode(text: &str) -> Option<GhosttyThemeMode> {
+    let text = text.trim().trim_matches('\'').trim_matches('"');
+    match text {
+        "prefer-dark" => Some(GhosttyThemeMode::Dark),
+        "prefer-light" => Some(GhosttyThemeMode::Light),
+        _ => None,
+    }
+}
+
+#[cfg(not(target_os = "macos"))]
+fn kde_globals_theme_mode() -> Option<GhosttyThemeMode> {
+    kde_globals_paths().into_iter().find_map(|path| {
         let text = read_ghostty_regular_file(&path, 64 * 1024)?;
-        gtk_settings_theme_mode(&text)
+        kde_globals_text_theme_mode(&text)
     })
+}
+
+#[cfg(not(target_os = "macos"))]
+fn kde_globals_paths() -> Vec<PathBuf> {
+    let mut paths = Vec::new();
+    if let Some(config_home) = std::env::var_os("XDG_CONFIG_HOME").map(PathBuf::from) {
+        paths.push(config_home.join("kdeglobals"));
+    }
+    if let Some(home) = platform::home_dir() {
+        let path = home.join(".config").join("kdeglobals");
+        if !paths.contains(&path) {
+            paths.push(path);
+        }
+    }
+    paths
+}
+
+#[cfg(any(test, not(target_os = "macos")))]
+fn kde_globals_text_theme_mode(text: &str) -> Option<GhosttyThemeMode> {
+    for line in text.lines() {
+        let line = line.trim();
+        let Some((key, value)) = line.split_once('=') else { continue };
+        if key.trim() == "ColorScheme" {
+            return gtk_theme_name_theme_mode(value.trim());
+        }
+    }
+    None
 }
 
 #[cfg(not(target_os = "macos"))]
@@ -3028,23 +3280,21 @@ fn gtk_settings_theme_mode(text: &str) -> Option<GhosttyThemeMode> {
 #[cfg(any(test, not(target_os = "macos")))]
 fn gtk_theme_name_theme_mode(value: &str) -> Option<GhosttyThemeMode> {
     let value = value.to_ascii_lowercase();
-    if value.split([':', '-', '_']).any(|part| part == "dark") {
+    if value.ends_with("dark") || value.split([':', '-', '_']).any(|part| part == "dark") {
         return Some(GhosttyThemeMode::Dark);
     }
-    if value.split([':', '-', '_']).any(|part| part == "light") {
+    if value.ends_with("light") || value.split([':', '-', '_']).any(|part| part == "light") {
         return Some(GhosttyThemeMode::Light);
     }
     None
 }
 
-fn terminal_background_theme_mode() -> Option<GhosttyThemeMode> {
-    let value = std::env::var("COLORFGBG").ok()?;
-    let background = value.rsplit(';').next()?.parse::<u16>().ok()?;
-    match background {
-        0..=6 | 8 => Some(GhosttyThemeMode::Dark),
-        7 | 15 => Some(GhosttyThemeMode::Light),
-        _ => None,
-    }
+fn ghostty_background_is_light(background: Rgb) -> bool {
+    let luminance = (0.299 * f64::from(background.r)
+        + 0.587 * f64::from(background.g)
+        + 0.114 * f64::from(background.b))
+        / 255.0;
+    luminance > 0.5
 }
 
 #[cfg(target_os = "macos")]
@@ -3153,9 +3403,16 @@ fn resolve_ghostty_theme_defaults(
     theme_candidates: &[GhosttyThemeCandidate],
     theme_dirs: &[PathBuf],
     theme_selection: GhosttyThemeSelection,
+    overrides: &DefaultColors,
 ) -> DefaultColors {
+    if theme_candidates.is_empty() {
+        return DefaultColors::default();
+    }
+    let resolved_selection = theme_selection.resolve_for_parse();
     for candidate in theme_candidates {
-        if let Some(defaults) = load_ghostty_theme(candidate, theme_dirs, theme_selection) {
+        if let Some(defaults) =
+            load_ghostty_theme(candidate, theme_dirs, resolved_selection, overrides)
+        {
             return defaults;
         }
     }
@@ -3168,10 +3425,19 @@ fn parse_ghostty_window_theme(value: &str) -> Option<GhosttyThemeSelection> {
         return Some(GhosttyThemeSelection::Mode(mode));
     }
     match value {
-        "auto" | "system" => Some(GhosttyThemeSelection::System),
+        "auto" => Some(auto_ghostty_theme_selection()),
+        "system" => Some(GhosttyThemeSelection::System),
         "ghostty" => Some(GhosttyThemeSelection::Ghostty),
         _ => None,
     }
+}
+
+fn auto_ghostty_theme_selection() -> GhosttyThemeSelection {
+    auto_ghostty_theme_selection_for_target(cfg!(target_os = "macos"))
+}
+
+fn auto_ghostty_theme_selection_for_target(is_macos: bool) -> GhosttyThemeSelection {
+    if is_macos { GhosttyThemeSelection::System } else { GhosttyThemeSelection::Ghostty }
 }
 
 /// Parse the fully resolved `ghostty +show-config` output. Theme lines are
@@ -3287,20 +3553,51 @@ fn apply_ghostty_default(defaults: &mut DefaultColors, key: &str, value: &str) {
 fn load_ghostty_theme(
     candidate: &GhosttyThemeCandidate,
     theme_dirs: &[PathBuf],
-    theme_selection: GhosttyThemeSelection,
+    theme_selection: ResolvedGhosttyThemeSelection,
+    overrides: &DefaultColors,
 ) -> Option<DefaultColors> {
-    let theme = selected_ghostty_theme(candidate.value.trim_matches('"'), theme_selection);
+    let value = candidate.value.trim_matches('"');
+    let ghostty_background = if theme_selection == ResolvedGhosttyThemeSelection::Ghostty {
+        ghostty_theme_selection_background(value, candidate, theme_dirs, overrides)
+    } else {
+        None
+    };
+    let theme = selected_ghostty_theme(value, theme_selection, ghostty_background);
     let path = resolve_ghostty_theme_path(theme, candidate.base_dir.as_deref(), theme_dirs)?;
     let text = read_ghostty_regular_file(&path, GHOSTTY_CONFIG_MAX_BYTES)?;
     Some(parse_resolved_ghostty_defaults(&text))
 }
 
+fn ghostty_theme_selection_background(
+    value: &str,
+    candidate: &GhosttyThemeCandidate,
+    theme_dirs: &[PathBuf],
+    overrides: &DefaultColors,
+) -> Option<Rgb> {
+    overrides.bg.or_else(|| {
+        let light = selected_conditional_ghostty_theme(
+            value,
+            ResolvedGhosttyThemeSelection::Mode(GhosttyThemeMode::Light),
+            None,
+        )?;
+        let path = resolve_ghostty_theme_path(light, candidate.base_dir.as_deref(), theme_dirs)?;
+        let text = read_ghostty_regular_file(&path, GHOSTTY_CONFIG_MAX_BYTES)?;
+        parse_resolved_ghostty_defaults(&text).bg
+    })
+}
+
 fn read_ghostty_regular_file(path: &Path, max_bytes: u64) -> Option<String> {
-    let metadata = std::fs::metadata(path).ok()?;
+    let file = std::fs::File::open(path).ok()?;
+    let metadata = file.metadata().ok()?;
     if !metadata.file_type().is_file() || metadata.len() > max_bytes {
         return None;
     }
-    let text = std::fs::read_to_string(path).ok()?;
+    read_ghostty_limited_string(file, max_bytes)
+}
+
+fn read_ghostty_limited_string(reader: impl Read, max_bytes: u64) -> Option<String> {
+    let mut text = String::new();
+    reader.take(max_bytes.saturating_add(1)).read_to_string(&mut text).ok()?;
     if text.len() as u64 > max_bytes {
         return None;
     }
@@ -3333,13 +3630,18 @@ fn expand_home_relative_path(value: &str) -> Option<PathBuf> {
     }
 }
 
-fn selected_ghostty_theme(value: &str, theme_selection: GhosttyThemeSelection) -> &str {
-    selected_conditional_ghostty_theme(value, theme_selection).unwrap_or(value)
+fn selected_ghostty_theme(
+    value: &str,
+    theme_selection: ResolvedGhosttyThemeSelection,
+    ghostty_background: Option<Rgb>,
+) -> &str {
+    selected_conditional_ghostty_theme(value, theme_selection, ghostty_background).unwrap_or(value)
 }
 
 fn selected_conditional_ghostty_theme(
     value: &str,
-    theme_selection: GhosttyThemeSelection,
+    theme_selection: ResolvedGhosttyThemeSelection,
+    ghostty_background: Option<Rgb>,
 ) -> Option<&str> {
     let mut light = None;
     let mut dark = None;
@@ -3352,7 +3654,7 @@ fn selected_conditional_ghostty_theme(
             _ => return None,
         }
     }
-    match theme_selection.resolve() {
+    match theme_selection.resolve(ghostty_background) {
         GhosttyThemeMode::Light if light.is_some() && dark.is_some() => light,
         GhosttyThemeMode::Dark if light.is_some() && dark.is_some() => dark,
         _ => None,
@@ -4388,6 +4690,51 @@ mod tests {
     }
 
     #[test]
+    fn ghostty_config_parse_deadline_discards_partial_defaults() {
+        let _guard = CONFIG_ENV_LOCK.lock().unwrap();
+        let dir = std::env::temp_dir().join(format!(
+            "cmux-tui-ghostty-deadline-{}-{}",
+            std::process::id(),
+            SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_nanos()
+        ));
+        let ghostty_dir = dir.join("ghostty");
+        std::fs::create_dir_all(&ghostty_dir).unwrap();
+        std::fs::write(
+            ghostty_dir.join("config"),
+            "background = #010203\nconfig-file = colors.conf\n",
+        )
+        .unwrap();
+        std::fs::write(ghostty_dir.join("colors.conf"), "foreground = #040506\n").unwrap();
+
+        let mut theme_selection = auto_ghostty_theme_selection();
+        let mut theme_candidates = Vec::new();
+        let outcome = parse_ghostty_config_file_with_deadline(
+            &ghostty_dir.join("config"),
+            &mut theme_selection,
+            &mut theme_candidates,
+            Duration::ZERO,
+        );
+        let full = parse_ghostty_defaults_from_path(&ghostty_dir.join("config"), &[])
+            .expect("config parses without deadline pressure");
+
+        let _ = std::fs::remove_dir_all(dir);
+
+        assert!(matches!(outcome, GhosttyConfigParseOutcome::TimedOut));
+        assert_eq!(full.bg, Some(Rgb { r: 0x01, g: 0x02, b: 0x03 }));
+        assert_eq!(full.fg, Some(Rgb { r: 0x04, g: 0x05, b: 0x06 }));
+    }
+
+    #[test]
+    fn ghostty_file_reader_enforces_byte_limit_during_read() {
+        let text = "foreground = #010203\n";
+        assert_eq!(
+            read_ghostty_limited_string(text.as_bytes(), text.len() as u64),
+            Some(text.to_string())
+        );
+        assert_eq!(read_ghostty_limited_string(text.as_bytes(), text.len() as u64 - 1), None);
+    }
+
+    #[test]
     fn ghostty_theme_loader_skips_non_regular_and_oversized_candidates() {
         let _guard = CONFIG_ENV_LOCK.lock().unwrap();
         let dir = std::env::temp_dir().join(format!(
@@ -4445,6 +4792,53 @@ mod tests {
         let stdout = String::from_utf8(output.stdout).unwrap();
         assert!(!stdout.contains("CMUX_MACHINE_PROVIDER_TOKEN="), "{stdout}");
         assert!(!stdout.contains("CMUX_PROVIDER_WORKSPACE_AUTHORITY="), "{stdout}");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn ghostty_config_helper_cleanup_reaps_killed_child() {
+        let child = Command::new("/bin/sleep").arg("5").spawn().unwrap();
+        let pid = child.id() as libc::pid_t;
+
+        terminate_ghostty_helper_child(child);
+
+        let deadline = Instant::now() + Duration::from_secs(2);
+        while unix_process_exists(pid) && Instant::now() < deadline {
+            std::thread::sleep(Duration::from_millis(10));
+        }
+
+        assert!(!unix_process_exists(pid), "helper child {pid} was not reaped");
+    }
+
+    #[cfg(unix)]
+    fn unix_process_exists(pid: libc::pid_t) -> bool {
+        if unsafe { libc::kill(pid, 0) } == 0 {
+            return true;
+        }
+        std::io::Error::last_os_error().raw_os_error() != Some(libc::ESRCH)
+    }
+
+    #[test]
+    fn ghostty_config_helper_output_reader_drains_large_palette() {
+        let mut output = String::new();
+        for index in 0..256 {
+            output.push_str(&format!("palette.{index}=#010203\n"));
+        }
+        assert!(output.len() > 4 * 1024);
+
+        let reader =
+            read_ghostty_helper_output_async(std::io::Cursor::new(output.clone())).unwrap();
+
+        assert_eq!(reader.join().unwrap(), Some(output));
+    }
+
+    #[test]
+    fn ghostty_config_helper_output_reader_enforces_byte_limit() {
+        let output = "x".repeat(GHOSTTY_HELPER_OUTPUT_MAX_BYTES as usize + 1);
+
+        let reader = read_ghostty_helper_output_async(std::io::Cursor::new(output)).unwrap();
+
+        assert_eq!(reader.join().unwrap(), None);
     }
 
     #[test]
@@ -4565,26 +4959,47 @@ mod tests {
     }
 
     #[test]
-    fn ghostty_platform_light_mode_wins_over_dark_terminal_background_hint() {
+    fn ghostty_system_theme_uses_platform_appearance() {
         let _guard = CONFIG_ENV_LOCK.lock().unwrap();
         let old_apple_interface_style = std::env::var_os("AppleInterfaceStyle");
-        let old_colorfgbg = std::env::var_os("COLORFGBG");
         // SAFETY: env mutation in tests is serialized by CONFIG_ENV_LOCK.
-        unsafe {
-            std::env::remove_var("AppleInterfaceStyle");
-            std::env::set_var("COLORFGBG", "15;0");
-        }
+        unsafe { std::env::remove_var("AppleInterfaceStyle") };
 
         let mode = system_ghostty_theme_mode(Some(GhosttyThemeMode::Light));
 
         restore_env_var("AppleInterfaceStyle", old_apple_interface_style);
-        restore_env_var("COLORFGBG", old_colorfgbg);
 
         assert_eq!(mode, GhosttyThemeMode::Light);
     }
 
     #[test]
-    fn ghostty_non_macos_gtk_sources_detect_system_theme_mode() {
+    fn ghostty_auto_window_theme_is_platform_specific() {
+        assert_eq!(auto_ghostty_theme_selection_for_target(true), GhosttyThemeSelection::System);
+        assert_eq!(auto_ghostty_theme_selection_for_target(false), GhosttyThemeSelection::Ghostty);
+    }
+
+    #[test]
+    fn ghostty_background_luminance_matches_ghostty_threshold() {
+        assert!(ghostty_background_is_light(Rgb { r: 255, g: 255, b: 255 }));
+        assert!(!ghostty_background_is_light(Rgb { r: 0, g: 0, b: 0 }));
+        assert!(!ghostty_background_is_light(Rgb { r: 0x28, g: 0x2c, b: 0x34 }));
+    }
+
+    #[test]
+    fn ghostty_non_macos_desktop_sources_detect_system_theme_mode() {
+        assert_eq!(
+            freedesktop_portal_color_scheme_theme_mode("(<'uint32 1'>,)"),
+            Some(GhosttyThemeMode::Dark)
+        );
+        assert_eq!(
+            freedesktop_portal_color_scheme_theme_mode("(<uint32 2>,)"),
+            Some(GhosttyThemeMode::Light)
+        );
+        assert_eq!(
+            gnome_color_scheme_output_theme_mode("'prefer-dark'\n"),
+            Some(GhosttyThemeMode::Dark)
+        );
+        assert_eq!(gnome_color_scheme_output_theme_mode("'default'\n"), None);
         assert_eq!(
             gtk_settings_theme_mode("[Settings]\ngtk-application-prefer-dark-theme=1\n"),
             Some(GhosttyThemeMode::Dark)
@@ -4605,13 +5020,16 @@ mod tests {
         );
         assert_eq!(gtk_theme_name_theme_mode("Adwaita:dark"), Some(GhosttyThemeMode::Dark));
         assert_eq!(gtk_theme_name_theme_mode("Yaru-light"), Some(GhosttyThemeMode::Light));
+        assert_eq!(
+            kde_globals_text_theme_mode("[General]\nColorScheme=BreezeDark\n"),
+            Some(GhosttyThemeMode::Dark)
+        );
     }
 
     #[test]
-    fn ghostty_window_theme_uses_terminal_background_separately_from_system() {
+    fn ghostty_window_theme_uses_resolved_background_separately_from_system() {
         let _guard = CONFIG_ENV_LOCK.lock().unwrap();
         let old_apple_interface_style = std::env::var_os("AppleInterfaceStyle");
-        let old_colorfgbg = std::env::var_os("COLORFGBG");
         let dir = std::env::temp_dir().join(format!(
             "cmux-tui-ghostty-theme-source-{}-{}",
             std::process::id(),
@@ -4629,27 +5047,25 @@ mod tests {
         )
         .unwrap();
         // SAFETY: env mutation in tests is serialized by CONFIG_ENV_LOCK.
-        unsafe {
-            std::env::set_var("AppleInterfaceStyle", "Light");
-            std::env::set_var("COLORFGBG", "15;0");
-        }
+        unsafe { std::env::set_var("AppleInterfaceStyle", "Light") };
 
         let system = parse_ghostty_defaults_with_theme_dirs(
             "window-theme = system\n\
+             background = #101112\n\
              theme = light:Light Source Theme,dark:Dark Source Theme\n",
             std::slice::from_ref(&dir),
         );
         let ghostty = parse_ghostty_defaults_with_theme_dirs(
             "window-theme = ghostty\n\
+             background = #101112\n\
              theme = light:Light Source Theme,dark:Dark Source Theme\n",
             std::slice::from_ref(&dir),
         );
 
         restore_env_var("AppleInterfaceStyle", old_apple_interface_style);
-        restore_env_var("COLORFGBG", old_colorfgbg);
         let _ = std::fs::remove_dir_all(dir);
 
-        assert_eq!(system.bg, Some(Rgb { r: 0xf0, g: 0xf1, b: 0xf2 }));
+        assert_eq!(system.bg, Some(Rgb { r: 0x10, g: 0x11, b: 0x12 }));
         assert_eq!(system.fg, Some(Rgb { r: 0xf3, g: 0xf4, b: 0xf5 }));
         assert_eq!(ghostty.bg, Some(Rgb { r: 0x10, g: 0x11, b: 0x12 }));
         assert_eq!(ghostty.fg, Some(Rgb { r: 0x13, g: 0x14, b: 0x15 }));

--- a/cmux-tui/crates/cmux-tui/src/config.rs
+++ b/cmux-tui/crates/cmux-tui/src/config.rs
@@ -2679,9 +2679,9 @@ fn ghostty_show_config_command(installation: &platform::GhosttyInstallation) -> 
 /// Parse the subset of Ghostty's `key = value` config used by cmux-tui.
 ///
 /// When the Ghostty executable is unavailable, a theme is only accepted if
-/// its file can be read. This preserves Ghostty's fail-soft behavior: a
-/// later theme entries are ignored, matching Ghostty's first-theme-wins
-/// behavior.
+/// its file can be read. This preserves Ghostty's fail-soft behavior: keep
+/// looking after unreadable theme entries, then stop after the first theme
+/// that resolves successfully.
 #[cfg(test)]
 pub(crate) fn parse_ghostty_defaults(text: &str) -> DefaultColors {
     parse_ghostty_defaults_with_theme_dirs(text, &platform::ghostty_theme_dirs())
@@ -2689,20 +2689,24 @@ pub(crate) fn parse_ghostty_defaults(text: &str) -> DefaultColors {
 
 #[cfg(test)]
 fn parse_ghostty_defaults_with_theme_dirs(text: &str, theme_dirs: &[PathBuf]) -> DefaultColors {
-    parse_ghostty_config_text(text, theme_dirs, GhosttyThemeMode::default()).defaults
+    let mut theme_mode = None;
+    let mut theme_selected = false;
+    parse_ghostty_config_text(text, theme_dirs, &mut theme_mode, &mut theme_selected).defaults
 }
 
 fn parse_ghostty_defaults_from_path(path: &Path, theme_dirs: &[PathBuf]) -> Option<DefaultColors> {
     let mut loaded = HashSet::new();
-    let mut theme_mode = GhosttyThemeMode::default();
-    parse_ghostty_config_file(path, theme_dirs, &mut loaded, &mut theme_mode)
+    let mut theme_mode = None;
+    let mut theme_selected = false;
+    parse_ghostty_config_file(path, theme_dirs, &mut loaded, &mut theme_mode, &mut theme_selected)
 }
 
 fn parse_ghostty_config_file(
     path: &Path,
     theme_dirs: &[PathBuf],
     loaded: &mut HashSet<PathBuf>,
-    theme_mode: &mut GhosttyThemeMode,
+    theme_mode: &mut Option<GhosttyThemeMode>,
+    theme_selected: &mut bool,
 ) -> Option<DefaultColors> {
     let text = std::fs::read_to_string(path).ok()?;
     let identity = path.canonicalize().unwrap_or_else(|_| path.to_path_buf());
@@ -2710,11 +2714,12 @@ fn parse_ghostty_config_file(
         return Some(DefaultColors::default());
     }
     let base_dir = path.parent().unwrap_or_else(|| Path::new("."));
-    let parsed = parse_ghostty_config_text(&text, theme_dirs, *theme_mode);
+    let parsed = parse_ghostty_config_text(&text, theme_dirs, theme_mode, theme_selected);
     *theme_mode = parsed.theme_mode;
     let mut defaults = parsed.defaults;
     for include in parsed.config_files.into_iter().filter_map(|include| include.resolve(base_dir)) {
-        if let Some(included) = parse_ghostty_config_file(&include, theme_dirs, loaded, theme_mode)
+        if let Some(included) =
+            parse_ghostty_config_file(&include, theme_dirs, loaded, theme_mode, theme_selected)
         {
             overlay_ghostty_defaults(&mut defaults, included);
         }
@@ -2725,7 +2730,7 @@ fn parse_ghostty_config_file(
 struct ParsedGhosttyConfig {
     defaults: DefaultColors,
     config_files: Vec<GhosttyConfigFile>,
-    theme_mode: GhosttyThemeMode,
+    theme_mode: Option<GhosttyThemeMode>,
 }
 
 struct GhosttyConfigFile {
@@ -2747,34 +2752,132 @@ impl GhosttyConfigFile {
     }
 }
 
-#[derive(Clone, Copy, Default)]
+#[derive(Clone, Copy)]
 enum GhosttyThemeMode {
-    #[default]
     Light,
     Dark,
+}
+
+impl GhosttyThemeMode {
+    fn detect() -> Self {
+        if let Some(mode) = std::env::var_os("AppleInterfaceStyle").as_deref().and_then(Self::parse)
+        {
+            return mode;
+        }
+        #[cfg(target_os = "macos")]
+        if macos_prefers_dark_appearance() {
+            return Self::Dark;
+        }
+        terminal_background_theme_mode().unwrap_or(Self::Light)
+    }
+
+    fn parse(value: &std::ffi::OsStr) -> Option<Self> {
+        let value = value.to_string_lossy();
+        match value.trim_matches('"').to_ascii_lowercase().as_str() {
+            "light" => Some(Self::Light),
+            "dark" => Some(Self::Dark),
+            _ => None,
+        }
+    }
+}
+
+fn terminal_background_theme_mode() -> Option<GhosttyThemeMode> {
+    let value = std::env::var("COLORFGBG").ok()?;
+    let background = value.rsplit(';').next()?.parse::<u16>().ok()?;
+    match background {
+        0..=6 | 8 => Some(GhosttyThemeMode::Dark),
+        7 | 15 => Some(GhosttyThemeMode::Light),
+        _ => None,
+    }
+}
+
+#[cfg(target_os = "macos")]
+fn macos_prefers_dark_appearance() -> bool {
+    use std::ffi::CString;
+    use std::os::raw::{c_char, c_void};
+    use std::ptr;
+
+    type CfTypeRef = *const c_void;
+    type CfStringRef = *const c_void;
+    type Boolean = u8;
+
+    const K_CF_STRING_ENCODING_UTF8: u32 = 0x0800_0100;
+
+    #[link(name = "CoreFoundation", kind = "framework")]
+    unsafe extern "C" {
+        static kCFPreferencesAnyApplication: CfStringRef;
+        static kCFPreferencesCurrentUser: CfStringRef;
+        static kCFPreferencesAnyHost: CfStringRef;
+
+        fn CFStringCreateWithCString(
+            alloc: *const c_void,
+            c_str: *const c_char,
+            encoding: u32,
+        ) -> CfStringRef;
+        fn CFPreferencesCopyValue(
+            key: CfStringRef,
+            application_id: CfStringRef,
+            user_name: CfStringRef,
+            host_name: CfStringRef,
+        ) -> CfTypeRef;
+        fn CFEqual(cf1: CfTypeRef, cf2: CfTypeRef) -> Boolean;
+        fn CFRelease(cf: CfTypeRef);
+    }
+
+    let Some(key) = CString::new("AppleInterfaceStyle").ok() else {
+        return false;
+    };
+    let Some(dark) = CString::new("Dark").ok() else {
+        return false;
+    };
+    unsafe {
+        let key_ref =
+            CFStringCreateWithCString(ptr::null(), key.as_ptr(), K_CF_STRING_ENCODING_UTF8);
+        if key_ref.is_null() {
+            return false;
+        }
+        let dark_ref =
+            CFStringCreateWithCString(ptr::null(), dark.as_ptr(), K_CF_STRING_ENCODING_UTF8);
+        if dark_ref.is_null() {
+            CFRelease(key_ref);
+            return false;
+        }
+        let value = CFPreferencesCopyValue(
+            key_ref,
+            kCFPreferencesAnyApplication,
+            kCFPreferencesCurrentUser,
+            kCFPreferencesAnyHost,
+        );
+        let is_dark = !value.is_null() && CFEqual(value, dark_ref) != 0;
+        if !value.is_null() {
+            CFRelease(value);
+        }
+        CFRelease(dark_ref);
+        CFRelease(key_ref);
+        is_dark
+    }
 }
 
 fn parse_ghostty_config_text(
     text: &str,
     theme_dirs: &[PathBuf],
-    mut theme_mode: GhosttyThemeMode,
+    theme_mode: &mut Option<GhosttyThemeMode>,
+    theme_selected: &mut bool,
 ) -> ParsedGhosttyConfig {
     let mut overrides = DefaultColors::default();
-    let mut theme = None;
+    let mut theme_candidates = Vec::new();
     let mut config_files = Vec::new();
     for line in text.lines() {
         let line = line.trim();
         let Some((key, value)) = line.split_once('=') else { continue };
         match key.trim() {
             "theme" => {
-                if theme.is_none() {
-                    theme = Some(value.trim().to_owned());
+                if !*theme_selected {
+                    theme_candidates.push(value.trim().to_owned());
                 }
             }
             "window-theme" => {
-                if let Some(mode) = parse_ghostty_window_theme(value.trim()) {
-                    theme_mode = mode;
-                }
+                *theme_mode = parse_ghostty_window_theme(value.trim());
             }
             "config-file" => {
                 if let Some(include) = GhosttyConfigFile::parse(value) {
@@ -2785,19 +2888,22 @@ fn parse_ghostty_config_text(
         }
     }
 
-    let mut defaults = theme
-        .and_then(|theme| load_ghostty_theme(&theme, theme_dirs, theme_mode))
-        .unwrap_or_default();
+    let mut defaults = DefaultColors::default();
+    if !*theme_selected {
+        for theme in theme_candidates {
+            if let Some(theme_defaults) = load_ghostty_theme(&theme, theme_dirs, *theme_mode) {
+                defaults = theme_defaults;
+                *theme_selected = true;
+                break;
+            }
+        }
+    }
     overlay_ghostty_defaults(&mut defaults, overrides);
-    ParsedGhosttyConfig { defaults, config_files, theme_mode }
+    ParsedGhosttyConfig { defaults, config_files, theme_mode: *theme_mode }
 }
 
 fn parse_ghostty_window_theme(value: &str) -> Option<GhosttyThemeMode> {
-    match value.trim_matches('"') {
-        "light" => Some(GhosttyThemeMode::Light),
-        "dark" => Some(GhosttyThemeMode::Dark),
-        _ => None,
-    }
+    GhosttyThemeMode::parse(std::ffi::OsStr::new(value))
 }
 
 /// Parse the fully resolved `ghostty +show-config` output. Theme lines are
@@ -2869,7 +2975,7 @@ fn apply_ghostty_default(defaults: &mut DefaultColors, key: &str, value: &str) {
 fn load_ghostty_theme(
     value: &str,
     theme_dirs: &[PathBuf],
-    theme_mode: GhosttyThemeMode,
+    theme_mode: Option<GhosttyThemeMode>,
 ) -> Option<DefaultColors> {
     let theme = selected_ghostty_theme(value.trim_matches('"'), theme_mode);
     let path = if Path::new(theme).is_absolute() {
@@ -2883,11 +2989,14 @@ fn load_ghostty_theme(
     Some(parse_resolved_ghostty_defaults(&text))
 }
 
-fn selected_ghostty_theme(value: &str, theme_mode: GhosttyThemeMode) -> &str {
+fn selected_ghostty_theme(value: &str, theme_mode: Option<GhosttyThemeMode>) -> &str {
     selected_conditional_ghostty_theme(value, theme_mode).unwrap_or(value)
 }
 
-fn selected_conditional_ghostty_theme(value: &str, theme_mode: GhosttyThemeMode) -> Option<&str> {
+fn selected_conditional_ghostty_theme(
+    value: &str,
+    theme_mode: Option<GhosttyThemeMode>,
+) -> Option<&str> {
     let mut light = None;
     let mut dark = None;
     for part in value.split(',') {
@@ -2899,7 +3008,7 @@ fn selected_conditional_ghostty_theme(value: &str, theme_mode: GhosttyThemeMode)
             _ => return None,
         }
     }
-    match theme_mode {
+    match theme_mode.unwrap_or_else(GhosttyThemeMode::detect) {
         GhosttyThemeMode::Light if light.is_some() && dark.is_some() => light,
         GhosttyThemeMode::Dark if light.is_some() && dark.is_some() => dark,
         _ => None,
@@ -3410,7 +3519,8 @@ mod tests {
         std::fs::create_dir_all(&themes).unwrap();
         std::fs::write(
             ghostty_dir.join("config"),
-            "theme = dark:Dark Resource Theme, light:Light Resource Theme\n\
+            "window-theme = light\n\
+             theme = dark:Dark Resource Theme, light:Light Resource Theme\n\
              background = #444444\n",
         )
         .unwrap();
@@ -3542,6 +3652,117 @@ mod tests {
         assert_eq!(config.terminal_defaults.fg, Some(Rgb { r: 0xaa, g: 0xaa, b: 0xaa }));
         assert_eq!(config.terminal_defaults.bg, Some(Rgb { r: 0x44, g: 0x44, b: 0x44 }));
         assert_eq!(config.terminal_defaults.palette[1], Some(Rgb { r: 0xcc, g: 0xcc, b: 0xcc }));
+    }
+
+    #[test]
+    fn ghostty_fallback_theme_selection_skips_unreadable_themes() {
+        let _guard = CONFIG_ENV_LOCK.lock().unwrap();
+        let dir = std::env::temp_dir().join(format!(
+            "cmux-tui-ghostty-theme-missing-{}-{}",
+            std::process::id(),
+            SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_nanos()
+        ));
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(
+            dir.join("Readable Theme"),
+            "background = #101112\nforeground = #131415\npalette = 1=#161718\n",
+        )
+        .unwrap();
+
+        let defaults = parse_ghostty_defaults_with_theme_dirs(
+            "theme = Missing Theme\n\
+             theme = Readable Theme\n",
+            std::slice::from_ref(&dir),
+        );
+
+        let _ = std::fs::remove_dir_all(dir);
+
+        assert_eq!(defaults.bg, Some(Rgb { r: 0x10, g: 0x11, b: 0x12 }));
+        assert_eq!(defaults.fg, Some(Rgb { r: 0x13, g: 0x14, b: 0x15 }));
+        assert_eq!(defaults.palette[1], Some(Rgb { r: 0x16, g: 0x17, b: 0x18 }));
+    }
+
+    #[test]
+    fn ghostty_included_config_cannot_replace_successful_root_theme() {
+        let _guard = CONFIG_ENV_LOCK.lock().unwrap();
+        let dir = std::env::temp_dir().join(format!(
+            "cmux-tui-ghostty-theme-include-first-{}-{}",
+            std::process::id(),
+            SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_nanos()
+        ));
+        let ghostty_dir = dir.join("ghostty");
+        let themes = dir.join("themes");
+        std::fs::create_dir_all(&ghostty_dir).unwrap();
+        std::fs::create_dir_all(&themes).unwrap();
+        std::fs::write(
+            ghostty_dir.join("config"),
+            "window-theme = light\n\
+             theme = Root Theme\n\
+             config-file = colors.conf\n",
+        )
+        .unwrap();
+        std::fs::write(
+            ghostty_dir.join("colors.conf"),
+            "theme = Include Theme\n\
+             foreground = #303132\n",
+        )
+        .unwrap();
+        std::fs::write(
+            themes.join("Root Theme"),
+            "background = #202122\nforeground = #232425\npalette = 1=#262728\n",
+        )
+        .unwrap();
+        std::fs::write(
+            themes.join("Include Theme"),
+            "background = #909192\nforeground = #939495\npalette = 1=#969798\n",
+        )
+        .unwrap();
+
+        let defaults = parse_ghostty_defaults_from_path(&ghostty_dir.join("config"), &[themes])
+            .expect("config parses");
+
+        let _ = std::fs::remove_dir_all(dir);
+
+        assert_eq!(defaults.bg, Some(Rgb { r: 0x20, g: 0x21, b: 0x22 }));
+        assert_eq!(defaults.fg, Some(Rgb { r: 0x30, g: 0x31, b: 0x32 }));
+        assert_eq!(defaults.palette[1], Some(Rgb { r: 0x26, g: 0x27, b: 0x28 }));
+    }
+
+    #[test]
+    fn ghostty_automatic_window_theme_uses_detected_dark_mode_for_conditional_theme() {
+        let _guard = CONFIG_ENV_LOCK.lock().unwrap();
+        let old_apple_interface_style = std::env::var_os("AppleInterfaceStyle");
+        let dir = std::env::temp_dir().join(format!(
+            "cmux-tui-ghostty-theme-auto-{}-{}",
+            std::process::id(),
+            SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_nanos()
+        ));
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(
+            dir.join("Light Auto Theme"),
+            "background = #f0f1f2\nforeground = #f3f4f5\npalette = 1=#f6f7f8\n",
+        )
+        .unwrap();
+        std::fs::write(
+            dir.join("Dark Auto Theme"),
+            "background = #101112\nforeground = #131415\npalette = 1=#161718\n",
+        )
+        .unwrap();
+        // SAFETY: env mutation in tests is serialized by CONFIG_ENV_LOCK.
+        unsafe { std::env::set_var("AppleInterfaceStyle", "Dark") };
+
+        let defaults = parse_ghostty_defaults_with_theme_dirs(
+            "window-theme = auto\n\
+             theme = light:Light Auto Theme,dark:Dark Auto Theme\n",
+            std::slice::from_ref(&dir),
+        );
+
+        restore_env_var("AppleInterfaceStyle", old_apple_interface_style);
+        let _ = std::fs::remove_dir_all(dir);
+
+        assert_eq!(defaults.bg, Some(Rgb { r: 0x10, g: 0x11, b: 0x12 }));
+        assert_eq!(defaults.fg, Some(Rgb { r: 0x13, g: 0x14, b: 0x15 }));
+        assert_eq!(defaults.palette[1], Some(Rgb { r: 0x16, g: 0x17, b: 0x18 }));
     }
 
     #[test]

--- a/cmux-tui/crates/cmux-tui/src/config.rs
+++ b/cmux-tui/crates/cmux-tui/src/config.rs
@@ -2691,14 +2691,34 @@ pub(crate) fn parse_ghostty_defaults(text: &str) -> DefaultColors {
 fn parse_ghostty_defaults_with_theme_dirs(text: &str, theme_dirs: &[PathBuf]) -> DefaultColors {
     let mut theme_mode = None;
     let mut theme_selected = false;
-    parse_ghostty_config_text(text, theme_dirs, &mut theme_mode, &mut theme_selected).defaults
+    let mut theme_defaults = DefaultColors::default();
+    let parsed = parse_ghostty_config_text(
+        text,
+        theme_dirs,
+        &mut theme_mode,
+        &mut theme_selected,
+        &mut theme_defaults,
+    );
+    let mut defaults = theme_defaults;
+    overlay_ghostty_defaults(&mut defaults, parsed.overrides);
+    defaults
 }
 
 fn parse_ghostty_defaults_from_path(path: &Path, theme_dirs: &[PathBuf]) -> Option<DefaultColors> {
     let mut loaded = HashSet::new();
     let mut theme_mode = None;
     let mut theme_selected = false;
-    parse_ghostty_config_file(path, theme_dirs, &mut loaded, &mut theme_mode, &mut theme_selected)
+    let mut theme_defaults = DefaultColors::default();
+    let overrides = parse_ghostty_config_file(
+        path,
+        theme_dirs,
+        &mut loaded,
+        &mut theme_mode,
+        &mut theme_selected,
+        &mut theme_defaults,
+    )?;
+    overlay_ghostty_defaults(&mut theme_defaults, overrides);
+    Some(theme_defaults)
 }
 
 fn parse_ghostty_config_file(
@@ -2707,6 +2727,7 @@ fn parse_ghostty_config_file(
     loaded: &mut HashSet<PathBuf>,
     theme_mode: &mut Option<GhosttyThemeMode>,
     theme_selected: &mut bool,
+    theme_defaults: &mut DefaultColors,
 ) -> Option<DefaultColors> {
     let text = std::fs::read_to_string(path).ok()?;
     let identity = path.canonicalize().unwrap_or_else(|_| path.to_path_buf());
@@ -2714,21 +2735,27 @@ fn parse_ghostty_config_file(
         return Some(DefaultColors::default());
     }
     let base_dir = path.parent().unwrap_or_else(|| Path::new("."));
-    let parsed = parse_ghostty_config_text(&text, theme_dirs, theme_mode, theme_selected);
+    let parsed =
+        parse_ghostty_config_text(&text, theme_dirs, theme_mode, theme_selected, theme_defaults);
     *theme_mode = parsed.theme_mode;
-    let mut defaults = parsed.defaults;
+    let mut overrides = parsed.overrides;
     for include in parsed.config_files.into_iter().filter_map(|include| include.resolve(base_dir)) {
-        if let Some(included) =
-            parse_ghostty_config_file(&include, theme_dirs, loaded, theme_mode, theme_selected)
-        {
-            overlay_ghostty_defaults(&mut defaults, included);
+        if let Some(included) = parse_ghostty_config_file(
+            &include,
+            theme_dirs,
+            loaded,
+            theme_mode,
+            theme_selected,
+            theme_defaults,
+        ) {
+            overlay_ghostty_defaults(&mut overrides, included);
         }
     }
-    Some(defaults)
+    Some(overrides)
 }
 
 struct ParsedGhosttyConfig {
-    defaults: DefaultColors,
+    overrides: DefaultColors,
     config_files: Vec<GhosttyConfigFile>,
     theme_mode: Option<GhosttyThemeMode>,
 }
@@ -2877,6 +2904,7 @@ fn parse_ghostty_config_text(
     theme_dirs: &[PathBuf],
     theme_mode: &mut Option<GhosttyThemeMode>,
     theme_selected: &mut bool,
+    theme_defaults: &mut DefaultColors,
 ) -> ParsedGhosttyConfig {
     let mut overrides = DefaultColors::default();
     let mut theme_candidates = Vec::new();
@@ -2902,18 +2930,16 @@ fn parse_ghostty_config_text(
         }
     }
 
-    let mut defaults = DefaultColors::default();
     if !*theme_selected {
         for theme in theme_candidates {
-            if let Some(theme_defaults) = load_ghostty_theme(&theme, theme_dirs, *theme_mode) {
-                defaults = theme_defaults;
+            if let Some(defaults) = load_ghostty_theme(&theme, theme_dirs, *theme_mode) {
+                *theme_defaults = defaults;
                 *theme_selected = true;
                 break;
             }
         }
     }
-    overlay_ghostty_defaults(&mut defaults, overrides);
-    ParsedGhosttyConfig { defaults, config_files, theme_mode: *theme_mode }
+    ParsedGhosttyConfig { overrides, config_files, theme_mode: *theme_mode }
 }
 
 fn parse_ghostty_window_theme(value: &str) -> Option<GhosttyThemeMode> {
@@ -3663,7 +3689,7 @@ mod tests {
         let _ = std::fs::remove_dir_all(&dir);
 
         assert!(!resolver_ran, "config load must not run ghostty +show-config at startup");
-        assert_eq!(config.terminal_defaults.fg, Some(Rgb { r: 0xaa, g: 0xaa, b: 0xaa }));
+        assert_eq!(config.terminal_defaults.fg, Some(Rgb { r: 0x01, g: 0x01, b: 0x01 }));
         assert_eq!(config.terminal_defaults.bg, Some(Rgb { r: 0x44, g: 0x44, b: 0x44 }));
         assert_eq!(config.terminal_defaults.palette[1], Some(Rgb { r: 0xcc, g: 0xcc, b: 0xcc }));
     }
@@ -3740,6 +3766,42 @@ mod tests {
         assert_eq!(defaults.bg, Some(Rgb { r: 0x20, g: 0x21, b: 0x22 }));
         assert_eq!(defaults.fg, Some(Rgb { r: 0x30, g: 0x31, b: 0x32 }));
         assert_eq!(defaults.palette[1], Some(Rgb { r: 0x26, g: 0x27, b: 0x28 }));
+    }
+
+    #[test]
+    fn ghostty_parent_explicit_color_wins_over_theme_loaded_by_include() {
+        let _guard = CONFIG_ENV_LOCK.lock().unwrap();
+        let dir = std::env::temp_dir().join(format!(
+            "cmux-tui-ghostty-theme-include-overrides-{}-{}",
+            std::process::id(),
+            SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_nanos()
+        ));
+        let ghostty_dir = dir.join("ghostty");
+        let themes = dir.join("themes");
+        std::fs::create_dir_all(&ghostty_dir).unwrap();
+        std::fs::create_dir_all(&themes).unwrap();
+        std::fs::write(
+            ghostty_dir.join("config"),
+            "window-theme = dark\n\
+             foreground = #010203\n\
+             config-file = colors.conf\n",
+        )
+        .unwrap();
+        std::fs::write(ghostty_dir.join("colors.conf"), "theme = Include Theme\n").unwrap();
+        std::fs::write(
+            themes.join("Include Theme"),
+            "background = #202122\nforeground = #a0a1a2\npalette = 1=#232425\n",
+        )
+        .unwrap();
+
+        let defaults = parse_ghostty_defaults_from_path(&ghostty_dir.join("config"), &[themes])
+            .expect("config parses");
+
+        let _ = std::fs::remove_dir_all(dir);
+
+        assert_eq!(defaults.fg, Some(Rgb { r: 0x01, g: 0x02, b: 0x03 }));
+        assert_eq!(defaults.bg, Some(Rgb { r: 0x20, g: 0x21, b: 0x22 }));
+        assert_eq!(defaults.palette[1], Some(Rgb { r: 0x23, g: 0x24, b: 0x25 }));
     }
 
     #[test]

--- a/cmux-tui/crates/cmux-tui/src/config.rs
+++ b/cmux-tui/crates/cmux-tui/src/config.rs
@@ -2690,16 +2690,9 @@ pub(crate) fn parse_ghostty_defaults(text: &str) -> DefaultColors {
 #[cfg(test)]
 fn parse_ghostty_defaults_with_theme_dirs(text: &str, theme_dirs: &[PathBuf]) -> DefaultColors {
     let mut theme_mode = None;
-    let mut theme_selected = false;
-    let mut theme_defaults = DefaultColors::default();
-    let parsed = parse_ghostty_config_text(
-        text,
-        theme_dirs,
-        &mut theme_mode,
-        &mut theme_selected,
-        &mut theme_defaults,
-    );
-    let mut defaults = theme_defaults;
+    let mut theme_candidates = Vec::new();
+    let parsed = parse_ghostty_config_text(text, &mut theme_mode, &mut theme_candidates);
+    let mut defaults = resolve_ghostty_theme_defaults(&theme_candidates, theme_dirs, theme_mode);
     overlay_ghostty_defaults(&mut defaults, parsed.overrides);
     defaults
 }
@@ -2707,18 +2700,17 @@ fn parse_ghostty_defaults_with_theme_dirs(text: &str, theme_dirs: &[PathBuf]) ->
 fn parse_ghostty_defaults_from_path(path: &Path, theme_dirs: &[PathBuf]) -> Option<DefaultColors> {
     let mut loaded = HashSet::new();
     let mut theme_mode = None;
-    let mut theme_selected = false;
-    let mut theme_defaults = DefaultColors::default();
+    let mut theme_candidates = Vec::new();
     let overrides = parse_ghostty_config_file(
         path,
         theme_dirs,
         &mut loaded,
         &mut theme_mode,
-        &mut theme_selected,
-        &mut theme_defaults,
+        &mut theme_candidates,
     )?;
-    overlay_ghostty_defaults(&mut theme_defaults, overrides);
-    Some(theme_defaults)
+    let mut defaults = resolve_ghostty_theme_defaults(&theme_candidates, theme_dirs, theme_mode);
+    overlay_ghostty_defaults(&mut defaults, overrides);
+    Some(defaults)
 }
 
 fn parse_ghostty_config_file(
@@ -2726,8 +2718,7 @@ fn parse_ghostty_config_file(
     theme_dirs: &[PathBuf],
     loaded: &mut HashSet<PathBuf>,
     theme_mode: &mut Option<GhosttyThemeMode>,
-    theme_selected: &mut bool,
-    theme_defaults: &mut DefaultColors,
+    theme_candidates: &mut Vec<String>,
 ) -> Option<DefaultColors> {
     let text = std::fs::read_to_string(path).ok()?;
     let identity = path.canonicalize().unwrap_or_else(|_| path.to_path_buf());
@@ -2735,19 +2726,13 @@ fn parse_ghostty_config_file(
         return Some(DefaultColors::default());
     }
     let base_dir = path.parent().unwrap_or_else(|| Path::new("."));
-    let parsed =
-        parse_ghostty_config_text(&text, theme_dirs, theme_mode, theme_selected, theme_defaults);
+    let parsed = parse_ghostty_config_text(&text, theme_mode, theme_candidates);
     *theme_mode = parsed.theme_mode;
     let mut overrides = parsed.overrides;
     for include in parsed.config_files.into_iter().filter_map(|include| include.resolve(base_dir)) {
-        if let Some(included) = parse_ghostty_config_file(
-            &include,
-            theme_dirs,
-            loaded,
-            theme_mode,
-            theme_selected,
-            theme_defaults,
-        ) {
+        if let Some(included) =
+            parse_ghostty_config_file(&include, theme_dirs, loaded, theme_mode, theme_candidates)
+        {
             overlay_ghostty_defaults(&mut overrides, included);
         }
     }
@@ -2901,22 +2886,17 @@ fn macos_appearance_theme_mode() -> Option<GhosttyThemeMode> {
 
 fn parse_ghostty_config_text(
     text: &str,
-    theme_dirs: &[PathBuf],
     theme_mode: &mut Option<GhosttyThemeMode>,
-    theme_selected: &mut bool,
-    theme_defaults: &mut DefaultColors,
+    theme_candidates: &mut Vec<String>,
 ) -> ParsedGhosttyConfig {
     let mut overrides = DefaultColors::default();
-    let mut theme_candidates = Vec::new();
     let mut config_files = Vec::new();
     for line in text.lines() {
         let line = line.trim();
         let Some((key, value)) = line.split_once('=') else { continue };
         match key.trim() {
             "theme" => {
-                if !*theme_selected {
-                    theme_candidates.push(value.trim().to_owned());
-                }
+                theme_candidates.push(value.trim().to_owned());
             }
             "window-theme" => {
                 *theme_mode = parse_ghostty_window_theme(value.trim());
@@ -2930,16 +2910,20 @@ fn parse_ghostty_config_text(
         }
     }
 
-    if !*theme_selected {
-        for theme in theme_candidates {
-            if let Some(defaults) = load_ghostty_theme(&theme, theme_dirs, *theme_mode) {
-                *theme_defaults = defaults;
-                *theme_selected = true;
-                break;
-            }
+    ParsedGhosttyConfig { overrides, config_files, theme_mode: *theme_mode }
+}
+
+fn resolve_ghostty_theme_defaults(
+    theme_candidates: &[String],
+    theme_dirs: &[PathBuf],
+    theme_mode: Option<GhosttyThemeMode>,
+) -> DefaultColors {
+    for theme in theme_candidates {
+        if let Some(defaults) = load_ghostty_theme(theme, theme_dirs, theme_mode) {
+            return defaults;
         }
     }
-    ParsedGhosttyConfig { overrides, config_files, theme_mode: *theme_mode }
+    DefaultColors::default()
 }
 
 fn parse_ghostty_window_theme(value: &str) -> Option<GhosttyThemeMode> {
@@ -3802,6 +3786,50 @@ mod tests {
         assert_eq!(defaults.fg, Some(Rgb { r: 0x01, g: 0x02, b: 0x03 }));
         assert_eq!(defaults.bg, Some(Rgb { r: 0x20, g: 0x21, b: 0x22 }));
         assert_eq!(defaults.palette[1], Some(Rgb { r: 0x23, g: 0x24, b: 0x25 }));
+    }
+
+    #[test]
+    fn ghostty_included_window_theme_controls_parent_conditional_theme() {
+        let _guard = CONFIG_ENV_LOCK.lock().unwrap();
+        let old_apple_interface_style = std::env::var_os("AppleInterfaceStyle");
+        let dir = std::env::temp_dir().join(format!(
+            "cmux-tui-ghostty-theme-include-window-theme-{}-{}",
+            std::process::id(),
+            SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_nanos()
+        ));
+        let ghostty_dir = dir.join("ghostty");
+        let themes = dir.join("themes");
+        std::fs::create_dir_all(&ghostty_dir).unwrap();
+        std::fs::create_dir_all(&themes).unwrap();
+        std::fs::write(
+            ghostty_dir.join("config"),
+            "theme = light:Root Light Theme,dark:Root Dark Theme\n\
+             config-file = colors.conf\n",
+        )
+        .unwrap();
+        std::fs::write(ghostty_dir.join("colors.conf"), "window-theme = dark\n").unwrap();
+        std::fs::write(
+            themes.join("Root Light Theme"),
+            "background = #f0f1f2\nforeground = #f3f4f5\npalette = 1=#f6f7f8\n",
+        )
+        .unwrap();
+        std::fs::write(
+            themes.join("Root Dark Theme"),
+            "background = #101112\nforeground = #131415\npalette = 1=#161718\n",
+        )
+        .unwrap();
+        // SAFETY: env mutation in tests is serialized by CONFIG_ENV_LOCK.
+        unsafe { std::env::set_var("AppleInterfaceStyle", "Light") };
+
+        let defaults = parse_ghostty_defaults_from_path(&ghostty_dir.join("config"), &[themes])
+            .expect("config parses");
+
+        restore_env_var("AppleInterfaceStyle", old_apple_interface_style);
+        let _ = std::fs::remove_dir_all(dir);
+
+        assert_eq!(defaults.bg, Some(Rgb { r: 0x10, g: 0x11, b: 0x12 }));
+        assert_eq!(defaults.fg, Some(Rgb { r: 0x13, g: 0x14, b: 0x15 }));
+        assert_eq!(defaults.palette[1], Some(Rgb { r: 0x16, g: 0x17, b: 0x18 }));
     }
 
     #[test]

--- a/cmux-tui/crates/cmux-tui/src/config.rs
+++ b/cmux-tui/crates/cmux-tui/src/config.rs
@@ -3577,11 +3577,14 @@ fn resolve_ghostty_theme_defaults(
     if ghostty_config_deadline_expired(deadline_at) {
         return DefaultColors::default();
     }
+    let mut theme_mode = None;
     for candidate in theme_candidates {
         if ghostty_config_deadline_expired(deadline_at) {
             return DefaultColors::default();
         }
-        if let Some(defaults) = load_ghostty_theme(candidate, theme_dirs, deadline_at) {
+        if let Some(defaults) =
+            load_ghostty_theme(candidate, theme_dirs, deadline_at, &mut theme_mode)
+        {
             return defaults;
         }
     }
@@ -3713,12 +3716,13 @@ fn load_ghostty_theme(
     candidate: &GhosttyThemeCandidate,
     theme_dirs: &[PathBuf],
     deadline_at: Option<Instant>,
+    theme_mode: &mut Option<GhosttyThemeMode>,
 ) -> Option<DefaultColors> {
     if ghostty_config_deadline_expired(deadline_at) {
         return None;
     }
     let value = candidate.value.trim_matches('"');
-    let theme = selected_ghostty_theme(value, deadline_at);
+    let theme = selected_ghostty_theme(value, deadline_at, theme_mode);
     if ghostty_config_deadline_expired(deadline_at) {
         return None;
     }
@@ -3771,11 +3775,18 @@ fn expand_home_relative_path(value: &str) -> Option<PathBuf> {
     }
 }
 
-fn selected_ghostty_theme(value: &str, deadline_at: Option<Instant>) -> &str {
+fn selected_ghostty_theme<'a>(
+    value: &'a str,
+    deadline_at: Option<Instant>,
+    theme_mode: &mut Option<GhosttyThemeMode>,
+) -> &'a str {
     let Some((light, dark)) = conditional_ghostty_themes(value) else {
         return value;
     };
-    match system_ghostty_theme_mode(platform_appearance_theme_mode(deadline_at)) {
+    let mode = *theme_mode.get_or_insert_with(|| {
+        system_ghostty_theme_mode(platform_appearance_theme_mode(deadline_at))
+    });
+    match mode {
         GhosttyThemeMode::Light => light,
         GhosttyThemeMode::Dark => dark,
     }
@@ -5411,10 +5422,40 @@ mod tests {
     #[test]
     fn ghostty_fixed_theme_selection_does_not_require_appearance_budget() {
         let expired = Instant::now().checked_sub(Duration::from_millis(1)).unwrap();
+        let mut theme_mode = None;
 
-        let selected = selected_ghostty_theme("Monokai", Some(expired));
+        let selected = selected_ghostty_theme("Monokai", Some(expired), &mut theme_mode);
 
         assert_eq!(selected, "Monokai");
+        assert_eq!(theme_mode, None);
+    }
+
+    #[test]
+    fn ghostty_conditional_theme_selection_reuses_cached_appearance_mode() {
+        let _guard = CONFIG_ENV_LOCK.lock().unwrap();
+        let old_apple_interface_style = std::env::var_os("AppleInterfaceStyle");
+        let mut theme_mode = None;
+        // SAFETY: env mutation in tests is serialized by CONFIG_ENV_LOCK.
+        unsafe { std::env::set_var("AppleInterfaceStyle", "Dark") };
+
+        let missing = selected_ghostty_theme(
+            "light:Missing Light Theme,dark:Missing Dark Theme",
+            None,
+            &mut theme_mode,
+        );
+        // SAFETY: env mutation in tests is serialized by CONFIG_ENV_LOCK.
+        unsafe { std::env::set_var("AppleInterfaceStyle", "Light") };
+        let fallback = selected_ghostty_theme(
+            "light:Light Fallback Theme,dark:Dark Fallback Theme",
+            None,
+            &mut theme_mode,
+        );
+
+        restore_env_var("AppleInterfaceStyle", old_apple_interface_style);
+
+        assert_eq!(missing, "Missing Dark Theme");
+        assert_eq!(fallback, "Dark Fallback Theme");
+        assert_eq!(theme_mode, Some(GhosttyThemeMode::Dark));
     }
 
     #[test]

--- a/cmux-tui/crates/cmux-tui/src/config.rs
+++ b/cmux-tui/crates/cmux-tui/src/config.rs
@@ -2691,7 +2691,7 @@ pub(crate) fn parse_ghostty_defaults(text: &str) -> DefaultColors {
 fn parse_ghostty_defaults_with_theme_dirs(text: &str, theme_dirs: &[PathBuf]) -> DefaultColors {
     let mut theme_mode = None;
     let mut theme_candidates = Vec::new();
-    let parsed = parse_ghostty_config_text(text, &mut theme_mode, &mut theme_candidates);
+    let parsed = parse_ghostty_config_text(text, None, &mut theme_mode, &mut theme_candidates);
     let mut defaults = resolve_ghostty_theme_defaults(&theme_candidates, theme_dirs, theme_mode);
     overlay_ghostty_defaults(&mut defaults, parsed.overrides);
     defaults
@@ -2718,7 +2718,7 @@ fn parse_ghostty_config_file(
     theme_dirs: &[PathBuf],
     loaded: &mut HashSet<PathBuf>,
     theme_mode: &mut Option<GhosttyThemeMode>,
-    theme_candidates: &mut Vec<String>,
+    theme_candidates: &mut Vec<GhosttyThemeCandidate>,
 ) -> Option<DefaultColors> {
     let text = std::fs::read_to_string(path).ok()?;
     let identity = path.canonicalize().unwrap_or_else(|_| path.to_path_buf());
@@ -2726,7 +2726,7 @@ fn parse_ghostty_config_file(
         return Some(DefaultColors::default());
     }
     let base_dir = path.parent().unwrap_or_else(|| Path::new("."));
-    let parsed = parse_ghostty_config_text(&text, theme_mode, theme_candidates);
+    let parsed = parse_ghostty_config_text(&text, Some(base_dir), theme_mode, theme_candidates);
     *theme_mode = parsed.theme_mode;
     let mut overrides = parsed.overrides;
     for include in parsed.config_files.into_iter().filter_map(|include| include.resolve(base_dir)) {
@@ -2745,6 +2745,11 @@ struct ParsedGhosttyConfig {
     theme_mode: Option<GhosttyThemeMode>,
 }
 
+struct GhosttyThemeCandidate {
+    value: String,
+    base_dir: Option<PathBuf>,
+}
+
 struct GhosttyConfigFile {
     path: String,
 }
@@ -2759,6 +2764,9 @@ impl GhosttyConfigFile {
     }
 
     fn resolve(self, base_dir: &Path) -> Option<PathBuf> {
+        if let Some(path) = expand_home_relative_path(&self.path) {
+            return Some(path);
+        }
         let path = Path::new(&self.path);
         if path.is_absolute() { Some(path.to_path_buf()) } else { Some(base_dir.join(path)) }
     }
@@ -2886,8 +2894,9 @@ fn macos_appearance_theme_mode() -> Option<GhosttyThemeMode> {
 
 fn parse_ghostty_config_text(
     text: &str,
+    base_dir: Option<&Path>,
     theme_mode: &mut Option<GhosttyThemeMode>,
-    theme_candidates: &mut Vec<String>,
+    theme_candidates: &mut Vec<GhosttyThemeCandidate>,
 ) -> ParsedGhosttyConfig {
     let mut overrides = DefaultColors::default();
     let mut config_files = Vec::new();
@@ -2896,7 +2905,10 @@ fn parse_ghostty_config_text(
         let Some((key, value)) = line.split_once('=') else { continue };
         match key.trim() {
             "theme" => {
-                theme_candidates.push(value.trim().to_owned());
+                theme_candidates.push(GhosttyThemeCandidate {
+                    value: value.trim().to_owned(),
+                    base_dir: base_dir.map(Path::to_path_buf),
+                });
             }
             "window-theme" => {
                 *theme_mode = parse_ghostty_window_theme(value.trim());
@@ -2914,12 +2926,12 @@ fn parse_ghostty_config_text(
 }
 
 fn resolve_ghostty_theme_defaults(
-    theme_candidates: &[String],
+    theme_candidates: &[GhosttyThemeCandidate],
     theme_dirs: &[PathBuf],
     theme_mode: Option<GhosttyThemeMode>,
 ) -> DefaultColors {
-    for theme in theme_candidates {
-        if let Some(defaults) = load_ghostty_theme(theme, theme_dirs, theme_mode) {
+    for candidate in theme_candidates {
+        if let Some(defaults) = load_ghostty_theme(candidate, theme_dirs, theme_mode) {
             return defaults;
         }
     }
@@ -2997,20 +3009,40 @@ fn apply_ghostty_default(defaults: &mut DefaultColors, key: &str, value: &str) {
 }
 
 fn load_ghostty_theme(
-    value: &str,
+    candidate: &GhosttyThemeCandidate,
     theme_dirs: &[PathBuf],
     theme_mode: Option<GhosttyThemeMode>,
 ) -> Option<DefaultColors> {
-    let theme = selected_ghostty_theme(value.trim_matches('"'), theme_mode);
-    let path = if Path::new(theme).is_absolute() {
-        PathBuf::from(theme)
-    } else if Path::new(theme).file_name().is_some_and(|name| name == theme) {
-        theme_dirs.iter().map(|dir| dir.join(theme)).find(|path| path.is_file())?
-    } else {
-        return None;
-    };
+    let theme = selected_ghostty_theme(candidate.value.trim_matches('"'), theme_mode);
+    let path = resolve_ghostty_theme_path(theme, candidate.base_dir.as_deref(), theme_dirs)?;
     let text = std::fs::read_to_string(path).ok()?;
     Some(parse_resolved_ghostty_defaults(&text))
+}
+
+fn resolve_ghostty_theme_path(
+    theme: &str,
+    base_dir: Option<&Path>,
+    theme_dirs: &[PathBuf],
+) -> Option<PathBuf> {
+    if let Some(path) = expand_home_relative_path(theme) {
+        return Some(path);
+    }
+    let path = Path::new(theme);
+    if path.is_absolute() {
+        return Some(path.to_path_buf());
+    }
+    if path.file_name().is_some_and(|name| name == theme) {
+        return theme_dirs.iter().map(|dir| dir.join(theme)).find(|path| path.is_file());
+    }
+    base_dir.map(|base_dir| base_dir.join(path))
+}
+
+fn expand_home_relative_path(value: &str) -> Option<PathBuf> {
+    let home = platform::home_dir()?;
+    match value {
+        "~" => Some(home),
+        value => value.strip_prefix("~/").map(|rest| home.join(rest)),
+    }
 }
 
 fn selected_ghostty_theme(value: &str, theme_mode: Option<GhosttyThemeMode>) -> &str {
@@ -3830,6 +3862,74 @@ mod tests {
         assert_eq!(defaults.bg, Some(Rgb { r: 0x10, g: 0x11, b: 0x12 }));
         assert_eq!(defaults.fg, Some(Rgb { r: 0x13, g: 0x14, b: 0x15 }));
         assert_eq!(defaults.palette[1], Some(Rgb { r: 0x16, g: 0x17, b: 0x18 }));
+    }
+
+    #[test]
+    fn ghostty_config_file_expands_required_and_optional_home_relative_paths() {
+        let _guard = CONFIG_ENV_LOCK.lock().unwrap();
+        let old_home = std::env::var_os("HOME");
+        let dir = std::env::temp_dir().join(format!(
+            "cmux-tui-ghostty-home-include-{}-{}",
+            std::process::id(),
+            SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_nanos()
+        ));
+        let home = dir.join("home");
+        let ghostty_dir = dir.join("ghostty");
+        let include_dir = home.join(".config").join("ghostty");
+        std::fs::create_dir_all(&ghostty_dir).unwrap();
+        std::fs::create_dir_all(&include_dir).unwrap();
+        std::fs::write(
+            ghostty_dir.join("config"),
+            "config-file = ~/.config/ghostty/colors.conf\n\
+             config-file = ?~/.config/ghostty/missing.conf\n",
+        )
+        .unwrap();
+        std::fs::write(
+            include_dir.join("colors.conf"),
+            "foreground = #010203\nbackground = #040506\n",
+        )
+        .unwrap();
+        // SAFETY: env mutation in tests is serialized by CONFIG_ENV_LOCK.
+        unsafe { std::env::set_var("HOME", &home) };
+
+        let defaults = parse_ghostty_defaults_from_path(&ghostty_dir.join("config"), &[])
+            .expect("config parses");
+
+        restore_env_var("HOME", old_home);
+        let _ = std::fs::remove_dir_all(dir);
+
+        assert_eq!(defaults.fg, Some(Rgb { r: 0x01, g: 0x02, b: 0x03 }));
+        assert_eq!(defaults.bg, Some(Rgb { r: 0x04, g: 0x05, b: 0x06 }));
+    }
+
+    #[test]
+    fn ghostty_relative_theme_path_uses_declaring_config_directory() {
+        let _guard = CONFIG_ENV_LOCK.lock().unwrap();
+        let dir = std::env::temp_dir().join(format!(
+            "cmux-tui-ghostty-relative-theme-{}-{}",
+            std::process::id(),
+            SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_nanos()
+        ));
+        let ghostty_dir = dir.join("ghostty");
+        let nested_dir = ghostty_dir.join("nested");
+        let nested_themes = nested_dir.join("themes");
+        std::fs::create_dir_all(&nested_themes).unwrap();
+        std::fs::write(ghostty_dir.join("config"), "config-file = nested/colors.conf\n").unwrap();
+        std::fs::write(nested_dir.join("colors.conf"), "theme = ./themes/custom\n").unwrap();
+        std::fs::write(
+            nested_themes.join("custom"),
+            "foreground = #111213\nbackground = #141516\npalette = 1=#171819\n",
+        )
+        .unwrap();
+
+        let defaults = parse_ghostty_defaults_from_path(&ghostty_dir.join("config"), &[])
+            .expect("config parses");
+
+        let _ = std::fs::remove_dir_all(dir);
+
+        assert_eq!(defaults.fg, Some(Rgb { r: 0x11, g: 0x12, b: 0x13 }));
+        assert_eq!(defaults.bg, Some(Rgb { r: 0x14, g: 0x15, b: 0x16 }));
+        assert_eq!(defaults.palette[1], Some(Rgb { r: 0x17, g: 0x18, b: 0x19 }));
     }
 
     #[test]

--- a/cmux-tui/crates/cmux-tui/src/config.rs
+++ b/cmux-tui/crates/cmux-tui/src/config.rs
@@ -2797,7 +2797,14 @@ fn read_ghostty_helper_output_async(
 
 fn terminate_ghostty_helper_child(mut child: Child) {
     #[cfg(unix)]
+    let descendant_groups = ghostty_helper_descendant_process_groups(child.id() as libc::pid_t);
+    #[cfg(unix)]
     unsafe {
+        for group in descendant_groups {
+            // SAFETY: group IDs are read from the process table for descendants
+            // of the helper being terminated.
+            libc::killpg(group, libc::SIGKILL);
+        }
         // SAFETY: killpg only sends SIGKILL to the helper-owned process group.
         libc::killpg(child.id() as libc::pid_t, libc::SIGKILL);
     }
@@ -2810,6 +2817,46 @@ fn terminate_ghostty_helper_child(mut child: Child) {
             let _ = child.wait();
         },
     );
+}
+
+#[cfg(unix)]
+fn ghostty_helper_descendant_process_groups(root_pid: libc::pid_t) -> Vec<libc::pid_t> {
+    let Ok(output) = Command::new("/bin/ps").args(["-axo", "pid=,ppid=,pgid="]).output() else {
+        return Vec::new();
+    };
+    if !output.status.success() {
+        return Vec::new();
+    }
+    let text = String::from_utf8_lossy(&output.stdout);
+    let mut children = HashMap::<libc::pid_t, Vec<(libc::pid_t, libc::pid_t)>>::new();
+    for line in text.lines() {
+        let mut parts = line.split_whitespace();
+        let Some(pid) = parts.next().and_then(|value| value.parse::<libc::pid_t>().ok()) else {
+            continue;
+        };
+        let Some(ppid) = parts.next().and_then(|value| value.parse::<libc::pid_t>().ok()) else {
+            continue;
+        };
+        let Some(pgid) = parts.next().and_then(|value| value.parse::<libc::pid_t>().ok()) else {
+            continue;
+        };
+        children.entry(ppid).or_default().push((pid, pgid));
+    }
+
+    let mut groups = HashSet::<libc::pid_t>::new();
+    let mut stack = vec![root_pid];
+    while let Some(parent) = stack.pop() {
+        let Some(descendants) = children.get(&parent) else {
+            continue;
+        };
+        for &(pid, pgid) in descendants {
+            stack.push(pid);
+            if pgid > 0 && pgid != root_pid {
+                groups.insert(pgid);
+            }
+        }
+    }
+    groups.into_iter().collect()
 }
 
 #[cfg(any(not(test), all(test, unix)))]
@@ -4996,6 +5043,73 @@ mod tests {
 
         assert!(!unix_process_exists(parent_pid), "helper parent {parent_pid} was not reaped");
         assert!(!unix_process_exists(child_pid), "helper child {child_pid} was not killed");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn ghostty_config_helper_cleanup_kills_descendant_process_groups() {
+        const CHILD_MARKER: &str = "CMUX_TEST_GHOSTTY_HELPER_DESCENDANT_GROUP";
+        const CHILD_PID_PATH: &str = "CMUX_TEST_GHOSTTY_HELPER_DESCENDANT_PID";
+        if std::env::var_os(CHILD_MARKER).is_some() {
+            let pid_path =
+                PathBuf::from(std::env::var_os(CHILD_PID_PATH).expect("child pid path set"));
+            let mut command = Command::new("/bin/sleep");
+            command.arg("5").process_group(0);
+            let mut child = command.spawn().unwrap();
+            std::fs::write(pid_path, child.id().to_string()).unwrap();
+            let _ = child.wait();
+            return;
+        }
+
+        let dir = std::env::temp_dir().join(format!(
+            "cmux-tui-ghostty-helper-descendant-group-{}-{}",
+            std::process::id(),
+            SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_nanos()
+        ));
+        std::fs::create_dir_all(&dir).unwrap();
+        let child_pid_path = dir.join("child.pid");
+        let mut command = Command::new(std::env::current_exe().unwrap());
+        command
+            .args([
+                "--exact",
+                "config::tests::ghostty_config_helper_cleanup_kills_descendant_process_groups",
+                "--nocapture",
+            ])
+            .env(CHILD_MARKER, "1")
+            .env(CHILD_PID_PATH, &child_pid_path)
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .process_group(0);
+        let child = command.spawn().unwrap();
+        let parent_pid = child.id() as libc::pid_t;
+        let child_pid = {
+            let deadline = Instant::now() + Duration::from_secs(2);
+            loop {
+                if let Ok(text) = std::fs::read_to_string(&child_pid_path)
+                    && let Ok(pid) = text.trim().parse::<libc::pid_t>()
+                {
+                    break pid;
+                }
+                assert!(Instant::now() < deadline, "descendant pid was not written");
+                std::thread::sleep(Duration::from_millis(10));
+            }
+        };
+
+        terminate_ghostty_helper_child(child);
+
+        let deadline = Instant::now() + Duration::from_secs(2);
+        while (unix_process_exists(parent_pid) || unix_process_exists(child_pid))
+            && Instant::now() < deadline
+        {
+            std::thread::sleep(Duration::from_millis(10));
+        }
+        let _ = std::fs::remove_dir_all(dir);
+
+        assert!(!unix_process_exists(parent_pid), "helper parent {parent_pid} was not reaped");
+        assert!(
+            !unix_process_exists(child_pid),
+            "descendant process-group child {child_pid} was not killed"
+        );
     }
 
     #[cfg(unix)]

--- a/cmux-tui/crates/cmux-tui/src/config.rs
+++ b/cmux-tui/crates/cmux-tui/src/config.rs
@@ -126,7 +126,7 @@ use std::process::Child;
 use std::process::Command;
 #[cfg(not(test))]
 use std::process::Stdio as ProcessStdio;
-#[cfg(all(test, unix))]
+#[cfg(unix)]
 use std::process::Stdio;
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
@@ -2821,13 +2821,60 @@ fn terminate_ghostty_helper_child(mut child: Child) {
 
 #[cfg(unix)]
 fn ghostty_helper_descendant_process_groups(root_pid: libc::pid_t) -> Vec<libc::pid_t> {
-    let Ok(output) = Command::new("/bin/ps").args(["-axo", "pid=,ppid=,pgid="]).output() else {
+    let Some(text) = ghostty_helper_process_table_snapshot() else {
         return Vec::new();
     };
-    if !output.status.success() {
-        return Vec::new();
+    ghostty_helper_descendant_process_groups_from_table(root_pid, &text)
+}
+
+#[cfg(unix)]
+fn ghostty_helper_process_table_snapshot() -> Option<String> {
+    let mut command = Command::new("/bin/ps");
+    command
+        .args(["-axo", "pid=,ppid=,pgid="])
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .process_group(0);
+    let Ok(mut child) = command.spawn() else {
+        return None;
+    };
+    let Some(stdout) = child.stdout.take() else {
+        terminate_ghostty_process_scan_child(child);
+        return None;
+    };
+    let Some(output_reader) = read_ghostty_helper_output_async(stdout) else {
+        terminate_ghostty_process_scan_child(child);
+        return None;
+    };
+    let status = match child.wait_timeout(GHOSTTY_PROCESS_SCAN_DEADLINE) {
+        Ok(Some(status)) => status,
+        Ok(None) | Err(_) => {
+            terminate_ghostty_process_scan_child(child);
+            return None;
+        }
+    };
+    if !status.success() {
+        return None;
     }
-    let text = String::from_utf8_lossy(&output.stdout);
+    output_reader.join().ok().flatten()
+}
+
+#[cfg(unix)]
+fn terminate_ghostty_process_scan_child(mut child: Child) {
+    unsafe {
+        // SAFETY: this only targets the bounded process-scan child group.
+        libc::killpg(child.id() as libc::pid_t, libc::SIGKILL);
+    }
+    let _ = child.kill();
+    let _ = child.wait_timeout(Duration::from_millis(10));
+}
+
+#[cfg(unix)]
+fn ghostty_helper_descendant_process_groups_from_table(
+    root_pid: libc::pid_t,
+    text: &str,
+) -> Vec<libc::pid_t> {
     let mut children = HashMap::<libc::pid_t, Vec<(libc::pid_t, libc::pid_t)>>::new();
     for line in text.lines() {
         let mut parts = line.split_whitespace();
@@ -2968,6 +3015,8 @@ const GHOSTTY_CONFIG_MAX_DEPTH: usize = 16;
 const GHOSTTY_CONFIG_MAX_BYTES: u64 = 1024 * 1024;
 const GHOSTTY_HELPER_OUTPUT_MAX_BYTES: u64 = 64 * 1024;
 const GHOSTTY_CONFIG_PARSE_DEADLINE: Duration = Duration::from_millis(250);
+#[cfg(unix)]
+const GHOSTTY_PROCESS_SCAN_DEADLINE: Duration = Duration::from_millis(150);
 #[cfg(not(test))]
 const GHOSTTY_CONFIG_HELPER_PARENT_DEADLINE: Duration = Duration::from_millis(300);
 #[cfg(not(target_os = "macos"))]
@@ -5034,7 +5083,7 @@ mod tests {
         terminate_ghostty_helper_child(child);
 
         let deadline = Instant::now() + Duration::from_secs(2);
-        while (unix_process_exists(parent_pid) || unix_process_exists(child_pid))
+        while (unix_process_exists(parent_pid) || unix_process_is_live(child_pid))
             && Instant::now() < deadline
         {
             std::thread::sleep(Duration::from_millis(10));
@@ -5107,9 +5156,26 @@ mod tests {
 
         assert!(!unix_process_exists(parent_pid), "helper parent {parent_pid} was not reaped");
         assert!(
-            !unix_process_exists(child_pid),
+            !unix_process_is_live(child_pid),
             "descendant process-group child {child_pid} was not killed"
         );
+    }
+
+    #[cfg(unix)]
+    fn unix_process_is_live(pid: libc::pid_t) -> bool {
+        if !unix_process_exists(pid) {
+            return false;
+        }
+        let Ok(output) =
+            Command::new("/bin/ps").args(["-o", "stat=", "-p", &pid.to_string()]).output()
+        else {
+            return true;
+        };
+        if !output.status.success() {
+            return unix_process_exists(pid);
+        }
+        let stat = String::from_utf8_lossy(&output.stdout);
+        !stat.trim_start().starts_with('Z')
     }
 
     #[cfg(unix)]

--- a/cmux-tui/crates/cmux-tui/src/config.rs
+++ b/cmux-tui/crates/cmux-tui/src/config.rs
@@ -128,8 +128,6 @@ use std::process::Command;
 use std::process::Stdio as ProcessStdio;
 #[cfg(all(test, unix))]
 use std::process::Stdio;
-#[cfg(not(test))]
-use std::thread;
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
 use cmux_tui_core::BrowserMode;
@@ -142,6 +140,8 @@ use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 use ratatui::style::Color;
 use serde::{Deserialize, Deserializer};
 use serde_json::{Value, json};
+#[cfg(not(test))]
+use wait_timeout::ChildExt;
 
 use crate::localization::catalog;
 
@@ -2725,26 +2725,20 @@ fn parse_ghostty_defaults_from_helper() -> Option<DefaultColors> {
     scrub_ghostty_helper_secret_environment(&mut command);
     let mut child = command.spawn().ok()?;
     let mut stdout = child.stdout.take()?;
-    let started_at = Instant::now();
-    loop {
-        match child.try_wait() {
-            Ok(Some(status)) => {
-                if !status.success() {
-                    return None;
-                }
-                let mut output = String::new();
-                stdout.read_to_string(&mut output).ok()?;
-                return Some(parse_resolved_ghostty_defaults(&output));
-            }
-            Ok(None) if started_at.elapsed() >= GHOSTTY_CONFIG_PARSE_DEADLINE => {
-                let _ = child.kill();
-                let _ = child.wait();
-                return None;
-            }
-            Ok(None) => thread::yield_now(),
-            Err(_) => return None,
+    let status = match child.wait_timeout(GHOSTTY_CONFIG_PARSE_DEADLINE).ok()? {
+        Some(status) => status,
+        None => {
+            let _ = child.kill();
+            let _ = child.wait();
+            return None;
         }
+    };
+    if !status.success() {
+        return None;
     }
+    let mut output = String::new();
+    stdout.read_to_string(&mut output).ok()?;
+    Some(parse_resolved_ghostty_defaults(&output))
 }
 
 #[cfg(any(not(test), all(test, unix)))]
@@ -3094,7 +3088,7 @@ fn serialize_ghostty_defaults(defaults: DefaultColors) -> String {
             CursorShape::Block => Some("block"),
             CursorShape::Underline => Some("underline"),
             CursorShape::Bar => Some("bar"),
-            CursorShape::BlockHollow => None,
+            CursorShape::BlockHollow => Some("block_hollow"),
         };
         if let Some(style) = style {
             out.push_str(&format!("cursor-style = {style}\n"));
@@ -3148,6 +3142,7 @@ fn apply_ghostty_default(defaults: &mut DefaultColors, key: &str, value: &str) {
                 "block" => Some(CursorShape::Block),
                 "underline" => Some(CursorShape::Underline),
                 "bar" => Some(CursorShape::Bar),
+                "block_hollow" => Some(CursorShape::BlockHollow),
                 _ => None,
             };
             if style.is_some() {
@@ -3325,6 +3320,9 @@ mod tests {
         );
         assert_eq!(quoted.cursor_style, Some(CursorShape::Bar));
         assert_eq!(quoted.cursor_blink, Some(false));
+
+        let hollow = parse_ghostty_defaults("cursor-style = block_hollow\n");
+        assert_eq!(hollow.cursor_style, Some(CursorShape::BlockHollow));
     }
 
     #[test]

--- a/cmux-tui/crates/cmux-tui/src/config.rs
+++ b/cmux-tui/crates/cmux-tui/src/config.rs
@@ -118,10 +118,11 @@
 //! keys.
 
 use std::collections::{HashMap, HashSet};
-use std::io::{Read, Write};
+use std::io::Write;
 use std::path::{Path, PathBuf};
+#[cfg(all(test, unix))]
 use std::process::{Command, Stdio};
-use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+use std::time::{SystemTime, UNIX_EPOCH};
 
 use cmux_tui_core::BrowserMode;
 use cmux_tui_core::SidebarPluginOptions;
@@ -2629,13 +2630,10 @@ fn parse_color(s: &str) -> Option<Color> {
 /// The user's relevant Ghostty settings with non-optional application defaults
 /// resolved for values that the low-level terminal otherwise leaves unset.
 fn ghostty_defaults() -> DefaultColors {
-    let parsed = resolved_ghostty_defaults()
-        .or_else(|| {
-            let text = platform::ghostty_config_paths()
-                .iter()
-                .find_map(|path| std::fs::read_to_string(path).ok())?;
-            Some(parse_ghostty_defaults(&text))
-        })
+    let parsed = platform::ghostty_config_paths()
+        .iter()
+        .find_map(|path| std::fs::read_to_string(path).ok())
+        .map(|text| parse_ghostty_defaults(&text))
         .unwrap_or_default();
     resolve_ghostty_application_defaults(parsed)
 }
@@ -2649,19 +2647,7 @@ fn resolve_ghostty_application_defaults(mut defaults: DefaultColors) -> DefaultC
     defaults
 }
 
-/// Ask Ghostty to resolve its configuration so cmux-tui inherits precisely the
-/// same theme-loading behavior as the graphical terminal. A failed or slow
-/// invocation is deliberately ignored; startup then uses the file fallback.
-fn resolved_ghostty_defaults() -> Option<DefaultColors> {
-    resolved_ghostty_defaults_from(&platform::ghostty_installations())
-}
-
-fn resolved_ghostty_defaults_from(
-    installations: &[platform::GhosttyInstallation],
-) -> Option<DefaultColors> {
-    resolved_ghostty_defaults_from_with(installations, run_ghostty_show_config)
-}
-
+#[cfg(test)]
 fn resolved_ghostty_defaults_from_with(
     installations: &[platform::GhosttyInstallation],
     mut resolve: impl FnMut(&platform::GhosttyInstallation) -> Option<String>,
@@ -2677,6 +2663,7 @@ fn resolved_ghostty_defaults_from_with(
     })
 }
 
+#[cfg(all(test, unix))]
 fn ghostty_show_config_command(installation: &platform::GhosttyInstallation) -> Command {
     let mut command = Command::new(&installation.binary);
     command
@@ -2688,30 +2675,6 @@ fn ghostty_show_config_command(installation: &platform::GhosttyInstallation) -> 
         command.env("GHOSTTY_RESOURCES_DIR", resources_dir);
     }
     command
-}
-
-fn run_ghostty_show_config(installation: &platform::GhosttyInstallation) -> Option<String> {
-    let mut command = ghostty_show_config_command(installation);
-    let mut child = command.spawn().ok()?;
-    let deadline = Instant::now() + Duration::from_secs(2);
-    let status = loop {
-        match child.try_wait().ok()? {
-            Some(status) => break status,
-            None if Instant::now() >= deadline => {
-                let _ = child.kill();
-                let _ = child.wait();
-                return None;
-            }
-            None => std::thread::sleep(Duration::from_millis(10)),
-        }
-    };
-    if !status.success() {
-        return None;
-    }
-
-    let mut output = String::new();
-    child.stdout.take()?.read_to_string(&mut output).ok()?;
-    Some(output)
 }
 
 /// Parse the subset of Ghostty's `key = value` config used by cmux-tui.

--- a/cmux-tui/crates/cmux-tui/src/config.rs
+++ b/cmux-tui/crates/cmux-tui/src/config.rs
@@ -3223,6 +3223,7 @@ mod tests {
         let _guard = CONFIG_ENV_LOCK.lock().unwrap();
         let old_ghostty_bin = std::env::var_os("GHOSTTY_BIN");
         let old_ghostty_resources = std::env::var_os("GHOSTTY_RESOURCES_DIR");
+        let old_cmux_tui_config = std::env::var_os("CMUX_TUI_CONFIG");
         let old_mux_config = std::env::var_os("CMUX_MUX_CONFIG");
         let old_xdg_config_home = std::env::var_os("XDG_CONFIG_HOME");
         let dir = std::env::temp_dir()
@@ -3248,6 +3249,8 @@ mod tests {
         // SAFETY: env mutation in tests is serialized by CONFIG_ENV_LOCK.
         unsafe { std::env::remove_var("GHOSTTY_RESOURCES_DIR") };
         // SAFETY: env mutation in tests is serialized by CONFIG_ENV_LOCK.
+        unsafe { std::env::remove_var("CMUX_TUI_CONFIG") };
+        // SAFETY: env mutation in tests is serialized by CONFIG_ENV_LOCK.
         unsafe { std::env::remove_var("CMUX_MUX_CONFIG") };
         // SAFETY: env mutation in tests is serialized by CONFIG_ENV_LOCK.
         unsafe { std::env::set_var("XDG_CONFIG_HOME", &dir) };
@@ -3256,6 +3259,7 @@ mod tests {
 
         restore_env_var("GHOSTTY_BIN", old_ghostty_bin);
         restore_env_var("GHOSTTY_RESOURCES_DIR", old_ghostty_resources);
+        restore_env_var("CMUX_TUI_CONFIG", old_cmux_tui_config);
         restore_env_var("CMUX_MUX_CONFIG", old_mux_config);
         restore_env_var("XDG_CONFIG_HOME", old_xdg_config_home);
         let resolver_ran = marker.exists();

--- a/cmux-tui/crates/cmux-tui/src/config.rs
+++ b/cmux-tui/crates/cmux-tui/src/config.rs
@@ -2776,7 +2776,7 @@ fn apply_ghostty_default(defaults: &mut DefaultColors, key: &str, value: &str) {
 }
 
 fn load_ghostty_theme(value: &str, theme_dirs: &[PathBuf]) -> Option<DefaultColors> {
-    let theme = value.trim_matches('"');
+    let theme = selected_ghostty_theme(value.trim_matches('"'));
     let path = if Path::new(theme).is_absolute() {
         PathBuf::from(theme)
     } else if Path::new(theme).file_name().is_some_and(|name| name == theme) {
@@ -2786,6 +2786,27 @@ fn load_ghostty_theme(value: &str, theme_dirs: &[PathBuf]) -> Option<DefaultColo
     };
     let text = std::fs::read_to_string(path).ok()?;
     Some(parse_resolved_ghostty_defaults(&text))
+}
+
+fn selected_ghostty_theme(value: &str) -> &str {
+    // Match Ghostty's static conditional default without running its resolver
+    // during startup; the GUI can switch later, but cmux-tui needs one frame now.
+    selected_conditional_ghostty_theme(value).unwrap_or(value)
+}
+
+fn selected_conditional_ghostty_theme(value: &str) -> Option<&str> {
+    let mut light = None;
+    let mut dark = None;
+    for part in value.split(',') {
+        let (key, theme) = part.split_once(':').or_else(|| part.split_once('='))?;
+        let theme = theme.trim();
+        match key.trim() {
+            "light" if !theme.is_empty() => light = Some(theme),
+            "dark" if !theme.is_empty() => dark = Some(theme),
+            _ => return None,
+        }
+    }
+    if light.is_some() && dark.is_some() { light } else { None }
 }
 
 fn overlay_ghostty_defaults(defaults: &mut DefaultColors, overrides: DefaultColors) {
@@ -3268,6 +3289,80 @@ mod tests {
         assert!(!resolver_ran, "config load must not run ghostty +show-config at startup");
         assert_eq!(config.terminal_defaults.fg, Some(Rgb { r: 1, g: 2, b: 3 }));
         assert_eq!(config.terminal_defaults.bg, None);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn load_resolves_ghostty_resource_theme_without_invoking_external_resolver() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let _guard = CONFIG_ENV_LOCK.lock().unwrap();
+        let old_ghostty_bin = std::env::var_os("GHOSTTY_BIN");
+        let old_ghostty_resources = std::env::var_os("GHOSTTY_RESOURCES_DIR");
+        let old_cmux_tui_config = std::env::var_os("CMUX_TUI_CONFIG");
+        let old_mux_config = std::env::var_os("CMUX_MUX_CONFIG");
+        let old_xdg_config_home = std::env::var_os("XDG_CONFIG_HOME");
+        let dir = std::env::temp_dir()
+            .join(format!("mux-ghostty-startup-resource-theme-{}", std::process::id()));
+        let ghostty_dir = dir.join("ghostty");
+        let resources = dir.join("resources");
+        let themes = resources.join("themes");
+        let marker = dir.join("resolver-ran");
+        let resolver = dir.join("ghostty-resolver");
+        std::fs::create_dir_all(&ghostty_dir).unwrap();
+        std::fs::create_dir_all(&themes).unwrap();
+        std::fs::write(
+            ghostty_dir.join("config"),
+            "theme = dark:Dark Resource Theme, light:Light Resource Theme\n\
+             background = #444444\n",
+        )
+        .unwrap();
+        std::fs::write(
+            themes.join("Light Resource Theme"),
+            "foreground = #111111\nbackground = #222222\npalette = 1=#333333\n",
+        )
+        .unwrap();
+        std::fs::write(
+            themes.join("Dark Resource Theme"),
+            "foreground = #aaaaaa\nbackground = #bbbbbb\npalette = 1=#cccccc\n",
+        )
+        .unwrap();
+        std::fs::write(
+            &resolver,
+            format!(
+                "#!/bin/sh\n\
+                 printf marker > '{}'\n\
+                 printf 'foreground = #ddeeff\\nbackground = #000000\\n'\n",
+                marker.display()
+            ),
+        )
+        .unwrap();
+        std::fs::set_permissions(&resolver, std::fs::Permissions::from_mode(0o700)).unwrap();
+        // SAFETY: env mutation in tests is serialized by CONFIG_ENV_LOCK.
+        unsafe { std::env::set_var("GHOSTTY_BIN", &resolver) };
+        // SAFETY: env mutation in tests is serialized by CONFIG_ENV_LOCK.
+        unsafe { std::env::set_var("GHOSTTY_RESOURCES_DIR", &resources) };
+        // SAFETY: env mutation in tests is serialized by CONFIG_ENV_LOCK.
+        unsafe { std::env::remove_var("CMUX_TUI_CONFIG") };
+        // SAFETY: env mutation in tests is serialized by CONFIG_ENV_LOCK.
+        unsafe { std::env::remove_var("CMUX_MUX_CONFIG") };
+        // SAFETY: env mutation in tests is serialized by CONFIG_ENV_LOCK.
+        unsafe { std::env::set_var("XDG_CONFIG_HOME", &dir) };
+
+        let config = load();
+
+        restore_env_var("GHOSTTY_BIN", old_ghostty_bin);
+        restore_env_var("GHOSTTY_RESOURCES_DIR", old_ghostty_resources);
+        restore_env_var("CMUX_TUI_CONFIG", old_cmux_tui_config);
+        restore_env_var("CMUX_MUX_CONFIG", old_mux_config);
+        restore_env_var("XDG_CONFIG_HOME", old_xdg_config_home);
+        let resolver_ran = marker.exists();
+        let _ = std::fs::remove_dir_all(&dir);
+
+        assert!(!resolver_ran, "config load must not run ghostty +show-config at startup");
+        assert_eq!(config.terminal_defaults.fg, Some(Rgb { r: 0x11, g: 0x11, b: 0x11 }));
+        assert_eq!(config.terminal_defaults.bg, Some(Rgb { r: 0x44, g: 0x44, b: 0x44 }));
+        assert_eq!(config.terminal_defaults.palette[1], Some(Rgb { r: 0x33, g: 0x33, b: 0x33 }));
     }
 
     #[test]

--- a/cmux-tui/crates/cmux-tui/src/config.rs
+++ b/cmux-tui/crates/cmux-tui/src/config.rs
@@ -3252,6 +3252,57 @@ mod tests {
         assert_eq!(config.terminal_defaults.palette[1], Some(Rgb { r: 0x77, g: 0x88, b: 0x99 }));
     }
 
+    #[cfg(unix)]
+    #[test]
+    fn load_uses_file_ghostty_defaults_without_invoking_external_resolver() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let _guard = CONFIG_ENV_LOCK.lock().unwrap();
+        let old_ghostty_bin = std::env::var_os("GHOSTTY_BIN");
+        let old_ghostty_resources = std::env::var_os("GHOSTTY_RESOURCES_DIR");
+        let old_mux_config = std::env::var_os("CMUX_MUX_CONFIG");
+        let old_xdg_config_home = std::env::var_os("XDG_CONFIG_HOME");
+        let dir = std::env::temp_dir()
+            .join(format!("mux-ghostty-startup-file-only-{}", std::process::id()));
+        let ghostty_dir = dir.join("ghostty");
+        let marker = dir.join("resolver-ran");
+        let resolver = dir.join("ghostty-resolver");
+        std::fs::create_dir_all(&ghostty_dir).unwrap();
+        std::fs::write(ghostty_dir.join("config"), "foreground = #010203\n").unwrap();
+        std::fs::write(
+            &resolver,
+            format!(
+                "#!/bin/sh\n\
+                 printf marker > '{}'\n\
+                 printf 'foreground = #aabbcc\\nbackground = #ddeeff\\n'\n",
+                marker.display()
+            ),
+        )
+        .unwrap();
+        std::fs::set_permissions(&resolver, std::fs::Permissions::from_mode(0o700)).unwrap();
+        // SAFETY: env mutation in tests is serialized by CONFIG_ENV_LOCK.
+        unsafe { std::env::set_var("GHOSTTY_BIN", &resolver) };
+        // SAFETY: env mutation in tests is serialized by CONFIG_ENV_LOCK.
+        unsafe { std::env::remove_var("GHOSTTY_RESOURCES_DIR") };
+        // SAFETY: env mutation in tests is serialized by CONFIG_ENV_LOCK.
+        unsafe { std::env::remove_var("CMUX_MUX_CONFIG") };
+        // SAFETY: env mutation in tests is serialized by CONFIG_ENV_LOCK.
+        unsafe { std::env::set_var("XDG_CONFIG_HOME", &dir) };
+
+        let config = load();
+
+        restore_env_var("GHOSTTY_BIN", old_ghostty_bin);
+        restore_env_var("GHOSTTY_RESOURCES_DIR", old_ghostty_resources);
+        restore_env_var("CMUX_MUX_CONFIG", old_mux_config);
+        restore_env_var("XDG_CONFIG_HOME", old_xdg_config_home);
+        let resolver_ran = marker.exists();
+        let _ = std::fs::remove_dir_all(&dir);
+
+        assert!(!resolver_ran, "config load must not run ghostty +show-config at startup");
+        assert_eq!(config.terminal_defaults.fg, Some(Rgb { r: 1, g: 2, b: 3 }));
+        assert_eq!(config.terminal_defaults.bg, None);
+    }
+
     #[test]
     fn omitted_ghostty_cursor_blink_remains_unspecified() {
         let _guard = CONFIG_ENV_LOCK.lock().unwrap();

--- a/cmux-tui/crates/cmux-tui/src/config.rs
+++ b/cmux-tui/crates/cmux-tui/src/config.rs
@@ -3208,13 +3208,19 @@ impl GhosttyThemeMode {
     }
 }
 
-fn system_ghostty_theme_mode(platform_appearance: Option<GhosttyThemeMode>) -> GhosttyThemeMode {
+fn system_ghostty_theme_mode(deadline_at: Option<Instant>) -> GhosttyThemeMode {
+    system_ghostty_theme_mode_with_platform(|| platform_appearance_theme_mode(deadline_at))
+}
+
+fn system_ghostty_theme_mode_with_platform(
+    mut platform_appearance: impl FnMut() -> Option<GhosttyThemeMode>,
+) -> GhosttyThemeMode {
     if let Some(mode) =
         std::env::var_os("AppleInterfaceStyle").as_deref().and_then(GhosttyThemeMode::parse)
     {
         return mode;
     }
-    if let Some(mode) = platform_appearance {
+    if let Some(mode) = platform_appearance() {
         return mode;
     }
     GhosttyThemeMode::Light
@@ -3783,9 +3789,7 @@ fn selected_ghostty_theme<'a>(
     let Some((light, dark)) = conditional_ghostty_themes(value) else {
         return value;
     };
-    let mode = *theme_mode.get_or_insert_with(|| {
-        system_ghostty_theme_mode(platform_appearance_theme_mode(deadline_at))
-    });
+    let mode = *theme_mode.get_or_insert_with(|| system_ghostty_theme_mode(deadline_at));
     match mode {
         GhosttyThemeMode::Light => light,
         GhosttyThemeMode::Dark => dark,
@@ -5465,11 +5469,30 @@ mod tests {
         // SAFETY: env mutation in tests is serialized by CONFIG_ENV_LOCK.
         unsafe { std::env::remove_var("AppleInterfaceStyle") };
 
-        let mode = system_ghostty_theme_mode(Some(GhosttyThemeMode::Light));
+        let mode = system_ghostty_theme_mode_with_platform(|| Some(GhosttyThemeMode::Light));
 
         restore_env_var("AppleInterfaceStyle", old_apple_interface_style);
 
         assert_eq!(mode, GhosttyThemeMode::Light);
+    }
+
+    #[test]
+    fn ghostty_system_theme_uses_environment_before_platform_probe() {
+        let _guard = CONFIG_ENV_LOCK.lock().unwrap();
+        let old_apple_interface_style = std::env::var_os("AppleInterfaceStyle");
+        let mut platform_calls = 0;
+        // SAFETY: env mutation in tests is serialized by CONFIG_ENV_LOCK.
+        unsafe { std::env::set_var("AppleInterfaceStyle", "Dark") };
+
+        let mode = system_ghostty_theme_mode_with_platform(|| {
+            platform_calls += 1;
+            Some(GhosttyThemeMode::Light)
+        });
+
+        restore_env_var("AppleInterfaceStyle", old_apple_interface_style);
+
+        assert_eq!(mode, GhosttyThemeMode::Dark);
+        assert_eq!(platform_calls, 0);
     }
 
     #[test]

--- a/cmux-tui/crates/cmux-tui/src/config.rs
+++ b/cmux-tui/crates/cmux-tui/src/config.rs
@@ -2757,19 +2757,21 @@ fn parse_ghostty_defaults_from_paths(
 
 #[cfg(test)]
 fn parse_ghostty_defaults_with_theme_dirs(text: &str, theme_dirs: &[PathBuf]) -> DefaultColors {
-    let mut theme_mode = None;
+    let mut theme_selection = GhosttyThemeSelection::System;
     let mut theme_candidates = Vec::new();
-    let parsed = parse_ghostty_config_text(text, None, &mut theme_mode, &mut theme_candidates);
-    let mut defaults = resolve_ghostty_theme_defaults(&theme_candidates, theme_dirs, theme_mode);
+    let parsed = parse_ghostty_config_text(text, None, &mut theme_selection, &mut theme_candidates);
+    let mut defaults =
+        resolve_ghostty_theme_defaults(&theme_candidates, theme_dirs, theme_selection);
     overlay_ghostty_defaults(&mut defaults, parsed.overrides);
     defaults
 }
 
 fn parse_ghostty_defaults_from_path(path: &Path, theme_dirs: &[PathBuf]) -> Option<DefaultColors> {
-    let mut theme_mode = None;
+    let mut theme_selection = GhosttyThemeSelection::System;
     let mut theme_candidates = Vec::new();
-    let overrides = parse_ghostty_config_file(path, &mut theme_mode, &mut theme_candidates)?;
-    let mut defaults = resolve_ghostty_theme_defaults(&theme_candidates, theme_dirs, theme_mode);
+    let overrides = parse_ghostty_config_file(path, &mut theme_selection, &mut theme_candidates)?;
+    let mut defaults =
+        resolve_ghostty_theme_defaults(&theme_candidates, theme_dirs, theme_selection);
     overlay_ghostty_defaults(&mut defaults, overrides);
     Some(defaults)
 }
@@ -2786,7 +2788,7 @@ struct PendingGhosttyConfig {
 
 fn parse_ghostty_config_file(
     path: &Path,
-    theme_mode: &mut Option<GhosttyThemeMode>,
+    theme_selection: &mut GhosttyThemeSelection,
     theme_candidates: &mut Vec<GhosttyThemeCandidate>,
 ) -> Option<DefaultColors> {
     let started_at = Instant::now();
@@ -2819,8 +2821,9 @@ fn parse_ghostty_config_file(
         loaded_root |= pending.depth == 0;
 
         let base_dir = pending.path.parent().unwrap_or_else(|| Path::new("."));
-        let parsed = parse_ghostty_config_text(&text, Some(base_dir), theme_mode, theme_candidates);
-        *theme_mode = parsed.theme_mode;
+        let parsed =
+            parse_ghostty_config_text(&text, Some(base_dir), theme_selection, theme_candidates);
+        *theme_selection = parsed.theme_selection;
         overlay_ghostty_defaults(&mut overrides, parsed.overrides);
 
         for include in
@@ -2836,7 +2839,7 @@ fn parse_ghostty_config_file(
 struct ParsedGhosttyConfig {
     overrides: DefaultColors,
     config_files: Vec<GhosttyConfigFile>,
-    theme_mode: Option<GhosttyThemeMode>,
+    theme_selection: GhosttyThemeSelection,
 }
 
 struct GhosttyThemeCandidate {
@@ -2872,16 +2875,24 @@ enum GhosttyThemeMode {
     Dark,
 }
 
-enum GhosttyWindowTheme {
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum GhosttyThemeSelection {
     Mode(GhosttyThemeMode),
-    Automatic,
+    System,
+    Ghostty,
+}
+
+impl GhosttyThemeSelection {
+    fn resolve(self) -> GhosttyThemeMode {
+        match self {
+            Self::Mode(mode) => mode,
+            Self::System => system_ghostty_theme_mode(platform_appearance_theme_mode()),
+            Self::Ghostty => ghostty_background_theme_mode(platform_appearance_theme_mode()),
+        }
+    }
 }
 
 impl GhosttyThemeMode {
-    fn detect() -> Self {
-        detected_ghostty_theme_mode(platform_appearance_theme_mode())
-    }
-
     fn parse(value: &std::ffi::OsStr) -> Option<Self> {
         let value = value.to_string_lossy();
         match value.trim_matches('"').to_ascii_lowercase().as_str() {
@@ -2892,7 +2903,7 @@ impl GhosttyThemeMode {
     }
 }
 
-fn detected_ghostty_theme_mode(platform_appearance: Option<GhosttyThemeMode>) -> GhosttyThemeMode {
+fn system_ghostty_theme_mode(platform_appearance: Option<GhosttyThemeMode>) -> GhosttyThemeMode {
     if let Some(mode) =
         std::env::var_os("AppleInterfaceStyle").as_deref().and_then(GhosttyThemeMode::parse)
     {
@@ -2901,7 +2912,14 @@ fn detected_ghostty_theme_mode(platform_appearance: Option<GhosttyThemeMode>) ->
     if let Some(mode) = platform_appearance {
         return mode;
     }
-    terminal_background_theme_mode().unwrap_or(GhosttyThemeMode::Light)
+    GhosttyThemeMode::Light
+}
+
+fn ghostty_background_theme_mode(
+    platform_appearance: Option<GhosttyThemeMode>,
+) -> GhosttyThemeMode {
+    terminal_background_theme_mode()
+        .unwrap_or_else(|| system_ghostty_theme_mode(platform_appearance))
 }
 
 #[cfg(target_os = "macos")]
@@ -2994,7 +3012,7 @@ fn macos_appearance_theme_mode() -> Option<GhosttyThemeMode> {
 fn parse_ghostty_config_text(
     text: &str,
     base_dir: Option<&Path>,
-    theme_mode: &mut Option<GhosttyThemeMode>,
+    theme_selection: &mut GhosttyThemeSelection,
     theme_candidates: &mut Vec<GhosttyThemeCandidate>,
 ) -> ParsedGhosttyConfig {
     let mut overrides = DefaultColors::default();
@@ -3010,11 +3028,8 @@ fn parse_ghostty_config_text(
                 });
             }
             "window-theme" => {
-                if let Some(window_theme) = parse_ghostty_window_theme(value.trim()) {
-                    match window_theme {
-                        GhosttyWindowTheme::Mode(mode) => *theme_mode = Some(mode),
-                        GhosttyWindowTheme::Automatic => *theme_mode = None,
-                    }
+                if let Some(selection) = parse_ghostty_window_theme(value.trim()) {
+                    *theme_selection = selection;
                 }
             }
             "config-file" => {
@@ -3026,29 +3041,30 @@ fn parse_ghostty_config_text(
         }
     }
 
-    ParsedGhosttyConfig { overrides, config_files, theme_mode: *theme_mode }
+    ParsedGhosttyConfig { overrides, config_files, theme_selection: *theme_selection }
 }
 
 fn resolve_ghostty_theme_defaults(
     theme_candidates: &[GhosttyThemeCandidate],
     theme_dirs: &[PathBuf],
-    theme_mode: Option<GhosttyThemeMode>,
+    theme_selection: GhosttyThemeSelection,
 ) -> DefaultColors {
     for candidate in theme_candidates {
-        if let Some(defaults) = load_ghostty_theme(candidate, theme_dirs, theme_mode) {
+        if let Some(defaults) = load_ghostty_theme(candidate, theme_dirs, theme_selection) {
             return defaults;
         }
     }
     DefaultColors::default()
 }
 
-fn parse_ghostty_window_theme(value: &str) -> Option<GhosttyWindowTheme> {
+fn parse_ghostty_window_theme(value: &str) -> Option<GhosttyThemeSelection> {
     let value = value.trim_matches('"');
     if let Some(mode) = GhosttyThemeMode::parse(std::ffi::OsStr::new(value)) {
-        return Some(GhosttyWindowTheme::Mode(mode));
+        return Some(GhosttyThemeSelection::Mode(mode));
     }
     match value {
-        "auto" | "system" | "ghostty" => Some(GhosttyWindowTheme::Automatic),
+        "auto" | "system" => Some(GhosttyThemeSelection::System),
+        "ghostty" => Some(GhosttyThemeSelection::Ghostty),
         _ => None,
     }
 }
@@ -3166,9 +3182,9 @@ fn apply_ghostty_default(defaults: &mut DefaultColors, key: &str, value: &str) {
 fn load_ghostty_theme(
     candidate: &GhosttyThemeCandidate,
     theme_dirs: &[PathBuf],
-    theme_mode: Option<GhosttyThemeMode>,
+    theme_selection: GhosttyThemeSelection,
 ) -> Option<DefaultColors> {
-    let theme = selected_ghostty_theme(candidate.value.trim_matches('"'), theme_mode);
+    let theme = selected_ghostty_theme(candidate.value.trim_matches('"'), theme_selection);
     let path = resolve_ghostty_theme_path(theme, candidate.base_dir.as_deref(), theme_dirs)?;
     let text = read_ghostty_regular_file(&path, GHOSTTY_CONFIG_MAX_BYTES)?;
     Some(parse_resolved_ghostty_defaults(&text))
@@ -3212,13 +3228,13 @@ fn expand_home_relative_path(value: &str) -> Option<PathBuf> {
     }
 }
 
-fn selected_ghostty_theme(value: &str, theme_mode: Option<GhosttyThemeMode>) -> &str {
-    selected_conditional_ghostty_theme(value, theme_mode).unwrap_or(value)
+fn selected_ghostty_theme(value: &str, theme_selection: GhosttyThemeSelection) -> &str {
+    selected_conditional_ghostty_theme(value, theme_selection).unwrap_or(value)
 }
 
 fn selected_conditional_ghostty_theme(
     value: &str,
-    theme_mode: Option<GhosttyThemeMode>,
+    theme_selection: GhosttyThemeSelection,
 ) -> Option<&str> {
     let mut light = None;
     let mut dark = None;
@@ -3231,7 +3247,7 @@ fn selected_conditional_ghostty_theme(
             _ => return None,
         }
     }
-    match theme_mode.unwrap_or_else(GhosttyThemeMode::detect) {
+    match theme_selection.resolve() {
         GhosttyThemeMode::Light if light.is_some() && dark.is_some() => light,
         GhosttyThemeMode::Dark if light.is_some() && dark.is_some() => dark,
         _ => None,
@@ -4374,12 +4390,60 @@ mod tests {
             std::env::set_var("COLORFGBG", "15;0");
         }
 
-        let mode = detected_ghostty_theme_mode(Some(GhosttyThemeMode::Light));
+        let mode = system_ghostty_theme_mode(Some(GhosttyThemeMode::Light));
 
         restore_env_var("AppleInterfaceStyle", old_apple_interface_style);
         restore_env_var("COLORFGBG", old_colorfgbg);
 
         assert_eq!(mode, GhosttyThemeMode::Light);
+    }
+
+    #[test]
+    fn ghostty_window_theme_uses_terminal_background_separately_from_system() {
+        let _guard = CONFIG_ENV_LOCK.lock().unwrap();
+        let old_apple_interface_style = std::env::var_os("AppleInterfaceStyle");
+        let old_colorfgbg = std::env::var_os("COLORFGBG");
+        let dir = std::env::temp_dir().join(format!(
+            "cmux-tui-ghostty-theme-source-{}-{}",
+            std::process::id(),
+            SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_nanos()
+        ));
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(
+            dir.join("Light Source Theme"),
+            "background = #f0f1f2\nforeground = #f3f4f5\n",
+        )
+        .unwrap();
+        std::fs::write(
+            dir.join("Dark Source Theme"),
+            "background = #101112\nforeground = #131415\n",
+        )
+        .unwrap();
+        // SAFETY: env mutation in tests is serialized by CONFIG_ENV_LOCK.
+        unsafe {
+            std::env::set_var("AppleInterfaceStyle", "Light");
+            std::env::set_var("COLORFGBG", "15;0");
+        }
+
+        let system = parse_ghostty_defaults_with_theme_dirs(
+            "window-theme = system\n\
+             theme = light:Light Source Theme,dark:Dark Source Theme\n",
+            std::slice::from_ref(&dir),
+        );
+        let ghostty = parse_ghostty_defaults_with_theme_dirs(
+            "window-theme = ghostty\n\
+             theme = light:Light Source Theme,dark:Dark Source Theme\n",
+            std::slice::from_ref(&dir),
+        );
+
+        restore_env_var("AppleInterfaceStyle", old_apple_interface_style);
+        restore_env_var("COLORFGBG", old_colorfgbg);
+        let _ = std::fs::remove_dir_all(dir);
+
+        assert_eq!(system.bg, Some(Rgb { r: 0xf0, g: 0xf1, b: 0xf2 }));
+        assert_eq!(system.fg, Some(Rgb { r: 0xf3, g: 0xf4, b: 0xf5 }));
+        assert_eq!(ghostty.bg, Some(Rgb { r: 0x10, g: 0x11, b: 0x12 }));
+        assert_eq!(ghostty.fg, Some(Rgb { r: 0x13, g: 0x14, b: 0x15 }));
     }
 
     #[test]

--- a/cmux-tui/crates/cmux-tui/src/config.rs
+++ b/cmux-tui/crates/cmux-tui/src/config.rs
@@ -122,6 +122,8 @@ use std::io::Write;
 use std::path::{Path, PathBuf};
 #[cfg(all(test, unix))]
 use std::process::{Command, Stdio};
+use std::sync::mpsc;
+use std::thread;
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
 use cmux_tui_core::BrowserMode;
@@ -2630,10 +2632,11 @@ fn parse_color(s: &str) -> Option<Color> {
 /// The user's relevant Ghostty settings with non-optional application defaults
 /// resolved for values that the low-level terminal otherwise leaves unset.
 fn ghostty_defaults() -> DefaultColors {
-    let parsed = platform::ghostty_config_paths()
-        .iter()
-        .find_map(|path| parse_ghostty_defaults_from_path(path, &platform::ghostty_theme_dirs()))
-        .unwrap_or_default();
+    let parsed = parse_ghostty_defaults_from_paths(
+        platform::ghostty_config_paths(),
+        platform::ghostty_theme_dirs(),
+    )
+    .unwrap_or_default();
     resolve_ghostty_application_defaults(parsed)
 }
 
@@ -2685,6 +2688,23 @@ fn ghostty_show_config_command(installation: &platform::GhosttyInstallation) -> 
 #[cfg(test)]
 pub(crate) fn parse_ghostty_defaults(text: &str) -> DefaultColors {
     parse_ghostty_defaults_with_theme_dirs(text, &platform::ghostty_theme_dirs())
+}
+
+fn parse_ghostty_defaults_from_paths(
+    config_paths: Vec<PathBuf>,
+    theme_dirs: Vec<PathBuf>,
+) -> Option<DefaultColors> {
+    let (tx, rx) = mpsc::channel();
+    thread::Builder::new()
+        .name("cmux-tui-ghostty-config".to_owned())
+        .spawn(move || {
+            let parsed = config_paths
+                .iter()
+                .find_map(|path| parse_ghostty_defaults_from_path(path, &theme_dirs));
+            let _ = tx.send(parsed);
+        })
+        .ok()?;
+    rx.recv_timeout(GHOSTTY_CONFIG_PARSE_DEADLINE).ok().flatten()
 }
 
 #[cfg(test)]
@@ -2812,6 +2832,11 @@ impl GhosttyConfigFile {
 enum GhosttyThemeMode {
     Light,
     Dark,
+}
+
+enum GhosttyWindowTheme {
+    Mode(GhosttyThemeMode),
+    Automatic,
 }
 
 impl GhosttyThemeMode {
@@ -2947,7 +2972,12 @@ fn parse_ghostty_config_text(
                 });
             }
             "window-theme" => {
-                *theme_mode = parse_ghostty_window_theme(value.trim());
+                if let Some(window_theme) = parse_ghostty_window_theme(value.trim()) {
+                    match window_theme {
+                        GhosttyWindowTheme::Mode(mode) => *theme_mode = Some(mode),
+                        GhosttyWindowTheme::Automatic => *theme_mode = None,
+                    }
+                }
             }
             "config-file" => {
                 if let Some(include) = GhosttyConfigFile::parse(value) {
@@ -2974,8 +3004,15 @@ fn resolve_ghostty_theme_defaults(
     DefaultColors::default()
 }
 
-fn parse_ghostty_window_theme(value: &str) -> Option<GhosttyThemeMode> {
-    GhosttyThemeMode::parse(std::ffi::OsStr::new(value))
+fn parse_ghostty_window_theme(value: &str) -> Option<GhosttyWindowTheme> {
+    let value = value.trim_matches('"');
+    if let Some(mode) = GhosttyThemeMode::parse(std::ffi::OsStr::new(value)) {
+        return Some(GhosttyWindowTheme::Mode(mode));
+    }
+    match value {
+        "auto" | "system" | "ghostty" => Some(GhosttyWindowTheme::Automatic),
+        _ => None,
+    }
 }
 
 /// Parse the fully resolved `ghostty +show-config` output. Theme lines are
@@ -3891,6 +3928,44 @@ mod tests {
 
         let defaults = parse_ghostty_defaults_from_path(&ghostty_dir.join("config"), &[themes])
             .expect("config parses");
+
+        restore_env_var("AppleInterfaceStyle", old_apple_interface_style);
+        let _ = std::fs::remove_dir_all(dir);
+
+        assert_eq!(defaults.bg, Some(Rgb { r: 0x10, g: 0x11, b: 0x12 }));
+        assert_eq!(defaults.fg, Some(Rgb { r: 0x13, g: 0x14, b: 0x15 }));
+        assert_eq!(defaults.palette[1], Some(Rgb { r: 0x16, g: 0x17, b: 0x18 }));
+    }
+
+    #[test]
+    fn ghostty_invalid_window_theme_does_not_clear_prior_valid_mode() {
+        let _guard = CONFIG_ENV_LOCK.lock().unwrap();
+        let old_apple_interface_style = std::env::var_os("AppleInterfaceStyle");
+        let dir = std::env::temp_dir().join(format!(
+            "cmux-tui-ghostty-invalid-window-theme-{}-{}",
+            std::process::id(),
+            SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_nanos()
+        ));
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(
+            dir.join("Light Theme"),
+            "background = #f0f1f2\nforeground = #f3f4f5\npalette = 1=#f6f7f8\n",
+        )
+        .unwrap();
+        std::fs::write(
+            dir.join("Dark Theme"),
+            "background = #101112\nforeground = #131415\npalette = 1=#161718\n",
+        )
+        .unwrap();
+        // SAFETY: env mutation in tests is serialized by CONFIG_ENV_LOCK.
+        unsafe { std::env::set_var("AppleInterfaceStyle", "Light") };
+
+        let defaults = parse_ghostty_defaults_with_theme_dirs(
+            "window-theme = dark\n\
+             window-theme = drak\n\
+             theme = light:Light Theme,dark:Dark Theme\n",
+            std::slice::from_ref(&dir),
+        );
 
         restore_env_var("AppleInterfaceStyle", old_apple_interface_style);
         let _ = std::fs::remove_dir_all(dir);

--- a/cmux-tui/crates/cmux-tui/src/config.rs
+++ b/cmux-tui/crates/cmux-tui/src/config.rs
@@ -2999,16 +2999,9 @@ fn parse_ghostty_defaults_from_paths_result_until(
 
 #[cfg(test)]
 fn parse_ghostty_defaults_with_theme_dirs(text: &str, theme_dirs: &[PathBuf]) -> DefaultColors {
-    let mut theme_selection = auto_ghostty_theme_selection();
     let mut theme_candidates = Vec::new();
-    let parsed = parse_ghostty_config_text(text, None, &mut theme_selection, &mut theme_candidates);
-    resolve_parsed_ghostty_defaults(
-        theme_candidates,
-        theme_dirs,
-        parsed.theme_selection,
-        parsed.overrides,
-        None,
-    )
+    let parsed = parse_ghostty_config_text(text, None, &mut theme_candidates);
+    resolve_parsed_ghostty_defaults(theme_candidates, theme_dirs, parsed.overrides, None)
 }
 
 #[cfg(test)]
@@ -3033,21 +3026,15 @@ fn parse_ghostty_defaults_from_path_result_until(
     theme_dirs: &[PathBuf],
     deadline_at: Option<Instant>,
 ) -> GhosttyConfigParseOutcome {
-    let mut theme_selection = auto_ghostty_theme_selection();
     let mut theme_candidates = Vec::new();
-    let overrides = match parse_ghostty_config_file_until(
-        path,
-        &mut theme_selection,
-        &mut theme_candidates,
-        deadline_at,
-    ) {
+    let overrides = match parse_ghostty_config_file_until(path, &mut theme_candidates, deadline_at)
+    {
         GhosttyConfigParseOutcome::Parsed(overrides) => overrides,
         outcome => return outcome,
     };
     GhosttyConfigParseOutcome::Parsed(resolve_parsed_ghostty_defaults(
         theme_candidates,
         theme_dirs,
-        theme_selection,
         overrides,
         deadline_at,
     ))
@@ -3076,13 +3063,11 @@ struct PendingGhosttyConfig {
 #[cfg(test)]
 fn parse_ghostty_config_file_with_deadline(
     path: &Path,
-    theme_selection: &mut GhosttyThemeSelection,
     theme_candidates: &mut Vec<GhosttyThemeCandidate>,
     deadline: Duration,
 ) -> GhosttyConfigParseOutcome {
     parse_ghostty_config_file_until(
         path,
-        theme_selection,
         theme_candidates,
         Some(ghostty_config_deadline_from_now(deadline)),
     )
@@ -3090,7 +3075,6 @@ fn parse_ghostty_config_file_with_deadline(
 
 fn parse_ghostty_config_file_until(
     path: &Path,
-    theme_selection: &mut GhosttyThemeSelection,
     theme_candidates: &mut Vec<GhosttyThemeCandidate>,
     deadline_at: Option<Instant>,
 ) -> GhosttyConfigParseOutcome {
@@ -3125,9 +3109,7 @@ fn parse_ghostty_config_file_until(
         loaded_root |= pending.depth == 0;
 
         let base_dir = pending.path.parent().unwrap_or_else(|| Path::new("."));
-        let parsed =
-            parse_ghostty_config_text(&text, Some(base_dir), theme_selection, theme_candidates);
-        *theme_selection = parsed.theme_selection;
+        let parsed = parse_ghostty_config_text(&text, Some(base_dir), theme_candidates);
         overlay_ghostty_defaults(&mut overrides, parsed.overrides);
 
         for include in
@@ -3180,7 +3162,6 @@ fn kill_ghostty_process_group(group: libc::pid_t) {
 struct ParsedGhosttyConfig {
     overrides: DefaultColors,
     config_files: Vec<GhosttyConfigFile>,
-    theme_selection: GhosttyThemeSelection,
 }
 
 struct GhosttyThemeCandidate {
@@ -3216,40 +3197,6 @@ enum GhosttyThemeMode {
     Dark,
 }
 
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-enum GhosttyThemeSelection {
-    Mode(GhosttyThemeMode),
-    System,
-    Ghostty,
-}
-
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-enum ResolvedGhosttyThemeSelection {
-    Mode(GhosttyThemeMode),
-    Ghostty,
-}
-
-impl GhosttyThemeSelection {
-    fn resolve_for_parse(self, deadline_at: Option<Instant>) -> ResolvedGhosttyThemeSelection {
-        match self {
-            Self::Mode(mode) => ResolvedGhosttyThemeSelection::Mode(mode),
-            Self::System => ResolvedGhosttyThemeSelection::Mode(system_ghostty_theme_mode(
-                platform_appearance_theme_mode(deadline_at),
-            )),
-            Self::Ghostty => ResolvedGhosttyThemeSelection::Ghostty,
-        }
-    }
-}
-
-impl ResolvedGhosttyThemeSelection {
-    fn resolve(self, ghostty_background: Option<Rgb>) -> GhosttyThemeMode {
-        match self {
-            Self::Mode(mode) => mode,
-            Self::Ghostty => ghostty_background_theme_mode(ghostty_background),
-        }
-    }
-}
-
 impl GhosttyThemeMode {
     fn parse(value: &std::ffi::OsStr) -> Option<Self> {
         let value = value.to_string_lossy();
@@ -3271,15 +3218,6 @@ fn system_ghostty_theme_mode(platform_appearance: Option<GhosttyThemeMode>) -> G
         return mode;
     }
     GhosttyThemeMode::Light
-}
-
-fn ghostty_background_theme_mode(background: Option<Rgb>) -> GhosttyThemeMode {
-    let background = background.unwrap_or(Rgb { r: 0x28, g: 0x2c, b: 0x34 });
-    if ghostty_background_is_light(background) {
-        GhosttyThemeMode::Light
-    } else {
-        GhosttyThemeMode::Dark
-    }
 }
 
 #[cfg(target_os = "macos")]
@@ -3522,6 +3460,7 @@ fn gtk_theme_name_theme_mode(value: &str) -> Option<GhosttyThemeMode> {
     None
 }
 
+#[cfg(test)]
 fn ghostty_background_is_light(background: Rgb) -> bool {
     let luminance = (0.299 * f64::from(background.r)
         + 0.587 * f64::from(background.g)
@@ -3600,7 +3539,6 @@ fn macos_appearance_theme_mode() -> Option<GhosttyThemeMode> {
 fn parse_ghostty_config_text(
     text: &str,
     base_dir: Option<&Path>,
-    theme_selection: &mut GhosttyThemeSelection,
     theme_candidates: &mut Vec<GhosttyThemeCandidate>,
 ) -> ParsedGhosttyConfig {
     let mut overrides = DefaultColors::default();
@@ -3615,11 +3553,7 @@ fn parse_ghostty_config_text(
                     base_dir: base_dir.map(Path::to_path_buf),
                 });
             }
-            "window-theme" => {
-                if let Some(selection) = parse_ghostty_window_theme(value.trim()) {
-                    *theme_selection = selection;
-                }
-            }
+            "window-theme" => {}
             "config-file" => {
                 if let Some(include) = GhosttyConfigFile::parse(value) {
                     config_files.push(include);
@@ -3629,14 +3563,12 @@ fn parse_ghostty_config_text(
         }
     }
 
-    ParsedGhosttyConfig { overrides, config_files, theme_selection: *theme_selection }
+    ParsedGhosttyConfig { overrides, config_files }
 }
 
 fn resolve_ghostty_theme_defaults(
     theme_candidates: &[GhosttyThemeCandidate],
     theme_dirs: &[PathBuf],
-    theme_selection: GhosttyThemeSelection,
-    overrides: &DefaultColors,
     deadline_at: Option<Instant>,
 ) -> DefaultColors {
     if theme_candidates.is_empty() {
@@ -3645,14 +3577,12 @@ fn resolve_ghostty_theme_defaults(
     if ghostty_config_deadline_expired(deadline_at) {
         return DefaultColors::default();
     }
-    let resolved_selection = theme_selection.resolve_for_parse(deadline_at);
+    let theme_mode = system_ghostty_theme_mode(platform_appearance_theme_mode(deadline_at));
     for candidate in theme_candidates {
         if ghostty_config_deadline_expired(deadline_at) {
             return DefaultColors::default();
         }
-        if let Some(defaults) =
-            load_ghostty_theme(candidate, theme_dirs, resolved_selection, overrides, deadline_at)
-        {
+        if let Some(defaults) = load_ghostty_theme(candidate, theme_dirs, theme_mode, deadline_at) {
             return defaults;
         }
     }
@@ -3662,40 +3592,12 @@ fn resolve_ghostty_theme_defaults(
 fn resolve_parsed_ghostty_defaults(
     theme_candidates: Vec<GhosttyThemeCandidate>,
     theme_dirs: &[PathBuf],
-    theme_selection: GhosttyThemeSelection,
     overrides: DefaultColors,
     deadline_at: Option<Instant>,
 ) -> DefaultColors {
-    let mut defaults = resolve_ghostty_theme_defaults(
-        &theme_candidates,
-        theme_dirs,
-        theme_selection,
-        &overrides,
-        deadline_at,
-    );
+    let mut defaults = resolve_ghostty_theme_defaults(&theme_candidates, theme_dirs, deadline_at);
     overlay_ghostty_defaults(&mut defaults, overrides);
     defaults
-}
-
-fn parse_ghostty_window_theme(value: &str) -> Option<GhosttyThemeSelection> {
-    let value = value.trim_matches('"');
-    if let Some(mode) = GhosttyThemeMode::parse(std::ffi::OsStr::new(value)) {
-        return Some(GhosttyThemeSelection::Mode(mode));
-    }
-    match value {
-        "auto" => Some(auto_ghostty_theme_selection()),
-        "system" => Some(GhosttyThemeSelection::System),
-        "ghostty" => Some(GhosttyThemeSelection::Ghostty),
-        _ => None,
-    }
-}
-
-fn auto_ghostty_theme_selection() -> GhosttyThemeSelection {
-    auto_ghostty_theme_selection_for_target(cfg!(target_os = "macos"))
-}
-
-fn auto_ghostty_theme_selection_for_target(is_macos: bool) -> GhosttyThemeSelection {
-    if is_macos { GhosttyThemeSelection::System } else { GhosttyThemeSelection::Ghostty }
 }
 
 /// Parse the fully resolved `ghostty +show-config` output. Theme lines are
@@ -3811,51 +3713,17 @@ fn apply_ghostty_default(defaults: &mut DefaultColors, key: &str, value: &str) {
 fn load_ghostty_theme(
     candidate: &GhosttyThemeCandidate,
     theme_dirs: &[PathBuf],
-    theme_selection: ResolvedGhosttyThemeSelection,
-    overrides: &DefaultColors,
+    theme_mode: GhosttyThemeMode,
     deadline_at: Option<Instant>,
 ) -> Option<DefaultColors> {
     if ghostty_config_deadline_expired(deadline_at) {
         return None;
     }
     let value = candidate.value.trim_matches('"');
-    let ghostty_background = if theme_selection == ResolvedGhosttyThemeSelection::Ghostty {
-        ghostty_theme_selection_background(value, candidate, theme_dirs, overrides, deadline_at)
-    } else {
-        None
-    };
-    if ghostty_config_deadline_expired(deadline_at) {
-        return None;
-    }
-    let theme = selected_ghostty_theme(value, theme_selection, ghostty_background);
+    let theme = selected_ghostty_theme(value, theme_mode);
     let path = resolve_ghostty_theme_path(theme, candidate.base_dir.as_deref(), theme_dirs)?;
     let text = read_ghostty_regular_file(&path, GHOSTTY_CONFIG_MAX_BYTES)?;
     Some(parse_resolved_ghostty_defaults(&text))
-}
-
-fn ghostty_theme_selection_background(
-    value: &str,
-    candidate: &GhosttyThemeCandidate,
-    theme_dirs: &[PathBuf],
-    overrides: &DefaultColors,
-    deadline_at: Option<Instant>,
-) -> Option<Rgb> {
-    overrides.bg.or_else(|| {
-        if ghostty_config_deadline_expired(deadline_at) {
-            return None;
-        }
-        let light = selected_conditional_ghostty_theme(
-            value,
-            ResolvedGhosttyThemeSelection::Mode(GhosttyThemeMode::Light),
-            None,
-        )?;
-        let path = resolve_ghostty_theme_path(light, candidate.base_dir.as_deref(), theme_dirs)?;
-        if ghostty_config_deadline_expired(deadline_at) {
-            return None;
-        }
-        let text = read_ghostty_regular_file(&path, GHOSTTY_CONFIG_MAX_BYTES)?;
-        parse_resolved_ghostty_defaults(&text).bg
-    })
 }
 
 fn read_ghostty_regular_file(path: &Path, max_bytes: u64) -> Option<String> {
@@ -3902,19 +3770,11 @@ fn expand_home_relative_path(value: &str) -> Option<PathBuf> {
     }
 }
 
-fn selected_ghostty_theme(
-    value: &str,
-    theme_selection: ResolvedGhosttyThemeSelection,
-    ghostty_background: Option<Rgb>,
-) -> &str {
-    selected_conditional_ghostty_theme(value, theme_selection, ghostty_background).unwrap_or(value)
+fn selected_ghostty_theme(value: &str, theme_mode: GhosttyThemeMode) -> &str {
+    selected_conditional_ghostty_theme(value, theme_mode).unwrap_or(value)
 }
 
-fn selected_conditional_ghostty_theme(
-    value: &str,
-    theme_selection: ResolvedGhosttyThemeSelection,
-    ghostty_background: Option<Rgb>,
-) -> Option<&str> {
+fn selected_conditional_ghostty_theme(value: &str, theme_mode: GhosttyThemeMode) -> Option<&str> {
     let mut light = None;
     let mut dark = None;
     for part in value.split(',') {
@@ -3926,7 +3786,7 @@ fn selected_conditional_ghostty_theme(
             _ => return None,
         }
     }
-    match theme_selection.resolve(ghostty_background) {
+    match theme_mode {
         GhosttyThemeMode::Light if light.is_some() && dark.is_some() => light,
         GhosttyThemeMode::Dark if light.is_some() && dark.is_some() => dark,
         _ => None,
@@ -4374,6 +4234,7 @@ mod tests {
         let old_cmux_tui_config = std::env::var_os("CMUX_TUI_CONFIG");
         let old_mux_config = std::env::var_os("CMUX_MUX_CONFIG");
         let old_xdg_config_home = std::env::var_os("XDG_CONFIG_HOME");
+        let old_apple_interface_style = std::env::var_os("AppleInterfaceStyle");
         let dir = std::env::temp_dir()
             .join(format!("mux-ghostty-startup-file-only-{}", std::process::id()));
         let ghostty_dir = dir.join("ghostty");
@@ -4402,6 +4263,8 @@ mod tests {
         unsafe { std::env::remove_var("CMUX_MUX_CONFIG") };
         // SAFETY: env mutation in tests is serialized by CONFIG_ENV_LOCK.
         unsafe { std::env::set_var("XDG_CONFIG_HOME", &dir) };
+        // SAFETY: env mutation in tests is serialized by CONFIG_ENV_LOCK.
+        unsafe { std::env::set_var("AppleInterfaceStyle", "Light") };
 
         let config = load();
 
@@ -4410,6 +4273,7 @@ mod tests {
         restore_env_var("CMUX_TUI_CONFIG", old_cmux_tui_config);
         restore_env_var("CMUX_MUX_CONFIG", old_mux_config);
         restore_env_var("XDG_CONFIG_HOME", old_xdg_config_home);
+        restore_env_var("AppleInterfaceStyle", old_apple_interface_style);
         let resolver_ran = marker.exists();
         let _ = std::fs::remove_dir_all(&dir);
 
@@ -4429,6 +4293,7 @@ mod tests {
         let old_cmux_tui_config = std::env::var_os("CMUX_TUI_CONFIG");
         let old_mux_config = std::env::var_os("CMUX_MUX_CONFIG");
         let old_xdg_config_home = std::env::var_os("XDG_CONFIG_HOME");
+        let old_apple_interface_style = std::env::var_os("AppleInterfaceStyle");
         let dir = std::env::temp_dir()
             .join(format!("mux-ghostty-startup-resource-theme-{}", std::process::id()));
         let ghostty_dir = dir.join("ghostty");
@@ -4476,6 +4341,10 @@ mod tests {
         unsafe { std::env::remove_var("CMUX_MUX_CONFIG") };
         // SAFETY: env mutation in tests is serialized by CONFIG_ENV_LOCK.
         unsafe { std::env::set_var("XDG_CONFIG_HOME", &dir) };
+        // SAFETY: env mutation in tests is serialized by CONFIG_ENV_LOCK.
+        unsafe { std::env::set_var("AppleInterfaceStyle", "Light") };
+        let theme_dirs = platform::ghostty_theme_dirs();
+        assert!(theme_dirs.contains(&themes), "{theme_dirs:?}");
 
         let config = load();
 
@@ -4484,6 +4353,7 @@ mod tests {
         restore_env_var("CMUX_TUI_CONFIG", old_cmux_tui_config);
         restore_env_var("CMUX_MUX_CONFIG", old_mux_config);
         restore_env_var("XDG_CONFIG_HOME", old_xdg_config_home);
+        restore_env_var("AppleInterfaceStyle", old_apple_interface_style);
         let resolver_ran = marker.exists();
         let _ = std::fs::remove_dir_all(&dir);
 
@@ -4504,6 +4374,7 @@ mod tests {
         let old_cmux_tui_config = std::env::var_os("CMUX_TUI_CONFIG");
         let old_mux_config = std::env::var_os("CMUX_MUX_CONFIG");
         let old_xdg_config_home = std::env::var_os("XDG_CONFIG_HOME");
+        let old_apple_interface_style = std::env::var_os("AppleInterfaceStyle");
         let dir = std::env::temp_dir()
             .join(format!("mux-ghostty-startup-include-theme-{}", std::process::id()));
         let ghostty_dir = dir.join("ghostty");
@@ -4558,6 +4429,8 @@ mod tests {
         unsafe { std::env::remove_var("CMUX_MUX_CONFIG") };
         // SAFETY: env mutation in tests is serialized by CONFIG_ENV_LOCK.
         unsafe { std::env::set_var("XDG_CONFIG_HOME", &dir) };
+        // SAFETY: env mutation in tests is serialized by CONFIG_ENV_LOCK.
+        unsafe { std::env::set_var("AppleInterfaceStyle", "Dark") };
 
         let config = load();
 
@@ -4566,6 +4439,7 @@ mod tests {
         restore_env_var("CMUX_TUI_CONFIG", old_cmux_tui_config);
         restore_env_var("CMUX_MUX_CONFIG", old_mux_config);
         restore_env_var("XDG_CONFIG_HOME", old_xdg_config_home);
+        restore_env_var("AppleInterfaceStyle", old_apple_interface_style);
         let resolver_ran = marker.exists();
         let _ = std::fs::remove_dir_all(&dir);
 
@@ -4686,7 +4560,7 @@ mod tests {
     }
 
     #[test]
-    fn ghostty_included_window_theme_controls_parent_conditional_theme() {
+    fn ghostty_included_window_theme_does_not_control_parent_conditional_theme() {
         let _guard = CONFIG_ENV_LOCK.lock().unwrap();
         let old_apple_interface_style = std::env::var_os("AppleInterfaceStyle");
         let dir = std::env::temp_dir().join(format!(
@@ -4724,13 +4598,13 @@ mod tests {
         restore_env_var("AppleInterfaceStyle", old_apple_interface_style);
         let _ = std::fs::remove_dir_all(dir);
 
-        assert_eq!(defaults.bg, Some(Rgb { r: 0x10, g: 0x11, b: 0x12 }));
-        assert_eq!(defaults.fg, Some(Rgb { r: 0x13, g: 0x14, b: 0x15 }));
-        assert_eq!(defaults.palette[1], Some(Rgb { r: 0x16, g: 0x17, b: 0x18 }));
+        assert_eq!(defaults.bg, Some(Rgb { r: 0xf0, g: 0xf1, b: 0xf2 }));
+        assert_eq!(defaults.fg, Some(Rgb { r: 0xf3, g: 0xf4, b: 0xf5 }));
+        assert_eq!(defaults.palette[1], Some(Rgb { r: 0xf6, g: 0xf7, b: 0xf8 }));
     }
 
     #[test]
-    fn ghostty_invalid_window_theme_does_not_clear_prior_valid_mode() {
+    fn ghostty_window_theme_does_not_control_conditional_terminal_theme() {
         let _guard = CONFIG_ENV_LOCK.lock().unwrap();
         let old_apple_interface_style = std::env::var_os("AppleInterfaceStyle");
         let dir = std::env::temp_dir().join(format!(
@@ -4762,9 +4636,9 @@ mod tests {
         restore_env_var("AppleInterfaceStyle", old_apple_interface_style);
         let _ = std::fs::remove_dir_all(dir);
 
-        assert_eq!(defaults.bg, Some(Rgb { r: 0x10, g: 0x11, b: 0x12 }));
-        assert_eq!(defaults.fg, Some(Rgb { r: 0x13, g: 0x14, b: 0x15 }));
-        assert_eq!(defaults.palette[1], Some(Rgb { r: 0x16, g: 0x17, b: 0x18 }));
+        assert_eq!(defaults.bg, Some(Rgb { r: 0xf0, g: 0xf1, b: 0xf2 }));
+        assert_eq!(defaults.fg, Some(Rgb { r: 0xf3, g: 0xf4, b: 0xf5 }));
+        assert_eq!(defaults.palette[1], Some(Rgb { r: 0xf6, g: 0xf7, b: 0xf8 }));
     }
 
     #[test]
@@ -4978,11 +4852,9 @@ mod tests {
         .unwrap();
         std::fs::write(ghostty_dir.join("colors.conf"), "foreground = #040506\n").unwrap();
 
-        let mut theme_selection = auto_ghostty_theme_selection();
         let mut theme_candidates = Vec::new();
         let outcome = parse_ghostty_config_file_with_deadline(
             &ghostty_dir.join("config"),
-            &mut theme_selection,
             &mut theme_candidates,
             Duration::ZERO,
         );
@@ -5019,14 +4891,12 @@ mod tests {
         let loaded = resolve_parsed_ghostty_defaults(
             vec![GhosttyThemeCandidate { value: "Dark Budget Theme".to_string(), base_dir: None }],
             std::slice::from_ref(&dir),
-            GhosttyThemeSelection::Mode(GhosttyThemeMode::Dark),
             overrides,
             None,
         );
         let expired = resolve_parsed_ghostty_defaults(
             vec![GhosttyThemeCandidate { value: "Dark Budget Theme".to_string(), base_dir: None }],
             std::slice::from_ref(&dir),
-            GhosttyThemeSelection::Mode(GhosttyThemeMode::Dark),
             overrides,
             Some(Instant::now().checked_sub(Duration::from_millis(1)).unwrap()),
         );
@@ -5499,6 +5369,43 @@ mod tests {
     }
 
     #[test]
+    fn ghostty_conditional_terminal_theme_ignores_ghostty_window_theme() {
+        let _guard = CONFIG_ENV_LOCK.lock().unwrap();
+        let old_apple_interface_style = std::env::var_os("AppleInterfaceStyle");
+        let dir = std::env::temp_dir().join(format!(
+            "cmux-tui-ghostty-theme-window-ghostty-{}-{}",
+            std::process::id(),
+            SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_nanos()
+        ));
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(
+            dir.join("Light Window Theme"),
+            "background = #f0f1f2\nforeground = #f3f4f5\npalette = 1=#f6f7f8\n",
+        )
+        .unwrap();
+        std::fs::write(
+            dir.join("Dark Window Theme"),
+            "background = #101112\nforeground = #131415\npalette = 1=#161718\n",
+        )
+        .unwrap();
+        // SAFETY: env mutation in tests is serialized by CONFIG_ENV_LOCK.
+        unsafe { std::env::set_var("AppleInterfaceStyle", "Dark") };
+
+        let defaults = parse_ghostty_defaults_with_theme_dirs(
+            "window-theme = ghostty\n\
+             theme = light:Light Window Theme,dark:Dark Window Theme\n",
+            std::slice::from_ref(&dir),
+        );
+
+        restore_env_var("AppleInterfaceStyle", old_apple_interface_style);
+        let _ = std::fs::remove_dir_all(dir);
+
+        assert_eq!(defaults.bg, Some(Rgb { r: 0x10, g: 0x11, b: 0x12 }));
+        assert_eq!(defaults.fg, Some(Rgb { r: 0x13, g: 0x14, b: 0x15 }));
+        assert_eq!(defaults.palette[1], Some(Rgb { r: 0x16, g: 0x17, b: 0x18 }));
+    }
+
+    #[test]
     fn ghostty_system_theme_uses_platform_appearance() {
         let _guard = CONFIG_ENV_LOCK.lock().unwrap();
         let old_apple_interface_style = std::env::var_os("AppleInterfaceStyle");
@@ -5510,12 +5417,6 @@ mod tests {
         restore_env_var("AppleInterfaceStyle", old_apple_interface_style);
 
         assert_eq!(mode, GhosttyThemeMode::Light);
-    }
-
-    #[test]
-    fn ghostty_auto_window_theme_is_platform_specific() {
-        assert_eq!(auto_ghostty_theme_selection_for_target(true), GhosttyThemeSelection::System);
-        assert_eq!(auto_ghostty_theme_selection_for_target(false), GhosttyThemeSelection::Ghostty);
     }
 
     #[test]
@@ -5567,7 +5468,7 @@ mod tests {
     }
 
     #[test]
-    fn ghostty_window_theme_uses_resolved_background_separately_from_system() {
+    fn ghostty_window_theme_does_not_use_resolved_background_for_terminal_theme() {
         let _guard = CONFIG_ENV_LOCK.lock().unwrap();
         let old_apple_interface_style = std::env::var_os("AppleInterfaceStyle");
         let dir = std::env::temp_dir().join(format!(
@@ -5608,7 +5509,7 @@ mod tests {
         assert_eq!(system.bg, Some(Rgb { r: 0x10, g: 0x11, b: 0x12 }));
         assert_eq!(system.fg, Some(Rgb { r: 0xf3, g: 0xf4, b: 0xf5 }));
         assert_eq!(ghostty.bg, Some(Rgb { r: 0x10, g: 0x11, b: 0x12 }));
-        assert_eq!(ghostty.fg, Some(Rgb { r: 0x13, g: 0x14, b: 0x15 }));
+        assert_eq!(ghostty.fg, Some(Rgb { r: 0xf3, g: 0xf4, b: 0xf5 }));
     }
 
     #[test]

--- a/cmux-tui/crates/cmux-tui/src/config.rs
+++ b/cmux-tui/crates/cmux-tui/src/config.rs
@@ -119,7 +119,7 @@
 
 use std::collections::{HashMap, HashSet};
 use std::io::{Read, Write};
-#[cfg(all(unix, not(test)))]
+#[cfg(unix)]
 use std::os::unix::process::CommandExt;
 use std::path::{Path, PathBuf};
 use std::process::Child;
@@ -3206,13 +3206,15 @@ fn desktop_theme_command_output(
     if timeout.is_zero() {
         return None;
     }
-    let mut child = Command::new(program)
+    let mut command = Command::new(program);
+    command
         .args(args)
         .stdin(std::process::Stdio::null())
         .stdout(std::process::Stdio::piped())
-        .stderr(std::process::Stdio::null())
-        .spawn()
-        .ok()?;
+        .stderr(std::process::Stdio::null());
+    #[cfg(unix)]
+    command.process_group(0);
+    let mut child = command.spawn().ok()?;
     let Some(stdout) = child.stdout.take() else {
         terminate_ghostty_helper_child(child);
         return None;
@@ -4952,6 +4954,48 @@ mod tests {
         }
 
         assert!(!unix_process_exists(pid), "helper child {pid} was not reaped");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn ghostty_config_helper_cleanup_reaps_process_group_children() {
+        let dir = std::env::temp_dir().join(format!(
+            "cmux-tui-ghostty-helper-process-group-{}-{}",
+            std::process::id(),
+            SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_nanos()
+        ));
+        std::fs::create_dir_all(&dir).unwrap();
+        let child_pid_path = dir.join("child.pid");
+        let script = format!("sleep 5 & echo $! > '{}'; wait", child_pid_path.display());
+        let mut command = Command::new("/bin/sh");
+        command.arg("-c").arg(script).process_group(0);
+        let child = command.spawn().unwrap();
+        let parent_pid = child.id() as libc::pid_t;
+        let child_pid = {
+            let deadline = Instant::now() + Duration::from_secs(2);
+            loop {
+                if let Ok(text) = std::fs::read_to_string(&child_pid_path)
+                    && let Ok(pid) = text.trim().parse::<libc::pid_t>()
+                {
+                    break pid;
+                }
+                assert!(Instant::now() < deadline, "child pid was not written");
+                std::thread::sleep(Duration::from_millis(10));
+            }
+        };
+
+        terminate_ghostty_helper_child(child);
+
+        let deadline = Instant::now() + Duration::from_secs(2);
+        while (unix_process_exists(parent_pid) || unix_process_exists(child_pid))
+            && Instant::now() < deadline
+        {
+            std::thread::sleep(Duration::from_millis(10));
+        }
+        let _ = std::fs::remove_dir_all(dir);
+
+        assert!(!unix_process_exists(parent_pid), "helper parent {parent_pid} was not reaped");
+        assert!(!unix_process_exists(child_pid), "helper child {child_pid} was not killed");
     }
 
     #[cfg(unix)]

--- a/cmux-tui/crates/cmux-tui/src/config.rs
+++ b/cmux-tui/crates/cmux-tui/src/config.rs
@@ -2765,7 +2765,7 @@ fn ghostty_defaults_from_helper() -> GhosttyHelperDefaults {
         terminate_ghostty_helper_child(child);
         return GhosttyHelperDefaults::Unavailable;
     };
-    let status = match child.wait_timeout(GHOSTTY_CONFIG_PARSE_DEADLINE) {
+    let status = match child.wait_timeout(GHOSTTY_CONFIG_HELPER_PARENT_DEADLINE) {
         Ok(status) => status,
         Err(_) => {
             terminate_ghostty_helper_child(child);
@@ -2845,8 +2845,20 @@ fn parse_ghostty_defaults_from_paths_result(
     config_paths: Vec<PathBuf>,
     theme_dirs: Vec<PathBuf>,
 ) -> GhosttyConfigParseOutcome {
+    let deadline_at = ghostty_config_deadline_from_now(GHOSTTY_CONFIG_PARSE_DEADLINE);
+    parse_ghostty_defaults_from_paths_result_until(config_paths, theme_dirs, Some(deadline_at))
+}
+
+fn parse_ghostty_defaults_from_paths_result_until(
+    config_paths: Vec<PathBuf>,
+    theme_dirs: Vec<PathBuf>,
+    deadline_at: Option<Instant>,
+) -> GhosttyConfigParseOutcome {
     for path in config_paths {
-        match parse_ghostty_defaults_from_path_result(&path, &theme_dirs) {
+        if ghostty_config_deadline_expired(deadline_at) {
+            return GhosttyConfigParseOutcome::TimedOut;
+        }
+        match parse_ghostty_defaults_from_path_result_until(&path, &theme_dirs, deadline_at) {
             GhosttyConfigParseOutcome::Missing => {}
             outcome => return outcome,
         }
@@ -2859,14 +2871,13 @@ fn parse_ghostty_defaults_with_theme_dirs(text: &str, theme_dirs: &[PathBuf]) ->
     let mut theme_selection = auto_ghostty_theme_selection();
     let mut theme_candidates = Vec::new();
     let parsed = parse_ghostty_config_text(text, None, &mut theme_selection, &mut theme_candidates);
-    let mut defaults = resolve_ghostty_theme_defaults(
-        &theme_candidates,
+    resolve_parsed_ghostty_defaults(
+        theme_candidates,
         theme_dirs,
-        theme_selection,
-        &parsed.overrides,
-    );
-    overlay_ghostty_defaults(&mut defaults, parsed.overrides);
-    defaults
+        parsed.theme_selection,
+        parsed.overrides,
+        None,
+    )
 }
 
 #[cfg(test)]
@@ -2877,21 +2888,38 @@ fn parse_ghostty_defaults_from_path(path: &Path, theme_dirs: &[PathBuf]) -> Opti
     }
 }
 
+#[cfg(test)]
 fn parse_ghostty_defaults_from_path_result(
     path: &Path,
     theme_dirs: &[PathBuf],
 ) -> GhosttyConfigParseOutcome {
+    let deadline_at = ghostty_config_deadline_from_now(GHOSTTY_CONFIG_PARSE_DEADLINE);
+    parse_ghostty_defaults_from_path_result_until(path, theme_dirs, Some(deadline_at))
+}
+
+fn parse_ghostty_defaults_from_path_result_until(
+    path: &Path,
+    theme_dirs: &[PathBuf],
+    deadline_at: Option<Instant>,
+) -> GhosttyConfigParseOutcome {
     let mut theme_selection = auto_ghostty_theme_selection();
     let mut theme_candidates = Vec::new();
-    let overrides =
-        match parse_ghostty_config_file(path, &mut theme_selection, &mut theme_candidates) {
-            GhosttyConfigParseOutcome::Parsed(overrides) => overrides,
-            outcome => return outcome,
-        };
-    let mut defaults =
-        resolve_ghostty_theme_defaults(&theme_candidates, theme_dirs, theme_selection, &overrides);
-    overlay_ghostty_defaults(&mut defaults, overrides);
-    GhosttyConfigParseOutcome::Parsed(defaults)
+    let overrides = match parse_ghostty_config_file_until(
+        path,
+        &mut theme_selection,
+        &mut theme_candidates,
+        deadline_at,
+    ) {
+        GhosttyConfigParseOutcome::Parsed(overrides) => overrides,
+        outcome => return outcome,
+    };
+    GhosttyConfigParseOutcome::Parsed(resolve_parsed_ghostty_defaults(
+        theme_candidates,
+        theme_dirs,
+        theme_selection,
+        overrides,
+        deadline_at,
+    ))
 }
 
 const GHOSTTY_CONFIG_MAX_FILES: usize = 64;
@@ -2899,32 +2927,37 @@ const GHOSTTY_CONFIG_MAX_DEPTH: usize = 16;
 const GHOSTTY_CONFIG_MAX_BYTES: u64 = 1024 * 1024;
 const GHOSTTY_HELPER_OUTPUT_MAX_BYTES: u64 = 64 * 1024;
 const GHOSTTY_CONFIG_PARSE_DEADLINE: Duration = Duration::from_millis(250);
+#[cfg(not(test))]
+const GHOSTTY_CONFIG_HELPER_PARENT_DEADLINE: Duration = Duration::from_millis(300);
+#[cfg(not(target_os = "macos"))]
+const GHOSTTY_DESKTOP_APPEARANCE_DEADLINE: Duration = Duration::from_millis(75);
 
 struct PendingGhosttyConfig {
     path: PathBuf,
     depth: usize,
 }
 
-fn parse_ghostty_config_file(
-    path: &Path,
-    theme_selection: &mut GhosttyThemeSelection,
-    theme_candidates: &mut Vec<GhosttyThemeCandidate>,
-) -> GhosttyConfigParseOutcome {
-    parse_ghostty_config_file_with_deadline(
-        path,
-        theme_selection,
-        theme_candidates,
-        GHOSTTY_CONFIG_PARSE_DEADLINE,
-    )
-}
-
+#[cfg(test)]
 fn parse_ghostty_config_file_with_deadline(
     path: &Path,
     theme_selection: &mut GhosttyThemeSelection,
     theme_candidates: &mut Vec<GhosttyThemeCandidate>,
     deadline: Duration,
 ) -> GhosttyConfigParseOutcome {
-    let started_at = Instant::now();
+    parse_ghostty_config_file_until(
+        path,
+        theme_selection,
+        theme_candidates,
+        Some(ghostty_config_deadline_from_now(deadline)),
+    )
+}
+
+fn parse_ghostty_config_file_until(
+    path: &Path,
+    theme_selection: &mut GhosttyThemeSelection,
+    theme_candidates: &mut Vec<GhosttyThemeCandidate>,
+    deadline_at: Option<Instant>,
+) -> GhosttyConfigParseOutcome {
     let mut stack = vec![PendingGhosttyConfig { path: path.to_path_buf(), depth: 0 }];
     let mut loaded = HashSet::new();
     let mut files_loaded = 0usize;
@@ -2933,7 +2966,7 @@ fn parse_ghostty_config_file_with_deadline(
     let mut overrides = DefaultColors::default();
 
     while let Some(pending) = stack.pop() {
-        if files_loaded > 0 && started_at.elapsed() > deadline {
+        if files_loaded > 0 && ghostty_config_deadline_expired(deadline_at) {
             return GhosttyConfigParseOutcome::TimedOut;
         }
         if pending.depth > GHOSTTY_CONFIG_MAX_DEPTH || files_loaded >= GHOSTTY_CONFIG_MAX_FILES {
@@ -2966,7 +2999,7 @@ fn parse_ghostty_config_file_with_deadline(
         {
             stack.push(PendingGhosttyConfig { path: include, depth: pending.depth + 1 });
         }
-        if started_at.elapsed() > deadline {
+        if ghostty_config_deadline_expired(deadline_at) {
             return GhosttyConfigParseOutcome::TimedOut;
         }
     }
@@ -2976,6 +3009,21 @@ fn parse_ghostty_config_file_with_deadline(
     } else {
         GhosttyConfigParseOutcome::Missing
     }
+}
+
+fn ghostty_config_deadline_from_now(deadline: Duration) -> Instant {
+    Instant::now().checked_add(deadline).unwrap_or_else(Instant::now)
+}
+
+fn ghostty_config_deadline_expired(deadline_at: Option<Instant>) -> bool {
+    deadline_at.is_some_and(|deadline_at| Instant::now() >= deadline_at)
+}
+
+#[cfg(not(target_os = "macos"))]
+fn ghostty_config_deadline_remaining(deadline_at: Option<Instant>) -> Option<Duration> {
+    deadline_at.map_or(Some(Duration::MAX), |deadline_at| {
+        deadline_at.checked_duration_since(Instant::now())
+    })
 }
 
 struct ParsedGhosttyConfig {
@@ -3031,11 +3079,11 @@ enum ResolvedGhosttyThemeSelection {
 }
 
 impl GhosttyThemeSelection {
-    fn resolve_for_parse(self) -> ResolvedGhosttyThemeSelection {
+    fn resolve_for_parse(self, deadline_at: Option<Instant>) -> ResolvedGhosttyThemeSelection {
         match self {
             Self::Mode(mode) => ResolvedGhosttyThemeSelection::Mode(mode),
             Self::System => ResolvedGhosttyThemeSelection::Mode(system_ghostty_theme_mode(
-                platform_appearance_theme_mode(),
+                platform_appearance_theme_mode(deadline_at),
             )),
             Self::Ghostty => ResolvedGhosttyThemeSelection::Ghostty,
         }
@@ -3084,22 +3132,25 @@ fn ghostty_background_theme_mode(background: Option<Rgb>) -> GhosttyThemeMode {
 }
 
 #[cfg(target_os = "macos")]
-fn platform_appearance_theme_mode() -> Option<GhosttyThemeMode> {
+fn platform_appearance_theme_mode(_deadline_at: Option<Instant>) -> Option<GhosttyThemeMode> {
     macos_appearance_theme_mode()
 }
 
 #[cfg(not(target_os = "macos"))]
-fn platform_appearance_theme_mode() -> Option<GhosttyThemeMode> {
-    non_macos_appearance_theme_mode()
+fn platform_appearance_theme_mode(deadline_at: Option<Instant>) -> Option<GhosttyThemeMode> {
+    non_macos_appearance_theme_mode(deadline_at)
 }
 
 #[cfg(not(target_os = "macos"))]
-fn non_macos_appearance_theme_mode() -> Option<GhosttyThemeMode> {
-    if let Some(mode) = freedesktop_portal_theme_mode() {
+fn non_macos_appearance_theme_mode(deadline_at: Option<Instant>) -> Option<GhosttyThemeMode> {
+    if let Some(mode) = freedesktop_portal_theme_mode(deadline_at) {
         return Some(mode);
     }
-    if let Some(mode) = gnome_color_scheme_theme_mode() {
+    if let Some(mode) = gnome_color_scheme_theme_mode(deadline_at) {
         return Some(mode);
+    }
+    if ghostty_config_deadline_expired(deadline_at) {
+        return None;
     }
     if let Some(mode) = std::env::var_os("GTK_THEME")
         .as_deref()
@@ -3110,14 +3161,17 @@ fn non_macos_appearance_theme_mode() -> Option<GhosttyThemeMode> {
     gtk_settings_paths()
         .into_iter()
         .find_map(|path| {
+            if ghostty_config_deadline_expired(deadline_at) {
+                return None;
+            }
             let text = read_ghostty_regular_file(&path, 64 * 1024)?;
             gtk_settings_theme_mode(&text)
         })
-        .or_else(kde_globals_theme_mode)
+        .or_else(|| kde_globals_theme_mode(deadline_at))
 }
 
 #[cfg(not(target_os = "macos"))]
-fn freedesktop_portal_theme_mode() -> Option<GhosttyThemeMode> {
+fn freedesktop_portal_theme_mode(deadline_at: Option<Instant>) -> Option<GhosttyThemeMode> {
     let output = desktop_theme_command_output(
         "gdbus",
         &[
@@ -3132,21 +3186,32 @@ fn freedesktop_portal_theme_mode() -> Option<GhosttyThemeMode> {
             "org.freedesktop.appearance",
             "color-scheme",
         ],
+        deadline_at,
     )?;
     freedesktop_portal_color_scheme_theme_mode(&output)
 }
 
 #[cfg(not(target_os = "macos"))]
-fn gnome_color_scheme_theme_mode() -> Option<GhosttyThemeMode> {
+fn gnome_color_scheme_theme_mode(deadline_at: Option<Instant>) -> Option<GhosttyThemeMode> {
     let output = desktop_theme_command_output(
         "gsettings",
         &["get", "org.gnome.desktop.interface", "color-scheme"],
+        deadline_at,
     )?;
     gnome_color_scheme_output_theme_mode(&output)
 }
 
 #[cfg(not(target_os = "macos"))]
-fn desktop_theme_command_output(program: &str, args: &[&str]) -> Option<String> {
+fn desktop_theme_command_output(
+    program: &str,
+    args: &[&str],
+    deadline_at: Option<Instant>,
+) -> Option<String> {
+    let timeout =
+        ghostty_config_deadline_remaining(deadline_at)?.min(GHOSTTY_DESKTOP_APPEARANCE_DEADLINE);
+    if timeout.is_zero() {
+        return None;
+    }
     let mut child = Command::new(program)
         .args(args)
         .stdin(std::process::Stdio::null())
@@ -3162,7 +3227,7 @@ fn desktop_theme_command_output(program: &str, args: &[&str]) -> Option<String> 
         terminate_ghostty_helper_child(child);
         return None;
     };
-    let status = match child.wait_timeout(Duration::from_millis(75)) {
+    let status = match child.wait_timeout(timeout) {
         Ok(Some(status)) => status,
         Ok(None) | Err(_) => {
             terminate_ghostty_helper_child(child);
@@ -3197,8 +3262,11 @@ fn gnome_color_scheme_output_theme_mode(text: &str) -> Option<GhosttyThemeMode> 
 }
 
 #[cfg(not(target_os = "macos"))]
-fn kde_globals_theme_mode() -> Option<GhosttyThemeMode> {
+fn kde_globals_theme_mode(deadline_at: Option<Instant>) -> Option<GhosttyThemeMode> {
     kde_globals_paths().into_iter().find_map(|path| {
+        if ghostty_config_deadline_expired(deadline_at) {
+            return None;
+        }
         let text = read_ghostty_regular_file(&path, 64 * 1024)?;
         kde_globals_text_theme_mode(&text)
     })
@@ -3404,19 +3472,44 @@ fn resolve_ghostty_theme_defaults(
     theme_dirs: &[PathBuf],
     theme_selection: GhosttyThemeSelection,
     overrides: &DefaultColors,
+    deadline_at: Option<Instant>,
 ) -> DefaultColors {
     if theme_candidates.is_empty() {
         return DefaultColors::default();
     }
-    let resolved_selection = theme_selection.resolve_for_parse();
+    if ghostty_config_deadline_expired(deadline_at) {
+        return DefaultColors::default();
+    }
+    let resolved_selection = theme_selection.resolve_for_parse(deadline_at);
     for candidate in theme_candidates {
+        if ghostty_config_deadline_expired(deadline_at) {
+            return DefaultColors::default();
+        }
         if let Some(defaults) =
-            load_ghostty_theme(candidate, theme_dirs, resolved_selection, overrides)
+            load_ghostty_theme(candidate, theme_dirs, resolved_selection, overrides, deadline_at)
         {
             return defaults;
         }
     }
     DefaultColors::default()
+}
+
+fn resolve_parsed_ghostty_defaults(
+    theme_candidates: Vec<GhosttyThemeCandidate>,
+    theme_dirs: &[PathBuf],
+    theme_selection: GhosttyThemeSelection,
+    overrides: DefaultColors,
+    deadline_at: Option<Instant>,
+) -> DefaultColors {
+    let mut defaults = resolve_ghostty_theme_defaults(
+        &theme_candidates,
+        theme_dirs,
+        theme_selection,
+        &overrides,
+        deadline_at,
+    );
+    overlay_ghostty_defaults(&mut defaults, overrides);
+    defaults
 }
 
 fn parse_ghostty_window_theme(value: &str) -> Option<GhosttyThemeSelection> {
@@ -3555,13 +3648,20 @@ fn load_ghostty_theme(
     theme_dirs: &[PathBuf],
     theme_selection: ResolvedGhosttyThemeSelection,
     overrides: &DefaultColors,
+    deadline_at: Option<Instant>,
 ) -> Option<DefaultColors> {
+    if ghostty_config_deadline_expired(deadline_at) {
+        return None;
+    }
     let value = candidate.value.trim_matches('"');
     let ghostty_background = if theme_selection == ResolvedGhosttyThemeSelection::Ghostty {
-        ghostty_theme_selection_background(value, candidate, theme_dirs, overrides)
+        ghostty_theme_selection_background(value, candidate, theme_dirs, overrides, deadline_at)
     } else {
         None
     };
+    if ghostty_config_deadline_expired(deadline_at) {
+        return None;
+    }
     let theme = selected_ghostty_theme(value, theme_selection, ghostty_background);
     let path = resolve_ghostty_theme_path(theme, candidate.base_dir.as_deref(), theme_dirs)?;
     let text = read_ghostty_regular_file(&path, GHOSTTY_CONFIG_MAX_BYTES)?;
@@ -3573,14 +3673,21 @@ fn ghostty_theme_selection_background(
     candidate: &GhosttyThemeCandidate,
     theme_dirs: &[PathBuf],
     overrides: &DefaultColors,
+    deadline_at: Option<Instant>,
 ) -> Option<Rgb> {
     overrides.bg.or_else(|| {
+        if ghostty_config_deadline_expired(deadline_at) {
+            return None;
+        }
         let light = selected_conditional_ghostty_theme(
             value,
             ResolvedGhosttyThemeSelection::Mode(GhosttyThemeMode::Light),
             None,
         )?;
         let path = resolve_ghostty_theme_path(light, candidate.base_dir.as_deref(), theme_dirs)?;
+        if ghostty_config_deadline_expired(deadline_at) {
+            return None;
+        }
         let text = read_ghostty_regular_file(&path, GHOSTTY_CONFIG_MAX_BYTES)?;
         parse_resolved_ghostty_defaults(&text).bg
     })
@@ -4722,6 +4829,49 @@ mod tests {
         assert!(matches!(outcome, GhosttyConfigParseOutcome::TimedOut));
         assert_eq!(full.bg, Some(Rgb { r: 0x01, g: 0x02, b: 0x03 }));
         assert_eq!(full.fg, Some(Rgb { r: 0x04, g: 0x05, b: 0x06 }));
+    }
+
+    #[test]
+    fn ghostty_theme_deadline_keeps_parsed_overrides() {
+        let _guard = CONFIG_ENV_LOCK.lock().unwrap();
+        let dir = std::env::temp_dir().join(format!(
+            "cmux-tui-ghostty-theme-deadline-{}-{}",
+            std::process::id(),
+            SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_nanos()
+        ));
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(
+            dir.join("Dark Budget Theme"),
+            "background = #101112\nforeground = #131415\npalette = 1=#161718\n",
+        )
+        .unwrap();
+        let overrides = DefaultColors {
+            fg: Some(Rgb { r: 0x01, g: 0x02, b: 0x03 }),
+            bg: Some(Rgb { r: 0x04, g: 0x05, b: 0x06 }),
+            ..Default::default()
+        };
+
+        let loaded = resolve_parsed_ghostty_defaults(
+            vec![GhosttyThemeCandidate { value: "Dark Budget Theme".to_string(), base_dir: None }],
+            std::slice::from_ref(&dir),
+            GhosttyThemeSelection::Mode(GhosttyThemeMode::Dark),
+            overrides,
+            None,
+        );
+        let expired = resolve_parsed_ghostty_defaults(
+            vec![GhosttyThemeCandidate { value: "Dark Budget Theme".to_string(), base_dir: None }],
+            std::slice::from_ref(&dir),
+            GhosttyThemeSelection::Mode(GhosttyThemeMode::Dark),
+            overrides,
+            Some(Instant::now().checked_sub(Duration::from_millis(1)).unwrap()),
+        );
+
+        let _ = std::fs::remove_dir_all(dir);
+
+        assert_eq!(loaded.palette[1], Some(Rgb { r: 0x16, g: 0x17, b: 0x18 }));
+        assert_eq!(expired.fg, Some(Rgb { r: 0x01, g: 0x02, b: 0x03 }));
+        assert_eq!(expired.bg, Some(Rgb { r: 0x04, g: 0x05, b: 0x06 }));
+        assert_eq!(expired.palette[1], None);
     }
 
     #[test]

--- a/cmux-tui/crates/cmux-tui/src/config.rs
+++ b/cmux-tui/crates/cmux-tui/src/config.rs
@@ -3577,12 +3577,11 @@ fn resolve_ghostty_theme_defaults(
     if ghostty_config_deadline_expired(deadline_at) {
         return DefaultColors::default();
     }
-    let theme_mode = system_ghostty_theme_mode(platform_appearance_theme_mode(deadline_at));
     for candidate in theme_candidates {
         if ghostty_config_deadline_expired(deadline_at) {
             return DefaultColors::default();
         }
-        if let Some(defaults) = load_ghostty_theme(candidate, theme_dirs, theme_mode, deadline_at) {
+        if let Some(defaults) = load_ghostty_theme(candidate, theme_dirs, deadline_at) {
             return defaults;
         }
     }
@@ -3713,14 +3712,16 @@ fn apply_ghostty_default(defaults: &mut DefaultColors, key: &str, value: &str) {
 fn load_ghostty_theme(
     candidate: &GhosttyThemeCandidate,
     theme_dirs: &[PathBuf],
-    theme_mode: GhosttyThemeMode,
     deadline_at: Option<Instant>,
 ) -> Option<DefaultColors> {
     if ghostty_config_deadline_expired(deadline_at) {
         return None;
     }
     let value = candidate.value.trim_matches('"');
-    let theme = selected_ghostty_theme(value, theme_mode);
+    let theme = selected_ghostty_theme(value, deadline_at);
+    if ghostty_config_deadline_expired(deadline_at) {
+        return None;
+    }
     let path = resolve_ghostty_theme_path(theme, candidate.base_dir.as_deref(), theme_dirs)?;
     let text = read_ghostty_regular_file(&path, GHOSTTY_CONFIG_MAX_BYTES)?;
     Some(parse_resolved_ghostty_defaults(&text))
@@ -3770,11 +3771,17 @@ fn expand_home_relative_path(value: &str) -> Option<PathBuf> {
     }
 }
 
-fn selected_ghostty_theme(value: &str, theme_mode: GhosttyThemeMode) -> &str {
-    selected_conditional_ghostty_theme(value, theme_mode).unwrap_or(value)
+fn selected_ghostty_theme(value: &str, deadline_at: Option<Instant>) -> &str {
+    let Some((light, dark)) = conditional_ghostty_themes(value) else {
+        return value;
+    };
+    match system_ghostty_theme_mode(platform_appearance_theme_mode(deadline_at)) {
+        GhosttyThemeMode::Light => light,
+        GhosttyThemeMode::Dark => dark,
+    }
 }
 
-fn selected_conditional_ghostty_theme(value: &str, theme_mode: GhosttyThemeMode) -> Option<&str> {
+fn conditional_ghostty_themes(value: &str) -> Option<(&str, &str)> {
     let mut light = None;
     let mut dark = None;
     for part in value.split(',') {
@@ -3786,11 +3793,7 @@ fn selected_conditional_ghostty_theme(value: &str, theme_mode: GhosttyThemeMode)
             _ => return None,
         }
     }
-    match theme_mode {
-        GhosttyThemeMode::Light if light.is_some() && dark.is_some() => light,
-        GhosttyThemeMode::Dark if light.is_some() && dark.is_some() => dark,
-        _ => None,
-    }
+    Some((light?, dark?))
 }
 
 fn overlay_ghostty_defaults(defaults: &mut DefaultColors, overrides: DefaultColors) {
@@ -5403,6 +5406,15 @@ mod tests {
         assert_eq!(defaults.bg, Some(Rgb { r: 0x10, g: 0x11, b: 0x12 }));
         assert_eq!(defaults.fg, Some(Rgb { r: 0x13, g: 0x14, b: 0x15 }));
         assert_eq!(defaults.palette[1], Some(Rgb { r: 0x16, g: 0x17, b: 0x18 }));
+    }
+
+    #[test]
+    fn ghostty_fixed_theme_selection_does_not_require_appearance_budget() {
+        let expired = Instant::now().checked_sub(Duration::from_millis(1)).unwrap();
+
+        let selected = selected_ghostty_theme("Monokai", Some(expired));
+
+        assert_eq!(selected, "Monokai");
     }
 
     #[test]

--- a/cmux-tui/crates/cmux-tui/src/config.rs
+++ b/cmux-tui/crates/cmux-tui/src/config.rs
@@ -2752,7 +2752,7 @@ impl GhosttyConfigFile {
     }
 }
 
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
 enum GhosttyThemeMode {
     Light,
     Dark,
@@ -2760,15 +2760,7 @@ enum GhosttyThemeMode {
 
 impl GhosttyThemeMode {
     fn detect() -> Self {
-        if let Some(mode) = std::env::var_os("AppleInterfaceStyle").as_deref().and_then(Self::parse)
-        {
-            return mode;
-        }
-        #[cfg(target_os = "macos")]
-        if macos_prefers_dark_appearance() {
-            return Self::Dark;
-        }
-        terminal_background_theme_mode().unwrap_or(Self::Light)
+        detected_ghostty_theme_mode(platform_appearance_theme_mode())
     }
 
     fn parse(value: &std::ffi::OsStr) -> Option<Self> {
@@ -2779,6 +2771,28 @@ impl GhosttyThemeMode {
             _ => None,
         }
     }
+}
+
+fn detected_ghostty_theme_mode(platform_appearance: Option<GhosttyThemeMode>) -> GhosttyThemeMode {
+    if let Some(mode) =
+        std::env::var_os("AppleInterfaceStyle").as_deref().and_then(GhosttyThemeMode::parse)
+    {
+        return mode;
+    }
+    if let Some(mode) = platform_appearance {
+        return mode;
+    }
+    terminal_background_theme_mode().unwrap_or(GhosttyThemeMode::Light)
+}
+
+#[cfg(target_os = "macos")]
+fn platform_appearance_theme_mode() -> Option<GhosttyThemeMode> {
+    macos_appearance_theme_mode()
+}
+
+#[cfg(not(target_os = "macos"))]
+fn platform_appearance_theme_mode() -> Option<GhosttyThemeMode> {
+    None
 }
 
 fn terminal_background_theme_mode() -> Option<GhosttyThemeMode> {
@@ -2792,7 +2806,7 @@ fn terminal_background_theme_mode() -> Option<GhosttyThemeMode> {
 }
 
 #[cfg(target_os = "macos")]
-fn macos_prefers_dark_appearance() -> bool {
+fn macos_appearance_theme_mode() -> Option<GhosttyThemeMode> {
     use std::ffi::CString;
     use std::os::raw::{c_char, c_void};
     use std::ptr;
@@ -2824,23 +2838,19 @@ fn macos_prefers_dark_appearance() -> bool {
         fn CFRelease(cf: CfTypeRef);
     }
 
-    let Some(key) = CString::new("AppleInterfaceStyle").ok() else {
-        return false;
-    };
-    let Some(dark) = CString::new("Dark").ok() else {
-        return false;
-    };
+    let key = CString::new("AppleInterfaceStyle").ok()?;
+    let dark = CString::new("Dark").ok()?;
     unsafe {
         let key_ref =
             CFStringCreateWithCString(ptr::null(), key.as_ptr(), K_CF_STRING_ENCODING_UTF8);
         if key_ref.is_null() {
-            return false;
+            return None;
         }
         let dark_ref =
             CFStringCreateWithCString(ptr::null(), dark.as_ptr(), K_CF_STRING_ENCODING_UTF8);
         if dark_ref.is_null() {
             CFRelease(key_ref);
-            return false;
+            return None;
         }
         let value = CFPreferencesCopyValue(
             key_ref,
@@ -2848,13 +2858,17 @@ fn macos_prefers_dark_appearance() -> bool {
             kCFPreferencesCurrentUser,
             kCFPreferencesAnyHost,
         );
-        let is_dark = !value.is_null() && CFEqual(value, dark_ref) != 0;
+        let mode = if !value.is_null() && CFEqual(value, dark_ref) != 0 {
+            GhosttyThemeMode::Dark
+        } else {
+            GhosttyThemeMode::Light
+        };
         if !value.is_null() {
             CFRelease(value);
         }
         CFRelease(dark_ref);
         CFRelease(key_ref);
-        is_dark
+        Some(mode)
     }
 }
 
@@ -3763,6 +3777,25 @@ mod tests {
         assert_eq!(defaults.bg, Some(Rgb { r: 0x10, g: 0x11, b: 0x12 }));
         assert_eq!(defaults.fg, Some(Rgb { r: 0x13, g: 0x14, b: 0x15 }));
         assert_eq!(defaults.palette[1], Some(Rgb { r: 0x16, g: 0x17, b: 0x18 }));
+    }
+
+    #[test]
+    fn ghostty_platform_light_mode_wins_over_dark_terminal_background_hint() {
+        let _guard = CONFIG_ENV_LOCK.lock().unwrap();
+        let old_apple_interface_style = std::env::var_os("AppleInterfaceStyle");
+        let old_colorfgbg = std::env::var_os("COLORFGBG");
+        // SAFETY: env mutation in tests is serialized by CONFIG_ENV_LOCK.
+        unsafe {
+            std::env::remove_var("AppleInterfaceStyle");
+            std::env::set_var("COLORFGBG", "15;0");
+        }
+
+        let mode = detected_ghostty_theme_mode(Some(GhosttyThemeMode::Light));
+
+        restore_env_var("AppleInterfaceStyle", old_apple_interface_style);
+        restore_env_var("COLORFGBG", old_colorfgbg);
+
+        assert_eq!(mode, GhosttyThemeMode::Light);
     }
 
     #[test]

--- a/cmux-tui/crates/cmux-tui/src/config.rs
+++ b/cmux-tui/crates/cmux-tui/src/config.rs
@@ -124,10 +124,8 @@ use std::os::unix::process::CommandExt;
 use std::path::{Path, PathBuf};
 use std::process::Child;
 use std::process::Command;
-#[cfg(not(test))]
-use std::process::Stdio as ProcessStdio;
-#[cfg(unix)]
 use std::process::Stdio;
+use std::sync::mpsc;
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
 use cmux_tui_core::BrowserMode;
@@ -2743,12 +2741,20 @@ fn ghostty_defaults_from_helper() -> GhosttyHelperDefaults {
     let mut command = Command::new(exe);
     command
         .arg("__ghostty-config-defaults")
-        .stdin(ProcessStdio::null())
-        .stdout(ProcessStdio::piped())
-        .stderr(ProcessStdio::null());
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null());
     #[cfg(unix)]
     command.process_group(0);
     scrub_ghostty_helper_secret_environment(&mut command);
+    ghostty_defaults_from_helper_command(command, GHOSTTY_CONFIG_HELPER_PARENT_DEADLINE)
+}
+
+#[cfg(any(not(test), all(test, unix)))]
+fn ghostty_defaults_from_helper_command(
+    mut command: Command,
+    parent_deadline: Duration,
+) -> GhosttyHelperDefaults {
     let Ok(mut child) = command.spawn() else {
         return GhosttyHelperDefaults::Unavailable;
     };
@@ -2760,7 +2766,7 @@ fn ghostty_defaults_from_helper() -> GhosttyHelperDefaults {
         terminate_ghostty_helper_child(child);
         return GhosttyHelperDefaults::Unavailable;
     };
-    let status = match child.wait_timeout(GHOSTTY_CONFIG_HELPER_PARENT_DEADLINE) {
+    let status = match child.wait_timeout(parent_deadline) {
         Ok(status) => status,
         Err(_) => {
             terminate_ghostty_helper_child(child);
@@ -2780,7 +2786,7 @@ fn ghostty_defaults_from_helper() -> GhosttyHelperDefaults {
         }
         return GhosttyHelperDefaults::Unavailable;
     }
-    match output_reader.join().ok().flatten() {
+    match output_reader.wait() {
         Some(output) => GhosttyHelperDefaults::Resolved(parse_resolved_ghostty_defaults(&output)),
         None => GhosttyHelperDefaults::Unavailable,
     }
@@ -2788,11 +2794,42 @@ fn ghostty_defaults_from_helper() -> GhosttyHelperDefaults {
 
 fn read_ghostty_helper_output_async(
     stdout: impl Read + Send + 'static,
-) -> Option<std::thread::JoinHandle<Option<String>>> {
+) -> Option<GhosttyHelperOutputReader> {
+    read_ghostty_limited_output_async(
+        stdout,
+        GHOSTTY_HELPER_OUTPUT_MAX_BYTES,
+        "cmux-tui-ghostty-helper-output",
+    )
+}
+
+fn read_ghostty_limited_output_async(
+    stdout: impl Read + Send + 'static,
+    max_bytes: u64,
+    thread_name: &'static str,
+) -> Option<GhosttyHelperOutputReader> {
+    let (sender, receiver) = mpsc::channel();
     std::thread::Builder::new()
-        .name("cmux-tui-ghostty-helper-output".to_string())
-        .spawn(move || read_ghostty_limited_string(stdout, GHOSTTY_HELPER_OUTPUT_MAX_BYTES))
-        .ok()
+        .name(thread_name.to_string())
+        .spawn(move || {
+            let _ = sender.send(read_ghostty_limited_string(stdout, max_bytes));
+        })
+        .ok()?;
+    Some(GhosttyHelperOutputReader { receiver })
+}
+
+struct GhosttyHelperOutputReader {
+    receiver: mpsc::Receiver<Option<String>>,
+}
+
+impl GhosttyHelperOutputReader {
+    fn wait(self) -> Option<String> {
+        self.receiver.recv().ok().flatten()
+    }
+
+    #[cfg(not(target_os = "macos"))]
+    fn recv_timeout(&self, timeout: Duration) -> Result<Option<String>, mpsc::RecvTimeoutError> {
+        self.receiver.recv_timeout(timeout)
+    }
 }
 
 fn terminate_ghostty_helper_child(mut child: Child) {
@@ -2836,7 +2873,11 @@ fn ghostty_helper_process_table_snapshot() -> Option<String> {
         terminate_ghostty_process_scan_child(child);
         return None;
     };
-    let Some(output_reader) = read_ghostty_helper_output_async(stdout) else {
+    let Some(output_reader) = read_ghostty_limited_output_async(
+        stdout,
+        GHOSTTY_PROCESS_SCAN_OUTPUT_MAX_BYTES,
+        "cmux-tui-ghostty-process-scan-output",
+    ) else {
         terminate_ghostty_process_scan_child(child);
         return None;
     };
@@ -2850,7 +2891,7 @@ fn ghostty_helper_process_table_snapshot() -> Option<String> {
     if !status.success() {
         return None;
     }
-    output_reader.join().ok().flatten()
+    output_reader.wait()
 }
 
 #[cfg(unix)]
@@ -3016,11 +3057,14 @@ const GHOSTTY_CONFIG_MAX_FILES: usize = 64;
 const GHOSTTY_CONFIG_MAX_DEPTH: usize = 16;
 const GHOSTTY_CONFIG_MAX_BYTES: u64 = 1024 * 1024;
 const GHOSTTY_HELPER_OUTPUT_MAX_BYTES: u64 = 64 * 1024;
+#[cfg(unix)]
+const GHOSTTY_PROCESS_SCAN_OUTPUT_MAX_BYTES: u64 = 1024 * 1024;
 const GHOSTTY_CONFIG_PARSE_DEADLINE: Duration = Duration::from_millis(250);
 #[cfg(unix)]
 const GHOSTTY_PROCESS_SCAN_DEADLINE: Duration = Duration::from_millis(150);
-#[cfg(not(test))]
-const GHOSTTY_CONFIG_HELPER_PARENT_DEADLINE: Duration = Duration::from_millis(300);
+// The child owns a 250 ms parse deadline. The parent starts timing before
+// spawn/exec and still needs room for setup, stdout drain, and normal exit.
+const GHOSTTY_CONFIG_HELPER_PARENT_DEADLINE: Duration = Duration::from_millis(500);
 #[cfg(not(target_os = "macos"))]
 const GHOSTTY_DESKTOP_APPEARANCE_DEADLINE: Duration = Duration::from_millis(75);
 
@@ -3113,9 +3157,24 @@ fn ghostty_config_deadline_expired(deadline_at: Option<Instant>) -> bool {
 
 #[cfg(not(target_os = "macos"))]
 fn ghostty_config_deadline_remaining(deadline_at: Option<Instant>) -> Option<Duration> {
-    deadline_at.map_or(Some(Duration::MAX), |deadline_at| {
-        deadline_at.checked_duration_since(Instant::now())
-    })
+    deadline_at.map_or(Some(Duration::MAX), |deadline_at| Some(ghostty_duration_until(deadline_at)))
+}
+
+#[cfg(not(target_os = "macos"))]
+fn ghostty_duration_until(deadline_at: Instant) -> Duration {
+    deadline_at.checked_duration_since(Instant::now()).unwrap_or(Duration::ZERO)
+}
+
+#[cfg(all(unix, not(target_os = "macos")))]
+fn kill_ghostty_process_group(group: libc::pid_t) {
+    if group <= 0 {
+        return;
+    }
+    unsafe {
+        // SAFETY: callers pass process-group IDs that were either created by
+        // cmux-tui for short-lived helpers or discovered under those helpers.
+        libc::killpg(group, libc::SIGKILL);
+    }
 }
 
 struct ParsedGhosttyConfig {
@@ -3304,6 +3363,7 @@ fn desktop_theme_command_output(
     if timeout.is_zero() {
         return None;
     }
+    let command_deadline = Instant::now() + timeout;
     let mut command = Command::new(program);
     command
         .args(args)
@@ -3313,6 +3373,8 @@ fn desktop_theme_command_output(
     #[cfg(unix)]
     command.process_group(0);
     let mut child = command.spawn().ok()?;
+    #[cfg(unix)]
+    let child_group = child.id() as libc::pid_t;
     let Some(stdout) = child.stdout.take() else {
         terminate_ghostty_helper_child(child);
         return None;
@@ -3331,7 +3393,16 @@ fn desktop_theme_command_output(
     if !status.success() {
         return None;
     }
-    output_reader.join().ok().flatten()
+    match output_reader.recv_timeout(ghostty_duration_until(command_deadline)) {
+        Ok(output) => output,
+        Err(mpsc::RecvTimeoutError::Timeout) => {
+            #[cfg(unix)]
+            kill_ghostty_process_group(child_group);
+            let _ = output_reader.recv_timeout(Duration::from_millis(10));
+            None
+        }
+        Err(mpsc::RecvTimeoutError::Disconnected) => None,
+    }
 }
 
 #[cfg(any(test, not(target_os = "macos")))]
@@ -5074,6 +5145,82 @@ mod tests {
 
     #[cfg(unix)]
     #[test]
+    fn ghostty_config_helper_parent_deadline_allows_startup_margin() {
+        let mut command = Command::new("/bin/sh");
+        command
+            .args(["-c", "sleep 0.32; printf 'foreground=#010203\nbackground=#040506\n'"])
+            .stdin(Stdio::null())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::null())
+            .process_group(0);
+
+        let defaults =
+            ghostty_defaults_from_helper_command(command, GHOSTTY_CONFIG_HELPER_PARENT_DEADLINE);
+
+        let GhosttyHelperDefaults::Resolved(defaults) = defaults else {
+            panic!("helper should resolve within parent startup margin");
+        };
+        assert_eq!(defaults.fg, Some(Rgb { r: 0x01, g: 0x02, b: 0x03 }));
+        assert_eq!(defaults.bg, Some(Rgb { r: 0x04, g: 0x05, b: 0x06 }));
+    }
+
+    #[cfg(all(unix, not(target_os = "macos")))]
+    #[test]
+    fn ghostty_desktop_probe_cleanup_kills_stdout_inheriting_child() {
+        let dir = std::env::temp_dir().join(format!(
+            "cmux-tui-ghostty-desktop-probe-{}-{}",
+            std::process::id(),
+            SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_nanos()
+        ));
+        std::fs::create_dir_all(&dir).unwrap();
+        let script_path = dir.join("probe.sh");
+        let child_pid_path = dir.join("child.pid");
+        let script = format!(
+            "sleep 5 &\necho $! > {}\nprintf \"'prefer-dark'\\n\"\nexit 0\n",
+            shell_quote_path(&child_pid_path)
+        );
+        std::fs::write(&script_path, script).unwrap();
+        let script_arg = script_path.to_string_lossy().to_string();
+
+        let started_at = Instant::now();
+        let output = desktop_theme_command_output(
+            "/bin/sh",
+            &[script_arg.as_str()],
+            Some(Instant::now() + Duration::from_secs(1)),
+        );
+
+        assert_eq!(output, None);
+        assert!(
+            started_at.elapsed() < Duration::from_secs(1),
+            "desktop probe output drain was not bounded"
+        );
+
+        let child_pid = {
+            let deadline = Instant::now() + Duration::from_secs(2);
+            loop {
+                if let Ok(text) = std::fs::read_to_string(&child_pid_path)
+                    && let Ok(pid) = text.trim().parse::<libc::pid_t>()
+                {
+                    break pid;
+                }
+                assert!(Instant::now() < deadline, "desktop probe child pid was not written");
+                std::thread::sleep(Duration::from_millis(10));
+            }
+        };
+        let deadline = Instant::now() + Duration::from_secs(2);
+        while unix_process_is_live(child_pid) && Instant::now() < deadline {
+            std::thread::sleep(Duration::from_millis(10));
+        }
+        let _ = std::fs::remove_dir_all(dir);
+
+        assert!(
+            !unix_process_is_live(child_pid),
+            "stdout-inheriting desktop probe child {child_pid} was not killed"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
     fn ghostty_config_helper_cleanup_reaps_process_group_children() {
         let dir = std::env::temp_dir().join(format!(
             "cmux-tui-ghostty-helper-process-group-{}-{}",
@@ -5206,6 +5353,11 @@ mod tests {
         std::io::Error::last_os_error().raw_os_error() != Some(libc::ESRCH)
     }
 
+    #[cfg(all(unix, not(target_os = "macos")))]
+    fn shell_quote_path(path: &Path) -> String {
+        format!("'{}'", path.to_string_lossy().replace('\'', "'\\''"))
+    }
+
     #[test]
     fn ghostty_config_helper_output_reader_drains_large_palette() {
         let mut output = String::new();
@@ -5217,7 +5369,7 @@ mod tests {
         let reader =
             read_ghostty_helper_output_async(std::io::Cursor::new(output.clone())).unwrap();
 
-        assert_eq!(reader.join().unwrap(), Some(output));
+        assert_eq!(reader.wait(), Some(output));
     }
 
     #[test]
@@ -5226,7 +5378,7 @@ mod tests {
 
         let reader = read_ghostty_helper_output_async(std::io::Cursor::new(output)).unwrap();
 
-        assert_eq!(reader.join().unwrap(), None);
+        assert_eq!(reader.wait(), None);
     }
 
     #[test]

--- a/cmux-tui/crates/cmux-tui/src/config.rs
+++ b/cmux-tui/crates/cmux-tui/src/config.rs
@@ -2641,20 +2641,30 @@ fn ghostty_defaults() -> DefaultColors {
     let config_paths = platform::ghostty_config_paths();
     let theme_dirs = platform::ghostty_theme_dirs();
     #[cfg(not(test))]
-    let helper_defaults = parse_ghostty_defaults_from_helper();
+    let helper_defaults = ghostty_defaults_from_helper();
     #[cfg(test)]
-    let helper_defaults = None;
+    let helper_defaults = GhosttyHelperDefaults::Unavailable;
     ghostty_defaults_from_sources(config_paths, theme_dirs, helper_defaults)
+}
+
+enum GhosttyHelperDefaults {
+    Resolved(DefaultColors),
+    Unavailable,
+    TimedOut,
 }
 
 fn ghostty_defaults_from_sources(
     config_paths: Vec<PathBuf>,
     theme_dirs: Vec<PathBuf>,
-    helper_defaults: Option<DefaultColors>,
+    helper_defaults: GhosttyHelperDefaults,
 ) -> DefaultColors {
-    let parsed = helper_defaults
-        .or_else(|| parse_ghostty_defaults_from_paths(config_paths, theme_dirs))
-        .unwrap_or_default();
+    let parsed = match helper_defaults {
+        GhosttyHelperDefaults::Resolved(defaults) => defaults,
+        GhosttyHelperDefaults::Unavailable => {
+            parse_ghostty_defaults_from_paths(config_paths, theme_dirs).unwrap_or_default()
+        }
+        GhosttyHelperDefaults::TimedOut => DefaultColors::default(),
+    };
     resolve_ghostty_application_defaults(parsed)
 }
 
@@ -2723,8 +2733,10 @@ pub(crate) fn run_ghostty_config_helper() -> i32 {
 }
 
 #[cfg(not(test))]
-fn parse_ghostty_defaults_from_helper() -> Option<DefaultColors> {
-    let exe = std::env::current_exe().ok()?;
+fn ghostty_defaults_from_helper() -> GhosttyHelperDefaults {
+    let Ok(exe) = std::env::current_exe() else {
+        return GhosttyHelperDefaults::Unavailable;
+    };
     let mut command = Command::new(exe);
     command
         .arg("__ghostty-config-defaults")
@@ -2732,22 +2744,34 @@ fn parse_ghostty_defaults_from_helper() -> Option<DefaultColors> {
         .stdout(ProcessStdio::piped())
         .stderr(ProcessStdio::null());
     scrub_ghostty_helper_secret_environment(&mut command);
-    let mut child = command.spawn().ok()?;
-    let mut stdout = child.stdout.take()?;
-    let status = match child.wait_timeout(GHOSTTY_CONFIG_PARSE_DEADLINE).ok()? {
+    let Ok(mut child) = command.spawn() else {
+        return GhosttyHelperDefaults::Unavailable;
+    };
+    let Some(mut stdout) = child.stdout.take() else {
+        let _ = child.kill();
+        let _ = child.wait();
+        return GhosttyHelperDefaults::Unavailable;
+    };
+    let status = match child.wait_timeout(GHOSTTY_CONFIG_PARSE_DEADLINE) {
+        Ok(status) => status,
+        Err(_) => return GhosttyHelperDefaults::Unavailable,
+    };
+    let status = match status {
         Some(status) => status,
         None => {
             let _ = child.kill();
             let _ = child.wait();
-            return None;
+            return GhosttyHelperDefaults::TimedOut;
         }
     };
     if !status.success() {
-        return None;
+        return GhosttyHelperDefaults::Unavailable;
     }
     let mut output = String::new();
-    stdout.read_to_string(&mut output).ok()?;
-    Some(parse_resolved_ghostty_defaults(&output))
+    if stdout.read_to_string(&mut output).is_err() {
+        return GhosttyHelperDefaults::Unavailable;
+    }
+    GhosttyHelperDefaults::Resolved(parse_resolved_ghostty_defaults(&output))
 }
 
 #[cfg(any(not(test), all(test, unix)))]
@@ -2991,7 +3015,7 @@ fn gtk_settings_theme_mode(text: &str) -> Option<GhosttyThemeMode> {
         match key {
             "gtk-application-prefer-dark-theme" => match value.to_ascii_lowercase().as_str() {
                 "1" | "true" | "yes" => return Some(GhosttyThemeMode::Dark),
-                "0" | "false" | "no" => return Some(GhosttyThemeMode::Light),
+                "0" | "false" | "no" => {}
                 _ => {}
             },
             "gtk-theme-name" => theme_name = gtk_theme_name_theme_mode(value),
@@ -4435,12 +4459,71 @@ mod tests {
         let config = dir.join("config");
         std::fs::write(&config, "foreground = #010203\nbackground = #040506\n").unwrap();
 
-        let defaults = ghostty_defaults_from_sources(vec![config], Vec::new(), None);
+        let defaults = ghostty_defaults_from_sources(
+            vec![config],
+            Vec::new(),
+            GhosttyHelperDefaults::Unavailable,
+        );
 
         let _ = std::fs::remove_dir_all(dir);
 
         assert_eq!(defaults.fg, Some(Rgb { r: 0x01, g: 0x02, b: 0x03 }));
         assert_eq!(defaults.bg, Some(Rgb { r: 0x04, g: 0x05, b: 0x06 }));
+        assert_eq!(defaults.cursor_style, Some(CursorShape::Block));
+    }
+
+    #[test]
+    fn ghostty_defaults_use_helper_result_before_file_fallback() {
+        let _guard = CONFIG_ENV_LOCK.lock().unwrap();
+        let dir = std::env::temp_dir().join(format!(
+            "cmux-tui-ghostty-helper-result-{}-{}",
+            std::process::id(),
+            SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_nanos()
+        ));
+        std::fs::create_dir_all(&dir).unwrap();
+        let config = dir.join("config");
+        std::fs::write(&config, "foreground = #010203\nbackground = #040506\n").unwrap();
+        let helper = DefaultColors {
+            fg: Some(Rgb { r: 0xa0, g: 0xa1, b: 0xa2 }),
+            bg: Some(Rgb { r: 0xb0, g: 0xb1, b: 0xb2 }),
+            ..Default::default()
+        };
+
+        let defaults = ghostty_defaults_from_sources(
+            vec![config],
+            Vec::new(),
+            GhosttyHelperDefaults::Resolved(helper),
+        );
+
+        let _ = std::fs::remove_dir_all(dir);
+
+        assert_eq!(defaults.fg, Some(Rgb { r: 0xa0, g: 0xa1, b: 0xa2 }));
+        assert_eq!(defaults.bg, Some(Rgb { r: 0xb0, g: 0xb1, b: 0xb2 }));
+        assert_eq!(defaults.cursor_style, Some(CursorShape::Block));
+    }
+
+    #[test]
+    fn ghostty_defaults_do_not_retry_files_after_helper_timeout() {
+        let _guard = CONFIG_ENV_LOCK.lock().unwrap();
+        let dir = std::env::temp_dir().join(format!(
+            "cmux-tui-ghostty-helper-timeout-{}-{}",
+            std::process::id(),
+            SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_nanos()
+        ));
+        std::fs::create_dir_all(&dir).unwrap();
+        let config = dir.join("config");
+        std::fs::write(&config, "foreground = #010203\nbackground = #040506\n").unwrap();
+
+        let defaults = ghostty_defaults_from_sources(
+            vec![config],
+            Vec::new(),
+            GhosttyHelperDefaults::TimedOut,
+        );
+
+        let _ = std::fs::remove_dir_all(dir);
+
+        assert_eq!(defaults.fg, None);
+        assert_eq!(defaults.bg, None);
         assert_eq!(defaults.cursor_style, Some(CursorShape::Block));
     }
 
@@ -4507,8 +4590,14 @@ mod tests {
             Some(GhosttyThemeMode::Dark)
         );
         assert_eq!(
-            gtk_settings_theme_mode("[Settings]\ngtk-application-prefer-dark-theme=false\n"),
-            Some(GhosttyThemeMode::Light)
+            gtk_settings_theme_mode(
+                "[Settings]\ngtk-application-prefer-dark-theme=false\ngtk-theme-name=Adwaita-dark\n"
+            ),
+            Some(GhosttyThemeMode::Dark)
+        );
+        assert_eq!(
+            gtk_settings_theme_mode("[Settings]\ngtk-application-prefer-dark-theme=0\n"),
+            None
         );
         assert_eq!(
             gtk_settings_theme_mode("[Settings]\ngtk-theme-name=Adwaita-dark\n"),

--- a/cmux-tui/crates/cmux-tui/src/config.rs
+++ b/cmux-tui/crates/cmux-tui/src/config.rs
@@ -2632,8 +2632,7 @@ fn parse_color(s: &str) -> Option<Color> {
 fn ghostty_defaults() -> DefaultColors {
     let parsed = platform::ghostty_config_paths()
         .iter()
-        .find_map(|path| std::fs::read_to_string(path).ok())
-        .map(|text| parse_ghostty_defaults(&text))
+        .find_map(|path| parse_ghostty_defaults_from_path(path, &platform::ghostty_theme_dirs()))
         .unwrap_or_default();
     resolve_ghostty_application_defaults(parsed)
 }
@@ -2683,30 +2682,122 @@ fn ghostty_show_config_command(installation: &platform::GhosttyInstallation) -> 
 /// its file can be read. This preserves Ghostty's fail-soft behavior: a
 /// later theme entries are ignored, matching Ghostty's first-theme-wins
 /// behavior.
+#[cfg(test)]
 pub(crate) fn parse_ghostty_defaults(text: &str) -> DefaultColors {
     parse_ghostty_defaults_with_theme_dirs(text, &platform::ghostty_theme_dirs())
 }
 
+#[cfg(test)]
 fn parse_ghostty_defaults_with_theme_dirs(text: &str, theme_dirs: &[PathBuf]) -> DefaultColors {
+    parse_ghostty_config_text(text, theme_dirs, GhosttyThemeMode::default()).defaults
+}
+
+fn parse_ghostty_defaults_from_path(path: &Path, theme_dirs: &[PathBuf]) -> Option<DefaultColors> {
+    let mut loaded = HashSet::new();
+    let mut theme_mode = GhosttyThemeMode::default();
+    parse_ghostty_config_file(path, theme_dirs, &mut loaded, &mut theme_mode)
+}
+
+fn parse_ghostty_config_file(
+    path: &Path,
+    theme_dirs: &[PathBuf],
+    loaded: &mut HashSet<PathBuf>,
+    theme_mode: &mut GhosttyThemeMode,
+) -> Option<DefaultColors> {
+    let text = std::fs::read_to_string(path).ok()?;
+    let identity = path.canonicalize().unwrap_or_else(|_| path.to_path_buf());
+    if !loaded.insert(identity) {
+        return Some(DefaultColors::default());
+    }
+    let base_dir = path.parent().unwrap_or_else(|| Path::new("."));
+    let parsed = parse_ghostty_config_text(&text, theme_dirs, *theme_mode);
+    *theme_mode = parsed.theme_mode;
+    let mut defaults = parsed.defaults;
+    for include in parsed.config_files.into_iter().filter_map(|include| include.resolve(base_dir)) {
+        if let Some(included) = parse_ghostty_config_file(&include, theme_dirs, loaded, theme_mode)
+        {
+            overlay_ghostty_defaults(&mut defaults, included);
+        }
+    }
+    Some(defaults)
+}
+
+struct ParsedGhosttyConfig {
+    defaults: DefaultColors,
+    config_files: Vec<GhosttyConfigFile>,
+    theme_mode: GhosttyThemeMode,
+}
+
+struct GhosttyConfigFile {
+    path: String,
+}
+
+impl GhosttyConfigFile {
+    fn parse(value: &str) -> Option<Self> {
+        let value = value.trim();
+        let value = value.strip_prefix('?').unwrap_or(value);
+        let value =
+            value.strip_prefix('"').and_then(|value| value.strip_suffix('"')).unwrap_or(value);
+        if value.is_empty() { None } else { Some(Self { path: value.to_owned() }) }
+    }
+
+    fn resolve(self, base_dir: &Path) -> Option<PathBuf> {
+        let path = Path::new(&self.path);
+        if path.is_absolute() { Some(path.to_path_buf()) } else { Some(base_dir.join(path)) }
+    }
+}
+
+#[derive(Clone, Copy, Default)]
+enum GhosttyThemeMode {
+    #[default]
+    Light,
+    Dark,
+}
+
+fn parse_ghostty_config_text(
+    text: &str,
+    theme_dirs: &[PathBuf],
+    mut theme_mode: GhosttyThemeMode,
+) -> ParsedGhosttyConfig {
     let mut overrides = DefaultColors::default();
     let mut theme = None;
+    let mut config_files = Vec::new();
     for line in text.lines() {
         let line = line.trim();
         let Some((key, value)) = line.split_once('=') else { continue };
-        if key.trim() == "theme" {
-            if theme.is_none()
-                && let Some(theme_defaults) = load_ghostty_theme(value.trim(), theme_dirs)
-            {
-                theme = Some(theme_defaults);
+        match key.trim() {
+            "theme" => {
+                if theme.is_none() {
+                    theme = Some(value.trim().to_owned());
+                }
             }
-        } else {
-            apply_ghostty_default(&mut overrides, key.trim(), value.trim());
+            "window-theme" => {
+                if let Some(mode) = parse_ghostty_window_theme(value.trim()) {
+                    theme_mode = mode;
+                }
+            }
+            "config-file" => {
+                if let Some(include) = GhosttyConfigFile::parse(value) {
+                    config_files.push(include);
+                }
+            }
+            key => apply_ghostty_default(&mut overrides, key, value.trim()),
         }
     }
 
-    let mut defaults = theme.unwrap_or_default();
+    let mut defaults = theme
+        .and_then(|theme| load_ghostty_theme(&theme, theme_dirs, theme_mode))
+        .unwrap_or_default();
     overlay_ghostty_defaults(&mut defaults, overrides);
-    defaults
+    ParsedGhosttyConfig { defaults, config_files, theme_mode }
+}
+
+fn parse_ghostty_window_theme(value: &str) -> Option<GhosttyThemeMode> {
+    match value.trim_matches('"') {
+        "light" => Some(GhosttyThemeMode::Light),
+        "dark" => Some(GhosttyThemeMode::Dark),
+        _ => None,
+    }
 }
 
 /// Parse the fully resolved `ghostty +show-config` output. Theme lines are
@@ -2775,8 +2866,12 @@ fn apply_ghostty_default(defaults: &mut DefaultColors, key: &str, value: &str) {
     }
 }
 
-fn load_ghostty_theme(value: &str, theme_dirs: &[PathBuf]) -> Option<DefaultColors> {
-    let theme = selected_ghostty_theme(value.trim_matches('"'));
+fn load_ghostty_theme(
+    value: &str,
+    theme_dirs: &[PathBuf],
+    theme_mode: GhosttyThemeMode,
+) -> Option<DefaultColors> {
+    let theme = selected_ghostty_theme(value.trim_matches('"'), theme_mode);
     let path = if Path::new(theme).is_absolute() {
         PathBuf::from(theme)
     } else if Path::new(theme).file_name().is_some_and(|name| name == theme) {
@@ -2788,13 +2883,11 @@ fn load_ghostty_theme(value: &str, theme_dirs: &[PathBuf]) -> Option<DefaultColo
     Some(parse_resolved_ghostty_defaults(&text))
 }
 
-fn selected_ghostty_theme(value: &str) -> &str {
-    // Match Ghostty's static conditional default without running its resolver
-    // during startup; the GUI can switch later, but cmux-tui needs one frame now.
-    selected_conditional_ghostty_theme(value).unwrap_or(value)
+fn selected_ghostty_theme(value: &str, theme_mode: GhosttyThemeMode) -> &str {
+    selected_conditional_ghostty_theme(value, theme_mode).unwrap_or(value)
 }
 
-fn selected_conditional_ghostty_theme(value: &str) -> Option<&str> {
+fn selected_conditional_ghostty_theme(value: &str, theme_mode: GhosttyThemeMode) -> Option<&str> {
     let mut light = None;
     let mut dark = None;
     for part in value.split(',') {
@@ -2806,7 +2899,11 @@ fn selected_conditional_ghostty_theme(value: &str) -> Option<&str> {
             _ => return None,
         }
     }
-    if light.is_some() && dark.is_some() { light } else { None }
+    match theme_mode {
+        GhosttyThemeMode::Light if light.is_some() && dark.is_some() => light,
+        GhosttyThemeMode::Dark if light.is_some() && dark.is_some() => dark,
+        _ => None,
+    }
 }
 
 fn overlay_ghostty_defaults(defaults: &mut DefaultColors, overrides: DefaultColors) {
@@ -3363,6 +3460,88 @@ mod tests {
         assert_eq!(config.terminal_defaults.fg, Some(Rgb { r: 0x11, g: 0x11, b: 0x11 }));
         assert_eq!(config.terminal_defaults.bg, Some(Rgb { r: 0x44, g: 0x44, b: 0x44 }));
         assert_eq!(config.terminal_defaults.palette[1], Some(Rgb { r: 0x33, g: 0x33, b: 0x33 }));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn load_applies_ghostty_config_file_after_root_and_respects_dark_theme_mode() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let _guard = CONFIG_ENV_LOCK.lock().unwrap();
+        let old_ghostty_bin = std::env::var_os("GHOSTTY_BIN");
+        let old_ghostty_resources = std::env::var_os("GHOSTTY_RESOURCES_DIR");
+        let old_cmux_tui_config = std::env::var_os("CMUX_TUI_CONFIG");
+        let old_mux_config = std::env::var_os("CMUX_MUX_CONFIG");
+        let old_xdg_config_home = std::env::var_os("XDG_CONFIG_HOME");
+        let dir = std::env::temp_dir()
+            .join(format!("mux-ghostty-startup-include-theme-{}", std::process::id()));
+        let ghostty_dir = dir.join("ghostty");
+        let resources = dir.join("resources");
+        let themes = resources.join("themes");
+        let marker = dir.join("resolver-ran");
+        let resolver = dir.join("ghostty-resolver");
+        std::fs::create_dir_all(&ghostty_dir).unwrap();
+        std::fs::create_dir_all(&themes).unwrap();
+        std::fs::write(
+            ghostty_dir.join("config"),
+            "foreground = #010101\n\
+             config-file = colors.conf\n\
+             background = #020202\n",
+        )
+        .unwrap();
+        std::fs::write(
+            ghostty_dir.join("colors.conf"),
+            "window-theme = dark\n\
+             theme = light:Light Include Theme,dark:Dark Include Theme\n\
+             background = #444444\n",
+        )
+        .unwrap();
+        std::fs::write(
+            themes.join("Light Include Theme"),
+            "foreground = #111111\nbackground = #222222\npalette = 1=#333333\n",
+        )
+        .unwrap();
+        std::fs::write(
+            themes.join("Dark Include Theme"),
+            "foreground = #aaaaaa\nbackground = #bbbbbb\npalette = 1=#cccccc\n",
+        )
+        .unwrap();
+        std::fs::write(
+            &resolver,
+            format!(
+                "#!/bin/sh\n\
+                 printf marker > '{}'\n\
+                 printf 'foreground = #ddeeff\\nbackground = #000000\\n'\n",
+                marker.display()
+            ),
+        )
+        .unwrap();
+        std::fs::set_permissions(&resolver, std::fs::Permissions::from_mode(0o700)).unwrap();
+        // SAFETY: env mutation in tests is serialized by CONFIG_ENV_LOCK.
+        unsafe { std::env::set_var("GHOSTTY_BIN", &resolver) };
+        // SAFETY: env mutation in tests is serialized by CONFIG_ENV_LOCK.
+        unsafe { std::env::set_var("GHOSTTY_RESOURCES_DIR", &resources) };
+        // SAFETY: env mutation in tests is serialized by CONFIG_ENV_LOCK.
+        unsafe { std::env::remove_var("CMUX_TUI_CONFIG") };
+        // SAFETY: env mutation in tests is serialized by CONFIG_ENV_LOCK.
+        unsafe { std::env::remove_var("CMUX_MUX_CONFIG") };
+        // SAFETY: env mutation in tests is serialized by CONFIG_ENV_LOCK.
+        unsafe { std::env::set_var("XDG_CONFIG_HOME", &dir) };
+
+        let config = load();
+
+        restore_env_var("GHOSTTY_BIN", old_ghostty_bin);
+        restore_env_var("GHOSTTY_RESOURCES_DIR", old_ghostty_resources);
+        restore_env_var("CMUX_TUI_CONFIG", old_cmux_tui_config);
+        restore_env_var("CMUX_MUX_CONFIG", old_mux_config);
+        restore_env_var("XDG_CONFIG_HOME", old_xdg_config_home);
+        let resolver_ran = marker.exists();
+        let _ = std::fs::remove_dir_all(&dir);
+
+        assert!(!resolver_ran, "config load must not run ghostty +show-config at startup");
+        assert_eq!(config.terminal_defaults.fg, Some(Rgb { r: 0xaa, g: 0xaa, b: 0xaa }));
+        assert_eq!(config.terminal_defaults.bg, Some(Rgb { r: 0x44, g: 0x44, b: 0x44 }));
+        assert_eq!(config.terminal_defaults.palette[1], Some(Rgb { r: 0xcc, g: 0xcc, b: 0xcc }));
     }
 
     #[test]

--- a/cmux-tui/crates/cmux-tui/src/config.rs
+++ b/cmux-tui/crates/cmux-tui/src/config.rs
@@ -2657,16 +2657,11 @@ fn ghostty_defaults_from_sources(
     theme_dirs: Vec<PathBuf>,
     helper_defaults: GhosttyHelperDefaults,
 ) -> DefaultColors {
-    #[cfg(not(test))]
-    let _ = (&config_paths, &theme_dirs);
     let parsed = match helper_defaults {
         GhosttyHelperDefaults::Resolved(defaults) => defaults,
-        #[cfg(test)]
         GhosttyHelperDefaults::Unavailable => {
             parse_ghostty_defaults_from_paths(config_paths, theme_dirs).unwrap_or_default()
         }
-        #[cfg(not(test))]
-        GhosttyHelperDefaults::Unavailable => DefaultColors::default(),
         GhosttyHelperDefaults::TimedOut => DefaultColors::default(),
     };
     resolve_ghostty_application_defaults(parsed)
@@ -2824,7 +2819,6 @@ fn scrub_ghostty_helper_secret_environment(command: &mut Command) {
     }
 }
 
-#[cfg(test)]
 fn parse_ghostty_defaults_from_paths(
     config_paths: Vec<PathBuf>,
     theme_dirs: Vec<PathBuf>,

--- a/cmux-tui/crates/cmux-tui/src/config.rs
+++ b/cmux-tui/crates/cmux-tui/src/config.rs
@@ -2638,14 +2638,23 @@ fn parse_color(s: &str) -> Option<Color> {
 /// The user's relevant Ghostty settings with non-optional application defaults
 /// resolved for values that the low-level terminal otherwise leaves unset.
 fn ghostty_defaults() -> DefaultColors {
-    #[cfg(test)]
-    let parsed = parse_ghostty_defaults_from_paths(
-        platform::ghostty_config_paths(),
-        platform::ghostty_theme_dirs(),
-    )
-    .unwrap_or_default();
+    let config_paths = platform::ghostty_config_paths();
+    let theme_dirs = platform::ghostty_theme_dirs();
     #[cfg(not(test))]
-    let parsed = parse_ghostty_defaults_from_helper().unwrap_or_default();
+    let helper_defaults = parse_ghostty_defaults_from_helper();
+    #[cfg(test)]
+    let helper_defaults = None;
+    ghostty_defaults_from_sources(config_paths, theme_dirs, helper_defaults)
+}
+
+fn ghostty_defaults_from_sources(
+    config_paths: Vec<PathBuf>,
+    theme_dirs: Vec<PathBuf>,
+    helper_defaults: Option<DefaultColors>,
+) -> DefaultColors {
+    let parsed = helper_defaults
+        .or_else(|| parse_ghostty_defaults_from_paths(config_paths, theme_dirs))
+        .unwrap_or_default();
     resolve_ghostty_application_defaults(parsed)
 }
 
@@ -4412,6 +4421,27 @@ mod tests {
         let stdout = String::from_utf8(output.stdout).unwrap();
         assert!(!stdout.contains("CMUX_MACHINE_PROVIDER_TOKEN="), "{stdout}");
         assert!(!stdout.contains("CMUX_PROVIDER_WORKSPACE_AUTHORITY="), "{stdout}");
+    }
+
+    #[test]
+    fn ghostty_defaults_falls_back_to_files_when_helper_is_unavailable() {
+        let _guard = CONFIG_ENV_LOCK.lock().unwrap();
+        let dir = std::env::temp_dir().join(format!(
+            "cmux-tui-ghostty-helper-fallback-{}-{}",
+            std::process::id(),
+            SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_nanos()
+        ));
+        std::fs::create_dir_all(&dir).unwrap();
+        let config = dir.join("config");
+        std::fs::write(&config, "foreground = #010203\nbackground = #040506\n").unwrap();
+
+        let defaults = ghostty_defaults_from_sources(vec![config], Vec::new(), None);
+
+        let _ = std::fs::remove_dir_all(dir);
+
+        assert_eq!(defaults.fg, Some(Rgb { r: 0x01, g: 0x02, b: 0x03 }));
+        assert_eq!(defaults.bg, Some(Rgb { r: 0x04, g: 0x05, b: 0x06 }));
+        assert_eq!(defaults.cursor_style, Some(CursorShape::Block));
     }
 
     #[test]

--- a/cmux-tui/crates/cmux-tui/src/config.rs
+++ b/cmux-tui/crates/cmux-tui/src/config.rs
@@ -2809,14 +2809,7 @@ fn terminate_ghostty_helper_child(mut child: Child) {
         libc::killpg(child.id() as libc::pid_t, libc::SIGKILL);
     }
     let _ = child.kill();
-    if matches!(child.wait_timeout(Duration::from_millis(10)), Ok(Some(_))) {
-        return;
-    }
-    let _ = std::thread::Builder::new().name("cmux-tui-ghostty-helper-reaper".to_string()).spawn(
-        move || {
-            let _ = child.wait();
-        },
-    );
+    reap_ghostty_child_after_short_wait(child, "cmux-tui-ghostty-helper-reaper");
 }
 
 #[cfg(unix)]
@@ -2867,7 +2860,16 @@ fn terminate_ghostty_process_scan_child(mut child: Child) {
         libc::killpg(child.id() as libc::pid_t, libc::SIGKILL);
     }
     let _ = child.kill();
-    let _ = child.wait_timeout(Duration::from_millis(10));
+    reap_ghostty_child_after_short_wait(child, "cmux-tui-ghostty-process-scan-reaper");
+}
+
+fn reap_ghostty_child_after_short_wait(mut child: Child, reaper_name: &'static str) {
+    if matches!(child.wait_timeout(Duration::from_millis(10)), Ok(Some(_))) {
+        return;
+    }
+    let _ = std::thread::Builder::new().name(reaper_name.to_string()).spawn(move || {
+        let _ = child.wait();
+    });
 }
 
 #[cfg(unix)]
@@ -5050,6 +5052,24 @@ mod tests {
         }
 
         assert!(!unix_process_exists(pid), "helper child {pid} was not reaped");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn ghostty_process_scan_cleanup_reaps_killed_child() {
+        let mut command = Command::new("/bin/sleep");
+        command.arg("5").process_group(0);
+        let child = command.spawn().unwrap();
+        let pid = child.id() as libc::pid_t;
+
+        terminate_ghostty_process_scan_child(child);
+
+        let deadline = Instant::now() + Duration::from_secs(2);
+        while unix_process_exists(pid) && Instant::now() < deadline {
+            std::thread::sleep(Duration::from_millis(10));
+        }
+
+        assert!(!unix_process_exists(pid), "process scan child {pid} was not reaped");
     }
 
     #[cfg(unix)]

--- a/cmux-tui/crates/cmux-tui/src/config.rs
+++ b/cmux-tui/crates/cmux-tui/src/config.rs
@@ -118,11 +118,17 @@
 //! keys.
 
 use std::collections::{HashMap, HashSet};
+#[cfg(not(test))]
+use std::io::Read;
 use std::io::Write;
 use std::path::{Path, PathBuf};
+#[cfg(any(not(test), all(test, unix)))]
+use std::process::Command;
+#[cfg(not(test))]
+use std::process::Stdio as ProcessStdio;
 #[cfg(all(test, unix))]
-use std::process::{Command, Stdio};
-use std::sync::mpsc;
+use std::process::Stdio;
+#[cfg(not(test))]
 use std::thread;
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
@@ -2632,11 +2638,14 @@ fn parse_color(s: &str) -> Option<Color> {
 /// The user's relevant Ghostty settings with non-optional application defaults
 /// resolved for values that the low-level terminal otherwise leaves unset.
 fn ghostty_defaults() -> DefaultColors {
+    #[cfg(test)]
     let parsed = parse_ghostty_defaults_from_paths(
         platform::ghostty_config_paths(),
         platform::ghostty_theme_dirs(),
     )
     .unwrap_or_default();
+    #[cfg(not(test))]
+    let parsed = parse_ghostty_defaults_from_helper().unwrap_or_default();
     resolve_ghostty_application_defaults(parsed)
 }
 
@@ -2690,21 +2699,66 @@ pub(crate) fn parse_ghostty_defaults(text: &str) -> DefaultColors {
     parse_ghostty_defaults_with_theme_dirs(text, &platform::ghostty_theme_dirs())
 }
 
+pub(crate) fn is_ghostty_config_helper_invocation(args: &[String]) -> bool {
+    args.first().map(String::as_str) == Some("__ghostty-config-defaults")
+}
+
+pub(crate) fn run_ghostty_config_helper() -> i32 {
+    let defaults = parse_ghostty_defaults_from_paths(
+        platform::ghostty_config_paths(),
+        platform::ghostty_theme_dirs(),
+    )
+    .unwrap_or_default();
+    print!("{}", serialize_ghostty_defaults(defaults));
+    0
+}
+
+#[cfg(not(test))]
+fn parse_ghostty_defaults_from_helper() -> Option<DefaultColors> {
+    let exe = std::env::current_exe().ok()?;
+    let mut command = Command::new(exe);
+    command
+        .arg("__ghostty-config-defaults")
+        .stdin(ProcessStdio::null())
+        .stdout(ProcessStdio::piped())
+        .stderr(ProcessStdio::null());
+    scrub_ghostty_helper_secret_environment(&mut command);
+    let mut child = command.spawn().ok()?;
+    let mut stdout = child.stdout.take()?;
+    let started_at = Instant::now();
+    loop {
+        match child.try_wait() {
+            Ok(Some(status)) => {
+                if !status.success() {
+                    return None;
+                }
+                let mut output = String::new();
+                stdout.read_to_string(&mut output).ok()?;
+                return Some(parse_resolved_ghostty_defaults(&output));
+            }
+            Ok(None) if started_at.elapsed() >= GHOSTTY_CONFIG_PARSE_DEADLINE => {
+                let _ = child.kill();
+                let _ = child.wait();
+                return None;
+            }
+            Ok(None) => thread::yield_now(),
+            Err(_) => return None,
+        }
+    }
+}
+
+#[cfg(any(not(test), all(test, unix)))]
+fn scrub_ghostty_helper_secret_environment(command: &mut Command) {
+    for name in ["CMUX_MACHINE_PROVIDER_TOKEN", "CMUX_PROVIDER_WORKSPACE_AUTHORITY"] {
+        command.env_remove(name);
+    }
+}
+
 fn parse_ghostty_defaults_from_paths(
     config_paths: Vec<PathBuf>,
     theme_dirs: Vec<PathBuf>,
 ) -> Option<DefaultColors> {
-    let (tx, rx) = mpsc::channel();
-    thread::Builder::new()
-        .name("cmux-tui-ghostty-config".to_owned())
-        .spawn(move || {
-            let parsed = config_paths
-                .iter()
-                .find_map(|path| parse_ghostty_defaults_from_path(path, &theme_dirs));
-            let _ = tx.send(parsed);
-        })
-        .ok()?;
-    rx.recv_timeout(GHOSTTY_CONFIG_PARSE_DEADLINE).ok().flatten()
+    config_paths.iter().find_map(|path| parse_ghostty_defaults_from_path(path, &theme_dirs))
 }
 
 #[cfg(test)]
@@ -2756,25 +2810,15 @@ fn parse_ghostty_config_file(
         if pending.depth > GHOSTTY_CONFIG_MAX_DEPTH || files_loaded >= GHOSTTY_CONFIG_MAX_FILES {
             continue;
         }
-        let metadata = match std::fs::metadata(&pending.path) {
-            Ok(metadata) if metadata.file_type().is_file() => metadata,
-            _ if pending.depth == 0 => return None,
-            _ => continue,
-        };
-        if bytes_loaded.saturating_add(metadata.len()) > GHOSTTY_CONFIG_MAX_BYTES {
-            if pending.depth == 0 && files_loaded == 0 {
-                return None;
-            }
-            continue;
-        }
         let identity = pending.path.canonicalize().unwrap_or_else(|_| pending.path.clone());
         if !loaded.insert(identity) {
             continue;
         }
-        let text = match std::fs::read_to_string(&pending.path) {
-            Ok(text) => text,
-            Err(_) if pending.depth == 0 && files_loaded == 0 => return None,
-            Err(_) => continue,
+        let remaining_bytes = GHOSTTY_CONFIG_MAX_BYTES.saturating_sub(bytes_loaded);
+        let text = match read_ghostty_regular_file(&pending.path, remaining_bytes) {
+            Some(text) => text,
+            None if pending.depth == 0 && files_loaded == 0 => return None,
+            None => continue,
         };
         bytes_loaded = bytes_loaded.saturating_add(text.len() as u64);
         files_loaded += 1;
@@ -3028,6 +3072,49 @@ fn parse_resolved_ghostty_defaults(text: &str) -> DefaultColors {
     defaults
 }
 
+fn serialize_ghostty_defaults(defaults: DefaultColors) -> String {
+    let mut out = String::new();
+    if let Some(color) = defaults.fg {
+        out.push_str(&format!("foreground = {}\n", format_ghostty_rgb(color)));
+    }
+    if let Some(color) = defaults.bg {
+        out.push_str(&format!("background = {}\n", format_ghostty_rgb(color)));
+    }
+    if let Some(color) = defaults.cursor {
+        out.push_str(&format!("cursor-color = {}\n", format_ghostty_rgb(color)));
+    }
+    if let Some(color) = defaults.selection_bg {
+        out.push_str(&format!("selection-background = {}\n", format_ghostty_rgb(color)));
+    }
+    if let Some(color) = defaults.selection_fg {
+        out.push_str(&format!("selection-foreground = {}\n", format_ghostty_rgb(color)));
+    }
+    if let Some(style) = defaults.cursor_style {
+        let style = match style {
+            CursorShape::Block => Some("block"),
+            CursorShape::Underline => Some("underline"),
+            CursorShape::Bar => Some("bar"),
+            CursorShape::BlockHollow => None,
+        };
+        if let Some(style) = style {
+            out.push_str(&format!("cursor-style = {style}\n"));
+        }
+    }
+    if let Some(blink) = defaults.cursor_blink {
+        out.push_str(&format!("cursor-style-blink = {blink}\n"));
+    }
+    for (index, color) in defaults.palette.into_iter().enumerate() {
+        if let Some(color) = color {
+            out.push_str(&format!("palette = {index}={}\n", format_ghostty_rgb(color)));
+        }
+    }
+    out
+}
+
+fn format_ghostty_rgb(color: Rgb) -> String {
+    format!("#{:02x}{:02x}{:02x}", color.r, color.g, color.b)
+}
+
 fn apply_ghostty_default(defaults: &mut DefaultColors, key: &str, value: &str) {
     let value = value.strip_prefix('"').and_then(|value| value.strip_suffix('"')).unwrap_or(value);
     match key {
@@ -3088,8 +3175,20 @@ fn load_ghostty_theme(
 ) -> Option<DefaultColors> {
     let theme = selected_ghostty_theme(candidate.value.trim_matches('"'), theme_mode);
     let path = resolve_ghostty_theme_path(theme, candidate.base_dir.as_deref(), theme_dirs)?;
-    let text = std::fs::read_to_string(path).ok()?;
+    let text = read_ghostty_regular_file(&path, GHOSTTY_CONFIG_MAX_BYTES)?;
     Some(parse_resolved_ghostty_defaults(&text))
+}
+
+fn read_ghostty_regular_file(path: &Path, max_bytes: u64) -> Option<String> {
+    let metadata = std::fs::metadata(path).ok()?;
+    if !metadata.file_type().is_file() || metadata.len() > max_bytes {
+        return None;
+    }
+    let text = std::fs::read_to_string(path).ok()?;
+    if text.len() as u64 > max_bytes {
+        return None;
+    }
+    Some(text)
 }
 
 fn resolve_ghostty_theme_path(
@@ -4167,6 +4266,66 @@ mod tests {
 
         assert_eq!(defaults.fg, Some(Rgb { r: 0x01, g: 0x02, b: 0x03 }));
         assert_eq!(defaults.bg, Some(Rgb { r: 0x04, g: 0x05, b: 0x06 }));
+    }
+
+    #[test]
+    fn ghostty_theme_loader_skips_non_regular_and_oversized_candidates() {
+        let _guard = CONFIG_ENV_LOCK.lock().unwrap();
+        let dir = std::env::temp_dir().join(format!(
+            "cmux-tui-ghostty-theme-size-limit-{}-{}",
+            std::process::id(),
+            SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_nanos()
+        ));
+        let ghostty_dir = dir.join("ghostty");
+        let themes = ghostty_dir.join("themes");
+        std::fs::create_dir_all(themes.join("Theme Directory")).unwrap();
+        std::fs::write(
+            ghostty_dir.join("config"),
+            "theme = Theme Directory\n\
+             theme = Huge Theme\n\
+             theme = Readable Theme\n",
+        )
+        .unwrap();
+        std::fs::write(
+            themes.join("Huge Theme"),
+            "foreground = #a0a1a2\n".repeat((GHOSTTY_CONFIG_MAX_BYTES as usize / 20) + 1),
+        )
+        .unwrap();
+        std::fs::write(
+            themes.join("Readable Theme"),
+            "foreground = #010203\nbackground = #040506\n",
+        )
+        .unwrap();
+
+        let defaults = parse_ghostty_defaults_from_path(
+            &ghostty_dir.join("config"),
+            std::slice::from_ref(&themes),
+        )
+        .expect("config parses");
+
+        let _ = std::fs::remove_dir_all(dir);
+
+        assert_eq!(defaults.fg, Some(Rgb { r: 0x01, g: 0x02, b: 0x03 }));
+        assert_eq!(defaults.bg, Some(Rgb { r: 0x04, g: 0x05, b: 0x06 }));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn ghostty_config_helper_scrubs_provider_secret_environment() {
+        let output = {
+            let mut command = Command::new("/usr/bin/env");
+            command
+                .env("CMUX_MACHINE_PROVIDER_TOKEN", "edge-test-bearer")
+                .env("CMUX_PROVIDER_WORKSPACE_AUTHORITY", "provider-workspace-authority-test")
+                .stdout(Stdio::piped())
+                .stderr(Stdio::piped());
+            scrub_ghostty_helper_secret_environment(&mut command);
+            command.output().unwrap()
+        };
+        assert!(output.status.success());
+        let stdout = String::from_utf8(output.stdout).unwrap();
+        assert!(!stdout.contains("CMUX_MACHINE_PROVIDER_TOKEN="), "{stdout}");
+        assert!(!stdout.contains("CMUX_PROVIDER_WORKSPACE_AUTHORITY="), "{stdout}");
     }
 
     #[test]

--- a/cmux-tui/crates/cmux-tui/src/config.rs
+++ b/cmux-tui/crates/cmux-tui/src/config.rs
@@ -122,7 +122,7 @@ use std::io::Write;
 use std::path::{Path, PathBuf};
 #[cfg(all(test, unix))]
 use std::process::{Command, Stdio};
-use std::time::{SystemTime, UNIX_EPOCH};
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
 use cmux_tui_core::BrowserMode;
 use cmux_tui_core::SidebarPluginOptions;
@@ -2698,45 +2698,81 @@ fn parse_ghostty_defaults_with_theme_dirs(text: &str, theme_dirs: &[PathBuf]) ->
 }
 
 fn parse_ghostty_defaults_from_path(path: &Path, theme_dirs: &[PathBuf]) -> Option<DefaultColors> {
-    let mut loaded = HashSet::new();
     let mut theme_mode = None;
     let mut theme_candidates = Vec::new();
-    let overrides = parse_ghostty_config_file(
-        path,
-        theme_dirs,
-        &mut loaded,
-        &mut theme_mode,
-        &mut theme_candidates,
-    )?;
+    let overrides = parse_ghostty_config_file(path, &mut theme_mode, &mut theme_candidates)?;
     let mut defaults = resolve_ghostty_theme_defaults(&theme_candidates, theme_dirs, theme_mode);
     overlay_ghostty_defaults(&mut defaults, overrides);
     Some(defaults)
 }
 
+const GHOSTTY_CONFIG_MAX_FILES: usize = 64;
+const GHOSTTY_CONFIG_MAX_DEPTH: usize = 16;
+const GHOSTTY_CONFIG_MAX_BYTES: u64 = 1024 * 1024;
+const GHOSTTY_CONFIG_PARSE_DEADLINE: Duration = Duration::from_millis(250);
+
+struct PendingGhosttyConfig {
+    path: PathBuf,
+    depth: usize,
+}
+
 fn parse_ghostty_config_file(
     path: &Path,
-    theme_dirs: &[PathBuf],
-    loaded: &mut HashSet<PathBuf>,
     theme_mode: &mut Option<GhosttyThemeMode>,
     theme_candidates: &mut Vec<GhosttyThemeCandidate>,
 ) -> Option<DefaultColors> {
-    let text = std::fs::read_to_string(path).ok()?;
-    let identity = path.canonicalize().unwrap_or_else(|_| path.to_path_buf());
-    if !loaded.insert(identity) {
-        return Some(DefaultColors::default());
-    }
-    let base_dir = path.parent().unwrap_or_else(|| Path::new("."));
-    let parsed = parse_ghostty_config_text(&text, Some(base_dir), theme_mode, theme_candidates);
-    *theme_mode = parsed.theme_mode;
-    let mut overrides = parsed.overrides;
-    for include in parsed.config_files.into_iter().filter_map(|include| include.resolve(base_dir)) {
-        if let Some(included) =
-            parse_ghostty_config_file(&include, theme_dirs, loaded, theme_mode, theme_candidates)
+    let started_at = Instant::now();
+    let mut stack = vec![PendingGhosttyConfig { path: path.to_path_buf(), depth: 0 }];
+    let mut loaded = HashSet::new();
+    let mut files_loaded = 0usize;
+    let mut bytes_loaded = 0u64;
+    let mut loaded_root = false;
+    let mut overrides = DefaultColors::default();
+
+    while let Some(pending) = stack.pop() {
+        if started_at.elapsed() > GHOSTTY_CONFIG_PARSE_DEADLINE {
+            break;
+        }
+        if pending.depth > GHOSTTY_CONFIG_MAX_DEPTH || files_loaded >= GHOSTTY_CONFIG_MAX_FILES {
+            continue;
+        }
+        let metadata = match std::fs::metadata(&pending.path) {
+            Ok(metadata) if metadata.file_type().is_file() => metadata,
+            _ if pending.depth == 0 => return None,
+            _ => continue,
+        };
+        if bytes_loaded.saturating_add(metadata.len()) > GHOSTTY_CONFIG_MAX_BYTES {
+            if pending.depth == 0 && files_loaded == 0 {
+                return None;
+            }
+            continue;
+        }
+        let identity = pending.path.canonicalize().unwrap_or_else(|_| pending.path.clone());
+        if !loaded.insert(identity) {
+            continue;
+        }
+        let text = match std::fs::read_to_string(&pending.path) {
+            Ok(text) => text,
+            Err(_) if pending.depth == 0 && files_loaded == 0 => return None,
+            Err(_) => continue,
+        };
+        bytes_loaded = bytes_loaded.saturating_add(text.len() as u64);
+        files_loaded += 1;
+        loaded_root |= pending.depth == 0;
+
+        let base_dir = pending.path.parent().unwrap_or_else(|| Path::new("."));
+        let parsed = parse_ghostty_config_text(&text, Some(base_dir), theme_mode, theme_candidates);
+        *theme_mode = parsed.theme_mode;
+        overlay_ghostty_defaults(&mut overrides, parsed.overrides);
+
+        for include in
+            parsed.config_files.into_iter().rev().filter_map(|include| include.resolve(base_dir))
         {
-            overlay_ghostty_defaults(&mut overrides, included);
+            stack.push(PendingGhosttyConfig { path: include, depth: pending.depth + 1 });
         }
     }
-    Some(overrides)
+
+    loaded_root.then_some(overrides)
 }
 
 struct ParsedGhosttyConfig {
@@ -3930,6 +3966,132 @@ mod tests {
         assert_eq!(defaults.fg, Some(Rgb { r: 0x11, g: 0x12, b: 0x13 }));
         assert_eq!(defaults.bg, Some(Rgb { r: 0x14, g: 0x15, b: 0x16 }));
         assert_eq!(defaults.palette[1], Some(Rgb { r: 0x17, g: 0x18, b: 0x19 }));
+    }
+
+    #[test]
+    fn ghostty_config_file_skips_non_regular_includes() {
+        let _guard = CONFIG_ENV_LOCK.lock().unwrap();
+        let dir = std::env::temp_dir().join(format!(
+            "cmux-tui-ghostty-nonregular-include-{}-{}",
+            std::process::id(),
+            SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_nanos()
+        ));
+        let ghostty_dir = dir.join("ghostty");
+        std::fs::create_dir_all(ghostty_dir.join("not-a-file")).unwrap();
+        std::fs::write(
+            ghostty_dir.join("config"),
+            "config-file = not-a-file\n\
+             config-file = colors.conf\n",
+        )
+        .unwrap();
+        std::fs::write(ghostty_dir.join("colors.conf"), "foreground = #010203\n").unwrap();
+
+        let defaults = parse_ghostty_defaults_from_path(&ghostty_dir.join("config"), &[])
+            .expect("config parses");
+
+        let _ = std::fs::remove_dir_all(dir);
+
+        assert_eq!(defaults.fg, Some(Rgb { r: 0x01, g: 0x02, b: 0x03 }));
+    }
+
+    #[test]
+    fn ghostty_config_file_depth_limit_bounds_include_chain() {
+        let _guard = CONFIG_ENV_LOCK.lock().unwrap();
+        let dir = std::env::temp_dir().join(format!(
+            "cmux-tui-ghostty-depth-limit-{}-{}",
+            std::process::id(),
+            SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_nanos()
+        ));
+        let ghostty_dir = dir.join("ghostty");
+        std::fs::create_dir_all(&ghostty_dir).unwrap();
+        for index in 0..=(GHOSTTY_CONFIG_MAX_DEPTH + 2) {
+            let color = 0x10 + index as u8;
+            let include = if index < GHOSTTY_CONFIG_MAX_DEPTH + 2 {
+                format!("config-file = file{}.conf\n", index + 1)
+            } else {
+                String::new()
+            };
+            std::fs::write(
+                ghostty_dir.join(format!("file{index}.conf")),
+                format!("foreground = #{color:02x}{color:02x}{color:02x}\n{include}"),
+            )
+            .unwrap();
+        }
+
+        let defaults = parse_ghostty_defaults_from_path(&ghostty_dir.join("file0.conf"), &[])
+            .expect("config parses");
+
+        let _ = std::fs::remove_dir_all(dir);
+        let color = 0x10 + GHOSTTY_CONFIG_MAX_DEPTH as u8;
+
+        assert_eq!(defaults.fg, Some(Rgb { r: color, g: color, b: color }));
+    }
+
+    #[test]
+    fn ghostty_config_file_count_limit_bounds_broad_include_graph() {
+        let _guard = CONFIG_ENV_LOCK.lock().unwrap();
+        let dir = std::env::temp_dir().join(format!(
+            "cmux-tui-ghostty-file-count-limit-{}-{}",
+            std::process::id(),
+            SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_nanos()
+        ));
+        let ghostty_dir = dir.join("ghostty");
+        std::fs::create_dir_all(&ghostty_dir).unwrap();
+        let include_count = GHOSTTY_CONFIG_MAX_FILES + 2;
+        let mut root = String::new();
+        for index in 0..include_count {
+            root.push_str(&format!("config-file = colors{index}.conf\n"));
+            let color = 0x10 + index as u8;
+            std::fs::write(
+                ghostty_dir.join(format!("colors{index}.conf")),
+                format!("foreground = #{color:02x}{color:02x}{color:02x}\n"),
+            )
+            .unwrap();
+        }
+        std::fs::write(ghostty_dir.join("config"), root).unwrap();
+
+        let defaults = parse_ghostty_defaults_from_path(&ghostty_dir.join("config"), &[])
+            .expect("config parses");
+
+        let _ = std::fs::remove_dir_all(dir);
+        let expected_index = GHOSTTY_CONFIG_MAX_FILES - 2;
+        let color = 0x10 + expected_index as u8;
+
+        assert_eq!(defaults.fg, Some(Rgb { r: color, g: color, b: color }));
+    }
+
+    #[test]
+    fn ghostty_config_file_size_limit_skips_oversized_includes() {
+        let _guard = CONFIG_ENV_LOCK.lock().unwrap();
+        let dir = std::env::temp_dir().join(format!(
+            "cmux-tui-ghostty-size-limit-{}-{}",
+            std::process::id(),
+            SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_nanos()
+        ));
+        let ghostty_dir = dir.join("ghostty");
+        std::fs::create_dir_all(&ghostty_dir).unwrap();
+        std::fs::write(
+            ghostty_dir.join("config"),
+            "config-file = small.conf\n\
+             config-file = large.conf\n\
+             config-file = later.conf\n",
+        )
+        .unwrap();
+        std::fs::write(ghostty_dir.join("small.conf"), "foreground = #010203\n").unwrap();
+        std::fs::write(
+            ghostty_dir.join("large.conf"),
+            "background = #a0a1a2\n".repeat((GHOSTTY_CONFIG_MAX_BYTES as usize / 20) + 1),
+        )
+        .unwrap();
+        std::fs::write(ghostty_dir.join("later.conf"), "background = #040506\n").unwrap();
+
+        let defaults = parse_ghostty_defaults_from_path(&ghostty_dir.join("config"), &[])
+            .expect("config parses");
+
+        let _ = std::fs::remove_dir_all(dir);
+
+        assert_eq!(defaults.fg, Some(Rgb { r: 0x01, g: 0x02, b: 0x03 }));
+        assert_eq!(defaults.bg, Some(Rgb { r: 0x04, g: 0x05, b: 0x06 }));
     }
 
     #[test]

--- a/cmux-tui/crates/cmux-tui/src/main.rs
+++ b/cmux-tui/crates/cmux-tui/src/main.rs
@@ -1012,6 +1012,11 @@ fn main() {
         return;
     }
     if config::is_ghostty_config_helper_invocation(&raw_args) {
+        if let Err(error) = harden_provider_secret_process() {
+            eprintln!("cmux-tui: cannot protect machine-provider credentials: {error}");
+            std::process::exit(1);
+        }
+        discard_provider_secret_environment();
         std::process::exit(config::run_ghostty_config_helper());
     }
     if let Err(error) = harden_provider_secret_process() {

--- a/cmux-tui/crates/cmux-tui/src/main.rs
+++ b/cmux-tui/crates/cmux-tui/src/main.rs
@@ -1011,6 +1011,9 @@ fn main() {
         }
         return;
     }
+    if config::is_ghostty_config_helper_invocation(&raw_args) {
+        std::process::exit(config::run_ghostty_config_helper());
+    }
     if let Err(error) = harden_provider_secret_process() {
         eprintln!("cmux-tui: cannot protect machine-provider credentials: {error}");
         std::process::exit(1);

--- a/cmux-tui/crates/cmux-tui/tests/cli.rs
+++ b/cmux-tui/crates/cmux-tui/tests/cli.rs
@@ -679,6 +679,44 @@ fn machine_agent_is_a_real_entrypoint_without_changing_ordinary_cli_dispatch() {
     assert!(String::from_utf8(version.stdout).unwrap().starts_with("cmux "));
 }
 
+#[test]
+fn ghostty_config_helper_outputs_resolved_file_defaults() {
+    let dir = unique_temp_dir("ghostty-config-helper-output");
+    let config_home = dir.join("config");
+    let ghostty_dir = config_home.join("ghostty");
+    fs::create_dir_all(&ghostty_dir).unwrap();
+    fs::write(
+        ghostty_dir.join("config"),
+        "foreground = #010203\n\
+         background = #040506\n\
+         cursor-color = #070809\n\
+         cursor-style = underline\n\
+         cursor-style-blink = false\n\
+         palette = 2=#0a0b0c\n",
+    )
+    .unwrap();
+
+    let output = Command::new(bin())
+        .arg("__ghostty-config-defaults")
+        .env("HOME", dir.join("home"))
+        .env("CFFIXED_USER_HOME", dir.join("home"))
+        .env("XDG_CONFIG_HOME", &config_home)
+        .env_remove("CMUX_TUI_SOCKET")
+        .output()
+        .unwrap();
+
+    assert_success(&output);
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    fs::remove_dir_all(dir).unwrap();
+
+    assert!(stdout.contains("foreground = #010203\n"), "{stdout}");
+    assert!(stdout.contains("background = #040506\n"), "{stdout}");
+    assert!(stdout.contains("cursor-color = #070809\n"), "{stdout}");
+    assert!(stdout.contains("cursor-style = underline\n"), "{stdout}");
+    assert!(stdout.contains("cursor-style-blink = false\n"), "{stdout}");
+    assert!(stdout.contains("palette = 2=#0a0b0c\n"), "{stdout}");
+}
+
 #[cfg(unix)]
 #[test]
 fn machine_agent_argument_failures_are_stable_and_localized() {
@@ -892,27 +930,17 @@ impl Drop for DisconnectablePtyChild {
 
 #[cfg(unix)]
 #[test]
-fn startup_config_helper_inherits_no_provider_secrets() {
-    let dir = unique_temp_dir("provider-secret-config-helper");
+fn startup_does_not_invoke_external_ghostty_config_resolver() {
+    let dir = unique_temp_dir("external-ghostty-config-resolver");
     fs::create_dir_all(&dir).unwrap();
-    let helper = dir.join("ghostty-secret-probe");
-    let capture = dir.join("inherited-env.txt");
+    let helper = dir.join("ghostty-config-probe");
+    let capture = dir.join("resolver-invoked.txt");
     let socket = dir.join("mux.sock");
     fs::write(
         &helper,
         r#"#!/bin/sh
-{
-if [ "${CMUX_MACHINE_PROVIDER_TOKEN+x}" = x ]; then
-    echo token=present
-else
-    echo token=absent
-fi
-if [ "${CMUX_PROVIDER_WORKSPACE_AUTHORITY+x}" = x ]; then
-    echo authority=present
-else
-    echo authority=absent
-fi
-} > "$CMUX_TEST_SECRET_CAPTURE"
+echo invoked > "$CMUX_TEST_GHOSTTY_CAPTURE"
+exit 0
 "#,
     )
     .unwrap();
@@ -922,7 +950,7 @@ fi
         .args(["--machine-provider", "/does/not/exist", "--headless", "--socket"])
         .arg(&socket)
         .env("GHOSTTY_BIN", &helper)
-        .env("CMUX_TEST_SECRET_CAPTURE", &capture)
+        .env("CMUX_TEST_GHOSTTY_CAPTURE", &capture)
         .env("CMUX_MACHINE_PROVIDER_TOKEN", "edge-test-bearer")
         .env("CMUX_PROVIDER_WORKSPACE_AUTHORITY", "provider-workspace-authority-test-00000001")
         .env_remove("CMUX_TUI_SOCKET")
@@ -930,8 +958,7 @@ fi
         .unwrap();
 
     assert!(!output.status.success(), "conflicting provider launch unexpectedly succeeded");
-    let inherited = fs::read_to_string(&capture).unwrap();
-    assert_eq!(inherited, "token=absent\nauthority=absent\n");
+    assert!(!capture.exists(), "startup invoked external Ghostty config resolver");
     fs::remove_dir_all(dir).unwrap();
 }
 

--- a/cmux-tui/crates/cmux-tui/tests/cli.rs
+++ b/cmux-tui/crates/cmux-tui/tests/cli.rs
@@ -717,6 +717,59 @@ fn ghostty_config_helper_outputs_resolved_file_defaults() {
     assert!(stdout.contains("palette = 2=#0a0b0c\n"), "{stdout}");
 }
 
+#[cfg(target_os = "linux")]
+#[test]
+fn ghostty_config_helper_scrubs_provider_env_before_desktop_probe() {
+    let dir = unique_temp_dir("ghostty-config-helper-provider-env");
+    let config_home = dir.join("config");
+    let ghostty_dir = config_home.join("ghostty");
+    let theme_dir = ghostty_dir.join("themes");
+    let bin_dir = dir.join("bin");
+    fs::create_dir_all(&theme_dir).unwrap();
+    fs::create_dir_all(&bin_dir).unwrap();
+    fs::write(
+        ghostty_dir.join("config"),
+        "window-theme = system\n\
+         theme = dark:Dark Direct Probe, light:Light Direct Probe\n",
+    )
+    .unwrap();
+    fs::write(theme_dir.join("Dark Direct Probe"), "foreground = #010203\n").unwrap();
+    fs::write(theme_dir.join("Light Direct Probe"), "foreground = #a0b0c0\n").unwrap();
+    let gdbus = bin_dir.join("gdbus");
+    fs::write(
+        &gdbus,
+        "#!/bin/sh\n\
+         if [ \"${CMUX_MACHINE_PROVIDER_TOKEN+x}\" = x ] || [ \"${CMUX_PROVIDER_WORKSPACE_AUTHORITY+x}\" = x ]; then\n\
+         \tprintf '(<uint32 2>,)\\n'\n\
+         \texit 0\n\
+         fi\n\
+         printf '(<uint32 1>,)\\n'\n",
+    )
+    .unwrap();
+    fs::set_permissions(&gdbus, fs::Permissions::from_mode(0o700)).unwrap();
+
+    let output = Command::new(bin())
+        .arg("__ghostty-config-defaults")
+        .env("HOME", dir.join("home"))
+        .env("CFFIXED_USER_HOME", dir.join("home"))
+        .env("XDG_CONFIG_HOME", &config_home)
+        .env("PATH", &bin_dir)
+        .env("CMUX_MACHINE_PROVIDER_TOKEN", "direct-helper-token")
+        .env("CMUX_PROVIDER_WORKSPACE_AUTHORITY", "direct-helper-authority")
+        .env_remove("AppleInterfaceStyle")
+        .env_remove("GTK_THEME")
+        .env_remove("CMUX_TUI_SOCKET")
+        .output()
+        .unwrap();
+
+    assert_success(&output);
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    fs::remove_dir_all(dir).unwrap();
+
+    assert!(stdout.contains("foreground = #010203\n"), "{stdout}");
+    assert!(!stdout.contains("foreground = #a0b0c0\n"), "{stdout}");
+}
+
 #[cfg(unix)]
 #[test]
 fn machine_agent_argument_failures_are_stable_and_localized() {

--- a/cmux-tui/crates/cmux-tui/tests/cli.rs
+++ b/cmux-tui/crates/cmux-tui/tests/cli.rs
@@ -690,7 +690,7 @@ fn ghostty_config_helper_outputs_resolved_file_defaults() {
         "foreground = #010203\n\
          background = #040506\n\
          cursor-color = #070809\n\
-         cursor-style = underline\n\
+         cursor-style = block_hollow\n\
          cursor-style-blink = false\n\
          palette = 2=#0a0b0c\n",
     )
@@ -712,7 +712,7 @@ fn ghostty_config_helper_outputs_resolved_file_defaults() {
     assert!(stdout.contains("foreground = #010203\n"), "{stdout}");
     assert!(stdout.contains("background = #040506\n"), "{stdout}");
     assert!(stdout.contains("cursor-color = #070809\n"), "{stdout}");
-    assert!(stdout.contains("cursor-style = underline\n"), "{stdout}");
+    assert!(stdout.contains("cursor-style = block_hollow\n"), "{stdout}");
     assert!(stdout.contains("cursor-style-blink = false\n"), "{stdout}");
     assert!(stdout.contains("palette = 2=#0a0b0c\n"), "{stdout}");
 }


### PR DESCRIPTION
## Summary

`cmux-tui` startup no longer runs `ghostty +show-config` from `config::load`. It reads the user Ghostty config file directly, parses the color/cursor defaults we already support, and keeps the resolver parser path covered by tests without invoking an external process on startup.

The first commit adds a regression test that fails on main because `load()` executes the configured `GHOSTTY_BIN`. The second commit removes the startup subprocess path and makes that test pass.

## Incident Notes

Benchmark harness: isolated `UV_CACHE_DIR`, `UV_TOOL_DIR`, `UV_PYTHON_INSTALL_DIR`, `npm_config_cache`, isolated `XDG_RUNTIME_DIR`, isolated cmux state roots, PTY first-draw detection. Baseline was taken before editing on main. Current-head package validation used local debug-size packages built from this branch, so cold package numbers include package-manager install work but are not release artifact size forecasts.

Baseline public package samples on main:

| path | n | median | p90 | max |
| --- | ---: | ---: | ---: | ---: |
| `uvx cmux --help` cold | 7 | 2397 ms | 2730 ms | 2744 ms |
| `npx cmux --help` cold | 7 | 907 ms | 923 ms | 983 ms |
| `uvx cmux --help` warm | 15 | 214 ms | 226 ms | 234 ms |
| `npx cmux --help` warm | 15 | 289 ms | 345 ms | 357 ms |
| direct PyPI console script help | 15 | 40 ms | 45 ms | 47 ms |
| direct npm node shim help | 15 | 35 ms | 39 ms | 40 ms |
| direct Rust help | 15 | 4 to 7 ms median by package binary | 7 to 8 ms | 7 to 9 ms |
| `uvx cmux` warm first draw | 9 | 8634 ms | 8850 ms | 9042 ms |
| `npx cmux` warm first draw | 9 | 9007 ms | 9051 ms | 9157 ms |
| direct Rust warm first draw | 9 | 8624 ms | 8632 ms | 8649 ms |

Current-head local package samples:

| path | n | median | p90 | max |
| --- | ---: | ---: | ---: | ---: |
| local `uvx --from <wheel> cmux --help` cold | 5 | 1468 ms | 1471 ms | 1471 ms |
| local `npx --package file:<pkg> cmux --help` cold | 5 | 3267 ms | 3358 ms | 3358 ms |
| local `uvx --from <wheel> cmux --help` warm | 9 | 52 ms | 65 ms | 65 ms |
| local `npx --package file:<pkg> cmux --help` warm | 9 | 237 ms | 409 ms | 477 ms |
| direct PyPI console script help | 9 | 33 ms | 34 ms | 36 ms |
| direct npm node shim help | 9 | 37 ms | 46 ms | 104 ms |
| direct Rust help | 9 | 7 ms | 9 ms | 991 ms outlier |
| local `uvx --from <wheel> cmux` cold first draw | 5 | 1626 ms | 1668 ms | 1668 ms |
| local `npx --package file:<pkg> cmux` cold first draw | 5 | 3720 ms | 5706 ms | 5706 ms |
| local `uvx --from <wheel> cmux` warm first draw | 9 | 91 ms | 96 ms | 102 ms |
| local `npx --package file:<pkg> cmux` warm first draw | 9 | 299 ms | 368 ms | 431 ms |
| direct Rust warm first draw | 9 | 40 ms | 48 ms | 52 ms |

Decomposition:

- Package-manager cold work is real and still visible: baseline registry `uvx` cold help was 2.4 s median, baseline registry `npx` cold help was 0.9 s median. Local debug packages are not size-comparable to release packages, but they keep package-manager install work in the measured path.
- Warm package-manager and launcher overhead is bounded: current warm `uvx` local help is 52 ms median versus 33 ms direct console script; current warm `npx` local help is 237 ms median versus 37 ms direct node shim.
- Rust process startup is not the owner: direct `--help` stays around 7 ms median, with one scheduler outlier at 991 ms.
- Daemon/saved-state recovery was not the owner for this incident: sampling a slow launch stopped in `config::load`, before terminal recovery completed.
- Time until terminal usable was owned by eager config resolution: warm first draw went from 8.6 to 9.0 s median to 91 ms for local `uvx`, 299 ms for local `npx`, and 40 ms direct.

## Tests

- `CARGO_TARGET_DIR=/tmp/cmux-tui-startup-latency-target rustup run 1.94.0 cargo test -p cmux-tui ghostty -- --nocapture`
- `CARGO_TARGET_DIR=/tmp/cmux-tui-startup-latency-target rustup run 1.94.0 cargo test -p cmux-tui load_uses_file_ghostty_defaults_without_invoking_external_resolver -- --nocapture`
- `CARGO_TARGET_DIR=/tmp/cmux-tui-startup-latency-target rustup run 1.94.0 cargo build -p cmux-tui --bin cmux-tui`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/9738"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788657667&installation_model_id=21920&pr_number=9738&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F9738&signature=9df9d55d2717eaa698baab9d95a3db3f5fc5d5b9d40bbda7e66a50f910b80daf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Speed up `cmux-tui` startup by resolving Ghostty defaults with an in-binary, self-reexec helper instead of calling `ghostty +show-config`. Warm launch is ~90 ms via `uvx`, ~300 ms via `npx`, and ~40 ms direct.

- **Bug Fixes**
  - Add `__ghostty-config-defaults` helper with a ~250 ms budget, bounded stdout drains, bounded descendant scan, and process‑group kill/reap; prints fg/bg/cursor/blink/palette.
  - Startup never invokes an external Ghostty resolver (`GHOSTTY_BIN`); on helper miss, fall back to bounded file parsing; on timeout, skip fallback to keep startup bounded.
  - Match Ghostty file semantics: bounded includes with `~` and optional `?`, deferred theme resolution, preserve resource themes, explicit overrides beat themes, first resolvable theme wins; `cursor-style = block_hollow`; `window-theme` supports `light`/`dark`/`system`/`auto`; select light/dark from system appearance on macOS and Linux/BSD; skip probes when `window-theme` is fixed.
  - Prefer Ghostty theme env (if set) before desktop appearance probes; cache conditional theme mode to avoid repeated probes and keep launches consistent.
  - Harden helper entrypoint and isolate desktop probes; scrub provider secret env vars before probing.

- **Dependencies**
  - Add `wait-timeout` to bound the helper process and reads.

<sup>Written for commit b423d56bb7a64afa7b9142ff7df8dbfdb30b133d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/9738?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Ghostty configuration defaults now load reliably from readable configuration files and included files.
  - Conditional light and dark theme selections are handled correctly during startup.
  - Theme settings from files and bundled resources are detected more consistently.
  - Circular configuration includes are prevented from causing startup issues.
  - Startup no longer depends on an external Ghostty configuration command, reducing related delays and failures.

- **Refactor**
  - Simplified configuration loading and parsing for more consistent startup behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large change to startup config resolution with subprocess timeouts, process-group kills, and desktop appearance probes; wrong defaults or hung children could affect every launch, but behavior is heavily tested and bounded.
> 
> **Overview**
> Startup no longer shells out to **`ghostty +show-config`** (or **`GHOSTTY_BIN`**) during **`config::load`**. Terminal colors and cursor defaults come from a self-reexec path **`__ghostty-config-defaults`** that parses Ghostty config files inside the same binary, with a **~250 ms** parse budget and **~500 ms** parent wait via **`wait-timeout`**.
> 
> The helper serializes resolved fg/bg/cursor/palette lines on stdout; the main process prefers that result, falls back to the same bounded file parser on failure, and on helper **timeout** skips file fallback so startup stays bounded. Process cleanup uses isolated process groups, capped stdout reads, optional **`ps`** descendant scan, and scrubs provider secret env vars before any desktop theme probes.
> 
> File parsing now matches more Ghostty behavior: **`config-file`** includes (depth/file/byte limits), deferred theme resolution, first successful theme, light/dark conditional themes from system appearance (macOS / Linux desktop probes with short deadlines), **`cursor-style = block_hollow`**, and explicit overrides winning over themes. **`main`** handles the helper argv early; CLI tests assert no external resolver at startup and correct helper output.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b423d56bb7a64afa7b9142ff7df8dbfdb30b133d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->