### PR TITLE
Restrict coderouter sign-in to passwordless email

### DIFF
--- a/web/app/handler/[...stack]/page.tsx
+++ b/web/app/handler/[...stack]/page.tsx
@@ -1,14 +1,52 @@
 import { Suspense } from "react";
-import { StackHandler } from "@stackframe/stack";
+import { MagicLinkSignIn, StackHandler } from "@stackframe/stack";
+import { headers } from "next/headers";
 import { notFound } from "next/navigation";
 import { stackServerApp } from "../../lib/stack";
 
-export default function StackHandlerPage(props: { params: Promise<{ stack: string[] }> }) {
+export default async function StackHandlerPage(
+  props: { params: Promise<{ stack: string[] }> },
+) {
   if (!stackServerApp) notFound();
+  const [{ stack }, requestHeaders] = await Promise.all([
+    props.params,
+    headers(),
+  ]);
+
+  if (
+    coderouterHost(requestHeaders.get("host")) &&
+    stack.length === 1 &&
+    stack[0] === "sign-in"
+  ) {
+    // The shared cmux Google connector requests Drive, Gmail, and Calendar
+    // scopes for optional integrations. Those scopes are inappropriate for
+    // coderouter authentication, so coderouter deliberately offers
+    // passwordless email only.
+    return (
+      <main className="flex min-h-screen items-center justify-center bg-[#faf9f6] px-6 text-[#25231f]">
+        <section className="w-full max-w-sm border border-[#ded9cf] bg-white p-7 shadow-[4px_4px_0_#eee8dc]">
+          <p className="mb-2 font-mono text-xs lowercase tracking-[0.16em] text-[#9a5b22]">
+            coderouter
+          </p>
+          <h1 className="mb-2 text-xl font-medium">sign in</h1>
+          <p className="mb-6 text-sm leading-6 text-[#6f6a61]">
+            use your cmux account email. we’ll send a one-time code.
+          </p>
+          <MagicLinkSignIn />
+        </section>
+      </main>
+    );
+  }
 
   return (
     <Suspense>
       <StackHandler fullPage app={stackServerApp} params={props.params} />
     </Suspense>
   );
+}
+
+function coderouterHost(host: string | null): boolean {
+  const hostname = host?.split(":", 1)[0]?.toLowerCase();
+  return hostname === "coderouter.dev" ||
+    hostname?.endsWith(".coderouter.dev") === true;
 }

--- a/web/tests/coderouter-signin.test.ts
+++ b/web/tests/coderouter-signin.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+describe("coderouter sign-in privacy", () => {
+  test("uses passwordless email instead of the broad shared Google connector", () => {
+    const source = readFileSync(
+      resolve(
+        fileURLToPath(new URL(".", import.meta.url)),
+        "../app/handler/[...stack]/page.tsx",
+      ),
+      "utf8",
+    );
+    expect(source).toContain("coderouterHost");
+    expect(source).toContain("<MagicLinkSignIn />");
+    expect(source).toContain("Drive, Gmail, and Calendar");
+  });
+});


### PR DESCRIPTION
The shared cmux Google connector requests Drive, Gmail, and Calendar scopes. coderouter authentication now renders only Stack passwordless email on coderouter.dev, preserving cmux auth elsewhere and avoiding unnecessary OAuth grants.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/9740"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788659035&installation_model_id=21920&pr_number=9740&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F9740&signature=889a93f883d7a82510ea85f8558a903e74cacb40ad4265ddc1f33e8aec17e4fb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes authentication routing for a production domain; incorrect host matching could expose the wrong sign-in UI or block login, but scope is limited to the sign-in path on coderouter hosts.
> 
> **Overview**
> **coderouter.dev** sign-in no longer goes through the default Stack handler (and its shared Google OAuth with Drive, Gmail, and Calendar scopes). For `coderouter.dev` / `*.coderouter.dev` on the `/handler/sign-in` route, the app now renders a dedicated **passwordless email** flow via `MagicLinkSignIn` instead.
> 
> Other hosts and Stack routes still use `StackHandler` as before. A small Bun test asserts the handler page keeps the host gate and magic-link UI and documents the Google-scope rationale in source.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b3aff34c8426eb07a818f4ca823b4b14576e5892. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restricts sign-in on coderouter.dev to passwordless email to avoid broad Google OAuth scopes. Other domains keep the existing cmux auth flow.

- **New Features**
  - Routes coderouter.dev `/sign-in` to a minimal UI with passwordless email using `MagicLinkSignIn` from `@stackframe/stack`.
  - Preserves the shared Google connector elsewhere; no change to existing flows.
  - Adds a test to verify the host check and the passwordless path, and to guard against Drive/Gmail/Calendar scope usage.

<sup>Written for commit b3aff34c8426eb07a818f4ca823b4b14576e5892. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/9740?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a custom passwordless email sign-in experience for the coderouter.dev sign-in page.
  * Preserved the existing interface for all other routes.
  * Improved domain recognition across subdomains, ports, and capitalization.

* **Tests**
  * Added coverage verifying passwordless sign-in and the expected limited Google connector access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->