### PR TITLE
Fix browser popover appearance contrast

### DIFF
--- a/Sources/Debug/UITests/BrowserDownloadsPopoverAppearanceUITestPresenter.swift
+++ b/Sources/Debug/UITests/BrowserDownloadsPopoverAppearanceUITestPresenter.swift
@@ -1,0 +1,26 @@
+#if DEBUG
+import SwiftUI
+
+/// Debug-only modifier that opens the downloads popover for its appearance UI test.
+struct BrowserDownloadsPopoverAppearanceUITestPresenter: ViewModifier {
+    @Environment(\.colorScheme) private var colorScheme
+    @Binding var isPresented: Bool
+
+    func body(content: Content) -> some View {
+        content
+            .onAppear {
+                presentIfReady()
+            }
+            .onChange(of: colorScheme) { _, _ in
+                presentIfReady()
+            }
+    }
+
+    private func presentIfReady() {
+        guard BrowserDownloadsPopoverAppearanceUITestSupport().shouldPresent(for: colorScheme) else {
+            return
+        }
+        isPresented = true
+    }
+}
+#endif

--- a/Sources/Debug/UITests/BrowserDownloadsPopoverAppearanceUITestRecorder.swift
+++ b/Sources/Debug/UITests/BrowserDownloadsPopoverAppearanceUITestRecorder.swift
@@ -1,0 +1,18 @@
+#if DEBUG
+import SwiftUI
+
+/// Debug-only bridge that records the real popover window and SwiftUI color scheme.
+struct BrowserDownloadsPopoverAppearanceUITestRecorder: View {
+    @Environment(\.colorScheme) private var colorScheme
+
+    @ViewBuilder
+    var body: some View {
+        let support = BrowserDownloadsPopoverAppearanceUITestSupport()
+        if support.isEnabled {
+            WindowAccessor(dedupeByWindow: false, refreshID: colorScheme) { window in
+                support.record(window: window, contentColorScheme: colorScheme)
+            }
+        }
+    }
+}
+#endif

--- a/Sources/Debug/UITests/BrowserDownloadsPopoverAppearanceUITestRecorder.swift
+++ b/Sources/Debug/UITests/BrowserDownloadsPopoverAppearanceUITestRecorder.swift
@@ -9,7 +9,7 @@ struct BrowserDownloadsPopoverAppearanceUITestRecorder: View {
     var body: some View {
         let support = BrowserDownloadsPopoverAppearanceUITestSupport()
         if support.isEnabled {
-            WindowAccessor(dedupeByWindow: false, refreshID: colorScheme) { window in
+            BrowserDownloadsPopoverAppearanceWindowAccessor { window in
                 support.record(window: window, contentColorScheme: colorScheme)
             }
         }

--- a/Sources/Debug/UITests/BrowserDownloadsPopoverAppearanceUITestSupport.swift
+++ b/Sources/Debug/UITests/BrowserDownloadsPopoverAppearanceUITestSupport.swift
@@ -1,0 +1,86 @@
+#if DEBUG
+import AppKit
+import CmuxTestSupport
+import Foundation
+import SwiftUI
+
+/// Debug-only state and capture support for the downloads-popover appearance UI test.
+@MainActor
+struct BrowserDownloadsPopoverAppearanceUITestSupport {
+    private static let probePathEnvironmentKey = "CMUX_UI_TEST_DOWNLOADS_POPOVER_APPEARANCE_PATH"
+    private static let fixturePathEnvironmentKey = "CMUX_UI_TEST_DOWNLOADS_POPOVER_FIXTURE_PATH"
+
+    private let environment: [String: String]
+    private let sink: UITestCaptureSink
+
+    init(environment: [String: String] = ProcessInfo.processInfo.environment) {
+        self.environment = environment
+        self.sink = UITestCaptureSink(environment: environment)
+    }
+
+    var isEnabled: Bool {
+        configuredPath(for: Self.probePathEnvironmentKey) != nil
+    }
+
+    var fixtureDownload: BrowserDownloadRecord? {
+        guard isEnabled,
+              let fixturePath = configuredPath(for: Self.fixturePathEnvironmentKey) else { return nil }
+        let fixtureURL = URL(fileURLWithPath: fixturePath)
+        return BrowserDownloadRecord(
+            id: "ui-test-downloads-popover-appearance",
+            filename: fixtureURL.lastPathComponent,
+            fileURL: fixtureURL,
+            state: .saved,
+            byteCount: 5_400
+        )
+    }
+
+    func shouldPresent(for colorScheme: ColorScheme) -> Bool {
+        isEnabled && colorScheme == .light
+    }
+
+    func record(window: NSWindow, contentColorScheme: ColorScheme) {
+        writeSnapshot(window: window, contentColorScheme: contentColorScheme)
+        Task { @MainActor [weak window] in
+            await Task.yield()
+            guard let window else { return }
+            self.writeSnapshot(window: window, contentColorScheme: contentColorScheme)
+        }
+    }
+
+    private func writeSnapshot(window: NSWindow, contentColorScheme: ColorScheme) {
+        let windowAppearance: String
+        switch window.effectiveAppearance.bestMatch(from: [.aqua, .darkAqua]) {
+        case .aqua:
+            windowAppearance = "light"
+        case .darkAqua:
+            windowAppearance = "dark"
+        default:
+            windowAppearance = "unknown"
+        }
+
+        let contentScheme: String
+        switch contentColorScheme {
+        case .light:
+            contentScheme = "light"
+        case .dark:
+            contentScheme = "dark"
+        @unknown default:
+            contentScheme = "unknown"
+        }
+
+        _ = sink.mutateJSONObjectIfConfigured(envKey: Self.probePathEnvironmentKey) { payload in
+            payload["contentColorScheme"] = contentScheme
+            payload["windowAppearance"] = windowAppearance
+            payload["windowClass"] = String(describing: type(of: window))
+            payload["windowVisible"] = window.isVisible ? "true" : "false"
+        }
+    }
+
+    private func configuredPath(for key: String) -> String? {
+        guard let value = environment[key]?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !value.isEmpty else { return nil }
+        return value
+    }
+}
+#endif

--- a/Sources/Debug/UITests/BrowserDownloadsPopoverAppearanceUITestSupport.swift
+++ b/Sources/Debug/UITests/BrowserDownloadsPopoverAppearanceUITestSupport.swift
@@ -41,11 +41,6 @@ struct BrowserDownloadsPopoverAppearanceUITestSupport {
 
     func record(window: NSWindow, contentColorScheme: ColorScheme) {
         writeSnapshot(window: window, contentColorScheme: contentColorScheme)
-        Task { @MainActor [weak window] in
-            await Task.yield()
-            guard let window else { return }
-            self.writeSnapshot(window: window, contentColorScheme: contentColorScheme)
-        }
     }
 
     private func writeSnapshot(window: NSWindow, contentColorScheme: ColorScheme) {

--- a/Sources/Debug/UITests/BrowserDownloadsPopoverAppearanceWindowAccessor.swift
+++ b/Sources/Debug/UITests/BrowserDownloadsPopoverAppearanceWindowAccessor.swift
@@ -18,6 +18,7 @@ struct BrowserDownloadsPopoverAppearanceWindowAccessor: NSViewRepresentable {
         context: Context
     ) {
         nsView.onWindow = onWindow
+        nsView.reportWindowIfAttached()
     }
 }
 #endif

--- a/Sources/Debug/UITests/BrowserDownloadsPopoverAppearanceWindowAccessor.swift
+++ b/Sources/Debug/UITests/BrowserDownloadsPopoverAppearanceWindowAccessor.swift
@@ -1,0 +1,23 @@
+#if DEBUG
+import AppKit
+import SwiftUI
+
+/// Debug-only accessor that reports a popover window after its view has attached.
+@MainActor
+struct BrowserDownloadsPopoverAppearanceWindowAccessor: NSViewRepresentable {
+    let onWindow: @MainActor (NSWindow) -> Void
+
+    func makeNSView(context: Context) -> BrowserDownloadsPopoverAppearanceWindowObservingView {
+        let view = BrowserDownloadsPopoverAppearanceWindowObservingView()
+        view.onWindow = onWindow
+        return view
+    }
+
+    func updateNSView(
+        _ nsView: BrowserDownloadsPopoverAppearanceWindowObservingView,
+        context: Context
+    ) {
+        nsView.onWindow = onWindow
+    }
+}
+#endif

--- a/Sources/Debug/UITests/BrowserDownloadsPopoverAppearanceWindowObservingView.swift
+++ b/Sources/Debug/UITests/BrowserDownloadsPopoverAppearanceWindowObservingView.swift
@@ -1,0 +1,24 @@
+#if DEBUG
+import AppKit
+
+/// Debug-only view that reports attachment and effective-appearance lifecycle changes.
+@MainActor
+final class BrowserDownloadsPopoverAppearanceWindowObservingView: NSView {
+    var onWindow: (@MainActor (NSWindow) -> Void)?
+
+    override func viewDidMoveToWindow() {
+        super.viewDidMoveToWindow()
+        reportWindowIfAttached()
+    }
+
+    override func viewDidChangeEffectiveAppearance() {
+        super.viewDidChangeEffectiveAppearance()
+        reportWindowIfAttached()
+    }
+
+    private func reportWindowIfAttached() {
+        guard let window else { return }
+        onWindow?(window)
+    }
+}
+#endif

--- a/Sources/Debug/UITests/BrowserDownloadsPopoverAppearanceWindowObservingView.swift
+++ b/Sources/Debug/UITests/BrowserDownloadsPopoverAppearanceWindowObservingView.swift
@@ -16,7 +16,7 @@ final class BrowserDownloadsPopoverAppearanceWindowObservingView: NSView {
         reportWindowIfAttached()
     }
 
-    private func reportWindowIfAttached() {
+    func reportWindowIfAttached() {
         guard let window else { return }
         onWindow?(window)
     }

--- a/Sources/Panels/BrowserChromePopoverAppearance.swift
+++ b/Sources/Panels/BrowserChromePopoverAppearance.swift
@@ -1,0 +1,14 @@
+import SwiftUI
+
+extension View {
+    /// Gives the popover presentation the same appearance that browser chrome
+    /// uses for its semantic foreground colors and terminal-derived backdrop.
+    ///
+    /// Browser chrome can intentionally differ from the app/window appearance.
+    /// An environment-only override colors SwiftUI content but does not define
+    /// the enclosing AppKit popover material. A presentation preference does
+    /// both, so the material and every semantic foreground resolve together.
+    func browserChromePopoverAppearance(_ colorScheme: ColorScheme) -> some View {
+        preferredColorScheme(colorScheme)
+    }
+}

--- a/Sources/Panels/BrowserDownloadsToolbarButton.swift
+++ b/Sources/Panels/BrowserDownloadsToolbarButton.swift
@@ -1,9 +1,5 @@
 import SwiftUI
 
-#if DEBUG
-import AppKit
-#endif
-
 /// Safari/Chrome-style downloads button for the browser omnibar. Shows a
 /// popover listing recent downloads with Open / Show in Finder actions.
 ///
@@ -79,13 +75,9 @@ struct BrowserDownloadsToolbarButton: View {
         .buttonStyle(OmnibarAddressButtonStyle())
         .safeHelp(String(localized: "browser.downloads.title", defaultValue: "Downloads"))
         .accessibilityLabel(String(localized: "browser.downloads.title", defaultValue: "Downloads"))
-        .onAppear {
-            presentAppearanceProbeIfReady()
-        }
-        .onChange(of: colorScheme) { _, _ in
-            presentAppearanceProbeIfReady()
-        }
-        .accessibilityIdentifier("BrowserDownloadsButton")
+        #if DEBUG
+        .modifier(BrowserDownloadsPopoverAppearanceUITestPresenter(isPresented: $isPresented))
+        #endif
         .onChange(of: isPresented) { _, presented in
             if presented {
                 seenIDs = Set(downloads.map(\.id))
@@ -101,19 +93,9 @@ struct BrowserDownloadsToolbarButton: View {
             .browserChromePopoverAppearance(colorScheme)
         }
     }
-
-    private func presentAppearanceProbeIfReady() {
-        #if DEBUG
-        guard BrowserDownloadsPopoverAppearanceUITestProbe.isEnabled,
-              colorScheme == .light else { return }
-        isPresented = true
-        #endif
-    }
 }
 
 private struct BrowserDownloadsPopoverContent: View {
-    @Environment(\.colorScheme) private var colorScheme
-
     let downloads: [BrowserDownloadRecord]
     let onOpen: (BrowserDownloadRecord) -> Void
     let onReveal: (BrowserDownloadRecord) -> Void
@@ -124,7 +106,6 @@ private struct BrowserDownloadsPopoverContent: View {
             HStack {
                 Text(String(localized: "browser.downloads.title", defaultValue: "Downloads"))
                     .font(.headline)
-                    .accessibilityIdentifier("BrowserDownloadsPopoverTitle")
                 Spacer()
                 if !downloads.isEmpty {
                     Button(String(localized: "browser.downloads.clear", defaultValue: "Clear")) {
@@ -160,22 +141,8 @@ private struct BrowserDownloadsPopoverContent: View {
             }
         }
         .frame(width: 340)
-        .accessibilityElement(children: .contain)
-        .accessibilityIdentifier("BrowserDownloadsPopover")
-        .background(appearanceProbe)
-    }
-
-    @ViewBuilder
-    private var appearanceProbe: some View {
         #if DEBUG
-        if BrowserDownloadsPopoverAppearanceUITestProbe.isEnabled {
-            WindowAccessor(dedupeByWindow: false, refreshID: colorScheme) { window in
-                BrowserDownloadsPopoverAppearanceUITestProbe.record(
-                    window: window,
-                    contentColorScheme: colorScheme
-                )
-            }
-        }
+        .background(BrowserDownloadsPopoverAppearanceUITestRecorder())
         #endif
     }
 }
@@ -194,7 +161,6 @@ private struct BrowserDownloadRow: View {
                 Text(record.filename)
                     .lineLimit(1)
                     .truncationMode(.middle)
-                    .accessibilityIdentifier("BrowserDownloadFilename")
                 Text(subtitle)
                     .font(.caption)
                     .foregroundStyle(record.state == .failed ? Color.red : Color.secondary)
@@ -208,7 +174,6 @@ private struct BrowserDownloadRow: View {
                 }
                 .buttonStyle(.borderless)
                 .font(.callout)
-                .accessibilityIdentifier("BrowserDownloadOpenButton")
 
                 Button {
                     onReveal(record)
@@ -260,79 +225,3 @@ private struct BrowserDownloadRow: View {
         }
     }
 }
-
-#if DEBUG
-enum BrowserDownloadsPopoverAppearanceUITestProbe {
-    private static let probePathEnvironmentKey = "CMUX_UI_TEST_DOWNLOADS_POPOVER_APPEARANCE_PATH"
-    private static let fixturePathEnvironmentKey = "CMUX_UI_TEST_DOWNLOADS_POPOVER_FIXTURE_PATH"
-
-    static var isEnabled: Bool {
-        configuredPath(for: probePathEnvironmentKey) != nil
-    }
-
-    static var fixtureDownload: BrowserDownloadRecord? {
-        guard isEnabled,
-              let fixturePath = configuredPath(for: fixturePathEnvironmentKey) else { return nil }
-        let fixtureURL = URL(fileURLWithPath: fixturePath)
-        return BrowserDownloadRecord(
-            id: "ui-test-downloads-popover-appearance",
-            filename: fixtureURL.lastPathComponent,
-            fileURL: fixtureURL,
-            state: .saved,
-            byteCount: 5_400
-        )
-    }
-
-    @MainActor
-    static func record(window: NSWindow, contentColorScheme: ColorScheme) {
-        guard let probePath = configuredPath(for: probePathEnvironmentKey) else { return }
-
-        let writeSnapshot = { @MainActor [weak window] in
-            guard let window else { return }
-            let windowAppearance: String
-            switch window.effectiveAppearance.bestMatch(from: [.aqua, .darkAqua]) {
-            case .aqua:
-                windowAppearance = "light"
-            case .darkAqua:
-                windowAppearance = "dark"
-            default:
-                windowAppearance = "unknown"
-            }
-
-            let contentScheme: String
-            switch contentColorScheme {
-            case .light:
-                contentScheme = "light"
-            case .dark:
-                contentScheme = "dark"
-            @unknown default:
-                contentScheme = "unknown"
-            }
-
-            let payload: [String: String] = [
-                "contentColorScheme": contentScheme,
-                "windowAppearance": windowAppearance,
-                "windowClass": String(describing: type(of: window)),
-                "windowVisible": window.isVisible ? "true" : "false",
-            ]
-            guard let data = try? JSONSerialization.data(withJSONObject: payload, options: [.sortedKeys]) else {
-                return
-            }
-            try? data.write(to: URL(fileURLWithPath: probePath), options: .atomic)
-        }
-
-        writeSnapshot()
-        Task { @MainActor in
-            await Task.yield()
-            writeSnapshot()
-        }
-    }
-
-    private static func configuredPath(for key: String) -> String? {
-        guard let value = ProcessInfo.processInfo.environment[key]?
-            .trimmingCharacters(in: .whitespacesAndNewlines),
-              !value.isEmpty else { return nil }
-        return value
-    }
-}
-#endif

--- a/Sources/Panels/BrowserDownloadsToolbarButton.swift
+++ b/Sources/Panels/BrowserDownloadsToolbarButton.swift
@@ -1,5 +1,9 @@
 import SwiftUI
 
+#if DEBUG
+import AppKit
+#endif
+
 /// Safari/Chrome-style downloads button for the browser omnibar. Shows a
 /// popover listing recent downloads with Open / Show in Finder actions.
 ///
@@ -7,6 +11,8 @@ import SwiftUI
 /// (`BrowserDownloadRecord`) plus action closures — no `BrowserPanel` store
 /// crosses the popover's `ForEach` boundary (CLAUDE.md snapshot-boundary rule).
 struct BrowserDownloadsToolbarButton: View {
+    @Environment(\.colorScheme) private var colorScheme
+
     let downloads: [BrowserDownloadRecord]
     let isDownloading: Bool
     let iconPointSize: CGFloat
@@ -73,6 +79,13 @@ struct BrowserDownloadsToolbarButton: View {
         .buttonStyle(OmnibarAddressButtonStyle())
         .safeHelp(String(localized: "browser.downloads.title", defaultValue: "Downloads"))
         .accessibilityLabel(String(localized: "browser.downloads.title", defaultValue: "Downloads"))
+        .onAppear {
+            presentAppearanceProbeIfReady()
+        }
+        .onChange(of: colorScheme) { _, _ in
+            presentAppearanceProbeIfReady()
+        }
+        .accessibilityIdentifier("BrowserDownloadsButton")
         .onChange(of: isPresented) { _, presented in
             if presented {
                 seenIDs = Set(downloads.map(\.id))
@@ -87,9 +100,19 @@ struct BrowserDownloadsToolbarButton: View {
             )
         }
     }
+
+    private func presentAppearanceProbeIfReady() {
+        #if DEBUG
+        guard BrowserDownloadsPopoverAppearanceUITestProbe.isEnabled,
+              colorScheme == .light else { return }
+        isPresented = true
+        #endif
+    }
 }
 
 private struct BrowserDownloadsPopoverContent: View {
+    @Environment(\.colorScheme) private var colorScheme
+
     let downloads: [BrowserDownloadRecord]
     let onOpen: (BrowserDownloadRecord) -> Void
     let onReveal: (BrowserDownloadRecord) -> Void
@@ -100,6 +123,7 @@ private struct BrowserDownloadsPopoverContent: View {
             HStack {
                 Text(String(localized: "browser.downloads.title", defaultValue: "Downloads"))
                     .font(.headline)
+                    .accessibilityIdentifier("BrowserDownloadsPopoverTitle")
                 Spacer()
                 if !downloads.isEmpty {
                     Button(String(localized: "browser.downloads.clear", defaultValue: "Clear")) {
@@ -135,6 +159,23 @@ private struct BrowserDownloadsPopoverContent: View {
             }
         }
         .frame(width: 340)
+        .accessibilityElement(children: .contain)
+        .accessibilityIdentifier("BrowserDownloadsPopover")
+        .background(appearanceProbe)
+    }
+
+    @ViewBuilder
+    private var appearanceProbe: some View {
+        #if DEBUG
+        if BrowserDownloadsPopoverAppearanceUITestProbe.isEnabled {
+            WindowAccessor(dedupeByWindow: false, refreshID: colorScheme) { window in
+                BrowserDownloadsPopoverAppearanceUITestProbe.record(
+                    window: window,
+                    contentColorScheme: colorScheme
+                )
+            }
+        }
+        #endif
     }
 }
 
@@ -152,6 +193,7 @@ private struct BrowserDownloadRow: View {
                 Text(record.filename)
                     .lineLimit(1)
                     .truncationMode(.middle)
+                    .accessibilityIdentifier("BrowserDownloadFilename")
                 Text(subtitle)
                     .font(.caption)
                     .foregroundStyle(record.state == .failed ? Color.red : Color.secondary)
@@ -165,6 +207,7 @@ private struct BrowserDownloadRow: View {
                 }
                 .buttonStyle(.borderless)
                 .font(.callout)
+                .accessibilityIdentifier("BrowserDownloadOpenButton")
 
                 Button {
                     onReveal(record)
@@ -216,3 +259,76 @@ private struct BrowserDownloadRow: View {
         }
     }
 }
+
+#if DEBUG
+enum BrowserDownloadsPopoverAppearanceUITestProbe {
+    private static let probePathEnvironmentKey = "CMUX_UI_TEST_DOWNLOADS_POPOVER_APPEARANCE_PATH"
+    private static let fixturePathEnvironmentKey = "CMUX_UI_TEST_DOWNLOADS_POPOVER_FIXTURE_PATH"
+
+    static var isEnabled: Bool {
+        configuredPath(for: probePathEnvironmentKey) != nil
+    }
+
+    static var fixtureDownload: BrowserDownloadRecord? {
+        guard isEnabled,
+              let fixturePath = configuredPath(for: fixturePathEnvironmentKey) else { return nil }
+        let fixtureURL = URL(fileURLWithPath: fixturePath)
+        return BrowserDownloadRecord(
+            id: "ui-test-downloads-popover-appearance",
+            filename: fixtureURL.lastPathComponent,
+            fileURL: fixtureURL,
+            state: .saved,
+            byteCount: 5_400
+        )
+    }
+
+    @MainActor
+    static func record(window: NSWindow, contentColorScheme: ColorScheme) {
+        guard let probePath = configuredPath(for: probePathEnvironmentKey) else { return }
+
+        let writeSnapshot = { @MainActor [weak window] in
+            guard let window else { return }
+            let windowAppearance: String
+            switch window.effectiveAppearance.bestMatch(from: [.aqua, .darkAqua]) {
+            case .aqua:
+                windowAppearance = "light"
+            case .darkAqua:
+                windowAppearance = "dark"
+            default:
+                windowAppearance = "unknown"
+            }
+
+            let contentScheme: String
+            switch contentColorScheme {
+            case .light:
+                contentScheme = "light"
+            case .dark:
+                contentScheme = "dark"
+            @unknown default:
+                contentScheme = "unknown"
+            }
+
+            let payload: [String: String] = [
+                "contentColorScheme": contentScheme,
+                "windowAppearance": windowAppearance,
+                "windowClass": String(describing: type(of: window)),
+                "windowVisible": window.isVisible ? "true" : "false",
+            ]
+            guard let data = try? JSONSerialization.data(withJSONObject: payload, options: [.sortedKeys]) else {
+                return
+            }
+            try? data.write(to: URL(fileURLWithPath: probePath), options: .atomic)
+        }
+
+        writeSnapshot()
+        DispatchQueue.main.async(execute: writeSnapshot)
+    }
+
+    private static func configuredPath(for key: String) -> String? {
+        guard let value = ProcessInfo.processInfo.environment[key]?
+            .trimmingCharacters(in: .whitespacesAndNewlines),
+              !value.isEmpty else { return nil }
+        return value
+    }
+}
+#endif

--- a/Sources/Panels/BrowserDownloadsToolbarButton.swift
+++ b/Sources/Panels/BrowserDownloadsToolbarButton.swift
@@ -98,6 +98,7 @@ struct BrowserDownloadsToolbarButton: View {
                 onReveal: onReveal,
                 onClear: onClear
             )
+            .browserChromePopoverAppearance(colorScheme)
         }
     }
 
@@ -321,7 +322,10 @@ enum BrowserDownloadsPopoverAppearanceUITestProbe {
         }
 
         writeSnapshot()
-        DispatchQueue.main.async(execute: writeSnapshot)
+        Task { @MainActor in
+            await Task.yield()
+            writeSnapshot()
+        }
     }
 
     private static func configuredPath(for key: String) -> String? {

--- a/Sources/Panels/BrowserPanelView.swift
+++ b/Sources/Panels/BrowserPanelView.swift
@@ -1391,7 +1391,7 @@ struct BrowserPanelView: View {
         .buttonStyle(OmnibarAddressButtonStyle())
         .frame(width: addressBarButtonSize, height: addressBarButtonSize, alignment: .center)
         .popover(isPresented: $isBrowserProfileMenuPresented, arrowEdge: .bottom) {
-            browserProfilePopover
+            browserProfilePopover.browserChromePopoverAppearance(browserChromeColorScheme)
         }
         .safeHelp(
             String(
@@ -1465,7 +1465,7 @@ struct BrowserPanelView: View {
         .buttonStyle(OmnibarAddressButtonStyle())
         .frame(width: addressBarButtonSize, height: addressBarButtonSize, alignment: .center)
         .popover(isPresented: $isBrowserThemeMenuPresented, arrowEdge: .bottom) {
-            browserThemeModePopover
+            browserThemeModePopover.browserChromePopoverAppearance(browserChromeColorScheme)
         }
         .safeHelp(
             String(
@@ -1495,7 +1495,7 @@ struct BrowserPanelView: View {
         }
         .buttonStyle(OmnibarAddressButtonStyle())
         .popover(isPresented: $isBrowserImportHintPopoverPresented, arrowEdge: .bottom) {
-            browserImportHintPopover
+            browserImportHintPopover.browserChromePopoverAppearance(browserChromeColorScheme)
         }
         .safeHelp(String(localized: "browser.import.hint.toolbar.help", defaultValue: "Import browser data"))
         .accessibilityIdentifier("BrowserImportHintToolbarChip")

--- a/Sources/Panels/BrowserPanelView.swift
+++ b/Sources/Panels/BrowserPanelView.swift
@@ -1232,9 +1232,9 @@ struct BrowserPanelView: View {
                 hitSize: addressBarButtonHitSize
             )
 
-            if panel.isDownloading || !panel.recentDownloads.isEmpty {
+            if panel.isDownloading || !browserToolbarDownloads.isEmpty {
                 BrowserDownloadsToolbarButton(
-                    downloads: panel.recentDownloads,
+                    downloads: browserToolbarDownloads,
                     isDownloading: panel.isDownloading,
                     iconPointSize: chromeMetrics.navigationIconFontSize,
                     hitSize: addressBarButtonHitSize,
@@ -1244,6 +1244,16 @@ struct BrowserPanelView: View {
                 )
             }
         }
+    }
+
+    private var browserToolbarDownloads: [BrowserDownloadRecord] {
+        #if DEBUG
+        if panel.recentDownloads.isEmpty,
+           let fixtureDownload = BrowserDownloadsPopoverAppearanceUITestProbe.fixtureDownload {
+            return [fixtureDownload]
+        }
+        #endif
+        return panel.recentDownloads
     }
 
     private var screenshotPageButton: some View {

--- a/Sources/Panels/BrowserPanelView.swift
+++ b/Sources/Panels/BrowserPanelView.swift
@@ -1249,7 +1249,7 @@ struct BrowserPanelView: View {
     private var browserToolbarDownloads: [BrowserDownloadRecord] {
         #if DEBUG
         if panel.recentDownloads.isEmpty,
-           let fixtureDownload = BrowserDownloadsPopoverAppearanceUITestProbe.fixtureDownload {
+           let fixtureDownload = BrowserDownloadsPopoverAppearanceUITestSupport().fixtureDownload {
             return [fixtureDownload]
         }
         #endif

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -330,6 +330,9 @@ C0DE71B10000000000000001 /* AppDelegate+AgentChatNotifications.swift in Sources 
 		C59240010000000000000003 /* BrowserDownloadFilenameResolverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C59240010000000000000004 /* BrowserDownloadFilenameResolverTests.swift */; };
 		C67540020000000000000001 /* BrowserDownloadHTTPStatusDecision.swift in Sources */ = {isa = PBXBuildFile; fileRef = C67540020000000000000002 /* BrowserDownloadHTTPStatusDecision.swift */; };
 		C67540110000000000000001 /* BrowserDownloadRecord.swift in Sources */ = {isa = PBXBuildFile; fileRef = C67540110000000000000002 /* BrowserDownloadRecord.swift */; };
+		D93410030000000000000001 /* BrowserDownloadsPopoverAppearanceUITestPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = D93410030000000000000002 /* BrowserDownloadsPopoverAppearanceUITestPresenter.swift */; };
+		D93410040000000000000001 /* BrowserDownloadsPopoverAppearanceUITestRecorder.swift in Sources */ = {isa = PBXBuildFile; fileRef = D93410040000000000000002 /* BrowserDownloadsPopoverAppearanceUITestRecorder.swift */; };
+		D93410020000000000000001 /* BrowserDownloadsPopoverAppearanceUITestSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = D93410020000000000000002 /* BrowserDownloadsPopoverAppearanceUITestSupport.swift */; };
 		D93410000000000000000001 /* BrowserDownloadsPopoverContrastUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D93410000000000000000002 /* BrowserDownloadsPopoverContrastUITests.swift */; };
 		C67540120000000000000001 /* BrowserDownloadsToolbarButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = C67540120000000000000002 /* BrowserDownloadsToolbarButton.swift */; };
 		B5A5E55B0000000000000001 /* BrowserEphemeralRestorationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5A5E55B0000000000000002 /* BrowserEphemeralRestorationTests.swift */; };
@@ -3032,6 +3035,9 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 		C59240010000000000000004 /* BrowserDownloadFilenameResolverTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowserDownloadFilenameResolverTests.swift; sourceTree = "<group>"; };
 		C67540020000000000000002 /* BrowserDownloadHTTPStatusDecision.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/BrowserDownloadHTTPStatusDecision.swift; sourceTree = "<group>"; };
 		C67540110000000000000002 /* BrowserDownloadRecord.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/BrowserDownloadRecord.swift; sourceTree = "<group>"; };
+		D93410030000000000000002 /* BrowserDownloadsPopoverAppearanceUITestPresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Debug/UITests/BrowserDownloadsPopoverAppearanceUITestPresenter.swift; sourceTree = "<group>"; };
+		D93410040000000000000002 /* BrowserDownloadsPopoverAppearanceUITestRecorder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Debug/UITests/BrowserDownloadsPopoverAppearanceUITestRecorder.swift; sourceTree = "<group>"; };
+		D93410020000000000000002 /* BrowserDownloadsPopoverAppearanceUITestSupport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Debug/UITests/BrowserDownloadsPopoverAppearanceUITestSupport.swift; sourceTree = "<group>"; };
 		D93410000000000000000002 /* BrowserDownloadsPopoverContrastUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowserDownloadsPopoverContrastUITests.swift; sourceTree = "<group>"; };
 		C67540120000000000000002 /* BrowserDownloadsToolbarButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/BrowserDownloadsToolbarButton.swift; sourceTree = "<group>"; };
 		B5A5E55B0000000000000002 /* BrowserEphemeralRestorationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowserEphemeralRestorationTests.swift; sourceTree = "<group>"; };
@@ -6079,6 +6085,9 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				CA52C0170000000000000000 /* Workspace+SurfaceNavigation.swift */,
 				875200000000000000000004 /* SurfacePaneMovement.swift */,
 				822900000000000000000002 /* Workspace+TerminalResizeInteraction.swift */,
+				D93410030000000000000002 /* BrowserDownloadsPopoverAppearanceUITestPresenter.swift */,
+				D93410040000000000000002 /* BrowserDownloadsPopoverAppearanceUITestRecorder.swift */,
+				D93410020000000000000002 /* BrowserDownloadsPopoverAppearanceUITestSupport.swift */,
 				CC2639000000000000000002 /* GotoSplitCycleUITestSupport.swift */,
 				A5001511 /* UITestRecorder.swift */,
 				A5001520 /* PostHogAnalytics.swift */,
@@ -8726,6 +8735,9 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				C59240010000000000000001 /* BrowserDownloadFilenameResolver.swift in Sources */,
 				C67540020000000000000001 /* BrowserDownloadHTTPStatusDecision.swift in Sources */,
 				C67540110000000000000001 /* BrowserDownloadRecord.swift in Sources */,
+				D93410030000000000000001 /* BrowserDownloadsPopoverAppearanceUITestPresenter.swift in Sources */,
+				D93410040000000000000001 /* BrowserDownloadsPopoverAppearanceUITestRecorder.swift in Sources */,
+				D93410020000000000000001 /* BrowserDownloadsPopoverAppearanceUITestSupport.swift in Sources */,
 				C67540120000000000000001 /* BrowserDownloadsToolbarButton.swift in Sources */,
 				C2035A010000000000000001 /* BrowserErrorPage.swift in Sources */,
 				C2035A020000000000000001 /* BrowserErrorPageContent.swift in Sources */,

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -333,6 +333,8 @@ C0DE71B10000000000000001 /* AppDelegate+AgentChatNotifications.swift in Sources 
 		D93410030000000000000001 /* BrowserDownloadsPopoverAppearanceUITestPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = D93410030000000000000002 /* BrowserDownloadsPopoverAppearanceUITestPresenter.swift */; };
 		D93410040000000000000001 /* BrowserDownloadsPopoverAppearanceUITestRecorder.swift in Sources */ = {isa = PBXBuildFile; fileRef = D93410040000000000000002 /* BrowserDownloadsPopoverAppearanceUITestRecorder.swift */; };
 		D93410020000000000000001 /* BrowserDownloadsPopoverAppearanceUITestSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = D93410020000000000000002 /* BrowserDownloadsPopoverAppearanceUITestSupport.swift */; };
+		D93410050000000000000001 /* BrowserDownloadsPopoverAppearanceWindowAccessor.swift in Sources */ = {isa = PBXBuildFile; fileRef = D93410050000000000000002 /* BrowserDownloadsPopoverAppearanceWindowAccessor.swift */; };
+		D93410060000000000000001 /* BrowserDownloadsPopoverAppearanceWindowObservingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D93410060000000000000002 /* BrowserDownloadsPopoverAppearanceWindowObservingView.swift */; };
 		D93410000000000000000001 /* BrowserDownloadsPopoverContrastUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D93410000000000000000002 /* BrowserDownloadsPopoverContrastUITests.swift */; };
 		C67540120000000000000001 /* BrowserDownloadsToolbarButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = C67540120000000000000002 /* BrowserDownloadsToolbarButton.swift */; };
 		B5A5E55B0000000000000001 /* BrowserEphemeralRestorationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5A5E55B0000000000000002 /* BrowserEphemeralRestorationTests.swift */; };
@@ -3038,6 +3040,8 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 		D93410030000000000000002 /* BrowserDownloadsPopoverAppearanceUITestPresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Debug/UITests/BrowserDownloadsPopoverAppearanceUITestPresenter.swift; sourceTree = "<group>"; };
 		D93410040000000000000002 /* BrowserDownloadsPopoverAppearanceUITestRecorder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Debug/UITests/BrowserDownloadsPopoverAppearanceUITestRecorder.swift; sourceTree = "<group>"; };
 		D93410020000000000000002 /* BrowserDownloadsPopoverAppearanceUITestSupport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Debug/UITests/BrowserDownloadsPopoverAppearanceUITestSupport.swift; sourceTree = "<group>"; };
+		D93410050000000000000002 /* BrowserDownloadsPopoverAppearanceWindowAccessor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Debug/UITests/BrowserDownloadsPopoverAppearanceWindowAccessor.swift; sourceTree = "<group>"; };
+		D93410060000000000000002 /* BrowserDownloadsPopoverAppearanceWindowObservingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Debug/UITests/BrowserDownloadsPopoverAppearanceWindowObservingView.swift; sourceTree = "<group>"; };
 		D93410000000000000000002 /* BrowserDownloadsPopoverContrastUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowserDownloadsPopoverContrastUITests.swift; sourceTree = "<group>"; };
 		C67540120000000000000002 /* BrowserDownloadsToolbarButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/BrowserDownloadsToolbarButton.swift; sourceTree = "<group>"; };
 		B5A5E55B0000000000000002 /* BrowserEphemeralRestorationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowserEphemeralRestorationTests.swift; sourceTree = "<group>"; };
@@ -6088,6 +6092,8 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				D93410030000000000000002 /* BrowserDownloadsPopoverAppearanceUITestPresenter.swift */,
 				D93410040000000000000002 /* BrowserDownloadsPopoverAppearanceUITestRecorder.swift */,
 				D93410020000000000000002 /* BrowserDownloadsPopoverAppearanceUITestSupport.swift */,
+				D93410050000000000000002 /* BrowserDownloadsPopoverAppearanceWindowAccessor.swift */,
+				D93410060000000000000002 /* BrowserDownloadsPopoverAppearanceWindowObservingView.swift */,
 				CC2639000000000000000002 /* GotoSplitCycleUITestSupport.swift */,
 				A5001511 /* UITestRecorder.swift */,
 				A5001520 /* PostHogAnalytics.swift */,
@@ -8738,6 +8744,8 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				D93410030000000000000001 /* BrowserDownloadsPopoverAppearanceUITestPresenter.swift in Sources */,
 				D93410040000000000000001 /* BrowserDownloadsPopoverAppearanceUITestRecorder.swift in Sources */,
 				D93410020000000000000001 /* BrowserDownloadsPopoverAppearanceUITestSupport.swift in Sources */,
+				D93410050000000000000001 /* BrowserDownloadsPopoverAppearanceWindowAccessor.swift in Sources */,
+				D93410060000000000000001 /* BrowserDownloadsPopoverAppearanceWindowObservingView.swift in Sources */,
 				C67540120000000000000001 /* BrowserDownloadsToolbarButton.swift in Sources */,
 				C2035A010000000000000001 /* BrowserErrorPage.swift in Sources */,
 				C2035A020000000000000001 /* BrowserErrorPageContent.swift in Sources */,

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -291,6 +291,7 @@ C0DE71B10000000000000001 /* AppDelegate+AgentChatNotifications.swift in Sources 
 		805600000000000000000007 /* BrowserAutomationViewportError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 805600000000000000000008 /* BrowserAutomationViewportError.swift */; };
 		BCBC0A0E0000000000000C01 /* BrowserChromeMetrics.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCBC0A0E0000000000000C02 /* BrowserChromeMetrics.swift */; };
 		BCBC0A0E0000000000000D01 /* BrowserChromeMetricsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCBC0A0E0000000000000D02 /* BrowserChromeMetricsTests.swift */; };
+		D93410010000000000000001 /* BrowserChromePopoverAppearance.swift in Sources */ = {isa = PBXBuildFile; fileRef = D93410010000000000000002 /* BrowserChromePopoverAppearance.swift */; };
 		D7032A020000000000000001 /* BrowserClientCertificateAuthenticationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7032A020000000000000002 /* BrowserClientCertificateAuthenticationController.swift */; };
 		D7032A050000000000000001 /* BrowserClientCertificateCredentialPicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7032A050000000000000002 /* BrowserClientCertificateCredentialPicker.swift */; };
 		D7032A030000000000000001 /* BrowserClientCertificateCredentialPickerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7032A030000000000000002 /* BrowserClientCertificateCredentialPickerTests.swift */; };
@@ -2992,6 +2993,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 		805600000000000000000008 /* BrowserAutomationViewportError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Panels/BrowserAutomationViewportError.swift"; sourceTree = "<group>"; };
 		BCBC0A0E0000000000000C02 /* BrowserChromeMetrics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/BrowserChromeMetrics.swift; sourceTree = "<group>"; };
 		BCBC0A0E0000000000000D02 /* BrowserChromeMetricsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowserChromeMetricsTests.swift; sourceTree = "<group>"; };
+		D93410010000000000000002 /* BrowserChromePopoverAppearance.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/BrowserChromePopoverAppearance.swift; sourceTree = "<group>"; };
 		D7032A020000000000000002 /* BrowserClientCertificateAuthenticationController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/BrowserClientCertificateAuthenticationController.swift; sourceTree = "<group>"; };
 		D7032A050000000000000002 /* BrowserClientCertificateCredentialPicker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/BrowserClientCertificateCredentialPicker.swift; sourceTree = "<group>"; };
 		D7032A030000000000000002 /* BrowserClientCertificateCredentialPickerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowserClientCertificateCredentialPickerTests.swift; sourceTree = "<group>"; };
@@ -6639,6 +6641,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				BABA2500000000000000000E /* BrowserHTTPBasicAuthPromptRequest.swift */,
 				BABA2500000000000000000A /* BrowserNavigationDelegate.swift */,
 				C67540080000000000000002 /* BrowserNavigationDebugURL.swift */,
+				D93410010000000000000002 /* BrowserChromePopoverAppearance.swift */,
 				C67540110000000000000002 /* BrowserDownloadRecord.swift */,
 				C67540120000000000000002 /* BrowserDownloadsToolbarButton.swift */,
 				C67540100000000000000002 /* BrowserNavigationPopupPolicy.swift */,
@@ -8695,6 +8698,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				8054A0070000000000000007 /* BrowserAutomationSnapshotResult.swift in Sources */,
 				805600000000000000000007 /* BrowserAutomationViewportError.swift in Sources */,
 				BCBC0A0E0000000000000C01 /* BrowserChromeMetrics.swift in Sources */,
+				D93410010000000000000001 /* BrowserChromePopoverAppearance.swift in Sources */,
 				D7032A020000000000000001 /* BrowserClientCertificateAuthenticationController.swift in Sources */,
 				D7032A050000000000000001 /* BrowserClientCertificateCredentialPicker.swift in Sources */,
 				D35A0000000000000000001F /* BrowserDesignModeArtifactRetention.swift in Sources */,

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -329,6 +329,7 @@ C0DE71B10000000000000001 /* AppDelegate+AgentChatNotifications.swift in Sources 
 		C59240010000000000000003 /* BrowserDownloadFilenameResolverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C59240010000000000000004 /* BrowserDownloadFilenameResolverTests.swift */; };
 		C67540020000000000000001 /* BrowserDownloadHTTPStatusDecision.swift in Sources */ = {isa = PBXBuildFile; fileRef = C67540020000000000000002 /* BrowserDownloadHTTPStatusDecision.swift */; };
 		C67540110000000000000001 /* BrowserDownloadRecord.swift in Sources */ = {isa = PBXBuildFile; fileRef = C67540110000000000000002 /* BrowserDownloadRecord.swift */; };
+		D93410000000000000000001 /* BrowserDownloadsPopoverContrastUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D93410000000000000000002 /* BrowserDownloadsPopoverContrastUITests.swift */; };
 		C67540120000000000000001 /* BrowserDownloadsToolbarButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = C67540120000000000000002 /* BrowserDownloadsToolbarButton.swift */; };
 		B5A5E55B0000000000000001 /* BrowserEphemeralRestorationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5A5E55B0000000000000002 /* BrowserEphemeralRestorationTests.swift */; };
 		C2035A010000000000000001 /* BrowserErrorPage.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2035A010000000000000002 /* BrowserErrorPage.swift */; };
@@ -3029,6 +3030,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 		C59240010000000000000004 /* BrowserDownloadFilenameResolverTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowserDownloadFilenameResolverTests.swift; sourceTree = "<group>"; };
 		C67540020000000000000002 /* BrowserDownloadHTTPStatusDecision.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/BrowserDownloadHTTPStatusDecision.swift; sourceTree = "<group>"; };
 		C67540110000000000000002 /* BrowserDownloadRecord.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/BrowserDownloadRecord.swift; sourceTree = "<group>"; };
+		D93410000000000000000002 /* BrowserDownloadsPopoverContrastUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowserDownloadsPopoverContrastUITests.swift; sourceTree = "<group>"; };
 		C67540120000000000000002 /* BrowserDownloadsToolbarButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/BrowserDownloadsToolbarButton.swift; sourceTree = "<group>"; };
 		B5A5E55B0000000000000002 /* BrowserEphemeralRestorationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowserEphemeralRestorationTests.swift; sourceTree = "<group>"; };
 		C2035A010000000000000002 /* BrowserErrorPage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/BrowserErrorPage.swift; sourceTree = "<group>"; };
@@ -5455,6 +5457,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				FE00AA11C1B2C3D4E5F60718 /* FocusHistoryShortcutUITests.swift */,
 				D0E0F0B5A1B2C3D4E5F60718 /* FindSelectionShortcutUITests.swift */,
 				D0E0F0B3A1B2C3D4E5F60718 /* BrowserOmnibarSuggestionsUITests.swift */,
+				D93410000000000000000002 /* BrowserDownloadsPopoverContrastUITests.swift */,
 				FB100001A1B2C3D4E5F60718 /* BrowserImportProfilesUITests.swift */,
 				7B5F1A2E9C0D4B6A8E217301 /* BrowserFixtureInteractionUITests.swift */,
 				81464EB0D515022903F26DD8 /* WorkspaceWorkingDirectorySpawnUITests.swift */,
@@ -10322,6 +10325,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 			files = (
 				B9000012A1B2C3D4E5F60719 /* AutomationSocketUITests.swift in Sources */,
 				AA1B2C3D4E5F60718 /* BonsplitTabDragUITests.swift in Sources */,
+				D93410000000000000000001 /* BrowserDownloadsPopoverContrastUITests.swift in Sources */,
 				7B5F1A2E9C0D4B6A8E217302 /* BrowserFixtureInteractionUITests.swift in Sources */,
 				8478B0000000000000000002 /* BrowserFixtureSocketTestCase+PendingRequest.swift in Sources */,
 				FB100000A1B2C3D4E5F60718 /* BrowserImportProfilesUITests.swift in Sources */,

--- a/cmuxUITests/BrowserDownloadsPopoverContrastUITests.swift
+++ b/cmuxUITests/BrowserDownloadsPopoverContrastUITests.swift
@@ -1,0 +1,243 @@
+import Foundation
+import XCTest
+
+final class BrowserDownloadsPopoverContrastUITests: XCTestCase {
+    private var app: XCUIApplication?
+    private var appProcess: Process?
+    private var appLogPath = ""
+    private var isolatedHome: URL?
+    private var launchTag = ""
+    private var probePath = ""
+    private var setupPath = ""
+
+    override func setUp() {
+        super.setUp()
+        continueAfterFailure = false
+        let token = UUID().uuidString
+        let temporaryDirectory = FileManager.default.temporaryDirectory
+        appLogPath = temporaryDirectory
+            .appendingPathComponent("cmux-ui-test-downloads-popover-\(token).log")
+            .path
+        launchTag = "ui-tests-downloads-popover-\(token.prefix(8))"
+        probePath = temporaryDirectory
+            .appendingPathComponent("cmux-ui-test-downloads-popover-probe-\(token).json")
+            .path
+        setupPath = temporaryDirectory
+            .appendingPathComponent("cmux-ui-test-downloads-popover-setup-\(token).json")
+            .path
+        removeTestArtifacts()
+    }
+
+    override func tearDown() {
+        app?.terminate()
+        terminateAppProcess()
+        if let isolatedHome {
+            try? FileManager.default.removeItem(at: isolatedHome)
+        }
+        removeTestArtifacts()
+        super.tearDown()
+    }
+
+    func testDownloadsPopoverKeepsLightChromeReadableWhenAppKitAppearanceIsDark() throws {
+        let isolatedHome = try makeIsolatedHomeWithLightTerminalTheme()
+        self.isolatedHome = isolatedHome
+        let fixtureURL = isolatedHome
+            .appendingPathComponent("Downloads", isDirectory: true)
+            .appendingPathComponent("error.txt", isDirectory: false)
+        try Data(repeating: 0x41, count: 5_400).write(to: fixtureURL, options: .atomic)
+
+        let app = XCUIApplication(bundleIdentifier: "com.cmuxterm.app.debug")
+        self.app = app
+        app.terminate()
+
+        let launchArguments = [
+            "-appearanceMode", "dark",
+            "-browserThemeMode", "light",
+            "-browserAskWhereToSaveDownloads", "false",
+        ]
+        let launchEnvironment = [
+            "HOME": isolatedHome.path,
+            "CFFIXED_USER_HOME": isolatedHome.path,
+            "XDG_CONFIG_HOME": isolatedHome.appendingPathComponent(".config", isDirectory: true).path,
+            "CMUX_TAG": launchTag,
+            "CMUX_UI_TEST_PROCESS": "1",
+            "CMUX_UI_TEST_MODE": "1",
+            "CMUX_UI_TEST_GOTO_SPLIT_SETUP": "1",
+            "CMUX_UI_TEST_GOTO_SPLIT_PATH": setupPath,
+            "CMUX_UI_TEST_GOTO_SPLIT_BROWSER_URL": makePageDataURL(),
+            "CMUX_UI_TEST_GOTO_SPLIT_USE_GHOSTTY_CONFIG": "1",
+            "CMUX_UI_TEST_DOWNLOADS_POPOVER_APPEARANCE_PATH": probePath,
+            "CMUX_UI_TEST_DOWNLOADS_POPOVER_FIXTURE_PATH": fixtureURL.path,
+        ]
+        try launchAppProcess(arguments: launchArguments, environment: launchEnvironment)
+
+        XCTAssertTrue(
+            waitForJSON(atPath: setupPath, timeout: 12) { $0["browserPageTitle"] == "downloads-popover-contrast" },
+            "Expected the browser fixture to finish loading. " +
+                "data=\(loadJSON(atPath: setupPath) ?? [:]) app=\(launchedAppDiagnostics()) " +
+                "log=\(appLogTail())"
+        )
+        XCTAssertTrue(
+            waitForJSON(atPath: probePath, timeout: 8) {
+                $0["contentColorScheme"] != nil && $0["windowAppearance"] != nil
+            },
+            "Expected the real downloads popover to report its presentation appearance. " +
+                "probe=\(loadJSON(atPath: probePath) ?? [:]) app=\(launchedAppDiagnostics()) " +
+                "log=\(appLogTail())"
+        )
+
+        let probe = try XCTUnwrap(loadJSON(atPath: probePath))
+        XCTAssertEqual(
+            probe["contentColorScheme"],
+            "light",
+            "Expected the popover content to inherit the light browser-chrome scheme. probe=\(probe)"
+        )
+        XCTAssertEqual(
+            probe["windowAppearance"],
+            "light",
+            "Expected the AppKit popover presentation and its semantic foregrounds to resolve " +
+                "under the same light appearance. probe=\(probe)"
+        )
+    }
+
+    private func makeIsolatedHomeWithLightTerminalTheme() throws -> URL {
+        let fileManager = FileManager.default
+        let home = fileManager.temporaryDirectory.appendingPathComponent(
+            "cmux-ui-test-downloads-popover-home-\(UUID().uuidString)",
+            isDirectory: true
+        )
+        let ghosttyDirectory = home
+            .appendingPathComponent("Library/Application Support", isDirectory: true)
+            .appendingPathComponent("com.mitchellh.ghostty", isDirectory: true)
+        try fileManager.createDirectory(at: ghosttyDirectory, withIntermediateDirectories: true)
+        try fileManager.createDirectory(
+            at: home.appendingPathComponent("Downloads", isDirectory: true),
+            withIntermediateDirectories: true
+        )
+
+        let config = """
+        # Force browser chrome to resolve light while AppKit remains dark.
+        working-directory = \(home.path)
+        background = #f5f5f5
+        foreground = #111111
+        background-opacity = 1
+
+        """
+        try config.write(
+            to: ghosttyDirectory.appendingPathComponent("config.ghostty", isDirectory: false),
+            atomically: true,
+            encoding: .utf8
+        )
+        return home
+    }
+
+    private func makePageDataURL() -> String {
+        let html = """
+        <!doctype html>
+        <html>
+        <head><meta charset="utf-8"><title>downloads-popover-contrast</title></head>
+        <body></body>
+        </html>
+        """
+        return "data:text/html;base64,\(Data(html.utf8).base64EncodedString())"
+    }
+
+    private func launchAppProcess(arguments: [String], environment: [String: String]) throws {
+        // XCUIApplication.launch() waits for foreground activation and aborts
+        // after 60 seconds on headless runners. Launch the built binary directly;
+        // the app-side probe exercises the real popover without AX interaction.
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: try resolveAppBinaryPath())
+        process.arguments = arguments
+        var launchEnvironment = ProcessInfo.processInfo.environment
+        for (key, value) in environment {
+            launchEnvironment[key] = value
+        }
+        process.environment = launchEnvironment
+
+        _ = FileManager.default.createFile(atPath: appLogPath, contents: nil)
+        let logHandle = try FileHandle(forWritingTo: URL(fileURLWithPath: appLogPath))
+        process.standardOutput = logHandle
+        process.standardError = logHandle
+
+        try process.run()
+        appProcess = process
+    }
+
+    private func resolveAppBinaryPath() throws -> String {
+        let testBundle = Bundle(for: Self.self)
+        let productsDirectory = testBundle.bundleURL
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+        let binaryPath = productsDirectory
+            .appendingPathComponent("cmux DEV.app")
+            .appendingPathComponent("Contents/MacOS/cmux DEV")
+            .path
+        guard FileManager.default.fileExists(atPath: binaryPath) else {
+            throw NSError(
+                domain: "BrowserDownloadsPopoverContrastUITests",
+                code: 1,
+                userInfo: [
+                    NSLocalizedDescriptionKey:
+                        "App binary not found at \(binaryPath). testBundle=\(testBundle.bundleURL.path)"
+                ]
+            )
+        }
+        return binaryPath
+    }
+
+    private func terminateAppProcess() {
+        guard let process = appProcess else { return }
+        defer { appProcess = nil }
+        guard process.isRunning else { return }
+
+        process.terminate()
+        let deadline = Date().addingTimeInterval(5)
+        while process.isRunning && Date() < deadline {
+            RunLoop.current.run(until: Date().addingTimeInterval(0.1))
+        }
+        if process.isRunning {
+            process.interrupt()
+        }
+    }
+
+    private func launchedAppDiagnostics() -> String {
+        guard let process = appProcess else { return "not-launched" }
+        return "pid=\(process.processIdentifier) running=\(process.isRunning)"
+    }
+
+    private func appLogTail() -> String {
+        (try? String(contentsOfFile: appLogPath, encoding: .utf8))
+            .map { String($0.suffix(2_000)) } ?? "<empty>"
+    }
+
+    private func removeTestArtifacts() {
+        for path in [setupPath, probePath, appLogPath] where !path.isEmpty {
+            try? FileManager.default.removeItem(atPath: path)
+        }
+    }
+
+    private func waitForJSON(
+        atPath path: String,
+        timeout: TimeInterval,
+        predicate: @escaping ([String: String]) -> Bool
+    ) -> Bool {
+        let expectation = XCTNSPredicateExpectation(
+            predicate: NSPredicate { _, _ in
+                guard let data = self.loadJSON(atPath: path) else { return false }
+                return predicate(data)
+            },
+            object: nil
+        )
+        return XCTWaiter().wait(for: [expectation], timeout: timeout) == .completed
+    }
+
+    private func loadJSON(atPath path: String) -> [String: String]? {
+        guard let data = try? Data(contentsOf: URL(fileURLWithPath: path)) else {
+            return nil
+        }
+        return (try? JSONSerialization.jsonObject(with: data)) as? [String: String]
+    }
+}

--- a/cmuxUITests/BrowserDownloadsPopoverContrastUITests.swift
+++ b/cmuxUITests/BrowserDownloadsPopoverContrastUITests.swift
@@ -79,7 +79,9 @@ final class BrowserDownloadsPopoverContrastUITests: XCTestCase {
         )
         XCTAssertTrue(
             waitForJSON(atPath: probePath, timeout: 8) {
-                $0["contentColorScheme"] != nil && $0["windowAppearance"] != nil
+                $0["contentColorScheme"] == "light" &&
+                    $0["windowAppearance"] == "light" &&
+                    $0["windowClass"] == "_NSPopoverWindow"
             },
             "Expected the real downloads popover to report its presentation appearance. " +
                 "probe=\(loadJSON(atPath: probePath) ?? [:]) app=\(launchedAppDiagnostics()) " +
@@ -97,6 +99,11 @@ final class BrowserDownloadsPopoverContrastUITests: XCTestCase {
             "light",
             "Expected the AppKit popover presentation and its semantic foregrounds to resolve " +
                 "under the same light appearance. probe=\(probe)"
+        )
+        XCTAssertEqual(
+            probe["windowClass"],
+            "_NSPopoverWindow",
+            "Expected the probe to observe the genuine AppKit popover window. probe=\(probe)"
         )
     }
 
@@ -194,13 +201,22 @@ final class BrowserDownloadsPopoverContrastUITests: XCTestCase {
         guard process.isRunning else { return }
 
         process.terminate()
-        let deadline = Date().addingTimeInterval(5)
-        while process.isRunning && Date() < deadline {
-            RunLoop.current.run(until: Date().addingTimeInterval(0.1))
+        if waitForProcessExit(process, timeout: 5) {
+            return
         }
-        if process.isRunning {
-            process.interrupt()
-        }
+        process.interrupt()
+        XCTAssertTrue(
+            waitForProcessExit(process, timeout: 2),
+            "Expected UI-test app process \(process.processIdentifier) to exit after interrupt"
+        )
+    }
+
+    private func waitForProcessExit(_ process: Process, timeout: TimeInterval) -> Bool {
+        let expectation = XCTNSPredicateExpectation(
+            predicate: NSPredicate { _, _ in !process.isRunning },
+            object: nil
+        )
+        return XCTWaiter().wait(for: [expectation], timeout: timeout) == .completed
     }
 
     private func launchedAppDiagnostics() -> String {


### PR DESCRIPTION
## Summary

- Resolve each browser toolbar popover's AppKit material and SwiftUI semantic foregrounds from the same browser-chrome color scheme.
- Apply one shared presentation-boundary modifier to Downloads, profile, theme, and import-hint popovers so mixed light/dark appearance resolution cannot recur across sibling surfaces.
- Add a focused debug-only behavioral probe and XCUITest that opens the real Downloads popover with a synthetic download under dark app / light browser chrome.

Issue: https://github.com/manaflow-ai/cmux/issues/9341

Closes #9341

## Testing

- Regression red: https://github.com/manaflow-ai/cmux/actions/runs/31142528059 at test-only commit `189ac5b27b`; exactly one focused test executed and failed because both the popover SwiftUI environment and `_NSPopoverWindow.effectiveAppearance` resolved dark.
- Final focused green: https://github.com/manaflow-ai/cmux/actions/runs/31144853751 at exact checkout SHA `981d4d78166f721b65c9d78f4a9d2253821fd5ec`; exactly one focused test executed with zero failures in 6.514 seconds. Artifact: https://github.com/manaflow-ai/cmux-dev-artifacts/issues/9469.
- Passed `./scripts/check-pbxproj.sh`.
- Passed `./scripts/lint-pbxproj-test-wiring.sh` (654 test files).
- Passed `python3 scripts/check-package-resolved-policy.py`, `git diff --check`, and Swift parser checks for all changed Swift files.
- Synthetic merge with current `origin/main` (`80054fcaca`) succeeds without conflicts.
- Per task constraints, no local build, local `xcodebuild test`, or local XCUITest was run.

Localization audit: no user-facing strings changed; the changed Swift surfaces were checked for newly introduced bare English, and no localization catalog changes are needed.

Warning audit: no warning-budget or file-length-budget file is changed.

## Demo Video

- Not recorded. The requested build/dogfood step is intentionally deferred until explicit user approval; the focused headless UI test validates the genuine SwiftUI/AppKit popover presentation boundary.

## Review Trigger

Requested separately after the latest commit:

```text
@coderabbitai review
@greptile-apps review
@cubic-dev-ai review
```

## Checklist

- [ ] I tested the change locally (intentionally deferred by task constraints)
- [x] I added or updated tests for behavior changes
- [x] I updated docs/changelog if needed (not needed for this scoped bug fix)
- [x] I requested bot reviews after my latest commit
- [x] All code review bot comments are resolved
- [x] All human review comments are resolved

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/9744"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788664421&installation_model_id=21920&pr_number=9744&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F9744&signature=d2e83edf97b955e51914dd553fe0b1d448a6f00dbf9ce69b40e3f89742dd6098"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped SwiftUI/AppKit appearance wiring and DEBUG-only test probes; no auth, data, or release-path behavior changes beyond popover styling.
> 
> **Overview**
> Fixes **mixed light/dark contrast** in browser toolbar popovers when the app appearance and browser chrome disagree (e.g. dark app with light terminal-derived chrome).
> 
> A shared **`browserChromePopoverAppearance`** modifier applies `preferredColorScheme` to popover content so SwiftUI semantics and the AppKit `_NSPopoverWindow` material resolve from the same **browser-chrome** scheme. It is wired on the **Downloads**, **profile**, **theme**, and **import-hint** popovers; the downloads popover also reads the chrome scheme from its toolbar button.
> 
> **DEBUG-only** UI-test hooks auto-present the real downloads popover, inject a fixture download, and record `contentColorScheme`, `windowAppearance`, and window class via an `NSView` window accessor. A new **headless XCUITest** launches the binary directly and asserts both schemes stay **light** under dark app / light browser chrome.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 981d4d78166f721b65c9d78f4a9d2253821fd5ec. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes mixed light/dark contrast in browser toolbar popovers by resolving both SwiftUI content and the AppKit popover from the browser‑chrome color scheme. Applies to Downloads, profile, theme, and import‑hint popovers and adds a lifecycle‑driven UI test to prevent regressions. Fixes #9341.

- **Bug Fixes**
  - Added a shared `browserChromePopoverAppearance` so popover material and semantic colors resolve from the browser‑chrome scheme.
  - Applied it to Downloads, profile, theme, and import‑hint popovers.
  - DEBUG-only probe now records the real `_NSPopoverWindow` and content scheme and refreshes on attach, effective-appearance changes, and SwiftUI updates.
  - Headless XCUITest auto-presents the Downloads popover (injects a fixture download) and asserts it stays light under a dark app appearance.

<sup>Written for commit 981d4d78166f721b65c9d78f4a9d2253821fd5ec. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/9744?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Browser downloads and related browser popovers now consistently follow the selected browser color scheme, even when the system appearance differs.
  * Downloads popovers provide improved visual consistency with the rest of the browser interface.

* **Bug Fixes**
  * Resolved appearance mismatches that could cause browser popovers to display with incorrect light or dark styling.
  * Improved reliability when opening downloads and other browser toolbar popovers across mixed appearance settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->