### PR TITLE
Give Pi sessions stable cmux identities

### DIFF
--- a/Packages/macOS/CmuxTerminal/Sources/CmuxTerminal/Spawn/TerminalSurface+StartupEnvironment.swift
+++ b/Packages/macOS/CmuxTerminal/Sources/CmuxTerminal/Spawn/TerminalSurface+StartupEnvironment.swift
@@ -179,6 +179,11 @@ extension TerminalSurface {
                 shimDirectory: shimDirectory,
                 fileManager: fileManager
             )
+            installPiCommandShimIfPossible(
+                claudeWrapperURL: wrapperURL,
+                shimDirectory: shimDirectory,
+                fileManager: fileManager
+            )
             return ClaudeCommandShim(
                 directoryPath: shimDirectory.path,
                 executablePath: shimURL.path,
@@ -261,6 +266,62 @@ extension TerminalSurface {
             )
         } catch {
             return nil
+        }
+    }
+
+    /// Writes the per-surface `pi` wrapper shim into `shimDirectory`, if the
+    /// bundled `cmux-pi-wrapper` exists alongside `cmux-claude-wrapper`.
+    @discardableResult
+    public static func installPiCommandShimIfPossible(
+        claudeWrapperURL: URL,
+        shimDirectory: URL,
+        fileManager: FileManager = .default
+    ) -> Bool {
+        let piWrapperURL = claudeWrapperURL
+            .deletingLastPathComponent()
+            .appendingPathComponent("cmux-pi-wrapper", isDirectory: false)
+            .standardizedFileURL
+        guard fileManager.isExecutableFile(atPath: piWrapperURL.path) else {
+            return false
+        }
+
+        let shimURL = shimDirectory.appendingPathComponent("pi", isDirectory: false)
+        do {
+            let script = """
+            #!/usr/bin/env bash
+            cmux_wrapper=\(shellSingleQuoted(piWrapperURL.path))
+            if [[ ! -x "$cmux_wrapper" && -n "${CMUX_BUNDLED_CLI_PATH:-}" ]]; then
+                cmux_candidate="$(dirname "$CMUX_BUNDLED_CLI_PATH")/cmux-pi-wrapper"
+                if [[ -x "$cmux_candidate" ]]; then
+                    cmux_wrapper="$cmux_candidate"
+                fi
+            fi
+            export CMUX_PI_WRAPPER_SHIM=\(shellSingleQuoted(shimURL.path))
+            if [[ -x "$cmux_wrapper" ]]; then
+                exec "$cmux_wrapper" "$@"
+            fi
+            cmux_path_without_shim=""
+            cmux_old_ifs="$IFS"
+            IFS=:
+            for cmux_entry in ${PATH:-}; do
+                if [[ "$cmux_entry" == */cmux-cli-shims/* || "$cmux_entry" == */cmux-cli-shims ]]; then
+                    continue
+                fi
+                if [[ -z "$cmux_path_without_shim" ]]; then
+                    cmux_path_without_shim="$cmux_entry"
+                else
+                    cmux_path_without_shim="$cmux_path_without_shim:$cmux_entry"
+                fi
+            done
+            IFS="$cmux_old_ifs"
+            export PATH="$cmux_path_without_shim"
+            exec pi "$@"
+            """
+            try script.write(to: shimURL, atomically: true, encoding: .utf8)
+            try fileManager.setAttributes([.posixPermissions: 0o700], ofItemAtPath: shimURL.path)
+            return true
+        } catch {
+            return false
         }
     }
 

--- a/Packages/macOS/CmuxTerminal/Tests/CmuxTerminalTests/TerminalSurfaceCommandShimPermissionsTests.swift
+++ b/Packages/macOS/CmuxTerminal/Tests/CmuxTerminalTests/TerminalSurfaceCommandShimPermissionsTests.swift
@@ -43,4 +43,62 @@ struct TerminalSurfaceCommandShimPermissionsTests {
             #expect(permissions.uint16Value == 0o700)
         }
     }
+
+    @Test("Install creates a Pi shim beside the Claude shim")
+    func installCreatesPiShim() throws {
+        let fileManager = FileManager.default
+        let root = URL.temporaryDirectory.appending(
+            path: "TerminalSurfacePiCommandShimTests-\(UUID().uuidString)",
+            directoryHint: .isDirectory
+        )
+        let temporaryDirectory = root.appending(path: "tmp", directoryHint: .isDirectory)
+        let wrapperDirectory = root.appending(path: "bin", directoryHint: .isDirectory)
+        let claudeWrapper = wrapperDirectory.appending(
+            path: "cmux-claude-wrapper",
+            directoryHint: .notDirectory
+        )
+        let piWrapper = wrapperDirectory.appending(
+            path: "cmux-pi-wrapper",
+            directoryHint: .notDirectory
+        )
+        let log = root.appending(path: "pi.log", directoryHint: .notDirectory)
+        defer { try? fileManager.removeItem(at: root) }
+
+        try fileManager.createDirectory(at: wrapperDirectory, withIntermediateDirectories: true)
+        try "#!/bin/sh\nexit 0\n".write(to: claudeWrapper, atomically: true, encoding: .utf8)
+        try """
+        #!/bin/sh
+        printf '%s\n' "${CMUX_PI_WRAPPER_SHIM:-}" > "$CMUX_TEST_LOG"
+        printf '%s\n' "$*" >> "$CMUX_TEST_LOG"
+        """.write(to: piWrapper, atomically: true, encoding: .utf8)
+        for wrapper in [claudeWrapper, piWrapper] {
+            try fileManager.setAttributes([.posixPermissions: 0o700], ofItemAtPath: wrapper.path)
+        }
+
+        let claudeShim = try #require(
+            TerminalSurface.installClaudeCommandShimIfPossible(
+                wrapperURL: claudeWrapper,
+                surfaceId: UUID(),
+                temporaryDirectory: temporaryDirectory,
+                fileManager: fileManager
+            )
+        )
+        let piShim = URL(fileURLWithPath: claudeShim.directoryPath, isDirectory: true)
+            .appending(path: "pi", directoryHint: .notDirectory)
+        #expect(fileManager.isExecutableFile(atPath: piShim.path))
+
+        let process = Process()
+        process.executableURL = piShim
+        process.arguments = ["hello", "two words"]
+        process.environment = [
+            "PATH": "/usr/bin:/bin",
+            "CMUX_TEST_LOG": log.path,
+        ]
+        try process.run()
+        process.waitUntilExit()
+
+        #expect(process.terminationStatus == 0)
+        let output = try String(contentsOf: log, encoding: .utf8)
+        #expect(output == "\(piShim.path)\nhello two words\n")
+    }
 }

--- a/Resources/bin/cmux-pi-wrapper
+++ b/Resources/bin/cmux-pi-wrapper
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+# cmux Pi wrapper - gives each cmux terminal surface a stable Pi session id.
+
+set -u
+
+is_cmux_pi_shim() {
+    local candidate="$1"
+    if [[ -n "${CMUX_PI_WRAPPER_SHIM:-}" &&
+          -e "$candidate" &&
+          -e "$CMUX_PI_WRAPPER_SHIM" &&
+          "$candidate" -ef "$CMUX_PI_WRAPPER_SHIM" ]]; then
+        return 0
+    fi
+    case "$candidate" in
+        */cmux-cli-shims/*/pi|*/cmux-cli-shims/pi|*/Contents/Resources/bin/pi|*/Resources/bin/pi)
+            return 0
+            ;;
+    esac
+    return 1
+}
+
+find_real_pi() {
+    local wrapper_path candidate directory old_ifs
+    wrapper_path="${BASH_SOURCE[0]}"
+    old_ifs="$IFS"
+    IFS=:
+    for directory in ${PATH:-}; do
+        [[ -n "$directory" ]] || directory=.
+        candidate="$directory/pi"
+        [[ -x "$candidate" ]] || continue
+        if [[ -e "$wrapper_path" && "$candidate" -ef "$wrapper_path" ]]; then
+            continue
+        fi
+        if is_cmux_pi_shim "$candidate"; then
+            continue
+        fi
+        IFS="$old_ifs"
+        printf '%s\n' "$candidate"
+        return 0
+    done
+    IFS="$old_ifs"
+    return 1
+}
+
+supports_stable_session_ids() {
+    local version major minor
+    version="$("$REAL_PI" --version 2>/dev/null | head -n 1)"
+    version="${version#v}"
+    major="${version%%.*}"
+    version="${version#*.}"
+    minor="${version%%.*}"
+    [[ "$major" =~ ^[0-9]+$ && "$minor" =~ ^[0-9]+$ ]] || return 1
+    (( major > 0 || minor >= 84 ))
+}
+
+has_explicit_session_choice() {
+    local argument
+    for argument in "$@"; do
+        case "$argument" in
+            --session|--session=*|--session-id|--session-id=*|--fork|--fork=*|\
+            --continue|-c|--resume|-r|--no-session)
+                return 0
+                ;;
+        esac
+    done
+    return 1
+}
+
+is_utility_invocation() {
+    local first="${1:-}"
+    case "$first" in
+        install|remove|uninstall|update|list|config|auth|--help|-h|--version|-v)
+            return 0
+            ;;
+    esac
+    return 1
+}
+
+REAL_PI="$(find_real_pi)" || {
+    echo "Error: pi not found in PATH" >&2
+    exit 127
+}
+
+surface_id="${CMUX_SURFACE_ID:-}"
+if [[ -z "$surface_id" || ! "$surface_id" =~ ^[A-Za-z0-9][A-Za-z0-9._-]*$ ]] ||
+   is_utility_invocation "$@" ||
+   has_explicit_session_choice "$@" ||
+   ! supports_stable_session_ids; then
+    exec "$REAL_PI" "$@"
+fi
+
+exec "$REAL_PI" --session-id "cmux-$surface_id" "$@"

--- a/Resources/shell-integration/cmux-bash-integration.bash
+++ b/Resources/shell-integration/cmux-bash-integration.bash
@@ -420,6 +420,7 @@ _cmux_install_cli_wrapper() {
     fi
 }
 _cmux_install_cli_wrapper claude _CMUX_CLAUDE_WRAPPER cmux-claude-wrapper
+_cmux_install_cli_wrapper pi _CMUX_PI_WRAPPER cmux-pi-wrapper
 _cmux_install_cli_wrapper grok _CMUX_GROK_WRAPPER
 _cmux_now() {
     printf '%s\n' "${EPOCHSECONDS:-$SECONDS}"

--- a/Resources/shell-integration/cmux-zsh-integration.zsh
+++ b/Resources/shell-integration/cmux-zsh-integration.zsh
@@ -427,6 +427,7 @@ _cmux_install_cli_wrapper() {
     fi
 }
 _cmux_install_cli_wrapper claude _CMUX_CLAUDE_WRAPPER cmux-claude-wrapper
+_cmux_install_cli_wrapper pi _CMUX_PI_WRAPPER cmux-pi-wrapper
 _cmux_install_cli_wrapper grok _CMUX_GROK_WRAPPER
 
 _cmux_normalize_claude_config_dir() {

--- a/Resources/shell-integration/fish/config.fish
+++ b/Resources/shell-integration/fish/config.fish
@@ -415,6 +415,7 @@ if test "$_cmux_integration_enabled" != 0
     end
 
     _cmux_install_cli_wrapper claude cmux-claude-wrapper
+    _cmux_install_cli_wrapper pi cmux-pi-wrapper
     _cmux_install_cli_wrapper grok grok
 
     function _cmux_report_tty_once

--- a/Sources/App/TextBoxSubmitAction.swift
+++ b/Sources/App/TextBoxSubmitAction.swift
@@ -41,6 +41,15 @@ struct TextBoxSubmitAction: Codable, Equatable, Identifiable, Sendable {
         backgroundColorHex: "#FFFFFF"
     )
 
+    static let piAction = builtInAgentAction(
+        id: "pi",
+        title: "Pi",
+        commandPrefix: "pi --",
+        systemImage: "brain.head.profile",
+        assetName: "AgentIcons/Pi",
+        backgroundColorHex: "#D0B3FF"
+    )
+
     static let builtInActions: [TextBoxSubmitAction] = [
         builtInAgentAction(
             id: "claude",
@@ -66,14 +75,7 @@ struct TextBoxSubmitAction: Codable, Equatable, Identifiable, Sendable {
             assetName: "AgentIcons/OpenCode",
             backgroundColorHex: "#B5E48C"
         ),
-        builtInAgentAction(
-            id: "pi",
-            title: "Pi",
-            commandPrefix: "pi --",
-            systemImage: "brain.head.profile",
-            assetName: "AgentIcons/Pi",
-            backgroundColorHex: "#D0B3FF"
-        ),
+        piAction,
     ]
 
     private static func builtInAgentAction(
@@ -172,12 +174,23 @@ struct TextBoxSubmitAction: Codable, Equatable, Identifiable, Sendable {
         return command.isEmpty ? nil : command
     }
 
-    func command(forPrompt prompt: String) -> String? {
+    func command(forPrompt prompt: String, surfaceId: UUID? = nil) -> String? {
         guard kind == .commandTemplate,
               let commandTemplate,
               commandTemplate.contains(Self.promptPlaceholder),
               Self.promptPlaceholdersAreUnquoted(in: commandTemplate) else {
             return nil
+        }
+        if self == Self.piAction, let surfaceId {
+            let script = "case \"$(pi --version 2>/dev/null)\" in 0.8[4-9].*|0.9[0-9].*|[1-9]*.*) exec pi --session-id \"$1\" -- \"$2\" ;; *) exec pi -- \"$2\" ;; esac"
+            return [
+                "sh",
+                "-c",
+                Self.shellQuoted(script),
+                "sh",
+                Self.shellQuoted("cmux-\(surfaceId.uuidString)"),
+                Self.shellQuoted(prompt),
+            ].joined(separator: " ")
         }
         return commandTemplate.replacingOccurrences(
             of: Self.promptPlaceholder,

--- a/Sources/App/TextBoxSubmitAction.swift
+++ b/Sources/App/TextBoxSubmitAction.swift
@@ -44,7 +44,7 @@ struct TextBoxSubmitAction: Codable, Equatable, Identifiable, Sendable {
     static let piAction = builtInAgentAction(
         id: "pi",
         title: "Pi",
-        commandPrefix: "pi --",
+        commandPrefix: "pi",
         systemImage: "brain.head.profile",
         assetName: "AgentIcons/Pi",
         backgroundColorHex: "#D0B3FF"
@@ -182,7 +182,7 @@ struct TextBoxSubmitAction: Codable, Equatable, Identifiable, Sendable {
             return nil
         }
         if self == Self.piAction, let surfaceId {
-            let script = "case \"$(pi --version 2>/dev/null)\" in 0.8[4-9].*|0.9[0-9].*|[1-9]*.*) exec pi --session-id \"$1\" -- \"$2\" ;; *) exec pi -- \"$2\" ;; esac"
+            let script = "case \"$(pi --version 2>/dev/null)\" in 0.8[4-9].*|0.9[0-9].*|[1-9]*.*) exec pi --session-id \"$1\" \"$2\" ;; *) exec pi \"$2\" ;; esac"
             return [
                 "sh",
                 "-c",

--- a/Sources/TextBoxSubmitActions.swift
+++ b/Sources/TextBoxSubmitActions.swift
@@ -499,7 +499,8 @@ extension TextBoxInputContainer {
             shouldForceTextEntrySubmit: shouldForceTextEntrySubmit,
             allowsCommandTemplateSubmit: allowsCommandTemplateSubmit,
             terminalAgentContext: terminalAgentContext,
-            pendingProviderLaunchAction: pendingProviderLaunchAction
+            pendingProviderLaunchAction: pendingProviderLaunchAction,
+            surfaceId: surface.id
         )
     }
 
@@ -509,7 +510,8 @@ extension TextBoxInputContainer {
         shouldForceTextEntrySubmit: Bool,
         allowsCommandTemplateSubmit: Bool,
         terminalAgentContext: String,
-        pendingProviderLaunchAction: TextBoxSubmitAction?
+        pendingProviderLaunchAction: TextBoxSubmitAction?,
+        surfaceId: UUID? = nil
     ) -> SubmitDispatchPlan {
         guard !shouldForceTextEntrySubmit, allowsCommandTemplateSubmit else {
             let textEntryContext = Self.textEntryTerminalAgentContext(
@@ -525,7 +527,10 @@ extension TextBoxInputContainer {
             )
         }
 
-        guard let command = action.command(forPrompt: TextBoxSubmissionFormatter.formattedText(from: parts)) else {
+        guard let command = action.command(
+            forPrompt: TextBoxSubmissionFormatter.formattedText(from: parts),
+            surfaceId: surfaceId
+        ) else {
             let textEntryContext = Self.textEntryTerminalAgentContext(
                 allowsCommandTemplateSubmit: allowsCommandTemplateSubmit,
                 terminalAgentContext: terminalAgentContext,

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -578,6 +578,7 @@ C0DE71B10000000000000001 /* AppDelegate+AgentChatNotifications.swift in Sources 
 		B900000BA1B2C3D4E5F60719 /* cmux in Copy CLI */ = {isa = PBXBuildFile; fileRef = B9000004A1B2C3D4E5F60719 /* cmux */; };
 		C1ADE20002A1B2C3D4E5F719 /* cmux-claude-wrapper in Copy CLI */ = {isa = PBXBuildFile; fileRef = C1ADE20001A1B2C3D4E5F719 /* cmux-claude-wrapper */; };
 		C1ADE30002A1B2C3D4E5F719 /* cmux-codex-wrapper in Copy CLI */ = {isa = PBXBuildFile; fileRef = C1ADE30001A1B2C3D4E5F719 /* cmux-codex-wrapper */; };
+		C1ADE40002A1B2C3D4E5F719 /* cmux-pi-wrapper in Copy CLI */ = {isa = PBXBuildFile; fileRef = C1ADE40001A1B2C3D4E5F719 /* cmux-pi-wrapper */; };
 		A5001623 /* cmux.sdef in Resources */ = {isa = PBXBuildFile; fileRef = A5001622 /* cmux.sdef */; };
 		B9000002A1B2C3D4E5F60719 /* cmux.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9000001A1B2C3D4E5F60719 /* cmux.swift */; };
 		C0DE1A060000000000000001 /* cmux_layout.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE1A060000000000000002 /* cmux_layout.swift */; };
@@ -2689,6 +2690,7 @@ C0DE71B10000000000000001 /* AppDelegate+AgentChatNotifications.swift in Sources 
 				B900000BA1B2C3D4E5F60719 /* cmux in Copy CLI */,
 				C1ADE20002A1B2C3D4E5F719 /* cmux-claude-wrapper in Copy CLI */,
 				C1ADE30002A1B2C3D4E5F719 /* cmux-codex-wrapper in Copy CLI */,
+				C1ADE40002A1B2C3D4E5F719 /* cmux-pi-wrapper in Copy CLI */,
 				C1ADE10002A1B2C3D4E5F719 /* grok in Copy CLI */,
 					D1BEF00002A1B2C3D4E5F719 /* open in Copy CLI */,
 					C0DE70500000000000000002 /* start-cmux-profiling in Copy CLI */,
@@ -3278,6 +3280,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 		A5001018 /* cmux-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "cmux-Bridging-Header.h"; sourceTree = "<group>"; };
 		C1ADE20001A1B2C3D4E5F719 /* cmux-claude-wrapper */ = {isa = PBXFileReference; lastKnownFileType = text.script.sh; path = "Resources/bin/cmux-claude-wrapper"; sourceTree = SOURCE_ROOT; };
 		C1ADE30001A1B2C3D4E5F719 /* cmux-codex-wrapper */ = {isa = PBXFileReference; lastKnownFileType = text.script.sh; path = "Resources/bin/cmux-codex-wrapper"; sourceTree = SOURCE_ROOT; };
+		C1ADE40001A1B2C3D4E5F719 /* cmux-pi-wrapper */ = {isa = PBXFileReference; lastKnownFileType = text.script.sh; path = "Resources/bin/cmux-pi-wrapper"; sourceTree = SOURCE_ROOT; };
 		A5001000 /* cmux.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = cmux.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		A5001622 /* cmux.sdef */ = {isa = PBXFileReference; lastKnownFileType = text.sdef; path = cmux.sdef; sourceTree = "<group>"; };
 		B9000001A1B2C3D4E5F60719 /* cmux.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = cmux.swift; sourceTree = "<group>"; };
@@ -5377,6 +5380,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				A5002001 /* THIRD_PARTY_LICENSES.md */,
 					C1ADE20001A1B2C3D4E5F719 /* cmux-claude-wrapper */,
 					C1ADE30001A1B2C3D4E5F719 /* cmux-codex-wrapper */,
+					C1ADE40001A1B2C3D4E5F719 /* cmux-pi-wrapper */,
 					C1ADE10001A1B2C3D4E5F719 /* grok */,
 					C0DE70500000000000000001 /* start-cmux-profiling */,
 					C0DE70530000000000000001 /* submit-cmux-profile */,

--- a/cmuxTests/TextBoxSubmitActionTests.swift
+++ b/cmuxTests/TextBoxSubmitActionTests.swift
@@ -191,7 +191,7 @@ struct TextBoxSubmitActionTests {
 
         XCTAssertEqual(
             plan.launchCommand,
-            "sh -c 'case \"$(pi --version 2>/dev/null)\" in 0.8[4-9].*|0.9[0-9].*|[1-9]*.*) exec pi --session-id \"$1\" -- \"$2\" ;; *) exec pi -- \"$2\" ;; esac' sh 'cmux-12345678-1234-1234-1234-123456789ABC' 'keep this session'"
+            "sh -c 'case \"$(pi --version 2>/dev/null)\" in 0.8[4-9].*|0.9[0-9].*|[1-9]*.*) exec pi --session-id \"$1\" \"$2\" ;; *) exec pi \"$2\" ;; esac' sh 'cmux-12345678-1234-1234-1234-123456789ABC' 'keep this session'"
         )
     }
 
@@ -414,7 +414,7 @@ struct TextBoxSubmitActionTests {
 
         XCTAssertTrue(template.contains(#""commandTemplate" : "codex --yolo -- {{prompt}}""#))
         XCTAssertTrue(template.contains(#""commandTemplate" : "opencode --prompt {{prompt}}""#))
-        XCTAssertTrue(template.contains(#""commandTemplate" : "pi -- {{prompt}}""#))
+        XCTAssertTrue(template.contains(#""commandTemplate" : "pi {{prompt}}""#))
         XCTAssertFalse(template.contains(#""preservePromptAfterLaunch" : true"#))
     }
 

--- a/cmuxTests/TextBoxSubmitActionTests.swift
+++ b/cmuxTests/TextBoxSubmitActionTests.swift
@@ -148,6 +148,13 @@ struct TextBoxSubmitActionTests {
             try #require(actionsByID["pi"]).command(forPrompt: prompt),
             "pi -- \(quotedPrompt)"
         )
+        XCTAssertEqual(
+            try #require(actionsByID["pi"]).command(
+                forPrompt: prompt,
+                surfaceId: UUID(uuidString: "12345678-1234-1234-1234-123456789ABC")
+            ),
+            "sh -c 'case \"$(pi --version 2>/dev/null)\" in 0.8[4-9].*|0.9[0-9].*|[1-9]*.*) exec pi --session-id \"$1\" -- \"$2\" ;; *) exec pi -- \"$2\" ;; esac' sh 'cmux-12345678-1234-1234-1234-123456789ABC' \(quotedPrompt)"
+        )
         XCTAssertTrue(launchCommandsByID.isEmpty)
     }
     @Test
@@ -167,6 +174,25 @@ struct TextBoxSubmitActionTests {
         XCTAssertEqual(plan.launchCommand, expectedCommand)
         XCTAssertEqual(plan.launchContextCommand, "codex --yolo --")
         XCTAssertEqual(plan.events, TextBoxSubmit.dispatchEvents(for: [.text(expectedCommand)], terminalAgentContext: ""))
+    }
+
+    @Test
+    func testPiSubmitPlanCarriesSurfaceIdentityIntoRemoteShellCommand() {
+        let surfaceId = UUID(uuidString: "12345678-1234-1234-1234-123456789ABC")
+        let plan = TextBoxInputContainer.dispatchPlan(
+            [.text("keep this session")],
+            applying: TextBoxSubmitAction.piAction,
+            shouldForceTextEntrySubmit: false,
+            allowsCommandTemplateSubmit: true,
+            terminalAgentContext: "",
+            pendingProviderLaunchAction: nil,
+            surfaceId: surfaceId
+        )
+
+        XCTAssertEqual(
+            plan.launchCommand,
+            "sh -c 'case \"$(pi --version 2>/dev/null)\" in 0.8[4-9].*|0.9[0-9].*|[1-9]*.*) exec pi --session-id \"$1\" -- \"$2\" ;; *) exec pi -- \"$2\" ;; esac' sh 'cmux-12345678-1234-1234-1234-123456789ABC' 'keep this session'"
+        )
     }
 
     @Test

--- a/cmuxTests/TextBoxSubmitActionTests.swift
+++ b/cmuxTests/TextBoxSubmitActionTests.swift
@@ -146,14 +146,14 @@ struct TextBoxSubmitActionTests {
         )
         XCTAssertEqual(
             try #require(actionsByID["pi"]).command(forPrompt: prompt),
-            "pi -- \(quotedPrompt)"
+            "pi \(quotedPrompt)"
         )
         XCTAssertEqual(
             try #require(actionsByID["pi"]).command(
                 forPrompt: prompt,
                 surfaceId: UUID(uuidString: "12345678-1234-1234-1234-123456789ABC")
             ),
-            "sh -c 'case \"$(pi --version 2>/dev/null)\" in 0.8[4-9].*|0.9[0-9].*|[1-9]*.*) exec pi --session-id \"$1\" -- \"$2\" ;; *) exec pi -- \"$2\" ;; esac' sh 'cmux-12345678-1234-1234-1234-123456789ABC' \(quotedPrompt)"
+            "sh -c 'case \"$(pi --version 2>/dev/null)\" in 0.8[4-9].*|0.9[0-9].*|[1-9]*.*) exec pi --session-id \"$1\" \"$2\" ;; *) exec pi \"$2\" ;; esac' sh 'cmux-12345678-1234-1234-1234-123456789ABC' \(quotedPrompt)"
         )
         XCTAssertTrue(launchCommandsByID.isEmpty)
     }

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -192,6 +192,8 @@ Built-in action IDs: `claude`, `codex`, `opencode`, `pi`.
 Set `textBoxDefaultSubmitAction` to `text-entry` to force plain Text Entry for new terminals.
 Built-in provider actions shell-quote `{{prompt}}` before pasting the command. Claude may still show its workspace trust prompt before processing the prompt. Built-ins run `claude --dangerously-skip-permissions -- {{prompt}}`, `codex --yolo -- {{prompt}}`, `opencode --prompt {{prompt}}`, and `pi -- {{prompt}}`.
 
+Inside a cmux terminal, Pi 0.84 and newer automatically receives `--session-id cmux-<surface-id>`. Relaunching `pi` in the same restored surface reattaches to that project session. Explicit `--session`, `--session-id`, `--fork`, `--continue`, and `--resume` arguments keep their normal Pi behavior. Older Pi versions pass through unchanged.
+
 Action fields:
 
 - `id`: stable action ID.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -192,7 +192,7 @@ Built-in action IDs: `claude`, `codex`, `opencode`, `pi`.
 Set `textBoxDefaultSubmitAction` to `text-entry` to force plain Text Entry for new terminals.
 Built-in provider actions shell-quote `{{prompt}}` before pasting the command. Claude may still show its workspace trust prompt before processing the prompt. Built-ins run `claude --dangerously-skip-permissions -- {{prompt}}`, `codex --yolo -- {{prompt}}`, `opencode --prompt {{prompt}}`, and `pi -- {{prompt}}`.
 
-Inside a cmux terminal, Pi 0.84 and newer automatically receives `--session-id cmux-<surface-id>`. Relaunching `pi` in the same restored surface reattaches to that project session. Explicit `--session`, `--session-id`, `--fork`, `--continue`, and `--resume` arguments keep their normal Pi behavior. Older Pi versions pass through unchanged.
+Pi 0.84 and newer automatically receives `--session-id cmux-<surface-id>`. The built-in Pi action renders the ID into its command, including inside an SSH shell. Local hand-typed `pi` commands receive it through cmux's wrapper. Relaunching Pi in the same restored surface reattaches to that project session. Explicit `--session`, `--session-id`, `--fork`, `--continue`, and `--resume` arguments keep their normal Pi behavior. Older Pi versions pass through unchanged.
 
 Action fields:
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -190,7 +190,7 @@ Press Shift-Tab in the TextBox to cycle the default action. This shortcut is `sh
 Built-in action IDs: `claude`, `codex`, `opencode`, `pi`.
 
 Set `textBoxDefaultSubmitAction` to `text-entry` to force plain Text Entry for new terminals.
-Built-in provider actions shell-quote `{{prompt}}` before pasting the command. Claude may still show its workspace trust prompt before processing the prompt. Built-ins run `claude --dangerously-skip-permissions -- {{prompt}}`, `codex --yolo -- {{prompt}}`, `opencode --prompt {{prompt}}`, and `pi -- {{prompt}}`.
+Built-in provider actions shell-quote `{{prompt}}` before pasting the command. Claude may still show its workspace trust prompt before processing the prompt. Built-ins run `claude --dangerously-skip-permissions -- {{prompt}}`, `codex --yolo -- {{prompt}}`, `opencode --prompt {{prompt}}`, and `pi {{prompt}}`.
 
 Pi 0.84 and newer automatically receives `--session-id cmux-<surface-id>`. The built-in Pi action renders the ID into its command, including inside an SSH shell. Local hand-typed `pi` commands receive it through cmux's wrapper. Relaunching Pi in the same restored surface reattaches to that project session. Explicit `--session`, `--session-id`, `--fork`, `--continue`, and `--resume` arguments keep their normal Pi behavior. Older Pi versions pass through unchanged.
 

--- a/tests/test_pi_wrapper_session_id.py
+++ b/tests/test_pi_wrapper_session_id.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import os
+import subprocess
+import tempfile
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+WRAPPER = ROOT / "Resources" / "bin" / "cmux-pi-wrapper"
+
+
+def write_fake_pi(directory: Path, version: str) -> Path:
+    executable = directory / "pi"
+    executable.write_text(
+        f"""#!/bin/sh
+if [ "${{1:-}}" = "--version" ]; then
+  printf '%s\\n' '{version}'
+  exit 0
+fi
+printf '%s\\n' "$@"
+""",
+        encoding="utf-8",
+    )
+    executable.chmod(0o755)
+    return executable
+
+
+def run_wrapper(
+    fake_bin: Path,
+    arguments: list[str],
+    *,
+    surface_id: str | None,
+) -> subprocess.CompletedProcess[str]:
+    environment = {
+        "HOME": os.environ.get("HOME", str(ROOT)),
+        "PATH": f"{fake_bin}:/usr/bin:/bin",
+    }
+    if surface_id is not None:
+        environment["CMUX_SURFACE_ID"] = surface_id
+    return subprocess.run(
+        [str(WRAPPER), *arguments],
+        env=environment,
+        capture_output=True,
+        text=True,
+        timeout=10,
+        check=False,
+    )
+
+
+def output_lines(result: subprocess.CompletedProcess[str]) -> list[str]:
+    assert result.returncode == 0, result.stderr
+    return result.stdout.splitlines()
+
+
+def test_assigns_stable_surface_session_id() -> None:
+    with tempfile.TemporaryDirectory(prefix="cmux-pi-wrapper-") as temporary:
+        fake_bin = Path(temporary)
+        write_fake_pi(fake_bin, "0.84.0")
+
+        first = run_wrapper(fake_bin, ["hello"], surface_id="ABCD-1234")
+        second = run_wrapper(fake_bin, ["again"], surface_id="ABCD-1234")
+
+        assert output_lines(first) == ["--session-id", "cmux-ABCD-1234", "hello"]
+        assert output_lines(second) == ["--session-id", "cmux-ABCD-1234", "again"]
+
+
+def test_preserves_explicit_session_choices() -> None:
+    with tempfile.TemporaryDirectory(prefix="cmux-pi-wrapper-") as temporary:
+        fake_bin = Path(temporary)
+        write_fake_pi(fake_bin, "0.84.0")
+
+        resumed = run_wrapper(
+            fake_bin,
+            ["--session", "known-session"],
+            surface_id="ABCD-1234",
+        )
+        custom = run_wrapper(
+            fake_bin,
+            ["--session-id=custom-session", "hello"],
+            surface_id="ABCD-1234",
+        )
+
+        assert output_lines(resumed) == ["--session", "known-session"]
+        assert output_lines(custom) == ["--session-id=custom-session", "hello"]
+
+
+def test_degrades_for_older_pi_and_non_cmux_shells() -> None:
+    with tempfile.TemporaryDirectory(prefix="cmux-pi-wrapper-") as temporary:
+        fake_bin = Path(temporary)
+        write_fake_pi(fake_bin, "0.83.2")
+        old_pi = run_wrapper(fake_bin, ["hello"], surface_id="ABCD-1234")
+
+        write_fake_pi(fake_bin, "0.84.0")
+        outside_cmux = run_wrapper(fake_bin, ["hello"], surface_id=None)
+
+        assert output_lines(old_pi) == ["hello"]
+        assert output_lines(outside_cmux) == ["hello"]


### PR DESCRIPTION
## Summary

- give Pi 0.84+ a stable session ID derived from the cmux surface
- preserve explicit Pi session choices and fall back unchanged on older Pi versions
- carry the same identity through the built-in TextBox action, including interactive SSH shells
- remove Pi's unsupported `--` prompt separator

## Verification

- `python3 -m pytest -q tests/test_pi_wrapper_session_id.py`, 3 passed
- `swift test --package-path Packages/macOS/CmuxTerminal --skip-build --filter TerminalSurfaceCommandShimPermissionsTests`, 2 passed
- Xcode project and workspace policy checks passed
- tagged cloud reload `pisess` passed
- visible TextBox launch passed and a cmux restart restored the same transcript
- hosted `TextBoxSubmitActionTests`, 50 passed: https://github.com/manaflow-ai/cmux/actions/runs/31147883068

The focused hosted UI test could not activate the app on Blacksmith, Warp, or the isolated Tart VM. Each run stopped at `Running Background` before reaching TextBox; local Computer Use covered the same visible path.