### PR TITLE
Register-when-ready Iroh hosts, bounded dial phases, cold-start release gate

### DIFF
--- a/.github/workflows/iroh-release-gate.yml
+++ b/.github/workflows/iroh-release-gate.yml
@@ -19,6 +19,7 @@ on:
           - relay-expiry
           - direct-only
           - private-path
+          - cold-start
 
 permissions:
   contents: read
@@ -59,7 +60,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        mode: ${{ fromJSON(inputs.mode == 'all' && '["automatic","relay-only","relay-expiry","direct-only","private-path"]' || format('["{0}"]', inputs.mode)) }}
+        mode: ${{ fromJSON(inputs.mode == 'all' && '["automatic","relay-only","relay-expiry","direct-only","private-path","cold-start"]' || format('["{0}"]', inputs.mode)) }}
     runs-on: ${{ vars.MACOS_RUNNER_STREAMED_VALIDATION || 'warp-macos-15-arm64-6x' }}
     timeout-minutes: 120
     steps:

--- a/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohClientSession.swift
+++ b/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohClientSession.swift
@@ -6,6 +6,12 @@ public actor CmxIrohClientSession {
     public typealias PrivateFallbackContextProvider = @Sendable () async throws -> CmxIrohClientContext
 
     private let endpoint: any CmxIrohEndpoint
+    /// Bound on each dial phase. A peer that has not answered by then is
+    /// almost always a stale-hint or half-ready target (issue 9724 recorded a
+    /// 16s hang against a just-relaunched Mac); failing fast hands control to
+    /// the retry layer, which redials with fresher hints. Cancellation crosses
+    /// the FFI boundary, so the raced attempt aborts promptly.
+    private let dialPhaseTimeout: Duration
     private let targetIdentity: CmxIrohPeerIdentity
     private let dialPlan: CmxIrohDialPlan
     private let credential: CmxIrohAdmissionCredential
@@ -44,6 +50,7 @@ public actor CmxIrohClientSession {
         privateFallbackAuthorization: CmxIrohPrivateFallbackAuthorization? = nil,
         privateFallbackValidator: (any CmxIrohPrivateFallbackValidating)? = nil,
         privateFallbackContextProvider: PrivateFallbackContextProvider? = nil,
+        dialPhaseTimeout: Duration = .seconds(5),
         protocolConfiguration: CmxIrohProtocolConfiguration = .cmuxMobileV1
     ) throws {
         self.endpoint = endpoint
@@ -53,6 +60,7 @@ public actor CmxIrohClientSession {
         self.privateFallbackAuthorization = privateFallbackAuthorization
         self.privateFallbackValidator = privateFallbackValidator
         self.privateFallbackContextProvider = privateFallbackContextProvider
+        self.dialPhaseTimeout = dialPhaseTimeout
         self.protocolConfiguration = protocolConfiguration
         headerCodec = try CmxIrohStreamHeaderCodec(configuration: protocolConfiguration)
     }
@@ -278,17 +286,42 @@ public actor CmxIrohClientSession {
         controlReceiveBuffer.removeAll(keepingCapacity: false)
     }
 
+    /// Dials one address within `dialPhaseTimeout`, cancelling the attempt at
+    /// the bound so it cannot outlive the budget on a hung or stale path.
+    private func connectBounded(
+        to address: CmxIrohEndpointAddress
+    ) async throws -> any CmxIrohConnection {
+        let endpoint = endpoint
+        let alpn = protocolConfiguration.alpn
+        let bound = dialPhaseTimeout
+        return try await withThrowingTaskGroup(
+            of: (any CmxIrohConnection)?.self
+        ) { group in
+            group.addTask {
+                try await endpoint.connect(to: address, alpn: alpn)
+            }
+            group.addTask {
+                try await ContinuousClock().sleep(for: bound)
+                return nil
+            }
+            defer { group.cancelAll() }
+            guard let first = try await group.next(), let connection = first else {
+                throw CmxIrohClientSessionError.dialTimedOut
+            }
+            return connection
+        }
+    }
+
     private func establishConnection() async throws -> CmxIrohConnectedControl {
         var establishedConnection: (any CmxIrohConnection)?
         var publicConnectionError: (any Error)?
         if !dialPlan.publicPaths.isEmpty {
             do {
-                establishedConnection = try await endpoint.connect(
+                establishedConnection = try await connectBounded(
                     to: CmxIrohEndpointAddress(
                         identity: targetIdentity,
                         pathHints: dialPlan.publicPaths
-                    ),
-                    alpn: protocolConfiguration.alpn
+                    )
                 )
             } catch {
                 try Task.checkCancellation()
@@ -326,12 +359,11 @@ public actor CmxIrohClientSession {
                 authorization
             )
             try Task.checkCancellation()
-            establishedConnection = try await endpoint.connect(
+            establishedConnection = try await connectBounded(
                 to: CmxIrohEndpointAddress(
                     identity: targetIdentity,
                     pathHints: fallbackPaths
-                ),
-                alpn: protocolConfiguration.alpn
+                )
             )
         }
         guard let establishedConnection else {

--- a/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohClientSessionError.swift
+++ b/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohClientSessionError.swift
@@ -12,6 +12,9 @@ public enum CmxIrohClientSessionError: Error, Equatable, Sendable {
     /// A role-invalid frame appeared during the admission barrier.
     case invalidAdmissionFrame
 
+    /// A dial phase exceeded its bound before the peer answered.
+    case dialTimedOut
+
     /// An operation required an admitted control stream.
     case notConnected
 

--- a/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohDiagnosticFailure.swift
+++ b/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohDiagnosticFailure.swift
@@ -176,6 +176,8 @@ extension CmxIrohClientSessionError: DiagnosticFailureProviding {
             .identityMismatch
         case .admissionDenied:
             .admissionDenied
+        case .dialTimedOut:
+            .timedOut
         case .alreadyClosed, .notConnected, .unexpectedEndOfStream:
             .connectionClosed
         case .invalidAdmissionFrame, .invalidMaximumByteCount,

--- a/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohHostRuntime.swift
+++ b/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohHostRuntime.swift
@@ -74,6 +74,10 @@ public actor CmxIrohHostRuntime {
     let registrationClock: any CmxIrohRelayClock
     let registrationRetrySchedule: CmxIrohRetrySchedule
     let registrationRetryJitter: @Sendable () -> Double
+    /// How long automatic-mode startup waits for relay attachment before
+    /// publishing the bootstrap binding anyway. Correctness over liveness only
+    /// within this bound; a timeout never fails activation.
+    let automaticRelayReadinessTimeout: Duration
     let handleTransport: TransportHandler
     let handleBinding: BindingHandler
     let handleRoute: RouteHandler
@@ -129,6 +133,7 @@ public actor CmxIrohHostRuntime {
         registrationRetryJitter: @escaping @Sendable () -> Double = {
             Double.random(in: 0 ... 1)
         },
+        automaticRelayReadinessTimeout: Duration = .seconds(5),
         handleTransport: @escaping TransportHandler,
         handleBinding: @escaping BindingHandler = { _, _, _ in },
         handleRoute: @escaping RouteHandler = { _, _ in },
@@ -147,6 +152,7 @@ public actor CmxIrohHostRuntime {
         self.registrationClock = registrationClock
         self.registrationRetrySchedule = registrationRetrySchedule
         self.registrationRetryJitter = registrationRetryJitter
+        self.automaticRelayReadinessTimeout = automaticRelayReadinessTimeout
         self.handleTransport = handleTransport
         self.handleBinding = handleBinding
         self.handleRoute = handleRoute
@@ -275,6 +281,7 @@ public actor CmxIrohHostRuntime {
                 bindingID: policy.binding.bindingID
             )
             var publishedPolicy = policy
+            var relayActivatedDuringStart = false
             let requiresRelayReadiness = !protocolConfiguration
                 .allowsNATTraversalAfterAdmission
             if requiresRelayReadiness {
@@ -314,6 +321,58 @@ public actor CmxIrohHostRuntime {
                 // The online event that released the barrier is already folded
                 // into `readyPolicy`; do not immediately publish a third copy.
                 registrationRefreshPending = false
+            } else if let relayCoordinator {
+                // Register-when-ready for automatic mode: the bootstrap
+                // registration above happens before relay attachment, so its
+                // advertised hints describe a half-ready endpoint that phones
+                // dial and lose against (issue 9724). Start relay activation
+                // now (async, its coordinator owns retries exactly as in the
+                // scheduled path below) and give the relay a bounded window
+                // to become usable so the first published binding carries
+                // dialable hints. Unlike the strict relay-only barrier,
+                // nothing here may fail or stall activation: on timeout or
+                // broker error the bootstrap policy stands and the standard
+                // refresh-on-online path repairs the registration.
+                scheduleRelayActivation(
+                    relayCoordinator,
+                    binding: policy.binding,
+                    endpointID: endpointID,
+                    bootstrap: policy.relayBootstrap,
+                    revision: revision
+                )
+                relayActivatedDuringStart = true
+                do {
+                    try await connectivityEngine.waitForUsableHomeRelay(
+                        timeout: automaticRelayReadinessTimeout
+                    )
+                    try requireCurrent(revision)
+                    let readyPolicy = try await resolvePolicy(
+                        engine: connectivityEngine,
+                        expectedEndpointID: endpointID,
+                        revision: revision,
+                        allowCachedFallback: false
+                    )
+                    try requireCurrent(revision)
+                    if readyPolicy.binding.bindingID == policy.binding.bindingID {
+                        await admissionController.update(
+                            keys: readyPolicy.grantVerificationKeys,
+                            acceptor: grantPeer(for: readyPolicy.binding),
+                            pairingEnabled: readyPolicy.pairingEnabled
+                        )
+                        try requireCurrent(revision)
+                        localBinding = readyPolicy.binding
+                        endpointAttestation = readyPolicy.attestation
+                            ?? endpointAttestation
+                        lanRendezvous = readyPolicy.lanRendezvous
+                        publishedPolicy = readyPolicy
+                        registrationRefreshPending = false
+                    }
+                } catch is CancellationError {
+                    throw CancellationError()
+                } catch {
+                    // Supersession still aborts; readiness failures do not.
+                    try requireCurrent(revision)
+                }
             }
             let publishedFreshBinding: Bool
             if let registration = publishedPolicy.registration,
@@ -355,7 +414,8 @@ public actor CmxIrohHostRuntime {
                 registrationRefreshPending = false
                 scheduleRegistrationRefresh(revision: revision)
             }
-            if let relayCoordinator, !requiresRelayReadiness {
+            if let relayCoordinator, !requiresRelayReadiness,
+               !relayActivatedDuringStart {
                 scheduleRelayActivation(
                     relayCoordinator,
                     binding: policy.binding,

--- a/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohClientSessionTests.swift
+++ b/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohClientSessionTests.swift
@@ -15,6 +15,27 @@ struct CmxIrohClientSessionTests {
         credential = try .pairGrant("e30.e30.AA")
     }
 
+    @Test("a hung dial fails at the phase bound instead of hanging")
+    func hungDialFailsAtThePhaseBound() async throws {
+        let endpoint = TestDialingIrohEndpoint(
+            localIdentity: localIdentity,
+            dialResults: [.hang]
+        )
+        let session = try CmxIrohClientSession(
+            endpoint: endpoint,
+            targetIdentity: remoteIdentity,
+            dialPlan: try testIrohDialPlan(publicPaths: [try publicRelayHint()]),
+            credential: credential,
+            dialPhaseTimeout: .milliseconds(40)
+        )
+        let clock = ContinuousClock()
+        let started = clock.now
+        await #expect(throws: CmxIrohClientSessionError.dialTimedOut) {
+            try await session.connect()
+        }
+        #expect(clock.now - started < .seconds(2))
+    }
+
     @Test
     func publicDialAdmitsControlAndPreservesFollowingRPCBytes() async throws {
         let events = TestIrohEventRecorder()

--- a/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohHostRuntimeLifecycleRaceTests.swift
+++ b/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohHostRuntimeLifecycleRaceTests.swift
@@ -107,16 +107,20 @@ extension CmxIrohHostRuntimeTests {
             ),
             configuration: fixture.configuration,
             pendingRevocations: fixture.pendingRevocations(),
+            // The in-start readiness pass may wait this long for the relay,
+            // but a hung credential installation must never block activation
+            // or binding publication beyond it.
+            automaticRelayReadinessTimeout: .milliseconds(20),
             handleTransport: { session, _ in await session.close() },
             handleBinding: { _, _, _ in await bindings.record() }
         )
         let start = Task { try await runtime.start() }
         await gate.waitUntilSuspended()
 
+        try await start.value
         #expect(await bindings.count() == 1)
 
         await gate.resume()
-        try await start.value
         await runtime.stop()
     }
 

--- a/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohHostRuntimeTests.swift
+++ b/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohHostRuntimeTests.swift
@@ -85,8 +85,7 @@ struct CmxIrohHostRuntimeTests {
             registrationBinding: fixture.binding,
             discovery: fixture.discovery,
             subsequentRegistrationBindings: [readyBinding],
-            subsequentDiscoveries: [readyDiscovery],
-            relayIssueHook: { await endpoint.emit(.online) }
+            subsequentDiscoveries: [readyDiscovery]
         )
         let routes = HostRuntimeRouteRecorder()
         let runtime = CmxIrohHostRuntime(
@@ -97,11 +96,13 @@ struct CmxIrohHostRuntimeTests {
             handleTransport: { session, _ in await session.close() },
             handleRoute: { binding, pathHints in
                 await routes.record(binding: binding, pathHints: pathHints)
-            }
+            },
+            handleRelayCredential: { _, _ in await endpoint.emit(.online) }
         )
 
         try await runtime.start()
 
+        #expect(await broker.observedRelayIssueCount() == 1)
         let published = await routes.values()
         let firstHints = try #require(published.first?.pathHints)
         #expect(

--- a/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohHostRuntimeTests.swift
+++ b/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohHostRuntimeTests.swift
@@ -62,6 +62,56 @@ struct CmxIrohHostRuntimeTests {
         await runtime.stop()
     }
 
+    @Test("automatic startup publishes relay-ready hints, not the bootstrap snapshot")
+    func automaticStartupPublishesRelayReadyHints() async throws {
+        let fixture = try HostRuntimeFixture()
+        let now = Date()
+        let readyBinding = try HostRuntimeFixture.binding(
+            endpointID: fixture.endpointID.endpointID,
+            publicHintObservedAt: now,
+            publicHintExpiresAt: now.addingTimeInterval(30 * 60)
+        )
+        let readyDiscovery = try HostRuntimeFixture.discovery(
+            binding: readyBinding,
+            relays: HostRuntimeFixture.relayURLs,
+            revision: 2
+        )
+        let endpoint = TestIrohEndpoint(identity: fixture.endpointID)
+        // The broker's bootstrap round returns a binding with no usable path
+        // hints (the endpoint has not attached to its home relay yet); the
+        // post-attach round returns the relay-hinted binding. Relay token
+        // issuance is the earliest moment the endpoint can come online.
+        let broker = TestIrohHostBroker(
+            registrationBinding: fixture.binding,
+            discovery: fixture.discovery,
+            subsequentRegistrationBindings: [readyBinding],
+            subsequentDiscoveries: [readyDiscovery],
+            relayIssueHook: { await endpoint.emit(.online) }
+        )
+        let routes = HostRuntimeRouteRecorder()
+        let runtime = CmxIrohHostRuntime(
+            factory: TestIrohEndpointFactory(endpoints: [endpoint]),
+            broker: broker,
+            configuration: fixture.configuration,
+            pendingRevocations: fixture.pendingRevocations(),
+            handleTransport: { session, _ in await session.close() },
+            handleRoute: { binding, pathHints in
+                await routes.record(binding: binding, pathHints: pathHints)
+            }
+        )
+
+        try await runtime.start()
+
+        let published = await routes.values()
+        let firstHints = try #require(published.first?.pathHints)
+        #expect(
+            firstHints.contains { $0.kind == .relayURL },
+            "the binding advertised at activation must carry post-relay-attach hints"
+        )
+        #expect(await broker.observedRegistrationCount() == 2)
+        await runtime.stop()
+    }
+
     @Test
     func unavailableRelayPolicyStillAllowsDirectDiscovery() async throws {
         let fixture = try HostRuntimeFixture()

--- a/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/TestDialingIrohEndpoint.swift
+++ b/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/TestDialingIrohEndpoint.swift
@@ -31,7 +31,7 @@ actor TestDialingIrohEndpoint: CmxIrohEndpoint {
     func connect(
         to address: CmxIrohEndpointAddress,
         alpn _: Data
-    ) throws -> any CmxIrohConnection {
+    ) async throws -> any CmxIrohConnection {
         dialedAddresses.append(address)
         guard !dialResults.isEmpty else {
             throw TestIrohTransportError.unsupported
@@ -41,6 +41,9 @@ actor TestDialingIrohEndpoint: CmxIrohEndpoint {
             return connection
         case let .failure(error):
             throw error
+        case .hang:
+            try await Task.sleep(for: .seconds(3600))
+            throw TestIrohTransportError.unsupported
         }
     }
 

--- a/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/TestIrohDialResult.swift
+++ b/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/TestIrohDialResult.swift
@@ -1,4 +1,7 @@
 enum TestIrohDialResult {
     case connection(TestIrohConnection)
     case failure(TestIrohTransportError)
+    /// Suspends until the dial attempt is cancelled, like a peer that never
+    /// answers on a stale path hint.
+    case hang
 }

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShellReleaseGateSupport/MobileIrohReleaseGateScenario.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShellReleaseGateSupport/MobileIrohReleaseGateScenario.swift
@@ -7,5 +7,8 @@ public enum MobileIrohReleaseGateScenario: String, Equatable, Sendable {
     case relayRollover = "relay_rollover"
     /// Hold the initial credential and require the relay to close at expiry.
     case relayExpiry = "relay_expiry"
+    /// Dial a Mac that launched moments ago; the orchestrator enforces the
+    /// launch-to-usable-session deadline, this scenario marks the report.
+    case coldStartDial = "cold_start_dial"
 }
 #endif

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShellReleaseGateSupport/MobileShellComposite+IrohReleaseGate.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShellReleaseGateSupport/MobileShellComposite+IrohReleaseGate.swift
@@ -67,7 +67,9 @@ extension MobileShellComposite {
         var unrefreshedExpiryDisconnectVerified = false
 
         switch scenario {
-        case .standard:
+        case .standard, .coldStartDial:
+            // Cold-start proves the same usable-session legs as standard;
+            // its timing assertion lives at the orchestrator script layer.
             try await verifyReversibleWorkspaceRename(
                 workspace: workspace,
                 marker: marker

--- a/ios/cmuxPackage/Sources/CmuxIrohReleaseGateSupport/MobileIrohReleaseGateRunner.swift
+++ b/ios/cmuxPackage/Sources/CmuxIrohReleaseGateSupport/MobileIrohReleaseGateRunner.swift
@@ -49,7 +49,9 @@ final class MobileIrohReleaseGateRunner {
             } else {
                 scenario = .standard
             }
-            guard scenario == .standard || mode == .relayOnly else { return nil }
+            guard scenario == .standard
+                || scenario == .coldStartDial
+                || mode == .relayOnly else { return nil }
             self.mode = mode
             self.scenario = scenario
             self.reportURL = cachesDirectory.appendingPathComponent(Self.reportFilename)
@@ -168,6 +170,7 @@ final class MobileIrohReleaseGateRunner {
                 Self.postReportReadyNotification()
             },
             timeout: configuration.scenario == .standard
+                || configuration.scenario == .coldStartDial
                 ? Self.standardTimeout
                 : Self.extendedTimeout
         )
@@ -501,6 +504,10 @@ final class MobileIrohReleaseGateRunner {
     ) -> Bool {
         switch scenario {
         case .standard:
+            return true
+        case .coldStartDial:
+            // The launch-to-usable deadline is enforced by the orchestrator
+            // script; the report only proves the session was genuinely usable.
             return true
         case .relayRollover:
             return probe.relayCredentialRolloverVerified

--- a/ios/cmuxPackage/Tests/cmuxFeatureTests/MobileIrohReleaseGateRunnerTests.swift
+++ b/ios/cmuxPackage/Tests/cmuxFeatureTests/MobileIrohReleaseGateRunnerTests.swift
@@ -10,6 +10,16 @@ import Testing
 @MainActor
 struct MobileIrohReleaseGateRunnerTests {
     @Test
+    func coldStartDialScenarioIsAdmittedWithAutomaticMode() throws {
+        let configuration = try temporaryConfiguration(
+            mode: .automatic,
+            scenario: .coldStartDial
+        )
+        #expect(configuration.scenario == .coldStartDial)
+        #expect(configuration.mode == .automatic)
+    }
+
+    @Test
     func taskRestartReusesOneRunAndOneReportWrite() async throws {
         let configuration = try temporaryConfiguration(mode: .relayOnly)
         let probeStarted = AsyncStream<Void>.makeStream(

--- a/scripts/run-iroh-release-gate.sh
+++ b/scripts/run-iroh-release-gate.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 usage() {
   cat <<'EOF'
-Usage: scripts/run-iroh-release-gate.sh --mode <automatic|relay-only|relay-expiry|direct-only|private-path> --tag <tag>
+Usage: scripts/run-iroh-release-gate.sh --mode <automatic|relay-only|relay-expiry|direct-only|private-path|cold-start> --tag <tag>
        [--staging-base-url <url>] [--presence-base-url <url>]
        [--skip-build] [--keep-simulator]
        [--report-output <path>] [--print-plan]
@@ -83,6 +83,11 @@ case "$MODE" in
   relay-expiry) RAW_MODE="relayOnly"; GATE_SCENARIO="relay_expiry"; GATE_PLAN="app-rpc" ;;
   direct-only) RAW_MODE="directOnly"; GATE_SCENARIO="standard"; GATE_PLAN="simulator-direct-transport" ;;
   private-path) RAW_MODE=""; GATE_SCENARIO="standard"; GATE_PLAN="host-private-path-transport" ;;
+  # Launch-dial regression gate (issue 9724): the tagged Mac is relaunched
+  # fresh above, and the phone must reach a usable RPC session against that
+  # still-warming Mac inside a pinned deadline. A half-ready registration or
+  # an unbounded dial blows the deadline and fails the gate.
+  cold-start) RAW_MODE="automatic"; GATE_SCENARIO="cold_start_dial"; GATE_PLAN="app-rpc" ;;
   *) echo "error: invalid mode '$MODE'" >&2; exit 2 ;;
 esac
 
@@ -546,6 +551,13 @@ MOBILE_LAUNCH_ARGS=(
 )
 if [[ "$PRODUCTION" -eq 1 ]]; then
   MOBILE_LAUNCH_ARGS+=(--credentials-file "$PROD_CREDENTIALS_FILE")
+fi
+# cold_start_dial pins the launch-to-usable deadline explicitly so the
+# assertion cannot drift with the helper's ambient default: launch, sign-in,
+# broker registration, discovery, dial, and admission against the freshly
+# relaunched Mac must all complete inside it.
+if [[ "$GATE_SCENARIO" == "cold_start_dial" ]]; then
+  export CMUX_ATTACH_READY_TIMEOUT_SECONDS=20
 fi
 CMUX_ATTACH_MINT_MAX_ATTEMPTS=600 \
 CMUX_IROH_RELEASE_GATE_SCENARIO="$GATE_SCENARIO" \


### PR DESCRIPTION
Fixes https://github.com/manaflow-ai/cmux/issues/9724 in three layers.

Summary
- Mac register-when-ready: automatic-mode host startup starts relay activation eagerly and gives the relay a bounded window (`automaticRelayReadinessTimeout`, default 5s) to become usable, so the binding published at activation carries post-attach dialable hints instead of the half-ready bootstrap snapshot phones were racing. Only the cancellation-safe `waitForUsableHomeRelay` is awaited; timeout, broker error, or a hung credential install publishes the bootstrap policy exactly as before and leaves repair to the standard refresh-on-online path. Direct-only startup still skips readiness; the strict relay-only barrier is unchanged.
- Bounded dial phases: `CmxIrohClientSession.establishConnection` awaited `endpoint.connect` with no clock on either the public or the private-fallback phase, which is where the dogfood trace burned a 16.2s hang against stale hints. Each phase now races the fork's cancellable ConnectAttempt against `dialPhaseTimeout` (default 5s); expiry cancels the FFI dial promptly, surfaces `dialTimedOut` (diagnostic kind `timedOut`), and a timed-out public phase still falls through to the private fallback.
- Cold-start release gate: new `--mode cold-start` (`GATE_SCENARIO=cold_start_dial`) pins the launch-to-usable deadline to 20s on the gate's phone launch against the freshly relaunched Mac, making this race a permanent tripwire. Also selectable in the iroh-release-gate workflow matrix.

Evidence base: decoded cmuxdiag timeline from the PR 9430 dogfood round (discovery succeeded at t+7s; dial 1 connected then failed pairing after 7.6s; dial 2 hung 16.2s; dial 3 connected in 455ms; usable at ~t+43s), full decode in the issue.

Verification
- Red/green regression pair for register-when-ready: commit 6c2984a123 adds the failing test (automatic startup published bootstrap hints, one registration), commit feb58d3407 turns it green.
- swift test --package-path Packages/Shared/CmuxIrohTransport: 572 tests, 64 suites, all pass, including the new hung-dial bound test and the credential-installation race test updated to the bounded contract.
- swift build --package-path Packages/iOS/CmuxMobileShell compiles the new scenario case.

Build and behavior verification (2026-08-07, tag irdy)
- The app-target build caught a non-exhaustive scenario switch in the release-gate probe, fixed in 1cd310bef7 (cold-start reuses the standard probe legs).
- macOS + iOS simulator builds green on tag irdy; sim app signed in and attached to the tagged Mac (workspace list live).
- Behavior preflight of the fixed path: quit and relaunch the tagged Mac with the sim app open; the sim's terminal-events subscription re-established 22s after relaunch, including full Mac cold start, with no hung-dial churn. The pre-fix baseline on tag asrm was 70+ seconds with a 16.2s transportDialFailed hang (https://github.com/manaflow-ai/cmux/issues/9724).
- iPhone: dev.cmux.ios.irdy built, signed, and installed on the personal iPhone; the signed launch retry is pending the phone being awake.

Pending verification
- Runner admission test for the new scenario: hosted iOS lane dispatched at head 1cd310bef7 (plus the PR 9668 test-compile fix on throwaway branch ci-irdy-gate-verify): https://github.com/manaflow-ai/cmux/actions/runs/31215706452
- A cold-start gate run (`--mode cold-start`) on this branch.
- Dogfood round on the phone.

Deferred (documented in the issue)
- Server-side `ready` flag on iroh_endpoint_bindings needs a schema migration via the cloud-vm-ops flow; this PR is client-only.
- Between-retry hint re-fetch on iOS (registry context provider snapshot caches) is the remaining Layer 2 half, follow-up PR.

Notes
- no autoreview, Codex review, Claude review, or second-model review was invoked

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/9752"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788668280&installation_model_id=21920&pr_number=9752&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F9752&signature=b7b328dad71162ac937be9885dfd71cb707f8d9a6af469f2189bdd69b70a69bd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 1592f48833fe8d2bd4fe3785c85c96c909d03e7e. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents long post-restart dial hangs by publishing relay-ready hints during automatic host startup and by bounding each dial phase. Adds a cold-start release gate that relaunches the Mac and enforces a 20s launch-to-usable deadline via the orchestrator.

- **Bug Fixes**
  - Automatic-mode `CmxIrohHostRuntime` eagerly activates relay and waits up to 5s for readiness before publishing; on timeout/error it publishes bootstrap and refreshes later. Direct-only behavior is unchanged.
  - `CmxIrohClientSession` bounds each dial phase with `dialPhaseTimeout` (default 5s); expiry cancels the connect, surfaces `dialTimedOut`, and public timeouts still fall back to private paths.
  - Diagnostic mapping adds `.timedOut` for `dialTimedOut`.

- **New Features**
  - Release-gate mode `cold-start` (`cold_start_dial`) with a 20s launch-to-usable deadline; added to the workflow matrix, runner admission, probe switch, and `scripts/run-iroh-release-gate.sh`. The probe reuses standard usability checks; timing is enforced by the script.

<sup>Written for commit 1cd310bef7e12f5063f3e994398ec42651b2ab0f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/9752?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added cold-start release-gate testing for recently launched devices.
  - Added configurable connection and relay-readiness timeouts.
  - Added explicit timeout reporting for connection attempts.
  - Improved automatic relay startup and route publication.

- **Bug Fixes**
  - Prevented stalled connections from blocking session establishment.
  - Improved startup when relay credentials or bindings are temporarily unavailable.

- **Tests**
  - Added coverage for stalled dialing, cold-start scenarios, relay readiness, and startup lifecycle races.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
