### PR TITLE
Honor Team subscriptions for hosted coderouter

### DIFF
--- a/web/app/api/coderouter/session/route.ts
+++ b/web/app/api/coderouter/session/route.ts
@@ -1,5 +1,5 @@
 import { env } from "../../../env";
-import { hasActiveStripeProSubscription } from "../../../../services/billing/pro";
+import { hasActiveCoderouterSubscription } from "../../../../services/billing/pro";
 import {
   authenticateRouteToken,
   issueRouteToken,
@@ -18,14 +18,14 @@ export const dynamic = "force-dynamic";
 
 type SessionDependencies = {
   readonly resolveContext: typeof resolveCodeRouterRequestContext;
-  readonly hasActivePro: typeof hasActiveStripeProSubscription;
+  readonly hasActiveEntitlement: typeof hasActiveCoderouterSubscription;
   readonly issueToken: typeof issueRouteToken;
   readonly hostedProRequired: () => boolean;
 };
 
 const defaultDependencies: SessionDependencies = {
   resolveContext: resolveCodeRouterRequestContext,
-  hasActivePro: hasActiveStripeProSubscription,
+  hasActiveEntitlement: hasActiveCoderouterSubscription,
   issueToken: issueRouteToken,
   hostedProRequired: () => env.CODEROUTER_HOSTED_PRO_REQUIRED === "1",
 };
@@ -73,12 +73,17 @@ export function makeCoderouterSessionPostHandler(
     const userId = resolved.value.user.id;
     if (dependencies.hostedProRequired()) {
       try {
-        if (!(await dependencies.hasActivePro(userId))) {
+        if (
+          !(await dependencies.hasActiveEntitlement(
+            userId,
+            resolved.value.team.teamId,
+          ))
+        ) {
           return Response.json(
             {
               error: "pro_required",
               message:
-                "Hosted coderouter requires cmux Pro. Upgrade or connect a self-hosted server.",
+                "Hosted coderouter requires cmux Pro or Team. Upgrade or connect a self-hosted server.",
               retryable: false,
             },
             {

--- a/web/services/billing/pro.ts
+++ b/web/services/billing/pro.ts
@@ -6,7 +6,7 @@
 // `cmuxVmPlan` takes precedence over `cmuxPlan` there and is left untouched
 // here so manual overrides survive.
 
-import { inArray, eq, and } from "drizzle-orm";
+import { inArray, eq, and, or } from "drizzle-orm";
 
 import { cloudDb } from "../../db/client";
 import { stripeSubscriptions } from "../../db/schema";
@@ -272,6 +272,45 @@ export async function hasActiveTeamSubscriptionForTeam(
           eq(stripeSubscriptions.scope, "team"),
           eq(stripeSubscriptions.plan, TEAM_PLAN_ID),
           inArray(stripeSubscriptions.status, ACTIVE_STRIPE_PRO_STATUSES),
+        ),
+      )
+      .limit(1);
+    return rows.length > 0;
+  } catch (error) {
+    if (isMissingDatabaseConfig(error)) return false;
+    throw error;
+  }
+}
+
+/**
+ * A hosted coderouter seat is covered either by the user's own Pro
+ * subscription or by the selected team's Team subscription. Keep this as one
+ * indexed query so route-session issuance does not serialize two RDS reads.
+ * The caller must establish membership in `stackTeamId` before calling.
+ */
+export async function hasActiveCoderouterSubscription(
+  stackUserId: string,
+  stackTeamId: string,
+): Promise<boolean> {
+  try {
+    const rows = await cloudDb()
+      .select({ id: stripeSubscriptions.id })
+      .from(stripeSubscriptions)
+      .where(
+        and(
+          inArray(stripeSubscriptions.status, ACTIVE_STRIPE_PRO_STATUSES),
+          or(
+            and(
+              eq(stripeSubscriptions.stackUserId, stackUserId),
+              eq(stripeSubscriptions.scope, "user"),
+              eq(stripeSubscriptions.plan, PRO_PLAN_ID),
+            ),
+            and(
+              eq(stripeSubscriptions.stackTeamId, stackTeamId),
+              eq(stripeSubscriptions.scope, "team"),
+              eq(stripeSubscriptions.plan, TEAM_PLAN_ID),
+            ),
+          ),
         ),
       )
       .limit(1);

--- a/web/tests/coderouter-session-route.test.ts
+++ b/web/tests/coderouter-session-route.test.ts
@@ -39,14 +39,14 @@ describe("coderouter hosted entitlement", () => {
     expect(invalid.status).toBe(401);
   });
 
-  test("requires Pro before issuing a hosted route token", async () => {
+  test("requires Pro or Team before issuing a hosted route token", async () => {
     const issueToken = mock(async () => ({
       token: "crt_test",
       expiresAt: new Date("2026-09-01T00:00:00Z"),
     }));
     const POST = makeCoderouterSessionPostHandler({
       resolveContext: mock(async () => context) as never,
-      hasActivePro: mock(async () => false),
+      hasActiveEntitlement: mock(async () => false),
       issueToken,
       hostedProRequired: () => true,
     });
@@ -69,10 +69,10 @@ describe("coderouter hosted entitlement", () => {
       token: "crt_test",
       expiresAt: new Date("2026-09-01T00:00:00Z"),
     }));
-    const hasActivePro = mock(async () => false);
+    const hasActiveEntitlement = mock(async () => false);
     const POST = makeCoderouterSessionPostHandler({
       resolveContext: mock(async () => context) as never,
-      hasActivePro,
+      hasActiveEntitlement,
       issueToken,
       hostedProRequired: () => false,
     });
@@ -88,14 +88,14 @@ describe("coderouter hosted entitlement", () => {
       token: "crt_test",
       openaiBaseUrl: "https://router.example.com/v1",
     });
-    expect(hasActivePro).not.toHaveBeenCalled();
+    expect(hasActiveEntitlement).not.toHaveBeenCalled();
     expect(issueToken).toHaveBeenCalledWith("team_1", "user_1");
   });
 
   test("fails closed when hosted entitlement storage is unavailable", async () => {
     const POST = makeCoderouterSessionPostHandler({
       resolveContext: mock(async () => context) as never,
-      hasActivePro: mock(async () => {
+      hasActiveEntitlement: mock(async () => {
         throw new Error("database unavailable");
       }),
       issueToken: mock(async () => {
@@ -112,5 +112,31 @@ describe("coderouter hosted entitlement", () => {
 
     expect(response.status).toBe(503);
     expect(response.headers.get("retry-after")).toBeNull();
+  });
+
+  test("issues a hosted route token for a selected Team entitlement", async () => {
+    const issueToken = mock(async () => ({
+      token: "crt_team",
+      expiresAt: new Date("2026-09-01T00:00:00Z"),
+    }));
+    const hasActiveEntitlement = mock(async (...args: unknown[]) =>
+      args[0] === "user_1" && args[1] === "team_1"
+    );
+    const POST = makeCoderouterSessionPostHandler({
+      resolveContext: mock(async () => context) as never,
+      hasActiveEntitlement: hasActiveEntitlement as never,
+      issueToken,
+      hostedProRequired: () => true,
+    });
+
+    const response = await POST(
+      new Request("https://coderouter.dev/api/coderouter/session", {
+        method: "POST",
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(hasActiveEntitlement).toHaveBeenCalledWith("user_1", "team_1");
+    expect(issueToken).toHaveBeenCalledWith("team_1", "user_1");
   });
 });


### PR DESCRIPTION
A live annual Team validation exposed that route-session issuance checked only user-scoped Pro rows. This changes entitlement resolution to one indexed query covering user Pro OR the already-authorized selected team’s Team subscription, adds the Team path test, and updates the actionable error.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/9753"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788668286&installation_model_id=21920&pr_number=9753&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F9753&signature=41500f49b1ef3e563a61a7fcefdd2ad1383f98975186749ef0af16aaf6ca9f97"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 999b0e747e802962983a5912e7814807c092b107. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hosted coderouter now accepts either a user Pro subscription or the selected team’s Team subscription when issuing a route session. Entitlement is resolved with a single indexed query; error text and tests are updated.

- **Bug Fixes**
  - Added `hasActiveCoderouterSubscription` to check user Pro OR selected team’s Team in one query.
  - Updated session route to use the new check and clarified error: “requires cmux Pro or Team.”
  - Expanded tests to cover Team entitlements and the non-hosted path.

<sup>Written for commit 999b0e747e802962983a5912e7814807c092b107. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/9753?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Team plan subscribers can now access CodeRouter sessions.
  * CodeRouter access is validated against the selected team’s active entitlement.

* **Bug Fixes**
  * Improved subscription checks to correctly recognize eligible Pro and Team plans.
  * Updated access messaging to reflect that Team plans are supported.
  * Preserved self-hosted access behavior when entitlement services are unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->