### PR TITLE
Fix drag-to-split cursor focus reconciliation

### DIFF
--- a/Sources/AppDelegate+DockSurfaceMove.swift
+++ b/Sources/AppDelegate+DockSurfaceMove.swift
@@ -208,11 +208,12 @@ extension AppDelegate {
         }
 
         if let splitTarget, let movedTabId = destinationWorkspace.surfaceIdFromPanelId(panelId) {
-            _ = destinationWorkspace.bonsplitController.splitPane(
+            _ = destinationWorkspace.splitPaneMovingTab(
                 resolvedPane,
                 orientation: splitTarget.orientation,
                 movingTab: movedTabId,
-                insertFirst: splitTarget.insertFirst
+                insertFirst: splitTarget.insertFirst,
+                focusIntent: focus ? .activateMovedTab : .preserveCurrent
             )
         }
         destinationWorkspace.scheduleTerminalGeometryReconcile()

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -5074,11 +5074,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         if destinationWorkspace.id == sourceWorkspace.id {
             if let splitTarget {
                 guard let sourceTabId = sourceWorkspace.surfaceIdFromPanelId(panelId),
-                      sourceWorkspace.bonsplitController.splitPane(
+                      sourceWorkspace.splitPaneMovingTab(
                         resolvedTargetPane,
                         orientation: splitTarget.orientation,
                         movingTab: sourceTabId,
-                        insertFirst: splitTarget.insertFirst
+                        insertFirst: splitTarget.insertFirst,
+                        focusIntent: focus ? .activateMovedTab : .preserveCurrent
                       ) != nil else {
 #if DEBUG
                     cmuxDebugLog(
@@ -5167,11 +5168,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
             let splitStart = ProcessInfo.processInfo.systemUptime
 #endif
             guard let movedTabId = destinationWorkspace.surfaceIdFromPanelId(panelId),
-                  destinationWorkspace.bonsplitController.splitPane(
+                  destinationWorkspace.splitPaneMovingTab(
                     resolvedTargetPane,
                     orientation: splitTarget.orientation,
                     movingTab: movedTabId,
-                    insertFirst: splitTarget.insertFirst
+                    insertFirst: splitTarget.insertFirst,
+                    focusIntent: focus ? .activateMovedTab : .preserveCurrent
                   ) != nil else {
                 if let detachedFromDestination = destinationWorkspace.detachSurface(panelId: panelId) {
                     rollbackDetachedSurface(

--- a/Sources/TerminalController+ControlSidebarContext3.swift
+++ b/Sources/TerminalController+ControlSidebarContext3.swift
@@ -161,10 +161,11 @@ extension TerminalController {
         }
 
         let orientation: SplitOrientation = orientationIsHorizontal ? .horizontal : .vertical
-        guard let newPaneId = tab.bonsplitController.splitPane(
+        guard let newPaneId = tab.splitPaneMovingTab(
             orientation: orientation,
             movingTab: bonsplitTabId,
-            insertFirst: insertFirst
+            insertFirst: insertFirst,
+            focusIntent: .preserveCurrent
         ) else {
             return .splitFailed
         }

--- a/Sources/TerminalController+MoveTabToNewWorkspace.swift
+++ b/Sources/TerminalController+MoveTabToNewWorkspace.swift
@@ -179,11 +179,11 @@ extension TerminalController {
                 ])
                 return
             }
-            let previousFocusedPanelId = ws.focusedPanelId
-            guard let newPaneId = ws.bonsplitController.splitPane(
+            guard let newPaneId = ws.splitPaneMovingTab(
                 orientation: orientation,
                 movingTab: bonsplitTabId,
-                insertFirst: insertFirst
+                insertFirst: insertFirst,
+                focusIntent: focus ? .activateMovedTab : .preserveCurrent
             ) else {
                 result = .err(code: "internal_error", message: SurfaceSplitOffMessage.splitPaneFailed, data: nil)
                 return
@@ -192,8 +192,6 @@ extension TerminalController {
                 _ = app.focusMainWindow(windowId: located.windowId)
                 setActiveTabManager(located.tabManager)
                 located.tabManager.focusTab(ws.id, surfaceId: surfaceId, suppressFlash: true)
-            } else if let previousFocusedPanelId, ws.panels[previousFocusedPanelId] != nil {
-                ws.focusPanel(previousFocusedPanelId)
             }
             let windowId = located.windowId
             result = .ok([

--- a/Sources/Workspace+MovingTabSplit.swift
+++ b/Sources/Workspace+MovingTabSplit.swift
@@ -1,0 +1,102 @@
+import AppKit
+import Bonsplit
+
+extension Workspace {
+    enum MovingTabSplitFocusIntent {
+        case activateMovedTab
+        case preserveCurrent
+    }
+
+    /// Moves an existing tab into a new split while making focus intent explicit.
+    ///
+    /// Bonsplit updates its focused pane synchronously but emits only `didSplitPane`
+    /// for this operation. The scoped intent lets that delegate callback either
+    /// commit the moved tab through Workspace's focus owner or restore the previous
+    /// Bonsplit pane and any responder focus that panel actually owned.
+    @discardableResult
+    func splitPaneMovingTab(
+        _ paneId: PaneID? = nil,
+        orientation: SplitOrientation,
+        movingTab tabId: TabID,
+        insertFirst: Bool,
+        focusIntent: MovingTabSplitFocusIntent
+    ) -> PaneID? {
+        let previousIntent = activeMovingTabSplitFocusIntent
+        let previousFocusedPanelId = focusedPanelId
+        let previousOwnedFocusIntent = previousFocusedPanelId
+            .flatMap { panels[$0] }
+            .flatMap { ownedFocusIntent(for: $0) }
+        activeMovingTabSplitFocusIntent = focusIntent
+        defer { activeMovingTabSplitFocusIntent = previousIntent }
+
+        guard let newPaneId = bonsplitController.splitPane(
+            paneId,
+            orientation: orientation,
+            movingTab: tabId,
+            insertFirst: insertFirst
+        ) else {
+            return nil
+        }
+
+        if case .preserveCurrent = focusIntent,
+           let previousFocusedPanelId,
+           let previousPaneId = self.paneId(forPanelId: previousFocusedPanelId),
+           let previousTabId = surfaceIdFromPanelId(previousFocusedPanelId) {
+            if bonsplitController.selectedTab(inPane: previousPaneId)?.id != previousTabId {
+                bonsplitController.selectTab(previousTabId)
+            }
+            if bonsplitController.focusedPaneId != previousPaneId {
+                bonsplitController.focusPane(previousPaneId)
+            }
+            if let previousOwnedFocusIntent {
+                focusPanel(
+                    previousFocusedPanelId,
+                    focusIntent: previousOwnedFocusIntent
+                )
+            }
+        }
+
+        return newPaneId
+    }
+
+    var preservesFocusDuringMovingTabSplit: Bool {
+        if case .preserveCurrent? = activeMovingTabSplitFocusIntent {
+            return true
+        }
+        return false
+    }
+
+    /// Commits the moved tab while protecting the terminal that owns AppKit focus
+    /// from the responder churn caused by the following SwiftUI reparent pass.
+    func activateMovedTabAfterSplit(_ tabId: TabID, inPane paneId: PaneID) {
+        let previousHostedView = terminalHostedViewOwningFirstResponder()
+        let terminalFocusPanelId = panelIdFromSurfaceId(tabId).flatMap { panelId in
+            terminalPanel(for: panelId) == nil ? nil : panelId
+        }
+
+        suppressReparentFocusUntilLayoutFollowUp(
+            previousHostedView,
+            reason: "workspace.movingTabSplitReparent",
+            terminalFocusPanelId: terminalFocusPanelId
+        )
+        applyTabSelection(
+            tabId: tabId,
+            inPane: paneId,
+            previousTerminalHostedView: previousHostedView
+        )
+    }
+
+    private func ownedFocusIntent(for panel: any Panel) -> PanelFocusIntent? {
+        guard let window = NSApp.keyWindow,
+              let firstResponder = window.firstResponder else { return nil }
+        return panel.ownedFocusIntent(for: firstResponder, in: window)
+    }
+
+    private func terminalHostedViewOwningFirstResponder() -> GhosttySurfaceScrollView? {
+        guard let responder = (NSApp.keyWindow ?? NSApp.mainWindow)?.firstResponder,
+              let panelId = responder.cmuxTerminalFocusOwningGhosttyView()?.terminalSurface?.id else {
+            return nil
+        }
+        return terminalPanel(for: panelId)?.hostedView
+    }
+}

--- a/Sources/Workspace+SurfaceNavigation.swift
+++ b/Sources/Workspace+SurfaceNavigation.swift
@@ -98,11 +98,12 @@ extension Workspace {
             )
         } else if let directionalSplit,
                   let tabId = surfaceIdFromPanelId(panelId),
-                  let newPaneId = bonsplitController.splitPane(
+                  let newPaneId = splitPaneMovingTab(
                       sourcePaneId,
                       orientation: directionalSplit.orientation,
                       movingTab: tabId,
-                      insertFirst: directionalSplit.insertFirst
+                      insertFirst: directionalSplit.insertFirst,
+                      focusIntent: .activateMovedTab
                   ) {
             bonsplitController.focusPane(newPaneId)
             bonsplitController.selectTab(tabId)

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -2355,6 +2355,7 @@ final class Workspace: Identifiable, ObservableObject {
         get { splitLayout.isProgrammaticSplit }
         set { splitLayout.isProgrammaticSplit = newValue }
     }
+    var activeMovingTabSplitFocusIntent: MovingTabSplitFocusIntent?
     private var debugStressPreloadSelectionDepth = 0
 
     /// Last terminal panel used as an inheritance source (typically last focused terminal).
@@ -10550,21 +10551,28 @@ final class Workspace: Identifiable, ObservableObject {
 
     func suppressReparentFocusUntilLayoutFollowUp(
         _ hostedView: GhosttySurfaceScrollView?,
-        reason: String
+        reason: String,
+        terminalFocusPanelId: UUID? = nil
     ) {
-        guard let hostedView else { return }
-        hostedView.suppressReparentFocus()
-        pendingReparentFocusSuppressionViews[ObjectIdentifier(hostedView)] = hostedView
+        guard hostedView != nil || terminalFocusPanelId != nil else { return }
+        if let hostedView {
+            hostedView.suppressReparentFocus()
+            pendingReparentFocusSuppressionViews[ObjectIdentifier(hostedView)] = hostedView
 #if DEBUG
-        cmuxDebugLog("focus.reparent.suppressPending reason=\(reason) count=\(pendingReparentFocusSuppressionViews.count)")
+            cmuxDebugLog("focus.reparent.suppressPending reason=\(reason) count=\(pendingReparentFocusSuppressionViews.count)")
 #endif
+        }
 
         guard portalRenderingEnabled else {
             clearPendingReparentFocusSuppressions(reason: "\(reason).portalDisabled")
             return
         }
 
-        beginEventDrivenLayoutFollowUp(reason: reason, includeGeometry: true)
+        beginEventDrivenLayoutFollowUp(
+            reason: reason,
+            terminalFocusPanelId: terminalFocusPanelId,
+            includeGeometry: true
+        )
     }
 
     private func clearPendingReparentFocusSuppressions(reason: String) {
@@ -12734,7 +12742,8 @@ extension Workspace: BonsplitDelegate {
 
     func splitTabBar(_ controller: BonsplitController, didSelectTab tab: Bonsplit.Tab, inPane pane: PaneID) {
         // Mirror bookkeeping restores selection from its transaction snapshot.
-        guard !remoteTmuxMirrorMutations.suppressesFocusActivation else { return }
+        guard !remoteTmuxMirrorMutations.suppressesFocusActivation,
+              !preservesFocusDuringMovingTabSplit else { return }
         applyTabSelection(tabId: tab.id, inPane: pane)
     }
 
@@ -12813,7 +12822,8 @@ extension Workspace: BonsplitDelegate {
 
     func splitTabBar(_ controller: BonsplitController, didFocusPane pane: PaneID) {
         // Mirror bookkeeping restores pane focus without re-running activation.
-        guard !remoteTmuxMirrorMutations.suppressesFocusActivation else { return }
+        guard !remoteTmuxMirrorMutations.suppressesFocusActivation,
+              !preservesFocusDuringMovingTabSplit else { return }
         // When a pane is focused, focus its selected tab's panel
         guard let tab = controller.selectedTab(inPane: pane) else { return }
 #if DEBUG
@@ -13044,6 +13054,13 @@ extension Workspace: BonsplitDelegate {
             }
             normalizePinnedTabs(in: originalPane)
             normalizePinnedTabs(in: newPane)
+            // Moving a tab into a new split does not emit didMoveTab or didSelectTab.
+            // Interactive moves activate the selected destination through Workspace's
+            // focus owner; explicit non-focus transactions leave activation untouched.
+            if !preservesFocusDuringMovingTabSplit,
+               let movedTab = controller.selectedTab(inPane: newPane) {
+                activateMovedTabAfterSplit(movedTab.id, inPane: newPane)
+            }
             scheduleTerminalGeometryReconcile()
             return
         }

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -2531,6 +2531,7 @@ C0DE71B10000000000000001 /* AppDelegate+AgentChatNotifications.swift in Sources 
 		901000010000000000000001 /* WorkspaceCustomLayoutOrderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 901000010000000000000002 /* WorkspaceCustomLayoutOrderTests.swift */; };
 		281F3AEA52379AF45C5C1189 /* WorkspaceCustomSidebarPullRequestContextTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE74DFAC5946F9C2EEDBE577 /* WorkspaceCustomSidebarPullRequestContextTests.swift */; };
 		E6FA9084A1B2C3D4E5F60718 /* WorkspaceDescriptionUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6FA9085A1B2C3D4E5F60718 /* WorkspaceDescriptionUITests.swift */; };
+		9504D5F00000000000000001 /* WorkspaceDragSplitFocusTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9504D5F00000000000000002 /* WorkspaceDragSplitFocusTests.swift */; };
 		72DB1838A0F1B710BFB45DC1 /* WorkspaceEnvironmentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B561A95C6DC21BA9C4B2BCDD /* WorkspaceEnvironmentTests.swift */; };
 		C0DE36230000000000000001 /* WorkspaceFinderDirectoryResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE36230000000000000002 /* WorkspaceFinderDirectoryResolver.swift */; };
 		F0ACC0DE000000000000000B /* WorkspaceForkAgentConversationAvailability.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0ACC0DE000000000000000C /* WorkspaceForkAgentConversationAvailability.swift */; };
@@ -5140,6 +5141,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 		901000010000000000000002 /* WorkspaceCustomLayoutOrderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceCustomLayoutOrderTests.swift; sourceTree = "<group>"; };
 		CE74DFAC5946F9C2EEDBE577 /* WorkspaceCustomSidebarPullRequestContextTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceCustomSidebarPullRequestContextTests.swift; sourceTree = "<group>"; };
 		E6FA9085A1B2C3D4E5F60718 /* WorkspaceDescriptionUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceDescriptionUITests.swift; sourceTree = "<group>"; };
+		9504D5F00000000000000002 /* WorkspaceDragSplitFocusTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceDragSplitFocusTests.swift; sourceTree = "<group>"; };
 		B561A95C6DC21BA9C4B2BCDD /* WorkspaceEnvironmentTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceEnvironmentTests.swift; sourceTree = "<group>"; };
 		C0DE36230000000000000002 /* WorkspaceFinderDirectoryResolver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceFinderDirectoryResolver.swift; sourceTree = "<group>"; };
 		F0ACC0DE000000000000000C /* WorkspaceForkAgentConversationAvailability.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceForkAgentConversationAvailability.swift; sourceTree = "<group>"; };
@@ -7618,6 +7620,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				C0DE00000000000000000D37 /* WorkspaceCreateIdempotencyTombstoneTests.swift */,
 				D1A700000000000000000009 /* WorkspaceCreateReviewRegressionTests.swift */,
 				D1A700000000000000000007 /* WorkspaceCreateIdempotencyRecoveryTests.swift */,
+				9504D5F00000000000000002 /* WorkspaceDragSplitFocusTests.swift */,
 				71F8ED92A4B55D34BE6A0668 /* WorkspaceSplitStartupCommandTests.swift */,
 				6342F0C20000000000000001 /* WorkspaceTerminalFocusRecoveryTests.swift */,
 				6047C0DE6047C0DE60470002 /* WorkspaceTerminalTabWorkingDirectoryTests.swift */,
@@ -11022,6 +11025,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				E60812C95246E275F29D3C1B /* WorkspaceCreationWorkingDirectorySpawnPolicyTests.swift in Sources */,
 				901000010000000000000001 /* WorkspaceCustomLayoutOrderTests.swift in Sources */,
 				281F3AEA52379AF45C5C1189 /* WorkspaceCustomSidebarPullRequestContextTests.swift in Sources */,
+				9504D5F00000000000000001 /* WorkspaceDragSplitFocusTests.swift in Sources */,
 				72DB1838A0F1B710BFB45DC1 /* WorkspaceEnvironmentTests.swift in Sources */,
 				F0ACC0DE0000000000000005 /* WorkspaceForkConversationContextMenuTests.swift in Sources */,
 				C9A57401C9A57401C9A57401 /* WorkspaceGroupMoveToMenuStateTests.swift in Sources */,

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -2478,6 +2478,7 @@ C0DE71B10000000000000001 /* AppDelegate+AgentChatNotifications.swift in Sources 
 		F0ACC0DE0000000000000003 /* Workspace+ForkConversationContextMenu.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0ACC0DE0000000000000004 /* Workspace+ForkConversationContextMenu.swift */; };
 		F17F00000000000000000005 /* Workspace+FullWidthTab.swift in Sources */ = {isa = PBXBuildFile; fileRef = F17F00000000000000000006 /* Workspace+FullWidthTab.swift */; };
 		C0DE1A050000000000000001 /* Workspace+LayoutCapture.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE1A050000000000000002 /* Workspace+LayoutCapture.swift */; };
+		9504A0010000000000000001 /* Workspace+MovingTabSplit.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9504A0010000000000000002 /* Workspace+MovingTabSplit.swift */; };
 		8B45A4329C234E6FB261E635 /* Workspace+NotificationsPane.swift in Sources */ = {isa = PBXBuildFile; fileRef = 688C3F45DAA548B3B57DE780 /* Workspace+NotificationsPane.swift */; };
 		C3744E010000000000000001 /* Workspace+PanelLifecycle.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3744E020000000000000001 /* Workspace+PanelLifecycle.swift */; };
 		797800030000000000000001 /* Workspace+PersistentRemotePTYReattach.swift in Sources */ = {isa = PBXBuildFile; fileRef = 797800030000000000000002 /* Workspace+PersistentRemotePTYReattach.swift */; };
@@ -5088,6 +5089,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 		F0ACC0DE0000000000000004 /* Workspace+ForkConversationContextMenu.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Workspace+ForkConversationContextMenu.swift"; sourceTree = "<group>"; };
 		F17F00000000000000000006 /* Workspace+FullWidthTab.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Workspace+FullWidthTab.swift"; sourceTree = "<group>"; };
 		C0DE1A050000000000000002 /* Workspace+LayoutCapture.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Workspace+LayoutCapture.swift"; sourceTree = "<group>"; };
+		9504A0010000000000000002 /* Workspace+MovingTabSplit.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Workspace+MovingTabSplit.swift"; sourceTree = "<group>"; };
 		688C3F45DAA548B3B57DE780 /* Workspace+NotificationsPane.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Workspace+NotificationsPane.swift"; sourceTree = "<group>"; };
 		C3744E020000000000000001 /* Workspace+PanelLifecycle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Workspace+PanelLifecycle.swift"; sourceTree = "<group>"; };
 		797800030000000000000002 /* Workspace+PersistentRemotePTYReattach.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Workspace+PersistentRemotePTYReattach.swift"; sourceTree = "<group>"; };
@@ -6078,6 +6080,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				804100000000000000000002 /* TabManager+AdjacentWorkspaceReordering.swift */,
 				E3B7A400000000000000020B /* Workspace+WorkspaceSurfaceTreeReading.swift */,
 				CA52C0170000000000000000 /* Workspace+SurfaceNavigation.swift */,
+				9504A0010000000000000002 /* Workspace+MovingTabSplit.swift */,
 				875200000000000000000004 /* SurfacePaneMovement.swift */,
 				822900000000000000000002 /* Workspace+TerminalResizeInteraction.swift */,
 				CC2639000000000000000002 /* GotoSplitCycleUITestSupport.swift */,
@@ -10070,6 +10073,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				F0ACC0DE0000000000000003 /* Workspace+ForkConversationContextMenu.swift in Sources */,
 				F17F00000000000000000005 /* Workspace+FullWidthTab.swift in Sources */,
 				C0DE1A050000000000000001 /* Workspace+LayoutCapture.swift in Sources */,
+				9504A0010000000000000001 /* Workspace+MovingTabSplit.swift in Sources */,
 				8B45A4329C234E6FB261E635 /* Workspace+NotificationsPane.swift in Sources */,
 				C3744E010000000000000001 /* Workspace+PanelLifecycle.swift in Sources */,
 				797800030000000000000001 /* Workspace+PersistentRemotePTYReattach.swift in Sources */,

--- a/cmuxTests/WorkspaceDragSplitFocusTests.swift
+++ b/cmuxTests/WorkspaceDragSplitFocusTests.swift
@@ -1,0 +1,75 @@
+import AppKit
+import Testing
+import CmuxTerminal
+
+#if canImport(cmux_DEV)
+@testable import cmux_DEV
+#elseif canImport(cmux)
+@testable import cmux
+#endif
+
+@MainActor
+@Suite(.serialized)
+struct WorkspaceDragSplitFocusSwiftTests {
+#if DEBUG
+    @Test
+    func movedTerminalBecomesSoleFocusedCursor() throws {
+        let originalAppDelegate = AppDelegate.shared
+        AppDelegate.shared = nil
+        defer { AppDelegate.shared = originalAppDelegate }
+
+        let workspace = Workspace()
+        let originalPanelId = try #require(workspace.focusedPanelId)
+        let originalPanel = try #require(workspace.terminalPanel(for: originalPanelId))
+        let sourcePane = try #require(workspace.paneId(forPanelId: originalPanelId))
+        let movedPanel = try #require(
+            workspace.newTerminalSurface(inPane: sourcePane, focus: false)
+        )
+        let movedTab = try #require(workspace.surfaceIdFromPanelId(movedPanel.id))
+
+        let window = makeWindow()
+        defer { window.orderOut(nil) }
+        let contentView = try #require(window.contentView, "Expected content view")
+
+        originalPanel.hostedView.frame = contentView.bounds
+        movedPanel.hostedView.frame = contentView.bounds
+        contentView.addSubview(originalPanel.hostedView)
+        contentView.addSubview(movedPanel.hostedView)
+        originalPanel.hostedView.setVisibleInUI(true)
+        movedPanel.hostedView.setVisibleInUI(true)
+
+        window.makeKeyAndOrderFront(nil)
+        window.displayIfNeeded()
+        contentView.layoutSubtreeIfNeeded()
+        originalPanel.hostedView.layoutSubtreeIfNeeded()
+        movedPanel.hostedView.layoutSubtreeIfNeeded()
+
+        workspace.focusPanel(originalPanelId)
+        #expect(originalPanel.surface.debugDesiredFocusState())
+        #expect(!movedPanel.surface.debugDesiredFocusState())
+
+        let newPane = try #require(
+            workspace.bonsplitController.splitPane(
+                sourcePane,
+                orientation: .vertical,
+                movingTab: movedTab,
+                insertFirst: false
+            )
+        )
+
+        #expect(workspace.bonsplitController.focusedPaneId == newPane)
+        #expect(workspace.focusedPanelId == movedPanel.id)
+        #expect(!originalPanel.surface.debugDesiredFocusState())
+        #expect(movedPanel.surface.debugDesiredFocusState())
+    }
+#endif
+
+    private func makeWindow() -> NSWindow {
+        NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 360, height: 220),
+            styleMask: [.titled, .closable],
+            backing: .buffered,
+            defer: false
+        )
+    }
+}

--- a/cmuxTests/WorkspaceDragSplitFocusTests.swift
+++ b/cmuxTests/WorkspaceDragSplitFocusTests.swift
@@ -1,6 +1,7 @@
 import AppKit
-import Testing
+import Bonsplit
 import CmuxTerminal
+import Testing
 
 #if canImport(cmux_DEV)
 @testable import cmux_DEV
@@ -18,7 +19,168 @@ struct WorkspaceDragSplitFocusSwiftTests {
         AppDelegate.shared = nil
         defer { AppDelegate.shared = originalAppDelegate }
 
-        let workspace = Workspace()
+        let fixture = try makeFixture()
+        defer {
+            fixture.window.orderOut(nil)
+            fixture.previousKeyWindow?.makeKey()
+        }
+
+        fixture.workspace.focusPanel(fixture.originalPanel.id)
+        #expect(fixture.originalPanel.surface.debugDesiredFocusState())
+        #expect(!fixture.movedPanel.surface.debugDesiredFocusState())
+        #expect(fixture.originalPanel.hostedView.isSurfaceViewFirstResponder())
+
+        let newPane = try #require(
+            fixture.workspace.bonsplitController.splitPane(
+                fixture.sourcePane,
+                orientation: .vertical,
+                movingTab: fixture.movedTab,
+                insertFirst: false
+            )
+        )
+
+        #expect(fixture.workspace.bonsplitController.focusedPaneId == newPane)
+        #expect(fixture.workspace.focusedPanelId == fixture.movedPanel.id)
+        #expect(!fixture.originalPanel.surface.debugDesiredFocusState())
+        #expect(fixture.movedPanel.surface.debugDesiredFocusState())
+        #expect(fixture.movedPanel.hostedView.isSurfaceViewFirstResponder())
+
+        fixture.workspace.debugAttemptEventDrivenLayoutFollowUpForTesting()
+
+        #expect(!fixture.originalPanel.hostedView.debugIsSuppressingReparentFocusForTesting())
+        #expect(fixture.workspace.bonsplitController.focusedPaneId == newPane)
+        #expect(fixture.workspace.focusedPanelId == fixture.movedPanel.id)
+        #expect(!fixture.originalPanel.surface.debugDesiredFocusState())
+        #expect(fixture.movedPanel.surface.debugDesiredFocusState())
+        #expect(fixture.movedPanel.hostedView.isSurfaceViewFirstResponder())
+    }
+
+    @Test
+    func activatedSharedSplitReassertsFocusWithoutPreviousTerminalResponder() throws {
+        let originalAppDelegate = AppDelegate.shared
+        let appDelegate = AppDelegate()
+        let tabManager = TabManager(autoWelcomeIfNeeded: false)
+        appDelegate.tabManager = tabManager
+        AppDelegate.shared = appDelegate
+        defer {
+            tabManager.tabs.forEach { $0.teardownAllPanels() }
+            appDelegate.tabManager = nil
+            AppDelegate.shared = originalAppDelegate
+        }
+
+        let workspace = try #require(tabManager.selectedWorkspace)
+        let fixture = try makeFixture(workspace: workspace)
+        defer {
+            fixture.window.orderOut(nil)
+            fixture.previousKeyWindow?.makeKey()
+        }
+
+        fixture.workspace.focusPanel(fixture.originalPanel.id)
+        #expect(fixture.window.makeFirstResponder(fixture.focusSink))
+        #expect(!fixture.originalPanel.hostedView.isSurfaceViewFirstResponder())
+        #expect(!fixture.movedPanel.hostedView.isSurfaceViewFirstResponder())
+
+        let newPane = try #require(
+            fixture.workspace.splitPaneMovingTab(
+                fixture.sourcePane,
+                orientation: .vertical,
+                movingTab: fixture.movedTab,
+                insertFirst: false,
+                focusIntent: .activateMovedTab
+            )
+        )
+
+        #expect(fixture.workspace.bonsplitController.focusedPaneId == newPane)
+        #expect(fixture.workspace.focusedPanelId == fixture.movedPanel.id)
+        #expect(fixture.movedPanel.hostedView.isSurfaceViewFirstResponder())
+        #expect(!fixture.workspace.debugHasPendingReparentFocusSuppressionsForTesting())
+
+        // Model the responder loss that SwiftUI reparenting can cause after the
+        // synchronous split delegate returns, then run its event-driven follow-up.
+        #expect(fixture.window.makeFirstResponder(fixture.focusSink))
+        #expect(!fixture.movedPanel.hostedView.isSurfaceViewFirstResponder())
+
+        fixture.workspace.debugAttemptEventDrivenLayoutFollowUpForTesting()
+
+        #expect(fixture.workspace.bonsplitController.focusedPaneId == newPane)
+        #expect(fixture.workspace.focusedPanelId == fixture.movedPanel.id)
+        #expect(!fixture.originalPanel.surface.debugDesiredFocusState())
+        #expect(fixture.movedPanel.surface.debugDesiredFocusState())
+        #expect(fixture.movedPanel.hostedView.isSurfaceViewFirstResponder())
+    }
+
+    @Test
+    func nonFocusSplitPreservesCursorAndHibernation() throws {
+        let originalAppDelegate = AppDelegate.shared
+        AppDelegate.shared = nil
+        defer { AppDelegate.shared = originalAppDelegate }
+
+        let fixture = try makeFixture()
+        defer {
+            fixture.window.orderOut(nil)
+            fixture.previousKeyWindow?.makeKey()
+        }
+
+        fixture.workspace.focusPanel(fixture.originalPanel.id)
+        #expect(fixture.originalPanel.hostedView.isSurfaceViewFirstResponder())
+        let hibernatedAgent = SessionRestorableAgentSnapshot(
+            kind: .codex,
+            sessionId: "issue-9504-non-focus-split",
+            workingDirectory: "/tmp/issue-9504",
+            launchCommand: AgentLaunchCommandSnapshot(
+                launcher: "codex",
+                executablePath: "/usr/local/bin/codex",
+                arguments: ["/usr/local/bin/codex"],
+                workingDirectory: "/tmp/issue-9504",
+                environment: nil,
+                capturedAt: nil,
+                source: nil
+            )
+        )
+        #expect(
+            fixture.workspace.enterAgentHibernation(
+                panelId: fixture.movedPanel.id,
+                agent: hibernatedAgent,
+                lastActivityAt: Date(timeIntervalSince1970: 0)
+            )
+        )
+
+        let newPane = try #require(
+            fixture.workspace.splitPaneMovingTab(
+                fixture.sourcePane,
+                orientation: .vertical,
+                movingTab: fixture.movedTab,
+                insertFirst: false,
+                focusIntent: .preserveCurrent
+            )
+        )
+
+        #expect(
+            fixture.workspace.bonsplitController.tabs(inPane: newPane)
+                .contains { $0.id == fixture.movedTab }
+        )
+        #expect(fixture.workspace.bonsplitController.focusedPaneId == fixture.sourcePane)
+        #expect(fixture.workspace.focusedPanelId == fixture.originalPanel.id)
+        #expect(fixture.originalPanel.surface.debugDesiredFocusState())
+        #expect(!fixture.movedPanel.surface.debugDesiredFocusState())
+        #expect(fixture.movedPanel.isAgentHibernated)
+        #expect(fixture.originalPanel.hostedView.isSurfaceViewFirstResponder())
+    }
+#endif
+
+    private struct Fixture {
+        let workspace: Workspace
+        let originalPanel: TerminalPanel
+        let movedPanel: TerminalPanel
+        let sourcePane: PaneID
+        let movedTab: TabID
+        let window: NSWindow
+        let previousKeyWindow: NSWindow?
+        let focusSink: FocusSinkView
+    }
+
+    private func makeFixture(workspace: Workspace? = nil) throws -> Fixture {
+        let workspace = workspace ?? Workspace()
         let originalPanelId = try #require(workspace.focusedPanelId)
         let originalPanel = try #require(workspace.terminalPanel(for: originalPanelId))
         let sourcePane = try #require(workspace.paneId(forPanelId: originalPanelId))
@@ -26,15 +188,23 @@ struct WorkspaceDragSplitFocusSwiftTests {
             workspace.newTerminalSurface(inPane: sourcePane, focus: false)
         )
         let movedTab = try #require(workspace.surfaceIdFromPanelId(movedPanel.id))
-
+        let previousKeyWindow = NSApp.keyWindow
         let window = makeWindow()
-        defer { window.orderOut(nil) }
+        var didBuildFixture = false
+        defer {
+            if !didBuildFixture {
+                window.orderOut(nil)
+                previousKeyWindow?.makeKey()
+            }
+        }
         let contentView = try #require(window.contentView, "Expected content view")
+        let focusSink = FocusSinkView(frame: .zero)
 
         originalPanel.hostedView.frame = contentView.bounds
         movedPanel.hostedView.frame = contentView.bounds
         contentView.addSubview(originalPanel.hostedView)
         contentView.addSubview(movedPanel.hostedView)
+        contentView.addSubview(focusSink)
         originalPanel.hostedView.setVisibleInUI(true)
         movedPanel.hostedView.setVisibleInUI(true)
 
@@ -44,25 +214,22 @@ struct WorkspaceDragSplitFocusSwiftTests {
         originalPanel.hostedView.layoutSubtreeIfNeeded()
         movedPanel.hostedView.layoutSubtreeIfNeeded()
 
-        workspace.focusPanel(originalPanelId)
-        #expect(originalPanel.surface.debugDesiredFocusState())
-        #expect(!movedPanel.surface.debugDesiredFocusState())
-
-        let newPane = try #require(
-            workspace.bonsplitController.splitPane(
-                sourcePane,
-                orientation: .vertical,
-                movingTab: movedTab,
-                insertFirst: false
-            )
+        didBuildFixture = true
+        return Fixture(
+            workspace: workspace,
+            originalPanel: originalPanel,
+            movedPanel: movedPanel,
+            sourcePane: sourcePane,
+            movedTab: movedTab,
+            window: window,
+            previousKeyWindow: previousKeyWindow,
+            focusSink: focusSink
         )
-
-        #expect(workspace.bonsplitController.focusedPaneId == newPane)
-        #expect(workspace.focusedPanelId == movedPanel.id)
-        #expect(!originalPanel.surface.debugDesiredFocusState())
-        #expect(movedPanel.surface.debugDesiredFocusState())
     }
-#endif
+
+    private final class FocusSinkView: NSView {
+        override var acceptsFirstResponder: Bool { true }
+    }
 
     private func makeWindow() -> NSWindow {
         NSWindow(


### PR DESCRIPTION
## Summary

- make focus intent explicit for every existing-tab-to-new-split transaction
- reconcile Bonsplit pane selection, Workspace focus, Ghostty cursor focus, and AppKit first responder through one shared path
- reuse the existing event-driven layout follow-up so SwiftUI reparenting cannot leave cursor styling stale

## Root cause

Bonsplit moves the tab and changes its focused pane synchronously, but that operation emits only `didSplitPane`. Workspace therefore did not commit the moved tab through its focus owner, and the following SwiftUI reparent pass could disturb AppKit first responder independently. The model, cursor, and responder layers could diverge even though Bonsplit still tracked only one focused pane.

## Testing

- red regression proof (test-only commit): https://github.com/manaflow-ai/cmux/actions/runs/31150335744
- final focused regression suite (pending): https://github.com/manaflow-ai/cmux/actions/runs/31288642691
- final full CI (pending): https://github.com/manaflow-ai/cmux/actions/runs/31288643314
- final isolated tagged macOS build (pending): https://github.com/manaflow-ai/cmux/actions/runs/31288643900

## Audit

- no user-facing strings changed; localization files require no updates
- no warning-budget files changed

Closes #9504

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/9754"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788668339&installation_model_id=21920&pr_number=9754&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F9754&signature=57f57f125c2e60263db2cdf88ab2dad1d8574ae0ab4a6139662d20900219494e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix drag-to-split so the moved terminal becomes the only focused cursor when requested, or preserves current focus and agent hibernation when not. Makes focus intent explicit for all moving‑tab splits and reconciles AppKit first responder through SwiftUI reparenting (fixes #9504).

- **Bug Fixes**
  - Added `Workspace.splitPaneMovingTab(..., focusIntent: ...)` with `MovingTabSplitFocusIntent`; on preserve, restore previous pane/tab and the panel’s owned responder; suppress Bonsplit delegate activation.
  - In the Bonsplit delegate, for moving‑tab splits call `activateMovedTabAfterSplit`; guard responder churn via `suppressReparentFocusUntilLayoutFollowUp(..., terminalFocusPanelId: ...)`; ignore `didSelectTab`/`didFocusPane` while preserving focus.
  - Routed all call sites through the helper: AppDelegate (dock and same‑workspace moves) and directional navigation use `.activateMovedTab`; control sidebar and `surface.split_off` use `.preserveCurrent`. Added DEBUG tests for sole‑cursor activation, reassertion without a previous terminal responder, and non‑focus split hibernation.

<sup>Written for commit 5f19f1682fd4eabf2b40355cc59bd5f844895c6c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/9754?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes focus ownership across many split/move entry points and Bonsplit delegate handling; regressions would show up as wrong terminal focus or lost hibernation after drag-to-split, but behavior is covered by new tests.
> 
> **Overview**
> Fixes **drag-to-split** and other **move-tab-into-split** paths so keyboard focus matches intent: the moved terminal becomes the sole focused cursor when activation is requested, and stays inactive when focus must be preserved.
> 
> Introduces **`Workspace.splitPaneMovingTab`** with **`MovingTabSplitFocusIntent`** (`activateMovedTab` vs `preserveCurrent`). Call sites in **AppDelegate** (dock and cross-workspace moves), **surface navigation**, **control sidebar**, and **`surface.split_off`** route through it instead of calling **`bonsplitController.splitPane`** directly.
> 
> On **`didSplitPane`** for moving-tab splits, **`activateMovedTabAfterSplit`** applies tab selection and **`suppressReparentFocusUntilLayoutFollowUp`** (now optionally keyed by **`terminalFocusPanelId`**) so AppKit first responder survives SwiftUI reparenting. **`didSelectTab`** / **`didFocusPane`** are skipped while preserving focus; preserve mode restores the prior pane, tab, and owned responder (including agent hibernation).
> 
> Adds **`WorkspaceDragSplitFocusTests`** for activation, post-reparent reassertion, and non-focus preservation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5f19f1682fd4eabf2b40355cc59bd5f844895c6c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved focus handling when moving terminal tabs into new split panes.
  * Correctly activates the moved terminal when requested.
  * Preserves current focus, cursor state, and agent hibernation when focus should remain unchanged.
  * Prevents focus conflicts while closing tabs during detach operations.
  * Applies consistent focus behavior across workspace, sidebar, and directional split actions.

* **Tests**
  * Added coverage for focus transfer and preservation after moving terminals into split panes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->