### PR TITLE
Revoke team route tokens when billing lapses

### DIFF
--- a/web/app/api/coderouter/session/route.ts
+++ b/web/app/api/coderouter/session/route.ts
@@ -1,5 +1,5 @@
 import { env } from "../../../env";
-import { hasActiveStripeProSubscription } from "../../../../services/billing/pro";
+import { hasActiveCoderouterSubscription } from "../../../../services/billing/pro";
 import {
   authenticateRouteToken,
   issueRouteToken,
@@ -18,14 +18,14 @@ export const dynamic = "force-dynamic";
 
 type SessionDependencies = {
   readonly resolveContext: typeof resolveCodeRouterRequestContext;
-  readonly hasActivePro: typeof hasActiveStripeProSubscription;
+  readonly hasActiveEntitlement: typeof hasActiveCoderouterSubscription;
   readonly issueToken: typeof issueRouteToken;
   readonly hostedProRequired: () => boolean;
 };
 
 const defaultDependencies: SessionDependencies = {
   resolveContext: resolveCodeRouterRequestContext,
-  hasActivePro: hasActiveStripeProSubscription,
+  hasActiveEntitlement: hasActiveCoderouterSubscription,
   issueToken: issueRouteToken,
   hostedProRequired: () => env.CODEROUTER_HOSTED_PRO_REQUIRED === "1",
 };
@@ -73,12 +73,17 @@ export function makeCoderouterSessionPostHandler(
     const userId = resolved.value.user.id;
     if (dependencies.hostedProRequired()) {
       try {
-        if (!(await dependencies.hasActivePro(userId))) {
+        if (
+          !(await dependencies.hasActiveEntitlement(
+            userId,
+            resolved.value.team.teamId,
+          ))
+        ) {
           return Response.json(
             {
               error: "pro_required",
               message:
-                "Hosted coderouter requires cmux Pro. Upgrade or connect a self-hosted server.",
+                "Hosted coderouter requires cmux Pro or Team. Upgrade or connect a self-hosted server.",
               retryable: false,
             },
             {

--- a/web/app/api/stripe/webhook/route.ts
+++ b/web/app/api/stripe/webhook/route.ts
@@ -19,7 +19,10 @@ import {
   recordCheckoutCompletion as recordCheckoutCompletionDefault,
 } from "../../../../services/billing/purchase";
 import { sendProSignupWelcome as sendProSignupWelcomeDefault } from "../../../../services/billing/proFulfillment";
-import { revokeRouteTokensForUser as revokeRouteTokensForUserDefault } from "../../../../services/coderouter/repository";
+import {
+  revokeRouteTokensForTeam as revokeRouteTokensForTeamDefault,
+  revokeRouteTokensForUser as revokeRouteTokensForUserDefault,
+} from "../../../../services/coderouter/repository";
 import { isStripeBillingConfigured, stripe } from "../../../../services/billing/stripe";
 import {
   recordSpanError,
@@ -39,6 +42,7 @@ type StripeWebhookDependencies = {
   applySubscriptionUpdate: typeof applySubscriptionUpdateDefault;
   sendProSignupWelcome: typeof sendProSignupWelcomeDefault;
   revokeCoderouterRouteTokens: typeof revokeRouteTokensForUserDefault;
+  revokeCoderouterTeamRouteTokens: typeof revokeRouteTokensForTeamDefault;
   captureStripeBillingEvent: typeof captureStripeBillingEventDefault;
   defer: (task: () => Promise<void>) => void;
 };
@@ -52,6 +56,7 @@ const defaultDependencies: StripeWebhookDependencies = {
   applySubscriptionUpdate: applySubscriptionUpdateDefault,
   sendProSignupWelcome: sendProSignupWelcomeDefault,
   revokeCoderouterRouteTokens: revokeRouteTokensForUserDefault,
+  revokeCoderouterTeamRouteTokens: revokeRouteTokensForTeamDefault,
   captureStripeBillingEvent: captureStripeBillingEventDefault,
   defer: (task) => after(task),
 };
@@ -278,10 +283,13 @@ async function applySubscriptionEntitlementUpdate(
   const result = await dependencies.applySubscriptionUpdate(subscription);
   if (
     !("skipped" in result)
-    && result.scope === "user"
     && !result.isActive
   ) {
-    await dependencies.revokeCoderouterRouteTokens(result.stackUserId);
+    if (result.scope === "user") {
+      await dependencies.revokeCoderouterRouteTokens(result.stackUserId);
+    } else {
+      await dependencies.revokeCoderouterTeamRouteTokens(result.stackTeamId);
+    }
   }
   return result;
 }

--- a/web/services/billing/pro.ts
+++ b/web/services/billing/pro.ts
@@ -6,7 +6,7 @@
 // `cmuxVmPlan` takes precedence over `cmuxPlan` there and is left untouched
 // here so manual overrides survive.
 
-import { inArray, eq, and } from "drizzle-orm";
+import { inArray, eq, and, or } from "drizzle-orm";
 
 import { cloudDb } from "../../db/client";
 import { stripeSubscriptions } from "../../db/schema";
@@ -272,6 +272,45 @@ export async function hasActiveTeamSubscriptionForTeam(
           eq(stripeSubscriptions.scope, "team"),
           eq(stripeSubscriptions.plan, TEAM_PLAN_ID),
           inArray(stripeSubscriptions.status, ACTIVE_STRIPE_PRO_STATUSES),
+        ),
+      )
+      .limit(1);
+    return rows.length > 0;
+  } catch (error) {
+    if (isMissingDatabaseConfig(error)) return false;
+    throw error;
+  }
+}
+
+/**
+ * A hosted coderouter seat is covered either by the user's own Pro
+ * subscription or by the selected team's Team subscription. Keep this as one
+ * indexed query so route-session issuance does not serialize two RDS reads.
+ * The caller must establish membership in `stackTeamId` before calling.
+ */
+export async function hasActiveCoderouterSubscription(
+  stackUserId: string,
+  stackTeamId: string,
+): Promise<boolean> {
+  try {
+    const rows = await cloudDb()
+      .select({ id: stripeSubscriptions.id })
+      .from(stripeSubscriptions)
+      .where(
+        and(
+          inArray(stripeSubscriptions.status, ACTIVE_STRIPE_PRO_STATUSES),
+          or(
+            and(
+              eq(stripeSubscriptions.stackUserId, stackUserId),
+              eq(stripeSubscriptions.scope, "user"),
+              eq(stripeSubscriptions.plan, PRO_PLAN_ID),
+            ),
+            and(
+              eq(stripeSubscriptions.stackTeamId, stackTeamId),
+              eq(stripeSubscriptions.scope, "team"),
+              eq(stripeSubscriptions.plan, TEAM_PLAN_ID),
+            ),
+          ),
         ),
       )
       .limit(1);

--- a/web/services/billing/reconcile.ts
+++ b/web/services/billing/reconcile.ts
@@ -5,6 +5,10 @@ import type Stripe from "stripe";
 import { cloudDb } from "../../db/client";
 import { stripeSubscriptions } from "../../db/schema";
 import { captureCoderouterError } from "../errors";
+import {
+  revokeRouteTokensForTeam,
+  revokeRouteTokensForUser,
+} from "../coderouter/repository";
 import { applySubscriptionUpdate } from "./purchase";
 import { stripe } from "./stripe";
 
@@ -69,8 +73,7 @@ async function reconcileStripeSubscriptionsLocked(
   const list = dependencies.list ?? listSubscriptionSnapshots;
   const retrieve = dependencies.retrieve ??
     ((id) => stripe().subscriptions.retrieve(id));
-  const apply = dependencies.apply ?? ((subscription) =>
-    applySubscriptionUpdate(subscription));
+  const apply = dependencies.apply ?? applySubscriptionUpdateAndRevokeRoutes;
   const markChecked = dependencies.markChecked ?? markSubscriptionsChecked;
   const captureError = dependencies.captureError ?? captureCoderouterError;
   const rows = await list(limit + 1);
@@ -120,6 +123,20 @@ async function reconcileStripeSubscriptionsLocked(
     message: "Stripe subscription reconciliation completed",
     data: result,
   });
+  return result;
+}
+
+async function applySubscriptionUpdateAndRevokeRoutes(
+  subscription: Stripe.Subscription,
+) {
+  const result = await applySubscriptionUpdate(subscription);
+  if (!("skipped" in result) && !result.isActive) {
+    if (result.scope === "user") {
+      await revokeRouteTokensForUser(result.stackUserId);
+    } else {
+      await revokeRouteTokensForTeam(result.stackTeamId);
+    }
+  }
   return result;
 }
 

--- a/web/services/coderouter/repository.ts
+++ b/web/services/coderouter/repository.ts
@@ -60,6 +60,19 @@ export async function revokeRouteTokensForUser(
     ));
 }
 
+export async function revokeRouteTokensForTeam(
+  teamId: string,
+  now = new Date(),
+): Promise<void> {
+  await cloudDb()
+    .update(coderouterRouteTokens)
+    .set({ revokedAt: now })
+    .where(and(
+      eq(coderouterRouteTokens.teamId, teamId),
+      isNull(coderouterRouteTokens.revokedAt),
+    ));
+}
+
 export async function authenticateRouteToken(
   token: string,
   now = new Date(),

--- a/web/tests/coderouter-session-route.test.ts
+++ b/web/tests/coderouter-session-route.test.ts
@@ -39,14 +39,14 @@ describe("coderouter hosted entitlement", () => {
     expect(invalid.status).toBe(401);
   });
 
-  test("requires Pro before issuing a hosted route token", async () => {
+  test("requires Pro or Team before issuing a hosted route token", async () => {
     const issueToken = mock(async () => ({
       token: "crt_test",
       expiresAt: new Date("2026-09-01T00:00:00Z"),
     }));
     const POST = makeCoderouterSessionPostHandler({
       resolveContext: mock(async () => context) as never,
-      hasActivePro: mock(async () => false),
+      hasActiveEntitlement: mock(async () => false),
       issueToken,
       hostedProRequired: () => true,
     });
@@ -69,10 +69,10 @@ describe("coderouter hosted entitlement", () => {
       token: "crt_test",
       expiresAt: new Date("2026-09-01T00:00:00Z"),
     }));
-    const hasActivePro = mock(async () => false);
+    const hasActiveEntitlement = mock(async () => false);
     const POST = makeCoderouterSessionPostHandler({
       resolveContext: mock(async () => context) as never,
-      hasActivePro,
+      hasActiveEntitlement,
       issueToken,
       hostedProRequired: () => false,
     });
@@ -88,14 +88,14 @@ describe("coderouter hosted entitlement", () => {
       token: "crt_test",
       openaiBaseUrl: "https://router.example.com/v1",
     });
-    expect(hasActivePro).not.toHaveBeenCalled();
+    expect(hasActiveEntitlement).not.toHaveBeenCalled();
     expect(issueToken).toHaveBeenCalledWith("team_1", "user_1");
   });
 
   test("fails closed when hosted entitlement storage is unavailable", async () => {
     const POST = makeCoderouterSessionPostHandler({
       resolveContext: mock(async () => context) as never,
-      hasActivePro: mock(async () => {
+      hasActiveEntitlement: mock(async () => {
         throw new Error("database unavailable");
       }),
       issueToken: mock(async () => {
@@ -112,5 +112,31 @@ describe("coderouter hosted entitlement", () => {
 
     expect(response.status).toBe(503);
     expect(response.headers.get("retry-after")).toBeNull();
+  });
+
+  test("issues a hosted route token for a selected Team entitlement", async () => {
+    const issueToken = mock(async () => ({
+      token: "crt_team",
+      expiresAt: new Date("2026-09-01T00:00:00Z"),
+    }));
+    const hasActiveEntitlement = mock(async (...args: unknown[]) =>
+      args[0] === "user_1" && args[1] === "team_1"
+    );
+    const POST = makeCoderouterSessionPostHandler({
+      resolveContext: mock(async () => context) as never,
+      hasActiveEntitlement: hasActiveEntitlement as never,
+      issueToken,
+      hostedProRequired: () => true,
+    });
+
+    const response = await POST(
+      new Request("https://coderouter.dev/api/coderouter/session", {
+        method: "POST",
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(hasActiveEntitlement).toHaveBeenCalledWith("user_1", "team_1");
+    expect(issueToken).toHaveBeenCalledWith("team_1", "user_1");
   });
 });

--- a/web/tests/stripe-webhook-route.test.ts
+++ b/web/tests/stripe-webhook-route.test.ts
@@ -25,6 +25,7 @@ let applySubscriptionUpdateResult: unknown = {
 };
 const applySubscriptionUpdate = mock(async () => applySubscriptionUpdateResult);
 const revokeCoderouterRouteTokens = mock(async () => {});
+const revokeCoderouterTeamRouteTokens = mock(async () => {});
 const captureStripeBillingEvent = mock(async () => {});
 const deferredTasks: Array<() => Promise<void>> = [];
 const sendProSignupWelcome = mock(async () => {
@@ -107,6 +108,7 @@ const POST = makeStripeWebhookHandler({
   applySubscriptionUpdate: applySubscriptionUpdate as never,
   sendProSignupWelcome,
   revokeCoderouterRouteTokens,
+  revokeCoderouterTeamRouteTokens,
   captureStripeBillingEvent,
   defer: (task) => deferredTasks.push(task),
 });
@@ -158,6 +160,7 @@ describe("Stripe billing webhook route", () => {
     recordCheckoutCompletion.mockClear();
     applySubscriptionUpdate.mockClear();
     revokeCoderouterRouteTokens.mockClear();
+    revokeCoderouterTeamRouteTokens.mockClear();
     captureStripeBillingEvent.mockClear();
     deferredTasks.length = 0;
     sendProSignupWelcome.mockClear();
@@ -397,6 +400,37 @@ describe("Stripe billing webhook route", () => {
         status: "canceled",
       },
     );
+  });
+
+  test("revokes every selected-team route after Team cancellation", async () => {
+    applySubscriptionUpdateResult = {
+      scope: "team",
+      stackTeamId: "team_1",
+      isActive: false,
+    };
+    currentEvent = {
+      id: "evt_team_deleted",
+      type: "customer.subscription.deleted",
+      data: {
+        object: {
+          id: "sub_team",
+          customer: "cus_team",
+          status: "canceled",
+          metadata: { stackTeamId: "team_1", app: "cmux", plan: "team" },
+        },
+      },
+    };
+    retrievedSubscription = {
+      ...(currentEvent.data as { object: Record<string, unknown> }).object,
+      cancel_at_period_end: false,
+      items: { data: [] },
+    };
+
+    const response = await POST(webhookRequest());
+
+    expect(response.status).toBe(200);
+    expect(revokeCoderouterTeamRouteTokens).toHaveBeenCalledWith("team_1");
+    expect(revokeCoderouterRouteTokens).not.toHaveBeenCalled();
   });
 
   test("repairs delayed subscription events from Stripe's current state", async () => {


### PR DESCRIPTION
Follow-up to the Team entitlement fix: cancellation and reconciliation now revoke every route token for the affected team, rather than only handling user-scoped Pro tokens. Includes explicit Team cancellation coverage.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/9761"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788668987&installation_model_id=21920&pr_number=9761&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F9761&signature=a4e37ec7d6d65804a74411087813e659abad3c02df97874cf0e91402c2557eda"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 1b92d45187bd0071b0d6908306e4cc5383aeb1ca. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Honor Team subscriptions for hosted coderouter and revoke team route tokens when billing lapses. This ensures Team members can get hosted tokens when entitled and blocks access immediately after cancellation.

- **Bug Fixes**
  - Issue hosted route tokens when either user Pro or selected Team is active via `hasActiveCoderouterSubscription(userId, teamId)` (single indexed query).
  - Revoke coderouter route tokens on inactive subscriptions for the correct scope: user or team, including `revokeRouteTokensForTeam`, applied in both Stripe webhook handling and reconciliation.
  - Tests updated to cover Team entitlement checks and team-wide revocation.

<sup>Written for commit 1b92d45187bd0071b0d6908306e4cc5383aeb1ca. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/9761?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * CodeRouter access now supports active Team subscriptions in addition to Pro subscriptions.
  * Team route tokens are automatically revoked when a Team subscription becomes inactive.

* **Bug Fixes**
  * Improved subscription entitlement checks and handling of storage errors.
  * Personal and Team token revocation now correctly follows the affected subscription scope.

* **Tests**
  * Added coverage for Team entitlement access, self-hosted access, failed storage checks, and subscription cancellation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->