### PR TITLE
Mitigate Sparkle updater-agent timeouts under endpoint security

### DIFF
--- a/Packages/macOS/CmuxUpdater/Package.resolved
+++ b/Packages/macOS/CmuxUpdater/Package.resolved
@@ -6,8 +6,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/sparkle-project/Sparkle",
       "state" : {
-        "revision" : "d46d456107feacc80711b21847b82b07bd9fb46e",
-        "version" : "2.9.3"
+        "revision" : "79bc9e872948e47877e76f194cb0c8e0412b0b90",
+        "version" : "2.9.5"
       }
     }
   ],

--- a/Packages/macOS/CmuxUpdater/Sources/CmuxUpdater/UpdateStateModel+ErrorFormatting.swift
+++ b/Packages/macOS/CmuxUpdater/Sources/CmuxUpdater/UpdateStateModel+ErrorFormatting.swift
@@ -104,6 +104,12 @@ extension UpdateStateModel {
                 break
             }
         }
+        if isUpdaterAgentConnectionFailure(nsError) {
+            return String(
+                localized: "update.error.installerAgent.message",
+                defaultValue: "macOS didn’t start cmux’s updater helper in time. Security software can delay it. Retry once; if it still fails, restart your Mac or download and install the latest version below."
+            )
+        }
         if nsError.domain == SUSparkleErrorDomain {
             switch nsError.code {
             case 2001:

--- a/Packages/macOS/CmuxUpdater/Sources/CmuxUpdater/UpdateStateModel+ErrorFormatting.swift
+++ b/Packages/macOS/CmuxUpdater/Sources/CmuxUpdater/UpdateStateModel+ErrorFormatting.swift
@@ -104,7 +104,7 @@ extension UpdateStateModel {
                 break
             }
         }
-        if isUpdaterAgentConnectionFailure(nsError) {
+        if isUpdaterAgentStartupTimeout(nsError) {
             return String(
                 localized: "update.error.installerAgent.message",
                 defaultValue: "macOS didn’t start cmux’s updater helper in time. Security software can delay it. Retry once; if it still fails, restart your Mac or download and install the latest version below."
@@ -135,6 +135,23 @@ extension UpdateStateModel {
         return String(localized: "update.error.failed.message", defaultValue: "Something went wrong while checking for updates. Try again, or check the update log for details.")
     }
 
+    /// Whether a Sparkle installation error contains the exact updater-agent startup timeout.
+    ///
+    /// Sparkle uses its internal error code 10 for many installer-helper failures. The message
+    /// below is emitted specifically when ``Autoupdate``'s 18-second agent-connection deadline
+    /// expires, so endpoint-security guidance must require that signal rather than code 10 alone.
+    private static func isUpdaterAgentStartupTimeout(_ error: NSError) -> Bool {
+        guard error.domain == SUSparkleErrorDomain, error.code == 4005 else { return false }
+        let underlying = error.userInfo[NSUnderlyingErrorKey] as? NSError
+        return [error, underlying].compactMap { $0 }.contains { candidate in
+            let text = [
+                candidate.localizedDescription,
+                (candidate.userInfo[NSLocalizedFailureReasonErrorKey] as? String) ?? "",
+                (candidate.userInfo[NSLocalizedRecoverySuggestionErrorKey] as? String) ?? "",
+            ].joined(separator: "\n").lowercased()
+            return text.contains("agent connection was never initiated")
+        }
+    }
 }
 
 /// Whether an error reflects Sparkle's updater helper agent never connecting.
@@ -142,15 +159,16 @@ extension UpdateStateModel {
 /// The login session's launchd domain can wedge into on-demand-only mode after a very long
 /// uptime, so launchd refuses to spawn Sparkle's installer/progress agent and the install times
 /// out ("agent connection was never initiated"). This surfaces as ``SUAgentInvalidationError``
-/// (4010), or as ``SUInstallationError`` (4005) wrapping Sparkle's internal IPC-timeout error
-/// (code 10) or carrying the agent-connection text in its trace.
+/// (4010), or as ``SUInstallationError`` (4005) wrapping Sparkle's internal installer-helper error
+/// (code 10) or carrying agent-connection text in its trace. This broad classification is suitable
+/// for the title; use ``isUpdaterAgentStartupTimeout(_:)`` for cause-specific recovery guidance.
 private func isUpdaterAgentConnectionFailure(_ error: NSError) -> Bool {
     guard error.domain == SUSparkleErrorDomain else { return false }
     if error.code == 4010 { return true }
     guard error.code == 4005 else { return false }
     let underlying = error.userInfo[NSUnderlyingErrorKey] as? NSError
-    // Sparkle's internal "agent connection was never initiated" timeout is code 10 in its own
-    // domain; that is the precise wedged-launchd signal.
+    // Sparkle uses code 10 for installer-helper errors. Keep the existing broad title
+    // classification, but do not use this code alone for cause-specific recovery guidance.
     if let underlying, underlying.domain == SUSparkleErrorDomain, underlying.code == 10 {
         return true
     }

--- a/Packages/macOS/CmuxUpdater/Sources/CmuxUpdater/UpdateStateModel+ErrorFormatting.swift
+++ b/Packages/macOS/CmuxUpdater/Sources/CmuxUpdater/UpdateStateModel+ErrorFormatting.swift
@@ -135,22 +135,23 @@ extension UpdateStateModel {
         return String(localized: "update.error.failed.message", defaultValue: "Something went wrong while checking for updates. Try again, or check the update log for details.")
     }
 
-    /// Whether a Sparkle installation error contains the exact updater-agent startup timeout.
-    ///
-    /// Sparkle uses its internal error code 10 for many installer-helper failures. The message
-    /// below is emitted specifically when ``Autoupdate``'s 18-second agent-connection deadline
-    /// expires, so endpoint-security guidance must require that signal rather than code 10 alone.
-    private static func isUpdaterAgentStartupTimeout(_ error: NSError) -> Bool {
-        guard error.domain == SUSparkleErrorDomain, error.code == 4005 else { return false }
-        let underlying = error.userInfo[NSUnderlyingErrorKey] as? NSError
-        return [error, underlying].compactMap { $0 }.contains { candidate in
-            let text = [
-                candidate.localizedDescription,
-                (candidate.userInfo[NSLocalizedFailureReasonErrorKey] as? String) ?? "",
-                (candidate.userInfo[NSLocalizedRecoverySuggestionErrorKey] as? String) ?? "",
-            ].joined(separator: "\n").lowercased()
-            return text.contains("agent connection was never initiated")
-        }
+}
+
+/// Whether a Sparkle installation error contains the exact updater-agent startup timeout.
+///
+/// Sparkle uses its internal error code 10 for many installer-helper failures. The message below
+/// is emitted specifically when ``Autoupdate``'s 18-second agent-connection deadline expires, so
+/// endpoint-security guidance must require that signal rather than code 10 alone.
+private func isUpdaterAgentStartupTimeout(_ error: NSError) -> Bool {
+    guard error.domain == SUSparkleErrorDomain, error.code == 4005 else { return false }
+    let underlying = error.userInfo[NSUnderlyingErrorKey] as? NSError
+    return [error, underlying].compactMap { $0 }.contains { candidate in
+        let text = [
+            candidate.localizedDescription,
+            (candidate.userInfo[NSLocalizedFailureReasonErrorKey] as? String) ?? "",
+            (candidate.userInfo[NSLocalizedRecoverySuggestionErrorKey] as? String) ?? "",
+        ].joined(separator: "\n").lowercased()
+        return text.contains("agent connection was never initiated")
     }
 }
 

--- a/Packages/macOS/CmuxUpdater/Tests/CmuxUpdaterTests/UpdateStateModelTests.swift
+++ b/Packages/macOS/CmuxUpdater/Tests/CmuxUpdaterTests/UpdateStateModelTests.swift
@@ -180,12 +180,18 @@ import Testing
             userInfo: [NSUnderlyingErrorKey: underlying]
         )
         #expect(UpdateStateModel.userFacingErrorTitle(for: err).contains("Start Updater"))
+        let message = UpdateStateModel.userFacingErrorMessage(for: err)
+        #expect(!message.localizedCaseInsensitiveContains("security software"))
+        #expect(message.localizedCaseInsensitiveContains("Applications"))
         #expect(UpdateManualDownloadRecovery().url(for: err)?.absoluteString.hasSuffix("cmux-macos.dmg") == true)
     }
 
     @Test func agentInvalidationErrorIsTreatedAsAgentFailure() {
         let err = NSError(domain: "SUSparkleErrorDomain", code: 4010)
         #expect(UpdateStateModel.userFacingErrorTitle(for: err).contains("Start Updater"))
+        let message = UpdateStateModel.userFacingErrorMessage(for: err)
+        #expect(!message.localizedCaseInsensitiveContains("security software"))
+        #expect(message.localizedCaseInsensitiveContains("Applications"))
         #expect(UpdateManualDownloadRecovery().url(for: err) != nil)
     }
 
@@ -225,6 +231,20 @@ import Testing
             NSLocalizedFailureReasonErrorKey: "The remote port connection was invalidated from the updater.",
         ])
         #expect(UpdateStateModel.userFacingErrorTitle(for: err).contains("Start Updater"))
+        let message = UpdateStateModel.userFacingErrorMessage(for: err)
+        #expect(!message.localizedCaseInsensitiveContains("security software"))
+        #expect(message.localizedCaseInsensitiveContains("Applications"))
+    }
+
+    /// Some Sparkle traces carry the exact timeout only on the top-level installation error.
+    @Test func installFailureWithStartupTimeoutTextExplainsEndpointSecurityRecovery() {
+        let err = NSError(domain: "SUSparkleErrorDomain", code: 4005, userInfo: [
+            NSLocalizedDescriptionKey: "An error occurred while running the updater.",
+            NSLocalizedFailureReasonErrorKey: "Timeout: agent connection was never initiated",
+        ])
+        let message = UpdateStateModel.userFacingErrorMessage(for: err)
+        #expect(message.localizedCaseInsensitiveContains("security software"))
+        #expect(!message.localizedCaseInsensitiveContains("Applications"))
     }
 
     @Test func downloadErrorOffersManualDownload() {

--- a/Packages/macOS/CmuxUpdater/Tests/CmuxUpdaterTests/UpdateStateModelTests.swift
+++ b/Packages/macOS/CmuxUpdater/Tests/CmuxUpdaterTests/UpdateStateModelTests.swift
@@ -148,10 +148,10 @@ import Testing
     // constant, so tests don't need to import Sparkle. Title/message assertions check English
     // substrings because `String(localized:)` falls back to its `defaultValue` under the test bundle.
 
-    /// Regression: a 4005 installation error wrapping an agent-connection timeout (the wedged
-    /// launchd-session case) adds restart guidance on top of the existing "move into Applications"
-    /// guidance, rather than replacing it. Both must be present.
-    @Test func installerAgentFailureKeepsRelocateGuidanceAndAddsRestart() {
+    /// Regression for #9660: a 4005 installation error wrapping an agent-connection timeout must
+    /// explain that endpoint security can delay the helper and direct the user to the one-time
+    /// manual upgrade. Generic permission/location guidance is inaccurate for this precise error.
+    @Test func installerAgentFailureExplainsEndpointSecurityRecovery() {
         let underlying = NSError(
             domain: "SUSparkleErrorDomain",
             code: 10,
@@ -166,8 +166,10 @@ import Testing
             ]
         )
         let message = UpdateStateModel.userFacingErrorMessage(for: err)
-        #expect(message.localizedCaseInsensitiveContains("Applications"))
+        #expect(message.localizedCaseInsensitiveContains("security software"))
         #expect(message.localizedCaseInsensitiveContains("restart"))
+        #expect(message.localizedCaseInsensitiveContains("download"))
+        #expect(!message.localizedCaseInsensitiveContains("Applications"))
     }
 
     @Test func installerAgentFailureHasOwnTitleAndOffersManualDownload() {

--- a/Packages/macOS/CmuxUpdater/Tests/CmuxUpdaterTests/UpdateStateModelTests.swift
+++ b/Packages/macOS/CmuxUpdater/Tests/CmuxUpdaterTests/UpdateStateModelTests.swift
@@ -167,6 +167,7 @@ import Testing
         )
         let message = UpdateStateModel.userFacingErrorMessage(for: err)
         #expect(message.localizedCaseInsensitiveContains("security software"))
+        #expect(message.localizedCaseInsensitiveContains("retry"))
         #expect(message.localizedCaseInsensitiveContains("restart"))
         #expect(message.localizedCaseInsensitiveContains("download"))
         #expect(!message.localizedCaseInsensitiveContains("Applications"))
@@ -244,6 +245,9 @@ import Testing
         ])
         let message = UpdateStateModel.userFacingErrorMessage(for: err)
         #expect(message.localizedCaseInsensitiveContains("security software"))
+        #expect(message.localizedCaseInsensitiveContains("retry"))
+        #expect(message.localizedCaseInsensitiveContains("restart"))
+        #expect(message.localizedCaseInsensitiveContains("download"))
         #expect(!message.localizedCaseInsensitiveContains("Applications"))
     }
 

--- a/Packages/macOS/CmuxUpdaterUI/Package.resolved
+++ b/Packages/macOS/CmuxUpdaterUI/Package.resolved
@@ -6,8 +6,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/sparkle-project/Sparkle",
       "state" : {
-        "revision" : "d46d456107feacc80711b21847b82b07bd9fb46e",
-        "version" : "2.9.3"
+        "revision" : "79bc9e872948e47877e76f194cb0c8e0412b0b90",
+        "version" : "2.9.5"
       }
     }
   ],

--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -260329,6 +260329,23 @@
         }
       }
     },
+    "update.error.installerAgent.message": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "macOS didn’t start cmux’s updater helper in time. Security software can delay it. Retry once; if it still fails, restart your Mac or download and install the latest version below."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "macOS が cmux のアップデーターヘルパーを時間内に起動できませんでした。セキュリティソフトウェアによって起動が遅れることがあります。まず再試行し、それでも失敗する場合は Mac を再起動するか、下から最新バージョンをダウンロードして手動でインストールしてください。"
+          }
+        }
+      }
+    },
     "update.error.installerAgent.title": {
       "extractionState": "manual",
       "localizations": {

--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -260332,16 +260332,124 @@
     "update.error.installerAgent.message": {
       "extractionState": "manual",
       "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "لم يتمكّن macOS من تشغيل أداة تحديث cmux المساعدة في الوقت المحدد. قد تتسبب برامج الأمان في تأخير تشغيلها. أعد المحاولة مرة واحدة؛ وإذا استمر الفشل، فأعد تشغيل Mac أو نزّل أحدث إصدار أدناه وثبّته."
+          }
+        },
+        "bs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "macOS nije pokrenuo pomoćni program za ažuriranje cmux-a na vrijeme. Sigurnosni softver može odgoditi njegovo pokretanje. Pokušajte ponovo jednom; ako i dalje ne uspije, ponovo pokrenite Mac ili preuzmite i instalirajte najnoviju verziju ispod."
+          }
+        },
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "macOS startede ikke cmux’ opdateringshjælper i tide. Sikkerhedssoftware kan forsinke den. Prøv igen én gang. Hvis det stadig mislykkes, skal du genstarte din Mac eller hente og installere den nyeste version nedenfor."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "macOS hat den Update-Hilfsprozess von cmux nicht rechtzeitig gestartet. Sicherheitssoftware kann den Start verzögern. Versuche es einmal erneut. Falls es weiterhin fehlschlägt, starte deinen Mac neu oder lade unten die neueste Version herunter und installiere sie."
+          }
+        },
         "en": {
           "stringUnit": {
             "state": "translated",
             "value": "macOS didn’t start cmux’s updater helper in time. Security software can delay it. Retry once; if it still fails, restart your Mac or download and install the latest version below."
           }
         },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "macOS no inició a tiempo el proceso auxiliar de actualización de cmux. El software de seguridad puede retrasarlo. Vuelve a intentarlo una vez; si sigue fallando, reinicia el Mac o descarga e instala la versión más reciente a continuación."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "macOS n’a pas lancé à temps l’utilitaire de mise à jour de cmux. Un logiciel de sécurité peut retarder son lancement. Réessayez une fois ; si l’échec persiste, redémarrez votre Mac ou téléchargez et installez la dernière version ci-dessous."
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "macOS non ha avviato in tempo l’helper di aggiornamento di cmux. Il software di sicurezza può ritardarne l’avvio. Riprova una volta; se il problema persiste, riavvia il Mac oppure scarica e installa l’ultima versione qui sotto."
+          }
+        },
         "ja": {
           "stringUnit": {
             "state": "translated",
             "value": "macOS が cmux のアップデーターヘルパーを時間内に起動できませんでした。セキュリティソフトウェアによって起動が遅れることがあります。まず再試行し、それでも失敗する場合は Mac を再起動するか、下から最新バージョンをダウンロードして手動でインストールしてください。"
+          }
+        },
+        "km": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "macOS មិនបានចាប់ផ្តើមកម្មវិធីជំនួយធ្វើបច្ចុប្បន្នភាពរបស់ cmux ទាន់ពេលទេ។ កម្មវិធីសុវត្ថិភាពអាចពន្យារពេលវាបាន។ សូមព្យាយាមម្តងទៀត; ប្រសិនបើនៅតែបរាជ័យ សូមចាប់ផ្តើម Mac របស់អ្នកឡើងវិញ ឬទាញយក និងដំឡើងកំណែចុងក្រោយខាងក្រោម។"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "macOS가 cmux 업데이트 도우미를 제시간에 시작하지 못했습니다. 보안 소프트웨어로 인해 시작이 지연될 수 있습니다. 한 번 다시 시도하세요. 그래도 실패하면 Mac을 재시동하거나 아래에서 최신 버전을 다운로드하여 설치하세요."
+          }
+        },
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "macOS startet ikke oppdateringshjelperen til cmux i tide. Sikkerhetsprogramvare kan forsinke den. Prøv på nytt én gang. Hvis det fortsatt mislykkes, starter du Macen på nytt eller laster ned og installerer den nyeste versjonen nedenfor."
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "System macOS nie uruchomił na czas procesu pomocniczego aktualizatora cmux. Oprogramowanie zabezpieczające może opóźnić jego uruchomienie. Spróbuj ponownie raz. Jeśli nadal się nie uda, uruchom ponownie Maca albo pobierz i zainstaluj najnowszą wersję poniżej."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "O macOS não iniciou o auxiliar de atualização do cmux a tempo. O software de segurança pode atrasar a inicialização. Tente novamente uma vez; se ainda falhar, reinicie o Mac ou baixe e instale a versão mais recente abaixo."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "macOS не успела запустить вспомогательный процесс обновления cmux. Защитное ПО может задерживать его запуск. Повторите попытку один раз. Если ошибка повторится, перезагрузите Mac либо скачайте и установите последнюю версию ниже."
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "macOS ไม่ได้เริ่มตัวช่วยอัปเดตของ cmux ภายในเวลาที่กำหนด ซอฟต์แวร์รักษาความปลอดภัยอาจทำให้การเริ่มทำงานล่าช้า ลองอีกครั้งหนึ่งครั้ง หากยังไม่สำเร็จ ให้รีสตาร์ท Mac หรือดาวน์โหลดและติดตั้งเวอร์ชันล่าสุดด้านล่าง"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "macOS, cmux güncelleme yardımcısını zamanında başlatamadı. Güvenlik yazılımı başlangıcı geciktirebilir. Bir kez yeniden deneyin; yine başarısız olursa Mac’inizi yeniden başlatın veya aşağıdan en son sürümü indirip yükleyin."
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "macOS не встигла запустити допоміжний процес оновлення cmux. Захисне програмне забезпечення може затримувати його запуск. Повторіть спробу один раз. Якщо помилка повториться, перезапустіть Mac або завантажте й інсталюйте останню версію нижче."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "macOS 未能及时启动 cmux 的更新助手。安全软件可能会延迟其启动。请重试一次；如果仍然失败，请重新启动 Mac，或在下方下载并安装最新版本。"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "macOS 未能及時啟動 cmux 的更新輔助程式。安全軟體可能會延遲其啟動。請重試一次；如果仍然失敗，請重新啟動 Mac，或在下方下載並安裝最新版本。"
           }
         }
       }

--- a/cmux.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/cmux.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -60,8 +60,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/sparkle-project/Sparkle",
       "state" : {
-        "revision" : "d46d456107feacc80711b21847b82b07bd9fb46e",
-        "version" : "2.9.3"
+        "revision" : "79bc9e872948e47877e76f194cb0c8e0412b0b90",
+        "version" : "2.9.5"
       }
     },
     {


### PR DESCRIPTION
## Summary

- advance the resolved Sparkle dependency from 2.9.3 to 2.9.5, retaining the hardened installer-agent startup path introduced in Sparkle 2.9.0
- recognize Sparkle installation error 4005 wrapping error 10 as the updater-agent handshake failure and show endpoint-security-specific recovery instead of inaccurate Applications guidance
- localize the new recovery copy in English and Japanese
- preserve the existing Applications guidance for unrelated installation failures

Fixes #9660.

## Root cause and architecture

The download and extraction are already complete when this failure occurs. Sparkle launches its own Autoupdate helper, then waits for that helper to establish the XPC connection. CrowdStrike Falcon can hold the helper exec for an EndpointSecurity authorization decision beyond Sparkle's compiled 18-second handshake deadline.

That deadline and launch protocol live inside Sparkle's helper and are not configurable by cmux. Adding a second cmux timeout, retry loop, process launcher, or updater state owner would race Sparkle and create split lifecycle ownership. This change therefore keeps UpdateStateModel as the single @MainActor flow owner, upgrades the owned dependency boundary, and improves the precise error classification/recovery path.

Sparkle PR [#2852](https://github.com/sparkle-project/Sparkle/pull/2852), released in 2.9.0, probes the status service earlier during agent startup to reduce launch/handshake delays. This PR resolves the latest 2.9.x release, 2.9.5.

## Upgrade limitation

A running cmux update uses the Sparkle helper embedded in the currently installed app, not the helper inside the downloaded update. A user still on cmux v0.64.17 is running Sparkle 2.8.1, so one manual download/install is required to cross this failure. Future updates then run through the newer embedded Sparkle helper.

## Reproduction and coverage

A genuine Falcon EndpointSecurity exec hold requires a managed CrowdStrike machine and cannot be faithfully created by a unit test or an unmanaged cloud Mac. The deterministic regression instead constructs the exact observed error chain:

- outer SUSparkleErrorDomain 4005
- underlying SUSparkleErrorDomain 10
- “agent connection was never initiated”

The two-commit history records the red/green boundary:

1. 403740a722 — test-only regression requiring security-software, restart, and manual-download guidance while rejecting Applications guidance
2. 7ad31287b7 — Sparkle 2.9.5 resolution plus the localized recovery message

Pre-fix focused package execution produced the expected assertion failures. The first remote full-unit attempt was canceled by its workflow-wide 20-minute cap before its buffered output was emitted, so it is not represented as valid red proof: https://github.com/manaflow-ai/cmux/actions/runs/31147887804. A standalone Swift-package CI run pinned to the test-only SHA is in progress: https://github.com/manaflow-ai/cmux/actions/runs/31149069830.

Fixed-HEAD CI: https://github.com/manaflow-ai/cmux/actions/runs/31149237395.

## Validation

- focused CmuxUpdaterTests.installerAgentFailureExplainsEndpointSecurityRecovery passes with the implementation present; Swift Testing executed the selected test, although this Mac's launcher then reported its existing arm64/x86_64 bundle-loader mismatch, so the overall local command is not claimed as a clean run
- git diff --check
- jq empty Resources/Localizable.xcstrings
- python3 scripts/check-package-resolved-policy.py
- localization audit: the only changed user-facing surface is the updater-agent error message; Resources/Localizable.xcstrings contains both en and ja, and changed Swift files were checked for unlocalized UI literals

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the macOS auto-update dependency and user recovery paths for Sparkle install failures; misclassification could mislead users during failed updates, but scope is limited to updater error formatting and messaging.
> 
> **Overview**
> Bumps the resolved **Sparkle** dependency from **2.9.3** to **2.9.5** across the macOS updater packages and the main Xcode workspace lockfile.
> 
> When Sparkle reports installation error **4005** with the specific **“agent connection was never initiated”** timeout text (including on the top-level error or underlying code 10), user-facing recovery copy now explains that **security software** can delay the updater helper and suggests **retry**, **restart**, or **manual download**—instead of the generic **Move to Applications** guidance. Other updater-agent failures (broad code 10, 4010, remote-port invalidation) still use the existing Applications/restart message and **“Couldn’t Start Updater”** title.
> 
> Adds **`update.error.installerAgent.message`** localizations and updates **`UpdateStateModelTests`** to lock in the split between timeout-specific vs generic agent failure messaging.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e4ea68913aff24eb92f125de17de476e216a6327. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved update error messages for updater-helper startup timeouts.
  * Added clearer guidance for resolving endpoint-security issues and manually downloading updates.
  * Preserved existing guidance for other updater-agent failures.

* **Localization**
  * Added English and Japanese translations for the new timeout recovery guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->