### PR TITLE
Accept restart-stable ids wherever the control socket accepts an identifier

### DIFF
--- a/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Coordinator/ControlCommandCoordinator.swift
+++ b/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Coordinator/ControlCommandCoordinator.swift
@@ -46,6 +46,14 @@ public final class ControlCommandCoordinator {
     nonisolated let simulatorOperationAdmissionGate =
         ControlSimulatorOperationAdmissionGate(maximumConcurrentOperations: 4)
 
+    /// Restart-stable to runtime identity aliases, so a `cmux://` link's ids
+    /// address the same object through the CLI that they address when opened.
+    ///
+    /// `nonisolated`: the legacy app-side param parse resolves identifiers off
+    /// the main actor and must not take a hop to interpret one.
+    @ObservationIgnored
+    public nonisolated let stableIdentities = ControlStableIdentityTable()
+
     /// Creates a coordinator.
     ///
     /// - Parameters:
@@ -211,6 +219,25 @@ public final class ControlCommandCoordinator {
         handles.removeRef(kind: kind, uuid: uuid)
     }
 
+    /// Publishes the restart-stable identity of every live object of one kind,
+    /// so callers can address it by the id a `cmux://` link carries.
+    ///
+    /// The app calls this from the same topology refresh that mints `kind:N`
+    /// refs, replacing the previous table wholesale.
+    ///
+    /// - Parameters:
+    ///   - kind: The handle kind the aliases belong to.
+    ///   - aliases: Stable id to current runtime id.
+    ///   - runtimeIds: Every live runtime id of this kind, which an alias may
+    ///     never shadow.
+    public func setStableAliases(
+        kind: ControlHandleKind,
+        _ aliases: [UUID: UUID],
+        runtimeIds: Set<UUID>
+    ) {
+        stableIdentities.replace(kind: kind, aliases: aliases, excludingRuntimeIds: runtimeIds)
+    }
+
     // MARK: - Wire helpers
 
     /// The `kind:N` ref for an optional id as a JSON value: the ref string, or
@@ -238,6 +265,22 @@ public final class ControlCommandCoordinator {
         guard case .string(let raw)? = params[key] else { return nil }
         let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
         return trimmed.isEmpty ? nil : trimmed
+    }
+
+    /// The handle kind a routing param names, or `nil` for params whose value
+    /// is not an addressable topology object.
+    ///
+    /// `terminal_id` and `tab_id` are the legacy spellings of `surface_id` and
+    /// address the same object, exactly as ``routingSelectors(_:)`` treats them.
+    public nonisolated static func handleKind(forParamKey key: String) -> ControlHandleKind? {
+        switch key {
+        case "window_id": return .window
+        case "workspace_id": return .workspace
+        case "group_id": return .workspaceGroup
+        case "pane_id": return .pane
+        case "surface_id", "terminal_id", "tab_id": return .surface
+        default: return nil
+        }
     }
 
     /// A UUID param, accepting either a UUID string or a `kind:N` ref resolved

--- a/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Coordinator/ControlCommandCoordinator.swift
+++ b/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Coordinator/ControlCommandCoordinator.swift
@@ -283,12 +283,19 @@ public final class ControlCommandCoordinator {
         }
     }
 
-    /// A UUID param, accepting either a UUID string or a `kind:N` ref resolved
-    /// through the handle registry (matches legacy `v2UUID`).
+    /// A UUID param, accepting a runtime UUID, a restart-stable UUID copied
+    /// from a `cmux://` link, or a `kind:N` ref resolved through the handle
+    /// registry (extends legacy `v2UUID`, which accepted only the latter two).
+    ///
+    /// Stable-to-runtime mapping happens here, at the one place every command's
+    /// identifier params are parsed, so `send`, `read-screen`, `list-*`, and
+    /// every other verb accept a pasted deep-link id without each resolver
+    /// growing its own fallback.
     func uuid(_ params: [String: JSONValue], _ key: String) -> UUID? {
         guard let raw = string(params, key) else { return nil }
         if let parsed = UUID(uuidString: raw) {
-            return parsed
+            guard let kind = Self.handleKind(forParamKey: key) else { return parsed }
+            return stableIdentities.runtimeUUID(for: parsed, kind: kind)
         }
         return handles.uuid(forRef: raw)
     }

--- a/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Wire/ControlStableIdentityTable.swift
+++ b/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Wire/ControlStableIdentityTable.swift
@@ -1,0 +1,68 @@
+public import Foundation
+
+/// Maps restart-stable object identities to the runtime identities the control
+/// socket routes with.
+///
+/// Workspaces and surfaces carry two identifiers. The runtime id
+/// (`Workspace.id` / `Panel.panelId`) is re-minted every launch and is what
+/// every resolver matches on. The stable id (`Workspace.stableId` /
+/// `Panel.stableSurfaceId`) is persisted in the session snapshot, re-adopted on
+/// restore, and is what the UI's copied `cmux://` links carry. Without a
+/// mapping, a link that navigates correctly when opened fails with
+/// `not_found` when its ids are handed to the CLI.
+///
+/// Read from both control-socket lanes: the main-actor coordinator and the
+/// legacy `nonisolated` param parse, which must not take a main-actor hop just
+/// to interpret an identifier. An `NSLock` box therefore replaces the
+/// main-actor registry that holds the `kind:N` refs.
+///
+/// Precedence lives in ``replace(kind:aliases:excludingRuntimeIds:)`` rather
+/// than in the lookup: an alias that collides with a live runtime id is dropped
+/// when the table is built, so a runtime id can never be reinterpreted as
+/// another object's stable id and the lookup stays a single dictionary read.
+/// This matches `CmuxNavigationTargetResolver`, which tries the runtime id
+/// first and falls back to the stable id.
+public final class ControlStableIdentityTable: @unchecked Sendable {
+    private let lock = NSLock()
+    private var runtimeIdByStableId: [ControlHandleKind: [UUID: UUID]] = [:]
+
+    /// Creates an empty table.
+    public init() {}
+
+    /// Replaces the aliases for one handle kind.
+    ///
+    /// Replacement is wholesale, not a merge: a closed workspace's stable id
+    /// must stop resolving rather than route a later command to a dead runtime
+    /// id.
+    ///
+    /// - Parameters:
+    ///   - kind: The handle kind these aliases address.
+    ///   - aliases: Stable id to current runtime id, for every live object.
+    ///   - excludingRuntimeIds: Every live runtime id of this kind. An alias
+    ///     keyed by one of these is dropped, so runtime identity always wins.
+    public func replace(
+        kind: ControlHandleKind,
+        aliases: [UUID: UUID],
+        excludingRuntimeIds: Set<UUID>
+    ) {
+        let filtered = aliases.filter { stableId, runtimeId in
+            stableId != runtimeId && !excludingRuntimeIds.contains(stableId)
+        }
+        lock.lock()
+        runtimeIdByStableId[kind] = filtered
+        lock.unlock()
+    }
+
+    /// Maps a caller-supplied identifier to the runtime identity to route with.
+    ///
+    /// - Parameters:
+    ///   - candidate: The identifier the caller supplied.
+    ///   - kind: The handle kind the identifier is being used as.
+    /// - Returns: The aliased runtime id, or `candidate` unchanged when it is
+    ///   already a runtime id or matches no known stable id.
+    public func runtimeUUID(for candidate: UUID, kind: ControlHandleKind) -> UUID {
+        lock.lock()
+        defer { lock.unlock() }
+        return runtimeIdByStableId[kind]?[candidate] ?? candidate
+    }
+}

--- a/Packages/macOS/CmuxControlSocket/Tests/CmuxControlSocketTests/ControlStableIdentityResolutionTests.swift
+++ b/Packages/macOS/CmuxControlSocket/Tests/CmuxControlSocketTests/ControlStableIdentityResolutionTests.swift
@@ -1,0 +1,158 @@
+import Foundation
+import Testing
+@testable import CmuxControlSocket
+
+/// Regression coverage for https://github.com/manaflow-ai/cmux/issues/9745.
+///
+/// The UI's `Copy cmux link` emits restart-stable ids (`Workspace.stableId` /
+/// `Panel.stableSurfaceId`), not the runtime ids the socket routes with. Every
+/// identifier param must accept either, or a pasted link fails with
+/// `not_found` through the CLI while navigating correctly when opened.
+@MainActor
+@Suite("Control socket stable identity resolution")
+struct ControlStableIdentityResolutionTests {
+    private let stableWorkspace = UUID()
+    private let runtimeWorkspace = UUID()
+    private let stableSurface = UUID()
+    private let runtimeSurface = UUID()
+
+    private func coordinator() -> ControlCommandCoordinator {
+        let c = ControlCommandCoordinator()
+        c.setStableAliases(
+            kind: .workspace,
+            [stableWorkspace: runtimeWorkspace],
+            runtimeIds: [runtimeWorkspace]
+        )
+        c.setStableAliases(
+            kind: .surface,
+            [stableSurface: runtimeSurface],
+            runtimeIds: [runtimeSurface]
+        )
+        return c
+    }
+
+    @Test func routesAStableWorkspaceIdToItsRuntimeId() {
+        let c = coordinator()
+        #expect(c.uuid(["workspace_id": .string(stableWorkspace.uuidString)], "workspace_id")
+            == runtimeWorkspace)
+    }
+
+    @Test func routesAStableSurfaceIdToItsRuntimeId() {
+        let c = coordinator()
+        #expect(c.uuid(["surface_id": .string(stableSurface.uuidString)], "surface_id")
+            == runtimeSurface)
+    }
+
+    /// `terminal_id` and `tab_id` are legacy spellings of `surface_id` and must
+    /// not silently keep the old runtime-only behavior.
+    @Test func routesStableIdsThroughTheLegacySurfaceParamSpellings() {
+        let c = coordinator()
+        #expect(c.uuid(["terminal_id": .string(stableSurface.uuidString)], "terminal_id")
+            == runtimeSurface)
+        #expect(c.uuid(["tab_id": .string(stableSurface.uuidString)], "tab_id")
+            == runtimeSurface)
+    }
+
+    /// The whole routing selector set resolves at once, which is what makes
+    /// every command inherit the behavior from one parse site.
+    @Test func routingSelectorsResolveStableIdsForWorkspaceAndSurface() {
+        let c = coordinator()
+        let selectors = c.routingSelectors([
+            "workspace_id": .string(stableWorkspace.uuidString),
+            "surface_id": .string(stableSurface.uuidString),
+        ])
+        #expect(selectors.workspaceID == runtimeWorkspace)
+        #expect(selectors.surfaceID == runtimeSurface)
+    }
+
+    @Test func leavesRuntimeIdsUntouched() {
+        let c = coordinator()
+        #expect(c.uuid(["surface_id": .string(runtimeSurface.uuidString)], "surface_id")
+            == runtimeSurface)
+        #expect(c.uuid(["workspace_id": .string(runtimeWorkspace.uuidString)], "workspace_id")
+            == runtimeWorkspace)
+    }
+
+    @Test func leavesUnknownIdsUntouchedSoResolversStillReportNotFound() {
+        let c = coordinator()
+        let unknown = UUID()
+        #expect(c.uuid(["surface_id": .string(unknown.uuidString)], "surface_id") == unknown)
+    }
+
+    /// Aliases are namespaced per kind: a surface's stable id must not rewrite a
+    /// workspace param, or a link would route to an unrelated object.
+    @Test func doesNotApplyAnAliasAcrossHandleKinds() {
+        let c = coordinator()
+        #expect(c.uuid(["workspace_id": .string(stableSurface.uuidString)], "workspace_id")
+            == stableSurface)
+    }
+
+    /// Params that do not name a topology object keep raw UUID passthrough.
+    @Test func leavesNonTopologyParamsUnmapped() {
+        let c = coordinator()
+        #expect(ControlCommandCoordinator.handleKind(forParamKey: "checkpoint_id") == nil)
+        #expect(c.uuid(["checkpoint_id": .string(stableSurface.uuidString)], "checkpoint_id")
+            == stableSurface)
+    }
+
+    @Test func refsStillResolveThroughTheHandleRegistry() {
+        let c = coordinator()
+        let ref = c.ensureRef(kind: .surface, uuid: runtimeSurface)
+        #expect(c.uuid(["surface_id": .string(ref)], "surface_id") == runtimeSurface)
+    }
+}
+
+/// The table's own invariants, independent of param parsing.
+@Suite("ControlStableIdentityTable")
+struct ControlStableIdentityTableTests {
+    /// A live runtime id must never be reinterpreted as another object's stable
+    /// id, matching `CmuxNavigationTargetResolver`'s runtime-first precedence.
+    @Test func runtimeIdentityWinsOverACollidingAlias() {
+        let table = ControlStableIdentityTable()
+        let contested = UUID()
+        let other = UUID()
+        table.replace(
+            kind: .surface,
+            aliases: [contested: other],
+            excludingRuntimeIds: [contested]
+        )
+        #expect(table.runtimeUUID(for: contested, kind: .surface) == contested)
+    }
+
+    @Test func selfAliasesAreDropped() {
+        let table = ControlStableIdentityTable()
+        let id = UUID()
+        table.replace(kind: .workspace, aliases: [id: id], excludingRuntimeIds: [])
+        #expect(table.runtimeUUID(for: id, kind: .workspace) == id)
+    }
+
+    /// Replacement is wholesale: a closed workspace's stable id must stop
+    /// resolving rather than route a later command to a dead runtime id.
+    @Test func replacingForgetsAliasesForClosedObjects() {
+        let table = ControlStableIdentityTable()
+        let stale = UUID()
+        let staleRuntime = UUID()
+        let live = UUID()
+        let liveRuntime = UUID()
+        table.replace(
+            kind: .workspace,
+            aliases: [stale: staleRuntime, live: liveRuntime],
+            excludingRuntimeIds: [staleRuntime, liveRuntime]
+        )
+        #expect(table.runtimeUUID(for: stale, kind: .workspace) == staleRuntime)
+
+        table.replace(kind: .workspace, aliases: [live: liveRuntime], excludingRuntimeIds: [liveRuntime])
+        #expect(table.runtimeUUID(for: stale, kind: .workspace) == stale)
+        #expect(table.runtimeUUID(for: live, kind: .workspace) == liveRuntime)
+    }
+
+    @Test func kindsAreIndependent() {
+        let table = ControlStableIdentityTable()
+        let stable = UUID()
+        let runtime = UUID()
+        table.replace(kind: .surface, aliases: [stable: runtime], excludingRuntimeIds: [runtime])
+        #expect(table.runtimeUUID(for: stable, kind: .surface) == runtime)
+        #expect(table.runtimeUUID(for: stable, kind: .workspace) == stable)
+        #expect(table.runtimeUUID(for: stable, kind: .pane) == stable)
+    }
+}

--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -307,6 +307,12 @@ class TerminalController {
     /// `init`; its `context` is wired to `self` once `self` is available.
     let controlCommandCoordinator = ControlCommandCoordinator()
 
+    /// The coordinator's stable-to-runtime identity table, cached by reference
+    /// so the `nonisolated` param parse can map a pasted `cmux://` link's ids
+    /// without a main-actor hop. Same instance the coordinator reads; assigned
+    /// in `init`, never replaced.
+    nonisolated let controlStableIdentities: ControlStableIdentityTable
+
     private struct V2BrowserElementRefEntry {
         let surfaceId: UUID
         let selector: String
@@ -386,6 +392,7 @@ class TerminalController {
         nativeSSHConnectionBroker: NativeSSHConnectionBroker = NativeSSHConnectionBroker()
     ) {
         self.passwordStore = passwordStore
+        self.controlStableIdentities = controlCommandCoordinator.stableIdentities
         let socketPasswordFileWatcher = passwordStore.passwordFileURL.map {
             FileWatcher(path: $0.path)
         }
@@ -3703,6 +3710,13 @@ class TerminalController {
     func v2RefreshKnownRefs() {
         guard let app = AppDelegate.shared else { return }
 
+        // Rebuilt from scratch each refresh so a closed workspace's stable id
+        // stops resolving rather than routing to a dead runtime id.
+        var workspaceStableAliases: [UUID: UUID] = [:]
+        var surfaceStableAliases: [UUID: UUID] = [:]
+        var workspaceRuntimeIds: Set<UUID> = []
+        var surfaceRuntimeIds: Set<UUID> = []
+
         let windows = app.listMainWindowSummaries()
         for item in windows {
             _ = v2EnsureHandleRef(kind: .window, uuid: item.windowId)
@@ -3710,6 +3724,13 @@ class TerminalController {
                 for ws in tm.tabs {
                     _ = v2EnsureHandleRef(kind: .workspace, uuid: ws.id)
                     v2RefreshRemoteTmuxAwarePaneAndSurfaceRefs(workspace: ws)
+                    v2CollectStableAliases(
+                        workspace: ws,
+                        workspaces: &workspaceStableAliases,
+                        surfaces: &surfaceStableAliases,
+                        workspaceRuntimeIds: &workspaceRuntimeIds,
+                        surfaceRuntimeIds: &surfaceRuntimeIds
+                    )
                 }
                 // Mint workspace_group refs for groups that exist before any
                 // workspace.group.* call so callers can pass `workspace_group:N`
@@ -3719,6 +3740,39 @@ class TerminalController {
                     _ = v2EnsureHandleRef(kind: .workspaceGroup, uuid: group.id)
                 }
             }
+        }
+
+        controlCommandCoordinator.setStableAliases(
+            kind: .workspace,
+            workspaceStableAliases,
+            runtimeIds: workspaceRuntimeIds
+        )
+        controlCommandCoordinator.setStableAliases(
+            kind: .surface,
+            surfaceStableAliases,
+            runtimeIds: surfaceRuntimeIds
+        )
+    }
+
+    /// Records one workspace's restart-stable identities for the socket's
+    /// alias table.
+    ///
+    /// Reads the same ``Workspace/cmuxNavigationDescriptor`` snapshot that
+    /// `cmux://` navigation resolves against, so a link resolves to the same
+    /// object whether it is opened or passed to the CLI.
+    private func v2CollectStableAliases(
+        workspace: Workspace,
+        workspaces: inout [UUID: UUID],
+        surfaces: inout [UUID: UUID],
+        workspaceRuntimeIds: inout Set<UUID>,
+        surfaceRuntimeIds: inout Set<UUID>
+    ) {
+        let descriptor = workspace.cmuxNavigationDescriptor
+        workspaceRuntimeIds.insert(descriptor.workspaceId)
+        workspaces[descriptor.stableId] = descriptor.workspaceId
+        for surface in descriptor.surfaces {
+            surfaceRuntimeIds.insert(surface.panelId)
+            surfaces[surface.stableSurfaceId] = surface.panelId
         }
     }
 

--- a/Sources/TerminalControllerV2ParamParsingSupport.swift
+++ b/Sources/TerminalControllerV2ParamParsingSupport.swift
@@ -1,5 +1,6 @@
 import Foundation
 import Bonsplit
+import CmuxControlSocket
 
 extension TerminalController {
     nonisolated func v2String(_ params: [String: Any], _ key: String) -> String? {
@@ -84,10 +85,20 @@ extension TerminalController {
         return (min(max(rawPosition, 0.1), 0.9), nil)
     }
 
+    /// The legacy lane's twin of `ControlCommandCoordinator.uuid(_:_:)`,
+    /// including its restart-stable to runtime mapping, so the verbs still
+    /// served here (workspace move, mobile, file open) accept a pasted
+    /// `cmux://` link's ids exactly as the coordinator-owned verbs do.
+    ///
+    /// The alias lookup is `nonisolated` by design: this parse runs off the
+    /// main actor and must not take a hop to interpret an identifier.
     nonisolated func v2UUID(_ params: [String: Any], _ key: String) -> UUID? {
         guard let s = v2String(params, key) else { return nil }
         if let uuid = UUID(uuidString: s) {
-            return uuid
+            guard let kind = ControlCommandCoordinator.handleKind(forParamKey: key) else {
+                return uuid
+            }
+            return controlStableIdentities.runtimeUUID(for: uuid, kind: kind)
         }
         return v2MainSync { v2ResolveHandleRef(s) }
     }


### PR DESCRIPTION
Fixes https://github.com/manaflow-ai/cmux/issues/9745.

`Copy cmux link` emits restart-stable ids (`Workspace.stableId` / `Panel.stableSurfaceId`). Every control-socket resolver matched runtime ids (`Workspace.id` / `Panel.panelId`), which are re-minted each launch. So a link that navigates correctly when opened failed through the CLI:

```
$ cmux read-screen --surface 706F14A5-0659-491E-8727-8EFAFD7A4374
Error: not_found: Workspace not found
```

The only workaround was reading `~/Library/Application Support/cmux/session-<bundle-id>.json` and matching panel order and titles by hand. Agents handed a pasted link concluded the surface did not exist.

Stable-to-runtime mapping now happens at the two places identifier params are parsed, `ControlCommandCoordinator.uuid(_:_:)` and the legacy off-main `v2UUID`, so every verb inherits it instead of each resolver growing its own fallback. `terminal_id` and `tab_id` map as surfaces, matching `routingSelectors`.

The alias table is published from `v2RefreshKnownRefs`, the same topology refresh that mints `kind:N` refs, and is built from `Workspace.cmuxNavigationDescriptor`: the snapshot `CmuxNavigationTargetResolver` already resolves deep links against. Deep links and the CLI now share one identity policy rather than two that disagree.

Precedence is enforced when the table is built, not at lookup: an alias colliding with a live runtime id is dropped, so a runtime id is never reinterpreted as another object's stable id, and the lookup stays a single dictionary read. The table is replaced wholesale each refresh, so a closed workspace's stable id stops resolving instead of routing to a dead runtime id. It lives in an `NSLock` box rather than the main-actor handle registry because the legacy param parse runs off-main and must not take a main-actor hop to interpret an identifier.

## Verification

Preflighted on tag `stbid` against a live tagged instance whose stable and runtime ids differ (stable workspace `3B964989…` vs runtime `80D7C5ED…`; stable surface `4F19FD55…` vs runtime `BF80B4BA…`):

- `read-screen --surface <stable>` returns the screen (was `not_found`)
- `list-pane-surfaces --workspace <stable>` returns the pane (was `not_found`)
- `send --workspace <stable> --surface <stable>` reports `OK surface:1 workspace:1` and the text lands in the right terminal
- an unknown UUID still returns `not_found`

375 `CmuxControlSocket` package tests pass. The first commit is test-only so CI shows the 4 resolution expectations red, the second turns them green.

## Not in this PR

`tree`/`identify`/`list-*` still never emit stable ids at any `--id-format`, so a durable ref can only be obtained from the UI's copy command, not from the CLI. Tracked separately in https://github.com/manaflow-ai/cmux/issues/9767.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/9766"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788669408&installation_model_id=21920&pr_number=9766&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F9766&signature=a302dbb4afd67a0d9b7f2a9bad753a22738b56dcbde3bdc6f8ad6acbe4912697"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes identifier parsing for all control-socket commands; incorrect mapping could route CLI actions to the wrong workspace or surface, though precedence rules and wholesale refresh limit exposure.
> 
> **Overview**
> **CLI and control-socket commands now accept restart-stable UUIDs** (from copied `cmux://` links) for workspace and surface routing params, mapping them to runtime ids at parse time instead of returning `not_found`.
> 
> A new **`ControlStableIdentityTable`** holds stable→runtime aliases per handle kind, refreshed wholesale from **`v2RefreshKnownRefs`** using the same **`cmuxNavigationDescriptor`** snapshot deep-link navigation uses. **`ControlCommandCoordinator.uuid`** and legacy off-main **`v2UUID`** consult the table for topology param keys (`workspace_id`, `surface_id`, `terminal_id`, `tab_id`, etc.); runtime ids and `kind:N` refs behave as before, with runtime id precedence when an alias would collide.
> 
> The table is **`nonisolated`** with an **`NSLock`** so the legacy param path does not require a main-actor hop. Regression tests cover resolution, legacy surface param spellings, cross-kind isolation, and table replacement when objects close.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3e728dc23b4af21144c28e99e7fb2a5b9c81d45d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added stable identity support for workspace and surface control commands.
  * Stable IDs now resolve to the current runtime objects, even after navigation changes or restarts.
  * Legacy surface parameter names remain supported.

* **Bug Fixes**
  * Prevented stale identities from resolving to closed objects.
  * Runtime IDs take precedence over stable aliases, while unknown IDs and non-UUID references retain existing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->