### PR TITLE
Preserve admitted Iroh sessions across auth refresh blips

### DIFF
--- a/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxConnectivityEngine.swift
+++ b/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxConnectivityEngine.swift
@@ -735,7 +735,7 @@ public actor CmxConnectivityEngine {
         } catch {
             guard routeRevision != nil,
                   CmxIrohTrustBrokerClientError
-                    .preservesVerifiedPolicyDuringRefresh(error) else {
+                    .preservesVerifiedStateDuringRefresh(error) else {
                 throw error
             }
         }

--- a/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohClientRuntime+PolicyRefresh.swift
+++ b/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohClientRuntime+PolicyRefresh.swift
@@ -130,7 +130,7 @@ extension CmxIrohClientRuntime {
                 throw error
             }
             guard !CmxIrohTrustBrokerClientError
-                .preservesVerifiedPolicyDuringRefresh(error) else {
+                .preservesVerifiedStateDuringRefresh(error) else {
                 // Keep the last exact verified binding while broker availability
                 // prevents a refresh.
                 return .failed(DiagnosticFailureKind.classify(error))

--- a/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohHostRuntime+PolicyRefresh.swift
+++ b/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohHostRuntime+PolicyRefresh.swift
@@ -269,7 +269,7 @@ extension CmxIrohHostRuntime {
         }
         guard allowFallback,
               CmxIrohTrustBrokerClientError
-                .preservesVerifiedPolicyDuringRefresh(error),
+                .preservesVerifiedStateDuringRefresh(error),
               let cached = configuration.cachedHostPolicy else {
             throw error
         }
@@ -586,7 +586,7 @@ extension CmxIrohHostRuntime {
             guard lifecyclePhase == .active,
                   lifecycleRevision == revision else { return }
             guard CmxIrohTrustBrokerClientError
-                .preservesVerifiedPolicyDuringRefresh(error) else {
+                .preservesVerifiedStateDuringRefresh(error) else {
                 lifecyclePhase = .stopping
                 lifecycleRevision &+= 1
                 let failureRevision = lifecycleRevision

--- a/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohHostRuntime+PublicAPI.swift
+++ b/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohHostRuntime+PublicAPI.swift
@@ -173,7 +173,7 @@ extension CmxIrohHostRuntime {
                 return .failed(.superseded)
             }
             if CmxIrohTrustBrokerClientError
-                .preservesVerifiedPolicyDuringRefresh(error) {
+                .preservesVerifiedStateDuringRefresh(error) {
                 return .failed(DiagnosticFailureKind.classify(error))
             }
             lifecyclePhase = .stopping

--- a/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohOnlineAdmissionRegistry.swift
+++ b/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohOnlineAdmissionRegistry.swift
@@ -33,7 +33,7 @@ public actor CmxIrohOnlineAdmissionRegistry {
 
     private enum Revalidation {
         case active(Date)
-        case connectivity
+        case deferred
         case terminal(CmxIrohOnlineAdmissionInvalidationReason)
     }
 
@@ -269,7 +269,7 @@ public actor CmxIrohOnlineAdmissionRegistry {
                 nextOnlineCheck = fetchedAt.addingTimeInterval(
                     Self.maximumOnlineSnapshotAge
                 )
-            case .connectivity:
+            case .deferred:
                 nextOnlineCheck = clock.now().addingTimeInterval(
                     Self.maximumOnlineSnapshotAge
                 )
@@ -307,9 +307,12 @@ public actor CmxIrohOnlineAdmissionRegistry {
             guard clock.now() < lease.expiresAt else {
                 return .terminal(.leaseExpired)
             }
-            return Self.isConnectivity(error) && policyRevision == revision
-                ? .connectivity
-                : .terminal(.revalidationFailed)
+            let preservesVerifiedState = CmxIrohTrustBrokerClientError
+                .preservesVerifiedStateDuringRefresh(error)
+            guard policyRevision == revision, preservesVerifiedState else {
+                return .terminal(.revalidationFailed)
+            }
+            return .deferred
         }
     }
 

--- a/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohTrustBrokerClientError.swift
+++ b/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohTrustBrokerClientError.swift
@@ -17,7 +17,11 @@ public enum CmxIrohTrustBrokerClientError:
     case rejected(statusCode: Int, code: String?)
     case invalidResponse
 
-    static func preservesVerifiedPolicyDuringRefresh(_ error: any Error) -> Bool {
+    /// Whether an inconclusive refresh may preserve already-verified state.
+    ///
+    /// This never admits a new peer. Callers may retain only state whose own
+    /// signed lease or policy expiry remains authoritative.
+    static func preservesVerifiedStateDuringRefresh(_ error: any Error) -> Bool {
         if (error as? any CmxRetryAfterProviding)?.retryAfterSeconds != nil {
             return true
         }
@@ -32,11 +36,11 @@ public enum CmxIrohTrustBrokerClientError:
             // broker client's single force-refresh retry, so it is a session
             // transition still settling (rotation race, locked token store) or
             // a server-side availability condition — not a trust change. The
-            // cached policy was verified when stored; tearing the runtime down
-            // buys nothing and turns a seconds-long auth blip into a full
-            // endpoint rebuild. A genuinely dead session clears auth state
-            // through the coordinator, which stops the runtime through the
-            // lifecycle owner instead.
+            // existing state remains bounded by its signed expiry; tearing it
+            // down buys nothing and turns a seconds-long auth blip into a full
+            // endpoint or session rebuild. A genuinely dead session clears
+            // auth state through the coordinator, which stops the runtime
+            // through the lifecycle owner instead.
             return statusCode == 401
                 || statusCode == 408
                 || statusCode == 425

--- a/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohOnlineAdmissionRegistryLeaseTests.swift
+++ b/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohOnlineAdmissionRegistryLeaseTests.swift
@@ -248,6 +248,94 @@ extension CmxIrohOnlineAdmissionRegistryTests {
         await registry.stop()
     }
 
+    @Test(arguments: [
+        CmxIrohTrustBrokerClientError.rejected(
+            statusCode: 401,
+            code: "unauthorized"
+        ),
+        .rejected(statusCode: 408, code: "request_timeout"),
+        .rejected(statusCode: 425, code: "too_early"),
+        .rateLimited(code: "rate_limited", retryAfterSeconds: 5),
+        .rejected(statusCode: 503, code: "unavailable"),
+    ])
+    func retryableRefreshFailureDoesNotCloseVerifiedLease(
+        _ error: CmxIrohTrustBrokerClientError
+    ) async throws {
+        let fixture = try OnlineAdmissionFixture()
+        let clock = OnlineAdmissionManualClock(now: fixture.now)
+        let broker = OnlineAdmissionBroker(responses: [
+            .success(try fixture.discovery()),
+            .failure(error),
+        ])
+        let registry = fixture.registry(broker: broker, clock: clock)
+        let lease = try #require(
+            await registry.authorizePairGrant(
+                fixture.grant(),
+                authenticatedPeerID: fixture.initiator.endpointID
+            ).lease
+        )
+        let closeRecorder = OnlineAdmissionCloseRecorder()
+        await registry.monitor(lease, connection: fixture.connection()) { reason in
+            await closeRecorder.close(reason: reason)
+        }
+        await clock.waitUntilSleeping()
+
+        clock.advance(by: 30)
+        await broker.waitForCallCount(2)
+        for _ in 0 ..< 1_024 {
+            if await closeRecorder.count() > 0
+                || clock.sleepingDeadlines()
+                    == [fixture.now.addingTimeInterval(60)] {
+                break
+            }
+            await Task.yield()
+        }
+
+        #expect(await closeRecorder.count() == 0)
+        #expect(
+            clock.sleepingDeadlines()
+                == [fixture.now.addingTimeInterval(60)]
+        )
+        await registry.stop()
+    }
+
+    @Test(arguments: [
+        CmxIrohTrustBrokerClientError.missingAuthentication,
+        .invalidAuthentication,
+        .rejected(statusCode: 403, code: "forbidden"),
+        .invalidResponse,
+    ])
+    func definitiveRefreshFailureClosesVerifiedLease(
+        _ error: CmxIrohTrustBrokerClientError
+    ) async throws {
+        let fixture = try OnlineAdmissionFixture()
+        let clock = OnlineAdmissionManualClock(now: fixture.now)
+        let broker = OnlineAdmissionBroker(responses: [
+            .success(try fixture.discovery()),
+            .failure(error),
+        ])
+        let registry = fixture.registry(broker: broker, clock: clock)
+        let lease = try #require(
+            await registry.authorizePairGrant(
+                fixture.grant(),
+                authenticatedPeerID: fixture.initiator.endpointID
+            ).lease
+        )
+        let closeRecorder = OnlineAdmissionCloseRecorder()
+        await registry.monitor(lease, connection: fixture.connection()) { reason in
+            await closeRecorder.close(reason: reason)
+        }
+        await clock.waitUntilSleeping()
+
+        clock.advance(by: 30)
+        await closeRecorder.waitUntilClosed()
+
+        #expect(
+            await closeRecorder.observedReasons()
+                == [.revalidationFailed]
+        )
+    }
+
     @Test
     func quickTransportRegistrationRetainsMonitorForConnectionLifetime() async throws {
         let fixture = try OnlineAdmissionFixture()

--- a/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohTrustBrokerClientAuthClassifierTests.swift
+++ b/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohTrustBrokerClientAuthClassifierTests.swift
@@ -8,14 +8,14 @@ import Testing
 /// race into a multi-minute connectivity gap on every app foreground.
 struct CmxIrohTrustBrokerClientAuthClassifierTests {
     @Test
-    func unauthorizedRejectionPreservesVerifiedPolicyDuringRefresh() {
-        #expect(CmxIrohTrustBrokerClientError.preservesVerifiedPolicyDuringRefresh(
+    func unauthorizedRejectionPreservesVerifiedStateDuringRefresh() {
+        #expect(CmxIrohTrustBrokerClientError.preservesVerifiedStateDuringRefresh(
             CmxIrohTrustBrokerClientError.rejected(
                 statusCode: 401,
                 code: "unauthorized"
             )
         ))
-        #expect(!CmxIrohTrustBrokerClientError.preservesVerifiedPolicyDuringRefresh(
+        #expect(!CmxIrohTrustBrokerClientError.preservesVerifiedStateDuringRefresh(
             CmxIrohTrustBrokerClientError.rejected(statusCode: 403, code: nil)
         ))
     }


### PR DESCRIPTION
## Summary

- Preserve already-verified Iroh admission leases across retryable broker refresh failures.
- Keep definitive policy/authentication failures and signed lease expiry fail-closed.
- Reuse the verified-state refresh classifier across live admission revalidation.

## Testing

- Test-only red run: https://github.com/manaflow-ai/cmux/actions/runs/31147437964
- Fixed run: https://github.com/manaflow-ai/cmux/actions/runs/31147540620
- Rebased patches verified unchanged with `git range-diff`.
- Added parameterized coverage for retryable and definitive broker failures.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/9775"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788671339&installation_model_id=21920&pr_number=9775&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F9775&signature=9fa523ce8b0c477d2797bf4c24fec00b0a4cd36540b2142b6917a9afc8cefb85"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes live session admission revalidation during broker/auth outages in security-sensitive Iroh transport code, though definitive trust failures and lease expiry remain fail-closed.
> 
> **Overview**
> Renames the broker refresh classifier to **`preservesVerifiedStateDuringRefresh`** and wires it through connectivity engine route reconciliation, client/host policy refresh, and live online admission revalidation so inconclusive broker errors no longer tear down already-verified state.
> 
> **Online admission lease monitors** no longer close admitted sessions when periodic revalidation hits retryable broker failures (connectivity, 401 after refresh retry, 408/425/429, rate limits, 5xx). Revalidation is **deferred** and the monitor reschedules; definitive failures (missing/invalid auth, 403, invalid response) and signed lease expiry still fail closed with **`revalidationFailed`**.
> 
> Adds parameterized lease tests for retryable vs definitive refresh errors and updates classifier regression naming/docs to stress that preservation never admits new peers—only retains state bounded by signed lease or policy expiry.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e996d8a3f64165927c1be5be9979748bec67e821. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves admitted Iroh sessions during transient broker refresh failures to avoid needless disconnects on iOS. Still fails closed on definitive auth errors or lease expiry.

- **Bug Fixes**
  - Treat retryable broker refresh errors (401, 408, 425, 429 rate-limited, 503, 5xx) as non-terminal; keep verified state until its signed expiry.
  - Keep fail-closed for missing/invalid auth, 403, invalid responses, and signed lease expiry.
  - Rename and reuse a unified classifier `preservesVerifiedStateDuringRefresh` across connectivity engine, client/host policy refresh, and online admission revalidation.
  - Switch revalidation from a “connectivity” state to a “deferred” state and reschedule checks without closing; add parameterized lease tests that expose premature disconnects and verify retryable vs definitive paths.

<sup>Written for commit 7ffe71cc844e50badd0a9fbd0dc69d1ceed43f07. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/9775?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of trust-broker refresh failures during active connections.
  * Retryable failures now preserve verified access and schedule another refresh.
  * Definitive failures now correctly close the active lease and report revalidation failure.
  * Improved distinction between temporary broker issues and connectivity failures.

* **Tests**
  * Added coverage for lease preservation, retry behavior, and definitive authorization failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

