### PR TITLE
iOS: inline Move to Group context-menu picker for workspaces

### DIFF
--- a/Packages/iOS/CmuxMobileShellModel/Sources/CmuxMobileShellModel/MobileWorkspaceGroupMoveMenu.swift
+++ b/Packages/iOS/CmuxMobileShellModel/Sources/CmuxMobileShellModel/MobileWorkspaceGroupMoveMenu.swift
@@ -1,0 +1,113 @@
+import Foundation
+
+/// Menu model for moving one workspace into a workspace group without dragging.
+///
+/// Computes the "Move to Group" picker shown in a workspace row's context menu:
+/// one entry per candidate group on the workspace's own Mac, plus whether a
+/// "Remove from Group" action applies. Selection routes through the same move
+/// intent path as drag-and-drop (`MobileWorkspaceMovePolicy`), so the picker can
+/// never offer a move the drop path would reject.
+public struct MobileWorkspaceGroupMoveMenu: Equatable, Sendable {
+    /// One selectable group target in the picker.
+    public struct Entry: Equatable, Sendable {
+        /// The candidate destination group.
+        public let group: MobileWorkspaceGroupPreview
+        /// Whether the workspace is already a member of this group. Current
+        /// membership renders as a checked, non-actionable item.
+        public let isCurrent: Bool
+        /// Whether choosing this group is a valid move for the workspace.
+        public let isEnabled: Bool
+
+        /// Creates a picker entry.
+        /// - Parameters:
+        ///   - group: The candidate destination group.
+        ///   - isCurrent: Whether the workspace already belongs to the group.
+        ///   - isEnabled: Whether the move is valid.
+        public init(group: MobileWorkspaceGroupPreview, isCurrent: Bool, isEnabled: Bool) {
+            self.group = group
+            self.isCurrent = isCurrent
+            self.isEnabled = isEnabled
+        }
+    }
+
+    /// Candidate groups in section order, restricted to the workspace's Mac.
+    public let entries: [Entry]
+    /// Whether the workspace can leave its current group ("Remove from Group").
+    public let canRemoveFromGroup: Bool
+
+    /// Whether the picker offers nothing and should be hidden entirely.
+    public var isEmpty: Bool {
+        entries.isEmpty && !canRemoveFromGroup
+    }
+
+    /// Builds the picker for one workspace against a rendered list snapshot.
+    ///
+    /// Group anchors get an empty picker: an anchor is its group's header and
+    /// moves with the group, matching the host's `workspace.move` rejection.
+    ///
+    /// - Parameters:
+    ///   - workspaces: The displayed workspace order (optimistic when a move is
+    ///     already in flight), as validated by ``MobileWorkspaceMovePolicy``.
+    ///   - groups: The known workspace groups in section order.
+    ///   - movedWorkspaceID: The workspace the context menu belongs to.
+    public init(
+        workspaces: [MobileWorkspacePreview],
+        groups: [MobileWorkspaceGroupPreview],
+        movedWorkspaceID: MobileWorkspacePreview.ID
+    ) {
+        guard let moved = workspaces.first(where: { $0.id == movedWorkspaceID }),
+              !groups.contains(where: { $0.anchorWorkspaceID == movedWorkspaceID }) else {
+            entries = []
+            canRemoveFromGroup = false
+            return
+        }
+        let policy = MobileWorkspaceMovePolicy(workspaces: workspaces, groups: groups)
+        entries = groups.filter { group in
+            Self.sameMac(group: group, workspace: moved)
+        }.map { group in
+            let isCurrent = moved.groupID == group.id
+            return Entry(
+                group: group,
+                isCurrent: isCurrent,
+                isEnabled: !isCurrent && policy.normalizedIntent(
+                    MobileWorkspaceMoveIntent(
+                        groupID: group.id,
+                        beforeWorkspaceID: nil,
+                        movesGroup: false
+                    ),
+                    movedWorkspaceID: movedWorkspaceID
+                ) != nil
+            )
+        }
+        let currentGroupIsKnown = moved.groupID.map { groupID in
+            groups.contains(where: { $0.id == groupID })
+        } ?? false
+        canRemoveFromGroup = currentGroupIsKnown
+            && policy.normalizedIntent(
+                MobileWorkspaceMoveIntent(
+                    groupID: nil,
+                    beforeWorkspaceID: nil,
+                    movesGroup: false
+                ),
+                movedWorkspaceID: movedWorkspaceID
+            ) != nil
+    }
+
+    /// Whether a group and a workspace belong to the same Mac app instance.
+    ///
+    /// Aggregation stamps `macDeviceID` on groups unconditionally (possibly as
+    /// an empty string) but on workspaces only when non-empty, so empty and
+    /// `nil` must compare as the same "unscoped" owner.
+    private static func sameMac(
+        group: MobileWorkspaceGroupPreview,
+        workspace: MobileWorkspacePreview
+    ) -> Bool {
+        normalized(group.macDeviceID) == normalized(workspace.macDeviceID)
+            && normalized(group.macInstanceTag) == normalized(workspace.macInstanceTag)
+    }
+
+    private static func normalized(_ value: String?) -> String? {
+        guard let value, !value.isEmpty else { return nil }
+        return value
+    }
+}

--- a/Packages/iOS/CmuxMobileShellModel/Tests/CmuxMobileShellModelTests/MobileWorkspaceGroupMoveMenuTests.swift
+++ b/Packages/iOS/CmuxMobileShellModel/Tests/CmuxMobileShellModelTests/MobileWorkspaceGroupMoveMenuTests.swift
@@ -1,0 +1,186 @@
+import Foundation
+import Testing
+
+@testable import CmuxMobileShellModel
+
+@Suite struct MobileWorkspaceGroupMoveMenuTests {
+    private func workspace(
+        _ id: String,
+        group: String? = nil,
+        pinned: Bool = false,
+        mac: String? = nil,
+        tag: String? = nil
+    ) -> MobileWorkspacePreview {
+        var workspace = MobileWorkspacePreview(
+            id: .init(rawValue: id),
+            name: id,
+            isPinned: pinned,
+            groupID: group.map { .init(rawValue: $0) },
+            terminals: []
+        )
+        workspace.macDeviceID = mac
+        workspace.macInstanceTag = tag
+        return workspace
+    }
+
+    private func group(
+        _ id: String,
+        anchor: String,
+        collapsed: Bool = false,
+        mac: String? = nil,
+        tag: String? = nil
+    ) -> MobileWorkspaceGroupPreview {
+        var group = MobileWorkspaceGroupPreview(
+            id: .init(rawValue: id),
+            name: id,
+            isCollapsed: collapsed,
+            anchorWorkspaceID: .init(rawValue: anchor)
+        )
+        group.macDeviceID = mac
+        group.macInstanceTag = tag
+        return group
+    }
+
+    private func makeMenu(
+        _ workspaces: [MobileWorkspacePreview],
+        _ groups: [MobileWorkspaceGroupPreview],
+        moved: String
+    ) -> MobileWorkspaceGroupMoveMenu {
+        MobileWorkspaceGroupMoveMenu(
+            workspaces: workspaces,
+            groups: groups,
+            movedWorkspaceID: .init(rawValue: moved)
+        )
+    }
+
+    @Test func rootWorkspaceSeesEveryGroupEnabledAndCannotRemove() {
+        let menu = makeMenu(
+            [
+                workspace("g-anchor", group: "g"),
+                workspace("g-one", group: "g"),
+                workspace("h-anchor", group: "h"),
+                workspace("root"),
+            ],
+            [group("g", anchor: "g-anchor"), group("h", anchor: "h-anchor")],
+            moved: "root"
+        )
+        #expect(menu.entries.map(\.group.id.rawValue) == ["g", "h"])
+        #expect(menu.entries.allSatisfy { $0.isEnabled && !$0.isCurrent })
+        #expect(!menu.canRemoveFromGroup)
+        #expect(!menu.isEmpty)
+    }
+
+    @Test func groupedWorkspaceGetsCheckedDisabledCurrentEntryAndCanRemove() {
+        let menu = makeMenu(
+            [
+                workspace("g-anchor", group: "g"),
+                workspace("g-one", group: "g"),
+                workspace("h-anchor", group: "h"),
+            ],
+            [group("g", anchor: "g-anchor"), group("h", anchor: "h-anchor")],
+            moved: "g-one"
+        )
+        let current = menu.entries.first { $0.group.id.rawValue == "g" }
+        let other = menu.entries.first { $0.group.id.rawValue == "h" }
+        #expect(current?.isCurrent == true)
+        #expect(current?.isEnabled == false)
+        #expect(other?.isCurrent == false)
+        #expect(other?.isEnabled == true)
+        #expect(menu.canRemoveFromGroup)
+    }
+
+    @Test func anchorWorkspaceGetsEmptyMenu() {
+        let menu = makeMenu(
+            [
+                workspace("g-anchor", group: "g"),
+                workspace("g-one", group: "g"),
+                workspace("h-anchor", group: "h"),
+            ],
+            [group("g", anchor: "g-anchor"), group("h", anchor: "h-anchor")],
+            moved: "g-anchor"
+        )
+        #expect(menu.entries.isEmpty)
+        #expect(!menu.canRemoveFromGroup)
+        #expect(menu.isEmpty)
+    }
+
+    @Test func unknownWorkspaceGetsEmptyMenu() {
+        let menu = makeMenu(
+            [workspace("g-anchor", group: "g")],
+            [group("g", anchor: "g-anchor")],
+            moved: "missing"
+        )
+        #expect(menu.isEmpty)
+    }
+
+    @Test func groupsFromAnotherMacAreExcluded() {
+        let menu = makeMenu(
+            [
+                workspace("a-anchor", group: "a-group", mac: "mac-a", tag: "dev"),
+                workspace("a-root", mac: "mac-a", tag: "dev"),
+                workspace("b-anchor", group: "b-group", mac: "mac-b"),
+            ],
+            [
+                group("a-group", anchor: "a-anchor", mac: "mac-a", tag: "dev"),
+                group("b-group", anchor: "b-anchor", mac: "mac-b"),
+            ],
+            moved: "a-root"
+        )
+        #expect(menu.entries.map(\.group.id.rawValue) == ["a-group"])
+    }
+
+    @Test func emptyMacStampOnGroupMatchesUnstampedWorkspace() {
+        // Aggregation stamps groups unconditionally (possibly with an empty
+        // device id) but workspaces only when the owner id is non-empty.
+        let menu = makeMenu(
+            [
+                workspace("g-anchor", group: "g"),
+                workspace("root"),
+            ],
+            [group("g", anchor: "g-anchor", mac: "")],
+            moved: "root"
+        )
+        #expect(menu.entries.map(\.group.id.rawValue) == ["g"])
+        #expect(menu.entries.first?.isEnabled == true)
+    }
+
+    @Test func collapsedGroupIsStillATarget() {
+        let menu = makeMenu(
+            [
+                workspace("g-anchor", group: "g"),
+                workspace("root"),
+            ],
+            [group("g", anchor: "g-anchor", collapsed: true)],
+            moved: "root"
+        )
+        #expect(menu.entries.first?.isEnabled == true)
+    }
+
+    @Test func workspaceWhoseGroupNoLongerExistsCannotRemove() {
+        let menu = makeMenu(
+            [
+                workspace("orphan", group: "deleted"),
+                workspace("g-anchor", group: "g"),
+            ],
+            [group("g", anchor: "g-anchor")],
+            moved: "orphan"
+        )
+        #expect(!menu.canRemoveFromGroup)
+        #expect(menu.entries.map(\.group.id.rawValue) == ["g"])
+    }
+
+    @Test func soleGroupMembershipStillShowsMenuThroughRemove() {
+        let menu = makeMenu(
+            [
+                workspace("g-anchor", group: "g"),
+                workspace("g-one", group: "g"),
+            ],
+            [group("g", anchor: "g-anchor")],
+            moved: "g-one"
+        )
+        #expect(menu.entries.count == 1)
+        #expect(menu.entries.first?.isEnabled == false)
+        #expect(menu.canRemoveFromGroup)
+        #expect(!menu.isEmpty)
+    }
+}

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListTable.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListTable.swift
@@ -35,6 +35,12 @@ struct WorkspaceListTable: UIViewControllerRepresentable {
     let moveRows: ((IndexSet, Int) -> Void)?
     let canDropIntoGroup: ((MobileWorkspacePreview.ID, MobileWorkspaceGroupPreview.ID) -> Bool)?
     let dropIntoGroup: ((MobileWorkspacePreview.ID, MobileWorkspaceGroupPreview.ID) -> Void)?
+    /// Builds the row's "Move to Group" picker on demand (context-menu open),
+    /// so no per-row menu state is computed during list updates.
+    var groupMoveMenu: ((MobileWorkspacePreview.ID) -> MobileWorkspaceGroupMoveMenu?)? = nil
+    /// Moves the workspace to the end of a group, or out of its group when the
+    /// target is `nil`. Same optimistic move path as drag-and-drop.
+    var moveToGroup: ((MobileWorkspacePreview.ID, MobileWorkspaceGroupPreview.ID?) -> Void)? = nil
 
     let selectWorkspace: (MobileWorkspacePreview.ID) -> Void
     let closeWorkspace: ((MobileWorkspacePreview.ID) -> Void)?

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListTableCoordinator+Actions.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListTableCoordinator+Actions.swift
@@ -9,9 +9,9 @@ extension WorkspaceListTableCoordinator {
         sourceView: UIView,
         renameTitle: String? = nil,
         contextMenuIdentifier: String? = nil
-    ) -> [UIAction] {
+    ) -> [UIMenuElement] {
         let capabilities = workspace.actionCapabilities
-        var actions: [UIAction] = []
+        var actions: [UIMenuElement] = []
         if capabilities.supportsWorkspaceActions, let setPinned = configuration.setPinned {
             let action = UIAction(
                 title: workspace.isPinned
@@ -56,6 +56,15 @@ extension WorkspaceListTableCoordinator {
             }
             action.accessibilityIdentifier = "MobileWorkspaceReadStateMenuButton-\(workspace.id.rawValue)"
             actions.append(action)
+        }
+        if capabilities.supportsMoveActions,
+           let moveToGroup = configuration.moveToGroup,
+           let menuModel = configuration.groupMoveMenu?(workspace.id) {
+            actions.append(groupMoveSubmenu(
+                for: workspace,
+                menuModel: menuModel,
+                moveToGroup: moveToGroup
+            ))
         }
         if capabilities.supportsCloseActions, configuration.closeWorkspace != nil {
             let action = UIAction(
@@ -165,6 +174,50 @@ extension WorkspaceListTableCoordinator {
             sections.append(UIMenu(options: .displayInline, children: destructiveActions))
         }
         return sections
+    }
+
+    /// The "Move to Group" picker: one item per candidate group (current
+    /// membership checked and disabled), plus a trailing "Remove from Group"
+    /// section when the workspace is grouped.
+    private func groupMoveSubmenu(
+        for workspace: MobileWorkspacePreview,
+        menuModel: MobileWorkspaceGroupMoveMenu,
+        moveToGroup: @escaping (MobileWorkspacePreview.ID, MobileWorkspaceGroupPreview.ID?) -> Void
+    ) -> UIMenu {
+        var children: [UIMenuElement] = menuModel.entries.map { entry in
+            let action = UIAction(
+                title: entry.group.name,
+                image: entry.group.iconSymbol.flatMap(UIImage.init(systemName:)),
+                attributes: entry.isEnabled ? [] : .disabled,
+                state: entry.isCurrent ? .on : .off
+            ) { _ in
+                moveToGroup(workspace.id, entry.group.id)
+            }
+            action.accessibilityIdentifier =
+                "MobileWorkspaceMoveToGroupTarget-\(workspace.id.rawValue)-\(entry.group.id.rawValue)"
+            return action
+        }
+        if menuModel.canRemoveFromGroup {
+            let remove = UIAction(
+                title: L10n.string(
+                    "mobile.workspace.removeFromGroup",
+                    defaultValue: "Remove from Group"
+                ),
+                image: UIImage(systemName: "folder.badge.minus")
+            ) { _ in
+                moveToGroup(workspace.id, nil)
+            }
+            remove.accessibilityIdentifier =
+                "MobileWorkspaceRemoveFromGroupButton-\(workspace.id.rawValue)"
+            children.append(UIMenu(options: .displayInline, children: [remove]))
+        }
+        let submenu = UIMenu(
+            title: L10n.string("mobile.workspace.moveToGroup", defaultValue: "Move to Group"),
+            image: UIImage(systemName: "folder"),
+            children: children
+        )
+        submenu.accessibilityIdentifier = "MobileWorkspaceMoveToGroupMenu-\(workspace.id.rawValue)"
+        return submenu
     }
 
     func readStateActionTitle(for workspace: MobileWorkspacePreview) -> String {

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListView+DragDrop.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListView+DragDrop.swift
@@ -176,9 +176,24 @@ extension WorkspaceListView {
             ) != nil
     }
 
+    /// The context-menu "Move to Group" picker for one workspace row, or `nil`
+    /// when moves are unavailable (drag gating applies identically) or the
+    /// picker would be empty.
+    func groupMoveMenu(for workspaceID: MobileWorkspacePreview.ID) -> MobileWorkspaceGroupMoveMenu? {
+        guard enablesWorkspaceReorder, rendersGroupedSections else { return nil }
+        let menu = MobileWorkspaceGroupMoveMenu(
+            workspaces: displayedGroupedWorkspaces,
+            groups: groups,
+            movedWorkspaceID: workspaceID
+        )
+        return menu.isEmpty ? nil : menu
+    }
+
+    /// Joins a group at its end, or leaves the current group when `groupID` is
+    /// `nil`. Shared by the drop-into-group path and the context-menu picker.
     func joinGroupAtEnd(
         workspaceID: MobileWorkspacePreview.ID,
-        groupID: MobileWorkspaceGroupPreview.ID
+        groupID: MobileWorkspaceGroupPreview.ID?
     ) {
         guard enablesWorkspaceReorder, rendersGroupedSections else { return }
         let sourceWorkspaces = displayedGroupedWorkspaces

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListView+Table.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListView+Table.swift
@@ -112,6 +112,12 @@ extension WorkspaceListView {
             dropIntoGroup: enablesReorder && grouped ? { workspaceID, groupID in
                 joinGroupAtEnd(workspaceID: workspaceID, groupID: groupID)
             } : nil,
+            groupMoveMenu: enablesReorder && grouped ? { workspaceID in
+                groupMoveMenu(for: workspaceID)
+            } : nil,
+            moveToGroup: enablesReorder && grouped ? { workspaceID, groupID in
+                joinGroupAtEnd(workspaceID: workspaceID, groupID: groupID)
+            } : nil,
             selectWorkspace: { id in _ = selectWorkspaceFromList(id) },
             closeWorkspace: closeWorkspace,
             setUnread: setUnread,

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListView.swift
@@ -782,6 +782,12 @@ struct WorkspaceListView: View {
                 && capabilities.supportsWorkspaceMetadata ? customizeWorkspace : nil,
             setPinned: capabilities.supportsWorkspaceActions ? setPinned : nil,
             setUnread: capabilities.supportsReadStateActions ? setUnread : nil,
+            groupMoveMenu: capabilities.supportsMoveActions ? {
+                groupMoveMenu(for: workspace.id)
+            } : nil,
+            moveToGroup: capabilities.supportsMoveActions ? { id, groupID in
+                joinGroupAtEnd(workspaceID: id, groupID: groupID)
+            } : nil,
             closeWorkspace: capabilities.supportsCloseActions ? requestWorkspaceClose : nil,
             isConfirmingClose: closeConfirmationBinding(for: workspace.id),
             confirmCloseWorkspace: capabilities.supportsCloseActions && closeWorkspace != nil ? { _ in

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceNavigationRow.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceNavigationRow.swift
@@ -29,6 +29,13 @@ struct WorkspaceNavigationRow: View {
     /// Mark the workspace read or unread on the Mac. When `nil` the read-state
     /// affordance is hidden.
     var setUnread: ((MobileWorkspacePreview.ID, Bool) -> Void)? = nil
+    /// Builds the "Move to Group" picker when the context menu opens; `nil`
+    /// result (or `nil` closure) hides the picker. Lazy so recycled rows never
+    /// compute menu state during list updates.
+    var groupMoveMenu: (() -> MobileWorkspaceGroupMoveMenu?)? = nil
+    /// Move the workspace to the end of a group, or out of its group when the
+    /// target is `nil`. When `nil` the picker is hidden.
+    var moveToGroup: ((MobileWorkspacePreview.ID, MobileWorkspaceGroupPreview.ID?) -> Void)? = nil
     /// Close the workspace on the Mac. When `nil` the delete affordance is
     /// hidden.
     var closeWorkspace: ((MobileWorkspacePreview.ID) -> Void)? = nil
@@ -216,6 +223,46 @@ struct WorkspaceNavigationRow: View {
                 Label(readStateActionTitle, systemImage: readStateActionSystemImage)
             }
             .accessibilityIdentifier("MobileWorkspaceReadStateMenuButton-\(workspace.id.rawValue)")
+        }
+        if let groupMoveMenu, let moveToGroup, let menuModel = groupMoveMenu() {
+            Menu {
+                ForEach(menuModel.entries, id: \.group.id) { entry in
+                    Button {
+                        moveToGroup(workspace.id, entry.group.id)
+                    } label: {
+                        if entry.isCurrent {
+                            Label(entry.group.name, systemImage: "checkmark")
+                        } else {
+                            Text(entry.group.name)
+                        }
+                    }
+                    .disabled(!entry.isEnabled)
+                    .accessibilityIdentifier(
+                        "MobileWorkspaceMoveToGroupTarget-\(workspace.id.rawValue)-\(entry.group.id.rawValue)"
+                    )
+                }
+                if menuModel.canRemoveFromGroup {
+                    Divider()
+                    Button {
+                        moveToGroup(workspace.id, nil)
+                    } label: {
+                        Label(
+                            L10n.string(
+                                "mobile.workspace.removeFromGroup",
+                                defaultValue: "Remove from Group"
+                            ),
+                            systemImage: "folder.badge.minus"
+                        )
+                    }
+                    .accessibilityIdentifier("MobileWorkspaceRemoveFromGroupButton-\(workspace.id.rawValue)")
+                }
+            } label: {
+                Label(
+                    L10n.string("mobile.workspace.moveToGroup", defaultValue: "Move to Group"),
+                    systemImage: "folder"
+                )
+            }
+            .accessibilityIdentifier("MobileWorkspaceMoveToGroupMenu-\(workspace.id.rawValue)")
         }
         if let closeWorkspace {
             Button(role: .destructive) {

--- a/Packages/iOS/CmuxMobileShellUI/Tests/CmuxMobileShellUITests/WorkspaceListScrollUpdateTests.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Tests/CmuxMobileShellUITests/WorkspaceListScrollUpdateTests.swift
@@ -331,6 +331,75 @@ import UIKit
         #expect(identifiers.contains("MobileWorkspaceRenameButton-workspace-1"))
     }
 
+    @Test func workspaceContextMenuOffersMoveToGroupPicker() {
+        let capabilities = MobileWorkspaceActionCapabilities(
+            supportsWorkspaceActions: false,
+            supportsWorkspaceMetadata: false,
+            supportsReadStateActions: false,
+            supportsCloseActions: false,
+            supportsMoveActions: true,
+            supportsGroupActions: false,
+            supportsGroupCreate: false
+        )
+        let group = MobileWorkspaceGroupPreview(
+            id: "group-1",
+            name: "Release",
+            anchorWorkspaceID: "anchor-1"
+        )
+        var anchor = MobileWorkspacePreview(
+            id: "anchor-1",
+            name: "anchor-1",
+            groupID: group.id,
+            terminals: []
+        )
+        anchor.actionCapabilities = capabilities
+        var grouped = MobileWorkspacePreview(
+            id: "workspace-2",
+            name: "workspace-2",
+            groupID: group.id,
+            terminals: []
+        )
+        grouped.actionCapabilities = capabilities
+        var root = MobileWorkspacePreview(id: "workspace-1", name: "workspace-1", terminals: [])
+        root.actionCapabilities = capabilities
+        let snapshot = [anchor, grouped, root]
+
+        var initial = configuration(workspaces: snapshot, groups: [group])
+        var moves: [(MobileWorkspacePreview.ID, MobileWorkspaceGroupPreview.ID?)] = []
+        initial.groupMoveMenu = { workspaceID in
+            let menu = MobileWorkspaceGroupMoveMenu(
+                workspaces: snapshot,
+                groups: [group],
+                movedWorkspaceID: workspaceID
+            )
+            return menu.isEmpty ? nil : menu
+        }
+        initial.moveToGroup = { workspaceID, groupID in
+            moves.append((workspaceID, groupID))
+        }
+        let coordinator = WorkspaceListTableCoordinator(configuration: initial)
+        let sourceView = UIView()
+
+        let rootIdentifiers = menuActionIdentifiers(
+            in: coordinator.contextMenuActions(for: root, sourceView: sourceView)
+        )
+        #expect(rootIdentifiers.contains("MobileWorkspaceMoveToGroupTarget-workspace-1-group-1"))
+        #expect(!rootIdentifiers.contains("MobileWorkspaceRemoveFromGroupButton-workspace-1"))
+
+        let groupedIdentifiers = menuActionIdentifiers(
+            in: coordinator.contextMenuActions(for: grouped, sourceView: sourceView)
+        )
+        #expect(groupedIdentifiers.contains("MobileWorkspaceMoveToGroupTarget-workspace-2-group-1"))
+        #expect(groupedIdentifiers.contains("MobileWorkspaceRemoveFromGroupButton-workspace-2"))
+
+        // Anchors move with their group; the picker must not appear at all.
+        let anchorIdentifiers = menuActionIdentifiers(
+            in: coordinator.contextMenuActions(for: anchor, sourceView: sourceView)
+        )
+        #expect(!anchorIdentifiers.contains { $0.hasPrefix("MobileWorkspaceMoveToGroup") })
+        #expect(moves.isEmpty)
+    }
+
     @Test func groupHeaderReloadsNativeActionsWhenAnchorReadStateChanges() {
         let group = MobileWorkspaceGroupPreview(
             id: "group-1",

--- a/ios/cmux/Resources/Localizable.xcstrings
+++ b/ios/cmux/Resources/Localizable.xcstrings
@@ -13162,6 +13162,40 @@
         }
       }
     },
+    "mobile.workspace.moveToGroup": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Move to Group"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "グループに移動"
+          }
+        }
+      }
+    },
+    "mobile.workspace.removeFromGroup": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Remove from Group"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "グループから削除"
+          }
+        }
+      }
+    },
     "mobile.workspace.new": {
       "extractionState": "manual",
       "localizations": {


### PR DESCRIPTION
Moving a workspace into a group on iOS previously required drag-and-drop, which is fiddly on the phone and impossible when a drag is hard to start (long lists, collapsed groups). Long-pressing a workspace row now shows a **Move to Group** submenu with one entry per workspace group on that Mac; the current group renders checked and disabled, and grouped workspaces also get **Remove from Group**.

Selection routes through the exact drag-and-drop path: `MobileWorkspaceMovePolicy.normalizedIntent` for validity, the optimistic `joinGroupAtEnd` move chain, and the existing `workspace.move` RPC, so the picker can never offer a move the drop path would reject, and gating (pending-move cap, search/filter flattening, foreground-Mac-only mutations in All Computers) is identical. A new pure model, `MobileWorkspaceGroupMoveMenu`, computes the entries (same-Mac filtering with the aggregation empty-vs-nil stamp quirk handled) and is unit-tested; the picker appears in both row pipelines (UIKit table coordinator context menu and the SwiftUI row `.contextMenu`).

Anchor workspaces get no picker (an anchor moves with its group, matching the host's `workspace.move` rejection). `Remove from Group` maps to `workspace.move` without `group_id`, which the host resolves as ungroup + move to end of the root list — the same order the optimistic prediction applies locally.

Localization: `mobile.workspace.moveToGroup` and `mobile.workspace.removeFromGroup` added to the iOS catalog (en, ja), matching the macOS sidebar's existing `contextMenu.workspaceGroup.moveTo`/`.remove` strings.

Tests: 9 new `MobileWorkspaceGroupMoveMenuTests` (all 247 CmuxMobileShellModel tests green locally) and a coordinator test asserting the submenu structure per capability/anchor/grouped state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/9779"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788673132&installation_model_id=21920&pr_number=9779&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F9779&signature=ad4b5f81ffb17f1a7cff5dbf45e83affc266425374a8c78dcd16e95c9a82ce00"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches workspace list mutation UX and extends the grouped move path, but actions still go through the established policy, optimistic ordering, and `workspace.move` RPC with capability and Mac-scoping gates.
> 
> **Overview**
> Adds a **Move to Group** context-menu path on iOS workspace rows so grouping no longer depends on drag-and-drop alone.
> 
> A new **`MobileWorkspaceGroupMoveMenu`** model builds picker entries (same-Mac groups, current group checked/disabled, **Remove from Group** when valid) using **`MobileWorkspaceMovePolicy.normalizedIntent`**, matching drag-and-drop rules. Anchor workspaces get no menu; orphan `groupID` values cannot remove until the group exists in the snapshot.
> 
> **`joinGroupAtEnd`** now accepts an optional group id (`nil` = leave group) and is shared by drop-into-group and the menu. The UIKit table coordinator and SwiftUI **`WorkspaceNavigationRow`** both wire lazy **`groupMoveMenu`** / **`moveToGroup`** callbacks with the same reorder gating as drags. English and Japanese strings were added for the new menu labels.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b6d07f4e11ab7b360485f9640bd6a8fcf91a9150. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an inline “Move to Group” context-menu picker on iOS so a workspace can join or leave a group without drag-and-drop. Keeps move behavior identical to drag-and-drop, including gating and ordering.

- **New Features**
  - Long-press a workspace to open “Move to Group” with one item per group on the same Mac; current group is checked and disabled, and “Remove from Group” is shown when applicable.
  - Uses the same path as drag-and-drop: `MobileWorkspaceMovePolicy` + optimistic `joinGroupAtEnd` + `workspace.move` RPC, so invalid moves are never offered.
  - Available in both UIKit table menus and SwiftUI row `.contextMenu`.
  - Anchor workspaces don’t show the picker; removing from a group ungroups and moves to end of the root list.
  - Added iOS localization entries for `mobile.workspace.moveToGroup` and `mobile.workspace.removeFromGroup`, plus unit/UI tests for menu logic and structure.

<sup>Written for commit b6d07f4e11ab7b360485f9640bd6a8fcf91a9150. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/9779?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added workspace context-menu and navigation-row actions for moving workspaces between groups.
  * Added support for moving workspaces into ungrouped destinations or removing them from groups.
  * Group menus now show valid destinations, current membership, and unavailable options.
  * Added English and Japanese labels for group movement actions.

* **Bug Fixes**
  * Prevented unsupported group anchors and invalid destinations from appearing as move options.

* **Tests**
  * Added coverage for grouped, ungrouped, cross-device, anchor, and removal scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->