### PR TITLE
Fix duplicate Codex hook channels and watchdog leaks

### DIFF
--- a/CLI/CMUXCLI+AgentHookDefinitions.swift
+++ b/CLI/CMUXCLI+AgentHookDefinitions.swift
@@ -188,6 +188,20 @@ extension CMUXCLI {
     }
 
     static func feedHookCommandString(for def: AgentHookDef, agentEvent: String) -> String {
+        if def.name == "codex",
+           let injectedEvent = CodexHookInjectionSchema.current.events.first(where: {
+               $0.agentEvent == agentEvent
+           }) {
+            let inline = codexFireAndForgetAgentHookShellCommand(
+                "cmux hooks codex \(injectedEvent.cmuxSubcommand)",
+                for: def
+            )
+            return codexPersistentHookScriptCommand(
+                inline,
+                eventTag: "feed-\(agentEvent)"
+            )
+        }
+
         let inline: String
         let noOpCommand = feedHookNoOpShellCommand(for: def, agentEvent: agentEvent)
         switch def.format {

--- a/CLI/CMUXCLI+CodexFireAndForgetHooks.swift
+++ b/CLI/CMUXCLI+CodexFireAndForgetHooks.swift
@@ -4,17 +4,22 @@ import Foundation
 extension CMUXCLI {
     /// Emit, NUL-separated to stdout, the exact codex arg list the wrapper must
     /// splice ahead of the user's args to enable + inject cmux's fire-and-forget
-    /// hooks for one codex invocation. Returns the arg list:
+    /// hooks for one codex invocation when no persistent cmux channel is
+    /// installed. Returns the arg list:
     ///   --enable\0hooks\0--dangerously-bypass-hook-trust\0
     ///   -c\0hooks.SessionStart=[{hooks=[{type="command",command='''<ff>''',timeout=10000}]}]\0
     ///   -c\0hooks.UserPromptSubmit=...\0 ... (one `-c` pair per event)
     /// where `<ff>` is `codexFireAndForgetAgentHookShellCommand(...)` so each
     /// hook returns `{}` to codex instantly and backgrounds the real cmux call.
-    /// Requires no live socket: pure string construction from the agent def.
+    /// Before emission, an existing cmux-owned persistent hook channel is
+    /// reconciled in place and supersedes wrapper injection for this launch.
+    /// No live socket is required.
     func emitCodexWrapperInjectArgs() throws {
         guard let codexDef = Self.agentDef(named: "codex") else {
             throw CLIError(message: "Codex hook integration is unavailable.")
         }
+        let usesPersistentChannel = reconcileCodexPersistentHooksForWrapper()
+        let eventsToInject = usesPersistentChannel ? [] : CodexHookInjectionSchema.current.events
         // Prefer a #!/bin/sh SCRIPT FILE as the hook command over an inline shell
         // snippet. Some codex-compatible runtimes (subrouters, proxies) exec the
         // `command` string directly as a program instead of via a shell, so an
@@ -26,8 +31,15 @@ extension CMUXCLI {
         // hooks), not the user's ~/.codex. Any write failure falls back to the
         // inline snippet so the working path can never regress.
         let hooksDir = Self.codexHookScriptsDirectory()
+        defer {
+            Self.garbageCollectCodexHookScripts(
+                retaining: Self.currentCodexWrapperHookScriptFilenames(for: codexDef)
+                    .union(Self.installedCodexHookScriptFilenames(for: codexDef))
+            )
+        }
+        guard !eventsToInject.isEmpty else { return }
         var args: [String] = ["--enable", "hooks", "--dangerously-bypass-hook-trust"]
-        for event in CodexHookInjectionSchema.current.events {
+        for event in eventsToInject {
             let ff = Self.codexFireAndForgetAgentHookShellCommand(
                 "cmux hooks codex \(event.cmuxSubcommand)", for: codexDef
             )
@@ -114,9 +126,100 @@ extension CMUXCLI {
         }
     }
 
+    /// Names that the current wrapper schema may reference from a live session.
+    static func currentCodexWrapperHookScriptFilenames(for def: AgentHookDef) -> Set<String> {
+        Set(CodexHookInjectionSchema.current.events.compactMap { event in
+            let body = codexFireAndForgetAgentHookShellCommand(
+                "cmux hooks codex \(event.cmuxSubcommand)",
+                for: def
+            )
+            return CodexHookScriptName(
+                contents: "#!/bin/sh\n\(body)\n",
+                subcommand: event.cmuxSubcommand
+            )?.filename
+        })
+    }
+
+    /// Cmux-generated script names referenced by the active persistent config.
+    static func installedCodexHookScriptFilenames(for def: AgentHookDef) -> Set<String> {
+        let fileURL = URL(fileURLWithPath: def.resolvedConfigDir(), isDirectory: true)
+            .appendingPathComponent(def.configFile, isDirectory: false)
+        guard let data = try? Data(contentsOf: fileURL),
+              let root = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let hooks = root["hooks"] as? [String: Any],
+              let hooksDirectory = codexHookScriptsDirectory()?.standardizedFileURL else {
+            return []
+        }
+
+        var filenames = Set<String>()
+        for value in hooks.values {
+            guard let groups = value as? [[String: Any]] else { continue }
+            for group in groups {
+                guard let handlers = group["hooks"] as? [[String: Any]] else { continue }
+                for handler in handlers {
+                    guard let command = handler["command"] as? String else { continue }
+                    let url = URL(fileURLWithPath: command, isDirectory: false)
+                    guard url.deletingLastPathComponent().standardizedFileURL == hooksDirectory,
+                          CodexHookScriptName(filename: url.lastPathComponent) != nil else {
+                        continue
+                    }
+                    filenames.insert(url.lastPathComponent)
+                }
+            }
+        }
+        return filenames
+    }
+
+    /// Removes obsolete regular files only when their names prove cmux ownership.
+    /// Live Codex sessions may still hold paths from another tagged build, and
+    /// concurrent launches can briefly overlap script generation, so collection
+    /// waits until no Codex process is running and leaves recent files alone.
+    static func garbageCollectCodexHookScripts(retaining filenames: Set<String>) {
+        guard !hasRunningCodexProcess(),
+              let directory = codexHookScriptsDirectory(),
+              let contents = try? FileManager.default.contentsOfDirectory(
+                  at: directory,
+                  includingPropertiesForKeys: [.contentModificationDateKey, .isRegularFileKey],
+                  options: [.skipsHiddenFiles]
+              ) else {
+            return
+        }
+
+        let newestRemovableDate = Date().addingTimeInterval(-60)
+        for url in contents where !filenames.contains(url.lastPathComponent) {
+            let values = try? url.resourceValues(forKeys: [
+                .contentModificationDateKey,
+                .isRegularFileKey,
+            ])
+            guard CodexHookScriptName(filename: url.lastPathComponent) != nil,
+                  values?.isRegularFile == true,
+                  let modificationDate = values?.contentModificationDate,
+                  modificationDate < newestRemovableDate else {
+                continue
+            }
+            try? FileManager.default.removeItem(at: url)
+        }
+    }
+
+    /// Conservatively detects sessions that may still reference an older hook generation.
+    private static func hasRunningCodexProcess() -> Bool {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/pgrep")
+        process.arguments = ["-x", "codex"]
+        process.standardOutput = FileHandle.nullDevice
+        process.standardError = FileHandle.nullDevice
+        do {
+            try process.run()
+            process.waitUntilExit()
+            return process.terminationStatus == 0
+        } catch {
+            return true
+        }
+    }
+
     static func codexFireAndForgetAgentHookShellCommand(_ command: String, for def: AgentHookDef) -> String {
         let routedArguments = command.hasPrefix("cmux ") ? String(command.dropFirst("cmux ".count)) : command
-        let runner = "payload=\"$1\"; shift; \"$@\" <\"$payload\" >/dev/null 2>&1 & child=\"$!\"; ( sleep 30; kill \"$child\" 2>/dev/null || true ) & watchdog=\"$!\"; wait \"$child\" 2>/dev/null || true; kill \"$watchdog\" 2>/dev/null || true; rm -f \"$payload\""
+        let runner = "payload=\"$1\"; shift; \"$@\" <\"$payload\" >/dev/null 2>&1 & child=\"$!\"; ( timer=; trap \"kill \\$timer 2>/dev/null || true; wait \\$timer 2>/dev/null || true; exit 0\" HUP INT TERM; sleep 30 & timer=\"$!\"; wait \"$timer\" 2>/dev/null || true; timer=; kill \"$child\" 2>/dev/null || true ) & watchdog=\"$!\"; wait \"$child\" 2>/dev/null || true; kill \"$watchdog\" 2>/dev/null || true; wait \"$watchdog\" 2>/dev/null || true; rm -f \"$payload\""
         let noOp = stdinDrainingHookNoOpShellCommand
         return [
             "cmux_cli=\"${CMUX_BUNDLED_CLI_PATH:-}\"",

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -29668,7 +29668,10 @@ export default CMUXSessionRestore;
         return false
     }
 
-    private func installAgentHooks(_ def: AgentHookDef) throws {
+    private func installAgentHooks(
+        _ def: AgentHookDef,
+        automaticReconciliation: Bool = false
+    ) throws {
         if def.name == "opencode" { try installOpenCodePluginHooks(def); return }
         if def.name == "pi" { try installPiExtensionHooks(def); return }
         if def.name == "omp" { try installOmpExtensionHooks(def); return }
@@ -29697,7 +29700,8 @@ export default CMUXSessionRestore;
         let fm = FileManager.default
         let configDir = def.resolvedConfigDir()
         let filePath = "\(configDir)/\(def.configFile)"
-        let skipConfirm = ProcessInfo.processInfo.arguments.contains("--yes")
+        let skipConfirm = automaticReconciliation
+            || ProcessInfo.processInfo.arguments.contains("--yes")
             || ProcessInfo.processInfo.arguments.contains("-y")
 
         let configDirectoryFileError = String.localizedStringWithFormat(
@@ -29713,7 +29717,9 @@ export default CMUXSessionRestore;
             if def.createConfigDirIfMissing {
                 throw CLIError(message: configDirectoryFileError)
             }
-            print("Required agent configuration is missing. Run `cmux hooks setup` after installing your agent CLI.")
+            if !automaticReconciliation {
+                print("Required agent configuration is missing. Run `cmux hooks setup` after installing your agent CLI.")
+            }
             return
         }
         if !configPathExists {
@@ -29724,7 +29730,9 @@ export default CMUXSessionRestore;
                     throw CLIError(message: configDirectoryFileError)
                 }
             } else {
-                print("Required agent configuration is missing. Run `cmux hooks setup` after installing your agent CLI.")
+                if !automaticReconciliation {
+                    print("Required agent configuration is missing. Run `cmux hooks setup` after installing your agent CLI.")
+                }
                 return
             }
         }
@@ -29735,6 +29743,12 @@ export default CMUXSessionRestore;
                 throw CLIError(message: "\(filePath) exists but is not valid JSON. Fix or remove it before installing hooks.")
             }
             existing = json
+        }
+
+        let existingHooksValue: Any = existing["hooks"] ?? [String: Any]()
+        if automaticReconciliation,
+           !Self.jsonHookValueContainsCmuxOwnedCommand(existingHooksValue, for: def) {
+            return
         }
 
         var hooks = existing["hooks"] as? [String: Any] ?? [:]
@@ -29880,7 +29894,9 @@ export default CMUXSessionRestore;
 
         if oldString == newString {
             // No-op install; skip the write and the prompt entirely.
-            print("\(def.displayName) hooks already up to date at \(filePath)")
+            if !automaticReconciliation {
+                print("\(def.displayName) hooks already up to date at \(filePath)")
+            }
         } else {
             if !skipConfirm {
                 Self.printInstallPreview(
@@ -29896,10 +29912,12 @@ export default CMUXSessionRestore;
                 }
             }
             try newData.write(to: URL(fileURLWithPath: filePath), options: .atomic)
-            print("\(def.displayName) hooks installed at \(filePath)")
+            if !automaticReconciliation {
+                print("\(def.displayName) hooks installed at \(filePath)")
+            }
         }
 
-        if let note = def.postInstallNote {
+        if !automaticReconciliation, let note = def.postInstallNote {
             print(note)
         }
 
@@ -29945,13 +29963,39 @@ export default CMUXSessionRestore;
                         }
                     }
                     try newContent.write(toFile: configPath, atomically: true, encoding: .utf8)
-                    if def.name == "codex", !codexHookTrustEntries.isEmpty, trustInstall.installedTrust {
-                        print("Enabled hooks and approved cmux hooks in \(configPath)")
-                    } else {
-                        print("Enabled hooks in \(configPath)")
+                    if !automaticReconciliation {
+                        if def.name == "codex", !codexHookTrustEntries.isEmpty, trustInstall.installedTrust {
+                            print("Enabled hooks and approved cmux hooks in \(configPath)")
+                        } else {
+                            print("Enabled hooks in \(configPath)")
+                        }
                     }
                 }
             }
+        }
+
+        if def.name == "codex", !automaticReconciliation {
+            Self.garbageCollectCodexHookScripts(
+                retaining: Self.currentCodexWrapperHookScriptFilenames(for: def)
+                    .union(Self.installedCodexHookScriptFilenames(for: def))
+            )
+        }
+    }
+
+    /// Repairs an opted-in persistent Codex channel before wrapper launch.
+    func reconcileCodexPersistentHooksForWrapper() -> Bool {
+        guard let def = Self.agentDef(named: "codex") else { return false }
+        try? installAgentHooks(def, automaticReconciliation: true)
+
+        let fileURL = URL(fileURLWithPath: def.resolvedConfigDir(), isDirectory: true)
+            .appendingPathComponent(def.configFile, isDirectory: false)
+        guard let data = try? Data(contentsOf: fileURL),
+              let root = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let hooks = root["hooks"] as? [String: Any] else {
+            return false
+        }
+        return hooks.values.contains {
+            Self.jsonHookValueContainsCmuxOwnedCommand($0, for: def)
         }
     }
 
@@ -32699,7 +32743,28 @@ export default CMUXSessionRestore;
         surfaceId: String? = nil,
         socketPassword: String? = nil
     ) {
-        let hookEventName = Self.feedEventName(forClaudeSubcommand: subcommand)
+        let fallbackHookEventName = Self.feedEventName(forClaudeSubcommand: subcommand)
+        let reportedHookEventName = parsedInput.object.flatMap {
+            firstString(in: $0, keys: ["hook_event_name", "hookEventName", "event", "event_name"])
+        } ?? parsedInput.rawObject.flatMap {
+            firstString(in: $0, keys: ["hook_event_name", "hookEventName", "event", "event_name"])
+        }
+        let hookEventName: String
+        if source == "codex",
+           let reportedHookEventName,
+           reportedHookEventName.replacingOccurrences(of: "_", with: "").lowercased()
+               == "permissionrequest" {
+            // A single notification handler now owns Codex PermissionRequest.
+            // Preserve the existing non-blocking Feed classification while that
+            // same handler drives the needs-input lifecycle and alert.
+            hookEventName = FeedEventClassifier.classify(
+                source: source,
+                event: reportedHookEventName,
+                toolName: ""
+            ).0
+        } else {
+            hookEventName = fallbackHookEventName
+        }
         guard !hookEventName.isEmpty else { return }
         let promptText = hookEventName == "UserPromptSubmit"
             ? (feedPromptText(from: parsedInput.object) ?? parsedInput.rawFallback)

--- a/Resources/bin/cmux-codex-wrapper
+++ b/Resources/bin/cmux-codex-wrapper
@@ -2,9 +2,11 @@
 # cmux codex wrapper - per-invocation Codex hook injection + launch detection.
 #
 # When running inside a cmux terminal (CMUX_SURFACE_ID is set), this wrapper
-# makes `codex` carry cmux's hooks for THIS invocation only (nothing is written
-# to ~/.codex), so Codex's own SessionStart/UserPromptSubmit/Stop/PreToolUse/
-# PostToolUse/PermissionRequest fire back into cmux with Codex's real session_id.
+# makes `codex` carry exactly one cmux hook channel. If ~/.codex/hooks.json has
+# a cmux-owned persistent channel, the emitter reconciles it and emits no
+# overlapping overrides; otherwise it injects hooks for THIS invocation only.
+# Codex's own SessionStart/UserPromptSubmit/Stop/PreToolUse/PostToolUse/
+# PermissionRequest then fire back into cmux with Codex's real session_id.
 # Those hook payloads are the source of truth for session identity; the wrapper
 # never predicts fresh-vs-resume state from Codex's command-line syntax.
 #
@@ -245,9 +247,11 @@ export CMUX_AGENT_LAUNCH_CWD="$PWD"
     [[ -n "$cmux_codex_argv_b64" ]] && export CMUX_AGENT_LAUNCH_ARGV_B64="$cmux_codex_argv_b64"
 }
 
-# Build the per-invocation [hooks] injection. The cmux CLI emits the exact arg
-# list (NUL-separated) that enables hooks and injects cmux's FIRE-AND-FORGET hook
-# command for each event. Fire-and-forget is critical: codex runs hooks
+# Select the launch's cmux hook channel. The cmux CLI first reconciles an
+# installed cmux-owned persistent channel, when present; otherwise it emits the
+# exact arg list (NUL-separated) that enables hooks and injects cmux's
+# FIRE-AND-FORGET hook command for each event. Fire-and-forget is critical:
+# codex runs hooks
 # synchronously and BLOCKS until they return, so a synchronous `cmux hooks codex
 # <sub>` made every launch hang ~35s on "Running SessionStart hook". The emitted
 # command captures codex's stdin payload to a temp file, nohup-backgrounds the
@@ -284,6 +288,7 @@ if cmux_codex_read_inject_args; then
     exec "$REAL_CODEX" "${cmux_codex_injected_args[@]}" "$@"
 fi
 
-# Emit failed or returned nothing: preserve the cmux surface context so native
-# or future hook paths can still bind this session after a transient outage.
+# A reconciled persistent channel intentionally emits no overrides; an emitter
+# failure also returns nothing. In both cases preserve the cmux surface context
+# so persistent, native, or future hooks can still bind this session.
 exec "$REAL_CODEX" "$@"

--- a/cmuxTests/CLICodexHookTimeoutRegressionTests.swift
+++ b/cmuxTests/CLICodexHookTimeoutRegressionTests.swift
@@ -123,6 +123,15 @@ struct CLICodexHookTimeoutRegressionTests {
         try makeCodexHookExecutableShellFile(at: legacyStopScript, lines: ["#!/bin/sh", "echo '{}'"])
         try makeCodexHookExecutableShellFile(at: staleHashedScript, lines: ["#!/bin/sh", "echo '{}'"])
         try makeCodexHookExecutableShellFile(at: userScript, lines: ["#!/bin/sh", "echo user-hook"])
+        let staleDate = Date(timeIntervalSince1970: 0)
+        try FileManager.default.setAttributes(
+            [.modificationDate: staleDate],
+            ofItemAtPath: legacyStopScript.path
+        )
+        try FileManager.default.setAttributes(
+            [.modificationDate: staleDate],
+            ofItemAtPath: staleHashedScript.path
+        )
 
         var stopGroups = try #require(hookGroups["Stop"] as? [[String: Any]])
         stopGroups.append([
@@ -180,6 +189,65 @@ struct CLICodexHookTimeoutRegressionTests {
         #expect(!FileManager.default.fileExists(atPath: legacyStopScript.path))
         #expect(!FileManager.default.fileExists(atPath: staleHashedScript.path))
         #expect(FileManager.default.fileExists(atPath: userScript.path))
+    }
+
+    @Test func codexPermissionRequestHandlerPreservesFeedTelemetryAndNeedsInputState() throws {
+        let cliPath = try bundledCLIPath()
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cmux-codex-permission-handler-\(UUID().uuidString)", isDirectory: true)
+        let socketPath = makeCodexHookSocketPath("codex-permission")
+        let listenerFD = try bindCodexHookUnixSocket(at: socketPath)
+        let commands = CodexHookCapturedSocketCommands()
+        let workspaceId = "11111111-1111-1111-1111-111111111111"
+        let surfaceId = "22222222-2222-2222-2222-222222222222"
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer {
+            Darwin.close(listenerFD)
+            unlink(socketPath)
+            try? FileManager.default.removeItem(at: root)
+        }
+        startCodexHookMockSocketServerAccepting(
+            listenerFD: listenerFD,
+            commands: commands,
+            surfaceId: surfaceId,
+            connectionLimit: 16
+        )
+
+        let result = runCodexHookProcess(
+            executablePath: cliPath,
+            arguments: ["hooks", "codex", "notification"],
+            environment: [
+                "HOME": root.path,
+                "PATH": "/usr/bin:/bin:/usr/sbin:/sbin",
+                "PWD": root.path,
+                "CMUX_SOCKET_PATH": socketPath,
+                "CMUX_WORKSPACE_ID": workspaceId,
+                "CMUX_SURFACE_ID": surfaceId,
+                "CMUX_AGENT_HOOK_STATE_DIR": root.path,
+                "CMUX_CLI_SENTRY_DISABLED": "1",
+            ],
+            standardInput: #"{"session_id":"codex-permission-session","cwd":"\#(root.path)","hook_event_name":"PermissionRequest","message":"approval required"}"#,
+            timeout: 5
+        )
+
+        #expect(!result.timedOut, Comment(rawValue: result.stderr))
+        #expect(result.status == 0, Comment(rawValue: result.stderr))
+        #expect(result.stdout == "{}\n")
+        #expect(waitForConditionBlocking(timeout: 1) {
+            commands.snapshot().contains { command in
+                guard let object = codexHookJSONObject(command),
+                      object["method"] as? String == "feed.push",
+                      let params = object["params"] as? [String: Any],
+                      let event = params["event"] as? [String: Any] else {
+                    return false
+                }
+                return event["hook_event_name"] as? String == "PreToolUse"
+            }
+        })
+        #expect(commands.snapshot().contains {
+            $0.hasPrefix("set_agent_lifecycle codex needsInput --tab=\(workspaceId)")
+                && $0.contains("--panel=\(surfaceId)")
+        })
     }
 
     @Test func codexInstalledHookReturnsBeforeSlowCmuxCommandFinishes() throws {
@@ -327,6 +395,8 @@ struct CLICodexHookTimeoutRegressionTests {
         try makeCodexHookExecutableShellFile(at: fakeCLI, lines: [
             "#!/bin/sh",
             "cat >/dev/null",
+            "attempt=0",
+            "while [ ! -s \"$CMUX_TEST_SLEEP_PID\" ] && [ \"$attempt\" -lt 100 ]; do /bin/sleep 0.01; attempt=$((attempt + 1)); done",
             "printf done > \"$CMUX_TEST_CHILD_DONE\"",
         ])
         try makeCodexHookExecutableShellFile(at: fakeSleep, lines: [

--- a/cmuxTests/CLICodexHookTimeoutRegressionTests.swift
+++ b/cmuxTests/CLICodexHookTimeoutRegressionTests.swift
@@ -1,3 +1,4 @@
+import Darwin
 import Foundation
 import Testing
 
@@ -34,7 +35,6 @@ struct CLICodexHookTimeoutRegressionTests {
         let sessionStartHooks = hooks.filter { $0.eventName == "SessionStart" }
         let promptHooks = hooks.filter { $0.eventName == "UserPromptSubmit" }
         let stopHooks = hooks.filter { $0.eventName == "Stop" }
-        let feedHooks = hooks.filter { $0.body.contains("hooks feed --source codex") }
         #expect(!hooks.map(\.body).contains(previousCommand), "Installer should remove stale synchronous hook")
         #expect(sessionStartHooks.count == 1, "Installer should install one session-start hook")
         #expect(sessionStartHooks.allSatisfy { $0.body.contains("hooks codex session-start") })
@@ -48,21 +48,138 @@ struct CLICodexHookTimeoutRegressionTests {
         #expect(stopHooks.allSatisfy { $0.body.contains("hooks codex stop") })
         #expect(stopHooks.allSatisfy { $0.body.contains("nohup sh -c") && $0.body.contains("cat >\"$payload\"") })
         #expect(stopHooks.allSatisfy { $0.body.contains("agent_pid=") && $0.body.contains("CMUX_CODEX_PID=") })
-        let expectedFeedEvents: Set<String> = [
-            "PreToolUse",
-            "PermissionRequest",
-            "PostToolUse",
+        let wrapperEquivalentEvents = [
+            "PreToolUse": "pre-tool-use",
+            "PermissionRequest": "notification",
+            "PostToolUse": "post-tool-use",
+        ]
+        for (eventName, subcommand) in wrapperEquivalentEvents {
+            let eventHooks = hooks.filter { $0.eventName == eventName }
+            #expect(eventHooks.count == 1, "Installer should install one \(eventName) hook")
+            #expect(eventHooks.allSatisfy { $0.body.contains("hooks codex \(subcommand)") })
+            #expect(eventHooks.allSatisfy {
+                $0.body.contains("nohup sh -c") && $0.body.contains("cat >\"$payload\"")
+            })
+        }
+
+        let persistentOnlyFeedEvents: Set<String> = [
             "PreCompact",
             "PostCompact",
             "SubagentStart",
             "SubagentStop",
         ]
-        let installedFeedEvents = Set(feedHooks.compactMap { hook in
-            expectedFeedEvents.first { hook.body.contains("--event \($0)") }
+        let persistentOnlyFeedHooks = hooks.filter { hook in
+            hook.body.contains("hooks feed --source codex")
+                && persistentOnlyFeedEvents.contains(hook.eventName)
+        }
+        let installedFeedEvents = Set(persistentOnlyFeedHooks.compactMap { hook in
+            persistentOnlyFeedEvents.first { hook.body.contains("--event \($0)") }
         })
-        #expect(feedHooks.count == expectedFeedEvents.count, "Installer should install every Codex feed hook")
-        #expect(installedFeedEvents == expectedFeedEvents)
-        #expect(feedHooks.allSatisfy { !$0.body.contains("nohup sh -c") && !$0.body.contains(">/dev/null 2>&1 &") })
+        #expect(persistentOnlyFeedHooks.count == persistentOnlyFeedEvents.count)
+        #expect(installedFeedEvents == persistentOnlyFeedEvents)
+        #expect(persistentOnlyFeedHooks.allSatisfy {
+            !$0.body.contains("nohup sh -c") && !$0.body.contains(">/dev/null 2>&1 &")
+        })
+    }
+
+    @Test func codexWrapperReconcilesPersistentHooksToOneProducerPerEvent() throws {
+        let cliPath = try bundledCLIPath()
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cmux-codex-one-producer-\(UUID().uuidString)", isDirectory: true)
+        let codexHome = root.appendingPathComponent(".codex", isDirectory: true)
+        let hooksDirectory = root
+            .appendingPathComponent(".cmux", isDirectory: true)
+            .appendingPathComponent("hooks", isDirectory: true)
+        try FileManager.default.createDirectory(at: codexHome, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let environment = codexHookTestEnvironment(root: root, codexHome: codexHome)
+        let install = runCodexHookProcess(
+            executablePath: cliPath,
+            arguments: ["hooks", "codex", "install", "--yes"],
+            environment: environment,
+            timeout: 10
+        )
+        #expect(!install.timedOut, Comment(rawValue: install.stderr))
+        #expect(install.status == 0, Comment(rawValue: install.stderr))
+
+        let hooksURL = codexHome.appendingPathComponent("hooks.json", isDirectory: false)
+        var json = try #require(
+            JSONSerialization.jsonObject(with: Data(contentsOf: hooksURL)) as? [String: Any]
+        )
+        var hookGroups = try #require(json["hooks"] as? [String: Any])
+        var preToolGroups = try #require(hookGroups["PreToolUse"] as? [[String: Any]])
+        preToolGroups.insert(try #require(preToolGroups.first), at: 0)
+
+        let legacyStopScript = hooksDirectory
+            .appendingPathComponent("cmux-codex-hook-stop.sh", isDirectory: false)
+        let staleHashedScript = hooksDirectory
+            .appendingPathComponent(
+                "cmux-codex-hook-0123456789abcdef-old-generation.sh",
+                isDirectory: false
+            )
+        let userScript = hooksDirectory
+            .appendingPathComponent("cmux-codex-hook-unrecognized.sh", isDirectory: false)
+        try makeCodexHookExecutableShellFile(at: legacyStopScript, lines: ["#!/bin/sh", "echo '{}'"])
+        try makeCodexHookExecutableShellFile(at: staleHashedScript, lines: ["#!/bin/sh", "echo '{}'"])
+        try makeCodexHookExecutableShellFile(at: userScript, lines: ["#!/bin/sh", "echo user-hook"])
+
+        var stopGroups = try #require(hookGroups["Stop"] as? [[String: Any]])
+        stopGroups.append([
+            "hooks": [[
+                "command": legacyStopScript.path,
+                "timeout": 10_000,
+                "type": "command",
+            ]],
+        ])
+        stopGroups.append([
+            "hooks": [[
+                "command": userScript.path,
+                "timeout": 10_000,
+                "type": "command",
+            ]],
+        ])
+        hookGroups["PreToolUse"] = preToolGroups
+        hookGroups["Stop"] = stopGroups
+        json["hooks"] = hookGroups
+        try JSONSerialization.data(withJSONObject: json, options: [.prettyPrinted, .sortedKeys])
+            .write(to: hooksURL, options: .atomic)
+
+        let emit = runCodexHookProcess(
+            executablePath: cliPath,
+            arguments: ["hooks", "codex", "inject-args"],
+            environment: environment,
+            timeout: 10
+        )
+        #expect(!emit.timedOut, Comment(rawValue: emit.stderr))
+        #expect(emit.status == 0, Comment(rawValue: emit.stderr))
+
+        let emittedEvents = injectedCodexHookEventNames(emit.stdout)
+        let installedHooks = try codexHookEntries(in: codexHome)
+        let wrapperEvents = [
+            "SessionStart",
+            "UserPromptSubmit",
+            "Stop",
+            "PreToolUse",
+            "PostToolUse",
+            "PermissionRequest",
+        ]
+        for eventName in wrapperEvents {
+            let installedProducerCount = installedHooks.filter {
+                $0.eventName == eventName
+                    && ($0.body.contains("hooks codex ")
+                        || $0.body.contains("hooks feed --source codex"))
+            }.count
+            let emittedProducerCount = emittedEvents.filter { $0 == eventName }.count
+            #expect(
+                installedProducerCount + emittedProducerCount == 1,
+                "Expected one cmux producer for \(eventName), installed=\(installedProducerCount) emitted=\(emittedProducerCount)"
+            )
+        }
+        #expect(installedHooks.contains { $0.command == userScript.path })
+        #expect(!FileManager.default.fileExists(atPath: legacyStopScript.path))
+        #expect(!FileManager.default.fileExists(atPath: staleHashedScript.path))
+        #expect(FileManager.default.fileExists(atPath: userScript.path))
     }
 
     @Test func codexInstalledHookReturnsBeforeSlowCmuxCommandFinishes() throws {
@@ -191,6 +308,78 @@ struct CLICodexHookTimeoutRegressionTests {
         #expect(waitForFile(capturedArgs, containing: "--socket /tmp/cmux-test.sock hooks codex stop", timeout: 1))
         #expect(waitForFile(capturedPID, containing: "4242", timeout: 1))
         #expect(waitForFile(doneFile, containing: "done", timeout: 3))
+    }
+
+    @Test func codexFireAndForgetWatchdogReapsItsTimerProcess() throws {
+        let cliPath = try bundledCLIPath()
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cmux-codex-watchdog-reap-\(UUID().uuidString)", isDirectory: true)
+        let codexHome = root.appendingPathComponent(".codex", isDirectory: true)
+        let binDirectory = root.appendingPathComponent("bin", isDirectory: true)
+        let fakeCLI = binDirectory.appendingPathComponent("cmux", isDirectory: false)
+        let fakeSleep = binDirectory.appendingPathComponent("sleep", isDirectory: false)
+        let sleepPIDFile = root.appendingPathComponent("watchdog-sleep-pid.txt", isDirectory: false)
+        let childDoneFile = root.appendingPathComponent("hook-child-done.txt", isDirectory: false)
+        try FileManager.default.createDirectory(at: codexHome, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: binDirectory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        try makeCodexHookExecutableShellFile(at: fakeCLI, lines: [
+            "#!/bin/sh",
+            "cat >/dev/null",
+            "printf done > \"$CMUX_TEST_CHILD_DONE\"",
+        ])
+        try makeCodexHookExecutableShellFile(at: fakeSleep, lines: [
+            "#!/bin/sh",
+            "printf '%s\\n' \"$$\" > \"$CMUX_TEST_SLEEP_PID\"",
+            "exec /usr/bin/tail -f /dev/null",
+        ])
+
+        let install = runCodexHookProcess(
+            executablePath: cliPath,
+            arguments: ["hooks", "codex", "install", "--yes"],
+            environment: codexHookTestEnvironment(root: root, codexHome: codexHome),
+            timeout: 5
+        )
+        #expect(!install.timedOut, Comment(rawValue: install.stderr))
+        #expect(install.status == 0, Comment(rawValue: install.stderr))
+
+        let command = try #require(
+            codexHookEntries(in: codexHome).first { $0.eventName == "UserPromptSubmit" }?.command
+        )
+        let run = runCodexHookProcess(
+            executablePath: "/bin/sh",
+            arguments: ["-c", command],
+            environment: [
+                "HOME": root.path,
+                "PATH": "\(binDirectory.path):/usr/bin:/bin:/usr/sbin:/sbin",
+                "TMPDIR": root.path,
+                "CMUX_SURFACE_ID": "surface-123",
+                "CMUX_BUNDLED_CLI_PATH": fakeCLI.path,
+                "CMUX_CODEX_PID": "4242",
+                "CMUX_TEST_SLEEP_PID": sleepPIDFile.path,
+                "CMUX_TEST_CHILD_DONE": childDoneFile.path,
+            ],
+            standardInput: #"{"session_id":"codex-session","prompt":"run"}"#,
+            timeout: 2
+        )
+
+        #expect(!run.timedOut, Comment(rawValue: run.stderr))
+        #expect(run.status == 0, Comment(rawValue: run.stderr))
+        #expect(run.stdout == "{}\n")
+        #expect(waitForFile(sleepPIDFile, containing: "\n", timeout: 1))
+        #expect(waitForFile(childDoneFile, containing: "done", timeout: 1))
+
+        let sleepPIDText = try String(contentsOf: sleepPIDFile, encoding: .utf8)
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        let sleepPID = try #require(Int32(sleepPIDText))
+        defer { _ = Darwin.kill(sleepPID, SIGKILL) }
+        #expect(
+            waitForConditionBlocking(timeout: 1) {
+                Darwin.kill(sleepPID, 0) == -1 && errno == ESRCH
+            },
+            "The watchdog timer process \(sleepPID) outlived its completed hook invocation"
+        )
     }
 
     @Test func codexDisabledInstalledStopConsumesPayloadBeforeReturning() throws {
@@ -863,5 +1052,15 @@ struct CLICodexHookTimeoutRegressionTests {
 
     private func bundledCLIPath() throws -> String {
         try BundledCLITestSupport.bundledCLIPath(for: BundledCLILinkageTests.self)
+    }
+
+    private func injectedCodexHookEventNames(_ output: String) -> [String] {
+        output.split(separator: "\0").compactMap { argument in
+            guard argument.hasPrefix("hooks."),
+                  let equals = argument.firstIndex(of: "=") else {
+                return nil
+            }
+            return String(argument[argument.index(argument.startIndex, offsetBy: "hooks.".count)..<equals])
+        }
     }
 }


### PR DESCRIPTION
## Summary

- Reconcile any opted-in cmux Codex hooks in `~/.codex/hooks.json` before launch and use that as the sole channel; otherwise retain the existing session-scoped wrapper injection.
- Give persistent `PreToolUse`, `PostToolUse`, and `PermissionRequest` the same fire-and-forget behavior as wrapper hooks, while one `PermissionRequest` invocation still drives needs-input UI and the existing non-blocking Feed telemetry.
- Reap the watchdog timer process explicitly so completed hook invocations leave no orphaned `sleep 30` process.
- Garbage-collect superseded cmux-owned script generations while preserving third-party files, active Codex sessions, recent concurrent generations, and scripts referenced by current config.

## Behavior and compatibility

- Exactly one cmux producer is registered for each wrapper event after reconciliation.
- Tool-use transport stays off the Codex critical path.
- Persistent hooks remain available for custom launchers that bypass the wrapper and short-circuit outside cmux before invoking the cmux CLI or socket.
- The injected argument schema is unchanged, so current and legacy saved-layout sanitizer recognition remains intact.
- Tagged DEV builds share content-addressed scripts safely; cleanup waits until no Codex process can reference an older generation.

## Regression coverage

- Commit `a26cf6d570` adds behavior regressions for one producer per event, owned-generation cleanup, and watchdog timer reaping before the fix.
- Commit `6b79b62d9a` implements the fix and adds preservation coverage for Codex permission notification and Feed behavior.

## Validation

- `swiftc -frontend -parse` on all changed Swift files
- `bash -n Resources/bin/cmux-codex-wrapper`
- `python3 tests/test_codex_wrapper_resume_hooks.py`
- `./scripts/lint-pbxproj-test-wiring.sh` (654 test files checked)
- `swift test --package-path Packages/macOS/CMUXAgentLaunch`: all 281 Swift Testing tests passed; the command exits nonzero only because this machine cannot load the arm64 XCTest compatibility bundle from its x86_64 test host.

No app build, local Xcode test, or XCUITest was run, per the issue constraints. No user-facing strings changed.

Related investigation: https://github.com/manaflow-ai/cmux/issues/9768

Closes #9768

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/9780"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788673258&installation_model_id=21920&pr_number=9780&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F9780&signature=5f6bcf44776f81a5daa92451c251a24425a0dcd76d2566a5cf4724e9af19ba6e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Codex session binding, hook install/reconcile paths, and background hook processes; mistakes could duplicate hooks, block Codex, or leak processes, but behavior is heavily regression-tested and failures fall back to exec real codex.
> 
> **Overview**
> Codex launches now use **one cmux hook channel** instead of overlapping persistent `~/.codex/hooks.json` entries and per-invocation wrapper injection. Before `inject-args`, the CLI **reconciles** an opted-in persistent config (`installAgentHooks` with `automaticReconciliation`) and skips wrapper overrides when cmux-owned hooks are present; the codex wrapper documents that empty emit is intentional in that case.
> 
> **Persistent Codex hooks** for wrapper-equivalent events (`PreToolUse`, `PostToolUse`, `PermissionRequest`) now use the same **fire-and-forget** script path as session/prompt/stop hooks instead of synchronous `hooks feed` bridges, while compact/subagent events still use feed-only hooks. `sendFeedTelemetry` maps Codex `PermissionRequest` through `FeedEventClassifier` so Feed telemetry stays non-blocking while the notification handler still drives needs-input UI.
> 
> The fire-and-forget shell runner **reaps its 30s watchdog timer** (trap + wait on watchdog) to avoid orphaned `sleep` processes. **Garbage collection** removes stale cmux-owned hook scripts in `~/.cmux/hooks` when no Codex is running, files are older than 60s, and names are not referenced by current wrapper or installed config; user/unrecognized scripts are preserved.
> 
> Regression tests cover one producer per event, permission/Feed behavior, watchdog reaping, and install expectations for fire-and-forget tool-use hooks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6b79b62d9a065907dc6bc47420ff702b9e87a11c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Deduplicates Codex hook producers and fixes watchdog leaks. We now reconcile a persistent channel at launch and reap the timer process to prevent duplicate events and orphaned `sleep` processes. Closes #9768.

- **Bug Fixes**
  - One producer per event: reconcile cmux-owned hooks in `~/.codex/hooks.json` and prefer that channel; otherwise inject per-invocation wrapper args.
  - Persistent `PreToolUse`, `PostToolUse`, and `PermissionRequest` now run fire-and-forget like wrapper hooks; one `PermissionRequest` still drives needs‑input UI while Feed telemetry stays non‑blocking.
  - Watchdog fix: explicitly reap the timer so completed invocations leave no `sleep 30` process.
  - Script cleanup: garbage‑collect superseded cmux-owned hook scripts; keep third‑party files, active sessions, recent generations, and current‑config references.
  - Tests: added coverage for producer deduplication, watchdog reaping, and permission notification behavior.

<sup>Written for commit 6b79b62d9a065907dc6bc47420ff702b9e87a11c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/9780?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

