### PR TITLE
Prototype persistent Pi sessions in cmux TUI

### DIFF
--- a/cmux-tui/README.md
+++ b/cmux-tui/README.md
@@ -13,6 +13,7 @@
 - [Mouse](docs/mouse.md)
 - [Configuration](docs/configuration.md)
 - [Machines and remote sessions](docs/machines.md)
+- [Persistent Pi sessions](docs/pi-sessions.md)
 - [Public CLI](spec/cli.md)
 - [SDK contract](spec/bindings.md)
 - [Public resource protocol](spec/resource-api-v2.md)

--- a/cmux-tui/crates/cmux-tui-core/src/mux.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/mux.rs
@@ -13537,7 +13537,16 @@ fn terminal_launch_spec(options: &SurfaceOptions) -> Value {
         .extra_env
         .iter()
         .map(|(key, _)| key.as_str())
-        .filter(|key| matches!(*key, "CMUX_TUI_SOCKET" | "CMUX_MUX_SOCKET" | "CMUX_SIDEBAR"))
+        .filter(|key| {
+            matches!(
+                *key,
+                "CMUX_TUI_SOCKET"
+                    | "CMUX_MUX_SOCKET"
+                    | "CMUX_TUI_BIN"
+                    | "CMUX_TUI_TERMINAL_ID"
+                    | "CMUX_SIDEBAR"
+            )
+        })
         .collect::<Vec<_>>();
     serde_json::json!({
         // This is diagnostic shape, not a respawn recipe. argv and cwd can

--- a/cmux-tui/crates/cmux-tui-core/src/surface.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/surface.rs
@@ -1957,7 +1957,7 @@ impl Surface {
 
     fn spawn_with_terminal_id_and_resource_identity_at_cell_pixels(
         id: SurfaceId,
-        opts: SurfaceOptions,
+        mut opts: SurfaceOptions,
         mux: Weak<Mux>,
         terminal_id: Option<crate::terminal_host::TerminalId>,
         resource_identity: Option<TabResourceIdentity>,
@@ -1973,6 +1973,13 @@ impl Surface {
                 )
             })
             .transpose()?;
+        if let Some(terminal_public_id) = terminal_public_id.as_ref() {
+            opts.extra_env.retain(|(key, _)| key != "CMUX_TUI_TERMINAL_ID");
+            opts.extra_env.push((
+                "CMUX_TUI_TERMINAL_ID".to_string(),
+                terminal_public_id.as_str().to_string(),
+            ));
+        }
         let kitty_reservation =
             mux.upgrade().map(|mux| mux.reserve_kitty_image_surface(id)).transpose()?;
         let initial_kitty_limits = kitty_reservation

--- a/cmux-tui/crates/cmux-tui-core/tests/pty.rs
+++ b/cmux-tui/crates/cmux-tui-core/tests/pty.rs
@@ -163,6 +163,29 @@ fn surface_runs_command_and_screen_updates() {
 }
 
 #[test]
+fn terminal_child_receives_its_authoritative_public_id() {
+    let mut options = shell_opts("printf 'terminal-id=%s\\n' \"$CMUX_TUI_TERMINAL_ID\"; sleep 30");
+    options.extra_env.push((
+        "CMUX_TUI_TERMINAL_ID".to_string(),
+        "term_00000000000000000000000000000000".to_string(),
+    ));
+    let mux = Mux::new(unique_session("test-terminal-public-id-env"), options);
+    let surface = mux.new_workspace(None, None).unwrap();
+    let public_id = surface.resource_identity().unwrap().content_id.as_str().to_string();
+
+    let text = wait_for(
+        || {
+            let text = surface.with_terminal(|terminal| terminal.plain_text()).unwrap().unwrap();
+            text.contains(&format!("terminal-id={public_id}")).then_some(text)
+        },
+        Duration::from_secs(10),
+    );
+    assert!(text.is_some(), "authoritative terminal ID never appeared on screen");
+
+    mux.close_surface(surface.id).unwrap();
+}
+
+#[test]
 fn surface_resize_reports_whether_the_size_changed() {
     let mux = Mux::new(unique_session("test-resize-bool"), shell_opts("sleep 30"));
     let surface = mux.new_workspace(None, Some((80, 24))).unwrap();

--- a/cmux-tui/crates/cmux-tui/assets/cmux-pi-session.ts
+++ b/cmux-tui/crates/cmux-tui/assets/cmux-pi-session.ts
@@ -1,0 +1,35 @@
+// cmux-tui-pi-session-extension v1
+// Reports Pi lifecycle to the remote cmux-tui session that owns this terminal.
+
+import { spawn } from "node:child_process";
+import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
+
+function report(ctx: ExtensionContext, state: "working" | "idle" | "done"): void {
+  const socket = process.env.CMUX_TUI_SOCKET;
+  const terminal = process.env.CMUX_TUI_TERMINAL_ID;
+  const session = ctx.sessionManager.getSessionId();
+  if (!socket || !terminal || !session) return;
+
+  const binary = process.env.CMUX_TUI_BIN || "cmux-tui";
+  const child = spawn(binary, [
+    "--socket", socket,
+    "--quiet",
+    "agent", "report",
+    "--terminal", terminal,
+    "--state", state,
+    "--source", "hook",
+    "--source-session", session,
+  ], {
+    shell: false,
+    stdio: "ignore",
+  });
+  child.on("error", () => {});
+  child.unref();
+}
+
+export default function cmuxTuiPiSession(pi: ExtensionAPI): void {
+  pi.on("session_start", (_event, ctx) => report(ctx, "idle"));
+  pi.on("before_agent_start", (_event, ctx) => report(ctx, "working"));
+  pi.on("agent_settled", (_event, ctx) => report(ctx, "done"));
+  pi.on("session_shutdown", (_event, ctx) => report(ctx, "done"));
+}

--- a/cmux-tui/crates/cmux-tui/src/cli.rs
+++ b/cmux-tui/crates/cmux-tui/src/cli.rs
@@ -4,6 +4,7 @@
 //! is deliberately isolated in `cli/wire.rs`, so public commands cannot
 //! accidentally fall back to the private command protocol.
 
+mod agent_hooks;
 mod command;
 mod raw;
 mod wire;
@@ -95,6 +96,7 @@ pub fn run(args: &[String], startup_usage: &str) -> i32 {
         }
         Ok(ParsedCommand::Command { global, plan }) => match plan {
             CommandPlan::Protocol(request) => wire::run(global, request),
+            CommandPlan::AgentHooks(hooks) => agent_hooks::run(global, hooks),
             CommandPlan::Plugin(plugin) => command::run_plugin(global, plugin),
             CommandPlan::ProviderAuthority(authority) => {
                 command::run_provider_authority(global, authority)
@@ -395,6 +397,7 @@ const AGENT_HELP: &str = "\
 USAGE
   cmux agent list [OPTIONS]
   cmux agent report --terminal <selector> --state <value> --source <value>
+  cmux agent hooks install pi [--force]
 ";
 
 const SIDEBAR_HELP: &str = "\

--- a/cmux-tui/crates/cmux-tui/src/cli/agent_hooks.rs
+++ b/cmux-tui/crates/cmux-tui/src/cli/agent_hooks.rs
@@ -1,0 +1,126 @@
+use std::fs::{self, OpenOptions};
+use std::io::Write;
+use std::path::{Path, PathBuf};
+
+use serde_json::json;
+
+use super::{GlobalArgs, UsageError};
+
+const PI_EXTENSION: &str = include_str!("../../assets/cmux-pi-session.ts");
+const MANAGED_MARKER: &str = "// cmux-tui-pi-session-extension v1";
+
+pub(super) struct AgentHooksPlan {
+    pub force: bool,
+}
+
+pub(super) fn run(global: GlobalArgs, plan: AgentHooksPlan) -> i32 {
+    match install_pi_extension(plan.force) {
+        Ok((path, changed)) => super::wire::print_local_success(
+            &json!({"installed": true, "changed": changed, "path": path}),
+            global.output,
+        ),
+        Err(error) => super::wire::print_local_error(
+            &json!({
+                "code": "agent_hooks.install_failed",
+                "message": error.to_string(),
+                "details": {},
+                "retryable": false,
+            }),
+            global.output,
+            1,
+        ),
+    }
+}
+
+fn install_pi_extension(force: bool) -> Result<(PathBuf, bool), UsageError> {
+    let root = pi_agent_root()?;
+    install_pi_extension_at(&root, force)
+}
+
+fn pi_agent_root() -> Result<PathBuf, UsageError> {
+    if let Some(path) = std::env::var_os("PI_CODING_AGENT_DIR").filter(|value| !value.is_empty()) {
+        return Ok(PathBuf::from(path));
+    }
+    cmux_tui_core::platform::home_dir()
+        .map(|home| home.join(".pi").join("agent"))
+        .ok_or_else(|| UsageError::new("cannot determine Pi agent directory"))
+}
+
+fn install_pi_extension_at(root: &Path, force: bool) -> Result<(PathBuf, bool), UsageError> {
+    let directory = root.join("extensions");
+    fs::create_dir_all(&directory).map_err(|error| {
+        UsageError::new(format!("cannot create {}: {error}", directory.display()))
+    })?;
+    let path = directory.join("cmux-tui-session.ts");
+    match fs::read_to_string(&path) {
+        Ok(current) if current == PI_EXTENSION => return Ok((path, false)),
+        Ok(current) if !force && !current.starts_with(MANAGED_MARKER) => {
+            return Err(UsageError::new(format!(
+                "{} is not managed by cmux; pass --force to replace it",
+                path.display()
+            )));
+        }
+        Ok(_) => {}
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+        Err(error) => {
+            return Err(UsageError::new(format!("cannot read {}: {error}", path.display())));
+        }
+    }
+
+    let mut temporary = None;
+    for attempt in 0..16 {
+        let candidate =
+            directory.join(format!(".cmux-tui-session.{}.{}.tmp", std::process::id(), attempt));
+        let mut options = OpenOptions::new();
+        options.write(true).create_new(true);
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::OpenOptionsExt;
+            options.mode(0o600);
+        }
+        match options.open(&candidate) {
+            Ok(mut file) => {
+                file.write_all(PI_EXTENSION.as_bytes()).map_err(|error| {
+                    UsageError::new(format!("cannot write {}: {error}", candidate.display()))
+                })?;
+                file.sync_all().map_err(|error| {
+                    UsageError::new(format!("cannot sync {}: {error}", candidate.display()))
+                })?;
+                temporary = Some(candidate);
+                break;
+            }
+            Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => continue,
+            Err(error) => {
+                return Err(UsageError::new(format!(
+                    "cannot create extension beside {}: {error}",
+                    path.display()
+                )));
+            }
+        }
+    }
+    let temporary = temporary.ok_or_else(|| UsageError::new("cannot allocate extension file"))?;
+    if let Err(error) = fs::rename(&temporary, &path) {
+        let _ = fs::remove_file(&temporary);
+        return Err(UsageError::new(format!("cannot install {}: {error}", path.display())));
+    }
+    Ok((path, true))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn install_is_idempotent_and_does_not_replace_unmanaged_files() {
+        let directory = tempfile::tempdir().unwrap();
+        let (path, changed) = install_pi_extension_at(directory.path(), false).unwrap();
+        assert!(changed);
+        assert_eq!(fs::read_to_string(&path).unwrap(), PI_EXTENSION);
+        assert!(!install_pi_extension_at(directory.path(), false).unwrap().1);
+
+        fs::write(&path, "user extension\n").unwrap();
+        assert!(install_pi_extension_at(directory.path(), false).is_err());
+        assert_eq!(fs::read_to_string(&path).unwrap(), "user extension\n");
+        assert!(install_pi_extension_at(directory.path(), true).unwrap().1);
+    }
+}

--- a/cmux-tui/crates/cmux-tui/src/cli/command.rs
+++ b/cmux-tui/crates/cmux-tui/src/cli/command.rs
@@ -17,6 +17,7 @@ pub(super) enum ParsedCommand {
 
 pub(super) enum CommandPlan {
     Protocol(RequestPlan),
+    AgentHooks(super::agent_hooks::AgentHooksPlan),
     Plugin(PluginPlan),
     ProviderAuthority(ProviderAuthorityPlan),
     RawCommand(super::raw::RawCommandPlan),
@@ -1154,7 +1155,7 @@ fn parse_agent(words: &[String], flags: &mut Flags) -> Result<CommandPlan, Usage
                 validate_one_of(
                     "--state",
                     &state,
-                    &["idle", "running", "waiting", "done", "error"],
+                    &["working", "blocked", "idle", "done", "unknown"],
                 )?;
                 params.insert("state".into(), Value::String(state));
             }
@@ -1164,7 +1165,7 @@ fn parse_agent(words: &[String], flags: &mut Flags) -> Result<CommandPlan, Usage
             let terminal = flags.required("terminal")?;
             validate_prefixed_id("terminal", "term", &terminal)?;
             let state = flags.required("state")?;
-            validate_one_of("--state", &state, &["idle", "running", "waiting", "done", "error"])?;
+            validate_one_of("--state", &state, &["working", "blocked", "idle", "done", "unknown"])?;
             let source = flags.required("source")?;
             validate_one_of("--source", &source, &["hook", "socket"])?;
             let mut params = json!({
@@ -1177,6 +1178,11 @@ fn parse_agent(words: &[String], flags: &mut Flags) -> Result<CommandPlan, Usage
             .expect("literal object");
             insert_optional_string(&mut params, flags, "source-session", "source_session");
             request(ResourceOperation::AgentReport, &selectors, flags, params)
+        }
+        ["hooks", "install", "pi"] => {
+            Ok(CommandPlan::AgentHooks(super::agent_hooks::AgentHooksPlan {
+                force: flags.boolean("force"),
+            }))
         }
         _ => usage("agent action"),
     }
@@ -3199,7 +3205,7 @@ mod tests {
                 ],
                 "notification.create",
             ),
-            (vec!["agent", "list", "--terminal", TERMINAL, "--state", "running"], "agent.list"),
+            (vec!["agent", "list", "--terminal", TERMINAL, "--state", "working"], "agent.list"),
             (
                 vec![
                     "agent",
@@ -3207,7 +3213,7 @@ mod tests {
                     "--terminal",
                     TERMINAL,
                     "--state",
-                    "running",
+                    "working",
                     "--source",
                     "socket",
                     "--source-session",

--- a/cmux-tui/crates/cmux-tui/src/main.rs
+++ b/cmux-tui/crates/cmux-tui/src/main.rs
@@ -1386,6 +1386,9 @@ fn run_server(
     }
     surface_options.extra_env.push(("CMUX_TUI_SOCKET".into(), socket_path.display().to_string()));
     surface_options.extra_env.push(("CMUX_MUX_SOCKET".into(), socket_path.display().to_string()));
+    if let Ok(executable) = std::env::current_exe() {
+        surface_options.extra_env.push(("CMUX_TUI_BIN".into(), executable.display().to_string()));
+    }
 
     let state_root = if args.ephemeral {
         None

--- a/cmux-tui/docs/README.md
+++ b/cmux-tui/docs/README.md
@@ -11,6 +11,7 @@
 - [Configuration](configuration.md): full `cmux-tui.json` reference with defaults and a worked example.
 - [Remote daemon](remote.md): authenticated clients, SSH, WebSocket, Iroh, relays, RPC, and port forwarding. The exact agent RPC wire schema is in the [remote RPC contract](../spec/remote-rpc.md).
 - [Machines](machines.md): optional dual rails, static Unix/SSH targets, relay, `npx cmux` remote setup, and outbound `npx cmux machine-agent` registration.
+- [Persistent Pi sessions](pi-sessions.md): Pi hook installation, durable terminal identity, reconnect, and the SSH authority boundary.
 - [Raw control protocol](protocol.md): private protocol-v10 JSON-lines commands and compatibility rules.
 - [Public resource protocol](../spec/resource-api-v2.md): stable opaque IDs, requests, mutations, streams, and errors.
 - [Public CLI](../spec/cli.md): noun-first commands and selectors.

--- a/cmux-tui/docs/pi-sessions.md
+++ b/cmux-tui/docs/pi-sessions.md
@@ -1,0 +1,20 @@
+# Persistent Pi sessions
+
+Run Pi inside a named cmux TUI session on the SSH host. The TUI daemon owns the PTY, so Pi keeps running when an SSH client disconnects.
+
+```sh
+cmux-tui --headless --session agents
+cmux-tui agent hooks install pi
+cmux-tui attach --session agents
+```
+
+The installed Pi extension reads the durable terminal ID from `CMUX_TUI_TERMINAL_ID` and reports Pi's real `ctx.sessionManager.getSessionId()` through the local `CMUX_TUI_SOCKET`. It never assigns a Pi session ID. Reconnecting clients can inspect and attach to the same terminal:
+
+```sh
+cmux-tui --session agents agent list
+cmux-tui attach --session agents --terminal term_...
+```
+
+## SSH security boundary
+
+The daemon, PTY, Pi process, hook, and Unix socket all stay on the SSH host. A client connects with `cmux-tui relay --session agents` over SSH standard input and output. Do not reverse-forward a local cmux socket, copy a local relay credential to the host, or expose arbitrary local RPC. The SSH transport uses `ClearAllForwardings=yes` and `ForwardAgent=no`; future macOS `cmux ssh` integration must preserve this client-to-remote authority direction.


### PR DESCRIPTION
## Summary

- install a Pi lifecycle extension with `cmux-tui agent hooks install pi`
- expose each durable TUI terminal ID to its child process and report Pi's real session ID
- document reconnecting through the existing SSH stdio relay without reverse forwarding local authority
- align the agent CLI state vocabulary with the public resource schema

## Security boundary

The Pi hook talks only to the remote TUI daemon over its existing owner-only Unix socket. It does not reverse-forward a local cmux socket, put a local relay credential on the remote host, or expose arbitrary local RPC. Existing SSH transport remains fail-closed with strict host keys, `ForwardAgent=no`, and `ClearAllForwardings=yes`.

## Verification

- `cargo test -p cmux-tui cli::command::tests --no-fail-fast`
- `cargo test -p cmux-tui cli::agent_hooks::tests --no-fail-fast`
- `cargo test -p cmux-tui ssh_transport_is_noninteractive_and_fail_closed --no-fail-fast`
- `cargo test -p cmux-tui-core --test pty terminal_child_receives_its_authoritative_public_id --no-fail-fast`
- `cargo build -p cmux-tui`
- live Pi session reported its generated ID, then the same projection was read through a fresh SSH stdio relay connection

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/9783"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788673509&installation_model_id=21920&pr_number=9783&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F9783&signature=39a1bee1d53fe30fe198e163a5f27bd2e5b858333dc43e452aa070433f395404"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes agent reporting and PTY child env injection for remote session workflows; hook install writes user Pi extensions but stays on the documented local-socket authority boundary.
> 
> **Overview**
> Adds **persistent Pi sessions** in headless cmux TUI: Pi keeps running on the host when SSH clients detach because the daemon owns the PTY.
> 
> **Pi hook install** — New `cmux agent hooks install pi [--force]` writes a managed Pi extension (`cmux-pi-session.ts`) that reports lifecycle (`working` / `idle` / `done`) via `cmux agent report`, using Pi’s real session ID from `ctx.sessionManager.getSessionId()` (not a cmux-assigned ID). The hook spawns the cmux binary with `--socket`, `--terminal`, and `--source hook`.
> 
> **Child environment** — Terminal surfaces now inject the **authoritative** public terminal ID into `CMUX_TUI_TERMINAL_ID` at spawn (overriding any preset value). Startup also sets `CMUX_TUI_BIN` from the current executable so hooks can invoke the same binary. Launch diagnostics include these env keys.
> 
> **CLI alignment** — `agent list` / `agent report` `--state` values change from `running` / `waiting` / `error` to **`working`**, **`blocked`**, **`idle`**, **`done`**, **`unknown`** to match the public resource schema.
> 
> **Docs** — New `docs/pi-sessions.md` and index links describe install, reconnect via `agent list` / `attach --terminal`, and the SSH boundary (stdio relay only; no reverse-forwarding local authority).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3b5cd16ee16e57e70242881971d83195fb6f1129. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a Pi lifecycle hook and durable terminal identity so Pi sessions keep running and can be reattached in `cmux-tui` after SSH reconnects. Reports the real Pi session ID over the remote Unix socket and updates the CLI and docs.

- **New Features**
  - New command: `cmux-tui agent hooks install pi [--force]` installs a Pi session hook.
  - Terminal children now get their authoritative ID in `CMUX_TUI_TERMINAL_ID`; `CMUX_TUI_BIN` is set for child processes.
  - Pi hook reports `working | idle | done` via `cmux-tui agent report` using `CMUX_TUI_SOCKET` and `CMUX_TUI_TERMINAL_ID`.
  - Agent state vocabulary aligned to `working | blocked | idle | done | unknown`.
  - Added docs for persistent Pi sessions and links from READMEs.
  - Tests cover terminal ID propagation and hook installation behavior.

- **Security**
  - Hook communicates only with the remote TUI daemon over its owner-only Unix socket.
  - No reverse-forwarding of local sockets or credentials; no arbitrary local RPC.
  - SSH transport remains fail-closed with strict host keys, `ForwardAgent=no`, and `ClearAllForwardings=yes`.

<sup>Written for commit 3b5cd16ee16e57e70242881971d83195fb6f1129. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/9783?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for installing Pi coding agent hooks with optional forced replacement.
  * Pi sessions now report idle, working, and completed states to cmux TUI.
  * Terminal processes receive their authoritative terminal ID automatically.

* **Documentation**
  * Added guidance for persistent Pi sessions, reconnection, and SSH security considerations.
  * Linked the new Pi session documentation from the documentation indexes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->