### PR TITLE
Add tracked website installers and coderouter landing

### DIFF
--- a/web/app/[locale]/(landing)/tui/install-tabs.tsx
+++ b/web/app/[locale]/(landing)/tui/install-tabs.tsx
@@ -138,6 +138,17 @@ export function TuiInstallTabs({
             aria-label={copied ? copiedLabel : copyLabel}
             title={copied ? copiedLabel : copyLabel}
             onClick={() => {
+              void fetch("/api/install-events", {
+                method: "POST",
+                headers: { "content-type": "application/json" },
+                body: JSON.stringify({
+                  event: "command_copied",
+                  product: "tui",
+                  platform,
+                  method: platform === "unix" ? "curl" : "powershell",
+                }),
+                keepalive: true,
+              }).catch(() => undefined);
               void navigator.clipboard.writeText(commands[platform]).then(() => {
                 setCopied(true);
                 window.setTimeout(() => setCopied(false), 1500);

--- a/web/app/api/install-events/route.ts
+++ b/web/app/api/install-events/route.ts
@@ -1,0 +1,51 @@
+import { NextResponse } from "next/server";
+import { checkRateLimit } from "@vercel/firewall";
+
+import {
+  captureInstallEvent,
+  validInstallEventBody,
+} from "../../../services/analytics/install";
+
+export const dynamic = "force-dynamic";
+
+export async function POST(request: Request): Promise<Response> {
+  const ruleId = process.env.CMUX_ANALYTICS_RATE_LIMIT_ID?.trim();
+  if (process.env.VERCEL === "1" && ruleId) {
+    const { error, rateLimited } = await checkRateLimit(ruleId, { request });
+    if (rateLimited || (error && error !== "not-found")) {
+      // Analytics must never affect installation or clipboard UX.
+      return new Response(null, {
+        status: 204,
+        headers: { "cache-control": "no-store" },
+      });
+    }
+  }
+  const length = Number(request.headers.get("content-length") ?? "0");
+  if (!Number.isFinite(length) || length > 512) {
+    return NextResponse.json({ error: "invalid_request" }, { status: 400 });
+  }
+  let raw: string;
+  try {
+    raw = await request.text();
+  } catch {
+    return NextResponse.json({ error: "invalid_request" }, { status: 400 });
+  }
+  if (raw.length > 512) {
+    return NextResponse.json({ error: "invalid_request" }, { status: 400 });
+  }
+  let body: unknown;
+  try {
+    body = JSON.parse(raw);
+  } catch {
+    return NextResponse.json({ error: "invalid_request" }, { status: 400 });
+  }
+  const event = validInstallEventBody(body);
+  if (!event) {
+    return NextResponse.json({ error: "invalid_request" }, { status: 400 });
+  }
+  captureInstallEvent(event);
+  return new Response(null, {
+    status: 204,
+    headers: { "cache-control": "no-store" },
+  });
+}

--- a/web/app/coderouter/install-command.tsx
+++ b/web/app/coderouter/install-command.tsx
@@ -1,0 +1,50 @@
+"use client";
+
+import { useState } from "react";
+
+const command = "curl -fsSL https://cmux.com/coderouter/install.sh | sh";
+
+export function CoderouterInstallCommand() {
+  const [copied, setCopied] = useState(false);
+
+  return (
+    <div className="mt-8">
+      <div className="flex items-center border border-black/15 bg-white">
+        <span aria-hidden className="pl-4 font-mono text-sm text-black/35">$</span>
+        <pre className="min-w-0 flex-1 overflow-x-auto px-3 py-4 font-mono text-[13px] text-black/75">
+          <code>{command}</code>
+        </pre>
+        <button
+          type="button"
+          className="mr-2 border border-black/15 px-3 py-2 font-mono text-[11px] text-black/55 hover:border-black/35 hover:text-black"
+          onClick={() => {
+            void fetch("/api/install-events", {
+              method: "POST",
+              headers: { "content-type": "application/json" },
+              body: JSON.stringify({
+                event: "command_copied",
+                product: "coderouter",
+                platform: "unix",
+                method: "curl",
+              }),
+              keepalive: true,
+            }).catch(() => undefined);
+            void navigator.clipboard.writeText(command).then(() => {
+              setCopied(true);
+              window.setTimeout(() => setCopied(false), 1_500);
+            });
+          }}
+        >
+          {copied ? "copied" : "copy"}
+        </button>
+      </div>
+      <div className="mt-3 flex flex-wrap gap-x-5 gap-y-2 font-mono text-[11px] text-black/40">
+        <a className="underline underline-offset-4" href="/coderouter/install.sh">
+          view script
+        </a>
+        <span>macOS + Linux</span>
+        <span>checksum verified</span>
+      </div>
+    </div>
+  );
+}

--- a/web/app/coderouter/install.sh/route.ts
+++ b/web/app/coderouter/install.sh/route.ts
@@ -1,0 +1,15 @@
+import { captureInstallEvent } from "../../../services/analytics/install";
+
+export const dynamic = "force-dynamic";
+
+export function GET(request: Request): Response {
+  captureInstallEvent({
+    event: "website_install_script_requested",
+    product: "coderouter",
+    method: "curl",
+  });
+  return Response.redirect(
+    new URL("/coderouter/install-static.sh", request.url),
+    307,
+  );
+}

--- a/web/app/coderouter/page.tsx
+++ b/web/app/coderouter/page.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next";
+import { CoderouterInstallCommand } from "./install-command";
 
 const tagline =
   "coderouter - route Codex/Claude Code traffic across multiple ChatGPT Pro/Claude Max/OpenCode subscriptions and API keys.";
@@ -11,57 +12,59 @@ export const metadata: Metadata = {
 
 export default function CoderouterLandingPage() {
   return (
-    <main className="min-h-screen bg-[#fafafa] text-[#111]">
-      <nav className="mx-auto flex h-16 max-w-6xl items-center justify-between px-6">
+    <main className="min-h-screen bg-[#faf9f6] text-[#211f1b]">
+      <nav className="mx-auto flex h-16 max-w-2xl items-center justify-between px-6">
         <span className="font-mono text-sm font-medium tracking-[-0.02em]">
           coderouter
         </span>
-        <span className="rounded-full border border-black/10 bg-white px-3 py-1 font-mono text-[11px] text-black/50">
+        <span className="border border-[#d9d2c5] bg-white px-3 py-1 font-mono text-[11px] text-black/50">
           private beta
         </span>
       </nav>
 
-      <section className="mx-auto flex min-h-[calc(100vh-8rem)] max-w-6xl items-center px-6 py-20">
-        <div className="max-w-4xl">
-          <p className="mb-6 font-mono text-xs uppercase tracking-[0.14em] text-black/40">
-            one endpoint. every subscription.
-          </p>
-          <h1 className="max-w-4xl text-balance text-4xl font-medium leading-[1.08] tracking-[-0.045em] sm:text-6xl lg:text-7xl">
-            {tagline}
-          </h1>
+      <section className="mx-auto max-w-2xl px-6 pb-24 pt-20 sm:pt-28">
+        <p className="font-mono text-xs tracking-[0.14em] text-[#9a5b22]">
+          one endpoint. every subscription.
+        </p>
+        <h1 className="mt-5 text-balance text-4xl font-medium leading-[1.08] tracking-[-0.045em] sm:text-6xl">
+          keep coding when one account runs out.
+        </h1>
+        <p className="mt-6 max-w-xl text-base leading-7 text-black/55">
+          Route Codex traffic across multiple ChatGPT Pro and OpenCode
+          subscriptions. Your tools stay the same; coderouter chooses healthy
+          capacity.
+        </p>
 
-          <div className="mt-12 inline-flex items-center gap-5 rounded-xl border border-black/10 bg-white p-2 pl-5 shadow-[0_1px_2px_rgba(0,0,0,0.04)]">
-            <code className="font-mono text-sm text-black/70">
-              cr codex
-            </code>
-            <span className="select-none rounded-lg bg-black px-4 py-2 font-mono text-xs text-white">
-              private beta
-            </span>
-          </div>
+        <CoderouterInstallCommand />
 
-          <p className="mt-5 max-w-xl font-mono text-[11px] leading-5 text-black/40">
-            Codex and OpenCode Go are available now. Pi support is experimental.
-            Claude Max and API-key routing are coming soon.
-          </p>
-
-          <div className="mt-20 grid max-w-3xl gap-px overflow-hidden rounded-xl border border-black/10 bg-black/10 sm:grid-cols-3">
-            {[
-              ["01", "connect", "Add subscriptions with provider-native authorization."],
-              ["02", "route", "Use one OpenAI-compatible endpoint from any agent."],
-              ["03", "continue", "Move to healthy capacity without changing your workflow."],
-            ].map(([number, title, description]) => (
-              <div key={number} className="bg-[#fafafa] p-6">
-                <p className="font-mono text-[11px] text-black/30">{number}</p>
-                <h2 className="mt-8 text-sm font-medium">{title}</h2>
-                <p className="mt-2 text-sm leading-6 text-black/50">{description}</p>
-              </div>
-            ))}
-          </div>
+        <div className="mt-14 border-t border-[#d9d2c5]">
+          {[
+            ["1", "install", "One verified native binary. No daemon."],
+            ["2", "connect", "Run cr login, then cr add."],
+            ["3", "route", "Use cr codex, cr pi, or cr opencode."],
+          ].map(([number, title, body]) => (
+            <div
+              key={number}
+              className="grid grid-cols-[2rem_7rem_1fr] gap-3 border-b border-[#d9d2c5] py-4 text-sm"
+            >
+              <span className="font-mono text-black/30">{number}</span>
+              <strong className="font-medium">{title}</strong>
+              <span className="text-black/50">{body}</span>
+            </div>
+          ))}
         </div>
+
+        <p className="mt-8 font-mono text-[11px] leading-5 text-black/40">
+          Codex and OpenCode Go are available now. Pi is experimental. Hosted
+          routing requires cmux Pro or Team; self-hosting remains available.
+        </p>
       </section>
 
-      <footer className="mx-auto flex h-16 max-w-6xl items-center px-6 font-mono text-[11px] text-black/30">
-        coderouter.dev
+      <footer className="mx-auto flex h-16 max-w-2xl items-center justify-between border-t border-[#d9d2c5] px-6 font-mono text-[11px] text-black/30">
+        <span>coderouter.dev</span>
+        <a className="underline underline-offset-4" href="https://cmux.com">
+          by cmux
+        </a>
       </footer>
     </main>
   );

--- a/web/app/tui/install.ps1/route.ts
+++ b/web/app/tui/install.ps1/route.ts
@@ -1,0 +1,12 @@
+import { captureInstallEvent } from "../../../services/analytics/install";
+
+export const dynamic = "force-dynamic";
+
+export function GET(request: Request): Response {
+  captureInstallEvent({
+    event: "website_install_script_requested",
+    product: "tui",
+    method: "powershell",
+  });
+  return Response.redirect(new URL("/tui/install-static.ps1", request.url), 307);
+}

--- a/web/app/tui/install.sh/route.ts
+++ b/web/app/tui/install.sh/route.ts
@@ -1,0 +1,12 @@
+import { captureInstallEvent } from "../../../services/analytics/install";
+
+export const dynamic = "force-dynamic";
+
+export function GET(request: Request): Response {
+  captureInstallEvent({
+    event: "website_install_script_requested",
+    product: "tui",
+    method: "curl",
+  });
+  return Response.redirect(new URL("/tui/install-static.sh", request.url), 307);
+}

--- a/web/public/coderouter/install-static.sh
+++ b/web/public/coderouter/install-static.sh
@@ -1,0 +1,94 @@
+#!/bin/sh
+set -eu
+
+base_url="${CODEROUTER_DOWNLOAD_BASE_URL:-https://github.com/manaflow-ai/coderouter-releases/releases/latest/download}"
+install_root="${CODEROUTER_INSTALL:-$HOME/.coderouter}"
+bin_dir="$install_root/bin"
+
+os="$(uname -s)"
+arch="$(uname -m)"
+
+case "$os-$arch" in
+  Darwin-arm64) artifact="coderouter-darwin-arm64" ;;
+  Darwin-x86_64) artifact="coderouter-darwin-x64" ;;
+  Linux-x86_64 | Linux-amd64) artifact="coderouter-linux-x64" ;;
+  Linux-aarch64 | Linux-arm64) artifact="coderouter-linux-arm64" ;;
+  *)
+    echo "coderouter: unsupported platform $os-$arch" >&2
+    exit 1
+    ;;
+esac
+
+if ! command -v curl >/dev/null 2>&1; then
+  echo "coderouter: curl is required" >&2
+  exit 1
+fi
+
+tmp_dir="$(mktemp -d "${TMPDIR:-/tmp}/coderouter-install.XXXXXX")"
+trap 'rm -rf "$tmp_dir"' EXIT HUP INT TERM
+
+curl --proto '=https' --tlsv1.2 -fsSL "$base_url/manifest.json" \
+  -o "$tmp_dir/manifest.json"
+checksum="$(
+  sed -n "s/.*\"$artifact\"[[:space:]]*:[[:space:]]*\"\\([0-9a-f][0-9a-f]*\\)\".*/\\1/p" \
+    "$tmp_dir/manifest.json"
+)"
+version="$(
+  sed -n 's/.*"version"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' \
+    "$tmp_dir/manifest.json"
+)"
+if [ "${#checksum}" -ne 64 ]; then
+  echo "coderouter: $artifact is unavailable for this release" >&2
+  exit 1
+fi
+
+curl --proto '=https' --tlsv1.2 -fsSL "$base_url/$artifact" \
+  -o "$tmp_dir/coderouter"
+
+if command -v shasum >/dev/null 2>&1; then
+  actual="$(shasum -a 256 "$tmp_dir/coderouter" | awk '{print $1}')"
+elif command -v sha256sum >/dev/null 2>&1; then
+  actual="$(sha256sum "$tmp_dir/coderouter" | awk '{print $1}')"
+else
+  echo "coderouter: shasum or sha256sum is required" >&2
+  exit 1
+fi
+
+if [ "$actual" != "$checksum" ]; then
+  echo "coderouter: checksum verification failed" >&2
+  exit 1
+fi
+
+mkdir -p "$bin_dir"
+install -m 755 "$tmp_dir/coderouter" "$bin_dir/coderouter"
+ln -sf coderouter "$bin_dir/cr"
+
+case ":$PATH:" in
+  *":$bin_dir:"*) ;;
+  *)
+    shell_name="$(basename "${SHELL:-sh}")"
+    case "$shell_name" in
+      zsh) profile="$HOME/.zshrc"; line="export PATH=\"$bin_dir:\$PATH\"" ;;
+      bash) profile="$HOME/.bashrc"; line="export PATH=\"$bin_dir:\$PATH\"" ;;
+      fish)
+        profile="$HOME/.config/fish/config.fish"
+        line="fish_add_path \"$bin_dir\""
+        mkdir -p "$(dirname "$profile")"
+        ;;
+      *) profile=""; line="" ;;
+    esac
+    if [ -n "$profile" ] && ! grep -F "$bin_dir" "$profile" >/dev/null 2>&1; then
+      printf '\n# coderouter\n%s\n' "$line" >>"$profile"
+      echo "Added coderouter to PATH in $profile"
+    else
+      echo "Add $bin_dir to PATH to run coderouter from a new shell."
+    fi
+    ;;
+esac
+
+echo "Installed coderouter ${version:-unknown} to $bin_dir/coderouter"
+
+curl --proto '=https' --tlsv1.2 -fsS --max-time 2 \
+  -H 'content-type: application/json' \
+  -d "{\"product\":\"coderouter\",\"platform\":\"$os-$arch\",\"method\":\"curl\",\"version\":\"${version:-unknown}\"}" \
+  https://cmux.com/api/install-events >/dev/null 2>&1 || true

--- a/web/public/tui/install-static.ps1
+++ b/web/public/tui/install-static.ps1
@@ -57,3 +57,18 @@ if (($env:Path -split ";") -notcontains $BinDir) {
 }
 
 Write-Host "Installed cmux to $Destination"
+
+try {
+    $Telemetry = @{
+        product = "tui"
+        platform = "Windows-$Architecture"
+        method = "powershell"
+    } | ConvertTo-Json -Compress
+    Invoke-RestMethod -Method Post `
+        -Uri "https://cmux.com/api/install-events" `
+        -ContentType "application/json" `
+        -Body $Telemetry `
+        -TimeoutSec 2 | Out-Null
+} catch {
+    # Analytics is best effort and must never fail installation.
+}

--- a/web/public/tui/install-static.sh
+++ b/web/public/tui/install-static.sh
@@ -82,3 +82,8 @@ case ":$PATH:" in
 esac
 
 echo "Installed cmux to $bin_dir/cmux"
+
+curl --proto '=https' --tlsv1.2 -fsS --max-time 2 \
+  -H 'content-type: application/json' \
+  -d "{\"product\":\"tui\",\"platform\":\"$os-$arch\",\"method\":\"curl\"}" \
+  https://cmux.com/api/install-events >/dev/null 2>&1 || true

--- a/web/services/analytics/install.ts
+++ b/web/services/analytics/install.ts
@@ -1,0 +1,94 @@
+import { randomUUID } from "node:crypto";
+import { after } from "next/server";
+
+import { POSTHOG_HOST, POSTHOG_PROJECT_KEY } from "./iosEventPolicy";
+
+export type InstallProduct = "tui" | "coderouter";
+export type InstallMethod = "curl" | "powershell" | "npm" | "uv";
+export type InstallEventName =
+  | "website_install_command_copied"
+  | "website_install_script_requested"
+  | "website_install_succeeded";
+
+type InstallCapture = {
+  readonly event: InstallEventName;
+  readonly product: InstallProduct;
+  readonly method: InstallMethod;
+  readonly platform?: string;
+  readonly version?: string;
+};
+
+export function captureInstallEvent(input: InstallCapture): void {
+  if (
+    process.env.VERCEL_ENV !== "production" &&
+    process.env.INSTALL_ANALYTICS_FORCE !== "1"
+  ) return;
+  const properties: Record<string, string | number> = {
+    product: input.product,
+    method: input.method,
+    schema_version: 1,
+    $insert_id: randomUUID(),
+  };
+  if (safeLabel(input.platform)) properties.platform = input.platform!;
+  if (safeVersion(input.version)) properties.version = input.version!;
+  const body = JSON.stringify({
+    api_key: POSTHOG_PROJECT_KEY,
+    event: input.event,
+    distinct_id: `anonymous-install:${randomUUID()}`,
+    properties,
+    timestamp: new Date().toISOString(),
+  });
+  const task = fetch(`${POSTHOG_HOST}/capture/`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body,
+    signal: AbortSignal.timeout(2_000),
+  }).then(() => undefined).catch(() => undefined);
+  try {
+    after(task);
+  } catch {
+    void task;
+  }
+}
+
+export function validInstallEventBody(value: unknown): {
+  event: "website_install_command_copied" | "website_install_succeeded";
+  product: InstallProduct;
+  method: InstallMethod;
+  platform?: string;
+  version?: string;
+} | null {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return null;
+  const body = value as Record<string, unknown>;
+  if (body.product !== "tui" && body.product !== "coderouter") return null;
+  if (
+    body.method !== "curl" &&
+    body.method !== "powershell" &&
+    body.method !== "npm" &&
+    body.method !== "uv"
+  ) return null;
+  if (
+    body.event !== undefined &&
+    body.event !== "command_copied" &&
+    body.event !== "succeeded"
+  ) return null;
+  if (body.platform !== undefined && !safeLabel(body.platform)) return null;
+  if (body.version !== undefined && !safeVersion(body.version)) return null;
+  return {
+    event: body.event === "command_copied"
+      ? "website_install_command_copied"
+      : "website_install_succeeded",
+    product: body.product,
+    method: body.method,
+    ...(typeof body.platform === "string" ? { platform: body.platform } : {}),
+    ...(typeof body.version === "string" ? { version: body.version } : {}),
+  };
+}
+
+function safeLabel(value: unknown): value is string {
+  return typeof value === "string" && /^[A-Za-z0-9._-]{1,64}$/.test(value);
+}
+
+function safeVersion(value: unknown): value is string {
+  return typeof value === "string" && /^[A-Za-z0-9.+-]{1,32}$/.test(value);
+}

--- a/web/tests/install-analytics.test.tsx
+++ b/web/tests/install-analytics.test.tsx
@@ -1,0 +1,80 @@
+import { describe, expect, test } from "bun:test";
+import { renderToStaticMarkup } from "react-dom/server";
+
+import { validInstallEventBody } from "../services/analytics/install";
+import CoderouterLandingPage from "../app/coderouter/page";
+import { GET as coderouterInstall } from "../app/coderouter/install.sh/route";
+import { GET as tuiInstall } from "../app/tui/install.sh/route";
+import { GET as tuiPowerShellInstall } from "../app/tui/install.ps1/route";
+
+describe("website install analytics", () => {
+  test("renders the clean coderouter curl-install landing page", () => {
+    const html = renderToStaticMarkup(<CoderouterLandingPage />);
+    expect(html).toContain("keep coding when one account runs out");
+    expect(html).toContain(
+      "curl -fsSL https://cmux.com/coderouter/install.sh | sh",
+    );
+    expect(html).toContain("checksum verified");
+    expect(html).not.toContain("rounded-");
+  });
+
+  test("validates only bounded non-sensitive install dimensions", () => {
+    expect(validInstallEventBody({
+      product: "coderouter",
+      method: "curl",
+      platform: "Darwin-arm64",
+      version: "0.2.0",
+    })).toEqual({
+      event: "website_install_succeeded",
+      product: "coderouter",
+      method: "curl",
+      platform: "Darwin-arm64",
+      version: "0.2.0",
+    });
+    expect(validInstallEventBody({
+      product: "coderouter",
+      method: "curl",
+      platform: "x".repeat(65),
+    })).toBeNull();
+    expect(validInstallEventBody({
+      product: "coderouter",
+      method: "curl",
+      email: "person@example.com",
+    })).toEqual({
+      event: "website_install_succeeded",
+      product: "coderouter",
+      method: "curl",
+    });
+    expect(validInstallEventBody({
+      event: "command_copied",
+      product: "tui",
+      method: "powershell",
+    })).toEqual({
+      event: "website_install_command_copied",
+      product: "tui",
+      method: "powershell",
+    });
+  });
+
+  test("tracks then redirects to immutable static script bodies", () => {
+    const coderouter = coderouterInstall(
+      new Request("https://cmux.com/coderouter/install.sh"),
+    );
+    const tui = tuiInstall(new Request("https://cmux.com/tui/install.sh"));
+    const tuiPowerShell = tuiPowerShellInstall(
+      new Request("https://cmux.com/tui/install.ps1"),
+    );
+    expect(coderouter.status).toBe(307);
+    expect(coderouter.headers.get("location")).toBe(
+      "https://cmux.com/coderouter/install-static.sh",
+    );
+    expect(tui.status).toBe(307);
+    expect(tui.headers.get("location")).toBe(
+      "https://cmux.com/tui/install-static.sh",
+    );
+    expect(tuiPowerShell.status).toBe(307);
+    expect(tuiPowerShell.headers.get("location")).toBe(
+      "https://cmux.com/tui/install-static.ps1",
+    );
+  });
+});


### PR DESCRIPTION
Ships a square, minimal cmux.com/coderouter landing page; a checksum-verified curl installer backed by public binary-only releases; and privacy-safe PostHog events for TUI/coderouter command copies, script requests, and successful installs. Installer analytics is best-effort and never blocks installation.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/9784"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788673838&installation_model_id=21920&pr_number=9784&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F9784&signature=460fabd192150fc0552daf858d5af34974db3803fed3efabf5618d0e917bfb74"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Analytics is best-effort with strict input bounds and no user-identifying fields; install paths fail open on telemetry errors. Main surface area is new public install endpoints and static scripts, not auth or billing.
> 
> **Overview**
> Adds **privacy-safe PostHog install analytics** for TUI and coderouter: command copies, install-script fetches, and successful installs. Events go through a new `POST /api/install-events` route with bounded JSON validation, optional Vercel Firewall rate limiting (rate limits still return **204** so clipboard/install UX never breaks), and production-only capture via `captureInstallEvent`.
> 
> **coderouter** gets a redesigned minimal landing with a curl copy box, checksum-verified `install-static.sh` (GitHub releases + manifest), and `install.sh` routes that **track then 307-redirect** to static scripts. **TUI** install tabs and static `install.sh` / `install.ps1` scripts now fire the same analytics on copy and post-install success.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eb8a419e51d1c1613e7e237c58934e1a2232614e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a minimal `cmux.com/coderouter` landing and tracked website installers for `tui` and `coderouter`, with checksum-verified binaries and privacy-safe, best‑effort PostHog analytics that never block installation.

- **New Features**
  - New `cmux.com/coderouter` landing with a single curl command and copy-to-clipboard.
  - Installer routes: `/coderouter/install.sh`, `/tui/install.sh`, `/tui/install.ps1` log “script requested” then 307 to immutable static scripts.
  - Static installers: checksum-verified `coderouter` binary download, PATH setup, `cr` symlink; posts success to `/api/install-events` with a 2s timeout.
  - Client events: send `command_copied` from TUI install tabs and coderouter landing.
  - API: `/api/install-events` validates bounded fields, enforces ≤512B body, and rate-limits via `@vercel/firewall`; always returns 204 to avoid UX impact.
  - Analytics service: `captureInstallEvent` posts to PostHog with minimal schema; production-only unless `INSTALL_ANALYTICS_FORCE=1`.
  - Tests: verify landing content, input validation, and installer redirects.

<sup>Written for commit eb8a419e51d1c1613e7e237c58934e1a2232614e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/9784?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added one-step CodeRouter installation with platform detection, checksum verification, shell setup, and clear status reporting.
  - Added copy-to-clipboard installation commands with immediate confirmation feedback.
  - Added shell and PowerShell installation options for TUI and CodeRouter.
- **Improvements**
  - Redesigned the CodeRouter landing page with clearer installation, connection, and routing instructions.
  - Installers now handle unsupported platforms, missing tools, unavailable downloads, and verification failures more clearly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->