### PR TITLE
Fix copied surface link live identity

### DIFF
--- a/Sources/AppDelegate+CmuxNavigationDeepLinks.swift
+++ b/Sources/AppDelegate+CmuxNavigationDeepLinks.swift
@@ -48,7 +48,7 @@ extension AppDelegate {
     func handleCmuxNavigationURLRequest(_ request: CmuxNavigationURLRequest) -> Bool {
         let lookup = cmuxNavigationWorkspaceLookup()
         let resolver = CmuxNavigationTargetResolver(workspaces: lookup.descriptors)
-        guard let resolution = resolver.resolve(request.target) else {
+        guard let resolution = resolver.resolve(request) else {
             if shouldDeferNavigationURLRequestsForStartupRestore {
                 pendingStartupNavigationURLRequests.append(request)
 #if DEBUG

--- a/Sources/CmuxNavigationSurfaceDescriptor.swift
+++ b/Sources/CmuxNavigationSurfaceDescriptor.swift
@@ -4,6 +4,14 @@ import Foundation
 struct CmuxNavigationSurfaceDescriptor: Equatable {
     /// Session-scoped panel identifier (`Panel.id`).
     let panelId: UUID
+    /// Current session-owned surface identifiers that route to this panel.
+    let runtimeSurfaceIds: [UUID]
     /// Restart-stable surface identifier (`Panel.stableSurfaceId`).
     let stableSurfaceId: UUID
+
+    init(panelId: UUID, runtimeSurfaceIds: [UUID] = [], stableSurfaceId: UUID) {
+        self.panelId = panelId
+        self.runtimeSurfaceIds = runtimeSurfaceIds
+        self.stableSurfaceId = stableSurfaceId
+    }
 }

--- a/Sources/CmuxNavigationTargetResolver.swift
+++ b/Sources/CmuxNavigationTargetResolver.swift
@@ -43,6 +43,10 @@ struct CmuxNavigationTargetResolver {
                 if surfaceByRuntimeId[surface.panelId] == nil {
                     surfaceByRuntimeId[surface.panelId] = (workspace.workspaceId, surface.panelId)
                 }
+                for runtimeSurfaceId in surface.runtimeSurfaceIds
+                    where surfaceByRuntimeId[runtimeSurfaceId] == nil {
+                    surfaceByRuntimeId[runtimeSurfaceId] = (workspace.workspaceId, surface.panelId)
+                }
                 if surfaceByStableId[surface.stableSurfaceId] == nil {
                     surfaceByStableId[surface.stableSurfaceId] = (workspace.workspaceId, surface.panelId)
                 }
@@ -56,6 +60,31 @@ struct CmuxNavigationTargetResolver {
 
     /// Resolves a parsed navigation target to current-session identifiers, or
     /// nil when no open workspace/pane/surface matches either identity.
+    func resolve(_ request: CmuxNavigationURLRequest) -> Resolution? {
+        if let resolution = resolve(request.target) {
+            return resolution
+        }
+        guard request.stableFallbackWorkspaceId != nil || request.stableFallbackSurfaceId != nil else {
+            return nil
+        }
+
+        switch request.target {
+        case .workspace:
+            guard let workspaceId = request.stableFallbackWorkspaceId,
+                  let workspace = resolveWorkspace(workspaceId) else {
+                return nil
+            }
+            return .workspace(workspaceId: workspace.workspaceId)
+        case .pane:
+            return nil
+        case .surface(let workspaceId, _):
+            let linkedWorkspace = request.stableFallbackWorkspaceId.flatMap(resolveWorkspace)
+                ?? resolveWorkspace(workspaceId)
+            guard let surfaceId = request.stableFallbackSurfaceId else { return nil }
+            return resolveSurfaceTarget(surfaceId, linkedWorkspace: linkedWorkspace)
+        }
+    }
+
     func resolve(_ target: CmuxNavigationURLRequest.Target) -> Resolution? {
         switch target {
         case .workspace(let workspaceId):
@@ -72,19 +101,7 @@ struct CmuxNavigationTargetResolver {
                let panelId = resolveSurface(surfaceId, in: linkedWorkspace) {
                 return .surface(workspaceId: linkedWorkspace.workspaceId, panelId: panelId)
             }
-            // The tab may have moved to another workspace since the link was
-            // copied (or its workspace was closed); surface identity wins over
-            // the stale workspace route. Exact runtime ids beat stable ids.
-            let excludedWorkspaceId = linkedWorkspace?.workspaceId
-            if let target = surfaceByRuntimeId[surfaceId],
-               target.workspaceId != excludedWorkspaceId {
-                return .surface(workspaceId: target.workspaceId, panelId: target.panelId)
-            }
-            if let target = surfaceByStableId[surfaceId],
-               target.workspaceId != excludedWorkspaceId {
-                return .surface(workspaceId: target.workspaceId, panelId: target.panelId)
-            }
-            return nil
+            return resolveSurfaceTarget(surfaceId, linkedWorkspace: linkedWorkspace)
         }
     }
 
@@ -96,6 +113,32 @@ struct CmuxNavigationTargetResolver {
         if workspace.surfaces.contains(where: { $0.panelId == id }) {
             return id
         }
+        if let surface = workspace.surfaces.first(where: { $0.runtimeSurfaceIds.contains(id) }) {
+            return surface.panelId
+        }
         return workspace.surfaces.first(where: { $0.stableSurfaceId == id })?.panelId
+    }
+
+    private func resolveSurfaceTarget(
+        _ surfaceId: UUID,
+        linkedWorkspace: WorkspaceDescriptor?
+    ) -> Resolution? {
+        if let linkedWorkspace,
+           let panelId = resolveSurface(surfaceId, in: linkedWorkspace) {
+            return .surface(workspaceId: linkedWorkspace.workspaceId, panelId: panelId)
+        }
+        // The tab may have moved to another workspace since the link was copied
+        // or its workspace was closed. Surface identity wins over the stale
+        // workspace route. Exact runtime ids beat stable ids.
+        let excludedWorkspaceId = linkedWorkspace?.workspaceId
+        if let target = surfaceByRuntimeId[surfaceId],
+           target.workspaceId != excludedWorkspaceId {
+            return .surface(workspaceId: target.workspaceId, panelId: target.panelId)
+        }
+        if let target = surfaceByStableId[surfaceId],
+           target.workspaceId != excludedWorkspaceId {
+            return .surface(workspaceId: target.workspaceId, panelId: target.panelId)
+        }
+        return nil
     }
 }

--- a/Sources/CmuxSSHURLRequest.swift
+++ b/Sources/CmuxSSHURLRequest.swift
@@ -539,6 +539,8 @@ struct CmuxNavigationURLRequest: Equatable {
 
     let originalURL: URL
     let target: Target
+    let stableFallbackWorkspaceId: UUID?
+    let stableFallbackSurfaceId: UUID?
 
     static func parse(
         _ url: URL,
@@ -559,7 +561,6 @@ struct CmuxNavigationURLRequest: Equatable {
         guard components.user == nil,
               components.password == nil,
               components.port == nil,
-              components.percentEncodedQuery == nil,
               components.percentEncodedFragment == nil else {
             return .failure(.unsupportedURLShape)
         }
@@ -571,7 +572,19 @@ struct CmuxNavigationURLRequest: Equatable {
             return .failure(.invalidIdentifier("workspace"))
         }
         if route.count == 2 {
-            return .success(CmuxNavigationURLRequest(originalURL: url, target: .workspace(workspaceId)))
+            let fallback: (workspaceId: UUID?, surfaceId: UUID?)?
+            switch parseStableFallback(from: components, allowedNames: ["stable_workspace_id"]) {
+            case .success(let parsedFallback):
+                fallback = parsedFallback
+            case .failure(let error):
+                return .failure(error)
+            }
+            return .success(CmuxNavigationURLRequest(
+                originalURL: url,
+                target: .workspace(workspaceId),
+                stableFallbackWorkspaceId: fallback?.workspaceId,
+                stableFallbackSurfaceId: fallback?.surfaceId
+            ))
         }
 
         let childKind = route[2].lowercased()
@@ -588,17 +601,34 @@ struct CmuxNavigationURLRequest: Equatable {
 
         switch childKind {
         case "pane":
+            if components.percentEncodedQuery != nil {
+                return .failure(.unsupportedURLShape)
+            }
             return .success(
                 CmuxNavigationURLRequest(
                     originalURL: url,
-                    target: .pane(workspaceId: workspaceId, paneId: childId)
+                    target: .pane(workspaceId: workspaceId, paneId: childId),
+                    stableFallbackWorkspaceId: nil,
+                    stableFallbackSurfaceId: nil
                 )
             )
         case "surface", "panel":
+            let fallback: (workspaceId: UUID?, surfaceId: UUID?)?
+            switch parseStableFallback(
+                from: components,
+                allowedNames: ["stable_workspace_id", "stable_surface_id"]
+            ) {
+            case .success(let parsedFallback):
+                fallback = parsedFallback
+            case .failure(let error):
+                return .failure(error)
+            }
             return .success(
                 CmuxNavigationURLRequest(
                     originalURL: url,
-                    target: .surface(workspaceId: workspaceId, surfaceId: childId)
+                    target: .surface(workspaceId: workspaceId, surfaceId: childId),
+                    stableFallbackWorkspaceId: fallback?.workspaceId,
+                    stableFallbackSurfaceId: fallback?.surfaceId
                 )
             )
         default:
@@ -621,9 +651,22 @@ struct CmuxNavigationURLRequest: Equatable {
     static func surfaceLink(
         workspaceId: UUID,
         surfaceId: UUID,
+        stableWorkspaceId: UUID? = nil,
+        stableSurfaceId: UUID? = nil,
         scheme: String = AuthEnvironment.callbackScheme
     ) -> String {
-        "\(scheme)://workspace/\(workspaceId.uuidString)/surface/\(surfaceId.uuidString)"
+        var link = "\(scheme)://workspace/\(workspaceId.uuidString)/surface/\(surfaceId.uuidString)"
+        var queryItems: [String] = []
+        if let stableWorkspaceId {
+            queryItems.append("stable_workspace_id=\(stableWorkspaceId.uuidString)")
+        }
+        if let stableSurfaceId {
+            queryItems.append("stable_surface_id=\(stableSurfaceId.uuidString)")
+        }
+        if !queryItems.isEmpty {
+            link += "?\(queryItems.joined(separator: "&"))"
+        }
+        return link
     }
 
     private static func isSupportedScheme(_ scheme: String?, supportedSchemes: Set<String>) -> Bool {
@@ -641,6 +684,53 @@ struct CmuxNavigationURLRequest: Equatable {
             .split(separator: "/", omittingEmptySubsequences: true)
             .map(String.init)
         return route
+    }
+
+    private static func parseStableFallback(
+        from components: URLComponents,
+        allowedNames: Set<String>
+    ) -> Result<(workspaceId: UUID?, surfaceId: UUID?)?, CmuxNavigationURLParseError> {
+        guard components.percentEncodedQuery != nil else { return .success(nil) }
+        guard let items = components.queryItems, !items.isEmpty else {
+            return .failure(.unsupportedURLShape)
+        }
+
+        var stableWorkspaceId: UUID?
+        var stableSurfaceId: UUID?
+        var seenNames: Set<String> = []
+        for item in items {
+            guard allowedNames.contains(item.name),
+                  seenNames.insert(item.name).inserted,
+                  let value = item.value,
+                  !value.isEmpty else {
+                return .failure(.unsupportedURLShape)
+            }
+
+            guard let id = UUID(uuidString: value) else {
+                switch item.name {
+                case "stable_workspace_id":
+                    return .failure(.invalidIdentifier("stable_workspace"))
+                case "stable_surface_id":
+                    return .failure(.invalidIdentifier("stable_surface"))
+                default:
+                    return .failure(.unsupportedURLShape)
+                }
+            }
+
+            switch item.name {
+            case "stable_workspace_id":
+                stableWorkspaceId = id
+            case "stable_surface_id":
+                stableSurfaceId = id
+            default:
+                return .failure(.unsupportedURLShape)
+            }
+        }
+
+        return .success((
+            workspaceId: stableWorkspaceId,
+            surfaceId: stableSurfaceId
+        ))
     }
 }
 

--- a/Sources/ContentViewIdentifierCopyCommands.swift
+++ b/Sources/ContentViewIdentifierCopyCommands.swift
@@ -158,17 +158,15 @@ extension ContentView {
     }
 
     private func copyFocusedSurfaceLink() {
-        guard let panelContext = focusedPanelContext else {
+        guard let panelContext = focusedPanelContext,
+              let link = WorkspaceSurfaceIdentifierClipboardText.makeSurfaceLink(
+                workspace: panelContext.workspace,
+                panelId: panelContext.panelId
+              ) else {
             NSSound.beep()
             return
         }
-        // Links encode the restart-stable ids so they survive an app relaunch.
-        WorkspaceSurfaceIdentifierClipboardText.copy(
-            WorkspaceSurfaceIdentifierClipboardText.makeSurfaceLink(
-                workspaceId: panelContext.workspace.stableId,
-                surfaceId: panelContext.panel.stableSurfaceId
-            )
-        )
+        WorkspaceSurfaceIdentifierClipboardText.copy(link)
     }
 
     private func copyFocusedWorkspacePaneSurfaceIdentifiers() {

--- a/Sources/Workspace+CmuxNavigationDescriptor.swift
+++ b/Sources/Workspace+CmuxNavigationDescriptor.swift
@@ -13,8 +13,13 @@ extension Workspace {
             paneIds: bonsplitController.allPaneIds.map(\.id),
             surfaces: panels.compactMap { panelId, panel in
                 guard surfaceIdFromPanelId(panelId) != nil else { return nil }
+                let runtimeSurfaceIds = remoteTmuxControlPanes(containerPanelID: panelId)
+                    .map { $0.pane.panel.id }
+                    .filter { $0 != panelId }
                 return CmuxNavigationTargetResolver.SurfaceDescriptor(
                     panelId: panelId,
+                    runtimeSurfaceIds: Array(Set(runtimeSurfaceIds))
+                        .sorted { $0.uuidString < $1.uuidString },
                     stableSurfaceId: panel.stableSurfaceId
                 )
             }

--- a/Sources/WorkspaceSurfaceIdentifierClipboardText.swift
+++ b/Sources/WorkspaceSurfaceIdentifierClipboardText.swift
@@ -73,13 +73,30 @@ enum WorkspaceSurfaceIdentifierClipboardText {
         CmuxNavigationURLRequest.surfaceLink(workspaceId: workspaceId, surfaceId: surfaceId)
     }
 
+    static func makeSurfaceLink(
+        workspaceId: UUID,
+        surfaceId: UUID,
+        stableWorkspaceId: UUID?,
+        stableSurfaceId: UUID?
+    ) -> String {
+        CmuxNavigationURLRequest.surfaceLink(
+            workspaceId: workspaceId,
+            surfaceId: surfaceId,
+            stableWorkspaceId: stableWorkspaceId,
+            stableSurfaceId: stableSurfaceId
+        )
+    }
+
     @MainActor
     static func makeSurfaceLink(workspace: Workspace, panelId: UUID) -> String? {
-        guard let target = workspace.surfaceOwnershipTarget(for: panelId),
-              let containerPanel = workspace.panels[target.containerPanelID] else { return nil }
+        guard let target = workspace.surfaceOwnershipTarget(for: panelId) else { return nil }
+        let stableSurfaceId = workspace.panels[target.containerPanelID]?.stableSurfaceId
+            ?? target.panel.stableSurfaceId
         return makeSurfaceLink(
-            workspaceId: workspace.stableId,
-            surfaceId: containerPanel.stableSurfaceId
+            workspaceId: workspace.id,
+            surfaceId: target.surfaceID,
+            stableWorkspaceId: workspace.stableId,
+            stableSurfaceId: stableSurfaceId
         )
     }
 

--- a/cmuxTests/CmuxDurableDeepLinkRestoreTests.swift
+++ b/cmuxTests/CmuxDurableDeepLinkRestoreTests.swift
@@ -33,14 +33,18 @@ private final class DurableDeepLinkDockTestPanel: Panel, ObservableObject {
 struct CmuxDurableDeepLinkRestoreTests {
     private let scheme = AuthEnvironment.callbackScheme
 
-    private func parsedTarget(_ link: String) throws -> CmuxNavigationURLRequest.Target {
+    private func parsedRequest(_ link: String) throws -> CmuxNavigationURLRequest {
         let url = try #require(URL(string: link))
         switch CmuxNavigationURLRequest.parse(url, supportedSchemes: [scheme]) {
         case .success(let request):
-            return try #require(request).target
+            return try #require(request)
         case .failure(let error):
             throw error
         }
+    }
+
+    private func parsedTarget(_ link: String) throws -> CmuxNavigationURLRequest.Target {
+        try parsedRequest(link).target
     }
 
     private func makeMainWindow(id: UUID) -> NSWindow {
@@ -89,7 +93,7 @@ struct CmuxDurableDeepLinkRestoreTests {
         workspace.setPanelCustomTitle(panelId: linkedPanelId, title: "Linked tab")
         let linkedPanel = try #require(workspace.panels[linkedPanelId])
 
-        // What "Copy Surface Link" emits since durable deep links: stable ids.
+        // Legacy stable-path links from older builds still resolve after restore.
         let link = CmuxNavigationURLRequest.surfaceLink(
             workspaceId: workspace.stableId,
             surfaceId: linkedPanel.stableSurfaceId,
@@ -140,7 +144,7 @@ struct CmuxDurableDeepLinkRestoreTests {
         #expect(resolution == .surface(workspaceId: workspace.id, panelId: panelId))
     }
 
-    @Test func terminalContextMenuSurfaceLinkUsesMappedPanelStableId() throws {
+    @Test func terminalContextMenuSurfaceLinkUsesLivePanelId() throws {
         let manager = TabManager()
         let workspace = try #require(manager.selectedWorkspace)
         let pane = try #require(workspace.bonsplitController.allPaneIds.first)
@@ -157,8 +161,10 @@ struct CmuxDurableDeepLinkRestoreTests {
 
         #expect(
             link == CmuxNavigationURLRequest.surfaceLink(
-                workspaceId: workspace.stableId,
-                surfaceId: panel.stableSurfaceId,
+                workspaceId: workspace.id,
+                surfaceId: panel.id,
+                stableWorkspaceId: workspace.stableId,
+                stableSurfaceId: panel.stableSurfaceId,
                 scheme: scheme
             )
         )
@@ -188,7 +194,7 @@ struct CmuxDurableDeepLinkRestoreTests {
                 panelId: panel.id
             )
         )
-        let target = try parsedTarget(link)
+        let request = try parsedRequest(link)
 
         #expect(identifiers.contains("workspace_id=\(workspace.id.uuidString)"))
         #expect(identifiers.contains("surface_id=\(panel.id.uuidString)"))
@@ -196,10 +202,80 @@ struct CmuxDurableDeepLinkRestoreTests {
             link == CmuxNavigationURLRequest.surfaceLink(
                 workspaceId: workspace.id,
                 surfaceId: panel.id,
+                stableWorkspaceId: workspace.stableId,
+                stableSurfaceId: panel.stableSurfaceId,
                 scheme: scheme
             )
         )
-        #expect(target == .surface(workspaceId: workspace.id, surfaceId: panel.id))
+        #expect(request.target == .surface(workspaceId: workspace.id, surfaceId: panel.id))
+        #expect(request.stableFallbackWorkspaceId == workspace.stableId)
+        #expect(request.stableFallbackSurfaceId == panel.stableSurfaceId)
+    }
+
+    @Test func copiedLiveSurfaceLinkResolvesAfterRestoredPanelRemapsId() throws {
+        let manager = TabManager()
+        let workspace = try #require(manager.selectedWorkspace)
+        let pane = try #require(workspace.bonsplitController.allPaneIds.first)
+        let panel = try #require(workspace.newWorkspaceTodoSurface(inPane: pane, focus: true))
+        workspace.setPanelCustomTitle(panelId: panel.id, title: "Linked todo")
+
+        let link = try #require(
+            WorkspaceSurfaceIdentifierClipboardText.makeSurfaceLink(
+                workspace: workspace,
+                panelId: panel.id
+            )
+        )
+        #expect(
+            link == CmuxNavigationURLRequest.surfaceLink(
+                workspaceId: workspace.id,
+                surfaceId: panel.id,
+                stableWorkspaceId: workspace.stableId,
+                stableSurfaceId: panel.stableSurfaceId,
+                scheme: scheme
+            )
+        )
+        let request = try parsedRequest(link)
+
+        let snapshot = manager.sessionSnapshot(includeScrollback: false)
+        let restored = TabManager()
+        restored.restoreSessionSnapshot(snapshot)
+
+        let restoredWorkspace = try #require(restored.tabs.first)
+        let restoredPanelId = try #require(
+            restoredWorkspace.panelCustomTitles.first(where: { $0.value == "Linked todo" })?.key
+        )
+        #expect(restoredWorkspace.id == workspace.id)
+        #expect(restoredPanelId != panel.id)
+        let resolver = CmuxNavigationTargetResolver(
+            workspaces: restored.tabs.map(\.cmuxNavigationDescriptor)
+        )
+        #expect(resolver.resolve(request.target) == nil)
+        let restoredResolution = resolver.resolve(request)
+        #expect(
+            restoredResolution ==
+                .surface(workspaceId: restoredWorkspace.id, panelId: restoredPanelId)
+        )
+
+        let restoredSnapshot = restored.sessionSnapshot(includeScrollback: false)
+        _ = try #require(
+            restoredSnapshot.workspaces.first?.panels.first { $0.customTitle == "Linked todo" }
+        )
+
+        let restoredAgain = TabManager()
+        restoredAgain.restoreSessionSnapshot(restoredSnapshot)
+        let restoredAgainWorkspace = try #require(restoredAgain.tabs.first)
+        let restoredAgainPanelId = try #require(
+            restoredAgainWorkspace.panelCustomTitles.first(where: { $0.value == "Linked todo" })?.key
+        )
+        let restoredAgainResolver = CmuxNavigationTargetResolver(
+            workspaces: restoredAgain.tabs.map(\.cmuxNavigationDescriptor)
+        )
+        #expect(restoredAgainResolver.resolve(request.target) == nil)
+        let restoredAgainResolution = restoredAgainResolver.resolve(request)
+        #expect(
+            restoredAgainResolution ==
+                .surface(workspaceId: restoredAgainWorkspace.id, panelId: restoredAgainPanelId)
+        )
     }
 
     @Test func closedPanelRestoreWithLiveDockIdentityMintsFreshStableSurfaceId() throws {

--- a/cmuxTests/CmuxDurableDeepLinkRestoreTests.swift
+++ b/cmuxTests/CmuxDurableDeepLinkRestoreTests.swift
@@ -170,6 +170,38 @@ struct CmuxDurableDeepLinkRestoreTests {
         #expect(resolution == .surface(workspaceId: workspace.id, panelId: panel.id))
     }
 
+    @Test func copiedSurfaceLinkMatchesCopyIdsLiveIdentity() throws {
+        let manager = TabManager()
+        let workspace = try #require(manager.selectedWorkspace)
+        let pane = try #require(workspace.bonsplitController.allPaneIds.first)
+        let panel = try #require(workspace.newTerminalSurface(inPane: pane, focus: true))
+        let identifiers = WorkspaceSurfaceIdentifierClipboardText.makeWorkspacePaneSurfaceIdentifiers(
+            workspaceId: workspace.id,
+            paneId: workspace.paneId(forPanelId: panel.id)?.id,
+            surfaceId: panel.id,
+            includeRefs: false
+        )
+
+        let link = try #require(
+            WorkspaceSurfaceIdentifierClipboardText.makeSurfaceLink(
+                workspace: workspace,
+                panelId: panel.id
+            )
+        )
+        let target = try parsedTarget(link)
+
+        #expect(identifiers.contains("workspace_id=\(workspace.id.uuidString)"))
+        #expect(identifiers.contains("surface_id=\(panel.id.uuidString)"))
+        #expect(
+            link == CmuxNavigationURLRequest.surfaceLink(
+                workspaceId: workspace.id,
+                surfaceId: panel.id,
+                scheme: scheme
+            )
+        )
+        #expect(target == .surface(workspaceId: workspace.id, surfaceId: panel.id))
+    }
+
     @Test func closedPanelRestoreWithLiveDockIdentityMintsFreshStableSurfaceId() throws {
         let manager = TabManager()
         let workspace = try #require(manager.selectedWorkspace)

--- a/cmuxTests/CmuxNavigationTargetResolverTests.swift
+++ b/cmuxTests/CmuxNavigationTargetResolverTests.swift
@@ -68,6 +68,28 @@ struct CmuxNavigationTargetResolverTests {
         )
     }
 
+    @Test func ownedSurfaceRuntimeIdResolvesToContainerPanel() {
+        let ownedSurfaceId = UUID()
+        let descriptor = Resolver.WorkspaceDescriptor(
+            workspaceId: workspaceId,
+            stableId: stableWorkspaceId,
+            paneIds: [],
+            surfaces: [
+                Resolver.SurfaceDescriptor(
+                    panelId: panelId,
+                    runtimeSurfaceIds: [ownedSurfaceId],
+                    stableSurfaceId: stableSurfaceId
+                )
+            ]
+        )
+        let resolver = Resolver(workspaces: [descriptor])
+
+        #expect(
+            resolver.resolve(.surface(workspaceId: workspaceId, surfaceId: ownedSurfaceId))
+                == .surface(workspaceId: workspaceId, panelId: panelId)
+        )
+    }
+
     @Test func surfaceResolvesByStableIdsAfterRestart() {
         let resolver = Resolver(workspaces: [workspace])
 
@@ -94,6 +116,23 @@ struct CmuxNavigationTargetResolverTests {
             resolver.resolve(.surface(workspaceId: workspaceId, surfaceId: collidingPanelId))
                 == .surface(workspaceId: workspaceId, panelId: collidingPanelId)
         )
+    }
+
+    @Test func surfaceRequestUsesStableFallbackAfterRuntimeIdsChange() throws {
+        let resolver = Resolver(workspaces: [workspace])
+        let oldWorkspaceId = UUID()
+        let oldSurfaceId = UUID()
+        let request = CmuxNavigationURLRequest(
+            originalURL: try #require(
+                URL(string: "cmux-test://workspace/\(oldWorkspaceId.uuidString)/surface/\(oldSurfaceId.uuidString)")
+            ),
+            target: .surface(workspaceId: oldWorkspaceId, surfaceId: oldSurfaceId),
+            stableFallbackWorkspaceId: stableWorkspaceId,
+            stableFallbackSurfaceId: stableSurfaceId
+        )
+
+        #expect(resolver.resolve(request.target) == nil)
+        #expect(resolver.resolve(request) == .surface(workspaceId: workspaceId, panelId: panelId))
     }
 
     @Test func surfaceMovedToAnotherWorkspaceStillResolves() {

--- a/cmuxTests/RemoteTmuxNotificationLifecycleTests.swift
+++ b/cmuxTests/RemoteTmuxNotificationLifecycleTests.swift
@@ -111,6 +111,16 @@ struct RemoteTmuxNotificationLifecycleTests {
         }
     }
 
+    private func parsedRequest(_ link: String) throws -> CmuxNavigationURLRequest {
+        let url = try #require(URL(string: link))
+        switch CmuxNavigationURLRequest.parse(url) {
+        case .success(let request):
+            return try #require(request)
+        case .failure(let error):
+            throw error
+        }
+    }
+
     @Test
     func projectedPaneNotificationStoresOpensAndPreservesRecoverableRoute() throws {
         TerminalNotificationStore.shared.clearAll()
@@ -130,7 +140,6 @@ struct RemoteTmuxNotificationLifecycleTests {
                 forPanelId: panePanel.id
             ) != .notTerminalPanel
         )
-        let containerPanel = try #require(harness.workspace.panels[containerPanelID])
         let appDelegate = try #require(AppDelegate.shared)
         #expect(appDelegate.locateSurface(surfaceId: panePanel.id)?.workspaceId == harness.workspace.id)
         #expect(
@@ -139,14 +148,34 @@ struct RemoteTmuxNotificationLifecycleTests {
                 preferredWorkspaceId: harness.workspace.id
             )?.workspace === harness.workspace
         )
-        #expect(
+        let containerPanel = try #require(harness.workspace.panels[containerPanelID])
+        let copiedSurfaceLink = try #require(
             WorkspaceSurfaceIdentifierClipboardText.makeSurfaceLink(
                 workspace: harness.workspace,
                 panelId: panePanel.id
-            ) == WorkspaceSurfaceIdentifierClipboardText.makeSurfaceLink(
-                workspaceId: harness.workspace.stableId,
-                surfaceId: containerPanel.stableSurfaceId
             )
+        )
+        #expect(
+            copiedSurfaceLink == WorkspaceSurfaceIdentifierClipboardText.makeSurfaceLink(
+                workspaceId: harness.workspace.id,
+                surfaceId: panePanel.id,
+                stableWorkspaceId: harness.workspace.stableId,
+                stableSurfaceId: containerPanel.stableSurfaceId
+            )
+        )
+        let copiedSurfaceRequest = try parsedRequest(copiedSurfaceLink)
+        #expect(
+            copiedSurfaceRequest.target ==
+                .surface(workspaceId: harness.workspace.id, surfaceId: panePanel.id)
+        )
+        #expect(copiedSurfaceRequest.stableFallbackWorkspaceId == harness.workspace.stableId)
+        #expect(copiedSurfaceRequest.stableFallbackSurfaceId == containerPanel.stableSurfaceId)
+        let resolver = CmuxNavigationTargetResolver(
+            workspaces: [harness.workspace.cmuxNavigationDescriptor]
+        )
+        #expect(
+            resolver.resolve(copiedSurfaceRequest) ==
+                .surface(workspaceId: harness.workspace.id, panelId: containerPanelID)
         )
 
         let defaultsName = "remote-tmux-projected-link-\(UUID().uuidString)"


### PR DESCRIPTION
Fix Copy Surface Link so copied surface links use the same live identity as Copy IDs and the socket tree.

Root cause:
- Copy IDs and the control socket tree use `Workspace.id` and live surface IDs.
- Copy Surface Link used `Workspace.stableId` and `Panel.stableSurfaceId`.
- `ContentView.copyFocusedSurfaceLink()` built the link inline, so the command palette path bypassed the shared helper.

Fix:
- `WorkspaceSurfaceIdentifierClipboardText.makeSurfaceLink(workspace:panelId:)` now resolves the ownership target and emits `workspace.id` plus the live target surface ID.
- `ContentView.copyFocusedSurfaceLink()` now calls the shared helper.
- Tests cover the command-palette copy path and the remote-tmux projected-pane copy path.

Verification:
- Red test commit `163faca9b1c9f94f14eb5e295858bf0a9d39a2bd`: `cmuxTests/CmuxDurableDeepLinkRestoreTests` failed in https://github.com/manaflow-ai/cmux/actions/runs/31151528078 because `copiedSurfaceLinkMatchesCopyIdsLiveIdentity()` saw `cmux-dev://workspace/1FF69241-F971-4941-B1C4-FF6FFADAE43A/surface/2654739B-E6B9-4D11-9406-0292D9E84346` instead of live `workspace.id` and `panel.id` values `C64FB2DD-AF16-4C33-AA3A-09F88A6BED93` and `2C8401A5-C051-4B52-8FF9-02855C79F21A`.
- Fixed branch `d6f313aa4a8194c4fd46f2184231fbe0cead2a81`: `cmuxTests/CmuxDurableDeepLinkRestoreTests` passed in https://github.com/manaflow-ai/cmux/actions/runs/31150382314.
- Fixed branch `d6f313aa4a8194c4fd46f2184231fbe0cead2a81`: `cmuxTests/RemoteTmuxNotificationLifecycleTests` passed in https://github.com/manaflow-ai/cmux/actions/runs/31151227252.
- Cloud reload built `cmux DEV slink2.app` with `./scripts/reload-cloud.sh --tag slink2 --builder fleet --no-remote-derived-cache`.
- Isolated preflight used bundle `com.cmuxterm.app.debug.slink2` and socket `/tmp/cmux-debug-slink2.sock`, not the default socket. `Copy IDs` returned `workspace_id=8C25B979-6F70-4A44-9F62-18DC127EC319` and `surface_id=E8712CAF-3307-432F-875D-4C8A5F947F3A`. `Copy Surface Link` returned `cmux-dev-slink2://workspace/8C25B979-6F70-4A44-9F62-18DC127EC319/surface/E8712CAF-3307-432F-875D-4C8A5F947F3A`. `tree --all` on `/tmp/cmux-debug-slink2.sock` contained the workspace ID at line 80 and the surface ID at line 103.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes navigation URL parsing, link generation, and resolution paths used for focus and deep links; behavior is well covered by tests but touches session-restore edge cases.
> 
> **Overview**
> **Copy Surface Link** now matches **Copy IDs**: links use live `workspace.id` and the ownership target’s live surface ID, with optional `stable_workspace_id` / `stable_surface_id` query parameters for durability. The command palette path calls the shared `makeSurfaceLink(workspace:panelId:)` helper instead of building stable-only URLs inline.
> 
> **Deep link handling** parses those stable query params into `CmuxNavigationURLRequest.stableFallback`, and `AppDelegate` resolves full requests (not just path targets). When live path IDs are stale—e.g. after session restore remaps panel IDs—`CmuxNavigationTargetResolver` falls back to stable IDs. Surface descriptors also register **runtime surface aliases** (including remote tmux projected pane IDs) so links to owned/projected surfaces resolve to the container panel.
> 
> Tests cover live-vs-stable parity, restore after ID remap, owned runtime IDs, and remote tmux copy-link resolution.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 049f961df7b736a451f82a3f4172edacb47d07c6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes “Copy Surface Link” to use live `workspace.id` and live surface IDs, with stable-ID fallbacks so links keep working after restores, remaps, and remote tmux projections. Deep links now parse these fallbacks and resolve via the command palette and projected panes.

- **Bug Fixes**
  - `WorkspaceSurfaceIdentifierClipboardText.makeSurfaceLink(workspace:panelId:)` now emits live IDs and appends `stable_workspace_id` / `stable_surface_id` query params; added a helper to build links with fallbacks.
  - `CmuxNavigationURLRequest.parse` accepts and validates those fallback params and stores them as `stableFallbackWorkspaceId` / `stableFallbackSurfaceId`; `surfaceLink(...)` can include them when generating URLs.
  - `AppDelegate` passes the full request to `CmuxNavigationTargetResolver`, which adds `resolve(_ request:)` to use fallbacks when live IDs are stale and maps `runtimeSurfaceIds` (e.g., projected panes) back to the container panel.
  - `Workspace.cmuxNavigationDescriptor` now includes `runtimeSurfaceIds` for surfaces; `ContentView.copyFocusedSurfaceLink()` calls the shared helper.
  - Tests updated for live-ID parity with Copy IDs, fallback resolution after panel ID remaps across restores, and remote tmux projected-pane links.

<sup>Written for commit 957397c4a20b41958bc08e5b35342c585825a12e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/9786?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Surface links now preserve live workspace and panel identities, with stable fallback identifiers for reliable navigation.
  * Deep links continue to resolve after panel IDs change during session restoration.
  * Copied links are generated only when valid; failures provide immediate feedback.

* **Bug Fixes**
  * Improved navigation and restoration for remote tmux surfaces and legacy links.
  * Added validation to reject malformed or unsupported link parameters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->