### PR TITLE
Serve coderouter landing on cmux.com

### DIFF
--- a/web/proxy.ts
+++ b/web/proxy.ts
@@ -47,6 +47,13 @@ export default function middleware(request: NextRequest) {
     return NextResponse.next();
   }
 
+  // coderouter has one hostname-independent landing page. In particular,
+  // cmux.com/coderouter must not be rewritten to /<locale>/coderouter, because
+  // the page deliberately lives outside the localized cmux site tree.
+  if (pathname === "/coderouter" || pathname === "/coderouter/") {
+    return NextResponse.next();
+  }
+
   // cmux consumes this marker before navigation. If an ordinary browser
   // reaches the server, canonicalize the URL while preserving every public
   // query parameter.

--- a/web/tests/coderouter-middleware.test.ts
+++ b/web/tests/coderouter-middleware.test.ts
@@ -3,6 +3,17 @@ import { NextRequest } from "next/server";
 import middleware from "../proxy";
 
 describe("coderouter middleware", () => {
+  test("serves the same dedicated landing page on cmux.com/coderouter", () => {
+    const response = middleware(
+      new NextRequest("https://cmux.com/coderouter", {
+        headers: { host: "cmux.com" },
+      }),
+    );
+
+    expect(response.headers.get("x-middleware-rewrite")).toBeNull();
+    expect(response.headers.get("x-middleware-next")).toBe("1");
+  });
+
   test("serves a dedicated landing page on coderouter.dev", () => {
     const response = middleware(
       new NextRequest("https://coderouter.dev/", {


### PR DESCRIPTION
Bypasses next-intl for the hostname-independent `/coderouter` route so the newly shipped page works at both cmux.com/coderouter and coderouter.dev. Adds middleware regression coverage.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/9790"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788676172&installation_model_id=21920&pr_number=9790&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F9790&signature=424db7e47522fa9717da701a2fc2f57a8c6653f85ae5af340b2a8ef0c6853891"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow routing bypass for a single path with regression tests; no auth, data, or API behavior changes.
> 
> **Overview**
> **Middleware** now treats `/coderouter` (and trailing slash) like other routes outside the localized cmux tree—`NextResponse.next()` so **next-intl** does not rewrite `cmux.com/coderouter` to `/<locale>/coderouter`, matching the dedicated `app/coderouter` page and **coderouter.dev** behavior.
> 
> Adds a regression test asserting **cmux.com/coderouter** gets middleware **next** with no **rewrite** header.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 927bb11ab3e7e23dbd83eb17872109b2e00a929e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Serve the Coderouter landing page on both cmux.com/coderouter and coderouter.dev by bypassing `next-intl` for the `/coderouter` route. Added a middleware test to ensure no locale rewrite and prevent regressions.

<sup>Written for commit 927bb11ab3e7e23dbd83eb17872109b2e00a929e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/9790?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed direct access to the `/coderouter` landing page so it loads without being redirected to localized routing.
  * Added equivalent handling for `/coderouter/`.

* **Tests**
  * Added coverage to verify the page passes through correctly without rewriting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->