### PR TITLE
Harden install analytics privacy

### DIFF
--- a/web/services/analytics/install.ts
+++ b/web/services/analytics/install.ts
@@ -23,11 +23,15 @@ export function captureInstallEvent(input: InstallCapture): void {
     process.env.VERCEL_ENV !== "production" &&
     process.env.INSTALL_ANALYTICS_FORCE !== "1"
   ) return;
-  const properties: Record<string, string | number> = {
+  const properties: Record<string, string | number | boolean> = {
     product: input.product,
     method: input.method,
     schema_version: 1,
     $insert_id: randomUUID(),
+    // Requests are forwarded by Vercel, but explicitly disable GeoIP anyway
+    // and avoid creating persistent PostHog person profiles for installers.
+    $geoip_disable: true,
+    $process_person_profile: false,
   };
   if (safeLabel(input.platform)) properties.platform = input.platform!;
   if (safeVersion(input.version)) properties.version = input.version!;

--- a/web/tests/install-analytics.test.tsx
+++ b/web/tests/install-analytics.test.tsx
@@ -1,7 +1,10 @@
 import { describe, expect, test } from "bun:test";
 import { renderToStaticMarkup } from "react-dom/server";
 
-import { validInstallEventBody } from "../services/analytics/install";
+import {
+  captureInstallEvent,
+  validInstallEventBody,
+} from "../services/analytics/install";
 import CoderouterLandingPage from "../app/coderouter/page";
 import { GET as coderouterInstall } from "../app/coderouter/install.sh/route";
 import { GET as tuiInstall } from "../app/tui/install.sh/route";
@@ -54,6 +57,36 @@ describe("website install analytics", () => {
       product: "tui",
       method: "powershell",
     });
+  });
+
+  test("disables GeoIP and persistent person profiles", () => {
+    const originalFetch = globalThis.fetch;
+    const originalForce = process.env.INSTALL_ANALYTICS_FORCE;
+    let captured: Record<string, unknown> | undefined;
+    process.env.INSTALL_ANALYTICS_FORCE = "1";
+    globalThis.fetch = ((_url: string | URL | Request, init?: RequestInit) => {
+      captured = JSON.parse(String(init?.body)) as Record<string, unknown>;
+      return Promise.resolve(new Response(null, { status: 200 }));
+    }) as typeof fetch;
+    try {
+      captureInstallEvent({
+        event: "website_install_succeeded",
+        product: "coderouter",
+        method: "curl",
+      });
+      expect(captured?.distinct_id).toStartWith("anonymous-install:");
+      expect(captured?.properties).toMatchObject({
+        $geoip_disable: true,
+        $process_person_profile: false,
+      });
+    } finally {
+      globalThis.fetch = originalFetch;
+      if (originalForce === undefined) {
+        delete process.env.INSTALL_ANALYTICS_FORCE;
+      } else {
+        process.env.INSTALL_ANALYTICS_FORCE = originalForce;
+      }
+    }
   });
 
   test("tracks then redirects to immutable static script bodies", () => {


### PR DESCRIPTION
Explicitly disables GeoIP enrichment and persistent person-profile creation for the anonymous TUI/coderouter install funnel. Adds capture-payload regression coverage.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/9791"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788676398&installation_model_id=21920&pr_number=9791&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F9791&signature=0d143dc69c32f9f411367e4806b62ac50919dc58d1e97f37d69fa4536444e07d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 197c9c3abbe43c467c236194ef47bcdbd06fe0b8. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Locks down install analytics for TUI and coderouter by disabling GeoIP enrichment and blocking persistent person profiles, keeping installers anonymous. Adds a regression test to validate the payload.

- **Bug Fixes**
  - Set `$geoip_disable: true` and `$process_person_profile: false` on install events.
  - Allow boolean analytics properties and keep `distinct_id` prefixed with `anonymous-install:`.
  - Add a test that captures the request body and asserts the privacy flags and anonymity.

<sup>Written for commit 197c9c3abbe43c467c236194ef47bcdbd06fe0b8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/9791?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Install analytics events now support boolean properties.
  * Install events use anonymous identifiers and disable GeoIP enrichment and persistent profiles, improving privacy handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->