### PR TITLE
fix: compact Feed by agent session

### DIFF
--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -115972,13 +115972,13 @@
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "Claude finished — reply to continue"
+            "value": "Agent finished — reply to continue"
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "Claudeが完了しました。続行するには返信してください"
+            "value": "エージェントが完了しました。続行するには返信してください"
           }
         }
       }
@@ -115989,13 +115989,13 @@
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "Reply to Claude…"
+            "value": "Reply to agent…"
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "Claudeへの返信…"
+            "value": "エージェントへの返信…"
           }
         }
       }
@@ -116006,13 +116006,13 @@
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "Send to Claude"
+            "value": "Send to agent"
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "Claudeへ送信"
+            "value": "エージェントへ送信"
           }
         }
       }

--- a/Sources/Feed/FeedCoordinator.swift
+++ b/Sources/Feed/FeedCoordinator.swift
@@ -863,7 +863,7 @@ extension FeedCoordinator {
 
     /// Resolves `workstreamId` to a `(workspace, surface)` pair and
     /// types the user's `text` into that surface, followed by Return.
-    /// Used by Stop-kind cards so the user can reply to Claude from
+    /// Used by Stop-kind cards so the user can reply to the agent from
     /// the Feed without switching focus to the terminal.
     @MainActor
     @discardableResult
@@ -879,6 +879,43 @@ extension FeedCoordinator {
             text: text
         )
         return true
+    }
+
+    /// Resolves the live cmux surface or workspace name for a Feed session.
+    @MainActor
+    func sessionDisplayTitle(workstreamId: String) -> String? {
+        guard let parsed = FeedJumpResolver.parse(workstreamId),
+              let target = FeedJumpResolver.lookup(agent: parsed.agent, sessionId: parsed.sessionId),
+              let workspaceId = UUID(uuidString: target.workspaceId),
+              let tabManager = AppDelegate.shared?.tabManagerFor(tabId: workspaceId),
+              let workspace = tabManager.tabs.first(where: { $0.id == workspaceId }) else {
+            return nil
+        }
+
+        let surfaceTitle: String? = {
+            guard let surfaceId = UUID(uuidString: target.surfaceId) else { return nil }
+            if workspace.panels[surfaceId] != nil {
+                return workspace.panelCustomTitles[surfaceId]
+            }
+            guard let panelId = workspace.panelIdFromSurfaceId(TabID(uuid: surfaceId)) else {
+                return nil
+            }
+            return workspace.panelCustomTitles[panelId]
+        }()
+        return Self.preferredSessionTitle(
+            surfaceTitle: surfaceTitle,
+            workspaceTitle: workspace.customTitle ?? workspace.title
+        )
+    }
+
+    static func preferredSessionTitle(surfaceTitle: String?, workspaceTitle: String?) -> String? {
+        for candidate in [surfaceTitle, workspaceTitle] {
+            let trimmed = candidate?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+            if !trimmed.isEmpty {
+                return trimmed
+            }
+        }
+        return nil
     }
 }
 

--- a/Sources/Feed/FeedPanelView.swift
+++ b/Sources/Feed/FeedPanelView.swift
@@ -81,6 +81,7 @@ struct FeedPanelView: View {
             FeedListView(
                 filter: filter,
                 items: viewModel.items,
+                sessionTitlesByWorkstream: viewModel.sessionTitlesByWorkstream,
                 hasMorePersistedItems: viewModel.hasMorePersistedItems,
                 isLoadingOlderItems: viewModel.isLoadingOlderItems,
                 onLoadOlderItems: viewModel.loadOlderItems
@@ -162,6 +163,7 @@ private struct FeedSecondaryFilterButton: View {
 private struct FeedListView: View {
     let filter: FeedPanelView.Filter
     let items: [WorkstreamItem]
+    let sessionTitlesByWorkstream: [String: String]
     let hasMorePersistedItems: Bool
     let isLoadingOlderItems: Bool
     let onLoadOlderItems: () -> Void
@@ -398,29 +400,12 @@ private struct FeedListView: View {
     }
 
     private func filtered(_ items: [WorkstreamItem]) -> [WorkstreamItem] {
-        let base: [WorkstreamItem]
         switch filter {
         case .actionable:
-            base = items.filter { $0.kind.isActionable }
+            return FeedPanelViewModel.actionableItems(items)
         case .activity:
-            // Actionable kinds + todos + stop. Tool use, user prompts,
-            // assistant messages, session markers, and raw
-            // notifications are intentionally excluded — they're too
-            // noisy for a sidebar and already visible in the agent's
-            // terminal or the cmux notification system. Stop events
-            // render a "reply to Claude" textbox so the user can
-            // nudge Claude without switching focus to the terminal.
-            base = items.filter { item in
-                item.kind.isActionable
-                    || item.kind == .todos
-                    || item.kind == .stop
-            }
+            return FeedPanelViewModel.activityItems(items)
         }
-        // Newest first. Status isn't a sort key — resolved items stay
-        // in the chronological slot where they arrived so the user's
-        // mental map of "this was the second request I got" doesn't
-        // get shuffled when they answer it.
-        return Array(base.reversed())
     }
 
     private func visibleSnapshots(_ items: [WorkstreamItem]) -> [FeedItemSnapshot] {
@@ -428,6 +413,7 @@ private struct FeedListView: View {
         return filtered(items).map { item in
             FeedItemSnapshot(
                 item: item,
+                sessionTitle: sessionTitlesByWorkstream[item.workstreamId],
                 userPromptEcho: lastPromptByWorkstream[item.workstreamId]
             )
         }
@@ -897,6 +883,7 @@ struct FeedItemSnapshot: Equatable {
     let source: WorkstreamSource
     let kind: WorkstreamKind
     let title: String?
+    let sessionTitle: String?
     let cwd: String?
     let createdAt: Date
     let status: WorkstreamStatus
@@ -907,12 +894,17 @@ struct FeedItemSnapshot: Equatable {
     /// context, even when the agent payload doesn't carry it directly.
     let userPromptEcho: String?
 
-    init(item: WorkstreamItem, userPromptEcho: String? = nil) {
+    init(
+        item: WorkstreamItem,
+        sessionTitle: String? = nil,
+        userPromptEcho: String? = nil
+    ) {
         self.id = item.id
         self.workstreamId = item.workstreamId
         self.source = item.source
         self.kind = item.kind
         self.title = item.title
+        self.sessionTitle = sessionTitle
         self.cwd = item.cwd
         self.createdAt = item.createdAt
         self.status = item.status
@@ -1115,27 +1107,37 @@ struct FeedItemRow: View, Equatable {
         let questionHeader = questionHeaderForTitle
         if !promptLine.isEmpty {
             let detail = [questionHeader, promptLine].compactMap { $0 }.joined(separator: " · ")
-            if let cwd = snapshot.cwd, !cwd.isEmpty {
-                return "\(cwdBasename(cwd)) · \(detail)"
+            if let sessionTitle {
+                return "\(sessionTitle) · \(detail)"
             }
             return detail
         }
         if let questionHeader {
-            if let cwd = snapshot.cwd, !cwd.isEmpty {
-                return "\(cwdBasename(cwd)) · \(questionHeader)"
+            if let sessionTitle {
+                return "\(sessionTitle) · \(questionHeader)"
             }
             return questionHeader
         }
         if let title = snapshot.title, !title.isEmpty {
-            if let cwd = snapshot.cwd, !cwd.isEmpty {
-                return "\(cwdBasename(cwd)) · \(title)"
+            if let sessionTitle {
+                return "\(sessionTitle) · \(title)"
             }
             return title
         }
-        if let cwd = snapshot.cwd, !cwd.isEmpty {
-            return "\(cwdBasename(cwd)) · \(kindLabel.capitalized)"
+        if let sessionTitle {
+            return "\(sessionTitle) · \(kindLabel.capitalized)"
         }
         return kindLabel.capitalized
+    }
+
+    private var sessionTitle: String? {
+        let liveTitle = snapshot.sessionTitle?
+            .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        if !liveTitle.isEmpty {
+            return liveTitle
+        }
+        guard let cwd = snapshot.cwd, !cwd.isEmpty else { return nil }
+        return cwdBasename(cwd)
     }
 
     private var questionHeaderForTitle: String? {
@@ -3647,7 +3649,7 @@ private struct FlowLayout: Layout {
     }
 }
 
-/// Renders a Stop event (Claude finished a turn and is waiting for
+/// Renders a Stop event (the agent finished a turn and is waiting for
 /// the next user prompt). Shows a text field + Send button that
 /// types the reply into the agent's terminal surface and presses
 /// Return — so the user can reply without switching focus.
@@ -3680,14 +3682,14 @@ private struct StopActionArea: View {
                 Image(systemName: "checkmark.circle")
                     .cmuxFont(size: 10)
                     .foregroundColor(.secondary)
-                Text(String(localized: "feed.stop.label", defaultValue: "Claude finished — reply to continue"))
+                Text(String(localized: "feed.stop.label", defaultValue: "Agent finished — reply to continue"))
                     .cmuxFont(size: 11, weight: .medium)
                     .foregroundColor(.secondary)
             }
             FeedInlineTextField(
                 text: replyBinding,
                 focusRequest: focusRequest == 0 ? nil : focusRequest,
-                placeholder: String(localized: "feed.stop.placeholder", defaultValue: "Reply to Claude…"),
+                placeholder: String(localized: "feed.stop.placeholder", defaultValue: "Reply to agent…"),
                 isEnabled: true,
                 font: replyFont,
                 onFocus: onFocusRow,
@@ -3716,7 +3718,7 @@ private struct StopActionArea: View {
                 requestReplyFocus()
             }
             FeedButton(
-                label: String(localized: "feed.stop.send", defaultValue: "Send to Claude"),
+                label: String(localized: "feed.stop.send", defaultValue: "Send to agent"),
                 leadingIcon: "arrow.up.circle.fill",
                 kind: canSend ? .primary : .soft,
                 size: .medium,

--- a/Sources/Feed/FeedPanelViewModel.swift
+++ b/Sources/Feed/FeedPanelViewModel.swift
@@ -10,6 +10,7 @@ import SwiftUI
 @MainActor
 final class FeedPanelViewModel: ObservableObject {
     @Published private(set) var items: [WorkstreamItem] = []
+    @Published private(set) var sessionTitlesByWorkstream: [String: String] = [:]
     @Published private(set) var hasMorePersistedItems = false
     @Published private(set) var isLoadingOlderItems = false
     private var storeInstalledObserver: NSObjectProtocol?
@@ -36,7 +37,14 @@ final class FeedPanelViewModel: ObservableObject {
     private func arm() {
         guard let store = FeedCoordinator.shared.store else { return }
         withObservationTracking {
-            items = store.items
+            let nextItems = store.items
+            items = nextItems
+            sessionTitlesByWorkstream = Dictionary(
+                uniqueKeysWithValues: Set(nextItems.map(\.workstreamId)).compactMap { workstreamId in
+                    FeedCoordinator.shared.sessionDisplayTitle(workstreamId: workstreamId)
+                        .map { (workstreamId, $0) }
+                }
+            )
             hasMorePersistedItems = store.hasMorePersistedItems
             isLoadingOlderItems = store.isLoadingOlderItems
         } onChange: { [weak self] in
@@ -51,6 +59,31 @@ final class FeedPanelViewModel: ObservableObject {
             guard let self, !self.isLoadingOlderItems, self.hasMorePersistedItems else { return }
             await FeedCoordinator.shared.store?.loadOlderItems()
         }
+    }
+
+    /// Pending decisions for the Actionable filter, newest first.
+    nonisolated static func actionableItems(_ items: [WorkstreamItem]) -> [WorkstreamItem] {
+        items.reversed().filter { $0.kind.isActionable && $0.status.isPending }
+    }
+
+    /// One current card per agent session for the All Activity filter.
+    /// A new user prompt retires the previous turn's card until fresh
+    /// session activity arrives, so stale Stop rows never remain replyable.
+    nonisolated static func activityItems(_ items: [WorkstreamItem]) -> [WorkstreamItem] {
+        var latestByWorkstream: [String: (offset: Int, item: WorkstreamItem)] = [:]
+        for (offset, item) in items.enumerated() {
+            if item.kind == .userPrompt {
+                latestByWorkstream.removeValue(forKey: item.workstreamId)
+                continue
+            }
+            guard item.kind.isActionable || item.kind == .todos || item.kind == .stop else {
+                continue
+            }
+            latestByWorkstream[item.workstreamId] = (offset, item)
+        }
+        return latestByWorkstream.values
+            .sorted { $0.offset > $1.offset }
+            .map(\.item)
     }
 }
 

--- a/cmuxTests/FeedCoordinatorTests.swift
+++ b/cmuxTests/FeedCoordinatorTests.swift
@@ -33,7 +33,7 @@ struct FeedCoordinatorTests {
             payload: .stop(reason: nil)
         )
 
-        let visible = FeedPresentation.activityItems([
+        let visible = FeedPanelViewModel.activityItems([
             firstStop,
             secondStop,
             otherSession,
@@ -58,7 +58,7 @@ struct FeedCoordinatorTests {
             payload: .userPrompt(text: "continue")
         )
 
-        #expect(FeedPresentation.activityItems([oldStop, resumedPrompt]).isEmpty)
+        #expect(FeedPanelViewModel.activityItems([oldStop, resumedPrompt]).isEmpty)
 
         let currentStop = feedItem(
             id: "00000000-0000-0000-0000-000000000013",
@@ -68,7 +68,7 @@ struct FeedCoordinatorTests {
             payload: .stop(reason: nil)
         )
         #expect(
-            FeedPresentation.activityItems([oldStop, resumedPrompt, currentStop]).map(\.id)
+            FeedPanelViewModel.activityItems([oldStop, resumedPrompt, currentStop]).map(\.id)
                 == [currentStop.id]
         )
     }
@@ -101,24 +101,24 @@ struct FeedCoordinatorTests {
             status: .resolved(.permission(.once), at: Date(timeIntervalSince1970: 180))
         )
 
-        #expect(FeedPresentation.actionableItems([pending, resolved]).map(\.id) == [pending.id])
+        #expect(FeedPanelViewModel.actionableItems([pending, resolved]).map(\.id) == [pending.id])
     }
 
     @Test func feedSessionTitlePrefersSurfaceThenWorkspace() {
         #expect(
-            FeedSessionTitlePolicy.preferredTitle(
+            FeedCoordinator.preferredSessionTitle(
                 surfaceTitle: "Jero",
                 workspaceTitle: "Scope"
             ) == "Jero"
         )
         #expect(
-            FeedSessionTitlePolicy.preferredTitle(
+            FeedCoordinator.preferredSessionTitle(
                 surfaceTitle: "  ",
                 workspaceTitle: "Retrieval"
             ) == "Retrieval"
         )
         #expect(
-            FeedSessionTitlePolicy.preferredTitle(
+            FeedCoordinator.preferredSessionTitle(
                 surfaceTitle: nil,
                 workspaceTitle: nil
             ) == nil

--- a/cmuxTests/FeedCoordinatorTests.swift
+++ b/cmuxTests/FeedCoordinatorTests.swift
@@ -10,6 +10,140 @@ import CMUXAgentLaunch
 
 @Suite("Feed coordinator", .serialized)
 struct FeedCoordinatorTests {
+    @Test func activityFeedKeepsOnlyLatestCardPerSession() {
+        let firstStop = feedItem(
+            id: "00000000-0000-0000-0000-000000000001",
+            workstreamId: "codex-session-a",
+            kind: .stop,
+            minute: 1,
+            payload: .stop(reason: nil)
+        )
+        let secondStop = feedItem(
+            id: "00000000-0000-0000-0000-000000000002",
+            workstreamId: "codex-session-a",
+            kind: .stop,
+            minute: 2,
+            payload: .stop(reason: nil)
+        )
+        let otherSession = feedItem(
+            id: "00000000-0000-0000-0000-000000000003",
+            workstreamId: "codex-session-b",
+            kind: .stop,
+            minute: 3,
+            payload: .stop(reason: nil)
+        )
+
+        let visible = FeedPresentation.activityItems([
+            firstStop,
+            secondStop,
+            otherSession,
+        ])
+
+        #expect(visible.map(\.id) == [otherSession.id, secondStop.id])
+    }
+
+    @Test func newPromptRemovesPassedStopUntilSessionStopsAgain() {
+        let oldStop = feedItem(
+            id: "00000000-0000-0000-0000-000000000011",
+            workstreamId: "codex-session-a",
+            kind: .stop,
+            minute: 1,
+            payload: .stop(reason: nil)
+        )
+        let resumedPrompt = feedItem(
+            id: "00000000-0000-0000-0000-000000000012",
+            workstreamId: "codex-session-a",
+            kind: .userPrompt,
+            minute: 2,
+            payload: .userPrompt(text: "continue")
+        )
+
+        #expect(FeedPresentation.activityItems([oldStop, resumedPrompt]).isEmpty)
+
+        let currentStop = feedItem(
+            id: "00000000-0000-0000-0000-000000000013",
+            workstreamId: "codex-session-a",
+            kind: .stop,
+            minute: 3,
+            payload: .stop(reason: nil)
+        )
+        #expect(
+            FeedPresentation.activityItems([oldStop, resumedPrompt, currentStop]).map(\.id)
+                == [currentStop.id]
+        )
+    }
+
+    @Test func actionableFeedContainsOnlyPendingDecisions() {
+        let pending = feedItem(
+            id: "00000000-0000-0000-0000-000000000021",
+            workstreamId: "codex-session-a",
+            kind: .permissionRequest,
+            minute: 1,
+            payload: .permissionRequest(
+                requestId: "pending",
+                toolName: "shell",
+                toolInputJSON: "{}",
+                pattern: nil
+            ),
+            status: .pending
+        )
+        let resolved = feedItem(
+            id: "00000000-0000-0000-0000-000000000022",
+            workstreamId: "codex-session-b",
+            kind: .permissionRequest,
+            minute: 2,
+            payload: .permissionRequest(
+                requestId: "resolved",
+                toolName: "shell",
+                toolInputJSON: "{}",
+                pattern: nil
+            ),
+            status: .resolved(.permission(.once), at: Date(timeIntervalSince1970: 180))
+        )
+
+        #expect(FeedPresentation.actionableItems([pending, resolved]).map(\.id) == [pending.id])
+    }
+
+    @Test func feedSessionTitlePrefersSurfaceThenWorkspace() {
+        #expect(
+            FeedSessionTitlePolicy.preferredTitle(
+                surfaceTitle: "Jero",
+                workspaceTitle: "Scope"
+            ) == "Jero"
+        )
+        #expect(
+            FeedSessionTitlePolicy.preferredTitle(
+                surfaceTitle: "  ",
+                workspaceTitle: "Retrieval"
+            ) == "Retrieval"
+        )
+        #expect(
+            FeedSessionTitlePolicy.preferredTitle(
+                surfaceTitle: nil,
+                workspaceTitle: nil
+            ) == nil
+        )
+    }
+
+    private func feedItem(
+        id: String,
+        workstreamId: String,
+        kind: WorkstreamKind,
+        minute: TimeInterval,
+        payload: WorkstreamPayload,
+        status: WorkstreamStatus = .telemetry
+    ) -> WorkstreamItem {
+        WorkstreamItem(
+            id: UUID(uuidString: id)!,
+            workstreamId: workstreamId,
+            source: .codex,
+            kind: kind,
+            createdAt: Date(timeIntervalSince1970: minute * 60),
+            status: status,
+            payload: payload
+        )
+    }
+
     @Test func codexTeamsResolvesExplicitWorkingDirectoryFlags() {
         let base = "/tmp/cmux-base"
 


### PR DESCRIPTION
## Summary
- show the live cmux surface custom title or workspace title in Feed card headers
- keep one current All Activity card per agent session
- retire stale Stop cards as soon as a new prompt starts
- show only pending decisions in Actionable
- make Stop reply labels agent-neutral in English and Japanese

## Tests
- regression coverage for per-session compaction, stale Stop retirement, pending-only actionable filtering, and title precedence
- local tagged app build unavailable because this Mac has Command Line Tools rather than full Xcode; GitHub CI is the authoritative build check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/9792"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788676701&installation_model_id=21920&pr_number=9792&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F9792&signature=1c08ca39f1713c6e9d31f0f5ac4b3e9ee339b3961e4109b4a5ebf5f88e782d20"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Feed filtering and header resolution logic that affects which cards appear and how sessions are labeled; behavior is covered by new unit tests but touches core sidebar UX.
> 
> **Overview**
> **Compacts the Feed around agent sessions** so All Activity shows one current card per session and Actionable shows only **pending** decisions, with clearer headers and agent-neutral Stop reply text.
> 
> **All Activity** now keeps a single latest actionable/stop/todos card per `workstreamId`; a new user prompt clears that session’s slot until fresh activity arrives, so old Stop reply boxes don’t linger after you’ve already continued.
> 
> **Actionable** filters to pending actionable kinds only (resolved items drop out), still newest-first.
> 
> **Card headers** prefer the live surface custom title, then workspace title (from `FeedCoordinator.sessionDisplayTitle`), with cwd basename as fallback—replacing cwd in the title prefix.
> 
> **Stop UI** strings and defaults switch from “Claude” to “agent” (English and Japanese localizations).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 15755a1584fe936f873cd2e3ed6f907c27329c4e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Compacts the Feed by agent session to cut noise and prevent stale reply boxes. Users see one current card per session, pending-only Actionable items, and live session titles in headers.

- **Bug Fixes**
  - All Activity: keep one current card per session; a new user prompt retires the previous Stop until new activity.
  - Actionable: show only pending decisions.
  - Headers: use the live surface title, else the workspace title; fall back to the cwd name if none.
  - Stop UI text: agent-neutral in English and Japanese.
  - Tests: cover session compaction, Stop retirement on prompt, pending-only filtering, and title precedence.

<sup>Written for commit 15755a1584fe936f873cd2e3ed6f907c27329c4e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/9792?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Activity feed entries now display the associated session title when available, with a working-directory fallback.
  - Feed filtering more accurately shows pending actions and current activity.
  - Resumed sessions now retire outdated activity cards until a new stop event occurs.
  - Updated English and Japanese wording to refer generically to the agent.

- **Bug Fixes**
  - Session titles now prioritize custom surface titles before workspace titles.
  - Improved handling of stop events and resumed prompts in the activity feed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->