### PR TITLE
Fix browser pane Cmd+Z/Cmd+Shift+Z: perform undo/redo on a per-web-view undo manager

### DIFF
--- a/Sources/Panels/CmuxWebView.swift
+++ b/Sources/Panels/CmuxWebView.swift
@@ -13,6 +13,12 @@ final class CmuxWebView: WKWebView {
     var browserViewportModel: BrowserViewportModel?
     var onBrowserViewportHierarchyChanged: (() -> Void)?
 
+    // WebKit registers web-content edit commands on the view's `undoManager`;
+    // owning one per web view keeps every page's undo stack scoped to this
+    // view's lifetime instead of the window's shared undo manager.
+    // See CmuxWebViewWebContentUndo.swift.
+    let webContentUndoManager = UndoManager()
+
     // Some sites/WebKit paths report middle-click link activations as
     // WKNavigationAction.buttonNumber=4 instead of 2. Track a recent local
     // middle-click so navigation delegates can recover intent reliably.
@@ -801,6 +807,17 @@ final class CmuxWebView: WKWebView {
 #endif
                 return
             }
+        }
+
+        // An undo/redo chord reaching keyDown has already been offered to the
+        // page through performKeyEquivalent and declined (WebKit resends
+        // unhandled keys). Perform the web view's own editing undo/redo here;
+        // re-forwarding the chord into WebKit drops it (issue #9677).
+        if performWebContentUndoRedo(for: event) {
+#if DEBUG
+            route = "webContentUndoRedo"
+#endif
+            return
         }
 
         if Self.isPasteAsPlainTextCommandEquivalent(event) {

--- a/Sources/Panels/CmuxWebView.swift
+++ b/Sources/Panels/CmuxWebView.swift
@@ -682,6 +682,13 @@ final class CmuxWebView: WKWebView {
                     return finish(true)
                 }
                 let result = super.performKeyEquivalent(with: event)
+                // WebKit declining an undo/redo chord means the page already
+                // saw it and left it unhandled (WebKit resends such keys), so
+                // run the web view's own editing undo/redo before the blanket
+                // focus-mode consume below would swallow it (issue #9677).
+                if !result, performWebContentUndoRedo(for: event) {
+                    return finish(true)
+                }
                 // While focus mode is active, the page gets the shortcut once and cmux/main-menu
                 // fallback must not see unhandled command equivalents.
                 return finish(result || normalizedFlags.contains(.command))

--- a/Sources/Panels/CmuxWebViewWebContentUndo.swift
+++ b/Sources/Panels/CmuxWebViewWebContentUndo.swift
@@ -1,0 +1,54 @@
+import AppKit
+
+// Cmd+Z / Cmd+Shift+Z for browser web views.
+//
+// WebKit registers every web-content edit command on the web view's
+// `undoManager` (`WebViewImpl::registerEditCommand` calls
+// `[m_view undoManager]`). NSResponder's default implementation resolves that
+// to the window's shared undo manager, which mixes edit commands from every
+// web view in the window into one stack whose registered targets can outlive
+// their web view — the stale-target crash behind
+// https://github.com/manaflow-ai/cmux/issues/7272. The fix for that crash
+// routes the undo/redo chords away from the AppKit Edit menu whenever a
+// browser web view is focused, which also silenced in-page undo/redo because
+// nothing performed the command anymore
+// (https://github.com/manaflow-ai/cmux/issues/9677).
+//
+// Owning an undo manager per web view restores both invariants:
+// - web-content edit commands never reach the window's shared undo manager
+//   and never outlive their web view, so the stale-target class of crashes is
+//   impossible by construction;
+// - the routed chords can perform undo/redo directly on the focused web
+//   view's own stack, matching Safari's Edit-menu behavior.
+extension CmuxWebView {
+    override var undoManager: UndoManager? { webContentUndoManager }
+
+    /// Performs the page's native editing undo/redo for a routed
+    /// Cmd+Z / Cmd+Shift+Z chord.
+    ///
+    /// Returns `false` when `event` is not an undo/redo command equivalent.
+    /// Otherwise the chord is consumed even when the relevant stack is empty,
+    /// mirroring a disabled Edit-menu item rather than re-forwarding the key.
+    func performWebContentUndoRedo(for event: NSEvent) -> Bool {
+        guard event.cmuxIsUndoRedoCommandEquivalent else { return false }
+        let isRedo = event.modifierFlags
+            .intersection(.deviceIndependentFlagsMask)
+            .contains(.shift)
+#if DEBUG
+        cmuxDebugLog(
+            "browser.webContentUndoRedo \(isRedo ? "redo" : "undo") " +
+            "web=\(ObjectIdentifier(self)) " +
+            "canUndo=\(webContentUndoManager.canUndo ? 1 : 0) " +
+            "canRedo=\(webContentUndoManager.canRedo ? 1 : 0)"
+        )
+#endif
+        if isRedo {
+            if webContentUndoManager.canRedo {
+                webContentUndoManager.redo()
+            }
+        } else if webContentUndoManager.canUndo {
+            webContentUndoManager.undo()
+        }
+        return true
+    }
+}

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -866,6 +866,7 @@ C0DE71B10000000000000001 /* AppDelegate+AgentChatNotifications.swift in Sources 
 		C0DE58990000000000000004 /* CmuxWebViewKeyDownReentryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE58990000000000000002 /* CmuxWebViewKeyDownReentryTests.swift */; };
 		7D5DA4DC51454ECDBF9AC978 /* CmuxWebViewMouseNavigationButtonTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43F90FAF3FD44F11BF547BE9 /* CmuxWebViewMouseNavigationButtonTests.swift */; };
 		A28B087F0000000000000007 /* CmuxWebViewSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = A28B087F0000000000000008 /* CmuxWebViewSupport.swift */; };
+		C0DE58990000000000000024 /* CmuxWebViewWebContentUndo.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE58990000000000000022 /* CmuxWebViewWebContentUndo.swift */; };
 		C0DE58990000000000000014 /* CmuxWebViewWebContentUndoTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE58990000000000000012 /* CmuxWebViewWebContentUndoTests.swift */; };
 		5E55200000000000000000B3 /* CmuxWindowing in Frameworks */ = {isa = PBXBuildFile; productRef = 5E55200000000000000000B2 /* CmuxWindowing */; };
 		730600040000000000000001 /* CmuxWindowing in Frameworks */ = {isa = PBXBuildFile; productRef = 5E55200000000000000000B2 /* CmuxWindowing */; };
@@ -3523,6 +3524,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 		C0DE58990000000000000002 /* CmuxWebViewKeyDownReentryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CmuxWebViewKeyDownReentryTests.swift; sourceTree = "<group>"; };
 		43F90FAF3FD44F11BF547BE9 /* CmuxWebViewMouseNavigationButtonTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CmuxWebViewMouseNavigationButtonTests.swift; sourceTree = "<group>"; };
 		A28B087F0000000000000008 /* CmuxWebViewSupport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/CmuxWebViewSupport.swift; sourceTree = "<group>"; };
+		C0DE58990000000000000022 /* CmuxWebViewWebContentUndo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/CmuxWebViewWebContentUndo.swift; sourceTree = "<group>"; };
 		C0DE58990000000000000012 /* CmuxWebViewWebContentUndoTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CmuxWebViewWebContentUndoTests.swift; sourceTree = "<group>"; };
 		C51A73000000000000000014 /* CmuxWorkerEntrypoint.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CmuxWorkerEntrypoint.swift; sourceTree = "<group>"; };
 		E30750000000000000000003 /* CmuxWorkspaceDefinition.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CmuxWorkspaceDefinition.swift; sourceTree = "<group>"; };
@@ -6934,6 +6936,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				A5001426 /* FilePreviewPDFSizing.swift */,
 				C0DE86520000000000000008 /* FilePreviewPDFZoomChromeView.swift */,
 				A5001510 /* CmuxWebView.swift */,
+				C0DE58990000000000000022 /* CmuxWebViewWebContentUndo.swift */,
 				A28B087F0000000000000008 /* CmuxWebViewSupport.swift */,
 				A28B087F0000000000000010 /* BrowserImageCopyPasteboardPayload.swift */,
 				A28B087F0000000000000012 /* BrowserFocusModeKeyDecision.swift */,
@@ -9024,6 +9027,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				C67540030000000000000001 /* CmuxWebView+SubframeDownloadIntentScript.swift in Sources */,
 				A5001500 /* CmuxWebView.swift in Sources */,
 				A28B087F0000000000000007 /* CmuxWebViewSupport.swift in Sources */,
+				C0DE58990000000000000024 /* CmuxWebViewWebContentUndo.swift in Sources */,
 				C51A73000000000000000013 /* CmuxWorkerEntrypoint.swift in Sources */,
 				E30750000000000000000004 /* CmuxWorkspaceDefinition.swift in Sources */,
 				C0A1E5CE01C0A1E5CE01A001 /* CoalesceLatestPublisher.swift in Sources */,

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -866,6 +866,7 @@ C0DE71B10000000000000001 /* AppDelegate+AgentChatNotifications.swift in Sources 
 		C0DE58990000000000000004 /* CmuxWebViewKeyDownReentryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE58990000000000000002 /* CmuxWebViewKeyDownReentryTests.swift */; };
 		7D5DA4DC51454ECDBF9AC978 /* CmuxWebViewMouseNavigationButtonTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43F90FAF3FD44F11BF547BE9 /* CmuxWebViewMouseNavigationButtonTests.swift */; };
 		A28B087F0000000000000007 /* CmuxWebViewSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = A28B087F0000000000000008 /* CmuxWebViewSupport.swift */; };
+		C0DE58990000000000000014 /* CmuxWebViewWebContentUndoTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE58990000000000000012 /* CmuxWebViewWebContentUndoTests.swift */; };
 		5E55200000000000000000B3 /* CmuxWindowing in Frameworks */ = {isa = PBXBuildFile; productRef = 5E55200000000000000000B2 /* CmuxWindowing */; };
 		730600040000000000000001 /* CmuxWindowing in Frameworks */ = {isa = PBXBuildFile; productRef = 5E55200000000000000000B2 /* CmuxWindowing */; };
 		C51A73000000000000000013 /* CmuxWorkerEntrypoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = C51A73000000000000000014 /* CmuxWorkerEntrypoint.swift */; };
@@ -3522,6 +3523,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 		C0DE58990000000000000002 /* CmuxWebViewKeyDownReentryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CmuxWebViewKeyDownReentryTests.swift; sourceTree = "<group>"; };
 		43F90FAF3FD44F11BF547BE9 /* CmuxWebViewMouseNavigationButtonTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CmuxWebViewMouseNavigationButtonTests.swift; sourceTree = "<group>"; };
 		A28B087F0000000000000008 /* CmuxWebViewSupport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/CmuxWebViewSupport.swift; sourceTree = "<group>"; };
+		C0DE58990000000000000012 /* CmuxWebViewWebContentUndoTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CmuxWebViewWebContentUndoTests.swift; sourceTree = "<group>"; };
 		C51A73000000000000000014 /* CmuxWorkerEntrypoint.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CmuxWorkerEntrypoint.swift; sourceTree = "<group>"; };
 		E30750000000000000000003 /* CmuxWorkspaceDefinition.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CmuxWorkspaceDefinition.swift; sourceTree = "<group>"; };
 		A6AC72080000000000000002 /* CMUXWorkspaceLoadingCLIRegressionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CMUXWorkspaceLoadingCLIRegressionTests.swift; sourceTree = "<group>"; };
@@ -7632,6 +7634,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				8D828DA0070335773EBAE83F /* BrowserSystemProxyMirrorTests.swift */,
 				C59240010000000000000004 /* BrowserDownloadFilenameResolverTests.swift */,
 				C0DE58990000000000000002 /* CmuxWebViewKeyDownReentryTests.swift */,
+				C0DE58990000000000000012 /* CmuxWebViewWebContentUndoTests.swift */,
 				C0DE49870000000000000002 /* BrowserWebContentProcessTests.swift */,
 				43F90FAF3FD44F11BF547BE9 /* CmuxWebViewMouseNavigationButtonTests.swift */,
 				D3622001A1B2C3D4E5F60718 /* BrowserArrowKeyForwardingTests.swift */,
@@ -10696,6 +10699,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				D0B1000CA1B2C3D4E5F60001 /* CmuxWebViewDragRoutingTests.swift in Sources */,
 				C0DE58990000000000000004 /* CmuxWebViewKeyDownReentryTests.swift in Sources */,
 				7D5DA4DC51454ECDBF9AC978 /* CmuxWebViewMouseNavigationButtonTests.swift in Sources */,
+				C0DE58990000000000000014 /* CmuxWebViewWebContentUndoTests.swift in Sources */,
 					A6AC72080000000000000001 /* CMUXWorkspaceLoadingCLIRegressionTests.swift in Sources */,
 				AAE06C3AEC68484DA33D42A1 /* CoalesceLatestPublisherDemandTests.swift in Sources */,
 				A9E040000000000000000002 /* CodexAppServerSessionTests.swift in Sources */,

--- a/cmuxTests/AppDelegateShortcutRoutingTests.swift
+++ b/cmuxTests/AppDelegateShortcutRoutingTests.swift
@@ -12020,6 +12020,54 @@ final class AppDelegateShortcutRoutingTests: XCTestCase {
         XCTAssertFalse(harness.panel.isBrowserFocusModeExitArmed)
     }
 
+    // Regression for https://github.com/manaflow-ai/cmux/issues/9677 in browser
+    // focus mode: the focus-mode branch of CmuxWebView.performKeyEquivalent
+    // consumes every Command chord after the page declines it, so a resent
+    // Cmd+Z must run the web view's own editing undo there instead of being
+    // swallowed.
+    func testBrowserFocusModeCmdZPerformsWebContentUndoWhenPageDeclines() {
+        guard let harness = makeBrowserFocusModeHarness() else { return }
+        defer { closeWindow(withId: harness.windowId) }
+
+        installCmuxUnitTestWKWebViewPerformKeyEquivalentOverride()
+        // Model WebKit's resend of a page-unhandled chord: the web view
+        // declines the key equivalent while focus mode forwards it.
+        cmuxUnitTestWKWebViewPerformKeyEquivalentHook = { currentWebView, _ in
+            guard currentWebView === harness.webView else { return nil }
+            return false
+        }
+        defer { cmuxUnitTestWKWebViewPerformKeyEquivalentHook = nil }
+
+        XCTAssertTrue(
+            harness.panel.setBrowserFocusModeActive(true, reason: "unit.undoRedo", focusWebView: false)
+        )
+
+        final class WebContentUndoSpy {
+            var undoCount = 0
+        }
+        let spy = WebContentUndoSpy()
+        guard let undoManager = harness.webView.undoManager else {
+            XCTFail("Expected web view undo manager")
+            return
+        }
+        undoManager.registerUndo(withTarget: spy) { $0.undoCount += 1 }
+        XCTAssertTrue(undoManager.canUndo)
+
+        guard let commandZ = makeKeyDownEvent(
+            key: "z",
+            modifiers: [.command],
+            keyCode: UInt16(kVK_ANSI_Z),
+            windowNumber: harness.window.windowNumber
+        ) else {
+            XCTFail("Failed to construct Cmd+Z event")
+            return
+        }
+
+        XCTAssertTrue(harness.window.performKeyEquivalent(with: commandZ))
+        XCTAssertEqual(spy.undoCount, 1)
+        XCTAssertTrue(harness.panel.isBrowserFocusModeActive)
+    }
+
     func testBrowserFocusModeStaleExitArmRearmsOnNextEscape() {
         guard let appDelegate = AppDelegate.shared else {
             XCTFail("Expected AppDelegate.shared")

--- a/cmuxTests/CmuxWebViewWebContentUndoTests.swift
+++ b/cmuxTests/CmuxWebViewWebContentUndoTests.swift
@@ -1,0 +1,220 @@
+import AppKit
+import Carbon.HIToolbox
+import Testing
+import WebKit
+import ObjectiveC.runtime
+
+#if canImport(cmux_DEV)
+@testable import cmux_DEV
+#elseif canImport(cmux)
+@testable import cmux
+#endif
+
+/// Regression coverage for https://github.com/manaflow-ai/cmux/issues/9677.
+///
+/// With a browser web view focused, Cmd+Z / Cmd+Shift+Z are routed away from
+/// the AppKit Edit menu (the stale-`NSUndoManager` crash fix for
+/// https://github.com/manaflow-ai/cmux/issues/7272). When the page declines
+/// the chord, WebKit resends it and the routing must perform the web view's
+/// own editing undo/redo — not silently swallow the key, and not run it
+/// against the window's shared undo manager whose entries can outlive their
+/// web view.
+
+private var cmuxUnitTestWKWebViewKeyDownOverrideInstalled = false
+private var cmuxUnitTestWKWebViewKeyDownHook: ((WKWebView, NSEvent) -> Bool)?
+
+extension WKWebView {
+    @objc func cmuxUnitTestWebContentUndo_keyDown(with event: NSEvent) {
+        if cmuxUnitTestWKWebViewKeyDownHook?(self, event) == true {
+            return
+        }
+        cmuxUnitTestWebContentUndo_keyDown(with: event)
+    }
+}
+
+/// Swizzles `WKWebView.keyDown(with:)` so tests can observe and suppress key
+/// events forwarded into WebKit without launching a web content process.
+private func installCmuxUnitTestWKWebViewKeyDownOverride() {
+    guard !cmuxUnitTestWKWebViewKeyDownOverrideInstalled else { return }
+
+    let originalSelector = #selector(NSResponder.keyDown(with:))
+    let swizzledSelector = #selector(WKWebView.cmuxUnitTestWebContentUndo_keyDown(with:))
+
+    guard let originalMethod = class_getInstanceMethod(WKWebView.self, originalSelector),
+          let swizzledMethod = class_getInstanceMethod(WKWebView.self, swizzledSelector) else {
+        fatalError("Unable to locate WKWebView keyDown methods for swizzling")
+    }
+
+    let didAddMethod = class_addMethod(
+        WKWebView.self,
+        originalSelector,
+        method_getImplementation(swizzledMethod),
+        method_getTypeEncoding(swizzledMethod)
+    )
+
+    if didAddMethod {
+        class_replaceMethod(
+            WKWebView.self,
+            swizzledSelector,
+            method_getImplementation(originalMethod),
+            method_getTypeEncoding(originalMethod)
+        )
+    } else {
+        method_exchangeImplementations(originalMethod, swizzledMethod)
+    }
+
+    cmuxUnitTestWKWebViewKeyDownOverrideInstalled = true
+}
+
+private final class WebContentUndoSpy {
+    var undoCount = 0
+    var redoCount = 0
+}
+
+@Suite(.serialized)
+final class CmuxWebViewWebContentUndoTests {
+    @Test
+    @MainActor
+    func browserCmdZPerformsWebContentUndoWhenPageDeclinesTheChord() throws {
+        try withBrowserUndoWindow { window, webView, forwardedKeyDownEvents in
+            let spy = WebContentUndoSpy()
+            let undoManager = try #require(webView.undoManager)
+            undoManager.registerUndo(withTarget: spy) { $0.undoCount += 1 }
+            #expect(undoManager.canUndo)
+
+            let event = try #require(makeKeyDownEvent(
+                key: "z",
+                modifiers: [.command],
+                keyCode: UInt16(kVK_ANSI_Z),
+                windowNumber: window.windowNumber
+            ))
+
+            #expect(window.performKeyEquivalent(with: event))
+            #expect(spy.undoCount == 1)
+            #expect(forwardedKeyDownEvents().isEmpty)
+        }
+    }
+
+    @Test
+    @MainActor
+    func browserCmdShiftZPerformsWebContentRedoWhenPageDeclinesTheChord() throws {
+        try withBrowserUndoWindow { window, webView, forwardedKeyDownEvents in
+            let spy = WebContentUndoSpy()
+            let undoManager = try #require(webView.undoManager)
+            undoManager.registerUndo(withTarget: spy) { target in
+                target.undoCount += 1
+                undoManager.registerUndo(withTarget: target) { $0.redoCount += 1 }
+            }
+            undoManager.undo()
+            #expect(spy.undoCount == 1)
+            #expect(undoManager.canRedo)
+
+            let event = try #require(makeKeyDownEvent(
+                key: "z",
+                modifiers: [.command, .shift],
+                keyCode: UInt16(kVK_ANSI_Z),
+                windowNumber: window.windowNumber
+            ))
+
+            #expect(window.performKeyEquivalent(with: event))
+            #expect(spy.redoCount == 1)
+            #expect(forwardedKeyDownEvents().isEmpty)
+        }
+    }
+
+    /// WebKit registers every web-content edit command on the web view's
+    /// `undoManager`. The default NSResponder resolution reaches the window's
+    /// shared undo manager, mixing every web view's edit commands into one
+    /// stack whose targets can outlive their view — the stale-target crash
+    /// class behind https://github.com/manaflow-ai/cmux/issues/7272. Each web
+    /// view must own an undo manager scoped to its own lifetime.
+    @Test
+    @MainActor
+    func webContentUndoManagerIsScopedPerWebView() throws {
+        try withBrowserUndoWindow { window, webView, _ in
+            let secondWebView = CmuxWebView(
+                frame: webView.frame,
+                configuration: WKWebViewConfiguration()
+            )
+            defer { secondWebView.removeFromSuperview() }
+            webView.superview?.addSubview(secondWebView)
+
+            let firstManager = try #require(webView.undoManager)
+            let secondManager = try #require(secondWebView.undoManager)
+            #expect(firstManager !== secondManager)
+            #expect(firstManager !== window.undoManager)
+            #expect(secondManager !== window.undoManager)
+        }
+    }
+
+    @MainActor
+    private func withBrowserUndoWindow(
+        _ body: (NSWindow, CmuxWebView, () -> [NSEvent]) throws -> Void
+    ) rethrows {
+        _ = NSApplication.shared
+        AppDelegate.installWindowResponderSwizzlesForTesting()
+        installCmuxUnitTestWKWebViewPerformKeyEquivalentOverride()
+        installCmuxUnitTestWKWebViewKeyDownOverride()
+
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 640, height: 420),
+            styleMask: [.titled, .closable],
+            backing: .buffered,
+            defer: false
+        )
+        let container = NSView(frame: window.contentRect(forFrameRect: window.frame))
+        window.contentView = container
+
+        let webView = CmuxWebView(frame: container.bounds, configuration: WKWebViewConfiguration())
+        webView.autoresizingMask = [.width, .height]
+        container.addSubview(webView)
+
+        // Model WebKit's resend of a page-unhandled chord: the web view
+        // declines the key equivalent (WebViewImpl::doneWithKeyEvent resends
+        // the event and performKeyEquivalent returns NO for a resent key).
+        cmuxUnitTestWKWebViewPerformKeyEquivalentHook = { currentWebView, _ in
+            guard currentWebView === webView else { return nil }
+            return false
+        }
+
+        // Record any key events the browser view forwards into WebKit so the
+        // tests can assert routed undo/redo chords are executed, not
+        // re-forwarded, and so no web content process is spun up.
+        var forwardedKeyDownEvents: [NSEvent] = []
+        cmuxUnitTestWKWebViewKeyDownHook = { currentWebView, event in
+            guard currentWebView === webView else { return false }
+            forwardedKeyDownEvents.append(event)
+            return true
+        }
+
+        window.makeKeyAndOrderFront(nil)
+        defer {
+            cmuxUnitTestWKWebViewPerformKeyEquivalentHook = nil
+            cmuxUnitTestWKWebViewKeyDownHook = nil
+            window.orderOut(nil)
+        }
+
+        #expect(window.makeFirstResponder(webView))
+        try body(window, webView, { forwardedKeyDownEvents })
+    }
+
+    private func makeKeyDownEvent(
+        key: String,
+        modifiers: NSEvent.ModifierFlags,
+        keyCode: UInt16,
+        windowNumber: Int
+    ) -> NSEvent? {
+        NSEvent.keyEvent(
+            with: .keyDown,
+            location: .zero,
+            modifierFlags: modifiers,
+            timestamp: ProcessInfo.processInfo.systemUptime,
+            windowNumber: windowNumber,
+            context: nil,
+            characters: key,
+            charactersIgnoringModifiers: key,
+            isARepeat: false,
+            keyCode: keyCode
+        )
+    }
+}


### PR DESCRIPTION
Fixes https://github.com/manaflow-ai/cmux/issues/9677

## Summary

In a browser pane, `Cmd+Z` and `Cmd+Shift+Z` did nothing inside web page inputs while every other Command editing chord worked. The two dead chords are exactly the two that #7598 routes away from the AppKit Edit menu (the stale-`NSUndoManager` crash fix for #7272) — that routing consumed the chords but nothing performed the undo/redo command anymore.

### Root cause

WebKit registers every web-content edit command on the web view's `undoManager` (`WebViewImpl::registerEditCommand` calls `[m_view undoManager]`, [WebViewImpl.mm](https://github.com/WebKit/WebKit/blob/main/Source/WebKit/UIProcess/mac/WebViewImpl.mm)). `NSResponder`'s default implementation resolves that to the **window's shared undo manager**, so edit commands from every web view in the window pile into one stack whose registered targets can outlive their web view — the stale-target crash class behind #7272. Severing the Edit-menu path was the only safe option available to #7598, at the cost of in-page undo/redo.

### Fix

- `CmuxWebView` now owns a `webContentUndoManager` and overrides `undoManager`, so WebKit registers each page's edit commands into a manager whose lifetime equals the view's. Stale-target entries are impossible by construction, and the window's shared undo manager never sees web content (this also removes a latent wrong-pane-undo bug: multiple browser panes no longer share one undo stack).
- A `Cmd+Z`/`Cmd+Shift+Z` chord reaching `CmuxWebView.keyDown` has by construction already been offered to the page via `performKeyEquivalent` and declined — WebKit resends unhandled keys (`WebViewImpl::doneWithKeyEvent`) and declines the resent key equivalent, which lands in the routed `keyDown` fallback. `keyDown` now performs the web view's own editing undo/redo there instead of re-forwarding the chord into WebKit (where it was dropped). This mirrors how #8099 solved the same problem on Chromium surfaces by explicitly executing the editing command.
- Pages that handle `Cmd+Z` themselves (Google Docs, Monaco, VS Code Web) still consume the first `performKeyEquivalent` pass and never reach this path; browser focus mode and Web Inspector routing are unchanged. The window-level router (`cmuxRouteUndoRedoCommandEquivalentAwayFromAppKit`) is untouched.

## Regression tests (two-commit red/green)

Commit 1 adds only the failing tests, so CI proves they catch the bug; commit 2 adds the fix:

- `browserCmdZPerformsWebContentUndoWhenPageDeclinesTheChord` / `browserCmdShiftZPerformsWebContentRedoWhenPageDeclinesTheChord`: real `NSEvent`s through the real swizzled `NSWindow.performKeyEquivalent` routing into a real `CmuxWebView`, with WKWebView modeled as declining the chord (WebKit's resend behavior); assert undo/redo executes on the web view's undo manager and the chord is not re-forwarded into WebKit.
- `webContentUndoManagerIsScopedPerWebView`: the stale-target-crash-class invariant — each web view's undo manager is distinct from other web views' and from the window's.

## Reproduction note

The exact end-to-end repro (real keystrokes into a focused web page input) is not drivable from cmux browser automation: `press`/`fill` dispatch synthetic untrusted DOM events that neither create native undo-stack entries nor traverse the `NSWindow` key-equivalent path. The commit-1 tests reproduce the routing-level failure with real key events; the WebKit side of the mechanism (undo-manager registration and unhandled-key resend) is verified directly against WebKit source. Manual dogfood of the tagged build is the remaining verification step.

## Localization audit

No user-facing strings added or changed (code comments and a DEBUG-only log line); no `Localizable.xcstrings` or web message catalog changes required.

## Validation (CI is dispatch-only in this repo)

`ci.yml` runs only on `workflow_dispatch` ("CI pause"), so PR pushes trigger no build/test checks — the red/green story below comes from explicitly dispatched runs:

- **HEAD (`523089bf46`) green**: [CI run 31156695345](https://github.com/manaflow-ai/cmux/actions/runs/31156695345) — all four new tests executed and passed in app-host unit shard 1 (`browserCmdZPerformsWebContentUndoWhenPageDeclinesTheChord`, `browserCmdShiftZPerformsWebContentRedoWhenPageDeclinesTheChord`, `webContentUndoManagerIsScopedPerWebView`, `testBrowserFocusModeCmdZPerformsWebContentUndoWhenPageDeclines`). `workflow-guard-tests` (pbxproj test wiring) and `release-build` (Swift warning budget: zero new warnings) passed.
- **Focus-mode red proof**: [CI run 31157838408](https://github.com/manaflow-ai/cmux/actions/runs/31157838408) on `issue-9677-browser-cmdz-red-proof-2` (= commit 3, before the focus-mode fix): `testBrowserFocusModeCmdZPerformsWebContentUndoWhenPageDeclines` executed and **failed** (shard 1 log, 07:45:13Z), and passed at HEAD — red→green through real CI.
- **Commit-1 red proof caveat**: on [CI run 31157832910](https://github.com/manaflow-ai/cmux/actions/runs/31157832910) (`issue-9677-browser-cmdz-red-proof` = commit 1, no fix), the shard packer assigned the new suite to shard 4, which failed a pre-existing app-host isolation guard ("Ghostty accessed configuration outside the isolated app-host home") before its unit step ran, so the suite never executed there. Note the shard step also treats pure assertion failures as expected (`(0 unexpected)` → pass), so an assertion-level red can never redden a shard check in the current CI policy; the focus-mode log-level red above is the strongest obtainable demonstration, and it exercises the same routing chokepoint and undo-manager mechanics as the commit-1 tests.
- The remaining failing jobs at HEAD (`app-host unit tests 2–4`, `tests-build-and-lag`, aggregate `tests`/`ci-status`) fail identically on [main's own dispatched CI run](https://github.com/manaflow-ai/cmux/actions/runs/31150302964) with the same flaky families (crash-restart storms, isolation guards, unrelated integration suites); a per-test diff against the no-source-change control run shows no failure attributable to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
