### PR TITLE
Make cold PTY spawn unstarvable: reclaim bootstrap-window custody, bound the shim gate, unpin prime slots, surface queued sends (#9769)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -671,6 +671,27 @@ jobs:
             -only-testing:cmuxTests/GhosttySurfaceOverlayTests/testFiveTabRendererFootprintReturnsToOneRendererTargetAcrossHideRevealCycles \
             test
 
+      - name: Run PTY spawn starvation regressions
+        if: ${{ matrix.shard == fromJSON(env.CMUX_APP_HOST_FOCUSED_REGRESSION_SHARD) }}
+        run: |
+          # The tolerant full-suite step can accept ordinary assertion
+          # failures. Keep the issue #9769 coverage — background-prime work
+          # must exclude never-startable surfaces, and `cmux send` must
+          # surface queued delivery — on a non-tolerant focused invocation.
+          set -euo pipefail
+          SOURCE_PACKAGES_DIR="$PWD/.ci-source-packages"
+          scripts/ci/run-in-console-session.sh \
+            scripts/ci/run-app-host-xcodebuild.sh \
+            -project cmux.xcodeproj -scheme cmux-unit -configuration Debug \
+            -derivedDataPath "$CMUX_DERIVED_DATA_PATH" \
+            -clonedSourcePackagesDirPath "$SOURCE_PACKAGES_DIR" \
+            -disableAutomaticPackageResolution \
+            -destination "platform=macOS" \
+            CMUX_SKIP_ZIG_BUILD=1 \
+            -only-testing:cmuxTests/BackgroundPrimeStartableSurfaceTests \
+            -only-testing:cmuxTests/CLISendQueuedOutputTests \
+            test
+
       - name: Run notification routing regressions
         if: ${{ matrix.shard == fromJSON(env.CMUX_APP_HOST_FOCUSED_REGRESSION_SHARD) }}
         run: |

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -18313,7 +18313,7 @@ struct CMUXCLI {
         guard (payload["queued"] as? Bool) == true else { return summary }
         let suffix = String(
             localized: "cli.send.queuedSuffix",
-            defaultValue: "queued (terminal starting; input delivers when its PTY spawns)"
+            defaultValue: "queued (terminal starting; input will be sent when its PTY is ready)"
         )
         return "\(summary) \(suffix)"
     }

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -5317,7 +5317,7 @@ struct CMUXCLI {
             let sfId = try normalizeSurfaceHandle(surfaceArg, client: client, workspaceHandle: wsId, windowHandle: winId)
             if let sfId { params["surface_id"] = sfId }
             let payload = try client.sendV2(method: "surface.send_text", params: params)
-            printV2Payload(payload, jsonOutput: jsonOutput, idFormat: idFormat, fallbackText: v2OKSummary(payload, idFormat: idFormat))
+            printV2Payload(payload, jsonOutput: jsonOutput, idFormat: idFormat, fallbackText: v2SendSummary(payload, idFormat: idFormat))
 
         case "send-key":
             let (wsArg, rem0) = parseOption(commandArgs, name: "--workspace")
@@ -5336,7 +5336,7 @@ struct CMUXCLI {
             let sfId = try normalizeSurfaceHandle(surfaceArg, client: client, workspaceHandle: wsId, windowHandle: winId)
             if let sfId { params["surface_id"] = sfId }
             let payload = try client.sendV2(method: "surface.send_key", params: params)
-            printV2Payload(payload, jsonOutput: jsonOutput, idFormat: idFormat, fallbackText: v2OKSummary(payload, idFormat: idFormat))
+            printV2Payload(payload, jsonOutput: jsonOutput, idFormat: idFormat, fallbackText: v2SendSummary(payload, idFormat: idFormat))
 
         case "send-panel":
             let (wsArg, rem0) = parseOption(commandArgs, name: "--workspace")
@@ -5358,7 +5358,7 @@ struct CMUXCLI {
             let sfId = try normalizeSurfaceHandle(panelArg, client: client, workspaceHandle: wsId, windowHandle: winId)
             if let sfId { params["surface_id"] = sfId }
             let payload = try client.sendV2(method: "surface.send_text", params: params)
-            printV2Payload(payload, jsonOutput: jsonOutput, idFormat: idFormat, fallbackText: v2OKSummary(payload, idFormat: idFormat))
+            printV2Payload(payload, jsonOutput: jsonOutput, idFormat: idFormat, fallbackText: v2SendSummary(payload, idFormat: idFormat))
 
         case "send-key-panel":
             let (wsArg, rem0) = parseOption(commandArgs, name: "--workspace")
@@ -5380,7 +5380,7 @@ struct CMUXCLI {
             let sfId = try normalizeSurfaceHandle(panelArg, client: client, workspaceHandle: wsId, windowHandle: winId)
             if let sfId { params["surface_id"] = sfId }
             let payload = try client.sendV2(method: "surface.send_key", params: params)
-            printV2Payload(payload, jsonOutput: jsonOutput, idFormat: idFormat, fallbackText: v2OKSummary(payload, idFormat: idFormat))
+            printV2Payload(payload, jsonOutput: jsonOutput, idFormat: idFormat, fallbackText: v2SendSummary(payload, idFormat: idFormat))
 
         case "notify":
             let title = optionValue(commandArgs, name: "--title") ?? "Notification"
@@ -18303,6 +18303,19 @@ struct CMUXCLI {
             }
         }
         return parts.joined(separator: " ")
+    }
+
+    /// Summary for send verbs: annotates delivery that was queued behind a
+    /// pending terminal runtime spawn instead of written to a live PTY, so a
+    /// queued send is distinguishable from a delivered one (#9769).
+    func v2SendSummary(_ payload: [String: Any], idFormat: CLIIDFormat) -> String {
+        let summary = v2OKSummary(payload, idFormat: idFormat)
+        guard (payload["queued"] as? Bool) == true else { return summary }
+        let suffix = String(
+            localized: "cli.send.queuedSuffix",
+            defaultValue: "queued (terminal starting; input delivers when its PTY spawns)"
+        )
+        return "\(summary) \(suffix)"
     }
 
     /// Summary for remote-tmux creations whose pane or window arrives asynchronously.

--- a/Packages/macOS/CmuxTerminal/Sources/CmuxTerminal/Runtime/TerminalSurfaceRuntimeDependencies.swift
+++ b/Packages/macOS/CmuxTerminal/Sources/CmuxTerminal/Runtime/TerminalSurfaceRuntimeDependencies.swift
@@ -39,6 +39,17 @@ public struct TerminalSurfaceRuntimeDependencies {
     /// Filesystem probes and writers used by runtime creation.
     public let runtimeFilesystem: TerminalSurfaceRuntimeFilesystem
 
+    /// The bounded grace period runtime creation waits for the optional
+    /// Claude command-shim install before spawning without it.
+    ///
+    /// The shim is a PATH convenience; a hung install must never starve PTY
+    /// spawn (issue #9769). Defaults to five seconds.
+    public let claudeCommandShimInstallDeadline: Duration
+
+    /// The clock driving ``claudeCommandShimInstallDeadline``; injectable so
+    /// tests control the deadline deterministically.
+    public let claudeCommandShimInstallDeadlineClock: any Clock<Duration>
+
     /// The first port of the per-session `CMUX_PORT` allocation
     /// (snapshotted once per app session by the composition root).
     public let sessionPortBase: Int
@@ -66,6 +77,8 @@ public struct TerminalSurfaceRuntimeDependencies {
         runtimeTeardown: TerminalSurfaceRuntimeTeardownCoordinator,
         restoreSpawnScheduler: any TerminalSurfaceRuntimeSpawnScheduling,
         runtimeFilesystem: TerminalSurfaceRuntimeFilesystem,
+        claudeCommandShimInstallDeadline: Duration = .seconds(5),
+        claudeCommandShimInstallDeadlineClock: any Clock<Duration> = ContinuousClock(),
         sessionPortBase: Int,
         sessionPortRangeSize: Int,
         scrollbackReplayEnvironmentKey: String,
@@ -81,6 +94,8 @@ public struct TerminalSurfaceRuntimeDependencies {
         self.runtimeTeardown = runtimeTeardown
         self.restoreSpawnScheduler = restoreSpawnScheduler
         self.runtimeFilesystem = runtimeFilesystem
+        self.claudeCommandShimInstallDeadline = claudeCommandShimInstallDeadline
+        self.claudeCommandShimInstallDeadlineClock = claudeCommandShimInstallDeadlineClock
         self.sessionPortBase = sessionPortBase
         self.sessionPortRangeSize = sessionPortRangeSize
         self.scrollbackReplayEnvironmentKey = scrollbackReplayEnvironmentKey

--- a/Packages/macOS/CmuxTerminal/Sources/CmuxTerminal/Surface/TerminalSurface+ClaudeCommandShimLifecycle.swift
+++ b/Packages/macOS/CmuxTerminal/Sources/CmuxTerminal/Surface/TerminalSurface+ClaudeCommandShimLifecycle.swift
@@ -84,6 +84,15 @@ extension TerminalSurface {
         claudeCommandShimDeadlineTask?.cancel()
         claudeCommandShimDeadlineTask = nil
         claudeCommandShimPendingCreationSource = nil
+        // A deadline-released spawn marks the install completed without a
+        // shim so that one spawn is not starved. Once the in-flight install
+        // is cancelled, that state must not become permanent: reopen the
+        // gate so the next runtime creation (e.g. after an agent-hibernation
+        // resume) attempts a fresh install instead of running shim-less
+        // forever.
+        if claudeCommandShim == nil {
+            claudeCommandShimInstallCompleted = false
+        }
     }
 
     @MainActor

--- a/Packages/macOS/CmuxTerminal/Sources/CmuxTerminal/Surface/TerminalSurface+ClaudeCommandShimLifecycle.swift
+++ b/Packages/macOS/CmuxTerminal/Sources/CmuxTerminal/Surface/TerminalSurface+ClaudeCommandShimLifecycle.swift
@@ -43,9 +43,29 @@ extension TerminalSurface {
                 guard !Task.isCancelled else { return }
                 guard let self else { return }
                 self.claudeCommandShim = shim
-                self.claudeCommandShimInstallCompleted = true
                 self.claudeCommandShimInstallTask = nil
                 self.claudeCommandShimCompletionTask = nil
+                self.claudeCommandShimDeadlineTask?.cancel()
+                self.claudeCommandShimDeadlineTask = nil
+                // The deadline may have already released spawn without the
+                // shim; the late result still serves future runtime creations.
+                guard !self.claudeCommandShimInstallCompleted else { return }
+                self.claudeCommandShimInstallCompleted = true
+                let source = self.claudeCommandShimPendingCreationSource ?? source
+                self.claudeCommandShimPendingCreationSource = nil
+                self.resumeSurfaceCreationAfterClaudeCommandShimReady(view: view, source: source)
+            }
+            // Bounded, cancellable deadline (injected clock): the wrapper shim
+            // is an optional PATH convenience, and a hung install (disk
+            // pressure, starved queues) must never starve PTY spawn (#9769).
+            let deadline = claudeCommandShimInstallDeadline
+            let clock = claudeCommandShimInstallDeadlineClock
+            claudeCommandShimDeadlineTask = Task { @MainActor [weak self, weak view] in
+                try? await clock.sleep(for: deadline, tolerance: nil)
+                guard !Task.isCancelled else { return }
+                guard let self, !self.claudeCommandShimInstallCompleted else { return }
+                self.claudeCommandShimInstallCompleted = true
+                self.claudeCommandShimDeadlineTask = nil
                 let source = self.claudeCommandShimPendingCreationSource ?? source
                 self.claudeCommandShimPendingCreationSource = nil
                 self.resumeSurfaceCreationAfterClaudeCommandShimReady(view: view, source: source)
@@ -61,6 +81,8 @@ extension TerminalSurface {
         claudeCommandShimCompletionTask = nil
         claudeCommandShimInstallTask?.cancel()
         claudeCommandShimInstallTask = nil
+        claudeCommandShimDeadlineTask?.cancel()
+        claudeCommandShimDeadlineTask = nil
         claudeCommandShimPendingCreationSource = nil
     }
 

--- a/Packages/macOS/CmuxTerminal/Sources/CmuxTerminal/Surface/TerminalSurface+RuntimeLifecycle.swift
+++ b/Packages/macOS/CmuxTerminal/Sources/CmuxTerminal/Surface/TerminalSurface+RuntimeLifecycle.swift
@@ -37,7 +37,25 @@ extension TerminalSurface {
 
     @MainActor
     private func ensureHeadlessStartupWindowIfNeeded(reason: String) {
-        guard headlessStartupWindow == nil else { return }
+        if let existingWindow = headlessStartupWindow {
+            guard paneHost.window !== existingWindow else { return }
+            if paneHost.window != nil {
+                // The pane host reached a real window while a bootstrap
+                // window was still recorded; the bootstrap is stale.
+                headlessStartupWindow = nil
+                existingWindow.contentView = nil
+                existingWindow.close()
+                return
+            }
+            // Window-portal churn can reparent the pane host out of the
+            // bootstrap window and park it with no window at all
+            // (detachHostedView ends in removeFromSuperview). Reclaim custody
+            // instead of early-returning: otherwise every later cold start
+            // defers on the missing window and the surface never spawns a
+            // PTY (#9769).
+            adoptPaneHostIntoHeadlessStartupWindow(existingWindow, reason: reason)
+            return
+        }
         guard paneHost.window == nil else { return }
         let width = max(surfaceView.bounds.width, CGFloat(800))
         let height = max(surfaceView.bounds.height, CGFloat(600))
@@ -54,18 +72,30 @@ extension TerminalSurface {
         window.ignoresMouseEvents = true
         window.collectionBehavior = [.transient, .ignoresCycle, .stationary]
         window.isExcludedFromWindowsMenu = true
-        let contentView = NSView(frame: frame)
+        window.contentView = NSView(frame: frame)
+        headlessStartupWindow = window
+        adoptPaneHostIntoHeadlessStartupWindow(window, reason: reason)
+
+#if DEBUG
+        logDebugEvent(
+            "surface.headless_window.create surface=\(id.uuidString.prefix(8)) " +
+            "reason=\(reason) window=\(ObjectIdentifier(window))"
+        )
+#endif
+    }
+
+    @MainActor
+    private func adoptPaneHostIntoHeadlessStartupWindow(_ window: NSWindow, reason: String) {
+        guard let contentView = window.contentView else { return }
         paneHost.frame = contentView.bounds
         paneHost.autoresizingMask = [.width, .height]
         contentView.addSubview(paneHost)
-        window.contentView = contentView
-        headlessStartupWindow = window
         paneHost.setVisibleInUI(false)
         paneHost.setActive(false)
 
 #if DEBUG
         logDebugEvent(
-            "surface.headless_window.create surface=\(id.uuidString.prefix(8)) " +
+            "surface.headless_window.adopt surface=\(id.uuidString.prefix(8)) " +
             "reason=\(reason) window=\(ObjectIdentifier(window))"
         )
 #endif
@@ -175,6 +205,15 @@ extension TerminalSurface {
 
     func allowsRuntimeSurfaceCreation() -> Bool {
         portalLifecycleState == .live && !runtimeSurfaceSuspendedForAgentHibernation
+    }
+
+    /// Whether the surface lifecycle currently permits creating a runtime
+    /// surface (portal live, not suspended for agent hibernation).
+    ///
+    /// Background priming uses this to skip surfaces whose spawn can never
+    /// complete instead of retaining a hidden mount slot for them forever.
+    public var canCreateRuntimeSurface: Bool {
+        allowsRuntimeSurfaceCreation()
     }
 
     private var hasDeferredStartupWork: Bool {

--- a/Packages/macOS/CmuxTerminal/Sources/CmuxTerminal/Surface/TerminalSurface.swift
+++ b/Packages/macOS/CmuxTerminal/Sources/CmuxTerminal/Surface/TerminalSurface.swift
@@ -87,6 +87,8 @@ public final class TerminalSurface: Identifiable, ObservableObject {
     let runtimeTeardown: TerminalSurfaceRuntimeTeardownCoordinator
     let restoreSpawnScheduler: any TerminalSurfaceRuntimeSpawnScheduling
     let runtimeFilesystem: TerminalSurfaceRuntimeFilesystem
+    let claudeCommandShimInstallDeadline: Duration
+    let claudeCommandShimInstallDeadlineClock: any Clock<Duration>
     /// Port ordinal base/range for CMUX_PORT assignment, snapshotted by the app composition root.
     let sessionPortBase: Int
     let sessionPortRangeSize: Int
@@ -288,6 +290,7 @@ public final class TerminalSurface: Identifiable, ObservableObject {
     var claudeCommandShim: ClaudeCommandShim?
     var claudeCommandShimInstallTask: Task<ClaudeCommandShim?, Never>?
     var claudeCommandShimCompletionTask: Task<Void, Never>?
+    var claudeCommandShimDeadlineTask: Task<Void, Never>?
     var claudeCommandShimInstallCompleted = false
     var claudeCommandShimPendingCreationSource: RuntimeSurfaceCreationSource?
     /// The retained byte-tee lease for the libghostty PTY tee callback (cmux
@@ -541,6 +544,8 @@ public final class TerminalSurface: Identifiable, ObservableObject {
         self.runtimeTeardown = dependencies.runtimeTeardown
         self.restoreSpawnScheduler = dependencies.restoreSpawnScheduler
         self.runtimeFilesystem = dependencies.runtimeFilesystem
+        self.claudeCommandShimInstallDeadline = dependencies.claudeCommandShimInstallDeadline
+        self.claudeCommandShimInstallDeadlineClock = dependencies.claudeCommandShimInstallDeadlineClock
         self.requiresRestoreSpawnPacing = runtimeSpawnPolicy == .pacedSessionRestore
         self.sessionPortBase = dependencies.sessionPortBase
         self.sessionPortRangeSize = dependencies.sessionPortRangeSize

--- a/Packages/macOS/CmuxTerminal/Tests/CmuxTerminalTests/TerminalSurfaceBootstrapCustodyTests.swift
+++ b/Packages/macOS/CmuxTerminal/Tests/CmuxTerminalTests/TerminalSurfaceBootstrapCustodyTests.swift
@@ -120,7 +120,8 @@ import CmuxTerminalCore
             scheduler: scheduler,
             nativeView: nativeView,
             paneHost: paneHost,
-            runtimeFilesystem: runtimeFilesystem
+            runtimeFilesystem: runtimeFilesystem,
+            claudeCommandShimInstallDeadline: .milliseconds(100)
         )
         defer { surface.closeHeadlessStartupWindowIfNeeded() }
 
@@ -132,6 +133,9 @@ import CmuxTerminalCore
         // task never completes (disk pressure, starved queues), PTY spawn must
         // still proceed without it instead of waiting forever (#9769).
         await waitForCreateAttemptCount(surface, 1)
+
+        // Resume the parked install continuation so teardown stays clean.
+        await shimInstaller.complete()
     }
 
     private func waitForCreateAttemptCount(
@@ -156,7 +160,8 @@ import CmuxTerminalCore
             claudeCommandShimTemporaryDirectory: URL(fileURLWithPath: "/tmp/cmux-terminal-tests", isDirectory: true),
             installClaudeCommandShim: { _, _, _ in nil },
             isExecutableFile: { _ in false }
-        )
+        ),
+        claudeCommandShimInstallDeadline: Duration = .seconds(5)
     ) -> TerminalSurface {
         TerminalSurface(
             tabId: UUID(),
@@ -174,6 +179,7 @@ import CmuxTerminalCore
                 runtimeTeardown: TerminalSurfaceRuntimeTeardownCoordinator(),
                 restoreSpawnScheduler: scheduler,
                 runtimeFilesystem: runtimeFilesystem,
+                claudeCommandShimInstallDeadline: claudeCommandShimInstallDeadline,
                 sessionPortBase: 40_000,
                 sessionPortRangeSize: 100,
                 scrollbackReplayEnvironmentKey: "CMUX_TEST_SCROLLBACK_REPLAY"

--- a/Packages/macOS/CmuxTerminal/Tests/CmuxTerminalTests/TerminalSurfaceBootstrapCustodyTests.swift
+++ b/Packages/macOS/CmuxTerminal/Tests/CmuxTerminalTests/TerminalSurfaceBootstrapCustodyTests.swift
@@ -134,7 +134,15 @@ import CmuxTerminalCore
         // still proceed without it instead of waiting forever (#9769).
         await waitForCreateAttemptCount(surface, 1)
 
-        // Resume the parked install continuation so teardown stays clean.
+        // A deadline-released spawn must not lock the surface into shim-less
+        // mode: after the lifecycle cancels the hung install (teardown,
+        // agent-hibernation suspend), the next runtime creation attempts a
+        // fresh install instead of permanently reporting ready-without-shim.
+        surface.cancelClaudeCommandShimInstallLifecycle()
+        let regatedState = surface.claudeCommandShimStateForSurface(view: nativeView, source: .inputDemand)
+        #expect(!regatedState.isReady)
+
+        // Resume the parked install continuations so teardown stays clean.
         await shimInstaller.complete()
     }
 

--- a/Packages/macOS/CmuxTerminal/Tests/CmuxTerminalTests/TerminalSurfaceBootstrapCustodyTests.swift
+++ b/Packages/macOS/CmuxTerminal/Tests/CmuxTerminalTests/TerminalSurfaceBootstrapCustodyTests.swift
@@ -1,0 +1,183 @@
+import Foundation
+import AppKit
+import GhosttyKit
+import Testing
+import CmuxTerminalCore
+@testable import CmuxTerminal
+
+// Regression coverage for issue #9769: after a CLI dispatch burst, new
+// terminal surfaces never acquired a PTY. Two silent one-shot drops in the
+// cold-start path caused it:
+//
+// 1. Window-portal churn (`TerminalWindowPortal.detachHostedView` →
+//    `removeFromSuperview`) can park the pane host outside any window while
+//    the surface still records its hidden bootstrap startup window. The next
+//    runtime start then early-returns in `ensureHeadlessStartupWindowIfNeeded`
+//    (a bootstrap window exists) and the follow-up attach defers on the
+//    missing window — permanently, because nothing ever re-arms the start.
+// 2. The optional Claude command-shim install gates `createSurface`; when the
+//    install task never completes, PTY spawn is starved forever.
+@MainActor
+@Suite struct TerminalSurfaceBootstrapCustodyTests {
+    @Test func inputDemandStartReclaimsPaneHostParkedOutsideAnyWindow() {
+        let nativeView = FakeTerminalSurfaceNativeView(frame: NSRect(x: 0, y: 0, width: 800, height: 600))
+        let paneHost = FakeTerminalSurfacePaneHost(
+            surfaceView: nativeView,
+            attachesThroughSurfaceModel: true
+        )
+        let scheduler = RecordingRestoreSpawnScheduler()
+        let surface = makeSurface(scheduler: scheduler, nativeView: nativeView, paneHost: paneHost)
+        surface.claudeCommandShimInstallCompleted = true
+        defer { surface.closeHeadlessStartupWindowIfNeeded() }
+
+        // A first bootstrap start records the hidden startup window and
+        // attempts runtime creation. The fake engine has no runtime app, so
+        // the surface stays cold — like a spawn pending behind engine startup.
+        surface.scheduleHeadlessRuntimeStartIfNeeded(reason: "test-first-start", source: .inputDemand)
+        #expect(surface.debugRuntimeSurfaceCreateAttemptCountForTesting() == 1)
+        #expect(paneHost.window != nil)
+
+        // Window-portal churn reparents the pane host away from the bootstrap
+        // window and parks it with no superview and no window.
+        paneHost.removeFromSuperview()
+        #expect(paneHost.window == nil)
+
+        surface.scheduleHeadlessRuntimeStartIfNeeded(reason: "test-post-park", source: .inputDemand)
+
+        #expect(
+            surface.debugRuntimeSurfaceCreateAttemptCountForTesting() == 2,
+            "An input-demand start after portal churn parked the pane host must still attempt runtime creation (#9769)."
+        )
+        #expect(
+            paneHost.window != nil,
+            "The bootstrap start must reclaim the parked pane host into a window so libghostty can spawn (#9769)."
+        )
+    }
+
+    @Test func queuedSendToParkedPaneHostStillAttemptsRuntimeStart() async {
+        let nativeView = FakeTerminalSurfaceNativeView(frame: NSRect(x: 0, y: 0, width: 800, height: 600))
+        let paneHost = FakeTerminalSurfacePaneHost(
+            surfaceView: nativeView,
+            attachesThroughSurfaceModel: true
+        )
+        let scheduler = RecordingRestoreSpawnScheduler()
+        let surface = makeSurface(scheduler: scheduler, nativeView: nativeView, paneHost: paneHost)
+        surface.claudeCommandShimInstallCompleted = true
+        defer { surface.closeHeadlessStartupWindowIfNeeded() }
+
+        surface.scheduleHeadlessRuntimeStartIfNeeded(reason: "test-first-start", source: .inputDemand)
+        #expect(surface.debugRuntimeSurfaceCreateAttemptCountForTesting() == 1)
+        paneHost.removeFromSuperview()
+
+        // `cmux send` to the cold surface: the text queues and requests an
+        // input-demand start. The queued bytes must not be stranded behind a
+        // parked pane host — the spawn attempt has to happen so the pending
+        // input can flush once the runtime exists.
+        #expect(surface.sendText("echo issue9769\n"))
+
+        await waitForCreateAttemptCount(surface, 2)
+    }
+
+    @Test func backgroundPrimeStartToParkedPaneHostStillAttemptsRuntimeStart() async {
+        let nativeView = FakeTerminalSurfaceNativeView(frame: NSRect(x: 0, y: 0, width: 800, height: 600))
+        let paneHost = FakeTerminalSurfacePaneHost(
+            surfaceView: nativeView,
+            attachesThroughSurfaceModel: true
+        )
+        let scheduler = RecordingRestoreSpawnScheduler()
+        let surface = makeSurface(scheduler: scheduler, nativeView: nativeView, paneHost: paneHost)
+        surface.claudeCommandShimInstallCompleted = true
+        defer { surface.closeHeadlessStartupWindowIfNeeded() }
+
+        surface.scheduleHeadlessRuntimeStartIfNeeded(reason: "test-first-start", source: .inputDemand)
+        #expect(surface.debugRuntimeSurfaceCreateAttemptCountForTesting() == 1)
+        paneHost.removeFromSuperview()
+
+        // The background workspace prime coordinator re-requests cold starts
+        // through this entry point; it must not be droppable either.
+        surface.requestBackgroundSurfaceStartIfNeeded()
+
+        await waitForCreateAttemptCount(surface, 2)
+    }
+
+    @Test func hungClaudeShimInstallDoesNotStarveRuntimeSpawn() async throws {
+        _ = try #require(Bundle.main.resourceURL)
+        let nativeView = FakeTerminalSurfaceNativeView(frame: NSRect(x: 0, y: 0, width: 800, height: 600))
+        let paneHost = FakeTerminalSurfacePaneHost(
+            surfaceView: nativeView,
+            attachesThroughSurfaceModel: true
+        )
+        let scheduler = RecordingRestoreSpawnScheduler()
+        let shimInstaller = ManualClaudeCommandShimInstaller()
+        let runtimeFilesystem = TerminalSurfaceRuntimeFilesystem(
+            claudeCommandShimTemporaryDirectory: URL(fileURLWithPath: "/tmp/cmux-terminal-tests", isDirectory: true),
+            installClaudeCommandShim: {
+                await shimInstaller.install(wrapperURL: $0, surfaceId: $1, temporaryDirectory: $2)
+            },
+            isExecutableFile: { _ in false }
+        )
+        let surface = makeSurface(
+            scheduler: scheduler,
+            nativeView: nativeView,
+            paneHost: paneHost,
+            runtimeFilesystem: runtimeFilesystem
+        )
+        defer { surface.closeHeadlessStartupWindowIfNeeded() }
+
+        surface.scheduleHeadlessRuntimeStartIfNeeded(reason: "test-shim-hang", source: .inputDemand)
+        await shimInstaller.waitForInstallStart()
+        #expect(surface.debugRuntimeSurfaceCreateAttemptCountForTesting() == 0)
+
+        // The wrapper shim is an optional PATH convenience. When its install
+        // task never completes (disk pressure, starved queues), PTY spawn must
+        // still proceed without it instead of waiting forever (#9769).
+        await waitForCreateAttemptCount(surface, 1)
+    }
+
+    private func waitForCreateAttemptCount(
+        _ surface: TerminalSurface,
+        _ count: Int,
+        iterations: Int = 400
+    ) async {
+        for _ in 0..<iterations {
+            if surface.debugRuntimeSurfaceCreateAttemptCountForTesting() >= count { return }
+            try? await Task.sleep(for: .milliseconds(20))
+        }
+        let attempts = surface.debugRuntimeSurfaceCreateAttemptCountForTesting()
+        Issue.record("Timed out waiting for \(count) runtime surface create attempt(s); got \(attempts)")
+    }
+
+    private func makeSurface(
+        scheduler: RecordingRestoreSpawnScheduler,
+        nativeView: FakeTerminalSurfaceNativeView,
+        paneHost: FakeTerminalSurfacePaneHost,
+        engine: FakeTerminalEngine = FakeTerminalEngine(),
+        runtimeFilesystem: TerminalSurfaceRuntimeFilesystem = TerminalSurfaceRuntimeFilesystem(
+            claudeCommandShimTemporaryDirectory: URL(fileURLWithPath: "/tmp/cmux-terminal-tests", isDirectory: true),
+            installClaudeCommandShim: { _, _, _ in nil },
+            isExecutableFile: { _ in false }
+        )
+    ) -> TerminalSurface {
+        TerminalSurface(
+            tabId: UUID(),
+            context: GHOSTTY_SURFACE_CONTEXT_SPLIT,
+            configTemplate: nil,
+            runtimeSpawnPolicy: .immediate,
+            dependencies: TerminalSurfaceRuntimeDependencies(
+                registry: FakeSurfaceRegistry(),
+                engine: engine,
+                viewProvider: FakeTerminalSurfaceViewProvider(surfaceView: nativeView, paneHost: paneHost),
+                spawnPolicy: FakeSpawnPolicyProvider(),
+                byteTee: FakeTerminalByteTee(),
+                rendererRealization: FakeRendererRealizationScheduler(),
+                hibernationRecorder: FakeHibernationRecorder(),
+                runtimeTeardown: TerminalSurfaceRuntimeTeardownCoordinator(),
+                restoreSpawnScheduler: scheduler,
+                runtimeFilesystem: runtimeFilesystem,
+                sessionPortBase: 40_000,
+                sessionPortRangeSize: 100,
+                scrollbackReplayEnvironmentKey: "CMUX_TEST_SCROLLBACK_REPLAY"
+            )
+        )
+    }
+}

--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -37696,7 +37696,7 @@
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "queued (terminal starting; input delivers when its PTY spawns)"
+            "value": "queued (terminal starting; input will be sent when its PTY is ready)"
           }
         },
         "ja": {

--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -37690,6 +37690,23 @@
         }
       }
     },
+    "cli.send.queuedSuffix": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "queued (terminal starting; input delivers when its PTY spawns)"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "キュー済み（ターミナル起動中。PTY 生成後に入力が送信されます）"
+          }
+        }
+      }
+    },
     "cli.error.dismissNotificationSelector": {
       "extractionState": "manual",
       "localizations": {

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -4618,7 +4618,15 @@ final class Workspace: Identifiable, ObservableObject {
     }
 
     private func hasBackgroundSurfaceStartWork(for panel: TerminalPanel) -> Bool {
-        panel.surface.hasDeferredStartupWorkForBackgroundStart() ||
+        // A surface that can never create a runtime (closing/closed panel,
+        // agent-hibernation suspension) must not count as prime work: the
+        // prime coordinator's timeout path deliberately keeps the workspace's
+        // hidden mount retained, so a never-satisfiable surface would pin one
+        // of the two global background-mount slots forever (#9769).
+        guard panel.surface.surface != nil || panel.surface.canCreateRuntimeSurface else {
+            return false
+        }
+        return panel.surface.hasDeferredStartupWorkForBackgroundStart() ||
             pendingTerminalInputObserversByPanelId[panel.id]?.isEmpty == false
     }
 

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -255,6 +255,7 @@ C0DE71B10000000000000001 /* AppDelegate+AgentChatNotifications.swift in Sources 
 		7C592156DCB3419BB95383E5 /* AutoNamingEngineTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7752D68A758642EFA282C208 /* AutoNamingEngineTests.swift */; };
 		A4ECF22C62724853A72D6BDE /* AutoNamingGrokAdapterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 07EC52007B2144C59C047774 /* AutoNamingGrokAdapterTests.swift */; };
 		74AB3F34FE3B4974A3A5D264 /* AutoNamingHookPayloadAdapterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46792DAA478444ED87B17B31 /* AutoNamingHookPayloadAdapterTests.swift */; };
+		B00FC393AB29CFA85FB6D9F5 /* BackgroundPrimeStartableSurfaceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0673572C53588696D70F32A9 /* BackgroundPrimeStartableSurfaceTests.swift */; };
 		C0DE35860000000000000001 /* BackgroundWorkspacePrimeCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE35860000000000000002 /* BackgroundWorkspacePrimeCoordinator.swift */; };
 		A50012F1 /* Backport.swift in Sources */ = {isa = PBXBuildFile; fileRef = A50012F0 /* Backport.swift */; };
 		B057B0017E57B0017E57B001 /* Bonsplit in Frameworks */ = {isa = PBXBuildFile; productRef = A5001262 /* Bonsplit */; };
@@ -555,6 +556,7 @@ C0DE71B10000000000000001 /* AppDelegate+AgentChatNotifications.swift in Sources 
 		89930006AABBCCDDEEFF0001 /* CLIOmpSupersededCleanupTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 89930006AABBCCDDEEFF0002 /* CLIOmpSupersededCleanupTests.swift */; };
 		C0F16B000000000000000001 /* CLIRemoteShellStartupPerformanceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0F16B000000000000000002 /* CLIRemoteShellStartupPerformanceTests.swift */; };
 		A5D41209A1B2C3D4E5F60718 /* CLIRovoDevHookPersistenceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5D4120AA1B2C3D4E5F60718 /* CLIRovoDevHookPersistenceTests.swift */; };
+		FE89827F4FAB9F7524A38B41 /* CLISendQueuedOutputTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 85A183D9426E08846D029219 /* CLISendQueuedOutputTests.swift */; };
 		B900004AA1B2C3D4E5F60719 /* CLISocketPathResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = B900004BA1B2C3D4E5F60719 /* CLISocketPathResolver.swift */; };
 		C12985000000000000000002 /* CLISocketSentryTelemetry.swift in Sources */ = {isa = PBXBuildFile; fileRef = C12985000000000000000001 /* CLISocketSentryTelemetry.swift */; };
 		A8D837B3AA85F4353C493DE1 /* CLISSHPTYAttachProbeReplyRegressionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8CB1737C956A80E5F98E9DC5 /* CLISSHPTYAttachProbeReplyRegressionTests.swift */; };
@@ -2966,6 +2968,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 		7752D68A758642EFA282C208 /* AutoNamingEngineTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutoNamingEngineTests.swift; sourceTree = "<group>"; };
 		07EC52007B2144C59C047774 /* AutoNamingGrokAdapterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutoNamingGrokAdapterTests.swift; sourceTree = "<group>"; };
 		46792DAA478444ED87B17B31 /* AutoNamingHookPayloadAdapterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutoNamingHookPayloadAdapterTests.swift; sourceTree = "<group>"; };
+		0673572C53588696D70F32A9 /* BackgroundPrimeStartableSurfaceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackgroundPrimeStartableSurfaceTests.swift; sourceTree = "<group>"; };
 		C0DE35860000000000000002 /* BackgroundWorkspacePrimeCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackgroundWorkspacePrimeCoordinator.swift; sourceTree = "<group>"; };
 		A50012F0 /* Backport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Backport.swift; sourceTree = "<group>"; };
 		74060000000000000000001A /* BonsplitConfiguration+RemoteTmuxEmbedded.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "BonsplitConfiguration+RemoteTmuxEmbedded.swift"; sourceTree = "<group>"; };
@@ -3264,6 +3267,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 		89930006AABBCCDDEEFF0002 /* CLIOmpSupersededCleanupTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CLIOmpSupersededCleanupTests.swift; sourceTree = "<group>"; };
 		C0F16B000000000000000002 /* CLIRemoteShellStartupPerformanceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CLIRemoteShellStartupPerformanceTests.swift; sourceTree = "<group>"; };
 		A5D4120AA1B2C3D4E5F60718 /* CLIRovoDevHookPersistenceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CLIRovoDevHookPersistenceTests.swift; sourceTree = "<group>"; };
+		85A183D9426E08846D029219 /* CLISendQueuedOutputTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CLISendQueuedOutputTests.swift; sourceTree = "<group>"; };
 		B900004BA1B2C3D4E5F60719 /* CLISocketPathResolver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CLISocketPathResolver.swift; sourceTree = "<group>"; };
 		C12985000000000000000001 /* CLISocketSentryTelemetry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CLISocketSentryTelemetry.swift; sourceTree = "<group>"; };
 		8CB1737C956A80E5F98E9DC5 /* CLISSHPTYAttachProbeReplyRegressionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CLISSHPTYAttachProbeReplyRegressionTests.swift; sourceTree = "<group>"; };
@@ -7984,6 +7988,8 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				10D684CFFB8CDEF89CE2D9E1 /* TabManagerSessionSnapshotTests.swift */,
 				C0DE86540000000000000001 /* FocusHistoryScopeTests.swift */,
 				481E6848F8513F27E496F7BE /* TabManagerBackgroundWorkspaceMountBoundTests.swift */,
+				85A183D9426E08846D029219 /* CLISendQueuedOutputTests.swift */,
+				0673572C53588696D70F32A9 /* BackgroundPrimeStartableSurfaceTests.swift */,
 				C0DE4300000000000000000A /* CmuxAgentChatConfigTests.swift */,
 				C1A2B3C4D5E6F70800000002 /* CmuxConfigTests.swift */,
 				468100000000000000000002 /* CmuxNotificationHookCacheTests.swift */,
@@ -10484,6 +10490,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				7C592156DCB3419BB95383E5 /* AutoNamingEngineTests.swift in Sources */,
 				A4ECF22C62724853A72D6BDE /* AutoNamingGrokAdapterTests.swift in Sources */,
 				74AB3F34FE3B4974A3A5D264 /* AutoNamingHookPayloadAdapterTests.swift in Sources */,
+				B00FC393AB29CFA85FB6D9F5 /* BackgroundPrimeStartableSurfaceTests.swift in Sources */,
 				D3622000A1B2C3D4E5F60718 /* BrowserArrowKeyForwardingTests.swift in Sources */,
 				8054B0030000000000000003 /* BrowserAutomationRecoveryLifecycleTests.swift in Sources */,
 				BCBC0A0E0000000000000D01 /* BrowserChromeMetricsTests.swift in Sources */,
@@ -10573,6 +10580,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				89930006AABBCCDDEEFF0001 /* CLIOmpSupersededCleanupTests.swift in Sources */,
 				C0F16B000000000000000001 /* CLIRemoteShellStartupPerformanceTests.swift in Sources */,
 				A5D41209A1B2C3D4E5F60718 /* CLIRovoDevHookPersistenceTests.swift in Sources */,
+				FE89827F4FAB9F7524A38B41 /* CLISendQueuedOutputTests.swift in Sources */,
 				A8D837B3AA85F4353C493DE1 /* CLISSHPTYAttachProbeReplyRegressionTests.swift in Sources */,
 				C73660020000000000000001 /* CLISSHPTYAttachSessionLostRespawnTests.swift in Sources */,
 				C77070000000000000000004 /* CLISSHPTYAttachTransientBridgeFailureExitCodeTests.swift in Sources */,

--- a/cmuxTests/BackgroundPrimeStartableSurfaceTests.swift
+++ b/cmuxTests/BackgroundPrimeStartableSurfaceTests.swift
@@ -1,0 +1,45 @@
+import Foundation
+import Testing
+
+#if canImport(cmux_DEV)
+@testable import cmux_DEV
+#elseif canImport(cmux)
+@testable import cmux
+#endif
+
+@MainActor
+@Suite(.serialized)
+struct BackgroundPrimeStartableSurfaceTests {
+    // Regression coverage for issue #9769: `BackgroundWorkspacePrimeCoordinator`
+    // deliberately keeps a workspace's hidden mount slot retained when its 2s
+    // prime pass times out. A surface that can never create a runtime (closing
+    // panel, agent-hibernation suspension) therefore pins one of the two global
+    // mount slots forever, and background PTY spawn starves app-wide. Such a
+    // surface must not count as background-prime work at all.
+    @Test func closingSurfaceDoesNotCountAsBackgroundPrimeWork() throws {
+        let manager = TabManager()
+        let initialWorkspaceIDs = Set(manager.tabs.map(\.id))
+
+        _ = TerminalController.shared.v2WorkspaceCreate(
+            params: ["initial_command": "true", "focus": false],
+            tabManager: manager
+        )
+        let created = try #require(manager.tabs.first { !initialWorkspaceIDs.contains($0.id) })
+
+        // Sanity: with a pending initial command the workspace reports prime work.
+        #expect(created.hasBackgroundPrimeTerminalSurfaceStartWork())
+
+        for panel in created.panels.values.compactMap({ $0 as? TerminalPanel }) {
+            panel.surface.beginPortalCloseLifecycle(reason: "test.issue9769")
+        }
+
+        #expect(
+            !created.hasBackgroundPrimeTerminalSurfaceStartWork(),
+            "A surface whose lifecycle forbids runtime creation can never satisfy a prime pass; reporting it as prime work pins a background mount slot forever (#9769)."
+        )
+        #expect(
+            created.hasLoadedBackgroundPrimeTerminalSurface(),
+            "Priming must consider a workspace with only non-startable surfaces complete so the mount slot is released (#9769)."
+        )
+    }
+}

--- a/cmuxTests/CLISendQueuedOutputTests.swift
+++ b/cmuxTests/CLISendQueuedOutputTests.swift
@@ -1,0 +1,215 @@
+import Darwin
+import Foundation
+import Testing
+
+// Regression coverage for issue #9769: `cmux send` to a surface whose PTY has
+// not spawned yet is queued server-side, and the reply carries
+// `queued: true`. The CLI's human-readable output dropped that flag and
+// printed a bare `OK surface:N workspace:M`, indistinguishable from a
+// delivered send — so queued-then-starved input looked like success.
+@Suite(.serialized)
+struct CLISendQueuedOutputTests {
+    @Test func sendPrintsQueuedMarkerWhenDeliveryIsQueued() throws {
+        let result = try runSendAgainstMockServer(queuedReply: true)
+
+        #expect(!result.timedOut, Comment(rawValue: result.stderr))
+        #expect(result.status == 0, Comment(rawValue: result.stderr + result.stdout))
+        #expect(result.stdout.contains("OK"), Comment(rawValue: result.stdout))
+        #expect(result.stdout.contains(Self.surfaceRef), Comment(rawValue: result.stdout))
+        #expect(
+            result.stdout.contains("queued"),
+            Comment(rawValue: "A queued send must say so instead of printing plain OK (#9769). stdout: \(result.stdout)")
+        )
+    }
+
+    @Test func sendPrintsPlainOKWhenDeliveredToLiveSurface() throws {
+        let result = try runSendAgainstMockServer(queuedReply: false)
+
+        #expect(!result.timedOut, Comment(rawValue: result.stderr))
+        #expect(result.status == 0, Comment(rawValue: result.stderr + result.stdout))
+        #expect(result.stdout == "OK \(Self.surfaceRef) \(Self.workspaceRef)\n", Comment(rawValue: result.stdout))
+    }
+
+    private static let surfaceRef = "surface:11"
+    private static let workspaceRef = "workspace:7"
+
+    private struct ProcessRunResult {
+        let status: Int32
+        let stdout: String
+        let stderr: String
+        let timedOut: Bool
+    }
+
+    private final class CLISendQueuedOutputBundleToken {}
+
+    private func runSendAgainstMockServer(queuedReply: Bool) throws -> ProcessRunResult {
+        let socketPath = Self.makeSocketPath("send-q")
+        let listenerFD = try Self.bindUnixSocket(at: socketPath)
+        defer {
+            Darwin.close(listenerFD)
+            unlink(socketPath)
+        }
+
+        let handled = DispatchSemaphore(value: 0)
+        DispatchQueue.global(qos: .userInitiated).async {
+            defer { handled.signal() }
+            var clientAddr = sockaddr_un()
+            var clientAddrLen = socklen_t(MemoryLayout<sockaddr_un>.size)
+            let clientFD = withUnsafeMutablePointer(to: &clientAddr) { pointer in
+                pointer.withMemoryRebound(to: sockaddr.self, capacity: 1) { sockaddrPtr in
+                    Darwin.accept(listenerFD, sockaddrPtr, &clientAddrLen)
+                }
+            }
+            guard clientFD >= 0 else { return }
+            defer { Darwin.close(clientFD) }
+            cliMockServeLineFramedConnection(clientFD: clientFD) { line in
+                guard let payload = Self.jsonObject(line),
+                      let id = payload["id"] as? String,
+                      let method = payload["method"] as? String,
+                      method == "surface.send_text" else {
+                    return Self.v2Response(id: "unknown", ok: false, error: ["code": "unexpected_method"])
+                }
+                var result: [String: Any] = [
+                    "surface_ref": Self.surfaceRef,
+                    "workspace_ref": Self.workspaceRef,
+                ]
+                if queuedReply { result["queued"] = true }
+                return Self.v2Response(id: id, ok: true, result: result)
+            }
+        }
+
+        var environment = ProcessInfo.processInfo.environment
+        environment["CMUX_SOCKET_PATH"] = socketPath
+        environment["CMUX_CLI_SENTRY_DISABLED"] = "1"
+        environment.removeValue(forKey: "CMUX_WORKSPACE_ID")
+        environment.removeValue(forKey: "CMUX_SURFACE_ID")
+
+        let result = Self.runProcess(
+            executablePath: try BundledCLITestSupport.bundledCLIPath(for: CLISendQueuedOutputBundleToken.self),
+            arguments: ["send", "--surface", Self.surfaceRef, "echo issue9769"],
+            environment: environment,
+            timeout: 5
+        )
+        _ = handled.wait(timeout: .now() + 5)
+        return ProcessRunResult(
+            status: result.status,
+            stdout: result.stdout,
+            stderr: result.stderr,
+            timedOut: result.timedOut
+        )
+    }
+
+    private static func makeSocketPath(_ name: String) -> String {
+        let shortID = UUID().uuidString.replacingOccurrences(of: "-", with: "").prefix(8)
+        return URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("cli-\(name.prefix(6))-\(shortID).sock")
+            .path
+    }
+
+    private static func bindUnixSocket(at path: String) throws -> Int32 {
+        unlink(path)
+        let fd = Darwin.socket(AF_UNIX, SOCK_STREAM, 0)
+        guard fd >= 0 else {
+            throw POSIXError(POSIXErrorCode(rawValue: errno) ?? .EIO)
+        }
+
+        var addr = sockaddr_un()
+        addr.sun_family = sa_family_t(AF_UNIX)
+        let maxPathLength = MemoryLayout.size(ofValue: addr.sun_path)
+        let utf8 = Array(path.utf8)
+        guard utf8.count < maxPathLength else {
+            Darwin.close(fd)
+            throw NSError(domain: "cmux.tests", code: Int(ENAMETOOLONG), userInfo: [
+                NSLocalizedDescriptionKey: "Unix socket path is too long: \(path)",
+            ])
+        }
+        withUnsafeMutablePointer(to: &addr.sun_path) { pointer in
+            pointer.withMemoryRebound(to: CChar.self, capacity: maxPathLength) { buffer in
+                for index in 0..<utf8.count {
+                    buffer[index] = CChar(bitPattern: utf8[index])
+                }
+                buffer[utf8.count] = 0
+            }
+        }
+
+        let bindResult = withUnsafePointer(to: &addr) { pointer in
+            pointer.withMemoryRebound(to: sockaddr.self, capacity: 1) { sockaddrPtr in
+                Darwin.bind(fd, sockaddrPtr, socklen_t(MemoryLayout<sockaddr_un>.size))
+            }
+        }
+        guard bindResult == 0 else {
+            Darwin.close(fd)
+            throw POSIXError(POSIXErrorCode(rawValue: errno) ?? .EIO)
+        }
+        guard Darwin.listen(fd, 1) == 0 else {
+            Darwin.close(fd)
+            throw POSIXError(POSIXErrorCode(rawValue: errno) ?? .EIO)
+        }
+        return fd
+    }
+
+    private static func v2Response(
+        id: String,
+        ok: Bool,
+        result: [String: Any]? = nil,
+        error: [String: Any]? = nil
+    ) -> String {
+        var payload: [String: Any] = ["id": id, "ok": ok]
+        if let result { payload["result"] = result }
+        if let error { payload["error"] = error }
+        let data = try? JSONSerialization.data(withJSONObject: payload, options: [])
+        return String(data: data ?? Data("{}".utf8), encoding: .utf8) ?? "{}"
+    }
+
+    private static func jsonObject(_ line: String) -> [String: Any]? {
+        guard let data = line.data(using: .utf8) else { return nil }
+        return try? JSONSerialization.jsonObject(with: data, options: []) as? [String: Any]
+    }
+
+    private static func runProcess(
+        executablePath: String,
+        arguments: [String],
+        environment: [String: String],
+        timeout: TimeInterval
+    ) -> ProcessRunResult {
+        let process = Process()
+        let stdoutPipe = Pipe()
+        let stderrPipe = Pipe()
+        process.executableURL = URL(fileURLWithPath: executablePath)
+        process.arguments = arguments
+        process.environment = environment
+        process.standardInput = FileHandle.nullDevice
+        process.standardOutput = stdoutPipe
+        process.standardError = stderrPipe
+
+        do {
+            try process.run()
+        } catch {
+            return ProcessRunResult(status: -1, stdout: "", stderr: String(describing: error), timedOut: false)
+        }
+
+        let exitSignal = DispatchSemaphore(value: 0)
+        DispatchQueue.global(qos: .userInitiated).async {
+            process.waitUntilExit()
+            exitSignal.signal()
+        }
+
+        let timedOut = exitSignal.wait(timeout: .now() + timeout) == .timedOut
+        if timedOut {
+            process.terminate()
+            if exitSignal.wait(timeout: .now() + 1) == .timedOut {
+                kill(process.processIdentifier, SIGKILL)
+                _ = exitSignal.wait(timeout: .now() + 1)
+            }
+        }
+
+        let stdout = String(data: stdoutPipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? ""
+        let stderr = String(data: stderrPipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? ""
+        return ProcessRunResult(
+            status: process.isRunning ? SIGKILL : process.terminationStatus,
+            stdout: stdout,
+            stderr: stderr,
+            timedOut: timedOut
+        )
+    }
+}

--- a/cmuxTests/CLISendQueuedOutputTests.swift
+++ b/cmuxTests/CLISendQueuedOutputTests.swift
@@ -83,6 +83,10 @@ struct CLISendQueuedOutputTests {
         environment["CMUX_CLI_SENTRY_DISABLED"] = "1"
         environment.removeValue(forKey: "CMUX_WORKSPACE_ID")
         environment.removeValue(forKey: "CMUX_SURFACE_ID")
+        // Pin the child CLI to English so the queued-marker assertion is
+        // locale-independent.
+        environment["LANG"] = "en_US.UTF-8"
+        environment["LC_ALL"] = "en_US.UTF-8"
 
         let result = Self.runProcess(
             executablePath: try BundledCLITestSupport.bundledCLIPath(for: CLISendQueuedOutputBundleToken.self),
@@ -90,7 +94,13 @@ struct CLISendQueuedOutputTests {
             environment: environment,
             timeout: 5
         )
-        _ = handled.wait(timeout: .now() + 5)
+        guard handled.wait(timeout: .now() + 5) == .success else {
+            throw NSError(
+                domain: "cmux.tests",
+                code: Int(ETIMEDOUT),
+                userInfo: [NSLocalizedDescriptionKey: "Mock CLI socket server did not complete"]
+            )
+        }
         return ProcessRunResult(
             status: result.status,
             stdout: result.stdout,

--- a/cmuxTests/CLISendQueuedOutputTests.swift
+++ b/cmuxTests/CLISendQueuedOutputTests.swift
@@ -88,13 +88,16 @@ struct CLISendQueuedOutputTests {
         environment["LANG"] = "en_US.UTF-8"
         environment["LC_ALL"] = "en_US.UTF-8"
 
+        // Generous bounds: the tolerant full-suite pass runs this alongside
+        // dozens of parallel suites on a loaded app host, where CLI process
+        // startup alone can exceed a few seconds.
         let result = Self.runProcess(
             executablePath: try BundledCLITestSupport.bundledCLIPath(for: CLISendQueuedOutputBundleToken.self),
             arguments: ["send", "--surface", Self.surfaceRef, "echo issue9769"],
             environment: environment,
-            timeout: 5
+            timeout: 30
         )
-        guard handled.wait(timeout: .now() + 5) == .success else {
+        guard handled.wait(timeout: .now() + 30) == .success else {
             throw NSError(
                 domain: "cmux.tests",
                 code: Int(ETIMEDOUT),


### PR DESCRIPTION
Fixes #9769.

## What the investigation found

The issue's live data has two distinct signatures: transient socket refusals/timeouts during the burst, and a **permanent** PTY-spawn wedge that persists on a healthy socket (the follow-up comment shows `workspace:161`/`surface:380` never spawning while `tree` answers instantly). Tracing the full path (`handleSocketWorkerV2` → `v2MainSync` → `TabManager.addWorkspace` → `BackgroundWorkspacePrimeCoordinator` → `TerminalSurface` cold start → `ghostty_surface_new`) turned up a class of **silent one-shot drops** in the cold-start path, each with no re-arm:

1. **Bootstrap-window custody loss (the permanent wedge).** A cold surface starts its runtime inside a hidden borderless "bootstrap" `NSWindow` that hosts the pane host (`GhosttySurfaceScrollView`). Window-portal churn (`TerminalWindowPortal.detachHostedView` → `removeFromSuperview`) can reparent the pane host out of that window and park it with **no window at all** — while `headlessStartupWindow` stays recorded. From then on every cold start hits `ensureHeadlessStartupWindowIfNeeded`'s `guard headlessStartupWindow == nil else { return }`, and the follow-up `attachToView` defers on `noWindow` and returns. Nothing ever re-arms: input-demand starts (`cmux send`, `new-workspace --command`), background priming, everything funnels through the same dead end. The surface never acquires a PTY, and its queued socket input (the `--command` payload) never flushes — exactly symptoms (1) and (2).
2. **Claude command-shim gate.** `createSurface` returns early until a detached filesystem task installs the optional `claude` wrapper shim. If that task never completes (the machine had a 99%-full disk during part of the window), PTY spawn is starved forever by a PATH convenience.
3. **Background-prime mount-slot pinning (the app-wide amplifier).** `BackgroundWorkspacePrimeCoordinator`'s timeout path deliberately keeps a workspace's hidden mount retained. A surface that can never become ready (custody-wedged as above, closing panel, agent-hibernation suspension) therefore pins one of the **two** global mount slots forever, and every later workspace's prime pass starves behind it.
4. **Silent queued sends.** `surface.send_text` to a PTY-less surface queues the bytes and replies `ok` with `queued: true` — but the CLI's human output (`v2OKSummary`) dropped the flag and printed a bare `OK surface:N workspace:M`, indistinguishable from a delivered send. Symptom (3).

## The fix (removing the class, not patching a symptom)

- **Custody reclamation** (`TerminalSurface+RuntimeLifecycle.swift`): `ensureHeadlessStartupWindowIfNeeded` now (a) re-adopts a parked, windowless pane host into the existing bootstrap window, and (b) discards a stale bootstrap window once the pane host lives in a real window. The bootstrap path is now level-triggered: any cold-start request on a surface whose views are windowless deterministically ends with the pane host hosted in a window and `createSurface` attempted. This closes the drop for input-demand, queued-send, and background-prime starts in one place.
- **Shim deadline** (`TerminalSurface+ClaudeCommandShimLifecycle.swift`): a bounded, cancellable deadline (injected `Clock`, default 5s, stored task, cancelled on completion/teardown/hibernation) lets spawn proceed without the shim when the install hangs. A late install result still serves future runtime creations. (Clock-sleep carve-out per `cmux-architecture`: a genuine deadline, driven by an injected clock.)
- **Prime work excludes non-startable surfaces** (`Workspace.swift` + new `TerminalSurface.canCreateRuntimeSurface`): a surface whose lifecycle forbids runtime creation no longer counts as background-prime work, so the coordinator completes the workspace and releases its mount slot instead of pinning it forever.
- **Queued sends are visible** (`CLI/cmux.swift`): `send`, `send-key`, `send-panel`, `send-key-panel` append a localized `queued (terminal starting; input delivers when its PTY spawns)` marker when the reply says `queued: true`. Combined with the spawn fixes, `queued` is now a delivery guarantee rather than a silent maybe; overflow and dead-process cases already return errors (`input_queue_full`, `process_exited`). The v1 socket lane's bare-`OK` reply contract predates the queued flag and is left unchanged for legacy parsers — delivery itself is fixed at the surface level for every entrypoint.

## Regression tests (commit 1, red → commit 2, green)

- `TerminalSurfaceBootstrapCustodyTests` (CmuxTerminal package, runs in the `swift-package-tests` CI job): reproduces the parked-pane-host wedge for input-demand starts, queued sends, and background-prime starts, plus the hung-shim starvation. All four fail on the test-only commit (verified locally: the post-park start attempts stay at 0/1 forever) and pass with the fix.
- `BackgroundPrimeStartableSurfaceTests` (app-host): a closing surface must not count as background-prime work / must let priming complete.
- `CLISendQueuedOutputTests` (app-host, bundled CLI against a mock socket): a `queued: true` reply must print the queued marker; a plain reply must keep printing exactly `OK surface:N workspace:M`.

## What this PR does not claim to fix

The transient burst-time socket refusals/timeouts (symptom 4) are the #5757 family: every `.mainActor` command serializes through a timeout-less `DispatchQueue.main.sync` (`v2MainSync`), and connection threads pile up behind it until the accept-side limits (32 preauthorization slots, 32-connection stream buffer, 128 listen backlog) spill. Fixing that means moving CLI command execution off the main thread wholesale, which is an orthogonal, much larger change tracked in #5757 — this PR removes the part of #9769 that never recovers (PTY spawn and silent sends), which is also the part the issue's own follow-up data shows is independent of socket health. A true CI integration repro of the full multi-shell burst (3 concurrent CLI loops against a live app) is not cleanly testable in the app-host harness; the scheduling logic that wedged is covered by the deterministic unit/behavior tests above instead.

## Localization audit

New user-facing string: the CLI queued-send suffix, added as `cli.send.queuedSuffix` to `Resources/Localizable.xcstrings` with `en` and `ja` translations. No web UI, settings, menu, shortcut, schema, or docs text changed; no web message catalogs affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## CI evidence (dispatch-triggered; this repo's CI does not auto-run on PRs)

**Red on the test-only commit `6d4a2933a5`** ([run 31159985469](https://github.com/manaflow-ai/cmux/actions/runs/31159985469)): all four `TerminalSurfaceBootstrapCustodyTests` failed in `swift-package-tests` on exactly the intended assertions (post-park create attempts stuck at 0/1), and `BackgroundPrimeStartableSurfaceTests` failed in app-host shard 3 on its two assertions.

**Green on the head** ([run 31173407217](https://github.com/manaflow-ai/cmux/actions/runs/31173407217) + rerun): `swift-package-tests` green (custody, shim-deadline, and shim-re-gate tests), shard-4 focused gate green (`BackgroundPrimeStartableSurfaceTests`, `CLISendQueuedOutputTests` against the real bundled CLI), shards 1/2 green, `release-build` green on the head SHA, zero new Swift warnings.

**Jobs still red are the pre-existing main baseline**, verified fingerprint-identical against main's latest run ([31150302964](https://github.com/manaflow-ai/cmux/actions/runs/31150302964)):
- `tests-build-and-lag`: inherited warning-budget violation in `Sources/NotificationsPage.swift` (untouched here; main additionally has a second violation this branch predates).
- app-host shards 3/4: pre-existing environment-dependent suites (`CLINotifyProcessIntegrationRegressionTests` ssh/hostname expectations, `AgentSessionAutoResumeSettingsTests` `/usr/bin/ssh` normalization, `BrowserPanelRemoteStoreTests`, …) and the `RemoteTmuxMirrorCloseDetachTests` focused step exiting 65 after its suite passes — all reproduced on main's runner class. No `cmuxTests` failure on the head run's shard 4 at all.
- `tests` / `ci-status` aggregate the above. No required status checks are configured on `main`; the PR is `MERGEABLE`/`CLEAN`.
