### PR TITLE
Fix AppKit sidebar double-click inline rename committing instantly (#9495)

### DIFF
--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -11826,6 +11826,7 @@ struct VerticalTabsSidebar: View, Equatable {
             settings: input.settings,
             isActive: input.isActive,
             isMultiSelected: input.isMultiSelected,
+            hasUserCustomTitle: input.hasUserCustomTitle,
             canCloseWorkspace: input.canCloseWorkspace,
             accessibilityWorkspaceCount: input.workspaceCount,
             unreadCount: input.unreadCount,

--- a/Sources/Sidebar/AppKitList/Cells/SidebarRowInlineRenameSession.swift
+++ b/Sources/Sidebar/AppKitList/Cells/SidebarRowInlineRenameSession.swift
@@ -1,0 +1,98 @@
+import AppKit
+
+/// One inline-rename editing session for a pure-AppKit sidebar workspace row.
+///
+/// Reuses the SwiftUI sidebar's rename engine so both sidebars share a single
+/// behavior path: `SidebarInlineRenameTextField` takes focus and selects the
+/// whole title when it enters the window (no re-entrant `selectText(_:)`
+/// that would restart the field-editor session and instantly commit the
+/// untouched title — issue #9495), `SidebarInlineRenameCoordinator` resolves
+/// Enter, double-Escape, and focus loss at most once and passes IME
+/// composition through, and `SidebarInlineRenameCommit` decides whether the
+/// draft becomes a `customTitle` write. An unchanged title on a workspace
+/// without a user-owned custom title resolves to no write, so a stray commit
+/// can never freeze auto-naming.
+@MainActor
+final class SidebarRowInlineRenameSession {
+    /// The field hosted in the row while the session is active; it focuses
+    /// itself and selects the whole title when the row adds it to a
+    /// window-attached hierarchy.
+    let field: SidebarInlineRenameTextField
+
+    private let coordinator: SidebarInlineRenameCoordinator
+    private let baselineTitle: String
+    private let baselineHadUserCustomTitle: Bool
+    private let onResolve: @MainActor (String?) -> Void
+    private var isResolved = false
+
+    /// Creates a session seeded with the row's current title.
+    ///
+    /// - Parameters:
+    ///   - baselineTitle: The title shown when editing begins; also the
+    ///     baseline for the unchanged-title no-op rule.
+    ///   - baselineHadUserCustomTitle: Whether the workspace already had a
+    ///     user-owned custom title when editing began.
+    ///   - onResolve: Runs exactly once with the title to persist, or `nil`
+    ///     when the rename cancels or resolves to no write. The receiver
+    ///     owns tearing the session's field down.
+    init(
+        baselineTitle: String,
+        baselineHadUserCustomTitle: Bool,
+        onResolve: @escaping @MainActor (String?) -> Void
+    ) {
+        self.baselineTitle = baselineTitle
+        self.baselineHadUserCustomTitle = baselineHadUserCustomTitle
+        self.onResolve = onResolve
+        field = SidebarInlineRenameTextField(string: baselineTitle)
+        coordinator = SidebarInlineRenameCoordinator(onCommit: { _ in }, onCancel: {})
+        field.isBordered = false
+        field.drawsBackground = false
+        field.focusRingType = .none
+        field.usesSingleLineMode = true
+        field.cell?.usesSingleLineMode = true
+        field.lineBreakMode = .byTruncatingTail
+        field.placeholderString = String(
+            localized: "commandPalette.rename.workspacePlaceholder",
+            defaultValue: "Workspace name"
+        )
+        field.setAccessibilityLabel(String(
+            localized: "sidebar.workspace.rename.field.accessibilityLabel",
+            defaultValue: "Rename workspace"
+        ))
+        coordinator.onCommit = { [weak self] draft in self?.resolve(draft: draft) }
+        coordinator.onCancel = { [weak self] in self?.resolveAsCancel() }
+        field.delegate = coordinator
+    }
+
+    /// Resolves the session for a suspension teardown, returning the title
+    /// to persist (`nil` means nothing to write). The caller owns deferring
+    /// the write past the table mutation, so this never invokes `onResolve`;
+    /// the resolved state also neutralizes any field-editor end-editing that
+    /// fires while the field leaves the hierarchy.
+    func resolveForSuspension() -> String? {
+        guard !isResolved else { return nil }
+        isResolved = true
+        let draft = field.currentEditor()?.string ?? field.stringValue
+        return titleToCommit(draft: draft)
+    }
+
+    private func resolve(draft: String) {
+        guard !isResolved else { return }
+        isResolved = true
+        onResolve(titleToCommit(draft: draft))
+    }
+
+    private func resolveAsCancel() {
+        guard !isResolved else { return }
+        isResolved = true
+        onResolve(nil)
+    }
+
+    private func titleToCommit(draft: String) -> String? {
+        SidebarInlineRenameCommit().titleToCommit(
+            draft: draft,
+            baseline: baselineTitle,
+            baselineHadUserCustomTitle: baselineHadUserCustomTitle
+        )
+    }
+}

--- a/Sources/Sidebar/AppKitList/Cells/SidebarWorkspaceRowCellView.swift
+++ b/Sources/Sidebar/AppKitList/Cells/SidebarWorkspaceRowCellView.swift
@@ -32,7 +32,6 @@ final class SidebarWorkspaceRowTableCellView: NSTableCellView {
     private let mediaCameraView = NSImageView()
     private let statusGlyphButton = SidebarRowTaskStatusGlyphButton()
     private let titleView = SidebarRowTextView(lines: 1)
-    let renameField = SidebarRowInlineRenameField()
     private let trailingBadge = SidebarRowUnreadBadgeView()
     private var trailingSpinner: GPUSpinnerNSView?
     private let closeButton = SidebarHeaderGlyphButton()
@@ -65,7 +64,9 @@ final class SidebarWorkspaceRowTableCellView: NSTableCellView {
     private var contextMenuVisible = false
     private var contextMenuDidOpen: (() -> Void)?
     private var contextMenuDidClose: (() -> Void)?
-    var isEditing = false
+    /// Active inline-rename session; the title is display-only when nil.
+    private var renameSession: SidebarRowInlineRenameSession?
+    var isEditing: Bool { renameSession != nil }
     private var pumpCancellables: [AnyCancellable] = []
     private var isPresentationActive = true
 
@@ -202,8 +203,6 @@ final class SidebarWorkspaceRowTableCellView: NSTableCellView {
         contentContainer.addSubview(statusGlyphButton)
         contentContainer.addSubview(leadingBadge)
         contentContainer.addSubview(titleView)
-        renameField.isHidden = true
-        contentContainer.addSubview(renameField)
         contentContainer.addSubview(trailingBadge)
         closeButton.onClick = { [weak self] in self?.actions?.commands.closeWorkspace() }
         contentContainer.addSubview(closeButton)
@@ -268,14 +267,16 @@ final class SidebarWorkspaceRowTableCellView: NSTableCellView {
 
     func detachPresentation(commitEdits: Bool = false) -> [@MainActor () -> Void] {
         var postUpdateActions: [@MainActor () -> Void] = []
-        if commitEdits, isEditing {
-            let commitRename = actions?.commitRename
-            let text = renameField.stringValue
-            endInlineRename(commit: true)
-            postUpdateActions.append { commitRename?(text) }
+        if let session = renameSession {
+            // Resolve before teardown so field-editor end-editing can no
+            // longer re-enter commit; the write itself stays deferred past
+            // the table mutation.
+            let title = session.resolveForSuspension()
+            if commitEdits, let title, let commitRename = actions?.commitRename {
+                postUpdateActions.append { commitRename(title) }
+            }
+            removeInlineRenameSession()
         }
-        renameField.onCommit = nil
-        renameField.onCancel = nil
         if let checklistAction = checklistSection.detachPresentation(commitEdits: commitEdits) {
             postUpdateActions.append(checklistAction)
         }
@@ -325,7 +326,7 @@ final class SidebarWorkspaceRowTableCellView: NSTableCellView {
         let hoverChanged = self.isPointerHovering != isPointerHovering
         self.isPointerHovering = isPointerHovering
         if previous?.workspaceId != model.workspaceId {
-            endInlineRename(commit: false)
+            cancelInlineRename()
             if statusPopoverPresenter.isShown {
                 statusPopoverPresenter.close()
             }
@@ -995,32 +996,46 @@ final class SidebarWorkspaceRowTableCellView: NSTableCellView {
     }
 
     func beginInlineRename() {
-        guard let model else { return }
-        isEditing = true
-        renameField.stringValue = model.snapshot.title
-        renameField.font = .systemFont(ofSize: model.scaled(12.5), weight: .semibold)
-        renameField.textColor = palette(model).selectedForeground(1.0)
-        renameField.isHidden = false
+        guard let model, renameSession == nil else { return }
+        let session = SidebarRowInlineRenameSession(
+            baselineTitle: model.snapshot.title,
+            baselineHadUserCustomTitle: model.hasUserCustomTitle,
+            onResolve: { [weak self] title in
+                if let title { self?.actions?.commitRename(title) }
+                self?.removeInlineRenameSession()
+            }
+        )
+        session.field.font = .systemFont(ofSize: model.scaled(12.5), weight: .semibold)
+        session.field.inlineRenameTextColor = palette(model).selectedForeground(1.0)
+        renameSession = session
         titleView.isHidden = true
-        renameField.onCommit = { [weak self] text in
-            self?.actions?.commitRename(text)
-            self?.endInlineRename(commit: true)
-        }
-        renameField.onCancel = { [weak self] in
-            self?.endInlineRename(commit: false)
-        }
-        let tookFocus = window?.makeFirstResponder(renameField) ?? false
+        // Entering the window-attached hierarchy makes the field first
+        // responder and selects the whole title (the engine shared with the
+        // SwiftUI sidebar); no follow-up selection call may run, because
+        // `selectText(_:)` after focus restarts the field-editor session and
+        // synchronously commits the untouched title (#9495).
+        contentContainer.addSubview(session.field)
 #if DEBUG
-        cmuxDebugLog("sidebar.row.beginInlineRename tookFocus=\(tookFocus ? 1 : 0) window=\(window == nil ? 0 : 1)")
+        cmuxDebugLog(
+            "sidebar.row.beginInlineRename tookFocus=\(session.field.currentEditor() != nil ? 1 : 0) window=\(window == nil ? 0 : 1)"
+        )
 #endif
-        renameField.selectText(nil)
         needsLayout = true
     }
 
-    private func endInlineRename(commit: Bool) {
-        guard isEditing else { return }
-        isEditing = false
-        renameField.isHidden = true
+    /// Cancels any active rename without a write (the workspace changed
+    /// under the cell).
+    private func cancelInlineRename() {
+        guard let session = renameSession else { return }
+        _ = session.resolveForSuspension()
+        removeInlineRenameSession()
+    }
+
+    /// Tears down the session UI; resolution has already happened.
+    private func removeInlineRenameSession() {
+        guard let session = renameSession else { return }
+        renameSession = nil
+        session.field.removeFromSuperview()
         titleView.isHidden = false
         needsLayout = true
     }
@@ -1120,12 +1135,12 @@ final class SidebarWorkspaceRowTableCellView: NSTableCellView {
         let trailingSlotActive = !trailingBadge.isHidden || (trailingSpinner?.isHidden == false) || model.canCloseWorkspace
         let titleMaxX = trailingSlotActive ? (trailing - closeWidth - titleRowSpacing) : trailing
         let titleWidth = max(10, titleMaxX - x)
-        let titleHeight = isEditing
-            ? ceil(renameField.intrinsicContentSize.height)
-            : titleView.measuredHeight(width: titleWidth)
+        let renameField = renameSession?.field
+        let titleHeight = renameField.map { ceil($0.intrinsicContentSize.height) }
+            ?? titleView.measuredHeight(width: titleWidth)
         if apply {
             let frame = NSRect(x: x, y: y, width: titleWidth, height: titleHeight)
-            if isEditing {
+            if let renameField {
                 renameField.frame = frame
             } else {
                 titleView.frame = frame
@@ -1345,43 +1360,5 @@ final class SidebarWorkspaceRowTableCellView: NSTableCellView {
             )
         }
         return ceil(y)
-    }
-}
-
-/// Borderless single-line rename field (select-all on focus, Escape cancels).
-@MainActor
-final class SidebarRowInlineRenameField: NSTextField, NSTextFieldDelegate {
-    var onCommit: ((String) -> Void)?
-    var onCancel: (() -> Void)?
-
-    init() {
-        super.init(frame: .zero)
-        isBordered = false
-        drawsBackground = false
-        focusRingType = .none
-        usesSingleLineMode = true
-        lineBreakMode = .byTruncatingTail
-        delegate = self
-    }
-
-    required init?(coder: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
-    }
-
-    func control(_ control: NSControl, textView: NSTextView, doCommandBy commandSelector: Selector) -> Bool {
-        if commandSelector == #selector(NSResponder.cancelOperation(_:)) {
-            onCancel?()
-            return true
-        }
-        if commandSelector == #selector(NSResponder.insertNewline(_:)) {
-            onCommit?(stringValue)
-            return true
-        }
-        return false
-    }
-
-    func controlTextDidEndEditing(_ obj: Notification) {
-        guard !isHidden else { return }
-        onCommit?(stringValue)
     }
 }

--- a/Sources/Sidebar/AppKitList/Cells/SidebarWorkspaceRowCellView.swift
+++ b/Sources/Sidebar/AppKitList/Cells/SidebarWorkspaceRowCellView.swift
@@ -1009,18 +1009,24 @@ final class SidebarWorkspaceRowTableCellView: NSTableCellView {
         session.field.inlineRenameTextColor = palette(model).selectedForeground(1.0)
         renameSession = session
         titleView.isHidden = true
+        // Give the field its title-slot frame BEFORE it enters the window:
+        // the attach-time focus grab sizes the field editor from the current
+        // frame, and a zero-frame grab mis-sizes the editor's dark box (same
+        // lifecycle as SidebarRowChecklistItemLine's edit field).
+        needsLayout = true
+        layoutSubtreeIfNeeded()
         // Entering the window-attached hierarchy makes the field first
         // responder and selects the whole title (the engine shared with the
         // SwiftUI sidebar); no follow-up selection call may run, because
         // `selectText(_:)` after focus restarts the field-editor session and
         // synchronously commits the untouched title (#9495).
         contentContainer.addSubview(session.field)
+        SidebarRowChecklistFieldBridge.clearFieldEditorBackground(session.field)
 #if DEBUG
         cmuxDebugLog(
             "sidebar.row.beginInlineRename tookFocus=\(session.field.currentEditor() != nil ? 1 : 0) window=\(window == nil ? 0 : 1)"
         )
 #endif
-        needsLayout = true
     }
 
     /// Cancels any active rename without a write (the workspace changed

--- a/Sources/Sidebar/AppKitList/Cells/SidebarWorkspaceRowModel.swift
+++ b/Sources/Sidebar/AppKitList/Cells/SidebarWorkspaceRowModel.swift
@@ -19,6 +19,11 @@ struct SidebarWorkspaceRowModel: Equatable {
     // authoritative and reconciles on the next configure.
     var isActive: Bool
     var isMultiSelected: Bool
+    /// Whether the workspace already has a user-owned custom title; baseline
+    /// input for the inline-rename commit policy (committing an unchanged
+    /// automatic title must not convert it into a user title, which would
+    /// freeze auto-naming).
+    let hasUserCustomTitle: Bool
     let canCloseWorkspace: Bool
     let accessibilityWorkspaceCount: Int
     var unreadCount: Int

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -1995,6 +1995,7 @@ C0DE71B10000000000000001 /* AppDelegate+AgentChatNotifications.swift in Sources 
 		B804A0240000000000000024 /* SidebarWorkspaceRowCellView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B804B0240000000000000024 /* SidebarWorkspaceRowCellView.swift */; };
 		B804A02B000000000000002B /* SidebarWorkspaceRowChecklistSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = B804B02B000000000000002B /* SidebarWorkspaceRowChecklistSection.swift */; };
 		B804A0220000000000000022 /* SidebarWorkspaceRowCommands.swift in Sources */ = {isa = PBXBuildFile; fileRef = B804B0220000000000000022 /* SidebarWorkspaceRowCommands.swift */; };
+		B8624C0294950000000000A1 /* SidebarWorkspaceRowInlineRenameTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8624D0294950000000000A1 /* SidebarWorkspaceRowInlineRenameTests.swift */; };
 		6707F0116707F0116707F011 /* SidebarWorkspaceRowInput.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6707F0126707F0126707F012 /* SidebarWorkspaceRowInput.swift */; };
 		B804A0230000000000000023 /* SidebarWorkspaceRowModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B804B0230000000000000023 /* SidebarWorkspaceRowModel.swift */; };
 		B8624C040000000000000004 /* SidebarWorkspaceRowRetirementTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8624D040000000000000004 /* SidebarWorkspaceRowRetirementTests.swift */; };
@@ -4636,6 +4637,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 		B804B0240000000000000024 /* SidebarWorkspaceRowCellView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sidebar/AppKitList/Cells/SidebarWorkspaceRowCellView.swift; sourceTree = "<group>"; };
 		B804B02B000000000000002B /* SidebarWorkspaceRowChecklistSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sidebar/AppKitList/Cells/SidebarWorkspaceRowChecklistSection.swift; sourceTree = "<group>"; };
 		B804B0220000000000000022 /* SidebarWorkspaceRowCommands.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sidebar/AppKitList/Cells/SidebarWorkspaceRowCommands.swift; sourceTree = "<group>"; };
+		B8624D0294950000000000A1 /* SidebarWorkspaceRowInlineRenameTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarWorkspaceRowInlineRenameTests.swift; sourceTree = "<group>"; };
 		6707F0126707F0126707F012 /* SidebarWorkspaceRowInput.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarWorkspaceRowInput.swift; sourceTree = "<group>"; };
 		B804B0230000000000000023 /* SidebarWorkspaceRowModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sidebar/AppKitList/Cells/SidebarWorkspaceRowModel.swift; sourceTree = "<group>"; };
 		B8624D040000000000000004 /* SidebarWorkspaceRowRetirementTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarWorkspaceRowRetirementTests.swift; sourceTree = "<group>"; };
@@ -7956,6 +7958,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				B8624D060000000000000006 /* SidebarFocusBoundaryLifecycleTests.swift */,
 				B8624D010000000000000001 /* SidebarHiddenPresentationTests.swift */,
 				B8624D020000000000000002 /* SidebarWorkspaceRowSuspensionTests.swift */,
+				B8624D0294950000000000A1 /* SidebarWorkspaceRowInlineRenameTests.swift */,
 				B8624D050000000000000005 /* SidebarWorkspaceDropTargetSuspensionTests.swift */,
 				B8624D040000000000000004 /* SidebarWorkspaceRowRetirementTests.swift */,
 				B8624D030000000000000003 /* SidebarWorkspaceTableSuspensionTests.swift */,
@@ -11011,6 +11014,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				C9A57303C9A57303C9A57303 /* SidebarWorkspaceGroupHeaderMetricsTests.swift in Sources */,
 				6707F0236707F0236707F023 /* SidebarWorkspaceNotificationIndexTests.swift in Sources */,
 				C9A57305C9A57305C9A57305 /* SidebarWorkspaceReorderDropOverlayHitTestingTests.swift in Sources */,
+				B8624C0294950000000000A1 /* SidebarWorkspaceRowInlineRenameTests.swift in Sources */,
 				B8624C040000000000000004 /* SidebarWorkspaceRowRetirementTests.swift in Sources */,
 				2E057C19B76F8034F30969BF /* SidebarWorkspaceRowStatusGlyphRemovalTests.swift in Sources */,
 				B8624C020000000000000002 /* SidebarWorkspaceRowSuspensionTests.swift in Sources */,

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -1943,6 +1943,7 @@ C0DE71B10000000000000001 /* AppDelegate+AgentChatNotifications.swift in Sources 
 		B804A0330000000000000033 /* SidebarRowCompactStatusLine.swift in Sources */ = {isa = PBXBuildFile; fileRef = B804B0330000000000000033 /* SidebarRowCompactStatusLine.swift */; };
 		B804A0380000000000000038 /* SidebarRowContentContainerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B804B0380000000000000038 /* SidebarRowContentContainerView.swift */; };
 		AABBCC00000000000000020A /* SidebarRowDragGate.swift in Sources */ = {isa = PBXBuildFile; fileRef = AABBCC000000000000000209 /* SidebarRowDragGate.swift */; };
+		B804A03794950000000000B1 /* SidebarRowInlineRenameSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = B804B03794950000000000B1 /* SidebarRowInlineRenameSession.swift */; };
 		B804A0370000000000000037 /* SidebarRowPressedDim.swift in Sources */ = {isa = PBXBuildFile; fileRef = B804B0370000000000000037 /* SidebarRowPressedDim.swift */; };
 		B804A0310000000000000031 /* SidebarRowSwiftUIPopoverPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = B804B0310000000000000031 /* SidebarRowSwiftUIPopoverPresenter.swift */; };
 		B804A0320000000000000032 /* SidebarRowTaskStatusGlyphButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = B804B0320000000000000032 /* SidebarRowTaskStatusGlyphButton.swift */; };
@@ -4585,6 +4586,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 		B804B0330000000000000033 /* SidebarRowCompactStatusLine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sidebar/AppKitList/Cells/SidebarRowCompactStatusLine.swift; sourceTree = "<group>"; };
 		B804B0380000000000000038 /* SidebarRowContentContainerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sidebar/AppKitList/Cells/SidebarRowContentContainerView.swift; sourceTree = "<group>"; };
 		AABBCC000000000000000209 /* SidebarRowDragGate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sidebar/SidebarRowDragGate.swift; sourceTree = "<group>"; };
+		B804B03794950000000000B1 /* SidebarRowInlineRenameSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sidebar/AppKitList/Cells/SidebarRowInlineRenameSession.swift; sourceTree = "<group>"; };
 		B804B0370000000000000037 /* SidebarRowPressedDim.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sidebar/AppKitList/Cells/SidebarRowPressedDim.swift; sourceTree = "<group>"; };
 		B804B0310000000000000031 /* SidebarRowSwiftUIPopoverPresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sidebar/AppKitList/Cells/SidebarRowSwiftUIPopoverPresenter.swift; sourceTree = "<group>"; };
 		B804B0320000000000000032 /* SidebarRowTaskStatusGlyphButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sidebar/AppKitList/Cells/SidebarRowTaskStatusGlyphButton.swift; sourceTree = "<group>"; };
@@ -5952,6 +5954,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				B804B0350000000000000035 /* SidebarRowChecklistTransparentButton.swift */,
 				B804B0360000000000000036 /* SidebarRowChecklistFocusField.swift */,
 				B804B0370000000000000037 /* SidebarRowPressedDim.swift */,
+				B804B03794950000000000B1 /* SidebarRowInlineRenameSession.swift */,
 				B804B0380000000000000038 /* SidebarRowContentContainerView.swift */,
 				B804B0390000000000000039 /* SidebarRowChecklistFlippedView.swift */,
 				B804B02F000000000000002F /* SidebarRowChecklistAttachmentButton.swift */,
@@ -9733,6 +9736,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				B804A0330000000000000033 /* SidebarRowCompactStatusLine.swift in Sources */,
 				B804A0380000000000000038 /* SidebarRowContentContainerView.swift in Sources */,
 				AABBCC00000000000000020A /* SidebarRowDragGate.swift in Sources */,
+				B804A03794950000000000B1 /* SidebarRowInlineRenameSession.swift in Sources */,
 				B804A0370000000000000037 /* SidebarRowPressedDim.swift in Sources */,
 				B804A0310000000000000031 /* SidebarRowSwiftUIPopoverPresenter.swift in Sources */,
 				B804A0320000000000000032 /* SidebarRowTaskStatusGlyphButton.swift in Sources */,

--- a/cmuxTests/SidebarAppKitRowCellTests.swift
+++ b/cmuxTests/SidebarAppKitRowCellTests.swift
@@ -76,6 +76,7 @@ struct SidebarAppKitRowCellTests {
             settings: resolvedSettings,
             isActive: isActive,
             isMultiSelected: false,
+            hasUserCustomTitle: false,
             canCloseWorkspace: canClose,
             accessibilityWorkspaceCount: 1,
             unreadCount: 0,

--- a/cmuxTests/SidebarWorkspaceRowInlineRenameTests.swift
+++ b/cmuxTests/SidebarWorkspaceRowInlineRenameTests.swift
@@ -1,0 +1,156 @@
+import AppKit
+import Testing
+@testable import cmux_DEV
+
+/// Regression coverage for https://github.com/manaflow-ai/cmux/issues/9495:
+/// double-clicking a workspace name on the AppKit sidebar list must open a
+/// live inline-rename session (caret in the field, user can type) instead of
+/// synchronously tearing the editor down and committing the untouched title.
+///
+/// Tests drive the real AppKit editing path: a cell hosted in a window, the
+/// shared field editor as first responder, and commands dispatched through
+/// the field editor exactly as key handling would.
+@Suite
+@MainActor
+struct SidebarWorkspaceRowInlineRenameTests {
+    /// One configured cell in an ordered-front window with a rename recorder.
+    @MainActor
+    private final class Harness {
+        let window: NSWindow
+        let cell: SidebarWorkspaceRowTableCellView
+        private(set) var committedTitles: [String] = []
+
+        init() {
+            let model = SidebarWorkspaceRowSuspensionTests.makeModel()
+            cell = SidebarWorkspaceRowTableCellView(
+                frame: NSRect(x: 0, y: 0, width: 320, height: 80)
+            )
+            window = NSWindow(
+                contentRect: NSRect(x: 0, y: 0, width: 320, height: 80),
+                styleMask: [.borderless],
+                backing: .buffered,
+                defer: false
+            )
+            window.contentView = cell
+            window.orderFront(nil)
+            cell.configure(
+                model: model,
+                actions: SidebarWorkspaceRowSuspensionTests.makeActions(
+                    model: model,
+                    onCommitRename: { [weak self] title in
+                        self?.committedTitles.append(title)
+                    }
+                ),
+                isPointerHovering: false,
+                contextMenuDidOpen: {},
+                contextMenuDidClose: {}
+            )
+        }
+
+        /// The shared field editor driving the inline rename, or a test
+        /// failure if the rename session does not own focus.
+        func renameFieldEditor(
+            _ sourceLocation: SourceLocation = #_sourceLocation
+        ) throws -> NSTextView {
+            try #require(
+                window.firstResponder as? NSTextView,
+                "The inline rename field editor must be first responder",
+                sourceLocation: sourceLocation
+            )
+        }
+
+        func tearDown() {
+            window.contentView = nil
+            window.close()
+        }
+    }
+
+    @Test
+    func beginInlineRenameKeepsEditingSessionAliveWithoutCommit() throws {
+        let harness = Harness()
+        defer { harness.tearDown() }
+
+        harness.cell.beginInlineRename()
+
+        #expect(
+            harness.committedTitles.isEmpty,
+            "Opening the rename editor must not write a workspace title"
+        )
+        #expect(
+            harness.cell.isEditing,
+            "The rename session must stay alive until the user resolves it"
+        )
+        let editor = try harness.renameFieldEditor()
+        #expect(editor.string == "Workspace")
+    }
+
+    @Test
+    func enterWithUnchangedTitleClosesWithoutTitleWrite() throws {
+        let harness = Harness()
+        defer { harness.tearDown() }
+        harness.cell.beginInlineRename()
+        let editor = try harness.renameFieldEditor()
+
+        editor.doCommand(by: #selector(NSResponder.insertNewline(_:)))
+
+        #expect(
+            harness.committedTitles.isEmpty,
+            "Committing the unchanged title of an auto-named workspace must not freeze auto-naming with a custom-title write"
+        )
+        #expect(!harness.cell.isEditing)
+    }
+
+    @Test
+    func typedRenameCommitsLiveEditorTextOnce() throws {
+        let harness = Harness()
+        defer { harness.tearDown() }
+        harness.cell.beginInlineRename()
+        let editor = try harness.renameFieldEditor()
+
+        editor.string = "Renamed"
+        editor.doCommand(by: #selector(NSResponder.insertNewline(_:)))
+
+        #expect(
+            harness.committedTitles == ["Renamed"],
+            "Enter commits exactly the live field-editor text, exactly once"
+        )
+        #expect(!harness.cell.isEditing)
+    }
+
+    @Test
+    func escapeCancelsWithoutTitleWrite() throws {
+        let harness = Harness()
+        defer { harness.tearDown() }
+        harness.cell.beginInlineRename()
+        let editor = try harness.renameFieldEditor()
+
+        editor.string = "Abandoned draft"
+        // Escape parity with the SwiftUI sidebar: the first Escape moves the
+        // caret to the start, the second cancels the rename.
+        editor.doCommand(by: #selector(NSResponder.cancelOperation(_:)))
+        editor.doCommand(by: #selector(NSResponder.cancelOperation(_:)))
+
+        #expect(
+            harness.committedTitles.isEmpty,
+            "A cancelled rename must never write a workspace title"
+        )
+        #expect(!harness.cell.isEditing)
+    }
+
+    @Test
+    func focusLossCommitsTypedDraft() throws {
+        let harness = Harness()
+        defer { harness.tearDown() }
+        harness.cell.beginInlineRename()
+        let editor = try harness.renameFieldEditor()
+
+        editor.string = "Focus loss rename"
+        _ = harness.window.makeFirstResponder(nil)
+
+        #expect(
+            harness.committedTitles == ["Focus loss rename"],
+            "Focus loss commits the typed draft, exactly once"
+        )
+        #expect(!harness.cell.isEditing)
+    }
+}

--- a/cmuxTests/SidebarWorkspaceRowSuspensionTests.swift
+++ b/cmuxTests/SidebarWorkspaceRowSuspensionTests.swift
@@ -84,6 +84,7 @@ struct SidebarWorkspaceRowSuspensionTests {
             settings: settings,
             isActive: false,
             isMultiSelected: false,
+            hasUserCustomTitle: false,
             canCloseWorkspace: true,
             accessibilityWorkspaceCount: 1,
             unreadCount: 0,
@@ -204,14 +205,15 @@ struct SidebarWorkspaceRowSuspensionTests {
         )
         cell.beginInlineRename()
         let field = try #require(
-            Self.descendants(of: cell).compactMap { $0 as? SidebarRowInlineRenameField }.first
+            Self.descendants(of: cell).compactMap { $0 as? SidebarInlineRenameTextField }.first
         )
         field.stringValue = "Renamed while closing"
 
         cell.suspendPresentation(commitEdits: true)
 
         #expect(committedTitle == "Renamed while closing")
-        #expect(field.isHidden)
+        #expect(field.superview == nil)
+        #expect(!cell.isEditing)
     }
 
     @Test

--- a/cmuxTests/SidebarWorkspaceTableSuspensionTests.swift
+++ b/cmuxTests/SidebarWorkspaceTableSuspensionTests.swift
@@ -364,8 +364,8 @@ struct SidebarWorkspaceTableSuspensionTests {
             container.tableView.view(atColumn: 0, row: 1, makeIfNecessary: false)
                 as? SidebarWorkspaceRowTableCellView
         )
-        cell.isEditing = true
-        cell.renameField.stringValue = "Atomic reload rename"
+        cell.beginInlineRename()
+        try Self.setInlineRenameText(in: cell, to: "Atomic reload rename")
 
         let resizedFirstRow = makeRowConfiguration(
             workspaceId: firstId,
@@ -391,8 +391,8 @@ struct SidebarWorkspaceTableSuspensionTests {
             container.tableView.view(atColumn: 0, row: 0, makeIfNecessary: false)
                 as? SidebarWorkspaceRowTableCellView
         )
-        reloadedCell.isEditing = true
-        reloadedCell.renameField.stringValue = "Detached rename"
+        reloadedCell.beginInlineRename()
+        try Self.setInlineRenameText(in: reloadedCell, to: "Detached rename")
 
         controller.dismantleContainerView(container)
 
@@ -452,10 +452,11 @@ struct SidebarWorkspaceTableSuspensionTests {
         replacementRoot.addSubview(firstRoot)
 
         cell.beginInlineRename()
-        let field = try #require(
-            Self.descendants(of: cell).compactMap { $0 as? SidebarRowInlineRenameField }.first
+        try Self.setInlineRenameText(in: cell, to: "Reparented rename")
+        let editor = try #require(
+            Self.inlineRenameField(in: cell).currentEditor() as? NSTextView
         )
-        field.onCommit?("Reparented rename")
+        editor.doCommand(by: #selector(NSResponder.insertNewline(_:)))
         #expect(
             committedTitle == "Reparented rename",
             "A transient content-view reparent must not detach live row actions."
@@ -674,6 +675,35 @@ struct SidebarWorkspaceTableSuspensionTests {
 
     private static func descendants(of view: NSView) -> [NSView] {
         view.subviews + view.subviews.flatMap { descendants(of: $0) }
+    }
+
+    /// The active inline-rename field hosted in `cell`.
+    private static func inlineRenameField(
+        in cell: SidebarWorkspaceRowTableCellView,
+        _ sourceLocation: SourceLocation = #_sourceLocation
+    ) throws -> SidebarInlineRenameTextField {
+        try #require(
+            descendants(of: cell)
+                .compactMap { $0 as? SidebarInlineRenameTextField }.first,
+            "An inline-rename session must be hosting its field",
+            sourceLocation: sourceLocation
+        )
+    }
+
+    /// Types `text` into the cell's active rename session through the live
+    /// field editor when one is attached (window-hosted cells), falling back
+    /// to the field value for windowless cells.
+    private static func setInlineRenameText(
+        in cell: SidebarWorkspaceRowTableCellView,
+        to text: String,
+        _ sourceLocation: SourceLocation = #_sourceLocation
+    ) throws {
+        let field = try inlineRenameField(in: cell, sourceLocation)
+        if let editor = field.currentEditor() {
+            editor.string = text
+        } else {
+            field.stringValue = text
+        }
     }
 
     private struct TestRowContent: View, Equatable {


### PR DESCRIPTION
Fixes #9495.

## What was broken

Double-clicking a workspace name on the AppKit sidebar list (`sidebar-appkit-list-experiment`, default-on) created the inline rename field, gave it first responder, and then lost the field editor ~1 ms later, committing the pre-filled unchanged title. The field flashed and the user could never type.

Root cause, confirmed in code: `beginInlineRename()` called `window.makeFirstResponder(renameField)` (which begins the editing session) and then `renameField.selectText(nil)`. The extra `selectText(nil)` re-enters AppKit's field-editor machinery, synchronously tears down the just-begun session, and fires `controlTextDidEndEditing`, which the row's forked `SidebarRowInlineRenameField` honored by committing `stringValue` — the untouched title.

## Why the fix is structural, not a one-line patch

The AppKit list had forked the inline-rename engine instead of reusing the SwiftUI sidebar's canonical one (`SidebarInlineRenameTextField` + `SidebarInlineRenameCoordinator` + `SidebarInlineRenameCommit`). The fork had no once-only commit/cancel guarantee, no two-stage Escape, no IME (marked text) pass-through, committed stale `stringValue` instead of the live field-editor text, and treated *every* end-editing as a commit with no policy — so a spurious commit also wrote `customTitle`, converting an automatic title into a user title and freezing auto-naming (the `workspace.customTitle.write source=user` line in the issue's log).

Per the shared-behavior policy (one action path per behavior across entrypoints), this PR deletes the fork and routes the AppKit list through the same engine as the SwiftUI sidebar:

- **`SidebarRowInlineRenameSession`** (new focused file): one rename session per edit, owning the shared `SidebarInlineRenameTextField` (focus + select-all happens once, when the field enters the window — the `selectText(nil)` restart is gone by construction), the shared `SidebarInlineRenameCoordinator` (Enter/double-Escape/focus-loss resolve at most once; IME composition passes through; commits live editor text), and the shared `SidebarInlineRenameCommit` policy (empty drafts and unchanged auto-titles resolve to no write).
- **`SidebarWorkspaceRowTableCellView`**: `isEditing` is now derived from the session (`renameSession != nil`) instead of a mutable flag; the persistent hidden `renameField` subview is gone; suspension resolves the session *before* teardown so end-editing during teardown can never re-enter commit, while the write itself stays deferred past the table mutation (unchanged staging contract).
- **`SidebarWorkspaceRowModel`**: gains `hasUserCustomTitle` (plumbed from the existing `SidebarWorkspaceRowInput` field) so the commit policy has the same baseline input as the SwiftUI path.

Behavior parity gained with the SwiftUI sidebar: select-all on focus, Enter commits live text once, first Escape moves the caret to the start / second Escape cancels, focus loss commits, IME-safe, and unchanged-title commits no longer freeze auto-naming.

## Two-commit regression proof

- **Commit 1** adds `cmuxTests/SidebarWorkspaceRowInlineRenameTests` only — five behavior tests driving the real AppKit editing path (cell hosted in a window, commands dispatched through the shared field editor). Dispatched `test-e2e.yml` at the commit-1 SHA: **red** (run link in PR comments).
- **Commit 2** is the fix. Same dispatch at HEAD: **green**.

Existing suspension tests that poked the old field's internals (`cell.isEditing = true`, `renameField.stringValue`, `field.onCommit?(...)`) were updated in commit 2 to drive the real session (begin → type through the field editor → resolve), keeping their behavioral assertions (deferred commits through atomic reloads/detach) intact.

## Localization audit

No new user-facing strings. The AppKit rename field now carries the same localized placeholder (`commandPalette.rename.workspacePlaceholder`) and accessibility label (`sidebar.workspace.rename.field.accessibilityLabel`) as the SwiftUI field — both keys already exist in `Resources/Localizable.xcstrings`. Web catalogs unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/9798"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788680461&installation_model_id=21920&pr_number=9798&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F9798&signature=39e97d947cd8ed669cf410e56c00e40e2bee92e41e5b963734af211be4f2934b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized sidebar UI rename behavior with shared commit policy and regression tests; no auth, data, or persistence schema changes beyond existing custom-title writes.
> 
> **Overview**
> Fixes **#9495**: double-click rename on the AppKit sidebar list no longer flashes and immediately commits the untouched title.
> 
> The AppKit row **drops** its forked `SidebarRowInlineRenameField` and routes inline rename through **`SidebarRowInlineRenameSession`**, which wires the same **`SidebarInlineRenameTextField`**, **`SidebarInlineRenameCoordinator`**, and **`SidebarInlineRenameCommit`** path as the SwiftUI sidebar. Focus and select-all happen when the field enters the window hierarchy—**no** post-focus `selectText(_:)` that restarted the field editor and triggered spurious commits.
> 
> **`SidebarWorkspaceRowModel`** now carries **`hasUserCustomTitle`** so unchanged auto-titles resolve to **no** `customTitle` write (avoiding frozen auto-naming). Suspension/detach resolves the session before teardown while still deferring writes past table mutations.
> 
> Adds **`SidebarWorkspaceRowInlineRenameTests`** and updates suspension/table tests to drive the real field-editor path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ffd5b853c9fffbaa27a9ee9cf7a3c2650a15137c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the AppKit sidebar bug where double‑click inline rename instantly committed the unchanged title, and fixes the editor box sizing glitch on focus. The AppKit list now reuses the SwiftUI inline‑rename engine for stable, IME‑safe editing with consistent behavior.

- **Bug Fixes**
  - Removed the re‑entrant selection path; the field focuses and selects once, preventing the instant commit.
  - Commits use live field‑editor text; unchanged auto‑titles are a no‑op, so auto‑naming isn’t frozen.
  - Enter commits once; double Escape cancels; focus loss commits; IME composition passes through.
  - Pre‑sizes the rename field before attach and clears the shared field‑editor background to avoid a mis‑sized dark box on focus.
  - Added regression tests that drive a real AppKit editing path.

- **Refactors**
  - Replaced the forked field with `SidebarRowInlineRenameSession` using the shared `SidebarInlineRenameTextField`, `SidebarInlineRenameCoordinator`, and `SidebarInlineRenameCommit`.
  - `isEditing` now derives from the active session; suspension resolves before teardown and defers writes past table mutations.
  - `SidebarWorkspaceRowModel` adds `hasUserCustomTitle` and is plumbed from input for commit policy parity.

<sup>Written for commit c3472d67a4491960a88bd582fc3db2e573a5a638. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/9798?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved inline workspace renaming in the sidebar.
  * Pressing Enter commits changes, while Escape cancels without saving.
  * Renames now handle unchanged titles, focus loss, workspace changes, and temporary suspension more reliably.
  * User-customized workspace titles are preserved correctly during rename operations.

* **Tests**
  * Added coverage for committing, canceling, focus behavior, and suspension during inline renaming.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->