### PR TITLE
Scope OMP lifecycle hooks to the pane-owning top-level session

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1110,6 +1110,7 @@ jobs:
           CMUX_CLI_BIN="$CLI_BIN" python3 tests/test_pi_extension_dispatch.py
           CMUX_CLI_BIN="$CLI_BIN" python3 tests/test_pi_compacted_feed.py
           CMUX_CLI_BIN="$CLI_BIN" python3 tests/test_omp_extension_install.py
+          CMUX_CLI_BIN="$CLI_BIN" python3 tests/test_omp_subagent_lifecycle.py
           CMUX_CLI_BIN="$CLI_BIN" python3 tests/test_campfire_extension_install.py
 
       - name: Clean up isolated app-host home

--- a/CLI/CMUXCLI+OmpExtension.swift
+++ b/CLI/CMUXCLI+OmpExtension.swift
@@ -4,7 +4,7 @@ extension CMUXCLI {
     private static let ompExtensionMarker = "cmux-omp-session-extension-marker"
     private static let ompExtensionFilename = "cmux-omp-session.ts"
     private static let ompExtensionSource = #"""
-// cmux-omp-session-extension-marker v1
+// cmux-omp-session-extension-marker v2
 // Bridges OMP session lifecycle events into cmux's restorable session store.
 // Installed by `cmux hooks omp install` or `cmux hooks setup`.
 // DO NOT EDIT MANUALLY. cmux upgrades this file in place.
@@ -316,20 +316,65 @@ function sendHook(subcommand: string, ctx: ExtensionContext, extra: Record<strin
   return Promise.resolve();
 }
 
+// The pane's lifecycle in cmux must be owned by exactly one OMP session: the
+// top-level session driving the terminal. Subagents spawned by the task tool
+// run in the same process and inherit CMUX_SURFACE_ID, but each has its own
+// session id; without an ownership check, every subagent's agent_end reports
+// the whole pane idle while the main agent is still mid-turn, and Agent
+// Hibernation then SIGHUPs the live pane (issue #9591).
+let ownerSessionId: string | null = null;
+
+function contextSessionId(ctx: ExtensionContext): string | null {
+  return firstString(ctx.sessionManager.getSessionId());
+}
+
+function isOwnerContext(ctx: ExtensionContext): boolean {
+  const sessionId = contextSessionId(ctx);
+  return sessionId !== null && sessionId === ownerSessionId;
+}
+
 export default function cmuxOmpSessionExtension(api: ExtensionAPI) {
   api.on("session_start", async (_event, ctx) => {
+    // The top-level session bootstraps before any subagent can exist in this
+    // process, so the first session_start pins ownership. Later session_start
+    // events with a different session id are subagent bootstraps.
+    if (ownerSessionId === null) ownerSessionId = contextSessionId(ctx);
+    if (!isOwnerContext(ctx)) return;
     await sendHook("session-start", ctx);
   });
 
+  // In-process session transitions (/new, fork, resume, handoff) fire only on
+  // the top-level runtime; subagent sessions never switch or branch. Re-pin
+  // ownership to the new session id and rebind the surface in cmux.
+  const adoptSwitchedSession = async (_event: unknown, ctx: ExtensionContext) => {
+    const sessionId = contextSessionId(ctx);
+    if (!sessionId) return;
+    ownerSessionId = sessionId;
+    await sendHook("session-start", ctx);
+  };
+  api.on("session_switch", adoptSwitchedSession);
+  api.on("session_branch", adoptSwitchedSession);
+
   api.on("before_agent_start", async (event, ctx) => {
+    if (!isOwnerContext(ctx)) return;
     await sendHook("prompt-submit", ctx, { prompt: boundedHookText(event.prompt) });
   });
 
   api.on("agent_end", async (event, ctx) => {
+    if (!isOwnerContext(ctx)) return;
+    // OMP emits agent_end as the universal terminal settle. willContinue marks
+    // a scheduled automatic continuation (auto-retry, queued messages,
+    // session_stop continuations, background jobs), so the turn is still
+    // logically running and the pane must not report idle yet. Read it
+    // defensively: AgentEndEvent predates the field on older OMP versions.
+    if ((event as { willContinue?: unknown }).willContinue === true) return;
     await sendHook("stop", ctx, { last_assistant_message: boundedHookText(lastAssistantMessage(event)) });
   });
 
-  api.on("session_shutdown", async () => {
+  api.on("session_shutdown", async (_event, ctx) => {
+    // A subagent session's teardown must not drain (and drop queued
+    // prompt-submit entries of) the owner session's hook queue.
+    if (!isOwnerContext(ctx)) return;
     await awaitHookQueueDrain();
   });
 }

--- a/CLI/CMUXCLI+OmpExtension.swift
+++ b/CLI/CMUXCLI+OmpExtension.swift
@@ -322,7 +322,23 @@ function sendHook(subcommand: string, ctx: ExtensionContext, extra: Record<strin
 // session id; without an ownership check, every subagent's agent_end reports
 // the whole pane idle while the main agent is still mid-turn, and Agent
 // Hibernation then SIGHUPs the live pane (issue #9591).
-let ownerSessionId: string | null = null;
+//
+// Ownership must live on globalThis, not in module scope: OMP loads a fresh
+// copy of this module for every session in the process (each extension import
+// uses a unique ?mtime= cache-busting URL), so module state is per-session
+// while the pane is per-process.
+interface CmuxOmpPaneOwnership {
+  sessionId: string | null;
+}
+
+const cmuxOmpGlobals = globalThis as typeof globalThis & {
+  __cmuxOmpPaneOwnership?: CmuxOmpPaneOwnership;
+};
+
+function paneOwnership(): CmuxOmpPaneOwnership {
+  cmuxOmpGlobals.__cmuxOmpPaneOwnership ??= { sessionId: null };
+  return cmuxOmpGlobals.__cmuxOmpPaneOwnership;
+}
 
 function contextSessionId(ctx: ExtensionContext): string | null {
   return firstString(ctx.sessionManager.getSessionId());
@@ -330,7 +346,7 @@ function contextSessionId(ctx: ExtensionContext): string | null {
 
 function isOwnerContext(ctx: ExtensionContext): boolean {
   const sessionId = contextSessionId(ctx);
-  return sessionId !== null && sessionId === ownerSessionId;
+  return sessionId !== null && sessionId === paneOwnership().sessionId;
 }
 
 export default function cmuxOmpSessionExtension(api: ExtensionAPI) {
@@ -338,7 +354,8 @@ export default function cmuxOmpSessionExtension(api: ExtensionAPI) {
     // The top-level session bootstraps before any subagent can exist in this
     // process, so the first session_start pins ownership. Later session_start
     // events with a different session id are subagent bootstraps.
-    if (ownerSessionId === null) ownerSessionId = contextSessionId(ctx);
+    const ownership = paneOwnership();
+    if (ownership.sessionId === null) ownership.sessionId = contextSessionId(ctx);
     if (!isOwnerContext(ctx)) return;
     await sendHook("session-start", ctx);
   });
@@ -349,7 +366,7 @@ export default function cmuxOmpSessionExtension(api: ExtensionAPI) {
   const adoptSwitchedSession = async (_event: unknown, ctx: ExtensionContext) => {
     const sessionId = contextSessionId(ctx);
     if (!sessionId) return;
-    ownerSessionId = sessionId;
+    paneOwnership().sessionId = sessionId;
     await sendHook("session-start", ctx);
   };
   api.on("session_switch", adoptSwitchedSession);

--- a/CLI/CMUXCLI+OmpExtension.swift
+++ b/CLI/CMUXCLI+OmpExtension.swift
@@ -366,7 +366,12 @@ export default function cmuxOmpSessionExtension(api: ExtensionAPI) {
   const adoptSwitchedSession = async (_event: unknown, ctx: ExtensionContext) => {
     const sessionId = contextSessionId(ctx);
     if (!sessionId) return;
-    paneOwnership().sessionId = sessionId;
+    const ownership = paneOwnership();
+    // OMP's reload() re-emits session_switch for the unchanged session file.
+    // A same-id "switch" is not an ownership transition: a spurious
+    // session-start would mark an idle pane running with no agent_end coming.
+    if (ownership.sessionId === sessionId) return;
+    ownership.sessionId = sessionId;
     await sendHook("session-start", ctx);
   };
   api.on("session_switch", adoptSwitchedSession);

--- a/tests/test_omp_extension_install.py
+++ b/tests/test_omp_extension_install.py
@@ -642,6 +642,9 @@ for (const rawPid of hungPidLines.slice(-2)) {
 }
 """
         try:
+            # The choreography starts ~22 hook children sequentially (SIGSTOP,
+            # release, await completion each), so give it generous headroom on
+            # loaded machines and CI runners.
             check = subprocess.run(
                 [bun, "--eval", check_source],
                 cwd=root,
@@ -649,7 +652,7 @@ for (const rawPid of hungPidLines.slice(-2)) {
                 text=True,
                 check=False,
                 env=check_env,
-                timeout=20,
+                timeout=120,
             )
         except subprocess.TimeoutExpired:
             pid_lines = [

--- a/tests/test_omp_extension_install.py
+++ b/tests/test_omp_extension_install.py
@@ -503,7 +503,18 @@ const nestedCtx = {
     getSessionFile() { return process.env.CMUX_TEST_OMP_NESTED_SESSION_FILE; }
   }
 };
+const workerCtx = {
+  cwd: "/tmp/omp-project",
+  sessionManager: {
+    getSessionId() { return "omp-worker-task-session"; },
+    getSessionFile() { return process.env.CMUX_TEST_OMP_PARENT_SESSION_FILE; }
+  }
+};
 let currentSessionId = "omp-session-test";
+async function switchSession(sessionId, reason) {
+  currentSessionId = sessionId;
+  await handlers.get("session_switch")({ reason, previousSessionFile: undefined }, parentCtx);
+}
 async function expectHandlerCompletion(promise, label) {
   let completed = false;
   promise.then(() => { completed = true; });
@@ -572,24 +583,28 @@ const firstPhasePids = nonEmptyLines(process.env.FAKE_CMUX_PID_LOG);
 if (firstPhasePids.length !== 3) {
   throw new Error(`nested OMP task session spawned a hook child: ${firstPhasePids}`);
 }
-currentSessionId = "priority-stop-session";
-await handlers.get("session_start")({}, parentCtx);
+// Top-level session transitions go through session_switch; the queued Stop
+// must survive session-start/prompt pressure that overflows the hook queue.
+await switchSession("priority-stop-session", "new");
+const switchHookPid = await stoppedHookPID(4);
 await handlers.get("agent_end")({ messages: [], stopReason: "completed" }, parentCtx);
-for (let index = 0; index < 40; index += 1) {
-  currentSessionId = `priority-prompt-${index}`;
+for (let index = 0; index < 10; index += 1) {
+  await switchSession(`priority-prompt-${index}`, "new");
   await handlers.get("before_agent_start")({ prompt: `priority prompt ${index}` }, parentCtx);
 }
-await releaseHook(4);
+// A finished task-tool subagent's session teardown must not drain or evict
+// the owner session's queued hooks.
+await handlers.get("session_shutdown")({}, workerCtx);
+process.kill(switchHookPid, "SIGCONT");
 await waitForCompletedHooks(4);
-await releaseHook(5);
-await waitForCompletedHooks(5);
-const priorityPromptPid = await stoppedHookPID(6);
-const priorityDrain = handlers.get("session_shutdown")({}, parentCtx);
-process.kill(priorityPromptPid, "SIGCONT");
-await waitForCompletedHooks(6);
-await priorityDrain;
-currentSessionId = "omp-session-test";
-await handlers.get("session_start")({}, parentCtx);
+// active switch hook + 16-entry queue: the stop, 10 session-starts, and the
+// 5 prompts that survive eviction (2 evicted by session-starts, 3 dropped at
+// the full queue).
+for (let hook = 5; hook <= 20; hook += 1) {
+  await releaseHook(hook);
+  await waitForCompletedHooks(hook);
+}
+await switchSession("omp-session-test", "resume");
 for (let index = 0; index < 40; index += 1) {
   await handlers.get("before_agent_start")({ prompt: `hung omp ${index}` }, parentCtx);
 }
@@ -597,7 +612,7 @@ await handlers.get("agent_end")({ messages: [], stopReason: "completed" }, paren
 await handlers.get("session_shutdown")({}, parentCtx);
 const hungPidLines = nonEmptyLines(process.env.FAKE_CMUX_PID_LOG);
 const startedArgs = nonEmptyLines(process.env.FAKE_CMUX_STARTED_ARGS_LOG);
-if (hungPidLines.length !== 8) {
+if (hungPidLines.length !== 22) {
   throw new Error(`shutdown did not start the queued Stop after cancelling the active hook: ${hungPidLines}`);
 }
 if (
@@ -660,7 +675,7 @@ for (const rawPid of hungPidLines.slice(-2)) {
             print(f"stderr={check.stderr.strip()}")
             return 1
 
-        expected_invocations = 6
+        expected_invocations = 20
         args_log = wait_for_stable_text(fake_args_log, expected_invocations, timeout=20.0)
         stdin_log = wait_for_stable_text(fake_stdin_log, expected_invocations * 2, timeout=20.0)
         env_log = wait_for_stable_text(fake_env_log, expected_invocations * 4, timeout=20.0)
@@ -689,7 +704,19 @@ for (const rawPid of hungPidLines.slice(-2)) {
             print(f"FAIL: stop hook payload was missing: {stdin_log!r}")
             return 1
         if '"session_id":"priority-stop-session","cwd":"/tmp/omp-project","hook_event_name":"Stop"' not in stdin_log:
-            print(f"FAIL: queued stop hook was evicted under prompt pressure: {stdin_log!r}")
+            print(f"FAIL: queued stop hook was evicted under session-start/prompt pressure: {stdin_log!r}")
+            return 1
+        if '"session_id":"omp-worker-task-session"' in stdin_log:
+            print(f"FAIL: a non-owner session id reached cmux hooks: {stdin_log!r}")
+            return 1
+        if '"session_id":"priority-prompt-9","cwd":"/tmp/omp-project","hook_event_name":"SessionStart"' not in stdin_log:
+            print(f"FAIL: session_switch did not rebind the switched session: {stdin_log!r}")
+            return 1
+        if '"prompt":"priority prompt 2"' not in stdin_log:
+            print(f"FAIL: surviving queued prompt was not delivered: {stdin_log!r}")
+            return 1
+        if '"prompt":"priority prompt 0"' in stdin_log or '"prompt":"priority prompt 7"' in stdin_log:
+            print(f"FAIL: evicted/dropped prompt hooks were still delivered: {stdin_log!r}")
             return 1
         if '"prompt":"hello omp 39"' not in stdin_log or '"last_assistant_message":"done"' not in stdin_log:
             print(f"FAIL: extension did not pass prompt/assistant payload, got {stdin_log!r}")

--- a/tests/test_omp_extension_install.py
+++ b/tests/test_omp_extension_install.py
@@ -471,14 +471,23 @@ rmdir "$FAKE_CMUX_LOCK_DIR" 2>/dev/null || true
 import { spawnSync } from "node:child_process";
 import * as fs from "node:fs";
 const extensionPath = process.env.CMUX_TEST_OMP_EXTENSION_PATH;
-const mod = await import(extensionPath);
-if (typeof mod.default !== "function") throw new Error("missing default export");
-const handlers = new Map();
-mod.default({
-  on(name, handler) {
-    handlers.set(name, handler);
-  }
-});
+// OMP loads a fresh copy of the extension module for every session in the
+// process (unique ?mtime= cache-busting import URLs), so module scope is
+// per-session. Give each simulated session its own module instance.
+async function loadExtensionInstance(cacheBust) {
+  const mod = await import(`${extensionPath}?mtime=${cacheBust}`);
+  if (typeof mod.default !== "function") throw new Error("missing default export");
+  const instanceHandlers = new Map();
+  mod.default({
+    on(name, handler) {
+      instanceHandlers.set(name, handler);
+    }
+  });
+  return instanceHandlers;
+}
+const handlers = await loadExtensionInstance("2001");
+const nestedHandlers = await loadExtensionInstance("2002");
+const workerHandlers = await loadExtensionInstance("2003");
 for (const name of ["session_start", "before_agent_start", "agent_end", "session_shutdown"]) {
   if (typeof handlers.get(name) !== "function") throw new Error(`missing ${name}`);
 }
@@ -561,9 +570,9 @@ await handlers.get("agent_end")({
   ],
   stopReason: "completed"
 }, parentCtx);
-await handlers.get("session_start")({}, nestedCtx);
-await handlers.get("before_agent_start")({ prompt: "review the storage race" }, nestedCtx);
-await handlers.get("agent_end")({
+await nestedHandlers.get("session_start")({}, nestedCtx);
+await nestedHandlers.get("before_agent_start")({ prompt: "review the storage race" }, nestedCtx);
+await nestedHandlers.get("agent_end")({
   messages: [
     { role: "user", content: "review the storage race" },
     { role: "assistant", content: [{ type: "text", text: "nested done" }] }
@@ -592,9 +601,9 @@ for (let index = 0; index < 10; index += 1) {
   await switchSession(`priority-prompt-${index}`, "new");
   await handlers.get("before_agent_start")({ prompt: `priority prompt ${index}` }, parentCtx);
 }
-// A finished task-tool subagent's session teardown must not drain or evict
-// the owner session's queued hooks.
-await handlers.get("session_shutdown")({}, workerCtx);
+// A finished task-tool subagent's session teardown (arriving through its own
+// module instance) must not drain or evict the owner session's queued hooks.
+await workerHandlers.get("session_shutdown")({}, workerCtx);
 process.kill(switchHookPid, "SIGCONT");
 await waitForCompletedHooks(4);
 // active switch hook + 16-entry queue: the stop, 10 session-starts, and the

--- a/tests/test_omp_subagent_lifecycle.py
+++ b/tests/test_omp_subagent_lifecycle.py
@@ -203,6 +203,17 @@ await handlers.get("agent_end")(agentEndEvent("continuing", { willContinue: true
 // Main agent's terminal settle: this is the pane's real idle transition.
 await handlers.get("agent_end")(agentEndEvent("main done"), mainCtx);
 
+// /reload re-emits session_switch for the SAME session file and id. That is
+// not an ownership transition: it must emit nothing, or an idle pane's
+// record would flip back to running with no agent_end ever coming.
+const sameSessionSwitch = handlers.get("session_switch");
+if (typeof sameSessionSwitch === "function") {
+  await sameSessionSwitch(
+    { reason: "resume", previousSessionFile: process.env.CMUX_TEST_OMP_MAIN_SESSION_FILE },
+    mainCtx
+  );
+}
+
 // /new switches the top-level runtime to a fresh session id; ownership must
 // follow it and cmux must be rebound via a session-start hook. A missing
 // session_switch handler means post-switch sessions go dark; drive the

--- a/tests/test_omp_subagent_lifecycle.py
+++ b/tests/test_omp_subagent_lifecycle.py
@@ -126,17 +126,32 @@ printf '\\n---\\n' >> "$FAKE_CMUX_STDIN_LOG"
 
         check_source = """
 import * as fs from "node:fs";
+import * as path from "node:path";
 const extensionPath = process.env.CMUX_TEST_OMP_EXTENSION_PATH;
-const mod = await import(extensionPath);
-if (typeof mod.default !== "function") throw new Error("missing default export");
-const handlers = new Map();
-mod.default({
-  on(name, handler) {
-    handlers.set(name, handler);
+// OMP loads a fresh copy of the extension module for every session in the
+// process: each import goes through a unique ?mtime= cache-busting URL, so
+// module scope is per-session, never shared between the top-level session and
+// task subagents. Model that here - any cross-session state the extension
+// relies on must survive separate module instances.
+async function loadExtensionInstance(cacheBust) {
+  const url = `${path.resolve(extensionPath)}?mtime=${cacheBust}`;
+  const mod = await import(url);
+  if (typeof mod.default !== "function") throw new Error("missing default export");
+  const handlers = new Map();
+  mod.default({
+    on(name, handler) {
+      handlers.set(name, handler);
+    }
+  });
+  for (const name of ["session_start", "before_agent_start", "agent_end", "session_shutdown"]) {
+    if (typeof handlers.get(name) !== "function") throw new Error(`missing ${name}`);
   }
-});
-for (const name of ["session_start", "before_agent_start", "agent_end", "session_shutdown"]) {
-  if (typeof handlers.get(name) !== "function") throw new Error(`missing ${name}`);
+  return handlers;
+}
+const handlers = await loadExtensionInstance("1001");
+const subagentHandlers = await loadExtensionInstance("1002");
+if (subagentHandlers.get("agent_end") === handlers.get("agent_end")) {
+  throw new Error("test harness bug: subagent instance shared the main module instance");
 }
 process.argv.splice(
   0,
@@ -176,10 +191,11 @@ await handlers.get("session_start")({}, mainCtx);
 await handlers.get("before_agent_start")({ prompt: "plan the trip" }, mainCtx);
 
 // A background task-tool subagent boots, runs, and finishes while the main
-// agent is still mid-turn. None of this may reach cmux.
-await handlers.get("session_start")({}, subagentCtx);
-await handlers.get("before_agent_start")({ prompt: "scout the beaches" }, subagentCtx);
-await handlers.get("agent_end")(agentEndEvent("subagent done"), subagentCtx);
+// agent is still mid-turn. Its events arrive through its own freshly loaded
+// module instance, as in real OMP. None of this may reach cmux.
+await subagentHandlers.get("session_start")({}, subagentCtx);
+await subagentHandlers.get("before_agent_start")({ prompt: "scout the beaches" }, subagentCtx);
+await subagentHandlers.get("agent_end")(agentEndEvent("subagent done"), subagentCtx);
 
 // Main agent_end with a scheduled automatic continuation: still running.
 await handlers.get("agent_end")(agentEndEvent("continuing", { willContinue: true }), mainCtx);

--- a/tests/test_omp_subagent_lifecycle.py
+++ b/tests/test_omp_subagent_lifecycle.py
@@ -1,0 +1,310 @@
+#!/usr/bin/env python3
+"""
+Regression test for https://github.com/manaflow-ai/cmux/issues/9591.
+
+OMP task-tool subagents run in the same process as the top-level session and
+inherit CMUX_SURFACE_ID, but each has its own session id. The generated cmux
+extension must only report lifecycle hooks (session-start / prompt-submit /
+stop) for the top-level session that owns the pane; a background subagent's
+agent_end must never mark the whole pane idle while the main agent is still
+mid-turn, because Agent Hibernation SIGHUPs panes that read idle.
+
+Also covered:
+- agent_end with willContinue (a scheduled automatic continuation) must not
+  emit a stop hook.
+- session_switch (/new, fork, resume, handoff on the top-level runtime) must
+  re-pin ownership to the new session id and rebind it via a session-start
+  hook, so post-switch sessions do not go dark.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import tempfile
+from pathlib import Path
+
+from claude_teams_test_utils import resolve_cmux_cli
+
+
+def make_executable(path: Path, content: str) -> None:
+    path.write_text(content, encoding="utf-8")
+    path.chmod(0o755)
+
+
+def non_empty_lines(text: str) -> list[str]:
+    return [line for line in text.splitlines() if line.strip()]
+
+
+def main() -> int:
+    bun = shutil.which("bun")
+    if bun is None:
+        print("SKIP: bun not found")
+        return 0
+
+    try:
+        cli_path = resolve_cmux_cli()
+    except Exception as exc:
+        print(f"FAIL: {exc}")
+        return 1
+
+    with tempfile.TemporaryDirectory(prefix="cmux-omp-subagent-") as td:
+        root = Path(td)
+        home = root / "home"
+        home.mkdir()
+        agent_dir = root / "agent-dir"
+
+        env = os.environ.copy()
+        env["HOME"] = str(home)
+        env["PI_CODING_AGENT_DIR"] = str(agent_dir)
+        env.pop("CMUX_OMP_HOOKS_DISABLED", None)
+
+        install = subprocess.run(
+            [cli_path, "hooks", "omp", "install", "--yes"],
+            capture_output=True,
+            text=True,
+            check=False,
+            env=env,
+            timeout=20,
+        )
+        if install.returncode != 0:
+            print("FAIL: omp extension install failed")
+            print(f"exit={install.returncode}")
+            print(f"stdout={install.stdout.strip()}")
+            print(f"stderr={install.stderr.strip()}")
+            return 1
+        extension_path = agent_dir / "extensions" / "cmux-omp-session.ts"
+        if not extension_path.exists():
+            print(f"FAIL: expected extension at {extension_path}")
+            return 1
+        extension_override = os.environ.get("CMUX_TEST_OMP_EXTENSION_OVERRIDE")
+        if extension_override:
+            shutil.copyfile(extension_override, extension_path)
+
+        fake_cmux = root / "fake-cmux"
+        fake_args_log = root / "fake-cmux-args.log"
+        fake_stdin_log = root / "fake-cmux-stdin.log"
+        fake_args_log.touch()
+        fake_stdin_log.touch()
+        make_executable(
+            fake_cmux,
+            """#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\\n' "$*" >> "$FAKE_CMUX_ARGS_LOG"
+cat >> "$FAKE_CMUX_STDIN_LOG"
+printf '\\n---\\n' >> "$FAKE_CMUX_STDIN_LOG"
+""",
+        )
+
+        # Both session files live flat in the same sessions directory: OMP
+        # task-tool subagents are ordinary sessions, not nested artifact
+        # sessions, so the nested-artifact guard does not apply to them.
+        sessions_dir = root / "omp-sessions"
+        sessions_dir.mkdir()
+        main_session_file = sessions_dir / "2026-08-04T16-00-00_omp-main-session.jsonl"
+        main_session_file.write_text("{}\n", encoding="utf-8")
+        subagent_session_file = sessions_dir / "2026-08-04T16-20-36_omp-subagent-1.jsonl"
+        subagent_session_file.write_text("{}\n", encoding="utf-8")
+
+        check_env = env.copy()
+        for key in [
+            "CMUX_AGENT_LAUNCH_KIND",
+            "CMUX_AGENT_LAUNCH_EXECUTABLE",
+            "CMUX_AGENT_LAUNCH_ARGV_B64",
+            "CMUX_AGENT_LAUNCH_CWD",
+        ]:
+            check_env.pop(key, None)
+        check_env["CMUX_TEST_OMP_EXTENSION_PATH"] = str(extension_path)
+        check_env["CMUX_TEST_OMP_MAIN_SESSION_FILE"] = str(main_session_file)
+        check_env["CMUX_TEST_OMP_SUBAGENT_SESSION_FILE"] = str(subagent_session_file)
+        check_env["CMUX_SURFACE_ID"] = "surface-omp-subagent-test"
+        check_env["CMUX_OMP_CMUX_BIN"] = str(fake_cmux)
+        check_env["FAKE_CMUX_ARGS_LOG"] = str(fake_args_log)
+        check_env["FAKE_CMUX_STDIN_LOG"] = str(fake_stdin_log)
+
+        check_source = """
+import * as fs from "node:fs";
+const extensionPath = process.env.CMUX_TEST_OMP_EXTENSION_PATH;
+const mod = await import(extensionPath);
+if (typeof mod.default !== "function") throw new Error("missing default export");
+const handlers = new Map();
+mod.default({
+  on(name, handler) {
+    handlers.set(name, handler);
+  }
+});
+for (const name of ["session_start", "before_agent_start", "agent_end", "session_shutdown"]) {
+  if (typeof handlers.get(name) !== "function") throw new Error(`missing ${name}`);
+}
+process.argv.splice(
+  0,
+  process.argv.length,
+  "/Users/example/.bun/bin/omp",
+  "--model",
+  "anthropic/claude-sonnet-4-5"
+);
+let mainSessionId = "omp-main-session";
+const mainCtx = {
+  cwd: "/tmp/omp-subagent-project",
+  sessionManager: {
+    getSessionId() { return mainSessionId; },
+    getSessionFile() { return process.env.CMUX_TEST_OMP_MAIN_SESSION_FILE; }
+  }
+};
+const subagentCtx = {
+  cwd: "/tmp/omp-subagent-project",
+  sessionManager: {
+    getSessionId() { return "omp-subagent-1"; },
+    getSessionFile() { return process.env.CMUX_TEST_OMP_SUBAGENT_SESSION_FILE; }
+  }
+};
+function agentEndEvent(text, extra = {}) {
+  return {
+    messages: [
+      { role: "user", content: "plan the trip" },
+      { role: "assistant", content: [{ type: "text", text }] }
+    ],
+    stopReason: "completed",
+    ...extra
+  };
+}
+
+// Top-level session boots and starts a turn.
+await handlers.get("session_start")({}, mainCtx);
+await handlers.get("before_agent_start")({ prompt: "plan the trip" }, mainCtx);
+
+// A background task-tool subagent boots, runs, and finishes while the main
+// agent is still mid-turn. None of this may reach cmux.
+await handlers.get("session_start")({}, subagentCtx);
+await handlers.get("before_agent_start")({ prompt: "scout the beaches" }, subagentCtx);
+await handlers.get("agent_end")(agentEndEvent("subagent done"), subagentCtx);
+
+// Main agent_end with a scheduled automatic continuation: still running.
+await handlers.get("agent_end")(agentEndEvent("continuing", { willContinue: true }), mainCtx);
+
+// Main agent's terminal settle: this is the pane's real idle transition.
+await handlers.get("agent_end")(agentEndEvent("main done"), mainCtx);
+
+// /new switches the top-level runtime to a fresh session id; ownership must
+// follow it and cmux must be rebound via a session-start hook. A missing
+// session_switch handler means post-switch sessions go dark; drive the
+// remaining flow anyway so the delivered hook sequence exposes every gap.
+mainSessionId = "omp-new-session";
+const sessionSwitch = handlers.get("session_switch");
+if (typeof sessionSwitch === "function") {
+  await sessionSwitch(
+    { reason: "new", previousSessionFile: process.env.CMUX_TEST_OMP_MAIN_SESSION_FILE },
+    mainCtx
+  );
+}
+await handlers.get("agent_end")(agentEndEvent("new done"), mainCtx);
+
+// Wait for the async hook queue to deliver before shutdown: session_shutdown
+// intentionally strips still-queued prompt-submit entries, so shutting down
+// immediately would race the queue worker and make delivery timing-dependent.
+const expectedDeliveredHooks = 5;
+const deliveryDeadline = Date.now() + 10000;
+while (Date.now() < deliveryDeadline) {
+  const delivered = fs.readFileSync(process.env.FAKE_CMUX_ARGS_LOG, "utf8")
+    .split("\\n")
+    .filter((line) => line.trim().length > 0).length;
+  if (delivered >= expectedDeliveredHooks) break;
+  await new Promise((resolve) => setTimeout(resolve, 20));
+}
+
+await handlers.get("session_shutdown")({}, mainCtx);
+"""
+        check = subprocess.run(
+            [bun, "--eval", check_source],
+            cwd=root,
+            capture_output=True,
+            text=True,
+            check=False,
+            env=check_env,
+            timeout=30,
+        )
+        if check.returncode != 0:
+            print("FAIL: generated OMP extension did not satisfy the subagent lifecycle contract")
+            print(f"exit={check.returncode}")
+            print(f"stdout={check.stdout.strip()}")
+            print(f"stderr={check.stderr.strip()}")
+            return 1
+
+        args_lines = non_empty_lines(fake_args_log.read_text(encoding="utf-8"))
+        expected_args = [
+            "hooks omp session-start",
+            "hooks omp prompt-submit",
+            "hooks omp stop",
+            "hooks omp session-start",
+            "hooks omp stop",
+        ]
+        if args_lines != expected_args:
+            print("FAIL: hook invocation sequence did not match the top-level-session contract")
+            print(f"expected: {expected_args!r}")
+            print(f"got:      {args_lines!r}")
+            return 1
+
+        stdin_log = fake_stdin_log.read_text(encoding="utf-8")
+        payloads = []
+        for chunk in stdin_log.split("\n---\n"):
+            chunk = chunk.strip()
+            if not chunk:
+                continue
+            try:
+                payloads.append(json.loads(chunk))
+            except json.JSONDecodeError as exc:
+                print(f"FAIL: hook payload was not valid JSON: {exc}; chunk={chunk!r}")
+                return 1
+        if len(payloads) != len(expected_args):
+            print(f"FAIL: expected {len(expected_args)} hook payloads, got {payloads!r}")
+            return 1
+
+        if "omp-subagent-1" in stdin_log:
+            print(f"FAIL: a subagent session reached cmux lifecycle hooks: {stdin_log!r}")
+            return 1
+        if "subagent done" in stdin_log or "scout the beaches" in stdin_log:
+            print(f"FAIL: subagent turn content leaked into hook payloads: {stdin_log!r}")
+            return 1
+
+        session_ids = [payload.get("session_id") for payload in payloads]
+        expected_session_ids = [
+            "omp-main-session",
+            "omp-main-session",
+            "omp-main-session",
+            "omp-new-session",
+            "omp-new-session",
+        ]
+        if session_ids != expected_session_ids:
+            print("FAIL: hook payload session ids did not match the owning session")
+            print(f"expected: {expected_session_ids!r}")
+            print(f"got:      {session_ids!r}")
+            return 1
+
+        stops = [payload for payload in payloads if payload.get("hook_event_name") == "Stop"]
+        if len(stops) != 2:
+            print(f"FAIL: expected exactly 2 Stop payloads, got {payloads!r}")
+            return 1
+        if stops[0].get("last_assistant_message") != "main done":
+            print(
+                "FAIL: the pane's idle transition did not carry the main agent's terminal settle "
+                f"(willContinue agent_end must not stop the pane): {stops[0]!r}"
+            )
+            return 1
+        if stops[1].get("last_assistant_message") != "new done":
+            print(f"FAIL: post-switch session's stop payload was wrong: {stops[1]!r}")
+            return 1
+        if payloads[1].get("prompt") != "plan the trip":
+            print(f"FAIL: prompt-submit payload was wrong: {payloads[1]!r}")
+            return 1
+
+    print(
+        "PASS: OMP lifecycle hooks are owned by the top-level session; subagent agent_end "
+        "cannot idle the pane, willContinue defers stop, and session_switch re-pins ownership"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Fixes #9591 (the omp instance of #9523).

## Root cause

The generated OMP extension (`cmux hooks omp install`) forwarded `session_start` / `before_agent_start` / `agent_end` to cmux for **every** session in the process. OMP task-tool subagents run in-process, inherit `CMUX_SURFACE_ID`, and each has its own session id, so every background subagent independently fired `session-start` / `prompt-submit` / `stop` against the same surface. The lifecycle sink is last-write-wins per surface, so the last subagent to finish marked the whole pane idle while the main agent was still mid-turn — and the Agent Hibernation sweep SIGHUPed the live pane ~65s later, killing the main agent and every subagent.

## Fix: one session owns the pane's lifecycle

`CLI/CMUXCLI+OmpExtension.swift` (extension marker bumped to v2):

- **Owner pinning on `globalThis`.** The first `session_start` in the process pins the owning session id — the top-level runtime always bootstraps before any subagent can exist. Every lifecycle hook from a non-owner context (subagent sessions) is dropped: no more spoofed idle transitions, no more subagent sessions rewriting the pane's resume binding, no more subagent teardown draining the owner's queued hooks. The pin lives on `globalThis`, not module scope: OMP loads a **fresh copy of the extension module for every session** (each import uses a unique `?mtime=` cache-busting URL whose token is a monotonically increasing counter, verified in the omp 17.2.10 runtime), so module state is per-session while the pane is per-process. Structured review (Codex) caught the initial module-scope version of this pin; the dual-instance test harness below now models the real loader and fails that version.
- **Ownership follows top-level session transitions.** Verified against omp 17.2.10's runtime: `/new`, fork, resume, and handoff emit `session_switch` (not `session_start`), and only on the top-level runtime — subagent sessions never switch or branch. The v2 extension re-pins ownership on `session_switch` / `session_branch` and emits a `session-start` hook so cmux rebinds the surface to the new session id (previously, post-`/new` sessions were never rebound at all).
- **`willContinue` gates the idle transition.** OMP emits `agent_end` as the universal terminal settle; `agent_end` with `willContinue: true` means an automatic continuation is scheduled (auto-retry, queued messages, `session_stop` continuations, background jobs), so the pane must not report idle yet. This is the omp equivalent of the Pi `agent_end` → `agent_settled` fix (#8729), with no version gating needed: on older omp builds the field is absent and behavior degrades exactly to today's, while the ownership guard works everywhere.

### Why not `session_stop`?

omp has a `session_stop` settle event (since 16.0.5), but it never fires on abort (`if (signal.aborted) return` in the runtime) and fires *before* the final `agent_end` anyway — a pane finalizing only on `session_stop` would stay "running" forever after Esc. `agent_end` + `willContinue` is the authoritative terminal-settle signal and needs no version detection.

## Tests

Both bun harnesses load a **separate cache-busted module instance per simulated session**, mirroring OMP's real loader, so cross-session state must genuinely survive separate module scopes.

- **New `tests/test_omp_subagent_lifecycle.py`** (commit 1, fails against the v1 extension) drives the generated extension through the issue's exact repro shape: main session mid-turn, a background subagent that boots/runs/finishes through its own module instance, an `agent_end` with `willContinue`, the real terminal settle, then a `/new` switch. It asserts the exact delivered hook sequence and that no subagent session id or content ever reaches cmux. Local red output against v1:

  ```
  expected: ['hooks omp session-start', 'hooks omp prompt-submit', 'hooks omp stop', 'hooks omp session-start', 'hooks omp stop']
  got:      ['hooks omp session-start', 'hooks omp session-start', 'hooks omp prompt-submit', 'hooks omp prompt-submit', 'hooks omp stop', 'hooks omp stop', 'hooks omp stop']
  ```

  It also fails against the interim module-scope ownership pin (commit `98ba8953`), proving it covers the review finding, and against an unguarded session_switch handler (commit `d8ee541e` red before `63f0ea42`): a same-id `session_switch` (what OMP's `reload()` re-emits) must emit nothing, or an idle pane's record would flip back to running with no `agent_end` coming.

- **`tests/test_omp_extension_install.py`** updated to the ownership contract: in-process session-id changes flow through `session_switch`, the queue-pressure phase exercises eviction with session-start + prompt pressure from rapid switches (the queued `Stop` still survives, evicted/dropped prompts stay dropped), and a finished subagent's `session_shutdown` (through its own module instance) is verified not to disturb the owner's queued hooks.

### CI red/green proof status

`ci.yml` is workflow_dispatch-only ("CI pause"). I dispatched it at commit `51c37efe` (test-only) for the red proof, but the run failed in `workflow-guard-tests` on a **pre-existing main-tip finding** unrelated to this PR (`web/tests/install-analytics.test.tsx:15: live-network-host`, introduced by #9784), which skips the macOS layer where these tests run — so the dispatched runs never reached the omp step. The red/green evidence above is from local runs against the branch-built CLI (`test: OMP lifecycle hooks…` red → fix green, and `test: model OMP's per-session…` red against `98ba8953` → `fix: keep OMP pane ownership on globalThis…` green). Once the determinism finding on main is fixed, a ci.yml dispatch on this branch should pass end to end.

## Scope notes (umbrella #9523)

Intentionally not in this PR:

- **cmux-side session-scoped lifecycle writes** (`set_agent_lifecycle` is still last-write-wins per surface) — defense-in-depth across every agent integration, tracked by #9523.
- **Unread-output hibernation exclusion** (issue §2) — a hibernation-policy change independent of omp, tracked by #9523.
- The Pi/Amp/Campfire extensions share the multi-session hook structure; Pi subagents don't emit session-level extension events the way omp's do, but the Amp/Campfire siblings deserve the same ownership audit under #9523.

No user-facing strings changed (localization audit: extension TS + tests only). No Swift warnings introduced (change is inside a raw string literal).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
