### PR TITLE
Inject macos-background-from-layer only for compositing backgrounds

### DIFF
--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -1067,12 +1067,18 @@ class GhosttyApp {
                 return
             }
 
-            loadInlineGhosttyConfig(
-                "macos-background-from-layer = true",
-                into: fallbackConfig,
-                prefix: "cmux-renderer-bg",
-                logLabel: "renderer background (fallback)"
-            )
+            // Same layer-vs-Metal background ownership decision as the main
+            // config path; the minimal fallback config has an opaque default
+            // background, so this keeps Ghostty's stock in-Metal fill.
+            let fallbackUsesLayerBackground = hostLayerBackgroundDecision(probing: fallbackConfig)
+            if fallbackUsesLayerBackground {
+                loadInlineGhosttyConfig(
+                    "macos-background-from-layer = true",
+                    into: fallbackConfig,
+                    prefix: "cmux-renderer-bg",
+                    logLabel: "renderer background (fallback)"
+                )
+            }
             loadInlineGhosttyConfig(
                 "macos-titlebar-proxy-icon = hidden",
                 into: fallbackConfig,
@@ -1090,7 +1096,7 @@ class GhosttyApp {
             loadCmuxOwnedGhosttyKeybindOverrides(fallbackConfig)
             loadNoActiveDisplayVsyncFallbackIfNeeded(fallbackConfig)
             let fallbackRenderingModeChanged = setUsesHostLayerBackground(
-                true,
+                fallbackUsesLayerBackground,
                 source: "initialize.fallbackConfig"
             )
             ghostty_config_finalize(fallbackConfig)
@@ -1187,6 +1193,57 @@ class GhosttyApp {
                 )
             }
         }
+    }
+
+    /// Reads the effective background keys from a finalized clone of `config`
+    /// and decides whether the host CALayer must own default-background pixels.
+    /// A clone is probed because `theme` expansion at finalize time may set
+    /// background keys the raw load has not seen yet, and the real config must
+    /// receive the `macos-background-from-layer` injection before finalize.
+    private func hostLayerBackgroundDecision(probing config: ghostty_config_t) -> Bool {
+        guard let probe = ghostty_config_clone(config) else {
+            // Conservative fallback: keep the pre-existing layer-backdrop
+            // behavior rather than risking a transparent-window flash.
+            return true
+        }
+        defer { ghostty_config_free(probe) }
+        ghostty_config_finalize(probe)
+
+        var opacity: Double = 1.0
+        let opacityKey = "background-opacity"
+        _ = ghostty_config_get(probe, &opacity, opacityKey, UInt(opacityKey.lengthOfBytes(using: .utf8)))
+
+        var imagePath = ghostty_config_path_s()
+        let imageKey = "background-image"
+        let hasBackgroundImage = ghostty_config_get(
+            probe,
+            &imagePath,
+            imageKey,
+            UInt(imageKey.lengthOfBytes(using: .utf8))
+        )
+
+        return Self.shouldUseHostLayerBackground(
+            backgroundOpacity: opacity,
+            backgroundBlur: defaultBackgroundBlurValue(from: probe),
+            hasBackgroundImage: hasBackgroundImage
+        )
+    }
+
+    /// Pure decision for `macos-background-from-layer` /
+    /// ``usesHostLayerBackground``: the host CALayer owns the backdrop only
+    /// when the terminal background composites against other layers
+    /// (translucent, blurred, or image-backed). A plain opaque background uses
+    /// Ghostty's stock in-Metal fill, which is bit-identical to stock Ghostty;
+    /// the CoreAnimation-composited host layer drifts by +/-1/255 per channel.
+    static func shouldUseHostLayerBackground(
+        backgroundOpacity: Double,
+        backgroundBlur: GhosttyBackgroundBlur,
+        hasBackgroundImage: Bool
+    ) -> Bool {
+        if backgroundOpacity < 1.0 { return true }
+        if backgroundBlur != .disabled { return true }
+        if hasBackgroundImage { return true }
+        return false
     }
 
     private func loadCmuxDefaultAppearanceConfig(
@@ -1309,19 +1366,28 @@ class GhosttyApp {
         loadRealUserGhosttyConfig(config, preferredColorScheme: preferredColorScheme, themeColorScheme: themeColorScheme)
         #endif
         loadCJKFontFallbackIfNeeded(config)
+        // Let cmux own the window-level backdrop only when the terminal
+        // background actually composites against it: translucent background
+        // (opacity < 1), compositor blur, or a background image. That is the
+        // case `macos-background-from-layer` was added for (#2378): one host
+        // CALayer backdrop instead of separate translucent fills for terminal
+        // and chrome surfaces. A plain opaque background keeps Ghostty's stock
+        // in-Metal background fill so default-background pixels are
+        // bit-identical to stock Ghostty; routing them through CoreAnimation
+        // compositing drifts by +/-1/255 per channel.
+        let usesLayerBackground = hostLayerBackgroundDecision(probing: config)
         let renderingModeChanged = setUsesHostLayerBackground(
-            true,
+            usesLayerBackground,
             source: "loadDefaultConfigFilesWithLegacyFallback"
         )
-        // Let cmux own the window-level backdrop once, while Ghostty keeps
-        // rendering text, cell backgrounds, and background images. This avoids
-        // separate translucent fills for terminal and chrome surfaces.
-        loadInlineGhosttyConfig(
-            "macos-background-from-layer = true",
-            into: config,
-            prefix: "cmux-renderer-bg",
-            logLabel: "renderer background"
-        )
+        if usesLayerBackground {
+            loadInlineGhosttyConfig(
+                "macos-background-from-layer = true",
+                into: config,
+                prefix: "cmux-renderer-bg",
+                logLabel: "renderer background"
+            )
+        }
         // Hide Ghostty's native AppKit proxy icon at the source instead of
         // overriding NSWindow.representedURL on every cmux main window.
         loadInlineGhosttyConfig(

--- a/cmuxTests/GhosttyConfigTests.swift
+++ b/cmuxTests/GhosttyConfigTests.swift
@@ -6313,3 +6313,88 @@ final class BrowserImportScopeTests: XCTestCase {
         XCTAssertNil(scope)
     }
 }
+
+/// `macos-background-from-layer` is injected only when the terminal
+/// background actually composites against the host CALayer. A plain opaque
+/// background must keep Ghostty's stock in-Metal fill so default-background
+/// pixels are bit-identical to stock Ghostty (CoreAnimation compositing of
+/// the host layer drifts by +/-1/255 per channel).
+final class HostLayerBackgroundDecisionTests: XCTestCase {
+    func testOpaqueDefaultBackgroundUsesStockInMetalFill() {
+        XCTAssertFalse(
+            GhosttyApp.shouldUseHostLayerBackground(
+                backgroundOpacity: 1.0,
+                backgroundBlur: .disabled,
+                hasBackgroundImage: false
+            )
+        )
+    }
+
+    func testTranslucentBackgroundUsesHostLayer() {
+        XCTAssertTrue(
+            GhosttyApp.shouldUseHostLayerBackground(
+                backgroundOpacity: 0.95,
+                backgroundBlur: .disabled,
+                hasBackgroundImage: false
+            )
+        )
+    }
+
+    func testFullyTransparentBackgroundUsesHostLayer() {
+        XCTAssertTrue(
+            GhosttyApp.shouldUseHostLayerBackground(
+                backgroundOpacity: 0.0,
+                backgroundBlur: .disabled,
+                hasBackgroundImage: false
+            )
+        )
+    }
+
+    func testBlurRadiusUsesHostLayer() {
+        XCTAssertTrue(
+            GhosttyApp.shouldUseHostLayerBackground(
+                backgroundOpacity: 1.0,
+                backgroundBlur: .radius(20),
+                hasBackgroundImage: false
+            )
+        )
+    }
+
+    func testMacOSGlassBlurUsesHostLayer() {
+        XCTAssertTrue(
+            GhosttyApp.shouldUseHostLayerBackground(
+                backgroundOpacity: 1.0,
+                backgroundBlur: .macosGlassRegular,
+                hasBackgroundImage: false
+            )
+        )
+        XCTAssertTrue(
+            GhosttyApp.shouldUseHostLayerBackground(
+                backgroundOpacity: 1.0,
+                backgroundBlur: .macosGlassClear,
+                hasBackgroundImage: false
+            )
+        )
+    }
+
+    func testBackgroundImageUsesHostLayer() {
+        XCTAssertTrue(
+            GhosttyApp.shouldUseHostLayerBackground(
+                backgroundOpacity: 1.0,
+                backgroundBlur: .disabled,
+                hasBackgroundImage: true
+            )
+        )
+    }
+
+    func testOverrangeOpacityStaysOnStockFill() {
+        // Ghostty clamps background-opacity into 0...1; values >= 1 are opaque.
+        XCTAssertFalse(
+            GhosttyApp.shouldUseHostLayerBackground(
+                backgroundOpacity: 1.5,
+                backgroundBlur: .disabled,
+                hasBackgroundImage: false
+            )
+        )
+    }
+}


### PR DESCRIPTION
Part of the ghostty rendering-parity work (hq docs/ghostty-web-parity.md, D10): make cmux desktop render pixel-identically to stock desktop Ghostty for opaque (default) configs.

## Problem

cmux unconditionally injected `macos-background-from-layer = true` (inline config, prefix `cmux-renderer-bg`). That flag makes Ghostty skip its in-Metal background fill and zero the default-background alpha, so every default-background pixel is composited by CoreAnimation against a host CALayer. CA compositing drifts by +/-1/255 per channel (occasionally +/-2) versus Ghostty's stock deterministic in-Metal fill, so cmux could never bit-match stock Ghostty on default-background cells.

## Mechanism

The flag was added in #2378 to eliminate a transparent-window flash during sidebar toggles and to unify separate translucent fills for terminal and chrome. Both motivations only exist when the background actually composites against other layers. The injection is now conditional:

- inject `macos-background-from-layer = true` (and set `usesHostLayerBackground`) only when the finalized config has `background-opacity < 1`, `background-blur` enabled (radius or macOS glass), or a `background-image`;
- plain opaque backgrounds omit the flag, so Ghostty uses its stock in-Metal fill and `TerminalSurfaceBackgroundFillPlan` resolves to the existing `.ghosttyNativeRenderer` owner (host layer goes clear);
- the decision probes a finalized `ghostty_config_clone` because `theme` expansion at finalize time may set background keys, while the real config must receive the injection before finalize;
- both the app config path and the surface reload path go through `loadDefaultConfigFilesWithLegacyFallback`, so live opacity/blur/image/theme changes re-evaluate the decision on cmux's existing config-reload path; the minimal fallback config (invalid user config) takes the same decision.

The sidebar-toggle flash cannot regress for opaque configs: during Metal layer resize lag the window backdrop behind it is the same opaque theme color.

## Verification

- Unit tests for the pure decision (`HostLayerBackgroundDecisionTests` in `cmuxTests/GhosttyConfigTests.swift`): opaque default stays on the stock in-Metal fill; opacity < 1, blur radius, both glass modes, and background image each flip to the host layer.
- Pixel-diff verification vs a stock Ghostty.app build (same pinned ghostty tree, Menlo 12, DPR 2, 80x24, opaque): results table to follow in a comment.
- Translucency check (background-opacity < 1 still composites through the host layer): to follow.

Note on test commits: the decision function is new, so a red-first test commit could not compile; tests and fix land together.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/9802"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788682021&installation_model_id=21920&pr_number=9802&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F9802&signature=c8ca01f4bb4cc35afad9b0a60429a6310a7e1238a20cefad3d8f2ce51815a1ff"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes terminal background rendering ownership and Ghostty config injection on every init/reload; behavior is well-tested for the decision matrix but opaque vs translucent edge cases affect visible pixels and window chrome compositing.
> 
> **Overview**
> **cmux no longer always forces `macos-background-from-layer = true`**, so opaque default configs can match stock Ghostty’s in-Metal background fill instead of CoreAnimation compositing (which drifts ±1/255 per channel).
> 
> The host CALayer path and inline `macos-background-from-layer` injection now run only when a finalized config probe shows **translucent** background (`background-opacity < 1`), **blur** (radius or macOS glass), or a **background-image**. Theme expansion is evaluated via a cloned finalized config before the real config is finalized. The same logic applies on the main config load path and the minimal fallback init path; `usesHostLayerBackground` follows that decision.
> 
> **`GhosttyApp.shouldUseHostLayerBackground`** is the pure rule, with **`HostLayerBackgroundDecisionTests`** covering opaque default, translucency, blur modes, background image, and over-range opacity.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0422832a79ff467bfa0bd95a50b5e3f991b6d061. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Conditionally inject `macos-background-from-layer` so only compositing backgrounds use the host CALayer; opaque backgrounds keep Ghostty’s in‑Metal fill for pixel-identical output to stock desktop Ghostty. This removes CoreAnimation drift on default-background cells while preserving translucency and blur behavior.

- **Bug Fixes**
  - Inject `macos-background-from-layer` only when background-opacity < 1, background-blur is enabled, or a background-image is set; otherwise omit and set `usesHostLayerBackground` to false.
  - Probe a finalized config clone to honor theme-expanded background keys before injection.
  - Apply the same decision to the fallback config and re-evaluate on config reloads for live changes.
  - Added `HostLayerBackgroundDecisionTests` covering opaque, translucent, blur, glass, image, and overrange opacity cases.

<sup>Written for commit 0422832a79ff467bfa0bd95a50b5e3f991b6d061. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/9802?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved terminal background rendering for translucent, blurred, glass-effect, and image-based backgrounds.
  * Preserved in-terminal rendering for opaque plain backgrounds.
  * Added safer fallback behavior when background configuration cannot be finalized.

* **Tests**
  * Added coverage for background rendering decisions across opacity, blur, glass effects, and image backgrounds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->