### PR TITLE
Notify on codex PermissionRequest: new nativeApprovalPrompt feed semantic raises the agentPermissionPrompt alert

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1090,6 +1090,7 @@ jobs:
           CMUX_CLI_BIN="$CLI_BIN" python3 tests/test_pi_extension_install.py
           CMUX_CLI_BIN="$CLI_BIN" python3 tests/test_pi_extension_dispatch.py
           CMUX_CLI_BIN="$CLI_BIN" python3 tests/test_pi_compacted_feed.py
+          CMUX_CLI_BIN="$CLI_BIN" python3 tests/test_codex_permission_prompt_notification.py
           CMUX_CLI_BIN="$CLI_BIN" python3 tests/test_omp_extension_install.py
           CMUX_CLI_BIN="$CLI_BIN" python3 tests/test_campfire_extension_install.py
 

--- a/CLI/FeedEventClassifier.swift
+++ b/CLI/FeedEventClassifier.swift
@@ -35,9 +35,18 @@ struct FeedEventClassification: Equatable {
     /// Execution proceeded for an agent whose approval prompts notify via
     /// ``notifiesNativeApprovalPrompt`` — the approval resolved (user or
     /// auto-reviewer), so the bridge clears the pane's stale notifications.
-    /// Mirrors Claude's `pre-tool-use` hook, which runs `clear_notifications`
-    /// whenever the agent continues. Also the self-heal path for a prompt the
-    /// agent's auto-reviewer approved without user input.
+    /// Also the self-heal path for a prompt the agent's auto-reviewer
+    /// approved without user input.
+    ///
+    /// The clear is deliberately pane-wide and uncorrelated with any single
+    /// request: notifications carry no request identity anywhere in cmux,
+    /// and every agent integration clears the same way on progress signals —
+    /// Claude's `session-start`/`prompt-submit`/`pre-tool-use` hooks, the
+    /// generic `.approvalResponse` action (Hermes' resolved native
+    /// approvals), and codex's own `prompt-submit` hook (which also clears
+    /// deny-without-further-tools residue at the next turn). Pane
+    /// notifications are attention signals; agent progress in the pane makes
+    /// them stale as a set.
     let clearsNativeApprovalPrompt: Bool
 }
 

--- a/CLI/FeedEventClassifier.swift
+++ b/CLI/FeedEventClassifier.swift
@@ -17,11 +17,30 @@ import Foundation
 /// request — and unknown / future event names default to non-actionable
 /// telemetry that never notifies. Conflating a tool-start with an approval
 /// is the bug behind https://github.com/manaflow-ai/cmux/issues/4985.
+/// Resolved user-attention outcome for one raw agent hook event on the
+/// Feed bridge path.
+struct FeedEventClassification: Equatable {
+    /// The wire `hook_event_name` forwarded to the app via `feed.push`.
+    let hookEventName: String
+    /// Whether the Feed bridge blocks waiting for a user decision (and the
+    /// app may post an actionable approval card + banner).
+    let isActionable: Bool
+    /// The agent is blocked waiting for the user in its OWN approval UI
+    /// (e.g. Codex's approval reviewer). The feed event stays non-actionable
+    /// telemetry — cmux must not double-prompt — but the hook bridge must
+    /// raise the "Agent Needs Permission"-gated notification, or the blocked
+    /// agent is silent indefinitely.
+    /// https://github.com/manaflow-ai/cmux/issues/9592
+    let notifiesNativeApprovalPrompt: Bool
+}
+
 struct FeedEventClassifier {
     /// Classifies a raw agent hook event into our wire `hook_event_name`
     /// plus an `isActionable` flag that drives whether the Feed bridge
     /// blocks waiting for a user decision (and whether `FeedCoordinator`
-    /// posts a "needs approval" notification).
+    /// posts a "needs approval" notification), plus whether the bridge
+    /// itself must raise the permission-prompt notification for an agent
+    /// that blocks in its own native approval UI.
     ///
     /// - Parameters:
     ///   - source: The agent id that emitted the event (`claude`, `codex`,
@@ -29,13 +48,11 @@ struct FeedEventClassifier {
     ///   - event: The agent's raw hook event name.
     ///   - toolName: The tool the event refers to, used only for the two
     ///     tool-dependent semantics.
-    /// - Returns: The wire `hook_event_name` and whether the event is
-    ///   Feed-actionable (blocks + may notify).
     static func classify(
         source: String,
         event: String,
         toolName: String
-    ) -> (String, Bool) {
+    ) -> FeedEventClassification {
         let semantic = feedEventSemantic(source: source, event: event)
         return wireMapping(for: semantic, source: source, toolName: toolName)
     }
@@ -96,11 +113,11 @@ struct FeedEventClassifier {
 
     /// Tool names that carry their own dedicated approval wire event rather
     /// than the generic `PermissionRequest`. Returns the actionable wire
-    /// mapping for such a tool, or `nil` for ordinary tools.
-    private static func dedicatedApprovalEvent(for toolName: String) -> (String, Bool)? {
+    /// event name for such a tool, or `nil` for ordinary tools.
+    private static func dedicatedApprovalEvent(for toolName: String) -> String? {
         switch toolName {
-        case "ExitPlanMode": return ("ExitPlanMode", true)
-        case "AskUserQuestion": return ("AskUserQuestion", true)
+        case "ExitPlanMode": return "ExitPlanMode"
+        case "AskUserQuestion": return "AskUserQuestion"
         default: return nil
         }
     }
@@ -112,48 +129,64 @@ struct FeedEventClassifier {
         for semantic: FeedEventSemantic,
         source: String,
         toolName: String
-    ) -> (String, Bool) {
+    ) -> FeedEventClassification {
         switch semantic {
         case .approvalRequest:
-            return dedicatedApprovalEvent(for: toolName) ?? ("PermissionRequest", true)
+            return actionable(dedicatedApprovalEvent(for: toolName) ?? "PermissionRequest")
         case .toolStartMaybeApproval:
             if let dedicated = dedicatedApprovalEvent(for: toolName) {
-                return dedicated
+                return actionable(dedicated)
             }
             // Any tool that can mutate the environment surfaces as a
             // permission request so the user can approve/deny from the
             // Feed sidebar. Read-only tools stay non-actionable
             // telemetry so we don't flood the Actionable view.
             if Self.isSideEffectingTool(toolName, source: source) {
-                return ("PermissionRequest", true)
+                return actionable("PermissionRequest")
             }
-            return ("PreToolUse", false)
+            return telemetry("PreToolUse")
         case .toolStart:
-            return ("PreToolUse", false)
+            return telemetry("PreToolUse")
         case .toolEnd:
-            return ("PostToolUse", false)
+            return telemetry("PostToolUse")
         case .preCompact:
-            return ("PreCompact", false)
+            return telemetry("PreCompact")
         case .postCompact:
-            return ("PostCompact", false)
+            return telemetry("PostCompact")
         case .promptSubmit:
-            return ("UserPromptSubmit", false)
+            return telemetry("UserPromptSubmit")
         case .subagentStart:
-            return ("SubagentStart", false)
+            return telemetry("SubagentStart")
         case .response:
-            return ("Stop", false)
+            return telemetry("Stop")
         case .subagentResponse:
-            return ("SubagentStop", false)
+            return telemetry("SubagentStop")
         case .sessionStart:
-            return ("SessionStart", false)
+            return telemetry("SessionStart")
         case .sessionEnd:
-            return ("SessionEnd", false)
+            return telemetry("SessionEnd")
         case .statusNotification:
-            return ("Notification", false)
+            return telemetry("Notification")
         case .unknown:
             // Safe default: telemetry, no approval, no notification.
-            return ("PreToolUse", false)
+            return telemetry("PreToolUse")
         }
+    }
+
+    private static func actionable(_ hookEventName: String) -> FeedEventClassification {
+        FeedEventClassification(
+            hookEventName: hookEventName,
+            isActionable: true,
+            notifiesNativeApprovalPrompt: false
+        )
+    }
+
+    private static func telemetry(_ hookEventName: String) -> FeedEventClassification {
+        FeedEventClassification(
+            hookEventName: hookEventName,
+            isActionable: false,
+            notifiesNativeApprovalPrompt: false
+        )
     }
 
     /// Per-agent event-semantic tables. Each entry is the source of truth

--- a/CLI/FeedEventClassifier.swift
+++ b/CLI/FeedEventClassifier.swift
@@ -32,6 +32,13 @@ struct FeedEventClassification: Equatable {
     /// agent is silent indefinitely.
     /// https://github.com/manaflow-ai/cmux/issues/9592
     let notifiesNativeApprovalPrompt: Bool
+    /// Execution proceeded for an agent whose approval prompts notify via
+    /// ``notifiesNativeApprovalPrompt`` — the approval resolved (user or
+    /// auto-reviewer), so the bridge clears the pane's stale notifications.
+    /// Mirrors Claude's `pre-tool-use` hook, which runs `clear_notifications`
+    /// whenever the agent continues. Also the self-heal path for a prompt the
+    /// agent's auto-reviewer approved without user input.
+    let clearsNativeApprovalPrompt: Bool
 }
 
 struct FeedEventClassifier {
@@ -54,7 +61,29 @@ struct FeedEventClassifier {
         toolName: String
     ) -> FeedEventClassification {
         let semantic = feedEventSemantic(source: source, event: event)
-        return wireMapping(for: semantic, source: source, toolName: toolName)
+        let wire = wireMapping(for: semantic, source: source, toolName: toolName)
+        // Tool lifecycle progress proves any pending native approval prompt
+        // resolved; scoped to sources that actually raise those prompts so
+        // other agents' tool telemetry never touches the notification queue.
+        let clearsPrompt: Bool
+        switch semantic {
+        case .toolStart, .toolEnd:
+            clearsPrompt = sourceRaisesNativeApprovalPrompts(source)
+        default:
+            clearsPrompt = false
+        }
+        return FeedEventClassification(
+            hookEventName: wire.hookEventName,
+            isActionable: wire.isActionable,
+            notifiesNativeApprovalPrompt: wire.notifiesNativeApprovalPrompt,
+            clearsNativeApprovalPrompt: clearsPrompt
+        )
+    }
+
+    /// Whether any of `source`'s registered events carry the
+    /// ``FeedEventSemantic/nativeApprovalPrompt`` semantic.
+    private static func sourceRaisesNativeApprovalPrompts(_ source: String) -> Bool {
+        feedEventSemanticRegistry[source]?.values.contains(.nativeApprovalPrompt) == true
     }
 
     /// User-attention semantic of a hook/feed event, independent of the
@@ -161,7 +190,8 @@ struct FeedEventClassifier {
             return FeedEventClassification(
                 hookEventName: "PreToolUse",
                 isActionable: false,
-                notifiesNativeApprovalPrompt: true
+                notifiesNativeApprovalPrompt: true,
+                clearsNativeApprovalPrompt: false
             )
         case .toolEnd:
             return telemetry("PostToolUse")
@@ -193,7 +223,8 @@ struct FeedEventClassifier {
         FeedEventClassification(
             hookEventName: hookEventName,
             isActionable: true,
-            notifiesNativeApprovalPrompt: false
+            notifiesNativeApprovalPrompt: false,
+            clearsNativeApprovalPrompt: false
         )
     }
 
@@ -201,7 +232,8 @@ struct FeedEventClassifier {
         FeedEventClassification(
             hookEventName: hookEventName,
             isActionable: false,
-            notifiesNativeApprovalPrompt: false
+            notifiesNativeApprovalPrompt: false,
+            clearsNativeApprovalPrompt: false
         )
     }
 

--- a/CLI/FeedEventClassifier.swift
+++ b/CLI/FeedEventClassifier.swift
@@ -433,6 +433,75 @@ struct FeedEventClassifier {
         "generate_image",
     ]
 
+    /// Builds the pane-attention V1 socket command a classified feed event
+    /// carries — the `needs-permission`-gated `notify_target_async` for a
+    /// native approval prompt, or the pane-scoped `clear_notifications` for
+    /// a resolved one. Pure so the exact wire command (UUID gating, payload
+    /// shape, gate meta) is unit-testable; the CLI feed hook sends the
+    /// returned line request/response and awaits the app's acknowledgement.
+    ///
+    /// Returns `nil` when the classification carries no attention side
+    /// effect or when either identity is missing/not a UUID: the command is
+    /// advisory and must never fail the hook.
+    ///
+    /// The notification body deliberately names only the TOOL — mirroring
+    /// the in-app Feed approval banner (`feed.notification.permission.body`)
+    /// — and never the tool input: commands can embed credentials, and
+    /// notification banners reach lock screens, paired phones, and the
+    /// recorded notification history.
+    static func nativeApprovalPromptAttentionCommand(
+        classification: FeedEventClassification,
+        displayName: String,
+        toolName: String,
+        workspaceId: String?,
+        surfaceId: String?
+    ) -> String? {
+        guard classification.notifiesNativeApprovalPrompt
+                || classification.clearsNativeApprovalPrompt else { return nil }
+        guard let workspaceRaw = workspaceId?.trimmingCharacters(in: .whitespacesAndNewlines),
+              let workspaceUUID = UUID(uuidString: workspaceRaw),
+              let surfaceRaw = surfaceId?.trimmingCharacters(in: .whitespacesAndNewlines),
+              let surfaceUUID = UUID(uuidString: surfaceRaw)
+        else { return nil }
+        if classification.clearsNativeApprovalPrompt {
+            return "clear_notifications --tab=\(workspaceUUID.uuidString) --panel=\(surfaceUUID.uuidString)"
+        }
+        let subtitle = String(
+            localized: "agent.generic.notification.subtitle.permission",
+            defaultValue: "Permission"
+        )
+        let sanitizedToolName = attentionNotificationField(toolName)
+        let body: String
+        if sanitizedToolName.isEmpty {
+            body = String(
+                localized: "agent.generic.notification.body.approvalNeeded",
+                defaultValue: "Approval needed"
+            )
+        } else {
+            body = String(
+                localized: "feed.notification.permission.body",
+                defaultValue: "\(sanitizedToolName) needs approval"
+            )
+        }
+        guard let meta = AgentHookNotifyCategory.needsPermission.metaSegment(pending: false) else {
+            return nil
+        }
+        let payload = [attentionNotificationField(displayName), attentionNotificationField(subtitle), attentionNotificationField(body)]
+            .joined(separator: "|") + "|" + meta
+        return "notify_target_async \(workspaceUUID.uuidString) \(surfaceUUID.uuidString) \(payload)"
+    }
+
+    /// Notification payload fields are pipe-delimited single lines; agent
+    /// tool names are payload-controlled input, so normalize them the same
+    /// way `notificationPayload` sanitizes its fields.
+    private static func attentionNotificationField(_ value: String) -> String {
+        value
+            .components(separatedBy: .newlines)
+            .joined(separator: " ")
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .replacingOccurrences(of: "|", with: "¦")
+    }
+
     /// Whether a tool mutates state and deserves an approval prompt. Exact
     /// match against ``sideEffectingTools`` for every source; the `kiro`
     /// source additionally matches its case-insensitive internal aliases.

--- a/CLI/FeedEventClassifier.swift
+++ b/CLI/FeedEventClassifier.swift
@@ -32,11 +32,14 @@ struct FeedEventClassification: Equatable {
     /// agent is silent indefinitely.
     /// https://github.com/manaflow-ai/cmux/issues/9592
     let notifiesNativeApprovalPrompt: Bool
-    /// Execution proceeded for an agent whose approval prompts notify via
-    /// ``notifiesNativeApprovalPrompt`` — the approval resolved (user or
-    /// auto-reviewer), so the bridge clears the pane's stale notifications.
-    /// Also the self-heal path for a prompt the agent's auto-reviewer
-    /// approved without user input.
+    /// A tool COMPLETED for an agent whose approval prompts notify via
+    /// ``notifiesNativeApprovalPrompt`` — execution strictly follows any
+    /// approval, so the prompt resolved (approved by the user or by the
+    /// agent's own auto-reviewer) and the bridge clears the pane's stale
+    /// notifications. Only tool COMPLETION qualifies: pre-tool events fire
+    /// when the agent intends to run a tool, with no ordering guarantee
+    /// against the approval-prompt hook, so clearing there could erase a
+    /// just-raised prompt while the agent is still blocked.
     ///
     /// The clear is deliberately pane-wide and uncorrelated with any single
     /// request: notifications carry no request identity anywhere in cmux,
@@ -70,23 +73,7 @@ struct FeedEventClassifier {
         toolName: String
     ) -> FeedEventClassification {
         let semantic = feedEventSemantic(source: source, event: event)
-        let wire = wireMapping(for: semantic, source: source, toolName: toolName)
-        // Tool lifecycle progress proves any pending native approval prompt
-        // resolved; scoped to sources that actually raise those prompts so
-        // other agents' tool telemetry never touches the notification queue.
-        let clearsPrompt: Bool
-        switch semantic {
-        case .toolStart, .toolEnd:
-            clearsPrompt = sourceRaisesNativeApprovalPrompts(source)
-        default:
-            clearsPrompt = false
-        }
-        return FeedEventClassification(
-            hookEventName: wire.hookEventName,
-            isActionable: wire.isActionable,
-            notifiesNativeApprovalPrompt: wire.notifiesNativeApprovalPrompt,
-            clearsNativeApprovalPrompt: clearsPrompt
-        )
+        return wireMapping(for: semantic, source: source, toolName: toolName)
     }
 
     /// Whether any of `source`'s registered events carry the
@@ -192,6 +179,11 @@ struct FeedEventClassifier {
             }
             return telemetry("PreToolUse")
         case .toolStart:
+            // Never clears the native approval prompt: agents fire their
+            // pre-tool hooks when they INTEND to run a tool, with no ordering
+            // guarantee against the approval-prompt hook, so a start-time
+            // clear could erase a just-raised prompt while the agent is still
+            // blocked — reintroducing the silence behind #9592.
             return telemetry("PreToolUse")
         case .nativeApprovalPrompt:
             // Same telemetry wire mapping as .toolStart (no blocking, no
@@ -203,7 +195,18 @@ struct FeedEventClassifier {
                 clearsNativeApprovalPrompt: false
             )
         case .toolEnd:
-            return telemetry("PostToolUse")
+            // A completed tool ran, and execution strictly follows any
+            // approval — so this is the earliest progress signal that can
+            // safely clear a resolved native approval prompt (approved by
+            // the user or by the agent's own auto-reviewer). Scoped to
+            // sources that raise those prompts so other agents' tool
+            // telemetry never touches the notification queue.
+            return FeedEventClassification(
+                hookEventName: "PostToolUse",
+                isActionable: false,
+                notifiesNativeApprovalPrompt: false,
+                clearsNativeApprovalPrompt: sourceRaisesNativeApprovalPrompts(source)
+            )
         case .preCompact:
             return telemetry("PreCompact")
         case .postCompact:

--- a/CLI/FeedEventClassifier.swift
+++ b/CLI/FeedEventClassifier.swift
@@ -71,6 +71,14 @@ struct FeedEventClassifier {
         /// only. Used by agents that expose a *separate* approval event
         /// (Claude, Codex, Hermes) so their pre-tool hook never escalates.
         case toolStart
+        /// The agent is blocked waiting for the user in its OWN approval
+        /// UI (e.g. Codex's approval reviewer). The feed event stays
+        /// non-actionable telemetry — an actionable cmux Feed card would
+        /// compete with the agent's native prompt and bypass features like
+        /// Codex's "Approve for me" — but the bridge raises the
+        /// "Agent Needs Permission"-gated notification so the blocked
+        /// agent is not silent (#9592).
+        case nativeApprovalPrompt
         /// A tool is about to run and the agent has *no* dedicated approval
         /// event, so a side-effecting tool is escalated to an approval and
         /// read-only tools stay telemetry. Resolved against the tool name.
@@ -147,6 +155,14 @@ struct FeedEventClassifier {
             return telemetry("PreToolUse")
         case .toolStart:
             return telemetry("PreToolUse")
+        case .nativeApprovalPrompt:
+            // Same telemetry wire mapping as .toolStart (no blocking, no
+            // actionable card), plus the permission-prompt notification.
+            return FeedEventClassification(
+                hookEventName: "PreToolUse",
+                isActionable: false,
+                notifiesNativeApprovalPrompt: true
+            )
         case .toolEnd:
             return telemetry("PostToolUse")
         case .preCompact:
@@ -214,10 +230,12 @@ struct FeedEventClassifier {
         ],
         "codex": [
             // Codex runs PermissionRequest hooks before its own approval
-            // reviewer. Treat this as telemetry so "Approve for me" can still
-            // use Codex's auto-review path instead of blocking on cmux Feed.
-            "PermissionRequest": .toolStart,
-            "permission_request": .toolStart,
+            // reviewer. Keep the feed side telemetry so "Approve for me" can
+            // still use Codex's auto-review path instead of blocking on cmux
+            // Feed, but raise the permission-prompt notification: this is the
+            // only hook Codex fires while blocked on the user (#9592).
+            "PermissionRequest": .nativeApprovalPrompt,
+            "permission_request": .nativeApprovalPrompt,
             "PreToolUse": .toolStart,
             "pre_tool_use": .toolStart,
             "beforeShellExecution": .toolStart,

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -32674,14 +32674,6 @@ export default CMUXSessionRestore;
     /// "All" view even when no permission/plan/question event fires.
     /// Failures are swallowed.
     func sendBestEffortFeedTelemetry(socketPath: String, line: String, socketPassword: String?) {
-        sendBestEffortFeedTelemetry(socketPath: socketPath, lines: [line], socketPassword: socketPassword)
-    }
-
-    /// One connect + auth for the whole batch: feed hooks that emit a
-    /// second line (the native-approval-prompt notify/clear) must not pay a
-    /// second connection and Keychain/password lookup per tool event.
-    func sendBestEffortFeedTelemetry(socketPath: String, lines: [String], socketPassword: String?) {
-        guard !lines.isEmpty else { return }
         let oneWayClient = SocketClient(path: socketPath)
         defer { oneWayClient.close() }
         do {
@@ -32692,12 +32684,56 @@ export default CMUXSessionRestore;
                 socketPath: socketPath,
                 responseTimeout: 0.05
             )
-            for line in lines {
-                try oneWayClient.sendOneWay(command: line, writeTimeout: 0.05)
-            }
+            try oneWayClient.sendOneWay(command: line, writeTimeout: 0.05)
         } catch {
             return
         }
+    }
+
+    /// How long the feed hook waits for the app to acknowledge a
+    /// native-approval-prompt notify/clear before giving up and returning.
+    static let feedAttentionAcknowledgeTimeoutSeconds: TimeInterval = 2
+
+    /// Sends the pane-attention command (permission notify / resolved
+    /// clear) request/response, AWAITING the app's `OK`, then fires the
+    /// nonessential feed frame one-way on the same connection.
+    ///
+    /// Awaiting the attention line is what makes cross-process hook
+    /// ordering real: one-way writes return before the app's detached
+    /// per-connection worker has enqueued the mutation, so a completed
+    /// hook process is no proof its clear was applied — a delayed clear
+    /// could then erase a NEWER request's live notification (#9592's
+    /// silence, reintroduced). Codex runs these feed hooks synchronously,
+    /// so blocking this process until the app acknowledges the mutation
+    /// (same request/response contract Claude's and Hermes' hooks use for
+    /// `clear_notifications`/`notify_target_async`) guarantees the next
+    /// hook's process starts only after this mutation is in the app's
+    /// ordered lane. Failures never propagate: the hook always returns
+    /// `{}` after the bounded wait.
+    private func sendBestEffortFeedAttentionThenTelemetry(
+        socketPath: String,
+        attentionLine: String,
+        telemetryLine: String,
+        socketPassword: String?
+    ) {
+        let attentionClient = SocketClient(path: socketPath)
+        defer { attentionClient.close() }
+        do {
+            try attentionClient.connectWithoutRetry(responseTimeout: 0.05)
+            try authenticateClientIfNeeded(
+                attentionClient,
+                explicitPassword: socketPassword,
+                socketPath: socketPath,
+                responseTimeout: 0.05
+            )
+        } catch {
+            return
+        }
+        _ = try? attentionClient.send(
+            command: attentionLine,
+            responseTimeout: Self.feedAttentionAcknowledgeTimeoutSeconds
+        )
+        _ = try? attentionClient.sendOneWay(command: telemetryLine, writeTimeout: 0.05)
     }
 
     private func sendFeedTelemetry(
@@ -34973,21 +35009,35 @@ export default CMUXSessionRestore;
             } else {
                 promptLine = nil
             }
-            // The attention signal goes FIRST: the feed frame can be large
-            // and its best-effort write can fail under backpressure, and a
-            // failed write must never swallow the permission notification —
-            // that would recreate the silent-blocked-agent bug (#9592).
+            // The attention signal goes FIRST and is AWAITED (bounded): the
+            // app must acknowledge the notify/clear before this synchronous
+            // hook returns and codex fires its next event, or a delayed
+            // clear could erase a newer request's live notification. The
+            // feed frame stays one-way: it is nonessential telemetry, and a
+            // failed write must never swallow the permission notification.
             if let client {
                 if let promptLine {
-                    _ = try? client.sendOneWay(command: promptLine, writeTimeout: 0.05)
+                    _ = try? client.send(
+                        command: promptLine,
+                        responseTimeout: Self.feedAttentionAcknowledgeTimeoutSeconds
+                    )
                 }
                 _ = try? client.sendOneWay(command: line, writeTimeout: 0.05)
             } else if let socketPath {
-                sendBestEffortFeedTelemetry(
-                    socketPath: socketPath,
-                    lines: (promptLine.map { [$0] } ?? []) + [line],
-                    socketPassword: socketPassword
-                )
+                if let promptLine {
+                    sendBestEffortFeedAttentionThenTelemetry(
+                        socketPath: socketPath,
+                        attentionLine: promptLine,
+                        telemetryLine: line,
+                        socketPassword: socketPassword
+                    )
+                } else {
+                    sendBestEffortFeedTelemetry(
+                        socketPath: socketPath,
+                        line: line,
+                        socketPassword: socketPassword
+                    )
+                }
             }
             print("{}")
             return

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -32771,7 +32771,27 @@ export default CMUXSessionRestore;
         guard let data = try? JSONSerialization.data(withJSONObject: frame),
               let line = String(data: data, encoding: .utf8)
         else { return }
-        sendBestEffortFeedTelemetry(socketPath: client.socketPath, line: line, socketPassword: socketPassword)
+        // Shared side-effect path with `runFeedHook`: the wrapper-injected
+        // hooks route tool telemetry here (`hooks codex post-tool-use`), so
+        // the native-approval-prompt clear must ride this lane too — or
+        // wrapper-launched seats would post the permission notification via
+        // `hooks codex notification` and never clear it on tool completion.
+        // The clear precedes the (larger, nonessential) feed frame so a
+        // failed telemetry write cannot swallow it.
+        var lines: [String] = []
+        if FeedEventClassifier.classify(
+            source: source,
+            event: hookEventName,
+            toolName: toolName ?? ""
+        ).clearsNativeApprovalPrompt,
+           let clearLine = nativeApprovalPromptClearCommand(
+                eventDict: event,
+                env: ProcessInfo.processInfo.environment
+           ) {
+            lines.append(clearLine)
+        }
+        lines.append(line)
+        sendBestEffortFeedTelemetry(socketPath: client.socketPath, lines: lines, socketPassword: socketPassword)
     }
 
     private func feedContextForEvent(
@@ -34655,17 +34675,18 @@ export default CMUXSessionRestore;
     // MARK: - Feed (workstream) hook bridge
 
     /// Resolves the caller pane's (workspace, surface) UUID pair for the
-    /// best-effort native-approval-prompt notification commands. Returns
+    /// best-effort native-approval-prompt notification commands: the feed
+    /// event's own identities first, then the pane environment. Returns
     /// `nil` when either identity is missing or not a UUID: the commands
     /// are advisory and must never fail or delay the hook.
     private func nativeApprovalPromptTarget(
         eventDict: [String: Any],
         env: [String: String]
     ) -> (workspaceId: UUID, surfaceId: UUID)? {
-        guard let workspaceRaw = (eventDict["workspace_id"] as? String)?
+        guard let workspaceRaw = ((eventDict["workspace_id"] as? String) ?? env["CMUX_WORKSPACE_ID"])?
                 .trimmingCharacters(in: .whitespacesAndNewlines),
               let workspaceId = UUID(uuidString: workspaceRaw),
-              let surfaceRaw = env["CMUX_SURFACE_ID"]?
+              let surfaceRaw = ((eventDict["surface_id"] as? String) ?? env["CMUX_SURFACE_ID"])?
                 .trimmingCharacters(in: .whitespacesAndNewlines),
               let surfaceId = UUID(uuidString: surfaceRaw)
         else { return nil }
@@ -34963,15 +34984,19 @@ export default CMUXSessionRestore;
             } else {
                 promptLine = nil
             }
+            // The attention signal goes FIRST: the feed frame can be large
+            // and its best-effort write can fail under backpressure, and a
+            // failed write must never swallow the permission notification —
+            // that would recreate the silent-blocked-agent bug (#9592).
             if let client {
-                _ = try? client.sendOneWay(command: line, writeTimeout: 0.05)
                 if let promptLine {
                     _ = try? client.sendOneWay(command: promptLine, writeTimeout: 0.05)
                 }
+                _ = try? client.sendOneWay(command: line, writeTimeout: 0.05)
             } else if let socketPath {
                 sendBestEffortFeedTelemetry(
                     socketPath: socketPath,
-                    lines: [line] + (promptLine.map { [$0] } ?? []),
+                    lines: (promptLine.map { [$0] } ?? []) + [line],
                     socketPassword: socketPassword
                 )
             }

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -32771,27 +32771,16 @@ export default CMUXSessionRestore;
         guard let data = try? JSONSerialization.data(withJSONObject: frame),
               let line = String(data: data, encoding: .utf8)
         else { return }
-        // Shared side-effect path with `runFeedHook`: the wrapper-injected
-        // hooks route tool telemetry here (`hooks codex post-tool-use`), so
-        // the native-approval-prompt clear must ride this lane too — or
-        // wrapper-launched seats would post the permission notification via
-        // `hooks codex notification` and never clear it on tool completion.
-        // The clear precedes the (larger, nonessential) feed frame so a
-        // failed telemetry write cannot swallow it.
-        var lines: [String] = []
-        if FeedEventClassifier.classify(
-            source: source,
-            event: hookEventName,
-            toolName: toolName ?? ""
-        ).clearsNativeApprovalPrompt,
-           let clearLine = nativeApprovalPromptClearCommand(
-                eventDict: event,
-                env: ProcessInfo.processInfo.environment
-           ) {
-            lines.append(clearLine)
-        }
-        lines.append(line)
-        sendBestEffortFeedTelemetry(socketPath: client.socketPath, lines: lines, socketPassword: socketPassword)
+        // Deliberately NO native-approval-prompt clear on this lane: the
+        // wrapper-injected codex hooks that reach it (`hooks codex
+        // post-tool-use`) run as fire-and-forget nohup workers with no
+        // ordering guarantee, so a delayed completion worker's clear could
+        // erase a NEWER request's live permission notification — silencing a
+        // blocked agent (#9592). Only the synchronous feed-hook path
+        // (`runFeedHook`), whose events arrive in codex's own order, emits
+        // the clear; wrapper-path staleness self-heals at the next
+        // `prompt-submit`, which already clears the pane.
+        sendBestEffortFeedTelemetry(socketPath: client.socketPath, line: line, socketPassword: socketPassword)
     }
 
     private func feedContextForEvent(

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -32690,63 +32690,10 @@ export default CMUXSessionRestore;
         }
     }
 
-    /// How long the feed hook waits for the app to acknowledge a
-    /// native-approval-prompt notify/clear before giving up and returning.
+    /// The absolute deadline for the whole native-approval-prompt attention
+    /// delivery (connect, authentication, live-target resolution, and the
+    /// acknowledged send) before the feed hook gives up and returns.
     static let feedAttentionAcknowledgeTimeoutSeconds: TimeInterval = 2
-
-    /// Sends the pane-attention command (permission notify / resolved
-    /// clear) request/response on its own bounded connection, AWAITING the
-    /// app's `OK`.
-    ///
-    /// Awaiting the attention line is what makes cross-process hook
-    /// ordering real: one-way writes return before the app's detached
-    /// per-connection worker has enqueued the mutation, so a completed
-    /// hook process is no proof its clear was applied — a delayed clear
-    /// could then erase a NEWER request's live notification (#9592's
-    /// silence, reintroduced). Codex runs these feed hooks synchronously,
-    /// so blocking this process until the app acknowledges the mutation
-    /// (same request/response contract Claude's and Hermes' hooks use for
-    /// `clear_notifications`/`notify_target_async`) guarantees the next
-    /// hook's process starts only after this mutation is in the app's
-    /// ordered lane. Failures never propagate: the hook always returns
-    /// `{}` after the bounded wait, and the feed frame travels on a
-    /// separate bounded connection so no implicit (unbounded) relay
-    /// reconnect can outlive the agent's hook budget.
-    private func sendAcknowledgedFeedAttention(
-        socketPath: String,
-        attentionLine: String,
-        socketPassword: String?
-    ) {
-        // One absolute deadline across connect, authentication, and the
-        // acknowledged send. This line is the essential payload — unlike the
-        // fast-fail telemetry lane's 50 ms bounds, the budget must survive a
-        // relay-backed connection's multi-round-trip HMAC handshake, or
-        // remote terminals silently lose the permission notification and the
-        // agent blocks unannounced (#9592 again).
-        let deadline = Date().addingTimeInterval(Self.feedAttentionAcknowledgeTimeoutSeconds)
-        func remainingBudget() -> TimeInterval {
-            max(deadline.timeIntervalSinceNow, 0.05)
-        }
-        let attentionClient = SocketClient(path: socketPath)
-        defer { attentionClient.close() }
-        do {
-            try attentionClient.connectWithoutRetry(responseTimeout: remainingBudget())
-            try authenticateClientIfNeeded(
-                attentionClient,
-                explicitPassword: socketPassword,
-                socketPath: socketPath,
-                responseTimeout: remainingBudget(),
-                deadline: deadline
-            )
-        } catch {
-            return
-        }
-        _ = try? attentionClient.send(
-            command: attentionLine,
-            responseTimeout: remainingBudget(),
-            deadline: deadline
-        )
-    }
 
     private func sendFeedTelemetry(
         client: SocketClient,
@@ -34711,30 +34658,136 @@ export default CMUXSessionRestore;
 
     // MARK: - Feed (workstream) hook bridge
 
-    /// Builds the pane-attention command (permission notify / resolved
-    /// clear) for a classified feed event via the shared, unit-tested
-    /// builder — see
-    /// ``FeedEventClassifier/nativeApprovalPromptAttentionCommand``.
-    /// Identities come from the feed event first, then the pane
-    /// environment; a missing/non-UUID identity yields `nil` (advisory,
-    /// never fails the hook). The notification carries the same
-    /// `needs-permission` meta the generic agent `notification` hook uses,
-    /// so it gates under "Agent Needs Permission" exactly like Claude's
-    /// permission_prompt.
-    private func nativeApprovalPromptAttentionCommand(
+    /// Delivers the pane-attention command (permission notify / resolved
+    /// clear) for a classified feed event: resolves the LIVE pane identity,
+    /// builds the command via the shared, unit-tested builder
+    /// (``FeedEventClassifier/nativeApprovalPromptAttentionCommand``), and
+    /// sends it request/response, AWAITING the app's `OK`.
+    ///
+    /// Live-identity resolution uses the same alias-safe
+    /// `agent.resolve_delivery_target` `{surface_id}` re-home probe Claude's
+    /// hooks use: on a restored remote pane the ambient env IDs are snapshot
+    /// aliases, and the relay remaps IDs only inside JSON requests — a plain
+    /// V1 command built from ambient IDs would target a stale pane. The
+    /// probe's request IS remapped, so the app answers with live identities;
+    /// when it is unsupported or fails, the ambient identities are the
+    /// fallback (correct for local panes).
+    ///
+    /// Awaiting the attention line is what makes cross-process hook ordering
+    /// real: one-way writes return before the app's detached per-connection
+    /// worker has enqueued the mutation, so a completed hook process is no
+    /// proof its clear was applied — a delayed clear could then erase a
+    /// NEWER request's live notification (#9592's silence, reintroduced).
+    /// Codex runs these feed hooks synchronously, so blocking this process
+    /// until the app acknowledges the mutation (same request/response
+    /// contract Claude's and Hermes' hooks use) guarantees the next hook's
+    /// process starts only after this mutation is in the app's ordered lane.
+    ///
+    /// Everything runs under ONE absolute deadline spanning connect,
+    /// authentication, resolution, and the acknowledged send: this line is
+    /// the essential payload, and the budget must survive a relay-backed
+    /// connection's multi-round-trip handshake — unlike the telemetry
+    /// lane's deliberate 50 ms fast-fail bounds. Failures never propagate:
+    /// the hook always returns `{}` after the bounded wait.
+    private func deliverNativeApprovalPromptAttention(
         classification: FeedEventClassification,
         source: String,
         toolName: String,
         eventDict: [String: Any],
-        env: [String: String]
-    ) -> String? {
-        FeedEventClassifier.nativeApprovalPromptAttentionCommand(
+        env: [String: String],
+        client: SocketClient?,
+        socketPath: String?,
+        socketPassword: String?
+    ) {
+        let ambientWorkspaceId = (eventDict["workspace_id"] as? String) ?? env["CMUX_WORKSPACE_ID"]
+        let ambientSurfaceId = (eventDict["surface_id"] as? String) ?? env["CMUX_SURFACE_ID"]
+        let deadline = Date().addingTimeInterval(Self.feedAttentionAcknowledgeTimeoutSeconds)
+        func remainingBudget() -> TimeInterval {
+            max(deadline.timeIntervalSinceNow, 0.05)
+        }
+
+        var ownedClient: SocketClient?
+        defer { ownedClient?.close() }
+        let activeClient: SocketClient
+        if let client {
+            activeClient = client
+        } else if let socketPath {
+            let attentionClient = SocketClient(path: socketPath)
+            do {
+                try attentionClient.connectWithoutRetry(responseTimeout: remainingBudget())
+                try authenticateClientIfNeeded(
+                    attentionClient,
+                    explicitPassword: socketPassword,
+                    socketPath: socketPath,
+                    responseTimeout: remainingBudget(),
+                    deadline: deadline
+                )
+            } catch {
+                attentionClient.close()
+                return
+            }
+            ownedClient = attentionClient
+            activeClient = attentionClient
+        } else {
+            return
+        }
+
+        let liveTarget = resolvedAttentionDeliveryTarget(
+            workspaceId: ambientWorkspaceId,
+            surfaceId: ambientSurfaceId,
+            client: activeClient,
+            deadline: deadline
+        )
+        guard let attentionLine = FeedEventClassifier.nativeApprovalPromptAttentionCommand(
             classification: classification,
             displayName: Self.agentDef(named: source)?.displayName ?? source,
             toolName: toolName,
-            workspaceId: (eventDict["workspace_id"] as? String) ?? env["CMUX_WORKSPACE_ID"],
-            surfaceId: (eventDict["surface_id"] as? String) ?? env["CMUX_SURFACE_ID"]
+            workspaceId: liveTarget?.workspaceId ?? ambientWorkspaceId,
+            surfaceId: liveTarget?.surfaceId ?? ambientSurfaceId
+        ) else { return }
+        _ = try? activeClient.send(
+            command: attentionLine,
+            responseTimeout: remainingBudget(),
+            deadline: deadline
         )
+    }
+
+    /// The `{surface_id}` live-pane probe backing
+    /// ``deliverNativeApprovalPromptAttention``. Only a `source == "surface"`
+    /// answer with a live workspace UUID counts; anything else falls back to
+    /// the ambient identities.
+    private func resolvedAttentionDeliveryTarget(
+        workspaceId: String?,
+        surfaceId: String?,
+        client: SocketClient,
+        deadline: Date
+    ) -> (workspaceId: String, surfaceId: String)? {
+        guard let surfaceRaw = surfaceId?.trimmingCharacters(in: .whitespacesAndNewlines),
+              UUID(uuidString: surfaceRaw) != nil else {
+            return nil
+        }
+        var params: [String: Any] = ["surface_id": surfaceRaw]
+        if let workspaceRaw = workspaceId?.trimmingCharacters(in: .whitespacesAndNewlines),
+           UUID(uuidString: workspaceRaw) != nil {
+            params["workspace_id"] = workspaceRaw
+        }
+        guard let payload = try? client.sendV2(
+                method: "agent.resolve_delivery_target",
+                params: params,
+                responseTimeout: max(deadline.timeIntervalSinceNow, 0.05)
+              ),
+              (payload["source"] as? String) == "surface",
+              let liveWorkspaceId = (payload["workspace_id"] as? String)?
+                .trimmingCharacters(in: .whitespacesAndNewlines),
+              UUID(uuidString: liveWorkspaceId) != nil else {
+            return nil
+        }
+        let liveSurfaceId = (payload["surface_id"] as? String)?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        if let liveSurfaceId, UUID(uuidString: liveSurfaceId) != nil {
+            return (liveWorkspaceId, liveSurfaceId)
+        }
+        return (liveWorkspaceId, surfaceRaw)
     }
 
     /// Reads an agent hook JSON payload from stdin, forwards it to the
@@ -34951,22 +35004,12 @@ export default CMUXSessionRestore;
             // Codex-style agents block in their own approval UI while this
             // (telemetry) event is their only signal, so the permission-prompt
             // notification — and the clear once execution proceeds — ride
-            // alongside the feed frame.
-            let promptLine = nativeApprovalPromptAttentionCommand(
-                classification: classification,
-                source: source,
-                toolName: toolName,
-                eventDict: eventDict,
-                env: env
-            )
-            // The attention signal goes FIRST and is AWAITED (bounded): the
-            // app must acknowledge the notify/clear before this synchronous
-            // hook returns and codex fires its next event, or a delayed
-            // clear could erase a newer request's live notification. The
-            // feed frame stays one-way best-effort telemetry on its own
-            // bounded connection — a relay-backed `send` closes its socket
-            // after the acknowledged command, and an implicit reconnect
-            // inside `sendOneWay` is not bounded by the write timeout.
+            // alongside the feed frame. The attention signal goes FIRST and
+            // is AWAITED (bounded); the feed frame stays one-way best-effort
+            // telemetry on its own bounded connection — a relay-backed `send`
+            // closes its socket after the acknowledged command, and an
+            // implicit reconnect inside `sendOneWay` is not bounded by the
+            // write timeout.
             //
             // Known accepted residual: codex's fire-and-forget prompt-submit
             // worker clears the pane at turn start from a DETACHED process.
@@ -34976,19 +35019,19 @@ export default CMUXSessionRestore;
             // (`hooks codex notification`) has always had. Fencing clears by
             // origin time is a cross-layer protocol change deliberately out
             // of scope here.
-            if let promptLine {
-                if let client {
-                    _ = try? client.send(
-                        command: promptLine,
-                        responseTimeout: Self.feedAttentionAcknowledgeTimeoutSeconds
-                    )
-                } else if let socketPath {
-                    sendAcknowledgedFeedAttention(
-                        socketPath: socketPath,
-                        attentionLine: promptLine,
-                        socketPassword: socketPassword
-                    )
-                }
+            let sendsAttention = classification.notifiesNativeApprovalPrompt
+                || classification.clearsNativeApprovalPrompt
+            if sendsAttention {
+                deliverNativeApprovalPromptAttention(
+                    classification: classification,
+                    source: source,
+                    toolName: toolName,
+                    eventDict: eventDict,
+                    env: env,
+                    client: client,
+                    socketPath: socketPath,
+                    socketPassword: socketPassword
+                )
                 let telemetrySocketPath = socketPath ?? client?.socketPath
                 if let telemetrySocketPath {
                     sendBestEffortFeedTelemetry(

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -34722,11 +34722,13 @@ export default CMUXSessionRestore;
         // Decide whether this event is Feed-actionable. Non-actionable
         // events are forwarded as telemetry (non-blocking) and exit `{}`
         // so the agent proceeds without a decision.
-        let (hookEventName, isActionable) = FeedEventClassifier.classify(
+        let classification = FeedEventClassifier.classify(
             source: source,
             event: rawEvent,
             toolName: toolName
         )
+        let hookEventName = classification.hookEventName
+        let isActionable = classification.isActionable
         let env = ProcessInfo.processInfo.environment
         if Self.shouldSuppressKiroFeedEvent(
             source: source,

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -32695,8 +32695,8 @@ export default CMUXSessionRestore;
     static let feedAttentionAcknowledgeTimeoutSeconds: TimeInterval = 2
 
     /// Sends the pane-attention command (permission notify / resolved
-    /// clear) request/response, AWAITING the app's `OK`, then fires the
-    /// nonessential feed frame one-way on the same connection.
+    /// clear) request/response on its own bounded connection, AWAITING the
+    /// app's `OK`.
     ///
     /// Awaiting the attention line is what makes cross-process hook
     /// ordering real: one-way writes return before the app's detached
@@ -32709,11 +32709,12 @@ export default CMUXSessionRestore;
     /// `clear_notifications`/`notify_target_async`) guarantees the next
     /// hook's process starts only after this mutation is in the app's
     /// ordered lane. Failures never propagate: the hook always returns
-    /// `{}` after the bounded wait.
-    private func sendBestEffortFeedAttentionThenTelemetry(
+    /// `{}` after the bounded wait, and the feed frame travels on a
+    /// separate bounded connection so no implicit (unbounded) relay
+    /// reconnect can outlive the agent's hook budget.
+    private func sendAcknowledgedFeedAttention(
         socketPath: String,
         attentionLine: String,
-        telemetryLine: String,
         socketPassword: String?
     ) {
         let attentionClient = SocketClient(path: socketPath)
@@ -32733,7 +32734,6 @@ export default CMUXSessionRestore;
             command: attentionLine,
             responseTimeout: Self.feedAttentionAcknowledgeTimeoutSeconds
         )
-        _ = try? attentionClient.sendOneWay(command: telemetryLine, writeTimeout: 0.05)
     }
 
     private func sendFeedTelemetry(
@@ -34699,86 +34699,30 @@ export default CMUXSessionRestore;
 
     // MARK: - Feed (workstream) hook bridge
 
-    /// Resolves the caller pane's (workspace, surface) UUID pair for the
-    /// best-effort native-approval-prompt notification commands: the feed
-    /// event's own identities first, then the pane environment. Returns
-    /// `nil` when either identity is missing or not a UUID: the commands
-    /// are advisory and must never fail or delay the hook.
-    private func nativeApprovalPromptTarget(
-        eventDict: [String: Any],
-        env: [String: String]
-    ) -> (workspaceId: UUID, surfaceId: UUID)? {
-        guard let workspaceRaw = ((eventDict["workspace_id"] as? String) ?? env["CMUX_WORKSPACE_ID"])?
-                .trimmingCharacters(in: .whitespacesAndNewlines),
-              let workspaceId = UUID(uuidString: workspaceRaw),
-              let surfaceRaw = ((eventDict["surface_id"] as? String) ?? env["CMUX_SURFACE_ID"])?
-                .trimmingCharacters(in: .whitespacesAndNewlines),
-              let surfaceId = UUID(uuidString: surfaceRaw)
-        else { return nil }
-        return (workspaceId, surfaceId)
-    }
-
-    /// Builds the fire-and-forget `notify_target_async` line for a feed
-    /// event classified as a native approval prompt (the agent is blocked
-    /// in its OWN approval UI, e.g. Codex's reviewer — see
-    /// ``FeedEventClassification/notifiesNativeApprovalPrompt``). Carries
-    /// the same `needs-permission` payload meta the generic agent
-    /// `notification` hook uses, so the alert gates under the app's
-    /// "Agent Needs Permission" setting exactly like Claude's
-    /// permission_prompt. The body deliberately names only the TOOL —
-    /// mirroring the in-app Feed approval banner
-    /// (`feed.notification.permission.body`) — and never the tool input:
-    /// commands can embed credentials, and notification banners reach lock
-    /// screens, paired phones, and the recorded notification history.
-    private func nativeApprovalPromptNotifyCommand(
+    /// Builds the pane-attention command (permission notify / resolved
+    /// clear) for a classified feed event via the shared, unit-tested
+    /// builder — see
+    /// ``FeedEventClassifier/nativeApprovalPromptAttentionCommand``.
+    /// Identities come from the feed event first, then the pane
+    /// environment; a missing/non-UUID identity yields `nil` (advisory,
+    /// never fails the hook). The notification carries the same
+    /// `needs-permission` meta the generic agent `notification` hook uses,
+    /// so it gates under "Agent Needs Permission" exactly like Claude's
+    /// permission_prompt.
+    private func nativeApprovalPromptAttentionCommand(
+        classification: FeedEventClassification,
         source: String,
         toolName: String,
         eventDict: [String: Any],
         env: [String: String]
     ) -> String? {
-        guard let target = nativeApprovalPromptTarget(eventDict: eventDict, env: env) else {
-            return nil
-        }
-        let displayName = Self.agentDef(named: source)?.displayName ?? source
-        let body: String
-        if toolName.isEmpty {
-            body = String(
-                localized: "agent.generic.notification.body.approvalNeeded",
-                defaultValue: "Approval needed"
-            )
-        } else {
-            body = String(
-                localized: "feed.notification.permission.body",
-                defaultValue: "\(toolName) needs approval"
-            )
-        }
-        let payload = notificationPayload(
-            title: displayName,
-            subtitle: String(
-                localized: "agent.generic.notification.subtitle.permission",
-                defaultValue: "Permission"
-            ),
-            body: body,
-            meta: AgentHookNotifyCategory.needsPermission.metaSegment(pending: false)
+        FeedEventClassifier.nativeApprovalPromptAttentionCommand(
+            classification: classification,
+            displayName: Self.agentDef(named: source)?.displayName ?? source,
+            toolName: toolName,
+            workspaceId: (eventDict["workspace_id"] as? String) ?? env["CMUX_WORKSPACE_ID"],
+            surfaceId: (eventDict["surface_id"] as? String) ?? env["CMUX_SURFACE_ID"]
         )
-        return "notify_target_async \(target.workspaceId.uuidString) \(target.surfaceId.uuidString) \(payload)"
-    }
-
-    /// Builds the `clear_notifications` line sent when tool execution
-    /// proceeds for a native-approval-prompt agent (see
-    /// ``FeedEventClassification/clearsNativeApprovalPrompt``): the pending
-    /// approval resolved — approved by the user or by the agent's own
-    /// auto-reviewer — so the pane's stale notifications are cleared. Same
-    /// contract as Claude's `pre-tool-use` hook, which clears the pane's
-    /// notifications whenever the agent continues.
-    private func nativeApprovalPromptClearCommand(
-        eventDict: [String: Any],
-        env: [String: String]
-    ) -> String? {
-        guard let target = nativeApprovalPromptTarget(eventDict: eventDict, env: env) else {
-            return nil
-        }
-        return "clear_notifications --tab=\(target.workspaceId.uuidString)\(socketPanelOption(target.surfaceId.uuidString))"
     }
 
     /// Reads an agent hook JSON payload from stdin, forwards it to the
@@ -34994,50 +34938,52 @@ export default CMUXSessionRestore;
             let line = String(data: payload, encoding: .utf8) ?? "{}"
             // Codex-style agents block in their own approval UI while this
             // (telemetry) event is their only signal, so the permission-prompt
-            // notification — and the clear once execution proceeds — ride the
-            // same best-effort lane as the feed frame.
-            let promptLine: String?
-            if classification.notifiesNativeApprovalPrompt {
-                promptLine = nativeApprovalPromptNotifyCommand(
-                    source: source,
-                    toolName: toolName,
-                    eventDict: eventDict,
-                    env: env
-                )
-            } else if classification.clearsNativeApprovalPrompt {
-                promptLine = nativeApprovalPromptClearCommand(eventDict: eventDict, env: env)
-            } else {
-                promptLine = nil
-            }
+            // notification — and the clear once execution proceeds — ride
+            // alongside the feed frame.
+            let promptLine = nativeApprovalPromptAttentionCommand(
+                classification: classification,
+                source: source,
+                toolName: toolName,
+                eventDict: eventDict,
+                env: env
+            )
             // The attention signal goes FIRST and is AWAITED (bounded): the
             // app must acknowledge the notify/clear before this synchronous
             // hook returns and codex fires its next event, or a delayed
             // clear could erase a newer request's live notification. The
-            // feed frame stays one-way: it is nonessential telemetry, and a
-            // failed write must never swallow the permission notification.
-            if let client {
-                if let promptLine {
+            // feed frame stays one-way best-effort telemetry on its own
+            // bounded connection — a relay-backed `send` closes its socket
+            // after the acknowledged command, and an implicit reconnect
+            // inside `sendOneWay` is not bounded by the write timeout.
+            if let promptLine {
+                if let client {
                     _ = try? client.send(
                         command: promptLine,
                         responseTimeout: Self.feedAttentionAcknowledgeTimeoutSeconds
                     )
-                }
-                _ = try? client.sendOneWay(command: line, writeTimeout: 0.05)
-            } else if let socketPath {
-                if let promptLine {
-                    sendBestEffortFeedAttentionThenTelemetry(
+                } else if let socketPath {
+                    sendAcknowledgedFeedAttention(
                         socketPath: socketPath,
                         attentionLine: promptLine,
-                        telemetryLine: line,
                         socketPassword: socketPassword
                     )
-                } else {
+                }
+                let telemetrySocketPath = socketPath ?? client?.socketPath
+                if let telemetrySocketPath {
                     sendBestEffortFeedTelemetry(
-                        socketPath: socketPath,
+                        socketPath: telemetrySocketPath,
                         line: line,
                         socketPassword: socketPassword
                     )
                 }
+            } else if let client {
+                _ = try? client.sendOneWay(command: line, writeTimeout: 0.05)
+            } else if let socketPath {
+                sendBestEffortFeedTelemetry(
+                    socketPath: socketPath,
+                    line: line,
+                    socketPassword: socketPassword
+                )
             }
             print("{}")
             return

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -32674,6 +32674,14 @@ export default CMUXSessionRestore;
     /// "All" view even when no permission/plan/question event fires.
     /// Failures are swallowed.
     func sendBestEffortFeedTelemetry(socketPath: String, line: String, socketPassword: String?) {
+        sendBestEffortFeedTelemetry(socketPath: socketPath, lines: [line], socketPassword: socketPassword)
+    }
+
+    /// One connect + auth for the whole batch: feed hooks that emit a
+    /// second line (the native-approval-prompt notify/clear) must not pay a
+    /// second connection and Keychain/password lookup per tool event.
+    func sendBestEffortFeedTelemetry(socketPath: String, lines: [String], socketPassword: String?) {
+        guard !lines.isEmpty else { return }
         let oneWayClient = SocketClient(path: socketPath)
         defer { oneWayClient.close() }
         do {
@@ -32684,7 +32692,9 @@ export default CMUXSessionRestore;
                 socketPath: socketPath,
                 responseTimeout: 0.05
             )
-            try oneWayClient.sendOneWay(command: line, writeTimeout: 0.05)
+            for line in lines {
+                try oneWayClient.sendOneWay(command: line, writeTimeout: 0.05)
+            }
         } catch {
             return
         }
@@ -34961,16 +34971,9 @@ export default CMUXSessionRestore;
             } else if let socketPath {
                 sendBestEffortFeedTelemetry(
                     socketPath: socketPath,
-                    line: line,
+                    lines: [line] + (promptLine.map { [$0] } ?? []),
                     socketPassword: socketPassword
                 )
-                if let promptLine {
-                    sendBestEffortFeedTelemetry(
-                        socketPath: socketPath,
-                        line: promptLine,
-                        socketPassword: socketPassword
-                    )
-                }
             }
             print("{}")
             return

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -34644,6 +34644,49 @@ export default CMUXSessionRestore;
 
     // MARK: - Feed (workstream) hook bridge
 
+    /// Builds the fire-and-forget `notify_target_async` line for a feed
+    /// event classified as a native approval prompt (the agent is blocked
+    /// in its OWN approval UI, e.g. Codex's reviewer — see
+    /// ``FeedEventClassification/notifiesNativeApprovalPrompt``). Routes
+    /// through the same classifier + payload meta the generic agent
+    /// `notification` hook uses, so the alert gates under the app's
+    /// "Agent Needs Permission" setting exactly like Claude's
+    /// permission_prompt. Returns `nil` when the caller's workspace or
+    /// surface identity is missing or not a UUID: the notification is
+    /// best-effort and must never fail or delay the hook.
+    private func nativeApprovalPromptNotifyCommand(
+        source: String,
+        eventDict: [String: Any],
+        env: [String: String]
+    ) -> String? {
+        guard let workspaceRaw = (eventDict["workspace_id"] as? String)?
+                .trimmingCharacters(in: .whitespacesAndNewlines),
+              let workspaceId = UUID(uuidString: workspaceRaw),
+              let surfaceRaw = env["CMUX_SURFACE_ID"]?
+                .trimmingCharacters(in: .whitespacesAndNewlines),
+              let surfaceId = UUID(uuidString: surfaceRaw)
+        else { return nil }
+        let displayName = Self.agentDef(named: source)?.displayName ?? source
+        let toolSummary = (eventDict["context"] as? [String: Any])?["toolSummary"] as? String
+        // "PermissionRequest" is the classifier's permission cue, yielding the
+        // shared "Permission" / "Approval needed" strings and the
+        // needs-permission gate category; the tool summary (command, path)
+        // becomes the body when present.
+        let summary = AgentHookNotificationClassifier.classify(
+            displayName: displayName,
+            signal: "PermissionRequest",
+            message: toolSummary ?? "",
+            isFallback: false
+        )
+        let payload = notificationPayload(
+            title: displayName,
+            subtitle: summary.subtitle,
+            body: summary.body,
+            meta: summary.notifyCategory.metaSegment(pending: false)
+        )
+        return "notify_target_async \(workspaceId.uuidString) \(surfaceId.uuidString) \(payload)"
+    }
+
     /// Reads an agent hook JSON payload from stdin, forwards it to the
     /// running cmux app via the `feed.push` V2 socket verb, and (for
     /// actionable events: ExitPlanMode, AskUserQuestion, permission-
@@ -34855,14 +34898,30 @@ export default CMUXSessionRestore;
         if waitTimeout == 0 && !shouldAwaitTelemetryIngestion {
             let payload = try JSONSerialization.data(withJSONObject: request)
             let line = String(data: payload, encoding: .utf8) ?? "{}"
+            // Codex-style agents block in their own approval UI while this
+            // (telemetry) event is their only signal, so the permission-prompt
+            // notification rides the same best-effort lane as the feed frame.
+            let notifyLine = classification.notifiesNativeApprovalPrompt
+                ? nativeApprovalPromptNotifyCommand(source: source, eventDict: eventDict, env: env)
+                : nil
             if let client {
                 _ = try? client.sendOneWay(command: line, writeTimeout: 0.05)
+                if let notifyLine {
+                    _ = try? client.sendOneWay(command: notifyLine, writeTimeout: 0.05)
+                }
             } else if let socketPath {
                 sendBestEffortFeedTelemetry(
                     socketPath: socketPath,
                     line: line,
                     socketPassword: socketPassword
                 )
+                if let notifyLine {
+                    sendBestEffortFeedTelemetry(
+                        socketPath: socketPath,
+                        line: notifyLine,
+                        socketPassword: socketPassword
+                    )
+                }
             }
             print("{}")
             return

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -32695,6 +32695,16 @@ export default CMUXSessionRestore;
     /// acknowledged send) before the feed hook gives up and returns.
     static let feedAttentionAcknowledgeTimeoutSeconds: TimeInterval = 2
 
+    /// Portion of the attention deadline reserved for the essential
+    /// notify/clear send. The optional live-target probe may never consume
+    /// this: a stalled probe that ate the whole budget would starve the very
+    /// notification the attention lane exists to deliver.
+    static let feedAttentionSendReserveSeconds: TimeInterval = 0.75
+
+    /// Upper bound on the optional live-target probe, independent of the
+    /// remaining deadline.
+    static let feedAttentionProbeTimeoutCapSeconds: TimeInterval = 1.0
+
     private func sendFeedTelemetry(
         client: SocketClient,
         source: String,
@@ -34755,7 +34765,10 @@ export default CMUXSessionRestore;
     /// The `{surface_id}` live-pane probe backing
     /// ``deliverNativeApprovalPromptAttention``. Only a `source == "surface"`
     /// answer with a live workspace UUID counts; anything else falls back to
-    /// the ambient identities.
+    /// the ambient identities. The probe's timeout is capped and always
+    /// leaves ``feedAttentionSendReserveSeconds`` of the shared deadline for
+    /// the essential send — a stalled probe degrades to ambient addressing,
+    /// never to a starved notification.
     private func resolvedAttentionDeliveryTarget(
         workspaceId: String?,
         surfaceId: String?,
@@ -34766,6 +34779,11 @@ export default CMUXSessionRestore;
               UUID(uuidString: surfaceRaw) != nil else {
             return nil
         }
+        let probeTimeout = min(
+            deadline.timeIntervalSinceNow - Self.feedAttentionSendReserveSeconds,
+            Self.feedAttentionProbeTimeoutCapSeconds
+        )
+        guard probeTimeout > 0.05 else { return nil }
         var params: [String: Any] = ["surface_id": surfaceRaw]
         if let workspaceRaw = workspaceId?.trimmingCharacters(in: .whitespacesAndNewlines),
            UUID(uuidString: workspaceRaw) != nil {
@@ -34774,7 +34792,7 @@ export default CMUXSessionRestore;
         guard let payload = try? client.sendV2(
                 method: "agent.resolve_delivery_target",
                 params: params,
-                responseTimeout: max(deadline.timeIntervalSinceNow, 0.05)
+                responseTimeout: probeTimeout
               ),
               (payload["source"] as? String) == "surface",
               let liveWorkspaceId = (payload["workspace_id"] as? String)?

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -34955,6 +34955,15 @@ export default CMUXSessionRestore;
             // bounded connection — a relay-backed `send` closes its socket
             // after the acknowledged command, and an implicit reconnect
             // inside `sendOneWay` is not bounded by the write timeout.
+            //
+            // Known accepted residual: codex's fire-and-forget prompt-submit
+            // worker clears the pane at turn start from a DETACHED process.
+            // If that worker is slower than the model's first approval-needing
+            // tool call, its late clear can remove this notification — the
+            // same pre-existing exposure the wrapper-path notification
+            // (`hooks codex notification`) has always had. Fencing clears by
+            // origin time is a cross-layer protocol change deliberately out
+            // of scope here.
             if let promptLine {
                 if let client {
                     _ = try? client.send(

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -34644,21 +34644,14 @@ export default CMUXSessionRestore;
 
     // MARK: - Feed (workstream) hook bridge
 
-    /// Builds the fire-and-forget `notify_target_async` line for a feed
-    /// event classified as a native approval prompt (the agent is blocked
-    /// in its OWN approval UI, e.g. Codex's reviewer — see
-    /// ``FeedEventClassification/notifiesNativeApprovalPrompt``). Routes
-    /// through the same classifier + payload meta the generic agent
-    /// `notification` hook uses, so the alert gates under the app's
-    /// "Agent Needs Permission" setting exactly like Claude's
-    /// permission_prompt. Returns `nil` when the caller's workspace or
-    /// surface identity is missing or not a UUID: the notification is
-    /// best-effort and must never fail or delay the hook.
-    private func nativeApprovalPromptNotifyCommand(
-        source: String,
+    /// Resolves the caller pane's (workspace, surface) UUID pair for the
+    /// best-effort native-approval-prompt notification commands. Returns
+    /// `nil` when either identity is missing or not a UUID: the commands
+    /// are advisory and must never fail or delay the hook.
+    private func nativeApprovalPromptTarget(
         eventDict: [String: Any],
         env: [String: String]
-    ) -> String? {
+    ) -> (workspaceId: UUID, surfaceId: UUID)? {
         guard let workspaceRaw = (eventDict["workspace_id"] as? String)?
                 .trimmingCharacters(in: .whitespacesAndNewlines),
               let workspaceId = UUID(uuidString: workspaceRaw),
@@ -34666,25 +34659,70 @@ export default CMUXSessionRestore;
                 .trimmingCharacters(in: .whitespacesAndNewlines),
               let surfaceId = UUID(uuidString: surfaceRaw)
         else { return nil }
+        return (workspaceId, surfaceId)
+    }
+
+    /// Builds the fire-and-forget `notify_target_async` line for a feed
+    /// event classified as a native approval prompt (the agent is blocked
+    /// in its OWN approval UI, e.g. Codex's reviewer — see
+    /// ``FeedEventClassification/notifiesNativeApprovalPrompt``). Carries
+    /// the same `needs-permission` payload meta the generic agent
+    /// `notification` hook uses, so the alert gates under the app's
+    /// "Agent Needs Permission" setting exactly like Claude's
+    /// permission_prompt. The body deliberately names only the TOOL —
+    /// mirroring the in-app Feed approval banner
+    /// (`feed.notification.permission.body`) — and never the tool input:
+    /// commands can embed credentials, and notification banners reach lock
+    /// screens, paired phones, and the recorded notification history.
+    private func nativeApprovalPromptNotifyCommand(
+        source: String,
+        toolName: String,
+        eventDict: [String: Any],
+        env: [String: String]
+    ) -> String? {
+        guard let target = nativeApprovalPromptTarget(eventDict: eventDict, env: env) else {
+            return nil
+        }
         let displayName = Self.agentDef(named: source)?.displayName ?? source
-        let toolSummary = (eventDict["context"] as? [String: Any])?["toolSummary"] as? String
-        // "PermissionRequest" is the classifier's permission cue, yielding the
-        // shared "Permission" / "Approval needed" strings and the
-        // needs-permission gate category; the tool summary (command, path)
-        // becomes the body when present.
-        let summary = AgentHookNotificationClassifier.classify(
-            displayName: displayName,
-            signal: "PermissionRequest",
-            message: toolSummary ?? "",
-            isFallback: false
-        )
+        let body: String
+        if toolName.isEmpty {
+            body = String(
+                localized: "agent.generic.notification.body.approvalNeeded",
+                defaultValue: "Approval needed"
+            )
+        } else {
+            body = String(
+                localized: "feed.notification.permission.body",
+                defaultValue: "\(toolName) needs approval"
+            )
+        }
         let payload = notificationPayload(
             title: displayName,
-            subtitle: summary.subtitle,
-            body: summary.body,
-            meta: summary.notifyCategory.metaSegment(pending: false)
+            subtitle: String(
+                localized: "agent.generic.notification.subtitle.permission",
+                defaultValue: "Permission"
+            ),
+            body: body,
+            meta: AgentHookNotifyCategory.needsPermission.metaSegment(pending: false)
         )
-        return "notify_target_async \(workspaceId.uuidString) \(surfaceId.uuidString) \(payload)"
+        return "notify_target_async \(target.workspaceId.uuidString) \(target.surfaceId.uuidString) \(payload)"
+    }
+
+    /// Builds the `clear_notifications` line sent when tool execution
+    /// proceeds for a native-approval-prompt agent (see
+    /// ``FeedEventClassification/clearsNativeApprovalPrompt``): the pending
+    /// approval resolved — approved by the user or by the agent's own
+    /// auto-reviewer — so the pane's stale notifications are cleared. Same
+    /// contract as Claude's `pre-tool-use` hook, which clears the pane's
+    /// notifications whenever the agent continues.
+    private func nativeApprovalPromptClearCommand(
+        eventDict: [String: Any],
+        env: [String: String]
+    ) -> String? {
+        guard let target = nativeApprovalPromptTarget(eventDict: eventDict, env: env) else {
+            return nil
+        }
+        return "clear_notifications --tab=\(target.workspaceId.uuidString)\(socketPanelOption(target.surfaceId.uuidString))"
     }
 
     /// Reads an agent hook JSON payload from stdin, forwards it to the
@@ -34900,14 +34938,25 @@ export default CMUXSessionRestore;
             let line = String(data: payload, encoding: .utf8) ?? "{}"
             // Codex-style agents block in their own approval UI while this
             // (telemetry) event is their only signal, so the permission-prompt
-            // notification rides the same best-effort lane as the feed frame.
-            let notifyLine = classification.notifiesNativeApprovalPrompt
-                ? nativeApprovalPromptNotifyCommand(source: source, eventDict: eventDict, env: env)
-                : nil
+            // notification — and the clear once execution proceeds — ride the
+            // same best-effort lane as the feed frame.
+            let promptLine: String?
+            if classification.notifiesNativeApprovalPrompt {
+                promptLine = nativeApprovalPromptNotifyCommand(
+                    source: source,
+                    toolName: toolName,
+                    eventDict: eventDict,
+                    env: env
+                )
+            } else if classification.clearsNativeApprovalPrompt {
+                promptLine = nativeApprovalPromptClearCommand(eventDict: eventDict, env: env)
+            } else {
+                promptLine = nil
+            }
             if let client {
                 _ = try? client.sendOneWay(command: line, writeTimeout: 0.05)
-                if let notifyLine {
-                    _ = try? client.sendOneWay(command: notifyLine, writeTimeout: 0.05)
+                if let promptLine {
+                    _ = try? client.sendOneWay(command: promptLine, writeTimeout: 0.05)
                 }
             } else if let socketPath {
                 sendBestEffortFeedTelemetry(
@@ -34915,10 +34964,10 @@ export default CMUXSessionRestore;
                     line: line,
                     socketPassword: socketPassword
                 )
-                if let notifyLine {
+                if let promptLine {
                     sendBestEffortFeedTelemetry(
                         socketPath: socketPath,
-                        line: notifyLine,
+                        line: promptLine,
                         socketPassword: socketPassword
                     )
                 }

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -32717,22 +32717,34 @@ export default CMUXSessionRestore;
         attentionLine: String,
         socketPassword: String?
     ) {
+        // One absolute deadline across connect, authentication, and the
+        // acknowledged send. This line is the essential payload — unlike the
+        // fast-fail telemetry lane's 50 ms bounds, the budget must survive a
+        // relay-backed connection's multi-round-trip HMAC handshake, or
+        // remote terminals silently lose the permission notification and the
+        // agent blocks unannounced (#9592 again).
+        let deadline = Date().addingTimeInterval(Self.feedAttentionAcknowledgeTimeoutSeconds)
+        func remainingBudget() -> TimeInterval {
+            max(deadline.timeIntervalSinceNow, 0.05)
+        }
         let attentionClient = SocketClient(path: socketPath)
         defer { attentionClient.close() }
         do {
-            try attentionClient.connectWithoutRetry(responseTimeout: 0.05)
+            try attentionClient.connectWithoutRetry(responseTimeout: remainingBudget())
             try authenticateClientIfNeeded(
                 attentionClient,
                 explicitPassword: socketPassword,
                 socketPath: socketPath,
-                responseTimeout: 0.05
+                responseTimeout: remainingBudget(),
+                deadline: deadline
             )
         } catch {
             return
         }
         _ = try? attentionClient.send(
             command: attentionLine,
-            responseTimeout: Self.feedAttentionAcknowledgeTimeoutSeconds
+            responseTimeout: remainingBudget(),
+            deadline: deadline
         )
     }
 

--- a/cmuxTests/FeedEventClassificationTests.swift
+++ b/cmuxTests/FeedEventClassificationTests.swift
@@ -267,4 +267,90 @@ struct FeedEventClassificationTests {
         #expect(classify("gemini", "PreToolUse", tool: "write").actionable == false)
         #expect(classify("gemini", "PreToolUse", tool: "execute_bash").actionable == false)
     }
+
+    // MARK: Attention command construction (the wire the feed hook sends)
+
+    private static let workspaceUUID = "11111111-2222-3333-4444-555555555555"
+    private static let surfaceUUID = "66666666-7777-8888-9999-AAAAAAAAAAAA"
+
+    private func attentionCommand(
+        _ source: String,
+        _ event: String,
+        tool: String,
+        displayName: String = "Codex",
+        workspaceId: String? = workspaceUUID,
+        surfaceId: String? = surfaceUUID
+    ) -> String? {
+        FeedEventClassifier.nativeApprovalPromptAttentionCommand(
+            classification: FeedEventClassifier.classify(source: source, event: event, toolName: tool),
+            displayName: displayName,
+            toolName: tool,
+            workspaceId: workspaceId,
+            surfaceId: surfaceId
+        )
+    }
+
+    /// The exact `notify_target_async` line for a codex PermissionRequest:
+    /// UUID-addressed, tool-name-only body (never the tool input), and the
+    /// `c=needs-permission;p=0` meta that gates the alert under the "Agent
+    /// Needs Permission" setting. A malformed payload or dropped meta here
+    /// is what silently regresses https://github.com/manaflow-ai/cmux/issues/9592.
+    @Test func codexPermissionRequestBuildsGatedNotifyCommand() {
+        #expect(
+            attentionCommand("codex", "PermissionRequest", tool: "shell")
+                == "notify_target_async \(Self.workspaceUUID) \(Self.surfaceUUID) Codex|Permission|shell needs approval|c=needs-permission;p=0"
+        )
+    }
+
+    /// Without a tool name the body falls back to the shared "Approval
+    /// needed" string rather than an empty interpolation.
+    @Test func codexPermissionRequestWithoutToolNameFallsBackToApprovalNeeded() {
+        #expect(
+            attentionCommand("codex", "PermissionRequest", tool: "")
+                == "notify_target_async \(Self.workspaceUUID) \(Self.surfaceUUID) Codex|Permission|Approval needed|c=needs-permission;p=0"
+        )
+    }
+
+    /// Tool names are payload-controlled input: pipes are the payload
+    /// delimiter and must be neutralized.
+    @Test func attentionCommandSanitizesPipeInToolName() {
+        #expect(
+            attentionCommand("codex", "PermissionRequest", tool: "a|b")
+                == "notify_target_async \(Self.workspaceUUID) \(Self.surfaceUUID) Codex|Permission|a¦b needs approval|c=needs-permission;p=0"
+        )
+    }
+
+    /// Codex tool completion resolves the prompt: the exact pane-scoped
+    /// `clear_notifications` line.
+    @Test func codexToolCompletionBuildsPaneScopedClearCommand() {
+        #expect(
+            attentionCommand("codex", "PostToolUse", tool: "shell")
+                == "clear_notifications --tab=\(Self.workspaceUUID) --panel=\(Self.surfaceUUID)"
+        )
+    }
+
+    /// Lowercase UUIDs from the pane environment are normalized, not
+    /// rejected.
+    @Test func attentionCommandNormalizesLowercaseUUIDs() {
+        let command = attentionCommand(
+            "codex",
+            "PermissionRequest",
+            tool: "shell",
+            workspaceId: Self.workspaceUUID.lowercased(),
+            surfaceId: Self.surfaceUUID.lowercased()
+        )
+        #expect(command?.contains("notify_target_async \(Self.workspaceUUID) \(Self.surfaceUUID) ") == true)
+    }
+
+    /// The command is advisory: missing or non-UUID identities yield nil
+    /// instead of a malformed socket command, and events without attention
+    /// semantics never produce a command at all.
+    @Test func attentionCommandRequiresUUIDTargetsAndAttentionSemantics() {
+        #expect(attentionCommand("codex", "PermissionRequest", tool: "shell", workspaceId: nil) == nil)
+        #expect(attentionCommand("codex", "PermissionRequest", tool: "shell", surfaceId: "surface:1") == nil)
+        #expect(attentionCommand("codex", "PermissionRequest", tool: "shell", workspaceId: "workspace:1") == nil)
+        #expect(attentionCommand("codex", "PreToolUse", tool: "shell") == nil)
+        #expect(attentionCommand("claude", "PermissionRequest", tool: "Bash") == nil)
+        #expect(attentionCommand("totally-new-agent", "PermissionRequest", tool: "Bash") == nil)
+    }
 }

--- a/cmuxTests/FeedEventClassificationTests.swift
+++ b/cmuxTests/FeedEventClassificationTests.swift
@@ -312,11 +312,16 @@ struct FeedEventClassificationTests {
     }
 
     /// Tool names are payload-controlled input: pipes are the payload
-    /// delimiter and must be neutralized.
-    @Test func attentionCommandSanitizesPipeInToolName() {
+    /// delimiter and newlines would split the single socket command line,
+    /// so both must be neutralized.
+    @Test func attentionCommandSanitizesPipeAndNewlineInToolName() {
         #expect(
             attentionCommand("codex", "PermissionRequest", tool: "a|b")
                 == "notify_target_async \(Self.workspaceUUID) \(Self.surfaceUUID) Codex|Permission|a¦b needs approval|c=needs-permission;p=0"
+        )
+        #expect(
+            attentionCommand("codex", "PermissionRequest", tool: "a\nb")
+                == "notify_target_async \(Self.workspaceUUID) \(Self.surfaceUUID) Codex|Permission|a b needs approval|c=needs-permission;p=0"
         )
     }
 
@@ -347,6 +352,7 @@ struct FeedEventClassificationTests {
     /// semantics never produce a command at all.
     @Test func attentionCommandRequiresUUIDTargetsAndAttentionSemantics() {
         #expect(attentionCommand("codex", "PermissionRequest", tool: "shell", workspaceId: nil) == nil)
+        #expect(attentionCommand("codex", "PermissionRequest", tool: "shell", surfaceId: nil) == nil)
         #expect(attentionCommand("codex", "PermissionRequest", tool: "shell", surfaceId: "surface:1") == nil)
         #expect(attentionCommand("codex", "PermissionRequest", tool: "shell", workspaceId: "workspace:1") == nil)
         #expect(attentionCommand("codex", "PreToolUse", tool: "shell") == nil)

--- a/cmuxTests/FeedEventClassificationTests.swift
+++ b/cmuxTests/FeedEventClassificationTests.swift
@@ -19,10 +19,20 @@ import Testing
 @Suite("Feed event classification")
 struct FeedEventClassificationTests {
     private func classify(_ source: String, _ event: String, tool: String = "")
-        -> (name: String, actionable: Bool, notifiesNativeApprovalPrompt: Bool)
+        -> (
+            name: String,
+            actionable: Bool,
+            notifiesNativeApprovalPrompt: Bool,
+            clearsNativeApprovalPrompt: Bool
+        )
     {
         let result = FeedEventClassifier.classify(source: source, event: event, toolName: tool)
-        return (result.hookEventName, result.isActionable, result.notifiesNativeApprovalPrompt)
+        return (
+            result.hookEventName,
+            result.isActionable,
+            result.notifiesNativeApprovalPrompt,
+            result.clearsNativeApprovalPrompt
+        )
     }
 
     // MARK: Hermes Agent (the reported bug)
@@ -150,6 +160,25 @@ struct FeedEventClassificationTests {
         #expect(classify("codex", "PostToolUse", tool: "shell").notifiesNativeApprovalPrompt == false)
         #expect(classify("hermes-agent", "pre_approval_request").notifiesNativeApprovalPrompt == false)
         #expect(classify("totally-new-agent", "PermissionRequest", tool: "Bash").notifiesNativeApprovalPrompt == false)
+    }
+
+    /// Codex's tool lifecycle progress proves any pending native approval
+    /// prompt resolved (approved by the user or by Codex's own auto-review),
+    /// so those events clear the pane's stale permission notification —
+    /// mirroring Claude's `pre-tool-use` `clear_notifications` contract. The
+    /// clear stays scoped: agents that never raise native approval prompts
+    /// must not have their tool telemetry touch the notification queue, and
+    /// the prompt event itself notifies rather than clears.
+    @Test func codexToolLifecycleClearsNativeApprovalPrompt() {
+        #expect(classify("codex", "PreToolUse", tool: "shell").clearsNativeApprovalPrompt == true)
+        #expect(classify("codex", "pre_tool_use", tool: "shell").clearsNativeApprovalPrompt == true)
+        #expect(classify("codex", "PostToolUse", tool: "shell").clearsNativeApprovalPrompt == true)
+        #expect(classify("codex", "post_tool_use", tool: "shell").clearsNativeApprovalPrompt == true)
+        #expect(classify("codex", "PermissionRequest", tool: "shell").clearsNativeApprovalPrompt == false)
+        #expect(classify("codex", "Stop", tool: "").clearsNativeApprovalPrompt == false)
+        #expect(classify("claude", "PreToolUse", tool: "Bash").clearsNativeApprovalPrompt == false)
+        #expect(classify("gemini", "PreToolUse", tool: "Read").clearsNativeApprovalPrompt == false)
+        #expect(classify("totally-new-agent", "PreToolUse", tool: "Bash").clearsNativeApprovalPrompt == false)
     }
 
     @Test func codexLifecycleFeedEventsStayTelemetryAndPreserveNames() {

--- a/cmuxTests/FeedEventClassificationTests.swift
+++ b/cmuxTests/FeedEventClassificationTests.swift
@@ -162,23 +162,33 @@ struct FeedEventClassificationTests {
         #expect(classify("totally-new-agent", "PermissionRequest", tool: "Bash").notifiesNativeApprovalPrompt == false)
     }
 
-    /// Codex's tool lifecycle progress proves any pending native approval
-    /// prompt resolved (approved by the user or by Codex's own auto-review),
-    /// so those events clear the pane's stale permission notification —
-    /// mirroring Claude's `pre-tool-use` `clear_notifications` contract. The
-    /// clear stays scoped: agents that never raise native approval prompts
-    /// must not have their tool telemetry touch the notification queue, and
-    /// the prompt event itself notifies rather than clears.
-    @Test func codexToolLifecycleClearsNativeApprovalPrompt() {
-        #expect(classify("codex", "PreToolUse", tool: "shell").clearsNativeApprovalPrompt == true)
-        #expect(classify("codex", "pre_tool_use", tool: "shell").clearsNativeApprovalPrompt == true)
+    /// A COMPLETED codex tool proves any pending native approval prompt
+    /// resolved — execution strictly follows approval (by the user or by
+    /// Codex's own auto-review) — so PostToolUse clears the pane's stale
+    /// permission notification, mirroring the pane-wide clears Claude's
+    /// lifecycle hooks and Hermes' approval-response hook already perform.
+    @Test func codexToolCompletionClearsNativeApprovalPrompt() {
         #expect(classify("codex", "PostToolUse", tool: "shell").clearsNativeApprovalPrompt == true)
         #expect(classify("codex", "post_tool_use", tool: "shell").clearsNativeApprovalPrompt == true)
+    }
+
+    /// Pre-tool events must NOT clear: codex fires them when it INTENDS to
+    /// run a tool, with no ordering guarantee against the PermissionRequest
+    /// hook, so a start-time clear could erase the just-raised prompt while
+    /// the agent is still blocked — reintroducing #9592's silence. The clear
+    /// also stays scoped: the prompt event itself notifies rather than
+    /// clears, and agents that never raise native approval prompts must not
+    /// have their tool telemetry touch the notification queue.
+    @Test func nativeApprovalPromptClearStaysScopedToCodexToolCompletion() {
+        #expect(classify("codex", "PreToolUse", tool: "shell").clearsNativeApprovalPrompt == false)
+        #expect(classify("codex", "pre_tool_use", tool: "shell").clearsNativeApprovalPrompt == false)
+        #expect(classify("codex", "beforeShellExecution", tool: "shell").clearsNativeApprovalPrompt == false)
         #expect(classify("codex", "PermissionRequest", tool: "shell").clearsNativeApprovalPrompt == false)
         #expect(classify("codex", "Stop", tool: "").clearsNativeApprovalPrompt == false)
         #expect(classify("claude", "PreToolUse", tool: "Bash").clearsNativeApprovalPrompt == false)
+        #expect(classify("claude", "PostToolUse", tool: "Bash").clearsNativeApprovalPrompt == false)
         #expect(classify("gemini", "PreToolUse", tool: "Read").clearsNativeApprovalPrompt == false)
-        #expect(classify("totally-new-agent", "PreToolUse", tool: "Bash").clearsNativeApprovalPrompt == false)
+        #expect(classify("totally-new-agent", "PostToolUse", tool: "Bash").clearsNativeApprovalPrompt == false)
     }
 
     @Test func codexLifecycleFeedEventsStayTelemetryAndPreserveNames() {

--- a/cmuxTests/FeedEventClassificationTests.swift
+++ b/cmuxTests/FeedEventClassificationTests.swift
@@ -19,10 +19,10 @@ import Testing
 @Suite("Feed event classification")
 struct FeedEventClassificationTests {
     private func classify(_ source: String, _ event: String, tool: String = "")
-        -> (name: String, actionable: Bool)
+        -> (name: String, actionable: Bool, notifiesNativeApprovalPrompt: Bool)
     {
         let result = FeedEventClassifier.classify(source: source, event: event, toolName: tool)
-        return (result.0, result.1)
+        return (result.hookEventName, result.isActionable, result.notifiesNativeApprovalPrompt)
     }
 
     // MARK: Hermes Agent (the reported bug)
@@ -120,6 +120,36 @@ struct FeedEventClassificationTests {
         #expect(classify("codex", "beforeShellExecution", tool: "shell").name == "PreToolUse")
         #expect(classify("codex", "PermissionRequest", tool: "shell").name == "PreToolUse")
         #expect(classify("codex", "PermissionRequest", tool: "shell").actionable == false)
+    }
+
+    /// Codex blocks in its OWN approval reviewer when `PermissionRequest`
+    /// fires, so the feed event must stay non-actionable telemetry — but the
+    /// bridge must still raise the "Agent Needs Permission"-gated
+    /// notification, or a blocked codex seat is silent indefinitely.
+    /// https://github.com/manaflow-ai/cmux/issues/9592
+    @Test func codexPermissionRequestRaisesPermissionPromptNotification() {
+        for event in ["PermissionRequest", "permission_request"] {
+            let classification = classify("codex", event, tool: "shell")
+            #expect(classification.notifiesNativeApprovalPrompt == true)
+            // The blocking contract is unchanged: telemetry wire event, no
+            // cmux Feed approval card competing with Codex's own reviewer.
+            #expect(classification.name == "PreToolUse")
+            #expect(classification.actionable == false)
+        }
+    }
+
+    /// The permission-prompt notification is exclusive to agents that block
+    /// in their own approval UI. Blocking-capable agents (claude, gemini,
+    /// kiro) notify through the app's actionable-approval path, ordinary
+    /// telemetry never notifies, and unknown sources stay silent by default.
+    @Test func permissionPromptNotificationStaysScopedToNativeApprovalAgents() {
+        #expect(classify("claude", "PermissionRequest", tool: "Bash").notifiesNativeApprovalPrompt == false)
+        #expect(classify("gemini", "PreToolUse", tool: "Bash").notifiesNativeApprovalPrompt == false)
+        #expect(classify("kiro", "preToolUse", tool: "fs_write").notifiesNativeApprovalPrompt == false)
+        #expect(classify("codex", "PreToolUse", tool: "shell").notifiesNativeApprovalPrompt == false)
+        #expect(classify("codex", "PostToolUse", tool: "shell").notifiesNativeApprovalPrompt == false)
+        #expect(classify("hermes-agent", "pre_approval_request").notifiesNativeApprovalPrompt == false)
+        #expect(classify("totally-new-agent", "PermissionRequest", tool: "Bash").notifiesNativeApprovalPrompt == false)
     }
 
     @Test func codexLifecycleFeedEventsStayTelemetryAndPreserveNames() {

--- a/tests/test_codex_feed_hooks.py
+++ b/tests/test_codex_feed_hooks.py
@@ -86,6 +86,7 @@ class FakeCmuxSocket:
         surface_delivery_target: tuple[str, str] | None = None,
         method_errors: dict[str, tuple[str, str]] | None = None,
         single_batch_item_id: bool = False,
+        method_delays: dict[str, float] | None = None,
     ):
         self.path = path
         self.decision = decision
@@ -99,6 +100,7 @@ class FakeCmuxSocket:
         self.surface_delivery_target = surface_delivery_target
         self.method_errors = method_errors or {}
         self.single_batch_item_id = single_batch_item_id
+        self.method_delays = method_delays or {}
         self._dropped_surface_list = False
         self.frames: list[dict] = []
         self.frames_with_connection: list[tuple[int, dict]] = []
@@ -140,6 +142,21 @@ class FakeCmuxSocket:
                 threading.Thread(target=self._handle_conn, args=(conn, connection_id), daemon=True).start()
 
     def _handle_conn(self, conn: socket.socket, connection_id: int) -> None:
+        # A closed peer must not stop the drain: like the real app's
+        # per-connection worker, buffered request lines that were written
+        # before the peer hung up are still read and recorded — only the
+        # replies are skipped.
+        can_reply = True
+
+        def reply(payload: bytes) -> None:
+            nonlocal can_reply
+            if not can_reply:
+                return
+            try:
+                conn.sendall(payload)
+            except OSError:
+                can_reply = False
+
         with conn:
             data = b""
             while not self._stop.is_set():
@@ -158,13 +175,12 @@ class FakeCmuxSocket:
                         self.frames.append({"raw": raw_line})
                         if self.raw_response_delay > 0:
                             time.sleep(self.raw_response_delay)
-                        try:
-                            conn.sendall(b"OK\n")
-                        except OSError:
-                            return
+                        reply(b"OK\n")
                         continue
                     self.frames.append(frame)
                     self.frames_with_connection.append((connection_id, frame))
+                    if delay := self.method_delays.get(frame.get("method")):
+                        time.sleep(delay)
                     if method_error := self.method_errors.get(frame.get("method")):
                         code, message = method_error
                         response = {
@@ -175,10 +191,7 @@ class FakeCmuxSocket:
                                 "message": message,
                             },
                         }
-                        try:
-                            conn.sendall(json.dumps(response).encode("utf-8") + b"\n")
-                        except BrokenPipeError:
-                            return
+                        reply(json.dumps(response).encode("utf-8") + b"\n")
                         continue
                     if frame.get("method") == "feed.push":
                         self.feed_frame_received.set()
@@ -236,11 +249,7 @@ class FakeCmuxSocket:
                             "code": "feed_rejected",
                             "message": "Feed rejected the event",
                         }
-                    encoded_response = json.dumps(response).encode("utf-8") + b"\n"
-                    try:
-                        conn.sendall(encoded_response)
-                    except BrokenPipeError:
-                        return
+                    reply(json.dumps(response).encode("utf-8") + b"\n")
 
 
 def monitor_pids_for_session(session_id: str) -> list[int]:

--- a/tests/test_codex_permission_prompt_notification.py
+++ b/tests/test_codex_permission_prompt_notification.py
@@ -1,0 +1,241 @@
+#!/usr/bin/env python3
+"""
+Regression: a codex PermissionRequest feed hook raises the
+"Agent Needs Permission"-gated notification, acknowledged before the hook
+returns, and codex tool completion clears it.
+
+https://github.com/manaflow-ai/cmux/issues/9592: the feed bridge normalized
+codex PermissionRequest to non-actionable PreToolUse telemetry and never
+raised any notification, leaving a blocked codex seat silent indefinitely.
+These tests exercise the actual CLI delivery path (`cmux hooks feed`)
+against a fake socket: classification-only coverage cannot catch a broken
+or misrouted notify/clear dispatch.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import tempfile
+import time
+from pathlib import Path
+
+from claude_teams_test_utils import resolve_cmux_cli
+from test_codex_feed_hooks import (
+    FAKE_SURFACE_ID,
+    FAKE_WORKSPACE_ID,
+    FakeCmuxSocket,
+)
+
+EXPECTED_NOTIFY_COMMAND = (
+    f"notify_target_async {FAKE_WORKSPACE_ID} {FAKE_SURFACE_ID} "
+    "Codex|Permission|shell needs approval|c=needs-permission;p=0"
+)
+EXPECTED_CLEAR_COMMAND = (
+    f"clear_notifications --tab={FAKE_WORKSPACE_ID} --panel={FAKE_SURFACE_ID}"
+)
+
+
+def codex_payload(event: str) -> dict:
+    return {
+        "session_id": "codex-permission-prompt",
+        "turn_id": "turn-1",
+        "cwd": "/tmp/project",
+        "hook_event_name": event,
+        "tool_name": "shell",
+        "tool_input": {"command": "printf hi"},
+    }
+
+
+def strip_capability_prefix(raw: str) -> str:
+    if raw.startswith("_cmux_capability_v1 "):
+        parts = raw.split(" ", 2)
+        return parts[2] if len(parts) == 3 else raw
+    return raw
+
+
+def run_feed_hook_capture(
+    cli_path: str,
+    socket_path: Path,
+    event: str,
+    raw_response_delay: float = 0,
+) -> tuple[dict, list, float]:
+    """Runs `cmux hooks feed --source codex` and returns (stdout JSON,
+    ordered received frames, elapsed seconds)."""
+    env = os.environ.copy()
+    for key in ("CMUX_SOCKET", "CMUX_SOCKET_CAPABILITY", "CMUX_SOCKET_PATH", "CMUX_SOCKET_PASSWORD"):
+        env.pop(key, None)
+    env["CMUX_SURFACE_ID"] = FAKE_SURFACE_ID
+    env["CMUX_WORKSPACE_ID"] = FAKE_WORKSPACE_ID
+    with FakeCmuxSocket(socket_path, None, raw_response_delay=raw_response_delay) as fake:
+        started = time.monotonic()
+        result = subprocess.run(
+            [
+                cli_path,
+                "--socket",
+                str(socket_path),
+                "hooks",
+                "feed",
+                "--source",
+                "codex",
+                "--event",
+                event,
+            ],
+            input=json.dumps(codex_payload(event)),
+            capture_output=True,
+            text=True,
+            check=False,
+            env=env,
+            timeout=15,
+        )
+        elapsed = time.monotonic() - started
+        if result.returncode != 0:
+            raise AssertionError(
+                f"hooks feed failed exit={result.returncode}\n"
+                f"stdout={result.stdout}\nstderr={result.stderr}"
+            )
+        # The feed frame is one-way telemetry on its own connection; give the
+        # fake a moment to drain it after the hook exits.
+        deadline = time.monotonic() + 3
+        while time.monotonic() < deadline:
+            if any(frame.get("method") == "feed.push" for frame in fake.frames):
+                break
+            time.sleep(0.05)
+        stdout = json.loads(result.stdout.strip() or "{}")
+        return stdout, list(fake.frames), elapsed
+
+
+def raw_commands(frames: list) -> list[str]:
+    return [
+        strip_capability_prefix(frame["raw"])
+        for frame in frames
+        if isinstance(frame, dict) and "raw" in frame
+    ]
+
+
+def frame_index(frames: list, predicate) -> int:
+    for index, frame in enumerate(frames):
+        if predicate(frame):
+            return index
+    return -1
+
+
+def test_permission_request_sends_gated_notification_before_feed_push(
+    cli_path: str, root: Path
+) -> None:
+    stdout, frames, _ = run_feed_hook_capture(
+        cli_path, root / "cmux-notify.sock", "PermissionRequest"
+    )
+    if stdout != {}:
+        raise AssertionError(f"PermissionRequest must stay non-blocking: {stdout!r}")
+    commands = raw_commands(frames)
+    if EXPECTED_NOTIFY_COMMAND not in commands:
+        raise AssertionError(
+            f"missing gated permission notification, got raw commands {commands!r}"
+        )
+    notify_index = frame_index(
+        frames,
+        lambda frame: "raw" in frame
+        and strip_capability_prefix(frame["raw"]) == EXPECTED_NOTIFY_COMMAND,
+    )
+    feed_index = frame_index(frames, lambda frame: frame.get("method") == "feed.push")
+    if feed_index == -1:
+        raise AssertionError(f"missing feed.push telemetry frame: {frames!r}")
+    if notify_index > feed_index:
+        raise AssertionError(
+            f"notification must precede telemetry (notify at {notify_index}, "
+            f"feed.push at {feed_index}): {frames!r}"
+        )
+
+
+def test_post_tool_use_clears_pane_before_feed_push(cli_path: str, root: Path) -> None:
+    stdout, frames, _ = run_feed_hook_capture(
+        cli_path, root / "cmux-clear.sock", "PostToolUse"
+    )
+    if stdout != {}:
+        raise AssertionError(f"PostToolUse must stay non-blocking: {stdout!r}")
+    commands = raw_commands(frames)
+    if EXPECTED_CLEAR_COMMAND not in commands:
+        raise AssertionError(
+            f"missing resolved-approval clear, got raw commands {commands!r}"
+        )
+    clear_index = frame_index(
+        frames,
+        lambda frame: "raw" in frame
+        and strip_capability_prefix(frame["raw"]) == EXPECTED_CLEAR_COMMAND,
+    )
+    feed_index = frame_index(frames, lambda frame: frame.get("method") == "feed.push")
+    if feed_index == -1:
+        raise AssertionError(f"missing feed.push telemetry frame: {frames!r}")
+    if clear_index > feed_index:
+        raise AssertionError(
+            f"clear must precede telemetry (clear at {clear_index}, "
+            f"feed.push at {feed_index}): {frames!r}"
+        )
+
+
+def test_pre_tool_use_sends_no_attention_command(cli_path: str, root: Path) -> None:
+    """Pre-tool events have no ordering guarantee against PermissionRequest,
+    so they must neither notify nor clear (a start-time clear could erase a
+    just-raised prompt while the agent is still blocked)."""
+    _, frames, _ = run_feed_hook_capture(
+        cli_path, root / "cmux-pretool.sock", "PreToolUse"
+    )
+    offenders = [
+        command
+        for command in raw_commands(frames)
+        if command.startswith("notify_target_async") or command.startswith("clear_notifications")
+    ]
+    if offenders:
+        raise AssertionError(f"PreToolUse must not touch notifications: {offenders!r}")
+
+
+def test_permission_notification_is_acknowledged_before_hook_returns(
+    cli_path: str, root: Path
+) -> None:
+    """A one-way write would let the hook exit before the app processed the
+    notification, so the CLI must await the app's acknowledgement. With the
+    fake delaying its OK by 0.5s, a fire-and-forget regression returns
+    almost instantly; the awaited transport cannot."""
+    delay = 0.5
+    stdout, frames, elapsed = run_feed_hook_capture(
+        cli_path, root / "cmux-ack.sock", "PermissionRequest", raw_response_delay=delay
+    )
+    if stdout != {}:
+        raise AssertionError(f"PermissionRequest must stay non-blocking: {stdout!r}")
+    if EXPECTED_NOTIFY_COMMAND not in raw_commands(frames):
+        raise AssertionError(f"missing gated permission notification: {frames!r}")
+    if elapsed < delay - 0.1:
+        raise AssertionError(
+            f"hook returned in {elapsed:.2f}s without awaiting the delayed "
+            f"({delay}s) notification acknowledgement"
+        )
+
+
+def main() -> int:
+    try:
+        cli_path = resolve_cmux_cli()
+    except Exception as exc:
+        print(f"FAIL: {exc}")
+        return 1
+
+    with tempfile.TemporaryDirectory(
+        prefix="cmux-codex-permission-prompt-", dir="/tmp"
+    ) as td:
+        root = Path(td)
+        try:
+            test_permission_request_sends_gated_notification_before_feed_push(cli_path, root)
+            test_post_tool_use_clears_pane_before_feed_push(cli_path, root)
+            test_pre_tool_use_sends_no_attention_command(cli_path, root)
+            test_permission_notification_is_acknowledged_before_hook_returns(cli_path, root)
+        except Exception as exc:
+            print(f"FAIL: {exc}")
+            return 1
+
+    print("PASS: codex permission prompts notify, acknowledge, and clear")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_codex_permission_prompt_notification.py
+++ b/tests/test_codex_permission_prompt_notification.py
@@ -62,6 +62,8 @@ def run_feed_hook_capture(
     raw_response_delay: float = 0,
     socket_password: str | None = None,
     surface_delivery_target: tuple[str, str] | None = None,
+    method_delays: dict[str, float] | None = None,
+    settle_seconds: float = 0,
 ) -> tuple[dict, list, float]:
     """Runs `cmux hooks feed --source codex` and returns (stdout JSON,
     ordered received frames, elapsed seconds)."""
@@ -77,6 +79,7 @@ def run_feed_hook_capture(
         None,
         raw_response_delay=raw_response_delay,
         surface_delivery_target=surface_delivery_target,
+        method_delays=method_delays,
     ) as fake:
         started = time.monotonic()
         result = subprocess.run(
@@ -111,6 +114,8 @@ def run_feed_hook_capture(
             if any(frame.get("method") == "feed.push" for frame in fake.frames):
                 break
             time.sleep(0.05)
+        if settle_seconds > 0:
+            time.sleep(settle_seconds)
         stdout = json.loads(result.stdout.strip() or "{}")
         return stdout, list(fake.frames), elapsed
 
@@ -284,6 +289,30 @@ def test_permission_notification_targets_rehomed_pane(cli_path: str, root: Path)
         raise AssertionError(f"notification used stale ambient identities: {stale!r}")
 
 
+def test_stalled_live_target_probe_does_not_starve_notification(
+    cli_path: str, root: Path
+) -> None:
+    """The optional live-target probe shares the attention deadline with the
+    essential send. With the fake stalling `agent.resolve_delivery_target`
+    for 3s (past the whole deadline), the probe must give up within its
+    capped budget and the notification must still be WRITTEN — addressed to
+    the ambient identities. The fake's stalled handler drains it only after
+    waking, hence the settle window before snapshotting."""
+    stdout, frames, _ = run_feed_hook_capture(
+        cli_path,
+        root / "cmux-stall.sock",
+        "PermissionRequest",
+        method_delays={"agent.resolve_delivery_target": 3.0},
+        settle_seconds=3.0,
+    )
+    if stdout != {}:
+        raise AssertionError(f"PermissionRequest must stay non-blocking: {stdout!r}")
+    if EXPECTED_NOTIFY_COMMAND not in raw_commands(frames):
+        raise AssertionError(
+            f"a stalled live-target probe starved the notification: {frames!r}"
+        )
+
+
 def main() -> int:
     try:
         cli_path = resolve_cmux_cli()
@@ -302,6 +331,7 @@ def main() -> int:
             test_permission_notification_is_acknowledged_before_hook_returns(cli_path, root)
             test_permission_notification_survives_slow_authentication(cli_path, root)
             test_permission_notification_targets_rehomed_pane(cli_path, root)
+            test_stalled_live_target_probe_does_not_starve_notification(cli_path, root)
         except Exception as exc:
             print(f"FAIL: {exc}")
             return 1

--- a/tests/test_codex_permission_prompt_notification.py
+++ b/tests/test_codex_permission_prompt_notification.py
@@ -61,6 +61,7 @@ def run_feed_hook_capture(
     event: str,
     raw_response_delay: float = 0,
     socket_password: str | None = None,
+    surface_delivery_target: tuple[str, str] | None = None,
 ) -> tuple[dict, list, float]:
     """Runs `cmux hooks feed --source codex` and returns (stdout JSON,
     ordered received frames, elapsed seconds)."""
@@ -71,7 +72,12 @@ def run_feed_hook_capture(
     env["CMUX_WORKSPACE_ID"] = FAKE_WORKSPACE_ID
     if socket_password is not None:
         env["CMUX_SOCKET_PASSWORD"] = socket_password
-    with FakeCmuxSocket(socket_path, None, raw_response_delay=raw_response_delay) as fake:
+    with FakeCmuxSocket(
+        socket_path,
+        None,
+        raw_response_delay=raw_response_delay,
+        surface_delivery_target=surface_delivery_target,
+    ) as fake:
         started = time.monotonic()
         result = subprocess.run(
             [
@@ -242,6 +248,42 @@ def test_permission_notification_survives_slow_authentication(
         )
 
 
+def test_permission_notification_targets_rehomed_pane(cli_path: str, root: Path) -> None:
+    """On restored remote panes the ambient env IDs are snapshot aliases;
+    the relay remaps IDs only inside JSON requests, so a V1 command built
+    from ambient IDs would target a stale pane. The hook must resolve the
+    live identity through `agent.resolve_delivery_target` and address the
+    notification to the answer, not the ambient identities."""
+    live_workspace = "99999999-9999-9999-9999-999999999999"
+    live_surface = "88888888-8888-8888-8888-888888888888"
+    _, frames, _ = run_feed_hook_capture(
+        cli_path,
+        root / "cmux-rehome.sock",
+        "PermissionRequest",
+        surface_delivery_target=(live_workspace, live_surface),
+    )
+    resolve_frame = next(
+        (frame for frame in frames if frame.get("method") == "agent.resolve_delivery_target"),
+        None,
+    )
+    if resolve_frame is None:
+        raise AssertionError(f"hook did not probe the live delivery target: {frames!r}")
+    if resolve_frame.get("params", {}).get("surface_id") != FAKE_SURFACE_ID:
+        raise AssertionError(f"probe must carry the ambient surface identity: {resolve_frame!r}")
+    expected = (
+        f"notify_target_async {live_workspace} {live_surface} "
+        "Codex|Permission|shell needs approval|c=needs-permission;p=0"
+    )
+    commands = raw_commands(frames)
+    if expected not in commands:
+        raise AssertionError(
+            f"notification did not target the re-homed pane: {commands!r}"
+        )
+    stale = [c for c in commands if c.startswith(f"notify_target_async {FAKE_WORKSPACE_ID}")]
+    if stale:
+        raise AssertionError(f"notification used stale ambient identities: {stale!r}")
+
+
 def main() -> int:
     try:
         cli_path = resolve_cmux_cli()
@@ -259,6 +301,7 @@ def main() -> int:
             test_pre_tool_use_sends_no_attention_command(cli_path, root)
             test_permission_notification_is_acknowledged_before_hook_returns(cli_path, root)
             test_permission_notification_survives_slow_authentication(cli_path, root)
+            test_permission_notification_targets_rehomed_pane(cli_path, root)
         except Exception as exc:
             print(f"FAIL: {exc}")
             return 1

--- a/tests/test_codex_permission_prompt_notification.py
+++ b/tests/test_codex_permission_prompt_notification.py
@@ -60,6 +60,7 @@ def run_feed_hook_capture(
     socket_path: Path,
     event: str,
     raw_response_delay: float = 0,
+    socket_password: str | None = None,
 ) -> tuple[dict, list, float]:
     """Runs `cmux hooks feed --source codex` and returns (stdout JSON,
     ordered received frames, elapsed seconds)."""
@@ -68,6 +69,8 @@ def run_feed_hook_capture(
         env.pop(key, None)
     env["CMUX_SURFACE_ID"] = FAKE_SURFACE_ID
     env["CMUX_WORKSPACE_ID"] = FAKE_WORKSPACE_ID
+    if socket_password is not None:
+        env["CMUX_SOCKET_PASSWORD"] = socket_password
     with FakeCmuxSocket(socket_path, None, raw_response_delay=raw_response_delay) as fake:
         started = time.monotonic()
         result = subprocess.run(
@@ -213,6 +216,32 @@ def test_permission_notification_is_acknowledged_before_hook_returns(
         )
 
 
+def test_permission_notification_survives_slow_authentication(
+    cli_path: str, root: Path
+) -> None:
+    """The attention lane's connect/auth budget must cover slow links: a
+    relay-backed connection's HMAC handshake spans multiple round trips. With
+    the fake delaying every command reply (including `auth`) by 0.5s, a
+    fast-fail (50ms) attention transport silently drops the notification;
+    the deadline-budgeted transport delivers it. The telemetry lane keeps
+    its deliberate fast-fail bounds, so feed.push may legitimately be absent
+    in this scenario."""
+    stdout, frames, _ = run_feed_hook_capture(
+        cli_path,
+        root / "cmux-slow-auth.sock",
+        "PermissionRequest",
+        raw_response_delay=0.5,
+        socket_password="test-password",
+    )
+    if stdout != {}:
+        raise AssertionError(f"PermissionRequest must stay non-blocking: {stdout!r}")
+    if EXPECTED_NOTIFY_COMMAND not in raw_commands(frames):
+        raise AssertionError(
+            "notification was dropped behind a slow authentication handshake: "
+            f"{frames!r}"
+        )
+
+
 def main() -> int:
     try:
         cli_path = resolve_cmux_cli()
@@ -229,6 +258,7 @@ def main() -> int:
             test_post_tool_use_clears_pane_before_feed_push(cli_path, root)
             test_pre_tool_use_sends_no_attention_command(cli_path, root)
             test_permission_notification_is_acknowledged_before_hook_returns(cli_path, root)
+            test_permission_notification_survives_slow_authentication(cli_path, root)
         except Exception as exc:
             print(f"FAIL: {exc}")
             return 1


### PR DESCRIPTION
Fixes #9592.

## Problem

With `notifications.agentPermissionPrompt: true` (the default), a Codex seat blocked on its approval dialog never produces a user notification. Codex's `PermissionRequest` hook is wired to the Feed bridge (`cmux hooks feed --source codex --event PermissionRequest`), and `FeedEventClassifier` deliberately maps it to non-actionable `PreToolUse` telemetry so cmux's Feed does not double-prompt against Codex's own approval reviewer (that mapping is what keeps "Approve for me" working). But that normalization also silently dropped the one signal Codex fires while blocked on the user, so no `agentPermissionPrompt` notification was ever raised — exactly what the issue's bus capture shows (`agent.hook.PreToolUse` + `feed.item.*`, no `notification.*`).

## Fix

The classifier's actionability and its user-attention notification were conflated in one flag. This PR separates them with a new registry semantic instead of special-casing codex at a call site:

- `FeedEventClassifier` gains a `.nativeApprovalPrompt` semantic: "the agent is blocked waiting for the user in its **own** approval UI." Wire behavior is unchanged (non-actionable `PreToolUse` telemetry, no cmux Feed approval card, no blocking wait), but the classification now carries `notifiesNativeApprovalPrompt: true`. Codex's `PermissionRequest` / `permission_request` register with it. Any future agent with a native approval UI gets the same behavior with one registry line.
- `runFeedHook` delivers a fire-and-forget `notify_target_async` on that flag, built through the shared `AgentHookNotificationClassifier` (same "Permission" / "Approval needed" strings, same `c=needs-permission;p=0` meta the generic agent `notification` hook and Claude's `permission_prompt` path emit), so the app gates it under the existing "Agent Needs Permission" setting via `AgentNotificationDelivery`. The tool summary (command/path) becomes the notification body when present.

No new user-facing strings: the notification reuses the existing localized `agent.generic.notification.subtitle.permission` / `agent.generic.notification.body.approvalNeeded` keys and the agent display name ("Codex"). Localization audit: no UI/settings/menu/help text changed; no web message catalogs affected.

## Commits

1. **Failing regression test (CI red expected on this commit)** — widens `classify` to return a `FeedEventClassification` struct carrying `notifiesNativeApprovalPrompt` (false everywhere, behavior-neutral) and adds `codexPermissionRequestRaisesPermissionPromptNotification`, which fails against the old mapping. The struct widening is included so the test compiles; the behavioral assertion is the failing part.
2. **Fix** — the `.nativeApprovalPrompt` semantic, the codex registry entries, and the CLI notification delivery.

## Testing

- `FeedEventClassificationTests`: new tests assert codex `PermissionRequest`/`permission_request` classify as telemetry-with-notification, the completion-only clear scoping, and the exact attention wire commands (UUID gating, payload shape, pipe/newline sanitization, `needs-permission` meta).
- **CLI-level behavior suite (CI-wired)**: `tests/test_codex_permission_prompt_notification.py` spawns the real CLI against the existing `FakeCmuxSocket` harness and asserts the actual socket transport: the exact gated `notify_target_async` line precedes `feed.push` on `PermissionRequest`; the exact pane-scoped `clear_notifications` precedes telemetry on `PostToolUse`; `PreToolUse` emits neither; and the hook awaits the app's acknowledgement (0.5s-delayed OK is waited out — a fire-and-forget regression returns instantly). **Red/green proven**: the suite fails against release CLI 0.64.22 ("missing gated permission notification") and passes on this branch.
- Mock-socket repro of the issue's exact command (`cmux hooks feed --source codex --event PermissionRequest` with a codex payload from a bound pane env):
  - Before (release CLI 0.64.22): the CLI emits only the `feed.push` telemetry frame with `hook_event_name: "PreToolUse"` — no notification, matching the issue's bus capture.
  - After (this branch's tagged build): `PermissionRequest` emits the same unchanged `feed.push` frame **plus** `notify_target_async <workspace-uuid> <surface-uuid> Codex|Permission|shell needs approval|c=needs-permission;p=0`; `PreToolUse` emits only the `feed.push` frame (no over-notification, no premature clear); `PostToolUse` emits `feed.push` plus a pane-scoped `clear_notifications --tab=<ws> --panel=<sf>`.
- Not covered by automated tests: the end-to-end app-side banner (requires a live app + notification center); the app-side gating path (`AgentNotificationDelivery` / `agentNotificationShouldDeliver`) is pre-existing and already unit-tested.

## Review round (codex autoreview findings addressed)

- **Notification body no longer contains tool input.** The first cut put the tool summary (full shell command) in the notification body; commands can embed credentials and banners reach lock screens, paired phones, and the recorded notification history. The body now names only the tool — `"<tool> needs approval"` via the same `feed.notification.permission.body` string the in-app Feed approval banner uses (falling back to the existing "Approval needed").
- **Stale/false alerts self-heal — on tool completion only.** Codex's `PermissionRequest` fires before its own "Approve for me" reviewer (per #5507's contract), so an auto-approved request would leave a stale "Permission" alert. A completed tool strictly follows any approval, so codex `PostToolUse` feed events now clear the pane's notifications (mirroring the pane-wide clears Claude's lifecycle hooks and Hermes' approval-response hook already perform; codex's own `prompt-submit` hook clears denied-approval residue at the next turn). Pre-tool events deliberately do NOT clear: codex gives no ordering guarantee between `PermissionRequest` and its pre-tool hooks, so a start-time clear could race and erase the just-raised prompt while the agent is still blocked. The clear is registry-scoped: only sources that raise native approval prompts get it. The clear stays pane-wide and uncorrelated by design — notifications carry no request identity anywhere in cmux, and this matches every existing agent integration.
- **Clears ride only the synchronous feed-hook path.** A review round asked for the clear on the wrapper telemetry lane too (`hooks codex post-tool-use`); the next round correctly observed that wrapper-injected hooks run as fire-and-forget `nohup` workers with no ordering guarantee, so a delayed completion worker's clear could erase a newer request's live notification. The wrapper-lane clear was removed again (documented in `sendFeedTelemetry`); wrapper-path staleness is pre-existing shipped behavior that self-heals at the next `prompt-submit` pane clear. The feed-hook path's events arrive in codex's own order (synchronous hook commands), so its clear is ordering-safe.
- **Immediate notify retained deliberately.** Codex offers no post-reviewer "now prompting the user" hook, and the wrapper-injected hook schema (`CodexHookInjectionSchema` → `cmux hooks codex notification`) already posts this same immediate needs-permission notification today; suppressing until "authoritative" proof would recreate exactly the silence #9592 reports. The alert is gated by the user's "Agent Needs Permission" setting and now self-heals as above.

- **Transport ordering is acknowledged, not assumed.** The notify/clear line is sent request/response and awaited (bounded 2s) before the synchronous hook returns — the same contract Claude's and Hermes' hooks use — so the next hook's process starts only after the mutation is in the app's ordered lane. The feed frame stays one-way best-effort on its own bounded connection (no implicit relay reconnect can outlive the agent's hook budget). Warm hook latency ~0.15s measured.
- **Consciously accepted residual (documented in code):** codex's fire-and-forget `prompt-submit` worker clears the pane at turn start from a detached process; if that worker is slower than the model's very first approval-needing tool call, its late clear can remove the new notification. This is the same pre-existing exposure the shipped wrapper-path notification (`hooks codex notification`) has always had — this PR does not widen the class. Eliminating it requires origin-time-fenced clears (a cross-layer notification-store protocol change), deliberately out of scope.

## Open review findings (deferred — not addressed in this PR)

Thirteen structured-review rounds ran on this branch; every earlier finding was either fixed as prescribed (redaction, completion-only clears, acknowledged transport, relay deadline budget, alias-safe live-target resolution, probe budget reserve, CLI-level behavior tests) or consciously rejected with codebase evidence (per-request notification correlation, prompt-submit clear race). The final round raised three further transport-tail P1s that are deferred as follow-ups rather than iterated further here:

1. **Stalled-probe connection reuse**: after a timed-out live-target probe, the attention send reuses the same connection; the command is still written and processed, but the acknowledgement can consume the probe's late reply, weakening the pre-return-ack guarantee in that already-degraded tail (a delayed PostToolUse clear could then race a newer notification). Fix would probe on a separate connection.
2. **Relay handshake budget arithmetic**: if each relay-backed `send` requires a fresh HMAC handshake, the 2s attention deadline may not fit probe + notify on slow links; needs relay-path measurement to size properly.
3. **Oversized payloads bypass attention**: codex payloads over the 1 MiB stdin bound return `{}` before classification, so an oversized PermissionRequest doesn't notify; delivery could fall back to the trusted `--event` flag.

All three are narrower than the shipped baseline this PR improves on (previously *no* codex approval notification existed on any path), and each is confined to the new attention lane's degraded-transport tails.

## Notes / scope

- The in-app "Needs input" sidebar badge is intentionally not flipped for codex approval blocks: codex has no follow-up hook that reliably marks the approval resolved (approve → tool runs → `PostToolUse`; deny → turn continues), so setting needs-input state here would risk a stuck badge. The notification is the contract `agentPermissionPrompt` documents.
- Routing uses the caller pane's `CMUX_WORKSPACE_ID`/`CMUX_SURFACE_ID` (same identities the feed frame itself rides); if either is missing or not a UUID the notification is skipped best-effort, never failing the hook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
