### PR TITLE
Fix sidebar reorder breaking Mission Control

### DIFF
--- a/Sources/Sidebar/AppKitList/SidebarWorkspaceTableContainerView.swift
+++ b/Sources/Sidebar/AppKitList/SidebarWorkspaceTableContainerView.swift
@@ -1,13 +1,12 @@
 import AppKit
 
-/// AppKit container stacking the bonsplit drag destination above the
-/// virtualized table. Workspace reorder drops land on the table itself
-/// (native `validateDrop`/`acceptDrop`), so no reorder overlay is needed.
+/// AppKit container stacking drag destinations above the virtualized table.
 @MainActor
 final class SidebarWorkspaceTableContainerView: NSView {
     let scrollView = NSScrollView()
     let clipView = SidebarWorkspaceTableClipView()
     let tableView = SidebarWorkspaceTableViewImpl()
+    let reorderDropView = SidebarWorkspaceReorderDropView()
     let bonsplitDropView = SidebarBonsplitTabWorkspaceDropView()
     let emptyDropIndicatorView = SidebarWorkspaceTableEmptyDropIndicatorView()
 
@@ -19,9 +18,11 @@ final class SidebarWorkspaceTableContainerView: NSView {
         scrollView.contentView = clipView
 
         scrollView.translatesAutoresizingMaskIntoConstraints = false
+        reorderDropView.translatesAutoresizingMaskIntoConstraints = false
         bonsplitDropView.translatesAutoresizingMaskIntoConstraints = false
         emptyDropIndicatorView.translatesAutoresizingMaskIntoConstraints = true
         addSubview(scrollView)
+        addSubview(reorderDropView)
         addSubview(bonsplitDropView)
         addSubview(emptyDropIndicatorView)
         NSLayoutConstraint.activate([
@@ -29,6 +30,10 @@ final class SidebarWorkspaceTableContainerView: NSView {
             scrollView.trailingAnchor.constraint(equalTo: trailingAnchor),
             scrollView.topAnchor.constraint(equalTo: topAnchor),
             scrollView.bottomAnchor.constraint(equalTo: bottomAnchor),
+            reorderDropView.leadingAnchor.constraint(equalTo: leadingAnchor),
+            reorderDropView.trailingAnchor.constraint(equalTo: trailingAnchor),
+            reorderDropView.topAnchor.constraint(equalTo: topAnchor),
+            reorderDropView.bottomAnchor.constraint(equalTo: bottomAnchor),
             bonsplitDropView.leadingAnchor.constraint(equalTo: leadingAnchor),
             bonsplitDropView.trailingAnchor.constraint(equalTo: trailingAnchor),
             bonsplitDropView.topAnchor.constraint(equalTo: topAnchor),

--- a/Sources/Sidebar/AppKitList/SidebarWorkspaceTableController.swift
+++ b/Sources/Sidebar/AppKitList/SidebarWorkspaceTableController.swift
@@ -104,12 +104,6 @@ final class SidebarWorkspaceTableController: NSObject, NSTableViewDataSource, NS
         table.doubleAction = #selector(didDoubleClickTableRow)
         table.setDraggingSourceOperationMask(.move, forLocal: true)
         table.setDraggingSourceOperationMask(.move, forLocal: false)
-        table.registerForDraggedTypes([
-            NSPasteboard.PasteboardType(SidebarTabDragPayload.typeIdentifier),
-        ])
-        // The row cells and the container's empty-indicator bar own all drop
-        // visuals; the built-in gap/highlight feedback must never draw.
-        table.draggingDestinationFeedbackStyle = .none
 
         let column = NSTableColumn(identifier: NSUserInterfaceItemIdentifier("workspace"))
         column.resizingMask = .autoresizingMask
@@ -132,6 +126,9 @@ final class SidebarWorkspaceTableController: NSObject, NSTableViewDataSource, NS
         )
         scrollView.applySidebarOverlayScrollerConfiguration()
 
+        container.reorderDropView.registerForDraggedTypes([
+            SidebarWorkspaceReorderDropOverlay.pasteboardType,
+        ])
         dropTargetGeometry.attach(containerView: container)
         container.bonsplitDropView.targetBridge = dropTargetGeometry.bonsplitTargetBridge
 
@@ -847,10 +844,10 @@ final class SidebarWorkspaceTableController: NSObject, NSTableViewDataSource, NS
         retireReorderIndicator()
     }
 
-    // MARK: Workspace reorder drop (native NSTableView destination)
+    // MARK: Workspace reorder drop
 
     /// Window-space location of the live reorder drag. Present only between
-    /// an accepted validateDrop and the drop/exit/end that retires it; while
+    /// an accepted overlay update and the drop/exit/end that retires it; while
     /// present, every viewport change re-plans against it so the indicator
     /// tracks rows sliding under a stationary pointer during edge autoscroll.
     private var reorderDragWindowPoint: NSPoint?
@@ -861,17 +858,10 @@ final class SidebarWorkspaceTableController: NSObject, NSTableViewDataSource, NS
     /// the controller paints the affected cells directly instead.
     private var reorderIndicatorPainter: SidebarWorkspaceTableReorderIndicatorPainter?
 
-    /// Workspace id parsed from the drag pasteboard at validateDrop time.
+    /// Workspace id parsed from the live drag pasteboard by the overlay.
     /// Survives dragState teardown (app-resign failsafe) so re-plans and the
     /// final drop can re-arm the drag instead of silently no-oping.
     private var reorderDragPayloadWorkspaceId: UUID?
-
-    /// True while a reorder drop session is hovering the table (between an
-    /// accepted validateDrop and drop/exit/end). Gates the table's refusal of
-    /// AppKit's built-in drag autoscroll to drop sessions only.
-    var isReorderDropSessionActive: Bool {
-        reorderDragWindowPoint != nil || reorderIndicatorPainter != nil
-    }
 
     /// The plan whose indicator is currently painted. The drop commits this
     /// plan verbatim so the outcome always matches the line the user saw;
@@ -885,29 +875,16 @@ final class SidebarWorkspaceTableController: NSObject, NSTableViewDataSource, NS
     /// the release position.
     private var suppressSelectedScrollAfterLocalDrop = false
 
-    func tableView(
-        _ tableView: NSTableView,
-        validateDrop info: any NSDraggingInfo,
-        proposedRow row: Int,
-        proposedDropOperation dropOperation: NSTableView.DropOperation
-    ) -> NSDragOperation {
-        guard pasteboardCarriesReorderPayload(info) else { return [] }
-        reorderDragPayloadWorkspaceId = Self.reorderPayloadWorkspaceId(info.draggingPasteboard)
-        return updateReorderDrag(windowPoint: info.draggingLocation) ? .move : []
-    }
-
-    func tableView(
-        _ tableView: NSTableView,
-        acceptDrop info: any NSDraggingInfo,
-        row: Int,
-        dropOperation: NSTableView.DropOperation
+    private func performReorderDrop(
+        point: CGPoint,
+        targets: [SidebarWorkspaceReorderDropOverlay.Target],
+        payloadWorkspaceId: UUID?
     ) -> Bool {
         reorderDragWindowPoint = nil
-        guard pasteboardCarriesReorderPayload(info),
-              let actions,
-              let table = containerView?.tableView else { return false }
-        let payloadWorkspaceId = Self.reorderPayloadWorkspaceId(info.draggingPasteboard)
-        let point = table.convert(info.draggingLocation, from: nil)
+        guard let actions else {
+            retireReorderIndicator()
+            return false
+        }
         let performed: Bool
         let commitSource: String
         if let plan = lastAcceptedReorderDropPlan {
@@ -915,9 +892,8 @@ final class SidebarWorkspaceTableController: NSObject, NSTableViewDataSource, NS
             performed = actions.commitWorkspaceDropPlan(plan)
             commitSource = "paintedPlan"
         } else {
-            // No accepted hover reached this table (drop without a preceding
-            // validateDrop plan): resolve from the release point.
-            performed = actions.performWorkspaceDrop(point, reorderDropTargets(), payloadWorkspaceId)
+            // No accepted hover plan exists: resolve from the release point.
+            performed = actions.performWorkspaceDrop(point, targets, payloadWorkspaceId)
             commitSource = "releasePoint"
         }
 #if DEBUG
@@ -943,27 +919,43 @@ final class SidebarWorkspaceTableController: NSObject, NSTableViewDataSource, NS
         retireReorderIndicator()
     }
 
-    func reorderDropSessionEnded() {
-        reorderDropDragExited()
-    }
-
     /// Runs the shared reorder planner for a drag hovering at `windowPoint`
     /// and paints the resulting indicator. An accepted position is remembered
     /// (window space) so viewport changes can re-plan it; a rejected one
-    /// stops the re-plan loop until the pointer produces a new validateDrop.
+    /// stops the re-plan loop until the pointer produces a new overlay update.
     @discardableResult
     func updateReorderDrag(windowPoint: NSPoint) -> Bool {
-        guard let actions, let table = containerView?.tableView else {
+        guard let dropView = containerView?.reorderDropView else {
             reorderDragWindowPoint = nil
             retireReorderIndicator()
             return false
         }
-        let targets = reorderDropTargets()
+        let targets = refreshReorderDropTargets()
+        return updateReorderDrag(
+            point: dropView.convert(windowPoint, from: nil),
+            targets: targets,
+            windowPoint: windowPoint,
+            payloadWorkspaceId: reorderDragPayloadWorkspaceId
+        )
+    }
+
+    private func updateReorderDrag(
+        point: CGPoint,
+        targets: [SidebarWorkspaceReorderDropOverlay.Target],
+        windowPoint: NSPoint,
+        payloadWorkspaceId: UUID?
+    ) -> Bool {
+        guard let actions else {
+            reorderDragWindowPoint = nil
+            retireReorderIndicator()
+            return false
+        }
+        reorderDragPayloadWorkspaceId = payloadWorkspaceId
         guard !targets.isEmpty,
               let update = actions.updateWorkspaceDrag(
-                  table.convert(windowPoint, from: nil),
+                  point,
                   targets,
-                  reorderDragPayloadWorkspaceId
+                  payloadWorkspaceId
               )
         else {
             reorderDragWindowPoint = nil
@@ -1026,31 +1018,40 @@ final class SidebarWorkspaceTableController: NSObject, NSTableViewDataSource, NS
         }
     }
 
-    /// Visible-row drop targets in table coordinates, built synchronously at
-    /// hit-test time. The drag point is converted into the same space, so the
-    /// planner's point/frame comparisons stay coherent.
-    private func reorderDropTargets() -> [SidebarWorkspaceReorderDropOverlay.Target] {
-        guard let table = containerView?.tableView else { return [] }
+    /// Refreshes visible-row targets in the overlay's coordinate space.
+    @discardableResult
+    private func refreshReorderDropTargets() -> [SidebarWorkspaceReorderDropOverlay.Target] {
+        guard let container = containerView else { return [] }
+        let table = container.tableView
         let visibleRange = table.rows(in: table.visibleRect)
-        guard visibleRange.location != NSNotFound, visibleRange.length > 0 else { return [] }
+        guard visibleRange.location != NSNotFound, visibleRange.length > 0 else {
+            clearReorderDropTargets()
+            return []
+        }
         let lower = max(0, visibleRange.location)
         let upper = min(rows.count, visibleRange.location + visibleRange.length)
-        guard lower < upper else { return [] }
-        return (lower..<upper).map { row in
+        guard lower < upper else {
+            clearReorderDropTargets()
+            return []
+        }
+        let targets = (lower..<upper).map { row in
             let configuration = rows[row]
             return SidebarWorkspaceReorderDropOverlay.Target(
                 workspaceId: configuration.workspaceId,
                 groupId: configuration.groupId,
                 isGroupHeader: configuration.isGroupHeader,
-                frame: table.rect(ofRow: row)
+                frame: table.convert(table.rect(ofRow: row), to: container.reorderDropView)
             )
         }
+        container.reorderDropView.targets = targets
+        container.reorderDropView.targetsDidUpdate()
+        return targets
     }
 
-    private func pasteboardCarriesReorderPayload(_ info: any NSDraggingInfo) -> Bool {
-        info.draggingPasteboard.types?.contains(
-            NSPasteboard.PasteboardType(SidebarTabDragPayload.typeIdentifier)
-        ) == true
+    private func clearReorderDropTargets() {
+        guard let reorderDropView = containerView?.reorderDropView else { return }
+        reorderDropView.targets = []
+        reorderDropView.targetsDidUpdate()
     }
 
     /// Item-provider drag sources promise data rather than strings, so fall
@@ -1563,6 +1564,42 @@ final class SidebarWorkspaceTableController: NSObject, NSTableViewDataSource, NS
         in container: SidebarWorkspaceTableContainerView,
         actions: SidebarWorkspaceTableActions
     ) {
+        let reorder = container.reorderDropView
+        let livePayloadWorkspaceId = {
+            Self.reorderPayloadWorkspaceId(NSPasteboard(name: .drag))
+        }
+        reorder.isValidDrag = {
+            actions.isValidWorkspaceDrag() || livePayloadWorkspaceId() != nil
+        }
+        reorder.updateDrag = { [weak self, weak reorder] point, _ in
+            guard let self, let reorder else { return false }
+            let targets = self.refreshReorderDropTargets()
+            return self.updateReorderDrag(
+                point: point,
+                targets: targets,
+                windowPoint: reorder.convert(point, to: nil),
+                payloadWorkspaceId: livePayloadWorkspaceId()
+            )
+        }
+        reorder.performDropAtPoint = { [weak self] point, _ in
+            guard let self else { return false }
+            return self.performReorderDrop(
+                point: point,
+                targets: self.refreshReorderDropTargets(),
+                payloadWorkspaceId: livePayloadWorkspaceId()
+            )
+        }
+        reorder.clearDropIndicator = { [weak self] in
+            self?.reorderDropDragExited()
+        }
+        reorder.setWorkspaceDropTargetCollectionActive = { [weak self] isActive in
+            if isActive {
+                self?.refreshReorderDropTargets()
+            } else {
+                self?.clearReorderDropTargets()
+            }
+        }
+
         let bonsplit = container.bonsplitDropView
         bonsplit.canPerformAction = actions.canPerformBonsplitAction
         bonsplit.updateAutoscroll = actions.updateDragAutoscroll
@@ -1592,6 +1629,15 @@ final class SidebarWorkspaceTableController: NSObject, NSTableViewDataSource, NS
     }
 
     private func clearDropViewActions(in container: SidebarWorkspaceTableContainerView) {
+        let reorder = container.reorderDropView
+        reorder.targets = []
+        reorder.targetsDidUpdate()
+        reorder.isValidDrag = { false }
+        reorder.updateDrag = { _, _ in false }
+        reorder.performDropAtPoint = { _, _ in false }
+        reorder.clearDropIndicator = {}
+        reorder.setWorkspaceDropTargetCollectionActive = { _ in }
+
         let bonsplit = container.bonsplitDropView
         bonsplit.suspendPresentation()
         bonsplit.canPerformAction = { _, _ in false }

--- a/Sources/Sidebar/AppKitList/SidebarWorkspaceTableController.swift
+++ b/Sources/Sidebar/AppKitList/SidebarWorkspaceTableController.swift
@@ -1630,8 +1630,7 @@ final class SidebarWorkspaceTableController: NSObject, NSTableViewDataSource, NS
 
     private func clearDropViewActions(in container: SidebarWorkspaceTableContainerView) {
         let reorder = container.reorderDropView
-        reorder.targets = []
-        reorder.targetsDidUpdate()
+        reorder.suspendPresentation()
         reorder.isValidDrag = { false }
         reorder.updateDrag = { _, _ in false }
         reorder.performDropAtPoint = { _, _ in false }

--- a/Sources/Sidebar/AppKitList/SidebarWorkspaceTableDropTargetGeometryGate.swift
+++ b/Sources/Sidebar/AppKitList/SidebarWorkspaceTableDropTargetGeometryGate.swift
@@ -2,8 +2,8 @@ import AppKit
 import CmuxFoundation
 
 /// Builds bonsplit drop geometry only while an AppKit drag requests it.
-/// Workspace reorder drops resolve their targets synchronously per
-/// `validateDrop` in `SidebarWorkspaceTableController` and never touch this.
+/// Workspace reorder drops resolve their targets through the dedicated overlay
+/// in `SidebarWorkspaceTableController` and never touch this.
 @MainActor
 final class SidebarWorkspaceTableDropTargetGeometryGate {
     let bonsplitTargetBridge = SidebarBonsplitTabWorkspaceDropOverlay.TargetBridge()

--- a/Sources/Sidebar/AppKitList/SidebarWorkspaceTableViewImpl.swift
+++ b/Sources/Sidebar/AppKitList/SidebarWorkspaceTableViewImpl.swift
@@ -66,34 +66,6 @@ final class SidebarWorkspaceTableViewImpl: NSTableView {
         return workspaceController?.emptyAreaMenu()
     }
 
-    // The data-source drop callbacks have no exit/cancel counterpart, and a
-    // reorder drag that leaves the sidebar (or is cancelled with Escape while
-    // over it) would otherwise strand the custom drop indicator.
-    override func draggingExited(_ sender: (any NSDraggingInfo)?) {
-        super.draggingExited(sender)
-        workspaceController?.reorderDropDragExited()
-    }
-
-    // SidebarDragAutoScrollController owns drag autoscroll. As a native drag
-    // destination the table also gets AppKit's built-in drag autoscroll,
-    // whose engagement band, speed, and boundary behavior all differ — two
-    // drivers fighting reads as flaky scrolling and scrolling that continues
-    // after the pointer left the cmux edge zone. Decline ONLY while a reorder
-    // drop session is hovering: NSTableView's own mouseDown tracking also
-    // calls autoscroll during drag initiation, and returning false there
-    // makes every row drag die at birth (mouse-up lands as a plain click).
-    override func autoscroll(with event: NSEvent) -> Bool {
-        if workspaceController?.isReorderDropSessionActive == true {
-            return false
-        }
-        return super.autoscroll(with: event)
-    }
-
-    override func draggingEnded(_ sender: any NSDraggingInfo) {
-        super.draggingEnded(sender)
-        workspaceController?.reorderDropSessionEnded()
-    }
-
     private func updatePointer(with event: NSEvent) {
         setPointerWindowLocation(event.locationInWindow)
     }

--- a/Sources/SidebarWorkspaceReorderDropView.swift
+++ b/Sources/SidebarWorkspaceReorderDropView.swift
@@ -77,6 +77,11 @@ final class SidebarWorkspaceReorderDropView: NSView {
         setTargetCollectionActive(false)
     }
 
+    func suspendPresentation() {
+        setTargetCollectionActive(false)
+        targets = []
+    }
+
     func performPendingDropIfPossible() {
         guard let pendingDrop,
               pendingDrop.requestId == targetRequestId,

--- a/cmuxTests/SidebarWorkspaceDropTargetSuspensionTests.swift
+++ b/cmuxTests/SidebarWorkspaceDropTargetSuspensionTests.swift
@@ -7,6 +7,44 @@ import Testing
 @Suite
 @MainActor
 struct SidebarWorkspaceDropTargetSuspensionTests {
+    private final class MockDraggingInfo: NSObject, NSDraggingInfo {
+        let draggingDestinationWindow: NSWindow?
+        let draggingSourceOperationMask: NSDragOperation = .move
+        let draggingLocation: NSPoint
+        let draggedImageLocation: NSPoint
+        let draggedImage: NSImage? = nil
+        nonisolated(unsafe) let draggingPasteboard: NSPasteboard
+        nonisolated(unsafe) let draggingSource: Any? = nil
+        let draggingSequenceNumber = 1
+        var draggingFormation: NSDraggingFormation = .default
+        var animatesToDestination = false
+        var numberOfValidItemsForDrop = 1
+        let springLoadingHighlight: NSSpringLoadingHighlight = .none
+
+        init(window: NSWindow, location: NSPoint, pasteboard: NSPasteboard) {
+            draggingDestinationWindow = window
+            draggingLocation = location
+            draggedImageLocation = location
+            draggingPasteboard = pasteboard
+        }
+
+        func slideDraggedImage(to screenPoint: NSPoint) {}
+
+        override func namesOfPromisedFilesDropped(atDestination dropDestination: URL) -> [String]? {
+            nil
+        }
+
+        func enumerateDraggingItems(
+            options enumOpts: NSDraggingItemEnumerationOptions = [],
+            for view: NSView?,
+            classes classArray: [AnyClass],
+            searchOptions: [NSPasteboard.ReadingOptionKey: Any] = [:],
+            using block: (NSDraggingItem, Int, UnsafeMutablePointer<ObjCBool>) -> Void
+        ) {}
+
+        func resetSpringLoading() {}
+    }
+
     @Test
     func hidingDeactivatesBonsplitTargetsBeforeReveal() async {
         let controller = SidebarWorkspaceTableController()
@@ -60,6 +98,67 @@ struct SidebarWorkspaceDropTargetSuspensionTests {
         controller.dismantleContainerView(container)
 
         #expect(activeStates == [true, false])
+    }
+
+    @Test
+    func hidingRearmsReorderTargetsAfterReveal() async {
+        let controller = SidebarWorkspaceTableController()
+        let container = controller.makeContainerView()
+        let row = makeRowConfiguration()
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 320, height: 240),
+            styleMask: [.borderless],
+            backing: .buffered,
+            defer: false
+        )
+        window.contentView = container
+        defer {
+            window.contentView = nil
+            window.close()
+        }
+        let actions = makeTableActions { _ in }
+
+        controller.apply(
+            rows: [row],
+            actions: actions,
+            workspaceIds: [row.workspaceId],
+            selectedWorkspaceId: nil,
+            selectedScrollTargetWorkspaceId: nil
+        )
+        await flushStagedTableMutations()
+        container.layoutSubtreeIfNeeded()
+        container.tableView.layoutSubtreeIfNeeded()
+
+        let pasteboard = NSPasteboard(name: NSPasteboard.Name("workspace-reorder-\(UUID().uuidString)"))
+        pasteboard.clearContents()
+        pasteboard.setString(
+            row.workspaceId.uuidString,
+            forType: SidebarWorkspaceReorderDropOverlay.pasteboardType
+        )
+        let sender = MockDraggingInfo(
+            window: window,
+            location: NSPoint(x: 40, y: 80),
+            pasteboard: pasteboard
+        )
+
+        _ = container.reorderDropView.draggingEntered(sender)
+        #expect(!container.reorderDropView.targets.isEmpty)
+
+        controller.setPresentationActive(false, workspaceIds: [row.workspaceId])
+        #expect(container.reorderDropView.targets.isEmpty)
+
+        controller.setPresentationActive(true, workspaceIds: [row.workspaceId])
+        controller.apply(
+            rows: [row],
+            actions: actions,
+            workspaceIds: [row.workspaceId],
+            selectedWorkspaceId: nil,
+            selectedScrollTargetWorkspaceId: nil
+        )
+        await flushStagedTableMutations()
+
+        _ = container.reorderDropView.draggingEntered(sender)
+        #expect(!container.reorderDropView.targets.isEmpty)
     }
 
     private func makeRowConfiguration() -> SidebarWorkspaceTableRowConfiguration {

--- a/cmuxTests/SidebarWorkspaceTableSuspensionTests.swift
+++ b/cmuxTests/SidebarWorkspaceTableSuspensionTests.swift
@@ -270,7 +270,7 @@ struct SidebarWorkspaceTableSuspensionTests {
     }
 
     @Test
-    func hidingRetiresNativeReorderSession() async {
+    func hidingClearsReorderIndicator() async {
         let controller = SidebarWorkspaceTableController()
         let container = controller.makeContainerView()
         let workspaceIds = (0..<6).map { _ in UUID() }
@@ -310,11 +310,9 @@ struct SidebarWorkspaceTableSuspensionTests {
         container.tableView.layoutSubtreeIfNeeded()
 
         #expect(controller.updateReorderDrag(windowPoint: NSPoint(x: 40, y: 120)))
-        #expect(controller.isReorderDropSessionActive)
 
         controller.setPresentationActive(false, workspaceIds: workspaceIds)
 
-        #expect(!controller.isReorderDropSessionActive)
         #expect(indicatorClears == 1)
     }
 

--- a/cmuxTests/SidebarWorkspaceTableTests.swift
+++ b/cmuxTests/SidebarWorkspaceTableTests.swift
@@ -283,8 +283,8 @@ struct SidebarWorkspaceTableTests {
         await flushStagedTableMutations()
         #expect(computations == 0)
 
-        // Reorder drags resolve targets synchronously in validateDrop and
-        // must never wake the bonsplit geometry gate.
+        // Starting a reorder at the table must not wake the bonsplit-only
+        // geometry gate. The destination overlay resolves its own targets.
         controller.workspaceDragSessionDidBegin()
         controller.viewportDidChange()
         await flushStagedTableMutations()
@@ -306,7 +306,7 @@ struct SidebarWorkspaceTableTests {
 
     @Test
     @MainActor
-    func reorderDragReplansFromStoredWindowPointOnViewportChange() async {
+    func reorderDragReplansFromStoredWindowPointOnViewportChange() async throws {
         let controller = SidebarWorkspaceTableController()
         let container = controller.makeContainerView()
         let ids = (0..<30).map { _ in UUID() }
@@ -319,12 +319,14 @@ struct SidebarWorkspaceTableTests {
         window.contentView = container
         var plannedPoints: [CGPoint] = []
         var plannedTargetCounts: [Int] = []
+        var plannedTargetY: [CGFloat?] = []
         var indicatorClears = 0
         let draggedId = ids[2]
         let actions = makeTableActions(
             updateWorkspaceDrag: { point, targets, _ in
                 plannedPoints.append(point)
                 plannedTargetCounts.append(targets.count)
+                plannedTargetY.append(targets.first { $0.workspaceId == ids[5] }?.frame.minY)
                 return SidebarWorkspaceTableReorderDropUpdate(
                     indicator: SidebarDropIndicator(tabId: ids[5], edge: .top),
                     scope: .raw,
@@ -352,9 +354,9 @@ struct SidebarWorkspaceTableTests {
         // Targets are the visible rows only, not the full 30-row model.
         #expect(plannedTargetCounts == [container.tableView.rows(in: container.tableView.visibleRect).length])
 
-        // Autoscroll moves content under a stationary pointer: same window
-        // point, new viewport, so the stored point must re-plan and resolve
-        // to a shifted table-space position.
+        // Autoscroll moves overlay-space targets under a stationary pointer.
+        // The stored window point re-plans with a stable overlay point and
+        // freshly converted target frames.
         let originBefore = container.clipView.bounds.origin.y
         container.clipView.scroll(to: NSPoint(x: 0, y: originBefore + 100))
         container.scrollView.reflectScrolledClipView(container.clipView)
@@ -362,7 +364,10 @@ struct SidebarWorkspaceTableTests {
         await flushStagedTableMutations()
         #expect(plannedPoints.count == 2)
         let scrolledBy = container.clipView.bounds.origin.y - originBefore
-        #expect(abs((plannedPoints[1].y - plannedPoints[0].y) - scrolledBy) < 0.5)
+        #expect(plannedPoints[1] == plannedPoints[0])
+        let targetYBefore = try #require(plannedTargetY[0])
+        let targetYAfter = try #require(plannedTargetY[1])
+        #expect(abs((targetYAfter - targetYBefore) + scrolledBy) < 0.5)
 
         // Leaving the table retires the stored point: later viewport changes
         // must not keep planning a drag that is no longer over the sidebar.

--- a/cmuxTests/SidebarWorkspaceTableTests.swift
+++ b/cmuxTests/SidebarWorkspaceTableTests.swift
@@ -13,6 +13,19 @@ import Testing
 struct SidebarWorkspaceTableTests {
     @Test
     @MainActor
+    func reorderDropDestinationIsOverlayNotTable() throws {
+        let container = SidebarWorkspaceTableController().makeContainerView()
+        let pasteboardType = SidebarWorkspaceReorderDropOverlay.pasteboardType
+
+        #expect(!container.tableView.registeredDraggedTypes.contains(pasteboardType))
+        let reorderDropView = try #require(
+            container.subviews.lazy.compactMap { $0 as? SidebarWorkspaceReorderDropView }.first
+        )
+        #expect(reorderDropView.registeredDraggedTypes.contains(pasteboardType))
+    }
+
+    @Test
+    @MainActor
     func containerHasNoStructuralHorizontalRowInsetAndAlwaysActiveHoverTracking() throws {
         let container = SidebarWorkspaceTableController().makeContainerView()
         let column = try #require(container.tableView.tableColumns.first)


### PR DESCRIPTION
## Summary

- restore the dedicated workspace reorder overlay as the only drop destination
- keep `NSTableView` as the drag source and reuse the controller-owned indicator and accepted plan
- refresh visible reorder targets in overlay coordinates during viewport changes
- reset reorder target collection before hide or dismantle disconnects overlay callbacks

## Validation

- `git diff --check` passed
- `./scripts/lint-pbxproj-test-wiring.sh` passed (654 files)
- `./scripts/reload.sh --tag issue-9713 --launch` passed on `33364c05a`
- macOS 26.5 tagged dogfood completed two real mouse reorder operations, with a sidebar hide/reveal between them; both drops logged `source=paintedPlan performed=1` and changed the workspace order
- after each reorder, Mission Control switched between the temporary desktops and a Dock click activated Calculator across Spaces
- focused regression tests build successfully, but the local Xcode app-host did not materialize its test worker, so the runtime assertion remains for CI

Fixes #9713

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/9807"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788683716&installation_model_id=21920&pr_number=9807&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F9807&signature=066fb4601228f4843ef0c0ebc8d0714283d00bbcba23f0a42bc2d9188f73e697"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Reorders a core sidebar interaction path (AppKit drag destination + coordinate space) with Mission Control–related regressions in scope, though commit logic and indicators are largely reused rather than rewritten.
> 
> **Overview**
> **Workspace reordering no longer uses `NSTableView` as a drag destination.** Drops are handled only by a full-size `SidebarWorkspaceReorderDropView` layered above the table; the table remains the drag source and still drives the controller-owned reorder line and committed drop plan.
> 
> The controller registers `SidebarWorkspaceReorderDropOverlay.pasteboardType` on the overlay, wires `isValidDrag` / `updateDrag` / `performDropAtPoint` / target-collection callbacks, and builds visible-row targets by converting table row frames into overlay coordinates. Viewport changes and hide/reveal refresh or clear those targets so autoscroll re-plans against a stable pointer position.
> 
> **Removed table-only reorder plumbing:** pasteboard registration on the table, native `validateDrop`/`acceptDrop`, `isReorderDropSessionActive`, and `SidebarWorkspaceTableViewImpl` overrides for `draggingExited`, `draggingEnded`, and autoscroll suppression during reorder. Bonsplit drop geometry stays isolated from reorder targeting.
> 
> `suspendPresentation()` on the reorder overlay clears targets when the sidebar is hidden; tests assert overlay-only registration, indicator clearing on hide, and target rearming after reveal.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 33364c05aabdafee0cf437f49947f84d14486232. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores a dedicated overlay as the only drop destination for workspace reordering to stop Mission Control breakage. Targets are computed in overlay space so the indicator stays in sync during autoscroll, viewport changes, hide/reveal, and the drop lifecycle cleanly resets.

- **Bug Fixes**
  - Added SidebarWorkspaceReorderDropView and registered `SidebarWorkspaceReorderDropOverlay.pasteboardType`.
  - Wired overlay callbacks: isValidDrag, updateDrag, performDropAtPoint, clearDropIndicator, setWorkspaceDropTargetCollectionActive.
  - Overlay now owns and publishes targets in its coordinate space; clears on hide/drag exit, re-arms on reveal, and uses `suspendPresentation()` to fully reset.
  - Removed `NSTableView` as a reorder destination and its dragged types/feedback; dropped `draggingExited`/`draggingEnded`/autoscroll overrides. The table remains the drag source only.
  - Drop commits the last painted plan; if none, resolves from the release point against overlay targets.
  - Tests cover overlay-only destination, viewport re-plan with a stable overlay point, target rearming after reveal, indicator clearing on hide, and bonsplit isolation.

Fixes #9713.

<sup>Written for commit 33364c05aabdafee0cf437f49947f84d14486232. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/9807?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Workspace reordering now provides more reliable drop targeting across sidebar layouts and viewport positions.
  * Reorder indicators update smoothly while moving items and scrolling near sidebar edges.
* **Bug Fixes**
  * Fixed cases where reorder indicators could remain visible after hiding the sidebar or completing a drag.
  * Improved consistency when starting a subsequent workspace reorder operation.
  * Workspace reorder targets now correctly reset and become available again after the sidebar is hidden and shown.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
