### PR TITLE
Support image paste through mosh sessions

### DIFF
--- a/Sources/RemoteShellSessionParsing.swift
+++ b/Sources/RemoteShellSessionParsing.swift
@@ -4,6 +4,8 @@ import Darwin
 enum RemoteShellTransport: Sendable {
     case ssh
     case eternalTerminal
+    case mosh
+    case moshClient
 
     init?(executableName: String) {
         switch RemoteShellSessionParsing.normalizedExecutableName(executableName) {
@@ -11,6 +13,10 @@ enum RemoteShellTransport: Sendable {
             self = .ssh
         case "et":
             self = .eternalTerminal
+        case "mosh":
+            self = .mosh
+        case "mosh-client":
+            self = .moshClient
         default:
             return nil
         }
@@ -22,11 +28,25 @@ enum RemoteShellTransport: Sendable {
             return "ssh"
         case .eternalTerminal:
             return "et"
+        case .mosh:
+            return "mosh"
+        case .moshClient:
+            return "mosh-client"
         }
     }
 }
 
 enum RemoteShellSessionParsing {
+    private static let moshValueOptions: Set<String> = [
+        "bind-server",
+        "client",
+        "experimental-remote-ip",
+        "family",
+        "port",
+        "predict",
+        "server",
+        "ssh",
+    ]
     private static let eternalTerminalNoArgumentFlags = Set("efhNx")
     private static let eternalTerminalValueArgumentFlags = Set("cklprtu")
     private static let eternalTerminalLongValueOptions: Set<String> = [
@@ -75,6 +95,127 @@ enum RemoteShellSessionParsing {
         let trimmed = executableName.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty else { return "" }
         return trimmed.split(separator: "/").last.map(String.init)?.lowercased() ?? trimmed.lowercased()
+    }
+
+    /// Parses the original mosh command preserved in the running process arguments.
+    static func parseMoshCommandLine(
+        _ arguments: [String],
+        transport: RemoteShellTransport
+    ) -> DetectedSSHSession? {
+        let tokens: [String]
+        switch transport {
+        case .mosh:
+            guard !arguments.isEmpty else { return nil }
+            let startIndex = normalizedExecutableName(arguments[0]) == transport.executableName ? 1 : 0
+            tokens = Array(arguments.dropFirst(startIndex))
+        case .moshClient:
+            guard let marker = arguments.first(where: { $0.hasPrefix("-# ") }) else { return nil }
+            var commandLine = marker.dropFirst(3)
+            if commandLine.hasSuffix("|") {
+                commandLine = commandLine.dropLast()
+            }
+            tokens = commandLine.split(whereSeparator: \.isWhitespace).map(String.init)
+        case .ssh, .eternalTerminal:
+            return nil
+        }
+
+        return parseMoshArguments(tokens)
+    }
+
+    private static func parseMoshArguments(_ arguments: [String]) -> DetectedSSHSession? {
+        var destination: String?
+        var useIPv4 = false
+        var useIPv6 = false
+        var index = 0
+
+        while index < arguments.count {
+            let argument = arguments[index]
+            if argument == "--" {
+                let destinationIndex = index + 1
+                if destinationIndex < arguments.count {
+                    destination = arguments[destinationIndex]
+                }
+                break
+            }
+            if !argument.hasPrefix("-") || argument == "-" {
+                destination = argument
+                break
+            }
+
+            switch argument {
+            case "-4":
+                useIPv4 = true
+                useIPv6 = false
+                index += 1
+                continue
+            case "-6":
+                useIPv6 = true
+                useIPv4 = false
+                index += 1
+                continue
+            case "-p":
+                index += 2
+                continue
+            default:
+                break
+            }
+
+            if argument.hasPrefix("-p"), argument.count > 2 {
+                index += 1
+                continue
+            }
+
+            if argument.hasPrefix("--") {
+                let option = String(argument.dropFirst(2))
+                let parts = option.split(separator: "=", maxSplits: 1, omittingEmptySubsequences: false)
+                let optionName = String(parts[0])
+                if optionName == "family" {
+                    let value: String?
+                    if parts.count == 2 {
+                        value = String(parts[1])
+                        index += 1
+                    } else if index + 1 < arguments.count {
+                        value = arguments[index + 1]
+                        index += 2
+                    } else {
+                        return nil
+                    }
+                    switch value?.lowercased() {
+                    case "inet":
+                        useIPv4 = true
+                        useIPv6 = false
+                    case "inet6":
+                        useIPv6 = true
+                        useIPv4 = false
+                    default:
+                        break
+                    }
+                    continue
+                }
+                if moshValueOptions.contains(optionName), parts.count == 1 {
+                    guard index + 1 < arguments.count else { return nil }
+                    index += 2
+                    continue
+                }
+            }
+
+            index += 1
+        }
+
+        guard let destination, !destination.isEmpty else { return nil }
+        return DetectedSSHSession(
+            destination: destination,
+            port: nil,
+            identityFile: nil,
+            configFile: nil,
+            jumpHost: nil,
+            controlPath: nil,
+            useIPv4: useIPv4,
+            useIPv6: useIPv6,
+            forwardAgent: false,
+            compressionEnabled: false,
+            sshOptions: []
+        )
     }
 
     static func parseEternalTerminalCommandLine(_ arguments: [String]) -> DetectedSSHSession? {

--- a/Sources/TerminalSSHSessionDetector.swift
+++ b/Sources/TerminalSSHSessionDetector.swift
@@ -569,6 +569,8 @@ enum TerminalSSHSessionDetector {
             return parseSSHCommandLine(arguments)
         case .eternalTerminal:
             return RemoteShellSessionParsing.parseEternalTerminalCommandLine(arguments)
+        case .mosh, .moshClient:
+            return RemoteShellSessionParsing.parseMoshCommandLine(arguments, transport: transport)
         }
     }
 

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -2295,6 +2295,7 @@ C0DE71B10000000000000001 /* AppDelegate+AgentChatNotifications.swift in Sources 
 		859110000000000000000007 /* TerminalLinkOpenCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 859110000000000000000008 /* TerminalLinkOpenCoordinator.swift */; };
 		859100000000000000000001 /* TerminalLinkOpenCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 859100000000000000000002 /* TerminalLinkOpenCoordinatorTests.swift */; };
 		859110000000000000000009 /* TerminalLinkOpenRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 85911000000000000000000A /* TerminalLinkOpenRequest.swift */; };
+		A7F10000A1B2C3D4E5F60718 /* TerminalMoshSessionDetectorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7F10001A1B2C3D4E5F60718 /* TerminalMoshSessionDetectorTests.swift */; };
 		D79020000000000000000001 /* TerminalNotification+NavigationSnapshot.swift in Sources */ = {isa = PBXBuildFile; fileRef = D79020000000000000000002 /* TerminalNotification+NavigationSnapshot.swift */; };
 		A5F10000000000000000000B /* TerminalNotification.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5F10000000000000000000C /* TerminalNotification.swift */; };
 		A5C41101A1B2C3D4E5F60718 /* TerminalNotificationCallerResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5C41102A1B2C3D4E5F60718 /* TerminalNotificationCallerResolver.swift */; };
@@ -4929,6 +4930,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 		859110000000000000000008 /* TerminalLinkOpenCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalLinkOpenCoordinator.swift; sourceTree = "<group>"; };
 		859100000000000000000002 /* TerminalLinkOpenCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalLinkOpenCoordinatorTests.swift; sourceTree = "<group>"; };
 		85911000000000000000000A /* TerminalLinkOpenRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalLinkOpenRequest.swift; sourceTree = "<group>"; };
+		A7F10001A1B2C3D4E5F60718 /* TerminalMoshSessionDetectorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalMoshSessionDetectorTests.swift; sourceTree = "<group>"; };
 		D79020000000000000000002 /* TerminalNotification+NavigationSnapshot.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TerminalNotification+NavigationSnapshot.swift"; sourceTree = "<group>"; };
 		A5F10000000000000000000C /* TerminalNotification.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalNotification.swift; sourceTree = "<group>"; };
 		A5C41102A1B2C3D4E5F60718 /* TerminalNotificationCallerResolver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalNotificationCallerResolver.swift; sourceTree = "<group>"; };
@@ -7572,6 +7574,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				F6001001A1B2C3D4E5F60718 /* ShortcutUnbindingTests.swift */,
 				C73660030000000000000002 /* WorkspaceRemoteBadgeTruthTests.swift */,
 				F6100001A1B2C3D4E5F60718 /* WorkspaceRemoteConnectionTests.swift */,
+				A7F10001A1B2C3D4E5F60718 /* TerminalMoshSessionDetectorTests.swift */,
 				F6100001A1B2C3D4E5F60719 /* WorkspaceRemoteDaemonRecoveryTests.swift */,
 				C0DE7101C0DE7101C0DE7101 /* CodexTerminalErrorNotificationTests.swift */,
 				7277B0017277B0017277B001 /* WorkspaceRemoteDirectoryProvenanceTests.swift */,
@@ -11063,6 +11066,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				6190C0126190C0126190C012 /* TerminalCopyOnSelectManagedConfigLayeringTests.swift in Sources */,
 				851500000000000000000001 /* TerminalFontZoomSessionPersistenceTests.swift in Sources */,
 				859100000000000000000001 /* TerminalLinkOpenCoordinatorTests.swift in Sources */,
+				A7F10000A1B2C3D4E5F60718 /* TerminalMoshSessionDetectorTests.swift in Sources */,
 				A5C41103A1B2C3D4E5F60718 /* TerminalNotificationCallerTests.swift in Sources */,
 				A5A5A507A1B2C3D4E5F60718 /* TerminalNotificationClearAllTests.swift in Sources */,
 				A5A5A505A1B2C3D4E5F60718 /* TerminalNotificationDirectInteractionTests.swift in Sources */,

--- a/cmuxTests/TerminalMoshSessionDetectorTests.swift
+++ b/cmuxTests/TerminalMoshSessionDetectorTests.swift
@@ -1,0 +1,94 @@
+import Testing
+
+#if canImport(cmux_DEV)
+@testable import cmux_DEV
+#elseif canImport(cmux)
+@testable import cmux
+#endif
+
+/// Behavior tests for recovering an SSH upload destination from a foreground mosh session.
+@Suite struct TerminalMoshSessionDetectorTests {
+    @Test func detectsUpstreamWrapperMarker() throws {
+        let session = TerminalSSHSessionDetector.detectForTesting(
+            ttyName: "/dev/ttys004",
+            processes: [
+                .init(pid: 2145, pgid: 1967, tpgid: 1967, tty: "ttys004", executableName: "mosh-client"),
+            ],
+            argumentsByPID: [
+                2145: [
+                    "/opt/homebrew/bin/mosh-client",
+                    "-# -6 --predict=adaptive lawrence@example.com |",
+                    "2001:db8::1", "60002",
+                ],
+            ]
+        )
+
+        let detected = try #require(session)
+        #expect(detected.destination == "lawrence@example.com")
+        #expect(detected.useIPv6)
+        #expect(!detected.useIPv4)
+        #expect(detected.port == nil)
+    }
+
+    @Test func detectsForkingLauncherFromItsOwnArguments() throws {
+        let session = TerminalSSHSessionDetector.detectForTesting(
+            ttyName: "ttys004",
+            processes: [
+                .init(pid: 2140, pgid: 2140, tpgid: 2140, tty: "ttys004", executableName: "mosh"),
+                .init(pid: 2145, pgid: 2140, tpgid: 2140, tty: "ttys004", executableName: "mosh-client"),
+            ],
+            argumentsByPID: [
+                2140: ["/Users/test/.local/bin/mosh", "-p", "60001", "lawrence@example.com"],
+                2145: ["mosh-client", "192.0.2.1", "60001"],
+            ]
+        )
+
+        let detected = try #require(session)
+        #expect(detected.destination == "lawrence@example.com")
+        #expect(detected.port == nil)
+    }
+
+    @Test func prefersClientMarkerOverForkingLauncher() throws {
+        let session = TerminalSSHSessionDetector.detectForTesting(
+            ttyName: "ttys004",
+            processes: [
+                .init(pid: 2140, pgid: 2140, tpgid: 2140, tty: "ttys004", executableName: "mosh"),
+                .init(pid: 2145, pgid: 2140, tpgid: 2140, tty: "ttys004", executableName: "mosh-client"),
+            ],
+            argumentsByPID: [
+                2140: ["mosh", "stale@example.com"],
+                2145: ["mosh-client", "-# vps-he |", "192.0.2.1", "60002"],
+            ]
+        )
+
+        #expect(session?.destination == "vps-he")
+    }
+
+    @Test func ignoresDirectClientWithoutRecoverableDestination() {
+        let session = TerminalSSHSessionDetector.detectForTesting(
+            ttyName: "ttys004",
+            processes: [
+                .init(pid: 2145, pgid: 1967, tpgid: 1967, tty: "ttys004", executableName: "mosh-client"),
+            ],
+            argumentsByPID: [
+                2145: ["mosh-client", "192.0.2.1", "60001"],
+            ]
+        )
+
+        #expect(session == nil)
+    }
+
+    @Test func ignoresBackgroundLauncher() {
+        let session = TerminalSSHSessionDetector.detectForTesting(
+            ttyName: "ttys004",
+            processes: [
+                .init(pid: 2140, pgid: 2140, tpgid: 1967, tty: "ttys004", executableName: "mosh"),
+            ],
+            argumentsByPID: [
+                2140: ["mosh", "lawrence@example.com"],
+            ]
+        )
+
+        #expect(session == nil)
+    }
+}


### PR DESCRIPTION
## Summary
- detect foreground `mosh` and `mosh-client` processes when resolving an image-paste upload destination
- recover destinations from both the upstream mosh wrapper marker and wrappers that keep a launcher process alive
- preserve mosh IPv4 and IPv6 selection for the separate `scp` upload

## Testing
- `./scripts/lint-pbxproj-test-wiring.sh`
- `./scripts/check-pbxproj.sh`
- hosted test-only run: https://github.com/manaflow-ai/cmux/actions/runs/31170240807
- hosted fixed run: https://github.com/manaflow-ai/cmux/actions/runs/31170242926

## Attribution
- Ported and adapted from Alexander Pecheny's fork:
  - https://github.com/alexander-pecheny/cmux/commit/e1776bc6cb4ed7bfcb494934a9ba8c5af00654de
  - https://github.com/alexander-pecheny/cmux/commit/fef5b4c8a5138155940c55eaf89c5e56c2b5d55e

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how upload destinations are inferred from live process argv for mosh layouts; mistakes could mis-target `scp` or miss uploads, but scope is limited to parsing and mirrors existing ET/SSH detection patterns.
> 
> **Overview**
> Extends **remote shell session detection** so image paste can resolve an upload target when the foreground session is **mosh**, not only plain `ssh` or Eternal Terminal.
> 
> `RemoteShellTransport` now recognizes **`mosh`** and **`mosh-client`**. `RemoteShellSessionParsing` recovers the SSH-style destination from the launcher argv or from the **`mosh-client` `-# …` wrapper marker**, walks common mosh flags (`-4`, `-6`, `-p`, `--family`, and other value options) without treating them as the host, and builds a `DetectedSSHSession` with **IPv4/IPv6** hints for the follow-on **`scp`** upload (port/identity/jump options stay unset). `TerminalSSHSessionDetector` routes those transports through the new parser; foreground-process ordering means a client with a marker wins over a coexisting launcher with different args.
> 
> Adds **`TerminalMoshSessionDetectorTests`** for marker parsing, forking launcher fallback, preference over stale launcher argv, and cases where detection should not run.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 37a0c1331965da7677bbd68370edb31803d51252. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for detecting Mosh and Mosh Client terminal sessions.
  - Recovers remote destinations from Mosh launch commands, including IPv4 and IPv6 connections.
  - Recognizes supported Mosh options and port settings.
  - Rejects incomplete, invalid, or background launch commands when a reliable destination cannot be determined.
- **Tests**
  - Added coverage for destination detection, argument fallbacks, client markers, and invalid launch scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->