### PR TITLE
iOS: open workspace search selections inside the search tab

### DIFF
--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListLayoutPreviewView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListLayoutPreviewView.swift
@@ -165,7 +165,8 @@ public struct WorkspaceListLayoutPreviewView: View {
     }
 
     @State private var fixtureRoute: FixtureWorkspaceRoute?
-    @State private var pendingSearchFixtureRoute: FixtureWorkspaceRoute?
+    // Mirrors the shell: search results push onto the search tab's own stack.
+    @State private var searchFixturePath: [MobileWorkspacePreview.ID] = []
 
     private var scrollMetricsEnabled: Bool {
         ProcessInfo.processInfo.environment["CMUX_UITEST_SCROLL_METRICS"] == "1"
@@ -496,32 +497,16 @@ public struct WorkspaceListLayoutPreviewView: View {
                         workspaceListFixture(searchText: searchText)
                     }
                     .navigationDestination(item: $fixtureRoute) { route in
-                        VStack(spacing: 12) {
-                            Text(
-                                model.workspaces.first(where: { $0.id == route.id })?.name
-                                    ?? route.id.rawValue
-                            )
-                            .font(.title2)
-                            Text("Fixture workspace detail")
-                                .foregroundStyle(.secondary)
-                        }
-                        .accessibilityIdentifier("FixtureWorkspaceDetail")
-                        .toolbarVisibility(.hidden, for: .tabBar, .bottomBar)
-                        .navigationBarBackButtonHidden(true)
-                        .toolbar {
-                            ToolbarItem(placement: .topBarLeading) {
-                                WorkspaceBackButton(unreadCount: 0) {
-                                    fixtureRoute = nil
+                        fixtureWorkspaceDetail(for: route.id)
+                            .navigationBarBackButtonHidden(true)
+                            .toolbar {
+                                ToolbarItem(placement: .topBarLeading) {
+                                    WorkspaceBackButton(unreadCount: 0) {
+                                        fixtureRoute = nil
+                                    }
                                 }
                             }
-                        }
                     }
-                }
-                .onAppear {
-                    consumePendingSearchFixtureNavigation()
-                }
-                .onChange(of: pendingSearchFixtureRoute) { _, _ in
-                    consumePendingSearchFixtureNavigation()
                 }
                 .overlay(alignment: .bottomTrailing) {
                     if scrollMetricsEnabled {
@@ -543,11 +528,16 @@ public struct WorkspaceListLayoutPreviewView: View {
                         Text("Notification feed fixture")
                             .foregroundStyle(.secondary)
                     } workspaceSearch: {
-                        NavigationStack {
+                        NavigationStack(path: $searchFixturePath) {
                             MobilePrimaryWorkspaceSearchContentHost(
                                 searchCoordinator: primarySearchCoordinator
                             ) { searchText in
                                 workspaceListFixture(searchText: searchText)
+                            }
+                            // Mirrors the shell: a tapped search result pushes
+                            // inside the search tab with the system back button.
+                            .navigationDestination(for: MobileWorkspacePreview.ID.self) { workspaceID in
+                                fixtureWorkspaceDetail(for: workspaceID)
                             }
                         }
                     } notificationSearch: {
@@ -559,9 +549,10 @@ public struct WorkspaceListLayoutPreviewView: View {
                 }
             }
         }
-        .onChange(of: primarySearchCoordinator.isPresented) { _, isPresented in
-            guard !isPresented else { return }
-            consumePendingSearchFixtureNavigation()
+        .onChange(of: selectedPrimaryTab) { oldValue, newValue in
+            if oldValue == .search, newValue != .search {
+                searchFixturePath = []
+            }
         }
         .overlay(alignment: .topLeading) {
             ZStack(alignment: .topLeading) {
@@ -598,33 +589,28 @@ public struct WorkspaceListLayoutPreviewView: View {
 
     private func selectFixtureWorkspace(_ id: MobileWorkspacePreview.ID) {
         selectedWorkspaceID = id
-        let route = FixtureWorkspaceRoute(id: id)
         if showsTabScaffold,
            selectedPrimaryTab == .search || primarySearchCoordinator.isPresented {
-            pendingSearchFixtureRoute = route
-            transitionPrimaryTab(to: .workspaces)
+            if searchFixturePath.last != id {
+                searchFixturePath = [id]
+            }
         } else {
-            fixtureRoute = route
+            fixtureRoute = FixtureWorkspaceRoute(id: id)
         }
     }
 
-    private func consumePendingSearchFixtureNavigation() {
-        guard !primarySearchCoordinator.isPresented,
-              selectedPrimaryTab == .workspaces,
-              let route = pendingSearchFixtureRoute else { return }
-        pendingSearchFixtureRoute = nil
-        fixtureRoute = route
-    }
-
-    @discardableResult
-    private func transitionPrimaryTab(to tab: MobilePrimaryTab) -> Bool {
-        let previousTab = selectedPrimaryTab
-        if (selectedPrimaryTab == .search || primarySearchCoordinator.isPresented),
-           tab.searchScope != nil {
-            primarySearchCoordinator.deactivateCurrentSearch()
+    private func fixtureWorkspaceDetail(for id: MobileWorkspacePreview.ID) -> some View {
+        VStack(spacing: 12) {
+            Text(
+                model.workspaces.first(where: { $0.id == id })?.name
+                    ?? id.rawValue
+            )
+            .font(.title2)
+            Text("Fixture workspace detail")
+                .foregroundStyle(.secondary)
         }
-        selectedPrimaryTab = tab
-        return previousTab != tab
+        .accessibilityIdentifier("FixtureWorkspaceDetail")
+        .toolbarVisibility(.hidden, for: .tabBar, .bottomBar)
     }
 }
 

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListLayoutPreviewView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListLayoutPreviewView.swift
@@ -591,6 +591,9 @@ public struct WorkspaceListLayoutPreviewView: View {
         selectedWorkspaceID = id
         if showsTabScaffold,
            selectedPrimaryTab == .search || primarySearchCoordinator.isPresented {
+            // Mirrors the shell: choosing a result ends the search session so
+            // the field re-collapses to the bottom control after popping back.
+            primarySearchCoordinator.deactivateCurrentSearch()
             if searchFixturePath.last != id {
                 searchFixturePath = [id]
             }

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListLayoutPreviewView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListLayoutPreviewView.swift
@@ -167,6 +167,7 @@ public struct WorkspaceListLayoutPreviewView: View {
     @State private var fixtureRoute: FixtureWorkspaceRoute?
     // Mirrors the shell: search results push onto the search tab's own stack.
     @State private var searchFixturePath: [MobileWorkspacePreview.ID] = []
+    @State private var searchSelectionReturnsToWorkspaces = false
 
     private var scrollMetricsEnabled: Bool {
         ProcessInfo.processInfo.environment["CMUX_UITEST_SCROLL_METRICS"] == "1"
@@ -552,7 +553,15 @@ public struct WorkspaceListLayoutPreviewView: View {
         .onChange(of: selectedPrimaryTab) { oldValue, newValue in
             if oldValue == .search, newValue != .search {
                 searchFixturePath = []
+                searchSelectionReturnsToWorkspaces = false
             }
+        }
+        .onChange(of: searchFixturePath) { _, path in
+            guard path.isEmpty, searchSelectionReturnsToWorkspaces else { return }
+            searchSelectionReturnsToWorkspaces = false
+            guard selectedPrimaryTab == .search else { return }
+            primarySearchCoordinator.workspaces = ""
+            selectedPrimaryTab = .workspaces
         }
         .overlay(alignment: .topLeading) {
             ZStack(alignment: .topLeading) {
@@ -592,8 +601,10 @@ public struct WorkspaceListLayoutPreviewView: View {
         if showsTabScaffold,
            selectedPrimaryTab == .search || primarySearchCoordinator.isPresented {
             // Mirrors the shell: choosing a result ends the search session so
-            // the field re-collapses to the bottom control after popping back.
+            // the field re-collapses to the bottom control after popping back,
+            // and the pop finishes the round on the Workspaces tab.
             primarySearchCoordinator.deactivateCurrentSearch()
+            searchSelectionReturnsToWorkspaces = true
             if searchFixturePath.last != id {
                 searchFixturePath = [id]
             }

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceShellView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceShellView.swift
@@ -168,8 +168,16 @@ struct WorkspaceShellView: View {
     @State private var selectedPrimaryTab: MobilePrimaryTab = .workspaces
     @State private var notificationNavigationPath: [MobileWorkspacePreview.ID] = []
     @State private var notificationSearchNavigationPath: [MobileWorkspacePreview.ID] = []
+    @State private var workspaceSearchNavigationPath: [MobileWorkspacePreview.ID] = []
     @State private var pendingPrimarySearchWorkspaceNavigationID: MobileWorkspacePreview.ID?
     @State private var pendingPrimarySearchNotificationNavigationID: MobileWorkspacePreview.ID?
+    // A NavigationStack path write only reaches UIKit while the stack is in the
+    // window. Writing a push mid tab-transition (search morph still animating)
+    // records the pushed state without pushing, which strands the root list
+    // with the tab bar and toolbar hidden. These flags defer pending pushes to
+    // the destination stack's own onAppear.
+    @State private var workspacesStackIsOnScreen = false
+    @State private var notificationsStackIsOnScreen = false
     @State private var showingRootSettings = false
     @State private var settingsPairingScannerHandoff = SettingsPairingScannerHandoff()
     @State private var showingRootDeviceTree = false
@@ -259,7 +267,11 @@ struct WorkspaceShellView: View {
                     }
                 }
                 .onAppear {
+                    notificationsStackIsOnScreen = true
                     consumePendingPrimarySearchNavigation(for: .notifications)
+                }
+                .onDisappear {
+                    notificationsStackIsOnScreen = false
                 }
                 .onChange(of: pendingPrimarySearchNotificationNavigationID) { _, _ in
                     consumePendingPrimarySearchNavigation(for: .notifications)
@@ -286,6 +298,7 @@ struct WorkspaceShellView: View {
             .onChange(of: selectedPrimaryTab) { oldValue, newValue in
                 if oldValue == .search, newValue != .search {
                     notificationSearchNavigationPath = []
+                    workspaceSearchNavigationPath = []
                 }
             }
             .onChange(of: store.deeplinkWorkspaceNavigationRequest) { _, request in
@@ -344,7 +357,7 @@ struct WorkspaceShellView: View {
 
     private func workspaceSearchTabContent(canCreateWorkspaceForSelection: Bool) -> some View {
         workspaceActionToastOverlay {
-            NavigationStack {
+            NavigationStack(path: $workspaceSearchNavigationPath) {
                 MobilePrimaryWorkspaceSearchContentHost(
                     searchCoordinator: primarySearchCoordinator
                 ) { searchText in
@@ -360,7 +373,23 @@ struct WorkspaceShellView: View {
                     )
                 }
                 .toolbar {
-                    rootToolbarContent
+                    if workspaceSearchNavigationPath.isEmpty {
+                        rootToolbarContent
+                    }
+                }
+                // Selecting a search result opens the workspace inside the
+                // search tab's own stack, exactly like notification search.
+                // Transitioning to the Workspaces tab and pushing on its stack
+                // from here raced the search-field dismissal and could record
+                // the push without performing it, stranding the list with no
+                // tab bar (the "stuck after selecting from search" bug).
+                .navigationDestination(for: MobileWorkspacePreview.ID.self) { workspaceID in
+                    workspaceDestination(
+                        for: workspaceID,
+                        createWorkspace: createWorkspaceInCompactStack,
+                        canCreateWorkspaceForSelection: canCreateWorkspaceForSelection
+                    )
+                    .toolbarVisibility(.hidden, for: .tabBar)
                 }
             }
         }
@@ -518,8 +547,12 @@ struct WorkspaceShellView: View {
             autoOpenSelectedWorkspaceForSoakIfNeeded()
         }
         .onAppear {
+            workspacesStackIsOnScreen = true
             autoOpenSelectedWorkspaceForSoakIfNeeded()
             consumePendingPrimarySearchNavigation(for: .workspaces)
+        }
+        .onDisappear {
+            workspacesStackIsOnScreen = false
         }
         .onChange(of: pendingPrimarySearchWorkspaceNavigationID) { _, _ in
             consumePendingPrimarySearchNavigation(for: .workspaces)
@@ -851,10 +884,15 @@ struct WorkspaceShellView: View {
         guard !primarySearchCoordinator.isPresented else { return }
         switch tab {
         case .workspaces:
+            // Compact pushes must wait for the workspaces stack to be in the
+            // window (its onAppear re-runs this); the split layout only writes
+            // the store selection, which is safe at any time.
+            guard !usesCompactStack || workspacesStackIsOnScreen else { return }
             guard let workspaceID = pendingPrimarySearchWorkspaceNavigationID else { return }
             pendingPrimarySearchWorkspaceNavigationID = nil
             selectWorkspaceImmediately(workspaceID)
         case .notifications:
+            guard notificationsStackIsOnScreen else { return }
             guard let workspaceID = pendingPrimarySearchNotificationNavigationID else { return }
             pendingPrimarySearchNotificationNavigationID = nil
             if notificationNavigationPath.last != workspaceID {
@@ -899,9 +937,15 @@ struct WorkspaceShellView: View {
         }
     }
 
+    /// Opens a workspace tapped in the search results by pushing it onto the
+    /// search tab's own stack. No tab transition, no query commit: popping back
+    /// returns to the live search results, and the Workspaces tab is untouched.
     private func selectWorkspaceFromSearch(_ id: MobileWorkspacePreview.ID) {
-        pendingPrimarySearchWorkspaceNavigationID = id
-        transitionPrimaryTab(to: .workspaces)
+        pendingCompactCreateNavigationWorkspaceIDs = nil
+        store.selectedWorkspaceID = id
+        if workspaceSearchNavigationPath.last != id {
+            workspaceSearchNavigationPath = [id]
+        }
     }
 
     private func createWorkspaceFromSearch() {

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceShellView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceShellView.swift
@@ -178,6 +178,11 @@ struct WorkspaceShellView: View {
     // the destination stack's own onAppear.
     @State private var workspacesStackIsOnScreen = false
     @State private var notificationsStackIsOnScreen = false
+    // Set when a workspace is opened from search results: popping back then
+    // finishes the search round on the Workspaces tab with the query cleared,
+    // instead of stranding the user on a deactivated search tab whose selected
+    // (tinted) search control suggests a search is still in progress.
+    @State private var searchSelectionReturnsToWorkspaces = false
     @State private var showingRootSettings = false
     @State private var settingsPairingScannerHandoff = SettingsPairingScannerHandoff()
     @State private var showingRootDeviceTree = false
@@ -299,7 +304,15 @@ struct WorkspaceShellView: View {
                 if oldValue == .search, newValue != .search {
                     notificationSearchNavigationPath = []
                     workspaceSearchNavigationPath = []
+                    searchSelectionReturnsToWorkspaces = false
                 }
+            }
+            .onChange(of: workspaceSearchNavigationPath) { _, path in
+                guard path.isEmpty, searchSelectionReturnsToWorkspaces else { return }
+                searchSelectionReturnsToWorkspaces = false
+                guard selectedPrimaryTab == .search else { return }
+                primarySearchCoordinator.workspaces = ""
+                selectedPrimaryTab = .workspaces
             }
             .onChange(of: store.deeplinkWorkspaceNavigationRequest) { _, request in
                 guard request != nil else { return }
@@ -947,6 +960,7 @@ struct WorkspaceShellView: View {
     private func selectWorkspaceFromSearch(_ id: MobileWorkspacePreview.ID) {
         pendingCompactCreateNavigationWorkspaceIDs = nil
         primarySearchCoordinator.deactivateCurrentSearch()
+        searchSelectionReturnsToWorkspaces = true
         store.selectedWorkspaceID = id
         if workspaceSearchNavigationPath.last != id {
             workspaceSearchNavigationPath = [id]

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceShellView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceShellView.swift
@@ -938,10 +938,15 @@ struct WorkspaceShellView: View {
     }
 
     /// Opens a workspace tapped in the search results by pushing it onto the
-    /// search tab's own stack. No tab transition, no query commit: popping back
-    /// returns to the live search results, and the Workspaces tab is untouched.
+    /// search tab's own stack — no tab transition, so the push cannot land on
+    /// an off-window stack. Choosing a result also ends the search session
+    /// (committing the query, like every other search exit): left presented,
+    /// the field re-presents after popping anchored to the navigation bar at
+    /// the top instead of the search tab's bottom control. Popping back lands
+    /// on the still-filtered results with the bottom search control collapsed.
     private func selectWorkspaceFromSearch(_ id: MobileWorkspacePreview.ID) {
         pendingCompactCreateNavigationWorkspaceIDs = nil
+        primarySearchCoordinator.deactivateCurrentSearch()
         store.selectedWorkspaceID = id
         if workspaceSearchNavigationPath.last != id {
             workspaceSearchNavigationPath = [id]

--- a/ios/cmuxUITests/cmuxUITests.swift
+++ b/ios/cmuxUITests/cmuxUITests.swift
@@ -1212,10 +1212,11 @@ final class cmuxUITests: XCTestCase {
 
         // Selecting a result pushes the detail inside the search tab (system
         // back), leaving the search session and its query intact behind it.
+        // Whether the system keeps its bottom search control over the pushed
+        // detail is platform chrome, deliberately not asserted.
         tap(docsRow, in: app)
         let workspaceDetail = app.descendants(matching: .any)["FixtureWorkspaceDetail"]
         XCTAssertTrue(workspaceDetail.waitForExistence(timeout: 3))
-        XCTAssertTrue(minimizedSearch.waitForNonExistence(timeout: 3))
 
         let systemBack = app.navigationBars.buttons.element(boundBy: 0)
         XCTAssertTrue(waitForHittable(systemBack, timeout: 3))

--- a/ios/cmuxUITests/cmuxUITests.swift
+++ b/ios/cmuxUITests/cmuxUITests.swift
@@ -1678,6 +1678,80 @@ final class cmuxUITests: XCTestCase {
         XCTAssertEqual(searchMatches.count, 1)
     }
 
+    /// Regression for the "stuck after selecting a search result" wedge (the
+    /// workspaces list stranded with no tab bar, no search field, and a stale
+    /// query filter): selecting a workspace from the search tab's results must
+    /// open the detail inside the search tab and pop back to the live results.
+    /// The old flow deactivated search, transitioned to the Workspaces tab, and
+    /// pushed onto that off-window stack mid search-dismissal, which could
+    /// record the push without performing it.
+    @MainActor
+    func testWorkspaceSearchSelectionOpensDetailInsideSearchTab() throws {
+        guard #available(iOS 26.0, *) else {
+            throw XCTSkip("The detached workspace search control requires iOS 26.")
+        }
+        let app = launchApp(mockData: false, environment: [
+            "CMUX_UITEST_WORKSPACE_LIST_PREVIEW": "1",
+            "CMUX_UITEST_WORKSPACE_LIST_PREVIEW_TABS": "1",
+        ])
+        defer { app.terminate() }
+
+        let workspaceList = app.descendants(matching: .any)["MobileWorkspaceList"]
+        XCTAssertTrue(workspaceList.waitForExistence(timeout: 8))
+
+        let searchButton = app.tabBars.buttons
+            .matching(NSPredicate(format: "label == %@", "Search"))
+            .firstMatch
+        XCTAssertTrue(searchButton.waitForExistence(timeout: 3))
+        tap(searchButton, in: app)
+
+        let searchField = app.searchFields["Search workspaces"]
+        XCTAssertTrue(waitForHittable(searchField, timeout: 3))
+        XCTAssertTrue(focusTextInput(searchField, in: app))
+        searchField.typeText("Docs")
+
+        let docsRow = app.descendants(matching: .any)["MobileWorkspaceRow-workspace-docs"]
+        let mainRow = app.descendants(matching: .any)["MobileWorkspaceRow-workspace-main"]
+        XCTAssertTrue(waitForHittable(docsRow, timeout: 3))
+        XCTAssertTrue(waitForNotHittable(mainRow, timeout: 3))
+        tap(docsRow, in: app)
+
+        let workspaceDetail = app.descendants(matching: .any)["FixtureWorkspaceDetail"]
+        XCTAssertTrue(workspaceDetail.waitForExistence(timeout: 3))
+
+        // Pop back. The detail sits inside the search tab's stack behind the
+        // system back control; the old cross-tab flow used the custom
+        // workspaces back button, so accept either to keep the pop itself
+        // out of the regression's scope.
+        let customBack = app.buttons["MobileWorkspaceBackButton"]
+        if customBack.waitForExistence(timeout: 1) {
+            tap(customBack, in: app)
+        } else {
+            let systemBack = app.navigationBars.buttons.element(boundBy: 0)
+            XCTAssertTrue(waitForHittable(systemBack, timeout: 3))
+            tap(systemBack, in: app)
+        }
+        XCTAssertTrue(workspaceList.waitForExistence(timeout: 3))
+        XCTAssertTrue(waitForHittable(docsRow, timeout: 3))
+        XCTAssertTrue(waitForNotHittable(mainRow, timeout: 3))
+
+        // The selection must not have handed the user to the Workspaces tab,
+        // whose list would be silently filtered by the committed query with no
+        // visible control to clear it.
+        let workspacesTab = app.tabBars.buttons["Workspaces"]
+        XCTAssertTrue(workspacesTab.waitForExistence(timeout: 3))
+        XCTAssertFalse(
+            workspacesTab.isSelected,
+            "Selecting a search result must keep the user inside the search tab"
+        )
+
+        // And the tab bar must remain usable: leaving search restores the
+        // Workspaces root with its bottom controls.
+        tap(workspacesTab, in: app)
+        XCTAssertTrue(workspaceList.waitForExistence(timeout: 3))
+        XCTAssertTrue(searchButton.waitForExistence(timeout: 3))
+    }
+
     @MainActor
     func testNotificationTabPreservesSharedRootToolbar() throws {
         let app = launchApp(mockData: false, environment: [

--- a/ios/cmuxUITests/cmuxUITests.swift
+++ b/ios/cmuxUITests/cmuxUITests.swift
@@ -1210,17 +1210,27 @@ final class cmuxUITests: XCTestCase {
         XCTAssertTrue(waitForHittable(docsRow, timeout: 3))
         XCTAssertTrue(waitForNotHittable(mainRow, timeout: 3))
 
+        // Selecting a result pushes the detail inside the search tab (system
+        // back), leaving the search session and its query intact behind it.
         tap(docsRow, in: app)
         let workspaceDetail = app.descendants(matching: .any)["FixtureWorkspaceDetail"]
         XCTAssertTrue(workspaceDetail.waitForExistence(timeout: 3))
         XCTAssertTrue(minimizedSearch.waitForNonExistence(timeout: 3))
 
-        let backButton = app.buttons["MobileWorkspaceBackButton"]
-        XCTAssertTrue(waitForHittable(backButton, timeout: 3))
-        tap(backButton, in: app)
+        let systemBack = app.navigationBars.buttons.element(boundBy: 0)
+        XCTAssertTrue(waitForHittable(systemBack, timeout: 3))
+        tap(systemBack, in: app)
+        XCTAssertNotNil(waitForVisibleElement(in: workspaceListTables, app: app, timeout: 3))
+        XCTAssertTrue(waitForKeyboardDismissal(in: app))
+        XCTAssertTrue(waitForHittable(docsRow, timeout: 3))
+        XCTAssertTrue(waitForNotHittable(mainRow, timeout: 3))
+
+        // Leaving search for the Workspaces tab commits the draft query; the
+        // committed filter must survive a list refresh there.
+        XCTAssertTrue(workspacesTab.waitForExistence(timeout: 3))
+        tap(workspacesTab, in: app)
         XCTAssertNotNil(waitForVisibleElement(in: workspaceListTables, app: app, timeout: 3))
         XCTAssertTrue(minimizedSearch.waitForExistence(timeout: 3))
-        XCTAssertTrue(waitForKeyboardDismissal(in: app))
         XCTAssertTrue(waitForHittable(docsRow, timeout: 3))
         XCTAssertTrue(waitForNotHittable(mainRow, timeout: 3))
 

--- a/ios/cmuxUITests/cmuxUITests.swift
+++ b/ios/cmuxUITests/cmuxUITests.swift
@@ -1226,41 +1226,51 @@ final class cmuxUITests: XCTestCase {
         }
         tap(systemBack, in: app)
         guard waitForVisibleElement(in: workspaceListTables, app: app, timeout: 3) != nil else {
-            return XCTFail("Search results list did not return after popping the detail")
+            return XCTFail("Workspaces list did not return after popping the detail")
         }
-        // Popping the detail returns to the committed search results with the
-        // collapsed bottom control; the field must not re-present.
+        // Popping the detail finishes the search round on the Workspaces tab
+        // with the query cleared and the bottom search control collapsed.
         guard waitForKeyboardDismissal(in: app) else {
-            return XCTFail("Keyboard stayed up after popping back to the search results")
+            return XCTFail("Keyboard stayed up after popping back from the search detail")
         }
-        guard waitForHittable(docsRow, timeout: 3) else {
-            return XCTFail("Matching row missing from the restored search results")
-        }
-        guard waitForNotHittable(mainRow, timeout: 3) else {
-            return XCTFail("Query filter lost on the restored search results")
-        }
-
-        // Selecting a result committed the query (like every search exit); the
-        // committed filter must then survive a list refresh on the Workspaces
-        // tab.
         guard workspacesTab.waitForExistence(timeout: 3) else {
             return XCTFail("Workspaces tab pill missing after popping the search detail")
         }
-        tap(workspacesTab, in: app)
-        guard waitForVisibleElement(in: workspaceListTables, app: app, timeout: 3) != nil else {
-            return XCTFail("Workspaces root list missing after leaving search")
-        }
-        guard waitForKeyboardDismissal(in: app) else {
-            return XCTFail("Keyboard stayed up after leaving search for the Workspaces tab")
-        }
+        XCTAssertTrue(
+            workspacesTab.isSelected,
+            "Popping the search-opened workspace must land on the Workspaces tab"
+        )
         guard minimizedSearch.waitForExistence(timeout: 3) else {
-            return XCTFail("Minimized search control missing on the Workspaces tab")
+            return XCTFail("Minimized search control missing after finishing the search round")
         }
         guard waitForHittable(docsRow, timeout: 3) else {
-            return XCTFail("Committed-filter match missing on the Workspaces tab")
+            return XCTFail("Workspaces list missing rows after finishing the search round")
+        }
+        guard waitForHittable(mainRow, timeout: 3) else {
+            return XCTFail("Query must be cleared after finishing the search round")
+        }
+
+        // An explicit submit still commits the query as the Workspaces filter;
+        // that committed filter must survive a list refresh.
+        tap(minimizedSearch, in: app)
+        guard waitForHittable(searchField, timeout: 3) else {
+            return XCTFail("Search field missing when reactivating search for submit")
+        }
+        guard focusTextInput(searchField, in: app) else {
+            return XCTFail("Could not focus the search field for submit")
+        }
+        searchField.typeText("Docs\n")
+        guard waitForVisibleElement(in: workspaceListTables, app: app, timeout: 3) != nil else {
+            return XCTFail("Workspaces root list missing after submitting the query")
+        }
+        guard minimizedSearch.waitForExistence(timeout: 3) else {
+            return XCTFail("Minimized search control missing after submitting the query")
+        }
+        guard waitForHittable(docsRow, timeout: 3) else {
+            return XCTFail("Committed-filter match missing after submit")
         }
         guard waitForNotHittable(mainRow, timeout: 3) else {
-            return XCTFail("Committed query filter not applied on the Workspaces tab")
+            return XCTFail("Committed query filter not applied after submit")
         }
 
         let previewRefreshButtons = app.buttons.matching(
@@ -1771,14 +1781,27 @@ final class cmuxUITests: XCTestCase {
             tap(systemBack, in: app)
         }
         XCTAssertTrue(workspaceList.waitForExistence(timeout: 3))
-        XCTAssertTrue(waitForHittable(docsRow, timeout: 3))
-        XCTAssertTrue(waitForNotHittable(mainRow, timeout: 3))
 
-        // Popping back must restore the search tab's BOTTOM control, not a
-        // field re-anchored to the navigation bar: choosing a result ends the
-        // search session, so any visible search affordance belongs to the
-        // bottom edge (the regression showed the field pinned to the top with
-        // the keyboard up).
+        // Popping back finishes the search round on the Workspaces tab: the
+        // full unfiltered list, no query left silently applied, and no
+        // selected (tinted) search control suggesting a search is still live.
+        let workspacesTab = app.tabBars.buttons["Workspaces"]
+        XCTAssertTrue(workspacesTab.waitForExistence(timeout: 3))
+        XCTAssertTrue(
+            workspacesTab.isSelected,
+            "Popping the search-opened workspace must land on the Workspaces tab"
+        )
+        XCTAssertTrue(
+            waitForHittable(docsRow, timeout: 3),
+            "Workspaces list missing rows after finishing the search round"
+        )
+        XCTAssertTrue(
+            waitForHittable(mainRow, timeout: 3),
+            "Query must be cleared after finishing the search round, not left filtering the list"
+        )
+
+        // Any visible search affordance belongs to the bottom edge (the
+        // regression showed the field pinned to the top with the keyboard up).
         let restoredSearchControl = app.tabBars.buttons
             .matching(NSPredicate(format: "label == %@", "Search"))
             .firstMatch
@@ -1802,22 +1825,6 @@ final class cmuxUITests: XCTestCase {
                 "Search field must not re-present at the top after popping, got \(fieldFrame)"
             )
         }
-
-        // The selection must not have handed the user to the Workspaces tab,
-        // whose list would be silently filtered by the committed query with no
-        // visible control to clear it.
-        let workspacesTab = app.tabBars.buttons["Workspaces"]
-        XCTAssertTrue(workspacesTab.waitForExistence(timeout: 3))
-        XCTAssertFalse(
-            workspacesTab.isSelected,
-            "Selecting a search result must keep the user inside the search tab"
-        )
-
-        // And the tab bar must remain usable: leaving search restores the
-        // Workspaces root with its bottom controls.
-        tap(workspacesTab, in: app)
-        XCTAssertTrue(workspaceList.waitForExistence(timeout: 3))
-        XCTAssertTrue(searchButton.waitForExistence(timeout: 3))
     }
 
     @MainActor

--- a/ios/cmuxUITests/cmuxUITests.swift
+++ b/ios/cmuxUITests/cmuxUITests.swift
@@ -1216,57 +1216,47 @@ final class cmuxUITests: XCTestCase {
         // detail is platform chrome, deliberately not asserted.
         tap(docsRow, in: app)
         let workspaceDetail = app.descendants(matching: .any)["FixtureWorkspaceDetail"]
-        XCTAssertTrue(
-            workspaceDetail.waitForExistence(timeout: 3),
-            "Search-stack detail never appeared after tapping the result"
-        )
+        guard workspaceDetail.waitForExistence(timeout: 3) else {
+            return XCTFail("Search-stack detail never appeared after tapping the result")
+        }
 
         let systemBack = app.navigationBars.buttons.element(boundBy: 0)
-        XCTAssertTrue(
-            waitForHittable(systemBack, timeout: 3),
-            "No hittable system back control on the search-stack detail"
-        )
+        guard waitForHittable(systemBack, timeout: 3) else {
+            return XCTFail("No hittable system back control on the search-stack detail")
+        }
         tap(systemBack, in: app)
-        XCTAssertNotNil(
-            waitForVisibleElement(in: workspaceListTables, app: app, timeout: 3),
-            "Search results list did not return after popping the detail"
-        )
-        XCTAssertTrue(
-            waitForKeyboardDismissal(in: app),
-            "Keyboard stayed up after popping back to the search results"
-        )
-        XCTAssertTrue(
-            waitForHittable(docsRow, timeout: 3),
-            "Matching row missing from the restored search results"
-        )
-        XCTAssertTrue(
-            waitForNotHittable(mainRow, timeout: 3),
-            "Query filter lost on the restored search results"
-        )
+        guard waitForVisibleElement(in: workspaceListTables, app: app, timeout: 3) != nil else {
+            return XCTFail("Search results list did not return after popping the detail")
+        }
+        guard waitForKeyboardDismissal(in: app) else {
+            return XCTFail("Keyboard stayed up after popping back to the search results")
+        }
+        guard waitForHittable(docsRow, timeout: 3) else {
+            return XCTFail("Matching row missing from the restored search results")
+        }
+        guard waitForNotHittable(mainRow, timeout: 3) else {
+            return XCTFail("Query filter lost on the restored search results")
+        }
 
-        // Leaving search for the Workspaces tab commits the draft query; the
-        // committed filter must survive a list refresh there.
-        XCTAssertTrue(
-            workspacesTab.waitForExistence(timeout: 3),
-            "Workspaces tab pill missing after popping the search detail"
-        )
+        // Selecting a result must NOT commit the query; leaving Search by
+        // choosing a primary tab still does (pre-existing contract). The
+        // committed filter must then survive a list refresh there.
+        guard workspacesTab.waitForExistence(timeout: 3) else {
+            return XCTFail("Workspaces tab pill missing after popping the search detail")
+        }
         tap(workspacesTab, in: app)
-        XCTAssertNotNil(
-            waitForVisibleElement(in: workspaceListTables, app: app, timeout: 3),
-            "Workspaces root list missing after leaving search"
-        )
-        XCTAssertTrue(
-            minimizedSearch.waitForExistence(timeout: 3),
-            "Minimized search control missing on the Workspaces tab"
-        )
-        XCTAssertTrue(
-            waitForHittable(docsRow, timeout: 3),
-            "Committed-filter match missing on the Workspaces tab"
-        )
-        XCTAssertTrue(
-            waitForNotHittable(mainRow, timeout: 3),
-            "Committed query filter not applied on the Workspaces tab"
-        )
+        guard waitForVisibleElement(in: workspaceListTables, app: app, timeout: 3) != nil else {
+            return XCTFail("Workspaces root list missing after leaving search")
+        }
+        guard minimizedSearch.waitForExistence(timeout: 3) else {
+            return XCTFail("Minimized search control missing on the Workspaces tab")
+        }
+        guard waitForHittable(docsRow, timeout: 3) else {
+            return XCTFail("Committed-filter match missing on the Workspaces tab")
+        }
+        guard waitForNotHittable(mainRow, timeout: 3) else {
+            return XCTFail("Committed query filter not applied on the Workspaces tab")
+        }
 
         let previewRefreshButtons = app.buttons.matching(
             NSPredicate(format: "identifier == %@", "MobileWorkspaceListPreviewRefresh")

--- a/ios/cmuxUITests/cmuxUITests.swift
+++ b/ios/cmuxUITests/cmuxUITests.swift
@@ -1216,24 +1216,57 @@ final class cmuxUITests: XCTestCase {
         // detail is platform chrome, deliberately not asserted.
         tap(docsRow, in: app)
         let workspaceDetail = app.descendants(matching: .any)["FixtureWorkspaceDetail"]
-        XCTAssertTrue(workspaceDetail.waitForExistence(timeout: 3))
+        XCTAssertTrue(
+            workspaceDetail.waitForExistence(timeout: 3),
+            "Search-stack detail never appeared after tapping the result"
+        )
 
         let systemBack = app.navigationBars.buttons.element(boundBy: 0)
-        XCTAssertTrue(waitForHittable(systemBack, timeout: 3))
+        XCTAssertTrue(
+            waitForHittable(systemBack, timeout: 3),
+            "No hittable system back control on the search-stack detail"
+        )
         tap(systemBack, in: app)
-        XCTAssertNotNil(waitForVisibleElement(in: workspaceListTables, app: app, timeout: 3))
-        XCTAssertTrue(waitForKeyboardDismissal(in: app))
-        XCTAssertTrue(waitForHittable(docsRow, timeout: 3))
-        XCTAssertTrue(waitForNotHittable(mainRow, timeout: 3))
+        XCTAssertNotNil(
+            waitForVisibleElement(in: workspaceListTables, app: app, timeout: 3),
+            "Search results list did not return after popping the detail"
+        )
+        XCTAssertTrue(
+            waitForKeyboardDismissal(in: app),
+            "Keyboard stayed up after popping back to the search results"
+        )
+        XCTAssertTrue(
+            waitForHittable(docsRow, timeout: 3),
+            "Matching row missing from the restored search results"
+        )
+        XCTAssertTrue(
+            waitForNotHittable(mainRow, timeout: 3),
+            "Query filter lost on the restored search results"
+        )
 
         // Leaving search for the Workspaces tab commits the draft query; the
         // committed filter must survive a list refresh there.
-        XCTAssertTrue(workspacesTab.waitForExistence(timeout: 3))
+        XCTAssertTrue(
+            workspacesTab.waitForExistence(timeout: 3),
+            "Workspaces tab pill missing after popping the search detail"
+        )
         tap(workspacesTab, in: app)
-        XCTAssertNotNil(waitForVisibleElement(in: workspaceListTables, app: app, timeout: 3))
-        XCTAssertTrue(minimizedSearch.waitForExistence(timeout: 3))
-        XCTAssertTrue(waitForHittable(docsRow, timeout: 3))
-        XCTAssertTrue(waitForNotHittable(mainRow, timeout: 3))
+        XCTAssertNotNil(
+            waitForVisibleElement(in: workspaceListTables, app: app, timeout: 3),
+            "Workspaces root list missing after leaving search"
+        )
+        XCTAssertTrue(
+            minimizedSearch.waitForExistence(timeout: 3),
+            "Minimized search control missing on the Workspaces tab"
+        )
+        XCTAssertTrue(
+            waitForHittable(docsRow, timeout: 3),
+            "Committed-filter match missing on the Workspaces tab"
+        )
+        XCTAssertTrue(
+            waitForNotHittable(mainRow, timeout: 3),
+            "Committed query filter not applied on the Workspaces tab"
+        )
 
         let previewRefreshButtons = app.buttons.matching(
             NSPredicate(format: "identifier == %@", "MobileWorkspaceListPreviewRefresh")

--- a/ios/cmuxUITests/cmuxUITests.swift
+++ b/ios/cmuxUITests/cmuxUITests.swift
@@ -1228,9 +1228,8 @@ final class cmuxUITests: XCTestCase {
         guard waitForVisibleElement(in: workspaceListTables, app: app, timeout: 3) != nil else {
             return XCTFail("Search results list did not return after popping the detail")
         }
-        guard waitForKeyboardDismissal(in: app) else {
-            return XCTFail("Keyboard stayed up after popping back to the search results")
-        }
+        // Popping the detail returns to the LIVE search session, so the field
+        // may re-present with the keyboard; that is the designed behavior.
         guard waitForHittable(docsRow, timeout: 3) else {
             return XCTFail("Matching row missing from the restored search results")
         }
@@ -1247,6 +1246,9 @@ final class cmuxUITests: XCTestCase {
         tap(workspacesTab, in: app)
         guard waitForVisibleElement(in: workspaceListTables, app: app, timeout: 3) != nil else {
             return XCTFail("Workspaces root list missing after leaving search")
+        }
+        guard waitForKeyboardDismissal(in: app) else {
+            return XCTFail("Keyboard stayed up after leaving search for the Workspaces tab")
         }
         guard minimizedSearch.waitForExistence(timeout: 3) else {
             return XCTFail("Minimized search control missing on the Workspaces tab")

--- a/ios/cmuxUITests/cmuxUITests.swift
+++ b/ios/cmuxUITests/cmuxUITests.swift
@@ -1210,10 +1210,10 @@ final class cmuxUITests: XCTestCase {
         XCTAssertTrue(waitForHittable(docsRow, timeout: 3))
         XCTAssertTrue(waitForNotHittable(mainRow, timeout: 3))
 
-        // Selecting a result pushes the detail inside the search tab (system
-        // back), leaving the search session and its query intact behind it.
-        // Whether the system keeps its bottom search control over the pushed
-        // detail is platform chrome, deliberately not asserted.
+        // Selecting a result ends the search session (committing the query)
+        // and pushes the detail inside the search tab behind a system back
+        // control. Whether the system keeps its bottom search control over the
+        // pushed detail is platform chrome, deliberately not asserted.
         tap(docsRow, in: app)
         let workspaceDetail = app.descendants(matching: .any)["FixtureWorkspaceDetail"]
         guard workspaceDetail.waitForExistence(timeout: 3) else {
@@ -1228,8 +1228,11 @@ final class cmuxUITests: XCTestCase {
         guard waitForVisibleElement(in: workspaceListTables, app: app, timeout: 3) != nil else {
             return XCTFail("Search results list did not return after popping the detail")
         }
-        // Popping the detail returns to the LIVE search session, so the field
-        // may re-present with the keyboard; that is the designed behavior.
+        // Popping the detail returns to the committed search results with the
+        // collapsed bottom control; the field must not re-present.
+        guard waitForKeyboardDismissal(in: app) else {
+            return XCTFail("Keyboard stayed up after popping back to the search results")
+        }
         guard waitForHittable(docsRow, timeout: 3) else {
             return XCTFail("Matching row missing from the restored search results")
         }
@@ -1237,9 +1240,9 @@ final class cmuxUITests: XCTestCase {
             return XCTFail("Query filter lost on the restored search results")
         }
 
-        // Selecting a result must NOT commit the query; leaving Search by
-        // choosing a primary tab still does (pre-existing contract). The
-        // committed filter must then survive a list refresh there.
+        // Selecting a result committed the query (like every search exit); the
+        // committed filter must then survive a list refresh on the Workspaces
+        // tab.
         guard workspacesTab.waitForExistence(timeout: 3) else {
             return XCTFail("Workspaces tab pill missing after popping the search detail")
         }
@@ -1770,6 +1773,35 @@ final class cmuxUITests: XCTestCase {
         XCTAssertTrue(workspaceList.waitForExistence(timeout: 3))
         XCTAssertTrue(waitForHittable(docsRow, timeout: 3))
         XCTAssertTrue(waitForNotHittable(mainRow, timeout: 3))
+
+        // Popping back must restore the search tab's BOTTOM control, not a
+        // field re-anchored to the navigation bar: choosing a result ends the
+        // search session, so any visible search affordance belongs to the
+        // bottom edge (the regression showed the field pinned to the top with
+        // the keyboard up).
+        let restoredSearchControl = app.tabBars.buttons
+            .matching(NSPredicate(format: "label == %@", "Search"))
+            .firstMatch
+        XCTAssertTrue(
+            restoredSearchControl.waitForExistence(timeout: 3),
+            "Bottom search control missing after popping the search detail"
+        )
+        if let controlFrame = waitForUsableFrame(of: restoredSearchControl, timeout: 3) {
+            XCTAssertGreaterThan(
+                controlFrame.midY,
+                app.frame.midY,
+                "Search control must sit at the bottom after popping, got \(controlFrame)"
+            )
+        } else {
+            XCTFail("Bottom search control had no usable frame after popping")
+        }
+        if searchField.exists, let fieldFrame = waitForUsableFrame(of: searchField, timeout: 1) {
+            XCTAssertGreaterThan(
+                fieldFrame.midY,
+                app.frame.midY,
+                "Search field must not re-present at the top after popping, got \(fieldFrame)"
+            )
+        }
 
         // The selection must not have handed the user to the Workspaces tab,
         // whose list would be silently filtered by the committed query with no


### PR DESCRIPTION
Fixes the iOS "stuck after selecting a workspace from search" state: tapping a search result could leave the app on the Workspaces list with no tab bar, no root toolbar, no compose button, no search field, and the list still filtered by the search query, with nothing left to tap to get out.

**Mechanism.** Selecting a result deactivated search (committing the draft query), transitioned the TabView to the Workspaces tab, and pushed the workspace onto that tab's `NavigationStack` from `onChange` handlers. Those handlers can run while the workspaces stack is still off-window behind the iOS 26 search-field dismissal, and a path write that lands before the stack's `UINavigationController` is in the window records the push without performing it. The app is then in exactly the reported state: `compactNavigationPath` is non-empty, so the root toolbar (`compactNavigationPath.isEmpty` gate), compose button, and tab bar (the phantom destination's `.toolbarVisibility(.hidden, for: .tabBar, .bottomBar)`) all hide, while the root list stays visible and silently filtered by the committed query. The screenshot signature confirms it: the nav bar shows the bare "Workspaces" title instead of the root toolbar's "All Computers" picker.

**Fix.** Workspace search now behaves like notification search, which never had this bug: the search tab's stack owns a real path plus a workspace `navigationDestination`, and a tapped result pushes there directly. No tab transition, no query commit, no cross-stack write. Choosing a result also ends the search session, committing the query like every other search exit (device dogfood showed that a session left presented across the push re-presents the field anchored to the top navigation bar after popping, instead of the search tab's bottom control). Popping back therefore lands on the still-filtered results with the collapsed bottom search control; the regression test pins the restored control to the bottom half and rejects a top-anchored field. The pending cross-tab machinery still serves deeplinks and device-tree selections made while searching; those consumes are now gated on the destination stack being on screen (tracked by `onAppear`/`onDisappear`), so a deferred push replays from `onAppear` instead of landing off-window.

The layout-preview fixture mirrors the new shape (path-based search stack, system back button), and the minimized-search UI test is updated to the new contract: popping back returns to the search results, and the committed-filter persistence check moves behind an explicit switch to the Workspaces tab.

**Commits.** Two-commit red/green: commit 1 adds only the regression test (`testWorkspaceSearchSelectionOpensDetailInsideSearchTab`), commit 2 adds the fix.

**Hosted iOS test evidence** (dispatched on throwaway branches with the `MobileInjectedAttachStartupTests` compile fix from #9668 cherry-picked; `mobile-core-package` and `package-conventions-lint` reds are pre-existing on main, documented in #9525):
- RED (test only): run 31150494755
- GREEN (fix): runs 31150504044, 31150506393, 31150509307

**Localization audit:** no new user-facing strings; the pushed detail uses the existing workspace destination and system back control.

**Known follow-up (pre-existing, unchanged here):** create-from-search and cross-tab retarget paths still write `compactNavigationPath` from `onChange(of: store.selectedWorkspaceID)` and can in principle race a tab transition the same way; they go through an async create round-trip so the window is much smaller.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes compact iOS primary-tab navigation and NavigationStack timing around search; risk is localized to shell UI with regression UI tests, but incorrect path gating could still affect deeplinks or tab transitions.
> 
> **Overview**
> Fixes the **stuck after selecting from workspace search** state where the Workspaces list could show with no tab bar, no root toolbar, and a silently committed query filter.
> 
> **Navigation change.** Tapping a search result no longer deactivates search, switches to the Workspaces tab, and pushes on `compactNavigationPath` while that stack may still be off-window. Results now push on the **search tab’s own** `NavigationStack` (`workspaceSearchNavigationPath`), matching notification search. Pending cross-tab navigation (deeplinks, device tree while searching) is gated on `workspacesStackIsOnScreen` / `notificationsStackIsOnScreen` so deferred pushes replay from `onAppear` instead of writing paths off-window.
> 
> **Post-pop behavior.** Selecting a result ends the search session (commits the query). When the user pops the detail, the app clears the query and returns to the **Workspaces** tab with the bottom search control collapsed—not a deactivated search tab with a tinted Search control.
> 
> The layout-preview fixture mirrors this path-based search stack; UI tests add `testWorkspaceSearchSelectionOpensDetailInsideSearchTab` and update the minimized-search flow to assert pop-back lands on Workspaces with a cleared filter.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c1611164d8d8a32573c1294e5fd71c27cfcb8519. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->