### PR TITLE
Fix deprecated `depends_on macos:` syntax in cask generators

### DIFF
--- a/.github/workflows/update-homebrew.yml
+++ b/.github/workflows/update-homebrew.yml
@@ -104,7 +104,7 @@ jobs:
               strategy :github_latest
             end
 
-            depends_on macos: ">= :sonoma"
+            depends_on macos: :sonoma
 
             app "cmux.app"
             binary "#{appdir}/cmux.app/Contents/Resources/bin/cmux"

--- a/scripts/build-sign-upload.sh
+++ b/scripts/build-sign-upload.sh
@@ -180,7 +180,7 @@ cask "cmux" do
     strategy :github_latest
   end
 
-  depends_on macos: ">= :ventura"
+  depends_on macos: :ventura
 
   app "cmux.app"
   binary "#{appdir}/cmux.app/Contents/Resources/bin/cmux"


### PR DESCRIPTION
Installing or upgrading the cask currently prints this warning three times:

```
Warning: Calling string comparison format for `depends_on macos:` is deprecated!
Use `depends_on macos: :sonoma` instead.
Please report this issue to the manaflow-ai/homebrew-cmux tap (not Homebrew/* repositories),
or even better, submit a PR to fix it:
  /opt/homebrew/Library/Taps/manaflow-ai/homebrew-cmux/Casks/cmux.rb:15
```

Homebrew deprecated the string comparison format for `depends_on macos:`.

The tap's `Casks/cmux.rb` is generated, not hand-maintained, so fixing it in
`manaflow-ai/homebrew-cmux` would be overwritten on the next release. The fix belongs in
the two generators in this repo:

- `.github/workflows/update-homebrew.yml` (the heredoc that the release workflow writes)
- `scripts/build-sign-upload.sh` (a second copy of the same cask template)

## Why this is safe

A bare symbol already defaults to the `>=` comparator — see `MacOSRequirement.parse` in
`Homebrew/requirements/macos_requirement.rb`, where the symbol branch passes the caller's
comparator, which defaults to `>=`. Homebrew's own deprecation message suggests exactly
this replacement. Syntax-only change, no behavior difference; each generator keeps its
existing version symbol.

## Note (not changed here)

The two generators pin different minimum versions — the workflow uses `:sonoma`, and
`scripts/build-sign-upload.sh` uses `:ventura`. That looked like it might be unintentional,
but it's a behavior question rather than part of this deprecation fix, so I left both as-is.
Happy to align them in a follow-up if you tell me which is correct.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/9823"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788695810&installation_model_id=21920&pr_number=9823&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F9823&signature=dbbe5448cc2b91a645f1fc096bf9a199ce2d62f6e631a2c2a704284b399eb780"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 4a6b53188f741a888de8e9ba472c5dd8f17ef015. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update the cask generators to use the new symbol form for `depends_on macos:` to remove Homebrew deprecation warnings. Behavior is unchanged; the same minimum macOS versions still apply.

- **Bug Fixes**
  - In `.github/workflows/update-homebrew.yml`, replace `depends_on macos: ">= :sonoma"` with `depends_on macos: :sonoma`.
  - In `scripts/build-sign-upload.sh`, replace `depends_on macos: ">= :ventura"` with `depends_on macos: :ventura`.
  - Stops the repeated deprecation warnings in the generated `Casks/cmux.rb`.

<sup>Written for commit 4a6b53188f741a888de8e9ba472c5dd8f17ef015. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/9823?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the Homebrew installation requirements to use the correct macOS version declaration.
  * Homebrew installation compatibility now targets macOS Ventura or newer.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->