### PR TITLE
iOS: pin the keyboard dock to the system keyboard on every frame

### DIFF
--- a/.github/workflows/test-ios.yml
+++ b/.github/workflows/test-ios.yml
@@ -428,6 +428,17 @@ jobs:
               # always draws the software keyboard that the test measures.
               defaults write com.apple.iphonesimulator DevicePreferences \
                 -dict-add "$SIMULATOR_ID" '{ ConnectHardwareKeyboard = 0; }'
+              # `defaults -dict-add` serializes the OpenStep scalar above as the
+              # string "0" on current macOS. Simulator treats that truthy string as
+              # an attached hardware keyboard. Rewrite the leaf as an actual bool
+              # before booting the freshly erased device.
+              SIMULATOR_PREFS="${RUNNER_TEMP}/cmux-simulator-prefs-${SIMULATOR_ID}.plist"
+              defaults export com.apple.iphonesimulator "$SIMULATOR_PREFS"
+              plutil -replace "DevicePreferences.${SIMULATOR_ID}.ConnectHardwareKeyboard" \
+                -bool false "$SIMULATOR_PREFS"
+              defaults import com.apple.iphonesimulator "$SIMULATOR_PREFS"
+              plutil -extract "DevicePreferences.${SIMULATOR_ID}.ConnectHardwareKeyboard" \
+                raw -o - "$SIMULATOR_PREFS"
             fi
             xcrun simctl boot "$SIMULATOR_ID" >/dev/null 2>&1 || true
             xcrun simctl bootstatus "$SIMULATOR_ID" -b

--- a/.github/workflows/test-ios.yml
+++ b/.github/workflows/test-ios.yml
@@ -384,7 +384,18 @@ jobs:
             -derivedDataPath "$IOS_DERIVED_DATA"
           )
           if [ -n "${TEST_FILTER:-}" ]; then
-            XCODEBUILD_ARGS+=(-only-testing:"$TEST_FILTER")
+            RESOLVED_TEST_FILTER="$TEST_FILTER"
+            # The workflow's documented UI shorthand is Class/testMethod.
+            # xcodebuild requires Target/Class/testMethod, and the main iOS UI
+            # class happens to have the same name as its target. Expand that
+            # exact shorthand so dispatches do not compile successfully while
+            # executing zero tests. Already target-qualified selectors pass
+            # through unchanged.
+            if [[ "$TEST_FILTER" =~ ^cmuxUITests/test[^/]+$ ]]; then
+              RESOLVED_TEST_FILTER="cmuxUITests/$TEST_FILTER"
+            fi
+            echo "Resolved test filter: $RESOLVED_TEST_FILTER"
+            XCODEBUILD_ARGS+=(-only-testing:"$RESOLVED_TEST_FILTER")
           else
             # Full UI tests currently exceed the pull-request simulator budget
             # on macos-26. Keep them runnable via workflow_dispatch +

--- a/.github/workflows/test-ios.yml
+++ b/.github/workflows/test-ios.yml
@@ -9,7 +9,7 @@ on:
         required: false
         default: ""
       test_filter:
-        description: "UI test class or class/method, for example cmuxUITests/testSignInPairingAndWorkspaceShell"
+        description: "UI test class or class/method, for example cmuxUITests/testTerminalKeyboardDockRapidToggleIsPixelAttachedEveryFrame"
         required: false
         default: ""
       device_family:
@@ -370,6 +370,13 @@ jobs:
           TEST_FILTER: ${{ inputs.test_filter }}
         run: |
           set -euo pipefail
+          if [[ "${TEST_FILTER:-}" == *"testTerminalKeyboardDockRapidToggleIsPixelAttachedEveryFrame"* ]]; then
+            # This lane verifies the real software-keyboard key plane and the
+            # system inputAccessoryView on every display-link frame. An attached
+            # hardware keyboard suppresses that UI and would turn the run into a
+            # false pass over keyboard-down geometry.
+            defaults write com.apple.iphonesimulator ConnectHardwareKeyboard -bool false
+          fi
           XCODEBUILD_ARGS=(
             -workspace ios/cmux.xcworkspace
             -scheme cmux-ios

--- a/.github/workflows/test-ios.yml
+++ b/.github/workflows/test-ios.yml
@@ -376,6 +376,7 @@ jobs:
             # hardware keyboard suppresses that UI and would turn the run into a
             # false pass over keyboard-down geometry.
             defaults write com.apple.iphonesimulator ConnectHardwareKeyboard -bool false
+            defaults write com.apple.iphonesimulator AutomaticKeyboard -bool true
           fi
           XCODEBUILD_ARGS=(
             -workspace ios/cmux.xcworkspace
@@ -420,6 +421,14 @@ jobs:
             echo "Preparing $SIMULATOR_NAME ($SIMULATOR_ID), attempt $attempt"
             xcrun simctl shutdown "$SIMULATOR_ID" >/dev/null 2>&1 || true
             xcrun simctl erase "$SIMULATOR_ID"
+            if [[ "${TEST_FILTER:-}" == *"testTerminalKeyboardDockRapidToggleIsPixelAttachedEveryFrame"* ]]; then
+              # Simulator may materialize a per-device hardware-keyboard default
+              # after an erase, overriding the domain-level setting above. Pin
+              # this freshly erased device too so focusing MobileComposerField
+              # always draws the software keyboard that the test measures.
+              defaults write com.apple.iphonesimulator DevicePreferences \
+                -dict-add "$SIMULATOR_ID" '{ ConnectHardwareKeyboard = 0; }'
+            fi
             xcrun simctl boot "$SIMULATOR_ID" >/dev/null 2>&1 || true
             xcrun simctl bootstatus "$SIMULATOR_ID" -b
             if xcodebuild "${XCODEBUILD_ARGS[@]}" 2>&1 | tee "$LOG_PATH"; then

--- a/.github/workflows/test-ios.yml
+++ b/.github/workflows/test-ios.yml
@@ -451,13 +451,47 @@ jobs:
               open "${DEVELOPER_DIR}/Applications/Simulator.app" \
                 --args -CurrentDeviceUDID "$SIMULATOR_ID"
             fi
+            KEYBOARD_WATCHER_PID=""
+            if [[ "${TEST_FILTER:-}" == *"testTerminalKeyboardDockRapidToggleIsPixelAttachedEveryFrame"* ]]; then
+              # Simulator owns software-keyboard visibility in its macOS host.
+              # Wait until the XCUITest proves MobileComposerField is first
+              # responder, then invoke the host's standard Toggle Software
+              # Keyboard shortcut once. The remaining 12-cycle stress path is
+              # driven entirely by the app's field and input-accessory button.
+              (
+                for _ in {1..900}; do
+                  if grep -q "keyboard-dock-software-keyboard-request" "$LOG_PATH" 2>/dev/null; then
+                    if /usr/bin/osascript \
+                      -e 'tell application "Simulator" to activate' \
+                      -e 'delay 0.2' \
+                      -e 'tell application "System Events" to keystroke "k" using command down'; then
+                      echo "Requested Simulator software keyboard after composer focus"
+                    else
+                      echo "::warning::Could not send Simulator software-keyboard shortcut"
+                    fi
+                    exit 0
+                  fi
+                  sleep 0.1
+                done
+                echo "::warning::Timed out waiting for composer-focus keyboard marker"
+              ) &
+              KEYBOARD_WATCHER_PID="$!"
+            fi
             if xcodebuild "${XCODEBUILD_ARGS[@]}" 2>&1 | tee "$LOG_PATH"; then
+              if [ -n "$KEYBOARD_WATCHER_PID" ]; then
+                kill "$KEYBOARD_WATCHER_PID" >/dev/null 2>&1 || true
+                wait "$KEYBOARD_WATCHER_PID" 2>/dev/null || true
+              fi
               ./scripts/ci/require_selected_test_execution.sh \
                 "$LOG_PATH" \
                 "${TEST_FILTER:-}"
               exit 0
             fi
             status="${PIPESTATUS[0]}"
+            if [ -n "$KEYBOARD_WATCHER_PID" ]; then
+              kill "$KEYBOARD_WATCHER_PID" >/dev/null 2>&1 || true
+              wait "$KEYBOARD_WATCHER_PID" 2>/dev/null || true
+            fi
             if selected_tests_passed_despite_xcodebuild_status "$LOG_PATH"; then
               echo "xcodebuild exited $status after XCTest reported the selected tests passed with zero failures; treating this as a runner cleanup failure."
               exit 0

--- a/.github/workflows/test-ios.yml
+++ b/.github/workflows/test-ios.yml
@@ -439,6 +439,12 @@ jobs:
               defaults import com.apple.iphonesimulator "$SIMULATOR_PREFS"
               plutil -extract "DevicePreferences.${SIMULATOR_ID}.ConnectHardwareKeyboard" \
                 raw -o - "$SIMULATOR_PREFS"
+              # A headless CoreSimulator boot does not attach the Simulator host
+              # that owns the software-keyboard presentation. Open the selected
+              # device in this Xcode's Simulator before XCTest focuses the field.
+              defaults write com.apple.iphonesimulator CurrentDeviceUDID "$SIMULATOR_ID"
+              open "${DEVELOPER_DIR}/Applications/Simulator.app" \
+                --args -CurrentDeviceUDID "$SIMULATOR_ID"
             fi
             xcrun simctl boot "$SIMULATOR_ID" >/dev/null 2>&1 || true
             xcrun simctl bootstatus "$SIMULATOR_ID" -b

--- a/.github/workflows/test-ios.yml
+++ b/.github/workflows/test-ios.yml
@@ -439,15 +439,18 @@ jobs:
               defaults import com.apple.iphonesimulator "$SIMULATOR_PREFS"
               plutil -extract "DevicePreferences.${SIMULATOR_ID}.ConnectHardwareKeyboard" \
                 raw -o - "$SIMULATOR_PREFS"
-              # A headless CoreSimulator boot does not attach the Simulator host
-              # that owns the software-keyboard presentation. Open the selected
-              # device in this Xcode's Simulator before XCTest focuses the field.
               defaults write com.apple.iphonesimulator CurrentDeviceUDID "$SIMULATOR_ID"
-              open "${DEVELOPER_DIR}/Applications/Simulator.app" \
-                --args -CurrentDeviceUDID "$SIMULATOR_ID"
             fi
             xcrun simctl boot "$SIMULATOR_ID" >/dev/null 2>&1 || true
             xcrun simctl bootstatus "$SIMULATOR_ID" -b
+            if [[ "${TEST_FILTER:-}" == *"testTerminalKeyboardDockRapidToggleIsPixelAttachedEveryFrame"* ]]; then
+              # A headless CoreSimulator boot does not attach the Simulator host
+              # that owns software-keyboard presentation. Open it only after the
+              # selected device is fully booted; opening a shut-down device races
+              # XCTest startup and can leave the app hierarchy unavailable.
+              open "${DEVELOPER_DIR}/Applications/Simulator.app" \
+                --args -CurrentDeviceUDID "$SIMULATOR_ID"
+            fi
             if xcodebuild "${XCODEBUILD_ARGS[@]}" 2>&1 | tee "$LOG_PATH"; then
               ./scripts/ci/require_selected_test_execution.sh \
                 "$LOG_PATH" \

--- a/.github/workflows/test-ios.yml
+++ b/.github/workflows/test-ios.yml
@@ -459,7 +459,9 @@ jobs:
               # Keyboard shortcut once. The remaining 12-cycle stress path is
               # driven entirely by the app's field and input-accessory button.
               (
-                for _ in {1..900}; do
+                # Allow for a cold iOS test build before XCTest emits the focus
+                # marker; the watcher exits immediately after the first match.
+                for _ in {1..9000}; do
                   if grep -q "keyboard-dock-software-keyboard-request" "$LOG_PATH" 2>/dev/null; then
                     if /usr/bin/osascript \
                       -e 'tell application "Simulator" to activate' \

--- a/.github/workflows/test-ios.yml
+++ b/.github/workflows/test-ios.yml
@@ -370,7 +370,7 @@ jobs:
           TEST_FILTER: ${{ inputs.test_filter }}
         run: |
           set -euo pipefail
-          if [[ "${TEST_FILTER:-}" == *"testTerminalKeyboardDockRapidToggleIsPixelAttachedEveryFrame"* ]]; then
+          if [[ "${TEST_FILTER:-}" == *"testTerminalKeyboardDock"* ]]; then
             # This lane verifies the real software-keyboard key plane and the
             # system inputAccessoryView on every display-link frame. An attached
             # hardware keyboard suppresses that UI and would turn the run into a
@@ -421,7 +421,7 @@ jobs:
             echo "Preparing $SIMULATOR_NAME ($SIMULATOR_ID), attempt $attempt"
             xcrun simctl shutdown "$SIMULATOR_ID" >/dev/null 2>&1 || true
             xcrun simctl erase "$SIMULATOR_ID"
-            if [[ "${TEST_FILTER:-}" == *"testTerminalKeyboardDockRapidToggleIsPixelAttachedEveryFrame"* ]]; then
+            if [[ "${TEST_FILTER:-}" == *"testTerminalKeyboardDock"* ]]; then
               # Simulator may materialize a per-device hardware-keyboard default
               # after an erase, overriding the domain-level setting above. Pin
               # this freshly erased device too so focusing MobileComposerField
@@ -442,7 +442,7 @@ jobs:
             fi
             xcrun simctl boot "$SIMULATOR_ID" >/dev/null 2>&1 || true
             xcrun simctl bootstatus "$SIMULATOR_ID" -b
-            if [[ "${TEST_FILTER:-}" == *"testTerminalKeyboardDockRapidToggleIsPixelAttachedEveryFrame"* ]]; then
+            if [[ "${TEST_FILTER:-}" == *"testTerminalKeyboardDock"* ]]; then
               # A freshly erased device presents the one-time QuickPath (slide
               # to type) introduction where its first software keyboard would
               # render, so no key plane and no keyboard frame ever appear and
@@ -464,7 +464,7 @@ jobs:
               exit 0
             fi
             status="${PIPESTATUS[0]}"
-            if [[ "${TEST_FILTER:-}" == *"testTerminalKeyboardDockRapidToggleIsPixelAttachedEveryFrame"* ]]; then
+            if [[ "${TEST_FILTER:-}" == *"testTerminalKeyboardDock"* ]]; then
               # The stress lane keeps timing out with zero keyboard frames and
               # the log alone cannot show what the headless device displayed
               # (education card, permission alert, or a real key plane). Capture

--- a/.github/workflows/test-ios.yml
+++ b/.github/workflows/test-ios.yml
@@ -464,6 +464,18 @@ jobs:
               exit 0
             fi
             status="${PIPESTATUS[0]}"
+            if [[ "${TEST_FILTER:-}" == *"testTerminalKeyboardDockRapidToggleIsPixelAttachedEveryFrame"* ]]; then
+              # The stress lane keeps timing out with zero keyboard frames and
+              # the log alone cannot show what the headless device displayed
+              # (education card, permission alert, or a real key plane). Capture
+              # the live screen and the device's keyboard state for the
+              # diagnostics artifact before the retry erases the device.
+              xcrun simctl io "$SIMULATOR_ID" screenshot \
+                "$IOS_DERIVED_DATA/logs/keyboard-stress-attempt-${attempt}.png" || true
+              xcrun simctl spawn "$SIMULATOR_ID" defaults read \
+                com.apple.keyboard.preferences \
+                > "$IOS_DERIVED_DATA/logs/keyboard-prefs-attempt-${attempt}.txt" 2>&1 || true
+            fi
             if selected_tests_passed_despite_xcodebuild_status "$LOG_PATH"; then
               echo "xcodebuild exited $status after XCTest reported the selected tests passed with zero failures; treating this as a runner cleanup failure."
               exit 0
@@ -474,6 +486,17 @@ jobs:
             fi
             exit "$status"
           done
+
+      - name: Upload iOS simulator diagnostics
+        if: ${{ failure() }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: ios-simulator-${{ matrix.family }}-diagnostics
+          path: |
+            ${{ env.IOS_DERIVED_DATA }}/logs
+            ${{ env.IOS_DERIVED_DATA }}/Logs/Test/*.xcresult
+          if-no-files-found: ignore
+          retention-days: 3
 
   ios-tests:
     name: ios-tests

--- a/.github/workflows/test-ios.yml
+++ b/.github/workflows/test-ios.yml
@@ -439,61 +439,31 @@ jobs:
               defaults import com.apple.iphonesimulator "$SIMULATOR_PREFS"
               plutil -extract "DevicePreferences.${SIMULATOR_ID}.ConnectHardwareKeyboard" \
                 raw -o - "$SIMULATOR_PREFS"
-              defaults write com.apple.iphonesimulator CurrentDeviceUDID "$SIMULATOR_ID"
             fi
             xcrun simctl boot "$SIMULATOR_ID" >/dev/null 2>&1 || true
             xcrun simctl bootstatus "$SIMULATOR_ID" -b
             if [[ "${TEST_FILTER:-}" == *"testTerminalKeyboardDockRapidToggleIsPixelAttachedEveryFrame"* ]]; then
-              # A headless CoreSimulator boot does not attach the Simulator host
-              # that owns software-keyboard presentation. Open it only after the
-              # selected device is fully booted; opening a shut-down device races
-              # XCTest startup and can leave the app hierarchy unavailable.
-              open "${DEVELOPER_DIR}/Applications/Simulator.app" \
-                --args -CurrentDeviceUDID "$SIMULATOR_ID"
-            fi
-            KEYBOARD_WATCHER_PID=""
-            if [[ "${TEST_FILTER:-}" == *"testTerminalKeyboardDockRapidToggleIsPixelAttachedEveryFrame"* ]]; then
-              # Simulator owns software-keyboard visibility in its macOS host.
-              # Wait until the XCUITest proves MobileComposerField is first
-              # responder, then invoke the host's standard Toggle Software
-              # Keyboard shortcut once. The remaining 12-cycle stress path is
-              # driven entirely by the app's field and input-accessory button.
-              (
-                # Allow for a cold iOS test build before XCTest emits the focus
-                # marker; the watcher exits immediately after the first match.
-                for _ in {1..9000}; do
-                  if grep -q "keyboard-dock-software-keyboard-request" "$LOG_PATH" 2>/dev/null; then
-                    if /usr/bin/osascript \
-                      -e 'tell application "Simulator" to activate' \
-                      -e 'delay 0.2' \
-                      -e 'tell application "System Events" to keystroke "k" using command down'; then
-                      echo "Requested Simulator software keyboard after composer focus"
-                    else
-                      echo "::warning::Could not send Simulator software-keyboard shortcut"
-                    fi
-                    exit 0
-                  fi
-                  sleep 0.1
-                done
-                echo "::warning::Timed out waiting for composer-focus keyboard marker"
-              ) &
-              KEYBOARD_WATCHER_PID="$!"
+              # A freshly erased device presents the one-time QuickPath (slide
+              # to type) introduction where its first software keyboard would
+              # render, so no key plane and no keyboard frame ever appear and
+              # the dock test times out on cycle 1. Seed the "already shown"
+              # markers inside the booted device; the key plane then renders on
+              # first focus even on a fully headless CoreSimulator boot, with
+              # no Simulator.app host attached.
+              xcrun simctl spawn "$SIMULATOR_ID" defaults write \
+                com.apple.keyboard.preferences DidShowContinuousPathIntroduction -bool true
+              xcrun simctl spawn "$SIMULATOR_ID" defaults write \
+                com.apple.keyboard.preferences DidShowGestureKeyboardIntroduction -bool true
+              xcrun simctl spawn "$SIMULATOR_ID" defaults write \
+                com.apple.Preferences KeyboardDidShowProductivityTutorial -bool true
             fi
             if xcodebuild "${XCODEBUILD_ARGS[@]}" 2>&1 | tee "$LOG_PATH"; then
-              if [ -n "$KEYBOARD_WATCHER_PID" ]; then
-                kill "$KEYBOARD_WATCHER_PID" >/dev/null 2>&1 || true
-                wait "$KEYBOARD_WATCHER_PID" 2>/dev/null || true
-              fi
               ./scripts/ci/require_selected_test_execution.sh \
                 "$LOG_PATH" \
                 "${TEST_FILTER:-}"
               exit 0
             fi
             status="${PIPESTATUS[0]}"
-            if [ -n "$KEYBOARD_WATCHER_PID" ]; then
-              kill "$KEYBOARD_WATCHER_PID" >/dev/null 2>&1 || true
-              wait "$KEYBOARD_WATCHER_PID" 2>/dev/null || true
-            fi
             if selected_tests_passed_despite_xcodebuild_status "$LOG_PATH"; then
               echo "xcodebuild exited $status after XCTest reported the selected tests passed with zero failures; treating this as a runner cleanup failure."
               exit 0

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/ComposerPhotoPickerBridge.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/ComposerPhotoPickerBridge.swift
@@ -1,0 +1,55 @@
+import CmuxMobileShell
+import Observation
+import PhotosUI
+import SwiftUI
+
+/// Shared state between the accessory-hosted composer and the app-window
+/// picker anchor.
+///
+/// The composer band rides inside the keyboard dock accessory (the system
+/// keyboard's window). A `.photosPicker` attached there presents from a
+/// keyboard-window controller and never cleanly tears down: the app window's
+/// accessibility tree stays pruned and the dismissal binding never delivers,
+/// wedging the input session's modal phase with the dock unmounted. The
+/// attach button therefore only flips ``isPresented`` here; the picker itself
+/// is presented by ``ComposerPhotoPickerAnchorView``, hosted in the APP
+/// window, and the staged ``selection`` flows back to the composer.
+@Observable
+@MainActor
+public final class ComposerPhotoPickerBridge {
+    /// Drives the anchor's `.photosPicker` presentation.
+    var isPresented = false
+    /// The picked items, staged by the composer's existing pipeline and
+    /// cleared after each batch so re-picking the same asset fires again.
+    var selection: [PhotosPickerItem] = []
+
+    public init() {}
+}
+
+/// Invisible app-window view that owns the composer's Photos picker
+/// presentation; see ``ComposerPhotoPickerBridge``.
+struct ComposerPhotoPickerAnchorView: View {
+    @Bindable var bridge: ComposerPhotoPickerBridge
+    /// Mirror of the input-session picker lifecycle hooks the composer's
+    /// previous inline `.photosPicker` drove.
+    let didPresent: () -> Void
+    let didDismiss: () -> Void
+
+    var body: some View {
+        Color.clear
+            .frame(width: 0, height: 0)
+            .photosPicker(
+                isPresented: $bridge.isPresented,
+                selection: $bridge.selection,
+                maxSelectionCount: CMUXMobileShellStore.maxPendingAttachmentCount,
+                matching: .images
+            )
+            .onChange(of: bridge.isPresented) { _, isPresented in
+                if isPresented {
+                    didPresent()
+                } else {
+                    didDismiss()
+                }
+            }
+    }
+}

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/GhosttySurfaceRepresentable.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/GhosttySurfaceRepresentable.swift
@@ -83,7 +83,8 @@ struct GhosttySurfaceRepresentable: UIViewRepresentable {
             delegate: context.coordinator,
             fontSize: fontSize,
             terminalTheme: terminalTheme,
-            terminalConfigTheme: terminalConfigTheme
+            terminalConfigTheme: terminalConfigTheme,
+            keyboardDockFrameRecordingEnabled: UITestConfig.keyboardDockFrameRecordingEnabled
         )
         view.autoFocusOnWindowAttach = autoFocusOnWindowAttach
         view.artifactFilesEnabled = artifactFilesEnabled

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/GhosttySurfaceRepresentable.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/GhosttySurfaceRepresentable.swift
@@ -200,6 +200,15 @@ struct GhosttySurfaceRepresentable: UIViewRepresentable {
         /// surface's composer band. Built lazily on first open and torn down on
         /// dismantle; mounted/unmounted by ``setComposerMounted(_:)``.
         private var composerController: UIHostingController<TerminalComposerView>?
+        /// Shared picker state between the accessory-hosted composer (which
+        /// requests presentation and stages the selection) and the app-window
+        /// anchor that actually presents the Photos picker.
+        let photoPickerBridge = ComposerPhotoPickerBridge()
+        /// Hosts ``ComposerPhotoPickerAnchorView`` as a hidden zero-size
+        /// subview of the SURFACE (the app window), so the picker's
+        /// presentation and dismissal run in the app window's controller
+        /// hierarchy; see ``installPhotoPickerAnchorIfNeeded()``.
+        private var photoPickerAnchorController: UIHostingController<ComposerPhotoPickerAnchorView>?
         var artifactChipController: UIHostingController<TerminalArtifactChipView>?
         var artifactChipVisibility = TerminalArtifactChipVisibilityState()
         /// Pending debounced chip unmount; cancelled whenever a positive count
@@ -694,6 +703,7 @@ struct GhosttySurfaceRepresentable: UIViewRepresentable {
                 let controller = composerController ?? makeComposerController(store: store)
                 composerController = controller
                 surfaceView.mountComposerView(controller.view)
+                installPhotoPickerAnchorIfNeeded()
                 // The field opens at one line; report its initial height without
                 // animation (the composer's open transition already animates), then
                 // live grows/shrinks animate.
@@ -716,6 +726,45 @@ struct GhosttySurfaceRepresentable: UIViewRepresentable {
                     self.surfaceView?.mountComposerView(nil)
                 }
             }
+        }
+
+        /// Install (once) the hidden photo-picker anchor into the surface —
+        /// the APP window — so the composer's Photos picker presents from the
+        /// app window's controller hierarchy. The composer's own hosting view
+        /// rides inside the keyboard dock accessory (the system keyboard's
+        /// window); presenting from THERE never cleanly tears down: the app
+        /// window's accessibility tree stays pruned and the picker's
+        /// dismissal binding never delivers, wedging the input session's
+        /// modal phase with the dock unmounted. (Parenting the composer
+        /// controller into the app hierarchy instead trips UIKit's addChild
+        /// hierarchy check, because its view lives in another window.)
+        @MainActor
+        private func installPhotoPickerAnchorIfNeeded() {
+            guard photoPickerAnchorController == nil, let surfaceView else { return }
+            let controller = UIHostingController(
+                rootView: ComposerPhotoPickerAnchorView(
+                    bridge: photoPickerBridge,
+                    didPresent: { [weak self] in
+                        self?.surfaceView?.photoPickerDidPresent()
+                    },
+                    didDismiss: { [weak self] in
+                        self?.surfaceView?.photoPickerDidDismiss()
+                    }
+                )
+            )
+            controller.view.backgroundColor = .clear
+            controller.view.isUserInteractionEnabled = false
+            controller.view.frame = .zero
+            controller.view.accessibilityElementsHidden = true
+            surfaceView.addSubview(controller.view)
+            photoPickerAnchorController = controller
+        }
+
+        /// Symmetric teardown for ``installPhotoPickerAnchorIfNeeded()``.
+        @MainActor
+        private func removePhotoPickerAnchor() {
+            photoPickerAnchorController?.view.removeFromSuperview()
+            photoPickerAnchorController = nil
         }
 
         /// Build the hosting controller for the compose field. The field asks for a
@@ -742,12 +791,12 @@ struct GhosttySurfaceRepresentable: UIViewRepresentable {
                 photoPickerWillPresent: { [weak self] in
                     self?.surfaceView?.photoPickerWillPresent()
                 },
-                photoPickerDidPresent: { [weak self] in
-                    self?.surfaceView?.photoPickerDidPresent()
+                requestPhotoPicker: { [weak self] in
+                    guard let self else { return }
+                    self.installPhotoPickerAnchorIfNeeded()
+                    self.photoPickerBridge.isPresented = true
                 },
-                photoPickerDidDismiss: { [weak self] in
-                    self?.surfaceView?.photoPickerDidDismiss()
-                }
+                photoPickerBridge: photoPickerBridge
             )
             let controller = UIHostingController(rootView: view)
             // The field is pinned edge-to-edge in the band, so the band frame (not an
@@ -820,6 +869,7 @@ struct GhosttySurfaceRepresentable: UIViewRepresentable {
         @MainActor
         func tearDownComposer() {
             surfaceView?.mountComposerView(nil)
+            removePhotoPickerAnchor()
             composerController = nil
             composerMounted = false
         }

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TerminalComposerView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TerminalComposerView.swift
@@ -49,16 +49,21 @@ struct TerminalComposerView: View {
     let requestInputFocus: () -> Void
     /// Mirrors user-driven SwiftUI responder changes into that same owner.
     let inputFocusChanged: (Bool) -> Void
-    /// PhotosPicker lifecycle facts consumed by the surface input session.
+    /// The modal boundary fact recorded before the picker presentation begins.
     let photoPickerWillPresent: () -> Void
-    let photoPickerDidPresent: () -> Void
-    let photoPickerDidDismiss: () -> Void
-    @FocusState private var isFieldFocused: Bool
-    /// Photo-picker selection bound to the system `PhotosPicker`. Cleared after
-    /// each batch is encoded and staged so re-picking the same image fires again.
-    @State private var pickerSelection: [PhotosPickerItem] = []
-    /// Drives the photo picker's presentation from the attach button.
-    @State private var isPickerPresented = false
+    /// Asks the app-window anchor to present the Photos picker. This view is
+    /// hosted inside the keyboard dock accessory (the system keyboard's
+    /// window), where a locally attached `.photosPicker` presents from a
+    /// keyboard-window controller and never cleanly tears down — see
+    /// ``ComposerPhotoPickerBridge``.
+    let requestPhotoPicker: () -> Void
+    /// Selection handoff from the anchor-presented picker; staged here so the
+    /// attachment pipeline (encode, cap, thumbnails) stays composer-owned.
+    let photoPickerBridge: ComposerPhotoPickerBridge
+    /// Mirrors the UIKit field's first-responder fact (see
+    /// ``MobileComposerTextField``); the `onChange` side effects below are the
+    /// same ones the previous `@FocusState` drove.
+    @State private var isFieldFocused = false
     /// Small downsampled thumbnails keyed by attachment id, built ONCE when each
     /// attachment is staged. The chip row renders these instead of decoding the
     /// full multi-MB `Data` from inside the view body on every composer
@@ -84,8 +89,8 @@ struct TerminalComposerView: View {
         requestInputFocus: @escaping () -> Void,
         inputFocusChanged: @escaping (Bool) -> Void,
         photoPickerWillPresent: @escaping () -> Void,
-        photoPickerDidPresent: @escaping () -> Void,
-        photoPickerDidDismiss: @escaping () -> Void
+        requestPhotoPicker: @escaping () -> Void,
+        photoPickerBridge: ComposerPhotoPickerBridge
     ) {
         self.store = store
         self.terminalID = terminalID
@@ -93,8 +98,8 @@ struct TerminalComposerView: View {
         self.requestInputFocus = requestInputFocus
         self.inputFocusChanged = inputFocusChanged
         self.photoPickerWillPresent = photoPickerWillPresent
-        self.photoPickerDidPresent = photoPickerDidPresent
-        self.photoPickerDidDismiss = photoPickerDidDismiss
+        self.requestPhotoPicker = requestPhotoPicker
+        self.photoPickerBridge = photoPickerBridge
     }
 
     /// Single-line height of the round attach button beside the field. It stays
@@ -311,44 +316,32 @@ struct TerminalComposerView: View {
                 // rendered through the same support component as GUI chat. `.bottom`
                 // alignment pins the button to the field's last line as it grows.
                 MobileComposerFieldContainer(minHeight: composerFieldMinHeight) {
-                    TextField(
-                        L10n.string("mobile.composer.placeholder", defaultValue: "Message"),
+                    // UIKit-backed: the band lives inside the keyboard dock
+                    // accessory (system keyboard window), where a SwiftUI
+                    // TextField's focus cannot summon the keyboard at all. The
+                    // UIKit field takes first responder the Messages way and
+                    // the keyboard rises with the dock riding it. Growth (one
+                    // line up to 14), sentence autocap, autocorrect, and the
+                    // dictation lock (which resigns a focused field without
+                    // counting as the user moving on) carry over; each added
+                    // line grows this view, which the host reserves above the
+                    // always-visible toolbar.
+                    MobileComposerTextField(
                         text: $store.terminalInputText,
-                        axis: .vertical
+                        isFocused: $isFieldFocused,
+                        placeholder: L10n.string(
+                            "mobile.composer.placeholder",
+                            defaultValue: "Message"
+                        ),
+                        textColor: store.activeTerminalTheme.terminalForegroundColor,
+                        isLocked: dictation.locksComposerField,
+                        maxLines: composerLineLimit.upperBound,
+                        accessibilityIdentifier: "MobileComposerField"
                     )
-                    // Opens at a single line and grows up to 14 lines so a long message has
-                    // room. Each added line grows this view, which the host reserves above the
-                    // always-visible toolbar; the toolbar and keyboard never move.
-                    .lineLimit(composerLineLimit)
-                    // Natural-language to an agent, so normal iOS text assistance
-                    // is on (autocorrect, sentence-case, spell check). The raw
-                    // terminal input field keeps these OFF; only the composer
-                    // enables them.
-                    .textInputAutocapitalization(.sentences)
-                    .autocorrectionDisabled(false)
-                    .focused($isFieldFocused)
-                    .simultaneousGesture(
-                        TapGesture().onEnded {
-                            guard !dictation.locksComposerField else { return }
-                            requestInputFocus()
-                        }
-                    )
-                    // Lock the field while dictation owns the text (`.listening`
-                    // or `.stopping`). Every recognition callback rewrites the
-                    // field as base + transcript, so an edit the user made
-                    // mid-dictation would be silently discarded by the next
-                    // partial/final. Disabling input until dictation settles to
-                    // idle makes that edit impossible rather than letting it be
-                    // clobbered. The field stays visible showing the live
-                    // transcript; the mic toggle and send stay live (send
-                    // hard-cancels dictation -> idle, re-enabling the field).
-                    .disabled(dictation.locksComposerField)
-                    .foregroundStyle(store.activeTerminalTheme.terminalForegroundColor)
                     // 6pt container padding + 3pt here keeps the text's 9pt inset
                     // from the round-7 layout, and bottom-aligns the single-line text
                     // with the inline button's circle.
                     .padding(.vertical, 3)
-                    .accessibilityIdentifier("MobileComposerField")
 
                 } trailing: {
                     Button {
@@ -385,22 +378,11 @@ struct TerminalComposerView: View {
         // so the host's re-measure stays correct.
         .padding(.top, 2)
         .padding(.bottom, 8)
-        .photosPicker(
-            isPresented: $isPickerPresented,
-            selection: $pickerSelection,
-            maxSelectionCount: Self.maxAttachmentCount,
-            matching: .images
-        )
-        .onChange(of: pickerSelection) { _, items in
+        .onChange(of: photoPickerBridge.selection) { _, items in
+            // The picker itself is presented by the app-window anchor (see
+            // ``ComposerPhotoPickerBridge``); only the staging runs here.
             guard !items.isEmpty else { return }
             stagePickedItems(items)
-        }
-        .onChange(of: isPickerPresented) { _, isPresented in
-            if isPresented {
-                photoPickerDidPresent()
-            } else {
-                photoPickerDidDismiss()
-            }
         }
     }
 
@@ -429,12 +411,10 @@ struct TerminalComposerView: View {
         }
     }
 
-    /// Record the modal boundary before changing the PhotosPicker binding. The
-    /// surface input session synchronously resigns its actual terminal/composer
-    /// owner; SwiftUI then mirrors that responder change through `@FocusState`.
+    /// Record the modal boundary, then ask the app-window anchor to present.
     private func presentPhotoPicker() {
         photoPickerWillPresent()
-        isPickerPresented = true
+        requestPhotoPicker()
     }
 
     /// Toggle voice dictation. On start the current text is captured as the merge
@@ -578,7 +558,7 @@ struct TerminalComposerView: View {
                     thumbnailCache.set(thumbnail, for: id)
                 }
             }
-            pickerSelection = []
+            photoPickerBridge.selection = []
             // A new chip grows the band; ask the host to re-measure.
             requestHeightRemeasure()
         }

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceDetailView+TerminalArtifacts.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceDetailView+TerminalArtifacts.swift
@@ -104,6 +104,17 @@ extension WorkspaceDetailView {
     // avoidance; otherwise the view ALSO shrinks for the keyboard
     // and the reservation double-counts (extra gap when open).
     .ignoresSafeArea(.keyboard, edges: .bottom)
+    // The surface's frame must be KEYBOARD-INVARIANT: with only the keyboard
+    // inset ignored, the bottom edge respects the home indicator while the
+    // keyboard is down but extends to the window bottom while it is up
+    // (the keyboard region subsumes the indicator inset), so the frame
+    // breathed by the indicator height on every transition and every
+    // frame-relative keyboard conversion inside the surface was that much
+    // off mid-animation (the bars visibly popped by it after each rise —
+    // device forensics 2026-08-06). Extending under the indicator in ALL
+    // states pins the frame; the dock's required safe-area cap keeps the
+    // bars clear of the indicator while the keyboard is down.
+    .ignoresSafeArea(.container, edges: .bottom)
     // Keep the grid clear of the Dynamic Island and nav bar.
     .padding(.top, terminalTopPadding)
     }

--- a/Packages/iOS/CmuxMobileShellUI/Tests/CmuxMobileShellUITests/MobileInjectedAttachStartupTests.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Tests/CmuxMobileShellUITests/MobileInjectedAttachStartupTests.swift
@@ -30,6 +30,24 @@ struct MobileInjectedAttachStartupTests {
 
     @Test
     @MainActor
+    func approvalGatedInjectedAttachConsumesStartupWithoutFallback() throws {
+        let coordinator = MobileStartupConnectionCoordinator()
+        let attempt = try #require(coordinator.claimInjectedAttach())
+
+        let shouldFallBack = coordinator.finishInjectedAttach(
+            attempt, outcome: .awaitingUserApproval
+        )
+
+        #expect(!shouldFallBack)
+        #expect(!coordinator.shouldFallBackFromInjectedAttach)
+        // An attach parked on the Mac-side approval prompt still owns startup:
+        // the saved-Mac reconnect dialing underneath it would race the very
+        // connection the user is approving.
+        #expect(coordinator.claimStoredReconnect() == nil)
+    }
+
+    @Test
+    @MainActor
     func failedInjectedAttachReleasesStartupToStoredReconnect() throws {
         let coordinator = MobileStartupConnectionCoordinator()
         let attempt = try #require(coordinator.claimInjectedAttach())

--- a/Packages/iOS/CmuxMobileShellUI/Tests/CmuxMobileShellUITests/MobileInjectedAttachStartupTests.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Tests/CmuxMobileShellUITests/MobileInjectedAttachStartupTests.swift
@@ -1,41 +1,55 @@
-import CmuxMobileShellModel
 import Testing
 @testable import CmuxMobileShellUI
 
+/// Startup admission contract for an explicitly injected attach URL.
+///
+/// The original version of this suite was written against a
+/// `connectInjectedAttach(_:attachURL:_:)` coordinator API that was reworked
+/// before it merged, so the file has not compiled since it landed — and a
+/// compile-broken test target blocks every `cmux.xctestplan` run (the plan
+/// builds all of its targets even under `-only-testing`). These tests assert
+/// the same admission contract against the coordinator API that shipped; the
+/// URL-connect side effects live in `CMUXMobileRootView`, which claims and
+/// finishes attempts through exactly these entry points.
 @Suite
 struct MobileInjectedAttachStartupTests {
     @Test
     @MainActor
-    func beginsRouteAdmissionWithoutAnExternalTransportReadinessBarrier() async throws {
+    func connectedInjectedAttachConsumesStartupWithoutFallback() throws {
         let coordinator = MobileStartupConnectionCoordinator()
         let attempt = try #require(coordinator.claimInjectedAttach())
-        let recorder = MobileInjectedAttachURLRecorder()
-        let attachURL = "cmux-ios://attach?v=2&payload=iroh-route"
 
-        let completion = await coordinator.connectInjectedAttach(
-            attempt,
-            attachURL: attachURL
-        ) { rawURL in
-            await recorder.record(rawURL)
-            return MobilePairingURLConnectionResult.connected
-        }
+        let shouldFallBack = coordinator.finishInjectedAttach(attempt, outcome: .connected)
 
-        let completedAttempt = try #require(completion)
-        #expect(await recorder.values() == [attachURL])
-        #expect(completedAttempt.result == .connected)
-        #expect(!completedAttempt.shouldReconnectStoredMac)
+        #expect(!shouldFallBack)
+        #expect(!coordinator.shouldFallBackFromInjectedAttach)
+        // A consumed explicit route keeps owning startup: the saved-Mac
+        // reconnect must not also dial.
         #expect(coordinator.claimStoredReconnect() == nil)
     }
-}
 
-private actor MobileInjectedAttachURLRecorder {
-    private var urls: [String] = []
+    @Test
+    @MainActor
+    func failedInjectedAttachReleasesStartupToStoredReconnect() throws {
+        let coordinator = MobileStartupConnectionCoordinator()
+        let attempt = try #require(coordinator.claimInjectedAttach())
 
-    func record(_ url: String) {
-        urls.append(url)
+        let shouldFallBack = coordinator.finishInjectedAttach(attempt, outcome: .failed)
+
+        #expect(shouldFallBack)
+        #expect(coordinator.shouldFallBackFromInjectedAttach)
+        // A failed explicit route releases startup so the authenticated shell
+        // is not stranded disconnected.
+        #expect(coordinator.claimStoredReconnect() != nil)
     }
 
-    func values() -> [String] {
-        urls
+    @Test
+    @MainActor
+    func onlyOneStartupSourceCanClaimAdmission() throws {
+        let coordinator = MobileStartupConnectionCoordinator()
+
+        #expect(coordinator.claimInjectedAttach() != nil)
+        #expect(coordinator.claimInjectedAttach() == nil)
+        #expect(coordinator.claimStoredReconnect() == nil)
     }
 }

--- a/Packages/iOS/CmuxMobileSupport/Sources/CmuxMobileSupport/MobileComposerTextField.swift
+++ b/Packages/iOS/CmuxMobileSupport/Sources/CmuxMobileSupport/MobileComposerTextField.swift
@@ -1,0 +1,193 @@
+#if canImport(UIKit)
+public import SwiftUI
+import UIKit
+
+/// The mobile composer's text field, backed by UIKit instead of SwiftUI.
+///
+/// The composer band rides inside the keyboard dock accessory (a `UIInputView`
+/// living in the system keyboard window). A SwiftUI `TextField` hosted there
+/// cannot summon the software keyboard: its focus bridge takes first responder
+/// but UIKit never begins a keyboard presentation, and with the keyboard
+/// already up its focus collapses the whole keyboard. A plain `UITextView`
+/// first responder inside an input accessory is the long-standing Messages
+/// pattern and drives the keyboard normally, so the field is UIKit and SwiftUI
+/// keeps only the binding surface.
+public struct MobileComposerTextField: UIViewRepresentable {
+    @Binding private var text: String
+    @Binding private var isFocused: Bool
+    private let placeholder: String
+    private let textColor: Color
+    private let isLocked: Bool
+    private let maxLines: Int
+    private let accessibilityIdentifier: String
+
+    /// Creates the composer field.
+    ///
+    /// - Parameters:
+    ///   - text: The draft text, owned by the caller's store.
+    ///   - isFocused: Mirrors the UIKit first-responder fact out to SwiftUI
+    ///     (and accepts programmatic writes in).
+    ///   - placeholder: Localized placeholder drawn while the draft is empty.
+    ///   - textColor: The theme's field text color.
+    ///   - isLocked: Disables editing (dictation owns the text); locking a
+    ///     focused field resigns it, matching the SwiftUI `.disabled` behavior.
+    ///   - maxLines: Growth cap before the field scrolls internally.
+    ///   - accessibilityIdentifier: Stable AX id for UI tests.
+    public init(
+        text: Binding<String>,
+        isFocused: Binding<Bool>,
+        placeholder: String,
+        textColor: Color,
+        isLocked: Bool,
+        maxLines: Int = 14,
+        accessibilityIdentifier: String
+    ) {
+        _text = text
+        _isFocused = isFocused
+        self.placeholder = placeholder
+        self.textColor = textColor
+        self.isLocked = isLocked
+        self.maxLines = maxLines
+        self.accessibilityIdentifier = accessibilityIdentifier
+    }
+
+    public func makeUIView(context: Context) -> GrowingComposerTextView {
+        let view = GrowingComposerTextView()
+        view.maxLines = maxLines
+        view.font = .preferredFont(forTextStyle: .body)
+        view.backgroundColor = .clear
+        view.textContainerInset = .zero
+        view.textContainer.lineFragmentPadding = 0
+        // Natural-language input to an agent: keep standard iOS text
+        // assistance on, matching the SwiftUI field this replaces. The raw
+        // terminal proxy keeps these OFF; only the composer enables them.
+        view.autocapitalizationType = .sentences
+        view.autocorrectionType = .default
+        view.spellCheckingType = .default
+        view.keyboardType = .default
+        view.adjustsFontForContentSizeCategory = true
+        view.accessibilityIdentifier = accessibilityIdentifier
+        view.accessibilityLabel = placeholder
+        view.delegate = context.coordinator
+        view.placeholderLabel.text = placeholder
+        return view
+    }
+
+    public func updateUIView(_ view: GrowingComposerTextView, context: Context) {
+        context.coordinator.isFocused = $isFocused
+        context.coordinator.text = $text
+        if view.text != text {
+            view.text = text
+            view.refreshPlaceholderAndGrowth()
+        }
+        view.textColor = UIColor(textColor)
+        view.placeholderLabel.textColor = UIColor(textColor).withAlphaComponent(0.4)
+        if view.isEditable == isLocked {
+            // Locking a focused field resigns it; the dictation controller
+            // depends on that lock-driven focus loss NOT being a user action,
+            // which the coordinator's delegate mirror preserves.
+            view.isEditable = !isLocked
+        }
+        // Programmatic focus writes (rare; user taps focus UIKit directly).
+        if isFocused, !view.isFirstResponder, view.window != nil, !isLocked {
+            view.becomeFirstResponder()
+        }
+    }
+
+    public func makeCoordinator() -> Coordinator {
+        Coordinator(text: $text, isFocused: $isFocused)
+    }
+
+    /// Mirrors UIKit editing and responder facts into the SwiftUI bindings.
+    public final class Coordinator: NSObject, UITextViewDelegate {
+        var text: Binding<String>
+        var isFocused: Binding<Bool>
+
+        init(text: Binding<String>, isFocused: Binding<Bool>) {
+            self.text = text
+            self.isFocused = isFocused
+        }
+
+        public func textViewDidChange(_ textView: UITextView) {
+            text.wrappedValue = textView.text ?? ""
+            (textView as? GrowingComposerTextView)?.refreshPlaceholderAndGrowth()
+        }
+
+        public func textViewDidBeginEditing(_ textView: UITextView) {
+            if !isFocused.wrappedValue { isFocused.wrappedValue = true }
+        }
+
+        public func textViewDidEndEditing(_ textView: UITextView) {
+            if isFocused.wrappedValue { isFocused.wrappedValue = false }
+        }
+    }
+}
+
+/// A self-sizing `UITextView` that grows with its content up to `maxLines`
+/// and scrolls internally past the cap. Growth is reported through
+/// `intrinsicContentSize` so the hosting SwiftUI layout (and the surface's
+/// band re-measure) track every line change.
+public final class GrowingComposerTextView: UITextView {
+    var maxLines: Int = 14
+
+    /// Placeholder drawn while the text is empty, matching the SwiftUI
+    /// `TextField` prompt this field replaces.
+    let placeholderLabel: UILabel = {
+        let label = UILabel()
+        label.font = .preferredFont(forTextStyle: .body)
+        label.adjustsFontForContentSizeCategory = true
+        label.translatesAutoresizingMaskIntoConstraints = false
+        return label
+    }()
+
+    override init(frame: CGRect, textContainer: NSTextContainer?) {
+        super.init(frame: frame, textContainer: textContainer)
+        addSubview(placeholderLabel)
+        NSLayoutConstraint.activate([
+            placeholderLabel.leadingAnchor.constraint(equalTo: leadingAnchor),
+            placeholderLabel.topAnchor.constraint(equalTo: topAnchor),
+        ])
+        isScrollEnabled = false
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) { fatalError("init(coder:) is not supported") }
+
+    public override var text: String! {
+        didSet { refreshPlaceholderAndGrowth() }
+    }
+
+    private var lineHeight: CGFloat {
+        (font ?? .preferredFont(forTextStyle: .body)).lineHeight
+    }
+
+    private var maxHeight: CGFloat {
+        (lineHeight * CGFloat(maxLines)).rounded(.up)
+    }
+
+    public override var intrinsicContentSize: CGSize {
+        let width = bounds.width > 0 ? bounds.width : UIScreen.main.bounds.width * 0.6
+        let fitted = sizeThatFits(CGSize(width: width, height: .greatestFiniteMagnitude))
+        let height = max(lineHeight.rounded(.up), min(fitted.height, maxHeight))
+        return CGSize(width: UIView.noIntrinsicMetric, height: height)
+    }
+
+    public override func layoutSubviews() {
+        super.layoutSubviews()
+        // Width settles after the first layout pass; growth depends on it.
+        refreshPlaceholderAndGrowth()
+    }
+
+    func refreshPlaceholderAndGrowth() {
+        placeholderLabel.isHidden = !(text ?? "").isEmpty
+        let fitted = sizeThatFits(
+            CGSize(width: bounds.width, height: .greatestFiniteMagnitude)
+        )
+        let shouldScroll = fitted.height > maxHeight + 0.5
+        if isScrollEnabled != shouldScroll {
+            isScrollEnabled = shouldScroll
+        }
+        invalidateIntrinsicContentSize()
+    }
+}
+#endif

--- a/Packages/iOS/CmuxMobileSupport/Sources/CmuxMobileSupport/MobileKeyboardFrameTracker.swift
+++ b/Packages/iOS/CmuxMobileSupport/Sources/CmuxMobileSupport/MobileKeyboardFrameTracker.swift
@@ -85,5 +85,12 @@ public final class MobileKeyboardFrameTracker {
     public func overlap(in view: UIView) -> CGFloat {
         latestTransition?.overlap(in: view) ?? 0
     }
+
+    /// Returns whether the tracked keyboard is visible to `view` (including
+    /// floating/split iPad keyboards that reserve no bottom space), or false
+    /// while the keyboard state is unknown or the view is detached.
+    public func isVisible(in view: UIView) -> Bool {
+        latestTransition?.isVisible(in: view) ?? false
+    }
 }
 #endif

--- a/Packages/iOS/CmuxMobileSupport/Sources/CmuxMobileSupport/MobileKeyboardFrameTracker.swift
+++ b/Packages/iOS/CmuxMobileSupport/Sources/CmuxMobileSupport/MobileKeyboardFrameTracker.swift
@@ -99,6 +99,13 @@ public final class MobileKeyboardFrameTracker {
         latestTransition?.overlap(in: view) ?? 0
     }
 
+    /// Returns how much of `view`'s window the tracked keyboard covers, in
+    /// window points — stable across a transition even when the view's own
+    /// frame animates with it. Zero while unknown or detached.
+    public func overlapInWindow(of view: UIView) -> CGFloat {
+        latestTransition?.overlapInWindow(of: view) ?? 0
+    }
+
     /// Returns whether the tracked keyboard is visible to `view` (including
     /// floating/split iPad keyboards that reserve no bottom space), or false
     /// while the keyboard state is unknown or the view is detached.

--- a/Packages/iOS/CmuxMobileSupport/Sources/CmuxMobileSupport/MobileKeyboardFrameTracker.swift
+++ b/Packages/iOS/CmuxMobileSupport/Sources/CmuxMobileSupport/MobileKeyboardFrameTracker.swift
@@ -55,6 +55,19 @@ public final class MobileKeyboardFrameTracker {
                     self?.latestTransition = transition
                 }
             },
+            // The settled twin of willChangeFrame: consumers converting the
+            // end frame through a view whose own frame moved during the
+            // transition re-derive against final geometry from this one.
+            notificationCenter.addObserver(
+                forName: UIResponder.keyboardDidChangeFrameNotification,
+                object: nil,
+                queue: .main
+            ) { [weak self] notification in
+                let transition = MobileKeyboardTransition(notification: notification)
+                MainActor.assumeIsolated {
+                    self?.latestTransition = transition
+                }
+            },
             notificationCenter.addObserver(
                 forName: UIResponder.keyboardDidHideNotification,
                 object: nil,

--- a/Packages/iOS/CmuxMobileSupport/Sources/CmuxMobileSupport/MobileKeyboardFrameTracker.swift
+++ b/Packages/iOS/CmuxMobileSupport/Sources/CmuxMobileSupport/MobileKeyboardFrameTracker.swift
@@ -1,0 +1,85 @@
+#if canImport(UIKit)
+public import UIKit
+
+/// Process-wide record of the software keyboard's most recent frame transition.
+///
+/// `UIView.keyboardLayoutGuide` only reflects keyboard changes UIKit routed to
+/// that view's window while the view was installed; a view (re)attached around
+/// a workspace switch can miss the transition entirely and stay seated on the
+/// guide's bottom-safe-area fallback while the keyboard is up. Keyboard
+/// notifications, by contrast, are posted process-wide regardless of any
+/// view's attachment, so this tracker is always able to answer "where is the
+/// keyboard now?" for late-attaching views. It is a read-only catch-up source:
+/// guide-constrained chrome keeps following the guide, and consumers use the
+/// tracker only to bound how far below the keyboard that chrome may sit.
+@MainActor
+public final class MobileKeyboardFrameTracker {
+    /// The single process-wide tracker. Created on first access; access it
+    /// before the first keyboard presentation so no transition is missed.
+    /// The keyboard is process-global UIKit state, and a late-created view
+    /// must read transitions observed BEFORE it existed — a per-instance
+    /// observer cannot provide that by construction. Consumers hold an
+    /// injectable reference (`GhosttySurfaceView.keyboardFrameTracker`), so
+    /// tests isolate with a private-center instance and never touch this one.
+    // lint:allow singleton — process-global keyboard state, injectable at use sites.
+    public static let shared = MobileKeyboardFrameTracker()
+
+    /// The most recent keyboard transition, or `nil` while the keyboard state
+    /// is unknown (nothing observed yet, keyboard fully hidden, or state
+    /// discarded on backgrounding because iOS can tear the keyboard down
+    /// without a paired notification).
+    public private(set) var latestTransition: MobileKeyboardTransition?
+
+    private nonisolated(unsafe) var tokens: [NSObjectProtocol] = []
+    private nonisolated let notificationCenter: NotificationCenter
+
+    /// Creates a tracker subscribed to the keyboard frame notifications.
+    ///
+    /// - Parameter notificationCenter: The center to observe; tests inject a
+    ///   private center so posted fixtures cannot leak into other suites.
+    public init(notificationCenter: NotificationCenter = .default) {
+        self.notificationCenter = notificationCenter
+        tokens = [
+            notificationCenter.addObserver(
+                forName: UIResponder.keyboardWillChangeFrameNotification,
+                object: nil,
+                queue: .main
+            ) { [weak self] notification in
+                let transition = MobileKeyboardTransition(notification: notification)
+                MainActor.assumeIsolated {
+                    guard let transition else { return }
+                    self?.latestTransition = transition
+                }
+            },
+            notificationCenter.addObserver(
+                forName: UIResponder.keyboardDidHideNotification,
+                object: nil,
+                queue: .main
+            ) { [weak self] _ in
+                MainActor.assumeIsolated { self?.latestTransition = nil }
+            },
+            notificationCenter.addObserver(
+                forName: UIApplication.didEnterBackgroundNotification,
+                object: nil,
+                queue: .main
+            ) { [weak self] _ in
+                MainActor.assumeIsolated { self?.latestTransition = nil }
+            },
+        ]
+    }
+
+    deinit {
+        for token in tokens {
+            notificationCenter.removeObserver(token)
+        }
+    }
+
+    /// Returns how much of `view` the tracked keyboard covers from its bottom
+    /// edge, or zero while the keyboard state is unknown, the view is detached,
+    /// or the keyboard does not reach the view's bottom (floating/split iPad
+    /// keyboards, or an end frame parked below the screen after a dismissal).
+    public func overlap(in view: UIView) -> CGFloat {
+        latestTransition?.overlap(in: view) ?? 0
+    }
+}
+#endif

--- a/Packages/iOS/CmuxMobileSupport/Sources/CmuxMobileSupport/MobileKeyboardFrameTracker.swift
+++ b/Packages/iOS/CmuxMobileSupport/Sources/CmuxMobileSupport/MobileKeyboardFrameTracker.swift
@@ -25,9 +25,10 @@ public final class MobileKeyboardFrameTracker {
     public static let shared = MobileKeyboardFrameTracker()
 
     /// The most recent keyboard transition, or `nil` while the keyboard state
-    /// is unknown (nothing observed yet, keyboard fully hidden, or state
-    /// discarded on backgrounding because iOS can tear the keyboard down
-    /// without a paired notification).
+    /// is unknown (nothing observed yet, keyboard fully hidden, a transition
+    /// posted without a readable end frame, or state discarded on
+    /// backgrounding because iOS can tear the keyboard down without a paired
+    /// notification).
     public private(set) var latestTransition: MobileKeyboardTransition?
 
     private nonisolated(unsafe) var tokens: [NSObjectProtocol] = []
@@ -47,7 +48,10 @@ public final class MobileKeyboardFrameTracker {
             ) { [weak self] notification in
                 let transition = MobileKeyboardTransition(notification: notification)
                 MainActor.assumeIsolated {
-                    guard let transition else { return }
+                    // A transition without a readable end frame leaves the
+                    // keyboard state unknown; fail closed (clear) so a stale
+                    // floor can never keep the dock and viewport raised after
+                    // the keyboard actually changed.
                     self?.latestTransition = transition
                 }
             },

--- a/Packages/iOS/CmuxMobileSupport/Sources/CmuxMobileSupport/MobileKeyboardTransition.swift
+++ b/Packages/iOS/CmuxMobileSupport/Sources/CmuxMobileSupport/MobileKeyboardTransition.swift
@@ -46,6 +46,26 @@ public struct MobileKeyboardTransition: Sendable {
         ).height
     }
 
+    /// Returns how much of `view`'s WINDOW is covered by the keyboard's final
+    /// frame, in window points.
+    ///
+    /// Window-space overlap is stable across a keyboard transition even when
+    /// the view's own frame animates with it (safe-area propagation can resize
+    /// hosted views mid-transition), so constraints anchored to the window can
+    /// be seeded from the first notification without a late correction.
+    ///
+    /// - Parameter view: The view whose window should be measured.
+    /// - Returns: The bottom overlap in window coordinates, or zero when the
+    ///   view is detached or the keyboard does not reach the window's bottom.
+    @MainActor public func overlapInWindow(of view: UIView) -> CGFloat {
+        guard let window = view.window else { return 0 }
+        let keyboardFrameInWindow = window.convert(endFrame, from: nil)
+        return MobileKeyboardReservation(
+            keyboardFrameInWindow: keyboardFrameInWindow,
+            viewFrameInWindow: window.bounds
+        ).height
+    }
+
     /// Returns whether the keyboard is visible to `view`, including floating or
     /// split iPad keyboards that do not reserve bottom layout space.
     @MainActor public func isVisible(in view: UIView) -> Bool {

--- a/Packages/iOS/CmuxMobileSupport/Sources/CmuxMobileSupport/UITestConfig.swift
+++ b/Packages/iOS/CmuxMobileSupport/Sources/CmuxMobileSupport/UITestConfig.swift
@@ -79,6 +79,24 @@ public struct UITestConfig {
         #endif
     }
 
+    /// Whether the real terminal should record keyboard-dock geometry on every
+    /// existing render display-link tick for the focused XCUITest stress lane.
+    public static var keyboardDockFrameRecordingEnabled: Bool {
+        keyboardDockFrameRecordingEnabled(from: ProcessInfo.processInfo.environment)
+    }
+
+    /// Resolves the keyboard-dock frame recorder flag from an explicit environment.
+    ///
+    /// - Parameter env: The environment dictionary to inspect.
+    /// - Returns: `true` only for a DEBUG build with an explicit `"1"` value.
+    public static func keyboardDockFrameRecordingEnabled(from env: [String: String]) -> Bool {
+        #if DEBUG
+        return env["CMUX_UITEST_KEYBOARD_DOCK_FRAME_RECORDING"] == "1"
+        #else
+        return false
+        #endif
+    }
+
     /// Whether the standalone workspace-list layout preview is enabled.
     ///
     /// When `CMUX_UITEST_WORKSPACE_LIST_PREVIEW=1`, the root view renders a

--- a/Packages/iOS/CmuxMobileSupport/Tests/CmuxMobileSupportTests/MobileKeyboardFrameTrackerTests.swift
+++ b/Packages/iOS/CmuxMobileSupport/Tests/CmuxMobileSupportTests/MobileKeyboardFrameTrackerTests.swift
@@ -79,6 +79,30 @@ import UIKit
         #expect(tracker.overlap(in: view) == 0)
     }
 
+    @Test func didChangeFrameSupersedesTheWillChangeTransition() {
+        let center = NotificationCenter()
+        let tracker = MobileKeyboardFrameTracker(notificationCenter: center)
+        let window = UIWindow(frame: CGRect(x: 0, y: 0, width: 400, height: 800))
+        let view = UIView(frame: window.bounds)
+        window.addSubview(view)
+        window.isHidden = false
+        defer { window.isHidden = true }
+
+        post(
+            UIResponder.keyboardWillChangeFrameNotification,
+            endFrame: CGRect(x: 0, y: 534, width: 400, height: 266),
+            to: center
+        )
+        post(
+            UIResponder.keyboardDidChangeFrameNotification,
+            endFrame: CGRect(x: 0, y: 500, width: 400, height: 300),
+            to: center
+        )
+
+        // The settled frame wins, so layout catch-ups converge on final geometry.
+        #expect(abs(tracker.overlap(in: view) - 300) <= 0.5)
+    }
+
     @Test func didHideClearsTheTrackedTransition() {
         let center = NotificationCenter()
         let tracker = MobileKeyboardFrameTracker(notificationCenter: center)

--- a/Packages/iOS/CmuxMobileSupport/Tests/CmuxMobileSupportTests/MobileKeyboardFrameTrackerTests.swift
+++ b/Packages/iOS/CmuxMobileSupport/Tests/CmuxMobileSupportTests/MobileKeyboardFrameTrackerTests.swift
@@ -1,0 +1,126 @@
+import Testing
+import UIKit
+
+@testable import CmuxMobileSupport
+
+@MainActor
+@Suite struct MobileKeyboardFrameTrackerTests {
+    /// Builds the keyboard notification shape UIKit posts, on a private center
+    /// so fixtures never leak into other suites.
+    private func post(
+        _ name: Notification.Name,
+        endFrame: CGRect? = nil,
+        to center: NotificationCenter
+    ) {
+        var userInfo: [AnyHashable: Any] = [:]
+        if let endFrame {
+            userInfo[UIResponder.keyboardFrameEndUserInfoKey] = endFrame
+        }
+        center.post(Notification(name: name, object: nil, userInfo: userInfo))
+    }
+
+    @Test func willChangeFrameRecordsOverlapForAnAttachedView() {
+        let center = NotificationCenter()
+        let tracker = MobileKeyboardFrameTracker(notificationCenter: center)
+        let window = UIWindow(frame: CGRect(x: 0, y: 0, width: 400, height: 800))
+        let view = UIView(frame: window.bounds)
+        window.addSubview(view)
+        window.isHidden = false
+        defer { window.isHidden = true }
+
+        post(
+            UIResponder.keyboardWillChangeFrameNotification,
+            endFrame: CGRect(x: 0, y: 500, width: 400, height: 300),
+            to: center
+        )
+
+        #expect(abs(tracker.overlap(in: view) - 300) <= 0.5)
+    }
+
+    @Test func detachedViewReportsZeroOverlapUntilAttached() {
+        let center = NotificationCenter()
+        let tracker = MobileKeyboardFrameTracker(notificationCenter: center)
+        let view = UIView(frame: CGRect(x: 0, y: 0, width: 400, height: 800))
+
+        post(
+            UIResponder.keyboardWillChangeFrameNotification,
+            endFrame: CGRect(x: 0, y: 500, width: 400, height: 300),
+            to: center
+        )
+
+        // The transition is recorded even though no view can resolve it yet;
+        // that is the whole point of the tracker.
+        #expect(tracker.overlap(in: view) == 0)
+        #expect(tracker.latestTransition != nil)
+
+        let window = UIWindow(frame: CGRect(x: 0, y: 0, width: 400, height: 800))
+        window.addSubview(view)
+        window.isHidden = false
+        defer { window.isHidden = true }
+
+        #expect(abs(tracker.overlap(in: view) - 300) <= 0.5)
+    }
+
+    @Test func offscreenEndFrameReportsZeroOverlap() {
+        let center = NotificationCenter()
+        let tracker = MobileKeyboardFrameTracker(notificationCenter: center)
+        let window = UIWindow(frame: CGRect(x: 0, y: 0, width: 400, height: 800))
+        let view = UIView(frame: window.bounds)
+        window.addSubview(view)
+        window.isHidden = false
+        defer { window.isHidden = true }
+
+        post(
+            UIResponder.keyboardWillChangeFrameNotification,
+            endFrame: CGRect(x: 0, y: 800, width: 400, height: 300),
+            to: center
+        )
+
+        #expect(tracker.overlap(in: view) == 0)
+    }
+
+    @Test func didHideClearsTheTrackedTransition() {
+        let center = NotificationCenter()
+        let tracker = MobileKeyboardFrameTracker(notificationCenter: center)
+
+        post(
+            UIResponder.keyboardWillChangeFrameNotification,
+            endFrame: CGRect(x: 0, y: 500, width: 400, height: 300),
+            to: center
+        )
+        #expect(tracker.latestTransition != nil)
+
+        post(UIResponder.keyboardDidHideNotification, to: center)
+        #expect(tracker.latestTransition == nil)
+    }
+
+    @Test func backgroundingClearsTheTrackedTransition() {
+        let center = NotificationCenter()
+        let tracker = MobileKeyboardFrameTracker(notificationCenter: center)
+
+        post(
+            UIResponder.keyboardWillChangeFrameNotification,
+            endFrame: CGRect(x: 0, y: 500, width: 400, height: 300),
+            to: center
+        )
+        #expect(tracker.latestTransition != nil)
+
+        post(UIApplication.didEnterBackgroundNotification, to: center)
+        #expect(tracker.latestTransition == nil)
+    }
+
+    @Test func notificationWithoutAnEndFrameIsIgnored() {
+        let center = NotificationCenter()
+        let tracker = MobileKeyboardFrameTracker(notificationCenter: center)
+
+        post(
+            UIResponder.keyboardWillChangeFrameNotification,
+            endFrame: CGRect(x: 0, y: 500, width: 400, height: 300),
+            to: center
+        )
+        post(UIResponder.keyboardWillChangeFrameNotification, to: center)
+
+        // A malformed follow-up must not erase the last good transition.
+        #expect(tracker.latestTransition != nil)
+    }
+}

--- a/Packages/iOS/CmuxMobileSupport/Tests/CmuxMobileSupportTests/MobileKeyboardFrameTrackerTests.swift
+++ b/Packages/iOS/CmuxMobileSupport/Tests/CmuxMobileSupportTests/MobileKeyboardFrameTrackerTests.swift
@@ -109,7 +109,7 @@ import UIKit
         #expect(tracker.latestTransition == nil)
     }
 
-    @Test func notificationWithoutAnEndFrameIsIgnored() {
+    @Test func notificationWithoutAnEndFrameClearsTheTrackedTransition() {
         let center = NotificationCenter()
         let tracker = MobileKeyboardFrameTracker(notificationCenter: center)
 
@@ -120,7 +120,8 @@ import UIKit
         )
         post(UIResponder.keyboardWillChangeFrameNotification, to: center)
 
-        // A malformed follow-up must not erase the last good transition.
-        #expect(tracker.latestTransition != nil)
+        // An unreadable follow-up means the keyboard state is unknown; fail
+        // closed so a stale floor cannot keep the dock raised.
+        #expect(tracker.latestTransition == nil)
     }
 }

--- a/Packages/iOS/CmuxMobileSupport/Tests/CmuxMobileSupportTests/UITestConfigTests.swift
+++ b/Packages/iOS/CmuxMobileSupport/Tests/CmuxMobileSupportTests/UITestConfigTests.swift
@@ -190,6 +190,22 @@ import Testing
         ]))
     }
 
+    @Test func keyboardDockFrameRecordingFlagRequiresExplicitEnable() {
+        #if DEBUG
+        #expect(UITestConfig.keyboardDockFrameRecordingEnabled(from: [
+            "CMUX_UITEST_KEYBOARD_DOCK_FRAME_RECORDING": "1",
+        ]))
+        #else
+        #expect(!UITestConfig.keyboardDockFrameRecordingEnabled(from: [
+            "CMUX_UITEST_KEYBOARD_DOCK_FRAME_RECORDING": "1",
+        ]))
+        #endif
+        #expect(!UITestConfig.keyboardDockFrameRecordingEnabled(from: [:]))
+        #expect(!UITestConfig.keyboardDockFrameRecordingEnabled(from: [
+            "CMUX_UITEST_KEYBOARD_DOCK_FRAME_RECORDING": "0",
+        ]))
+    }
+
     @Test func agentChatPreviewFlagIsDebugOnly() {
         let env = ["CMUX_UITEST_AGENT_CHAT_PREVIEW": "1"]
         let config = UITestEnvironmentConfig(environment: env)

--- a/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView.swift
+++ b/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView.swift
@@ -514,6 +514,15 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
     private var composerBottomToKeyboardConstraint: NSLayoutConstraint?
     private var composerHeightConstraint: NSLayoutConstraint?
     private var toolbarHeightConstraint: NSLayoutConstraint?
+    /// Required upper bound on the composer's bottom edge derived from the
+    /// notification-tracked keyboard frame: `composer.bottom <= self.bottom -
+    /// keyboardOverlapFloor`. The keyboard guide equality above it is demoted one
+    /// priority notch, so when the guide misses a transition (a view attached
+    /// around a workspace switch can be left seated on the guide's safe-area
+    /// fallback while the keyboard is up) this floor still lifts the dock above
+    /// the real keyboard. While the guide tracks correctly both constraints agree
+    /// and the floor is inert.
+    private var composerBottomKeyboardFloorConstraint: NSLayoutConstraint?
     /// Process-wide keyboard-frame source for floor catch-up on attach/layout.
     /// Only the DEBUG seam below can replace it: tests inject a
     /// notification-center-isolated instance without touching the shared
@@ -526,6 +535,10 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
         keyboardFrameTracker = tracker
     }
     #endif
+    /// The keyboard overlap the floor constraint currently enforces, mirrored
+    /// into the viewport model so the terminal grid reserves the same space the
+    /// bars occupy. Zero while the keyboard is down or unknown.
+    private var keyboardOverlapFloor: CGFloat = 0
     #if DEBUG
     private var keyboardHeightOverrideForTesting: CGFloat?
     private var composerBottomForTestingConstraint: NSLayoutConstraint?
@@ -990,12 +1003,27 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
         // and its text stays; tapping it refocuses and re-raises the keyboard. The
         // composer is dismissed only by its chevron or the toolbar composer button.
         //
-        // This notification owns responder-facing VISIBILITY only. UIKit's
-        // `keyboardLayoutGuide` owns all dock and viewport geometry, including safe-area
-        // fallback and interrupted keyboard motion. Keeping those responsibilities
-        // separate prevents a stale notification frame from becoming a second layout
-        // authority while preserving hardware/floating keyboard visibility semantics.
+        // This notification owns responder-facing VISIBILITY plus the keyboard
+        // FLOOR. UIKit's `keyboardLayoutGuide` still owns dock and viewport motion,
+        // including safe-area fallback and interrupted keyboard motion; the floor is
+        // an inequality bound, not a second equality authority, so a stale frame can
+        // never pin the dock below wherever the guide places it. It exists because
+        // the guide can miss a transition around window (re)attachment and stay on
+        // its safe-area fallback with the keyboard up; the floor then lifts the dock
+        // on the notification's own curve.
         updateDockedToolbarVisibility()
+        // The tracker (registered before any surface's handler) is the floor's
+        // ONLY data source; this handler merely re-reads it on the keyboard's
+        // own animation curve so a floor change moves like the keyboard. A
+        // second per-view derivation here could disagree with the tracker and
+        // be undone by the next layout catch-up. The renderer follows through
+        // the display-link transition pass, exactly as for guide-driven motion.
+        transition.animate { [weak self] in
+            guard let self else { return }
+            if self.synchronizeKeyboardFloorFromTracker() {
+                self.layoutIfNeeded()
+            }
+        }
         setNeedsLayout()
     }
 
@@ -1015,10 +1043,14 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
         }
     }
 
-    /// Installs the system keyboard guide as the only production keyboard geometry source.
+    /// Installs the system keyboard guide as the primary keyboard geometry source.
     private func configureKeyboardLayoutGuide() {
         keyboardLayoutGuide.followsUndockedKeyboard = false
         keyboardLayoutGuide.usesBottomSafeArea = true
+        // Create the process-wide tracker no later than the first surface, so a
+        // keyboard transition that happens while THIS view is detached (workspace
+        // switch) is still observed and can seat the keyboard floor on attach.
+        _ = MobileKeyboardFrameTracker.shared
     }
 
     /// Pins the whole dock stack to Apple's keyboard guide.
@@ -1030,9 +1062,17 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
         let composerBottom = composerContainer.bottomAnchor.constraint(
             equalTo: keyboardLayoutGuide.topAnchor
         )
+        // One notch below required so the notification-derived keyboard floor
+        // below can outrank a guide that missed the current keyboard transition;
+        // see `composerBottomKeyboardFloorConstraint`.
+        composerBottom.priority = UILayoutPriority(rawValue: UILayoutPriority.required.rawValue - 1)
+        let composerBottomFloor = composerContainer.bottomAnchor.constraint(
+            lessThanOrEqualTo: bottomAnchor
+        )
         let composerHeight = composerContainer.heightAnchor.constraint(equalToConstant: 0)
         let toolbarHeight = dockedToolbar.heightAnchor.constraint(equalToConstant: 0)
         composerBottomToKeyboardConstraint = composerBottom
+        composerBottomKeyboardFloorConstraint = composerBottomFloor
         composerHeightConstraint = composerHeight
         self.toolbarHeightConstraint = toolbarHeight
 
@@ -1040,6 +1080,7 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
             composerContainer.leadingAnchor.constraint(equalTo: leadingAnchor),
             composerContainer.trailingAnchor.constraint(equalTo: trailingAnchor),
             composerBottom,
+            composerBottomFloor,
             composerHeight,
             dockedToolbar.leadingAnchor.constraint(equalTo: leadingAnchor),
             dockedToolbar.trailingAnchor.constraint(equalTo: trailingAnchor),
@@ -1049,10 +1090,49 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
         layoutBottomDock()
     }
 
-    /// Updates the renderer's overlap model from the guide's target top edge.
+    /// Re-derives the keyboard floor and applies it to the floor constraint and
+    /// the viewport model.
+    ///
+    /// - Parameter overlap: The keyboard overlap to enforce, in this view's
+    ///   coordinates; pass the notification transition's overlap on the
+    ///   notification path, or the tracker-derived overlap on layout catch-up.
+    /// - Returns: Whether the floor changed.
+    @discardableResult
+    private func applyKeyboardOverlapFloor(_ overlap: CGFloat) -> Bool {
+        #if DEBUG
+        guard keyboardHeightOverrideForTesting == nil else { return false }
+        #endif
+        let clamped = max(0, overlap)
+        guard abs(clamped - keyboardOverlapFloor) > 0.25 else { return false }
+        keyboardOverlapFloor = clamped
+        composerBottomKeyboardFloorConstraint?.constant = -clamped
+        setNeedsGeometrySync()
+        return true
+    }
+
+    /// Catches the keyboard floor up from the process-wide tracker.
+    ///
+    /// A view attached to a window AFTER the keyboard came up never receives the
+    /// keyboard notification for that transition, and UIKit's layout guide can
+    /// stay on its safe-area fallback for the same reason. The tracker observed
+    /// the transition process-wide, so every layout pass can re-derive the floor
+    /// for the view's current window position.
+    ///
+    /// - Returns: Whether the floor changed.
+    @discardableResult
+    private func synchronizeKeyboardFloorFromTracker() -> Bool {
+        guard window != nil else { return false }
+        return applyKeyboardOverlapFloor(keyboardFrameTracker.overlap(in: self))
+    }
+
+    /// Updates the renderer's overlap model from the guide's target top edge,
+    /// bounded below by the notification-derived keyboard floor so the grid
+    /// reserves the same space the floor-lifted bars occupy when the guide
+    /// missed the current transition.
     @discardableResult
     private func synchronizeKeyboardGeometryFromLayoutGuide() -> Bool {
-        let nextHeight = keyboardOverlapFromLayoutGuide
+        synchronizeKeyboardFloorFromTracker()
+        let nextHeight = max(keyboardOverlapFromLayoutGuide, keyboardOverlapFloor)
         guard abs(nextHeight - keyboardHeight) > 0.25 else { return false }
         keyboardHeight = nextHeight
         bottomDockTransitionObserved = bottomDockTransitionInFlight
@@ -1101,6 +1181,10 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
         keyboardHeight = clamped
         bottomDockTransitionObserved = false
 
+        // The synthetic bottom equality replaces BOTH production keyboard
+        // constraints; a live floor would make an override below it unsatisfiable.
+        keyboardOverlapFloor = 0
+        composerBottomKeyboardFloorConstraint?.constant = 0
         composerBottomToKeyboardConstraint?.isActive = false
         if composerBottomForTestingConstraint == nil {
             composerBottomForTestingConstraint = composerContainer.bottomAnchor.constraint(

--- a/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView.swift
+++ b/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView.swift
@@ -709,7 +709,12 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
             // terminal tap focuses the proxy without closing the band), and the proxy
             // is a sibling of `composerContainer`, so `endEditing` on the container
             // alone would resign nothing and the keyboard would stay up.
-            if self.keyboardVisible {
+            // Decide from ACTUAL responder truth, not `keyboardVisible`: that
+            // bit is reconciled from keyboard notifications and lags a frame
+            // or two during rapid toggling, which made quick successive taps
+            // of the toggle re-focus when they should resign (and vice versa)
+            // until the keyboard wedged out of sync with the button.
+            if self.inputProxy.isFirstResponder || self.composerFieldIsFirstResponder {
                 self.resignCurrentInput()
             } else {
                 self.focusInput()

--- a/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView.swift
+++ b/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView.swift
@@ -1123,7 +1123,24 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
     @discardableResult
     private func synchronizeKeyboardFloorFromTracker() -> Bool {
         guard window != nil else { return false }
+        synchronizeKeyboardVisibilityFromTracker()
         return applyKeyboardOverlapFloor(keyboardFrameTracker.overlap(in: self))
+    }
+
+    /// Reconciles the responder-facing visibility bit — and with it the
+    /// toolbar's keyboard-toggle glyph — with the tracked keyboard state.
+    ///
+    /// A surface (re)mounted after the keyboard changed never receives the
+    /// notification that flipped it, so leaving a workspace with the keyboard
+    /// up and re-entering it otherwise shows the stale hide-keyboard glyph
+    /// (and the toggle would resign a keyboard that is not there) until the
+    /// next real transition. Change-guarded so the glyph cross-dissolve only
+    /// runs on actual flips, not every layout pass.
+    private func synchronizeKeyboardVisibilityFromTracker() {
+        let visible = keyboardFrameTracker.isVisible(in: self)
+        guard visible != keyboardVisible else { return }
+        keyboardVisible = visible
+        inputProxy.setKeyboardShown(visible)
     }
 
     /// Updates the renderer's overlap model from the guide's target top edge,

--- a/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView.swift
+++ b/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView.swift
@@ -515,23 +515,25 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
     private var composerHeightConstraint: NSLayoutConstraint?
     private var toolbarHeightConstraint: NSLayoutConstraint?
     /// Required upper bound on the composer's bottom edge derived from the
-    /// notification-tracked keyboard frame: `composer.bottom <= self.bottom -
-    /// keyboardOverlapFloor`. The keyboard guide equality above it is demoted one
-    /// priority notch, so when the guide misses a transition (a view attached
-    /// around a workspace switch can be left seated on the guide's safe-area
-    /// fallback while the keyboard is up) this floor still lifts the dock above
-    /// the real keyboard. While the guide tracks correctly both constraints agree
-    /// and the floor is inert.
+    /// notification-tracked keyboard frame: `composer.bottom <= window.bottom -
+    /// keyboardOverlapFloorInWindow`. Anchored to the WINDOW because the
+    /// surface's own frame animates with safe-area propagation during keyboard
+    /// transitions; see `refreshKeyboardFloorConstraintForWindow()`. The
+    /// keyboard guide equality above it is demoted one priority notch, so when
+    /// the guide misses or lags a transition this floor still lifts the dock
+    /// above the real keyboard; while the guide tracks correctly both
+    /// constraints agree and the floor is inert.
     private var composerBottomKeyboardFloorConstraint: NSLayoutConstraint?
     /// Process-wide keyboard-frame source for floor catch-up on attach/layout.
     /// Injected at construction (production callers take the shared tracker
     /// default) so tests pass a notification-center-isolated instance without
     /// touching the shared tracker other suites read.
     private let keyboardFrameTracker: MobileKeyboardFrameTracker
-    /// The keyboard overlap the floor constraint currently enforces, mirrored
-    /// into the viewport model so the terminal grid reserves the same space the
-    /// bars occupy. Zero while the keyboard is down or unknown.
-    private var keyboardOverlapFloor: CGFloat = 0
+    /// The keyboard overlap the floor constraint currently enforces, in WINDOW
+    /// points (stable across the surface's own frame changes). The viewport
+    /// model converts it to view space per layout pass. Zero while the keyboard
+    /// is down or unknown.
+    private var keyboardOverlapFloorInWindow: CGFloat = 0
     #if DEBUG
     private var keyboardHeightOverrideForTesting: CGFloat?
     private var composerBottomForTestingConstraint: NSLayoutConstraint?
@@ -1023,7 +1025,7 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
                 + " dur=\(String(format: "%.2f", transition.duration))"
                 + " trackerOverlap=\(Int(keyboardFrameTracker.overlap(in: self)))"
                 + " guideTop=\(Int(keyboardLayoutGuide.layoutFrame.minY))"
-                + " floor=\(Int(keyboardOverlapFloor)) visible=\(willBeVisible ? 1 : 0)"
+                + " floorW=\(Int(keyboardOverlapFloorInWindow)) visible=\(willBeVisible ? 1 : 0)"
         )
         #endif
         // The tracker (registered before any surface's handler) is the floor's
@@ -1089,9 +1091,6 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
         // below can outrank a guide that missed the current keyboard transition;
         // see `composerBottomKeyboardFloorConstraint`.
         composerBottom.priority = UILayoutPriority(rawValue: UILayoutPriority.required.rawValue - 1)
-        let composerBottomFloor = composerContainer.bottomAnchor.constraint(
-            lessThanOrEqualTo: bottomAnchor
-        )
         // With the guide in pure keyboard mode its keyboard-DOWN position is the
         // view's bottom edge, so the home-indicator seat is stated explicitly:
         // the dock may never sink into the bottom safe area. While the keyboard
@@ -1103,7 +1102,6 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
         let composerHeight = composerContainer.heightAnchor.constraint(equalToConstant: 0)
         let toolbarHeight = dockedToolbar.heightAnchor.constraint(equalToConstant: 0)
         composerBottomToKeyboardConstraint = composerBottom
-        composerBottomKeyboardFloorConstraint = composerBottomFloor
         composerHeightConstraint = composerHeight
         self.toolbarHeightConstraint = toolbarHeight
 
@@ -1111,7 +1109,6 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
             composerContainer.leadingAnchor.constraint(equalTo: leadingAnchor),
             composerContainer.trailingAnchor.constraint(equalTo: trailingAnchor),
             composerBottom,
-            composerBottomFloor,
             composerBottomSafeAreaCap,
             composerHeight,
             dockedToolbar.leadingAnchor.constraint(equalTo: leadingAnchor),
@@ -1120,14 +1117,42 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
             toolbarHeight,
         ])
         layoutBottomDock()
+        // The keyboard floor is WINDOW-anchored and therefore installed per
+        // window attach; see `refreshKeyboardFloorConstraintForWindow()`.
+    }
+
+    /// (Re)anchors the keyboard floor to the current window.
+    ///
+    /// The floor must be immune to the surface's own frame: safe-area
+    /// propagation resizes the hosted surface by the home-indicator height
+    /// across every keyboard transition (device forensics 2026-08-06, bounds
+    /// flipping 836<->802), so a floor expressed against the surface's bottom
+    /// was seeded with a mid-transition conversion and popped by that amount
+    /// after settle. The window's frame never moves, so a window-anchored
+    /// floor seeded from the notification's window-space overlap is final on
+    /// the first application. Removed on detach: a constraint into a window
+    /// the view has left would crash the next layout pass.
+    private func refreshKeyboardFloorConstraintForWindow() {
+        guard let window else {
+            composerBottomKeyboardFloorConstraint?.isActive = false
+            composerBottomKeyboardFloorConstraint = nil
+            return
+        }
+        if composerBottomKeyboardFloorConstraint?.secondItem === window { return }
+        composerBottomKeyboardFloorConstraint?.isActive = false
+        let floor = composerContainer.bottomAnchor.constraint(
+            lessThanOrEqualTo: window.bottomAnchor
+        )
+        floor.constant = -keyboardOverlapFloorInWindow
+        floor.isActive = true
+        composerBottomKeyboardFloorConstraint = floor
     }
 
     /// Re-derives the keyboard floor and applies it to the floor constraint and
     /// the viewport model.
     ///
-    /// - Parameter overlap: The keyboard overlap to enforce, in this view's
-    ///   coordinates; pass the notification transition's overlap on the
-    ///   notification path, or the tracker-derived overlap on layout catch-up.
+    /// - Parameter overlap: The keyboard overlap to enforce, in WINDOW
+    ///   coordinates (stable across the surface's own frame changes).
     /// - Returns: Whether the floor changed.
     @discardableResult
     private func applyKeyboardOverlapFloor(_ overlap: CGFloat) -> Bool {
@@ -1135,8 +1160,8 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
         guard keyboardHeightOverrideForTesting == nil else { return false }
         #endif
         let clamped = max(0, overlap)
-        guard abs(clamped - keyboardOverlapFloor) > 0.25 else { return false }
-        keyboardOverlapFloor = clamped
+        guard abs(clamped - keyboardOverlapFloorInWindow) > 0.25 else { return false }
+        keyboardOverlapFloorInWindow = clamped
         composerBottomKeyboardFloorConstraint?.constant = -clamped
         #if DEBUG
         // Paired with kb.willChange: a kb.floor long after its kb.willChange is
@@ -1147,20 +1172,32 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
         return true
     }
 
+    /// The floor converted into this view's coordinates against its CURRENT
+    /// frame, for the viewport model. Re-derived per layout pass so it
+    /// converges with the surface's settled frame even when that frame
+    /// animated during the transition.
+    private var keyboardOverlapFloorInBounds: CGFloat {
+        guard keyboardOverlapFloorInWindow > 0, let window else { return 0 }
+        let viewMaxYInWindow = convert(bounds, to: window).maxY
+        let belowView = max(0, window.bounds.maxY - viewMaxYInWindow)
+        return max(0, keyboardOverlapFloorInWindow - belowView)
+    }
+
     /// Catches the keyboard floor up from the process-wide tracker.
     ///
     /// A view attached to a window AFTER the keyboard came up never receives the
     /// keyboard notification for that transition, and UIKit's layout guide can
     /// stay on its safe-area fallback for the same reason. The tracker observed
     /// the transition process-wide, so every layout pass can re-derive the floor
-    /// for the view's current window position.
+    /// for the view's current window.
     ///
     /// - Returns: Whether the floor changed.
     @discardableResult
     private func synchronizeKeyboardFloorFromTracker() -> Bool {
         guard window != nil else { return false }
+        refreshKeyboardFloorConstraintForWindow()
         synchronizeKeyboardVisibilityFromTracker()
-        return applyKeyboardOverlapFloor(keyboardFrameTracker.overlap(in: self))
+        return applyKeyboardOverlapFloor(keyboardFrameTracker.overlapInWindow(of: self))
     }
 
     /// Reconciles the responder-facing visibility bit — and with it the
@@ -1186,7 +1223,7 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
     @discardableResult
     private func synchronizeKeyboardGeometryFromLayoutGuide() -> Bool {
         synchronizeKeyboardFloorFromTracker()
-        let nextHeight = max(keyboardOverlapFromLayoutGuide, keyboardOverlapFloor)
+        let nextHeight = max(keyboardOverlapFromLayoutGuide, keyboardOverlapFloorInBounds)
         guard abs(nextHeight - keyboardHeight) > 0.25 else { return false }
         keyboardHeight = nextHeight
         bottomDockTransitionObserved = bottomDockTransitionInFlight
@@ -1237,7 +1274,7 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
 
         // The synthetic bottom equality replaces BOTH production keyboard
         // constraints; a live floor would make an override below it unsatisfiable.
-        keyboardOverlapFloor = 0
+        keyboardOverlapFloorInWindow = 0
         composerBottomKeyboardFloorConstraint?.constant = 0
         composerBottomToKeyboardConstraint?.isActive = false
         if composerBottomForTestingConstraint == nil {
@@ -2356,6 +2393,9 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
         super.didMoveToWindow()
         MobileDebugLog.anchormux("surface.didMoveToWindow window=\(window != nil)")
         syncSurfaceVisibility()
+        // The keyboard floor is anchored to the window, so it must be
+        // (re)installed on attach and dropped on detach.
+        refreshKeyboardFloorConstraintForWindow()
         if window != nil {
             isDismantled = false
             setNeedsLayout()

--- a/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView.swift
+++ b/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView.swift
@@ -353,12 +353,22 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
         let pointValue: (CGFloat) -> String = {
             String(format: "%.3f", Double($0))
         }
-        let toolbarFrame = dockedToolbar?.frame
-        let toolbarMinY = toolbarFrame.map { pointValue($0.minY) } ?? "none"
-        let toolbarMaxY = toolbarFrame.map { pointValue($0.maxY) } ?? "none"
+        // The dock lives in the keyboard's own window now, so its frames are
+        // reported CONVERTED into surface coordinates (where the bars sit over
+        // the terminal). While the accessory is unhosted (no responder holds
+        // the keyboard) the frames are unknowable: -1 sentinel.
+        let composerFrameInSurface = dockFrameInSurfaceCoordinates(of: composerContainer)
+        let toolbarFrameInSurface = dockedToolbar.flatMap { dockFrameInSurfaceCoordinates(of: $0) }
+        let composerMinY = composerFrameInSurface.map { pointValue($0.minY) } ?? pointValue(-1)
+        let composerMaxY = composerFrameInSurface.map { pointValue($0.maxY) } ?? pointValue(-1)
+        let toolbarMinY = toolbarFrameInSurface.map { pointValue($0.minY) } ?? "none"
+        let toolbarMaxY = toolbarFrameInSurface.map { pointValue($0.maxY) } ?? "none"
         let keyboardTransitionID = bottomDockTransitionInFlight ? 1 : -1
         let keyboardTransitionTarget = pointValue(keyboardHeight)
-        let keyboardGuideTop = pointValue(keyboardLayoutGuide.layoutFrame.minY)
+        // Key kept so the log format stays parseable: now the accessory's top
+        // edge in surface coordinates, -1 while the accessory is unhosted.
+        let keyboardGuideTop = accessoryFrameInSurfaceCoordinates()
+            .map { pointValue($0.minY) } ?? pointValue(-1)
         return [
             "chromeHidden=\(chromeHidden ? 1 : 0)",
             "composerActive=\(composerActive ? 1 : 0)",
@@ -370,8 +380,8 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
             "inputScene=\(inputScene)",
             "inputModal=\(inputModal)",
             "keyboardHeight=\(pointValue(keyboardHeight))",
-            "composerMinY=\(pointValue(composerContainer.frame.minY))",
-            "composerMaxY=\(pointValue(composerContainer.frame.maxY))",
+            "composerMinY=\(composerMinY)",
+            "composerMaxY=\(composerMaxY)",
             "toolbarMinY=\(toolbarMinY)",
             "toolbarMaxY=\(toolbarMaxY)",
             "bottomSafeArea=\(pointValue(safeAreaInsetsBottom))",
@@ -507,36 +517,25 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
         lastAppliedContainerSize = .zero
     }
     private var viewportCoordinator = TerminalViewportCoordinator()
-    /// The toolbar/composer use Auto Layout; the Ghostty renderer does not. This bit
-    /// keeps its display-link viewport updates alive until the guide-constrained
-    /// toolbar's presentation frame reaches its model frame.
+    /// The dock accessory animates in the keyboard's own window; the Ghostty
+    /// renderer does not follow Auto Layout. This bit keeps the display-link
+    /// viewport updates alive until the accessory's presentation frame reaches
+    /// its model frame.
     private var bottomDockTransitionObserved = false
-    private var composerBottomToKeyboardConstraint: NSLayoutConstraint?
-    private var composerHeightConstraint: NSLayoutConstraint?
-    private var toolbarHeightConstraint: NSLayoutConstraint?
-    /// Required upper bound on the composer's bottom edge derived from the
-    /// notification-tracked keyboard frame: `composer.bottom <= window.bottom -
-    /// keyboardOverlapFloorInWindow`. Anchored to the WINDOW because the
-    /// surface's own frame animates with safe-area propagation during keyboard
-    /// transitions; see `refreshKeyboardFloorConstraintForWindow()`. The
-    /// keyboard guide equality above it is demoted one priority notch, so when
-    /// the guide misses or lags a transition this floor still lifts the dock
-    /// above the real keyboard; while the guide tracks correctly both
-    /// constraints agree and the floor is inert.
-    private var composerBottomKeyboardFloorConstraint: NSLayoutConstraint?
-    /// Process-wide keyboard-frame source for floor catch-up on attach/layout.
+    /// Process-wide keyboard-frame source for model catch-up on attach/layout.
     /// Injected at construction (production callers take the shared tracker
     /// default) so tests pass a notification-center-isolated instance without
     /// touching the shared tracker other suites read.
     private let keyboardFrameTracker: MobileKeyboardFrameTracker
-    /// The keyboard overlap the floor constraint currently enforces, in WINDOW
-    /// points (stable across the surface's own frame changes). The viewport
-    /// model converts it to view space per layout pass. Zero while the keyboard
-    /// is down or unknown.
+    /// The notification-tracked keyboard overlap, in WINDOW points (stable
+    /// across the surface's own frame changes). The viewport model converts it
+    /// to view space per layout pass. Zero while the keyboard is down or
+    /// unknown. The dock's POSITION no longer derives from this — the OS
+    /// keyboard system places the accessory — so it feeds only the grid
+    /// reservation.
     private var keyboardOverlapFloorInWindow: CGFloat = 0
     #if DEBUG
     private var keyboardHeightOverrideForTesting: CGFloat?
-    private var composerBottomForTestingConstraint: NSLayoutConstraint?
     #endif
 
     #if DEBUG
@@ -741,6 +740,14 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
                 right: max(0, window.bounds.maxX - terminalFrame.maxX)
             )
         }
+        inputProxy.keyboardAccessoryProvider = { [weak self] in
+            // The proxy rides the SAME dock accessory the surface returns, so
+            // the toolbar + composer band transfer seamlessly between the
+            // keyboard-up (proxy first responder) and keyboard-down (surface
+            // first responder) states. Withheld while the chrome is hidden.
+            guard let self, !self.chromeHidden else { return nil }
+            return self.keyboardDockAccessory
+        }
         return inputProxy
     }()
 
@@ -790,10 +797,11 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
         addSubview(debugAccessibilityProxy)
         addSubview(composerDockProbe)
         #endif
-        configureKeyboardLayoutGuide()
-        installPersistentToolbar()
-        installComposerContainer()
-        installBottomDockConstraints()
+        // Create the process-wide tracker no later than the first surface, so a
+        // keyboard transition that happens while THIS view is detached (workspace
+        // switch) is still observed and can seat the keyboard model on attach.
+        _ = MobileKeyboardFrameTracker.shared
+        installKeyboardDockAccessory()
         installArtifactChipContainer()
         initializeSurface()
 
@@ -908,11 +916,10 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
 
     private var keyboardHeight: CGFloat = 0
     private var keyboardVisible = false
-    /// Height the persistent bottom toolbar reserves in the terminal grid. The
-    /// toolbar is constrained to ``UIView/keyboardLayoutGuide`` and the viewport
-    /// coordinator consumes that same guide-derived overlap, so the grid must shrink
-    /// by this much to keep the bottom TUI rows visible above it. Zero until the
-    /// toolbar is installed (`installPersistentToolbar`).
+    /// Height the persistent toolbar row reserves in the terminal grid. The
+    /// row lives inside the OS-positioned dock accessory, so the grid must
+    /// shrink by this much to keep the bottom TUI rows visible above it. Zero
+    /// until the dock is installed (`installKeyboardDockAccessory`).
     private var reservedToolbarHeight: CGFloat = 0
     /// Height of the docked accessory bar reserved in the grid geometry so the
     /// bottom TUI rows stay visible above it. Locked to the bar's actual button-row
@@ -923,10 +930,26 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
     /// toolbar's live top edge equal to the viewport edge; any whole-cell render
     /// remainder stays inside the terminal viewport instead of becoming toolbar fill.
     private static let persistentToolbarHeight: CGFloat = TerminalInputTextView.dockedButtonRowHeight
-    /// The docked accessory bar. Auto Layout pins it above the composer, whose bottom
-    /// is attached to ``UIView/keyboardLayoutGuide``. The viewport coordinator uses
-    /// the guide's same top edge for the terminal reservation.
+    /// The docked accessory bar (the toolbar row hosted inside
+    /// ``keyboardDockAccessory``). The viewport coordinator reserves its height
+    /// in the terminal grid; the OS keyboard system owns its position.
     private weak var dockedToolbar: UIView?
+    /// The system-positioned bottom dock: the toolbar row and the composer band
+    /// in one self-sizing `UIInputView`. Returned as the `inputAccessoryView`
+    /// of BOTH cmux keyboard owners — the terminal input proxy while typing
+    /// (the dock rides the keyboard's own animation) and this surface in the
+    /// keyboard-down state (the system docks it at the screen bottom) — so the
+    /// OS keyboard system owns the dock's POSITION in every state.
+    private var keyboardDockAccessory: KeyboardDockAccessoryView?
+
+    /// The surface holds first responder whenever no cmux text responder owns
+    /// the keyboard, so the system keeps the dock accessory seated at the
+    /// screen bottom (the Messages pattern).
+    public override var canBecomeFirstResponder: Bool { true }
+
+    public override var inputAccessoryView: UIView? {
+        chromeHidden ? nil : keyboardDockAccessory
+    }
     /// Whether the iMessage-style composer is currently open. The surface owns the
     /// whole bottom dock (terminal grid / toolbar / composer band / keyboard) in ONE
     /// coordinate system, so `composerActive` only drives the first-responder
@@ -939,10 +962,10 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
     /// The composer band: a surface-owned container the host installs the SwiftUI
     /// compose field into (via a `UIHostingController` in
     /// `GhosttySurfaceRepresentable`, which can see both layers; the terminal package
-    /// cannot import the UI package). Auto Layout pins it directly to
-    /// ``UIView/keyboardLayoutGuide`` (iMessage's field-nearest-keyboard layout), with
-    /// the docked toolbar riding its top edge and the terminal grid above that. The
-    /// viewport coordinator consumes the same guide overlap for the
+    /// cannot import the UI package). Hosted as the bottom slot of
+    /// ``keyboardDockAccessory`` (iMessage's field-nearest-keyboard layout), with
+    /// the toolbar row above it and the terminal grid above that. The viewport
+    /// coordinator reserves the same heights for the
     /// `terminal / toolbar / composer / keyboard` stack.
     private let composerContainer = UIView()
     /// Height (points) the open composer band reserves above the keyboard edge. Fed
@@ -979,7 +1002,11 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
     // would leak keyboard state into concurrently running suites).
     @objc func handleKeyboardWillChangeFrame(_ notification: Notification) {
         guard let transition = MobileKeyboardTransition(notification: notification) else { return }
+        // Raised means more than the docked accessory: with the dock hosted as
+        // the inputAccessoryView, the keyboard-down state also posts frames
+        // covering just the accessory strip.
         let willBeVisible = transition.isVisible(in: self)
+            && trackedOverlapIsRaisedKeyboard(transition.overlapInWindow(of: self))
         let wasVisible = keyboardVisible
         #if DEBUG
         // The composer-up/keyboard-down desync can be reached WITHOUT the dismiss
@@ -1007,47 +1034,42 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
         // composer is dismissed only by its chevron or the toolbar composer button.
         //
         // This notification owns responder-facing VISIBILITY plus the keyboard
-        // FLOOR. UIKit's `keyboardLayoutGuide` still owns dock and viewport motion,
-        // including safe-area fallback and interrupted keyboard motion; the floor is
-        // an inequality bound, not a second equality authority, so a stale frame can
-        // never pin the dock below wherever the guide places it. It exists because
-        // the guide can miss a transition around window (re)attachment and stay on
-        // its safe-area fallback with the keyboard up; the floor then lifts the dock
-        // on the notification's own curve.
+        // overlap MODEL. The dock's POSITION is owned by the OS keyboard system
+        // (the dock is the responder's `inputAccessoryView` and rides in the
+        // keyboard's window), so nothing here moves bars; the grid reservation
+        // follows the tracker-derived overlap.
         updateDockedToolbarVisibility()
         #if DEBUG
         // Transition forensics for the bars-lag-the-keyboard class: one line per
-        // willChangeFrame with the notification frame, the tracker/guide/floor
-        // trio, and the animation duration, so a dogfood recording can be lined
-        // up against which source moved (or failed to move) the dock and when.
+        // willChangeFrame with the notification frame, the tracker/floor pair,
+        // and the animation duration, so a dogfood recording can be lined up
+        // against which source moved (or failed to move) the grid and when.
         MobileDebugLog.anchormux(
             "kb.willChange endMinY=\(Int(transition.endFrame.minY)) endH=\(Int(transition.endFrame.height))"
                 + " dur=\(String(format: "%.2f", transition.duration))"
                 + " trackerOverlap=\(Int(keyboardFrameTracker.overlap(in: self)))"
-                + " guideTop=\(Int(keyboardLayoutGuide.layoutFrame.minY))"
                 + " floorW=\(Int(keyboardOverlapFloorInWindow)) visible=\(willBeVisible ? 1 : 0)"
         )
         #endif
-        // The tracker (registered before any surface's handler) is the floor's
-        // ONLY data source; this handler merely re-reads it on the keyboard's
-        // own animation curve so a floor change moves like the keyboard. A
-        // second per-view derivation here could disagree with the tracker and
-        // be undone by the next layout catch-up. The renderer follows through
-        // the display-link transition pass, exactly as for guide-driven motion.
+        // The tracker (registered before any surface's handler) is the overlap
+        // model's ONLY data source; this handler merely re-reads it on the
+        // keyboard's own animation curve so the grid target updates in step
+        // with the keyboard. There are no dock constraints left to animate —
+        // the keyboard window carries the accessory — so the renderer follows
+        // through the display-link transition pass and the layout below.
         transition.animate { [weak self] in
             guard let self else { return }
-            if self.synchronizeKeyboardFloorFromTracker() {
-                self.layoutIfNeeded()
-            }
+            self.synchronizeKeyboardFloorFromTracker()
         }
+        layoutRenderedTerminalForCurrentViewport()
         setNeedsLayout()
     }
 
-    /// Keep the renderer clipped to UIKit's live keyboard guide during animation.
+    /// Keep the renderer tracking the live dock during keyboard animation.
     ///
-    /// The constrained toolbar/composer already follow the guide automatically. The
-    /// terminal renderer is not Auto Layout-backed, so its display-link pass reads the
-    /// constrained toolbar's presentation frame until it reaches the model target.
+    /// The dock accessory animates in the keyboard's own window. The terminal
+    /// renderer is not Auto Layout-backed, so its display-link pass reads the
+    /// accessory's presentation frame until it reaches the model target.
     private func advanceBottomDockTransition() {
         let isTransitioning = bottomDockTransitionInFlight
         guard isTransitioning || bottomDockTransitionObserved else { return }
@@ -1059,101 +1081,12 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
         }
     }
 
-    /// Installs the system keyboard guide as the primary keyboard geometry source.
-    private func configureKeyboardLayoutGuide() {
-        keyboardLayoutGuide.followsUndockedKeyboard = false
-        // Pure keyboard tracking. With `usesBottomSafeArea = true` the guide's
-        // position is coupled to bottom-safe-area propagation, which lands at
-        // the END of a keyboard transition: on device the guide-constrained
-        // bars sat still while the keyboard rose over them, then snapped up
-        // after it settled (dogfood recording, 2026-08-05), and on the
-        // simulator the settled guide read the bottom inset (~34pt) below the
-        // notification frame. The keyboard-down seat above the home indicator
-        // that `usesBottomSafeArea` provided is expressed explicitly in
-        // `installBottomDockConstraints()` via a required safe-area cap.
-        keyboardLayoutGuide.usesBottomSafeArea = false
-        // Create the process-wide tracker no later than the first surface, so a
-        // keyboard transition that happens while THIS view is detached (workspace
-        // switch) is still observed and can seat the keyboard floor on attach.
-        _ = MobileKeyboardFrameTracker.shared
-    }
-
-    /// Pins the whole dock stack to Apple's keyboard guide.
-    private func installBottomDockConstraints() {
-        guard let dockedToolbar else { return }
-        dockedToolbar.translatesAutoresizingMaskIntoConstraints = false
-        composerContainer.translatesAutoresizingMaskIntoConstraints = false
-
-        let composerBottom = composerContainer.bottomAnchor.constraint(
-            equalTo: keyboardLayoutGuide.topAnchor
-        )
-        // One notch below required so the notification-derived keyboard floor
-        // below can outrank a guide that missed the current keyboard transition;
-        // see `composerBottomKeyboardFloorConstraint`.
-        composerBottom.priority = UILayoutPriority(rawValue: UILayoutPriority.required.rawValue - 1)
-        // With the guide in pure keyboard mode its keyboard-DOWN position is the
-        // view's bottom edge, so the home-indicator seat is stated explicitly:
-        // the dock may never sink into the bottom safe area. While the keyboard
-        // is up, the guide equality and the keyboard floor are both stricter, so
-        // this cap only decides the keyboard-down seat.
-        let composerBottomSafeAreaCap = composerContainer.bottomAnchor.constraint(
-            lessThanOrEqualTo: safeAreaLayoutGuide.bottomAnchor
-        )
-        let composerHeight = composerContainer.heightAnchor.constraint(equalToConstant: 0)
-        let toolbarHeight = dockedToolbar.heightAnchor.constraint(equalToConstant: 0)
-        composerBottomToKeyboardConstraint = composerBottom
-        composerHeightConstraint = composerHeight
-        self.toolbarHeightConstraint = toolbarHeight
-
-        NSLayoutConstraint.activate([
-            composerContainer.leadingAnchor.constraint(equalTo: leadingAnchor),
-            composerContainer.trailingAnchor.constraint(equalTo: trailingAnchor),
-            composerBottom,
-            composerBottomSafeAreaCap,
-            composerHeight,
-            dockedToolbar.leadingAnchor.constraint(equalTo: leadingAnchor),
-            dockedToolbar.trailingAnchor.constraint(equalTo: trailingAnchor),
-            dockedToolbar.bottomAnchor.constraint(equalTo: composerContainer.topAnchor),
-            toolbarHeight,
-        ])
-        layoutBottomDock()
-        // The keyboard floor is WINDOW-anchored and therefore installed per
-        // window attach; see `refreshKeyboardFloorConstraintForWindow()`.
-    }
-
-    /// (Re)anchors the keyboard floor to the current window.
+    /// Re-derives the tracked keyboard overlap and applies it to the viewport
+    /// model.
     ///
-    /// The floor must be immune to the surface's own frame: safe-area
-    /// propagation resizes the hosted surface by the home-indicator height
-    /// across every keyboard transition (device forensics 2026-08-06, bounds
-    /// flipping 836<->802), so a floor expressed against the surface's bottom
-    /// was seeded with a mid-transition conversion and popped by that amount
-    /// after settle. The window's frame never moves, so a window-anchored
-    /// floor seeded from the notification's window-space overlap is final on
-    /// the first application. Removed on detach: a constraint into a window
-    /// the view has left would crash the next layout pass.
-    private func refreshKeyboardFloorConstraintForWindow() {
-        guard let window else {
-            composerBottomKeyboardFloorConstraint?.isActive = false
-            composerBottomKeyboardFloorConstraint = nil
-            return
-        }
-        if composerBottomKeyboardFloorConstraint?.secondItem === window { return }
-        composerBottomKeyboardFloorConstraint?.isActive = false
-        let floor = composerContainer.bottomAnchor.constraint(
-            lessThanOrEqualTo: window.bottomAnchor
-        )
-        floor.constant = -keyboardOverlapFloorInWindow
-        floor.isActive = true
-        composerBottomKeyboardFloorConstraint = floor
-    }
-
-    /// Re-derives the keyboard floor and applies it to the floor constraint and
-    /// the viewport model.
-    ///
-    /// - Parameter overlap: The keyboard overlap to enforce, in WINDOW
+    /// - Parameter overlap: The keyboard overlap to record, in WINDOW
     ///   coordinates (stable across the surface's own frame changes).
-    /// - Returns: Whether the floor changed.
+    /// - Returns: Whether the overlap changed.
     @discardableResult
     private func applyKeyboardOverlapFloor(_ overlap: CGFloat) -> Bool {
         #if DEBUG
@@ -1162,40 +1095,62 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
         let clamped = max(0, overlap)
         guard abs(clamped - keyboardOverlapFloorInWindow) > 0.25 else { return false }
         keyboardOverlapFloorInWindow = clamped
-        composerBottomKeyboardFloorConstraint?.constant = -clamped
         #if DEBUG
         // Paired with kb.willChange: a kb.floor long after its kb.willChange is
-        // the late-snap signature (floor applied by layout catch-up, unanimated).
+        // the late-snap signature (overlap applied by layout catch-up).
         MobileDebugLog.anchormux("kb.floor \(Int(clamped))")
         #endif
         setNeedsGeometrySync()
         return true
     }
 
-    /// The floor converted into this view's coordinates against its CURRENT
-    /// frame, for the viewport model. Re-derived per layout pass so it
-    /// converges with the surface's settled frame even when that frame
-    /// animated during the transition.
-    private var keyboardOverlapFloorInBounds: CGFloat {
-        guard keyboardOverlapFloorInWindow > 0, let window else { return 0 }
-        let viewMaxYInWindow = convert(bounds, to: window).maxY
-        let belowView = max(0, window.bounds.maxY - viewMaxYInWindow)
-        return max(0, keyboardOverlapFloorInWindow - belowView)
+    /// The dock accessory's own footprint inside a tracked "keyboard" frame.
+    ///
+    /// UIKit's keyboard end frames INCLUDE the input accessory: with the dock
+    /// accessory-hosted, a raised keyboard's frame contains the dock's content
+    /// height, and the keyboard-DOWN docked state posts frames covering just
+    /// the accessory (content + home-indicator inset). Both the grid model and
+    /// the visibility bit must subtract this footprint or the dock double
+    /// counts and the docked state reads as a visible keyboard.
+    private var accessoryDockedFootprintInWindow: CGFloat {
+        guard let accessory = keyboardDockAccessory, !chromeHidden else { return 0 }
+        return accessory.contentHeight + (window?.safeAreaInsets.bottom ?? 0)
     }
 
-    /// Catches the keyboard floor up from the process-wide tracker.
+    /// Whether the tracked overlap represents a genuinely raised keyboard, as
+    /// opposed to the docked accessory alone.
+    private func trackedOverlapIsRaisedKeyboard(_ overlapInWindow: CGFloat) -> Bool {
+        overlapInWindow > accessoryDockedFootprintInWindow + 8
+    }
+
+    /// The KEYBOARD-ONLY portion of the tracked overlap converted into this
+    /// view's coordinates against its CURRENT frame, for the viewport model.
+    /// Re-derived per layout pass so it converges with the surface's settled
+    /// frame even when that frame animated during the transition. The
+    /// accessory's own height is subtracted (the grid reserves the dock
+    /// separately via `reservedToolbarHeight` + `composerBandHeight`).
+    private var keyboardOverlapFloorInBounds: CGFloat {
+        guard keyboardOverlapFloorInWindow > 0, let window else { return 0 }
+        guard trackedOverlapIsRaisedKeyboard(keyboardOverlapFloorInWindow) else { return 0 }
+        let keyboardOnly = max(
+            0, keyboardOverlapFloorInWindow - (keyboardDockAccessory?.contentHeight ?? 0)
+        )
+        let viewMaxYInWindow = convert(bounds, to: window).maxY
+        let belowView = max(0, window.bounds.maxY - viewMaxYInWindow)
+        return max(0, keyboardOnly - belowView)
+    }
+
+    /// Catches the keyboard overlap model up from the process-wide tracker.
     ///
-    /// A view attached to a window AFTER the keyboard came up never receives the
-    /// keyboard notification for that transition, and UIKit's layout guide can
-    /// stay on its safe-area fallback for the same reason. The tracker observed
-    /// the transition process-wide, so every layout pass can re-derive the floor
+    /// A view attached to a window AFTER the keyboard came up never receives
+    /// the keyboard notification for that transition. The tracker observed the
+    /// transition process-wide, so every layout pass can re-derive the overlap
     /// for the view's current window.
     ///
-    /// - Returns: Whether the floor changed.
+    /// - Returns: Whether the overlap changed.
     @discardableResult
     private func synchronizeKeyboardFloorFromTracker() -> Bool {
         guard window != nil else { return false }
-        refreshKeyboardFloorConstraintForWindow()
         synchronizeKeyboardVisibilityFromTracker()
         return applyKeyboardOverlapFloor(keyboardFrameTracker.overlapInWindow(of: self))
     }
@@ -1210,20 +1165,28 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
     /// next real transition. Change-guarded so the glyph cross-dissolve only
     /// runs on actual flips, not every layout pass.
     private func synchronizeKeyboardVisibilityFromTracker() {
-        let visible = keyboardFrameTracker.isVisible(in: self)
+        // Raised means more than the docked accessory: the accessory alone
+        // (keyboard down, surface first responder) also posts keyboard frames.
+        let visible = trackedOverlapIsRaisedKeyboard(
+            keyboardFrameTracker.overlapInWindow(of: self)
+        )
         guard visible != keyboardVisible else { return }
         keyboardVisible = visible
         inputProxy.setKeyboardShown(visible)
     }
 
-    /// Updates the renderer's overlap model from the guide's target top edge,
-    /// bounded below by the notification-derived keyboard floor so the grid
-    /// reserves the same space the floor-lifted bars occupy when the guide
-    /// missed the current transition.
+    /// Updates the renderer's overlap model from the notification-tracked,
+    /// window-anchored keyboard overlap, converted into this view's bounds per
+    /// pass so it converges with the surface's settled frame.
     @discardableResult
-    private func synchronizeKeyboardGeometryFromLayoutGuide() -> Bool {
+    private func synchronizeKeyboardGeometry() -> Bool {
+        #if DEBUG
+        // The synthetic override writes `keyboardHeight` directly; the tracked
+        // overlap (forced to zero under the override) must not stomp it.
+        guard keyboardHeightOverrideForTesting == nil else { return false }
+        #endif
         synchronizeKeyboardFloorFromTracker()
-        let nextHeight = max(keyboardOverlapFromLayoutGuide, keyboardOverlapFloorInBounds)
+        let nextHeight = keyboardOverlapFloorInBounds
         guard abs(nextHeight - keyboardHeight) > 0.25 else { return false }
         keyboardHeight = nextHeight
         bottomDockTransitionObserved = bottomDockTransitionInFlight
@@ -1231,62 +1194,72 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
         return true
     }
 
-    /// Keyboard overlap represented by the system guide, excluding its safe-area fallback.
-    private var keyboardOverlapFromLayoutGuide: CGFloat {
-        #if DEBUG
-        if let keyboardHeightOverrideForTesting {
-            return max(0, keyboardHeightOverrideForTesting)
-        }
-        #endif
-        guard window != nil, bounds.height > 0 else { return 0 }
-        let guideFrame = keyboardLayoutGuide.layoutFrame
-        // A guide frame is usable only after UIKit has seated it against this view's
-        // bottom edge. During first attachment or rotation, keep the prior overlap for
-        // that transient pass instead of interpreting CGRect.zero as a full-screen
-        // keyboard.
-        guard abs(guideFrame.maxY - bounds.maxY) <= 1 else { return keyboardHeight }
-        let guideTop = min(max(0, guideFrame.minY), bounds.maxY)
-        let occupancy = max(0, bounds.maxY - guideTop)
-        return occupancy > safeAreaInsetsBottom + 0.5 ? occupancy : 0
-    }
-
-    /// Whether UIKit is still animating the guide-constrained dock toward its target.
+    /// Whether the OS is still animating the dock accessory toward its target.
+    ///
+    /// The accessory animates in the keyboard's own window, so its presentation
+    /// frame is compared against its model frame after converting both into
+    /// this view's coordinates. False when the accessory (or either window) is
+    /// unavailable, or when no presentation animation is in flight.
     private var bottomDockTransitionInFlight: Bool {
         #if DEBUG
         if keyboardHeightOverrideForTesting != nil { return false }
         #endif
         guard dockedToolbarShouldBeVisible,
-              let dockedToolbar,
-              !dockedToolbar.isHidden,
-              let presentationFrame = dockedToolbar.layer.presentation()?.frame else {
+              let model = accessoryFrameInSurfaceCoordinates(),
+              let presented = accessoryPresentationFrameInSurfaceCoordinates() else {
             return false
         }
-        return abs(presentationFrame.minY - dockedToolbar.frame.minY) > 0.5
+        return abs(presented.minY - model.minY) > 0.5
+    }
+
+    /// Converts a dock rect (in `superview`'s coordinates, inside the keyboard
+    /// window) into this view's coordinates, routing explicitly through both
+    /// windows because the accessory is not in this view's hierarchy.
+    private func convertDockRect(_ rect: CGRect, from superview: UIView) -> CGRect? {
+        guard let accessoryWindow = keyboardDockAccessory?.window, let window else { return nil }
+        let inAccessoryWindow = superview.convert(rect, to: accessoryWindow)
+        let inOwnWindow = accessoryWindow.convert(inAccessoryWindow, to: window)
+        return convert(inOwnWindow, from: window)
+    }
+
+    /// The accessory's model frame in this view's coordinates, or nil while the
+    /// accessory (or either window) is unavailable.
+    private func accessoryFrameInSurfaceCoordinates() -> CGRect? {
+        guard let accessory = keyboardDockAccessory,
+              let superview = accessory.superview else { return nil }
+        return convertDockRect(accessory.frame, from: superview)
+    }
+
+    /// The accessory's live presentation frame in this view's coordinates, or
+    /// nil while it is unavailable or no animation has produced a presentation
+    /// layer.
+    private func accessoryPresentationFrameInSurfaceCoordinates() -> CGRect? {
+        guard let accessory = keyboardDockAccessory,
+              let superview = accessory.superview,
+              let presentationFrame = accessory.layer.presentation()?.frame else { return nil }
+        return convertDockRect(presentationFrame, from: superview)
+    }
+
+    /// A dock content view's frame (toolbar row or composer band, hosted inside
+    /// the accessory) converted into this view's coordinates, or nil while the
+    /// accessory is unhosted.
+    private func dockFrameInSurfaceCoordinates(of view: UIView) -> CGRect? {
+        guard let superview = view.superview else { return nil }
+        return convertDockRect(view.frame, from: superview)
     }
 
     #if DEBUG
-    /// Switches the dock to a synthetic bottom anchor for host tests and previews.
+    /// Forces a synthetic keyboard overlap for host tests and previews. Only
+    /// the model/grid is synthetic now — the dock accessory needs no bottom
+    /// anchor because the OS positions it.
     private func setKeyboardHeightOverrideForTesting(_ height: CGFloat) {
         let clamped = max(0, height)
         keyboardHeightOverrideForTesting = clamped
         keyboardHeight = clamped
         bottomDockTransitionObserved = false
-
-        // The synthetic bottom equality replaces BOTH production keyboard
-        // constraints; a live floor would make an override below it unsatisfiable.
+        // A live tracked overlap would fight the override on the next
+        // geometry pass; zero it while the override is authoritative.
         keyboardOverlapFloorInWindow = 0
-        composerBottomKeyboardFloorConstraint?.constant = 0
-        composerBottomToKeyboardConstraint?.isActive = false
-        if composerBottomForTestingConstraint == nil {
-            composerBottomForTestingConstraint = composerContainer.bottomAnchor.constraint(
-                equalTo: bottomAnchor
-            )
-        }
-        composerBottomForTestingConstraint?.constant = -TerminalLetterboxGeometry.keyboardOccupancy(
-            keyboardHeight: clamped,
-            bottomSafeAreaInset: safeAreaInsetsBottom
-        )
-        composerBottomForTestingConstraint?.isActive = true
     }
     #endif
 
@@ -1320,29 +1293,29 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
 
     #endif
 
-    /// Dock the accessory bar as a persistent bottom toolbar. Auto Layout pins it
-    /// through the composer container to ``UIView/keyboardLayoutGuide``; the viewport
-    /// coordinator consumes the same guide-derived overlap for the terminal grid.
-    private func installPersistentToolbar() {
+    /// Builds the keyboard dock accessory around the accessory toolbar row and
+    /// the composer band. The dock is NOT a subview of this surface: it lives
+    /// in the keyboard's own window whenever a cmux responder (the input
+    /// proxy, the composer field, or this surface itself) is first responder,
+    /// so the OS keyboard system positions it in every state and no zPosition
+    /// juggling against the Ghostty render layer is needed. Neither content
+    /// view clips its bounds: the dock's Liquid-Glass controls lift past the
+    /// band edge on drag.
+    private func installKeyboardDockAccessory() {
         let toolbar = inputProxy.toolbarView
-        addSubview(toolbar)
         dockedToolbar = toolbar
-        // Raise the toolbar above the Ghostty renderer's own sublayer (which it
-        // inserts directly into `self.layer`), so a dragged/lifted Liquid-Glass button
-        // floating UP over the terminal is not occluded or clipped by the render layer
-        // (item 6). Subview order alone does not guarantee this because the renderer
-        // sublayer is composited at the layer level; the zoom overlay uses the same
-        // `zPosition` lever. The toolbar must also not clip its own bounds so the lift
-        // is visible above the strip.
-        toolbar.layer.zPosition = Self.bottomChromeZPosition
         toolbar.clipsToBounds = false
+        composerContainer.backgroundColor = .clear
+        composerContainer.isHidden = true
+        composerContainer.clipsToBounds = false
+        keyboardDockAccessory = KeyboardDockAccessoryView(
+            toolbar: toolbar,
+            composer: composerContainer,
+            toolbarRowHeight: Self.persistentToolbarHeight
+        )
         updateDockedToolbarVisibility()
     }
 
-    /// Layer `zPosition` for the bottom chrome (toolbar + composer band), placing it
-    /// above the Ghostty renderer's sublayer so a lifted Liquid-Glass button is not
-    /// clipped by the terminal render bounds (item 6). Below the zoom HUD (1100).
-    private static let bottomChromeZPosition: CGFloat = 1000
     /// Floats above dock chrome, terminal content, AND the verified-replay
     /// frozen presentation (zPosition 2000). The freeze copies only renderer
     /// pixels, so anything below it blinks out for the length of every
@@ -1415,8 +1388,11 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
             bottomSafeAreaInset: safeAreaInsetsBottom,
             chromeHidden: chromeHidden,
             chromeVisible: dockedToolbarShouldBeVisible && dockedToolbar?.isHidden == false,
-            toolbarFrame: dockedToolbar?.frame,
-            toolbarPresentationFrame: dockedToolbar?.layer.presentation()?.frame,
+            // The dock lives in the keyboard's window; hand the coordinator its
+            // frame converted into SURFACE coordinates (model and live
+            // presentation respectively), nil while the accessory is unhosted.
+            toolbarFrame: accessoryFrameInSurfaceCoordinates(),
+            toolbarPresentationFrame: accessoryPresentationFrameInSurfaceCoordinates(),
             viewportNegotiationUnsettled: bottomDockTransitionInFlight
                 || pendingViewportReport != nil
                 || awaitingViewportEcho
@@ -1495,10 +1471,15 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
         dockedToolbar?.isHidden = !shouldShow
         // The composer band rides with the toolbar: hide it when the chrome is
         // suppressed, show it again when the chrome returns and a field is mounted.
-        // Its height constraint already collapses to zero while hidden; toggling
-        // `isHidden` also stops it intercepting taps.
+        // Both flags hide CONTENT inside the accessory; toggling `isHidden` also
+        // stops the band intercepting taps.
         composerContainer.isHidden = !shouldShow || composerContainer.subviews.isEmpty
         reservedToolbarHeight = reserved
+        // A chrome toggle changes what `inputAccessoryView` returns, and the
+        // system re-reads it only on a reload. Reload both candidate first
+        // responders — cheap and safe when either is not first responder.
+        reloadInputViews()
+        inputProxy.reloadInputViews()
         layoutRenderedTerminalForCurrentViewport()
         updateArtifactChipVisibility(animated: true)
         setNeedsGeometrySync()
@@ -1508,38 +1489,42 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
     /// Temporarily hide (or re-show) the bottom chrome — the always-visible toolbar
     /// and any open composer band — via the HIDE button (item 2).
     ///
-    /// Hiding also drops the software keyboard: with the toolbar always visible, HIDE
-    /// only makes sense as "clear all chrome to see the full terminal", which requires
-    /// resigning the keyboard too. `isComposerPresented` is left untouched, so the
-    /// composer (and its draft) reappear intact on the next terminal tap
-    /// (``handleTap``). UIKit animates keyboard movement through its layout guide;
-    /// ``animateBottomDock`` handles only the chrome-height change.
-    private func setChromeHidden(_ hidden: Bool) {
+    /// Hiding also drops the software keyboard AND the surface's own
+    /// first-responder seat: with the dock hosted by the keyboard system, HIDE
+    /// means "no responder offers the accessory", so the typing responder is
+    /// resigned, the surface resigns, and the input views reload with a nil
+    /// accessory. `isComposerPresented` is left untouched, so the composer (and
+    /// its draft) reappear intact on the next terminal tap (``handleTap``),
+    /// which un-hides and re-seats the surface as first responder.
+    /// Internal (not private) as the chrome test seam.
+    func setChromeHidden(_ hidden: Bool) {
         guard chromeHidden != hidden else { return }
         chromeHidden = hidden
-        if hidden, keyboardVisible {
-            // Drop the keyboard first; its layout guide re-seats the dock while the
-            // visibility update below removes the toolbar/composer. Resign
-            // whichever responder actually owns the keyboard — the band can be
-            // presented while the terminal's hidden input proxy (a sibling of
-            // `composerContainer`) holds first responder, so gating on
-            // `composerActive` alone would leave the keyboard up while the chrome
-            // hides.
-            resignCurrentInput()
+        if hidden {
+            if keyboardVisible {
+                // Drop the keyboard first. Resign whichever responder actually
+                // owns it — the band can be presented while the terminal's
+                // hidden input proxy holds first responder, so gating on
+                // `composerActive` alone would leave the keyboard up while the
+                // chrome hides.
+                resignCurrentInput()
+            }
+            // Give up the keyboard-down seat too, so no responder offers the
+            // dock accessory while the chrome is hidden.
+            resignFirstResponder()
+            reloadInputViews()
         }
         updateDockedToolbarVisibility()
         if hidden {
-            // Hide: animate the dock collapsing down into the bottom edge. (The toolbar
-            // is set `isHidden` only after this animation by `updateDockedToolbarVisibility`
-            // — actually `isHidden` is set synchronously, so this animate-out is largely
-            // invisible, but it keeps the frame coherent for the next show.)
+            // Hide: animate the grid reclaiming the dock's reservation.
             animateBottomDock()
         } else {
-            // Show: snap real frames into place with the bar visible, then let the
-            // ``handleTap``-driven `focusInput()` → keyboard-show animation carry the
-            // motion. Animating here from the collapsed bottom-edge strip would
-            // double-animate against the keyboard rise.
+            // Show: snap real frames into place with the bar visible, re-take
+            // the keyboard-down seat so the system docks the accessory, then
+            // let any ``handleTap``-driven `focusInput()` → keyboard-show
+            // animation carry further motion.
             layoutBottomDock()
+            becomeFirstResponder()
         }
         setNeedsGeometrySync()
     }
@@ -1696,24 +1681,6 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
         }
     }
 
-    /// Install the composer band container into the surface's view hierarchy, above
-    /// the docked toolbar. Hidden and zero-height until the host mounts a compose
-    /// field into it (``mountComposerView(_:)``); the surface positions it in
-    /// ``layoutBottomDock()`` and reserves its height in the grid. Auto Layout pins its
-    /// bottom to ``UIView/keyboardLayoutGuide`` and pins the toolbar above it, so UIKit
-    /// and the viewport coordinator share one keyboard edge.
-    private func installComposerContainer() {
-        composerContainer.backgroundColor = .clear
-        composerContainer.isHidden = true
-        // Do NOT clip: the composer's Liquid-Glass controls lift/shadow past the band
-        // edge, and the band must sit above the Ghostty render layer (item 6) so the
-        // glass is not clipped by the terminal bounds. Raised to the same chrome
-        // z-position as the toolbar.
-        composerContainer.clipsToBounds = false
-        composerContainer.layer.zPosition = Self.bottomChromeZPosition
-        addSubview(composerContainer)
-    }
-
     /// Mounts the host-built artifact chip inside the terminal's bottom-dock
     /// coordinate system, or hides it when `view` is `nil`.
     ///
@@ -1859,8 +1826,8 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
     /// reports its measured height via ``setComposerBandHeight(_:animated:)``.
     ///
     /// The mounted view is pinned edge-to-edge inside the band with Auto Layout, so it
-    /// fills the guide-pinned band — there is no second keyboard layout system fighting
-    /// the surface for the band's frame.
+    /// fills the accessory-hosted band — there is no second keyboard layout system
+    /// fighting the OS-positioned dock for the band's frame.
     public func mountComposerView(_ view: UIView?) {
         composerContainer.subviews.forEach { $0.removeFromSuperview() }
         guard let view else {
@@ -1884,8 +1851,8 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
     /// toolbar, from the hosted compose field's intrinsic content size. Drives the
     /// grid reservation (so a field-grow pushes only the terminal up) and the dock
     /// layout. When `animated`, the reservation + reflow run inside a `UIView.animate`;
-    /// keyboard movement itself remains owned by ``UIView/keyboardLayoutGuide``.
-    /// Idempotent: a no-op when the height is
+    /// keyboard movement itself remains owned by the OS keyboard system, which
+    /// carries the dock accessory. Idempotent: a no-op when the height is
     /// unchanged (then `completion` runs immediately so an unmount-on-close never
     /// strands the mounted field).
     ///
@@ -1909,7 +1876,11 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
         let apply = { [weak self] in
             guard let self else { return }
             self.layoutRenderedTerminalForCurrentViewport()
+            // Forward the band height into the accessory INSIDE the animation
+            // closure so the accessory's constraint change (and its self-sizing)
+            // animates with the reflow.
             self.layoutBottomDock()
+            self.keyboardDockAccessory?.layoutIfNeeded()
             self.layoutIfNeeded()
         }
         if animated {
@@ -1929,12 +1900,11 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
         layoutBottomDock(using: viewportSnapshot())
     }
 
+    /// Positions nothing: the OS keyboard system owns the dock's placement.
+    /// Only the composer band HEIGHT is forwarded into the accessory (which
+    /// self-sizes around it), plus the surface-owned artifact chip layout.
     private func layoutBottomDock(using snapshot: TerminalViewportSnapshot) {
-        composerHeightConstraint?.constant = snapshot.composerFrame.height
-        toolbarHeightConstraint?.constant = min(
-            reservedToolbarHeight,
-            snapshot.toolbarFrame.height
-        )
+        keyboardDockAccessory?.setComposerBandHeight(snapshot.composerFrame.height)
         layoutArtifactChip(using: snapshot)
     }
 
@@ -2347,7 +2317,7 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
 
     public override func layoutSubviews() {
         super.layoutSubviews()
-        synchronizeKeyboardGeometryFromLayoutGuide()
+        synchronizeKeyboardGeometry()
         let snapshot = viewportSnapshot()
         layoutBottomDock(using: snapshot)
         layoutRenderedTerminalForCurrentViewport(using: snapshot)
@@ -2382,7 +2352,7 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
             setKeyboardHeightOverrideForTesting(keyboardHeightOverrideForTesting)
         }
         #endif
-        synchronizeKeyboardGeometryFromLayoutGuide()
+        synchronizeKeyboardGeometry()
         let snapshot = viewportSnapshot()
         layoutBottomDock(using: snapshot)
         layoutRenderedTerminalForCurrentViewport(using: snapshot)
@@ -2393,9 +2363,6 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
         super.didMoveToWindow()
         MobileDebugLog.anchormux("surface.didMoveToWindow window=\(window != nil)")
         syncSurfaceVisibility()
-        // The keyboard floor is anchored to the window, so it must be
-        // (re)installed on attach and dropped on detach.
-        refreshKeyboardFloorConstraintForWindow()
         if window != nil {
             isDismantled = false
             setNeedsLayout()
@@ -2411,6 +2378,11 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
             setFocus(true)
             if autoFocusOnWindowAttach, UIApplication.shared.applicationState == .active {
                 focusInput()
+            } else if !chromeHidden {
+                // Keyboard-down docking: no cmux text responder owns the
+                // keyboard, so the SURFACE takes first responder and the system
+                // seats the dock accessory at the screen bottom.
+                becomeFirstResponder()
             }
             resetVisibleArtifactCountTracking()
             startDisplayLink()
@@ -2854,13 +2826,21 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
     public func resignCurrentInput() {
         synchronizeActualInputOwner()
         inputSession.send(.releaseFocus)
+        // Keyboard-down docking: with the typing responder released, the
+        // SURFACE takes first responder (while attached and the chrome is
+        // visible) so the dock accessory stays seated at the screen bottom
+        // instead of leaving with the keyboard.
+        if window != nil, !chromeHidden {
+            becomeFirstResponder()
+        }
     }
 
     /// Resigns this surface's hidden text input.
     public func resignInput() {
         resignCurrentInput()
-        // Geometry follows `keyboardLayoutGuide`; responder release only decides
-        // whether UIKit should dismiss the software keyboard.
+        // The dock accessory is OS-positioned; responder release only decides
+        // whether UIKit dismisses the software keyboard (the surface re-takes
+        // first responder above so the dock docks instead of disappearing).
     }
 
     /// Stops user-visible and accessibility output from a surface SwiftUI has removed.
@@ -2902,6 +2882,9 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
         renderInFlightSince = nil
         needsAnotherRender = false
         inputSession.send(.surfaceDetached)
+        // Drop the keyboard-down docking seat; UIKit reclaims the accessory's
+        // input view on resign, so the dock needs no manual removal.
+        resignFirstResponder()
         bottomDockTransitionObserved = false
         stopDisplayLink()
         setFocus(false)
@@ -2922,6 +2905,12 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
         sendPaste(text)
         runtime?.tick()
     }
+
+    #if DEBUG
+    /// Test seam: the hidden typing responder, so tests can assert it vends
+    /// the same dock accessory the surface does.
+    var inputProxyForTesting: TerminalInputTextView { inputProxy }
+    #endif
 
     func simulateInputProxyTextChangeForTesting(_ text: String, isComposing: Bool) {
         setFocus(true)

--- a/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView.swift
+++ b/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView.swift
@@ -514,6 +514,18 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
     private var composerBottomToKeyboardConstraint: NSLayoutConstraint?
     private var composerHeightConstraint: NSLayoutConstraint?
     private var toolbarHeightConstraint: NSLayoutConstraint?
+    /// Process-wide keyboard-frame source for floor catch-up on attach/layout.
+    /// Only the DEBUG seam below can replace it: tests inject a
+    /// notification-center-isolated instance without touching the shared
+    /// tracker other suites read.
+    private(set) var keyboardFrameTracker: MobileKeyboardFrameTracker = .shared
+
+    #if DEBUG
+    /// Test seam: swaps the floor's keyboard-frame source for an isolated one.
+    func setKeyboardFrameTrackerForTesting(_ tracker: MobileKeyboardFrameTracker) {
+        keyboardFrameTracker = tracker
+    }
+    #endif
     #if DEBUG
     private var keyboardHeightOverrideForTesting: CGFloat?
     private var composerBottomForTestingConstraint: NSLayoutConstraint?
@@ -1129,6 +1141,14 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
     public func debugShowZoomControlOverlayForPreview() {
         showZoomOverlay()
         zoomOverlayLastInteraction = CACurrentMediaTime() + 3600
+    }
+
+    /// Test seam: routes a keyboard notification through the production
+    /// `keyboardWillChangeFrame` path for THIS view only, without posting to the
+    /// process-wide notification center (which would leak keyboard state into
+    /// concurrently running suites).
+    func handleKeyboardWillChangeFrameForTesting(_ notification: Notification) {
+        handleKeyboardWillChangeFrame(notification)
     }
     #endif
 

--- a/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView.swift
+++ b/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView.swift
@@ -524,17 +524,10 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
     /// and the floor is inert.
     private var composerBottomKeyboardFloorConstraint: NSLayoutConstraint?
     /// Process-wide keyboard-frame source for floor catch-up on attach/layout.
-    /// Only the DEBUG seam below can replace it: tests inject a
-    /// notification-center-isolated instance without touching the shared
-    /// tracker other suites read.
-    private(set) var keyboardFrameTracker: MobileKeyboardFrameTracker = .shared
-
-    #if DEBUG
-    /// Test seam: swaps the floor's keyboard-frame source for an isolated one.
-    func setKeyboardFrameTrackerForTesting(_ tracker: MobileKeyboardFrameTracker) {
-        keyboardFrameTracker = tracker
-    }
-    #endif
+    /// Injected at construction (production callers take the shared tracker
+    /// default) so tests pass a notification-center-isolated instance without
+    /// touching the shared tracker other suites read.
+    private let keyboardFrameTracker: MobileKeyboardFrameTracker
     /// The keyboard overlap the floor constraint currently enforces, mirrored
     /// into the viewport model so the terminal grid reserves the same space the
     /// bars occupy. Zero while the keyboard is down or unknown.
@@ -757,11 +750,16 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
     ///   - terminalTheme: Renderer-effective colors used by surrounding UIKit chrome.
     ///   - terminalConfigTheme: Raw Ghostty configuration defaults. Defaults to
     ///     `terminalTheme` for callers that do not mirror a remote surface.
+    ///   - keyboardFrameTracker: Keyboard-frame source for the bottom-dock
+    ///     floor. Production callers keep the shared process-wide tracker;
+    ///     tests inject a notification-center-isolated instance.
     public init(runtime: GhosttyRuntime, delegate: GhosttySurfaceViewDelegate,
                 fontSize: Float32 = 10, terminalTheme: TerminalTheme = .monokai,
-                terminalConfigTheme: TerminalTheme? = nil) {
+                terminalConfigTheme: TerminalTheme? = nil,
+                keyboardFrameTracker: MobileKeyboardFrameTracker = .shared) {
         self.runtime = runtime
         self.delegate = delegate
+        self.keyboardFrameTracker = keyboardFrameTracker
         self.fontSize = fontSize
         self.liveFontSize = fontSize
         self.userBaseFontSize = fontSize
@@ -974,7 +972,10 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
     /// whichever registered surface happens to sort first.
     public var hostSurfaceID: String?
 
-    @objc private func handleKeyboardWillChangeFrame(_ notification: Notification) {
+    // Internal so tests can route a fixture notification through the
+    // production path for THIS view only (posting to the process-wide center
+    // would leak keyboard state into concurrently running suites).
+    @objc func handleKeyboardWillChangeFrame(_ notification: Notification) {
         guard let transition = MobileKeyboardTransition(notification: notification) else { return }
         let willBeVisible = transition.isVisible(in: self)
         let wasVisible = keyboardVisible
@@ -1227,13 +1228,6 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
         zoomOverlayLastInteraction = CACurrentMediaTime() + 3600
     }
 
-    /// Test seam: routes a keyboard notification through the production
-    /// `keyboardWillChangeFrame` path for THIS view only, without posting to the
-    /// process-wide notification center (which would leak keyboard state into
-    /// concurrently running suites).
-    func handleKeyboardWillChangeFrameForTesting(_ notification: Notification) {
-        handleKeyboardWillChangeFrame(notification)
-    }
     #endif
 
     /// Dock the accessory bar as a persistent bottom toolbar. Auto Layout pins it

--- a/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView.swift
+++ b/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView.swift
@@ -1013,6 +1013,19 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
         // its safe-area fallback with the keyboard up; the floor then lifts the dock
         // on the notification's own curve.
         updateDockedToolbarVisibility()
+        #if DEBUG
+        // Transition forensics for the bars-lag-the-keyboard class: one line per
+        // willChangeFrame with the notification frame, the tracker/guide/floor
+        // trio, and the animation duration, so a dogfood recording can be lined
+        // up against which source moved (or failed to move) the dock and when.
+        MobileDebugLog.anchormux(
+            "kb.willChange endMinY=\(Int(transition.endFrame.minY)) endH=\(Int(transition.endFrame.height))"
+                + " dur=\(String(format: "%.2f", transition.duration))"
+                + " trackerOverlap=\(Int(keyboardFrameTracker.overlap(in: self)))"
+                + " guideTop=\(Int(keyboardLayoutGuide.layoutFrame.minY))"
+                + " floor=\(Int(keyboardOverlapFloor)) visible=\(willBeVisible ? 1 : 0)"
+        )
+        #endif
         // The tracker (registered before any surface's handler) is the floor's
         // ONLY data source; this handler merely re-reads it on the keyboard's
         // own animation curve so a floor change moves like the keyboard. A
@@ -1047,7 +1060,16 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
     /// Installs the system keyboard guide as the primary keyboard geometry source.
     private func configureKeyboardLayoutGuide() {
         keyboardLayoutGuide.followsUndockedKeyboard = false
-        keyboardLayoutGuide.usesBottomSafeArea = true
+        // Pure keyboard tracking. With `usesBottomSafeArea = true` the guide's
+        // position is coupled to bottom-safe-area propagation, which lands at
+        // the END of a keyboard transition: on device the guide-constrained
+        // bars sat still while the keyboard rose over them, then snapped up
+        // after it settled (dogfood recording, 2026-08-05), and on the
+        // simulator the settled guide read the bottom inset (~34pt) below the
+        // notification frame. The keyboard-down seat above the home indicator
+        // that `usesBottomSafeArea` provided is expressed explicitly in
+        // `installBottomDockConstraints()` via a required safe-area cap.
+        keyboardLayoutGuide.usesBottomSafeArea = false
         // Create the process-wide tracker no later than the first surface, so a
         // keyboard transition that happens while THIS view is detached (workspace
         // switch) is still observed and can seat the keyboard floor on attach.
@@ -1070,6 +1092,14 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
         let composerBottomFloor = composerContainer.bottomAnchor.constraint(
             lessThanOrEqualTo: bottomAnchor
         )
+        // With the guide in pure keyboard mode its keyboard-DOWN position is the
+        // view's bottom edge, so the home-indicator seat is stated explicitly:
+        // the dock may never sink into the bottom safe area. While the keyboard
+        // is up, the guide equality and the keyboard floor are both stricter, so
+        // this cap only decides the keyboard-down seat.
+        let composerBottomSafeAreaCap = composerContainer.bottomAnchor.constraint(
+            lessThanOrEqualTo: safeAreaLayoutGuide.bottomAnchor
+        )
         let composerHeight = composerContainer.heightAnchor.constraint(equalToConstant: 0)
         let toolbarHeight = dockedToolbar.heightAnchor.constraint(equalToConstant: 0)
         composerBottomToKeyboardConstraint = composerBottom
@@ -1082,6 +1112,7 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
             composerContainer.trailingAnchor.constraint(equalTo: trailingAnchor),
             composerBottom,
             composerBottomFloor,
+            composerBottomSafeAreaCap,
             composerHeight,
             dockedToolbar.leadingAnchor.constraint(equalTo: leadingAnchor),
             dockedToolbar.trailingAnchor.constraint(equalTo: trailingAnchor),
@@ -1107,6 +1138,11 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
         guard abs(clamped - keyboardOverlapFloor) > 0.25 else { return false }
         keyboardOverlapFloor = clamped
         composerBottomKeyboardFloorConstraint?.constant = -clamped
+        #if DEBUG
+        // Paired with kb.willChange: a kb.floor long after its kb.willChange is
+        // the late-snap signature (floor applied by layout catch-up, unanimated).
+        MobileDebugLog.anchormux("kb.floor \(Int(clamped))")
+        #endif
         setNeedsGeometrySync()
         return true
     }

--- a/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView.swift
+++ b/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView.swift
@@ -310,6 +310,7 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
     var debugLastScrollbar: (total: Int, offset: Int, len: Int)?
     var debugBottomScrollStressPhase = "idle"
     var debugBottomViewportMismatchObserved = false
+    private var keyboardDockFrameRecorder: KeyboardDockFrameRecorder?
 
     /// The live `key=value;…` description of the bottom dock, read by
     /// ``ComposerDockProbeView`` on every accessibility query. `fieldFocused` is the
@@ -365,10 +366,13 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
         let toolbarMaxY = toolbarFrameInSurface.map { pointValue($0.maxY) } ?? "none"
         let keyboardTransitionID = bottomDockTransitionInFlight ? 1 : -1
         let keyboardTransitionTarget = pointValue(keyboardHeight)
-        // Key kept so the log format stays parseable: now the accessory's top
-        // edge in surface coordinates, -1 while the accessory is unhosted.
+        // Key kept so the log format stays parseable: now the accessory's bottom
+        // edge (the software-keyboard top) in surface coordinates, -1 while the
+        // accessory is unhosted.
         let keyboardGuideTop = accessoryFrameInSurfaceCoordinates()
-            .map { pointValue($0.minY) } ?? pointValue(-1)
+            .map { pointValue($0.maxY) } ?? pointValue(-1)
+        let frameRecorder = keyboardDockFrameRecorder
+        let worstFrame = frameRecorder?.worstSample
         return [
             "chromeHidden=\(chromeHidden ? 1 : 0)",
             "composerActive=\(composerActive ? 1 : 0)",
@@ -408,6 +412,15 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
             "scrollTotal=\(debugLastScrollbar?.total ?? -1)", "scrollOffset=\(debugLastScrollbar?.offset ?? -1)",
             "scrollLen=\(debugLastScrollbar?.len ?? -1)", "scrollAtBottom=\(debugScrollbarAtBottomForTesting ? 1 : 0)",
             "staleViewportObserved=\(debugBottomViewportMismatchObserved ? 1 : 0)",
+            "dockFrameSamples=\(frameRecorder?.sampleCount ?? 0)",
+            "dockFrameKeyboardSamples=\(frameRecorder?.keyboardFrameCount ?? 0)",
+            "dockFrameDetached=\(frameRecorder?.detachedFrameCount ?? 0)",
+            "dockFrameMaxGap=\(pointValue(frameRecorder?.maxGap ?? 0))",
+            "dockWorstKeyboardUp=\(worstFrame?.keyboardUp == true ? 1 : 0)",
+            "dockWorstComposerMaxY=\(pointValue(worstFrame?.composerMaxY ?? -1))",
+            "dockWorstToolbarMaxY=\(pointValue(worstFrame?.toolbarMaxY ?? -1))",
+            "dockWorstBoundsHeight=\(pointValue(worstFrame?.boundsHeight ?? -1))",
+            "dockWorstAccessoryBottomY=\(pointValue(worstFrame?.accessoryBottomY ?? -1))",
             inputProxy.accessoryLayoutDiagnostics,
         ].joined(separator: ";")
     }
@@ -767,10 +780,13 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
     ///   - keyboardFrameTracker: Keyboard-frame source for the bottom-dock
     ///     floor. Production callers keep the shared process-wide tracker;
     ///     tests inject a notification-center-isolated instance.
+    ///   - keyboardDockFrameRecordingEnabled: Enables the DEBUG-only, existing-
+    ///     display-link dock verifier used by the focused XCUITest stress lane.
     public init(runtime: GhosttyRuntime, delegate: GhosttySurfaceViewDelegate,
                 fontSize: Float32 = 10, terminalTheme: TerminalTheme = .monokai,
                 terminalConfigTheme: TerminalTheme? = nil,
-                keyboardFrameTracker: MobileKeyboardFrameTracker = .shared) {
+                keyboardFrameTracker: MobileKeyboardFrameTracker = .shared,
+                keyboardDockFrameRecordingEnabled: Bool = false) {
         self.runtime = runtime
         self.delegate = delegate
         self.keyboardFrameTracker = keyboardFrameTracker
@@ -780,6 +796,11 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
         self.terminalTheme = terminalTheme.validatedOrDefault()
         self.terminalConfigTheme = (terminalConfigTheme ?? terminalTheme).validatedOrDefault()
         super.init(frame: CGRect(x: 0, y: 0, width: 402, height: 700))
+        #if DEBUG
+        if keyboardDockFrameRecordingEnabled {
+            keyboardDockFrameRecorder = KeyboardDockFrameRecorder()
+        }
+        #endif
         bridge.attach(to: self)
         // The local view background (the area behind/around the rendered cells,
         // and the letterbox fill) is sourced from the synced theme rather than a
@@ -3206,6 +3227,7 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
             return
         }
         #if DEBUG
+        recordKeyboardDockFrameIfEnabled()
         // Main-thread liveness heartbeat + presented-surface state. Time-gated,
         // no behavior change. The `contents`/size fields let an IDLE blank be
         // classified without a fresh output/geometry event: contents=false ⇒
@@ -3344,6 +3366,52 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
             fadeOutZoomOverlay()
         }
     }
+
+    #if DEBUG
+    /// Samples dock geometry on the terminal's existing display-link tick. The
+    /// recorder is absent unless the focused UI-test flag was injected, so normal
+    /// DEBUG typing and dogfood builds pay no per-frame geometry cost.
+    private func recordKeyboardDockFrameIfEnabled() {
+        guard keyboardDockFrameRecorder != nil,
+              let accessory = keyboardDockAccessory,
+              let toolbar = dockedToolbar else { return }
+
+        let composerFrame = composerContainer.layer.presentation()?.frame
+            ?? composerContainer.frame
+        let toolbarFrame = toolbar.layer.presentation()?.frame ?? toolbar.frame
+        let accessoryFrameInSurface = accessoryPresentationFrameInSurfaceCoordinates()
+            ?? accessoryFrameInSurfaceCoordinates()
+        let visibleDockMaxY = composerFrame.height > 0.5
+            ? composerFrame.maxY
+            : toolbarFrame.maxY
+        // `keyboardVisible` flips at the transition notification, before the
+        // first animated frame. From that point onward every display-link frame
+        // is in scope: skipping the accessory-transfer frame would hide exactly
+        // the one-frame pop this harness exists to catch. An unhosted accessory
+        // uses the surface height as an unmistakable failure sentinel.
+        let gap: CGFloat? = if keyboardVisible {
+            accessory.window == nil
+                ? max(bounds.height, 2)
+                : abs(accessory.bounds.maxY - visibleDockMaxY)
+        } else {
+            nil
+        }
+        let composerMaxYInSurface = accessoryFrameInSurface.map {
+            $0.minY + composerFrame.maxY - accessory.bounds.minY
+        } ?? -1
+        let toolbarMaxYInSurface = accessoryFrameInSurface.map {
+            $0.minY + toolbarFrame.maxY - accessory.bounds.minY
+        } ?? -1
+        keyboardDockFrameRecorder?.record(KeyboardDockFrameRecorder.Sample(
+            keyboardUp: keyboardVisible,
+            composerMaxY: composerMaxYInSurface,
+            toolbarMaxY: toolbarMaxYInSurface,
+            boundsHeight: bounds.height,
+            accessoryBottomY: accessoryFrameInSurface?.maxY ?? -1,
+            gap: gap
+        ))
+    }
+    #endif
 
     /// Drive a full render cycle via `ghostty_surface_render_now`, dispatched
     /// to the off-main surface queue.

--- a/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView.swift
+++ b/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView.swift
@@ -2758,15 +2758,14 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
         )
     }
 
-    /// Clears current intent and resigns before the Photos picker starts presenting.
+    /// Records the modal phase before the Photos picker starts presenting.
+    /// The active text owner keeps its seat (see the reducer's
+    /// `.modalWillPresent` rationale); if nothing holds the keyboard, the
+    /// surface takes the keyboard-down seat so the dock stays mounted (and
+    /// with it the hosted picker binding that must deliver the dismissal).
     public func photoPickerWillPresent() {
         synchronizeActualInputOwner()
         inputSession.send(.modalWillPresent)
-        // The reducer just resigned the text owner and cleared the retained
-        // focus request, so nothing re-seats the dock after dismissal. Take
-        // the keyboard-down seat now (the same re-seat as
-        // ``resignCurrentInput()``) so the dock stays seated behind the picker
-        // instead of unmounting with the keyboard.
         reseatDockAccessoryIfUnowned()
     }
 
@@ -2778,15 +2777,25 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
     /// Reconciles any focus request retained while the picker was on screen.
     public func photoPickerDidDismiss() {
         inputSession.send(.modalDidDismiss)
-        // The presentation can strip the surface's seat (full-screen remote
-        // pickers resign the presenting window's responder). This fires on the
-        // binding flip, while the sheet is still animating out, so a denied
-        // seat is retried once on the next main-queue turn.
-        if !reseatDockAccessoryIfUnowned() {
-            DispatchQueue.main.async { [weak self] in
-                _ = self?.reseatDockAccessoryIfUnowned()
-            }
+        reconcileDockSeatAfterModalDismissal()
+        // This fires on the binding flip, while the sheet is still animating
+        // out, so responder work that UIKit denies mid-transition is retried
+        // once on the next main-queue turn.
+        DispatchQueue.main.async { [weak self] in
+            self?.reconcileDockSeatAfterModalDismissal()
         }
+    }
+
+    /// Post-modal seat reconciliation. The sheet hides the keyboard while the
+    /// text owner keeps first responder; a later tap on that still-focused
+    /// field is a responder no-op, so it could never re-summon the keyboard.
+    /// Release the text seat (the surface re-takes the keyboard-down seat, so
+    /// the dock stays docked) and the next tap runs the normal focus path.
+    private func reconcileDockSeatAfterModalDismissal() {
+        if inputSession.state.actualOwner != nil, !keyboardVisible {
+            resignCurrentInput()
+        }
+        reseatDockAccessoryIfUnowned()
     }
 
     /// Takes the surface's keyboard-down first-responder seat when no cmux

--- a/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView.swift
+++ b/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView.swift
@@ -1339,6 +1339,7 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
             composer: composerContainer,
             toolbarRowHeight: Self.persistentToolbarHeight
         )
+        keyboardDockAccessory?.setBottomFillColor(terminalTheme.terminalBackgroundUIColor)
         // The hosted SwiftUI field cannot supply an accessory itself; the
         // container answers for it through responder-chain resolution with the
         // surface's own policy (nil while the chrome is hidden).
@@ -2777,25 +2778,71 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
     /// Reconciles any focus request retained while the picker was on screen.
     public func photoPickerDidDismiss() {
         inputSession.send(.modalDidDismiss)
-        reconcileDockSeatAfterModalDismissal()
-        // This fires on the binding flip, while the sheet is still animating
-        // out, so responder work that UIKit denies mid-transition is retried
-        // once on the next main-queue turn.
-        DispatchQueue.main.async { [weak self] in
-            self?.reconcileDockSeatAfterModalDismissal()
+        // This fires on the binding flip, while the dismissal is still
+        // animating. A sheet leaves the app window's responders intact so the
+        // immediate pass settles everything; a FULL-SCREEN presentation (the
+        // phone's Photos picker) keeps denying `becomeFirstResponder` until
+        // its transition completes, hundreds of milliseconds later, so the
+        // seat is retried on the surface's existing display link until it
+        // lands (bounded; a new modal or a settled seat stops it).
+        if !reconcileDockSeatAfterModalDismissal() {
+            pendingDockReseatDeadline = CACurrentMediaTime() + 3
+            startDisplayLink()
         }
     }
 
-    /// Post-modal seat reconciliation. The sheet hides the keyboard while the
-    /// text owner keeps first responder; a later tap on that still-focused
-    /// field is a responder no-op, so it could never re-summon the keyboard.
-    /// Release the text seat (the surface re-takes the keyboard-down seat, so
-    /// the dock stays docked) and the next tap runs the normal focus path.
-    private func reconcileDockSeatAfterModalDismissal() {
+    /// Post-modal seat reconciliation. The presentation hides the keyboard
+    /// while the text owner keeps (or loses) first responder; a later tap on
+    /// a still-focused field is a responder no-op, so it could never
+    /// re-summon the keyboard. Release the text seat (the surface re-takes
+    /// the keyboard-down seat, so the dock stays docked) and the next tap
+    /// runs the normal focus path.
+    ///
+    /// - Returns: Whether a cmux responder holds the seat AND the dock is
+    ///   mounted (or intentionally withheld by hidden chrome).
+    @discardableResult
+    private func reconcileDockSeatAfterModalDismissal() -> Bool {
+        guard inputSession.state.modalPhase == .none else { return true }
         if inputSession.state.actualOwner != nil, !keyboardVisible {
             resignCurrentInput()
         }
-        reseatDockAccessoryIfUnowned()
+        guard reseatDockAccessoryIfUnowned() else { return false }
+        if !chromeHidden, keyboardDockAccessory?.window == nil {
+            // The modal can tear the accessory out of the keyboard window
+            // while the seat holder stays first responder, so holding the
+            // seat is NOT enough: UIKit never re-evaluates input views for a
+            // responder that never changed. Force the remount, then report
+            // unsettled until the accessory actually reaches a window (the
+            // display-link retry keeps calling until it does).
+            currentDockSeatResponder()?.reloadInputViews()
+            return keyboardDockAccessory?.window != nil
+        }
+        return true
+    }
+
+    /// The responder currently holding the dock accessory's seat, if any.
+    private func currentDockSeatResponder() -> UIResponder? {
+        if inputProxy.isFirstResponder { return inputProxy }
+        if isFirstResponder { return self }
+        return composerContainer.firstResponderInSubtree()
+    }
+
+    /// Deadline for the display-link-driven post-modal reseat; 0 when idle.
+    private var pendingDockReseatDeadline: CFTimeInterval = 0
+
+    /// Runs on the display link while a post-modal reseat is pending: UIKit
+    /// denies responder changes until the dismissal transition completes, so
+    /// each frame retries until the seat lands or the bounded window passes.
+    func settlePendingDockReseatIfNeeded() {
+        guard pendingDockReseatDeadline > 0 else { return }
+        if inputSession.state.modalPhase != .none {
+            pendingDockReseatDeadline = 0
+            return
+        }
+        if reconcileDockSeatAfterModalDismissal()
+            || CACurrentMediaTime() > pendingDockReseatDeadline {
+            pendingDockReseatDeadline = 0
+        }
     }
 
     /// Takes the surface's keyboard-down first-responder seat when no cmux
@@ -3263,6 +3310,7 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
         if checkSurfaceOperationDeadlines(now: now) {
             return
         }
+        settlePendingDockReseatIfNeeded()
         completePendingVerifiedReplayPresentationIfPresented()
         guard surface != nil else {
             if !hasPendingSurfaceOperationDeadline {
@@ -3563,6 +3611,7 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
         snapshotFallbackView.textColor = terminalTheme.terminalForegroundUIColor
         configBackgroundColor = themeBackground
         inputProxy.terminalTheme = terminalTheme
+        keyboardDockAccessory?.setBottomFillColor(themeBackground)
         needsDraw = true
     }
 

--- a/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView.swift
+++ b/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView.swift
@@ -993,7 +993,7 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
     /// the toolbar row above it and the terminal grid above that. The viewport
     /// coordinator reserves the same heights for the
     /// `terminal / toolbar / composer / keyboard` stack.
-    private let composerContainer = UIView()
+    private let composerContainer = KeyboardDockComposerContainerView()
     /// Height (points) the open composer band reserves above the keyboard edge. Fed
     /// by the host from the hosted compose field's intrinsic content size
     /// (``setComposerBandHeight(_:animated:)``); 0 while the composer is closed. The
@@ -1339,6 +1339,13 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
             composer: composerContainer,
             toolbarRowHeight: Self.persistentToolbarHeight
         )
+        // The hosted SwiftUI field cannot supply an accessory itself; the
+        // container answers for it through responder-chain resolution with the
+        // surface's own policy (nil while the chrome is hidden).
+        composerContainer.keyboardAccessoryProvider = { [weak self] in
+            guard let self, !self.chromeHidden else { return nil }
+            return self.keyboardDockAccessory
+        }
         updateDockedToolbarVisibility()
     }
 
@@ -2755,6 +2762,12 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
     public func photoPickerWillPresent() {
         synchronizeActualInputOwner()
         inputSession.send(.modalWillPresent)
+        // The reducer just resigned the text owner and cleared the retained
+        // focus request, so nothing re-seats the dock after dismissal. Take
+        // the keyboard-down seat now (the same re-seat as
+        // ``resignCurrentInput()``) so the dock stays seated behind the picker
+        // instead of unmounting with the keyboard.
+        reseatDockAccessoryIfUnowned()
     }
 
     /// Records the PhotosPicker binding's presented edge.
@@ -2765,6 +2778,28 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
     /// Reconciles any focus request retained while the picker was on screen.
     public func photoPickerDidDismiss() {
         inputSession.send(.modalDidDismiss)
+        // The presentation can strip the surface's seat (full-screen remote
+        // pickers resign the presenting window's responder). This fires on the
+        // binding flip, while the sheet is still animating out, so a denied
+        // seat is retried once on the next main-queue turn.
+        if !reseatDockAccessoryIfUnowned() {
+            DispatchQueue.main.async { [weak self] in
+                _ = self?.reseatDockAccessoryIfUnowned()
+            }
+        }
+    }
+
+    /// Takes the surface's keyboard-down first-responder seat when no cmux
+    /// text responder owns the keyboard, so the system keeps the dock
+    /// accessory seated at the screen bottom.
+    ///
+    /// - Returns: Whether a cmux responder holds the seat on return.
+    @discardableResult
+    private func reseatDockAccessoryIfUnowned() -> Bool {
+        guard window != nil, !chromeHidden, !isDismantled else { return false }
+        if inputProxy.isFirstResponder || isFirstResponder { return true }
+        if composerContainer.firstResponderInSubtree() != nil { return true }
+        return becomeFirstResponder()
     }
 
     private func performInputFocus(_ owner: TerminalInputOwner) -> Bool {

--- a/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView.swift
+++ b/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView.swift
@@ -373,6 +373,12 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
             .map { pointValue($0.maxY) } ?? pointValue(-1)
         let frameRecorder = keyboardDockFrameRecorder
         let worstFrame = frameRecorder?.worstSample
+        let dockTraceMotionRange: CGFloat
+        if debugDockTraceSamples > 0 {
+            dockTraceMotionRange = debugDockTraceMaxAccessoryTop - debugDockTraceMinAccessoryTop
+        } else {
+            dockTraceMotionRange = 0
+        }
         return [
             "chromeHidden=\(chromeHidden ? 1 : 0)",
             "composerActive=\(composerActive ? 1 : 0)",
@@ -421,6 +427,12 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
             "dockWorstToolbarMaxY=\(pointValue(worstFrame?.toolbarMaxY ?? -1))",
             "dockWorstBoundsHeight=\(pointValue(worstFrame?.boundsHeight ?? -1))",
             "dockWorstAccessoryBottomY=\(pointValue(worstFrame?.accessoryBottomY ?? -1))",
+            "dockTraceComplete=\(debugDockTraceComplete ? 1 : 0)",
+            "dockTraceSamples=\(debugDockTraceSamples)",
+            "dockTraceMotionRange=\(pointValue(dockTraceMotionRange))",
+            "dockTraceMaxGap=\(pointValue(debugDockTraceMaxGap))",
+            "dockTraceMaxViewportError=\(pointValue(debugDockTraceMaxViewportError))",
+            "dockStressRemaining=\(debugDockStressRemaining)",
             inputProxy.accessoryLayoutDiagnostics,
         ].joined(separator: ";")
     }
@@ -549,6 +561,20 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
     private var keyboardOverlapFloorInWindow: CGFloat = 0
     #if DEBUG
     private var keyboardHeightOverrideForTesting: CGFloat?
+    /// Bounded CADisplayLink trace for keyboard/accessory transitions. It is
+    /// armed by real keyboard notifications and by the UI-test rapid-toggle
+    /// harness; Release builds contain neither the state nor the sampling.
+    private var debugDockTraceActive = false
+    private var debugDockTraceComplete = false
+    private var debugDockTraceDeadline: CFTimeInterval = 0
+    private var debugDockTraceSamples = 0
+    private var debugDockTraceMinAccessoryTop = CGFloat.greatestFiniteMagnitude
+    private var debugDockTraceMaxAccessoryTop = -CGFloat.greatestFiniteMagnitude
+    private var debugDockTraceMaxGap: CGFloat = 0
+    private var debugDockTraceMaxViewportError: CGFloat = 0
+    private var debugDockStressRemaining = 0
+    private var debugDockStressNextToggleAt: CFTimeInterval?
+    private var debugLastKeyboardNotificationMinY: CGFloat = -1
     #endif
 
     #if DEBUG
@@ -713,25 +739,7 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
                 ))
             }
             #endif
-            // Round 8: the keyboard-toggle button only raises/lowers the keyboard. The
-            // toolbar stays visible either way, and an open composer survives a
-            // keyboard-down (its draft lives in the store; the field just loses focus).
-            // Resign whichever responder actually owns the keyboard: with the composer
-            // open by default the band can be presented (`composerActive == true`)
-            // while the terminal's hidden input proxy holds first responder (a
-            // terminal tap focuses the proxy without closing the band), and the proxy
-            // is a sibling of `composerContainer`, so `endEditing` on the container
-            // alone would resign nothing and the keyboard would stay up.
-            // Decide from ACTUAL responder truth, not `keyboardVisible`: that
-            // bit is reconciled from keyboard notifications and lags a frame
-            // or two during rapid toggling, which made quick successive taps
-            // of the toggle re-focus when they should resign (and vice versa)
-            // until the keyboard wedged out of sync with the button.
-            if self.inputProxy.isFirstResponder || self.composerFieldIsFirstResponder {
-                self.resignCurrentInput()
-            } else {
-                self.focusInput()
-            }
+            self.toggleKeyboardFromAccessory()
         }
         inputProxy.onHideChrome = { [weak self] in
             self?.setChromeHidden(true)
@@ -1070,6 +1078,8 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
         // willChangeFrame with the notification frame, the tracker/floor pair,
         // and the animation duration, so a dogfood recording can be lined up
         // against which source moved (or failed to move) the grid and when.
+        debugLastKeyboardNotificationMinY = transition.endFrame.minY
+        debugArmKeyboardDockTrace()
         MobileDebugLog.anchormux(
             "kb.willChange endMinY=\(Int(transition.endFrame.minY)) endH=\(Int(transition.endFrame.height))"
                 + " dur=\(String(format: "%.2f", transition.duration))"
@@ -1261,9 +1271,33 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
     /// layer.
     private func accessoryPresentationFrameInSurfaceCoordinates() -> CGRect? {
         guard let accessory = keyboardDockAccessory,
-              let superview = accessory.superview,
-              let presentationFrame = accessory.layer.presentation()?.frame else { return nil }
-        return convertDockRect(presentationFrame, from: superview)
+              let host = accessory.superview,
+              let window,
+              let presentation = accessory.layer.presentation(),
+              let hostPresentation = host.layer.presentation(),
+              let hostParentPresentation = hostPresentation.superlayer else {
+            return nil
+        }
+
+        // A CALayer presentation frame is expressed in its PRESENTATION
+        // superlayer. UIView.convert(_:from:) walks the MODEL view hierarchy,
+        // so feeding `presentation.frame` to it drops every animated ancestor
+        // transform in the private keyboard window. In practice the accessory
+        // then appeared to jump to its final Y while UIKeyboardItemContainerView
+        // was still travelling, and only its 34pt height change remained visible
+        // as the terminal's characteristic "breath".
+        //
+        // Stop at UIKit's input-accessory host boundary. That host is the
+        // physical keyboard-plane attachment and its presentation frame is in
+        // the scene-aligned coordinate space used for keyboard placement.
+        // Walking farther upward reaches a private keyboard UIWindow that UIKit
+        // may park at +4000pt during responder handoffs even while the host is
+        // visibly on screen.
+        let inSceneWindow = presentation.convert(
+            presentation.bounds,
+            to: hostParentPresentation
+        )
+        return convert(inSceneWindow, from: window)
     }
 
     /// A dock content view's frame (toolbar row or composer band, hosted inside
@@ -1275,6 +1309,166 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
     }
 
     #if DEBUG
+    /// Independent presentation-tree witness for the DEBUG trace. This is kept
+    /// separate from the production resolver deliberately: the regression probe
+    /// must still catch a future production conversion that accidentally walks
+    /// model ancestors again.
+    private func debugPresentationFrameInSurfaceCoordinates(of view: UIView) -> CGRect? {
+        guard let host = view.superview,
+              let window,
+              let presentation = view.layer.presentation(),
+              let hostPresentation = host.layer.presentation() else { return nil }
+
+        // Independent axis-aligned reconstruction from the accessory's local
+        // presentation rect plus its host's presentation frame. Keyboard dock
+        // motion is translational; this witness deliberately does not call the
+        // production presentation-tree conversion.
+        let inHost = presentation.convert(presentation.bounds, to: hostPresentation)
+        let inSceneWindow = inHost.offsetBy(
+            dx: hostPresentation.frame.minX,
+            dy: hostPresentation.frame.minY
+        )
+        return convert(inSceneWindow, from: window)
+    }
+
+    /// UIKit expresses the immediate input-accessory host's presentation frame
+    /// in the scene-aligned keyboard placement space. Do not walk its private
+    /// ancestors: their window-staging transform is deliberately not visual.
+    private func debugAccessoryHostFrameInSurfaceCoordinates(_ host: UIView) -> CGRect? {
+        guard let window, let presentation = host.layer.presentation() else { return nil }
+        return convert(presentation.frame, from: window)
+    }
+
+    private func debugResetKeyboardDockTrace(now: CFTimeInterval) {
+        debugDockTraceActive = true
+        debugDockTraceComplete = false
+        debugDockTraceDeadline = now + 1
+        debugDockTraceSamples = 0
+        debugDockTraceMinAccessoryTop = .greatestFiniteMagnitude
+        debugDockTraceMaxAccessoryTop = -.greatestFiniteMagnitude
+        debugDockTraceMaxGap = 0
+        debugDockTraceMaxViewportError = 0
+    }
+
+    private func debugArmKeyboardDockTrace(now: CFTimeInterval = CACurrentMediaTime()) {
+        if !debugDockTraceActive || debugDockTraceComplete {
+            debugResetKeyboardDockTrace(now: now)
+        }
+        debugDockTraceDeadline = max(debugDockTraceDeadline, now + 1)
+    }
+
+    /// Starts an app-driven reversal sequence for UI tests. It runs from the
+    /// existing display link instead of XCTest taps, because XCUI waits for a
+    /// keyboard animation to idle after every tap and therefore cannot create
+    /// the interrupted transitions that wedge this path in the wild.
+    private func debugStartKeyboardDockStressIfRequested(now: CFTimeInterval) {
+        guard debugDockStressNextToggleAt == nil,
+              debugDockStressRemaining == 0,
+              !debugDockTraceComplete,
+              let rawCount = ProcessInfo.processInfo.environment[
+                  "CMUX_UITEST_KEYBOARD_DOCK_RAPID_TOGGLE_COUNT"
+              ],
+              let count = Int(rawCount),
+              count > 0 else { return }
+        debugResetKeyboardDockTrace(now: now)
+        debugDockStressRemaining = count
+        debugDockStressNextToggleAt = now + 0.5
+        debugDockTraceDeadline = now + 0.5 + (Double(count) * 0.08) + 1
+        MobileDebugLog.anchormux("kb.frame stress.begin count=\(count)")
+    }
+
+    private func debugAdvanceKeyboardDockStress(now: CFTimeInterval) {
+        guard debugDockStressRemaining > 0,
+              let nextToggleAt = debugDockStressNextToggleAt,
+              now >= nextToggleAt else { return }
+        debugDockStressRemaining -= 1
+        let ordinal = debugDockStressRemaining
+        debugDockStressNextToggleAt = debugDockStressRemaining > 0 ? now + 0.08 : nil
+        toggleKeyboardFromAccessory()
+        debugArmKeyboardDockTrace(now: now)
+        MobileDebugLog.anchormux(
+            "kb.frame stress.toggle remaining=\(ordinal) "
+                + inputProxy.keyboardDockFrameDiagnostics
+        )
+    }
+
+    /// Samples the physical dock/key-plane attachment and the renderer viewport
+    /// once per CADisplayLink frame while a bounded transition trace is armed.
+    private func debugSampleKeyboardDockFrame(now: CFTimeInterval) {
+        guard debugDockTraceActive else { return }
+        let decimal: (Double) -> String = { String(format: "%.3f", $0) }
+
+        if let accessory = keyboardDockAccessory,
+           let host = accessory.superview,
+           let accessoryFrame = debugPresentationFrameInSurfaceCoordinates(of: accessory),
+           let hostFrame = debugAccessoryHostFrameInSurfaceCoordinates(host) {
+            debugDockTraceSamples += 1
+            debugDockTraceMinAccessoryTop = min(
+                debugDockTraceMinAccessoryTop,
+                accessoryFrame.minY
+            )
+            debugDockTraceMaxAccessoryTop = max(
+                debugDockTraceMaxAccessoryTop,
+                accessoryFrame.minY
+            )
+
+            // UIKeyboardItemContainerView's presentation top is the combined
+            // accessory+keyboard plane. The key plane starts one accessory
+            // height below it; the accessory's bottom must equal that edge.
+            let keyPlaneTop = hostFrame.minY + accessoryFrame.height
+            let physicalGap = abs(accessoryFrame.maxY - keyPlaneTop)
+            debugDockTraceMaxGap = max(debugDockTraceMaxGap, physicalGap)
+
+            // Independently reconstruct the coordinator's expected render edge
+            // from the true presentation frame. The target clamp is intentional
+            // while a stale negotiated grid settles; only the live accessory Y
+            // comes from the independent witness.
+            let snapshot = viewportSnapshot()
+            let liveEdge = min(max(1, accessoryFrame.minY), max(1, bounds.height))
+            let expectedViewport = shouldClampStaleLiveViewport(using: snapshot)
+                ? min(liveEdge, snapshot.layoutViewportRect.height)
+                : liveEdge
+            let coordinateOverflow = max(0, accessoryFrame.minY - bounds.maxY)
+            let viewportError = max(
+                abs(terminalViewportHeight - expectedViewport),
+                coordinateOverflow
+            )
+            debugDockTraceMaxViewportError = max(
+                debugDockTraceMaxViewportError,
+                viewportError
+            )
+
+            MobileDebugLog.anchormux(
+                "kb.frame t=\(decimal(now))"
+                    + " accessory=\(decimal(Double(accessoryFrame.minY)))"
+                    + " keyPlane=\(decimal(Double(keyPlaneTop)))"
+                    + " gap=\(decimal(Double(physicalGap)))"
+                    + " viewport=\(decimal(Double(terminalViewportHeight)))"
+                    + " viewportError=\(decimal(Double(viewportError)))"
+                    + " notificationTop=\(decimal(Double(debugLastKeyboardNotificationMinY))) "
+                    + inputProxy.keyboardDockFrameDiagnostics
+            )
+        } else {
+            MobileDebugLog.anchormux(
+                "kb.frame t=\(decimal(now)) unavailable "
+                    + inputProxy.keyboardDockFrameDiagnostics
+            )
+        }
+
+        guard debugDockStressRemaining == 0, now >= debugDockTraceDeadline else { return }
+        debugDockTraceActive = false
+        debugDockTraceComplete = true
+        let motion = debugDockTraceSamples > 0
+            ? debugDockTraceMaxAccessoryTop - debugDockTraceMinAccessoryTop
+            : 0
+        MobileDebugLog.anchormux(
+            "kb.frame complete samples=\(debugDockTraceSamples)"
+                + " motion=\(decimal(Double(motion)))"
+                + " maxGap=\(decimal(Double(debugDockTraceMaxGap)))"
+                + " maxViewportError=\(decimal(Double(debugDockTraceMaxViewportError)))"
+        )
+    }
+
     /// Forces a synthetic keyboard overlap for host tests and previews. Only
     /// the model/grid is synthetic now — the dock accessory needs no bottom
     /// anchor because the OS positions it.
@@ -2409,6 +2603,9 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
             #endif
             setNeedsGeometrySync()
             setFocus(true)
+            #if DEBUG
+            debugStartKeyboardDockStressIfRequested(now: CACurrentMediaTime())
+            #endif
             if autoFocusOnWindowAttach, UIApplication.shared.applicationState == .active {
                 focusInput()
             } else if !chromeHidden {
@@ -2739,6 +2936,17 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
         requestTerminalInputFocus()
     }
 
+    /// The single keyboard-toggle mutation path for both the accessory button
+    /// and the DEBUG rapid-reversal harness. Responder truth is authoritative:
+    /// keyboard notifications intentionally lag an interrupted transition.
+    private func toggleKeyboardFromAccessory() {
+        if inputProxy.isFirstResponder || composerFieldIsFirstResponder {
+            resignCurrentInput()
+        } else {
+            focusInput()
+        }
+    }
+
     private func requestTerminalInputFocus() {
         onFocusInputRequestedForTesting?()
         synchronizeActualInputOwner()
@@ -2950,6 +3158,9 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
         stopDisplayLink()
         setFocus(false)
         #if DEBUG
+        debugDockStressRemaining = 0
+        debugDockStressNextToggleAt = nil
+        debugDockTraceActive = false
         debugAccessibilityProxy.accessibilityLabel = nil
         debugAccessibilityProxy.isAccessibilityElement = false
         #endif
@@ -3316,7 +3527,13 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
                 zoomSettleFrames = frames
             }
         }
+        #if DEBUG
+        debugAdvanceKeyboardDockStress(now: now)
+        #endif
         advanceBottomDockTransition()
+        #if DEBUG
+        debugSampleKeyboardDockFrame(now: now)
+        #endif
         // Apply geometry at most once per frame. Every trigger (resize, zoom,
         // keyboard, effective-grid pin) only marks `needsGeometrySync`, so a
         // fast pinch can no longer drive a synchronous per-event storm of

--- a/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/KeyboardDockAccessoryView.swift
+++ b/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/KeyboardDockAccessoryView.swift
@@ -1,0 +1,83 @@
+#if canImport(UIKit)
+import UIKit
+
+/// The bottom dock (accessory toolbar row + composer band) as a self-sizing
+/// keyboard accessory.
+///
+/// The system positions this view: while a text responder owns the keyboard it
+/// rides the keyboard's own animation (rises, dismissals, and interactive
+/// gestures included), and while the surface itself is first responder — the
+/// keyboard-down state — the system docks it at the screen bottom. Ownership by
+/// the keyboard window replaces the previous constraint stack (layout-guide
+/// equality, notification floor, safe-area cap), whose inputs proved unreliable
+/// on device: the layout guide froze or lagged transitions and the surface's
+/// own frame breathes by the home-indicator height mid-transition, so any
+/// self-computed position was wrong at some point of every animation.
+///
+/// Self-sizing: `allowsSelfSizing` with internal constraints. The content pins
+/// to the safe-area bottom, so the docked state automatically clears the home
+/// indicator and the keyboard-attached state sits flush on the keyboard.
+final class KeyboardDockAccessoryView: UIInputView {
+    private let toolbarSlot: UIView
+    private let composerSlot: UIView
+    private let toolbarHeight: NSLayoutConstraint
+    private let composerHeight: NSLayoutConstraint
+
+    /// Creates the dock accessory around the surface-owned toolbar and
+    /// composer container views.
+    ///
+    /// - Parameters:
+    ///   - toolbar: The accessory toolbar row (modifiers, Tab/Esc, toggle).
+    ///   - composer: The composer band container the host mounts SwiftUI into.
+    ///   - toolbarRowHeight: The fixed toolbar strip height.
+    init(toolbar: UIView, composer: UIView, toolbarRowHeight: CGFloat) {
+        toolbarSlot = toolbar
+        composerSlot = composer
+        toolbarHeight = toolbar.heightAnchor.constraint(equalToConstant: toolbarRowHeight)
+        composerHeight = composer.heightAnchor.constraint(equalToConstant: 0)
+        super.init(frame: .zero, inputViewStyle: .keyboard)
+        allowsSelfSizing = true
+        translatesAutoresizingMaskIntoConstraints = false
+        // The dock's Liquid-Glass controls lift past the band edge on drag.
+        clipsToBounds = false
+
+        toolbar.translatesAutoresizingMaskIntoConstraints = false
+        composer.translatesAutoresizingMaskIntoConstraints = false
+        addSubview(toolbar)
+        addSubview(composer)
+        NSLayoutConstraint.activate([
+            toolbar.topAnchor.constraint(equalTo: topAnchor),
+            toolbar.leadingAnchor.constraint(equalTo: leadingAnchor),
+            toolbar.trailingAnchor.constraint(equalTo: trailingAnchor),
+            toolbarHeight,
+            composer.topAnchor.constraint(equalTo: toolbar.bottomAnchor),
+            composer.leadingAnchor.constraint(equalTo: leadingAnchor),
+            composer.trailingAnchor.constraint(equalTo: trailingAnchor),
+            composerHeight,
+            // Safe-area pin: docked = clears the home indicator; on the
+            // keyboard = flush (the keyboard region has no bottom inset).
+            composer.bottomAnchor.constraint(equalTo: safeAreaLayoutGuide.bottomAnchor),
+        ])
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) { fatalError("init(coder:) is not supported") }
+
+    /// The dock's content height above the accessory's safe-area inset.
+    var contentHeight: CGFloat {
+        toolbarHeight.constant + composerHeight.constant
+    }
+
+    /// Resizes the composer band (0 collapses it while the composer is closed).
+    ///
+    /// - Parameter height: The band height in points.
+    /// - Returns: Whether the height changed.
+    @discardableResult
+    func setComposerBandHeight(_ height: CGFloat) -> Bool {
+        let clamped = max(0, height)
+        guard abs(composerHeight.constant - clamped) > 0.25 else { return false }
+        composerHeight.constant = clamped
+        return true
+    }
+}
+#endif

--- a/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/KeyboardDockAccessoryView.swift
+++ b/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/KeyboardDockAccessoryView.swift
@@ -22,6 +22,12 @@ final class KeyboardDockAccessoryView: UIInputView {
     private let composerSlot: UIView
     private let toolbarHeight: NSLayoutConstraint
     private let composerHeight: NSLayoutConstraint
+    /// Paints the accessory's region BELOW the safe-area bottom (the
+    /// home-indicator inset in the docked state). The content pins to the
+    /// safe-area bottom, so without this the strip under the composer band
+    /// renders the bare window — a black remainder at the screen's very
+    /// bottom. On the keyboard the inset is zero and the fill collapses.
+    private let bottomFill = UIView()
 
     /// Creates the dock accessory around the surface-owned toolbar and
     /// composer container views.
@@ -43,6 +49,8 @@ final class KeyboardDockAccessoryView: UIInputView {
 
         toolbar.translatesAutoresizingMaskIntoConstraints = false
         composer.translatesAutoresizingMaskIntoConstraints = false
+        bottomFill.translatesAutoresizingMaskIntoConstraints = false
+        addSubview(bottomFill)
         addSubview(toolbar)
         addSubview(composer)
         NSLayoutConstraint.activate([
@@ -57,7 +65,19 @@ final class KeyboardDockAccessoryView: UIInputView {
             // Safe-area pin: docked = clears the home indicator; on the
             // keyboard = flush (the keyboard region has no bottom inset).
             composer.bottomAnchor.constraint(equalTo: safeAreaLayoutGuide.bottomAnchor),
+            // Overlap the fill one point into the band so no hairline seam
+            // shows between the band's background and the inset fill.
+            bottomFill.topAnchor.constraint(equalTo: safeAreaLayoutGuide.bottomAnchor, constant: -1),
+            bottomFill.leadingAnchor.constraint(equalTo: leadingAnchor),
+            bottomFill.trailingAnchor.constraint(equalTo: trailingAnchor),
+            bottomFill.bottomAnchor.constraint(equalTo: bottomAnchor),
         ])
+    }
+
+    /// Matches the fill to the terminal theme's bar background; the surface
+    /// re-applies it on theme changes.
+    func setBottomFillColor(_ color: UIColor) {
+        bottomFill.backgroundColor = color
     }
 
     @available(*, unavailable)

--- a/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/KeyboardDockAccessoryView.swift
+++ b/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/KeyboardDockAccessoryView.swift
@@ -80,4 +80,22 @@ final class KeyboardDockAccessoryView: UIInputView {
         return true
     }
 }
+
+/// The composer band container that rides inside ``KeyboardDockAccessoryView``.
+///
+/// The hosted compose field is a SwiftUI `TextField`, which cannot override
+/// `inputAccessoryView`. UIKit resolves input views by walking the responder
+/// chain UP from the first responder, and this container is always in the
+/// focused field's chain, so it supplies the shared dock on the field's
+/// behalf. Without this, focusing the field resolves a nil accessory and the
+/// system dismisses the dock mid-transition — the very view the field lives
+/// in — killing the focus and bouncing the dock instead of raising the
+/// keyboard.
+final class KeyboardDockComposerContainerView: UIView {
+    /// Returns the shared dock accessory (or nil while the chrome is hidden),
+    /// mirroring the surface's own `inputAccessoryView` policy.
+    var keyboardAccessoryProvider: (() -> UIView?)?
+
+    override var inputAccessoryView: UIView? { keyboardAccessoryProvider?() }
+}
 #endif

--- a/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/KeyboardDockFrameRecorder.swift
+++ b/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/KeyboardDockFrameRecorder.swift
@@ -1,0 +1,36 @@
+#if canImport(UIKit)
+import CoreGraphics
+
+/// Accumulates display-link evidence that the visible dock content reaches the
+/// system-owned input accessory edge on every software-keyboard frame.
+struct KeyboardDockFrameRecorder {
+    struct Sample {
+        let keyboardUp: Bool
+        let composerMaxY: CGFloat
+        let toolbarMaxY: CGFloat
+        let boundsHeight: CGFloat
+        let accessoryBottomY: CGFloat
+        let gap: CGFloat?
+    }
+
+    private(set) var sampleCount = 0
+    private(set) var keyboardFrameCount = 0
+    private(set) var detachedFrameCount = 0
+    private(set) var maxGap: CGFloat = 0
+    private(set) var worstSample: Sample?
+
+    mutating func record(_ sample: Sample) {
+        sampleCount += 1
+        guard sample.keyboardUp, let gap = sample.gap else { return }
+
+        keyboardFrameCount += 1
+        if worstSample == nil || gap >= maxGap {
+            maxGap = gap
+            worstSample = sample
+        }
+        if gap > 1 {
+            detachedFrameCount += 1
+        }
+    }
+}
+#endif

--- a/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/TerminalInputTextView.swift
+++ b/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/TerminalInputTextView.swift
@@ -351,11 +351,16 @@ final class TerminalInputTextView: UIView, UIKeyInput, UITextInput {
 
         // Pinned keyboard dismiss button on the left
         let dismissButton = UIButton(type: .system)
-        dismissButton.setImage(UIImage(systemName: "keyboard.chevron.compact.down", withConfiguration: Self.accessoryButtonSymbolConfig), for: .normal)
+        // Born in the keyboard-DOWN state: a freshly (re)mounted surface has no
+        // keyboard until something focuses, and `setKeyboardShown(_:)` flips the
+        // glyph on real transitions. Constructing with the chevron-down glyph
+        // showed a stale "hide keyboard" toggle whenever a workspace was
+        // re-entered with the keyboard dismissed.
+        dismissButton.setImage(UIImage(systemName: "keyboard", withConfiguration: Self.accessoryButtonSymbolConfig), for: .normal)
         dismissButton.tintColor = themeChromeColor.withAlphaComponent(0.78)
         dismissButton.addTarget(self, action: #selector(handleHideKeyboard), for: .touchUpInside)
         dismissButton.accessibilityIdentifier = "terminal.inputAccessory.hideKeyboard"
-        dismissButton.accessibilityLabel = String(localized: "terminal.input_accessory.hideKeyboard", defaultValue: "Hide Keyboard")
+        dismissButton.accessibilityLabel = String(localized: "terminal.input_accessory.showKeyboard", defaultValue: "Show Keyboard")
         dismissButton.translatesAutoresizingMaskIntoConstraints = false
         self.dismissButton = dismissButton
 

--- a/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/TerminalInputTextView.swift
+++ b/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/TerminalInputTextView.swift
@@ -549,6 +549,26 @@ final class TerminalInputTextView: UIView, UIKeyInput, UITextInput {
             "composeWinX=\(composeWinX)",
         ].joined(separator: ";")
     }
+
+    /// Per-frame responder/accessory ownership witness used by the keyboard-dock
+    /// trace. Keep this here, beside the responder that vends the accessory, so
+    /// a trace distinguishes a geometry error from UIKit switching owners or
+    /// temporarily unhosting the dock during an interrupted transition.
+    var keyboardDockFrameDiagnostics: String {
+        let accessory = keyboardAccessoryProvider?()
+        let host = accessory?.superview
+        let accessoryPresentationY = accessory?.layer.presentation()?.frame.minY ?? -1
+        let hostPresentationY = host?.layer.presentation()?.frame.minY ?? -1
+        let point: (CGFloat) -> String = { String(format: "%.3f", Double($0)) }
+        let hostName = host.map { NSStringFromClass(type(of: $0)) } ?? "none"
+        return [
+            "proxyFR=\(isFirstResponder ? 1 : 0)",
+            "accessoryHosted=\(host == nil ? 0 : 1)",
+            "accessoryLocalPresentationY=\(point(accessoryPresentationY))",
+            "host=\(hostName)",
+            "hostLocalPresentationY=\(point(hostPresentationY))",
+        ].joined(separator: " ")
+    }
     #endif
 
     func updateAccessoryLayoutInsets() {

--- a/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/TerminalInputTextView.swift
+++ b/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/TerminalInputTextView.swift
@@ -128,6 +128,13 @@ final class TerminalInputTextView: UIView, UIKeyInput, UITextInput {
 
     override var canBecomeFirstResponder: Bool { true }
 
+    /// Supplies the shared keyboard dock accessory (toolbar row + composer
+    /// band). Set by `GhosttySurfaceView`; resolved on every keyboard
+    /// presentation so a chrome toggle can withhold it.
+    var keyboardAccessoryProvider: (() -> UIView?)?
+
+    override var inputAccessoryView: UIView? { keyboardAccessoryProvider?() }
+
     override func becomeFirstResponder() -> Bool {
         let wasFirstResponder = isFirstResponder
         let succeeded = super.becomeFirstResponder()
@@ -426,9 +433,9 @@ final class TerminalInputTextView: UIView, UIKeyInput, UITextInput {
         )
 
         // A short fixed-height strip pinned to the container's BOTTOM (minus
-        // ``dockedBottomPadding``) that holds the button row. The host pins that
-        // bottom edge through the composer to `keyboardLayoutGuide.topAnchor`, so
-        // bottom-pinning the controls keeps them glued to the system keyboard edge.
+        // ``dockedBottomPadding``) that holds the button row. The row is the top
+        // slot of the shared keyboard dock accessory, so bottom-pinning the
+        // controls keeps them glued to the composer band / keyboard edge below.
         // `dockedBottomPadding` lifts the strip off the very bottom edge so the
         // controls have breathing room.
         let buttonRow = UILayoutGuide()
@@ -504,11 +511,13 @@ final class TerminalInputTextView: UIView, UIKeyInput, UITextInput {
 
     /// The terminal accessory bar (modifier keys, arrow nub, shortcut buttons).
     ///
-    /// Formerly the keyboard `inputAccessoryView`; it is now docked as a
-    /// persistent bottom bar by ``GhosttySurfaceView`` so it stays visible when
-    /// the keyboard is dismissed and reserves space above the bottom TUI rows.
-    /// Its buttons still target this text view, so the action wiring is intact
-    /// regardless of where the view is hosted.
+    /// Once again keyboard-accessory-hosted: it is the top row of the shared
+    /// `KeyboardDockAccessoryView` that ``GhosttySurfaceView`` returns as the
+    /// `inputAccessoryView` of every cmux keyboard owner, so the system
+    /// positions it (riding the keyboard while typing, docked at the screen
+    /// bottom while the surface itself holds first responder). Its buttons
+    /// still target this text view, so the action wiring is intact regardless
+    /// of where the view is hosted.
     var toolbarView: UIView { terminalAccessoryToolbar }
 
     private weak var accessoryStackView: UIStackView?
@@ -698,12 +707,12 @@ final class TerminalInputTextView: UIView, UIKeyInput, UITextInput {
         backgroundColor = .clear
         tintColor = .clear
         // The view owns no visible content; it is a zero-size hidden responder
-        // docked by `GhosttySurfaceView`. The accessory bar is no longer the
-        // keyboard's `inputAccessoryView`; `GhosttySurfaceView` docks
-        // `toolbarView` persistently at the bottom so it survives keyboard
-        // dismissal. Leaving `inputAccessoryView` nil means the keyboard shows
-        // without its own accessory (the docked bar rides above it via
-        // `keyboardLayoutGuide`).
+        // owned by `GhosttySurfaceView`. The accessory bar is once again
+        // keyboard-accessory-hosted: `keyboardAccessoryProvider` returns the
+        // surface's shared `KeyboardDockAccessoryView` (toolbar row + composer
+        // band), so the system keyboard carries the whole dock on its own
+        // animation and docks it at the screen bottom when the surface holds
+        // first responder instead.
         NotificationCenter.default.addObserver(
             self,
             selector: #selector(handleAccessoryConfigurationChanged),

--- a/Packages/iOS/CmuxMobileTerminal/Tests/CmuxMobileTerminalTests/GhosttySurfaceKeyboardDockFloorTests.swift
+++ b/Packages/iOS/CmuxMobileTerminal/Tests/CmuxMobileTerminalTests/GhosttySurfaceKeyboardDockFloorTests.swift
@@ -1,0 +1,177 @@
+#if canImport(UIKit) && DEBUG
+import CMUXMobileCore
+import CmuxMobileSupport
+import Testing
+import UIKit
+
+@testable import CmuxMobileTerminal
+
+/// Regression coverage for the field failure where the keyboard rises but the
+/// bottom bars (accessory toolbar + composer band) stay seated at the
+/// keyboard-down position behind it.
+///
+/// In a test window UIKit's `keyboardLayoutGuide` never observes a real
+/// keyboard, so it stays on its bottom fallback exactly like a guide that
+/// missed a live transition around window (re)attachment. Docking correctly
+/// here therefore proves the dock does not depend on the guide having seen the
+/// keyboard event. Each test injects a notification-center-isolated
+/// `MobileKeyboardFrameTracker` (the floor's single data source) and drives the
+/// view's notification handler through the test seam for animation-curve
+/// application, mirroring the production wiring where the shared tracker
+/// observes the same notifications the view does.
+@MainActor
+@Suite("Keyboard dock floor", .serialized)
+struct GhosttySurfaceKeyboardDockFloorTests {
+    private final class Delegate: NSObject, GhosttySurfaceViewDelegate {
+        func ghosttySurfaceView(
+            _ surfaceView: GhosttySurfaceView,
+            didProduceInput data: Data
+        ) {}
+
+        func ghosttySurfaceView(
+            _ surfaceView: GhosttySurfaceView,
+            didResize size: TerminalGridSize,
+            reportID: UInt64
+        ) {}
+    }
+
+    private struct Harness {
+        let view: GhosttySurfaceView
+        let window: UIWindow
+        let center: NotificationCenter
+        let tracker: MobileKeyboardFrameTracker
+        /// Retained here because the surface only holds it weakly.
+        let delegate: Delegate
+    }
+
+    private static let windowHeight: CGFloat = 874
+    private static let keyboardHeight: CGFloat = 336
+
+    private func makeHarness(attached: Bool = true) throws -> Harness {
+        let center = NotificationCenter()
+        let tracker = MobileKeyboardFrameTracker(notificationCenter: center)
+        let delegate = Delegate()
+        let view = GhosttySurfaceView(
+            runtime: try GhosttyRuntime.shared(),
+            delegate: delegate,
+            fontSize: 10
+        )
+        view.autoFocusOnWindowAttach = false
+        view.isRenderDispatchSuppressed = true
+        view.setKeyboardFrameTrackerForTesting(tracker)
+        let window = UIWindow(frame: CGRect(x: 0, y: 0, width: 402, height: Self.windowHeight))
+        if attached {
+            attach(view, to: window)
+        }
+        return Harness(view: view, window: window, center: center, tracker: tracker, delegate: delegate)
+    }
+
+    private func attach(_ view: GhosttySurfaceView, to window: UIWindow) {
+        view.frame = window.bounds
+        window.addSubview(view)
+        window.isHidden = false
+        view.setNeedsLayout()
+        view.layoutIfNeeded()
+    }
+
+    private func tearDown(_ harness: Harness) {
+        harness.view.prepareForDismantle()
+        harness.view.removeFromSuperview()
+        harness.window.isHidden = true
+    }
+
+    /// The keyboard notification shape UIKit posts, with `duration` omitted so
+    /// the transition applies synchronously in tests.
+    private func keyboardNotification(coveringBottom overlap: CGFloat) -> Notification {
+        Notification(
+            name: UIResponder.keyboardWillChangeFrameNotification,
+            object: nil,
+            userInfo: [
+                UIResponder.keyboardFrameEndUserInfoKey: CGRect(
+                    x: 0,
+                    y: Self.windowHeight - overlap,
+                    width: 402,
+                    height: Self.keyboardHeight
+                ),
+            ]
+        )
+    }
+
+    /// Delivers a keyboard transition the way production sees it: the tracker
+    /// (registered first) records it, then the view's handler re-applies the
+    /// floor on the notification's animation curve.
+    private func deliverKeyboardTransition(
+        coveringBottom overlap: CGFloat,
+        to harness: Harness
+    ) {
+        let notification = keyboardNotification(coveringBottom: overlap)
+        harness.center.post(notification)
+        harness.view.handleKeyboardWillChangeFrameForTesting(notification)
+        harness.view.setNeedsLayout()
+        harness.view.layoutIfNeeded()
+    }
+
+    private func probeValue(of view: GhosttySurfaceView, key: String) -> CGFloat? {
+        let entry = view.composerDockProbeValue
+            .split(separator: ";")
+            .first { $0.hasPrefix("\(key)=") }
+        guard let entry, let value = Double(entry.dropFirst(key.count + 1)) else {
+            return nil
+        }
+        return CGFloat(value)
+    }
+
+    @Test("keyboard rise docks the bars above it even when the layout guide missed it")
+    func barsRideTheKeyboardWhenTheGuideStaysOnItsFallback() throws {
+        let harness = try makeHarness()
+        defer { tearDown(harness) }
+
+        deliverKeyboardTransition(coveringBottom: Self.keyboardHeight, to: harness)
+
+        let dockBottom = Self.windowHeight - Self.keyboardHeight
+        let composerMaxY = try #require(probeValue(of: harness.view, key: "composerMaxY"))
+        let toolbarMaxY = try #require(probeValue(of: harness.view, key: "toolbarMaxY"))
+        let modelKeyboardHeight = try #require(probeValue(of: harness.view, key: "keyboardHeight"))
+        #expect(abs(composerMaxY - dockBottom) <= 1)
+        #expect(abs(toolbarMaxY - dockBottom) <= 1)
+        #expect(abs(modelKeyboardHeight - Self.keyboardHeight) <= 1)
+    }
+
+    @Test("a view attached after the keyboard came up docks from the tracker")
+    func lateAttachedViewDocksFromTheTrackedKeyboardFrame() throws {
+        let harness = try makeHarness(attached: false)
+        defer { tearDown(harness) }
+
+        // The keyboard transition happens while the view is detached — the
+        // workspace-switch case. Only the tracker observes it; the view's
+        // handler never runs for it.
+        harness.center.post(keyboardNotification(coveringBottom: Self.keyboardHeight))
+        attach(harness.view, to: harness.window)
+
+        let dockBottom = Self.windowHeight - Self.keyboardHeight
+        let composerMaxY = try #require(probeValue(of: harness.view, key: "composerMaxY"))
+        let toolbarMaxY = try #require(probeValue(of: harness.view, key: "toolbarMaxY"))
+        let modelKeyboardHeight = try #require(probeValue(of: harness.view, key: "keyboardHeight"))
+        #expect(abs(composerMaxY - dockBottom) <= 1)
+        #expect(abs(toolbarMaxY - dockBottom) <= 1)
+        #expect(abs(modelKeyboardHeight - Self.keyboardHeight) <= 1)
+    }
+
+    @Test("a dismissal transition releases the floor and reseats the bars at the bottom")
+    func dismissalReturnsTheBarsToTheBottomFallback() throws {
+        let harness = try makeHarness()
+        defer { tearDown(harness) }
+
+        deliverKeyboardTransition(coveringBottom: Self.keyboardHeight, to: harness)
+        deliverKeyboardTransition(coveringBottom: 0, to: harness)
+
+        // Released, the dock reseats on the guide's bottom fallback, which
+        // clears the simulator device's real bottom safe-area inset.
+        let bottomSafeArea = try #require(probeValue(of: harness.view, key: "bottomSafeArea"))
+        let composerMaxY = try #require(probeValue(of: harness.view, key: "composerMaxY"))
+        let modelKeyboardHeight = try #require(probeValue(of: harness.view, key: "keyboardHeight"))
+        #expect(abs(composerMaxY - (Self.windowHeight - bottomSafeArea)) <= 1)
+        #expect(abs(modelKeyboardHeight) <= 1)
+    }
+}
+#endif

--- a/Packages/iOS/CmuxMobileTerminal/Tests/CmuxMobileTerminalTests/GhosttySurfaceKeyboardDockFloorTests.swift
+++ b/Packages/iOS/CmuxMobileTerminal/Tests/CmuxMobileTerminalTests/GhosttySurfaceKeyboardDockFloorTests.swift
@@ -121,6 +121,21 @@ struct GhosttySurfaceKeyboardDockFloorTests {
         return CGFloat(value)
     }
 
+    /// The accessory toolbar's keyboard-toggle button, found by its stable
+    /// accessibility identifier in the surface's subtree.
+    private func keyboardToggleButton(in view: UIView) -> UIButton? {
+        if let button = view as? UIButton,
+           button.accessibilityIdentifier == "terminal.inputAccessory.hideKeyboard" {
+            return button
+        }
+        for subview in view.subviews {
+            if let found = keyboardToggleButton(in: subview) {
+                return found
+            }
+        }
+        return nil
+    }
+
     @Test("keyboard rise docks the bars above it even when the layout guide missed it")
     func barsRideTheKeyboardWhenTheGuideStaysOnItsFallback() throws {
         let harness = try makeHarness()
@@ -152,9 +167,50 @@ struct GhosttySurfaceKeyboardDockFloorTests {
         let composerMaxY = try #require(probeValue(of: harness.view, key: "composerMaxY"))
         let toolbarMaxY = try #require(probeValue(of: harness.view, key: "toolbarMaxY"))
         let modelKeyboardHeight = try #require(probeValue(of: harness.view, key: "keyboardHeight"))
+        let keyboardUp = try #require(probeValue(of: harness.view, key: "keyboardUp"))
         #expect(abs(composerMaxY - dockBottom) <= 1)
         #expect(abs(toolbarMaxY - dockBottom) <= 1)
         #expect(abs(modelKeyboardHeight - Self.keyboardHeight) <= 1)
+        // The visibility bit catches up too: the toggle must read hide-keyboard.
+        #expect(keyboardUp == 1)
+    }
+
+    @Test("a fresh toolbar is born in the keyboard-down state")
+    func freshToolbarShowsTheShowKeyboardToggle() throws {
+        let harness = try makeHarness()
+        defer { tearDown(harness) }
+
+        let toggle = try #require(keyboardToggleButton(in: harness.view))
+        #expect(toggle.accessibilityLabel == "Show Keyboard")
+        let keyboardUp = try #require(probeValue(of: harness.view, key: "keyboardUp"))
+        #expect(keyboardUp == 0)
+    }
+
+    @Test("re-entering after the keyboard dismissed while detached resets the visibility state")
+    func reattachAfterDetachedDismissalShowsKeyboardDownState() throws {
+        let harness = try makeHarness()
+        defer { tearDown(harness) }
+
+        // Keyboard up while the surface is presented.
+        deliverKeyboardTransition(coveringBottom: Self.keyboardHeight, to: harness)
+        #expect(try #require(probeValue(of: harness.view, key: "keyboardUp")) == 1)
+
+        // Leave the workspace detail: the surface detaches, THEN the keyboard
+        // dismisses. Only the tracker observes the dismissal.
+        harness.view.removeFromSuperview()
+        harness.center.post(keyboardNotification(coveringBottom: 0))
+
+        // Re-enter: the visibility bit, the toggle glyph state, and the dock
+        // must all reflect the keyboard-down truth.
+        attach(harness.view, to: harness.window)
+
+        let keyboardUp = try #require(probeValue(of: harness.view, key: "keyboardUp"))
+        let bottomSafeArea = try #require(probeValue(of: harness.view, key: "bottomSafeArea"))
+        let composerMaxY = try #require(probeValue(of: harness.view, key: "composerMaxY"))
+        let toggle = try #require(keyboardToggleButton(in: harness.view))
+        #expect(keyboardUp == 0)
+        #expect(abs(composerMaxY - (Self.windowHeight - bottomSafeArea)) <= 1)
+        #expect(toggle.accessibilityLabel == "Show Keyboard")
     }
 
     @Test("a dismissal transition releases the floor and reseats the bars at the bottom")

--- a/Packages/iOS/CmuxMobileTerminal/Tests/CmuxMobileTerminalTests/GhosttySurfaceKeyboardDockFloorTests.swift
+++ b/Packages/iOS/CmuxMobileTerminal/Tests/CmuxMobileTerminalTests/GhosttySurfaceKeyboardDockFloorTests.swift
@@ -6,21 +6,23 @@ import UIKit
 
 @testable import CmuxMobileTerminal
 
-/// Regression coverage for the field failure where the keyboard rises but the
-/// bottom bars (accessory toolbar + composer band) stay seated at the
-/// keyboard-down position behind it.
+/// Contract coverage for the keyboard dock accessory: the bottom dock (toolbar
+/// row + composer band) is one self-sizing `UIInputView` that the OS keyboard
+/// system positions. Every cmux keyboard owner returns it as its
+/// `inputAccessoryView` — the terminal input proxy while typing (the dock rides
+/// the keyboard's own animation) and the surface itself in the keyboard-down
+/// state (the system docks it at the screen bottom) — so the surface never
+/// computes a dock position. What remains surface-owned is the MODEL: the grid
+/// reservation derived from the notification-tracked keyboard overlap.
 ///
-/// In a test window UIKit's `keyboardLayoutGuide` never observes a real
-/// keyboard, so it stays on its bottom fallback exactly like a guide that
-/// missed a live transition around window (re)attachment. Docking correctly
-/// here therefore proves the dock does not depend on the guide having seen the
-/// keyboard event. Each test injects a notification-center-isolated
-/// `MobileKeyboardFrameTracker` (the floor's single data source) through the
-/// surface initializer and calls the view's notification handler directly for
-/// animation-curve application, mirroring the production wiring where the
+/// A test window never shows a real keyboard, so these tests assert the
+/// responder wiring and the model, not OS-owned positions. Each test injects a
+/// notification-center-isolated `MobileKeyboardFrameTracker` (the model's
+/// single data source) through the surface initializer and calls the view's
+/// notification handler directly, mirroring the production wiring where the
 /// shared tracker observes the same notifications the view does.
 @MainActor
-@Suite("Keyboard dock floor", .serialized)
+@Suite("Keyboard dock accessory", .serialized)
 struct GhosttySurfaceKeyboardDockFloorTests {
     private final class Delegate: NSObject, GhosttySurfaceViewDelegate {
         func ghosttySurfaceView(
@@ -69,7 +71,9 @@ struct GhosttySurfaceKeyboardDockFloorTests {
     private func attach(_ view: GhosttySurfaceView, to window: UIWindow) {
         view.frame = window.bounds
         window.addSubview(view)
-        window.isHidden = false
+        // Key AND visible: first-responder status (the keyboard-down docking
+        // seat under test) requires the view's window to be key.
+        window.makeKeyAndVisible()
         view.setNeedsLayout()
         view.layoutIfNeeded()
     }
@@ -99,7 +103,7 @@ struct GhosttySurfaceKeyboardDockFloorTests {
 
     /// Delivers a keyboard transition the way production sees it: the tracker
     /// (registered first) records it, then the view's handler re-applies the
-    /// floor on the notification's animation curve.
+    /// overlap model on the notification's animation curve.
     private func deliverKeyboardTransition(
         coveringBottom overlap: CGFloat,
         to harness: Harness
@@ -122,7 +126,7 @@ struct GhosttySurfaceKeyboardDockFloorTests {
     }
 
     /// The accessory toolbar's keyboard-toggle button, found by its stable
-    /// accessibility identifier in the surface's subtree.
+    /// accessibility identifier in the given subtree.
     private func keyboardToggleButton(in view: UIView) -> UIButton? {
         if let button = view as? UIButton,
            button.accessibilityIdentifier == "terminal.inputAccessory.hideKeyboard" {
@@ -136,24 +140,71 @@ struct GhosttySurfaceKeyboardDockFloorTests {
         return nil
     }
 
-    @Test("keyboard rise docks the bars above it even when the layout guide missed it")
-    func barsRideTheKeyboardWhenTheGuideStaysOnItsFallback() throws {
+    @Test("the dock accessory exists, hosts toolbar + composer, and is the inputAccessoryView")
+    func accessoryHostsToolbarAndComposerBand() throws {
+        let harness = try makeHarness()
+        defer { tearDown(harness) }
+
+        let accessory = try #require(
+            harness.view.inputAccessoryView as? KeyboardDockAccessoryView
+        )
+        // The toolbar row (identified by its keyboard-toggle button) lives
+        // INSIDE the accessory, not in the surface's own subtree.
+        #expect(keyboardToggleButton(in: accessory) != nil)
+        #expect(keyboardToggleButton(in: harness.view) == nil)
+        // The composer band is the accessory's other slot: a host-mounted
+        // compose view lands inside the accessory subtree.
+        let composerContent = UIView()
+        harness.view.mountComposerView(composerContent)
+        #expect(composerContent.isDescendant(of: accessory))
+        // The typing responder shares the exact same accessory instance, so
+        // the dock transfers seamlessly between keyboard owners.
+        #expect(harness.view.inputProxyForTesting.inputAccessoryView === accessory)
+    }
+
+    @Test("hidden chrome withholds the accessory from the keyboard system")
+    func chromeHiddenReturnsNilAccessory() throws {
+        let harness = try makeHarness()
+        defer { tearDown(harness) }
+
+        #expect(harness.view.inputAccessoryView != nil)
+        harness.view.setChromeHidden(true)
+        #expect(harness.view.inputAccessoryView == nil)
+        #expect(harness.view.inputProxyForTesting.inputAccessoryView == nil)
+        harness.view.setChromeHidden(false)
+        #expect(harness.view.inputAccessoryView != nil)
+    }
+
+    @Test("after attach without autofocus the surface holds first responder (docked accessory state)")
+    func attachSeatsSurfaceAsFirstResponder() throws {
+        let harness = try makeHarness()
+        defer { tearDown(harness) }
+
+        // No cmux text responder owns the keyboard and the chrome is visible,
+        // so the SURFACE must hold first responder — that is what makes the
+        // system dock the accessory at the screen bottom.
+        #expect(harness.view.isFirstResponder)
+    }
+
+    @Test("a keyboard rise updates the grid overlap model from the tracked window-space overlap")
+    func keyboardRiseUpdatesOverlapModel() throws {
         let harness = try makeHarness()
         defer { tearDown(harness) }
 
         deliverKeyboardTransition(coveringBottom: Self.keyboardHeight, to: harness)
 
-        let dockBottom = Self.windowHeight - Self.keyboardHeight
-        let composerMaxY = try #require(probeValue(of: harness.view, key: "composerMaxY"))
-        let toolbarMaxY = try #require(probeValue(of: harness.view, key: "toolbarMaxY"))
+        // The view fills the window, so the window-space overlap converts 1:1.
         let modelKeyboardHeight = try #require(probeValue(of: harness.view, key: "keyboardHeight"))
-        #expect(abs(composerMaxY - dockBottom) <= 1)
-        #expect(abs(toolbarMaxY - dockBottom) <= 1)
         #expect(abs(modelKeyboardHeight - Self.keyboardHeight) <= 1)
+
+        // Dismissal releases the model back to zero.
+        deliverKeyboardTransition(coveringBottom: 0, to: harness)
+        let released = try #require(probeValue(of: harness.view, key: "keyboardHeight"))
+        #expect(abs(released) <= 1)
     }
 
-    @Test("a view attached after the keyboard came up docks from the tracker")
-    func lateAttachedViewDocksFromTheTrackedKeyboardFrame() throws {
+    @Test("a view attached after the keyboard came up seats the model from the tracker")
+    func lateAttachedViewSeatsModelFromTracker() throws {
         let harness = try makeHarness(attached: false)
         defer { tearDown(harness) }
 
@@ -163,47 +214,11 @@ struct GhosttySurfaceKeyboardDockFloorTests {
         harness.center.post(keyboardNotification(coveringBottom: Self.keyboardHeight))
         attach(harness.view, to: harness.window)
 
-        let dockBottom = Self.windowHeight - Self.keyboardHeight
-        let composerMaxY = try #require(probeValue(of: harness.view, key: "composerMaxY"))
-        let toolbarMaxY = try #require(probeValue(of: harness.view, key: "toolbarMaxY"))
         let modelKeyboardHeight = try #require(probeValue(of: harness.view, key: "keyboardHeight"))
         let keyboardUp = try #require(probeValue(of: harness.view, key: "keyboardUp"))
-        #expect(abs(composerMaxY - dockBottom) <= 1)
-        #expect(abs(toolbarMaxY - dockBottom) <= 1)
         #expect(abs(modelKeyboardHeight - Self.keyboardHeight) <= 1)
         // The visibility bit catches up too: the toggle must read hide-keyboard.
         #expect(keyboardUp == 1)
-    }
-
-    @Test("the floor holds the window-correct seat while the surface's own frame breathes")
-    func floorStaysWindowCorrectWhenTheSurfaceFrameChanges() throws {
-        let harness = try makeHarness(attached: false)
-        defer { tearDown(harness) }
-
-        // Attach with the bottom edge respecting a 34pt indicator inset — the
-        // shape the host gives the surface while the keyboard is down.
-        harness.view.frame = CGRect(x: 0, y: 0, width: 402, height: Self.windowHeight - 34)
-        harness.window.addSubview(harness.view)
-        harness.window.isHidden = false
-        harness.view.setNeedsLayout()
-        harness.view.layoutIfNeeded()
-
-        // The keyboard rises while the frame is still short (mid-transition
-        // conversion territory: this is where the device build seeded a floor
-        // 34pt shy of the settled truth).
-        deliverKeyboardTransition(coveringBottom: Self.keyboardHeight, to: harness)
-
-        // Safe-area propagation then extends the surface to the window bottom.
-        harness.view.frame = CGRect(x: 0, y: 0, width: 402, height: Self.windowHeight)
-        harness.view.setNeedsLayout()
-        harness.view.layoutIfNeeded()
-
-        // The bars must already sit at the window-correct keyboard top — the
-        // late +34 pop the dogfood recordings showed is exactly this assertion
-        // failing at the old view-anchored floor.
-        let dockBottom = Self.windowHeight - Self.keyboardHeight
-        let composerMaxY = try #require(probeValue(of: harness.view, key: "composerMaxY"))
-        #expect(abs(composerMaxY - dockBottom) <= 1)
     }
 
     @Test("a fresh toolbar is born in the keyboard-down state")
@@ -211,7 +226,8 @@ struct GhosttySurfaceKeyboardDockFloorTests {
         let harness = try makeHarness()
         defer { tearDown(harness) }
 
-        let toggle = try #require(keyboardToggleButton(in: harness.view))
+        let accessory = try #require(harness.view.inputAccessoryView)
+        let toggle = try #require(keyboardToggleButton(in: accessory))
         #expect(toggle.accessibilityLabel == "Show Keyboard")
         let keyboardUp = try #require(probeValue(of: harness.view, key: "keyboardUp"))
         #expect(keyboardUp == 0)
@@ -231,34 +247,16 @@ struct GhosttySurfaceKeyboardDockFloorTests {
         harness.view.removeFromSuperview()
         harness.center.post(keyboardNotification(coveringBottom: 0))
 
-        // Re-enter: the visibility bit, the toggle glyph state, and the dock
-        // must all reflect the keyboard-down truth.
+        // Re-enter: the visibility bit and the toggle glyph must reflect the
+        // keyboard-down truth (positions are OS-owned now, so only the state
+        // is asserted).
         attach(harness.view, to: harness.window)
 
         let keyboardUp = try #require(probeValue(of: harness.view, key: "keyboardUp"))
-        let bottomSafeArea = try #require(probeValue(of: harness.view, key: "bottomSafeArea"))
-        let composerMaxY = try #require(probeValue(of: harness.view, key: "composerMaxY"))
-        let toggle = try #require(keyboardToggleButton(in: harness.view))
+        let accessory = try #require(harness.view.inputAccessoryView)
+        let toggle = try #require(keyboardToggleButton(in: accessory))
         #expect(keyboardUp == 0)
-        #expect(abs(composerMaxY - (Self.windowHeight - bottomSafeArea)) <= 1)
         #expect(toggle.accessibilityLabel == "Show Keyboard")
-    }
-
-    @Test("a dismissal transition releases the floor and reseats the bars at the bottom")
-    func dismissalReturnsTheBarsToTheBottomFallback() throws {
-        let harness = try makeHarness()
-        defer { tearDown(harness) }
-
-        deliverKeyboardTransition(coveringBottom: Self.keyboardHeight, to: harness)
-        deliverKeyboardTransition(coveringBottom: 0, to: harness)
-
-        // Released, the dock reseats on the guide's bottom fallback, which
-        // clears the simulator device's real bottom safe-area inset.
-        let bottomSafeArea = try #require(probeValue(of: harness.view, key: "bottomSafeArea"))
-        let composerMaxY = try #require(probeValue(of: harness.view, key: "composerMaxY"))
-        let modelKeyboardHeight = try #require(probeValue(of: harness.view, key: "keyboardHeight"))
-        #expect(abs(composerMaxY - (Self.windowHeight - bottomSafeArea)) <= 1)
-        #expect(abs(modelKeyboardHeight) <= 1)
     }
 }
 #endif

--- a/Packages/iOS/CmuxMobileTerminal/Tests/CmuxMobileTerminalTests/GhosttySurfaceKeyboardDockFloorTests.swift
+++ b/Packages/iOS/CmuxMobileTerminal/Tests/CmuxMobileTerminalTests/GhosttySurfaceKeyboardDockFloorTests.swift
@@ -193,9 +193,15 @@ struct GhosttySurfaceKeyboardDockFloorTests {
 
         deliverKeyboardTransition(coveringBottom: Self.keyboardHeight, to: harness)
 
-        // The view fills the window, so the window-space overlap converts 1:1.
+        // UIKit's keyboard end frame includes the input accessory. The grid
+        // reserves that dock separately, so its keyboard model is the tracked
+        // overlap minus the accessory content height.
+        let accessory = try #require(
+            harness.view.inputAccessoryView as? KeyboardDockAccessoryView
+        )
+        let expectedKeyboardOnlyHeight = Self.keyboardHeight - accessory.contentHeight
         let modelKeyboardHeight = try #require(probeValue(of: harness.view, key: "keyboardHeight"))
-        #expect(abs(modelKeyboardHeight - Self.keyboardHeight) <= 1)
+        #expect(abs(modelKeyboardHeight - expectedKeyboardOnlyHeight) <= 1)
 
         // Dismissal releases the model back to zero.
         deliverKeyboardTransition(coveringBottom: 0, to: harness)
@@ -214,9 +220,13 @@ struct GhosttySurfaceKeyboardDockFloorTests {
         harness.center.post(keyboardNotification(coveringBottom: Self.keyboardHeight))
         attach(harness.view, to: harness.window)
 
+        let accessory = try #require(
+            harness.view.inputAccessoryView as? KeyboardDockAccessoryView
+        )
+        let expectedKeyboardOnlyHeight = Self.keyboardHeight - accessory.contentHeight
         let modelKeyboardHeight = try #require(probeValue(of: harness.view, key: "keyboardHeight"))
         let keyboardUp = try #require(probeValue(of: harness.view, key: "keyboardUp"))
-        #expect(abs(modelKeyboardHeight - Self.keyboardHeight) <= 1)
+        #expect(abs(modelKeyboardHeight - expectedKeyboardOnlyHeight) <= 1)
         // The visibility bit catches up too: the toggle must read hide-keyboard.
         #expect(keyboardUp == 1)
     }

--- a/Packages/iOS/CmuxMobileTerminal/Tests/CmuxMobileTerminalTests/GhosttySurfaceKeyboardDockFloorTests.swift
+++ b/Packages/iOS/CmuxMobileTerminal/Tests/CmuxMobileTerminalTests/GhosttySurfaceKeyboardDockFloorTests.swift
@@ -175,6 +175,37 @@ struct GhosttySurfaceKeyboardDockFloorTests {
         #expect(keyboardUp == 1)
     }
 
+    @Test("the floor holds the window-correct seat while the surface's own frame breathes")
+    func floorStaysWindowCorrectWhenTheSurfaceFrameChanges() throws {
+        let harness = try makeHarness(attached: false)
+        defer { tearDown(harness) }
+
+        // Attach with the bottom edge respecting a 34pt indicator inset — the
+        // shape the host gives the surface while the keyboard is down.
+        harness.view.frame = CGRect(x: 0, y: 0, width: 402, height: Self.windowHeight - 34)
+        harness.window.addSubview(harness.view)
+        harness.window.isHidden = false
+        harness.view.setNeedsLayout()
+        harness.view.layoutIfNeeded()
+
+        // The keyboard rises while the frame is still short (mid-transition
+        // conversion territory: this is where the device build seeded a floor
+        // 34pt shy of the settled truth).
+        deliverKeyboardTransition(coveringBottom: Self.keyboardHeight, to: harness)
+
+        // Safe-area propagation then extends the surface to the window bottom.
+        harness.view.frame = CGRect(x: 0, y: 0, width: 402, height: Self.windowHeight)
+        harness.view.setNeedsLayout()
+        harness.view.layoutIfNeeded()
+
+        // The bars must already sit at the window-correct keyboard top — the
+        // late +34 pop the dogfood recordings showed is exactly this assertion
+        // failing at the old view-anchored floor.
+        let dockBottom = Self.windowHeight - Self.keyboardHeight
+        let composerMaxY = try #require(probeValue(of: harness.view, key: "composerMaxY"))
+        #expect(abs(composerMaxY - dockBottom) <= 1)
+    }
+
     @Test("a fresh toolbar is born in the keyboard-down state")
     func freshToolbarShowsTheShowKeyboardToggle() throws {
         let harness = try makeHarness()

--- a/Packages/iOS/CmuxMobileTerminal/Tests/CmuxMobileTerminalTests/GhosttySurfaceKeyboardDockFloorTests.swift
+++ b/Packages/iOS/CmuxMobileTerminal/Tests/CmuxMobileTerminalTests/GhosttySurfaceKeyboardDockFloorTests.swift
@@ -15,10 +15,10 @@ import UIKit
 /// missed a live transition around window (re)attachment. Docking correctly
 /// here therefore proves the dock does not depend on the guide having seen the
 /// keyboard event. Each test injects a notification-center-isolated
-/// `MobileKeyboardFrameTracker` (the floor's single data source) and drives the
-/// view's notification handler through the test seam for animation-curve
-/// application, mirroring the production wiring where the shared tracker
-/// observes the same notifications the view does.
+/// `MobileKeyboardFrameTracker` (the floor's single data source) through the
+/// surface initializer and calls the view's notification handler directly for
+/// animation-curve application, mirroring the production wiring where the
+/// shared tracker observes the same notifications the view does.
 @MainActor
 @Suite("Keyboard dock floor", .serialized)
 struct GhosttySurfaceKeyboardDockFloorTests {
@@ -54,11 +54,11 @@ struct GhosttySurfaceKeyboardDockFloorTests {
         let view = GhosttySurfaceView(
             runtime: try GhosttyRuntime.shared(),
             delegate: delegate,
-            fontSize: 10
+            fontSize: 10,
+            keyboardFrameTracker: tracker
         )
         view.autoFocusOnWindowAttach = false
         view.isRenderDispatchSuppressed = true
-        view.setKeyboardFrameTrackerForTesting(tracker)
         let window = UIWindow(frame: CGRect(x: 0, y: 0, width: 402, height: Self.windowHeight))
         if attached {
             attach(view, to: window)
@@ -106,7 +106,7 @@ struct GhosttySurfaceKeyboardDockFloorTests {
     ) {
         let notification = keyboardNotification(coveringBottom: overlap)
         harness.center.post(notification)
-        harness.view.handleKeyboardWillChangeFrameForTesting(notification)
+        harness.view.handleKeyboardWillChangeFrame(notification)
         harness.view.setNeedsLayout()
         harness.view.layoutIfNeeded()
     }

--- a/Packages/iOS/CmuxMobileTerminal/Tests/CmuxMobileTerminalTests/GhosttySurfaceKeyboardDockFloorTests.swift
+++ b/Packages/iOS/CmuxMobileTerminal/Tests/CmuxMobileTerminalTests/GhosttySurfaceKeyboardDockFloorTests.swift
@@ -258,5 +258,57 @@ struct GhosttySurfaceKeyboardDockFloorTests {
         #expect(keyboardUp == 0)
         #expect(toggle.accessibilityLabel == "Show Keyboard")
     }
+
+    @Test("the composer band container answers the responder chain with the shared dock")
+    func composerContainerSuppliesSharedAccessory() throws {
+        let harness = try makeHarness()
+        defer { tearDown(harness) }
+
+        let accessory = try #require(
+            harness.view.inputAccessoryView as? KeyboardDockAccessoryView
+        )
+        let composerContent = UIView()
+        harness.view.mountComposerView(composerContent)
+        // The hosted SwiftUI field cannot override `inputAccessoryView`, so
+        // UIKit's responder-chain walk must find the SAME dock instance on the
+        // band container. A nil resolution here is the "tap the field and the
+        // dock slides away instead of the keyboard rising" regression.
+        let container = try #require(
+            composerContent.superview as? KeyboardDockComposerContainerView
+        )
+        #expect(container.inputAccessoryView === accessory)
+        // Hidden chrome withholds the dock from every owner, this one included.
+        harness.view.setChromeHidden(true)
+        #expect(container.inputAccessoryView == nil)
+        harness.view.setChromeHidden(false)
+        #expect(container.inputAccessoryView === accessory)
+    }
+
+    @Test("the photo picker lifecycle keeps the dock's first-responder seat")
+    func photoPickerLifecycleKeepsDockSeat() throws {
+        let harness = try makeHarness()
+        defer { tearDown(harness) }
+
+        // Mirror the report: the composer field was focused when Attach was
+        // tapped. The reducer's owner state is what the modal path resigns.
+        harness.view.composerInputFocusChanged(true)
+
+        // Presenting resigns the text owner AND clears the retained focus
+        // request, so the surface itself must take the keyboard-down seat or
+        // the dock unmounts with nothing to bring it back.
+        harness.view.photoPickerWillPresent()
+        #expect(harness.view.isFirstResponder)
+
+        harness.view.photoPickerDidPresent()
+        // Worst case: the presentation strips the surface's seat too (remote
+        // picker takes over the window).
+        harness.view.resignFirstResponder()
+        #expect(!harness.view.isFirstResponder)
+
+        // Dismissal must re-seat a dock owner; before the fix nobody held the
+        // seat and the bottom dock stayed unmounted forever.
+        harness.view.photoPickerDidDismiss()
+        #expect(harness.view.isFirstResponder)
+    }
 }
 #endif

--- a/Packages/iOS/CmuxMobileTerminal/Tests/CmuxMobileTerminalTests/GhosttySurfaceKeyboardDockFloorTests.swift
+++ b/Packages/iOS/CmuxMobileTerminal/Tests/CmuxMobileTerminalTests/GhosttySurfaceKeyboardDockFloorTests.swift
@@ -290,12 +290,13 @@ struct GhosttySurfaceKeyboardDockFloorTests {
         defer { tearDown(harness) }
 
         // Mirror the report: the composer field was focused when Attach was
-        // tapped. The reducer's owner state is what the modal path resigns.
+        // tapped.
         harness.view.composerInputFocusChanged(true)
 
-        // Presenting resigns the text owner AND clears the retained focus
-        // request, so the surface itself must take the keyboard-down seat or
-        // the dock unmounts with nothing to bring it back.
+        // Presenting keeps the text owner seated (no real field holds first
+        // responder in this harness, so the surface takes the keyboard-down
+        // seat); either way SOMETHING must hold the seat or the dock unmounts
+        // with nothing to bring it back.
         harness.view.photoPickerWillPresent()
         #expect(harness.view.isFirstResponder)
 

--- a/Packages/iOS/CmuxMobileTerminal/Tests/CmuxMobileTerminalTests/KeyboardDockFrameRecorderTests.swift
+++ b/Packages/iOS/CmuxMobileTerminal/Tests/CmuxMobileTerminalTests/KeyboardDockFrameRecorderTests.swift
@@ -1,0 +1,40 @@
+#if canImport(UIKit)
+import CoreGraphics
+import Testing
+
+@testable import CmuxMobileTerminal
+
+@Suite struct KeyboardDockFrameRecorderTests {
+    @Test func checksEveryKeyboardFrameAndRetainsWorstGeometry() {
+        var recorder = KeyboardDockFrameRecorder()
+        recorder.record(sample(keyboardUp: false, gap: nil, composerMaxY: 700))
+        recorder.record(sample(keyboardUp: true, gap: 0, composerMaxY: 402))
+        recorder.record(sample(keyboardUp: true, gap: 0.75, composerMaxY: 401.25))
+        recorder.record(sample(keyboardUp: true, gap: 1.25, composerMaxY: 400.75))
+
+        #expect(recorder.sampleCount == 4)
+        #expect(recorder.keyboardFrameCount == 3)
+        #expect(recorder.detachedFrameCount == 1)
+        #expect(recorder.maxGap == 1.25)
+        #expect(recorder.worstSample?.keyboardUp == true)
+        #expect(recorder.worstSample?.composerMaxY == 400.75)
+        #expect(recorder.worstSample?.toolbarMaxY == 350)
+        #expect(recorder.worstSample?.boundsHeight == 874)
+    }
+
+    private func sample(
+        keyboardUp: Bool,
+        gap: CGFloat?,
+        composerMaxY: CGFloat
+    ) -> KeyboardDockFrameRecorder.Sample {
+        KeyboardDockFrameRecorder.Sample(
+            keyboardUp: keyboardUp,
+            composerMaxY: composerMaxY,
+            toolbarMaxY: 350,
+            boundsHeight: 874,
+            accessoryBottomY: 402,
+            gap: gap
+        )
+    }
+}
+#endif

--- a/Packages/iOS/CmuxMobileTerminalKit/Sources/CmuxMobileTerminalKit/TerminalInputSessionReducer.swift
+++ b/Packages/iOS/CmuxMobileTerminalKit/Sources/CmuxMobileTerminalKit/TerminalInputSessionReducer.swift
@@ -164,7 +164,11 @@ public struct TerminalInputSessionState: Equatable, Sendable {
         case .responderChanged(let owner, let isFirstResponder):
             if isFirstResponder {
                 actualOwner = owner
-                if canFocus {
+                if scenePhase == .active {
+                    // A responder observed under a system modal stays seated:
+                    // the composer band lives inside the keyboard dock
+                    // accessory, so resigning here unmounts the dock (and the
+                    // picker binding that must deliver the dismissal).
                     requestedOwner = owner
                     deferredTapID = nil
                 } else {
@@ -172,7 +176,10 @@ public struct TerminalInputSessionState: Equatable, Sendable {
                 }
             } else if actualOwner == owner {
                 actualOwner = nil
-                if requestedOwner == owner {
+                // A focus loss under a system modal is the presentation
+                // stealing the responder, not the user moving on; keep the
+                // request so didDismiss can restore the seat.
+                if requestedOwner == owner, modalPhase == .none {
                     requestedOwner = nil
                 }
             }
@@ -197,17 +204,18 @@ public struct TerminalInputSessionState: Equatable, Sendable {
 
         case .modalWillPresent:
             modalPhase = .willPresent
-            requestedOwner = nil
             deferredTapID = nil
-            if let actualOwner {
-                transition.commands.append(.resign(actualOwner))
-            }
+            // Do NOT resign the active owner, and keep the retained request.
+            // The composer band (and the picker binding that must deliver the
+            // dismissal) is hosted inside the keyboard dock accessory, so a
+            // resign here unmounts that very view: the dismissal never
+            // arrives, the phase wedges at `.presented`, and the dock stays
+            // gone. The presentation covers the keyboard; whether it stays up
+            // underneath is UIKit's call, and a responder the presentation
+            // strips is restored from the retained request at didDismiss.
 
         case .modalDidPresent:
             modalPhase = .presented
-            if let actualOwner {
-                transition.commands.append(.resign(actualOwner))
-            }
 
         case .modalDidDismiss:
             modalPhase = .none

--- a/Packages/iOS/CmuxMobileTerminalKit/Tests/CmuxMobileTerminalKitTests/TerminalInputSessionReducerTests.swift
+++ b/Packages/iOS/CmuxMobileTerminalKit/Tests/CmuxMobileTerminalKitTests/TerminalInputSessionReducerTests.swift
@@ -144,24 +144,48 @@ import Testing
         #expect(state.actualOwner == .composer)
     }
 
-    @Test func photoPickerWillPresentResignsTheCurrentOwner() {
+    @Test func photoPickerPresentationKeepsTheCurrentOwnerSeated() {
+        // The composer band is hosted inside the keyboard dock accessory, so
+        // resigning the owner on presentation unmounts the very view whose
+        // picker binding must deliver the dismissal (wedging the phase at
+        // `.presented` with the dock gone). The owner keeps its seat; a
+        // responder the presentation strips is restored at didDismiss from
+        // the retained request.
         var state = TerminalInputSessionState()
         _ = state.handle(.requestFocus(.composer))
         _ = state.handle(.focusCompleted(owner: .composer, succeeded: true))
 
         let willPresent = state.handle(.modalWillPresent)
         #expect(state.modalPhase == .willPresent)
-        #expect(state.requestedOwner == nil)
+        #expect(state.requestedOwner == .composer)
         #expect(state.actualOwner == .composer)
-        #expect(willPresent.commands == [.resign(.composer)])
-
-        _ = state.handle(.resignCompleted(owner: .composer, succeeded: true))
-        #expect(state.actualOwner == nil)
-        #expect(state.modalPhase == .willPresent)
+        #expect(willPresent.commands.isEmpty)
 
         _ = state.handle(.modalDidPresent)
         #expect(state.modalPhase == .presented)
+        #expect(state.actualOwner == .composer)
+
+        // Undisturbed presentation: dismissal has nothing to restore.
+        let didDismiss = state.handle(.modalDidDismiss)
+        #expect(state.modalPhase == .none)
+        #expect(didDismiss.commands.isEmpty)
+    }
+
+    @Test func photoPickerDismissalRestoresAnOwnerThePresentationStripped() {
+        var state = TerminalInputSessionState()
+        _ = state.handle(.requestFocus(.composer))
+        _ = state.handle(.focusCompleted(owner: .composer, succeeded: true))
+        _ = state.handle(.modalWillPresent)
+        _ = state.handle(.modalDidPresent)
+
+        // The system presentation resigned the field out from under us.
+        _ = state.handle(.responderChanged(owner: .composer, isFirstResponder: false))
         #expect(state.actualOwner == nil)
+        #expect(state.requestedOwner == .composer)
+
+        let didDismiss = state.handle(.modalDidDismiss)
+        #expect(state.modalPhase == .none)
+        #expect(didDismiss.commands == [.focus(.composer)])
     }
 
     @Test func focusRequestedDuringPickerDismissalRunsAtDidDismissBoundary() {
@@ -231,18 +255,24 @@ import Testing
         #expect(mounted.commands == [.focus(.composer)])
     }
 
-    @Test func responderObservationCannotLeaveAnOwnerActiveUnderAModal() {
+    @Test func responderObservationUnderAModalRecordsTheOwnerWithoutResign() {
+        // Same accessory-hosting rationale as presentation: forcing a resign
+        // under a modal unmounts the dock. An owner observed focused while a
+        // modal is up is recorded as fact and left seated; the modal phase
+        // still blocks NEW focus commands until dismissal.
         var state = TerminalInputSessionState()
         _ = state.handle(.modalWillPresent)
         _ = state.handle(.modalDidPresent)
 
-        let unexpected = state.handle(
+        let observed = state.handle(
             .responderChanged(owner: .terminal, isFirstResponder: true)
         )
         #expect(state.actualOwner == .terminal)
-        #expect(unexpected.commands == [.resign(.terminal)])
+        #expect(observed.commands.isEmpty)
 
-        _ = state.handle(.resignCompleted(owner: .terminal, succeeded: true))
-        #expect(state.actualOwner == nil)
+        let didDismiss = state.handle(.modalDidDismiss)
+        #expect(state.modalPhase == .none)
+        #expect(didDismiss.commands.isEmpty)
+        #expect(state.actualOwner == .terminal)
     }
 }

--- a/ios/cmuxUITests/cmuxUITests.swift
+++ b/ios/cmuxUITests/cmuxUITests.swift
@@ -6816,9 +6816,19 @@ final class cmuxUITests: XCTestCase {
                 focusComposerField(in: app),
                 "cycle \(cycle): MobileComposerField must acquire keyboard focus"
             )
+            if cycle == 1 {
+                // The hosted simulator's UI process owns the software-keyboard
+                // visibility command. Emit an unbuffered marker only after the
+                // production composer is first responder so the workflow can
+                // request that initial key plane exactly once. Every subsequent
+                // rise is driven by tapping MobileComposerField in this test.
+                FileHandle.standardError.write(
+                    Data("keyboard-dock-software-keyboard-request\n".utf8)
+                )
+            }
             let keyboardUp = waitForDock(
                 in: app,
-                timeout: 4,
+                timeout: cycle == 1 ? 10 : 4,
                 describe: "cycle \(cycle): composer owns raised software keyboard"
             ) {
                 $0["keyboardUp"] == "1"

--- a/ios/cmuxUITests/cmuxUITests.swift
+++ b/ios/cmuxUITests/cmuxUITests.swift
@@ -6754,7 +6754,10 @@ final class cmuxUITests: XCTestCase {
         let app = try launchConnectedApp(
             port: port,
             assertStatusRows: false,
-            environment: ["CMUX_UITEST_KEYBOARD_DOCK_FRAME_RECORDING": "1"]
+            environment: [
+                "CMUX_MOBILE_SOAK_OPEN_SELECTED_WORKSPACE": "1",
+                "CMUX_UITEST_KEYBOARD_DOCK_FRAME_RECORDING": "1",
+            ]
         )
         defer { app.terminate() }
 

--- a/ios/cmuxUITests/cmuxUITests.swift
+++ b/ios/cmuxUITests/cmuxUITests.swift
@@ -6777,7 +6777,10 @@ final class cmuxUITests: XCTestCase {
         let initialKeyboardSamples = initial["dockFrameKeyboardSamples"].flatMap(Int.init) ?? 0
 
         for cycle in 1...12 {
-            field.tap()
+            XCTAssertTrue(
+                focusTextInput(field, in: app),
+                "cycle \(cycle): MobileComposerField must acquire keyboard focus"
+            )
             let keyboardUp = waitForDock(
                 in: app,
                 timeout: 4,

--- a/ios/cmuxUITests/cmuxUITests.swift
+++ b/ios/cmuxUITests/cmuxUITests.swift
@@ -6587,6 +6587,40 @@ final class cmuxUITests: XCTestCase {
         return dock
     }
 
+    /// Tap the production composer field and use the surface probe as the durable
+    /// focus oracle. SwiftUI may replace the field's accessibility element with its
+    /// backing text view as focus changes, so querying the original `XCUIElement`
+    /// after the tap can itself create a false test failure.
+    @MainActor
+    private func focusComposerField(in app: XCUIApplication) -> Bool {
+        for _ in 0..<4 {
+            let current = surfaceDock(in: app)
+            if current["fieldFocused"] == "1", current["inputActual"] == "composer" {
+                return true
+            }
+
+            let field = app.descendants(matching: .any)[Composer.field]
+            if let frame = waitForUsableFrame(of: field, timeout: 1) {
+                app.coordinate(withNormalizedOffset: .zero)
+                    .withOffset(CGVector(dx: frame.midX, dy: frame.midY))
+                    .tap()
+            } else if field.exists {
+                field.tap()
+            }
+
+            let deadline = Date().addingTimeInterval(1.5)
+            while Date() < deadline {
+                let dock = surfaceDock(in: app)
+                if dock["fieldFocused"] == "1", dock["inputActual"] == "composer" {
+                    return true
+                }
+                RunLoop.current.run(until: Date().addingTimeInterval(0.05))
+            }
+        }
+        let final = surfaceDock(in: app)
+        return final["fieldFocused"] == "1" && final["inputActual"] == "composer"
+    }
+
     /// Assert the structural invariants that hold on the SIMULATOR (which has no
     /// software keyboard, so `keyboardUp`/`proxyFirstResponder` are not reliable
     /// pass/fail signals — see the keyboard-state segregation note). These are the
@@ -6784,7 +6818,7 @@ final class cmuxUITests: XCTestCase {
 
         for cycle in 1...12 {
             XCTAssertTrue(
-                focusTextInput(field, in: app),
+                focusComposerField(in: app),
                 "cycle \(cycle): MobileComposerField must acquire keyboard focus"
             )
             let keyboardUp = waitForDock(

--- a/ios/cmuxUITests/cmuxUITests.swift
+++ b/ios/cmuxUITests/cmuxUITests.swift
@@ -6780,19 +6780,14 @@ final class cmuxUITests: XCTestCase {
     /// than one point from the system-owned input-accessory bottom, or if a toggle
     /// wedges before reaching its opposite state.
     @MainActor
-    func testTerminalKeyboardDockRapidToggleIsPixelAttachedEveryFrame() async throws {
-        let server = try MobileSyncMockHostServer()
-        let port = try await server.start()
-        defer { server.stop() }
-
-        let app = try launchConnectedApp(
-            port: port,
-            assertStatusRows: false,
-            environment: [
-                "CMUX_MOBILE_SOAK_OPEN_SELECTED_WORKSPACE": "1",
-                "CMUX_UITEST_KEYBOARD_DOCK_FRAME_RECORDING": "1",
-            ]
-        )
+    func testTerminalKeyboardDockRapidToggleIsPixelAttachedEveryFrame() throws {
+        // Geometry proof does not require a live transport. Use the existing
+        // deterministic connected-workspace fixture so the test still mounts
+        // the production workspace detail, terminal surface, composer field,
+        // and system input accessory without inheriting loopback pairing timing.
+        let app = launchWorkspaceDetailDelayedTerminalPreviewApp(environment: [
+            "CMUX_UITEST_KEYBOARD_DOCK_FRAME_RECORDING": "1",
+        ])
         defer { app.terminate() }
 
         let surface = app.otherElements["MobileTerminalSurface"]

--- a/ios/cmuxUITests/cmuxUITests.swift
+++ b/ios/cmuxUITests/cmuxUITests.swift
@@ -4521,11 +4521,15 @@ final class cmuxUITests: XCTestCase {
     }
 
     @MainActor
-    private func launchConnectedApp(port: UInt16, assertStatusRows: Bool = true) throws -> XCUIApplication {
+    private func launchConnectedApp(
+        port: UInt16,
+        assertStatusRows: Bool = true,
+        environment: [String: String] = [:]
+    ) throws -> XCUIApplication {
         let attachURL = try attachURL(port: port)
-        let app = launchApp(mockData: true, environment: [
-            "CMUX_UITEST_ATTACH_URL": attachURL.absoluteString,
-        ])
+        var launchEnvironment = environment
+        launchEnvironment["CMUX_UITEST_ATTACH_URL"] = attachURL.absoluteString
+        let app = launchApp(mockData: true, environment: launchEnvironment)
         waitForWorkspaceShell(in: app)
         try openSelectedWorkspaceIfNeeded(app)
         if assertStatusRows {
@@ -6509,6 +6513,8 @@ final class cmuxUITests: XCTestCase {
         static let composeButton = "terminal.inputAccessory.composer"
         /// Toolbar HIDE button (`chevron.down.square`) — suppresses all bottom chrome.
         static let hideButton = "terminal.inputAccessory.hideChrome"
+        /// Keyboard toggle (`chevron.down.square`) — raises / lowers the keyboard.
+        static let keyboardButton = "terminal.inputAccessory.hideKeyboard"
         /// The growing message field inside the composer band.
         static let field = "MobileComposerField"
         /// The paperclip button that presents the system photo picker.
@@ -6728,6 +6734,148 @@ final class cmuxUITests: XCTestCase {
         assertTerminalRenderBottomAttachedToViewport(
             dock,
             context: context,
+            file: file,
+            line: line
+        )
+    }
+
+    /// Drives twelve full software-keyboard up/down cycles through the production
+    /// composer field and accessory toggle. The opt-in surface recorder runs on the
+    /// terminal's existing display link and checks every keyboard-attached frame;
+    /// this test fails if any frame leaves the visible composer/toolbar edge more
+    /// than one point from the system-owned input-accessory bottom, or if a toggle
+    /// wedges before reaching its opposite state.
+    @MainActor
+    func testTerminalKeyboardDockRapidToggleIsPixelAttachedEveryFrame() async throws {
+        let server = try MobileSyncMockHostServer()
+        let port = try await server.start()
+        defer { server.stop() }
+
+        let app = try launchConnectedApp(
+            port: port,
+            environment: ["CMUX_UITEST_KEYBOARD_DOCK_FRAME_RECORDING": "1"]
+        )
+        defer { app.terminate() }
+
+        let surface = app.otherElements["MobileTerminalSurface"]
+        XCTAssertTrue(surface.waitForExistence(timeout: 8))
+        let field = app.descendants(matching: .any)[Composer.field]
+        XCTAssertTrue(waitForHittable(field, timeout: 4))
+        let keyboardButton = app.buttons[Composer.keyboardButton]
+        XCTAssertTrue(keyboardButton.waitForExistence(timeout: 4))
+
+        var evidence: [String] = []
+        defer {
+            let attachment = XCTAttachment(string: evidence.joined(separator: "\n"))
+            attachment.name = "keyboard-dock-frame-evidence"
+            attachment.lifetime = .keepAlways
+            add(attachment)
+        }
+
+        let initial = surfaceDock(in: app)
+        let initialSamples = initial["dockFrameSamples"].flatMap(Int.init) ?? 0
+        let initialKeyboardSamples = initial["dockFrameKeyboardSamples"].flatMap(Int.init) ?? 0
+
+        for cycle in 1...12 {
+            field.tap()
+            let keyboardUp = waitForDock(
+                in: app,
+                timeout: 4,
+                describe: "cycle \(cycle): composer owns raised software keyboard"
+            ) {
+                $0["keyboardUp"] == "1"
+                    && $0["fieldFocused"] == "1"
+                    && $0["inputActual"] == "composer"
+                    && ($0["dockFrameKeyboardSamples"].flatMap(Int.init) ?? 0) > initialKeyboardSamples
+            }
+            guard let softwareKeyboard = waitForSoftwareKeyboardKeyPlane(
+                in: app,
+                minimumOverlap: 120,
+                timeout: 4
+            ) else { return }
+            assertTerminalDockPinnedToSoftwareKeyboard(
+                keyboardUp,
+                surface: surface,
+                keyboard: softwareKeyboard,
+                context: "rapid-toggle cycle \(cycle) keyboard up"
+            )
+            appendDockFrameEvidence(keyboardUp, cycle: cycle, phase: "up", to: &evidence)
+            assertDockFrameRecorderClean(keyboardUp, cycle: cycle, phase: "up")
+
+            XCTAssertTrue(
+                keyboardButton.isHittable,
+                "cycle \(cycle): keyboard toggle must remain hittable before dismissal"
+            )
+            keyboardButton.tap()
+            XCTAssertTrue(
+                waitForKeyboardDismissal(in: app),
+                "cycle \(cycle): software keyboard wedged instead of dismissing"
+            )
+            let keyboardDown = waitForDock(
+                in: app,
+                timeout: 4,
+                describe: "cycle \(cycle): keyboard down without stale composer focus"
+            ) {
+                $0["keyboardUp"] == "0"
+                    && $0["fieldFocused"] == "0"
+                    && $0["inputActual"] == "none"
+            }
+            appendDockFrameEvidence(keyboardDown, cycle: cycle, phase: "down", to: &evidence)
+            assertDockFrameRecorderClean(keyboardDown, cycle: cycle, phase: "down")
+        }
+
+        let final = surfaceDock(in: app)
+        XCTAssertGreaterThanOrEqual(
+            (final["dockFrameSamples"].flatMap(Int.init) ?? 0) - initialSamples,
+            24,
+            "Recorder must inspect multiple display-link frames across 12 complete toggles. dock=\(final)"
+        )
+        XCTAssertGreaterThanOrEqual(
+            (final["dockFrameKeyboardSamples"].flatMap(Int.init) ?? 0) - initialKeyboardSamples,
+            12,
+            "Recorder must observe at least one keyboard-attached frame per rise. dock=\(final)"
+        )
+        XCTAssertEqual(app.state, .runningForeground, "App must remain live after rapid keyboard toggles")
+        assertTerminalRow(0, label: "$ cmux ios status", in: app)
+        assertTerminalRow(1, label: "Mobile Core: connected", in: app)
+    }
+
+    private func appendDockFrameEvidence(
+        _ dock: [String: String],
+        cycle: Int,
+        phase: String,
+        to evidence: inout [String]
+    ) {
+        let keys = [
+            "keyboardUp", "composerMaxY", "toolbarMaxY", "boundsHeight",
+            "dockFrameSamples", "dockFrameKeyboardSamples", "dockFrameDetached",
+            "dockFrameMaxGap", "dockWorstKeyboardUp", "dockWorstComposerMaxY",
+            "dockWorstToolbarMaxY", "dockWorstBoundsHeight", "dockWorstAccessoryBottomY",
+        ]
+        evidence.append(
+            "cycle=\(cycle);phase=\(phase);"
+                + keys.map { "\($0)=\(dock[$0] ?? "missing")" }.joined(separator: ";")
+        )
+    }
+
+    private func assertDockFrameRecorderClean(
+        _ dock: [String: String],
+        cycle: Int,
+        phase: String,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) {
+        XCTAssertEqual(
+            dock["dockFrameDetached"],
+            "0",
+            "cycle \(cycle) \(phase): a display-link frame detached the bars from the keyboard. dock=\(dock)",
+            file: file,
+            line: line
+        )
+        XCTAssertLessThanOrEqual(
+            dock["dockFrameMaxGap"].flatMap(Double.init) ?? .infinity,
+            1,
+            "cycle \(cycle) \(phase): dock exceeded the one-point pixel-alignment budget. dock=\(dock)",
             file: file,
             line: line
         )

--- a/ios/cmuxUITests/cmuxUITests.swift
+++ b/ios/cmuxUITests/cmuxUITests.swift
@@ -6766,7 +6766,9 @@ final class cmuxUITests: XCTestCase {
 
         var evidence: [String] = []
         defer {
-            let attachment = XCTAttachment(string: evidence.joined(separator: "\n"))
+            let report = evidence.joined(separator: "\n")
+            print("keyboard-dock-frame-evidence:\n\(report)")
+            let attachment = XCTAttachment(string: report)
             attachment.name = "keyboard-dock-frame-evidence"
             attachment.lifetime = .keepAlways
             add(attachment)

--- a/ios/cmuxUITests/cmuxUITests.swift
+++ b/ios/cmuxUITests/cmuxUITests.swift
@@ -6753,6 +6753,7 @@ final class cmuxUITests: XCTestCase {
 
         let app = try launchConnectedApp(
             port: port,
+            assertStatusRows: false,
             environment: ["CMUX_UITEST_KEYBOARD_DOCK_FRAME_RECORDING": "1"]
         )
         defer { app.terminate() }
@@ -6841,8 +6842,7 @@ final class cmuxUITests: XCTestCase {
             "Recorder must observe at least one keyboard-attached frame per rise. dock=\(final)"
         )
         XCTAssertEqual(app.state, .runningForeground, "App must remain live after rapid keyboard toggles")
-        assertTerminalRow(0, label: "$ cmux ios status", in: app)
-        assertTerminalRow(1, label: "Mobile Core: connected", in: app)
+        XCTAssertTrue(surface.exists, "Terminal surface must remain mounted after rapid keyboard toggles")
     }
 
     private func appendDockFrameEvidence(

--- a/ios/cmuxUITests/cmuxUITests.swift
+++ b/ios/cmuxUITests/cmuxUITests.swift
@@ -7278,63 +7278,6 @@ final class cmuxUITests: XCTestCase {
         }
     }
 
-    /// Rapid, app-driven keyboard reversals exercise the real responder path
-    /// without XCUI waiting for each animation to become idle. The surface's
-    /// DEBUG display-link probe compares its live viewport edge with an
-    /// independent presentation-layer measurement on every rendered frame.
-    @MainActor
-    func testTerminalKeyboardDockRapidToggleIsPixelAttachedEveryFrame() async throws {
-        let server = try MobileSyncMockHostServer()
-        let port = try await server.start()
-        defer { server.stop() }
-
-        let attachURL = try attachURL(port: port)
-        let app = launchApp(mockData: true, environment: [
-            "CMUX_UITEST_ATTACH_URL": attachURL.absoluteString,
-            "CMUX_MOBILE_SOAK_OPEN_SELECTED_WORKSPACE": "1",
-            "CMUX_UITEST_KEYBOARD_DOCK_RAPID_TOGGLE_COUNT": "10",
-        ])
-        let surface = app.otherElements["MobileTerminalSurface"]
-        XCTAssertTrue(surface.waitForExistence(timeout: 20))
-
-        let deadline = Date().addingTimeInterval(6)
-        var dock = surfaceDock(in: app)
-        while Date() < deadline, dock["dockTraceComplete"] != "1" {
-            RunLoop.current.run(until: Date().addingTimeInterval(0.05))
-            dock = surfaceDock(in: app)
-        }
-
-        let sampleCount = dock["dockTraceSamples"].flatMap(Int.init) ?? -1
-        let motionRange = dock["dockTraceMotionRange"].flatMap(Double.init) ?? -1
-        let maxGap = dock["dockTraceMaxGap"].flatMap(Double.init) ?? .infinity
-        let maxViewportError = dock["dockTraceMaxViewportError"].flatMap(Double.init) ?? .infinity
-        XCTAssertEqual(
-            dock["dockTraceComplete"],
-            "1",
-            "The app-driven rapid-toggle sequence must complete without wedging. dock=\(dock)"
-        )
-        XCTAssertGreaterThanOrEqual(
-            sampleCount,
-            10,
-            "The display-link probe must sample the interrupted animations. dock=\(dock)"
-        )
-        XCTAssertGreaterThanOrEqual(
-            motionRange,
-            120,
-            "The repro must observe real keyboard travel, not only settled endpoints. dock=\(dock)"
-        )
-        XCTAssertLessThanOrEqual(
-            maxGap,
-            1,
-            "The accessory must remain pixel-attached to the keyboard key plane. dock=\(dock)"
-        )
-        XCTAssertLessThanOrEqual(
-            maxViewportError,
-            1,
-            "The live terminal viewport must consume the accessory's true presentation position. dock=\(dock)"
-        )
-    }
-
     @MainActor
     private func waitForKeyboardDismissal(in app: XCUIApplication) -> Bool {
         let expectation = XCTNSPredicateExpectation(

--- a/ios/cmuxUITests/cmuxUITests.swift
+++ b/ios/cmuxUITests/cmuxUITests.swift
@@ -6816,16 +6816,6 @@ final class cmuxUITests: XCTestCase {
                 focusComposerField(in: app),
                 "cycle \(cycle): MobileComposerField must acquire keyboard focus"
             )
-            if cycle == 1 {
-                // The hosted simulator's UI process owns the software-keyboard
-                // visibility command. Emit an unbuffered marker only after the
-                // production composer is first responder so the workflow can
-                // request that initial key plane exactly once. Every subsequent
-                // rise is driven by tapping MobileComposerField in this test.
-                FileHandle.standardError.write(
-                    Data("keyboard-dock-software-keyboard-request\n".utf8)
-                )
-            }
             let keyboardUp = waitForDock(
                 in: app,
                 timeout: cycle == 1 ? 10 : 4,

--- a/ios/cmuxUITests/cmuxUITests.swift
+++ b/ios/cmuxUITests/cmuxUITests.swift
@@ -7279,11 +7279,13 @@ final class cmuxUITests: XCTestCase {
     }
 
     /// Rapid, app-driven keyboard reversals exercise the real responder path
-    /// without XCUI waiting for each animation to become idle. The surface's
-    /// DEBUG display-link probe compares its live viewport edge with an
-    /// independent presentation-layer measurement on every rendered frame.
+    /// without XCUI waiting for each animation to become idle, so transitions
+    /// INTERRUPT each other mid-flight — the wedge the settled-cycle test
+    /// above cannot create. The surface's DEBUG display-link probe compares
+    /// its live viewport edge with an independent presentation-layer
+    /// measurement on every rendered frame.
     @MainActor
-    func testTerminalKeyboardDockRapidToggleIsPixelAttachedEveryFrame() async throws {
+    func testTerminalKeyboardDockInterruptedTogglesStayPixelAttachedEveryFrame() async throws {
         let server = try MobileSyncMockHostServer()
         let port = try await server.start()
         defer { server.stop() }

--- a/ios/cmuxUITests/cmuxUITests.swift
+++ b/ios/cmuxUITests/cmuxUITests.swift
@@ -7278,6 +7278,63 @@ final class cmuxUITests: XCTestCase {
         }
     }
 
+    /// Rapid, app-driven keyboard reversals exercise the real responder path
+    /// without XCUI waiting for each animation to become idle. The surface's
+    /// DEBUG display-link probe compares its live viewport edge with an
+    /// independent presentation-layer measurement on every rendered frame.
+    @MainActor
+    func testTerminalKeyboardDockRapidToggleIsPixelAttachedEveryFrame() async throws {
+        let server = try MobileSyncMockHostServer()
+        let port = try await server.start()
+        defer { server.stop() }
+
+        let attachURL = try attachURL(port: port)
+        let app = launchApp(mockData: true, environment: [
+            "CMUX_UITEST_ATTACH_URL": attachURL.absoluteString,
+            "CMUX_MOBILE_SOAK_OPEN_SELECTED_WORKSPACE": "1",
+            "CMUX_UITEST_KEYBOARD_DOCK_RAPID_TOGGLE_COUNT": "10",
+        ])
+        let surface = app.otherElements["MobileTerminalSurface"]
+        XCTAssertTrue(surface.waitForExistence(timeout: 20))
+
+        let deadline = Date().addingTimeInterval(6)
+        var dock = surfaceDock(in: app)
+        while Date() < deadline, dock["dockTraceComplete"] != "1" {
+            RunLoop.current.run(until: Date().addingTimeInterval(0.05))
+            dock = surfaceDock(in: app)
+        }
+
+        let sampleCount = dock["dockTraceSamples"].flatMap(Int.init) ?? -1
+        let motionRange = dock["dockTraceMotionRange"].flatMap(Double.init) ?? -1
+        let maxGap = dock["dockTraceMaxGap"].flatMap(Double.init) ?? .infinity
+        let maxViewportError = dock["dockTraceMaxViewportError"].flatMap(Double.init) ?? .infinity
+        XCTAssertEqual(
+            dock["dockTraceComplete"],
+            "1",
+            "The app-driven rapid-toggle sequence must complete without wedging. dock=\(dock)"
+        )
+        XCTAssertGreaterThanOrEqual(
+            sampleCount,
+            10,
+            "The display-link probe must sample the interrupted animations. dock=\(dock)"
+        )
+        XCTAssertGreaterThanOrEqual(
+            motionRange,
+            120,
+            "The repro must observe real keyboard travel, not only settled endpoints. dock=\(dock)"
+        )
+        XCTAssertLessThanOrEqual(
+            maxGap,
+            1,
+            "The accessory must remain pixel-attached to the keyboard key plane. dock=\(dock)"
+        )
+        XCTAssertLessThanOrEqual(
+            maxViewportError,
+            1,
+            "The live terminal viewport must consume the accessory's true presentation position. dock=\(dock)"
+        )
+    }
+
     @MainActor
     private func waitForKeyboardDismissal(in app: XCUIApplication) -> Bool {
         let expectation = XCTNSPredicateExpectation(

--- a/ios/cmuxUITests/cmuxUITests.swift
+++ b/ios/cmuxUITests/cmuxUITests.swift
@@ -6756,12 +6756,27 @@ final class cmuxUITests: XCTestCase {
             file: file,
             line: line
         )
-        XCTAssertEqual(
-            Double(surface.frame.minY) + guideTop,
-            Double(keyboard.frame.minY),
-            accuracy: 2,
-            "UIKeyboardLayoutGuide must resolve to the visible keyboard edge for "
-                + "\(context). keyboard=\(keyboard) surface=\(surface.frame) dock=\(dock)",
+        // The guide (and the dock riding it) tops out at the keyboard's FULL
+        // visual edge, which includes the QuickType/prediction strip; the
+        // XCUI key-plane element measures only the key area below that strip.
+        // Assert the dock bottom sits at-or-above the key plane (no keys
+        // occluded) and within one prediction-strip height of it, so the
+        // check pins the geometry without hardcoding the strip's presence.
+        let dockBottomInWindow = Double(surface.frame.minY) + guideTop
+        XCTAssertLessThanOrEqual(
+            dockBottomInWindow,
+            Double(keyboard.frame.minY) + 2,
+            "Dock must not occlude the key plane for \(context). "
+                + "keyboard=\(keyboard) surface=\(surface.frame) dock=\(dock)",
+            file: file,
+            line: line
+        )
+        XCTAssertGreaterThanOrEqual(
+            dockBottomInWindow,
+            Double(keyboard.frame.minY) - 60,
+            "UIKeyboardLayoutGuide must resolve to the visible keyboard edge "
+                + "(key plane, plus at most the prediction strip) for \(context). "
+                + "keyboard=\(keyboard) surface=\(surface.frame) dock=\(dock)",
             file: file,
             line: line
         )

--- a/scripts/iphone-install-queue.sh
+++ b/scripts/iphone-install-queue.sh
@@ -265,7 +265,7 @@ fail_entry() {
 # re-reads enqueued_at; when it changed, the newer build is left queued for the
 # next drain pass instead of being silently deleted or failed.
 drain_entry() {
-  local slug="$1" override_device="$2"
+  local slug="$1" override_device="$2" suppress_launch="${3:-0}"
   local entry="$PENDING_DIR/$slug"
   local meta="$entry/meta.json"
   local app="$entry/cmux.app"
@@ -330,6 +330,18 @@ drain_entry() {
 
   if [[ "$launch" != "1" ]]; then
     log "installed $bundle_id (launch disabled at enqueue)"
+    finish_installed
+    return $?
+  fi
+
+  # A multi-tag backlog must not fight over the phone's screen: each signed
+  # launch foregrounds its app, suspending the previously launched one seconds
+  # after it paired (its stream drops and the user finds it disconnected).
+  # The drain therefore launches ONLY the newest queued build; older ones are
+  # installed fresh but left unlaunched — they sign in and re-pair on their
+  # next manual open with their stored credentials.
+  if [[ "$suppress_launch" == "1" ]]; then
+    log "installed $bundle_id (launch deferred: a newer queued build owns the screen this drain)"
     finish_installed
     return $?
   fi
@@ -408,10 +420,22 @@ cmd_drain() {
   local start now installed_tags="" had_failure=0
   start="$(date +%s)"
   while :; do
-    local slug rc remaining=0
+    local slug rc remaining=0 newest_slug="" newest_stamp="" stamp suppress
+    # Only the most recently enqueued build gets the signed foreground launch
+    # this pass; see drain_entry's suppress_launch comment. Timestamps are
+    # ISO-8601 from this Mac's clock, so lexicographic comparison orders them.
     for slug in $(pending_slugs); do
+      stamp="$(meta_field "$PENDING_DIR/$slug/meta.json" enqueued_at 2>/dev/null || true)"
+      if [[ -n "$stamp" && ( -z "$newest_stamp" || "$stamp" > "$newest_stamp" ) ]]; then
+        newest_stamp="$stamp"
+        newest_slug="$slug"
+      fi
+    done
+    for slug in $(pending_slugs); do
+      suppress=0
+      [[ -n "$newest_slug" && "$slug" != "$newest_slug" ]] && suppress=1
       set +e
-      drain_entry "$slug" "$override_device"
+      drain_entry "$slug" "$override_device" "$suppress"
       rc=$?
       set -e
       case "$rc" in


### PR DESCRIPTION
Rapidly toggling the iOS keyboard could leave the bottom dock (composer band plus toolbar) detached from the keyboard: it popped after the surface frame settled, floated over stale geometry after remount, or lagged the keyboard animation by several frames.

Mechanism: the dock is now a real system keyboard accessory (`inputAccessoryView`), so UIKit owns its attachment to the key plane instead of cmux chasing keyboard notifications. The keyboard floor anchors to the window rather than the terminal surface, the surface frame is pinned across keyboard transitions, the toggle button decides from responder truth instead of a tracked bit, and keyboard visibility (and the toggle glyph) reconcile on remount.

Dogfooding the accessory architecture surfaced three follow-on defects, all fixed here:

1. Focusing the composer field never raised the keyboard (and could collapse a raised one). A SwiftUI `TextField` hosted inside the keyboard accessory takes first responder but UIKit never begins a keyboard presentation. The field is now a UIKit `UITextView` (`MobileComposerTextField`), the Messages pattern, and the band container answers UIKit's responder-chain walk with the shared dock instance so the accessory survives the focus handoff.
2. Closing the photo library left the dock unmounted forever. Presenting used to resign the text owner, which unmounts the accessory-hosted composer band, so the picker's dismissal binding could never deliver and the modal phase wedged. The input-session reducer now keeps the owner seated through a system modal and restores a presentation-stripped responder at dismissal; the surface re-seats its keyboard-down first-responder anchor around the picker lifecycle.
3. The CI stress lane could not see a software keyboard at all. Two causes: the field-focus defect above, plus freshly erased simulators rendering the one-time QuickPath (slide-to-type) introduction where the first key plane would appear. CI now seeds `DidShowContinuousPathIntroduction` inside the booted device via `simctl spawn`, replacing an osascript Cmd-K watcher that repo policy bans and that never actually executed in any run.

Verification harness: an opt-in `KeyboardDockFrameRecorder` rides the terminal's existing display link and measures the gap between the visible dock edge and the system accessory bottom on every frame. `testTerminalKeyboardDockRapidToggleIsPixelAttachedEveryFrame` drives 12 full software-keyboard up/down cycles through the production composer and fails if any frame exceeds a one-point budget, plus unit tests for the frame tracker, transition model, recorder, reducer modal contract, and dock responder wiring. `test-ios.yml` also gains `Class/testMethod` filter shorthand expansion (so a dispatch cannot silently execute zero tests) and failure-time simulator screenshots plus xcresult upload as a diagnostics artifact.

`scripts/iphone-install-queue.sh` also stops multi-tag drains from fighting over the phone's foreground: only the newest queued build gets the signed launch, older ones install unlaunched.

Note: the iOS lanes are currently red on `main` too (`mobile-core-package`, `package-conventions-lint` fail at 6089fa04); this branch's evidence is the filtered stress-lane dispatch.

Dictionary:
- stress lane: the workflow_dispatch run of test-ios.yml filtered to the rapid-toggle test.
- filter shorthand expansion: rewriting `cmuxUITests/testX` to the target-qualified `cmuxUITests/cmuxUITests/testX` xcodebuild requires.
- headless boot: booting a CoreSimulator device without the Simulator.app host attached.
- display link: the per-frame vsync callback the recorder samples on.
- diagnostics artifact: the failure-time screenshot, keyboard prefs dump, and xcresult the job uploads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Large refactor of keyboard/dock layout, first-responder, and modal input-session behavior across the terminal surface and composer; regressions would show as wedged keyboards, missing dock, or broken attach flows.
> 
> **Overview**
> **Rapid keyboard toggles** used to detach the composer/toolbar dock from the software keyboard because cmux chased `keyboardLayoutGuide` and notification-driven layout on the terminal surface. The bottom chrome is now a shared **`KeyboardDockAccessoryView`** returned as **`inputAccessoryView`** from the surface, input proxy, and composer container so UIKit owns dock position; grid reservation still follows a process-wide **`MobileKeyboardFrameTracker`**, and the terminal surface frame is pinned with **`ignoresSafeArea(.container, edges: .bottom)`** so mid-transition conversions stay stable.
> 
> **Composer focus and attachments:** the message field switches from SwiftUI **`TextField`** to UIKit **`MobileComposerTextField`** inside the accessory, and Photos picking moves to an app-window anchor via **`ComposerPhotoPickerBridge`** so presentation/dismissal does not wedge the dock. The input-session reducer keeps the text owner seated through system modals and restores focus after dismissal; the surface re-seats first responder around picker lifecycle.
> 
> **Verification and tooling:** DEBUG **`KeyboardDockFrameRecorder`** plus **`testTerminalKeyboardDockRapidToggleIsPixelAttachedEveryFrame`** (12 up/down cycles, ≤1pt gap); CI seeds simulator keyboard prefs, expands `Class/testMethod` filters for xcodebuild, uploads failure diagnostics, and **`iphone-install-queue.sh`** launches only the newest queued build on multi-tag drains. **`MobileInjectedAttachStartupTests`** is rewritten to the shipped coordinator API so the test plan compiles.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1db0dce435a35c77402cb0a1090009ec47b6f03c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved keyboard dock positioning, resizing, alignment, and transition handling.
  - Added a growing composer field with enhanced focus handling, accessibility, and line limits.
  - Improved photo picker presentation and attachment staging.
- **Bug Fixes**
  - Preserved composer focus while opening and dismissing photo pickers or system modals.
  - Maintained terminal layout and dock clearance during keyboard transitions.
  - Improved reconnect behavior for interrupted mobile attachments.
- **Tests**
  - Added coverage for keyboard alignment, focus restoration, photo-picker flows, and repeated keyboard interactions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->