### PR TITLE
iOS: custom sort for the All Computers workspace list

### DIFF
--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+WorkspaceActions.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+WorkspaceActions.swift
@@ -636,4 +636,40 @@ extension MobileShellComposite {
         )
         workspaceGroups[index].isCollapsed = collapsed
     }
+
+    /// Choose how the aggregated All Computers list orders its rows, on THIS
+    /// device only. Persists via the device-local sort store and rebuilds the
+    /// derived list so the change renders immediately; nothing is sent to a
+    /// Mac (each Mac keeps its own sidebar order).
+    public func setWorkspaceSortMode(_ mode: MobileWorkspaceSortMode) {
+        guard workspaceSortMode != mode else { return }
+        workspaceSortStore.setMode(mode)
+        workspaceSortMode = mode
+        recomputeDerivedWorkspaceState()
+    }
+
+    /// Persist the user's computer order for
+    /// ``MobileWorkspaceSortMode/computerPriority``, highest priority first,
+    /// as Mac device ids. Device-local, like the mode.
+    public func setWorkspaceComputerPriority(_ deviceIDs: [String]) {
+        guard workspaceComputerPriority != deviceIDs else { return }
+        workspaceSortStore.setComputerPriority(deviceIDs)
+        workspaceComputerPriority = deviceIDs
+        recomputeDerivedWorkspaceState()
+    }
+
+    /// The stored computer order expanded with each computer's stored alias
+    /// device ids, so a per-Mac state that reports an alias id still ranks
+    /// with its computer. Aliases follow their representative id directly,
+    /// keeping one physical Mac's entries adjacent in the expanded order.
+    func expandedWorkspaceComputerPriority() -> [String] {
+        var expanded: [String] = []
+        for deviceID in workspaceComputerPriority {
+            expanded.append(deviceID)
+            for alias in pairedMacAliasIDs(for: deviceID) where !expanded.contains(alias) {
+                expanded.append(alias)
+            }
+        }
+        return expanded
+    }
 }

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
@@ -434,6 +434,19 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
     /// Mac, then phone-owned. `@ObservationIgnored` (views read `workspaceGroups`);
     /// injected so tests/previews can pass a suite-scoped `UserDefaults`.
     @ObservationIgnored var groupCollapseStore: MobileWorkspaceGroupCollapseStore
+    /// Device-local sort preference for the aggregated All Computers list
+    /// (mode + user computer order). `@ObservationIgnored`: views read the
+    /// observable ``workspaceSortMode`` / ``workspaceComputerPriority``
+    /// mirrors below; this store only persists. Injected so tests/previews can
+    /// pass a suite-scoped `UserDefaults`.
+    @ObservationIgnored var workspaceSortStore: MobileWorkspaceSortStore
+    /// Observable mirror of ``MobileWorkspaceSortStore/mode``. Change through
+    /// ``setWorkspaceSortMode(_:)`` so persistence and the derived list stay
+    /// in step.
+    public internal(set) var workspaceSortMode: MobileWorkspaceSortMode = .automatic
+    /// Observable mirror of ``MobileWorkspaceSortStore/computerPriority``.
+    /// Change through ``setWorkspaceComputerPriority(_:)``.
+    public internal(set) var workspaceComputerPriority: [String] = []
     /// Device-local task templates used by the iOS task composer.
     @ObservationIgnored public let taskTemplateStore: (any MobileTaskTemplateStoring)?
     /// Mac/provider model responses observed by the task composer.
@@ -1440,6 +1453,7 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         feedbackStampProvider: @escaping @MainActor () -> MobileFeedbackStamp = { MobileShellComposite.emptyFeedbackStamp },
         draftStore: (any TerminalDraftStoring)? = nil,
         groupCollapseStore: MobileWorkspaceGroupCollapseStore = MobileWorkspaceGroupCollapseStore(),
+        workspaceSortStore: MobileWorkspaceSortStore = MobileWorkspaceSortStore(),
         workspaceChangesHintDismissalStore: MobileWorkspaceChangesHintDismissalStore = MobileWorkspaceChangesHintDismissalStore(),
         workspaceChangesSchedulingClock: any Clock<Duration> = ContinuousClock(),
         controlPlaneSchedulingClock: any Clock<Duration> = ContinuousClock(),
@@ -1452,6 +1466,9 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         self.runtime = runtime
         self.draftStore = draftStore
         self.groupCollapseStore = groupCollapseStore
+        self.workspaceSortStore = workspaceSortStore
+        self.workspaceSortMode = workspaceSortStore.mode
+        self.workspaceComputerPriority = workspaceSortStore.computerPriority
         self.workspaceChangesHintDismissalStore = workspaceChangesHintDismissalStore
         self.workspaceChangesSchedulingClock = workspaceChangesSchedulingClock
         self.controlPlaneSchedulingClock = controlPlaneSchedulingClock
@@ -6542,8 +6559,8 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
 
     /// Recompute the derived ``workspaces`` / ``workspaceGroups`` from the per-Mac
     /// source of truth. Pure and cheap; the only place those two are assigned,
-    /// called on any ``workspacesByMac`` or foreground change.
-    private func recomputeDerivedWorkspaceState() {
+    /// called on any ``workspacesByMac``, foreground, or sort-preference change.
+    func recomputeDerivedWorkspaceState() {
         updateStableMacColorSlots(); let previousSelection = selectedWorkspaceID.flatMap { id in
             workspaces.first { $0.id == id }
         }
@@ -6563,7 +6580,10 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         )
         let macIDsInDisplayOrder = workspaceAggregation.orderedMacIDs(
             statesByMac: statesByAggregateKey,
-            foregroundMacDeviceID: foregroundKey
+            foregroundMacDeviceID: foregroundKey,
+            computerPriority: workspaceSortMode == .computerPriority
+                ? expandedWorkspaceComputerPriority()
+                : []
         )
         var derived = workspaceAggregation.derivedWorkspaces(
             statesByMac: statesByAggregateKey,

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
@@ -6578,12 +6578,24 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         let statesByAggregateKey = Dictionary(
             uniqueKeysWithValues: workspacesByMac.map { ($0.key.pairingID, $0.value) }
         )
+        // "Last Opened" recency for the automatic order, keyed by device id.
+        // The pairing's lastSeenAt is the closest device-local record of when
+        // this phone last used that computer; the live foreground check inside
+        // the aggregation still beats it.
+        var lastOpenedByDeviceID: [String: Date] = [:]
+        for mac in pairedMacs {
+            let existing = lastOpenedByDeviceID[mac.macDeviceID]
+            if existing == nil || mac.lastSeenAt > existing! {
+                lastOpenedByDeviceID[mac.macDeviceID] = mac.lastSeenAt
+            }
+        }
         let macIDsInDisplayOrder = workspaceAggregation.orderedMacIDs(
             statesByMac: statesByAggregateKey,
             foregroundMacDeviceID: foregroundKey,
             computerPriority: workspaceSortMode == .computerPriority
                 ? expandedWorkspaceComputerPriority()
-                : []
+                : [],
+            lastOpenedAt: lastOpenedByDeviceID
         )
         var derived = workspaceAggregation.derivedWorkspaces(
             statesByMac: statesByAggregateKey,

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
@@ -2783,6 +2783,13 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
     /// active marker on its own).
     public private(set) var pairedMacs: [MobilePairedMac] = [] {
         didSet {
+            // The derived workspace list reads pairedMacs (Last Opened
+            // recency, per-Mac customization stamping), so a pairing refresh
+            // must rebuild it or the aggregate order goes stale until the next
+            // workspace event.
+            if oldValue != pairedMacs {
+                recomputeDerivedWorkspaceState()
+            }
             guard oldValue.count != pairedMacs.count else { return }
             analytics.setSuperProperties(["paired_mac_count": .int(pairedMacs.count)])
         }

--- a/Packages/iOS/CmuxMobileShellModel/Sources/CmuxMobileShellModel/MobileWorkspaceAggregation.swift
+++ b/Packages/iOS/CmuxMobileShellModel/Sources/CmuxMobileShellModel/MobileWorkspaceAggregation.swift
@@ -11,11 +11,28 @@ public struct MobileWorkspaceAggregation: Sendable {
     /// The aggregate keys in deterministic display order. A key is the
     /// foreground owner key or a pairing/device id for secondaries; sibling
     /// builds of one Mac order deterministically by instance tag.
+    ///
+    /// `computerPriority` lists Mac device ids the user ordered by hand
+    /// (``MobileWorkspaceSortMode/computerPriority``): matching Macs come
+    /// first, in list order, ahead of even the foreground Mac — an explicit
+    /// choice must beat the automatic rule or it is not a choice. Sibling
+    /// builds of one prioritized Mac stay adjacent (same rank, tag tiebreak),
+    /// and Macs not in the list keep the automatic order after the
+    /// prioritized ones. Ids that match no live state are ignored.
     public func orderedMacIDs(
         statesByMac: [String: MacWorkspaceState],
-        foregroundMacDeviceID foregroundKey: String?
+        foregroundMacDeviceID foregroundKey: String?,
+        computerPriority: [String] = []
     ) -> [String] {
-        statesByMac.sorted { lhs, rhs in
+        var priorityRank: [String: Int] = [:]
+        for (index, deviceID) in computerPriority.enumerated()
+            where !deviceID.isEmpty && priorityRank[deviceID] == nil {
+            priorityRank[deviceID] = index
+        }
+        return statesByMac.sorted { lhs, rhs in
+            let lhsRank = priorityRank[lhs.value.macDeviceID] ?? Int.max
+            let rhsRank = priorityRank[rhs.value.macDeviceID] ?? Int.max
+            if lhsRank != rhsRank { return lhsRank < rhsRank }
             let lhsForeground = lhs.key == foregroundKey
             let rhsForeground = rhs.key == foregroundKey
             if lhsForeground != rhsForeground { return lhsForeground }

--- a/Packages/iOS/CmuxMobileShellModel/Sources/CmuxMobileShellModel/MobileWorkspaceAggregation.swift
+++ b/Packages/iOS/CmuxMobileShellModel/Sources/CmuxMobileShellModel/MobileWorkspaceAggregation.swift
@@ -1,4 +1,4 @@
-import Foundation
+public import Foundation
 
 /// Pure derivations from the per-Mac state map to aggregated workspace and group shapes.
 ///
@@ -19,10 +19,15 @@ public struct MobileWorkspaceAggregation: Sendable {
     /// builds of one prioritized Mac stay adjacent (same rank, tag tiebreak),
     /// and Macs not in the list keep the automatic order after the
     /// prioritized ones. Ids that match no live state are ignored.
+    ///
+    /// `lastOpenedAt` (Mac device id → when this device last used that
+    /// computer) drives the automatic "Last Opened" order: foreground first,
+    /// then most recent, with unknown computers alphabetical last.
     public func orderedMacIDs(
         statesByMac: [String: MacWorkspaceState],
         foregroundMacDeviceID foregroundKey: String?,
-        computerPriority: [String] = []
+        computerPriority: [String] = [],
+        lastOpenedAt: [String: Date] = [:]
     ) -> [String] {
         var priorityRank: [String: Int] = [:]
         for (index, deviceID) in computerPriority.enumerated()
@@ -36,6 +41,20 @@ public struct MobileWorkspaceAggregation: Sendable {
             let lhsForeground = lhs.key == foregroundKey
             let rhsForeground = rhs.key == foregroundKey
             if lhsForeground != rhsForeground { return lhsForeground }
+            // "Last Opened": most recently used computers lead; unknown ones
+            // fall through to the name order below. The foreground check above
+            // stays authoritative — the connected Mac is "opened now" even
+            // when its stored timestamp lags.
+            switch (lastOpenedAt[lhs.value.macDeviceID], lastOpenedAt[rhs.value.macDeviceID]) {
+            case let (lhsDate?, rhsDate?) where lhsDate != rhsDate:
+                return lhsDate > rhsDate
+            case (_?, nil):
+                return true
+            case (nil, _?):
+                return false
+            default:
+                break
+            }
             let lhsName = lhs.value.displayName ?? lhs.value.macDeviceID
             let rhsName = rhs.value.displayName ?? rhs.value.macDeviceID
             if lhsName != rhsName { return lhsName.localizedCaseInsensitiveCompare(rhsName) == .orderedAscending }

--- a/Packages/iOS/CmuxMobileShellModel/Sources/CmuxMobileShellModel/MobileWorkspaceRecencyOrder.swift
+++ b/Packages/iOS/CmuxMobileShellModel/Sources/CmuxMobileShellModel/MobileWorkspaceRecencyOrder.swift
@@ -1,0 +1,36 @@
+internal import Foundation
+
+/// Flat, cross-computer presentation order for
+/// ``MobileWorkspaceSortMode/recentActivity``.
+///
+/// This runs at the presentation layer, not in the aggregation: time
+/// interleaving across Macs cannot keep one Mac's group members contiguous, so
+/// the aggregated `workspaces` array keeps its natural order (group sections,
+/// anchors, and move RPCs depend on it) and the list view applies this order to
+/// its flat path only.
+public struct MobileWorkspaceRecencyOrder: Sendable {
+    /// Create a recency-order helper.
+    public init() {}
+
+    /// Pinned rows first (the flat list's standing rule), then most recent
+    /// `lastActivityAt` first. Rows without a timestamp sort last, and every
+    /// tie keeps the incoming order so the list cannot shuffle between
+    /// refreshes of equal payloads.
+    public func displayOrder(_ workspaces: [MobileWorkspacePreview]) -> [MobileWorkspacePreview] {
+        workspaces.enumerated().sorted { lhs, rhs in
+            if lhs.element.isPinned != rhs.element.isPinned {
+                return lhs.element.isPinned
+            }
+            switch (lhs.element.lastActivityAt, rhs.element.lastActivityAt) {
+            case let (lhsDate?, rhsDate?) where lhsDate != rhsDate:
+                return lhsDate > rhsDate
+            case (_?, nil):
+                return true
+            case (nil, _?):
+                return false
+            default:
+                return lhs.offset < rhs.offset
+            }
+        }.map(\.element)
+    }
+}

--- a/Packages/iOS/CmuxMobileShellModel/Sources/CmuxMobileShellModel/MobileWorkspaceSortMode.swift
+++ b/Packages/iOS/CmuxMobileShellModel/Sources/CmuxMobileShellModel/MobileWorkspaceSortMode.swift
@@ -1,0 +1,19 @@
+/// How the aggregated multi-computer ("All Computers") workspace list orders
+/// its rows.
+///
+/// Each Mac only owns its own sidebar order, so the cross-Mac order is a
+/// per-device presentation choice with no shared source of truth. Raw values
+/// are persisted by ``MobileWorkspaceSortStore``.
+public enum MobileWorkspaceSortMode: String, CaseIterable, Codable, Sendable {
+    /// Foreground computer first, remaining computers by display name. Each
+    /// computer's workspaces keep the Mac's own sidebar order. The historical
+    /// default.
+    case automatic
+    /// Computers in the user-chosen ``MobileWorkspaceSortStore/computerPriority``
+    /// order first, remaining computers in `automatic` order. Each computer's
+    /// workspaces keep the Mac's own sidebar order.
+    case computerPriority
+    /// One flat list across every computer, most recent activity first. Group
+    /// sections cannot survive time interleaving, so this mode presents flat.
+    case recentActivity
+}

--- a/Packages/iOS/CmuxMobileShellModel/Sources/CmuxMobileShellModel/MobileWorkspaceSortStore.swift
+++ b/Packages/iOS/CmuxMobileShellModel/Sources/CmuxMobileShellModel/MobileWorkspaceSortStore.swift
@@ -1,0 +1,73 @@
+public import Foundation
+
+/// Device-local sort preference for the aggregated "All Computers" workspace
+/// list, persisted in an injected `UserDefaults`.
+///
+/// The sort is a per-device presentation choice, never sent to a Mac: phones
+/// and Macs may order the same workspaces differently. The backing
+/// `UserDefaults` is injected so the store is testable without touching
+/// `.standard` (mirroring ``MobileWorkspaceGroupCollapseStore``); the app
+/// constructs it at the composition root with `UserDefaults.standard`.
+public struct MobileWorkspaceSortStore: Sendable {
+    /// The defaults key under which the mode + computer order payload is stored.
+    public static let defaultsKey = "dev.cmux.mobile.workspaceList.sort.v1"
+
+    /// The persisted shape. `mode` stays a raw string so a value written by a
+    /// newer build with more modes still decodes here (reading as `.automatic`
+    /// without being rewritten).
+    private struct Payload: Codable {
+        var mode: String
+        var computerPriority: [String]
+    }
+
+    // UserDefaults is Apple-documented thread-safe; OK to hold nonisolated.
+    private nonisolated(unsafe) let defaults: UserDefaults
+    private var payload: Payload
+
+    /// Create a store backed by the given defaults.
+    /// - Parameter defaults: The persistence store. Inject a suite-scoped
+    ///   `UserDefaults` in tests; the app passes `.standard`.
+    public init(defaults: UserDefaults = .standard) {
+        self.defaults = defaults
+        if let data = defaults.data(forKey: Self.defaultsKey),
+           let decoded = try? JSONDecoder().decode(Payload.self, from: data) {
+            payload = decoded
+        } else {
+            payload = Payload(
+                mode: MobileWorkspaceSortMode.automatic.rawValue,
+                computerPriority: []
+            )
+        }
+    }
+
+    /// The persisted sort mode; unknown stored values read as `.automatic`.
+    public var mode: MobileWorkspaceSortMode {
+        MobileWorkspaceSortMode(rawValue: payload.mode) ?? .automatic
+    }
+
+    /// Mac device ids in the user's chosen computer order, highest priority
+    /// first. Applied only while ``mode`` is `.computerPriority`; ids that no
+    /// longer match a live computer are ignored by the aggregation, and kept
+    /// here so a temporarily offline computer retains its slot.
+    public var computerPriority: [String] { payload.computerPriority }
+
+    /// Persist a mode choice. No-op when unchanged.
+    public mutating func setMode(_ mode: MobileWorkspaceSortMode) {
+        guard payload.mode != mode.rawValue else { return }
+        payload.mode = mode.rawValue
+        persist()
+    }
+
+    /// Persist a user computer order. No-op when unchanged.
+    public mutating func setComputerPriority(_ deviceIDs: [String]) {
+        guard payload.computerPriority != deviceIDs else { return }
+        payload.computerPriority = deviceIDs
+        persist()
+    }
+
+    private func persist() {
+        if let data = try? JSONEncoder().encode(payload) {
+            defaults.set(data, forKey: Self.defaultsKey)
+        }
+    }
+}

--- a/Packages/iOS/CmuxMobileShellModel/Tests/CmuxMobileShellModelTests/MobileWorkspaceAggregationTests.swift
+++ b/Packages/iOS/CmuxMobileShellModel/Tests/CmuxMobileShellModelTests/MobileWorkspaceAggregationTests.swift
@@ -342,4 +342,132 @@ import Testing
         #expect(workspaces.map(\.rpcWorkspaceID.rawValue) == ["b1", "a1"])
         #expect(groups.map(\.rpcGroupID.rawValue) == ["group-b", "group-a"])
     }
+
+    @Test func computerPriorityOverridesForegroundAndNameOrder() {
+        let states = [
+            "mac-a": state("mac-a", name: "Alpha", ["a1"]),
+            "mac-b": state("mac-b", name: "Beta", ["b1"]),
+            "mac-c": state("mac-c", name: "Charlie", ["c1"]),
+        ]
+        let ordered = MobileWorkspaceAggregation().orderedMacIDs(
+            statesByMac: states,
+            foregroundMacDeviceID: "mac-a",
+            computerPriority: ["mac-c", "mac-b"]
+        )
+        // The user's explicit order beats both foreground-first and name order;
+        // the unprioritized foreground Mac follows the prioritized ones.
+        #expect(ordered == ["mac-c", "mac-b", "mac-a"])
+    }
+
+    @Test func unprioritizedMacsKeepAutomaticOrderAfterPrioritizedOnes() {
+        let states = [
+            "mac-a": state("mac-a", name: "Alpha", ["a1"]),
+            "mac-b": state("mac-b", name: "Beta", ["b1"]),
+            "mac-c": state("mac-c", name: "Charlie", ["c1"]),
+        ]
+        let ordered = MobileWorkspaceAggregation().orderedMacIDs(
+            statesByMac: states,
+            foregroundMacDeviceID: "mac-c",
+            computerPriority: ["mac-b"]
+        )
+        // mac-b is pinned first; the rest keep foreground-then-name order.
+        #expect(ordered == ["mac-b", "mac-c", "mac-a"])
+    }
+
+    @Test func computerPriorityIgnoresUnknownAndEmptyEntries() {
+        let states = [
+            "mac-a": state("mac-a", name: "Alpha", ["a1"]),
+            "mac-b": state("mac-b", name: "Beta", ["b1"]),
+        ]
+        let ordered = MobileWorkspaceAggregation().orderedMacIDs(
+            statesByMac: states,
+            foregroundMacDeviceID: nil,
+            computerPriority: ["", "gone-mac", "mac-b"]
+        )
+        #expect(ordered == ["mac-b", "mac-a"])
+    }
+
+    @Test func computerPriorityKeepsSiblingBuildsOfOneMacAdjacent() {
+        var nightly = state("mac-a", name: "Alpha", ["a-nightly"])
+        nightly.instanceTag = "nightly"
+        var stable = state("mac-a", name: "Alpha", ["a-stable"])
+        stable.instanceTag = nil
+        let states = [
+            "mac-a\u{1F}nightly": nightly,
+            "mac-a": stable,
+            "mac-b": state("mac-b", name: "Beta", ["b1"]),
+        ]
+        let ordered = MobileWorkspaceAggregation().orderedMacIDs(
+            statesByMac: states,
+            foregroundMacDeviceID: "mac-b",
+            computerPriority: ["mac-a"]
+        )
+        // Both builds of mac-a share one rank and stay adjacent (tag tiebreak),
+        // ahead of the unprioritized foreground Mac.
+        #expect(ordered == ["mac-a", "mac-a\u{1F}nightly", "mac-b"])
+    }
+
+    @Test func emptyComputerPriorityMatchesAutomaticOrder() {
+        let states = [
+            "mac-b": state("mac-b", name: "Beta", ["b1"]),
+            "mac-a": state("mac-a", name: "Alpha", ["a1"]),
+        ]
+        let aggregation = MobileWorkspaceAggregation()
+        let automatic = aggregation.orderedMacIDs(
+            statesByMac: states,
+            foregroundMacDeviceID: "mac-b"
+        )
+        let withEmptyPriority = aggregation.orderedMacIDs(
+            statesByMac: states,
+            foregroundMacDeviceID: "mac-b",
+            computerPriority: []
+        )
+        #expect(automatic == withEmptyPriority)
+    }
+
+    @Test func computerPriorityOrderDrivesWorkspaceAndGroupDerivations() {
+        var macAWorkspace = ws("a1", mac: "mac-a")
+        macAWorkspace.groupID = "group-a"
+        var macBWorkspace = ws("b1", mac: "mac-b")
+        macBWorkspace.groupID = "group-b"
+        let states = [
+            "mac-a": MacWorkspaceState(
+                macDeviceID: "mac-a",
+                displayName: "Alpha",
+                workspaces: [macAWorkspace],
+                groups: [group("group-a", anchor: "a1")],
+                status: .connected
+            ),
+            "mac-b": MacWorkspaceState(
+                macDeviceID: "mac-b",
+                displayName: "Beta",
+                workspaces: [macBWorkspace],
+                groups: [group("group-b", anchor: "b1")],
+                status: .connected
+            ),
+        ]
+        let aggregation = MobileWorkspaceAggregation()
+        let macIDsInDisplayOrder = aggregation.orderedMacIDs(
+            statesByMac: states,
+            foregroundMacDeviceID: "mac-a",
+            computerPriority: ["mac-b"]
+        )
+
+        let workspaces = aggregation.derivedWorkspaces(
+            statesByMac: states,
+            foregroundMacDeviceID: "mac-a",
+            machineColorIndex: machineColorIndex(statesByMac: states),
+            macIDsInDisplayOrder: macIDsInDisplayOrder
+        )
+        let groups = aggregation.derivedGroups(
+            statesByMac: states,
+            foregroundMacDeviceID: "mac-a",
+            macIDsInDisplayOrder: macIDsInDisplayOrder
+        )
+
+        // Workspaces and group sections both follow the prioritized Mac order,
+        // so sections never detach from their members.
+        #expect(workspaces.map(\.rpcWorkspaceID.rawValue) == ["b1", "a1"])
+        #expect(groups.map(\.rpcGroupID.rawValue) == ["group-b", "group-a"])
+    }
 }

--- a/Packages/iOS/CmuxMobileShellModel/Tests/CmuxMobileShellModelTests/MobileWorkspaceAggregationTests.swift
+++ b/Packages/iOS/CmuxMobileShellModel/Tests/CmuxMobileShellModelTests/MobileWorkspaceAggregationTests.swift
@@ -1,3 +1,4 @@
+import Foundation
 import Testing
 @testable import CmuxMobileShellModel
 
@@ -405,6 +406,41 @@ import Testing
         // Both builds of mac-a share one rank and stay adjacent (tag tiebreak),
         // ahead of the unprioritized foreground Mac.
         #expect(ordered == ["mac-a", "mac-a\u{1F}nightly", "mac-b"])
+    }
+
+    @Test func lastOpenedOrdersUnprioritizedMacsByRecencyThenName() {
+        let states = [
+            "mac-a": state("mac-a", name: "Alpha", ["a1"]),
+            "mac-b": state("mac-b", name: "Beta", ["b1"]),
+            "mac-c": state("mac-c", name: "Charlie", ["c1"]),
+            "mac-d": state("mac-d", name: "Delta", ["d1"]),
+        ]
+        let ordered = MobileWorkspaceAggregation().orderedMacIDs(
+            statesByMac: states,
+            foregroundMacDeviceID: "mac-a",
+            lastOpenedAt: [
+                "mac-a": Date(timeIntervalSince1970: 50),
+                "mac-c": Date(timeIntervalSince1970: 300),
+                "mac-b": Date(timeIntervalSince1970: 200),
+            ]
+        )
+        // Foreground still leads even with an older stamp (it is open NOW),
+        // then most recently opened, then never-opened computers by name.
+        #expect(ordered == ["mac-a", "mac-c", "mac-b", "mac-d"])
+    }
+
+    @Test func computerPriorityBeatsLastOpenedRecency() {
+        let states = [
+            "mac-a": state("mac-a", name: "Alpha", ["a1"]),
+            "mac-b": state("mac-b", name: "Beta", ["b1"]),
+        ]
+        let ordered = MobileWorkspaceAggregation().orderedMacIDs(
+            statesByMac: states,
+            foregroundMacDeviceID: nil,
+            computerPriority: ["mac-a"],
+            lastOpenedAt: ["mac-b": Date(timeIntervalSince1970: 500)]
+        )
+        #expect(ordered == ["mac-a", "mac-b"])
     }
 
     @Test func emptyComputerPriorityMatchesAutomaticOrder() {

--- a/Packages/iOS/CmuxMobileShellModel/Tests/CmuxMobileShellModelTests/MobileWorkspaceRecencyOrderTests.swift
+++ b/Packages/iOS/CmuxMobileShellModel/Tests/CmuxMobileShellModelTests/MobileWorkspaceRecencyOrderTests.swift
@@ -1,0 +1,69 @@
+import Foundation
+import Testing
+
+@testable import CmuxMobileShellModel
+
+/// Behavior tests for the `.recentActivity` flat presentation order.
+@Suite struct MobileWorkspaceRecencyOrderTests {
+    private func ws(
+        _ id: String,
+        activityAt: Date? = nil,
+        pinned: Bool = false
+    ) -> MobileWorkspacePreview {
+        var preview = MobileWorkspacePreview(
+            id: .init(rawValue: id),
+            name: id,
+            terminals: []
+        )
+        preview.lastActivityAt = activityAt
+        preview.isPinned = pinned
+        return preview
+    }
+
+    private func at(_ seconds: TimeInterval) -> Date {
+        Date(timeIntervalSince1970: seconds)
+    }
+
+    @Test func mostRecentActivityComesFirstAcrossComputers() {
+        let ordered = MobileWorkspaceRecencyOrder().displayOrder([
+            ws("old", activityAt: at(100)),
+            ws("newest", activityAt: at(300)),
+            ws("middle", activityAt: at(200)),
+        ])
+        #expect(ordered.map(\.id.rawValue) == ["newest", "middle", "old"])
+    }
+
+    @Test func pinnedRowsStayFirstLikeTheFlatList() {
+        let ordered = MobileWorkspaceRecencyOrder().displayOrder([
+            ws("newest", activityAt: at(300)),
+            ws("pinned-old", activityAt: at(100), pinned: true),
+        ])
+        #expect(ordered.map(\.id.rawValue) == ["pinned-old", "newest"])
+    }
+
+    @Test func rowsWithoutTimestampsSortLastKeepingIncomingOrder() {
+        let ordered = MobileWorkspaceRecencyOrder().displayOrder([
+            ws("no-time-1"),
+            ws("recent", activityAt: at(300)),
+            ws("no-time-2"),
+        ])
+        #expect(ordered.map(\.id.rawValue) == ["recent", "no-time-1", "no-time-2"])
+    }
+
+    @Test func equalTimestampsKeepIncomingOrder() {
+        let ordered = MobileWorkspaceRecencyOrder().displayOrder([
+            ws("first", activityAt: at(200)),
+            ws("second", activityAt: at(200)),
+            ws("third", activityAt: at(200)),
+        ])
+        #expect(ordered.map(\.id.rawValue) == ["first", "second", "third"])
+    }
+
+    @Test func pinnedTiesBreakByRecency() {
+        let ordered = MobileWorkspaceRecencyOrder().displayOrder([
+            ws("pinned-old", activityAt: at(100), pinned: true),
+            ws("pinned-new", activityAt: at(300), pinned: true),
+        ])
+        #expect(ordered.map(\.id.rawValue) == ["pinned-new", "pinned-old"])
+    }
+}

--- a/Packages/iOS/CmuxMobileShellModel/Tests/CmuxMobileShellModelTests/MobileWorkspaceSortStoreTests.swift
+++ b/Packages/iOS/CmuxMobileShellModel/Tests/CmuxMobileShellModelTests/MobileWorkspaceSortStoreTests.swift
@@ -1,0 +1,66 @@
+import Foundation
+import Testing
+
+@testable import CmuxMobileShellModel
+
+/// Behavior tests for ``MobileWorkspaceSortStore`` using a suite-scoped
+/// `UserDefaults` so they never touch `UserDefaults.standard`.
+@Suite struct MobileWorkspaceSortStoreTests {
+    private func makeDefaults() -> UserDefaults {
+        let suite = "MobileWorkspaceSortStoreTests.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suite)!
+        defaults.removePersistentDomain(forName: suite)
+        return defaults
+    }
+
+    @Test func freshStoreDefaultsToAutomaticWithNoPriority() {
+        let store = MobileWorkspaceSortStore(defaults: makeDefaults())
+        #expect(store.mode == .automatic)
+        #expect(store.computerPriority.isEmpty)
+    }
+
+    @Test func modeAndPriorityPersistAcrossInstances() {
+        let defaults = makeDefaults()
+        var store = MobileWorkspaceSortStore(defaults: defaults)
+        store.setMode(.computerPriority)
+        store.setComputerPriority(["mac-b", "mac-a"])
+
+        let reloaded = MobileWorkspaceSortStore(defaults: defaults)
+        #expect(reloaded.mode == .computerPriority)
+        #expect(reloaded.computerPriority == ["mac-b", "mac-a"])
+    }
+
+    @Test func corruptPayloadReadsAsDefaults() {
+        let defaults = makeDefaults()
+        defaults.set(Data("not json".utf8), forKey: MobileWorkspaceSortStore.defaultsKey)
+        let store = MobileWorkspaceSortStore(defaults: defaults)
+        #expect(store.mode == .automatic)
+        #expect(store.computerPriority.isEmpty)
+    }
+
+    @Test func unknownFutureModeReadsAsAutomaticWithoutRewriting() throws {
+        let defaults = makeDefaults()
+        let payload = Data(#"{"mode":"holographic","computerPriority":["mac-a"]}"#.utf8)
+        defaults.set(payload, forKey: MobileWorkspaceSortStore.defaultsKey)
+
+        var store = MobileWorkspaceSortStore(defaults: defaults)
+        #expect(store.mode == .automatic)
+        #expect(store.computerPriority == ["mac-a"])
+
+        // A same-value write must not clobber the newer build's stored mode.
+        store.setComputerPriority(["mac-a"])
+        let kept = try #require(defaults.data(forKey: MobileWorkspaceSortStore.defaultsKey))
+        #expect(String(decoding: kept, as: UTF8.self).contains("holographic"))
+    }
+
+    @Test func settingModePreservesPriorityAndViceVersa() {
+        let defaults = makeDefaults()
+        var store = MobileWorkspaceSortStore(defaults: defaults)
+        store.setComputerPriority(["mac-a"])
+        store.setMode(.recentActivity)
+
+        let reloaded = MobileWorkspaceSortStore(defaults: defaults)
+        #expect(reloaded.mode == .recentActivity)
+        #expect(reloaded.computerPriority == ["mac-a"])
+    }
+}

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceComputerOrderSheet.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceComputerOrderSheet.swift
@@ -1,0 +1,74 @@
+#if os(iOS)
+import CmuxMobileSupport
+import SwiftUI
+
+/// The reorder editor for ``MobileWorkspaceSortMode/computerPriority``: a
+/// drag-to-reorder list of the computers visible in the All Computers picker.
+///
+/// The sheet owns a local copy of the order for smooth drags and persists
+/// every committed move immediately (there is no cancel: the menu's mode
+/// picker already switched to Computer Order, so each move is a live,
+/// device-local preference write, matching how the collapse store commits).
+struct WorkspaceComputerOrderSheet: View {
+    /// Computers in their effective display order (stored priority first, then
+    /// the automatic order), one entry per physical Mac.
+    let machines: [WorkspaceFilterMachine]
+    /// Persist the new order, highest priority first, as Mac device ids.
+    let save: ([String]) -> Void
+
+    @Environment(\.dismiss) private var dismiss
+    @State private var orderedMachines: [WorkspaceFilterMachine]
+
+    init(machines: [WorkspaceFilterMachine], save: @escaping ([String]) -> Void) {
+        self.machines = machines
+        self.save = save
+        _orderedMachines = State(initialValue: machines)
+    }
+
+    var body: some View {
+        NavigationStack {
+            List {
+                Section {
+                    ForEach(orderedMachines) { machine in
+                        VStack(alignment: .leading, spacing: 1) {
+                            Text(machine.name)
+                            if let buildLabel = machine.buildLabel {
+                                Text(buildLabel)
+                                    .font(.caption)
+                                    .foregroundStyle(.secondary)
+                            }
+                        }
+                        .accessibilityIdentifier(
+                            "MobileWorkspaceComputerOrderRow-\(machine.macDeviceID)"
+                        )
+                    }
+                    .onMove { source, destination in
+                        orderedMachines.move(fromOffsets: source, toOffset: destination)
+                        save(orderedMachines.map(\.macDeviceID))
+                    }
+                } footer: {
+                    Text(L10n.string(
+                        "mobile.workspaces.sort.order.footer",
+                        defaultValue: "Workspaces keep each computer's own order. Drag computers to choose which come first."
+                    ))
+                }
+            }
+            .environment(\.editMode, .constant(.active))
+            .navigationTitle(L10n.string(
+                "mobile.workspaces.sort.order.title",
+                defaultValue: "Computer Order"
+            ))
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .confirmationAction) {
+                    Button(L10n.string("mobile.common.done", defaultValue: "Done")) {
+                        dismiss()
+                    }
+                    .accessibilityIdentifier("MobileWorkspaceComputerOrderDone")
+                }
+            }
+        }
+        .presentationDetents([.medium, .large])
+    }
+}
+#endif

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListFilterControls.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListFilterControls.swift
@@ -13,9 +13,10 @@ struct WorkspaceListFilterMenu: View, Equatable {
     /// Machines available to filter by. When fewer than two, the machine section
     /// is hidden (nothing to disambiguate).
     let machines: [WorkspaceFilterMachine]
-    /// The All Computers sort mode, or `nil` to hide the sort section (single
-    /// machine scope, previews). Like the machine section, sorting is only
-    /// offered while more than one machine is present.
+    /// The All Computers sort mode, or `nil` to hide the sort section. The
+    /// caller owns the gate (All Computers scope with 2+ known computers,
+    /// counting paired-but-offline ones): a non-nil mode always renders, so a
+    /// wedged or offline secondary Mac cannot hide the control.
     var sortMode: MobileWorkspaceSortMode? = nil
     let actions: WorkspaceListFilterMenuActions
 
@@ -36,7 +37,7 @@ struct WorkspaceListFilterMenu: View, Equatable {
                 }
             }
 
-            if let sortMode, let setSortMode = actions.setSortMode, showsMachineSection {
+            if let sortMode, let setSortMode = actions.setSortMode {
                 Picker(
                     L10n.string("mobile.workspaces.sort", defaultValue: "Sort By"),
                     selection: Binding(get: { sortMode }, set: { setSortMode($0) })

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListFilterControls.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListFilterControls.swift
@@ -13,10 +13,14 @@ struct WorkspaceListFilterMenu: View, Equatable {
     /// Machines available to filter by. When fewer than two, the machine section
     /// is hidden (nothing to disambiguate).
     let machines: [WorkspaceFilterMachine]
+    /// The All Computers sort mode, or `nil` to hide the sort section (single
+    /// machine scope, previews). Like the machine section, sorting is only
+    /// offered while more than one machine is present.
+    var sortMode: MobileWorkspaceSortMode? = nil
     let actions: WorkspaceListFilterMenuActions
 
     nonisolated static func == (lhs: Self, rhs: Self) -> Bool {
-        lhs.filter == rhs.filter && lhs.machines == rhs.machines
+        lhs.filter == rhs.filter && lhs.machines == rhs.machines && lhs.sortMode == rhs.sortMode
     }
 
     private var showsMachineSection: Bool { machines.count > 1 }
@@ -29,6 +33,32 @@ struct WorkspaceListFilterMenu: View, Equatable {
             ) {
                 ForEach(MobileWorkspaceReadStateFilter.allCases, id: \.self) { state in
                     Text(state.displayName).tag(state)
+                }
+            }
+
+            if let sortMode, let setSortMode = actions.setSortMode, showsMachineSection {
+                Picker(
+                    L10n.string("mobile.workspaces.sort", defaultValue: "Sort By"),
+                    selection: Binding(get: { sortMode }, set: { setSortMode($0) })
+                ) {
+                    ForEach(MobileWorkspaceSortMode.allCases, id: \.self) { mode in
+                        Text(mode.displayName).tag(mode)
+                    }
+                }
+                .accessibilityIdentifier("MobileWorkspaceSortPicker")
+                if sortMode == .computerPriority, let editComputerOrder = actions.editComputerOrder {
+                    Button {
+                        editComputerOrder()
+                    } label: {
+                        Label(
+                            L10n.string(
+                                "mobile.workspaces.sort.editOrder",
+                                defaultValue: "Edit Computer Order…"
+                            ),
+                            systemImage: "arrow.up.arrow.down"
+                        )
+                    }
+                    .accessibilityIdentifier("MobileWorkspaceSortEditOrder")
                 }
             }
 
@@ -74,6 +104,20 @@ extension MobileWorkspaceReadStateFilter {
             return L10n.string("mobile.workspaces.filter.all", defaultValue: "All Workspaces")
         case .unread:
             return L10n.string("mobile.workspaces.filter.unread", defaultValue: "Unread")
+        }
+    }
+}
+
+extension MobileWorkspaceSortMode {
+    /// The localized menu title for this All Computers sort mode.
+    var displayName: String {
+        switch self {
+        case .automatic:
+            return L10n.string("mobile.workspaces.sort.automatic", defaultValue: "Automatic")
+        case .computerPriority:
+            return L10n.string("mobile.workspaces.sort.computerOrder", defaultValue: "Computer Order")
+        case .recentActivity:
+            return L10n.string("mobile.workspaces.sort.recentActivity", defaultValue: "Recent Activity")
         }
     }
 }

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListFilterControls.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListFilterControls.swift
@@ -80,13 +80,13 @@ extension MobileWorkspaceReadStateFilter {
 
 extension MobileWorkspaceSortMode {
     /// The localized menu title for this All Computers sort mode. The
-    /// `.automatic` case reads "Connected First" because that is what the
-    /// automatic rule does: the connected computer leads, the rest follow by
-    /// name. The raw value (and persistence) keeps the `automatic` spelling.
+    /// `.automatic` case reads "Last Opened": the connected computer counts as
+    /// opened now, the rest order by when this device last used them. The raw
+    /// value (and persistence) keeps the `automatic` spelling.
     var displayName: String {
         switch self {
         case .automatic:
-            return L10n.string("mobile.workspaces.sort.automatic", defaultValue: "Connected First")
+            return L10n.string("mobile.workspaces.sort.automatic", defaultValue: "Last Opened")
         case .computerPriority:
             return L10n.string("mobile.workspaces.sort.computerOrder", defaultValue: "Computer Order")
         case .recentActivity:

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListFilterControls.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListFilterControls.swift
@@ -79,11 +79,14 @@ extension MobileWorkspaceReadStateFilter {
 }
 
 extension MobileWorkspaceSortMode {
-    /// The localized menu title for this All Computers sort mode.
+    /// The localized menu title for this All Computers sort mode. The
+    /// `.automatic` case reads "Connected First" because that is what the
+    /// automatic rule does: the connected computer leads, the rest follow by
+    /// name. The raw value (and persistence) keeps the `automatic` spelling.
     var displayName: String {
         switch self {
         case .automatic:
-            return L10n.string("mobile.workspaces.sort.automatic", defaultValue: "Automatic")
+            return L10n.string("mobile.workspaces.sort.automatic", defaultValue: "Connected First")
         case .computerPriority:
             return L10n.string("mobile.workspaces.sort.computerOrder", defaultValue: "Computer Order")
         case .recentActivity:

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListFilterControls.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListFilterControls.swift
@@ -13,15 +13,10 @@ struct WorkspaceListFilterMenu: View, Equatable {
     /// Machines available to filter by. When fewer than two, the machine section
     /// is hidden (nothing to disambiguate).
     let machines: [WorkspaceFilterMachine]
-    /// The All Computers sort mode, or `nil` to hide the sort section. The
-    /// caller owns the gate (All Computers scope with 2+ known computers,
-    /// counting paired-but-offline ones): a non-nil mode always renders, so a
-    /// wedged or offline secondary Mac cannot hide the control.
-    var sortMode: MobileWorkspaceSortMode? = nil
     let actions: WorkspaceListFilterMenuActions
 
     nonisolated static func == (lhs: Self, rhs: Self) -> Bool {
-        lhs.filter == rhs.filter && lhs.machines == rhs.machines && lhs.sortMode == rhs.sortMode
+        lhs.filter == rhs.filter && lhs.machines == rhs.machines
     }
 
     private var showsMachineSection: Bool { machines.count > 1 }
@@ -34,32 +29,6 @@ struct WorkspaceListFilterMenu: View, Equatable {
             ) {
                 ForEach(MobileWorkspaceReadStateFilter.allCases, id: \.self) { state in
                     Text(state.displayName).tag(state)
-                }
-            }
-
-            if let sortMode, let setSortMode = actions.setSortMode {
-                Picker(
-                    L10n.string("mobile.workspaces.sort", defaultValue: "Sort By"),
-                    selection: Binding(get: { sortMode }, set: { setSortMode($0) })
-                ) {
-                    ForEach(MobileWorkspaceSortMode.allCases, id: \.self) { mode in
-                        Text(mode.displayName).tag(mode)
-                    }
-                }
-                .accessibilityIdentifier("MobileWorkspaceSortPicker")
-                if sortMode == .computerPriority, let editComputerOrder = actions.editComputerOrder {
-                    Button {
-                        editComputerOrder()
-                    } label: {
-                        Label(
-                            L10n.string(
-                                "mobile.workspaces.sort.editOrder",
-                                defaultValue: "Edit Computer Order…"
-                            ),
-                            systemImage: "arrow.up.arrow.down"
-                        )
-                    }
-                    .accessibilityIdentifier("MobileWorkspaceSortEditOrder")
                 }
             }
 

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListFilterMenuActions.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListFilterMenuActions.swift
@@ -4,4 +4,9 @@ struct WorkspaceListFilterMenuActions {
     let setReadState: (MobileWorkspaceReadStateFilter) -> Void
     let clearMachines: () -> Void
     let toggleMachine: (String) -> Void
+    /// Persist an All Computers sort-mode choice. `nil` hides the sort section.
+    var setSortMode: ((MobileWorkspaceSortMode) -> Void)? = nil
+    /// Present the computer-order editor for
+    /// ``MobileWorkspaceSortMode/computerPriority``.
+    var editComputerOrder: (() -> Void)? = nil
 }

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListFilterMenuActions.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListFilterMenuActions.swift
@@ -4,9 +4,6 @@ struct WorkspaceListFilterMenuActions {
     let setReadState: (MobileWorkspaceReadStateFilter) -> Void
     let clearMachines: () -> Void
     let toggleMachine: (String) -> Void
-    /// Persist an All Computers sort-mode choice. `nil` hides the sort section.
+    /// Persist an All Computers sort-mode choice. `nil` hides the sort tiles.
     var setSortMode: ((MobileWorkspaceSortMode) -> Void)? = nil
-    /// Present the computer-order editor for
-    /// ``MobileWorkspaceSortMode/computerPriority``.
-    var editComputerOrder: (() -> Void)? = nil
 }

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListLayoutPreviewView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListLayoutPreviewView.swift
@@ -102,8 +102,15 @@ public struct WorkspaceListLayoutPreviewView: View {
     @State private var filterState = WorkspaceListFilterState()
     /// Store-free stand-ins for the device-local sort preference, so the
     /// fixture's sort menu and computer-order editor are fully interactive.
-    @State private var fixtureSortMode: MobileWorkspaceSortMode = .automatic
-    @State private var fixtureComputerPriority: [String] = []
+    /// `CMUX_UITEST_WORKSPACE_LIST_PREVIEW_SORT` (a raw mode value) and
+    /// `..._SORT_PRIORITY` (comma-separated Mac device ids) seed them so a
+    /// harness can verify each mode's rendering without driving the menu.
+    @State private var fixtureSortMode: MobileWorkspaceSortMode =
+        ProcessInfo.processInfo.environment["CMUX_UITEST_WORKSPACE_LIST_PREVIEW_SORT"]
+            .flatMap(MobileWorkspaceSortMode.init(rawValue:)) ?? .automatic
+    @State private var fixtureComputerPriority: [String] =
+        ProcessInfo.processInfo.environment["CMUX_UITEST_WORKSPACE_LIST_PREVIEW_SORT_PRIORITY"]
+            .map { $0.split(separator: ",").map(String.init) } ?? []
     // Safety: DEBUG screenshot-only presenter is owned by this preview view and
     // only mutates its fired flag from the SwiftUI task that requests the banner.
     private let notificationPresenter = ScreenshotNotificationPresenter()

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListLayoutPreviewView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListLayoutPreviewView.swift
@@ -100,6 +100,10 @@ public struct WorkspaceListLayoutPreviewView: View {
     @State private var selectedPrimaryTab: MobilePrimaryTab = .workspaces
     @State private var primarySearchCoordinator = MobilePrimarySearchCoordinator()
     @State private var filterState = WorkspaceListFilterState()
+    /// Store-free stand-ins for the device-local sort preference, so the
+    /// fixture's sort menu and computer-order editor are fully interactive.
+    @State private var fixtureSortMode: MobileWorkspaceSortMode = .automatic
+    @State private var fixtureComputerPriority: [String] = []
     // Safety: DEBUG screenshot-only presenter is owned by this preview view and
     // only mutates its fired flag from the SwiftUI task that requests the banner.
     private let notificationPresenter = ScreenshotNotificationPresenter()
@@ -383,9 +387,32 @@ public struct WorkspaceListLayoutPreviewView: View {
         refreshGeneration += 1
     }
 
+    /// The fixture's stand-in for the composite's priority-ordered aggregation:
+    /// a stable partition of the seeded rows by the chosen computer order.
+    /// Group headers follow their members' row positions, so reordering rows
+    /// alone reorders the visible sections exactly like the real derivation.
+    private var fixtureSortedWorkspaces: [MobileWorkspacePreview] {
+        guard fixtureSortMode == .computerPriority, !fixtureComputerPriority.isEmpty else {
+            return model.workspaces
+        }
+        var rank: [String: Int] = [:]
+        for (index, deviceID) in fixtureComputerPriority.enumerated()
+            where rank[deviceID] == nil {
+            rank[deviceID] = index
+        }
+        return model.workspaces.enumerated()
+            .sorted { lhs, rhs in
+                let lhsRank = rank[lhs.element.macDeviceID ?? ""] ?? Int.max
+                let rhsRank = rank[rhs.element.macDeviceID ?? ""] ?? Int.max
+                if lhsRank != rhsRank { return lhsRank < rhsRank }
+                return lhs.offset < rhs.offset
+            }
+            .map(\.element)
+    }
+
     private func workspaceListFixture(searchText: String) -> some View {
         WorkspaceListView(
-            workspaces: model.workspaces,
+            workspaces: fixtureSortedWorkspaces,
             groups: model.groups,
             selectedWorkspaceID: selectedWorkspaceID,
             host: "Visual Mock Mac",
@@ -474,6 +501,10 @@ public struct WorkspaceListLayoutPreviewView: View {
                 }
                 model.groups[index].isCollapsed = isCollapsed
             } : nil,
+            workspaceSortMode: fixtureSortMode,
+            setWorkspaceSortMode: { fixtureSortMode = $0 },
+            workspaceComputerPriority: fixtureComputerPriority,
+            setWorkspaceComputerPriority: { fixtureComputerPriority = $0 },
             filterState: filterState,
             searchText: searchText
         )

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListView+DragDrop.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListView+DragDrop.swift
@@ -18,6 +18,9 @@ extension WorkspaceListView {
             && trimmedQuery.isEmpty
             && filter.readState == .all
             && filter.machines.isEmpty
+            // The recency order is derived from timestamps, so a drag has no
+            // spatial position to send to the Mac.
+            && !appliesRecencySort
             && reorderableWorkspaces.hasSingleKnownWindow
             && (rendersGroupedSections || !filteredWorkspaces.contains(where: \.isPinned))
     }

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListView+Toolbar.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListView+Toolbar.swift
@@ -1,3 +1,4 @@
+import CmuxMobileSupport
 import SwiftUI
 
 extension WorkspaceListView {
@@ -12,10 +13,11 @@ extension WorkspaceListView {
 
     #if os(iOS)
     /// The sort + filter entry point: one toolbar button opening the Mail-style
-    /// view-options card (illustrated sort tiles + filter rows). The icon fills
-    /// while a narrowing filter is active, mirroring Mail.
+    /// view-options card (illustrated sort tiles + read-state rows; computer
+    /// selection stays in its dedicated title picker). The icon fills while a
+    /// narrowing filter is active, mirroring Mail.
     @ViewBuilder
-    func viewOptionsButton(filterMachines: [WorkspaceFilterMachine]) -> some View {
+    func viewOptionsButton() -> some View {
         Button {
             showingViewOptionsPopover = true
         } label: {
@@ -39,9 +41,7 @@ extension WorkspaceListView {
         .popover(isPresented: $showingViewOptionsPopover) {
             WorkspaceListViewOptionsPopover(
                 filter: filter,
-                machines: filterMachines,
                 sortMode: workspaceSortMenuMode,
-                computerPriority: workspaceComputerPriority,
                 orderMachines: computerOrderSheetMachines,
                 saveComputerOrder: setWorkspaceComputerPriority,
                 actions: workspaceListFilterMenuActions
@@ -82,7 +82,7 @@ extension WorkspaceListView {
                                     dismiss: dismissMacUpdateHint
                                 )
                             }
-                            viewOptionsButton(filterMachines: filterMachines)
+                            viewOptionsButton()
                             if canCreateWorkspace {
                                 newWorkspaceButton.equatable()
                             }

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListView+Toolbar.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListView+Toolbar.swift
@@ -6,22 +6,49 @@ extension WorkspaceListView {
             setReadState: { filter.readState = $0 },
             clearMachines: { filter.machines.removeAll() },
             toggleMachine: { filter.toggleMachine($0) },
-            setSortMode: setWorkspaceSortMode == nil ? nil : { mode in
-                setWorkspaceSortMode?(mode)
-                // First-time pick of Computer Order has no stored order yet, so
-                // the mode alone changes nothing; open the editor rather than
-                // leaving a silently inert choice.
-                if mode == .computerPriority,
-                   workspaceComputerPriority.isEmpty,
-                   setWorkspaceComputerPriority != nil {
-                    showingComputerOrderSheet = true
-                }
-            },
-            editComputerOrder: setWorkspaceComputerPriority == nil
-                ? nil
-                : { showingComputerOrderSheet = true }
+            setSortMode: setWorkspaceSortMode
         )
     }
+
+    #if os(iOS)
+    /// The sort + filter entry point: one toolbar button opening the Mail-style
+    /// view-options card (illustrated sort tiles + filter rows). The icon fills
+    /// while a narrowing filter is active, mirroring Mail.
+    @ViewBuilder
+    func viewOptionsButton(filterMachines: [WorkspaceFilterMachine]) -> some View {
+        Button {
+            showingViewOptionsPopover = true
+        } label: {
+            Image(systemName: filter.isActive
+                ? "line.3.horizontal.decrease.circle.fill"
+                : "line.3.horizontal.decrease.circle")
+        }
+        .accessibilityLabel(L10n.string("mobile.workspaces.filter", defaultValue: "Filter"))
+        .accessibilityIdentifier("MobileWorkspaceFilterMenu")
+        .onAppear {
+            // Headless harnesses cannot tap the toolbar; let the layout-preview
+            // fixture open the card at launch for screenshot verification.
+            #if DEBUG
+            if ProcessInfo.processInfo.environment[
+                "CMUX_UITEST_WORKSPACE_LIST_PREVIEW_VIEW_OPTIONS"
+            ] == "1" {
+                showingViewOptionsPopover = true
+            }
+            #endif
+        }
+        .popover(isPresented: $showingViewOptionsPopover) {
+            WorkspaceListViewOptionsPopover(
+                filter: filter,
+                machines: filterMachines,
+                sortMode: workspaceSortMenuMode,
+                computerPriority: workspaceComputerPriority,
+                orderMachines: computerOrderSheetMachines,
+                saveComputerOrder: setWorkspaceComputerPriority,
+                actions: workspaceListFilterMenuActions
+            )
+        }
+    }
+    #endif
 
     @ViewBuilder
     func workspaceListWithToolbar<Content: View>(
@@ -55,13 +82,7 @@ extension WorkspaceListView {
                                     dismiss: dismissMacUpdateHint
                                 )
                             }
-                            WorkspaceListFilterMenu(
-                                filter: filter,
-                                machines: filterMachines,
-                                sortMode: workspaceSortMenuMode,
-                                actions: workspaceListFilterMenuActions
-                            )
-                            .equatable()
+                            viewOptionsButton(filterMachines: filterMachines)
                             if canCreateWorkspace {
                                 newWorkspaceButton.equatable()
                             }

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListView+Toolbar.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListView+Toolbar.swift
@@ -5,7 +5,21 @@ extension WorkspaceListView {
         WorkspaceListFilterMenuActions(
             setReadState: { filter.readState = $0 },
             clearMachines: { filter.machines.removeAll() },
-            toggleMachine: { filter.toggleMachine($0) }
+            toggleMachine: { filter.toggleMachine($0) },
+            setSortMode: setWorkspaceSortMode == nil ? nil : { mode in
+                setWorkspaceSortMode?(mode)
+                // First-time pick of Computer Order has no stored order yet, so
+                // the mode alone changes nothing; open the editor rather than
+                // leaving a silently inert choice.
+                if mode == .computerPriority,
+                   workspaceComputerPriority.isEmpty,
+                   setWorkspaceComputerPriority != nil {
+                    showingComputerOrderSheet = true
+                }
+            },
+            editComputerOrder: setWorkspaceComputerPriority == nil
+                ? nil
+                : { showingComputerOrderSheet = true }
         )
     }
 
@@ -44,6 +58,7 @@ extension WorkspaceListView {
                             WorkspaceListFilterMenu(
                                 filter: filter,
                                 machines: filterMachines,
+                                sortMode: workspaceSortMenuMode,
                                 actions: workspaceListFilterMenuActions
                             )
                             .equatable()

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListView.swift
@@ -238,22 +238,39 @@ struct WorkspaceListView: View {
         }
     }
 
-    /// Computers offered by the computer-order editor, one per physical Mac
-    /// (present machines plus paired-but-offline ones, which keep their slot
-    /// while disconnected), in their effective order: stored priority first,
-    /// then the current display order, so the sheet opens showing exactly what
-    /// the list does.
+    /// Computers offered by the computer-order editor, one per physical Mac,
+    /// in their effective order: stored priority first, then the list's
+    /// current display order. Present computers come straight from the
+    /// aggregated rows (not the filter menu's machine list, which empties
+    /// below its two-machine floor and would drop a singleton or reorder the
+    /// tail); paired-but-offline computers follow, keeping their slot while
+    /// disconnected.
     var computerOrderSheetMachines: [WorkspaceFilterMachine] {
-        var machines = (machineSnapshots ?? liveMachineSnapshots).filterMachines
-        var seenDeviceIDs = Set(machines.map(\.macDeviceID))
         let names = macDisplayNamesByID()
-        for mac in displayPairedMacsForPicker where !mac.macDeviceID.isEmpty {
-            guard seenDeviceIDs.insert(mac.macDeviceID).inserted else { continue }
+        let aliasIndex = macSelectionScope.aliasIndex
+        var machines: [WorkspaceFilterMachine] = []
+        var seenDeviceIDs = Set<String>()
+        for workspace in workspaces {
+            guard let deviceID = workspace.macDeviceID, !deviceID.isEmpty else { continue }
+            let representativeID = aliasIndex.deviceRepresentativeID(for: deviceID)
+            guard seenDeviceIDs.insert(representativeID).inserted else { continue }
             machines.append(WorkspaceFilterMachine(
-                id: mac.macDeviceID,
-                macDeviceID: mac.macDeviceID,
+                id: representativeID,
+                macDeviceID: representativeID,
                 instanceTag: nil,
-                name: names[mac.macDeviceID] ?? mac.resolvedName,
+                name: names[representativeID] ?? names[deviceID]
+                    ?? workspace.macDisplayName ?? representativeID,
+                buildLabel: nil
+            ))
+        }
+        for mac in displayPairedMacsForPicker where !mac.macDeviceID.isEmpty {
+            let representativeID = aliasIndex.deviceRepresentativeID(for: mac.macDeviceID)
+            guard seenDeviceIDs.insert(representativeID).inserted else { continue }
+            machines.append(WorkspaceFilterMachine(
+                id: representativeID,
+                macDeviceID: representativeID,
+                instanceTag: nil,
+                name: names[representativeID] ?? mac.resolvedName,
                 buildLabel: nil
             ))
         }

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListView.swift
@@ -223,11 +223,27 @@ struct WorkspaceListView: View {
         }
     }
 
+    /// Distinct physical computers this device knows about: computers with
+    /// visible workspace rows plus every paired Mac (paired-but-offline
+    /// computers count — the sort preference governs them the moment they
+    /// reconnect, and a wedged secondary connection must not hide the control).
+    var knownComputerDeviceIDs: Set<String> {
+        var ids = Set(
+            (machineSnapshots ?? liveMachineSnapshots).filterMachines.map(\.macDeviceID)
+        )
+        for mac in displayPairedMacsForPicker {
+            ids.insert(mac.macDeviceID)
+        }
+        ids.remove("")
+        return ids
+    }
+
     /// The sort mode the filter menu offers, or `nil` to hide the sort section:
     /// sorting is an All Computers concern, so a single-machine scope (whose
-    /// order is the Mac's own sidebar order) offers none.
+    /// order is the Mac's own sidebar order) offers none, and a device that has
+    /// only ever known one computer has nothing to sort.
     var workspaceSortMenuMode: MobileWorkspaceSortMode? {
-        guard setWorkspaceSortMode != nil else { return nil }
+        guard setWorkspaceSortMode != nil, knownComputerDeviceIDs.count > 1 else { return nil }
         switch visibleMacSelection {
         case .all, .automatic:
             return workspaceSortMode
@@ -236,11 +252,25 @@ struct WorkspaceListView: View {
         }
     }
 
-    /// Computers offered by the computer-order editor, one per physical Mac, in
-    /// their effective order: stored priority first, then the current display
-    /// order, so the sheet opens showing exactly what the list does.
+    /// Computers offered by the computer-order editor, one per physical Mac
+    /// (present machines plus paired-but-offline ones, which keep their slot
+    /// while disconnected), in their effective order: stored priority first,
+    /// then the current display order, so the sheet opens showing exactly what
+    /// the list does.
     var computerOrderSheetMachines: [WorkspaceFilterMachine] {
-        let machines = (machineSnapshots ?? liveMachineSnapshots).filterMachines
+        var machines = (machineSnapshots ?? liveMachineSnapshots).filterMachines
+        var seenDeviceIDs = Set(machines.map(\.macDeviceID))
+        let names = macDisplayNamesByID()
+        for mac in displayPairedMacsForPicker where !mac.macDeviceID.isEmpty {
+            guard seenDeviceIDs.insert(mac.macDeviceID).inserted else { continue }
+            machines.append(WorkspaceFilterMachine(
+                id: mac.macDeviceID,
+                macDeviceID: mac.macDeviceID,
+                instanceTag: nil,
+                name: names[mac.macDeviceID] ?? mac.resolvedName,
+                buildLabel: nil
+            ))
+        }
         var rank: [String: Int] = [:]
         for (index, deviceID) in workspaceComputerPriority.enumerated()
             where rank[deviceID] == nil {

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListView.swift
@@ -106,6 +106,18 @@ struct WorkspaceListView: View {
     var isInitialConnectionLoading = false
     var initialConnectionTimedOut = false
     var retryInitialConnection: (() -> Void)?
+    /// How the aggregated All Computers list orders its rows. Passed as a value
+    /// snapshot so no `@Observable` store crosses the `List` boundary; the
+    /// device-local preference lives on the shell store.
+    var workspaceSortMode: MobileWorkspaceSortMode = .automatic
+    /// Persist a sort-mode choice on this device. `nil` hides the sort menu
+    /// (previews and macOS fallback).
+    var setWorkspaceSortMode: ((MobileWorkspaceSortMode) -> Void)? = nil
+    /// The user's computer order for ``MobileWorkspaceSortMode/computerPriority``,
+    /// highest first, as Mac device ids.
+    var workspaceComputerPriority: [String] = []
+    /// Persist a computer order on this device.
+    var setWorkspaceComputerPriority: (([String]) -> Void)? = nil
     /// Shared across the normal workspace tab and its native search
     /// presentation so filters compose with the active query.
     let filterState: WorkspaceListFilterState
@@ -114,6 +126,8 @@ struct WorkspaceListView: View {
     var searchText = ""
     @State private var showingShortcutsSettings = false
     @State private var showingSettings = false
+    /// Presents the drag-to-reorder computer-order editor from the sort menu.
+    @State var showingComputerOrderSheet = false
     @State private var settingsPairingScannerHandoff = SettingsPairingScannerHandoff()
     @State private var showingDeviceTree = false
     @State private var changesSheetTarget: WorkspaceChangesSheetTarget? = nil
@@ -195,14 +209,63 @@ struct WorkspaceListView: View {
         macTitlePickerPendingSelection != nil
     }
 
+    /// Whether the list presents the recency sort: chosen mode `.recentActivity`
+    /// while the visible scope spans computers (All Computers). A single-Mac
+    /// scope keeps that Mac's own order — the sort exists to make the
+    /// cross-computer order deterministic, not to rewrite one Mac's sidebar.
+    var appliesRecencySort: Bool {
+        guard workspaceSortMode == .recentActivity else { return false }
+        switch visibleMacSelection {
+        case .all, .automatic:
+            return true
+        case .machine:
+            return false
+        }
+    }
+
+    /// The sort mode the filter menu offers, or `nil` to hide the sort section:
+    /// sorting is an All Computers concern, so a single-machine scope (whose
+    /// order is the Mac's own sidebar order) offers none.
+    var workspaceSortMenuMode: MobileWorkspaceSortMode? {
+        guard setWorkspaceSortMode != nil else { return nil }
+        switch visibleMacSelection {
+        case .all, .automatic:
+            return workspaceSortMode
+        case .machine:
+            return nil
+        }
+    }
+
+    /// Computers offered by the computer-order editor, one per physical Mac, in
+    /// their effective order: stored priority first, then the current display
+    /// order, so the sheet opens showing exactly what the list does.
+    var computerOrderSheetMachines: [WorkspaceFilterMachine] {
+        let machines = (machineSnapshots ?? liveMachineSnapshots).filterMachines
+        var rank: [String: Int] = [:]
+        for (index, deviceID) in workspaceComputerPriority.enumerated()
+            where rank[deviceID] == nil {
+            rank[deviceID] = index
+        }
+        return machines.enumerated()
+            .sorted { lhs, rhs in
+                let lhsRank = rank[lhs.element.macDeviceID] ?? Int.max
+                let rhsRank = rank[rhs.element.macDeviceID] ?? Int.max
+                if lhsRank != rhsRank { return lhsRank < rhsRank }
+                return lhs.offset < rhs.offset
+            }
+            .map(\.element)
+    }
+
     /// Groups render from every available Mac payload while unfiltered. Search
     /// and explicit filters flatten the results; selecting All Computers does
-    /// not discard the group structure.
+    /// not discard the group structure. The recency sort interleaves computers
+    /// by time, which no group section can survive, so it also presents flat.
     var rendersGroupedSections: Bool {
         !groups.isEmpty
             && trimmedQuery.isEmpty
             && filter.readState == .all
             && filter.machines.isEmpty
+            && !appliesRecencySort
     }
 
     private func matchesQuery(
@@ -236,6 +299,9 @@ struct WorkspaceListView: View {
                 currentFilter.matches(workspace, parsedMachines: parsedMachines)
                     && matchesQuery(workspace, query: query, groupsByID: groupLookup)
             }
+        }
+        if appliesRecencySort {
+            return MobileWorkspaceRecencyOrder().displayOrder(matches)
         }
         return matches.enumerated()
             .sorted { lhs, rhs in
@@ -436,6 +502,14 @@ struct WorkspaceListView: View {
                     store: store,
                     selectWorkspace: { id in _ = selectWorkspaceFromList(id) },
                     showAddDevice: showAddDevice
+                )
+            }
+        }
+        .sheet(isPresented: $showingComputerOrderSheet) {
+            if let setWorkspaceComputerPriority {
+                WorkspaceComputerOrderSheet(
+                    machines: computerOrderSheetMachines,
+                    save: setWorkspaceComputerPriority
                 )
             }
         }

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListView.swift
@@ -223,27 +223,13 @@ struct WorkspaceListView: View {
         }
     }
 
-    /// Distinct physical computers this device knows about: computers with
-    /// visible workspace rows plus every paired Mac (paired-but-offline
-    /// computers count — the sort preference governs them the moment they
-    /// reconnect, and a wedged secondary connection must not hide the control).
-    var knownComputerDeviceIDs: Set<String> {
-        var ids = Set(
-            (machineSnapshots ?? liveMachineSnapshots).filterMachines.map(\.macDeviceID)
-        )
-        for mac in displayPairedMacsForPicker {
-            ids.insert(mac.macDeviceID)
-        }
-        ids.remove("")
-        return ids
-    }
-
     /// The sort mode the filter menu offers, or `nil` to hide the sort section:
     /// sorting is an All Computers concern, so a single-machine scope (whose
-    /// order is the Mac's own sidebar order) offers none, and a device that has
-    /// only ever known one computer has nothing to sort.
+    /// order is the Mac's own sidebar order) offers none. No computer-count
+    /// gate: the preference is worth setting before a second computer pairs,
+    /// and a wedged or offline secondary connection must not hide the control.
     var workspaceSortMenuMode: MobileWorkspaceSortMode? {
-        guard setWorkspaceSortMode != nil, knownComputerDeviceIDs.count > 1 else { return nil }
+        guard setWorkspaceSortMode != nil else { return nil }
         switch visibleMacSelection {
         case .all, .automatic:
             return workspaceSortMode

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListView.swift
@@ -126,8 +126,8 @@ struct WorkspaceListView: View {
     var searchText = ""
     @State private var showingShortcutsSettings = false
     @State private var showingSettings = false
-    /// Presents the drag-to-reorder computer-order editor from the sort menu.
-    @State var showingComputerOrderSheet = false
+    /// Presents the view-options card (sort tiles + filter rows).
+    @State var showingViewOptionsPopover = false
     @State private var settingsPairingScannerHandoff = SettingsPairingScannerHandoff()
     @State private var showingDeviceTree = false
     @State private var changesSheetTarget: WorkspaceChangesSheetTarget? = nil
@@ -518,14 +518,6 @@ struct WorkspaceListView: View {
                     store: store,
                     selectWorkspace: { id in _ = selectWorkspaceFromList(id) },
                     showAddDevice: showAddDevice
-                )
-            }
-        }
-        .sheet(isPresented: $showingComputerOrderSheet) {
-            if let setWorkspaceComputerPriority {
-                WorkspaceComputerOrderSheet(
-                    machines: computerOrderSheetMachines,
-                    save: setWorkspaceComputerPriority
                 )
             }
         }

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListViewOptionsPopover.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListViewOptionsPopover.swift
@@ -1,0 +1,316 @@
+#if os(iOS)
+import CmuxMobileShellModel
+import CmuxMobileSupport
+import SwiftUI
+
+/// The workspace list's view-options card: Mail-style illustrated sort tiles
+/// on top (each schematic renders what the mode actually does to the list, so
+/// "Computer Order" needs no explanation), then the read-state and machine
+/// filter rows.
+///
+/// A native `Menu` bridges to UIMenu, whose rows only render text plus an
+/// icon-sized image, so graphics this size are impossible there; this is a
+/// popover styled like a menu card instead. Selection does not dismiss: the
+/// list re-sorts live behind the card, which is the whole payoff of the
+/// illustrated tiles.
+struct WorkspaceListViewOptionsPopover: View {
+    let filter: MobileWorkspaceListFilter
+    let machines: [WorkspaceFilterMachine]
+    /// `nil` hides the sort tiles (single-machine scope keeps the Mac's order).
+    let sortMode: MobileWorkspaceSortMode?
+    /// The stored computer order; empty means Computer Order has never been
+    /// configured, so picking that tile auto-opens the editor.
+    var computerPriority: [String] = []
+    /// Computers offered by the order editor, effective order first.
+    var orderMachines: [WorkspaceFilterMachine] = []
+    /// Persist a new computer order. `nil` hides the editor row.
+    var saveComputerOrder: (([String]) -> Void)? = nil
+    let actions: WorkspaceListFilterMenuActions
+
+    /// The order editor presents from the popover itself: a parent-level sheet
+    /// cannot present while this popover owns the presentation slot.
+    @State private var showingOrderEditor = false
+
+    private var showsMachineSection: Bool { machines.count > 1 }
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 0) {
+                if let sortMode, let setSortMode = actions.setSortMode {
+                    sortTiles(selected: sortMode) { picked in
+                        setSortMode(picked)
+                        // First-time pick of Computer Order has no stored order
+                        // yet, so the mode alone changes nothing; open the
+                        // editor rather than leaving a silently inert choice.
+                        if picked == .computerPriority,
+                           computerPriority.isEmpty,
+                           saveComputerOrder != nil {
+                            showingOrderEditor = true
+                        }
+                    }
+                    if sortMode == .computerPriority, saveComputerOrder != nil {
+                        Divider().padding(.horizontal, 14)
+                        row(
+                            title: L10n.string(
+                                "mobile.workspaces.sort.editOrder",
+                                defaultValue: "Edit Computer Order…"
+                            ),
+                            systemImage: "arrow.up.arrow.down",
+                            checked: false
+                        ) {
+                            showingOrderEditor = true
+                        }
+                        .accessibilityIdentifier("MobileWorkspaceSortEditOrder")
+                    }
+                    sectionBreak
+                }
+
+                row(
+                    title: L10n.string("mobile.workspaces.filter.all", defaultValue: "All Workspaces"),
+                    checked: filter.readState == .all
+                ) {
+                    actions.setReadState(.all)
+                }
+                row(
+                    title: L10n.string("mobile.workspaces.filter.unread", defaultValue: "Unread"),
+                    checked: filter.readState == .unread
+                ) {
+                    actions.setReadState(.unread)
+                }
+
+                if showsMachineSection {
+                    sectionBreak
+                    Text(L10n.string("mobile.workspaces.filter.machines", defaultValue: "Machines"))
+                        .font(.footnote)
+                        .foregroundStyle(.secondary)
+                        .padding(.horizontal, 16)
+                        .padding(.top, 8)
+                        .padding(.bottom, 2)
+                    row(
+                        title: L10n.string(
+                            "mobile.workspaces.filter.allMachines",
+                            defaultValue: "All Machines"
+                        ),
+                        checked: filter.machines.isEmpty
+                    ) {
+                        actions.clearMachines()
+                    }
+                    ForEach(machines) { machine in
+                        row(
+                            title: machine.name,
+                            subtitle: machine.buildLabel,
+                            checked: filter.machines.contains(machine.id)
+                        ) {
+                            actions.toggleMachine(machine.id)
+                        }
+                        .accessibilityIdentifier("MobileWorkspaceFilterMachine-\(machine.id)")
+                    }
+                }
+            }
+            .padding(.vertical, 8)
+        }
+        .frame(minWidth: 300, maxWidth: 320)
+        .presentationCompactAdaptation(.popover)
+        .sheet(isPresented: $showingOrderEditor) {
+            if let saveComputerOrder {
+                WorkspaceComputerOrderSheet(
+                    machines: orderMachines,
+                    save: saveComputerOrder
+                )
+            }
+        }
+    }
+
+    private var sectionBreak: some View {
+        Rectangle()
+            .fill(Color(.separator).opacity(0.5))
+            .frame(height: 6)
+            .padding(.vertical, 4)
+    }
+
+    @ViewBuilder
+    private func sortTiles(
+        selected: MobileWorkspaceSortMode,
+        select: @escaping (MobileWorkspaceSortMode) -> Void
+    ) -> some View {
+        HStack(alignment: .top, spacing: 6) {
+            ForEach(MobileWorkspaceSortMode.allCases, id: \.self) { mode in
+                WorkspaceSortModeTile(
+                    mode: mode,
+                    isSelected: mode == selected,
+                    select: { select(mode) }
+                )
+            }
+        }
+        .padding(.horizontal, 12)
+        .padding(.top, 6)
+        .padding(.bottom, 10)
+        .accessibilityIdentifier("MobileWorkspaceSortPicker")
+    }
+
+    @ViewBuilder
+    private func row(
+        title: String,
+        subtitle: String? = nil,
+        systemImage: String? = nil,
+        checked: Bool,
+        action: @escaping () -> Void
+    ) -> some View {
+        Button(action: action) {
+            HStack(spacing: 10) {
+                Image(systemName: "checkmark")
+                    .font(.subheadline.weight(.semibold))
+                    .opacity(checked ? 1 : 0)
+                    .frame(width: 18)
+                VStack(alignment: .leading, spacing: 1) {
+                    Text(title)
+                        .foregroundStyle(.primary)
+                    if let subtitle {
+                        Text(subtitle)
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+                }
+                Spacer(minLength: 0)
+                if let systemImage {
+                    Image(systemName: systemImage)
+                        .foregroundStyle(.secondary)
+                }
+            }
+            .padding(.horizontal, 14)
+            .padding(.vertical, 9)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+    }
+}
+
+/// One illustrated sort-mode choice: a miniature workspace list drawn the way
+/// this mode would render it, the localized label, and a Mail-style radio.
+struct WorkspaceSortModeTile: View {
+    let mode: MobileWorkspaceSortMode
+    let isSelected: Bool
+    let select: () -> Void
+
+    var body: some View {
+        Button(action: select) {
+            VStack(spacing: 6) {
+                WorkspaceSortModeSchematic(mode: mode)
+                    .frame(width: 72, height: 96)
+                    .background(
+                        RoundedRectangle(cornerRadius: 10)
+                            .fill(Color(.secondarySystemGroupedBackground))
+                    )
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 10)
+                            .strokeBorder(
+                                isSelected ? Color.accentColor : Color(.separator),
+                                lineWidth: isSelected ? 2 : 1
+                            )
+                    )
+                Text(mode.displayName)
+                    .font(.caption2)
+                    .lineLimit(2)
+                    .multilineTextAlignment(.center)
+                    .foregroundStyle(.primary)
+                Image(systemName: isSelected ? "checkmark.circle.fill" : "circle")
+                    .font(.body)
+                    .foregroundStyle(isSelected ? Color.accentColor : Color(.tertiaryLabel))
+            }
+            .frame(maxWidth: .infinity)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .accessibilityIdentifier("MobileWorkspaceSortTile-\(mode.rawValue)")
+        .accessibilityAddTraits(isSelected ? .isSelected : [])
+        .accessibilityLabel(mode.displayName)
+    }
+}
+
+/// The miniature list rendering for one sort mode. Two computers are drawn in
+/// distinct tints; the shapes carry the meaning, no text:
+/// - automatic: computer-headed sections, first computer's section leading.
+/// - computerPriority: the same sections with rank badges and drag grips —
+///   the order is yours.
+/// - recentActivity: no sections, one flat run of rows with a clock badge.
+struct WorkspaceSortModeSchematic: View {
+    let mode: MobileWorkspaceSortMode
+
+    private let firstTint = Color.blue
+    private let secondTint = Color.orange
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            switch mode {
+            case .automatic:
+                header(tint: firstTint, symbol: "laptopcomputer")
+                rowBar; rowBar
+                header(tint: secondTint, symbol: "desktopcomputer")
+                rowBar
+            case .computerPriority:
+                header(tint: secondTint, symbol: "desktopcomputer", rank: 1, grip: true)
+                rowBar
+                header(tint: firstTint, symbol: "laptopcomputer", rank: 2, grip: true)
+                rowBar; rowBar
+            case .recentActivity:
+                timedRow(tint: firstTint, width: 0.9)
+                timedRow(tint: secondTint, width: 0.75)
+                timedRow(tint: firstTint, width: 0.85)
+                timedRow(tint: secondTint, width: 0.7)
+                timedRow(tint: firstTint, width: 0.6)
+            }
+        }
+        .padding(8)
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
+    }
+
+    @ViewBuilder
+    private func header(tint: Color, symbol: String, rank: Int? = nil, grip: Bool = false) -> some View {
+        HStack(spacing: 3) {
+            if let rank {
+                Text("\(rank)")
+                    .font(.system(size: 7, weight: .bold))
+                    .foregroundStyle(.white)
+                    .frame(width: 10, height: 10)
+                    .background(Circle().fill(tint))
+            }
+            Image(systemName: symbol)
+                .font(.system(size: 8, weight: .semibold))
+                .foregroundStyle(tint)
+            RoundedRectangle(cornerRadius: 2)
+                .fill(tint.opacity(0.55))
+                .frame(width: 18, height: 5)
+            Spacer(minLength: 0)
+            if grip {
+                Image(systemName: "line.3.horizontal")
+                    .font(.system(size: 7))
+                    .foregroundStyle(.tertiary)
+            }
+        }
+    }
+
+    private var rowBar: some View {
+        RoundedRectangle(cornerRadius: 2)
+            .fill(Color(.tertiarySystemFill))
+            .frame(height: 7)
+            .padding(.leading, 8)
+    }
+
+    @ViewBuilder
+    private func timedRow(tint: Color, width: CGFloat) -> some View {
+        HStack(spacing: 3) {
+            Circle()
+                .fill(tint.opacity(0.8))
+                .frame(width: 5, height: 5)
+            RoundedRectangle(cornerRadius: 2)
+                .fill(Color(.tertiarySystemFill))
+                .frame(height: 7)
+                .frame(maxWidth: .infinity)
+                .scaleEffect(x: width, y: 1, anchor: .leading)
+            Image(systemName: "clock")
+                .font(.system(size: 6))
+                .foregroundStyle(.tertiary)
+        }
+    }
+}
+#endif

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListViewOptionsPopover.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListViewOptionsPopover.swift
@@ -69,6 +69,11 @@ struct WorkspaceListViewOptionsPopover: View {
             .padding(.vertical, 8)
         }
         .frame(minWidth: 300, maxWidth: 320)
+        // The popover inherits the presenting toolbar button's font
+        // environment; pin every row to regular body so nothing renders with
+        // the toolbar's weight. Tile labels re-set their own smaller font.
+        .font(.body)
+        .fontWeight(.regular)
         .presentationCompactAdaptation(.popover)
         .sheet(isPresented: $showingOrderEditor) {
             if let saveComputerOrder {

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListViewOptionsPopover.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListViewOptionsPopover.swift
@@ -15,12 +15,8 @@ import SwiftUI
 /// illustrated tiles.
 struct WorkspaceListViewOptionsPopover: View {
     let filter: MobileWorkspaceListFilter
-    let machines: [WorkspaceFilterMachine]
     /// `nil` hides the sort tiles (single-machine scope keeps the Mac's order).
     let sortMode: MobileWorkspaceSortMode?
-    /// The stored computer order; empty means Computer Order has never been
-    /// configured, so picking that tile auto-opens the editor.
-    var computerPriority: [String] = []
     /// Computers offered by the order editor, effective order first.
     var orderMachines: [WorkspaceFilterMachine] = []
     /// Persist a new computer order. `nil` hides the editor row.
@@ -28,10 +24,10 @@ struct WorkspaceListViewOptionsPopover: View {
     let actions: WorkspaceListFilterMenuActions
 
     /// The order editor presents from the popover itself: a parent-level sheet
-    /// cannot present while this popover owns the presentation slot.
+    /// cannot present while this popover owns the presentation slot. It opens
+    /// only from the explicit row below the tiles — selecting the Computer
+    /// Order tile just selects; no surprise navigation.
     @State private var showingOrderEditor = false
-
-    private var showsMachineSection: Bool { machines.count > 1 }
 
     var body: some View {
         ScrollView {
@@ -39,14 +35,6 @@ struct WorkspaceListViewOptionsPopover: View {
                 if let sortMode, let setSortMode = actions.setSortMode {
                     sortTiles(selected: sortMode) { picked in
                         setSortMode(picked)
-                        // First-time pick of Computer Order has no stored order
-                        // yet, so the mode alone changes nothing; open the
-                        // editor rather than leaving a silently inert choice.
-                        if picked == .computerPriority,
-                           computerPriority.isEmpty,
-                           saveComputerOrder != nil {
-                            showingOrderEditor = true
-                        }
                     }
                     if sortMode == .computerPriority, saveComputerOrder != nil {
                         Divider().padding(.horizontal, 14)
@@ -76,35 +64,6 @@ struct WorkspaceListViewOptionsPopover: View {
                     checked: filter.readState == .unread
                 ) {
                     actions.setReadState(.unread)
-                }
-
-                if showsMachineSection {
-                    sectionBreak
-                    Text(L10n.string("mobile.workspaces.filter.machines", defaultValue: "Machines"))
-                        .font(.footnote)
-                        .foregroundStyle(.secondary)
-                        .padding(.horizontal, 16)
-                        .padding(.top, 8)
-                        .padding(.bottom, 2)
-                    row(
-                        title: L10n.string(
-                            "mobile.workspaces.filter.allMachines",
-                            defaultValue: "All Machines"
-                        ),
-                        checked: filter.machines.isEmpty
-                    ) {
-                        actions.clearMachines()
-                    }
-                    ForEach(machines) { machine in
-                        row(
-                            title: machine.name,
-                            subtitle: machine.buildLabel,
-                            checked: filter.machines.contains(machine.id)
-                        ) {
-                            actions.toggleMachine(machine.id)
-                        }
-                        .accessibilityIdentifier("MobileWorkspaceFilterMachine-\(machine.id)")
-                    }
                 }
             }
             .padding(.vertical, 8)
@@ -159,7 +118,7 @@ struct WorkspaceListViewOptionsPopover: View {
         Button(action: action) {
             HStack(spacing: 10) {
                 Image(systemName: "checkmark")
-                    .font(.subheadline.weight(.semibold))
+                    .font(.subheadline)
                     .opacity(checked ? 1 : 0)
                     .frame(width: 18)
                 VStack(alignment: .leading, spacing: 1) {
@@ -260,7 +219,8 @@ struct WorkspaceSortModeSchematic: View {
                 timedRow(tint: firstTint, width: 0.6)
             }
         }
-        .padding(8)
+        .padding(.vertical, 8)
+        .padding(.horizontal, 12)
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
     }
 

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListViewOptionsPopover.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListViewOptionsPopover.swift
@@ -138,6 +138,7 @@ struct WorkspaceListViewOptionsPopover: View {
                 Spacer(minLength: 0)
                 if let systemImage {
                     Image(systemName: systemImage)
+                        .font(.subheadline)
                         .foregroundStyle(.secondary)
                 }
             }
@@ -231,6 +232,8 @@ struct WorkspaceSortModeSchematic: View {
 
     @ViewBuilder
     private func header(tint: Color, symbol: String, rank: Int? = nil, grip: Bool = false) -> some View {
+        // Rank badges read as part of the miniature content, not the frame, so
+        // they take an extra indent off the tile border.
         HStack(spacing: 3) {
             if let rank {
                 Text("\(rank)")
@@ -238,6 +241,7 @@ struct WorkspaceSortModeSchematic: View {
                     .foregroundStyle(.white)
                     .frame(width: 10, height: 10)
                     .background(Circle().fill(tint))
+                    .padding(.leading, 4)
             }
             Image(systemName: symbol)
                 .font(.system(size: 8, weight: .semibold))

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceShellView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceShellView.swift
@@ -645,6 +645,10 @@ struct WorkspaceShellView: View {
             isInitialConnectionLoading: isInitialConnectionLoading,
             initialConnectionTimedOut: initialConnectionTimedOut,
             retryInitialConnection: retryInitialConnection,
+            workspaceSortMode: store.workspaceSortMode,
+            setWorkspaceSortMode: { store.setWorkspaceSortMode($0) },
+            workspaceComputerPriority: store.workspaceComputerPriority,
+            setWorkspaceComputerPriority: { store.setWorkspaceComputerPriority($0) },
             filterState: workspaceListFilterState,
             searchText: searchText
         )

--- a/Packages/iOS/CmuxMobileShellUI/Tests/CmuxMobileShellUITests/WorkspaceListSortTests.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Tests/CmuxMobileShellUITests/WorkspaceListSortTests.swift
@@ -148,17 +148,26 @@ import Testing
         #expect(view.computerOrderSheetMachines.map(\.macDeviceID).contains("mac-b"))
     }
 
-    @Test func sortMenuHiddenWhenOnlyOneComputerIsKnown() async throws {
-        let store = await shellStore(pairedMacs: [
+    @Test func sortMenuShowsEvenWithOneOrZeroKnownComputers() async throws {
+        // The preference is worth setting before a second computer pairs, and
+        // a count gate would hide the control behind connection state.
+        let oneMacStore = await shellStore(pairedMacs: [
             pairedMac(id: "mac-a", name: "Mac A", lastSeenAt: 20),
         ])
-        let view = workspaceListView(
+        let oneMacView = workspaceListView(
             workspaces: [workspace(id: "a-1", macDeviceID: "mac-a", activityAt: 100)],
-            store: store,
+            store: oneMacStore,
+            workspaceSortMode: .automatic
+        )
+        let emptyStore = await shellStore(pairedMacs: [])
+        let emptyView = workspaceListView(
+            workspaces: [],
+            store: emptyStore,
             workspaceSortMode: .automatic
         )
 
-        #expect(view.workspaceSortMenuMode == nil)
+        #expect(oneMacView.workspaceSortMenuMode == .automatic)
+        #expect(emptyView.workspaceSortMenuMode == .automatic)
     }
 
     @Test func computerOrderSheetListsStoredPriorityFirst() async throws {

--- a/Packages/iOS/CmuxMobileShellUI/Tests/CmuxMobileShellUITests/WorkspaceListSortTests.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Tests/CmuxMobileShellUITests/WorkspaceListSortTests.swift
@@ -129,6 +129,38 @@ import Testing
         #expect(machineView.workspaceSortMenuMode == nil)
     }
 
+    @Test func sortMenuShowsWhenSecondComputerIsPairedButOffline() async throws {
+        // A wedged or offline secondary Mac contributes no workspace rows, but
+        // the user still owns two computers; hiding the sort control would make
+        // it undiscoverable exactly when cross-computer order matters.
+        let store = await shellStore(pairedMacs: [
+            pairedMac(id: "mac-a", name: "Mac A", lastSeenAt: 20),
+            pairedMac(id: "mac-b", name: "Mac B", lastSeenAt: 10),
+        ])
+        let view = workspaceListView(
+            workspaces: [workspace(id: "a-1", macDeviceID: "mac-a", activityAt: 100)],
+            store: store,
+            workspaceSortMode: .automatic
+        )
+
+        #expect(view.workspaceSortMenuMode == .automatic)
+        // The order editor lists the offline computer so it keeps its slot.
+        #expect(view.computerOrderSheetMachines.map(\.macDeviceID).contains("mac-b"))
+    }
+
+    @Test func sortMenuHiddenWhenOnlyOneComputerIsKnown() async throws {
+        let store = await shellStore(pairedMacs: [
+            pairedMac(id: "mac-a", name: "Mac A", lastSeenAt: 20),
+        ])
+        let view = workspaceListView(
+            workspaces: [workspace(id: "a-1", macDeviceID: "mac-a", activityAt: 100)],
+            store: store,
+            workspaceSortMode: .automatic
+        )
+
+        #expect(view.workspaceSortMenuMode == nil)
+    }
+
     @Test func computerOrderSheetListsStoredPriorityFirst() async throws {
         let store = await shellStore(pairedMacs: [
             pairedMac(id: "mac-a", name: "Mac A", lastSeenAt: 20),

--- a/Packages/iOS/CmuxMobileShellUI/Tests/CmuxMobileShellUITests/WorkspaceListSortTests.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Tests/CmuxMobileShellUITests/WorkspaceListSortTests.swift
@@ -1,0 +1,252 @@
+import CMUXMobileCore
+import CmuxMobilePairedMac
+@testable import CmuxMobileShell
+import CmuxMobileShellModel
+import Foundation
+import SwiftUI
+import Testing
+@testable import CmuxMobileShellUI
+
+/// Behavior tests for the All Computers sort: recency flattening/ordering,
+/// single-machine scope exemption, sort-menu gating, and the computer-order
+/// editor's effective order.
+@MainActor
+@Suite struct WorkspaceListSortTests {
+    @Test func recencySortOrdersFlatRowsAcrossComputersByLastActivity() async throws {
+        let store = await shellStore(pairedMacs: [
+            pairedMac(id: "mac-a", name: "Mac A", lastSeenAt: 20),
+            pairedMac(id: "mac-b", name: "Mac B", lastSeenAt: 10),
+        ])
+        let view = workspaceListView(
+            workspaces: [
+                workspace(id: "a-old", macDeviceID: "mac-a", activityAt: 100),
+                workspace(id: "a-new", macDeviceID: "mac-a", activityAt: 300),
+                workspace(id: "b-mid", macDeviceID: "mac-b", activityAt: 200),
+            ],
+            store: store,
+            workspaceSortMode: .recentActivity
+        )
+
+        #expect(view.appliesRecencySort)
+        #expect(view.filteredWorkspaces.map(\.id.rawValue) == ["a-new", "b-mid", "a-old"])
+    }
+
+    @Test func recencySortFlattensGroupedSections() async throws {
+        let store = await shellStore(pairedMacs: [
+            pairedMac(id: "mac-a", name: "Mac A", lastSeenAt: 20),
+            pairedMac(id: "mac-b", name: "Mac B", lastSeenAt: 10),
+        ])
+        var grouped = workspace(id: "a-1", macDeviceID: "mac-a", activityAt: 100)
+        grouped.groupID = "group-a"
+        let groups = [MobileWorkspaceGroupPreview(
+            id: "group-a",
+            macDeviceID: "mac-a",
+            name: "Group A",
+            anchorWorkspaceID: grouped.id
+        )]
+
+        let automaticView = workspaceListView(
+            workspaces: [grouped],
+            groups: groups,
+            store: store,
+            workspaceSortMode: .automatic
+        )
+        let recencyView = workspaceListView(
+            workspaces: [grouped],
+            groups: groups,
+            store: store,
+            workspaceSortMode: .recentActivity
+        )
+
+        #expect(automaticView.rendersGroupedSections)
+        #expect(!recencyView.rendersGroupedSections)
+    }
+
+    @Test func recencySortDoesNotApplyToSingleMachineScope() async throws {
+        let store = await shellStore(pairedMacs: [
+            pairedMac(id: "mac-a", name: "Mac A", lastSeenAt: 20),
+            pairedMac(id: "mac-b", name: "Mac B", lastSeenAt: 10),
+        ])
+        let view = workspaceListView(
+            workspaces: [
+                workspace(id: "a-old", macDeviceID: "mac-a", activityAt: 100),
+                workspace(id: "a-new", macDeviceID: "mac-a", activityAt: 300),
+                workspace(id: "b-mid", macDeviceID: "mac-b", activityAt: 200),
+            ],
+            store: store,
+            macSelection: binding(initialValue: .machine("mac-a")),
+            workspaceSortMode: .recentActivity
+        )
+
+        // A single Mac's own sidebar order stays authoritative.
+        #expect(!view.appliesRecencySort)
+        #expect(view.filteredWorkspaces.map(\.id.rawValue) == ["a-old", "a-new"])
+    }
+
+    @Test func recencySortDisablesRowReorder() async throws {
+        let store = await shellStore(pairedMacs: [
+            pairedMac(id: "mac-a", name: "Mac A", lastSeenAt: 20),
+            pairedMac(id: "mac-b", name: "Mac B", lastSeenAt: 10),
+        ])
+        let view = workspaceListView(
+            workspaces: [
+                workspace(id: "a-1", macDeviceID: "mac-a", activityAt: 100),
+                workspace(id: "b-1", macDeviceID: "mac-b", activityAt: 200),
+            ],
+            store: store,
+            moveWorkspace: { _, _, _, _ in true },
+            workspaceSortMode: .recentActivity
+        )
+
+        // The recency order is derived from timestamps; a drag has no spatial
+        // destination to send, so reorder must be off regardless of other gates.
+        #expect(!view.enablesWorkspaceReorder)
+    }
+
+    @Test func sortMenuOffersModesOnlyInAllComputersScope() async throws {
+        let store = await shellStore(pairedMacs: [
+            pairedMac(id: "mac-a", name: "Mac A", lastSeenAt: 20),
+            pairedMac(id: "mac-b", name: "Mac B", lastSeenAt: 10),
+        ])
+        let workspaces = [
+            workspace(id: "a-1", macDeviceID: "mac-a", activityAt: 100),
+            workspace(id: "b-1", macDeviceID: "mac-b", activityAt: 200),
+        ]
+
+        let allView = workspaceListView(
+            workspaces: workspaces,
+            store: store,
+            workspaceSortMode: .recentActivity
+        )
+        let machineView = workspaceListView(
+            workspaces: workspaces,
+            store: store,
+            macSelection: binding(initialValue: .machine("mac-a")),
+            workspaceSortMode: .recentActivity
+        )
+
+        #expect(allView.workspaceSortMenuMode == .recentActivity)
+        #expect(machineView.workspaceSortMenuMode == nil)
+    }
+
+    @Test func computerOrderSheetListsStoredPriorityFirst() async throws {
+        let store = await shellStore(pairedMacs: [
+            pairedMac(id: "mac-a", name: "Mac A", lastSeenAt: 20),
+            pairedMac(id: "mac-b", name: "Mac B", lastSeenAt: 10),
+            pairedMac(id: "mac-c", name: "Mac C", lastSeenAt: 5),
+        ])
+        let view = workspaceListView(
+            workspaces: [
+                workspace(id: "a-1", macDeviceID: "mac-a", activityAt: 100),
+                workspace(id: "b-1", macDeviceID: "mac-b", activityAt: 200),
+                workspace(id: "c-1", macDeviceID: "mac-c", activityAt: 300),
+            ],
+            store: store,
+            workspaceSortMode: .computerPriority,
+            workspaceComputerPriority: ["mac-c", "mac-a"]
+        )
+
+        let deviceIDs = view.computerOrderSheetMachines.map(\.macDeviceID)
+        #expect(deviceIDs.first == "mac-c")
+        #expect(deviceIDs.count == 3)
+        let cIndex = try #require(deviceIDs.firstIndex(of: "mac-c"))
+        let aIndex = try #require(deviceIDs.firstIndex(of: "mac-a"))
+        let bIndex = try #require(deviceIDs.firstIndex(of: "mac-b"))
+        #expect(cIndex < aIndex && aIndex < bIndex)
+    }
+
+    private func workspaceListView(
+        workspaces: [MobileWorkspacePreview],
+        groups: [MobileWorkspaceGroupPreview] = [],
+        store: CMUXMobileShellStore,
+        macSelection: Binding<WorkspaceMacSelection>? = nil,
+        moveWorkspace: ((
+            MobileWorkspacePreview.ID,
+            MobileWorkspaceGroupPreview.ID?,
+            MobileWorkspacePreview.ID?,
+            Bool
+        ) async -> Bool)? = nil,
+        workspaceSortMode: MobileWorkspaceSortMode = .automatic,
+        workspaceComputerPriority: [String] = []
+    ) -> WorkspaceListView {
+        WorkspaceListView(
+            workspaces: workspaces,
+            groups: groups,
+            selectedWorkspaceID: nil,
+            host: "Test Mac",
+            connectionStatus: .unavailable,
+            navigationStyle: .push,
+            wrapWorkspaceTitles: false,
+            selectWorkspace: { _ in },
+            createWorkspace: {},
+            macSelection: macSelection ?? binding(initialValue: .all),
+            store: store,
+            moveWorkspace: moveWorkspace,
+            workspaceSortMode: workspaceSortMode,
+            setWorkspaceSortMode: { _ in },
+            workspaceComputerPriority: workspaceComputerPriority,
+            setWorkspaceComputerPriority: { _ in },
+            filterState: WorkspaceListFilterState(),
+            searchText: ""
+        )
+    }
+
+    private func binding(initialValue: WorkspaceMacSelection) -> Binding<WorkspaceMacSelection> {
+        var value = initialValue
+        return Binding(
+            get: { value },
+            set: { value = $0 }
+        )
+    }
+
+    private func shellStore(pairedMacs: [MobilePairedMac]) async -> CMUXMobileShellStore {
+        let suiteName = "WorkspaceListSortTests-\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName) ?? .standard
+        let store = MobileShellComposite(
+            isSignedIn: true,
+            connectionState: .disconnected,
+            pairedMacStore: WorkspaceMacSelectionPairedMacStore(pairedMacs),
+            clientIDRepository: MobileClientIDRepository(defaults: defaults),
+            identityProvider: WorkspaceMacSelectionIdentityProvider(userID: "user-1"),
+            teamIDProvider: { "team-a" },
+            pairingHintDefaults: defaults,
+            multiMacAggregationDefaults: defaults,
+            groupCollapseStore: MobileWorkspaceGroupCollapseStore(defaults: defaults),
+            workspaceSortStore: MobileWorkspaceSortStore(defaults: defaults)
+        )
+        await store.loadPairedMacs()
+        return store
+    }
+
+    private func workspace(
+        id: String,
+        macDeviceID: String,
+        activityAt: TimeInterval
+    ) -> MobileWorkspacePreview {
+        var preview = MobileWorkspacePreview(
+            id: .init(rawValue: id),
+            macDeviceID: macDeviceID,
+            name: id,
+            terminals: []
+        )
+        preview.lastActivityAt = Date(timeIntervalSince1970: activityAt)
+        return preview
+    }
+
+    private func pairedMac(
+        id: String,
+        name: String,
+        lastSeenAt: TimeInterval
+    ) -> MobilePairedMac {
+        MobilePairedMac(
+            macDeviceID: id,
+            displayName: name,
+            routes: [],
+            createdAt: Date(timeIntervalSince1970: 0),
+            lastSeenAt: Date(timeIntervalSince1970: lastSeenAt),
+            isActive: false,
+            stackUserID: "user-1",
+            teamID: "team-a"
+        )
+    }
+}

--- a/ios/cmux/Resources/Localizable.xcstrings
+++ b/ios/cmux/Resources/Localizable.xcstrings
@@ -13638,6 +13638,125 @@
         }
       }
     },
+    "mobile.workspaces.sort": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sort By"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "並べ替え"
+          }
+        }
+      }
+    },
+    "mobile.workspaces.sort.automatic": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Automatic"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "自動"
+          }
+        }
+      }
+    },
+    "mobile.workspaces.sort.computerOrder": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Computer Order"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "コンピュータの順序"
+          }
+        }
+      }
+    },
+    "mobile.workspaces.sort.editOrder": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Edit Computer Order…"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "コンピュータの順序を編集…"
+          }
+        }
+      }
+    },
+    "mobile.workspaces.sort.order.footer": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Workspaces keep each computer's own order. Drag computers to choose which come first."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ワークスペースは各コンピュータ内の順序を保ちます。コンピュータをドラッグして表示順を選べます。"
+          }
+        }
+      }
+    },
+    "mobile.workspaces.sort.order.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Computer Order"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "コンピュータの順序"
+          }
+        }
+      }
+    },
+    "mobile.workspaces.sort.recentActivity": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Recent Activity"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "最近のアクティビティ"
+          }
+        }
+      }
+    },
     "mobile.workspaces.search.placeholder": {
       "extractionState": "manual",
       "localizations": {

--- a/ios/cmux/Resources/Localizable.xcstrings
+++ b/ios/cmux/Resources/Localizable.xcstrings
@@ -13661,13 +13661,13 @@
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "Automatic"
+            "value": "Connected First"
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "自動"
+            "value": "接続中を先頭に"
           }
         }
       }

--- a/ios/cmux/Resources/Localizable.xcstrings
+++ b/ios/cmux/Resources/Localizable.xcstrings
@@ -13661,13 +13661,13 @@
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "Connected First"
+            "value": "Last Opened"
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "接続中を先頭に"
+            "value": "最近開いた順"
           }
         }
       }


### PR DESCRIPTION
Workspaces from different computers have no deterministic cross-Mac ordering of their own (each Mac only owns its sidebar order), so this makes the aggregate order a device-local, user-controlled choice. A new **Sort By** section in the workspace-list filter menu (All Computers scope only, 2+ computers) offers three modes:

- **Automatic** — foreground computer first, then name. The old behavior, still the default.
- **Computer Order** — computers in a user-dragged priority order (new reorder sheet, auto-opens on first pick so the mode is never silently inert); each computer's workspaces keep the Mac's own sidebar order, and prioritized computers rank ahead of even the foreground Mac. Sibling builds of one Mac stay adjacent, offline computers keep their slot.
- **Recent Activity** — one flat list across every computer, latest `lastActivityAt` first, pinned rows first, stable ties.

Mechanism: Computer Order runs inside `MobileWorkspaceAggregation` through the `macIDsInDisplayOrder` seam #9509 added, so group sections and their member rows reorder together and aggregate→Mac-local RPC translation is untouched. Recent Activity runs at the presentation layer only (`MobileWorkspaceRecencyOrder`), because time interleaving across Macs cannot keep one Mac's group members contiguous; it presents flat (like search/filter already do) and disables drag reorder, since a timestamp-derived order has no spatial move to send. The preference persists device-locally in `MobileWorkspaceSortStore` (injected `UserDefaults`, mirroring the group-collapse store) and never syncs to a Mac. A single-machine scope is unaffected: its order stays the Mac's own sidebar order.

Localization audit: new strings `mobile.workspaces.sort`(.automatic/.computerOrder/.recentActivity/.editOrder/.order.title/.order.footer) added en+ja; the sheet's Done button reuses `mobile.common.done`.

Tests: aggregation priority ordering (override-foreground, unknown/empty ids, sibling-build adjacency, group-follows-workspace), sort-store persistence (corrupt payload, unknown future mode preserved), recency order (pinned-first, nil-timestamp-last, stable ties) in `CmuxMobileShellModelTests`; scope gating, grouped-section flattening, reorder disable, and sheet ordering in `CmuxMobileShellUITests`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/9828"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788730410&installation_model_id=21920&pr_number=9828&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F9828&signature=db1a56195a0369009dcb22969b63976e8f1a8ac5fa79e3e403947240736f0966"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-layer and device-local UserDefaults preferences with broad test coverage; no Mac RPC or auth changes. Main risk is list-order edge cases (offline Macs, alias IDs, grouped vs flat modes).
> 
> **Overview**
> Adds **device-local sorting** for the aggregated All Computers workspace list, with preferences stored in `MobileWorkspaceSortStore` and never synced to Macs.
> 
> **Three modes:** **Last Opened** (default `automatic`—connected Mac first, then `lastSeenAt` recency), **Computer Order** (user-ranked Macs via drag sheet; aggregation honors priority ahead of foreground), and **Recent Activity** (flat cross-Mac list by `lastActivityAt`, pinned first).
> 
> **UI:** The workspace filter toolbar control opens a **view-options popover** with illustrated sort tiles plus read-state filters; Computer Order exposes **Edit Computer Order…** for the reorder sheet. Sort controls appear in All Computers scope only; single-Mac views keep the Mac sidebar order. Recent Activity flattens groups and disables drag reorder.
> 
> **Shell wiring:** `MobileShellComposite` persists mode/priority, expands alias IDs for priority, and rebuilds derived workspace state when pairing or sort prefs change. Tests cover aggregation, store persistence, recency ordering, and list gating.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 89c05452b31a4c24de0821dd3a66619ba5079c22. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds device‑local sorting to the All Computers workspace list with three modes: Last Opened (default), Computer Order, and Recent Activity. On iOS, a Mail‑style view‑options popover with illustrated tiles replaces the filter button; changes apply live.

- **New Features**
  - View‑options popover: three illustrated sort tiles plus read‑state rows; “Edit Computer Order…” opens a drag‑to‑reorder sheet. Machine selection stays in the title picker. Shown in All Computers regardless of computer count.
  - Last Opened (formerly Automatic/Connected First): connected Mac first, then most recently used by this device (`lastSeenAt`); never‑opened Macs alphabetical last. UI label is “Last Opened” (raw value remains `automatic`).
  - Computer Order: user‑ranked Macs come first (even before foreground); sibling builds stay adjacent; paired‑but‑offline Macs keep their slot.
  - Recent Activity: flat list across all computers by `lastActivityAt`; pinned first; stable ties; drag‑reorder disabled. Single‑Mac scopes keep that Mac’s sidebar order.
  - Persistence and wiring: device‑local in `MobileWorkspaceSortStore` (`UserDefaults`). `MobileShellComposite` mirrors mode/priority and expands alias IDs. Aggregation orders via `orderedMacIDs(..., computerPriority:, lastOpenedAt:)`; `.recentActivity` runs in the view via `MobileWorkspaceRecencyOrder`. Previews can seed mode/priority and auto‑open the popover. en/ja strings updated.

- **Bug Fixes**
  - Keep “Last Opened” fresh by recomputing the derived list on pairing refresh; the order no longer goes stale after pairing updates.
  - Seed the Computer Order editor from the aggregated rows and include paired‑but‑offline Macs, so editing never drops machines.
  - Visual polish: pin the popover to regular‑weight body text, inset schematic rank badges further, and shrink the “Edit Computer Order…” row icon.

<sup>Written for commit 89c05452b31a4c24de0821dd3a66619ba5079c22. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/9828?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added workspace sorting options for automatic order, computer priority, and recent activity.
  * Added persistent, device-local computer ordering with drag-and-drop editing.
  * Added workspace view controls for sorting, read-state filters, and machine filters.
  * Recent activity sorting prioritizes pinned workspaces and latest activity across computers.
  * Added English and Japanese localization for sorting features.

* **Bug Fixes**
  * Disabled workspace reordering when recent activity sorting is active.
  * Improved handling of duplicate, unavailable, or paired computer entries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->