### PR TITLE
Stop creating dev-artifact issues for E2E runs

### DIFF
--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -610,11 +610,11 @@ jobs:
           name: test-recording
           path: /tmp/test-recording.mp4
           if-no-files-found: warn
+          retention-days: 30
 
-      - name: Post results to cmux-dev-artifacts
+      - name: Publish test summary
         if: always()
         env:
-          GH_TOKEN: ${{ secrets.DEV_ARTIFACTS_TOKEN }}
           TEST_RESULT: ${{ steps.tests.outputs.test_result || 'failed' }}
           TEST_SUMMARY: ${{ steps.tests.outputs.test_summary }}
           TEST_OUTPUT: ${{ steps.tests.outputs.test_output }}
@@ -625,7 +625,6 @@ jobs:
         run: |
           set -euo pipefail
 
-          LABEL="$TEST_RESULT"
           if [ "$TEST_RESULT" = "passed" ]; then
             STATUS_EMOJI="PASSED"
           else
@@ -636,45 +635,37 @@ jobs:
           RUN_URL="https://github.com/${{ github.repository }}/actions/runs/$RUN_ID"
           ARTIFACT_URL="$RUN_URL#artifacts"
 
-          BODY="**Status:** $STATUS_EMOJI
-          **Ref:** \`$REF_DISPLAY\`
-          **SHA:** [\`${COMMIT_SHA:0:12}\`](https://github.com/${{ github.repository }}/commit/$COMMIT_SHA)
-          **Test:** \`$TEST_FILTER\`
-          **Workflow run:** $RUN_URL"
+          {
+            echo "## E2E test result"
+            echo
+            echo "**Status:** $STATUS_EMOJI"
+            echo "**Ref:** \`$REF_DISPLAY\`"
+            echo "**SHA:** [\`${COMMIT_SHA:0:12}\`](https://github.com/${{ github.repository }}/commit/$COMMIT_SHA)"
+            echo "**Test:** \`$TEST_FILTER\`"
+            echo "**Workflow run:** $RUN_URL"
 
-          if [ "$RECORD_VIDEO" = "true" ]; then
-            BODY="$BODY
-          **Recording:** [Download from artifacts]($ARTIFACT_URL)"
-          fi
+            if [ "$RECORD_VIDEO" = "true" ]; then
+              echo "**Recording:** [Download from artifacts]($ARTIFACT_URL) (retained for 30 days)"
+            fi
 
-          if [ -n "$TEST_OUTPUT" ]; then
-            BODY="$BODY
+            if [ -n "$TEST_OUTPUT" ]; then
+              echo
+              echo "<details><summary>Test output (last 200 lines)</summary>"
+              echo
+              echo '```'
+              printf '%s\n' "$TEST_OUTPUT"
+              echo '```'
+              echo
+              echo "</details>"
+            fi
 
-          <details><summary>Test output (last 200 lines)</summary>
-
-          \`\`\`
-          $TEST_OUTPUT
-          \`\`\`
-
-          </details>"
-          fi
-
-          if [ -n "$TEST_SUMMARY" ]; then
-            BODY="$BODY
-
-          \`\`\`
-          $TEST_SUMMARY
-          \`\`\`"
-          fi
-
-          ISSUE_URL=$(gh issue create \
-            --repo manaflow-ai/cmux-dev-artifacts \
-            --title "[$STATUS_EMOJI] $TEST_FILTER @ ${COMMIT_SHA:0:7} ($REF_DISPLAY)" \
-            --body "$BODY" \
-            --label "$LABEL")
-
-          echo "Issue posted: $ISSUE_URL"
-          echo "::notice title=Test Result Issue::$ISSUE_URL"
+            if [ -n "$TEST_SUMMARY" ]; then
+              echo
+              echo '```'
+              printf '%s\n' "$TEST_SUMMARY"
+              echo '```'
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Clean owned DerivedData
         if: always()

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -604,6 +604,7 @@ jobs:
             | xargs -I{} echo "Duration: {}s"
 
       - name: Upload recording artifact
+        id: recording
         if: ${{ always() && steps.filter.outputs.record_video == 'true' }}
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
@@ -622,6 +623,7 @@ jobs:
           COMMIT_SHA: ${{ steps.sha.outputs.sha }}
           RUN_ID: ${{ github.run_id }}
           RECORD_VIDEO: ${{ steps.filter.outputs.record_video }}
+          RECORDING_URL: ${{ steps.recording.outputs.artifact-url }}
         run: |
           set -euo pipefail
 
@@ -633,8 +635,6 @@ jobs:
 
           REF_DISPLAY="${{ inputs.ref || github.ref_name }}"
           RUN_URL="https://github.com/${{ github.repository }}/actions/runs/$RUN_ID"
-          ARTIFACT_URL="$RUN_URL#artifacts"
-
           {
             echo "## E2E test result"
             echo
@@ -645,7 +645,11 @@ jobs:
             echo "**Workflow run:** $RUN_URL"
 
             if [ "$RECORD_VIDEO" = "true" ]; then
-              echo "**Recording:** [Download from artifacts]($ARTIFACT_URL) (retained for 30 days)"
+              if [ -n "$RECORDING_URL" ]; then
+                echo "**Recording:** [Download artifact]($RECORDING_URL) (retained for 30 days)"
+              else
+                echo "**Recording:** unavailable"
+              fi
             fi
 
             if [ -n "$TEST_OUTPUT" ]; then

--- a/scripts/run-e2e.sh
+++ b/scripts/run-e2e.sh
@@ -94,10 +94,4 @@ if [ "$WAIT" = true ]; then
   echo ""
   echo "Result: $STATUS"
   echo "Run: $RUN_URL"
-
-  # Find the issue created for this run (search by run ID in body)
-  ISSUE_URL=$(gh search issues "$RUN_ID" --repo manaflow-ai/cmux-dev-artifacts --limit 1 --json url --jq '.[0].url' 2>/dev/null || true)
-  if [ -n "$ISSUE_URL" ]; then
-    echo "Issue: $ISSUE_URL"
-  fi
 fi


### PR DESCRIPTION
## Summary
- publish focused E2E results in the GitHub Actions job summary instead of opening a cross-repository issue
- retain video artifacts for 30 days
- stop `scripts/run-e2e.sh` from searching for generated issues

## Testing
- `actionlint .github/workflows/test-e2e.yml`
- `shellcheck scripts/run-e2e.sh`
- `git diff --check`

## Cleanup after merge
- archive `manaflow-ai/cmux-dev-artifacts` while preserving its committed screenshots
- remove the now-unused `DEV_ARTIFACTS_TOKEN` repository secret

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/9832"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788742520&installation_model_id=21920&pr_number=9832&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F9832&signature=fc880d22fabe87129d529e970ca73e1c7202bbfd6e810367ff5647a2e3eebf5f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only reporting and script cleanup; no app runtime or auth paths change. Follow-up is operational (archive repo, remove secret).
> 
> **Overview**
> E2E workflow reporting no longer opens issues in `manaflow-ai/cmux-dev-artifacts` or uses `DEV_ARTIFACTS_TOKEN`. The **Publish test summary** step writes status, ref, SHA, test filter, workflow link, optional recording link, and failure output/summary to **`GITHUB_STEP_SUMMARY`** on the Actions run.
> 
> Recording uploads now set **`retention-days: 30`** and expose **`steps.recording.outputs.artifact-url`** for a direct download link (or “unavailable” when upload did not produce a URL).
> 
> `scripts/run-e2e.sh` drops post-watch lookup of dev-artifact issues by run ID.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 482f59310b3feb2473eb3c4b25801953a1110432. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Publish E2E results directly to the GitHub Actions job summary and stop opening cross-repo dev-artifact issues. Videos are retained for 30 days, and the E2E script no longer searches for issue links.

- **Refactors**
  - Write E2E status, refs, SHA, test filter, run link, and artifacts to the job summary; video artifacts kept 30 days.
  - Remove cross-repo issue creation in `manaflow-ai/cmux-dev-artifacts` and drop `DEV_ARTIFACTS_TOKEN` usage.
  - Remove issue lookup from `scripts/run-e2e.sh`.

- **Migration**
  - Archive `manaflow-ai/cmux-dev-artifacts` (preserve committed screenshots).
  - Remove the `DEV_ARTIFACTS_TOKEN` repository secret.

<sup>Written for commit 228b8a95650dcdc787d61dbb44c45e72dacb9101. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/9832?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * End-to-end test results are now published directly in the workflow summary, including status, commit, test details, output, and links.
  * Test recording artifacts are retained for 30 days when available.

* **Improvements**
  * Test runs now report the workflow status and URL without creating or looking up external issue records.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->