### PR TITLE
Fix main compile break: classify() member access in CLI feed bridge

### DIFF
--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -32776,7 +32776,7 @@ export default CMUXSessionRestore;
                 source: source,
                 event: reportedHookEventName,
                 toolName: ""
-            ).0
+            ).hookEventName
         } else {
             hookEventName = fallbackHookEventName
         }


### PR DESCRIPTION
Current `main` fails to compile: https://github.com/manaflow-ai/cmux/pull/9804 merged `FeedEventClassifier.classify(...).0` after `classify()` had switched to returning the named `FeedEventClassification` struct, so every `app-host unit tests` shard and `tests-build-and-lag` job dies with `CLI/cmux.swift:32779: value of type 'FeedEventClassification' has no member '0'` (seen on merge-gate run https://github.com/manaflow-ai/cmux/actions/runs/31235977017, which gated https://github.com/manaflow-ai/cmux/pull/9779). The paused PR CI let the semantic conflict land silently.

One line: `.0` → `.hookEventName`, matching the struct field and the existing call site at `CLI/cmux.swift:34954`. No behavior change from what #9804 intended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/9834"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788750893&installation_model_id=21920&pr_number=9834&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F9834&signature=f758488dcfa47dd5ab27b8e26169b7ae40dbced0a997a8b2608e5252e76227a8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit bf121191c913acc82f5da2fd82dd33b851c3a3ce. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a compile error on `main` by switching tuple access to a named property in the CLI feed event classification, restoring CI builds and tests.

- **Bug Fixes**
  - Replace `FeedEventClassifier.classify(...).0` with `.hookEventName` in `CLI/cmux.swift` to match `FeedEventClassification`. No behavior change.

<sup>Written for commit bf121191c913acc82f5da2fd82dd33b851c3a3ce. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/9834?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved hook event name extraction to ensure CLI hook events are identified correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->