### PR TITLE
Add a one-line parallel-agents subtitle to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 <h1 align="center">cmux</h1>
 <p align="center">A Ghostty-based macOS terminal with vertical tabs and notifications for AI coding agents</p>
+<p align="center">Run many agents in parallel and see at a glance which one needs your input next.</p>
 
 <p align="center">
   <a href="https://github.com/manaflow-ai/cmux/releases/latest/download/cmux-macos.dmg">


### PR DESCRIPTION
Adds one sentence under the English README tagline describing the core workflow (many agents in parallel, notifications show which needs input).

Docs-only; no runtime change. The 20+ translated READMEs (`README.ja.md` etc.) are intentionally untouched; the new line exists only in English until the next translation sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/9839"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788753656&installation_model_id=21920&pr_number=9839&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F9839&signature=25c38e2eb0047a30edb73caced3b2213217b2f936bded2351e7bec989c60c7ca"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only README change with no application, build, or security impact.
> 
> **Overview**
> Adds a second centered subtitle line in **English `README.md`**, directly under the existing Ghostty/agents tagline: *Run many agents in parallel and see at a glance which one needs your input next.*
> 
> This is documentation-only marketing copy; **translated READMEs are not updated** in this PR.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 65fc4a55510f577308fb4b9599fba49021685c50. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a one-line subtitle to the English README to clarify the core workflow: run many agents in parallel and see which one needs your input next. Docs-only; no runtime changes, and translations will be updated in the next sync.

<sup>Written for commit 65fc4a55510f577308fb4b9599fba49021685c50. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/9839?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a README tagline highlighting support for running multiple agents in parallel.
  * Clarified that cmux helps identify which agent requires user input.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->