### PR TITLE
fix(shell-integration): back off PR polling for branches with no PR

### DIFF
--- a/Resources/shell-integration/cmux-bash-integration.bash
+++ b/Resources/shell-integration/cmux-bash-integration.bash
@@ -1276,6 +1276,24 @@ _cmux_report_pr_for_path() {
         _cmux_pr_debug_log "$branch" "cache-miss"
     fi
 
+    # A branch already known to have no PR is re-checked at most every 900s
+    # (the force signal still bypasses immediately). Without this, a panel
+    # sitting on a branch that will never have a PR (e.g. main) burns a
+    # GitHub GraphQL API call every poll interval forever — and the GraphQL
+    # quota (5,000/hr) is shared across the user's whole account.
+    # EPOCHSECONDS may be unavailable in older bash and the $SECONDS
+    # fallback is shell-relative, so normalize `now` to a real epoch here;
+    # this also makes the timestamp writes below epoch-based so the
+    # comparison stays coherent across shells.
+    now="$(command date +%s 2>/dev/null || echo "$now")"
+    local cache_timestamp=""
+    [[ -r "$timestamp_file" ]] && cache_timestamp="$(<"$timestamp_file")"
+    if [[ "${2:-0}" != "1" && -n "$branch" && "$cache_no_pr_branch" == "$branch" ]] \
+        && [[ "$cache_timestamp" =~ ^[0-9]+$ ]] && (( now - cache_timestamp < 900 )); then
+        _cmux_pr_debug_log "$branch" "no-pr-backoff"
+        return 0
+    fi
+
     repo_slug="$(_cmux_github_repo_slug_for_path "$repo_path")"
     if [[ -n "$repo_slug" ]]; then
         gh_repo_args=(--repo "$repo_slug")

--- a/Resources/shell-integration/cmux-bash-integration.bash
+++ b/Resources/shell-integration/cmux-bash-integration.bash
@@ -1281,17 +1281,28 @@ _cmux_report_pr_for_path() {
     # sitting on a branch that will never have a PR (e.g. main) burns a
     # GitHub GraphQL API call every poll interval forever — and the GraphQL
     # quota (5,000/hr) is shared across the user's whole account.
-    # EPOCHSECONDS may be unavailable in older bash and the $SECONDS
-    # fallback is shell-relative, so normalize `now` to a real epoch here;
-    # this also makes the timestamp writes below epoch-based so the
-    # comparison stays coherent across shells.
-    now="$(command date +%s 2>/dev/null || echo "$now")"
-    local cache_timestamp=""
-    [[ -r "$timestamp_file" ]] && cache_timestamp="$(<"$timestamp_file")"
-    if [[ "${2:-0}" != "1" && -n "$branch" && "$cache_no_pr_branch" == "$branch" ]] \
-        && [[ "$cache_timestamp" =~ ^[0-9]+$ ]] && (( now - cache_timestamp < 900 )); then
-        _cmux_pr_debug_log "$branch" "no-pr-backoff"
-        return 0
+    # The guard only trusts a cache record written for this exact repo with
+    # an explicit "none" result and a plausible (not future) epoch age.
+    # EPOCHSECONDS may be unavailable in older bash and the $SECONDS fallback is
+    # shell-relative, so `now` is normalized to a real epoch first; if that
+    # normalization fails the backoff is skipped for this invocation and
+    # `now` is left untouched.
+    local epoch_now="" cache_repo="" cache_timestamp=""
+    epoch_now="$(command date +%s 2>/dev/null || true)"
+    [[ "$epoch_now" =~ ^[0-9]+$ ]] || epoch_now=""
+    if [[ -n "$epoch_now" ]]; then
+        now="$epoch_now"
+        [[ -r "$timestamp_file" ]] && cache_timestamp="$(<"$timestamp_file")"
+        [[ -r "$repo_file" ]] && cache_repo="$(<"$repo_file")"
+        if [[ "${2:-0}" != "1" && -n "$branch" \
+            && "$cache_no_pr_branch" == "$branch" \
+            && "$cache_repo" == "$repo_path" \
+            && "$cache_result" == "none" ]] \
+            && [[ "$cache_timestamp" =~ ^[0-9]+$ ]] \
+            && (( now >= cache_timestamp && now - cache_timestamp < 900 )); then
+            _cmux_pr_debug_log "$branch" "no-pr-backoff"
+            return 0
+        fi
     fi
 
     repo_slug="$(_cmux_github_repo_slug_for_path "$repo_path")"

--- a/Resources/shell-integration/cmux-zsh-integration.zsh
+++ b/Resources/shell-integration/cmux-zsh-integration.zsh
@@ -1363,17 +1363,28 @@ _cmux_report_pr_for_path() {
     # sitting on a branch that will never have a PR (e.g. main) burns a
     # GitHub GraphQL API call every poll interval forever — and the GraphQL
     # quota (5,000/hr) is shared across the user's whole account.
-    # EPOCHSECONDS is unset unless zsh/datetime is loaded and the $SECONDS
-    # fallback is shell-relative, so normalize `now` to a real epoch here;
-    # this also makes the timestamp writes below epoch-based so the
-    # comparison stays coherent across shells.
-    now="$(command date +%s 2>/dev/null || echo "$now")"
-    local cache_timestamp=""
-    [[ -r "$timestamp_file" ]] && cache_timestamp="$(<"$timestamp_file")"
-    if [[ "${2:-0}" != "1" && -n "$branch" && "$cache_no_pr_branch" == "$branch" ]] \
-        && [[ "$cache_timestamp" == <-> ]] && (( now - cache_timestamp < 900 )); then
-        _cmux_pr_debug_log "$branch" "no-pr-backoff"
-        return 0
+    # The guard only trusts a cache record written for this exact repo with
+    # an explicit "none" result and a plausible (not future) epoch age.
+    # EPOCHSECONDS requires zsh/datetime and the $SECONDS fallback is
+    # shell-relative, so `now` is normalized to a real epoch first; if that
+    # normalization fails the backoff is skipped for this invocation and
+    # `now` is left untouched.
+    local epoch_now="" cache_repo="" cache_timestamp=""
+    epoch_now="$(command date +%s 2>/dev/null || true)"
+    [[ "$epoch_now" == <-> ]] || epoch_now=""
+    if [[ -n "$epoch_now" ]]; then
+        now="$epoch_now"
+        [[ -r "$timestamp_file" ]] && cache_timestamp="$(<"$timestamp_file")"
+        [[ -r "$repo_file" ]] && cache_repo="$(<"$repo_file")"
+        if [[ "${2:-0}" != "1" && -n "$branch" \
+            && "$cache_no_pr_branch" == "$branch" \
+            && "$cache_repo" == "$repo_path" \
+            && "$cache_result" == "none" ]] \
+            && [[ "$cache_timestamp" == <-> ]] \
+            && (( now >= cache_timestamp && now - cache_timestamp < 900 )); then
+            _cmux_pr_debug_log "$branch" "no-pr-backoff"
+            return 0
+        fi
     fi
 
     repo_slug="$(_cmux_github_repo_slug_for_path "$repo_path")"

--- a/Resources/shell-integration/cmux-zsh-integration.zsh
+++ b/Resources/shell-integration/cmux-zsh-integration.zsh
@@ -1358,6 +1358,24 @@ _cmux_report_pr_for_path() {
         _cmux_pr_debug_log "$branch" "cache-miss"
     fi
 
+    # A branch already known to have no PR is re-checked at most every 900s
+    # (the force signal still bypasses immediately). Without this, a panel
+    # sitting on a branch that will never have a PR (e.g. main) burns a
+    # GitHub GraphQL API call every poll interval forever — and the GraphQL
+    # quota (5,000/hr) is shared across the user's whole account.
+    # EPOCHSECONDS is unset unless zsh/datetime is loaded and the $SECONDS
+    # fallback is shell-relative, so normalize `now` to a real epoch here;
+    # this also makes the timestamp writes below epoch-based so the
+    # comparison stays coherent across shells.
+    now="$(command date +%s 2>/dev/null || echo "$now")"
+    local cache_timestamp=""
+    [[ -r "$timestamp_file" ]] && cache_timestamp="$(<"$timestamp_file")"
+    if [[ "${2:-0}" != "1" && -n "$branch" && "$cache_no_pr_branch" == "$branch" ]] \
+        && [[ "$cache_timestamp" == <-> ]] && (( now - cache_timestamp < 900 )); then
+        _cmux_pr_debug_log "$branch" "no-pr-backoff"
+        return 0
+    fi
+
     repo_slug="$(_cmux_github_repo_slug_for_path "$repo_path")"
     if [[ -n "$repo_slug" ]]; then
         gh_repo_args=(--repo "$repo_slug")


### PR DESCRIPTION
Fixes #9843.

## Problem

The per-panel PR poll loop calls `gh pr view` every `_CMUX_PR_POLL_INTERVAL` (45s) even when the probe's own cache already recorded that the current branch has no PR — the `.no-pr-branch` marker is written and read into a variable, but never used to skip polling. A panel sitting on `main` therefore burns one GitHub GraphQL call every 45s forever; with several workspaces open this consumes a large share of the user's account-wide 5,000/hr GraphQL quota (measured ~750 calls/hr with six workspaces).

## Fix

- In `_cmux_report_pr_for_path`, when not force-probed and the cached no-PR branch equals the current branch and the cache is fresher than 900s, skip the `gh` call (debug-logged as `no-pr-backoff`). The force-refresh signal still bypasses immediately; branches with PRs keep the 45s cadence; a PR opened later on a quiet branch is noticed within 15 minutes.
- Normalize `now` to a real epoch via `date +%s`: `EPOCHSECONDS` requires `zsh/datetime` (not loaded), so the existing `${EPOCHSECONDS:-$SECONDS}` fallback wrote shell-relative values to `.timestamp` — harmless while unread, but incorrect the moment anything compares them. This also makes the function's existing timestamp writes epoch-based.
- Same change applied to the bash integration (with a bash-compatible numeric check).

## Testing

Verified with a stub `gh` on PATH, a seeded per-panel cache, and a throwaway repo, across three cases: fresh no-PR cache + unforced probe → 0 gh calls; fresh cache + forced probe → 1 call; stale (>900s) cache + unforced → 1 call. `zsh -n` / `bash -n` clean on both files. Also running patched in production across four machines since 2026-08-07.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/9844"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788758620&installation_model_id=21920&pr_number=9844&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F9844&signature=f7e892dbaa053c1e9c299eec172e45a2114eb43f44d817b907ca3a73de582ea9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Shell-side polling and cache timing only; reduces GitHub API usage without changing auth or app server behavior.
> 
> **Overview**
> Stops **repeated `gh pr view` calls** when the per-panel PR cache already marks the current branch as having no PR (e.g. `main`). In `_cmux_report_pr_for_path`, unforced probes now **return early** if the cached no-PR branch matches, the timestamp is younger than **900s**, and log `no-pr-backoff`; **force refresh** still runs `gh` immediately, and branches with PRs keep the normal ~45s poll.
> 
> Also **normalizes time to wall-clock epoch** via `date +%s` before comparing cache timestamps and writing them, so backoff works when `EPOCHSECONDS` is missing (bash/zsh) and avoids shell-relative `$SECONDS` values breaking comparisons. Same logic in **bash** and **zsh** integration files.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 38b3176d798ee6c1d88bb2df33e39eceac1e8261. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Backs off PR polling for branches with no PR to cut unnecessary `gh` calls and guard against bad cache data. Also normalizes timestamp handling in `zsh`/`bash` for correct cache age checks (fixes #9843).

- **Bug Fixes**
  - Skip `gh pr view` for 900s when the cache says "no PR" for the same branch and repo with a valid, non-future timestamp; forced probes still bypass, and branches with PRs keep the 45s cadence.
  - Normalize timestamps to epoch via `date +%s`; if epoch derivation fails, skip the backoff for that check to avoid mixed time bases; apply to both shell integrations.

<sup>Written for commit 1dac9715069cb7e1ce6a5dd8211b1e97c330f7d1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/9844?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Reduced repeated pull request checks for branches recently confirmed to have no pull request.
  * Added a 15-minute cache backoff for matching non-forced checks.
  * Forced checks continue to bypass the backoff for immediate updates.
  * Checks proceed normally when cache timestamps are invalid, unavailable, or cannot be safely validated.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->