### PR TITLE
Publish agent lifecycle as agent.state.changed

### DIFF
--- a/Packages/Shared/CmuxAgentChat/Sources/CmuxAgentChat/Model/ChatAgentState.swift
+++ b/Packages/Shared/CmuxAgentChat/Sources/CmuxAgentChat/Model/ChatAgentState.swift
@@ -36,6 +36,19 @@ extension ChatAgentState: Codable {
         case ended
     }
 
+    /// The stable wire name for this state (`idle`, `working`, `needs_input`,
+    /// `ended`). Declared alongside the `Codable` form so the event stream and
+    /// the encoded state can never drift apart; the associated `since` value
+    /// is deliberately not part of it.
+    public var wireName: String {
+        switch self {
+        case .idle: return StateName.idle.rawValue
+        case .working: return StateName.working.rawValue
+        case .needsInput: return StateName.needsInput.rawValue
+        case .ended: return StateName.ended.rawValue
+        }
+    }
+
     public init(from decoder: any Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         let raw = try container.decode(String.self, forKey: .state)

--- a/Sources/CmuxEventPublishing.swift
+++ b/Sources/CmuxEventPublishing.swift
@@ -411,6 +411,42 @@ extension CmuxEventBus {
         )
     }
 
+    /// Publishes the semantic lifecycle state the session registry already
+    /// derives, so consumers observe agents through the event stream instead
+    /// of polling the private `<agent>-hook-sessions.json`.
+    ///
+    /// `cause` is the hook event that produced the state. It matters because
+    /// `needs_input` collapses four distinct hook events, so `state` alone
+    /// cannot separate a real permission gate (`PermissionRequest`,
+    /// `AskUserQuestion`, `ExitPlanMode`) from the idle-reminder timer
+    /// (`Notification`) — "blocked on me" from "done". It is nil for
+    /// transitions the hook stream did not drive, such as the liveness sweep
+    /// ending a dead session.
+    func publishAgentStateChanged(
+        agent: String,
+        sessionId: String,
+        state: String,
+        previousState: String?,
+        cause: String?,
+        workspaceId: String?,
+        surfaceId: String?
+    ) {
+        publish(
+            name: "agent.state.changed",
+            category: "agent",
+            source: agent,
+            workspaceId: workspaceId,
+            surfaceId: surfaceId,
+            payload: [
+                "agent": agent,
+                "session_id": sessionId,
+                "state": state,
+                "previous_state": previousState ?? NSNull(),
+                "cause": cause ?? NSNull()
+            ]
+        )
+    }
+
     // swiftlint:disable:next discouraged_optional_collection
     func publishWorkstreamEvent(_ event: WorkstreamEvent, phase: String, result: [String: Any]? = nil) {
         var payload = Self.workstreamPayload(event)

--- a/Sources/Mobile/AgentChat/AgentChatSessionRegistry.swift
+++ b/Sources/Mobile/AgentChat/AgentChatSessionRegistry.swift
@@ -504,7 +504,10 @@ final class AgentChatSessionRegistry {
         record.setHookLifecycleState(Self.nextState(previous: record.state, event: event))
         stampLifecycleTransition(previous: previous, current: &record, at: event.receivedAt)
         stampVersion(&record)
-        storeRecord(record, replacing: previous)
+        // `nextState` collapses four distinct hook events into `needsInput`;
+        // pass the originating event so consumers can still tell a real
+        // permission gate from the idle-reminder notification.
+        storeRecord(record, replacing: previous, cause: event.hookEventName)
         if shouldConsultStore {
             backfillBindingsFromStore(
                 sessionID: sessionID,
@@ -713,14 +716,45 @@ final class AgentChatSessionRegistry {
     }
 
     /// Stores one record and reconciles every derived registry structure.
+    ///
+    /// - Parameters:
+    ///   - record: The record to store.
+    ///   - previous: The record being replaced, nil for a brand-new session.
+    ///   - cause: The hook event that produced this state, when a hook drove
+    ///     the change. Only `noteHookEvent` still holds it; the liveness
+    ///     sweep, transcript observation, and store seeding pass nil.
     private func storeRecord(
         _ record: AgentChatSessionRecord,
-        replacing previous: AgentChatSessionRecord?
+        replacing previous: AgentChatSessionRecord?,
+        cause: WorkstreamEvent.HookEventName? = nil
     ) {
         records[record.sessionID] = record
         syncProcessExitWatch(for: record)
         updateSessionIndexes(previous: previous, current: record)
+        publishStateChangeIfNeeded(record, previous: previous, cause: cause)
         onRecordChanged?(record, previous)
+    }
+
+    /// Publishes `agent.state.changed` when a stored record's lifecycle state
+    /// actually moved. Every write path routes through `storeRecord`, so this
+    /// is the one place the transition is observable regardless of what drove
+    /// it. A brand-new record publishes with a null `previous_state` so a
+    /// subscriber learns the session exists.
+    private func publishStateChangeIfNeeded(
+        _ record: AgentChatSessionRecord,
+        previous: AgentChatSessionRecord?,
+        cause: WorkstreamEvent.HookEventName?
+    ) {
+        guard previous?.state != record.state else { return }
+        CmuxEventBus.shared.publishAgentStateChanged(
+            agent: record.agentKind.sourceName,
+            sessionId: record.sessionID,
+            state: record.state.wireName,
+            previousState: previous?.state.wireName,
+            cause: cause?.rawValue,
+            workspaceId: record.workspaceID,
+            surfaceId: record.surfaceID
+        )
     }
 
     /// Removes one record and reconciles every derived registry structure.

--- a/cmuxTests/AgentChatSessionRegistryLifecycleTests.swift
+++ b/cmuxTests/AgentChatSessionRegistryLifecycleTests.swift
@@ -497,6 +497,69 @@ struct AgentChatSessionRegistryLifecycleTests {
         #expect(resolved.sessionID == newer.sessionID)
     }
 
+    /// `needsInput` is reached from four distinct hook events, so `state`
+    /// alone cannot tell a real permission gate from the idle-reminder timer
+    /// firing after a finished turn. The published `cause` is what keeps them
+    /// apart.
+    @MainActor
+    @Test func agentStateChangedCarriesTheHookEventThatProducedNeedsInput() throws {
+        let gates: [WorkstreamEvent.HookEventName] = [
+            .permissionRequest, .askUserQuestion, .exitPlanMode, .notification,
+        ]
+
+        for gate in gates {
+            let registry = AgentChatSessionRegistry()
+            let sessionID = UUID().uuidString
+            let workspaceID = UUID().uuidString
+            let surfaceID = UUID().uuidString
+            let subscription = CmuxEventBus.shared.subscribe(
+                afterSequence: nil,
+                names: ["agent.state.changed"],
+                categories: []
+            ).subscription
+            defer { subscription.close() }
+
+            for hookEventName in [WorkstreamEvent.HookEventName.userPromptSubmit, gate] {
+                registry.noteHookEvent(WorkstreamEvent(
+                    sessionId: sessionID,
+                    hookEventName: hookEventName,
+                    source: "claude",
+                    workspaceId: workspaceID,
+                    surfaceId: surfaceID,
+                    transcriptPath: nil,
+                    cwd: "/Users/example/project",
+                    ppid: nil,
+                    receivedAt: Date(timeIntervalSince1970: 100)
+                ))
+            }
+
+            let published = drainStateChanges(subscription, sessionID: sessionID)
+            #expect(published.map { $0["state"] as? String } == ["working", "needs_input"])
+            #expect(published.first?["previous_state"] as? String == nil)
+            #expect(published.last?["previous_state"] as? String == "working")
+            #expect(published.last?["cause"] as? String == gate.rawValue)
+            #expect(published.last?["agent"] as? String == "claude")
+            #expect(published.last?["session_id"] as? String == sessionID)
+        }
+    }
+
+    /// Drains the already-queued `agent.state.changed` payloads for one
+    /// session. Publishing is synchronous, so a zero timeout suffices; the
+    /// session filter keeps concurrently running tests out of the result.
+    @MainActor
+    private func drainStateChanges(
+        _ subscription: CmuxEventSubscription,
+        sessionID: String
+    ) -> [[String: Any]] {
+        var payloads: [[String: Any]] = []
+        while let event = subscription.next(timeout: 0) {
+            guard let payload = event["payload"] as? [String: Any],
+                  payload["session_id"] as? String == sessionID else { continue }
+            payloads.append(payload)
+        }
+        return payloads
+    }
+
     private func temporaryHomeDirectory() throws -> URL {
         let url = FileManager.default.temporaryDirectory
             .appendingPathComponent("cmux-agent-chat-\(UUID().uuidString)", isDirectory: true)

--- a/docs/events.md
+++ b/docs/events.md
@@ -330,6 +330,7 @@ Feed and agent hooks:
 | `feed.item.completed` | `feed.push` returned a hook decision, timeout, or no-op result. |
 | `feed.item.resolved` | A Feed reply command resolved a permission, question, or plan item. |
 | `agent.hook.<HookEventName>` | Agent hook event received through Feed. Examples include Claude Code and Codex permission requests when their hooks are installed. |
+| `agent.state.changed` | An agent session's lifecycle state changed (`idle`, `working`, `needs_input`, `ended`). |
 
 App, browser, and config:
 
@@ -365,6 +366,45 @@ plugin bridge. The event stream publishes both agent and Feed events:
   }
 }
 ```
+
+## Agent lifecycle state
+
+`agent.hook.<HookEventName>` reports events in each agent's own hook
+vocabulary, which differs per integration. `agent.state.changed` reports the
+semantic lifecycle state cmux itself derives from those events, so consumers
+observe agents through the event stream instead of the private
+`~/.cmuxterm/<agent>-hook-sessions.json`:
+
+```json
+{
+  "name": "agent.state.changed",
+  "category": "agent",
+  "source": "claude",
+  "workspace_id": "9B6920C1-6C29-4C27-A069-78CF285F932A",
+  "surface_id": "83F4E6A4-5246-4DB8-A412-9CE7B059FA6C",
+  "payload": {
+    "agent": "claude",
+    "session_id": "session-123",
+    "state": "needs_input",
+    "previous_state": "working",
+    "cause": "PermissionRequest"
+  }
+}
+```
+
+`state` is `idle`, `working`, `needs_input`, or `ended`. `previous_state` is
+null the first time cmux observes a session.
+
+`cause` is the hook event that produced the state, and it is what separates
+"the agent is blocked on me" from "the agent is done": `needs_input` is
+reached from four distinct hook events, so `state` alone cannot tell a real
+permission gate (`PermissionRequest`, `AskUserQuestion`, `ExitPlanMode`) from
+the idle-reminder timer firing after a finished turn (`Notification`). It is
+null for transitions no hook drove, such as the liveness sweep observing a
+dead agent process.
+
+The event is published only when the state actually changes, from every write
+path, so `--after-seq` replay reconstructs a session's full lifecycle.
 
 The `feed.item.completed` event contains the same workstream payload plus a
 `result` object matching the `feed.push` socket response.


### PR DESCRIPTION
Closes #8951.

## What

`agent.state.changed` publishes the lifecycle state the session registry already derives, so `cmux events --name agent.state.changed` becomes the supported way to observe agents, the private `~/.cmuxterm/<agent>-hook-sessions.json` stops being a de facto API, and the stream's durable/resumable semantics (`--after-seq`, `--reconnect`) apply for free.

```json
{
  "name": "agent.state.changed",
  "category": "agent",
  "source": "claude",
  "workspace_id": "9B6920C1-6C29-4C27-A069-78CF285F932A",
  "surface_id": "83F4E6A4-5246-4DB8-A412-9CE7B059FA6C",
  "payload": {
    "agent": "claude",
    "session_id": "session-123",
    "state": "needs_input",
    "previous_state": "working",
    "cause": "PermissionRequest"
  }
}
```

## Why `cause` is in the payload

`AgentChatSessionRegistry+Lifecycle.nextState` maps four distinct hook events — `PermissionRequest`, `AskUserQuestion`, `ExitPlanMode`, `Notification` — onto a single `needsInput`. The state survives that collapse; the discriminator does not. Without `cause`, a real permission gate and the idle-reminder timer firing after a finished turn arrive at consumers as the same value, so "the agent is blocked on me" is indistinguishable from "the agent is done" — and a consumer has to go back to translating each agent's hook vocabulary, which is the workaround this event exists to retire.

The value is already in scope where it is dropped: `nextState` is switching on it at the moment it collapses it. `noteHookEvent` is the last caller that still holds the originating event, so it passes it forward.

Credit to @seanyoungberg for making this argument on the issue.

## Placement

Published from `storeRecord`, the single choke point every write path already routes through. That way transitions no hook drove are covered too — the liveness sweep ending a dead agent, and transcript-observed idle — rather than being silently unreported. Those publish with a null `cause`; only `noteHookEvent` passes one.

## One correction to the issue's proposed payload

The issue specified `state` as `running | idle | needsInput | unknown`. That is the hook-sessions JSON vocabulary, not `ChatAgentState`, which is `idle` / `working` / `needsInput` / `ended` — `working` not `running`, `ended` not `unknown`. This uses `ChatAgentState`'s existing `Codable` names (`idle`, `working`, `needs_input`, `ended`), exposed as `wireName` so the event and the encoded state cannot drift apart.

## Deliberately not in this PR

Persisting `hookEventName` on the session record, and the nil-preserving `lastSubtitle` / `lastBody` upsert that lets a stale field read as current. Both were raised on the issue and both look real, but they are a separate concern from publishing the event and would roughly double this diff. Happy to follow up if you want them.

## Test

`agentStateChangedCarriesTheHookEventThatProducedNeedsInput` drives all four gate events through the registry and asserts each lands on `needs_input` with a distinguishable `cause`, so `PermissionRequest` and `Notification` cannot silently merge again. Added to the existing `AgentChatSessionRegistryLifecycleTests`, which is already wired in the pbxproj; `scripts/lint-pbxproj-test-wiring.sh` passes.

## Build status, stated plainly

`swift build` on `Packages/Shared/CmuxAgentChat` passes. I was **not** able to complete a local app-target `xcodebuild` — it stalls during binary-artifact verification in the package graph phase against a keychain I can't get past on this machine (`iroh-ffi`, `sentry-cocoa`, `sparkle` ship `.xcframework`s). The app-target changes use only same-module APIs that existing `@MainActor` callers already use, but CI is the first full compile of this branch. If it goes red I will fix it promptly.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/9845"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788761499&installation_model_id=21920&pr_number=9845&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F9845&signature=413303fb5f8d639707b5c9e50809289e5eff82e5ad1398f73fa38a54c0aa19c0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the central session registry write path and adds a new public event contract; behavior is gated on real state changes and covered by tests, but any subscriber or replay logic depends on correct transitions and cause semantics.
> 
> **Overview**
> Adds **`agent.state.changed`** on the cmux event stream so tools can follow agent sessions (`idle`, `working`, `needs_input`, `ended`) without reading private hook-session JSON files.
> 
> Emissions go through **`storeRecord`** whenever lifecycle state actually changes, including liveness and transcript-driven updates—not only hook events. Payload includes **`previous_state`** and optional **`cause`** (the hook event name when hooks drove the transition). **`cause`** distinguishes real permission gates from idle **`Notification`** reminders, since several hook types collapse into **`needs_input`**.
> 
> **`ChatAgentState.wireName`** keeps event **`state`** strings aligned with existing Codable encoding. Docs catalog the event; a lifecycle test asserts each **`needs_input`** gate publishes a distinct **`cause`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 597d7d7c2afd12a4ae1cf4e99914109d1911bac1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Publishes agent session lifecycle changes as `agent.state.changed` events so consumers can observe agents through the event stream instead of the private hook-sessions JSON. This adds durable replay and reconnection semantics to lifecycle updates.

- **New Features**
  - New `agent.state.changed` event with `agent`, `session_id`, `state`, `previous_state`, and `cause`.
  - `cause` preserves the originating hook (`PermissionRequest`, `AskUserQuestion`, `ExitPlanMode`, `Notification`) so `needs_input` cases stay distinct.
  - Emitted from the registry’s single write path, covering all transitions (including sweeps and transcript-observed idle) with null `cause` when no hook drove the change.
  - Uses `ChatAgentState` wire names (`idle`, `working`, `needs_input`, `ended`) to keep event and encoding aligned; added `wireName` helper.
  - Tests verify `cause` is preserved; docs updated with payload and usage.

- **Migration**
  - Subscribe with `cmux events --name agent.state.changed` and rely on `--after-seq`/`--reconnect`.
  - Stop reading `~/.cmuxterm/<agent>-hook-sessions.json`. Use `state` and `cause` to drive UI/logic.

<sup>Written for commit 597d7d7c2afd12a4ae1cf4e99914109d1911bac1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/9845?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added lifecycle state notifications for agent sessions, including current state, previous state, triggering event, and session context.
  - Added stable state names for agent lifecycle states.
  - Initial session creation and subsequent state transitions are now reported consistently.

- **Documentation**
  - Documented the new agent lifecycle event, payload, state transitions, and replay behavior.

- **Tests**
  - Added coverage verifying lifecycle transitions and their triggering events.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->