### PR TITLE
feat(ui): native empty states, accent-aware palette matches

### DIFF
--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -110629,13 +110629,13 @@
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "Add controls to .cmux/dock.json."
+            "value": "Dock runs your project's commands in the right sidebar. Define them in .cmux/dock.json."
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": ".cmux/dock.json にコントロールを追加してください。"
+            "value": "Dockはプロジェクトのコマンドを右サイドバーで実行します。.cmux/dock.json で定義してください。"
           }
         }
       }
@@ -110646,13 +110646,13 @@
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "No Dock Controls"
+            "value": "No Dock controls yet"
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "Dockコントロールがありません"
+            "value": "Dockコントロールはまだありません"
           }
         }
       }
@@ -111435,13 +111435,64 @@
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "Empty Panel"
+            "value": "Nothing open here"
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "空のパネル"
+            "value": "ここには何も開いていません"
+          }
+        }
+      }
+    },
+    "emptyPanel.subtitle": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Open a terminal or a browser to fill this pane."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ターミナルまたはブラウザを開いて、このペインを使い始めます。"
+          }
+        }
+      }
+    },
+    "emptyPanel.action.newTerminal": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "New Terminal"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "新規ターミナル"
+          }
+        }
+      }
+    },
+    "emptyPanel.action.openBrowser": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Open Browser"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ブラウザを開く"
           }
         }
       }
@@ -147374,6 +147425,23 @@
         }
       }
     },
+    "search.close.label": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Close Find"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "検索を閉じる"
+          }
+        }
+      }
+    },
     "search.nextMatch.help": {
       "extractionState": "manual",
       "localizations": {
@@ -147489,6 +147557,23 @@
           "stringUnit": {
             "state": "translated",
             "value": "下一個符合項目 (Return)"
+          }
+        }
+      }
+    },
+    "search.nextMatch.label": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Next Match"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "次の一致"
           }
         }
       }
@@ -147727,6 +147812,23 @@
           "stringUnit": {
             "state": "translated",
             "value": "上一個符合項目 (Shift+Return)"
+          }
+        }
+      }
+    },
+    "search.previousMatch.label": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Previous Match"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "前の一致"
           }
         }
       }

--- a/Sources/CmuxEmptyStateView.swift
+++ b/Sources/CmuxEmptyStateView.swift
@@ -1,0 +1,128 @@
+import CmuxFoundation
+import SwiftUI
+
+/// Shared empty-state presentation for cmux surfaces that have nothing to
+/// show yet.
+///
+/// Reproduces the metrics and hierarchy of AppKit's
+/// `ContentUnavailableView` — large tinted glyph, short title, one line of
+/// guidance, then the actions that resolve the state — but renders through
+/// ``CmuxSystemSymbolImage`` and `cmuxFont` so the glyph and the type both
+/// follow the user's global font magnification. `ContentUnavailableView`
+/// styles its own labels with unmagnified system fonts, so it would ignore
+/// that setting.
+///
+/// The body is wrapped in a `ViewThatFits` ladder so the same call site
+/// works in a full-window pane and in a narrow split: the glyph is dropped
+/// first, then the description, rather than clipping the actions the user
+/// needs to press.
+///
+/// ```swift
+/// CmuxEmptyStateView(
+///     symbolName: "terminal",
+///     title: String(localized: "emptyPanel.title", defaultValue: "Nothing open here")
+/// ) {
+///     Button("New Terminal") { createTerminal() }
+/// }
+/// ```
+@MainActor
+struct CmuxEmptyStateView<Actions: View>: View {
+    /// SF Symbol drawn above the title, tinted with the tertiary style.
+    let symbolName: String
+    /// Short sentence-case statement of what is missing.
+    let title: String
+    /// Optional single line explaining how to fill the surface.
+    let description: String?
+    /// Controls that resolve the empty state, laid out in a centered row.
+    @ViewBuilder let actions: Actions
+
+    /// Creates an empty state.
+    ///
+    /// - Parameters:
+    ///   - symbolName: SF Symbol name for the glyph.
+    ///   - title: Short statement of what is missing.
+    ///   - description: Optional guidance line; omit when the title says enough.
+    ///   - actions: Buttons that resolve the state. Pass `EmptyView()` for none.
+    init(
+        symbolName: String,
+        title: String,
+        description: String? = nil,
+        @ViewBuilder actions: () -> Actions = { EmptyView() }
+    ) {
+        self.symbolName = symbolName
+        self.title = title
+        self.description = description
+        self.actions = actions()
+    }
+
+    var body: some View {
+        // Widest layout first: ViewThatFits picks the first child whose
+        // ideal size fits, so the glyph and description degrade in that
+        // order and the actions row always survives.
+        ViewThatFits(in: .vertical) {
+            stack(showsSymbol: true, showsDescription: true)
+            stack(showsSymbol: false, showsDescription: true)
+            stack(showsSymbol: false, showsDescription: false)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .padding(20)
+        // The glyph repeats the title, and the title is already read as the
+        // heading, so the image would only add noise for VoiceOver.
+        .accessibilityElement(children: .contain)
+    }
+
+    @ViewBuilder
+    private func stack(showsSymbol: Bool, showsDescription: Bool) -> some View {
+        VStack(spacing: 0) {
+            if showsSymbol {
+                CmuxSystemSymbolImage(magnified: symbolName, pointSize: 38)
+                    .foregroundStyle(.tertiary)
+                    .accessibilityHidden(true)
+                    .padding(.bottom, 12)
+            }
+
+            VStack(spacing: 0) {
+                Text(title)
+                    .cmuxFont(.title3, weight: .semibold)
+                    .foregroundStyle(.primary)
+                    .multilineTextAlignment(.center)
+                    .accessibilityAddTraits(.isHeader)
+
+                if showsDescription, let description {
+                    Text(description)
+                        .cmuxFont(.callout)
+                        .foregroundStyle(.secondary)
+                        .multilineTextAlignment(.center)
+                        .padding(.top, 4)
+                }
+            }
+            // Clamp only the text column, to roughly the measure AppKit
+            // gives ContentUnavailableView: a long description wraps into a
+            // readable block instead of one edge-to-edge line. The actions
+            // row is deliberately outside this clamp — constraining it too
+            // would push a pair of normal-width buttons into the stacked
+            // fallback even on a wide pane.
+            .frame(maxWidth: 360)
+            .fixedSize(horizontal: false, vertical: true)
+
+            actionsRow
+        }
+    }
+
+    @ViewBuilder
+    private var actionsRow: some View {
+        // `Actions` is EmptyView when the caller passes no buttons; the
+        // Group still lays out, so gate the top padding on the type to
+        // avoid a stray 16pt gap under the last line of text.
+        if Actions.self != EmptyView.self {
+            // A single row reads best, but the Dock and Feed panels are
+            // narrow enough that three buttons would run past the edge.
+            // Fall back to a column rather than truncating a button title.
+            ViewThatFits(in: .horizontal) {
+                HStack(spacing: 8) { actions }
+                VStack(spacing: 8) { actions }
+            }
+            .padding(.top, 16)
+        }
+    }
+}

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -5448,7 +5448,13 @@ struct ContentView: View {
 
             let segment = String(chars[index..<end])
             if isMatched {
-                result = result + Text(segment).foregroundColor(.blue)
+                // Follow the system accent rather than a fixed blue, and
+                // carry the match in weight as well as color so it still
+                // reads when accent and text hue are close, or for a user
+                // who cannot separate the two by color.
+                result = result + Text(segment)
+                    .foregroundColor(cmuxAccentColor())
+                    .fontWeight(.semibold)
             } else {
                 result = result + Text(segment).foregroundColor(.primary)
             }

--- a/Sources/DockEmptyView.swift
+++ b/Sources/DockEmptyView.swift
@@ -6,62 +6,48 @@ struct DockEmptyView: View {
     @State private var isPromptPopoverPresented = false
 
     var body: some View {
-        VStack(spacing: 10) {
-            Image(systemName: "dock.rectangle")
-                .cmuxFont(size: 24)
-                .foregroundStyle(.secondary)
-            Text(String(localized: "dock.empty.title", defaultValue: "No Dock Controls"))
-                .cmuxFont(size: 13, weight: .semibold)
-            Text(String(
+        CmuxEmptyStateView(
+            symbolName: "dock.rectangle",
+            title: String(localized: "dock.empty.title", defaultValue: "No Dock controls yet"),
+            description: String(
                 localized: "dock.empty.subtitle",
-                defaultValue: "Add controls to .cmux/dock.json."
-            ))
-            .cmuxFont(size: 12)
-            .foregroundStyle(.secondary)
-            VStack(spacing: 8) {
-                HStack(spacing: 4) {
-                    Button {
-                        copyAgentPrompt()
-                    } label: {
-                        Label(
-                            String(localized: "dock.empty.copyPrompt", defaultValue: "Copy Agent Prompt"),
-                            systemImage: "doc.on.doc"
-                        )
-                    }
-                    .buttonStyle(.bordered)
-                    .controlSize(.small)
-                    .help(String(localized: "dock.empty.copyPrompt.help", defaultValue: "Copy a prompt you can paste into an AI coding agent"))
-
-                    Button {
-                        isPromptPopoverPresented.toggle()
-                    } label: {
-                        Image(systemName: "info.circle")
-                    }
-                    .buttonStyle(.borderless)
-                    .controlSize(.small)
-                    .accessibilityLabel(String(localized: "dock.empty.promptInfo", defaultValue: "Show Agent Prompt"))
-                    .help(String(localized: "dock.empty.promptInfo.help", defaultValue: "Show the prompt that will be copied"))
-                    .popover(isPresented: $isPromptPopoverPresented, arrowEdge: .bottom) {
-                        agentPromptPopover
-                    }
-                }
-
-                Button {
-                    openDockDocs()
-                } label: {
-                    Label(
-                        String(localized: "dock.empty.openDocs", defaultValue: "Docs"),
-                        systemImage: "questionmark.circle"
-                    )
-                }
-                .buttonStyle(.bordered)
-                .controlSize(.small)
-                .help(String(localized: "dock.empty.openDocs.help", defaultValue: "Open the Dock documentation"))
+                defaultValue: "Dock runs your project's commands in the right sidebar. Define them in .cmux/dock.json."
+            )
+        ) {
+            Button {
+                copyAgentPrompt()
+            } label: {
+                Label(
+                    String(localized: "dock.empty.copyPrompt", defaultValue: "Copy Agent Prompt"),
+                    systemImage: "doc.on.doc"
+                )
             }
-            .padding(.top, 4)
+            .buttonStyle(.bordered)
+            .help(String(localized: "dock.empty.copyPrompt.help", defaultValue: "Copy a prompt you can paste into an AI coding agent"))
+
+            Button {
+                isPromptPopoverPresented.toggle()
+            } label: {
+                Image(systemName: "info.circle")
+            }
+            .buttonStyle(.borderless)
+            .accessibilityLabel(String(localized: "dock.empty.promptInfo", defaultValue: "Show Agent Prompt"))
+            .help(String(localized: "dock.empty.promptInfo.help", defaultValue: "Show the prompt that will be copied"))
+            .popover(isPresented: $isPromptPopoverPresented, arrowEdge: .bottom) {
+                agentPromptPopover
+            }
+
+            Button {
+                openDockDocs()
+            } label: {
+                Label(
+                    String(localized: "dock.empty.openDocs", defaultValue: "Docs"),
+                    systemImage: "questionmark.circle"
+                )
+            }
+            .buttonStyle(.bordered)
+            .help(String(localized: "dock.empty.openDocs.help", defaultValue: "Open the Dock documentation"))
         }
-        .padding(20)
-        .frame(maxWidth: .infinity, maxHeight: .infinity)
     }
 
     private var agentPromptPopover: some View {

--- a/Sources/Feed/FeedPanelView.swift
+++ b/Sources/Feed/FeedPanelView.swift
@@ -578,25 +578,19 @@ private struct FeedListView: View {
     }
 
     private var emptyState: some View {
-        VStack(spacing: 4) {
-            Text(filter == .actionable
-                 ? String(localized: "feed.empty.actionable.title",
-                          defaultValue: "No pending decisions")
-                 : String(localized: "feed.empty.activity.title",
-                          defaultValue: "No activity yet"))
-                .cmuxFont(size: 12)
-                .foregroundColor(.secondary)
-            Text(filter == .actionable
-                 ? String(localized: "feed.empty.actionable.subtitle",
-                          defaultValue: "Permission, plan, and question requests from AI agents will appear here.")
-                 : String(localized: "feed.empty.activity.subtitle",
-                          defaultValue: "Agent decisions and todo-list updates will appear here."))
-                .cmuxFont(size: 11)
-                .foregroundColor(.secondary.opacity(0.7))
-                .multilineTextAlignment(.center)
-                .padding(.horizontal, 16)
-        }
-        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        CmuxEmptyStateView(
+            symbolName: filter == .actionable ? "checklist.checked" : "clock",
+            title: filter == .actionable
+                ? String(localized: "feed.empty.actionable.title",
+                         defaultValue: "No pending decisions")
+                : String(localized: "feed.empty.activity.title",
+                         defaultValue: "No activity yet"),
+            description: filter == .actionable
+                ? String(localized: "feed.empty.actionable.subtitle",
+                         defaultValue: "Permission, plan, and question requests from AI agents will appear here.")
+                : String(localized: "feed.empty.activity.subtitle",
+                         defaultValue: "Agent decisions and todo-list updates will appear here.")
+        )
     }
 }
 

--- a/Sources/Find/BrowserSearchOverlay.swift
+++ b/Sources/Find/BrowserSearchOverlay.swift
@@ -70,7 +70,8 @@ struct BrowserSearchOverlay: View {
                     Image(systemName: "chevron.up")
                 }
                 .buttonStyle(SearchButtonStyle())
-                .safeHelp("Next match (Return)")
+                .accessibilityLabel(String(localized: "search.nextMatch.label", defaultValue: "Next Match"))
+                .safeHelp(String(localized: "search.nextMatch.help", defaultValue: "Next match (Return)"))
 
                 Button(action: {
                     #if DEBUG
@@ -81,7 +82,8 @@ struct BrowserSearchOverlay: View {
                     Image(systemName: "chevron.down")
                 }
                 .buttonStyle(SearchButtonStyle())
-                .safeHelp("Previous match (Shift+Return)")
+                .accessibilityLabel(String(localized: "search.previousMatch.label", defaultValue: "Previous Match"))
+                .safeHelp(String(localized: "search.previousMatch.help", defaultValue: "Previous match (Shift+Return)"))
 
                 Button(action: {
                     #if DEBUG
@@ -92,7 +94,8 @@ struct BrowserSearchOverlay: View {
                     Image(systemName: "xmark")
                 }
                 .buttonStyle(SearchButtonStyle())
-                .safeHelp("Close (Esc)")
+                .accessibilityLabel(String(localized: "search.close.label", defaultValue: "Close Find"))
+                .safeHelp(String(localized: "search.close.help", defaultValue: "Close (Esc)"))
             }
             .padding(8)
             .background(.background)

--- a/Sources/Find/SurfaceSearchOverlay.swift
+++ b/Sources/Find/SurfaceSearchOverlay.swift
@@ -87,6 +87,7 @@ struct SurfaceSearchOverlay: View {
                     Image(systemName: "chevron.up")
                 }
                 .buttonStyle(SearchButtonStyle())
+                .accessibilityLabel(String(localized: "search.nextMatch.label", defaultValue: "Next Match"))
                 .safeHelp(String(localized: "search.nextMatch.help", defaultValue: "Next match (Return)"))
 
                 Button(action: {
@@ -98,6 +99,7 @@ struct SurfaceSearchOverlay: View {
                     Image(systemName: "chevron.down")
                 }
                 .buttonStyle(SearchButtonStyle())
+                .accessibilityLabel(String(localized: "search.previousMatch.label", defaultValue: "Previous Match"))
                 .safeHelp(String(localized: "search.previousMatch.help", defaultValue: "Previous match (Shift+Return)"))
 
                 Button(action: {
@@ -109,6 +111,7 @@ struct SurfaceSearchOverlay: View {
                     Image(systemName: "xmark")
                 }
                 .buttonStyle(SearchButtonStyle())
+                .accessibilityLabel(String(localized: "search.close.label", defaultValue: "Close Find"))
                 .safeHelp(String(localized: "search.close.help", defaultValue: "Close (Esc)"))
             }
             .padding(8)

--- a/Sources/WorkspaceContentView.swift
+++ b/Sources/WorkspaceContentView.swift
@@ -773,16 +773,26 @@ struct EmptyPanelView: View {
     let paneId: PaneID
     @State private var keyboardShortcutSettingsObserver = KeyboardShortcutSettingsObserver.shared
 
+    /// Key-equivalent badge shown after a button's title.
+    ///
+    /// Styled against the button's own control background rather than a
+    /// hardcoded white-on-accent, so it stays legible in light and dark
+    /// appearance and under every system accent color.
     private struct ShortcutHint: View {
         let text: String
 
         var body: some View {
             Text(text)
-                .cmuxFont(size: 11, weight: .semibold, design: .rounded)
-                .foregroundStyle(.white.opacity(0.9))
-                .padding(.horizontal, 8)
-                .padding(.vertical, 3)
-                .background(.white.opacity(0.18), in: Capsule())
+                .cmuxFont(size: 11, weight: .medium, design: .rounded)
+                .foregroundStyle(.secondary)
+                .monospacedDigit()
+                .padding(.horizontal, 6)
+                .padding(.vertical, 2)
+                .background(Color.primary.opacity(0.08), in: Capsule())
+                // The shortcut is decoration next to a control that already
+                // carries the same key equivalent; VoiceOver reads the key
+                // equivalent from the button itself.
+                .accessibilityHidden(true)
         }
     }
 
@@ -824,7 +834,7 @@ struct EmptyPanelView: View {
         action: @escaping () -> Void
     ) -> some View {
         let button = Button(action: action) {
-            HStack(spacing: 10) {
+            HStack(spacing: 8) {
                 HStack(spacing: 6) {
                     CmuxSystemSymbolImage(systemName: systemImage, pointSize: 13)
                     Text(title)
@@ -832,7 +842,10 @@ struct EmptyPanelView: View {
                 ShortcutHint(text: shortcut.displayString)
             }
         }
-        .buttonStyle(.borderedProminent)
+        // Both choices carry equal weight, so neither takes the prominent
+        // (default-action) treatment macOS reserves for a single button.
+        .buttonStyle(.bordered)
+        .controlSize(.large)
 
         if let key = shortcut.keyEquivalent {
             button.keyboardShortcut(key, modifiers: shortcut.eventModifiers)
@@ -842,31 +855,34 @@ struct EmptyPanelView: View {
     }
 
     var body: some View {
-        VStack(spacing: 16) {
-            CmuxSystemSymbolImage(magnified: "terminal.fill", pointSize: 48)
-                .foregroundStyle(.tertiary)
+        CmuxEmptyStateView(
+            symbolName: "square.split.2x1",
+            title: String(localized: "emptyPanel.title", defaultValue: "Nothing open here"),
+            description: String(
+                localized: "emptyPanel.subtitle",
+                defaultValue: "Open a terminal or a browser to fill this pane."
+            )
+        ) {
+            emptyPaneActionButton(
+                title: String(
+                    localized: "emptyPanel.action.newTerminal",
+                    defaultValue: "New Terminal"
+                ),
+                systemImage: "terminal.fill",
+                shortcut: newSurfaceShortcut,
+                action: createTerminal
+            )
 
-            Text(String(localized: "emptyPanel.title", defaultValue: "Empty Panel"))
-                .cmuxFont(.headline)
-                .foregroundStyle(.secondary)
-
-            HStack(spacing: 12) {
-                emptyPaneActionButton(
-                    title: "Terminal",
-                    systemImage: "terminal.fill",
-                    shortcut: newSurfaceShortcut,
-                    action: createTerminal
-                )
-
-                emptyPaneActionButton(
-                    title: "Browser",
-                    systemImage: "globe",
-                    shortcut: openBrowserShortcut,
-                    action: createBrowser
-                )
-            }
+            emptyPaneActionButton(
+                title: String(
+                    localized: "emptyPanel.action.openBrowser",
+                    defaultValue: "Open Browser"
+                ),
+                systemImage: "globe",
+                shortcut: openBrowserShortcut,
+                action: createBrowser
+            )
         }
-        .frame(maxWidth: .infinity, maxHeight: .infinity)
         .background(Color(nsColor: GhosttyBackgroundTheme.currentColor()))
 #if DEBUG
         .onAppear {

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -739,6 +739,7 @@ C0DE71B10000000000000001 /* AppDelegate+AgentChatNotifications.swift in Sources 
 		CC0033E15A1B2C3D4E5F0013 /* CmuxDiffComments in Frameworks */ = {isa = PBXBuildFile; productRef = CC0033E15A1B2C3D4E5F0011 /* CmuxDiffComments */; };
 		D1320AA0D1320AA0D1320AA2 /* CmuxDockTilePlugin.plugin in Copy Dock Tile Plugin */ = {isa = PBXBuildFile; fileRef = D1320AA0D1320AA0D1320AA5 /* CmuxDockTilePlugin.plugin */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		C54860040000000000000001 /* CmuxDurableDeepLinkRestoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C54860040000000000000002 /* CmuxDurableDeepLinkRestoreTests.swift */; };
+		CE5700000000000000EA0001 /* CmuxEmptyStateView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE5700000000000000EA0002 /* CmuxEmptyStateView.swift */; };
 		E7E000000000000000000005 /* CmuxEventBus.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7E000000000000000000006 /* CmuxEventBus.swift */; };
 		E7E000000000000000000003 /* CmuxEventBusTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7E000000000000000000004 /* CmuxEventBusTests.swift */; };
 		E7E00000000000000000000D /* CmuxEventLogWriter.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7E00000000000000000000E /* CmuxEventLogWriter.swift */; };
@@ -3443,6 +3444,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 		A5FB1206 /* CmuxConfigWorkspaceActionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CmuxConfigWorkspaceActionTests.swift; sourceTree = "<group>"; };
 		D1320AA0D1320AA0D1320AA5 /* CmuxDockTilePlugin.plugin */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = CmuxDockTilePlugin.plugin; sourceTree = BUILT_PRODUCTS_DIR; };
 		C54860040000000000000002 /* CmuxDurableDeepLinkRestoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CmuxDurableDeepLinkRestoreTests.swift; sourceTree = "<group>"; };
+		CE5700000000000000EA0002 /* CmuxEmptyStateView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CmuxEmptyStateView.swift; sourceTree = "<group>"; };
 		E7E000000000000000000006 /* CmuxEventBus.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CmuxEventBus.swift; sourceTree = "<group>"; };
 		E7E000000000000000000004 /* CmuxEventBusTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CmuxEventBusTests.swift; sourceTree = "<group>"; };
 		E7E00000000000000000000E /* CmuxEventLogWriter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CmuxEventLogWriter.swift; sourceTree = "<group>"; };
@@ -7231,6 +7233,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				DCDC1000000000000000B00E /* DockSurfaceKind.swift */,
 				DCDC1000000000000000B010 /* DockTrustRequest.swift */,
 				D0C0D0C0D0C0D0C0D0C0D004 /* DockEmptyView.swift */,
+				CE5700000000000000EA0002 /* CmuxEmptyStateView.swift */,
 				8777A0028777A0028777A002 /* AppDelegate+DockAttentionRouting.swift */,
 				DCDC3000000000000000E002 /* AppDelegate+DockShortcutRouting.swift */,
 				CA52D0010000000000000000 /* Canvas */,
@@ -8963,6 +8966,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				A5001652 /* CmuxConfigExecutor.swift in Sources */,
 				C5D0DEC0CF00000000000A1 /* CmuxConfigStore+ConfigStoreReloading.swift in Sources */,
 				C0DEF0A10000000000000001 /* CmuxConfigUI.swift in Sources */,
+				CE5700000000000000EA0001 /* CmuxEmptyStateView.swift in Sources */,
 				E7E000000000000000000005 /* CmuxEventBus.swift in Sources */,
 				E7E00000000000000000000D /* CmuxEventLogWriter.swift in Sources */,
 				E7E000000000000000000007 /* CmuxEventPublishing.swift in Sources */,


### PR DESCRIPTION
## What

A focused native-design pass on cmux's empty and secondary states.

Adds `Sources/CmuxEmptyStateView.swift`, a shared empty-state component built on AppKit's `ContentUnavailableView` hierarchy — tertiary glyph, title, guidance line, actions — but rendered through `cmuxFont` and `CmuxSystemSymbolImage`. `ContentUnavailableView` styles its own labels with unmagnified system fonts, so dropping it in directly would have made these surfaces ignore the app's global font magnification setting.

A `ViewThatFits` ladder degrades the layout as the surface shrinks: the glyph drops first, then the description, and the actions row wraps to a column instead of clipping. cmux tiles panes, so an empty state has to survive a 300pt split.

Adopted in three surfaces that each hand-rolled their own spacing and type scale: the empty pane, the Dock panel, and the Feed panel.

## Also fixed in these surfaces

- **Shortcut badge contrast.** The empty pane's key-equivalent badge was `.white.opacity(0.9)` on `.white.opacity(0.18)` inside a `.borderedProminent` button — readable only because the default accent is dark. It now styles against the control background. Both buttons drop to `.bordered`: they are equal choices, and macOS reserves prominent for a single default action.
- **Unlocalized strings.** `"Terminal"` and `"Browser"` were bare English literals in the empty pane. The browser find bar's three tooltips were bare English too.
- **Palette match highlight.** The command palette's fuzzy-match runs were a hardcoded `.blue`, ignoring the system accent. Now accent-colored *and* semibold, so the match does not depend on color alone.
- **Find bar accessibility.** The icon-only next/previous/close buttons in both find bars had `.help()` but no `.accessibilityLabel`, so VoiceOver announced nothing useful.

## Performance

No hot-path code is touched. All four surfaces are cold: empty states, the find bar overlay (mounted only while find is open), and palette row labels (already rebuilt per keystroke by the existing search pipeline). No changes to `hitTest`, `TabItemView`, `forceRefresh`, or any list-boundary code.

## Verification

- Tagged Debug build green on this HEAD.
- `lint-pbxproj-test-wiring.sh`, `check-workspace-package-groups.py --check`, `check-package-resolved-policy.py` all pass.
- Layout verified by rendering the component offscreen with `ImageRenderer` at real surface sizes (760x520 pane, 380x240 split, 300x130 tight split, 320pt Dock, 340pt Feed) in both appearances, confirming the degradation ladder and that nothing clips.
- Localization audit: all 19 touched keys verified present with non-empty `en` and `ja`. Remaining bare literals in the changed files are numeric match counters and list indices, which are not translatable prose.

## Notes for review

- `DockEmptyView` has **zero call sites** in the repo. Its restyle is consistent with the new component but is currently unreachable; worth deciding whether to delete the file.
- `EmptyPanelView` is Bonsplit's `emptyPane` builder plus a "shouldn't happen normally" fallback. With `autoCloseEmptyPanes: true` it is transient — `MenuKeyEquivalentRoutingUITests` actually asserts it never appears during a close sequence. The Feed panel empty state is the one users will routinely see.
- Existing UI tests deliberately avoid asserting on the "Empty Panel" accessibility text and use the debug appearance counter instead, so the copy change does not break them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MvFyaETQGJb4qFABRMhXaC

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/9849"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788778414&installation_model_id=21920&pr_number=9849&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F9849&signature=d8e04aa000438d093153655efdad7d8f3ac0a40a9caec0590253bd14c35a78a1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a shared empty-state view that respects font magnification and adapts to narrow panes, and adopts it in the Empty Pane, Dock, and Feed. Also makes palette matches follow the system accent with better legibility.

- **New Features**
  - Introduced CmuxEmptyStateView: ContentUnavailableView-style layout using `cmuxFont` and `CmuxSystemSymbolImage`, with a ViewThatFits ladder that drops glyph/description and wraps actions instead of clipping.
  - Adopted in Empty Pane, Dock panel, and Feed panel to unify spacing/type and handle 300pt splits.
  - Palette match highlight now uses the system accent and semibold weight.

- **Bug Fixes**
  - Empty Pane actions: switched to `.bordered` buttons; shortcut badge now styles against the control background for proper contrast in all accents/appearances.
  - Localized previously hardcoded strings (e.g., “Terminal”, “Browser”) and added new `en`/`ja` keys for empty panel copy and find-bar labels/help.
  - Find bars: added accessibility labels for next/previous/close buttons.

<sup>Written for commit dc6afbc25aef744f23650d20fe034115a506af53. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/9849?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

