### PR TITLE
Unify iOS shortcut strip background

### DIFF
--- a/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/TerminalInputTextView.swift
+++ b/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/TerminalInputTextView.swift
@@ -367,13 +367,16 @@ final class TerminalInputTextView: UIView, UIKeyInput, UITextInput {
         scrollView.showsVerticalScrollIndicator = false
         scrollView.alwaysBounceHorizontal = true
         if #available(iOS 26.0, *) {
-            // The system's horizontal edge treatment is designed to separate
-            // scrollable content from fixed chrome. This compact strip already
-            // shares one background with its pinned controls, and the effect's
-            // fill covers the full 28pt height, making the scroller look like a
-            // separate gray rectangle in light mode.
+            // The system's edge treatments are designed to separate scrollable
+            // content from fixed chrome. This compact strip already shares one
+            // background with its pinned controls. At only 28pt high, the top and
+            // bottom fills overlap across the full scroller and make it look like
+            // a separate gray rectangle in light mode, even though it does not
+            // scroll vertically.
             scrollView.leftEdgeEffect.isHidden = true
             scrollView.rightEdgeEffect.isHidden = true
+            scrollView.topEdgeEffect.isHidden = true
+            scrollView.bottomEdgeEffect.isHidden = true
         }
         scrollView.translatesAutoresizingMaskIntoConstraints = false
 

--- a/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/TerminalInputTextView.swift
+++ b/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/TerminalInputTextView.swift
@@ -361,9 +361,20 @@ final class TerminalInputTextView: UIView, UIKeyInput, UITextInput {
 
         // Scrollable action buttons
         let scrollView = UIScrollView()
+        scrollView.backgroundColor = .clear
+        scrollView.isOpaque = false
         scrollView.showsHorizontalScrollIndicator = false
         scrollView.showsVerticalScrollIndicator = false
         scrollView.alwaysBounceHorizontal = true
+        if #available(iOS 26.0, *) {
+            // The system's horizontal edge treatment is designed to separate
+            // scrollable content from fixed chrome. This compact strip already
+            // shares one background with its pinned controls, and the effect's
+            // fill covers the full 28pt height, making the scroller look like a
+            // separate gray rectangle in light mode.
+            scrollView.leftEdgeEffect.isHidden = true
+            scrollView.rightEdgeEffect.isHidden = true
+        }
         scrollView.translatesAutoresizingMaskIntoConstraints = false
 
         let stack = UIStackView()

--- a/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/TerminalInputTextView.swift
+++ b/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/TerminalInputTextView.swift
@@ -1015,8 +1015,10 @@ final class TerminalInputTextView: UIView, UIKeyInput, UITextInput {
     }
 
     /// Build (or rebuild) a button's configuration for `item` and its current
-    /// armed/sticky state. On iOS 26 the bar uses real Liquid Glass
-    /// (`.glass()` resting, `.prominentGlass()` armed/sticky); earlier OSes keep
+    /// armed/sticky state. On iOS 26 the bar uses clear Liquid Glass. Regular
+    /// glass inside the clipped horizontal scroller composites one shared
+    /// rectangular backdrop behind every button; clear glass keeps each capsule
+    /// distinct over the toolbar's single themed background. Earlier OSes keep
     /// the flat gray/blue fill the bar shipped with. Built-in modifier titles
     /// follow `isMacRemote`; custom actions render their saved title/icon and
     /// never arm.
@@ -1080,7 +1082,9 @@ final class TerminalInputTextView: UIView, UIKeyInput, UITextInput {
         let activeBackground = UIColor.systemBlue
         let activeForeground = activeBackground.terminalReadableForeground
         if #available(iOS 26.0, *) {
-            var config: UIButton.Configuration = (armed || sticky) ? .prominentGlass() : .glass()
+            var config: UIButton.Configuration = (armed || sticky)
+                ? .prominentClearGlass()
+                : .clearGlass()
             config.baseForegroundColor = armed || sticky ? activeForeground : themeChromeColor
             if armed || sticky {
                 config.baseBackgroundColor = activeBackground

--- a/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/TerminalInputTextView.swift
+++ b/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/TerminalInputTextView.swift
@@ -366,21 +366,16 @@ final class TerminalInputTextView: UIView, UIKeyInput, UITextInput {
         scrollView.showsHorizontalScrollIndicator = false
         scrollView.showsVerticalScrollIndicator = false
         scrollView.alwaysBounceHorizontal = true
-        if #available(iOS 26.0, *) {
-            // The system's edge treatments are designed to separate scrollable
-            // content from fixed chrome. This compact strip already shares one
-            // background with its pinned controls. At only 28pt high, the top and
-            // bottom fills overlap across the full scroller and make it look like
-            // a separate gray rectangle in light mode, even though it does not
-            // scroll vertically.
-            scrollView.leftEdgeEffect.isHidden = true
-            scrollView.rightEdgeEffect.isHidden = true
-            scrollView.topEdgeEffect.isHidden = true
-            scrollView.bottomEdgeEffect.isHidden = true
-        }
         scrollView.translatesAutoresizingMaskIntoConstraints = false
 
         let stack = UIStackView()
+        // This stack is structural, not visual. UIStackView inherits UIView's
+        // opaque default even with no background color; when clipped through a
+        // UIScrollView, UIKit can composite that opaque region as a rectangular
+        // fill in light themes. Keep the toolbar's background owned solely by
+        // backgroundView.
+        stack.backgroundColor = .clear
+        stack.isOpaque = false
         stack.axis = .horizontal
         // Tighter inter-button spacing so the keys read as a compact row.
         stack.spacing = 4

--- a/Packages/iOS/CmuxMobileTerminal/Tests/CmuxMobileTerminalTests/GhosttySurfaceThemeTests.swift
+++ b/Packages/iOS/CmuxMobileTerminal/Tests/CmuxMobileTerminalTests/GhosttySurfaceThemeTests.swift
@@ -74,6 +74,8 @@ import UIKit
     if #available(iOS 26.0, *) {
         #expect(scrollView.leftEdgeEffect.isHidden)
         #expect(scrollView.rightEdgeEffect.isHidden)
+        #expect(scrollView.topEdgeEffect.isHidden)
+        #expect(scrollView.bottomEdgeEffect.isHidden)
     }
 }
 

--- a/Packages/iOS/CmuxMobileTerminal/Tests/CmuxMobileTerminalTests/GhosttySurfaceThemeTests.swift
+++ b/Packages/iOS/CmuxMobileTerminal/Tests/CmuxMobileTerminalTests/GhosttySurfaceThemeTests.swift
@@ -64,6 +64,20 @@ import UIKit
 }
 
 @MainActor
+@Test func accessoryShortcutScrollerDoesNotDrawSeparateChrome() throws {
+    let input = TerminalInputTextView()
+    let toolbar = input.toolbarView
+    let scrollView = try #require(toolbar.subviews.compactMap { $0 as? UIScrollView }.first)
+
+    #expect(scrollView.backgroundColor == UIColor.clear)
+    #expect(!scrollView.isOpaque)
+    if #available(iOS 26.0, *) {
+        #expect(scrollView.leftEdgeEffect.isHidden)
+        #expect(scrollView.rightEdgeEffect.isHidden)
+    }
+}
+
+@MainActor
 @Test func reverseModeOSCResetsUseRawConfigDefaults() async throws {
     let runtime = try GhosttyRuntime.shared()
     let delegate = ThemeTestSurfaceDelegate()

--- a/Packages/iOS/CmuxMobileTerminal/Tests/CmuxMobileTerminalTests/GhosttySurfaceThemeTests.swift
+++ b/Packages/iOS/CmuxMobileTerminal/Tests/CmuxMobileTerminalTests/GhosttySurfaceThemeTests.swift
@@ -68,15 +68,12 @@ import UIKit
     let input = TerminalInputTextView()
     let toolbar = input.toolbarView
     let scrollView = try #require(toolbar.subviews.compactMap { $0 as? UIScrollView }.first)
+    let stackView = try #require(scrollView.subviews.compactMap { $0 as? UIStackView }.first)
 
     #expect(scrollView.backgroundColor == UIColor.clear)
     #expect(!scrollView.isOpaque)
-    if #available(iOS 26.0, *) {
-        #expect(scrollView.leftEdgeEffect.isHidden)
-        #expect(scrollView.rightEdgeEffect.isHidden)
-        #expect(scrollView.topEdgeEffect.isHidden)
-        #expect(scrollView.bottomEdgeEffect.isHidden)
-    }
+    #expect(stackView.backgroundColor == UIColor.clear)
+    #expect(!stackView.isOpaque)
 }
 
 @MainActor


### PR DESCRIPTION
Fix the iOS 26 light-mode background mismatch in the terminal shortcut strip.

The horizontal shortcut scroller now stays transparent and suppresses iOS 26 scroll-edge effects, so the pinned controls and scrolling controls share one continuous dock background.

Adds a runtime UIKit regression that verifies the scroller does not draw separate chrome.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/9859"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788836252&installation_model_id=21920&pr_number=9859&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F9859&signature=27eaf06f4552b29ad6d21dda1faa56819d7fcc65d7fbc34ff864a3ed2758497c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized UIKit compositing and styling on the terminal input accessory bar; no input routing, networking, or auth changes.
> 
> **Overview**
> Fixes a **light-mode visual mismatch** on iOS where the horizontally scrolling shortcut row looked like it had its own background, separate from the pinned keyboard/dismiss controls and the dock’s `backgroundView`.
> 
> The accessory toolbar’s `UIScrollView` and inner `UIStackView` are now **clear and non-opaque**, with an inline note that UIKit can still composite an opaque stack inside a scroll view as a rectangular fill—so only `backgroundView` should own the bar color.
> 
> Adds **`accessoryShortcutScrollerDoesNotDrawSeparateChrome`** in `GhosttySurfaceThemeTests` to assert those transparency settings at runtime.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 55eb45e9baed67ddbca5464720e89b5aaac82297. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the iOS 26 light‑mode background mismatch in the terminal shortcut strip. The scroller/stack stay transparent, edge effects are hidden, and iOS 26 buttons use clear glass so pinned and scrolling controls share one continuous dock background.

- **Bug Fixes**
  - Made the shortcut `UIScrollView` and inner `UIStackView` clear/non‑opaque and hid iOS 26 edge effects; added a UIKit test to assert transparency and no separate chrome.
  - On iOS 26, switched shortcut buttons to `.clearGlass()` / `.prominentClearGlass()` to prevent a scroller‑wide backdrop and keep one dock background.

<sup>Written for commit bfb3611f9c75876eb12f112e491cdcce2b6a76bb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/9859?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the accessory toolbar’s shortcut scroller and supporting layout to use transparent, non-opaque backgrounds.
  * On iOS 26, accessory buttons now use clear Liquid Glass styling.
  * Preserved existing horizontal scrolling and scroll indicator behavior for a consistent interaction experience.
  * Added coverage to verify the accessory toolbar maintains its transparent appearance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->