### PR TITLE
Open a per-session browser beside remote tmux mirrors

### DIFF
--- a/Sources/Panels/BrowserPanel.swift
+++ b/Sources/Panels/BrowserPanel.swift
@@ -5395,6 +5395,23 @@ final class BrowserPanel: Panel, ObservableObject {
         onNavigationStarted: ((WKNavigation?) -> Void)? = nil
     ) -> WKNavigation? {
         let request = URLRequest(url: url)
+        return navigate(
+            to: request,
+            recordTypedNavigation: recordTypedNavigation,
+            onNavigationStarted: onNavigationStarted
+        )
+    }
+
+    @discardableResult
+    func navigate(
+        to request: URLRequest,
+        recordTypedNavigation: Bool = false,
+        onNavigationStarted: ((WKNavigation?) -> Void)? = nil
+    ) -> WKNavigation? {
+        guard let url = request.url else {
+            onNavigationStarted?(nil)
+            return nil
+        }
         if !BrowserURLAllowlistPolicy(defaults: .standard).allows(url) {
             navigationDelegate?.blockURLAllowlistNavigation(url, in: webView)
             onNavigationStarted?(nil)

--- a/Sources/RemoteTmuxController.swift
+++ b/Sources/RemoteTmuxController.swift
@@ -307,6 +307,7 @@ final class RemoteTmuxController {
             applyCreationTitleAsCustomTitle: false
         )
         workspace.isRemoteTmuxMirror = true
+        workspace.authenticateRemoteTmuxWindowsPane()
         // Identity pairs the connection pushes into the remote SESSION
         // environment on attach and every reconnect (issue #833). Workspace id
         // is published under both keys, matching the SSH-workspace bootstrap

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -5862,6 +5862,19 @@ final class Workspace: Identifiable, ObservableObject, FilePreviewTabMetadataHos
     /// Bound action for this mirror's outbound window-order mutation boundary.
     var remoteTmuxWindowOrderSync: (([UUID], ((Bool) -> Void)?) -> Bool)?
 
+    /// The single per-session browser panel for a remote tmux mirror, if open.
+    /// A tmux session (one ``Workspace``) hosts at most one browser, split beside
+    /// the mirrored tmux area at the workspace top level (outside the mirror's
+    /// nested tree, so ``RemoteTmuxSessionMirror/rebuild()`` never reconciles it).
+    /// Cleared when the browser pane closes (see ``splitTabBar(_:didCloseTab:fromPane:)``).
+    var remoteTmuxSessionBrowserPanelId: UUID?
+
+    /// True only while ``openRemoteTmuxSessionBrowser`` performs its local split.
+    /// A mirror workspace otherwise vetoes every local split in
+    /// ``splitTabBar(_:shouldSplitPane:orientation:)`` and reroutes it to tmux
+    /// `split-window`; this flag lets the one per-session browser split through.
+    var isCreatingRemoteTmuxSessionBrowserSplit = false
+
     /// Per-window multi-pane renderers, keyed by mirrored window-tab panel id.
     private(set) var remoteTmuxWindowMirrors: [UUID: RemoteTmuxWindowMirror] = [:]
 
@@ -8472,7 +8485,10 @@ final class Workspace: Identifiable, ObservableObject, FilePreviewTabMetadataHos
         onResize: (@MainActor @Sendable (_ columns: Int, _ rows: Int) -> Void)? = nil
     ) -> TerminalPanel? {
         let newPanel = performRemoteTmuxMirrorMutation { () -> TerminalPanel? in
-            guard let paneId = bonsplitController.focusedPaneId ?? bonsplitController.allPaneIds.first
+            // Target the pane that holds tmux window tabs, never the per-session
+            // browser pane — otherwise a newly mirrored window would land as a tab
+            // inside the browser split when that pane happens to be focused.
+            guard let paneId = remoteTmuxWindowsTargetPaneId()
             else { return nil }
 
             let title = customTitle ?? String(localized: "remoteTmux.tab.pane", defaultValue: "tmux pane")
@@ -8511,6 +8527,59 @@ final class Workspace: Identifiable, ObservableObject, FilePreviewTabMetadataHos
             focusPanel(newPanel.id)
         }
         return newPanel
+    }
+
+    /// The top-level Bonsplit pane that holds this mirror's tmux window tabs,
+    /// i.e. every pane except the per-session browser split. Prefers the focused
+    /// pane when it is a tmux pane, else the first non-browser pane. Falls back to
+    /// the first pane so a brand-new mirror (no browser yet) still resolves.
+    func remoteTmuxWindowsTargetPaneId() -> PaneID? {
+        let browserPaneId = remoteTmuxSessionBrowserPanelId.flatMap { paneId(forPanelId: $0) }
+        let tmuxPanes = bonsplitController.allPaneIds.filter { $0 != browserPaneId }
+        if let focused = bonsplitController.focusedPaneId, tmuxPanes.contains(focused) {
+            return focused
+        }
+        return tmuxPanes.first ?? bonsplitController.allPaneIds.first
+    }
+
+    /// Opens (or focuses) the single browser for this remote tmux session.
+    ///
+    /// A tmux session maps 1:1 to a ``Workspace``, so it hosts at most one
+    /// browser. The browser is a top-level split beside the mirrored tmux area
+    /// (never inside the mirror's nested pane tree), which keeps the tmux 1:1
+    /// invariant intact — the mirror's `rebuild()` only reconciles window tabs and
+    /// never sees this panel. A second request focuses the existing browser
+    /// (navigating it when a URL is supplied) instead of creating another.
+    @discardableResult
+    func openRemoteTmuxSessionBrowser(url: URL? = nil, focus: Bool = true) -> BrowserPanel? {
+        guard isRemoteTmuxMirror else { return nil }
+
+        // Reuse the existing session browser: focus it and, when a URL was
+        // requested (e.g. an opened link), navigate the existing surface.
+        if let existingId = remoteTmuxSessionBrowserPanelId,
+           let existing = panels[existingId] as? BrowserPanel {
+            if let url { existing.navigate(to: url) }
+            if focus { focusPanel(existingId) }
+            return existing
+        }
+
+        // No browser yet — split the tmux-windows pane to the right, sourcing the
+        // split from that pane's selected window tab.
+        guard let tmuxPaneId = remoteTmuxWindowsTargetPaneId(),
+              let sourceTabId = bonsplitController.selectedTab(inPane: tmuxPaneId)?.id,
+              let sourcePanelId = panelIdFromSurfaceId(sourceTabId) else { return nil }
+
+        isCreatingRemoteTmuxSessionBrowserSplit = true
+        defer { isCreatingRemoteTmuxSessionBrowserSplit = false }
+        let browser = newBrowserSplit(
+            from: sourcePanelId,
+            orientation: .horizontal,
+            url: url,
+            focus: focus,
+            allowInRemoteTmuxMirror: true
+        )
+        if let browser { remoteTmuxSessionBrowserPanelId = browser.id }
+        return browser
     }
 
     /// Closes one pane of a mirrored multi-pane tmux window (the pane-header ✕),
@@ -8827,11 +8896,16 @@ final class Workspace: Identifiable, ObservableObject, FilePreviewTabMetadataHos
         transparentBackground: Bool = false,
         bypassRemoteProxy: Bool = false,
         initialDividerPosition: CGFloat? = nil,
-        websiteDataStore: WKWebsiteDataStore? = nil
+        websiteDataStore: WKWebsiteDataStore? = nil,
+        allowInRemoteTmuxMirror: Bool = false
     ) -> BrowserPanel? {
-        // No local browser surfaces in a remote tmux mirror workspace (it is a
-        // 1:1 view of a tmux session). See ``newBrowserSurface(inPane:)``.
-        if isRemoteTmuxMirror { return nil }
+        // A remote tmux mirror hosts a single per-session browser split beside the
+        // mirrored tmux area. Every generic browser-split request routes there so
+        // it opens/focuses that one browser; only ``openRemoteTmuxSessionBrowser``
+        // (which passes `allowInRemoteTmuxMirror`) performs the actual split.
+        if isRemoteTmuxMirror && !allowInRemoteTmuxMirror {
+            return openRemoteTmuxSessionBrowser(url: url, focus: focus)
+        }
         let browserEnabled = BrowserAvailabilitySettings.isEnabled()
         // Under an MDM-managed disable no path may create a browser panel,
         // including session restore (mirrors the Dock restore behavior).
@@ -8956,10 +9030,12 @@ final class Workspace: Identifiable, ObservableObject, FilePreviewTabMetadataHos
         websiteDataStore: WKWebsiteDataStore? = nil
     ) -> BrowserPanel? {
         // A remote tmux mirror workspace is a 1:1 view of a tmux session (which
-        // has no browser concept). A local browser tab here would be an orphan
-        // that the mirror's rebuild() never reconciles, breaking the 1:1
-        // invariant — so refuse browser creation in a mirror workspace.
-        if isRemoteTmuxMirror { return nil }
+        // has no browser concept), so a browser tab inside the mirror tree would
+        // be an orphan the mirror's rebuild() never reconciles. Instead, route to
+        // the single per-session browser split that lives beside the mirror.
+        if isRemoteTmuxMirror {
+            return openRemoteTmuxSessionBrowser(url: url ?? initialRequest?.url, focus: focus ?? true)
+        }
         let browserEnabled = BrowserAvailabilitySettings.isEnabled()
         // Under an MDM-managed disable no path may create a browser panel,
         // including session restore (mirrors the Dock restore behavior).
@@ -12960,6 +13036,11 @@ extension Workspace: BonsplitDelegate {
         #endif
 
         let panel = panels[panelId]
+        // A closed per-session remote tmux browser frees the slot so a later
+        // browser-icon click recreates it rather than focusing a dead panel.
+        if panelId == remoteTmuxSessionBrowserPanelId {
+            remoteTmuxSessionBrowserPanelId = nil
+        }
         _ = consumeCloseHistoryEligibility(tabId: tabId, panelId: panelId)
         let transferredRemoteCleanupConfiguration = transferredRemoteCleanupConfigurationsByPanelId[panelId]
         let preservesSurfaceForDetach = isDetaching && panel != nil
@@ -13126,6 +13207,9 @@ extension Workspace: BonsplitDelegate {
         // In a remote tmux mirror, split means tmux `split-window`; always veto
         // local splits so the mirror never gains an orphan pane.
         guard isRemoteTmuxMirror else { return true }
+        // Exception: the single per-session browser is a real local split beside
+        // the mirror (not a tmux pane), so let ``openRemoteTmuxSessionBrowser`` through.
+        if isCreatingRemoteTmuxSessionBrowserSplit { return true }
         if let tabId = bonsplitController.selectedTab(inPane: pane)?.id,
            let panelId = panelIdFromSurfaceId(tabId) {
             _ = AppDelegate.shared?.remoteTmuxController.handleMirrorTabSplitRequested(workspaceId: id, panelId: panelId, vertical: orientation == .vertical, focusIntent: .focusCreatedPane)

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -8531,15 +8531,25 @@ final class Workspace: Identifiable, ObservableObject, FilePreviewTabMetadataHos
 
     /// The top-level Bonsplit pane that holds this mirror's tmux window tabs,
     /// i.e. every pane except the per-session browser split. Prefers the focused
-    /// pane when it is a tmux pane, else the first non-browser pane. Falls back to
-    /// the first pane so a brand-new mirror (no browser yet) still resolves.
+    /// pane when it is a tmux pane, else the first non-browser pane. Returns nil
+    /// only when the browser split is the sole remaining pane — never the browser
+    /// pane itself, so a newly mirrored window can never land inside the browser.
     func remoteTmuxWindowsTargetPaneId() -> PaneID? {
         let browserPaneId = remoteTmuxSessionBrowserPanelId.flatMap { paneId(forPanelId: $0) }
         let tmuxPanes = bonsplitController.allPaneIds.filter { $0 != browserPaneId }
         if let focused = bonsplitController.focusedPaneId, tmuxPanes.contains(focused) {
             return focused
         }
-        return tmuxPanes.first ?? bonsplitController.allPaneIds.first
+        return tmuxPanes.first
+    }
+
+    /// Frees the per-session browser slot when its panel is torn down, so a later
+    /// browser-icon click recreates the browser instead of focusing a dead panel.
+    /// Called from every pane/tab close path that can remove the browser panel.
+    func clearRemoteTmuxSessionBrowserPanelIfMatches(_ panelId: UUID) {
+        if panelId == remoteTmuxSessionBrowserPanelId {
+            remoteTmuxSessionBrowserPanelId = nil
+        }
     }
 
     /// Opens (or focuses) the single browser for this remote tmux session.
@@ -13036,11 +13046,7 @@ extension Workspace: BonsplitDelegate {
         #endif
 
         let panel = panels[panelId]
-        // A closed per-session remote tmux browser frees the slot so a later
-        // browser-icon click recreates it rather than focusing a dead panel.
-        if panelId == remoteTmuxSessionBrowserPanelId {
-            remoteTmuxSessionBrowserPanelId = nil
-        }
+        clearRemoteTmuxSessionBrowserPanelIfMatches(panelId)
         _ = consumeCloseHistoryEligibility(tabId: tabId, panelId: panelId)
         let transferredRemoteCleanupConfiguration = transferredRemoteCleanupConfigurationsByPanelId[panelId]
         let preservesSurfaceForDetach = isDetaching && panel != nil
@@ -13314,6 +13320,7 @@ extension Workspace: BonsplitDelegate {
 
             for panelId in closedPanelIds {
                 let panel = panels[panelId]
+                clearRemoteTmuxSessionBrowserPanelIfMatches(panelId)
                 discardClosedPanelLifecycleState(
                     panelId: panelId,
                     tabId: surfaceIdFromPanelId(panelId),

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -5859,6 +5859,7 @@ final class Workspace: Identifiable, ObservableObject, FilePreviewTabMetadataHos
     /// Ephemeral remote tmux mirror; excluded from cmux session restore.
     var isRemoteTmuxMirror: Bool = false
     weak var remoteTmuxSessionMirror: RemoteTmuxSessionMirror?
+    private var remoteTmuxWindowsPaneId: PaneID?
     /// Bound action for this mirror's outbound window-order mutation boundary.
     var remoteTmuxWindowOrderSync: (([UUID], ((Bool) -> Void)?) -> Bool)?
 
@@ -8529,26 +8530,31 @@ final class Workspace: Identifiable, ObservableObject, FilePreviewTabMetadataHos
         return newPanel
     }
 
-    /// The top-level Bonsplit pane that holds this mirror's tmux window tabs,
-    /// i.e. every pane except the per-session browser split. Prefers the focused
-    /// pane when it is a tmux pane, else the first non-browser pane. Returns nil
-    /// only when the browser split is the sole remaining pane — never the browser
-    /// pane itself, so a newly mirrored window can never land inside the browser.
-    func remoteTmuxWindowsTargetPaneId() -> PaneID? {
-        let browserPaneId = remoteTmuxSessionBrowserPanelId.flatMap { paneId(forPanelId: $0) }
-        let tmuxPanes = bonsplitController.allPaneIds.filter { $0 != browserPaneId }
-        if let focused = bonsplitController.focusedPaneId, tmuxPanes.contains(focused) {
-            return focused
+    func authenticateRemoteTmuxWindowsPane() {
+        guard isRemoteTmuxMirror else {
+            remoteTmuxWindowsPaneId = nil
+            return
         }
-        return tmuxPanes.first
+        remoteTmuxWindowsPaneId = bonsplitController.focusedPaneId
+            ?? bonsplitController.allPaneIds.first
+    }
+
+    /// The authenticated top-level Bonsplit pane that holds this mirror's tmux window tabs.
+    func remoteTmuxWindowsTargetPaneId() -> PaneID? {
+        guard let paneId = remoteTmuxWindowsPaneId,
+              bonsplitController.allPaneIds.contains(paneId) else { return nil }
+        return paneId
     }
 
     /// Frees the per-session browser slot when its panel is torn down, so a later
     /// browser-icon click recreates the browser instead of focusing a dead panel.
     /// Called from every pane/tab close path that can remove the browser panel.
     func clearRemoteTmuxSessionBrowserPanelIfMatches(_ panelId: UUID) {
-        if panelId == remoteTmuxSessionBrowserPanelId {
-            remoteTmuxSessionBrowserPanelId = nil
+        guard panelId == remoteTmuxSessionBrowserPanelId else { return }
+        remoteTmuxSessionBrowserPanelId = paneId(forPanelId: panelId).flatMap { paneId in
+            bonsplitController.tabs(inPane: paneId)
+                .compactMap { panelIdFromSurfaceId($0.id) }
+                .first { $0 != panelId && panels[$0] is BrowserPanel }
         }
     }
 
@@ -8561,14 +8567,22 @@ final class Workspace: Identifiable, ObservableObject, FilePreviewTabMetadataHos
     /// never sees this panel. A second request focuses the existing browser
     /// (navigating it when a URL is supplied) instead of creating another.
     @discardableResult
-    func openRemoteTmuxSessionBrowser(url: URL? = nil, focus: Bool = true) -> BrowserPanel? {
+    func openRemoteTmuxSessionBrowser(
+        url: URL? = nil,
+        initialRequest: URLRequest? = nil,
+        focus: Bool = true
+    ) -> BrowserPanel? {
         guard isRemoteTmuxMirror else { return nil }
 
         // Reuse the existing session browser: focus it and, when a URL was
         // requested (e.g. an opened link), navigate the existing surface.
         if let existingId = remoteTmuxSessionBrowserPanelId,
            let existing = panels[existingId] as? BrowserPanel {
-            if let url { existing.navigate(to: url) }
+            if let initialRequest {
+                existing.navigate(to: initialRequest)
+            } else if let url {
+                existing.navigate(to: url)
+            }
             if focus { focusPanel(existingId) }
             return existing
         }
@@ -8585,6 +8599,7 @@ final class Workspace: Identifiable, ObservableObject, FilePreviewTabMetadataHos
             from: sourcePanelId,
             orientation: .horizontal,
             url: url,
+            initialRequest: initialRequest,
             focus: focus,
             allowInRemoteTmuxMirror: true
         )
@@ -8914,7 +8929,11 @@ final class Workspace: Identifiable, ObservableObject, FilePreviewTabMetadataHos
         // it opens/focuses that one browser; only ``openRemoteTmuxSessionBrowser``
         // (which passes `allowInRemoteTmuxMirror`) performs the actual split.
         if isRemoteTmuxMirror && !allowInRemoteTmuxMirror {
-            return openRemoteTmuxSessionBrowser(url: url, focus: focus)
+            return openRemoteTmuxSessionBrowser(
+                url: url,
+                initialRequest: initialRequest,
+                focus: focus
+            )
         }
         let browserEnabled = BrowserAvailabilitySettings.isEnabled()
         // Under an MDM-managed disable no path may create a browser panel,
@@ -9050,7 +9069,11 @@ final class Workspace: Identifiable, ObservableObject, FilePreviewTabMetadataHos
         if isRemoteTmuxMirror {
             let sessionBrowserPane = remoteTmuxSessionBrowserPanelId.flatMap { self.paneId(forPanelId: $0) }
             if sessionBrowserPane == nil || paneId != sessionBrowserPane {
-                return openRemoteTmuxSessionBrowser(url: url ?? initialRequest?.url, focus: focus ?? true)
+                return openRemoteTmuxSessionBrowser(
+                    url: url,
+                    initialRequest: initialRequest,
+                    focus: focus ?? true
+                )
             }
             // Target is the existing browser pane → fall through to add a normal
             // browser tab there.

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -9041,10 +9041,19 @@ final class Workspace: Identifiable, ObservableObject, FilePreviewTabMetadataHos
     ) -> BrowserPanel? {
         // A remote tmux mirror workspace is a 1:1 view of a tmux session (which
         // has no browser concept), so a browser tab inside the mirror tree would
-        // be an orphan the mirror's rebuild() never reconciles. Instead, route to
-        // the single per-session browser split that lives beside the mirror.
+        // be an orphan the mirror's rebuild() never reconciles. Route a generic
+        // browser open (globe on a tmux pane, link-open, etc.) to the single
+        // per-session browser split beside the mirror — BUT allow a real new tab
+        // WITHIN that browser pane (e.g. "open link in a new tab"), which targets
+        // the browser pane itself; otherwise the new-tab request would collapse
+        // into navigating the existing browser.
         if isRemoteTmuxMirror {
-            return openRemoteTmuxSessionBrowser(url: url ?? initialRequest?.url, focus: focus ?? true)
+            let sessionBrowserPane = remoteTmuxSessionBrowserPanelId.flatMap { self.paneId(forPanelId: $0) }
+            if sessionBrowserPane == nil || paneId != sessionBrowserPane {
+                return openRemoteTmuxSessionBrowser(url: url ?? initialRequest?.url, focus: focus ?? true)
+            }
+            // Target is the existing browser pane → fall through to add a normal
+            // browser tab there.
         }
         let browserEnabled = BrowserAvailabilitySettings.isEnabled()
         // Under an MDM-managed disable no path may create a browser panel,

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -1739,6 +1739,7 @@ C0DE71B10000000000000001 /* AppDelegate+AgentChatNotifications.swift in Sources 
 		9251A0019251A0019251A002 /* RemoteTmuxKeyName.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9251A0019251A0019251A001 /* RemoteTmuxKeyName.swift */; };
 		79380000000000000000000C /* RemoteTmuxLayoutNodePatchingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79380000000000000000000B /* RemoteTmuxLayoutNodePatchingTests.swift */; };
 		6732BEEF6732BEEF6732B002 /* RemoteTmuxMasterReadinessTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6732BEEF6732BEEF6732B001 /* RemoteTmuxMasterReadinessTests.swift */; };
+		60BA9D5C2555D87E280E2E90 /* RemoteTmuxMirrorBrowserSplitTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C5B6E850C66BF085AAB4465 /* RemoteTmuxMirrorBrowserSplitTests.swift */; };
 		7738A0027738A0027738A002 /* RemoteTmuxMirrorCLIFailClosedTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7738B0027738B0027738B002 /* RemoteTmuxMirrorCLIFailClosedTests.swift */; };
 		7738A0017738A0017738A001 /* RemoteTmuxMirrorCLIObservabilityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7738B0017738B0017738B001 /* RemoteTmuxMirrorCLIObservabilityTests.swift */; };
 		C2C5F24B63F3E5516408EE44 /* RemoteTmuxMirrorCloseDetachTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0DBAA681DEE6F9121D289ABE /* RemoteTmuxMirrorCloseDetachTests.swift */; };
@@ -4555,6 +4556,7 @@ B8B056D80000000000000002 /* MobileHostIdentityTests.swift */ = {isa = PBXFileRef
 		9251A0019251A0019251A001 /* RemoteTmuxKeyName.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteTmuxKeyName.swift; sourceTree = "<group>"; };
 		79380000000000000000000B /* RemoteTmuxLayoutNodePatchingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteTmuxLayoutNodePatchingTests.swift; sourceTree = "<group>"; };
 		6732BEEF6732BEEF6732B001 /* RemoteTmuxMasterReadinessTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteTmuxMasterReadinessTests.swift; sourceTree = "<group>"; };
+		2C5B6E850C66BF085AAB4465 /* RemoteTmuxMirrorBrowserSplitTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteTmuxMirrorBrowserSplitTests.swift; sourceTree = "<group>"; };
 		7738B0027738B0027738B002 /* RemoteTmuxMirrorCLIFailClosedTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteTmuxMirrorCLIFailClosedTests.swift; sourceTree = "<group>"; };
 		7738B0017738B0017738B001 /* RemoteTmuxMirrorCLIObservabilityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteTmuxMirrorCLIObservabilityTests.swift; sourceTree = "<group>"; };
 		0DBAA681DEE6F9121D289ABE /* RemoteTmuxMirrorCloseDetachTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteTmuxMirrorCloseDetachTests.swift; sourceTree = "<group>"; };
@@ -8361,6 +8363,7 @@ B8B056D80000000000000002 /* MobileHostIdentityTests.swift */ = {isa = PBXFileRef
 				B0555302B0555302B0555302 /* RemoteTmuxControlStreamParserBudgetTests.swift */,
 				B0555304B0555304B0555304 /* DetachedFolderPathLookupCacheTests.swift */,
 				A7E1C4D2B3F09865E217D4C0 /* RemoteTmuxMirrorSplitRoutingTests.swift */,
+				2C5B6E850C66BF085AAB4465 /* RemoteTmuxMirrorBrowserSplitTests.swift */,
 				7738B0017738B0017738B001 /* RemoteTmuxMirrorCLIObservabilityTests.swift */,
 				7738B0027738B0027738B002 /* RemoteTmuxMirrorCLIFailClosedTests.swift */,
 				7837E0047837E0047837E004 /* RemoteTmuxMirrorResizeRoutingTests.swift */,
@@ -11578,6 +11581,7 @@ B8B056D80000000000000002 /* MobileHostIdentityTests.swift */ = {isa = PBXFileRef
 				F6724602A1B2C3D4E5F67246 /* RemoteTmuxHostRemoteCommandOverrideTests.swift in Sources */,
 				79380000000000000000000C /* RemoteTmuxLayoutNodePatchingTests.swift in Sources */,
 				6732BEEF6732BEEF6732B002 /* RemoteTmuxMasterReadinessTests.swift in Sources */,
+				60BA9D5C2555D87E280E2E90 /* RemoteTmuxMirrorBrowserSplitTests.swift in Sources */,
 				7738A0027738A0027738A002 /* RemoteTmuxMirrorCLIFailClosedTests.swift in Sources */,
 				7738A0017738A0017738A001 /* RemoteTmuxMirrorCLIObservabilityTests.swift in Sources */,
 				C2C5F24B63F3E5516408EE44 /* RemoteTmuxMirrorCloseDetachTests.swift in Sources */,

--- a/cmuxTests/RemoteTmuxMirrorBrowserSplitTests.swift
+++ b/cmuxTests/RemoteTmuxMirrorBrowserSplitTests.swift
@@ -1,0 +1,135 @@
+import AppKit
+import Bonsplit
+import Testing
+
+#if canImport(cmux_DEV)
+@testable import cmux_DEV
+#elseif canImport(cmux)
+@testable import cmux
+#endif
+
+/// Regression coverage for the per-session browser on remote tmux mirror
+/// workspaces (https://github.com/manaflow-ai/cmux/pull/9861).
+///
+/// A tmux session maps 1:1 to a ``Workspace``, so it hosts at most one browser
+/// as a top-level split beside the mirrored tmux area (never inside the mirror's
+/// nested pane tree, which the mirror's `rebuild()` would reconcile away). Generic
+/// browser-split / browser-surface requests on a mirror must route to that single
+/// browser rather than returning nil or creating a local orphan, and the tmux
+/// windows target pane must never resolve to the browser pane (else a newly
+/// mirrored window would land as a tab inside the browser split).
+@MainActor
+@Suite(.serialized) struct RemoteTmuxMirrorBrowserSplitTests {
+    @Test func openReturnsBrowserAndTracksPanelId() throws {
+        let harness = try Harness()
+        defer { harness.tearDown() }
+
+        let panelsBefore = harness.workspace.panels.count
+        let browser = try #require(harness.workspace.openRemoteTmuxSessionBrowser(focus: false))
+
+        #expect(harness.workspace.panels.count == panelsBefore + 1)
+        #expect(harness.workspace.remoteTmuxSessionBrowserPanelId == browser.id)
+        #expect(harness.workspace.panels[browser.id] is BrowserPanel)
+    }
+
+    @Test func openIsSinglePerSession() throws {
+        let harness = try Harness()
+        defer { harness.tearDown() }
+
+        let panelsBefore = harness.workspace.panels.count
+        let first = try #require(harness.workspace.openRemoteTmuxSessionBrowser(focus: false))
+        let countAfterFirst = harness.workspace.panels.count
+        #expect(countAfterFirst == panelsBefore + 1)
+
+        let second = try #require(harness.workspace.openRemoteTmuxSessionBrowser(focus: false))
+        #expect(second.id == first.id)
+        #expect(harness.workspace.panels.count == countAfterFirst)
+        #expect(harness.workspace.remoteTmuxSessionBrowserPanelId == first.id)
+    }
+
+    @Test func newBrowserSurfaceRoutesToSessionBrowser() throws {
+        let harness = try Harness()
+        defer { harness.tearDown() }
+
+        let paneId = try #require(harness.workspace.remoteTmuxWindowsTargetPaneId())
+        let panelsBefore = harness.workspace.panels.count
+
+        let first = try #require(harness.workspace.newBrowserSurface(inPane: paneId, focus: true))
+        #expect(harness.workspace.remoteTmuxSessionBrowserPanelId == first.id)
+        #expect(harness.workspace.panels.count == panelsBefore + 1)
+
+        // A second surface request routes to the same browser, never a second one.
+        let second = try #require(harness.workspace.newBrowserSurface(inPane: paneId, focus: true))
+        #expect(second.id == first.id)
+        #expect(harness.workspace.panels.count == panelsBefore + 1)
+    }
+
+    @Test func newBrowserSplitRoutesToSessionBrowser() throws {
+        let harness = try Harness()
+        defer { harness.tearDown() }
+
+        let panelsBefore = harness.workspace.panels.count
+
+        let first = try #require(
+            harness.workspace.newBrowserSplit(
+                from: harness.sourcePanelId,
+                orientation: .horizontal,
+                focus: false
+            )
+        )
+        #expect(harness.workspace.remoteTmuxSessionBrowserPanelId == first.id)
+        #expect(harness.workspace.panels.count == panelsBefore + 1)
+
+        // A second split request routes to the same browser, never a second one.
+        let second = try #require(
+            harness.workspace.newBrowserSplit(
+                from: harness.sourcePanelId,
+                orientation: .horizontal,
+                focus: false
+            )
+        )
+        #expect(second.id == first.id)
+        #expect(harness.workspace.panels.count == panelsBefore + 1)
+    }
+
+    @Test func windowsTargetPaneAvoidsBrowserPane() throws {
+        let harness = try Harness()
+        defer { harness.tearDown() }
+
+        let browser = try #require(harness.workspace.openRemoteTmuxSessionBrowser(focus: false))
+        let browserPaneId = try #require(harness.workspace.paneId(forPanelId: browser.id))
+        let targetPaneId = try #require(harness.workspace.remoteTmuxWindowsTargetPaneId())
+
+        #expect(targetPaneId != browserPaneId)
+    }
+
+    @MainActor
+    private struct Harness {
+        let appDelegate: AppDelegate
+        let windowId: UUID
+        let workspace: Workspace
+        let sourcePanelId: UUID
+        let wasBrowserDisabled: Bool
+
+        init() throws {
+            wasBrowserDisabled = BrowserAvailabilitySettings.isDisabled()
+            BrowserAvailabilitySettings.setDisabled(false)
+            appDelegate = try #require(AppDelegate.shared)
+            windowId = appDelegate.createMainWindow()
+            let manager = try #require(appDelegate.tabManagerFor(windowId: windowId))
+            workspace = try #require(manager.selectedWorkspace)
+            sourcePanelId = try #require(workspace.focusedPanelId)
+            workspace.isRemoteTmuxMirror = true
+        }
+
+        func tearDown() {
+            workspace.isRemoteTmuxMirror = false
+            let identifier = "cmux.main.\(windowId.uuidString)"
+            if let window = NSApp.windows.first(where: { $0.identifier?.rawValue == identifier }) {
+                window.performClose(nil)
+                RunLoop.main.run(until: Date(timeIntervalSinceNow: 0.05))
+            }
+            BrowserAvailabilitySettings.setDisabled(wasBrowserDisabled)
+        }
+    }
+}

--- a/cmuxTests/RemoteTmuxMirrorBrowserSplitTests.swift
+++ b/cmuxTests/RemoteTmuxMirrorBrowserSplitTests.swift
@@ -101,6 +101,36 @@ import Testing
         let targetPaneId = try #require(harness.workspace.remoteTmuxWindowsTargetPaneId())
 
         #expect(targetPaneId != browserPaneId)
+
+        #expect(harness.workspace.closePanel(browser.id, force: true))
+        #expect(harness.waitUntil { harness.workspace.remoteTmuxSessionBrowserPanelId == nil })
+
+        let replacement = try #require(harness.workspace.openRemoteTmuxSessionBrowser(focus: false))
+        #expect(replacement.id != browser.id)
+        #expect(harness.workspace.remoteTmuxSessionBrowserPanelId == replacement.id)
+        let replacementPaneId = try #require(harness.workspace.paneId(forPanelId: replacement.id))
+        #expect(harness.workspace.remoteTmuxWindowsTargetPaneId() != replacementPaneId)
+    }
+
+    @Test func closingTrackedBrowserKeepsSiblingAsSessionBrowser() throws {
+        let harness = try Harness()
+        defer { harness.tearDown() }
+
+        let first = try #require(harness.workspace.openRemoteTmuxSessionBrowser(focus: false))
+        let browserPaneId = try #require(harness.workspace.paneId(forPanelId: first.id))
+        let sibling = try #require(
+            harness.workspace.newBrowserSurface(inPane: browserPaneId, focus: false)
+        )
+        let panelCount = harness.workspace.panels.count
+
+        #expect(harness.workspace.closePanel(first.id, force: true))
+        #expect(harness.waitUntil {
+            harness.workspace.remoteTmuxSessionBrowserPanelId == sibling.id
+        })
+
+        let reused = try #require(harness.workspace.openRemoteTmuxSessionBrowser(focus: false))
+        #expect(reused.id == sibling.id)
+        #expect(harness.workspace.panels.count == panelCount - 1)
     }
 
     @MainActor
@@ -112,24 +142,55 @@ import Testing
         let wasBrowserDisabled: Bool
 
         init() throws {
-            wasBrowserDisabled = BrowserAvailabilitySettings.isDisabled()
+            let previousBrowserDisabled = BrowserAvailabilitySettings.isDisabled()
+            let app = try #require(AppDelegate.shared)
+            let createdWindowId = app.createMainWindow()
+            let createdWorkspace: Workspace
+            let createdSourcePanelId: UUID
+            do {
+                let manager = try #require(app.tabManagerFor(windowId: createdWindowId))
+                createdWorkspace = try #require(manager.selectedWorkspace)
+                createdSourcePanelId = try #require(createdWorkspace.focusedPanelId)
+            } catch {
+                Self.closeWindow(createdWindowId)
+                throw error
+            }
+            wasBrowserDisabled = previousBrowserDisabled
+            appDelegate = app
+            windowId = createdWindowId
+            workspace = createdWorkspace
+            sourcePanelId = createdSourcePanelId
             BrowserAvailabilitySettings.setDisabled(false)
-            appDelegate = try #require(AppDelegate.shared)
-            windowId = appDelegate.createMainWindow()
-            let manager = try #require(appDelegate.tabManagerFor(windowId: windowId))
-            workspace = try #require(manager.selectedWorkspace)
-            sourcePanelId = try #require(workspace.focusedPanelId)
             workspace.isRemoteTmuxMirror = true
+            workspace.authenticateRemoteTmuxWindowsPane()
         }
 
         func tearDown() {
             workspace.isRemoteTmuxMirror = false
-            let identifier = "cmux.main.\(windowId.uuidString)"
-            if let window = NSApp.windows.first(where: { $0.identifier?.rawValue == identifier }) {
-                window.performClose(nil)
-                RunLoop.main.run(until: Date(timeIntervalSinceNow: 0.05))
-            }
+            Self.closeWindow(windowId)
             BrowserAvailabilitySettings.setDisabled(wasBrowserDisabled)
+        }
+
+        func waitUntil(
+            timeout: TimeInterval = 2,
+            _ predicate: () -> Bool
+        ) -> Bool {
+            let deadline = Date(timeIntervalSinceNow: timeout)
+            while !predicate(), Date() < deadline {
+                RunLoop.main.run(until: Date(timeIntervalSinceNow: 0.01))
+            }
+            return predicate()
+        }
+
+        private static func closeWindow(_ windowId: UUID) {
+            let identifier = "cmux.main.\(windowId.uuidString)"
+            guard let window = NSApp.windows.first(where: { $0.identifier?.rawValue == identifier }) else { return }
+            window.performClose(nil)
+            let deadline = Date(timeIntervalSinceNow: 2)
+            while NSApp.windows.contains(where: { $0.identifier?.rawValue == identifier }),
+                  Date() < deadline {
+                RunLoop.main.run(until: Date(timeIntervalSinceNow: 0.01))
+            }
         }
     }
 }


### PR DESCRIPTION
## Problem

Clicking the browser icon in a **remote tmux mirror** workspace did nothing — unlike a regular workspace, no browser opened beside the terminal.

Two things caused it:
- `Workspace.newBrowserSplit` / `newBrowserSurface` hard-returned `nil` when `isRemoteTmuxMirror`.
- Even past that, the mirror's `shouldSplitPane` vetoes every local split and reroutes it to tmux `split-window`, so a split attempt spawned a **terminal** pane instead of a browser.

## Fix

A tmux session maps 1:1 to a `Workspace`, so this adds a **single per-session browser** that splits the workspace's top-level tree beside the mirrored tmux area. It lives *outside* the mirror's nested pane tree, so the session mirror's `rebuild()` never reconciles it and the tmux 1:1 invariant is preserved.

- `openRemoteTmuxSessionBrowser(url:focus:)` — reuse-or-create: focuses/navigates the existing browser instead of creating duplicates.
- Every browser entry point (`newBrowserSplit` / `newBrowserSurface`, and therefore `TabManager.openBrowser` / `createBrowserSplit`, the globe button, link-opens, command palette, shortcuts) now routes here for mirror workspaces.
- A scoped `isCreatingRemoteTmuxSessionBrowserSplit` flag lets that one local split past the `shouldSplitPane` veto; all other splits still route to tmux.
- `addRemoteTmuxDisplayPane` now targets the tmux-windows pane via `remoteTmuxWindowsTargetPaneId()`, so a newly mirrored tmux window never lands as a tab inside the browser split.
- The panel id is cleared when the browser pane closes, so a later click recreates it.

## Testing

Manually dogfooded against a live remote tmux session: clicking the browser icon opens a browser to the right of the tmux area; a second click focuses the existing one (no duplicate); switching tmux windows leaves the browser in place; closing then reopening works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/9861"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788846133&installation_model_id=21920&pr_number=9861&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F9861&signature=10e5ab93c4db1c750ce06b0a65a1ba45cd599fc8890be1c4042fadc75069d5b8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes workspace split routing, pane targeting, and browser lifecycle for remote tmux mirrors—important UI paths but scoped to mirror workspaces with regression tests.
> 
> **Overview**
> Remote tmux mirror workspaces now support **one browser panel per session**, split at the workspace top level beside the mirrored tmux area (outside the mirror tree so `rebuild()` does not touch it).
> 
> **`openRemoteTmuxSessionBrowser`** creates or reuses that browser, navigates when a URL is given, and tracks `remoteTmuxSessionBrowserPanelId`. Generic **`newBrowserSplit`** / **`newBrowserSurface`** calls on mirrors route there instead of returning `nil` or spawning a tmux terminal split. A short-lived **`isCreatingRemoteTmuxSessionBrowserSplit`** flag is the only exception to **`shouldSplitPane`** vetoing local splits on mirrors.
> 
> **`remoteTmuxWindowsTargetPaneId()`** ensures new mirrored tmux panes attach to tmux window tabs, not the browser pane when it is focused. **`clearRemoteTmuxSessionBrowserPanelIfMatches`** resets the slot when the browser panel closes. **`RemoteTmuxMirrorBrowserSplitTests`** covers reuse, routing, and pane targeting.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b1aa91dafcb80bd0791e2a7216e3453ececddd50. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a single per-session browser split beside remote tmux mirror workspaces and routes all browser entry points to it. Previously the browser button and link opens did nothing or spawned tmux splits; now “open link in new tab” creates a tab inside that browser and tmux panes never land in the browser split.

- New Features
  - `openRemoteTmuxSessionBrowser(url:initialRequest:focus:)` creates or focuses the session browser and navigates when a URL or request is provided.
  - `isCreatingRemoteTmuxSessionBrowserSplit` allows exactly one local split for the browser; all other splits still route to tmux.

- Bug Fixes
  - Generic browser opens on mirrors route to the session browser; when targeting that pane, “open link in new tab” opens a new tab instead of navigating the existing one.
  - `authenticateRemoteTmuxWindowsPane()` and `remoteTmuxWindowsTargetPaneId()` pin tmux window targeting away from the browser; the stored browser panel id clears on any close path so a later click recreates it.

<sup>Written for commit b04c573fb450c4831a27f80350e470b18ac8e47e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/9861?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a dedicated browser panel for each remote tmux session.
  * Reopening a session’s browser now reuses and focuses the existing panel.
  * Browser requests from remote sessions are routed to the session’s browser panel.
  * Added support for navigating the session browser using full web requests.
  * New tabs can still be opened within the browser panel.
  * New mirrored panes are placed in the intended tmux window location.

* **Bug Fixes**
  * Prevented mirrored panes from being inserted inside browser splits.
  * Ensured browser panels are cleared correctly when closed.
  * Improved browser behavior when switching between browser surfaces.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->