### PR TITLE
Don't confirm closing a surface whose coding agent is idle

### DIFF
--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -2802,6 +2802,42 @@ final class Workspace: Identifiable, ObservableObject {
         }
     }
 
+    /// The same decision, refined by the coding agent attached to the surface.
+    ///
+    /// A coding agent is one long-lived foreground command: the shell reports
+    /// `commandRunning` from `claude` launch until exit, so on the shell signal
+    /// alone EVERY agent surface confirms on close — including one whose turn
+    /// finished an hour ago and is sitting at its own prompt. The agent's
+    /// lifecycle is the finer signal, so `idle` (turn finished) and
+    /// `needsInput` (waiting on the user) mean there is no work to interrupt
+    /// and the close goes through silently.
+    ///
+    /// The agent state only ever RELAXES the shell signal, never tightens it,
+    /// so a surface already safe to close stays safe. `running`, and an absent
+    /// or unknown lifecycle, keep the existing answer: a plain `make`, `pytest`
+    /// or `rm -rf` in a non-agent surface still confirms. A stale `idle` cannot
+    /// suppress the warning for a later non-agent command in the same surface
+    /// either, because a dead agent's lifecycle is cleared by `clearAgentPID`,
+    /// which `clearStaleAgentPIDs` runs on the next return to the prompt.
+    nonisolated static func resolveCloseConfirmation(
+        shellActivityState: PanelShellActivityState?,
+        agentLifecycleState: AgentHibernationLifecycleState,
+        fallbackNeedsConfirmClose: Bool
+    ) -> Bool {
+        guard resolveCloseConfirmation(
+            shellActivityState: shellActivityState,
+            fallbackNeedsConfirmClose: fallbackNeedsConfirmClose
+        ) else {
+            return false
+        }
+        switch agentLifecycleState {
+        case .idle, .needsInput:
+            return false
+        case .running, .unknown:
+            return true
+        }
+    }
+
     nonisolated static func makeSessionRestorePolicyService()
         -> WorkspaceSessionRestorePolicyService<SurfaceResumeBindingSnapshot> {
         WorkspaceSessionRestorePolicyService(
@@ -5193,6 +5229,7 @@ final class Workspace: Identifiable, ObservableObject {
     func panelNeedsConfirmClose(panelId: UUID, fallbackNeedsConfirmClose: Bool) -> Bool {
         Self.resolveCloseConfirmation(
             shellActivityState: panelShellActivityStates[panelId],
+            agentLifecycleState: agentHibernationLifecycleState(panelId: panelId, fallback: nil),
             fallbackNeedsConfirmClose: fallbackNeedsConfirmClose
         )
     }

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -81,6 +81,7 @@
 		D36A00030000000000000003 /* AgentHibernationLifecycleState.swift in Sources */ = {isa = PBXBuildFile; fileRef = D36A00030000000000000002 /* AgentHibernationLifecycleState.swift */; };
 		8997C0028997C0028997C002 /* AgentHibernationMemoryPressureResponder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8997D0028997D0028997D002 /* AgentHibernationMemoryPressureResponder.swift */; };
 		9090E0039090E0039090E003 /* AgentHibernationPanelCloseCleanupTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9090F0039090F0039090F003 /* AgentHibernationPanelCloseCleanupTests.swift */; };
+		9090E0049090E0049090E004 /* AgentIdleCloseConfirmationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9090F0049090F0049090F004 /* AgentIdleCloseConfirmationTests.swift */; };
 		8997E0028997E0028997E002 /* AgentHibernationPanelPhase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8997F0028997F0028997F002 /* AgentHibernationPanelPhase.swift */; };
 		9090E0019090E0019090E001 /* AgentHibernationPanelState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9090F0019090F0019090F001 /* AgentHibernationPanelState.swift */; };
 		8997C00C8997C00C8997C00C /* AgentHibernationPlaceholderMode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8997D00C8997D00C8997D00C /* AgentHibernationPlaceholderMode.swift */; };
@@ -2825,6 +2826,7 @@ C0DE71B10000000000000001 /* AppDelegate+AgentChatNotifications.swift in Sources 
 		D36A00030000000000000002 /* AgentHibernationLifecycleState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentHibernation/AgentHibernationLifecycleState.swift; sourceTree = "<group>"; };
 		8997D0028997D0028997D002 /* AgentHibernationMemoryPressureResponder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = App/AgentHibernationMemoryPressureResponder.swift; sourceTree = "<group>"; };
 		9090F0039090F0039090F003 /* AgentHibernationPanelCloseCleanupTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentHibernationPanelCloseCleanupTests.swift; sourceTree = "<group>"; };
+		9090F0049090F0049090F004 /* AgentIdleCloseConfirmationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentIdleCloseConfirmationTests.swift; sourceTree = "<group>"; };
 		8997F0028997F0028997F002 /* AgentHibernationPanelPhase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentHibernation/AgentHibernationPanelPhase.swift; sourceTree = "<group>"; };
 		9090F0019090F0019090F001 /* AgentHibernationPanelState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentHibernation/AgentHibernationPanelState.swift; sourceTree = "<group>"; };
 		8997D00C8997D00C8997D00C /* AgentHibernationPlaceholderMode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/AgentHibernationPlaceholderMode.swift; sourceTree = "<group>"; };
@@ -7534,6 +7536,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				8740D0018740D0018740D001 /* AgentHibernationEvaluationSchedulingTests.swift */,
 				F65760010000000000000002 /* AgentHibernationPlannerSwiftTests.swift */,
 				9090F0039090F0039090F003 /* AgentHibernationPanelCloseCleanupTests.swift */,
+				9090F0049090F0049090F004 /* AgentIdleCloseConfirmationTests.swift */,
 				8997D0048997D0048997D004 /* AgentHibernationProcessTerminationTests.swift */,
 				8997D0138997D0138997D013 /* AgentHibernationProcessSignalBoundaryTests.swift */,
 				8997D0128997D0128997D012 /* AgentHibernationProcessSnapshotCoordinatorTests.swift */,
@@ -10550,6 +10553,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				A9E020000000000000000005 /* AgentExecutableResolverTests.swift in Sources */,
 				8740E0018740E0018740E001 /* AgentHibernationEvaluationSchedulingTests.swift in Sources */,
 				9090E0039090E0039090E003 /* AgentHibernationPanelCloseCleanupTests.swift in Sources */,
+				9090E0049090E0049090E004 /* AgentIdleCloseConfirmationTests.swift in Sources */,
 				F65760010000000000000001 /* AgentHibernationPlannerSwiftTests.swift in Sources */,
 				D72260010000000000000001 /* AgentHibernationPortalVisibilityTests.swift in Sources */,
 				8997C0138997C0138997C013 /* AgentHibernationProcessSignalBoundaryTests.swift in Sources */,

--- a/cmuxTests/AgentIdleCloseConfirmationTests.swift
+++ b/cmuxTests/AgentIdleCloseConfirmationTests.swift
@@ -1,0 +1,123 @@
+import Foundation
+import Testing
+
+#if canImport(cmux_DEV)
+@testable import cmux_DEV
+#elseif canImport(cmux)
+@testable import cmux
+#endif
+
+/// A coding agent is one long-lived foreground command, so the shell reports
+/// `commandRunning` for the agent's whole lifetime — from `claude` launch until
+/// exit. On that signal alone every agent surface confirms on close, including
+/// one whose turn finished an hour ago. Closing a surface whose agent is idle
+/// or waiting on the user must not confirm; a working agent and every non-agent
+/// command still must.
+@MainActor
+@Suite(.serialized)
+struct AgentIdleCloseConfirmationTests {
+    private func makeWorkspace(
+        agentLifecycle: AgentHibernationLifecycleState?,
+        shellActivityState: PanelShellActivityState
+    ) throws -> (workspace: Workspace, panelId: UUID) {
+        let workspace = Workspace()
+        let panelId = try #require(workspace.focusedPanelId)
+        if let agentLifecycle {
+            workspace.setAgentLifecycle(
+                key: "claude_code",
+                panelId: panelId,
+                lifecycle: agentLifecycle
+            )
+        }
+        workspace.updatePanelShellActivityState(panelId: panelId, state: shellActivityState)
+        return (workspace, panelId)
+    }
+
+    @Test
+    func idleAgentDoesNotConfirmWhileTheShellStillReportsARunningCommand() throws {
+        let (workspace, panelId) = try makeWorkspace(
+            agentLifecycle: .idle,
+            shellActivityState: .commandRunning
+        )
+        #expect(
+            workspace.panelNeedsConfirmClose(
+                panelId: panelId,
+                fallbackNeedsConfirmClose: true
+            ) == false
+        )
+    }
+
+    @Test
+    func agentWaitingOnTheUserDoesNotConfirm() throws {
+        let (workspace, panelId) = try makeWorkspace(
+            agentLifecycle: .needsInput,
+            shellActivityState: .commandRunning
+        )
+        #expect(
+            workspace.panelNeedsConfirmClose(
+                panelId: panelId,
+                fallbackNeedsConfirmClose: true
+            ) == false
+        )
+    }
+
+    @Test
+    func workingAgentStillConfirms() throws {
+        let (workspace, panelId) = try makeWorkspace(
+            agentLifecycle: .running,
+            shellActivityState: .commandRunning
+        )
+        #expect(
+            workspace.panelNeedsConfirmClose(
+                panelId: panelId,
+                fallbackNeedsConfirmClose: true
+            )
+        )
+    }
+
+    /// The regression guard for non-agent surfaces: a plain `make` or `rm -rf`
+    /// reports no agent lifecycle at all and must keep confirming.
+    @Test
+    func runningCommandWithNoAgentAttachedStillConfirms() throws {
+        let (workspace, panelId) = try makeWorkspace(
+            agentLifecycle: nil,
+            shellActivityState: .commandRunning
+        )
+        #expect(
+            workspace.panelNeedsConfirmClose(
+                panelId: panelId,
+                fallbackNeedsConfirmClose: false
+            )
+        )
+    }
+
+    /// Agent lifecycle only ever relaxes the shell signal, never tightens it: a
+    /// surface back at its prompt never confirms, whatever the lifecycle says.
+    @Test(arguments: AgentHibernationLifecycleState.allCases)
+    func idlePromptNeverConfirms(agentLifecycle: AgentHibernationLifecycleState) throws {
+        let (workspace, panelId) = try makeWorkspace(
+            agentLifecycle: agentLifecycle,
+            shellActivityState: .promptIdle
+        )
+        #expect(
+            workspace.panelNeedsConfirmClose(
+                panelId: panelId,
+                fallbackNeedsConfirmClose: true
+            ) == false
+        )
+    }
+
+    /// With no shell-integration signal the Ghostty fallback still decides, and
+    /// an absent agent lifecycle must not override it in either direction.
+    @Test(arguments: [true, false])
+    func unknownShellStateKeepsTheGhosttyFallback(fallbackNeedsConfirmClose: Bool) throws {
+        let workspace = Workspace()
+        let panelId = try #require(workspace.focusedPanelId)
+        #expect(
+            workspace.panelNeedsConfirmClose(
+                panelId: panelId,
+                fallbackNeedsConfirmClose: fallbackNeedsConfirmClose
+            ) == fallbackNeedsConfirmClose
+        )
+    }
+}


### PR DESCRIPTION
## Problem

A coding agent is one long-lived foreground command. Shell integration reports `commandRunning` from `claude` launch until exit, so `Workspace.resolveCloseConfirmation` sees "a command is running" for the agent's entire lifetime. Every agent surface therefore shows the "Close tab?" confirmation on Cmd+W — including one whose turn ended an hour ago and is sitting at its own prompt with nothing to interrupt.

For anyone who runs an agent in most surfaces, the confirmation fires on essentially every close, which is exactly the state where a warning stops carrying information.

## Fix

`resolveCloseConfirmation` gains an agent-lifecycle-aware overload, used by the close paths that go through `panelNeedsConfirmClose`. cmux already tracks per-surface agent lifecycle for hibernation (`idle` / `needsInput` / `running`), reported by the agent hooks; this reuses that signal.

The agent state only ever **relaxes** the shell signal, never tightens it:

| shell | agent lifecycle | confirms? |
| --- | --- | --- |
| `commandRunning` | `idle`, `needsInput` | no (changed) |
| `commandRunning` | `running` | yes |
| `commandRunning` | none / `unknown` | yes |
| `promptIdle` | anything | no |
| `unknown` | none / `unknown` | Ghostty fallback |

So a plain `make`, `pytest` or `rm -rf` in a non-agent surface is unaffected. A stale `idle` cannot suppress a later warning in the same surface either: a dead agent's lifecycle is cleared by `clearAgentPID`, which `clearStaleAgentPIDs` runs on the next return to the prompt.

The session-snapshot callers deliberately keep the shell-only overload — there `closeConfirmationRequired` gates scrollback persistence, which is about whether the terminal is safely at a prompt, not about interrupting work.

## Commits

Per the regression policy, two commits: the failing test first (CI red), then the fix (CI green). The `running`, no-agent, prompt-idle and unknown-shell cases pass in both commits and guard the fix against over-reaching.

## Not in scope

The Dock close path (`DockSplitStore.dockPanelNeedsConfirmClose`) goes straight to Ghostty's `needsConfirmClose()` and already ignores shell activity entirely, so it does not honour `promptIdle` today either. Aligning it is a separate behavioural change and is left alone here; happy to follow up if you want them unified.

## Validation

Not built or tested locally: this machine runs Santa in lockdown mode, which SIGKILLs the locally built Rust build scripts in the `Build Diff Sidecar` phase, so `xcodebuild test -scheme cmux-unit` cannot complete here. CI is the first real run of these tests. The changed files parse clean (`swiftc -parse`) and `./scripts/lint-pbxproj-test-wiring.sh` passes.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/9865"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788868350&installation_model_id=21920&pr_number=9865&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F9865&signature=9dc1bab4b9b0f700acab620f8ed3f292fcae43e60af11dfce221653d9f92a5ea"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 8d6f3bfc68e08ea74e3495b551409041a4521ff6. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop showing the close confirmation when a coding agent surface is idle or waiting for input, reducing noisy prompts. Confirmation still appears when the agent is running or the state is unknown; non-agent surfaces are unchanged.

- **Bug Fixes**
  - Added an agent-aware `resolveCloseConfirmation(...)` that relaxes the shell signal: `.idle` and `.needsInput` close silently; `.running` and `.unknown` still confirm.
  - Integrated via `panelNeedsConfirmClose`; session-snapshot paths keep the shell-only overload to gate scrollback persistence.
  - Preserved behavior: `.promptIdle` never confirms; unknown shell state defers to the Ghostty fallback; Dock close path remains unchanged.
  - Added `AgentIdleCloseConfirmationTests.swift` covering idle/needsInput, running, no-agent, prompt-idle, and unknown-shell cases.

<sup>Written for commit 8d6f3bfc68e08ea74e3495b551409041a4521ff6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/9865?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved close confirmation behavior based on agent activity.
  * Close warnings are suppressed when an agent is idle or waiting for input.
  * Warnings remain enabled for running or unknown agent states.
  * Existing confirmation behavior for non-agent commands is preserved.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->