### PR TITLE
feat: iTerm2-style user-configurable surface tab colors

### DIFF
--- a/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Coordinator/System/ControlCommandCoordinator+SystemTabAction.swift
+++ b/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Coordinator/System/ControlCommandCoordinator+SystemTabAction.swift
@@ -10,7 +10,7 @@ extension ControlCommandCoordinator {
         "close_left", "close_right", "close_others",
         "new_terminal_right", "new_browser_right",
         "reload", "duplicate", "move_to_new_workspace", "detach_to_workspace", "detach_to_new_workspace",
-        "pin", "unpin", "mark_read", "mark_unread", "toggle_full_width_tab",
+        "pin", "unpin", "mark_read", "mark_unread", "toggle_full_width_tab", "set_color", "clear_color",
     ]
 
     /// `surface.action` / `tab.action` — run one surface-tab mutation.
@@ -68,6 +68,8 @@ extension ControlCommandCoordinator {
             )
         case .invalidTitle:
             return .err(code: "invalid_params", message: "Missing or invalid title", data: nil)
+        case .invalidColor:
+            return .err(code: "invalid_params", message: "Invalid color. Use a named color or #RRGGBB.", data: nil)
         case .invalidURL(let rawURL):
             return .err(
                 code: "invalid_params",

--- a/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Coordinator/System/ControlTabActionResolution.swift
+++ b/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Coordinator/System/ControlTabActionResolution.swift
@@ -77,6 +77,8 @@ public enum ControlTabActionResolution: Sendable, Equatable {
     case unknownAction
     /// `rename` without a usable `title`.
     case invalidTitle
+    /// `set_color` without a palette name or valid `#RRGGBB` value.
+    case invalidColor
     /// `new_browser_right` with an unparsable `url`.
     case invalidURL(rawURL: String)
     /// `reload` on a non-browser surface.

--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -17009,6 +17009,125 @@
         }
       }
     },
+    "alert.tabColor.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "تعيين لون علامة التبويب"
+          }
+        },
+        "bs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Postavi boju kartice"
+          }
+        },
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Indstil fanefarve"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tabfarbe festlegen"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Set Tab Color"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Establecer color de la pestaña"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Définir la couleur de l'onglet"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Imposta colore della scheda"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "タブの色を設定"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "탭 색상 설정"
+          }
+        },
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Angi fanefarge"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ustaw kolor karty"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Definir Cor da Aba"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Задать цвет вкладки"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ตั้งค่าสีแท็บ"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sekme Rengini Ayarla"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Задати колір вкладки"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "设置标签页颜色"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "設定標籤頁顏色"
+          }
+        }
+      }
+    },
     "alert.invalidColor.emptyMessage": {
       "extractionState": "manual",
       "localizations": {

--- a/Sources/SessionPersistence.swift
+++ b/Sources/SessionPersistence.swift
@@ -1673,6 +1673,7 @@ struct SessionPanelSnapshot: Codable, Sendable {
     var customTitle: String?
     /// Provenance of `customTitle`; absent provenance restores as user-set for compatibility.
     var customTitleSource: Workspace.CustomTitleSource? = nil
+    var customColor: String? = nil
     var directory: String?
     var directoryIsTrustedRemoteReport: Bool? = nil
     var directoryRequiresRemoteTrust: Bool? = nil

--- a/Sources/TerminalController+ControlSystemContext2.swift
+++ b/Sources/TerminalController+ControlSystemContext2.swift
@@ -145,6 +145,26 @@ extension TerminalController {
             workspace.setPanelCustomTitle(panelId: panelId, title: nil)
             return finish(.none)
 
+        case "set_color":
+            guard let raw = moveParams["color"]?.foundationObject as? String else {
+                return .invalidColor
+            }
+            let input = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+            let paletteColor = WorkspaceTabColorSettings.palette().first {
+                $0.name.caseInsensitiveCompare(input) == .orderedSame
+            }?.hex
+            guard let color = paletteColor ?? WorkspaceTabColorSettings.normalizedHex(input),
+                  workspace.setSurfaceColor(panelId: panelId, color: color) else {
+                return .invalidColor
+            }
+            return finish(.none)
+
+        case "clear_color":
+            guard workspace.setSurfaceColor(panelId: panelId, color: nil) else {
+                return .tabNotFound(surfaceID: surfaceId)
+            }
+            return finish(.none)
+
         case "pin":
             workspace.setPanelPinned(panelId: panelId, pinned: true)
             return finish(.pinned(true))

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -406,6 +406,8 @@ extension Workspace {
         let customTitleSource: CustomTitleSource? = customTitle != nil
             ? (panelCustomTitleSources[panelId] ?? .user)
             : nil
+        let customColor = surfaceIdFromPanelId(panelId)
+            .flatMap { bonsplitController.tab($0)?.customColor }
         let directory: String? = {
             if let directory = panelDirectories[panelId]?.trimmingCharacters(in: .whitespacesAndNewlines),
                !directory.isEmpty {
@@ -721,6 +723,7 @@ extension Workspace {
             title: panelTitle,
             customTitle: customTitle,
             customTitleSource: customTitleSource,
+            customColor: customColor,
             directory: directory,
             directoryIsTrustedRemoteReport: directoryIsTrustedRemoteReport,
             directoryRequiresRemoteTrust: directoryRequiresRemoteTrust ? true : nil,
@@ -1855,6 +1858,7 @@ extension Workspace {
 
         setPanelCustomTitle(panelId: panelId, title: snapshot.customTitle, source: snapshot.customTitleSource ?? .user)
         setPanelPinned(panelId: panelId, pinned: snapshot.isPinned)
+        _ = setSurfaceColor(panelId: panelId, color: snapshot.customColor)
 
         // The bonsplit tab header only refreshes when `updateTab` is called; the writes
         // above never reach it (`setPanelCustomTitle` skips the sync when there is no
@@ -4586,6 +4590,21 @@ final class Workspace: Identifiable, ObservableObject {
                 workspaceId: id, panelId: panelId, title: trimmed
             )
         }
+        return true
+    }
+
+    @discardableResult
+    func setSurfaceColor(panelId: UUID, color: String?) -> Bool {
+        guard panels[panelId] != nil,
+              let tabId = surfaceIdFromPanelId(panelId) else { return false }
+        let normalized: String?
+        if let color {
+            guard let value = WorkspaceTabColorSettings.normalizedHex(color) else { return false }
+            normalized = value
+        } else {
+            normalized = nil
+        }
+        bonsplitController.updateTab(tabId, customColor: .some(normalized))
         return true
     }
 
@@ -13249,6 +13268,11 @@ extension Workspace: BonsplitDelegate {
         case .clearName:
             guard let panelId = panelIdFromSurfaceId(tab.id) else { return }
             setPanelCustomTitle(panelId: panelId, title: nil)
+        case .setColor:
+            promptSurfaceColor(panelId: panelIdFromSurfaceId(tab.id))
+        case .clearColor:
+            guard let panelId = panelIdFromSurfaceId(tab.id) else { return }
+            _ = setSurfaceColor(panelId: panelId, color: nil)
         case .copyIdentifiers:
             guard let panelId = panelIdFromSurfaceId(tab.id) else { return }
             copyIdentifiersToPasteboard(surfaceId: panelId)
@@ -13316,6 +13340,26 @@ extension Workspace: BonsplitDelegate {
         @unknown default:
             break
         }
+    }
+
+    private func promptSurfaceColor(panelId: UUID?) {
+        guard let panelId else { return }
+        let palette = WorkspaceTabColorSettings.palette()
+        guard !palette.isEmpty else { return }
+        let picker = NSPopUpButton(frame: NSRect(x: 0, y: 0, width: 240, height: 26))
+        picker.addItems(withTitles: palette.map(\.name))
+        if let current = surfaceIdFromPanelId(panelId).flatMap({ bonsplitController.tab($0)?.customColor }),
+           let index = palette.firstIndex(where: { $0.hex == current }) {
+            picker.selectItem(at: index)
+        }
+
+        let alert = NSAlert()
+        alert.messageText = String(localized: "alert.tabColor.title", defaultValue: "Set Tab Color")
+        alert.accessoryView = picker
+        alert.addButton(withTitle: String(localized: "alert.customColor.apply", defaultValue: "Apply"))
+        alert.addButton(withTitle: String(localized: "alert.customColor.cancel", defaultValue: "Cancel"))
+        guard alert.runCmuxModal() == .alertFirstButtonReturn else { return }
+        _ = setSurfaceColor(panelId: panelId, color: palette[picker.indexOfSelectedItem].hex)
     }
 
     private func handleForkConversationContextAction(_ action: TabContextAction, for tab: Bonsplit.Tab, inPane pane: PaneID) {

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -2117,6 +2117,7 @@ C0DE71B10000000000000001 /* AppDelegate+AgentChatNotifications.swift in Sources 
 		F27B00000000000000000001 /* SurfaceResumeRunPromptBatch.swift in Sources */ = {isa = PBXBuildFile; fileRef = F27B00000000000000000002 /* SurfaceResumeRunPromptBatch.swift */; };
 		A5001303 /* SurfaceSearchOverlay.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001301 /* SurfaceSearchOverlay.swift */; };
 		C51A73B40000000000000002 /* SurfaceTabBarButtonConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = C51A73B40000000000000001 /* SurfaceTabBarButtonConfiguration.swift */; };
+		A73BC001A73BC001A73BC001 /* SurfaceTabColorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A73BC002A73BC002A73BC002 /* SurfaceTabColorTests.swift */; };
 		F2100000000000000000000F /* SyntheticKeyEventFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1100000000000000000000F /* SyntheticKeyEventFactory.swift */; };
 		A7206A010000000000000001 /* SystemAppearanceObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7206A020000000000000001 /* SystemAppearanceObserver.swift */; };
 		A7206F010000000000000001 /* SystemAppearanceObserverEnvironment.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7206F020000000000000001 /* SystemAppearanceObserverEnvironment.swift */; };
@@ -4721,6 +4722,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 		F27B00000000000000000002 /* SurfaceResumeRunPromptBatch.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SurfaceResumeRunPromptBatch.swift; sourceTree = "<group>"; };
 		A5001301 /* SurfaceSearchOverlay.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Find/SurfaceSearchOverlay.swift; sourceTree = "<group>"; };
 		C51A73B40000000000000001 /* SurfaceTabBarButtonConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SurfaceTabBarButtonConfiguration.swift; sourceTree = "<group>"; };
+		A73BC002A73BC002A73BC002 /* SurfaceTabColorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SurfaceTabColorTests.swift; sourceTree = "<group>"; };
 		F1100000000000000000000F /* SyntheticKeyEventFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SyntheticKeyEventFactory.swift; sourceTree = "<group>"; };
 		A7206A020000000000000001 /* SystemAppearanceObserver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SystemAppearanceObserver.swift; sourceTree = "<group>"; };
 		A7206F020000000000000001 /* SystemAppearanceObserverEnvironment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SystemAppearanceObserverEnvironment.swift; sourceTree = "<group>"; };
@@ -7815,6 +7817,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				604500100000000000000004 /* WindowTitleTemplateTests.swift */,
 				D1FFC0DE000000000000C001 /* DiffCommentStoreTests.swift */,
 				C9A57002C9A57002C9A57002 /* WorkspaceGroupTests.swift */,
+				A73BC002A73BC002A73BC002 /* SurfaceTabColorTests.swift */,
 				9164A0029164A0029164A002 /* WorkspaceGroupNumberedSelectionTests.swift */,
 				C9A57402C9A57402C9A57402 /* WorkspaceGroupMoveToMenuStateTests.swift */,
 				FEED49850000000000000002 /* FeedEventClassificationTests.swift */,
@@ -10918,6 +10921,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				842300000000000000000007 /* SurfaceResumeAgentBindingGenerationTests.swift in Sources */,
 				F6572012A1B2C3D4E5F60718 /* SurfaceResumeBindingCodexUpdateCheckTests.swift in Sources */,
 				842300000000000000000001 /* SurfaceResumeExitedAgentLivenessTests.swift in Sources */,
+				A73BC001A73BC001A73BC001 /* SurfaceTabColorTests.swift in Sources */,
 				A7206B010000000000000001 /* SystemAppearanceObserverTests.swift in Sources */,
 				FBE660ABA1854983B84368C6 /* SystemWideHotkeyShortcutPolicyTests.swift in Sources */,
 				F8120F5386FBE726864D340B /* TabManagerBackgroundWorkspaceMountBoundTests.swift in Sources */,

--- a/cmuxTests/SurfaceTabColorTests.swift
+++ b/cmuxTests/SurfaceTabColorTests.swift
@@ -1,0 +1,101 @@
+import CmuxControlSocket
+import CmuxSettings
+import Foundation
+import Testing
+
+#if canImport(cmux_DEV)
+@testable import cmux_DEV
+#elseif canImport(cmux)
+@testable import cmux
+#endif
+
+@MainActor
+@Suite("Surface tab colors", .serialized)
+struct SurfaceTabColorTests {
+    private func makeTabManager() -> TabManager {
+        let suiteName = "cmux.surface-tab-color-tests.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defaults.removePersistentDomain(forName: suiteName)
+        let manager = TabManager(
+            autoWelcomeIfNeeded: false,
+            settings: UserDefaultsSettingsClient(defaults: defaults),
+            closeTabWarningDefaults: defaults
+        )
+        manager.addWorkspace(autoWelcomeIfNeeded: false)
+        return manager
+    }
+
+    @Test func setAndClearSurfaceColorMutatesTheTab() throws {
+        let manager = makeTabManager()
+        let workspace = try #require(manager.selectedWorkspace)
+        let panelId = try #require(workspace.focusedPanelId)
+        let tabId = try #require(workspace.surfaceIdFromPanelId(panelId))
+
+        #expect(workspace.bonsplitController.tab(tabId)?.customColor == nil)
+        #expect(workspace.setSurfaceColor(panelId: panelId, color: "#1a2b3c"))
+        #expect(workspace.bonsplitController.tab(tabId)?.customColor == "#1A2B3C")
+        #expect(workspace.setSurfaceColor(panelId: panelId, color: nil))
+        #expect(workspace.bonsplitController.tab(tabId)?.customColor == nil)
+    }
+
+    @Test func sessionSnapshotRoundTripPreservesSurfaceColor() throws {
+        let manager = makeTabManager()
+        let workspace = try #require(manager.selectedWorkspace)
+        let panelId = try #require(workspace.focusedPanelId)
+        #expect(workspace.setSurfaceColor(panelId: panelId, color: "#445566"))
+
+        let snapshot = workspace.sessionSnapshot(includeScrollback: false)
+        let restoredManager = makeTabManager()
+        let restored = try #require(restoredManager.selectedWorkspace)
+        restored.restoreSessionSnapshot(snapshot)
+        let restoredPanelId = try #require(restored.focusedPanelId)
+        let restoredTabId = try #require(restored.surfaceIdFromPanelId(restoredPanelId))
+
+        #expect(restored.bonsplitController.tab(restoredTabId)?.customColor == "#445566")
+    }
+
+    @Test func cliSetAndClearColorUseTheSharedMutationPath() throws {
+        let manager = makeTabManager()
+        let workspace = try #require(manager.selectedWorkspace)
+        let panelId = try #require(workspace.focusedPanelId)
+        let tabId = try #require(workspace.surfaceIdFromPanelId(panelId))
+        let routing = ControlRoutingSelectors(
+            hasWindowIDParam: false,
+            windowID: nil,
+            groupID: nil,
+            workspaceID: workspace.id,
+            surfaceID: panelId,
+            paneID: nil
+        )
+
+        let setResult = TerminalController.shared.controlTabAction(
+            routing: routing,
+            actionKey: "set_color",
+            title: nil,
+            rawURL: nil,
+            surfaceID: panelId,
+            requestedFocus: false,
+            moveParams: ["color": .string("blue")]
+        )
+        guard case .completed = setResult else {
+            Issue.record("Expected set_color to complete, got \(setResult)")
+            return
+        }
+        #expect(workspace.bonsplitController.tab(tabId)?.customColor == "#1565C0")
+
+        let clearResult = TerminalController.shared.controlTabAction(
+            routing: routing,
+            actionKey: "clear_color",
+            title: nil,
+            rawURL: nil,
+            surfaceID: panelId,
+            requestedFocus: false,
+            moveParams: [:]
+        )
+        guard case .completed = clearResult else {
+            Issue.record("Expected clear_color to complete, got \(clearResult)")
+            return
+        }
+        #expect(workspace.bonsplitController.tab(tabId)?.customColor == nil)
+    }
+}

--- a/docs/cli-contract.md
+++ b/docs/cli-contract.md
@@ -225,7 +225,7 @@ Workspace and tab action names:
 | Command | Actions |
 | --- | --- |
 | `workspace-action` | `pin`, `unpin`, `rename`, `clear-name`, `set-description`, `clear-description`, `move-up`, `move-down`, `move-top`, `close-others`, `close-above`, `close-below`, `mark-read`, `mark-unread`, `set-color`, `clear-color` |
-| `tab-action` | `rename`, `clear-name`, `close-left`, `close-right`, `close-others`, `new-terminal-right`, `new-browser-right`, `reload`, `duplicate`, `pin`, `unpin`, `mark-unread` |
+| `tab-action` | `rename`, `clear-name`, `close-left`, `close-right`, `close-others`, `new-terminal-right`, `new-browser-right`, `reload`, `duplicate`, `pin`, `unpin`, `mark-unread`, `set-color`, `clear-color` |
 
 ### Workspace environment variables
 


### PR DESCRIPTION
Adds iTerm2-style per-tab colors for individual cmux surface tabs.

## What
- **Persisted `customColor`** on surface tabs: stored in `SessionPanelSnapshot`, round-trips through session save/restore.
- **Small colored marker** rendered leading the tab title (bonsplit `TabItemView`), driven by the existing `WorkspaceTabColorSettings` named palette.
- **Set Tab Color… / Clear Tab Color** context-menu actions on surface tabs; the picker preselects the current color and presents via `runCmuxModal`.
- **CLI**: `tab-action set-color` / `clear-color`, accepting a palette name (case-insensitive) or `#RRGGBB`, matching the existing workspace-level `set-color` semantics (input trimmed, same validation). Docs updated in `docs/cli-contract.md`.

## Shared behavior
UI and CLI route through one mutation path, `Workspace.setSurfaceColor(panelId:color:)`, which normalizes and writes to the bonsplit tab model.

## Localization
New key `alert.tabColor.title` added to `Resources/Localizable.xcstrings` for all 19 locales; bonsplit menu strings added for en/ja (its supported set). Audit: enumerated changed surfaces (context-menu items, color alert, CLI error text), verified locale coverage per catalog, and grepped changed files for bare English literals.

## Tests
`cmuxTests/SurfaceTabColorTests.swift` (wired in pbxproj): set/clear mutation, snapshot round-trip, and CLI set/clear through the shared path.

## Dependencies
⚠️ Depends on bonsplit PR manaflow-ai/bonsplit#210 (customColor tab API). The submodule pointer references that PR's head commit (fetchable from upstream via the PR ref); after #210 merges, the pointer should be bumped to the merged bonsplit main SHA before this merges.

## Validation
Parse checks on all changed Swift files, pbxproj test-wiring lint, pbxproj check, xcstrings JSON validation, and `git diff --check` pass locally. Full xcodebuild + tests: this machine has no Xcode installation (CommandLineTools only), so relying on CI for the build/test leg; runtime dogfood is pending a machine with Xcode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/9880"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788916807&installation_model_id=21920&pr_number=9880&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F9880&signature=f1c65402b18abc805bd6242d444da9aa27f52264d85280786f5b2bc4c78e6180"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add iTerm2-style, user-settable colors for individual surface tabs. Colors show as a small tab marker, persist across sessions, and can be set via the UI or CLI.

- **New Features**
  - Persist `customColor` in `SessionPanelSnapshot` (save/restore).
  - Show a small color marker before the tab title using the `WorkspaceTabColorSettings` palette.
  - Surface tab menu: Set Tab Color… and Clear Tab Color.
  - CLI: `tab-action set-color` and `clear-color` accept a palette name or `#RRGGBB`; docs updated in `docs/cli-contract.md`.
  - UI and CLI share one mutation path: `Workspace.setSurfaceColor(panelId:color:)`.

- **Dependencies**
  - Requires `bonsplit` customColor tab API. `vendor/bonsplit` currently points at that PR; bump to the merged main before merging.

<sup>Written for commit d8b493a2729a374a05f8b8cb3dac932e89c64ff7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/9880?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added tab color customization through a palette or valid hexadecimal color.
  * Added options to clear tab colors from the context menu and command interface.
  * Tab colors are preserved when sessions are saved and restored.
  * Added localized color-selection alerts in multiple languages.

* **Bug Fixes**
  * Invalid color values now produce clear guidance to use a named color or `#RRGGBB`.

* **Documentation**
  * Updated the command reference with tab color actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->