### PR TITLE
Forward committed IME Return for Korean sources declared by language

### DIFF
--- a/Packages/macOS/CmuxTerminalCore/Sources/CmuxTerminalCore/KeyEvents/TerminalCommittedIMEReturnInputSourcePolicy.swift
+++ b/Packages/macOS/CmuxTerminalCore/Sources/CmuxTerminalCore/KeyEvents/TerminalCommittedIMEReturnInputSourcePolicy.swift
@@ -1,0 +1,29 @@
+import Foundation
+
+/// Decides whether the Return that just committed an IME composition should
+/// also be forwarded to the surface as a key press.
+///
+/// Korean IME: Enter commits the syllable AND executes the command (single step).
+/// Japanese/Chinese IME: Enter only confirms the conversion; a second Enter executes.
+/// So the extra Return is only forwarded for Korean input sources. Apple's Korean
+/// sources carry "korean" in their ID; third-party ones (e.g. Gureum:
+/// "org.youknowone.inputmethod.Gureum.han2") don't, so a source whose declared
+/// primary language (`kTISPropertyInputSourceLanguages`) is Korean also qualifies.
+public struct TerminalCommittedIMEReturnInputSourcePolicy: Sendable {
+    /// Creates the committed-IME-Return policy.
+    public init() {}
+
+    /// Returns whether the committed-composition Return should be forwarded for
+    /// the given input source.
+    ///
+    /// - Parameters:
+    ///   - sourceId: `kTISPropertyInputSourceID` of the current input source, or
+    ///     `nil` when it could not be read. A missing ID never qualifies.
+    ///   - languages: `kTISPropertyInputSourceLanguages` of the current input
+    ///     source, primary language first. Only the primary language is consulted.
+    public func shouldForwardReturn(sourceId: String?, languages: [String]) -> Bool {
+        guard let sourceId else { return false }
+        if sourceId.range(of: "korean", options: .caseInsensitive) != nil { return true }
+        return languages.first == "ko"
+    }
+}

--- a/Packages/macOS/CmuxTerminalCore/Tests/CmuxTerminalCoreTests/TerminalCommittedIMEReturnInputSourcePolicyTests.swift
+++ b/Packages/macOS/CmuxTerminalCore/Tests/CmuxTerminalCoreTests/TerminalCommittedIMEReturnInputSourcePolicyTests.swift
@@ -1,0 +1,45 @@
+import Testing
+import CmuxTerminalCore
+
+@Suite struct TerminalCommittedIMEReturnInputSourcePolicyTests {
+    private let policy = TerminalCommittedIMEReturnInputSourcePolicy()
+
+    @Test func appleKoreanSourceQualifiesByIdWithoutLanguageMetadata() {
+        #expect(policy.shouldForwardReturn(
+            sourceId: "com.apple.inputmethod.Korean.2SetKorean",
+            languages: []
+        ))
+    }
+
+    /// Third-party Korean IMEs like Gureum have no "korean" substring in their
+    /// input source ID; the declared primary language ("ko") must qualify them.
+    @Test func gureumQualifiesByDeclaredPrimaryLanguage() {
+        #expect(policy.shouldForwardReturn(
+            sourceId: "org.youknowone.inputmethod.Gureum.han2",
+            languages: ["ko"]
+        ))
+    }
+
+    /// Japanese/Chinese: Enter only confirms the conversion, so no extra Return.
+    @Test func japaneseAndChineseSourcesDoNotQualify() {
+        #expect(!policy.shouldForwardReturn(
+            sourceId: "com.apple.inputmethod.Kotoeri.RomajiTyping.Japanese",
+            languages: ["ja"]
+        ))
+        #expect(!policy.shouldForwardReturn(
+            sourceId: "com.apple.inputmethod.SCIM.ITABC",
+            languages: ["zh-Hans"]
+        ))
+    }
+
+    @Test func onlyPrimaryLanguageCounts() {
+        #expect(!policy.shouldForwardReturn(
+            sourceId: "org.example.inputmethod.Multi",
+            languages: ["ja", "ko"]
+        ))
+    }
+
+    @Test func missingSourceIdNeverQualifies() {
+        #expect(!policy.shouldForwardReturn(sourceId: nil, languages: ["ko"]))
+    }
+}

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -274,18 +274,6 @@ func terminalKeyboardCopyModeResolve(
     )
 }
 
-/// Korean IME: Enter commits the syllable AND executes the command (single step).
-/// Japanese/Chinese IME: Enter only confirms the conversion; a second Enter executes.
-/// Only forward the extra Return key for Korean input sources. Apple's Korean sources
-/// carry "korean" in their ID; third-party ones (e.g. Gureum:
-/// "org.youknowone.inputmethod.Gureum.han2") don't, so also accept sources whose
-/// declared primary language (kTISPropertyInputSourceLanguages) is Korean.
-func terminalCommittedIMEReturnQualifiesInputSource(sourceId: String?, languages: [String]) -> Bool {
-    guard let sourceId else { return false }
-    if sourceId.range(of: "korean", options: .caseInsensitive) != nil { return true }
-    return languages.first == "ko"
-}
-
 // GhosttySurfaceCallbackContext moved to CmuxTerminalCore behind the
 // TerminalSurfaceControlling/TerminalSurfaceHosting seams; the conformances
 // and concrete-typed convenience accessors live here.
@@ -6327,7 +6315,10 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
     private func shouldSendCommittedIMEConfirmKey(event: NSEvent, markedTextBefore: Bool) -> Bool {
         guard markedTextBefore, markedText.length == 0 else { return false }
         guard event.keyCode == 36 || event.keyCode == 76 else { return false }
-        return terminalCommittedIMEReturnQualifiesInputSource(
+        // Korean IME: Enter commits the syllable AND executes the command (single step).
+        // Japanese/Chinese IME: Enter only confirms the conversion; a second Enter executes.
+        // Only send the extra Return key for Korean input sources (see the policy).
+        return TerminalCommittedIMEReturnInputSourcePolicy().shouldForwardReturn(
             sourceId: KeyboardLayout.id,
             languages: KeyboardLayout.languages
         )

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -274,6 +274,18 @@ func terminalKeyboardCopyModeResolve(
     )
 }
 
+/// Korean IME: Enter commits the syllable AND executes the command (single step).
+/// Japanese/Chinese IME: Enter only confirms the conversion; a second Enter executes.
+/// Only forward the extra Return key for Korean input sources. Apple's Korean sources
+/// carry "korean" in their ID; third-party ones (e.g. Gureum:
+/// "org.youknowone.inputmethod.Gureum.han2") don't, so also accept sources whose
+/// declared primary language (kTISPropertyInputSourceLanguages) is Korean.
+func terminalCommittedIMEReturnQualifiesInputSource(sourceId: String?, languages: [String]) -> Bool {
+    guard let sourceId else { return false }
+    if sourceId.range(of: "korean", options: .caseInsensitive) != nil { return true }
+    return languages.first == "ko"
+}
+
 // GhosttySurfaceCallbackContext moved to CmuxTerminalCore behind the
 // TerminalSurfaceControlling/TerminalSurfaceHosting seams; the conformances
 // and concrete-typed convenience accessors live here.
@@ -6315,15 +6327,10 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
     private func shouldSendCommittedIMEConfirmKey(event: NSEvent, markedTextBefore: Bool) -> Bool {
         guard markedTextBefore, markedText.length == 0 else { return false }
         guard event.keyCode == 36 || event.keyCode == 76 else { return false }
-        // Korean IME: Enter commits the syllable AND executes the command (single step).
-        // Japanese/Chinese IME: Enter only confirms the conversion; a second Enter executes.
-        // Only send the extra Return key for Korean input sources. Third-party Korean
-        // IMEs (e.g. Gureum: "org.youknowone.inputmethod.Gureum.han2") don't carry
-        // "korean" in their source ID, so also accept sources whose declared primary
-        // language is Korean.
-        guard let sourceId = KeyboardLayout.id else { return false }
-        if sourceId.range(of: "korean", options: .caseInsensitive) != nil { return true }
-        return KeyboardLayout.languages.first == "ko"
+        return terminalCommittedIMEReturnQualifiesInputSource(
+            sourceId: KeyboardLayout.id,
+            languages: KeyboardLayout.languages
+        )
     }
 
     private func ghosttyKeyEvent(for event: NSEvent, surface: ghostty_surface_t) -> ghostty_input_key_s {

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -6317,9 +6317,13 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
         guard event.keyCode == 36 || event.keyCode == 76 else { return false }
         // Korean IME: Enter commits the syllable AND executes the command (single step).
         // Japanese/Chinese IME: Enter only confirms the conversion; a second Enter executes.
-        // Only send the extra Return key for Korean input sources.
+        // Only send the extra Return key for Korean input sources. Third-party Korean
+        // IMEs (e.g. Gureum: "org.youknowone.inputmethod.Gureum.han2") don't carry
+        // "korean" in their source ID, so also accept sources whose declared primary
+        // language is Korean.
         guard let sourceId = KeyboardLayout.id else { return false }
-        return sourceId.range(of: "korean", options: .caseInsensitive) != nil
+        if sourceId.range(of: "korean", options: .caseInsensitive) != nil { return true }
+        return KeyboardLayout.languages.first == "ko"
     }
 
     private func ghosttyKeyEvent(for event: NSEvent, surface: ghostty_surface_t) -> ghostty_input_key_s {

--- a/Sources/KeyboardLayout.swift
+++ b/Sources/KeyboardLayout.swift
@@ -10,8 +10,6 @@ class KeyboardLayout {
     /// Test-only override for the current input source ID.
     #if DEBUG
     static var debugInputSourceIdOverride: String?
-    /// Test-only override for the current input source languages.
-    static var debugInputSourceLanguagesOverride: [String]?
     #endif
 
     /// Return a string ID of the current keyboard input source.
@@ -31,9 +29,6 @@ class KeyboardLayout {
     /// Return the BCP-47 languages the current keyboard input source is intended
     /// for. The first element is the primary language (kTISPropertyInputSourceLanguages).
     static var languages: [String] {
-        #if DEBUG
-        if let override = debugInputSourceLanguagesOverride { return override }
-        #endif
         if let source = TISCopyCurrentKeyboardInputSource()?.takeRetainedValue(),
            let languagesPointer = TISGetInputSourceProperty(source, kTISPropertyInputSourceLanguages) {
             let languages = Unmanaged<CFArray>.fromOpaque(languagesPointer).takeUnretainedValue()

--- a/Sources/KeyboardLayout.swift
+++ b/Sources/KeyboardLayout.swift
@@ -10,6 +10,8 @@ class KeyboardLayout {
     /// Test-only override for the current input source ID.
     #if DEBUG
     static var debugInputSourceIdOverride: String?
+    /// Test-only override for the current input source languages.
+    static var debugInputSourceLanguagesOverride: [String]?
     #endif
 
     /// Return a string ID of the current keyboard input source.
@@ -24,6 +26,21 @@ class KeyboardLayout {
         }
 
         return nil
+    }
+
+    /// Return the BCP-47 languages the current keyboard input source is intended
+    /// for. The first element is the primary language (kTISPropertyInputSourceLanguages).
+    static var languages: [String] {
+        #if DEBUG
+        if let override = debugInputSourceLanguagesOverride { return override }
+        #endif
+        if let source = TISCopyCurrentKeyboardInputSource()?.takeRetainedValue(),
+           let languagesPointer = TISGetInputSourceProperty(source, kTISPropertyInputSourceLanguages) {
+            let languages = Unmanaged<CFArray>.fromOpaque(languagesPointer).takeUnretainedValue()
+            return (languages as? [String]) ?? []
+        }
+
+        return []
     }
 
     /// Translate a physical keyCode to the character AppKit would use for shortcut matching,

--- a/cmuxTests/CJKIMEInputTests.swift
+++ b/cmuxTests/CJKIMEInputTests.swift
@@ -1194,6 +1194,101 @@ final class KoreanIMEReturnCommitRegressionTests: XCTestCase {
         XCTAssertFalse(view.hasMarkedText(), "Return should commit the active Hangul composition")
         XCTAssertTrue(sawReturnPress, "Return should still be forwarded after IME commit so the command executes once")
     }
+
+    /// Third-party Korean IMEs like Gureum have no "korean" substring in their
+    /// input source ID; the declared primary language ("ko") must qualify them
+    /// for the committed-composition Return forwarding.
+    func testReturnAfterGureumCommitAlsoSendsReturnToSurface() {
+        _ = NSApplication.shared
+
+        let surface = TerminalSurface(
+            tabId: UUID(),
+            context: GHOSTTY_SURFACE_CONTEXT_SPLIT,
+            configTemplate: nil,
+            workingDirectory: nil
+        )
+        let hostedView = surface.hostedView
+
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 360, height: 240),
+            styleMask: [.titled, .closable],
+            backing: .buffered,
+            defer: false
+        )
+        defer {
+            GhosttyNSView.debugGhosttySurfaceKeyEventObserver = nil
+            window.orderOut(nil)
+        }
+
+        guard let contentView = window.contentView else {
+            XCTFail("Expected content view")
+            return
+        }
+
+        hostedView.frame = contentView.bounds
+        hostedView.autoresizingMask = [.width, .height]
+        contentView.addSubview(hostedView)
+
+        window.makeKeyAndOrderFront(nil)
+        window.displayIfNeeded()
+        contentView.layoutSubtreeIfNeeded()
+        hostedView.setVisibleInUI(true)
+        hostedView.setActive(true)
+        RunLoop.current.run(until: Date().addingTimeInterval(0.05))
+
+        guard let view = findGhosttyNSView(in: hostedView) else {
+            XCTFail("Expected hosted GhosttyNSView")
+            return
+        }
+
+        view.setMarkedText("한", selectedRange: NSRange(location: 0, length: 1), replacementRange: NSRange(location: NSNotFound, length: 0))
+
+        // Gureum reports source IDs like org.youknowone.inputmethod.Gureum.han2
+        // with TISIntendedLanguage "ko".
+        KeyboardLayout.debugInputSourceIdOverride = "org.youknowone.inputmethod.Gureum.han2"
+        KeyboardLayout.debugInputSourceLanguagesOverride = ["ko"]
+        installCJKIMEInterpretKeyEventsSwizzle()
+        cjkIMEInterpretKeyEventsHook = { candidateView, _ in
+            guard candidateView === view else { return false }
+            candidateView.insertText("한", replacementRange: NSRange(location: NSNotFound, length: 0))
+            return true
+        }
+        defer {
+            KeyboardLayout.debugInputSourceIdOverride = nil
+            KeyboardLayout.debugInputSourceLanguagesOverride = nil
+            cjkIMEInterpretKeyEventsHook = nil
+        }
+
+        var sawReturnPress = false
+        GhosttyNSView.debugGhosttySurfaceKeyEventObserver = { keyEvent in
+            guard keyEvent.action == GHOSTTY_ACTION_PRESS,
+                  keyEvent.keycode == 36,
+                  keyEvent.text == nil else { return }
+            sawReturnPress = true
+        }
+
+        guard let event = NSEvent.keyEvent(
+            with: .keyDown,
+            location: .zero,
+            modifierFlags: [],
+            timestamp: ProcessInfo.processInfo.systemUptime,
+            windowNumber: window.windowNumber,
+            context: nil,
+            characters: "\r",
+            charactersIgnoringModifiers: "\r",
+            isARepeat: false,
+            keyCode: 36
+        ) else {
+            XCTFail("Failed to create Return event")
+            return
+        }
+
+        window.makeFirstResponder(view)
+        view.keyDown(with: event)
+
+        XCTAssertFalse(view.hasMarkedText(), "Return should commit the active Hangul composition")
+        XCTAssertTrue(sawReturnPress, "Return should still be forwarded after a Gureum commit so the command executes once")
+    }
 }
 
 @MainActor

--- a/cmuxTests/CJKIMEInputTests.swift
+++ b/cmuxTests/CJKIMEInputTests.swift
@@ -1194,37 +1194,6 @@ final class KoreanIMEReturnCommitRegressionTests: XCTestCase {
         XCTAssertFalse(view.hasMarkedText(), "Return should commit the active Hangul composition")
         XCTAssertTrue(sawReturnPress, "Return should still be forwarded after IME commit so the command executes once")
     }
-
-    /// Third-party Korean IMEs like Gureum have no "korean" substring in their
-    /// input source ID; the declared primary language ("ko") must qualify them
-    /// for the committed-composition Return forwarding.
-    func testCommittedReturnQualifiesKoreanSourcesByIdOrDeclaredLanguage() {
-        // Apple 2-Set: matched by ID, language metadata not required.
-        XCTAssertTrue(terminalCommittedIMEReturnQualifiesInputSource(
-            sourceId: "com.apple.inputmethod.Korean.2SetKorean",
-            languages: []
-        ))
-        // Gureum reports org.youknowone.inputmethod.Gureum.han2 with TISIntendedLanguage "ko".
-        XCTAssertTrue(terminalCommittedIMEReturnQualifiesInputSource(
-            sourceId: "org.youknowone.inputmethod.Gureum.han2",
-            languages: ["ko"]
-        ))
-        // Japanese/Chinese: Enter only confirms the conversion, so no extra Return.
-        XCTAssertFalse(terminalCommittedIMEReturnQualifiesInputSource(
-            sourceId: "com.apple.inputmethod.Kotoeri.RomajiTyping.Japanese",
-            languages: ["ja"]
-        ))
-        XCTAssertFalse(terminalCommittedIMEReturnQualifiesInputSource(
-            sourceId: "com.apple.inputmethod.SCIM.ITABC",
-            languages: ["zh-Hans"]
-        ))
-        // Only the primary language counts, and a missing source ID never qualifies.
-        XCTAssertFalse(terminalCommittedIMEReturnQualifiesInputSource(
-            sourceId: "org.example.inputmethod.Multi",
-            languages: ["ja", "ko"]
-        ))
-        XCTAssertFalse(terminalCommittedIMEReturnQualifiesInputSource(sourceId: nil, languages: ["ko"]))
-    }
 }
 
 @MainActor

--- a/cmuxTests/CJKIMEInputTests.swift
+++ b/cmuxTests/CJKIMEInputTests.swift
@@ -1198,96 +1198,32 @@ final class KoreanIMEReturnCommitRegressionTests: XCTestCase {
     /// Third-party Korean IMEs like Gureum have no "korean" substring in their
     /// input source ID; the declared primary language ("ko") must qualify them
     /// for the committed-composition Return forwarding.
-    func testReturnAfterGureumCommitAlsoSendsReturnToSurface() {
-        _ = NSApplication.shared
-
-        let surface = TerminalSurface(
-            tabId: UUID(),
-            context: GHOSTTY_SURFACE_CONTEXT_SPLIT,
-            configTemplate: nil,
-            workingDirectory: nil
-        )
-        let hostedView = surface.hostedView
-
-        let window = NSWindow(
-            contentRect: NSRect(x: 0, y: 0, width: 360, height: 240),
-            styleMask: [.titled, .closable],
-            backing: .buffered,
-            defer: false
-        )
-        defer {
-            GhosttyNSView.debugGhosttySurfaceKeyEventObserver = nil
-            window.orderOut(nil)
-        }
-
-        guard let contentView = window.contentView else {
-            XCTFail("Expected content view")
-            return
-        }
-
-        hostedView.frame = contentView.bounds
-        hostedView.autoresizingMask = [.width, .height]
-        contentView.addSubview(hostedView)
-
-        window.makeKeyAndOrderFront(nil)
-        window.displayIfNeeded()
-        contentView.layoutSubtreeIfNeeded()
-        hostedView.setVisibleInUI(true)
-        hostedView.setActive(true)
-        RunLoop.current.run(until: Date().addingTimeInterval(0.05))
-
-        guard let view = findGhosttyNSView(in: hostedView) else {
-            XCTFail("Expected hosted GhosttyNSView")
-            return
-        }
-
-        view.setMarkedText("한", selectedRange: NSRange(location: 0, length: 1), replacementRange: NSRange(location: NSNotFound, length: 0))
-
-        // Gureum reports source IDs like org.youknowone.inputmethod.Gureum.han2
-        // with TISIntendedLanguage "ko".
-        KeyboardLayout.debugInputSourceIdOverride = "org.youknowone.inputmethod.Gureum.han2"
-        KeyboardLayout.debugInputSourceLanguagesOverride = ["ko"]
-        installCJKIMEInterpretKeyEventsSwizzle()
-        cjkIMEInterpretKeyEventsHook = { candidateView, _ in
-            guard candidateView === view else { return false }
-            candidateView.insertText("한", replacementRange: NSRange(location: NSNotFound, length: 0))
-            return true
-        }
-        defer {
-            KeyboardLayout.debugInputSourceIdOverride = nil
-            KeyboardLayout.debugInputSourceLanguagesOverride = nil
-            cjkIMEInterpretKeyEventsHook = nil
-        }
-
-        var sawReturnPress = false
-        GhosttyNSView.debugGhosttySurfaceKeyEventObserver = { keyEvent in
-            guard keyEvent.action == GHOSTTY_ACTION_PRESS,
-                  keyEvent.keycode == 36,
-                  keyEvent.text == nil else { return }
-            sawReturnPress = true
-        }
-
-        guard let event = NSEvent.keyEvent(
-            with: .keyDown,
-            location: .zero,
-            modifierFlags: [],
-            timestamp: ProcessInfo.processInfo.systemUptime,
-            windowNumber: window.windowNumber,
-            context: nil,
-            characters: "\r",
-            charactersIgnoringModifiers: "\r",
-            isARepeat: false,
-            keyCode: 36
-        ) else {
-            XCTFail("Failed to create Return event")
-            return
-        }
-
-        window.makeFirstResponder(view)
-        view.keyDown(with: event)
-
-        XCTAssertFalse(view.hasMarkedText(), "Return should commit the active Hangul composition")
-        XCTAssertTrue(sawReturnPress, "Return should still be forwarded after a Gureum commit so the command executes once")
+    func testCommittedReturnQualifiesKoreanSourcesByIdOrDeclaredLanguage() {
+        // Apple 2-Set: matched by ID, language metadata not required.
+        XCTAssertTrue(terminalCommittedIMEReturnQualifiesInputSource(
+            sourceId: "com.apple.inputmethod.Korean.2SetKorean",
+            languages: []
+        ))
+        // Gureum reports org.youknowone.inputmethod.Gureum.han2 with TISIntendedLanguage "ko".
+        XCTAssertTrue(terminalCommittedIMEReturnQualifiesInputSource(
+            sourceId: "org.youknowone.inputmethod.Gureum.han2",
+            languages: ["ko"]
+        ))
+        // Japanese/Chinese: Enter only confirms the conversion, so no extra Return.
+        XCTAssertFalse(terminalCommittedIMEReturnQualifiesInputSource(
+            sourceId: "com.apple.inputmethod.Kotoeri.RomajiTyping.Japanese",
+            languages: ["ja"]
+        ))
+        XCTAssertFalse(terminalCommittedIMEReturnQualifiesInputSource(
+            sourceId: "com.apple.inputmethod.SCIM.ITABC",
+            languages: ["zh-Hans"]
+        ))
+        // Only the primary language counts, and a missing source ID never qualifies.
+        XCTAssertFalse(terminalCommittedIMEReturnQualifiesInputSource(
+            sourceId: "org.example.inputmethod.Multi",
+            languages: ["ja", "ko"]
+        ))
+        XCTAssertFalse(terminalCommittedIMEReturnQualifiesInputSource(sourceId: nil, languages: ["ko"]))
     }
 }
 


### PR DESCRIPTION
### Problem

With third-party Korean IMEs such as [Gureum](https://github.com/gureum/gureum), pressing Return while a Hangul syllable is still composing only commits the syllable — the Return itself is swallowed, so Enter must be pressed twice to run a command. Arrow keys hit the equivalent path.

`shouldSendCommittedIMEConfirmKey` decides whether to forward the Return after an IME commit by checking for a `"korean"` substring in the input source ID. Apple's IME passes (`com.apple.inputmethod.Korean.2SetKorean`), but Gureum reports IDs like `org.youknowone.inputmethod.Gureum.han2`, which never match, so the confirm key is never forwarded.

### Fix

Also qualify input sources whose primary TIS language (`kTISPropertyInputSourceLanguages`) is `ko`. This is the language the input source itself declares (Gureum ships `TISIntendedLanguage = ko`), so any Korean IME is covered without maintaining an ID allow-list. Japanese/Chinese IMEs (where Enter must only confirm the conversion) are unaffected.

- `KeyboardLayout.languages`: new accessor for the current input source languages (`kTISPropertyInputSourceLanguages`).
- `TerminalCommittedIMEReturnInputSourcePolicy` (CmuxTerminalCore/KeyEvents): pure policy holding the Korean-source decision — ID substring match first (shipped behavior), then primary language `ko`. `shouldSendCommittedIMEConfirmKey` feeds it the current `KeyboardLayout.id` / `.languages`.

### Testing

- Added `TerminalCommittedIMEReturnInputSourcePolicyTests` in the package target, covering the policy with value snapshots: Apple 2-Set (ID match, no language metadata), Gureum (`org.youknowone.inputmethod.Gureum.han2` + `["ko"]`), Japanese/Chinese sources (no forward), non-primary `ko`, and a nil source ID. The existing `testReturnAfterKoreanCommitAlsoSendsReturnToSurface` in `cmuxTests` keeps covering the keyDown → Return-forwarding path.
- Earlier revisions used a second `debugInputSourceLanguagesOverride` static and then a file-scope helper; both dropped after review so no new test seam or top-level function lands in `Sources/`.
- Verified manually on a local Release build with Gureum 2-Set: `echo 안녕` + single Return commits the final syllable and executes the command.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Forwards the committed IME Return/Enter for Korean input sources by declared language, not just an ID substring. Previously we forwarded only when the source ID contained “korean”, causing double-Enter with IMEs like Gureum; now we also forward when the primary language is “ko”. Japanese/Chinese behavior is unchanged.

- Introduces `TerminalCommittedIMEReturnInputSourcePolicy` in `CmuxTerminalCore` with `shouldForwardReturn(sourceId:languages:)` (qualifies on ID “korean” or primary language “ko”).
- Uses the policy in `GhosttyNSView.shouldSendCommittedIMEConfirmKey`, passing `KeyboardLayout.id` and `KeyboardLayout.languages`.
- Adds `KeyboardLayout.languages` to read `kTISPropertyInputSourceLanguages`.
- Adds `TerminalCommittedIMEReturnInputSourcePolicyTests` covering Apple Korean by ID, Gureum by language, Japanese/Chinese negatives, non-primary “ko”, and nil ID.

<sup>Written for commit 0360de2a73a3e967d89a23f5006539a83e35da06. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/9881?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Korean IME Return-key handling by recognizing Korean input sources through both keyboard layout identifiers and declared language settings.
  * Prevented Return forwarding for unsupported, non-Korean, or unidentified input sources.

* **Tests**
  * Added coverage for Korean, Japanese, Chinese, and missing-source scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

