### PR TITLE
Finish CodeRouter organization UX and analytics operations

### DIFF
--- a/docs/coderouter-operations.md
+++ b/docs/coderouter-operations.md
@@ -109,6 +109,11 @@ the authenticated output if it contains a principal identifier.
   truncated or malformed PostHog data, timeouts, and Endpoint failures fail
   closed to an unavailable panel and never fall back to a cross-team,
   unfiltered, or free-form query.
+- Capture failures and fixed-Endpoint read failures emit privacy-safe
+  `coderouter.analytics_delivery` and `coderouter.analytics_query` Sentry
+  errors. Alert on either error in production. The report includes only a
+  bounded failure reason and HTTP status, never a team scope, team ID,
+  Endpoint credential, request body, prompt, or model output.
 
 Hexclave Analytics remains the authorization system around this data, but is
 not the metrics store today: its hosted custom-event ingestion currently

--- a/web/app/[locale]/dashboard/coderouter/page.tsx
+++ b/web/app/[locale]/dashboard/coderouter/page.tsx
@@ -22,6 +22,9 @@ import {
   type CoderouterTeamMetrics,
 } from "@/services/coderouter/teamMetrics";
 import {
+  coderouterOrganizationFromCookieHeader,
+} from "@/services/coderouter/organizationScope";
+import {
   AddAiAccountForms,
   DeleteAiAccountButton,
 } from "../components/ai-account-forms";
@@ -74,6 +77,9 @@ export default async function CoderouterOverviewPage({ params, searchParams }: P
     redirect("/");
   }
   const requestHeaders = await headers();
+  const scopedTeamId = coderouterOrganizationFromCookieHeader(
+    requestHeaders.get("cookie"),
+  );
   const tokenStore = {
     headers: { get: (name: string) => requestHeaders.get(name) },
   };
@@ -151,6 +157,7 @@ export default async function CoderouterOverviewPage({ params, searchParams }: P
   const selectedTeam = selectTeam(
     teams,
     team,
+    scopedTeamId,
     authenticated.selectedTeamId,
   );
   const [accountState, metrics] = await Promise.all([
@@ -453,12 +460,17 @@ function StatusPanel({ title, body }: { title: string; body: string }) {
 function selectTeam(
   teams: readonly DashboardTeam[],
   requestedTeamId: string | undefined,
+  scopedTeamId: string | null,
   selectedTeamId: string | null,
 ): DashboardTeam {
   const requested = requestedTeamId?.trim();
   if (requested) {
     const selected = teams.find((team) => team.id === requested);
     if (selected) return selected;
+  }
+  if (scopedTeamId) {
+    const scoped = teams.find((team) => team.id === scopedTeamId);
+    if (scoped) return scoped;
   }
   if (selectedTeamId) {
     const selected = teams.find((team) => team.id === selectedTeamId);

--- a/web/app/[locale]/dashboard/coderouter/page.tsx
+++ b/web/app/[locale]/dashboard/coderouter/page.tsx
@@ -79,6 +79,7 @@ export default async function CoderouterOverviewPage({ params, searchParams }: P
   let authenticated: {
     readonly authorized: Awaited<ReturnType<typeof authorizedSubrouterTeams>>;
     readonly accessToken: string | null;
+    readonly selectedTeamId: string | null;
   } | null;
   try {
     authenticated = await withSubrouterAuthorizationDeadline(
@@ -103,6 +104,7 @@ export default async function CoderouterOverviewPage({ params, searchParams }: P
         return {
           authorized,
           accessToken: authJson?.accessToken ?? null,
+          selectedTeamId: user.selectedTeamId,
         };
       },
     );
@@ -144,7 +146,11 @@ export default async function CoderouterOverviewPage({ params, searchParams }: P
   if (teams.length === 0) {
     redirect("/dashboard");
   }
-  const selectedTeam = selectTeam(teams, team);
+  const selectedTeam = selectTeam(
+    teams,
+    team,
+    authenticated.selectedTeamId,
+  );
   const [accountState, metrics] = await Promise.all([
     loadAccounts(selectedTeam, authenticated.accessToken),
     loadCoderouterTeamMetrics(selectedTeam.id),
@@ -442,10 +448,18 @@ function StatusPanel({ title, body }: { title: string; body: string }) {
   );
 }
 
-function selectTeam(teams: readonly DashboardTeam[], requestedTeamId: string | undefined): DashboardTeam {
+function selectTeam(
+  teams: readonly DashboardTeam[],
+  requestedTeamId: string | undefined,
+  selectedTeamId: string | null,
+): DashboardTeam {
   const requested = requestedTeamId?.trim();
   if (requested) {
     const selected = teams.find((team) => team.id === requested);
+    if (selected) return selected;
+  }
+  if (selectedTeamId) {
+    const selected = teams.find((team) => team.id === selectedTeamId);
     if (selected) return selected;
   }
   return teams[0];

--- a/web/app/[locale]/dashboard/coderouter/page.tsx
+++ b/web/app/[locale]/dashboard/coderouter/page.tsx
@@ -77,15 +77,13 @@ export default async function CoderouterOverviewPage({ params, searchParams }: P
     redirect("/");
   }
   const requestHeaders = await headers();
-  const scopedTeamId = coderouterOrganizationFromCookieHeader(
-    requestHeaders.get("cookie"),
-  );
   const tokenStore = {
     headers: { get: (name: string) => requestHeaders.get(name) },
   };
   let authenticated: {
     readonly authorized: Awaited<ReturnType<typeof authorizedSubrouterTeams>>;
     readonly accessToken: string | null;
+    readonly scopedTeamId: string | null;
     readonly selectedTeamId: string | null;
   } | null;
   try {
@@ -111,6 +109,10 @@ export default async function CoderouterOverviewPage({ params, searchParams }: P
         return {
           authorized,
           accessToken: authJson?.accessToken ?? null,
+          scopedTeamId: coderouterOrganizationFromCookieHeader(
+            requestHeaders.get("cookie"),
+            user.id,
+          ),
           selectedTeamId: user.selectedTeamId,
         };
       },
@@ -157,7 +159,7 @@ export default async function CoderouterOverviewPage({ params, searchParams }: P
   const selectedTeam = selectTeam(
     teams,
     team,
-    scopedTeamId,
+    authenticated.scopedTeamId,
     authenticated.selectedTeamId,
   );
   const [accountState, metrics] = await Promise.all([
@@ -475,10 +477,9 @@ function selectTeam(
   if (selectedTeamId) {
     const selected = teams.find((team) => team.id === selectedTeamId);
     if (selected) return selected;
-  } else {
-    const personal = teams.find((team) => team.personal);
-    if (personal) return personal;
   }
+  const personal = teams.find((team) => team.personal);
+  if (personal) return personal;
   return teams[0];
 }
 

--- a/web/app/[locale]/dashboard/coderouter/page.tsx
+++ b/web/app/[locale]/dashboard/coderouter/page.tsx
@@ -37,6 +37,7 @@ type DashboardTeam = {
   readonly name: string;
   readonly use: boolean;
   readonly manageAccounts: boolean;
+  readonly personal: boolean;
 };
 
 type AccountState =
@@ -142,6 +143,7 @@ export default async function CoderouterOverviewPage({ params, searchParams }: P
       name: candidate.teamName,
       use: candidate.use,
       manageAccounts: candidate.manageAccounts,
+      personal: candidate.personal,
     }));
   if (teams.length === 0) {
     redirect("/dashboard");
@@ -461,6 +463,9 @@ function selectTeam(
   if (selectedTeamId) {
     const selected = teams.find((team) => team.id === selectedTeamId);
     if (selected) return selected;
+  } else {
+    const personal = teams.find((team) => team.personal);
+    if (personal) return personal;
   }
   return teams[0];
 }

--- a/web/app/[locale]/dashboard/dashboard-account-menu.tsx
+++ b/web/app/[locale]/dashboard/dashboard-account-menu.tsx
@@ -161,10 +161,12 @@ function DashboardOrganizationSwitcher() {
   const selectableTeams = teams.filter((team) => permittedIds.has(team.id));
   const personal = permittedCatalogTeams.find((team) => team.personal);
   const requestedTeamId = searchParams.get("team");
-  // Match the CodeRouter page: the explicit deep link is authoritative, with
-  // a deterministic first-permitted fallback when it is absent or stale.
+  // Match the CodeRouter page: an explicit deep link wins, then the
+  // server-authoritative selected team, then a deterministic permitted team.
   const selectedTeamId = requestedTeamId && permittedIds.has(requestedTeamId)
     ? requestedTeamId
+    : data.selectedTeamId && permittedIds.has(data.selectedTeamId)
+    ? data.selectedTeamId
     : permittedCatalogTeams[0]?.id;
   const switchOrganization = async (
     team: (typeof selectableTeams)[number] | null,

--- a/web/app/[locale]/dashboard/dashboard-account-menu.tsx
+++ b/web/app/[locale]/dashboard/dashboard-account-menu.tsx
@@ -19,7 +19,6 @@ const ORGANIZATION_CATALOG_TIMEOUT_MS = 5_000;
 
 export function DashboardAccountMenu() {
   const t = useTranslations("dashboard.accountMenu");
-  const nav = useTranslations("dashboard.nav");
   const locale = useLocale();
   const router = useRouter();
   const user = useUser({ or: "return-null" });
@@ -41,73 +40,70 @@ export function DashboardAccountMenu() {
   }
 
   return (
-    <Menu.Root>
-      <Menu.Trigger
-        className="flex min-w-0 flex-1 items-center gap-2.5 px-1.5 py-1 text-left outline-none hover:bg-code-bg focus-visible:bg-code-bg"
-        aria-label={t("label")}
-      >
-        <UserAvatar size={24} user={user} />
-        <span className="hidden min-w-0 flex-1 truncate font-medium sm:block">
-          {user.displayName || user.primaryEmail}
-        </span>
-        <ChevronsUpDown />
-      </Menu.Trigger>
-      <Menu.Portal>
-        <Menu.Positioner side="top" align="start" sideOffset={8} className="z-50">
-          <Menu.Popup className="w-52 border border-border bg-background p-1 text-foreground shadow-xl shadow-black/10 outline-none">
-            <div className="border-b border-border px-2.5 py-2">
-              <div className="truncate text-sm font-medium">
-                {user.displayName || user.primaryEmail}
+    <div className="flex min-w-0 flex-1 flex-col gap-1">
+      <DashboardOrganizationSwitcher />
+      <Menu.Root>
+        <Menu.Trigger
+          className="flex w-full min-w-0 items-center gap-2.5 px-1.5 py-1 text-left outline-none hover:bg-code-bg focus-visible:bg-code-bg"
+          aria-label={t("label")}
+        >
+          <UserAvatar size={24} user={user} />
+          <span className="hidden min-w-0 flex-1 truncate font-medium sm:block">
+            {user.displayName || user.primaryEmail}
+          </span>
+          <ChevronsUpDown />
+        </Menu.Trigger>
+        <Menu.Portal>
+          <Menu.Positioner side="top" align="start" sideOffset={8} className="z-50">
+            <Menu.Popup className="w-52 border border-border bg-background p-1 text-foreground shadow-xl shadow-black/10 outline-none">
+              <div className="border-b border-border px-2.5 py-2">
+                <div className="truncate text-sm font-medium">
+                  {user.displayName || user.primaryEmail}
+                </div>
+                {user.displayName ? (
+                  <div className="truncate text-xs text-muted">{user.primaryEmail}</div>
+                ) : null}
               </div>
-              {user.displayName ? (
-                <div className="truncate text-xs text-muted">{user.primaryEmail}</div>
+              <Menu.Item render={<Link href="/dashboard/team" />} className={menuItemClass}>
+                <SettingsIcon />
+                <span>{t("settings")}</span>
+              </Menu.Item>
+              <Menu.Item render={<Link href="/dashboard/billing" />} className={menuItemClass}>
+                <BillingIcon />
+                <span>{t("billing")}</span>
+              </Menu.Item>
+              <Menu.Separator className="mx-1 my-1 h-px bg-border" />
+              <Menu.Item
+                className={`${menuItemClass} text-red-600 dark:text-red-400`}
+                disabled={signOutPending}
+                onClick={async (event) => {
+                  event.preventDefault();
+                  if (signOutPending) return;
+                  setSignOutPending(true);
+                  setSignOutError(false);
+                  try {
+                    await user.signOut();
+                    router.replace("/");
+                    router.refresh();
+                  } catch {
+                    setSignOutPending(false);
+                    setSignOutError(true);
+                  }
+                }}
+              >
+                <SignOutIcon />
+                <span>{signOutPending ? t("signingOut") : t("signOut")}</span>
+              </Menu.Item>
+              {signOutError ? (
+                <p role="alert" className="px-2.5 py-1.5 text-xs text-red-600 dark:text-red-400">
+                  {t("signOutError")}
+                </p>
               ) : null}
-            </div>
-            <div className="border-b border-border px-2.5 py-2">
-              <div className="mb-1.5 text-[11px] font-medium uppercase tracking-wide text-muted">
-                {nav("team")}
-              </div>
-              <DashboardOrganizationSwitcher />
-            </div>
-            <Menu.Item render={<Link href="/dashboard/team" />} className={menuItemClass}>
-              <SettingsIcon />
-              <span>{t("settings")}</span>
-            </Menu.Item>
-            <Menu.Item render={<Link href="/dashboard/billing" />} className={menuItemClass}>
-              <BillingIcon />
-              <span>{t("billing")}</span>
-            </Menu.Item>
-            <Menu.Separator className="mx-1 my-1 h-px bg-border" />
-            <Menu.Item
-              className={`${menuItemClass} text-red-600 dark:text-red-400`}
-              disabled={signOutPending}
-              onClick={async (event) => {
-                event.preventDefault();
-                if (signOutPending) return;
-                setSignOutPending(true);
-                setSignOutError(false);
-                try {
-                  await user.signOut();
-                  router.replace("/");
-                  router.refresh();
-                } catch {
-                  setSignOutPending(false);
-                  setSignOutError(true);
-                }
-              }}
-            >
-              <SignOutIcon />
-              <span>{signOutPending ? t("signingOut") : t("signOut")}</span>
-            </Menu.Item>
-            {signOutError ? (
-              <p role="alert" className="px-2.5 py-1.5 text-xs text-red-600 dark:text-red-400">
-                {t("signOutError")}
-              </p>
-            ) : null}
-          </Menu.Popup>
-        </Menu.Positioner>
-      </Menu.Portal>
-    </Menu.Root>
+            </Menu.Popup>
+          </Menu.Positioner>
+        </Menu.Portal>
+      </Menu.Root>
+    </div>
   );
 }
 
@@ -166,7 +162,7 @@ function DashboardOrganizationSwitcher() {
   const permittedIds = new Set(permittedCatalogTeams.map((team) => team.id));
   const selectableTeams = teams.filter((team) => permittedIds.has(team.id));
   const personal = permittedCatalogTeams.find((team) => team.personal);
-  const requestedTeamId = searchParams.get("team");
+  const requestedTeamId = searchParams.get("team")?.trim() || null;
   const catalogSelectedTeamId = data.selectedTeamId ?? personal?.id;
   // Match the CodeRouter page: an explicit deep link wins, then the
   // authenticated catalog selection, then a permitted fallback.

--- a/web/app/[locale]/dashboard/dashboard-account-menu.tsx
+++ b/web/app/[locale]/dashboard/dashboard-account-menu.tsx
@@ -15,7 +15,7 @@ import { Link, useRouter } from "@/i18n/navigation";
 
 const menuItemClass =
   "flex min-h-9 w-full cursor-default select-none items-center gap-2 px-2.5 py-2 text-left text-sm text-foreground no-underline outline-none data-[highlighted]:bg-code-bg";
-const ORGANIZATION_CATALOG_TIMEOUT_MS = 5_000;
+const ORGANIZATION_CATALOG_TIMEOUT_MS = 15_000;
 const ORGANIZATION_SWITCH_TIMEOUT_MS = 10_000;
 
 export function DashboardAccountMenu() {
@@ -139,7 +139,6 @@ function DashboardOrganizationSwitcher() {
     null,
   );
   const queuedSwitchRef = useRef<SwitchRequest | null>(null);
-  const latestSwitchRef = useRef<SwitchRequest | null>(null);
   const mountedRef = useRef(true);
   useEffect(() => {
     mountedRef.current = true;
@@ -147,7 +146,6 @@ function DashboardOrganizationSwitcher() {
       mountedRef.current = false;
       activeSwitchRef.current = null;
       queuedSwitchRef.current = null;
-      latestSwitchRef.current = null;
       if (activeSwitchTimerRef.current) {
         clearTimeout(activeSwitchTimerRef.current);
         activeSwitchTimerRef.current = null;
@@ -217,7 +215,6 @@ function DashboardOrganizationSwitcher() {
       team,
       organizationId,
     };
-    latestSwitchRef.current = request;
     // The URL is the dashboard's authoritative organization scope, so reflect
     // the user's choice immediately. Stack selection is serialized below only
     // to persist the default for later visits without an explicit team.
@@ -253,29 +250,15 @@ function DashboardOrganizationSwitcher() {
     const timeout = setTimeout(() => {
       if (!mountedRef.current) return;
       if (activeSwitchRef.current !== operation) return;
-      activeSwitchRef.current = null;
       activeSwitchTimerRef.current = null;
-      const queued = queuedSwitchRef.current;
-      queuedSwitchRef.current = null;
       setSwitchPending(false);
       setSwitchError(true);
-      if (queued) runSwitch(queued);
     }, ORGANIZATION_SWITCH_TIMEOUT_MS);
     activeSwitchTimerRef.current = timeout;
 
     void operation.then(() => {
       if (!mountedRef.current) return;
-      if (activeSwitchRef.current !== operation) {
-        if (activeSwitchRef.current) return;
-        const latest = latestSwitchRef.current;
-        if (!latest || latest === request) {
-          recordSuccessfulSwitch(request);
-          setSwitchError(false);
-        } else {
-          runSwitch(latest);
-        }
-        return;
-      }
+      if (activeSwitchRef.current !== operation) return;
       clearTimeout(timeout);
       activeSwitchTimerRef.current = null;
       activeSwitchRef.current = null;

--- a/web/app/[locale]/dashboard/dashboard-account-menu.tsx
+++ b/web/app/[locale]/dashboard/dashboard-account-menu.tsx
@@ -6,7 +6,7 @@ import {
   UserAvatar,
   useUser,
 } from "@stackframe/stack";
-import { useQuery } from "@tanstack/react-query";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { useLocale, useTranslations } from "next-intl";
 import { useSearchParams } from "next/navigation";
 import { useState } from "react";
@@ -127,8 +127,10 @@ function DashboardOrganizationSwitcher() {
   const user = useUser({ or: "throw" });
   const teams = user.useTeams();
   const router = useRouter();
+  const queryClient = useQueryClient();
   const searchParams = useSearchParams();
   const t = useTranslations("dashboard.accountMenu");
+  const [switchError, setSwitchError] = useState(false);
   const organizationQueryKey = [
     "coderouter-organizations",
     user.id,
@@ -161,21 +163,37 @@ function DashboardOrganizationSwitcher() {
   const selectableTeams = teams.filter((team) => permittedIds.has(team.id));
   const personal = permittedCatalogTeams.find((team) => team.personal);
   const requestedTeamId = searchParams.get("team");
-  // Match the CodeRouter page: an explicit deep link wins, then Stack's live
-  // selected team (where null means personal), then a permitted fallback.
+  const catalogSelectedTeamId = data.selectedTeamId ?? personal?.id;
+  // Match the CodeRouter page: an explicit deep link wins, then the
+  // authenticated catalog selection, then a permitted fallback.
   const selectedTeamId = requestedTeamId && permittedIds.has(requestedTeamId)
     ? requestedTeamId
-    : user.selectedTeam && permittedIds.has(user.selectedTeam.id)
-    ? user.selectedTeam.id
-    : user.selectedTeam === null && personal
-    ? personal.id
+    : catalogSelectedTeamId && permittedIds.has(catalogSelectedTeamId)
+    ? catalogSelectedTeamId
     : permittedCatalogTeams[0]?.id;
   const switchOrganization = async (
     team: (typeof selectableTeams)[number] | null,
   ) => {
     const organizationId = team?.id ?? personal?.id;
     if (!organizationId) return;
-    await user.setSelectedTeam(team);
+    setSwitchError(false);
+    try {
+      await user.setSelectedTeam(team);
+    } catch {
+      setSwitchError(true);
+      return;
+    }
+    queryClient.setQueryData<OrganizationCatalog>(
+      organizationQueryKey,
+      (current) =>
+        current
+          ? { ...current, selectedTeamId: team?.id ?? null }
+          : current,
+    );
+    void queryClient.invalidateQueries({
+      queryKey: organizationQueryKey,
+      exact: true,
+    });
     router.push(
       `/dashboard/coderouter?team=${
         encodeURIComponent(organizationId)
@@ -190,7 +208,7 @@ function DashboardOrganizationSwitcher() {
       "min-h-9 w-full border border-border bg-background px-2 text-left text-sm hover:bg-code-bg",
   };
 
-  return personal
+  const switcher = personal
     ? (
       <TeamSwitcher
         {...shared}
@@ -200,6 +218,19 @@ function DashboardOrganizationSwitcher() {
       />
     )
     : <TeamSwitcher {...shared} onChange={switchOrganization} />;
+  return (
+    <>
+      {switcher}
+      {switchError ? (
+        <p role="alert" className="mt-1 text-xs text-red-600 dark:text-red-400">
+          {t("organizationSwitchError")}{" "}
+          <Link href="/dashboard/team" className="underline">
+            {t("settings")}
+          </Link>
+        </p>
+      ) : null}
+    </>
+  );
 }
 
 async function loadOrganizationCatalog(): Promise<OrganizationCatalog> {

--- a/web/app/[locale]/dashboard/dashboard-account-menu.tsx
+++ b/web/app/[locale]/dashboard/dashboard-account-menu.tsx
@@ -265,6 +265,15 @@ function DashboardOrganizationSwitcher() {
       clearTimeout(timeout);
       activeSwitchTimerRef.current = null;
       activeSwitchRef.current = null;
+      if (timedOut) {
+        queuedSwitchRef.current = null;
+        void queryClient.invalidateQueries({
+          queryKey: organizationQueryKey,
+          exact: true,
+        });
+        setSwitchPending(false);
+        return;
+      }
       const queued = queuedSwitchRef.current;
       queuedSwitchRef.current = null;
       if (queued) {
@@ -272,24 +281,20 @@ function DashboardOrganizationSwitcher() {
         runSwitch(queued, request);
         return;
       }
-      if (!timedOut) {
-        applySuccessfulSwitch(request);
-        setSwitchPending(false);
-      } else {
-        // The request eventually settled after the UI deadline. Reconcile the
-        // catalog, but do not navigate away from whatever the user opened.
-        void queryClient.invalidateQueries({
-          queryKey: organizationQueryKey,
-          exact: true,
-        });
-        setSwitchPending(false);
-      }
+      applySuccessfulSwitch(request);
+      setSwitchPending(false);
     }, () => {
       if (!mountedRef.current) return;
       if (activeSwitchRef.current !== operation) return;
       clearTimeout(timeout);
       activeSwitchTimerRef.current = null;
       activeSwitchRef.current = null;
+      if (timedOut) {
+        queuedSwitchRef.current = null;
+        setSwitchPending(false);
+        setSwitchError(true);
+        return;
+      }
       const queued = queuedSwitchRef.current;
       queuedSwitchRef.current = null;
       if (queued) {

--- a/web/app/[locale]/dashboard/dashboard-account-menu.tsx
+++ b/web/app/[locale]/dashboard/dashboard-account-menu.tsx
@@ -8,10 +8,9 @@ import {
 } from "@stackframe/stack";
 import { useQuery } from "@tanstack/react-query";
 import { useLocale, useTranslations } from "next-intl";
-import { useRouter } from "next/navigation";
 import { useState } from "react";
 import { localizedVaultPath, vaultSignInHref } from "@/app/lib/vault-auth";
-import { Link } from "@/i18n/navigation";
+import { Link, useRouter } from "@/i18n/navigation";
 
 const menuItemClass =
   "flex min-h-9 w-full cursor-default select-none items-center gap-2 px-2.5 py-2 text-left text-sm text-foreground no-underline outline-none data-[highlighted]:bg-code-bg";
@@ -87,7 +86,7 @@ export function DashboardAccountMenu() {
                 setSignOutError(false);
                 try {
                   await user.signOut();
-                  router.replace(`/${locale}`);
+                  router.replace("/");
                   router.refresh();
                 } catch {
                   setSignOutPending(false);
@@ -123,28 +122,46 @@ function DashboardOrganizationSwitcher() {
   const user = useUser({ or: "throw" });
   const teams = user.useTeams();
   const router = useRouter();
-  const { data } = useQuery({
+  const t = useTranslations("dashboard.accountMenu");
+  const [selectedOrganizationId, setSelectedOrganizationId] = useState<
+    string | undefined
+  >(undefined);
+  const { data, isPending, isError } = useQuery({
     queryKey: ["coderouter-organizations"],
     queryFn: loadOrganizationCatalog,
     staleTime: 60_000,
   });
 
-  if (!data) {
+  if (isPending) {
     return <div aria-hidden="true" className="h-9 w-full animate-pulse bg-code-bg" />;
+  }
+  if (isError || !data) {
+    return (
+      <Link
+        href="/dashboard/team"
+        className="block min-h-9 border border-border px-2 py-2 text-sm text-muted hover:bg-code-bg hover:text-foreground"
+      >
+        {t("settings")}
+      </Link>
+    );
   }
 
   const authorizedIds = new Set(data.teams.map((team) => team.id));
   const selectableTeams = teams.filter((team) => authorizedIds.has(team.id));
   const personal = data.teams.find((team) => team.personal);
-  const selectedTeamId = data.selectedTeamId ?? data.teams[0]?.id;
+  const selectedTeamId = selectedOrganizationId ??
+    (user.selectedTeam && authorizedIds.has(user.selectedTeam.id)
+      ? user.selectedTeam.id
+      : data.selectedTeamId ?? data.teams[0]?.id);
   const switchOrganization = async (
     team: (typeof selectableTeams)[number] | null,
   ) => {
     const organizationId = team?.id ?? personal?.id;
     if (!organizationId) return;
     await user.setSelectedTeam(team);
+    setSelectedOrganizationId(organizationId);
     router.push(
-      `/dashboard/coderouter?organization=${
+      `/dashboard/coderouter?team=${
         encodeURIComponent(organizationId)
       }`,
     );

--- a/web/app/[locale]/dashboard/dashboard-account-menu.tsx
+++ b/web/app/[locale]/dashboard/dashboard-account-menu.tsx
@@ -9,14 +9,16 @@ import {
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { useLocale, useTranslations } from "next-intl";
 import { useSearchParams } from "next/navigation";
-import { useEffect, useRef, useState } from "react";
+import { useState } from "react";
 import { localizedVaultPath, vaultSignInHref } from "@/app/lib/vault-auth";
 import { Link, useRouter } from "@/i18n/navigation";
+import {
+  persistCoderouterOrganizationScope,
+} from "@/services/coderouter/organizationScope";
 
 const menuItemClass =
   "flex min-h-9 w-full cursor-default select-none items-center gap-2 px-2.5 py-2 text-left text-sm text-foreground no-underline outline-none data-[highlighted]:bg-code-bg";
 const ORGANIZATION_CATALOG_TIMEOUT_MS = 15_000;
-const ORGANIZATION_SWITCH_TIMEOUT_MS = 10_000;
 
 export function DashboardAccountMenu() {
   const t = useTranslations("dashboard.accountMenu");
@@ -128,30 +130,6 @@ function DashboardOrganizationSwitcher() {
   const queryClient = useQueryClient();
   const searchParams = useSearchParams();
   const t = useTranslations("dashboard.accountMenu");
-  const [switchError, setSwitchError] = useState(false);
-  const [switchPending, setSwitchPending] = useState(false);
-  type SwitchRequest = {
-    readonly team: (typeof teams)[number] | null;
-    readonly organizationId: string;
-  };
-  const activeSwitchRef = useRef<Promise<void> | null>(null);
-  const activeSwitchTimerRef = useRef<ReturnType<typeof setTimeout> | null>(
-    null,
-  );
-  const queuedSwitchRef = useRef<SwitchRequest | null>(null);
-  const mountedRef = useRef(true);
-  useEffect(() => {
-    mountedRef.current = true;
-    return () => {
-      mountedRef.current = false;
-      activeSwitchRef.current = null;
-      queuedSwitchRef.current = null;
-      if (activeSwitchTimerRef.current) {
-        clearTimeout(activeSwitchTimerRef.current);
-        activeSwitchTimerRef.current = null;
-      }
-    };
-  }, []);
   const organizationQueryKey = [
     "coderouter-organizations",
     user.id,
@@ -211,82 +189,25 @@ function DashboardOrganizationSwitcher() {
   ) => {
     const organizationId = team?.id ?? personal?.id;
     if (!organizationId) return;
-    const request = {
-      team,
-      organizationId,
-    };
-    // The URL is the dashboard's authoritative organization scope, so reflect
-    // the user's choice immediately. Stack selection is serialized below only
-    // to persist the default for later visits without an explicit team.
-    router.push(
-      `/dashboard/coderouter?team=${encodeURIComponent(organizationId)}`,
-    );
-    router.refresh();
-    if (activeSwitchRef.current) {
-      queuedSwitchRef.current = request;
-      return;
-    }
-    runSwitch(request);
-  };
-  function recordSuccessfulSwitch(request: SwitchRequest) {
-    const { team } = request;
+    // CodeRouter scope is independent of Stack's global selected team. Persist
+    // it synchronously, and validate it against fresh permissions on every read.
+    persistCoderouterOrganizationScope(organizationId);
     queryClient.setQueryData<OrganizationCatalog>(
       organizationQueryKey,
       (current) =>
         current
-          ? { ...current, selectedTeamId: team?.id ?? null }
+          ? { ...current, selectedTeamId: organizationId }
           : current,
     );
     void queryClient.invalidateQueries({
       queryKey: organizationQueryKey,
       exact: true,
     });
-  }
-  function runSwitch(request: SwitchRequest) {
-    setSwitchPending(true);
-    setSwitchError(false);
-    const operation = user.setSelectedTeam(request.team);
-    activeSwitchRef.current = operation;
-    const timeout = setTimeout(() => {
-      if (!mountedRef.current) return;
-      if (activeSwitchRef.current !== operation) return;
-      activeSwitchTimerRef.current = null;
-      setSwitchPending(false);
-      setSwitchError(true);
-    }, ORGANIZATION_SWITCH_TIMEOUT_MS);
-    activeSwitchTimerRef.current = timeout;
-
-    void operation.then(() => {
-      if (!mountedRef.current) return;
-      if (activeSwitchRef.current !== operation) return;
-      clearTimeout(timeout);
-      activeSwitchTimerRef.current = null;
-      activeSwitchRef.current = null;
-      recordSuccessfulSwitch(request);
-      const queued = queuedSwitchRef.current;
-      queuedSwitchRef.current = null;
-      if (queued) {
-        runSwitch(queued);
-        return;
-      }
-      setSwitchPending(false);
-      setSwitchError(false);
-    }, () => {
-      if (!mountedRef.current) return;
-      if (activeSwitchRef.current !== operation) return;
-      clearTimeout(timeout);
-      activeSwitchTimerRef.current = null;
-      activeSwitchRef.current = null;
-      const queued = queuedSwitchRef.current;
-      queuedSwitchRef.current = null;
-      if (queued) {
-        runSwitch(queued);
-        return;
-      }
-      setSwitchPending(false);
-      setSwitchError(true);
-    });
-  }
+    router.push(
+      `/dashboard/coderouter?team=${encodeURIComponent(organizationId)}`,
+    );
+    router.refresh();
+  };
   const shared = {
     teams: selectableTeams,
     teamId: personal?.id === selectedTeamId ? undefined : selectedTeamId,
@@ -305,26 +226,7 @@ function DashboardOrganizationSwitcher() {
     )
     : <TeamSwitcher {...shared} onChange={switchOrganization} />;
   return (
-    <>
-      <fieldset
-        disabled={switchPending}
-        aria-busy={switchPending}
-        className="m-0 min-w-0 border-0 p-0 disabled:cursor-wait disabled:opacity-60"
-      >
-        {switcher}
-      </fieldset>
-      {switchError ? (
-        <p role="alert" className="mt-1 text-xs text-red-600 dark:text-red-400">
-          <button
-            type="button"
-            className="text-left underline"
-            onClick={() => globalThis.location.reload()}
-          >
-            {t("organizationSwitchError")}
-          </button>
-        </p>
-      ) : null}
-    </>
+    switcher
   );
 }
 

--- a/web/app/[locale]/dashboard/dashboard-account-menu.tsx
+++ b/web/app/[locale]/dashboard/dashboard-account-menu.tsx
@@ -6,8 +6,9 @@ import {
   UserAvatar,
   useUser,
 } from "@stackframe/stack";
-import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { useQuery } from "@tanstack/react-query";
 import { useLocale, useTranslations } from "next-intl";
+import { useSearchParams } from "next/navigation";
 import { useState } from "react";
 import { localizedVaultPath, vaultSignInHref } from "@/app/lib/vault-auth";
 import { Link, useRouter } from "@/i18n/navigation";
@@ -115,6 +116,10 @@ type OrganizationCatalog = {
     readonly id: string;
     readonly name: string;
     readonly personal: boolean;
+    readonly permissions: {
+      readonly use: boolean;
+      readonly manageAccounts: boolean;
+    };
   }[];
 };
 
@@ -122,7 +127,7 @@ function DashboardOrganizationSwitcher() {
   const user = useUser({ or: "throw" });
   const teams = user.useTeams();
   const router = useRouter();
-  const queryClient = useQueryClient();
+  const searchParams = useSearchParams();
   const t = useTranslations("dashboard.accountMenu");
   const organizationQueryKey = [
     "coderouter-organizations",
@@ -148,26 +153,25 @@ function DashboardOrganizationSwitcher() {
     );
   }
 
-  const authorizedIds = new Set(data.teams.map((team) => team.id));
-  const selectableTeams = teams.filter((team) => authorizedIds.has(team.id));
-  const personal = data.teams.find((team) => team.personal);
-  const selectedTeamId =
-    personal && user.selectedTeam === null
-      ? personal.id
-      : user.selectedTeam && authorizedIds.has(user.selectedTeam.id)
-      ? user.selectedTeam.id
-      : data.selectedTeamId ?? data.teams[0]?.id;
+  // The dashboard supports both route users and account-only managers.
+  const permittedCatalogTeams = data.teams.filter(
+    (team) => team.permissions.use || team.permissions.manageAccounts,
+  );
+  const permittedIds = new Set(permittedCatalogTeams.map((team) => team.id));
+  const selectableTeams = teams.filter((team) => permittedIds.has(team.id));
+  const personal = permittedCatalogTeams.find((team) => team.personal);
+  const requestedTeamId = searchParams.get("team");
+  // Match the CodeRouter page: the explicit deep link is authoritative, with
+  // a deterministic first-permitted fallback when it is absent or stale.
+  const selectedTeamId = requestedTeamId && permittedIds.has(requestedTeamId)
+    ? requestedTeamId
+    : permittedCatalogTeams[0]?.id;
   const switchOrganization = async (
     team: (typeof selectableTeams)[number] | null,
   ) => {
     const organizationId = team?.id ?? personal?.id;
     if (!organizationId) return;
     await user.setSelectedTeam(team);
-    queryClient.setQueryData<OrganizationCatalog>(
-      organizationQueryKey,
-      (current) =>
-        current ? { ...current, selectedTeamId: organizationId } : current,
-    );
     router.push(
       `/dashboard/coderouter?team=${
         encodeURIComponent(organizationId)
@@ -226,6 +230,9 @@ function parseOrganizationCatalog(value: unknown): OrganizationCatalog | null {
       !validOrganizationText(raw.id) ||
       !validOrganizationText(raw.name) ||
       typeof raw.personal !== "boolean" ||
+      !isPlainRecord(raw.permissions) ||
+      typeof raw.permissions.use !== "boolean" ||
+      typeof raw.permissions.manageAccounts !== "boolean" ||
       seen.has(raw.id)
     ) {
       return null;
@@ -235,6 +242,10 @@ function parseOrganizationCatalog(value: unknown): OrganizationCatalog | null {
       id: raw.id,
       name: raw.name,
       personal: raw.personal,
+      permissions: {
+        use: raw.permissions.use,
+        manageAccounts: raw.permissions.manageAccounts,
+      },
     });
   }
   if (selectedTeamId !== null && !seen.has(selectedTeamId)) return null;

--- a/web/app/[locale]/dashboard/dashboard-account-menu.tsx
+++ b/web/app/[locale]/dashboard/dashboard-account-menu.tsx
@@ -9,7 +9,7 @@ import {
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { useLocale, useTranslations } from "next-intl";
 import { useSearchParams } from "next/navigation";
-import { useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { localizedVaultPath, vaultSignInHref } from "@/app/lib/vault-auth";
 import { Link, useRouter } from "@/i18n/navigation";
 
@@ -135,7 +135,23 @@ function DashboardOrganizationSwitcher() {
     readonly organizationId: string;
   };
   const activeSwitchRef = useRef<Promise<void> | null>(null);
+  const activeSwitchTimerRef = useRef<ReturnType<typeof setTimeout> | null>(
+    null,
+  );
   const queuedSwitchRef = useRef<SwitchRequest | null>(null);
+  const mountedRef = useRef(true);
+  useEffect(() => {
+    mountedRef.current = true;
+    return () => {
+      mountedRef.current = false;
+      activeSwitchRef.current = null;
+      queuedSwitchRef.current = null;
+      if (activeSwitchTimerRef.current) {
+        clearTimeout(activeSwitchTimerRef.current);
+        activeSwitchTimerRef.current = null;
+      }
+    };
+  }, []);
   const organizationQueryKey = [
     "coderouter-organizations",
     user.id,
@@ -229,14 +245,18 @@ function DashboardOrganizationSwitcher() {
     const operation = user.setSelectedTeam(request.team);
     activeSwitchRef.current = operation;
     const timeout = setTimeout(() => {
+      if (!mountedRef.current) return;
       if (activeSwitchRef.current !== operation) return;
       timedOut = true;
       setSwitchError(true);
     }, ORGANIZATION_SWITCH_TIMEOUT_MS);
+    activeSwitchTimerRef.current = timeout;
 
     void operation.then(() => {
+      if (!mountedRef.current) return;
       if (activeSwitchRef.current !== operation) return;
       clearTimeout(timeout);
+      activeSwitchTimerRef.current = null;
       activeSwitchRef.current = null;
       const queued = queuedSwitchRef.current;
       queuedSwitchRef.current = null;
@@ -257,8 +277,10 @@ function DashboardOrganizationSwitcher() {
         setSwitchPending(false);
       }
     }, () => {
+      if (!mountedRef.current) return;
       if (activeSwitchRef.current !== operation) return;
       clearTimeout(timeout);
+      activeSwitchTimerRef.current = null;
       activeSwitchRef.current = null;
       const queued = queuedSwitchRef.current;
       queuedSwitchRef.current = null;

--- a/web/app/[locale]/dashboard/dashboard-account-menu.tsx
+++ b/web/app/[locale]/dashboard/dashboard-account-menu.tsx
@@ -161,6 +161,16 @@ function DashboardOrganizationSwitcher() {
   const permittedCatalogTeams = data.teams.filter(
     (team) => team.permissions.use || team.permissions.manageAccounts,
   );
+  if (permittedCatalogTeams.length === 0) {
+    return (
+      <Link
+        href="/dashboard/team"
+        className="block min-h-9 border border-border px-2 py-2 text-sm text-muted hover:bg-code-bg hover:text-foreground"
+      >
+        {t("settings")}
+      </Link>
+    );
+  }
   const permittedIds = new Set(permittedCatalogTeams.map((team) => team.id));
   const selectableTeams = teams.filter((team) => permittedIds.has(team.id));
   const personal = permittedCatalogTeams.find((team) => team.personal);

--- a/web/app/[locale]/dashboard/dashboard-account-menu.tsx
+++ b/web/app/[locale]/dashboard/dashboard-account-menu.tsx
@@ -9,7 +9,7 @@ import {
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { useLocale, useTranslations } from "next-intl";
 import { useSearchParams } from "next/navigation";
-import { useState } from "react";
+import { useRef, useState } from "react";
 import { localizedVaultPath, vaultSignInHref } from "@/app/lib/vault-auth";
 import { Link, useRouter } from "@/i18n/navigation";
 
@@ -128,6 +128,8 @@ function DashboardOrganizationSwitcher() {
   const searchParams = useSearchParams();
   const t = useTranslations("dashboard.accountMenu");
   const [switchError, setSwitchError] = useState(false);
+  const [switchPending, setSwitchPending] = useState(false);
+  const switchPendingRef = useRef(false);
   const organizationQueryKey = [
     "coderouter-organizations",
     user.id,
@@ -174,32 +176,37 @@ function DashboardOrganizationSwitcher() {
   const switchOrganization = async (
     team: (typeof selectableTeams)[number] | null,
   ) => {
+    if (switchPendingRef.current) return;
     const organizationId = team?.id ?? personal?.id;
     if (!organizationId) return;
+    switchPendingRef.current = true;
+    setSwitchPending(true);
     setSwitchError(false);
     try {
       await user.setSelectedTeam(team);
+      queryClient.setQueryData<OrganizationCatalog>(
+        organizationQueryKey,
+        (current) =>
+          current
+            ? { ...current, selectedTeamId: team?.id ?? null }
+            : current,
+      );
+      void queryClient.invalidateQueries({
+        queryKey: organizationQueryKey,
+        exact: true,
+      });
+      router.push(
+        `/dashboard/coderouter?team=${
+          encodeURIComponent(organizationId)
+        }`,
+      );
+      router.refresh();
     } catch {
       setSwitchError(true);
-      return;
+    } finally {
+      switchPendingRef.current = false;
+      setSwitchPending(false);
     }
-    queryClient.setQueryData<OrganizationCatalog>(
-      organizationQueryKey,
-      (current) =>
-        current
-          ? { ...current, selectedTeamId: team?.id ?? null }
-          : current,
-    );
-    void queryClient.invalidateQueries({
-      queryKey: organizationQueryKey,
-      exact: true,
-    });
-    router.push(
-      `/dashboard/coderouter?team=${
-        encodeURIComponent(organizationId)
-      }`,
-    );
-    router.refresh();
   };
   const shared = {
     teams: selectableTeams,
@@ -220,7 +227,13 @@ function DashboardOrganizationSwitcher() {
     : <TeamSwitcher {...shared} onChange={switchOrganization} />;
   return (
     <>
-      {switcher}
+      <fieldset
+        disabled={switchPending}
+        aria-busy={switchPending}
+        className="m-0 min-w-0 border-0 p-0 disabled:cursor-wait disabled:opacity-60"
+      >
+        {switcher}
+      </fieldset>
       {switchError ? (
         <p role="alert" className="mt-1 text-xs text-red-600 dark:text-red-400">
           {t("organizationSwitchError")}{" "}

--- a/web/app/[locale]/dashboard/dashboard-account-menu.tsx
+++ b/web/app/[locale]/dashboard/dashboard-account-menu.tsx
@@ -161,12 +161,14 @@ function DashboardOrganizationSwitcher() {
   const selectableTeams = teams.filter((team) => permittedIds.has(team.id));
   const personal = permittedCatalogTeams.find((team) => team.personal);
   const requestedTeamId = searchParams.get("team");
-  // Match the CodeRouter page: an explicit deep link wins, then the
-  // server-authoritative selected team, then a deterministic permitted team.
+  // Match the CodeRouter page: an explicit deep link wins, then Stack's live
+  // selected team (where null means personal), then a permitted fallback.
   const selectedTeamId = requestedTeamId && permittedIds.has(requestedTeamId)
     ? requestedTeamId
-    : data.selectedTeamId && permittedIds.has(data.selectedTeamId)
-    ? data.selectedTeamId
+    : user.selectedTeam && permittedIds.has(user.selectedTeam.id)
+    ? user.selectedTeam.id
+    : user.selectedTeam === null && personal
+    ? personal.id
     : permittedCatalogTeams[0]?.id;
   const switchOrganization = async (
     team: (typeof selectableTeams)[number] | null,

--- a/web/app/[locale]/dashboard/dashboard-account-menu.tsx
+++ b/web/app/[locale]/dashboard/dashboard-account-menu.tsx
@@ -139,6 +139,7 @@ function DashboardOrganizationSwitcher() {
     null,
   );
   const queuedSwitchRef = useRef<SwitchRequest | null>(null);
+  const latestSwitchRef = useRef<SwitchRequest | null>(null);
   const mountedRef = useRef(true);
   useEffect(() => {
     mountedRef.current = true;
@@ -146,6 +147,7 @@ function DashboardOrganizationSwitcher() {
       mountedRef.current = false;
       activeSwitchRef.current = null;
       queuedSwitchRef.current = null;
+      latestSwitchRef.current = null;
       if (activeSwitchTimerRef.current) {
         clearTimeout(activeSwitchTimerRef.current);
         activeSwitchTimerRef.current = null;
@@ -215,6 +217,7 @@ function DashboardOrganizationSwitcher() {
       team,
       organizationId,
     };
+    latestSwitchRef.current = request;
     // The URL is the dashboard's authoritative organization scope, so reflect
     // the user's choice immediately. Stack selection is serialized below only
     // to persist the default for later visits without an explicit team.
@@ -250,13 +253,29 @@ function DashboardOrganizationSwitcher() {
     const timeout = setTimeout(() => {
       if (!mountedRef.current) return;
       if (activeSwitchRef.current !== operation) return;
+      activeSwitchRef.current = null;
+      activeSwitchTimerRef.current = null;
+      const queued = queuedSwitchRef.current;
+      queuedSwitchRef.current = null;
+      setSwitchPending(false);
       setSwitchError(true);
+      if (queued) runSwitch(queued);
     }, ORGANIZATION_SWITCH_TIMEOUT_MS);
     activeSwitchTimerRef.current = timeout;
 
     void operation.then(() => {
       if (!mountedRef.current) return;
-      if (activeSwitchRef.current !== operation) return;
+      if (activeSwitchRef.current !== operation) {
+        if (activeSwitchRef.current) return;
+        const latest = latestSwitchRef.current;
+        if (!latest || latest === request) {
+          recordSuccessfulSwitch(request);
+          setSwitchError(false);
+        } else {
+          runSwitch(latest);
+        }
+        return;
+      }
       clearTimeout(timeout);
       activeSwitchTimerRef.current = null;
       activeSwitchRef.current = null;

--- a/web/app/[locale]/dashboard/dashboard-account-menu.tsx
+++ b/web/app/[locale]/dashboard/dashboard-account-menu.tsx
@@ -1,7 +1,11 @@
 "use client";
 
 import { Menu } from "@base-ui-components/react/menu";
-import { UserAvatar, useUser } from "@stackframe/stack";
+import {
+  SelectedTeamSwitcher,
+  UserAvatar,
+  useUser,
+} from "@stackframe/stack";
 import { useLocale, useTranslations } from "next-intl";
 import { useState } from "react";
 import { localizedVaultPath, vaultSignInHref } from "@/app/lib/vault-auth";
@@ -12,6 +16,7 @@ const menuItemClass =
 
 export function DashboardAccountMenu() {
   const t = useTranslations("dashboard.accountMenu");
+  const nav = useTranslations("dashboard.nav");
   const locale = useLocale();
   const user = useUser({ or: "return-null" });
   const [signOutPending, setSignOutPending] = useState(false);
@@ -53,6 +58,17 @@ export function DashboardAccountMenu() {
               {user.displayName ? (
                 <div className="truncate text-xs text-muted">{user.primaryEmail}</div>
               ) : null}
+            </div>
+            <div className="border-b border-border px-2.5 py-2">
+              <div className="mb-1.5 text-[11px] font-medium uppercase tracking-wide text-muted">
+                {nav("team")}
+              </div>
+              <SelectedTeamSwitcher
+                triggerClassName="min-h-9 w-full border border-border bg-background px-2 text-left text-sm hover:bg-code-bg"
+                urlMap={(team) =>
+                  `/dashboard/coderouter?organization=${encodeURIComponent(team.id)}`
+                }
+              />
             </div>
             <Menu.Item render={<Link href="/dashboard/team" />} className={menuItemClass}>
               <SettingsIcon />

--- a/web/app/[locale]/dashboard/dashboard-account-menu.tsx
+++ b/web/app/[locale]/dashboard/dashboard-account-menu.tsx
@@ -194,11 +194,8 @@ function DashboardOrganizationSwitcher() {
     switchPendingRef.current = true;
     setSwitchPending(true);
     setSwitchError(false);
-    try {
-      await withDeadline(
-        user.setSelectedTeam(team),
-        ORGANIZATION_SWITCH_TIMEOUT_MS,
-      );
+    const operation = user.setSelectedTeam(team);
+    const applySuccessfulSwitch = () => {
       queryClient.setQueryData<OrganizationCatalog>(
         organizationQueryKey,
         (current) =>
@@ -216,11 +213,28 @@ function DashboardOrganizationSwitcher() {
         }`,
       );
       router.refresh();
-    } catch {
-      setSwitchError(true);
-    } finally {
+    };
+    const finishSwitch = () => {
       switchPendingRef.current = false;
       setSwitchPending(false);
+    };
+    try {
+      await withDeadline(
+        operation,
+        ORGANIZATION_SWITCH_TIMEOUT_MS,
+      );
+      applySuccessfulSwitch();
+      finishSwitch();
+    } catch (error) {
+      setSwitchError(true);
+      if (error instanceof OperationTimeoutError) {
+        // The Stack SDK does not expose cancellation. Keep this mutation
+        // exclusively owned until it really settles, then reconcile its result.
+        void operation.then(applySuccessfulSwitch).catch(() => undefined)
+          .finally(finishSwitch);
+      } else {
+        finishSwitch();
+      }
     }
   };
   const shared = {
@@ -289,7 +303,7 @@ async function withDeadline<T>(
   let timeout: ReturnType<typeof setTimeout> | undefined;
   const deadline = new Promise<never>((_resolve, reject) => {
     timeout = setTimeout(
-      () => reject(new Error("Operation timed out")),
+      () => reject(new OperationTimeoutError()),
       timeoutMs,
     );
   });
@@ -297,6 +311,13 @@ async function withDeadline<T>(
     return await Promise.race([operation, deadline]);
   } finally {
     if (timeout) clearTimeout(timeout);
+  }
+}
+
+class OperationTimeoutError extends Error {
+  constructor() {
+    super("Operation timed out");
+    this.name = "OperationTimeoutError";
   }
 }
 

--- a/web/app/[locale]/dashboard/dashboard-account-menu.tsx
+++ b/web/app/[locale]/dashboard/dashboard-account-menu.tsx
@@ -13,6 +13,7 @@ import { useState } from "react";
 import { localizedVaultPath, vaultSignInHref } from "@/app/lib/vault-auth";
 import { Link, useRouter } from "@/i18n/navigation";
 import {
+  clearCoderouterOrganizationScope,
   persistCoderouterOrganizationScope,
 } from "@/services/coderouter/organizationScope";
 
@@ -86,6 +87,7 @@ export function DashboardAccountMenu() {
                   setSignOutError(false);
                   try {
                     await user.signOut();
+                    clearCoderouterOrganizationScope();
                     router.replace("/");
                     router.refresh();
                   } catch {
@@ -191,7 +193,7 @@ function DashboardOrganizationSwitcher() {
     if (!organizationId) return;
     // CodeRouter scope is independent of Stack's global selected team. Persist
     // it synchronously, and validate it against fresh permissions on every read.
-    persistCoderouterOrganizationScope(organizationId);
+    persistCoderouterOrganizationScope(user.id, organizationId);
     queryClient.setQueryData<OrganizationCatalog>(
       organizationQueryKey,
       (current) =>

--- a/web/app/[locale]/dashboard/dashboard-account-menu.tsx
+++ b/web/app/[locale]/dashboard/dashboard-account-menu.tsx
@@ -139,7 +139,10 @@ function DashboardOrganizationSwitcher() {
   const { data, isPending } = useQuery({
     queryKey: organizationQueryKey,
     queryFn: ({ signal }) => loadOrganizationCatalog(signal),
-    staleTime: 60_000,
+    staleTime: 0,
+    refetchOnMount: "always",
+    refetchOnWindowFocus: "always",
+    refetchOnReconnect: "always",
   });
 
   if (isPending) {

--- a/web/app/[locale]/dashboard/dashboard-account-menu.tsx
+++ b/web/app/[locale]/dashboard/dashboard-account-menu.tsx
@@ -2,11 +2,13 @@
 
 import { Menu } from "@base-ui-components/react/menu";
 import {
-  SelectedTeamSwitcher,
+  TeamSwitcher,
   UserAvatar,
   useUser,
 } from "@stackframe/stack";
+import { useQuery } from "@tanstack/react-query";
 import { useLocale, useTranslations } from "next-intl";
+import { useRouter } from "next/navigation";
 import { useState } from "react";
 import { localizedVaultPath, vaultSignInHref } from "@/app/lib/vault-auth";
 import { Link } from "@/i18n/navigation";
@@ -18,6 +20,7 @@ export function DashboardAccountMenu() {
   const t = useTranslations("dashboard.accountMenu");
   const nav = useTranslations("dashboard.nav");
   const locale = useLocale();
+  const router = useRouter();
   const user = useUser({ or: "return-null" });
   const [signOutPending, setSignOutPending] = useState(false);
   const [signOutError, setSignOutError] = useState(false);
@@ -63,12 +66,7 @@ export function DashboardAccountMenu() {
               <div className="mb-1.5 text-[11px] font-medium uppercase tracking-wide text-muted">
                 {nav("team")}
               </div>
-              <SelectedTeamSwitcher
-                triggerClassName="min-h-9 w-full border border-border bg-background px-2 text-left text-sm hover:bg-code-bg"
-                urlMap={(team) =>
-                  `/dashboard/coderouter?organization=${encodeURIComponent(team.id)}`
-                }
-              />
+              <DashboardOrganizationSwitcher />
             </div>
             <Menu.Item render={<Link href="/dashboard/team" />} className={menuItemClass}>
               <SettingsIcon />
@@ -89,7 +87,8 @@ export function DashboardAccountMenu() {
                 setSignOutError(false);
                 try {
                   await user.signOut();
-                  window.location.assign(`/${locale}`);
+                  router.replace(`/${locale}`);
+                  router.refresh();
                 } catch {
                   setSignOutPending(false);
                   setSignOutError(true);
@@ -109,6 +108,84 @@ export function DashboardAccountMenu() {
       </Menu.Portal>
     </Menu.Root>
   );
+}
+
+type OrganizationCatalog = {
+  readonly selectedTeamId: string | null;
+  readonly teams: readonly {
+    readonly id: string;
+    readonly name: string;
+    readonly personal: boolean;
+  }[];
+};
+
+function DashboardOrganizationSwitcher() {
+  const user = useUser({ or: "throw" });
+  const teams = user.useTeams();
+  const router = useRouter();
+  const { data } = useQuery({
+    queryKey: ["coderouter-organizations"],
+    queryFn: loadOrganizationCatalog,
+    staleTime: 60_000,
+  });
+
+  if (!data) {
+    return <div aria-hidden="true" className="h-9 w-full animate-pulse bg-code-bg" />;
+  }
+
+  const authorizedIds = new Set(data.teams.map((team) => team.id));
+  const selectableTeams = teams.filter((team) => authorizedIds.has(team.id));
+  const personal = data.teams.find((team) => team.personal);
+  const selectedTeamId = data.selectedTeamId ?? data.teams[0]?.id;
+  const switchOrganization = async (
+    team: (typeof selectableTeams)[number] | null,
+  ) => {
+    const organizationId = team?.id ?? personal?.id;
+    if (!organizationId) return;
+    await user.setSelectedTeam(team);
+    router.push(
+      `/dashboard/coderouter?organization=${
+        encodeURIComponent(organizationId)
+      }`,
+    );
+    router.refresh();
+  };
+  const shared = {
+    teams: selectableTeams,
+    teamId: personal?.id === selectedTeamId ? undefined : selectedTeamId,
+    triggerClassName:
+      "min-h-9 w-full border border-border bg-background px-2 text-left text-sm hover:bg-code-bg",
+  };
+
+  return personal
+    ? (
+      <TeamSwitcher
+        {...shared}
+        allowNull
+        nullLabel={personal.name}
+        onChange={switchOrganization}
+      />
+    )
+    : <TeamSwitcher {...shared} onChange={switchOrganization} />;
+}
+
+async function loadOrganizationCatalog(): Promise<OrganizationCatalog> {
+  const response = await fetch("/api/coderouter/organizations", {
+    headers: { accept: "application/json" },
+  });
+  if (!response.ok) {
+    throw new Error("Could not load CodeRouter organizations");
+  }
+  const body: unknown = await response.json();
+  if (
+    typeof body !== "object" ||
+    body === null ||
+    !("teams" in body) ||
+    !Array.isArray(body.teams)
+  ) {
+    throw new Error("Invalid CodeRouter organization response");
+  }
+  return body as OrganizationCatalog;
 }
 
 function ChevronsUpDown() {

--- a/web/app/[locale]/dashboard/dashboard-account-menu.tsx
+++ b/web/app/[locale]/dashboard/dashboard-account-menu.tsx
@@ -8,7 +8,7 @@ import {
 } from "@stackframe/stack";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { useLocale, useTranslations } from "next-intl";
-import { useSearchParams } from "next/navigation";
+import { usePathname, useSearchParams } from "next/navigation";
 import { useEffect, useRef, useState } from "react";
 import { localizedVaultPath, vaultSignInHref } from "@/app/lib/vault-auth";
 import { Link, useRouter } from "@/i18n/navigation";
@@ -126,6 +126,7 @@ function DashboardOrganizationSwitcher() {
   const teams = user.useTeams();
   const router = useRouter();
   const queryClient = useQueryClient();
+  const pathname = usePathname();
   const searchParams = useSearchParams();
   const t = useTranslations("dashboard.accountMenu");
   const [switchError, setSwitchError] = useState(false);
@@ -133,13 +134,19 @@ function DashboardOrganizationSwitcher() {
   type SwitchRequest = {
     readonly team: (typeof teams)[number] | null;
     readonly organizationId: string;
+    readonly originLocation: string;
   };
   const activeSwitchRef = useRef<Promise<void> | null>(null);
   const activeSwitchTimerRef = useRef<ReturnType<typeof setTimeout> | null>(
     null,
   );
   const queuedSwitchRef = useRef<SwitchRequest | null>(null);
+  const currentLocation = `${pathname}?${searchParams.toString()}`;
+  const currentLocationRef = useRef(currentLocation);
   const mountedRef = useRef(true);
+  useEffect(() => {
+    currentLocationRef.current = currentLocation;
+  }, [currentLocation]);
   useEffect(() => {
     mountedRef.current = true;
     return () => {
@@ -211,7 +218,11 @@ function DashboardOrganizationSwitcher() {
   ) => {
     const organizationId = team?.id ?? personal?.id;
     if (!organizationId) return;
-    const request = { team, organizationId };
+    const request = {
+      team,
+      organizationId,
+      originLocation: currentLocationRef.current,
+    };
     if (activeSwitchRef.current) {
       queuedSwitchRef.current = request;
       return;
@@ -235,6 +246,12 @@ function DashboardOrganizationSwitcher() {
   }
   function applySuccessfulSwitch(request: SwitchRequest) {
     const organizationId = recordSuccessfulSwitch(request);
+    if (
+      !shouldNavigateAfterSwitch(
+        request.originLocation,
+        currentLocationRef.current,
+      )
+    ) return;
     router.push(
       `/dashboard/coderouter?team=${
         encodeURIComponent(organizationId)
@@ -267,10 +284,7 @@ function DashboardOrganizationSwitcher() {
       activeSwitchRef.current = null;
       if (timedOut) {
         queuedSwitchRef.current = null;
-        void queryClient.invalidateQueries({
-          queryKey: organizationQueryKey,
-          exact: true,
-        });
+        applySuccessfulSwitch(request);
         setSwitchPending(false);
         return;
       }
@@ -417,7 +431,14 @@ function isPlainRecord(value: unknown): value is Record<string, unknown> {
   return value !== null && typeof value === "object" && !Array.isArray(value);
 }
 
-export const __test = { parseOrganizationCatalog };
+function shouldNavigateAfterSwitch(
+  originLocation: string,
+  currentLocation: string,
+): boolean {
+  return originLocation === currentLocation;
+}
+
+export const __test = { parseOrganizationCatalog, shouldNavigateAfterSwitch };
 
 function ChevronsUpDown() {
   return (

--- a/web/app/[locale]/dashboard/dashboard-account-menu.tsx
+++ b/web/app/[locale]/dashboard/dashboard-account-menu.tsx
@@ -16,6 +16,7 @@ import { Link, useRouter } from "@/i18n/navigation";
 const menuItemClass =
   "flex min-h-9 w-full cursor-default select-none items-center gap-2 px-2.5 py-2 text-left text-sm text-foreground no-underline outline-none data-[highlighted]:bg-code-bg";
 const ORGANIZATION_CATALOG_TIMEOUT_MS = 5_000;
+const ORGANIZATION_SWITCH_TIMEOUT_MS = 10_000;
 
 export function DashboardAccountMenu() {
   const t = useTranslations("dashboard.accountMenu");
@@ -141,6 +142,7 @@ function DashboardOrganizationSwitcher() {
     refetchOnMount: "always",
     refetchOnWindowFocus: "always",
     refetchOnReconnect: "always",
+    networkMode: "always",
   });
 
   if (isPending) {
@@ -193,7 +195,10 @@ function DashboardOrganizationSwitcher() {
     setSwitchPending(true);
     setSwitchError(false);
     try {
-      await user.setSelectedTeam(team);
+      await withDeadline(
+        user.setSelectedTeam(team),
+        ORGANIZATION_SWITCH_TIMEOUT_MS,
+      );
       queryClient.setQueryData<OrganizationCatalog>(
         organizationQueryKey,
         (current) =>
@@ -277,6 +282,24 @@ async function loadOrganizationCatalog(
   return parsed;
 }
 
+async function withDeadline<T>(
+  operation: Promise<T>,
+  timeoutMs: number,
+): Promise<T> {
+  let timeout: ReturnType<typeof setTimeout> | undefined;
+  const deadline = new Promise<never>((_resolve, reject) => {
+    timeout = setTimeout(
+      () => reject(new Error("Operation timed out")),
+      timeoutMs,
+    );
+  });
+  try {
+    return await Promise.race([operation, deadline]);
+  } finally {
+    if (timeout) clearTimeout(timeout);
+  }
+}
+
 function parseOrganizationCatalog(value: unknown): OrganizationCatalog | null {
   if (!isPlainRecord(value) || !Array.isArray(value.teams)) return null;
   const selectedTeamId = value.selectedTeamId;
@@ -326,7 +349,7 @@ function isPlainRecord(value: unknown): value is Record<string, unknown> {
   return value !== null && typeof value === "object" && !Array.isArray(value);
 }
 
-export const __test = { parseOrganizationCatalog };
+export const __test = { parseOrganizationCatalog, withDeadline };
 
 function ChevronsUpDown() {
   return (

--- a/web/app/[locale]/dashboard/dashboard-account-menu.tsx
+++ b/web/app/[locale]/dashboard/dashboard-account-menu.tsx
@@ -152,7 +152,9 @@ function DashboardOrganizationSwitcher() {
   const selectableTeams = teams.filter((team) => authorizedIds.has(team.id));
   const personal = data.teams.find((team) => team.personal);
   const selectedTeamId =
-    user.selectedTeam && authorizedIds.has(user.selectedTeam.id)
+    personal && user.selectedTeam === null
+      ? personal.id
+      : user.selectedTeam && authorizedIds.has(user.selectedTeam.id)
       ? user.selectedTeam.id
       : data.selectedTeamId ?? data.teams[0]?.id;
   const switchOrganization = async (

--- a/web/app/[locale]/dashboard/dashboard-account-menu.tsx
+++ b/web/app/[locale]/dashboard/dashboard-account-menu.tsx
@@ -218,7 +218,7 @@ function DashboardOrganizationSwitcher() {
     }
     runSwitch(request);
   };
-  function applySuccessfulSwitch(request: SwitchRequest) {
+  function recordSuccessfulSwitch(request: SwitchRequest) {
     const { team, organizationId } = request;
     queryClient.setQueryData<OrganizationCatalog>(
       organizationQueryKey,
@@ -231,6 +231,10 @@ function DashboardOrganizationSwitcher() {
       queryKey: organizationQueryKey,
       exact: true,
     });
+    return organizationId;
+  }
+  function applySuccessfulSwitch(request: SwitchRequest) {
+    const organizationId = recordSuccessfulSwitch(request);
     router.push(
       `/dashboard/coderouter?team=${
         encodeURIComponent(organizationId)
@@ -238,7 +242,10 @@ function DashboardOrganizationSwitcher() {
     );
     router.refresh();
   }
-  function runSwitch(request: SwitchRequest) {
+  function runSwitch(
+    request: SwitchRequest,
+    fallback: SwitchRequest | null = null,
+  ) {
     setSwitchPending(true);
     setSwitchError(false);
     let timedOut = false;
@@ -261,7 +268,8 @@ function DashboardOrganizationSwitcher() {
       const queued = queuedSwitchRef.current;
       queuedSwitchRef.current = null;
       if (queued) {
-        runSwitch(queued);
+        recordSuccessfulSwitch(request);
+        runSwitch(queued, request);
         return;
       }
       if (!timedOut) {
@@ -285,11 +293,12 @@ function DashboardOrganizationSwitcher() {
       const queued = queuedSwitchRef.current;
       queuedSwitchRef.current = null;
       if (queued) {
-        runSwitch(queued);
+        runSwitch(queued, fallback);
         return;
       }
       setSwitchPending(false);
       setSwitchError(true);
+      if (fallback) applySuccessfulSwitch(fallback);
     });
   }
   const shared = {

--- a/web/app/[locale]/dashboard/dashboard-account-menu.tsx
+++ b/web/app/[locale]/dashboard/dashboard-account-menu.tsx
@@ -231,7 +231,6 @@ function DashboardOrganizationSwitcher() {
     const timeout = setTimeout(() => {
       if (activeSwitchRef.current !== operation) return;
       timedOut = true;
-      setSwitchPending(false);
       setSwitchError(true);
     }, ORGANIZATION_SWITCH_TIMEOUT_MS);
 
@@ -255,6 +254,7 @@ function DashboardOrganizationSwitcher() {
           queryKey: organizationQueryKey,
           exact: true,
         });
+        setSwitchPending(false);
       }
     }, () => {
       if (activeSwitchRef.current !== operation) return;
@@ -298,10 +298,13 @@ function DashboardOrganizationSwitcher() {
       </fieldset>
       {switchError ? (
         <p role="alert" className="mt-1 text-xs text-red-600 dark:text-red-400">
-          {t("organizationSwitchError")}{" "}
-          <Link href="/dashboard/team" className="underline">
-            {t("settings")}
-          </Link>
+          <button
+            type="button"
+            className="text-left underline"
+            onClick={() => globalThis.location.reload()}
+          >
+            {t("organizationSwitchError")}
+          </button>
         </p>
       ) : null}
     </>

--- a/web/app/[locale]/dashboard/dashboard-account-menu.tsx
+++ b/web/app/[locale]/dashboard/dashboard-account-menu.tsx
@@ -6,7 +6,7 @@ import {
   UserAvatar,
   useUser,
 } from "@stackframe/stack";
-import { useQuery } from "@tanstack/react-query";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { useLocale, useTranslations } from "next-intl";
 import { useState } from "react";
 import { localizedVaultPath, vaultSignInHref } from "@/app/lib/vault-auth";
@@ -122,12 +122,14 @@ function DashboardOrganizationSwitcher() {
   const user = useUser({ or: "throw" });
   const teams = user.useTeams();
   const router = useRouter();
+  const queryClient = useQueryClient();
   const t = useTranslations("dashboard.accountMenu");
-  const [selectedOrganizationId, setSelectedOrganizationId] = useState<
-    string | undefined
-  >(undefined);
+  const organizationQueryKey = [
+    "coderouter-organizations",
+    user.id,
+  ] as const;
   const { data, isPending } = useQuery({
-    queryKey: ["coderouter-organizations"],
+    queryKey: organizationQueryKey,
     queryFn: loadOrganizationCatalog,
     staleTime: 60_000,
   });
@@ -149,17 +151,21 @@ function DashboardOrganizationSwitcher() {
   const authorizedIds = new Set(data.teams.map((team) => team.id));
   const selectableTeams = teams.filter((team) => authorizedIds.has(team.id));
   const personal = data.teams.find((team) => team.personal);
-  const selectedTeamId = selectedOrganizationId ??
-    (user.selectedTeam && authorizedIds.has(user.selectedTeam.id)
+  const selectedTeamId =
+    user.selectedTeam && authorizedIds.has(user.selectedTeam.id)
       ? user.selectedTeam.id
-      : data.selectedTeamId ?? data.teams[0]?.id);
+      : data.selectedTeamId ?? data.teams[0]?.id;
   const switchOrganization = async (
     team: (typeof selectableTeams)[number] | null,
   ) => {
     const organizationId = team?.id ?? personal?.id;
     if (!organizationId) return;
     await user.setSelectedTeam(team);
-    setSelectedOrganizationId(organizationId);
+    queryClient.setQueryData<OrganizationCatalog>(
+      organizationQueryKey,
+      (current) =>
+        current ? { ...current, selectedTeamId: organizationId } : current,
+    );
     router.push(
       `/dashboard/coderouter?team=${
         encodeURIComponent(organizationId)
@@ -194,16 +200,57 @@ async function loadOrganizationCatalog(): Promise<OrganizationCatalog> {
     throw new Error("Could not load CodeRouter organizations");
   }
   const body: unknown = await response.json();
-  if (
-    typeof body !== "object" ||
-    body === null ||
-    !("teams" in body) ||
-    !Array.isArray(body.teams)
-  ) {
+  const parsed = parseOrganizationCatalog(body);
+  if (!parsed) {
     throw new Error("Invalid CodeRouter organization response");
   }
-  return body as OrganizationCatalog;
+  return parsed;
 }
+
+function parseOrganizationCatalog(value: unknown): OrganizationCatalog | null {
+  if (!isPlainRecord(value) || !Array.isArray(value.teams)) return null;
+  const selectedTeamId = value.selectedTeamId;
+  if (
+    selectedTeamId !== null &&
+    !validOrganizationText(selectedTeamId)
+  ) {
+    return null;
+  }
+  const teams: Array<OrganizationCatalog["teams"][number]> = [];
+  const seen = new Set<string>();
+  for (const raw of value.teams) {
+    if (
+      !isPlainRecord(raw) ||
+      !validOrganizationText(raw.id) ||
+      !validOrganizationText(raw.name) ||
+      typeof raw.personal !== "boolean" ||
+      seen.has(raw.id)
+    ) {
+      return null;
+    }
+    seen.add(raw.id);
+    teams.push({
+      id: raw.id,
+      name: raw.name,
+      personal: raw.personal,
+    });
+  }
+  if (selectedTeamId !== null && !seen.has(selectedTeamId)) return null;
+  return { selectedTeamId, teams };
+}
+
+function validOrganizationText(value: unknown): value is string {
+  return typeof value === "string" &&
+    value.length > 0 &&
+    value.length <= 200 &&
+    value === value.trim();
+}
+
+function isPlainRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+export const __test = { parseOrganizationCatalog };
 
 function ChevronsUpDown() {
   return (

--- a/web/app/[locale]/dashboard/dashboard-account-menu.tsx
+++ b/web/app/[locale]/dashboard/dashboard-account-menu.tsx
@@ -130,7 +130,12 @@ function DashboardOrganizationSwitcher() {
   const t = useTranslations("dashboard.accountMenu");
   const [switchError, setSwitchError] = useState(false);
   const [switchPending, setSwitchPending] = useState(false);
-  const switchPendingRef = useRef(false);
+  type SwitchRequest = {
+    readonly team: (typeof teams)[number] | null;
+    readonly organizationId: string;
+  };
+  const activeSwitchRef = useRef<Promise<void> | null>(null);
+  const queuedSwitchRef = useRef<SwitchRequest | null>(null);
   const organizationQueryKey = [
     "coderouter-organizations",
     user.id,
@@ -188,55 +193,83 @@ function DashboardOrganizationSwitcher() {
   const switchOrganization = async (
     team: (typeof selectableTeams)[number] | null,
   ) => {
-    if (switchPendingRef.current) return;
     const organizationId = team?.id ?? personal?.id;
     if (!organizationId) return;
-    switchPendingRef.current = true;
+    const request = { team, organizationId };
+    if (activeSwitchRef.current) {
+      queuedSwitchRef.current = request;
+      return;
+    }
+    runSwitch(request);
+  };
+  function applySuccessfulSwitch(request: SwitchRequest) {
+    const { team, organizationId } = request;
+    queryClient.setQueryData<OrganizationCatalog>(
+      organizationQueryKey,
+      (current) =>
+        current
+          ? { ...current, selectedTeamId: team?.id ?? null }
+          : current,
+    );
+    void queryClient.invalidateQueries({
+      queryKey: organizationQueryKey,
+      exact: true,
+    });
+    router.push(
+      `/dashboard/coderouter?team=${
+        encodeURIComponent(organizationId)
+      }`,
+    );
+    router.refresh();
+  }
+  function runSwitch(request: SwitchRequest) {
     setSwitchPending(true);
     setSwitchError(false);
-    const operation = user.setSelectedTeam(team);
-    const applySuccessfulSwitch = () => {
-      queryClient.setQueryData<OrganizationCatalog>(
-        organizationQueryKey,
-        (current) =>
-          current
-            ? { ...current, selectedTeamId: team?.id ?? null }
-            : current,
-      );
-      void queryClient.invalidateQueries({
-        queryKey: organizationQueryKey,
-        exact: true,
-      });
-      router.push(
-        `/dashboard/coderouter?team=${
-          encodeURIComponent(organizationId)
-        }`,
-      );
-      router.refresh();
-    };
-    const finishSwitch = () => {
-      switchPendingRef.current = false;
+    let timedOut = false;
+    const operation = user.setSelectedTeam(request.team);
+    activeSwitchRef.current = operation;
+    const timeout = setTimeout(() => {
+      if (activeSwitchRef.current !== operation) return;
+      timedOut = true;
       setSwitchPending(false);
-    };
-    try {
-      await withDeadline(
-        operation,
-        ORGANIZATION_SWITCH_TIMEOUT_MS,
-      );
-      applySuccessfulSwitch();
-      finishSwitch();
-    } catch (error) {
       setSwitchError(true);
-      if (error instanceof OperationTimeoutError) {
-        // The Stack SDK does not expose cancellation. Keep this mutation
-        // exclusively owned until it really settles, then reconcile its result.
-        void operation.then(applySuccessfulSwitch).catch(() => undefined)
-          .finally(finishSwitch);
-      } else {
-        finishSwitch();
+    }, ORGANIZATION_SWITCH_TIMEOUT_MS);
+
+    void operation.then(() => {
+      if (activeSwitchRef.current !== operation) return;
+      clearTimeout(timeout);
+      activeSwitchRef.current = null;
+      const queued = queuedSwitchRef.current;
+      queuedSwitchRef.current = null;
+      if (queued) {
+        runSwitch(queued);
+        return;
       }
-    }
-  };
+      if (!timedOut) {
+        applySuccessfulSwitch(request);
+        setSwitchPending(false);
+      } else {
+        // The request eventually settled after the UI deadline. Reconcile the
+        // catalog, but do not navigate away from whatever the user opened.
+        void queryClient.invalidateQueries({
+          queryKey: organizationQueryKey,
+          exact: true,
+        });
+      }
+    }, () => {
+      if (activeSwitchRef.current !== operation) return;
+      clearTimeout(timeout);
+      activeSwitchRef.current = null;
+      const queued = queuedSwitchRef.current;
+      queuedSwitchRef.current = null;
+      if (queued) {
+        runSwitch(queued);
+        return;
+      }
+      setSwitchPending(false);
+      setSwitchError(true);
+    });
+  }
   const shared = {
     teams: selectableTeams,
     teamId: personal?.id === selectedTeamId ? undefined : selectedTeamId,
@@ -296,31 +329,6 @@ async function loadOrganizationCatalog(
   return parsed;
 }
 
-async function withDeadline<T>(
-  operation: Promise<T>,
-  timeoutMs: number,
-): Promise<T> {
-  let timeout: ReturnType<typeof setTimeout> | undefined;
-  const deadline = new Promise<never>((_resolve, reject) => {
-    timeout = setTimeout(
-      () => reject(new OperationTimeoutError()),
-      timeoutMs,
-    );
-  });
-  try {
-    return await Promise.race([operation, deadline]);
-  } finally {
-    if (timeout) clearTimeout(timeout);
-  }
-}
-
-class OperationTimeoutError extends Error {
-  constructor() {
-    super("Operation timed out");
-    this.name = "OperationTimeoutError";
-  }
-}
-
 function parseOrganizationCatalog(value: unknown): OrganizationCatalog | null {
   if (!isPlainRecord(value) || !Array.isArray(value.teams)) return null;
   const selectedTeamId = value.selectedTeamId;
@@ -370,7 +378,7 @@ function isPlainRecord(value: unknown): value is Record<string, unknown> {
   return value !== null && typeof value === "object" && !Array.isArray(value);
 }
 
-export const __test = { parseOrganizationCatalog, withDeadline };
+export const __test = { parseOrganizationCatalog };
 
 function ChevronsUpDown() {
   return (

--- a/web/app/[locale]/dashboard/dashboard-account-menu.tsx
+++ b/web/app/[locale]/dashboard/dashboard-account-menu.tsx
@@ -15,6 +15,7 @@ import { Link, useRouter } from "@/i18n/navigation";
 
 const menuItemClass =
   "flex min-h-9 w-full cursor-default select-none items-center gap-2 px-2.5 py-2 text-left text-sm text-foreground no-underline outline-none data-[highlighted]:bg-code-bg";
+const ORGANIZATION_CATALOG_TIMEOUT_MS = 5_000;
 
 export function DashboardAccountMenu() {
   const t = useTranslations("dashboard.accountMenu");
@@ -137,7 +138,7 @@ function DashboardOrganizationSwitcher() {
   ] as const;
   const { data, isPending } = useQuery({
     queryKey: organizationQueryKey,
-    queryFn: loadOrganizationCatalog,
+    queryFn: ({ signal }) => loadOrganizationCatalog(signal),
     staleTime: 60_000,
   });
 
@@ -233,9 +234,15 @@ function DashboardOrganizationSwitcher() {
   );
 }
 
-async function loadOrganizationCatalog(): Promise<OrganizationCatalog> {
+async function loadOrganizationCatalog(
+  cancellationSignal: AbortSignal,
+): Promise<OrganizationCatalog> {
   const response = await fetch("/api/coderouter/organizations", {
     headers: { accept: "application/json" },
+    signal: AbortSignal.any([
+      cancellationSignal,
+      AbortSignal.timeout(ORGANIZATION_CATALOG_TIMEOUT_MS),
+    ]),
   });
   if (!response.ok) {
     throw new Error("Could not load CodeRouter organizations");
@@ -283,7 +290,6 @@ function parseOrganizationCatalog(value: unknown): OrganizationCatalog | null {
       },
     });
   }
-  if (selectedTeamId !== null && !seen.has(selectedTeamId)) return null;
   return { selectedTeamId, teams };
 }
 

--- a/web/app/[locale]/dashboard/dashboard-account-menu.tsx
+++ b/web/app/[locale]/dashboard/dashboard-account-menu.tsx
@@ -245,14 +245,11 @@ function DashboardOrganizationSwitcher() {
   function runSwitch(request: SwitchRequest) {
     setSwitchPending(true);
     setSwitchError(false);
-    let timedOut = false;
     const operation = user.setSelectedTeam(request.team);
     activeSwitchRef.current = operation;
     const timeout = setTimeout(() => {
       if (!mountedRef.current) return;
       if (activeSwitchRef.current !== operation) return;
-      timedOut = true;
-      setSwitchPending(false);
       setSwitchError(true);
     }, ORGANIZATION_SWITCH_TIMEOUT_MS);
     activeSwitchTimerRef.current = timeout;
@@ -270,7 +267,8 @@ function DashboardOrganizationSwitcher() {
         runSwitch(queued);
         return;
       }
-      if (!timedOut) setSwitchPending(false);
+      setSwitchPending(false);
+      setSwitchError(false);
     }, () => {
       if (!mountedRef.current) return;
       if (activeSwitchRef.current !== operation) return;

--- a/web/app/[locale]/dashboard/dashboard-account-menu.tsx
+++ b/web/app/[locale]/dashboard/dashboard-account-menu.tsx
@@ -126,7 +126,7 @@ function DashboardOrganizationSwitcher() {
   const [selectedOrganizationId, setSelectedOrganizationId] = useState<
     string | undefined
   >(undefined);
-  const { data, isPending, isError } = useQuery({
+  const { data, isPending } = useQuery({
     queryKey: ["coderouter-organizations"],
     queryFn: loadOrganizationCatalog,
     staleTime: 60_000,
@@ -135,7 +135,7 @@ function DashboardOrganizationSwitcher() {
   if (isPending) {
     return <div aria-hidden="true" className="h-9 w-full animate-pulse bg-code-bg" />;
   }
-  if (isError || !data) {
+  if (!data) {
     return (
       <Link
         href="/dashboard/team"

--- a/web/app/[locale]/dashboard/dashboard-account-menu.tsx
+++ b/web/app/[locale]/dashboard/dashboard-account-menu.tsx
@@ -8,7 +8,7 @@ import {
 } from "@stackframe/stack";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { useLocale, useTranslations } from "next-intl";
-import { usePathname, useSearchParams } from "next/navigation";
+import { useSearchParams } from "next/navigation";
 import { useEffect, useRef, useState } from "react";
 import { localizedVaultPath, vaultSignInHref } from "@/app/lib/vault-auth";
 import { Link, useRouter } from "@/i18n/navigation";
@@ -126,7 +126,6 @@ function DashboardOrganizationSwitcher() {
   const teams = user.useTeams();
   const router = useRouter();
   const queryClient = useQueryClient();
-  const pathname = usePathname();
   const searchParams = useSearchParams();
   const t = useTranslations("dashboard.accountMenu");
   const [switchError, setSwitchError] = useState(false);
@@ -134,19 +133,13 @@ function DashboardOrganizationSwitcher() {
   type SwitchRequest = {
     readonly team: (typeof teams)[number] | null;
     readonly organizationId: string;
-    readonly originLocation: string;
   };
   const activeSwitchRef = useRef<Promise<void> | null>(null);
   const activeSwitchTimerRef = useRef<ReturnType<typeof setTimeout> | null>(
     null,
   );
   const queuedSwitchRef = useRef<SwitchRequest | null>(null);
-  const currentLocation = `${pathname}?${searchParams.toString()}`;
-  const currentLocationRef = useRef(currentLocation);
   const mountedRef = useRef(true);
-  useEffect(() => {
-    currentLocationRef.current = currentLocation;
-  }, [currentLocation]);
   useEffect(() => {
     mountedRef.current = true;
     return () => {
@@ -221,8 +214,14 @@ function DashboardOrganizationSwitcher() {
     const request = {
       team,
       organizationId,
-      originLocation: currentLocationRef.current,
     };
+    // The URL is the dashboard's authoritative organization scope, so reflect
+    // the user's choice immediately. Stack selection is serialized below only
+    // to persist the default for later visits without an explicit team.
+    router.push(
+      `/dashboard/coderouter?team=${encodeURIComponent(organizationId)}`,
+    );
+    router.refresh();
     if (activeSwitchRef.current) {
       queuedSwitchRef.current = request;
       return;
@@ -230,7 +229,7 @@ function DashboardOrganizationSwitcher() {
     runSwitch(request);
   };
   function recordSuccessfulSwitch(request: SwitchRequest) {
-    const { team, organizationId } = request;
+    const { team } = request;
     queryClient.setQueryData<OrganizationCatalog>(
       organizationQueryKey,
       (current) =>
@@ -242,27 +241,8 @@ function DashboardOrganizationSwitcher() {
       queryKey: organizationQueryKey,
       exact: true,
     });
-    return organizationId;
   }
-  function applySuccessfulSwitch(request: SwitchRequest) {
-    const organizationId = recordSuccessfulSwitch(request);
-    if (
-      !shouldNavigateAfterSwitch(
-        request.originLocation,
-        currentLocationRef.current,
-      )
-    ) return;
-    router.push(
-      `/dashboard/coderouter?team=${
-        encodeURIComponent(organizationId)
-      }`,
-    );
-    router.refresh();
-  }
-  function runSwitch(
-    request: SwitchRequest,
-    fallback: SwitchRequest | null = null,
-  ) {
+  function runSwitch(request: SwitchRequest) {
     setSwitchPending(true);
     setSwitchError(false);
     let timedOut = false;
@@ -272,6 +252,7 @@ function DashboardOrganizationSwitcher() {
       if (!mountedRef.current) return;
       if (activeSwitchRef.current !== operation) return;
       timedOut = true;
+      setSwitchPending(false);
       setSwitchError(true);
     }, ORGANIZATION_SWITCH_TIMEOUT_MS);
     activeSwitchTimerRef.current = timeout;
@@ -282,42 +263,28 @@ function DashboardOrganizationSwitcher() {
       clearTimeout(timeout);
       activeSwitchTimerRef.current = null;
       activeSwitchRef.current = null;
-      if (timedOut) {
-        queuedSwitchRef.current = null;
-        applySuccessfulSwitch(request);
-        setSwitchPending(false);
-        return;
-      }
+      recordSuccessfulSwitch(request);
       const queued = queuedSwitchRef.current;
       queuedSwitchRef.current = null;
       if (queued) {
-        recordSuccessfulSwitch(request);
-        runSwitch(queued, request);
+        runSwitch(queued);
         return;
       }
-      applySuccessfulSwitch(request);
-      setSwitchPending(false);
+      if (!timedOut) setSwitchPending(false);
     }, () => {
       if (!mountedRef.current) return;
       if (activeSwitchRef.current !== operation) return;
       clearTimeout(timeout);
       activeSwitchTimerRef.current = null;
       activeSwitchRef.current = null;
-      if (timedOut) {
-        queuedSwitchRef.current = null;
-        setSwitchPending(false);
-        setSwitchError(true);
-        return;
-      }
       const queued = queuedSwitchRef.current;
       queuedSwitchRef.current = null;
       if (queued) {
-        runSwitch(queued, fallback);
+        runSwitch(queued);
         return;
       }
       setSwitchPending(false);
       setSwitchError(true);
-      if (fallback) applySuccessfulSwitch(fallback);
     });
   }
   const shared = {
@@ -431,14 +398,7 @@ function isPlainRecord(value: unknown): value is Record<string, unknown> {
   return value !== null && typeof value === "object" && !Array.isArray(value);
 }
 
-function shouldNavigateAfterSwitch(
-  originLocation: string,
-  currentLocation: string,
-): boolean {
-  return originLocation === currentLocation;
-}
-
-export const __test = { parseOrganizationCatalog, shouldNavigateAfterSwitch };
+export const __test = { parseOrganizationCatalog };
 
 function ChevronsUpDown() {
   return (

--- a/web/app/[locale]/dashboard/dashboard-shell.tsx
+++ b/web/app/[locale]/dashboard/dashboard-shell.tsx
@@ -88,7 +88,7 @@ export function DashboardShell({
             {t("brand")}
           </Link>
         </div>
-        <DashboardNav groups={groups} className="flex-1 overflow-y-auto px-2 py-3 pb-20" />
+        <DashboardNav groups={groups} className="flex-1 overflow-y-auto px-2 py-3 pb-28" />
       </aside>
 
       <div className="min-w-0">
@@ -120,7 +120,7 @@ export function DashboardShell({
             groups={groups}
             hidden={!mobileNavOpen}
             onNavigate={() => setMobileNavOpen(false)}
-            className="max-h-[calc(100vh-2.75rem)] overflow-y-auto border-t border-border px-2 py-3 sm:hidden"
+            className="max-h-[calc(100vh-6rem)] overflow-y-auto border-t border-border px-2 py-3 sm:hidden"
           />
         </header>
         <main className="min-w-0">{children}</main>

--- a/web/app/api/cli/config/route.ts
+++ b/web/app/api/cli/config/route.ts
@@ -25,7 +25,7 @@ export function GET(request: Request): Response {
 
   return Response.json(
     {
-      version: 3,
+      version: 4,
       auth: {
         apiUrl:
           process.env.NEXT_PUBLIC_STACK_API_URL?.trim() ||
@@ -39,6 +39,10 @@ export function GET(request: Request): Response {
       coderouter: {
         sessionUrl: new URL("/api/coderouter/session", request.url).toString(),
         accountsUrl: new URL("/api/coderouter/accounts", request.url).toString(),
+        organizationsUrl: new URL(
+          "/api/coderouter/organizations",
+          request.url,
+        ).toString(),
         openaiBaseUrl: new URL("/v1", request.url).toString(),
       },
       // Keep the hosted Subrouter fields for released sr clients while cmux

--- a/web/app/api/coderouter/organizations/route.ts
+++ b/web/app/api/coderouter/organizations/route.ts
@@ -1,0 +1,3 @@
+// Keep the released Subrouter URL as a compatibility alias while exposing the
+// same authoritative, permission-filtered organization list under CodeRouter.
+export { GET } from "../../subrouter/teams/route";

--- a/web/app/api/subrouter/teams/route.ts
+++ b/web/app/api/subrouter/teams/route.ts
@@ -26,6 +26,7 @@ export async function GET(request: Request): Promise<Response> {
       const authorized = await authorizedSubrouterTeams(user);
       const scopedTeamId = coderouterOrganizationFromCookieHeader(
         request.headers.get("cookie"),
+        user.id,
       );
       let selectedTeamId: string | null = null;
       let stackSelectedTeamId: string | null = null;

--- a/web/app/api/subrouter/teams/route.ts
+++ b/web/app/api/subrouter/teams/route.ts
@@ -9,6 +9,9 @@ import {
   authorizedSubrouterTeams,
   serviceUnavailableResponse,
 } from "../../../../services/subrouter/routeHelpers";
+import {
+  coderouterOrganizationFromCookieHeader,
+} from "../../../../services/coderouter/organizationScope";
 
 
 export async function GET(request: Request): Promise<Response> {
@@ -21,11 +24,17 @@ export async function GET(request: Request): Promise<Response> {
       if (!user) return unauthorized();
 
       const authorized = await authorizedSubrouterTeams(user);
-      const preferredTeamId = user.selectedTeamId;
+      const scopedTeamId = coderouterOrganizationFromCookieHeader(
+        request.headers.get("cookie"),
+      );
       let selectedTeamId: string | null = null;
+      let stackSelectedTeamId: string | null = null;
       const teams = [];
       for (const team of authorized) {
-        if (team.teamId === preferredTeamId) selectedTeamId = preferredTeamId;
+        if (team.teamId === scopedTeamId) selectedTeamId = scopedTeamId;
+        if (team.teamId === user.selectedTeamId) {
+          stackSelectedTeamId = user.selectedTeamId;
+        }
         teams.push({
           id: team.teamId,
           name: team.teamName,
@@ -36,6 +45,7 @@ export async function GET(request: Request): Promise<Response> {
           },
         });
       }
+      selectedTeamId ??= stackSelectedTeamId;
       return jsonResponse({ selectedTeamId, teams });
     });
   } catch (error) {

--- a/web/messages/ar.json
+++ b/web/messages/ar.json
@@ -158,6 +158,7 @@
       "signOut": "تسجيل الخروج",
       "signingOut": "جارٍ تسجيل الخروج…",
       "signOutError": "تعذّر تسجيل الخروج. حاول مرة أخرى.",
+      "organizationSwitchError": "تعذّر تبديل المؤسسة. حاول مرة أخرى.",
       "signIn": "تسجيل الدخول"
     },
     "aiAccounts": {

--- a/web/messages/bs.json
+++ b/web/messages/bs.json
@@ -158,6 +158,7 @@
       "signOut": "Odjavi se",
       "signingOut": "Odjava…",
       "signOutError": "Odjava nije uspjela. Pokušajte ponovo.",
+      "organizationSwitchError": "Nije moguće promijeniti organizaciju. Pokušajte ponovo.",
       "signIn": "Prijavi se"
     },
     "aiAccounts": {

--- a/web/messages/da.json
+++ b/web/messages/da.json
@@ -158,6 +158,7 @@
       "signOut": "Log ud",
       "signingOut": "Logger ud…",
       "signOutError": "Kunne ikke logge ud. Prøv igen.",
+      "organizationSwitchError": "Kunne ikke skifte organisation. Prøv igen.",
       "signIn": "Log ind"
     },
     "aiAccounts": {

--- a/web/messages/de.json
+++ b/web/messages/de.json
@@ -158,6 +158,7 @@
       "signOut": "Abmelden",
       "signingOut": "Wird abgemeldet…",
       "signOutError": "Abmeldung fehlgeschlagen. Erneut versuchen.",
+      "organizationSwitchError": "Organisation konnte nicht gewechselt werden. Erneut versuchen.",
       "signIn": "Anmelden"
     },
     "aiAccounts": {

--- a/web/messages/en.json
+++ b/web/messages/en.json
@@ -146,8 +146,8 @@
       "free": {
         "name": "Free",
         "body": "You are currently on the Free plan. Upgrade when you need Pro limits and hosted features.",
-        "upsellTitle": "Upgrade when you need cloud agents or team billing.",
-        "upsellBody": "Choose Pro for personal cloud features, or Team for shared billing and seats.",
+        "upsellTitle": "Upgrade when you need cloud agents or shared CodeRouter.",
+        "upsellBody": "Choose Pro for personal cloud features, or Team for shared CodeRouter with anonymous aggregate usage and cost analytics.",
         "testflightTitle": "Get the cmux iOS app",
         "testflightBody": "The iOS beta is available through TestFlight for active personal Pro subscribers.",
         "testflightCta": "Join the iOS beta"

--- a/web/messages/en.json
+++ b/web/messages/en.json
@@ -130,6 +130,7 @@
       "signOut": "Sign out",
       "signingOut": "Signing out…",
       "signOutError": "Could not sign out. Try again.",
+      "organizationSwitchError": "Could not switch organization. Try again.",
       "signIn": "Sign in"
     },
     "billing": {

--- a/web/messages/en.json
+++ b/web/messages/en.json
@@ -469,12 +469,7 @@
       "cta": "Get Teams",
       "featuresLead": "Everything in Pro, plus:",
       "features": [
-        "Unified billing: one invoice for the whole team",
-        "Centralized seat management: add and remove members anytime",
-        "Pooled Cloud VM compute hours shared across the team",
-        "Shared team rules, settings, and workspace templates",
-        "Team-wide CodeRouter with per-member usage and cost analytics",
-        "Centralized admin and priority email support"
+        "Team-wide CodeRouter with anonymous aggregate usage and cost analytics"
       ]
     },
     "enterprise": {
@@ -544,7 +539,7 @@
           "label": "Cloud agents on Cloud VMs",
           "free": "1 VM trial",
           "pro": "20 hrs/mo, then usage-based",
-          "team": "Pooled, usage-based",
+          "team": "20 hrs/mo, then usage-based",
           "enterprise": "Committed usage"
         },
         {
@@ -577,13 +572,6 @@
           "hostedNetworking": true
         },
         {
-          "label": "Unified billing and seat management",
-          "free": "false",
-          "pro": "false",
-          "team": "true",
-          "enterprise": "true"
-        },
-        {
           "label": "SSO and SAML sign-in",
           "free": "false",
           "pro": "false",
@@ -595,13 +583,6 @@
           "free": "false",
           "pro": "false",
           "team": "false",
-          "enterprise": "true"
-        },
-        {
-          "label": "Centralized admin and shared team rules",
-          "free": "false",
-          "pro": "false",
-          "team": "true",
           "enterprise": "true"
         },
         {
@@ -693,7 +674,7 @@
         },
         {
           "q": "Do you have a team plan?",
-          "a": "Yes. Team is $35/user/mo, or $28/user/mo when billed annually: unified billing for the whole team, centralized seat management, pooled Cloud VM hours, and shared team rules. Enterprise adds SSO, self-hosting, and audit logs."
+          "a": "Yes. Team is $35/user/mo, or $28/user/mo when billed annually, and adds shared CodeRouter with anonymous aggregate usage and cost analytics."
         }
       ]
     },

--- a/web/messages/es.json
+++ b/web/messages/es.json
@@ -158,6 +158,7 @@
       "signOut": "Cerrar sesión",
       "signingOut": "Cerrando sesión…",
       "signOutError": "No se pudo cerrar la sesión. Inténtalo de nuevo.",
+      "organizationSwitchError": "No se pudo cambiar de organización. Inténtalo de nuevo.",
       "signIn": "Iniciar sesión"
     },
     "aiAccounts": {

--- a/web/messages/fr.json
+++ b/web/messages/fr.json
@@ -158,6 +158,7 @@
       "signOut": "Se déconnecter",
       "signingOut": "Déconnexion…",
       "signOutError": "Impossible de se déconnecter. Réessayez.",
+      "organizationSwitchError": "Impossible de changer d’organisation. Réessayez.",
       "signIn": "Se connecter"
     },
     "aiAccounts": {

--- a/web/messages/it.json
+++ b/web/messages/it.json
@@ -158,6 +158,7 @@
       "signOut": "Esci",
       "signingOut": "Uscita…",
       "signOutError": "Impossibile uscire. Riprova.",
+      "organizationSwitchError": "Impossibile cambiare organizzazione. Riprova.",
       "signIn": "Accedi"
     },
     "aiAccounts": {

--- a/web/messages/ja.json
+++ b/web/messages/ja.json
@@ -146,8 +146,8 @@
       "free": {
         "name": "Free",
         "body": "現在はFreeプランです。Proの上限やホスト型機能が必要になったらアップグレードしてください。",
-        "upsellTitle": "クラウドエージェントやチーム請求が必要になったらアップグレードできます。",
-        "upsellBody": "個人向けクラウド機能にはPro、共有請求とシート管理にはTeamを選択してください。",
+        "upsellTitle": "クラウドエージェントや共有 CodeRouter が必要になったらアップグレードできます。",
+        "upsellBody": "個人向けクラウド機能には Pro、匿名の集計使用量・コスト分析付き共有 CodeRouter には Team を選択してください。",
         "testflightTitle": "cmux iOSアプリを入手",
         "testflightBody": "iOSベータは、有効な個人向けProサブスクリプションでTestFlightから利用できます。",
         "testflightCta": "iOSベータに参加"

--- a/web/messages/ja.json
+++ b/web/messages/ja.json
@@ -469,12 +469,7 @@
       "cta": "Teams を入手",
       "featuresLead": "Pro のすべてに加えて:",
       "features": [
-        "一元請求: チーム全体をまとめて1つの請求書に",
-        "シート管理: メンバーをいつでも追加・削除",
-        "チームで共有する Cloud VM のプール計算時間",
-        "共有のチームルール、設定、ワークスペーステンプレート",
-        "メンバーごとの使用量・コスト分析付きのチーム全体 CodeRouter",
-        "一元管理と優先メールサポート"
+        "匿名の集計使用量・コスト分析付きチーム全体 CodeRouter"
       ]
     },
     "enterprise": {
@@ -544,7 +539,7 @@
           "label": "Cloud VM 上のクラウドエージェント",
           "free": "VM 1台トライアル",
           "pro": "月20時間、以降従量課金",
-          "team": "プール制・従量課金",
+          "team": "20時間/月、以降は従量課金",
           "enterprise": "コミット利用"
         },
         {
@@ -577,13 +572,6 @@
           "hostedNetworking": true
         },
         {
-          "label": "一元請求とシート管理",
-          "free": "false",
-          "pro": "false",
-          "team": "true",
-          "enterprise": "true"
-        },
-        {
           "label": "SSO と SAML サインイン",
           "free": "false",
           "pro": "false",
@@ -595,13 +583,6 @@
           "free": "false",
           "pro": "false",
           "team": "false",
-          "enterprise": "true"
-        },
-        {
-          "label": "一元管理と共有チームルール",
-          "free": "false",
-          "pro": "false",
-          "team": "true",
           "enterprise": "true"
         },
         {
@@ -693,7 +674,7 @@
         },
         {
           "q": "チームプランはありますか?",
-          "a": "はい。Team は月払いで $35/ユーザー/月、年払いでは $28/ユーザー/月です。チーム全体の一元請求、シート管理、Cloud VM 時間のプール、共有チームルールが含まれます。Enterprise では SSO、セルフホスト、監査ログが追加されます。"
+          "a": "はい。Team は月払いで $35/ユーザー/月、年払いでは $28/ユーザー/月で、匿名の集計使用量・コスト分析付き共有 CodeRouter が追加されます。"
         }
       ]
     },

--- a/web/messages/ja.json
+++ b/web/messages/ja.json
@@ -130,6 +130,7 @@
       "signOut": "サインアウト",
       "signingOut": "サインアウト中…",
       "signOutError": "サインアウトできませんでした。もう一度お試しください。",
+      "organizationSwitchError": "組織を切り替えられませんでした。もう一度お試しください。",
       "signIn": "サインイン"
     },
     "billing": {

--- a/web/messages/km.json
+++ b/web/messages/km.json
@@ -158,6 +158,7 @@
       "signOut": "ចាកចេញ",
       "signingOut": "កំពុងចាកចេញ…",
       "signOutError": "មិនអាចចាកចេញបានទេ។ សូមព្យាយាមម្តងទៀត។",
+      "organizationSwitchError": "មិនអាចប្ដូរអង្គការបានទេ។ សូមព្យាយាមម្តងទៀត។",
       "signIn": "ចូល"
     },
     "aiAccounts": {

--- a/web/messages/ko.json
+++ b/web/messages/ko.json
@@ -158,6 +158,7 @@
       "signOut": "로그아웃",
       "signingOut": "로그아웃 중…",
       "signOutError": "로그아웃할 수 없습니다. 다시 시도하세요.",
+      "organizationSwitchError": "조직을 전환할 수 없습니다. 다시 시도하세요.",
       "signIn": "로그인"
     },
     "aiAccounts": {

--- a/web/messages/no.json
+++ b/web/messages/no.json
@@ -158,6 +158,7 @@
       "signOut": "Logg ut",
       "signingOut": "Logger ut…",
       "signOutError": "Kunne ikke logge ut. Prøv igjen.",
+      "organizationSwitchError": "Kunne ikke bytte organisasjon. Prøv igjen.",
       "signIn": "Logg inn"
     },
     "aiAccounts": {

--- a/web/messages/pl.json
+++ b/web/messages/pl.json
@@ -158,6 +158,7 @@
       "signOut": "Wyloguj się",
       "signingOut": "Wylogowywanie…",
       "signOutError": "Nie udało się wylogować. Spróbuj ponownie.",
+      "organizationSwitchError": "Nie udało się zmienić organizacji. Spróbuj ponownie.",
       "signIn": "Zaloguj się"
     },
     "aiAccounts": {

--- a/web/messages/pt-BR.json
+++ b/web/messages/pt-BR.json
@@ -158,6 +158,7 @@
       "signOut": "Sair",
       "signingOut": "Saindo…",
       "signOutError": "Não foi possível sair. Tente novamente.",
+      "organizationSwitchError": "Não foi possível trocar de organização. Tente novamente.",
       "signIn": "Entrar"
     },
     "aiAccounts": {

--- a/web/messages/ru.json
+++ b/web/messages/ru.json
@@ -158,6 +158,7 @@
       "signOut": "Выйти",
       "signingOut": "Выход…",
       "signOutError": "Не удалось выйти. Повторите попытку.",
+      "organizationSwitchError": "Не удалось сменить организацию. Повторите попытку.",
       "signIn": "Войти"
     },
     "aiAccounts": {

--- a/web/messages/th.json
+++ b/web/messages/th.json
@@ -158,6 +158,7 @@
       "signOut": "ออกจากระบบ",
       "signingOut": "กำลังออกจากระบบ…",
       "signOutError": "ออกจากระบบไม่ได้ โปรดลองอีกครั้ง",
+      "organizationSwitchError": "เปลี่ยนองค์กรไม่ได้ โปรดลองอีกครั้ง",
       "signIn": "เข้าสู่ระบบ"
     },
     "aiAccounts": {

--- a/web/messages/tr.json
+++ b/web/messages/tr.json
@@ -158,6 +158,7 @@
       "signOut": "Çıkış yap",
       "signingOut": "Çıkış yapılıyor…",
       "signOutError": "Çıkış yapılamadı. Tekrar deneyin.",
+      "organizationSwitchError": "Kuruluş değiştirilemedi. Tekrar deneyin.",
       "signIn": "Giriş yap"
     },
     "aiAccounts": {

--- a/web/messages/uk.json
+++ b/web/messages/uk.json
@@ -158,6 +158,7 @@
       "signOut": "Вийти",
       "signingOut": "Вихід…",
       "signOutError": "Не вдалося вийти. Спробуйте ще раз.",
+      "organizationSwitchError": "Не вдалося змінити організацію. Спробуйте ще раз.",
       "signIn": "Увійти"
     },
     "aiAccounts": {

--- a/web/messages/zh-CN.json
+++ b/web/messages/zh-CN.json
@@ -158,6 +158,7 @@
       "signOut": "退出登录",
       "signingOut": "正在退出…",
       "signOutError": "无法退出登录，请重试。",
+      "organizationSwitchError": "无法切换组织，请重试。",
       "signIn": "登录"
     },
     "aiAccounts": {

--- a/web/messages/zh-TW.json
+++ b/web/messages/zh-TW.json
@@ -158,6 +158,7 @@
       "signOut": "登出",
       "signingOut": "正在登出…",
       "signOutError": "無法登出，請再試一次。",
+      "organizationSwitchError": "無法切換組織，請再試一次。",
       "signIn": "登入"
     },
     "aiAccounts": {

--- a/web/services/coderouter/observability.ts
+++ b/web/services/coderouter/observability.ts
@@ -8,6 +8,7 @@ type CodeRouterFailure =
   | "legacy_cleanup"
   | "rds"
   | "analytics_delivery"
+  | "analytics_query"
   | "upstream_transport";
 
 const SENSITIVE_CONTEXT_KEY = /account.?id|authorization|body|content|cookie|credential|email|header|key|prompt|response|secret|session|team.?id|token/i;

--- a/web/services/coderouter/organizationScope.ts
+++ b/web/services/coderouter/organizationScope.ts
@@ -5,6 +5,7 @@ const ORGANIZATION_COOKIE_MAX_AGE_SECONDS = 60 * 60 * 24 * 365;
 
 export function coderouterOrganizationFromCookieHeader(
   cookieHeader: string | null,
+  userId: string,
 ): string | null {
   if (!cookieHeader) return null;
   for (const part of cookieHeader.split(";")) {
@@ -13,8 +14,16 @@ export function coderouterOrganizationFromCookieHeader(
     const name = part.slice(0, separator).trim();
     if (name !== CODEROUTER_ORGANIZATION_COOKIE) continue;
     try {
-      const value = decodeURIComponent(part.slice(separator + 1).trim());
-      return validOrganizationId(value) ? value : null;
+      const value: unknown = JSON.parse(
+        decodeURIComponent(part.slice(separator + 1).trim()),
+      );
+      if (
+        !Array.isArray(value) ||
+        value.length !== 2 ||
+        value[0] !== userId ||
+        typeof value[1] !== "string"
+      ) return null;
+      return validOrganizationId(value[1]) ? value[1] : null;
     } catch {
       return null;
     }
@@ -23,22 +32,33 @@ export function coderouterOrganizationFromCookieHeader(
 }
 
 export function persistCoderouterOrganizationScope(
+  userId: string,
   organizationId: string,
 ): void {
-  const cookie = coderouterOrganizationCookie(organizationId);
+  const cookie = coderouterOrganizationCookie(userId, organizationId);
   if (typeof document === "undefined" || !cookie) return;
   document.cookie = cookie;
 }
 
 export function coderouterOrganizationCookie(
+  userId: string,
   organizationId: string,
 ): string | null {
-  if (!validOrganizationId(organizationId)) return null;
+  if (!validOrganizationId(userId) || !validOrganizationId(organizationId)) {
+    return null;
+  }
   return `${
     CODEROUTER_ORGANIZATION_COOKIE
-  }=${encodeURIComponent(organizationId)}; Path=/; Max-Age=${
+  }=${encodeURIComponent(JSON.stringify([userId, organizationId]))}; Path=/; Max-Age=${
     ORGANIZATION_COOKIE_MAX_AGE_SECONDS
   }; SameSite=Lax; Secure`;
+}
+
+export function clearCoderouterOrganizationScope(): void {
+  if (typeof document === "undefined") return;
+  document.cookie = `${
+    CODEROUTER_ORGANIZATION_COOKIE
+  }=; Path=/; Max-Age=0; SameSite=Lax; Secure`;
 }
 
 function validOrganizationId(value: string): boolean {

--- a/web/services/coderouter/organizationScope.ts
+++ b/web/services/coderouter/organizationScope.ts
@@ -1,0 +1,46 @@
+export const CODEROUTER_ORGANIZATION_COOKIE =
+  "cmux_coderouter_organization";
+
+const ORGANIZATION_COOKIE_MAX_AGE_SECONDS = 60 * 60 * 24 * 365;
+
+export function coderouterOrganizationFromCookieHeader(
+  cookieHeader: string | null,
+): string | null {
+  if (!cookieHeader) return null;
+  for (const part of cookieHeader.split(";")) {
+    const separator = part.indexOf("=");
+    if (separator < 0) continue;
+    const name = part.slice(0, separator).trim();
+    if (name !== CODEROUTER_ORGANIZATION_COOKIE) continue;
+    try {
+      const value = decodeURIComponent(part.slice(separator + 1).trim());
+      return validOrganizationId(value) ? value : null;
+    } catch {
+      return null;
+    }
+  }
+  return null;
+}
+
+export function persistCoderouterOrganizationScope(
+  organizationId: string,
+): void {
+  const cookie = coderouterOrganizationCookie(organizationId);
+  if (typeof document === "undefined" || !cookie) return;
+  document.cookie = cookie;
+}
+
+export function coderouterOrganizationCookie(
+  organizationId: string,
+): string | null {
+  if (!validOrganizationId(organizationId)) return null;
+  return `${
+    CODEROUTER_ORGANIZATION_COOKIE
+  }=${encodeURIComponent(organizationId)}; Path=/; Max-Age=${
+    ORGANIZATION_COOKIE_MAX_AGE_SECONDS
+  }; SameSite=Lax; Secure`;
+}
+
+function validOrganizationId(value: string): boolean {
+  return value.length > 0 && value.length <= 200 && value === value.trim();
+}

--- a/web/services/coderouter/teamMetrics.ts
+++ b/web/services/coderouter/teamMetrics.ts
@@ -125,17 +125,18 @@ async function queryCoderouterTeamMetrics(
       dependencies.reportFailure?.("endpoint_status", response.status);
       return { kind: "unavailable" };
     }
-    let body: {
-      readonly columns?: unknown;
-      readonly results?: unknown;
-      readonly hasMore?: unknown;
-    };
+    let parsedBody: unknown;
     try {
-      body = await response.json() as typeof body;
+      parsedBody = await response.json();
     } catch {
       dependencies.reportFailure?.("malformed_response");
       return { kind: "unavailable" };
     }
+    if (!isPlainRecord(parsedBody)) {
+      dependencies.reportFailure?.("malformed_response");
+      return { kind: "unavailable" };
+    }
+    const body = parsedBody;
     const columns = body.columns;
     const results = body.results;
     if (

--- a/web/services/coderouter/teamMetrics.ts
+++ b/web/services/coderouter/teamMetrics.ts
@@ -2,6 +2,7 @@ import { unstable_cache } from "next/cache";
 
 import { coderouterTeamAnalyticsId } from "./analyticsIdentity";
 import { CODEROUTER_API_RATE_CARD_VERSION } from "./apiEquivalentPricing";
+import { reportCoderouterFailure } from "./observability";
 
 const PERIOD_DAYS = 30;
 const QUERY_TIMEOUT_MS = 5_000;
@@ -30,6 +31,7 @@ type MetricsDependencies = {
   readonly config: () => PostHogMetricsConfig | null;
   readonly fetch: typeof fetch;
   readonly now: () => Date;
+  readonly reportFailure?: (reason: string, status?: number) => void;
 };
 
 export type CoderouterTeamMetricsTotals = {
@@ -63,6 +65,16 @@ const defaultDependencies: MetricsDependencies = {
   config: postHogMetricsConfig,
   fetch,
   now: () => new Date(),
+  reportFailure: (reason, status) => {
+    reportCoderouterFailure(
+      "analytics_query",
+      new Error("CodeRouter analytics query failed"),
+      {
+        reason,
+        ...(status === undefined ? {} : { status }),
+      },
+    );
+  },
 };
 
 const cachedTeamMetrics = unstable_cache(
@@ -83,7 +95,10 @@ async function queryCoderouterTeamMetrics(
   dependencies: MetricsDependencies,
 ): Promise<CoderouterTeamMetrics> {
   const config = dependencies.config();
-  if (!config) return { kind: "unavailable" };
+  if (!config) {
+    dependencies.reportFailure?.("configuration_missing");
+    return { kind: "unavailable" };
+  }
   try {
     const response = await dependencies.fetch(
       `${config.apiHost}/api/projects/${
@@ -106,7 +121,10 @@ async function queryCoderouterTeamMetrics(
         signal: AbortSignal.timeout(QUERY_TIMEOUT_MS),
       },
     );
-    if (!response.ok) return { kind: "unavailable" };
+    if (!response.ok) {
+      dependencies.reportFailure?.("endpoint_status", response.status);
+      return { kind: "unavailable" };
+    }
     const body = await response.json() as {
       readonly columns?: unknown;
       readonly results?: unknown;
@@ -124,11 +142,14 @@ async function queryCoderouterTeamMetrics(
       !Array.isArray(results) ||
       results.length > MAX_ROWS
     ) {
+      dependencies.reportFailure?.("malformed_response");
       return { kind: "unavailable" };
     }
-    return metricsFromRows(results, dependencies.now()) ??
-      { kind: "unavailable" };
+    const metrics = metricsFromRows(results, dependencies.now());
+    if (!metrics) dependencies.reportFailure?.("invalid_metrics");
+    return metrics ?? { kind: "unavailable" };
   } catch {
+    dependencies.reportFailure?.("request_failed");
     return { kind: "unavailable" };
   }
 }

--- a/web/services/coderouter/teamMetrics.ts
+++ b/web/services/coderouter/teamMetrics.ts
@@ -125,11 +125,17 @@ async function queryCoderouterTeamMetrics(
       dependencies.reportFailure?.("endpoint_status", response.status);
       return { kind: "unavailable" };
     }
-    const body = await response.json() as {
+    let body: {
       readonly columns?: unknown;
       readonly results?: unknown;
       readonly hasMore?: unknown;
     };
+    try {
+      body = await response.json() as typeof body;
+    } catch {
+      dependencies.reportFailure?.("malformed_response");
+      return { kind: "unavailable" };
+    }
     const columns = body.columns;
     const results = body.results;
     if (

--- a/web/services/coderouter/teamMetrics.ts
+++ b/web/services/coderouter/teamMetrics.ts
@@ -125,9 +125,10 @@ async function queryCoderouterTeamMetrics(
       dependencies.reportFailure?.("endpoint_status", response.status);
       return { kind: "unavailable" };
     }
+    const responseText = await response.text();
     let parsedBody: unknown;
     try {
-      parsedBody = await response.json();
+      parsedBody = JSON.parse(responseText);
     } catch {
       dependencies.reportFailure?.("malformed_response");
       return { kind: "unavailable" };

--- a/web/tests/cli-config-route.test.ts
+++ b/web/tests/cli-config-route.test.ts
@@ -54,7 +54,7 @@ describe("CLI config route", () => {
       expect(response.status).toBe(200);
       expect(response.headers.get("cache-control")).toBe("no-store");
       expect(await response.json()).toEqual({
-        version: 3,
+        version: 4,
         auth: {
           apiUrl: testEnvironment.NEXT_PUBLIC_STACK_API_URL,
           projectId: testEnvironment.NEXT_PUBLIC_STACK_PROJECT_ID,
@@ -65,6 +65,8 @@ describe("CLI config route", () => {
         coderouter: {
           sessionUrl: "https://cmux.com/api/coderouter/session",
           accountsUrl: "https://cmux.com/api/coderouter/accounts",
+          organizationsUrl:
+            "https://cmux.com/api/coderouter/organizations",
           openaiBaseUrl: "https://cmux.com/v1",
         },
         subrouter: {

--- a/web/tests/coderouter-organization-scope.test.ts
+++ b/web/tests/coderouter-organization-scope.test.ts
@@ -8,21 +8,23 @@ describe("CodeRouter organization scope", () => {
   test("reads only a valid dedicated organization cookie", () => {
     expect(
       coderouterOrganizationFromCookieHeader(
-        "other=value; cmux_coderouter_organization=team%2Ftwo",
+        "other=value; cmux_coderouter_organization=%5B%22user-1%22%2C%22team%2Ftwo%22%5D",
+        "user-1",
       ),
     ).toBe("team/two");
     expect(
       coderouterOrganizationFromCookieHeader(
-        "cmux_coderouter_organization=%20team-two%20",
+        "cmux_coderouter_organization=%5B%22other-user%22%2C%22team-two%22%5D",
+        "user-1",
       ),
     ).toBeNull();
-    expect(coderouterOrganizationFromCookieHeader(null)).toBeNull();
+    expect(coderouterOrganizationFromCookieHeader(null, "user-1")).toBeNull();
   });
 
   test("writes a bounded secure same-site cookie", () => {
-    expect(coderouterOrganizationCookie("team/two")).toBe(
-      "cmux_coderouter_organization=team%2Ftwo; Path=/; Max-Age=31536000; SameSite=Lax; Secure",
+    expect(coderouterOrganizationCookie("user-1", "team/two")).toBe(
+      "cmux_coderouter_organization=%5B%22user-1%22%2C%22team%2Ftwo%22%5D; Path=/; Max-Age=31536000; SameSite=Lax; Secure",
     );
-    expect(coderouterOrganizationCookie(" team ")).toBeNull();
+    expect(coderouterOrganizationCookie("user-1", " team ")).toBeNull();
   });
 });

--- a/web/tests/coderouter-organization-scope.test.ts
+++ b/web/tests/coderouter-organization-scope.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, test } from "bun:test";
+import {
+  coderouterOrganizationCookie,
+  coderouterOrganizationFromCookieHeader,
+} from "../services/coderouter/organizationScope";
+
+describe("CodeRouter organization scope", () => {
+  test("reads only a valid dedicated organization cookie", () => {
+    expect(
+      coderouterOrganizationFromCookieHeader(
+        "other=value; cmux_coderouter_organization=team%2Ftwo",
+      ),
+    ).toBe("team/two");
+    expect(
+      coderouterOrganizationFromCookieHeader(
+        "cmux_coderouter_organization=%20team-two%20",
+      ),
+    ).toBeNull();
+    expect(coderouterOrganizationFromCookieHeader(null)).toBeNull();
+  });
+
+  test("writes a bounded secure same-site cookie", () => {
+    expect(coderouterOrganizationCookie("team/two")).toBe(
+      "cmux_coderouter_organization=team%2Ftwo; Path=/; Max-Age=31536000; SameSite=Lax; Secure",
+    );
+    expect(coderouterOrganizationCookie(" team ")).toBeNull();
+  });
+});

--- a/web/tests/coderouter-team-metrics.test.ts
+++ b/web/tests/coderouter-team-metrics.test.ts
@@ -184,6 +184,21 @@ describe("CodeRouter team metrics", () => {
     expect(result).toEqual({ kind: "unavailable" });
   });
 
+  test("reports endpoint failures without including the team identity", async () => {
+    const failures: Array<{ reason: string; status?: number }> = [];
+    const result = await metricsTest.queryCoderouterTeamMetrics("team-private", {
+      config: () => config,
+      fetch: mock(async () =>
+        new Response(null, { status: 503 })) as typeof fetch,
+      now: () => new Date("2026-08-08T12:00:00.000Z"),
+      reportFailure: (reason, status) => failures.push({ reason, status }),
+    });
+
+    expect(result).toEqual({ kind: "unavailable" });
+    expect(failures).toEqual([{ reason: "endpoint_status", status: 503 }]);
+    expect(JSON.stringify(failures)).not.toContain("team-private");
+  });
+
   test("rejects a 31st UTC day instead of silently truncating", async () => {
     const result = await metricsTest.queryCoderouterTeamMetrics("team-1", {
       config: () => config,

--- a/web/tests/coderouter-team-metrics.test.ts
+++ b/web/tests/coderouter-team-metrics.test.ts
@@ -216,6 +216,19 @@ describe("CodeRouter team metrics", () => {
     expect(failures).toEqual(["malformed_response"]);
   });
 
+  test("classifies a null endpoint JSON root as a malformed response", async () => {
+    const failures: string[] = [];
+    const result = await metricsTest.queryCoderouterTeamMetrics("team-private", {
+      config: () => config,
+      fetch: mock(async () => Response.json(null)) as typeof fetch,
+      now: () => new Date("2026-08-08T12:00:00.000Z"),
+      reportFailure: (reason) => failures.push(reason),
+    });
+
+    expect(result).toEqual({ kind: "unavailable" });
+    expect(failures).toEqual(["malformed_response"]);
+  });
+
   test("rejects a 31st UTC day instead of silently truncating", async () => {
     const result = await metricsTest.queryCoderouterTeamMetrics("team-1", {
       config: () => config,

--- a/web/tests/coderouter-team-metrics.test.ts
+++ b/web/tests/coderouter-team-metrics.test.ts
@@ -216,6 +216,24 @@ describe("CodeRouter team metrics", () => {
     expect(failures).toEqual(["malformed_response"]);
   });
 
+  test("classifies endpoint body stream failures as request failures", async () => {
+    const failures: string[] = [];
+    const result = await metricsTest.queryCoderouterTeamMetrics("team-private", {
+      config: () => config,
+      fetch: mock(async () =>
+        new Response(new ReadableStream({
+          start(controller) {
+            controller.error(new Error("stream failed"));
+          },
+        }), { status: 200 })) as typeof fetch,
+      now: () => new Date("2026-08-08T12:00:00.000Z"),
+      reportFailure: (reason) => failures.push(reason),
+    });
+
+    expect(result).toEqual({ kind: "unavailable" });
+    expect(failures).toEqual(["request_failed"]);
+  });
+
   test("classifies a null endpoint JSON root as a malformed response", async () => {
     const failures: string[] = [];
     const result = await metricsTest.queryCoderouterTeamMetrics("team-private", {

--- a/web/tests/coderouter-team-metrics.test.ts
+++ b/web/tests/coderouter-team-metrics.test.ts
@@ -199,6 +199,23 @@ describe("CodeRouter team metrics", () => {
     expect(JSON.stringify(failures)).not.toContain("team-private");
   });
 
+  test("classifies invalid endpoint JSON as a malformed response", async () => {
+    const failures: string[] = [];
+    const result = await metricsTest.queryCoderouterTeamMetrics("team-private", {
+      config: () => config,
+      fetch: mock(async () =>
+        new Response("{", {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        })) as typeof fetch,
+      now: () => new Date("2026-08-08T12:00:00.000Z"),
+      reportFailure: (reason) => failures.push(reason),
+    });
+
+    expect(result).toEqual({ kind: "unavailable" });
+    expect(failures).toEqual(["malformed_response"]);
+  });
+
   test("rejects a 31st UTC day instead of silently truncating", async () => {
     const result = await metricsTest.queryCoderouterTeamMetrics("team-1", {
       config: () => config,

--- a/web/tests/dashboard-account-menu.test.tsx
+++ b/web/tests/dashboard-account-menu.test.tsx
@@ -218,10 +218,7 @@ describe("dashboard account menu", () => {
       id: "team-2",
       displayName: "Authorized",
     });
-    expect(setSelectedTeam).toHaveBeenCalledWith({
-      id: "team-2",
-      displayName: "Authorized",
-    });
+    expect(setSelectedTeam).not.toHaveBeenCalled();
     expect(routerPush).toHaveBeenCalledWith(
       "/dashboard/coderouter?team=team-2",
     );
@@ -378,45 +375,7 @@ describe("dashboard account menu", () => {
     })).toMatchObject({ selectedTeamId: "missing" });
   });
 
-  test("keeps the explicit organization route when Stack persistence fails", async () => {
-    searchTeam = "team-2";
-    organizationQuery = {
-      data: {
-        selectedTeamId: "team-2",
-        teams: [{
-          id: "team-2",
-          name: "Team",
-          personal: false,
-          permissions: { use: true, manageAccounts: false },
-        }],
-      },
-      isPending: false,
-      isError: false,
-    };
-    routerPush.mockClear();
-    currentUser = {
-      id: "user-lawrence",
-      displayName: "Lawrence",
-      primaryEmail: "lawrence@example.com",
-      signOut: async () => undefined,
-      selectedTeam: { id: "team-2" },
-      useTeams: () => [{ id: "team-2", displayName: "Team" }],
-      setSelectedTeam: async () => {
-        throw new Error("Stack unavailable");
-      },
-    };
-    renderToStaticMarkup(<DashboardAccountMenu />);
-
-    await handlers.switchOrganization?.({
-      id: "team-2",
-      displayName: "Team",
-    });
-    expect(routerPush).toHaveBeenCalledWith(
-      "/dashboard/coderouter?team=team-2",
-    );
-  });
-
-  test("serializes organization switches and applies the latest request", async () => {
+  test("applies successive CodeRouter scopes without mutating Stack selection", async () => {
     searchTeam = "team-2";
     organizationQuery = {
       data: {
@@ -439,11 +398,8 @@ describe("dashboard account menu", () => {
       isPending: false,
       isError: false,
     };
-    let finishFirstSwitch: (() => void) | undefined;
-    const firstSwitch = new Promise<void>((resolve) => {
-      finishFirstSwitch = resolve;
-    });
-    const guardedSetSelectedTeam = mock(() => firstSwitch);
+    routerPush.mockClear();
+    const setSelectedTeam = mock(async () => undefined);
     currentUser = {
       id: "user-lawrence",
       displayName: "Lawrence",
@@ -454,80 +410,8 @@ describe("dashboard account menu", () => {
         { id: "team-2", displayName: "Team Two" },
         { id: "team-3", displayName: "Team Three" },
       ],
-      setSelectedTeam: guardedSetSelectedTeam,
+      setSelectedTeam,
     };
-    renderToStaticMarkup(<DashboardAccountMenu />);
-
-    const first = handlers.switchOrganization?.({
-      id: "team-2",
-      displayName: "Team Two",
-    });
-    const second = handlers.switchOrganization?.({
-      id: "team-3",
-      displayName: "Team Three",
-    });
-    await second;
-
-    expect(guardedSetSelectedTeam).toHaveBeenCalledTimes(1);
-    finishFirstSwitch?.();
-    await first;
-    await new Promise((resolve) => setTimeout(resolve, 0));
-    expect(guardedSetSelectedTeam).toHaveBeenCalledTimes(2);
-    expect(routerPush).toHaveBeenCalledWith(
-      "/dashboard/coderouter?team=team-3",
-    );
-    expect(routerPush).toHaveBeenCalledWith(
-      "/dashboard/coderouter?team=team-2",
-    );
-  });
-
-  test("keeps the latest explicit route when queued persistence fails", async () => {
-    searchTeam = "team-1";
-    organizationQuery = {
-      data: {
-        selectedTeamId: "team-1",
-        teams: [
-          {
-            id: "team-2",
-            name: "Team Two",
-            personal: false,
-            permissions: { use: true, manageAccounts: false },
-          },
-          {
-            id: "team-3",
-            name: "Team Three",
-            personal: false,
-            permissions: { use: true, manageAccounts: false },
-          },
-        ],
-      },
-      isPending: false,
-      isError: false,
-    };
-    let finishFirstSwitch: (() => void) | undefined;
-    const firstSwitch = new Promise<void>((resolve) => {
-      finishFirstSwitch = resolve;
-    });
-    let requestCount = 0;
-    const serialSetSelectedTeam = mock(() => {
-      requestCount += 1;
-      return requestCount === 1
-        ? firstSwitch
-        : Promise.reject(new Error("Stack unavailable"));
-    });
-    currentUser = {
-      id: "user-lawrence",
-      displayName: "Lawrence",
-      primaryEmail: "lawrence@example.com",
-      signOut: async () => undefined,
-      selectedTeam: { id: "team-1" },
-      useTeams: () => [
-        { id: "team-2", displayName: "Team Two" },
-        { id: "team-3", displayName: "Team Three" },
-      ],
-      setSelectedTeam: serialSetSelectedTeam,
-    };
-    routerPush.mockClear();
     renderToStaticMarkup(<DashboardAccountMenu />);
 
     await handlers.switchOrganization?.({
@@ -538,10 +422,8 @@ describe("dashboard account menu", () => {
       id: "team-3",
       displayName: "Team Three",
     });
-    finishFirstSwitch?.();
-    await new Promise((resolve) => setTimeout(resolve, 0));
 
-    expect(serialSetSelectedTeam).toHaveBeenCalledTimes(2);
+    expect(setSelectedTeam).not.toHaveBeenCalled();
     expect(routerPush).toHaveBeenCalledWith(
       "/dashboard/coderouter?team=team-3",
     );

--- a/web/tests/dashboard-account-menu.test.tsx
+++ b/web/tests/dashboard-account-menu.test.tsx
@@ -129,6 +129,7 @@ mock.module("@/i18n/navigation", () => ({
     replace: routerReplace,
     refresh: routerRefresh,
   }),
+  usePathname: () => "/dashboard/coderouter",
 }));
 
 const { DashboardAccountMenu, __test } = await import(

--- a/web/tests/dashboard-account-menu.test.tsx
+++ b/web/tests/dashboard-account-menu.test.tsx
@@ -36,6 +36,7 @@ const routerRefresh = mock(() => undefined);
 const setQueryData = mock(() => undefined);
 const invalidateQueries = mock(async () => undefined);
 let organizationQueryKey: readonly unknown[] | undefined;
+let organizationQueryNetworkMode: string | undefined;
 let searchTeam: string | null = null;
 
 mock.module("@stackframe/stack", () => ({
@@ -70,8 +71,12 @@ mock.module("@stackframe/stack", () => ({
 }));
 
 mock.module("@tanstack/react-query", () => ({
-  useQuery: (options: { queryKey: readonly unknown[] }) => {
+  useQuery: (options: {
+    queryKey: readonly unknown[];
+    networkMode?: string;
+  }) => {
     organizationQueryKey = options.queryKey;
+    organizationQueryNetworkMode = options.networkMode;
     return organizationQuery;
   },
   useQueryClient: () => ({ setQueryData, invalidateQueries }),
@@ -201,6 +206,7 @@ describe("dashboard account menu", () => {
       "coderouter-organizations",
       "user-lawrence",
     ]);
+    expect(organizationQueryNetworkMode).toBe("always");
 
     const invokeSwitch = handlers.switchOrganization as
       | ((
@@ -468,5 +474,11 @@ describe("dashboard account menu", () => {
     expect(routerPush).not.toHaveBeenCalledWith(
       "/dashboard/coderouter?team=team-3",
     );
+  });
+
+  test("bounds operations that never settle", async () => {
+    await expect(
+      __test.withDeadline(new Promise<void>(() => undefined), 1),
+    ).rejects.toThrow("timed out");
   });
 });

--- a/web/tests/dashboard-account-menu.test.tsx
+++ b/web/tests/dashboard-account-menu.test.tsx
@@ -255,6 +255,28 @@ describe("dashboard account menu", () => {
     expect(html).not.toContain("animate-pulse");
   });
 
+  test("shows account settings when no CodeRouter organizations are permitted", () => {
+    organizationQuery = {
+      data: { selectedTeamId: null, teams: [] },
+      isPending: false,
+      isError: false,
+    };
+    searchTeam = null;
+    currentUser = {
+      id: "user-lawrence",
+      displayName: "Lawrence",
+      primaryEmail: "lawrence@example.com",
+      signOut: async () => undefined,
+      selectedTeam: null,
+      useTeams: () => [],
+      setSelectedTeam: async () => undefined,
+    };
+    const html = renderToStaticMarkup(<DashboardAccountMenu />);
+
+    expect(html).toContain('href="/dashboard/team"');
+    expect(html).not.toContain('data-testid="team-switcher"');
+  });
+
   test("keeps a null Stack selection on the authorized personal organization", () => {
     organizationQuery = {
       data: {

--- a/web/tests/dashboard-account-menu.test.tsx
+++ b/web/tests/dashboard-account-menu.test.tsx
@@ -290,11 +290,11 @@ describe("dashboard account menu", () => {
     expect(html).not.toContain('data-team-id="team-2"');
   });
 
-  test("uses the live Stack selection when the URL has no team scope", () => {
+  test("uses the authenticated catalog selection when the URL has no team scope", () => {
     searchTeam = null;
     organizationQuery = {
       data: {
-        selectedTeamId: "team-1",
+        selectedTeamId: "team-2",
         teams: [
           {
             id: "team-1",

--- a/web/tests/dashboard-account-menu.test.tsx
+++ b/web/tests/dashboard-account-menu.test.tsx
@@ -6,6 +6,9 @@ let currentUser: {
   displayName: string;
   primaryEmail: string;
   signOut: () => Promise<void>;
+  selectedTeam: { id: string } | null;
+  useTeams: () => Array<{ id: string; displayName: string }>;
+  setSelectedTeam: (team: unknown) => Promise<void>;
 } | null = null;
 
 mock.module("@stackframe/stack", () => ({
@@ -14,15 +17,45 @@ mock.module("@stackframe/stack", () => ({
   UserAvatar: ({ size }: { size: number }) => (
     <span data-testid="avatar" data-size={size} />
   ),
-  SelectedTeamSwitcher: ({
-    urlMap,
+  TeamSwitcher: ({
+    teams,
+    teamId,
   }: {
-    urlMap: (team: { id: string }) => string;
+    teams: Array<{ id: string }>;
+    teamId?: string;
   }) => (
-    <a data-testid="team-switcher" href={urlMap({ id: "team-2" })}>
-      team-switcher
-    </a>
+    <span
+      data-testid="team-switcher"
+      data-team-id={teamId}
+      data-team-ids={teams.map((team) => team.id).join(",")}
+    />
   ),
+}));
+
+mock.module("@tanstack/react-query", () => ({
+  useQuery: () => ({
+    data: {
+      selectedTeamId: "team-2",
+      teams: [
+        {
+          id: "team-2",
+          name: "Authorized",
+          personal: false,
+          permissions: { use: true, manageAccounts: false },
+        },
+      ],
+    },
+  }),
+}));
+
+mock.module("next/navigation", () => ({
+  redirect: (target: string) => {
+    throw new Error(`redirect:${target}`);
+  },
+  useRouter: () => ({
+    push: () => undefined,
+    refresh: () => undefined,
+  }),
 }));
 
 mock.module("@base-ui-components/react/menu", () => ({
@@ -71,6 +104,12 @@ describe("dashboard account menu", () => {
       displayName: "Lawrence",
       primaryEmail: "lawrence@example.com",
       signOut: async () => undefined,
+      selectedTeam: { id: "team-1" },
+      useTeams: () => [
+        { id: "team-1", displayName: "Not authorized" },
+        { id: "team-2", displayName: "Authorized" },
+      ],
+      setSelectedTeam: async () => undefined,
     };
     const html = renderToStaticMarkup(<DashboardAccountMenu />);
 
@@ -80,7 +119,9 @@ describe("dashboard account menu", () => {
     expect(html).toContain('href="/dashboard/team"');
     expect(html).toContain('href="/dashboard/billing"');
     expect(html).toContain('data-testid="team-switcher"');
-    expect(html).toContain('href="/dashboard/coderouter?organization=team-2"');
+    expect(html).toContain('data-team-id="team-2"');
+    expect(html).toContain('data-team-ids="team-2"');
+    expect(html).not.toContain("Not authorized");
     expect(html).toContain("signOut");
   });
 

--- a/web/tests/dashboard-account-menu.test.tsx
+++ b/web/tests/dashboard-account-menu.test.tsx
@@ -343,7 +343,7 @@ describe("dashboard account menu", () => {
         personal: false,
         permissions: { use: true, manageAccounts: false },
       }],
-    })).toBeNull();
+    })).toMatchObject({ selectedTeamId: "missing" });
   });
 
   test("does not navigate when Stack rejects an organization switch", async () => {

--- a/web/tests/dashboard-account-menu.test.tsx
+++ b/web/tests/dashboard-account-menu.test.tsx
@@ -33,6 +33,8 @@ const handlers: {
 const routerPush = mock(() => undefined);
 const routerReplace = mock(() => undefined);
 const routerRefresh = mock(() => undefined);
+const setQueryData = mock(() => undefined);
+const invalidateQueries = mock(async () => undefined);
 let organizationQueryKey: readonly unknown[] | undefined;
 let searchTeam: string | null = null;
 
@@ -72,6 +74,7 @@ mock.module("@tanstack/react-query", () => ({
     organizationQueryKey = options.queryKey;
     return organizationQuery;
   },
+  useQueryClient: () => ({ setQueryData, invalidateQueries }),
 }));
 
 mock.module("next/navigation", () => ({
@@ -161,6 +164,8 @@ describe("dashboard account menu", () => {
     searchTeam = "team-2";
     routerPush.mockClear();
     routerRefresh.mockClear();
+    setQueryData.mockClear();
+    invalidateQueries.mockClear();
     const setSelectedTeam = mock(async () => undefined);
     currentUser = {
       id: "user-lawrence",
@@ -211,6 +216,8 @@ describe("dashboard account menu", () => {
       "/dashboard/coderouter?team=team-2",
     );
     expect(routerRefresh).toHaveBeenCalledTimes(1);
+    expect(setQueryData).toHaveBeenCalled();
+    expect(invalidateQueries).toHaveBeenCalled();
   });
 
   test("uses the unlocalized auth handler and names the compact sign-in link", () => {
@@ -337,5 +344,41 @@ describe("dashboard account menu", () => {
         permissions: { use: true, manageAccounts: false },
       }],
     })).toBeNull();
+  });
+
+  test("does not navigate when Stack rejects an organization switch", async () => {
+    searchTeam = "team-2";
+    organizationQuery = {
+      data: {
+        selectedTeamId: "team-2",
+        teams: [{
+          id: "team-2",
+          name: "Team",
+          personal: false,
+          permissions: { use: true, manageAccounts: false },
+        }],
+      },
+      isPending: false,
+      isError: false,
+    };
+    routerPush.mockClear();
+    currentUser = {
+      id: "user-lawrence",
+      displayName: "Lawrence",
+      primaryEmail: "lawrence@example.com",
+      signOut: async () => undefined,
+      selectedTeam: { id: "team-2" },
+      useTeams: () => [{ id: "team-2", displayName: "Team" }],
+      setSelectedTeam: async () => {
+        throw new Error("Stack unavailable");
+      },
+    };
+    renderToStaticMarkup(<DashboardAccountMenu />);
+
+    await handlers.switchOrganization?.({
+      id: "team-2",
+      displayName: "Team",
+    });
+    expect(routerPush).not.toHaveBeenCalled();
   });
 });

--- a/web/tests/dashboard-account-menu.test.tsx
+++ b/web/tests/dashboard-account-menu.test.tsx
@@ -46,12 +46,14 @@ mock.module("@stackframe/stack", () => ({
     teams,
     teamId,
     onChange,
+    allowNull,
   }: {
     teams: Array<{ id: string }>;
     teamId?: string;
     onChange: (
       team: { id: string; displayName: string } | null,
     ) => Promise<void>;
+    allowNull?: boolean;
   }) => {
     handlers.switchOrganization = onChange;
     return (
@@ -59,6 +61,7 @@ mock.module("@stackframe/stack", () => ({
         data-testid="team-switcher"
         data-team-id={teamId}
         data-team-ids={teams.map((team) => team.id).join(",")}
+        data-allow-null={allowNull}
       />
     );
   },
@@ -223,6 +226,43 @@ describe("dashboard account menu", () => {
 
     expect(html).toContain('href="/dashboard/team"');
     expect(html).not.toContain("animate-pulse");
+  });
+
+  test("keeps a null Stack selection on the authorized personal organization", () => {
+    organizationQuery = {
+      data: {
+        selectedTeamId: null,
+        teams: [
+          {
+            id: "user-lawrence",
+            name: "Personal",
+            personal: true,
+            permissions: { use: true, manageAccounts: true },
+          },
+          {
+            id: "team-2",
+            name: "Team",
+            personal: false,
+            permissions: { use: true, manageAccounts: true },
+          },
+        ],
+      },
+      isPending: false,
+      isError: false,
+    };
+    currentUser = {
+      id: "user-lawrence",
+      displayName: "Lawrence",
+      primaryEmail: "lawrence@example.com",
+      signOut: async () => undefined,
+      selectedTeam: null,
+      useTeams: () => [{ id: "team-2", displayName: "Team" }],
+      setSelectedTeam: async () => undefined,
+    };
+    const html = renderToStaticMarkup(<DashboardAccountMenu />);
+
+    expect(html).toContain('data-allow-null="true"');
+    expect(html).not.toContain('data-team-id="team-2"');
   });
 
   test("rejects malformed organization entries at the response boundary", () => {

--- a/web/tests/dashboard-account-menu.test.tsx
+++ b/web/tests/dashboard-account-menu.test.tsx
@@ -9,6 +9,7 @@ let currentUser: {
 } | null = null;
 
 mock.module("@stackframe/stack", () => ({
+  AccountSettings: () => <section data-testid="stack-account-settings" />,
   useUser: () => currentUser,
   UserAvatar: ({ size }: { size: number }) => (
     <span data-testid="avatar" data-size={size} />

--- a/web/tests/dashboard-account-menu.test.tsx
+++ b/web/tests/dashboard-account-menu.test.tsx
@@ -283,6 +283,35 @@ describe("dashboard account menu", () => {
     expect(html).not.toContain('data-team-id="team-2"');
   });
 
+  test("uses the catalog selection when the URL has no team scope", () => {
+    searchTeam = null;
+    organizationQuery = {
+      data: {
+        selectedTeamId: "team-2",
+        teams: [{
+          id: "team-2",
+          name: "Team",
+          personal: false,
+          permissions: { use: true, manageAccounts: false },
+        }],
+      },
+      isPending: false,
+      isError: false,
+    };
+    currentUser = {
+      id: "user-lawrence",
+      displayName: "Lawrence",
+      primaryEmail: "lawrence@example.com",
+      signOut: async () => undefined,
+      selectedTeam: null,
+      useTeams: () => [{ id: "team-2", displayName: "Team" }],
+      setSelectedTeam: async () => undefined,
+    };
+    const html = renderToStaticMarkup(<DashboardAccountMenu />);
+
+    expect(html).toContain('data-team-id="team-2"');
+  });
+
   test("rejects malformed organization entries at the response boundary", () => {
     expect(__test.parseOrganizationCatalog({
       selectedTeamId: null,

--- a/web/tests/dashboard-account-menu.test.tsx
+++ b/web/tests/dashboard-account-menu.test.tsx
@@ -477,4 +477,73 @@ describe("dashboard account menu", () => {
       "/dashboard/coderouter?team=team-2",
     );
   });
+
+  test("reconciles the last successful switch when the queued switch fails", async () => {
+    searchTeam = "team-1";
+    organizationQuery = {
+      data: {
+        selectedTeamId: "team-1",
+        teams: [
+          {
+            id: "team-2",
+            name: "Team Two",
+            personal: false,
+            permissions: { use: true, manageAccounts: false },
+          },
+          {
+            id: "team-3",
+            name: "Team Three",
+            personal: false,
+            permissions: { use: true, manageAccounts: false },
+          },
+        ],
+      },
+      isPending: false,
+      isError: false,
+    };
+    let finishFirstSwitch: (() => void) | undefined;
+    const firstSwitch = new Promise<void>((resolve) => {
+      finishFirstSwitch = resolve;
+    });
+    let requestCount = 0;
+    const serialSetSelectedTeam = mock(() => {
+      requestCount += 1;
+      return requestCount === 1
+        ? firstSwitch
+        : Promise.reject(new Error("Stack unavailable"));
+    });
+    currentUser = {
+      id: "user-lawrence",
+      displayName: "Lawrence",
+      primaryEmail: "lawrence@example.com",
+      signOut: async () => undefined,
+      selectedTeam: { id: "team-1" },
+      useTeams: () => [
+        { id: "team-2", displayName: "Team Two" },
+        { id: "team-3", displayName: "Team Three" },
+      ],
+      setSelectedTeam: serialSetSelectedTeam,
+    };
+    routerPush.mockClear();
+    renderToStaticMarkup(<DashboardAccountMenu />);
+
+    await handlers.switchOrganization?.({
+      id: "team-2",
+      displayName: "Team Two",
+    });
+    await handlers.switchOrganization?.({
+      id: "team-3",
+      displayName: "Team Three",
+    });
+    finishFirstSwitch?.();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(serialSetSelectedTeam).toHaveBeenCalledTimes(2);
+    expect(routerPush).toHaveBeenCalledWith(
+      "/dashboard/coderouter?team=team-2",
+    );
+    expect(routerPush).not.toHaveBeenCalledWith(
+      "/dashboard/coderouter?team=team-3",
+    );
+  });
 });

--- a/web/tests/dashboard-account-menu.test.tsx
+++ b/web/tests/dashboard-account-menu.test.tsx
@@ -13,6 +13,15 @@ mock.module("@stackframe/stack", () => ({
   UserAvatar: ({ size }: { size: number }) => (
     <span data-testid="avatar" data-size={size} />
   ),
+  SelectedTeamSwitcher: ({
+    urlMap,
+  }: {
+    urlMap: (team: { id: string }) => string;
+  }) => (
+    <a data-testid="team-switcher" href={urlMap({ id: "team-2" })}>
+      team-switcher
+    </a>
+  ),
 }));
 
 mock.module("@base-ui-components/react/menu", () => ({
@@ -69,6 +78,8 @@ describe("dashboard account menu", () => {
     expect(html).toContain('data-size="24"');
     expect(html).toContain('href="/dashboard/team"');
     expect(html).toContain('href="/dashboard/billing"');
+    expect(html).toContain('data-testid="team-switcher"');
+    expect(html).toContain('href="/dashboard/coderouter?organization=team-2"');
     expect(html).toContain("signOut");
   });
 

--- a/web/tests/dashboard-account-menu.test.tsx
+++ b/web/tests/dashboard-account-menu.test.tsx
@@ -10,6 +10,25 @@ let currentUser: {
   useTeams: () => Array<{ id: string; displayName: string }>;
   setSelectedTeam: (team: unknown) => Promise<void>;
 } | null = null;
+let organizationQuery: {
+  data?: {
+    selectedTeamId: string | null;
+    teams: Array<{
+      id: string;
+      name: string;
+      personal: boolean;
+      permissions: { use: boolean; manageAccounts: boolean };
+    }>;
+  };
+  isPending: boolean;
+  isError: boolean;
+} = { data: undefined, isPending: true, isError: false };
+let switchOrganization:
+  | ((team: { id: string; displayName: string } | null) => Promise<void>)
+  | null = null;
+const routerPush = mock(() => undefined);
+const routerReplace = mock(() => undefined);
+const routerRefresh = mock(() => undefined);
 
 mock.module("@stackframe/stack", () => ({
   AccountSettings: () => <section data-testid="stack-account-settings" />,
@@ -20,42 +39,33 @@ mock.module("@stackframe/stack", () => ({
   TeamSwitcher: ({
     teams,
     teamId,
+    onChange,
   }: {
     teams: Array<{ id: string }>;
     teamId?: string;
-  }) => (
-    <span
-      data-testid="team-switcher"
-      data-team-id={teamId}
-      data-team-ids={teams.map((team) => team.id).join(",")}
-    />
-  ),
+    onChange: (
+      team: { id: string; displayName: string } | null,
+    ) => Promise<void>;
+  }) => {
+    switchOrganization = onChange;
+    return (
+      <span
+        data-testid="team-switcher"
+        data-team-id={teamId}
+        data-team-ids={teams.map((team) => team.id).join(",")}
+      />
+    );
+  },
 }));
 
 mock.module("@tanstack/react-query", () => ({
-  useQuery: () => ({
-    data: {
-      selectedTeamId: "team-2",
-      teams: [
-        {
-          id: "team-2",
-          name: "Authorized",
-          personal: false,
-          permissions: { use: true, manageAccounts: false },
-        },
-      ],
-    },
-  }),
+  useQuery: () => organizationQuery,
 }));
 
 mock.module("next/navigation", () => ({
   redirect: (target: string) => {
     throw new Error(`redirect:${target}`);
   },
-  useRouter: () => ({
-    push: () => undefined,
-    refresh: () => undefined,
-  }),
 }));
 
 mock.module("@base-ui-components/react/menu", () => ({
@@ -92,6 +102,11 @@ mock.module("@/i18n/navigation", () => ({
   }: React.AnchorHTMLAttributes<HTMLAnchorElement> & { href: string }) => (
     <a href={href} {...props}>{children}</a>
   ),
+  useRouter: () => ({
+    push: routerPush,
+    replace: routerReplace,
+    refresh: routerRefresh,
+  }),
 }));
 
 const { DashboardAccountMenu } = await import(
@@ -99,7 +114,26 @@ const { DashboardAccountMenu } = await import(
 );
 
 describe("dashboard account menu", () => {
-  test("matches the chatmux identity row and exposes working account actions", () => {
+  test("matches the chatmux identity row and switches only authorized organizations", async () => {
+    organizationQuery = {
+      data: {
+        selectedTeamId: "team-2",
+        teams: [
+          {
+            id: "team-2",
+            name: "Authorized",
+            personal: false,
+            permissions: { use: true, manageAccounts: false },
+          },
+        ],
+      },
+      isPending: false,
+      isError: false,
+    };
+    switchOrganization = null;
+    routerPush.mockClear();
+    routerRefresh.mockClear();
+    const setSelectedTeam = mock(async () => undefined);
     currentUser = {
       displayName: "Lawrence",
       primaryEmail: "lawrence@example.com",
@@ -109,7 +143,7 @@ describe("dashboard account menu", () => {
         { id: "team-1", displayName: "Not authorized" },
         { id: "team-2", displayName: "Authorized" },
       ],
-      setSelectedTeam: async () => undefined,
+      setSelectedTeam,
     };
     const html = renderToStaticMarkup(<DashboardAccountMenu />);
 
@@ -123,6 +157,19 @@ describe("dashboard account menu", () => {
     expect(html).toContain('data-team-ids="team-2"');
     expect(html).not.toContain("Not authorized");
     expect(html).toContain("signOut");
+
+    await switchOrganization?.({
+      id: "team-2",
+      displayName: "Authorized",
+    });
+    expect(setSelectedTeam).toHaveBeenCalledWith({
+      id: "team-2",
+      displayName: "Authorized",
+    });
+    expect(routerPush).toHaveBeenCalledWith(
+      "/dashboard/coderouter?team=team-2",
+    );
+    expect(routerRefresh).toHaveBeenCalledTimes(1);
   });
 
   test("uses the unlocalized auth handler and names the compact sign-in link", () => {
@@ -133,5 +180,25 @@ describe("dashboard account menu", () => {
     expect(html).toContain('href="/handler/sign-in?');
     expect(html).toContain("dashboard");
     expect(html).not.toContain("/en/handler/sign-in");
+  });
+
+  test("shows account settings instead of an endless loader after catalog failure", () => {
+    organizationQuery = {
+      data: undefined,
+      isPending: false,
+      isError: true,
+    };
+    currentUser = {
+      displayName: "Lawrence",
+      primaryEmail: "lawrence@example.com",
+      signOut: async () => undefined,
+      selectedTeam: null,
+      useTeams: () => [],
+      setSelectedTeam: async () => undefined,
+    };
+    const html = renderToStaticMarkup(<DashboardAccountMenu />);
+
+    expect(html).toContain('href="/dashboard/team"');
+    expect(html).not.toContain("animate-pulse");
   });
 });

--- a/web/tests/dashboard-account-menu.test.tsx
+++ b/web/tests/dashboard-account-menu.test.tsx
@@ -267,7 +267,7 @@ describe("dashboard account menu", () => {
       isPending: false,
       isError: false,
     };
-    searchTeam = "user-lawrence";
+    searchTeam = null;
     currentUser = {
       id: "user-lawrence",
       displayName: "Lawrence",
@@ -283,17 +283,25 @@ describe("dashboard account menu", () => {
     expect(html).not.toContain('data-team-id="team-2"');
   });
 
-  test("uses the catalog selection when the URL has no team scope", () => {
+  test("uses the live Stack selection when the URL has no team scope", () => {
     searchTeam = null;
     organizationQuery = {
       data: {
-        selectedTeamId: "team-2",
-        teams: [{
-          id: "team-2",
-          name: "Team",
-          personal: false,
-          permissions: { use: true, manageAccounts: false },
-        }],
+        selectedTeamId: "team-1",
+        teams: [
+          {
+            id: "team-1",
+            name: "Old team",
+            personal: false,
+            permissions: { use: true, manageAccounts: false },
+          },
+          {
+            id: "team-2",
+            name: "Current team",
+            personal: false,
+            permissions: { use: true, manageAccounts: false },
+          },
+        ],
       },
       isPending: false,
       isError: false,
@@ -303,8 +311,11 @@ describe("dashboard account menu", () => {
       displayName: "Lawrence",
       primaryEmail: "lawrence@example.com",
       signOut: async () => undefined,
-      selectedTeam: null,
-      useTeams: () => [{ id: "team-2", displayName: "Team" }],
+      selectedTeam: { id: "team-2" },
+      useTeams: () => [
+        { id: "team-1", displayName: "Old team" },
+        { id: "team-2", displayName: "Current team" },
+      ],
       setSelectedTeam: async () => undefined,
     };
     const html = renderToStaticMarkup(<DashboardAccountMenu />);

--- a/web/tests/dashboard-account-menu.test.tsx
+++ b/web/tests/dashboard-account-menu.test.tsx
@@ -377,7 +377,7 @@ describe("dashboard account menu", () => {
     })).toMatchObject({ selectedTeamId: "missing" });
   });
 
-  test("does not navigate when Stack rejects an organization switch", async () => {
+  test("keeps the explicit organization route when Stack persistence fails", async () => {
     searchTeam = "team-2";
     organizationQuery = {
       data: {
@@ -410,7 +410,9 @@ describe("dashboard account menu", () => {
       id: "team-2",
       displayName: "Team",
     });
-    expect(routerPush).not.toHaveBeenCalled();
+    expect(routerPush).toHaveBeenCalledWith(
+      "/dashboard/coderouter?team=team-2",
+    );
   });
 
   test("serializes organization switches and applies the latest request", async () => {
@@ -473,12 +475,12 @@ describe("dashboard account menu", () => {
     expect(routerPush).toHaveBeenCalledWith(
       "/dashboard/coderouter?team=team-3",
     );
-    expect(routerPush).not.toHaveBeenCalledWith(
+    expect(routerPush).toHaveBeenCalledWith(
       "/dashboard/coderouter?team=team-2",
     );
   });
 
-  test("reconciles the last successful switch when the queued switch fails", async () => {
+  test("keeps the latest explicit route when queued persistence fails", async () => {
     searchTeam = "team-1";
     organizationQuery = {
       data: {
@@ -540,25 +542,10 @@ describe("dashboard account menu", () => {
 
     expect(serialSetSelectedTeam).toHaveBeenCalledTimes(2);
     expect(routerPush).toHaveBeenCalledWith(
-      "/dashboard/coderouter?team=team-2",
-    );
-    expect(routerPush).not.toHaveBeenCalledWith(
       "/dashboard/coderouter?team=team-3",
     );
-  });
-
-  test("does not replace navigation that happened after a switch started", () => {
-    expect(
-      __test.shouldNavigateAfterSwitch(
-        "/dashboard/coderouter?team=team-1",
-        "/dashboard/billing?",
-      ),
-    ).toBe(false);
-    expect(
-      __test.shouldNavigateAfterSwitch(
-        "/dashboard/coderouter?team=team-1",
-        "/dashboard/coderouter?team=team-1",
-      ),
-    ).toBe(true);
+    expect(routerPush).toHaveBeenCalledWith(
+      "/dashboard/coderouter?team=team-2",
+    );
   });
 });

--- a/web/tests/dashboard-account-menu.test.tsx
+++ b/web/tests/dashboard-account-menu.test.tsx
@@ -384,4 +384,67 @@ describe("dashboard account menu", () => {
     });
     expect(routerPush).not.toHaveBeenCalled();
   });
+
+  test("prevents a second organization switch while the first is pending", async () => {
+    searchTeam = "team-2";
+    organizationQuery = {
+      data: {
+        selectedTeamId: "team-2",
+        teams: [
+          {
+            id: "team-2",
+            name: "Team Two",
+            personal: false,
+            permissions: { use: true, manageAccounts: false },
+          },
+          {
+            id: "team-3",
+            name: "Team Three",
+            personal: false,
+            permissions: { use: true, manageAccounts: false },
+          },
+        ],
+      },
+      isPending: false,
+      isError: false,
+    };
+    let finishFirstSwitch: (() => void) | undefined;
+    const firstSwitch = new Promise<void>((resolve) => {
+      finishFirstSwitch = resolve;
+    });
+    const guardedSetSelectedTeam = mock(() => firstSwitch);
+    currentUser = {
+      id: "user-lawrence",
+      displayName: "Lawrence",
+      primaryEmail: "lawrence@example.com",
+      signOut: async () => undefined,
+      selectedTeam: { id: "team-2" },
+      useTeams: () => [
+        { id: "team-2", displayName: "Team Two" },
+        { id: "team-3", displayName: "Team Three" },
+      ],
+      setSelectedTeam: guardedSetSelectedTeam,
+    };
+    renderToStaticMarkup(<DashboardAccountMenu />);
+
+    const first = handlers.switchOrganization?.({
+      id: "team-2",
+      displayName: "Team Two",
+    });
+    const second = handlers.switchOrganization?.({
+      id: "team-3",
+      displayName: "Team Three",
+    });
+    await second;
+
+    expect(guardedSetSelectedTeam).toHaveBeenCalledTimes(1);
+    finishFirstSwitch?.();
+    await first;
+    expect(routerPush).toHaveBeenCalledWith(
+      "/dashboard/coderouter?team=team-2",
+    );
+    expect(routerPush).not.toHaveBeenCalledWith(
+      "/dashboard/coderouter?team=team-3",
+    );
+  });
 });

--- a/web/tests/dashboard-account-menu.test.tsx
+++ b/web/tests/dashboard-account-menu.test.tsx
@@ -4,6 +4,7 @@ import type React from "react";
 import { createNextNavigationMock } from "./helpers/next-navigation-mock";
 
 let currentUser: {
+  id: string;
   displayName: string;
   primaryEmail: string;
   signOut: () => Promise<void>;
@@ -32,6 +33,8 @@ const handlers: {
 const routerPush = mock(() => undefined);
 const routerReplace = mock(() => undefined);
 const routerRefresh = mock(() => undefined);
+const setQueryData = mock(() => undefined);
+let organizationQueryKey: readonly unknown[] | undefined;
 
 mock.module("@stackframe/stack", () => ({
   AccountSettings: () => <section data-testid="stack-account-settings" />,
@@ -62,7 +65,11 @@ mock.module("@stackframe/stack", () => ({
 }));
 
 mock.module("@tanstack/react-query", () => ({
-  useQuery: () => organizationQuery,
+  useQuery: (options: { queryKey: readonly unknown[] }) => {
+    organizationQueryKey = options.queryKey;
+    return organizationQuery;
+  },
+  useQueryClient: () => ({ setQueryData }),
 }));
 
 mock.module("next/navigation", () =>
@@ -111,7 +118,7 @@ mock.module("@/i18n/navigation", () => ({
   }),
 }));
 
-const { DashboardAccountMenu } = await import(
+const { DashboardAccountMenu, __test } = await import(
   "../app/[locale]/dashboard/dashboard-account-menu"
 );
 
@@ -136,8 +143,10 @@ describe("dashboard account menu", () => {
     delete handlers.switchOrganization;
     routerPush.mockClear();
     routerRefresh.mockClear();
+    setQueryData.mockClear();
     const setSelectedTeam = mock(async () => undefined);
     currentUser = {
+      id: "user-lawrence",
       displayName: "Lawrence",
       primaryEmail: "lawrence@example.com",
       signOut: async () => undefined,
@@ -160,6 +169,10 @@ describe("dashboard account menu", () => {
     expect(html).toContain('data-team-ids="team-2"');
     expect(html).not.toContain("Not authorized");
     expect(html).toContain("signOut");
+    expect(organizationQueryKey).toEqual([
+      "coderouter-organizations",
+      "user-lawrence",
+    ]);
 
     const invokeSwitch = handlers.switchOrganization as
       | ((
@@ -178,6 +191,7 @@ describe("dashboard account menu", () => {
       "/dashboard/coderouter?team=team-2",
     );
     expect(routerRefresh).toHaveBeenCalledTimes(1);
+    expect(setQueryData).toHaveBeenCalled();
   });
 
   test("uses the unlocalized auth handler and names the compact sign-in link", () => {
@@ -197,6 +211,7 @@ describe("dashboard account menu", () => {
       isError: true,
     };
     currentUser = {
+      id: "user-lawrence",
       displayName: "Lawrence",
       primaryEmail: "lawrence@example.com",
       signOut: async () => undefined,
@@ -208,5 +223,16 @@ describe("dashboard account menu", () => {
 
     expect(html).toContain('href="/dashboard/team"');
     expect(html).not.toContain("animate-pulse");
+  });
+
+  test("rejects malformed organization entries at the response boundary", () => {
+    expect(__test.parseOrganizationCatalog({
+      selectedTeamId: null,
+      teams: [null],
+    })).toBeNull();
+    expect(__test.parseOrganizationCatalog({
+      selectedTeamId: "missing",
+      teams: [{ id: "team-1", name: "Team", personal: false }],
+    })).toBeNull();
   });
 });

--- a/web/tests/dashboard-account-menu.test.tsx
+++ b/web/tests/dashboard-account-menu.test.tsx
@@ -413,7 +413,7 @@ describe("dashboard account menu", () => {
     expect(routerPush).not.toHaveBeenCalled();
   });
 
-  test("prevents a second organization switch while the first is pending", async () => {
+  test("serializes organization switches and applies the latest request", async () => {
     searchTeam = "team-2";
     organizationQuery = {
       data: {
@@ -468,17 +468,13 @@ describe("dashboard account menu", () => {
     expect(guardedSetSelectedTeam).toHaveBeenCalledTimes(1);
     finishFirstSwitch?.();
     await first;
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(guardedSetSelectedTeam).toHaveBeenCalledTimes(2);
     expect(routerPush).toHaveBeenCalledWith(
-      "/dashboard/coderouter?team=team-2",
-    );
-    expect(routerPush).not.toHaveBeenCalledWith(
       "/dashboard/coderouter?team=team-3",
     );
-  });
-
-  test("bounds operations that never settle", async () => {
-    await expect(
-      __test.withDeadline(new Promise<void>(() => undefined), 1),
-    ).rejects.toThrow("timed out");
+    expect(routerPush).not.toHaveBeenCalledWith(
+      "/dashboard/coderouter?team=team-2",
+    );
   });
 });

--- a/web/tests/dashboard-account-menu.test.tsx
+++ b/web/tests/dashboard-account-menu.test.tsx
@@ -23,9 +23,11 @@ let organizationQuery: {
   isPending: boolean;
   isError: boolean;
 } = { data: undefined, isPending: true, isError: false };
-let switchOrganization:
-  | ((team: { id: string; displayName: string } | null) => Promise<void>)
-  | null = null;
+const handlers: {
+  switchOrganization?: (
+    team: { id: string; displayName: string } | null,
+  ) => Promise<void>;
+} = {};
 const routerPush = mock(() => undefined);
 const routerReplace = mock(() => undefined);
 const routerRefresh = mock(() => undefined);
@@ -47,7 +49,7 @@ mock.module("@stackframe/stack", () => ({
       team: { id: string; displayName: string } | null,
     ) => Promise<void>;
   }) => {
-    switchOrganization = onChange;
+    handlers.switchOrganization = onChange;
     return (
       <span
         data-testid="team-switcher"
@@ -130,7 +132,7 @@ describe("dashboard account menu", () => {
       isPending: false,
       isError: false,
     };
-    switchOrganization = null;
+    delete handlers.switchOrganization;
     routerPush.mockClear();
     routerRefresh.mockClear();
     const setSelectedTeam = mock(async () => undefined);
@@ -158,7 +160,12 @@ describe("dashboard account menu", () => {
     expect(html).not.toContain("Not authorized");
     expect(html).toContain("signOut");
 
-    await switchOrganization?.({
+    const invokeSwitch = handlers.switchOrganization as
+      | ((
+        team: { id: string; displayName: string } | null,
+      ) => Promise<void>)
+      | undefined;
+    await invokeSwitch?.({
       id: "team-2",
       displayName: "Authorized",
     });

--- a/web/tests/dashboard-account-menu.test.tsx
+++ b/web/tests/dashboard-account-menu.test.tsx
@@ -161,7 +161,7 @@ describe("dashboard account menu", () => {
       isError: true,
     };
     delete handlers.switchOrganization;
-    searchTeam = "team-2";
+    searchTeam = " team-2 ";
     routerPush.mockClear();
     routerRefresh.mockClear();
     setQueryData.mockClear();
@@ -191,6 +191,9 @@ describe("dashboard account menu", () => {
     expect(html).toContain('data-testid="team-switcher"');
     expect(html).toContain('data-team-id="team-2"');
     expect(html).toContain('data-team-ids="team-2,team-4"');
+    expect(html.indexOf('data-testid="team-switcher"')).toBeLessThan(
+      html.indexOf('aria-label="label"'),
+    );
     expect(html).not.toContain("Not authorized");
     expect(html).not.toContain("Forbidden");
     expect(html).toContain("signOut");

--- a/web/tests/dashboard-account-menu.test.tsx
+++ b/web/tests/dashboard-account-menu.test.tsx
@@ -546,4 +546,19 @@ describe("dashboard account menu", () => {
       "/dashboard/coderouter?team=team-3",
     );
   });
+
+  test("does not replace navigation that happened after a switch started", () => {
+    expect(
+      __test.shouldNavigateAfterSwitch(
+        "/dashboard/coderouter?team=team-1",
+        "/dashboard/billing?",
+      ),
+    ).toBe(false);
+    expect(
+      __test.shouldNavigateAfterSwitch(
+        "/dashboard/coderouter?team=team-1",
+        "/dashboard/coderouter?team=team-1",
+      ),
+    ).toBe(true);
+  });
 });

--- a/web/tests/dashboard-account-menu.test.tsx
+++ b/web/tests/dashboard-account-menu.test.tsx
@@ -33,8 +33,8 @@ const handlers: {
 const routerPush = mock(() => undefined);
 const routerReplace = mock(() => undefined);
 const routerRefresh = mock(() => undefined);
-const setQueryData = mock(() => undefined);
 let organizationQueryKey: readonly unknown[] | undefined;
+let searchTeam: string | null = null;
 
 mock.module("@stackframe/stack", () => ({
   AccountSettings: () => <section data-testid="stack-account-settings" />,
@@ -72,13 +72,15 @@ mock.module("@tanstack/react-query", () => ({
     organizationQueryKey = options.queryKey;
     return organizationQuery;
   },
-  useQueryClient: () => ({ setQueryData }),
 }));
 
-mock.module("next/navigation", () =>
-  createNextNavigationMock((target: unknown) => {
+mock.module("next/navigation", () => ({
+  ...createNextNavigationMock((target: unknown) => {
     throw new Error(`redirect:${target}`);
-  }));
+  }),
+  useSearchParams: () =>
+    new URLSearchParams(searchTeam ? `team=${encodeURIComponent(searchTeam)}` : ""),
+}));
 
 mock.module("@base-ui-components/react/menu", () => ({
   Menu: {
@@ -137,6 +139,18 @@ describe("dashboard account menu", () => {
             personal: false,
             permissions: { use: true, manageAccounts: false },
           },
+          {
+            id: "team-3",
+            name: "Forbidden",
+            personal: false,
+            permissions: { use: false, manageAccounts: false },
+          },
+          {
+            id: "team-4",
+            name: "Manager",
+            personal: false,
+            permissions: { use: false, manageAccounts: true },
+          },
         ],
       },
       isPending: false,
@@ -144,9 +158,9 @@ describe("dashboard account menu", () => {
       isError: true,
     };
     delete handlers.switchOrganization;
+    searchTeam = "team-2";
     routerPush.mockClear();
     routerRefresh.mockClear();
-    setQueryData.mockClear();
     const setSelectedTeam = mock(async () => undefined);
     currentUser = {
       id: "user-lawrence",
@@ -157,6 +171,8 @@ describe("dashboard account menu", () => {
       useTeams: () => [
         { id: "team-1", displayName: "Not authorized" },
         { id: "team-2", displayName: "Authorized" },
+        { id: "team-3", displayName: "Forbidden" },
+        { id: "team-4", displayName: "Manager" },
       ],
       setSelectedTeam,
     };
@@ -169,8 +185,9 @@ describe("dashboard account menu", () => {
     expect(html).toContain('href="/dashboard/billing"');
     expect(html).toContain('data-testid="team-switcher"');
     expect(html).toContain('data-team-id="team-2"');
-    expect(html).toContain('data-team-ids="team-2"');
+    expect(html).toContain('data-team-ids="team-2,team-4"');
     expect(html).not.toContain("Not authorized");
+    expect(html).not.toContain("Forbidden");
     expect(html).toContain("signOut");
     expect(organizationQueryKey).toEqual([
       "coderouter-organizations",
@@ -194,7 +211,6 @@ describe("dashboard account menu", () => {
       "/dashboard/coderouter?team=team-2",
     );
     expect(routerRefresh).toHaveBeenCalledTimes(1);
-    expect(setQueryData).toHaveBeenCalled();
   });
 
   test("uses the unlocalized auth handler and names the compact sign-in link", () => {
@@ -213,6 +229,7 @@ describe("dashboard account menu", () => {
       isPending: false,
       isError: true,
     };
+    searchTeam = null;
     currentUser = {
       id: "user-lawrence",
       displayName: "Lawrence",
@@ -250,6 +267,7 @@ describe("dashboard account menu", () => {
       isPending: false,
       isError: false,
     };
+    searchTeam = "user-lawrence";
     currentUser = {
       id: "user-lawrence",
       displayName: "Lawrence",
@@ -272,7 +290,12 @@ describe("dashboard account menu", () => {
     })).toBeNull();
     expect(__test.parseOrganizationCatalog({
       selectedTeamId: "missing",
-      teams: [{ id: "team-1", name: "Team", personal: false }],
+      teams: [{
+        id: "team-1",
+        name: "Team",
+        personal: false,
+        permissions: { use: true, manageAccounts: false },
+      }],
     })).toBeNull();
   });
 });

--- a/web/tests/dashboard-account-menu.test.tsx
+++ b/web/tests/dashboard-account-menu.test.tsx
@@ -1,6 +1,7 @@
 import { describe, expect, mock, test } from "bun:test";
 import { renderToStaticMarkup } from "react-dom/server";
 import type React from "react";
+import { createNextNavigationMock } from "./helpers/next-navigation-mock";
 
 let currentUser: {
   displayName: string;
@@ -64,11 +65,10 @@ mock.module("@tanstack/react-query", () => ({
   useQuery: () => organizationQuery,
 }));
 
-mock.module("next/navigation", () => ({
-  redirect: (target: string) => {
+mock.module("next/navigation", () =>
+  createNextNavigationMock((target: unknown) => {
     throw new Error(`redirect:${target}`);
-  },
-}));
+  }));
 
 mock.module("@base-ui-components/react/menu", () => ({
   Menu: {

--- a/web/tests/dashboard-account-menu.test.tsx
+++ b/web/tests/dashboard-account-menu.test.tsx
@@ -130,7 +130,8 @@ describe("dashboard account menu", () => {
         ],
       },
       isPending: false,
-      isError: false,
+      // A failed background refetch must not hide previously cached data.
+      isError: true,
     };
     delete handlers.switchOrganization;
     routerPush.mockClear();

--- a/web/tests/dashboard-billing-page.test.tsx
+++ b/web/tests/dashboard-billing-page.test.tsx
@@ -98,7 +98,9 @@ describe("dashboard billing page", () => {
 
     expect(html).toContain("Free");
     expect(html).toContain("You are currently on the Free plan.");
-    expect(html).toContain("Upgrade when you need cloud agents or team billing.");
+    expect(html).toContain(
+      "Upgrade when you need cloud agents or shared CodeRouter.",
+    );
     expect(html).toContain(
       'href="/api/billing/checkout?plan=pro&amp;cmux_external_browser=1&amp;interval=month"',
     );
@@ -298,7 +300,9 @@ describe("dashboard billing page", () => {
     expect(html).toContain("cmux Team");
     expect(html).toContain("Team Pro renews on");
     expect(html).toContain('name="scope" value="team"');
-    expect(html).not.toContain("Upgrade when you need cloud agents or team billing.");
+    expect(html).not.toContain(
+      "Upgrade when you need cloud agents or shared CodeRouter.",
+    );
   });
 
   test("renders Stack metadata-only Pro as Free", async () => {

--- a/web/tests/dashboard-coderouter-page.test.tsx
+++ b/web/tests/dashboard-coderouter-page.test.tsx
@@ -9,6 +9,7 @@ let cutoverReady = true;
 let hostedControlConfigured = true;
 let hostedExchangeCalls = 0;
 let selectedTeamId: string | null = "team-1";
+let scopedTeamId: string | null = null;
 let authorizedTeams: Array<{
   teamId: string;
   teamName: string;
@@ -30,7 +31,16 @@ mock.module("next-intl/server", () => ({
 }));
 
 mock.module("next/headers", () => ({
-  headers: async () => new Headers(),
+  headers: async () =>
+    new Headers(
+      scopedTeamId
+        ? {
+          cookie: `cmux_coderouter_organization=${
+            encodeURIComponent(scopedTeamId)
+          }`,
+        }
+        : undefined,
+    ),
 }));
 
 mock.module("next/navigation", () => ({
@@ -151,6 +161,7 @@ describe("coderouter dashboard", () => {
     hostedExchangeCalls = 0;
     metricsTeamIds.length = 0;
     selectedTeamId = "team-1";
+    scopedTeamId = null;
     authorizedTeams = [{
       teamId: "team-1",
       teamName: "Team One",
@@ -241,6 +252,33 @@ describe("coderouter dashboard", () => {
   test("uses the authenticated selected team when the URL has no team scope", async () => {
     authorizationAvailable = true;
     selectedTeamId = "team-2";
+    authorizedTeams = [
+      {
+        teamId: "team-1",
+        teamName: "Team One",
+        use: true,
+        manageAccounts: true,
+      },
+      {
+        teamId: "team-2",
+        teamName: "Team Two",
+        use: true,
+        manageAccounts: true,
+      },
+    ];
+
+    await CoderouterOverviewPage({
+      params: Promise.resolve({ locale: "en" }),
+      searchParams: Promise.resolve({}),
+    });
+
+    expect(metricsTeamIds).toEqual(["team-2"]);
+  });
+
+  test("uses the persisted CodeRouter scope before the Stack default", async () => {
+    authorizationAvailable = true;
+    selectedTeamId = "team-1";
+    scopedTeamId = "team-2";
     authorizedTeams = [
       {
         teamId: "team-1",

--- a/web/tests/dashboard-coderouter-page.test.tsx
+++ b/web/tests/dashboard-coderouter-page.test.tsx
@@ -8,6 +8,13 @@ let authJsonAvailable = true;
 let cutoverReady = true;
 let hostedControlConfigured = true;
 let hostedExchangeCalls = 0;
+let selectedTeamId: string | null = "team-1";
+let authorizedTeams = [{
+  teamId: "team-1",
+  teamName: "Team One",
+  use: true,
+  manageAccounts: true,
+}];
 const metricsTeamIds: string[] = [];
 
 mock.module("next-intl/server", () => ({
@@ -60,7 +67,7 @@ mock.module("../services/vms/auth", () => ({
     if (!authorizationAvailable) throw authorizationFailure;
     return await operation(new AbortController().signal);
   },
-  verifySubrouterRequest: async () => ({ id: "user-1" }),
+  verifySubrouterRequest: async () => ({ id: "user-1", selectedTeamId }),
   SubrouterAuthorizationUnavailableError:
     TestSubrouterAuthorizationUnavailableError,
   isSubrouterAuthorizationError: (error: unknown) =>
@@ -69,12 +76,7 @@ mock.module("../services/vms/auth", () => ({
 }));
 
 mock.module("../services/subrouter/routeHelpers", () => ({
-  authorizedSubrouterTeams: async () => [{
-    teamId: "team-1",
-    teamName: "Team One",
-    use: true,
-    manageAccounts: true,
-  }],
+  authorizedSubrouterTeams: async () => authorizedTeams,
 }));
 
 mock.module("../services/subrouter/hostedClient", () => ({
@@ -142,6 +144,13 @@ describe("coderouter dashboard", () => {
     hostedControlConfigured = true;
     hostedExchangeCalls = 0;
     metricsTeamIds.length = 0;
+    selectedTeamId = "team-1";
+    authorizedTeams = [{
+      teamId: "team-1",
+      teamName: "Team One",
+      use: true,
+      manageAccounts: true,
+    }];
   });
 
   test("renders recovery UI when Stack authorization is unavailable", async () => {
@@ -221,6 +230,32 @@ describe("coderouter dashboard", () => {
     expect(html).toContain("$4.25");
     expect(html).toContain("No prompts, outputs, account labels, or member identities");
     expect(html).not.toContain("stack-user");
+  });
+
+  test("uses the authenticated selected team when the URL has no team scope", async () => {
+    authorizationAvailable = true;
+    selectedTeamId = "team-2";
+    authorizedTeams = [
+      {
+        teamId: "team-1",
+        teamName: "Team One",
+        use: true,
+        manageAccounts: true,
+      },
+      {
+        teamId: "team-2",
+        teamName: "Team Two",
+        use: true,
+        manageAccounts: true,
+      },
+    ];
+
+    await CoderouterOverviewPage({
+      params: Promise.resolve({ locale: "en" }),
+      searchParams: Promise.resolve({}),
+    });
+
+    expect(metricsTeamIds).toEqual(["team-2"]);
   });
 });
 

--- a/web/tests/dashboard-coderouter-page.test.tsx
+++ b/web/tests/dashboard-coderouter-page.test.tsx
@@ -36,7 +36,7 @@ mock.module("next/headers", () => ({
       scopedTeamId
         ? {
           cookie: `cmux_coderouter_organization=${
-            encodeURIComponent(scopedTeamId)
+            encodeURIComponent(JSON.stringify(["user-1", scopedTeamId]))
           }`,
         }
         : undefined,
@@ -305,6 +305,34 @@ describe("coderouter dashboard", () => {
   test("normalizes a null Stack selection to the personal organization", async () => {
     authorizationAvailable = true;
     selectedTeamId = null;
+    authorizedTeams = [
+      {
+        teamId: "team-1",
+        teamName: "Team One",
+        use: true,
+        manageAccounts: true,
+        personal: false,
+      },
+      {
+        teamId: "user-1",
+        teamName: "Personal",
+        use: true,
+        manageAccounts: true,
+        personal: true,
+      },
+    ];
+
+    await CoderouterOverviewPage({
+      params: Promise.resolve({ locale: "en" }),
+      searchParams: Promise.resolve({}),
+    });
+
+    expect(metricsTeamIds).toEqual(["user-1"]);
+  });
+
+  test("uses personal when the Stack-selected team is no longer authorized", async () => {
+    authorizationAvailable = true;
+    selectedTeamId = "stale-team";
     authorizedTeams = [
       {
         teamId: "team-1",

--- a/web/tests/dashboard-coderouter-page.test.tsx
+++ b/web/tests/dashboard-coderouter-page.test.tsx
@@ -9,7 +9,13 @@ let cutoverReady = true;
 let hostedControlConfigured = true;
 let hostedExchangeCalls = 0;
 let selectedTeamId: string | null = "team-1";
-let authorizedTeams = [{
+let authorizedTeams: Array<{
+  teamId: string;
+  teamName: string;
+  use: boolean;
+  manageAccounts: boolean;
+  personal?: boolean;
+}> = [{
   teamId: "team-1",
   teamName: "Team One",
   use: true,
@@ -256,6 +262,34 @@ describe("coderouter dashboard", () => {
     });
 
     expect(metricsTeamIds).toEqual(["team-2"]);
+  });
+
+  test("normalizes a null Stack selection to the personal organization", async () => {
+    authorizationAvailable = true;
+    selectedTeamId = null;
+    authorizedTeams = [
+      {
+        teamId: "team-1",
+        teamName: "Team One",
+        use: true,
+        manageAccounts: true,
+        personal: false,
+      },
+      {
+        teamId: "user-1",
+        teamName: "Personal",
+        use: true,
+        manageAccounts: true,
+        personal: true,
+      },
+    ];
+
+    await CoderouterOverviewPage({
+      params: Promise.resolve({ locale: "en" }),
+      searchParams: Promise.resolve({}),
+    });
+
+    expect(metricsTeamIds).toEqual(["user-1"]);
   });
 });
 

--- a/web/tests/dashboard-shell.test.tsx
+++ b/web/tests/dashboard-shell.test.tsx
@@ -55,6 +55,8 @@ describe("dashboard shell", () => {
       /<nav[^>]*id="dashboard-mobile-nav"[^>]*>/,
     )?.[0];
     expect(controlledNavigation).toContain("hidden");
+    expect(html).toContain("pb-28");
+    expect(html).toContain("max-h-[calc(100vh-6rem)]");
   });
 
   test("removes every Vault navigation entry when the release flag is off", () => {

--- a/web/tests/dashboard-team-page.test.tsx
+++ b/web/tests/dashboard-team-page.test.tsx
@@ -13,7 +13,7 @@ mock.module("@stackframe/stack", () => ({
   ),
   useUser: () => null,
   UserAvatar: () => <span data-testid="avatar" />,
-  SelectedTeamSwitcher: () => <span data-testid="team-switcher" />,
+  TeamSwitcher: () => <span data-testid="team-switcher" />,
 }));
 
 mock.module("next/navigation", () => ({
@@ -21,6 +21,14 @@ mock.module("next/navigation", () => ({
     redirectedTo = target;
     throw new Error(`redirect:${target}`);
   },
+  useRouter: () => ({
+    push: () => undefined,
+    refresh: () => undefined,
+  }),
+}));
+
+mock.module("@tanstack/react-query", () => ({
+  useQuery: () => ({ data: undefined }),
 }));
 
 mock.module("../app/lib/stack", () => ({

--- a/web/tests/dashboard-team-page.test.tsx
+++ b/web/tests/dashboard-team-page.test.tsx
@@ -11,6 +11,9 @@ mock.module("@stackframe/stack", () => ({
       profile, security, sessions, teams, and invitations
     </section>
   ),
+  useUser: () => null,
+  UserAvatar: () => <span data-testid="avatar" />,
+  SelectedTeamSwitcher: () => <span data-testid="team-switcher" />,
 }));
 
 mock.module("next/navigation", () => ({

--- a/web/tests/dashboard-team-page.test.tsx
+++ b/web/tests/dashboard-team-page.test.tsx
@@ -27,7 +27,6 @@ mock.module("next/navigation", () => {
 
 mock.module("@tanstack/react-query", () => ({
   useQuery: () => ({ data: undefined, isPending: true, isError: false }),
-  useQueryClient: () => ({ setQueryData: () => undefined }),
 }));
 
 mock.module("../app/lib/stack", () => ({

--- a/web/tests/dashboard-team-page.test.tsx
+++ b/web/tests/dashboard-team-page.test.tsx
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 import { renderToStaticMarkup } from "react-dom/server";
+import { createNextNavigationMock } from "./helpers/next-navigation-mock";
 
 let signedIn = true;
 let stackConfigured = true;
@@ -16,16 +17,13 @@ mock.module("@stackframe/stack", () => ({
   TeamSwitcher: () => <span data-testid="team-switcher" />,
 }));
 
-mock.module("next/navigation", () => ({
-  redirect: (target: string) => {
-    redirectedTo = target;
+mock.module("next/navigation", () => {
+  const navigation = createNextNavigationMock((target: unknown) => {
+    redirectedTo = String(target);
     throw new Error(`redirect:${target}`);
-  },
-  useRouter: () => ({
-    push: () => undefined,
-    refresh: () => undefined,
-  }),
-}));
+  });
+  return navigation;
+});
 
 mock.module("@tanstack/react-query", () => ({
   useQuery: () => ({ data: undefined, isPending: true, isError: false }),

--- a/web/tests/dashboard-team-page.test.tsx
+++ b/web/tests/dashboard-team-page.test.tsx
@@ -27,6 +27,7 @@ mock.module("next/navigation", () => {
 
 mock.module("@tanstack/react-query", () => ({
   useQuery: () => ({ data: undefined, isPending: true, isError: false }),
+  useQueryClient: () => ({ setQueryData: () => undefined }),
 }));
 
 mock.module("../app/lib/stack", () => ({

--- a/web/tests/dashboard-team-page.test.tsx
+++ b/web/tests/dashboard-team-page.test.tsx
@@ -28,7 +28,7 @@ mock.module("next/navigation", () => ({
 }));
 
 mock.module("@tanstack/react-query", () => ({
-  useQuery: () => ({ data: undefined }),
+  useQuery: () => ({ data: undefined, isPending: true, isError: false }),
 }));
 
 mock.module("../app/lib/stack", () => ({

--- a/web/tests/dashboard-team-page.test.tsx
+++ b/web/tests/dashboard-team-page.test.tsx
@@ -27,6 +27,10 @@ mock.module("next/navigation", () => {
 
 mock.module("@tanstack/react-query", () => ({
   useQuery: () => ({ data: undefined, isPending: true, isError: false }),
+  useQueryClient: () => ({
+    setQueryData: () => undefined,
+    invalidateQueries: async () => undefined,
+  }),
 }));
 
 mock.module("../app/lib/stack", () => ({

--- a/web/tests/hosted-subrouter-routes.test.ts
+++ b/web/tests/hosted-subrouter-routes.test.ts
@@ -56,6 +56,9 @@ const leaseEventsRoute = await import(
 );
 const logoutRoute = await import("../app/api/subrouter/logout/route");
 const teamsRoute = await import("../app/api/subrouter/teams/route");
+const organizationsRoute = await import(
+  "../app/api/coderouter/organizations/route"
+);
 const exchangeRoute = await import("../app/api/subrouter/exchange/route");
 
 const originalFetch = globalThis.fetch;
@@ -509,6 +512,34 @@ describe("hosted Subrouter account routes", () => {
     );
     expect(teamsResponse.status).toBe(200);
     expect(await teamsResponse.json()).toEqual({
+      selectedTeamId: "team-a",
+      teams: [
+        {
+          id: "team-a",
+          name: "Team A",
+          personal: false,
+          permissions: { use: true, manageAccounts: true },
+        },
+        {
+          id: "team-b",
+          name: "Team B",
+          personal: false,
+          permissions: { use: true, manageAccounts: true },
+        },
+        {
+          id: "user-1",
+          name: "User One",
+          personal: true,
+          permissions: { use: true, manageAccounts: true },
+        },
+      ],
+    });
+
+    const organizationsResponse = await organizationsRoute.GET(
+      request("/api/coderouter/organizations"),
+    );
+    expect(organizationsResponse.status).toBe(200);
+    expect(await organizationsResponse.json()).toEqual({
       selectedTeamId: "team-a",
       teams: [
         {

--- a/web/tests/hosted-subrouter-routes.test.ts
+++ b/web/tests/hosted-subrouter-routes.test.ts
@@ -538,7 +538,8 @@ describe("hosted Subrouter account routes", () => {
     const organizationsResponse = await organizationsRoute.GET(
       request("/api/coderouter/organizations", {
         headers: {
-          cookie: "cmux_coderouter_organization=team-b",
+          cookie:
+            "cmux_coderouter_organization=%5B%22user-1%22%2C%22team-b%22%5D",
         },
       }),
     );
@@ -570,7 +571,8 @@ describe("hosted Subrouter account routes", () => {
     const unauthorizedScopeResponse = await organizationsRoute.GET(
       request("/api/coderouter/organizations", {
         headers: {
-          cookie: "cmux_coderouter_organization=team-not-authorized",
+          cookie:
+            "cmux_coderouter_organization=%5B%22user-1%22%2C%22team-not-authorized%22%5D",
         },
       }),
     );

--- a/web/tests/hosted-subrouter-routes.test.ts
+++ b/web/tests/hosted-subrouter-routes.test.ts
@@ -536,11 +536,15 @@ describe("hosted Subrouter account routes", () => {
     });
 
     const organizationsResponse = await organizationsRoute.GET(
-      request("/api/coderouter/organizations"),
+      request("/api/coderouter/organizations", {
+        headers: {
+          cookie: "cmux_coderouter_organization=team-b",
+        },
+      }),
     );
     expect(organizationsResponse.status).toBe(200);
     expect(await organizationsResponse.json()).toEqual({
-      selectedTeamId: "team-a",
+      selectedTeamId: "team-b",
       teams: [
         {
           id: "team-a",
@@ -562,6 +566,18 @@ describe("hosted Subrouter account routes", () => {
         },
       ],
     });
+
+    const unauthorizedScopeResponse = await organizationsRoute.GET(
+      request("/api/coderouter/organizations", {
+        headers: {
+          cookie: "cmux_coderouter_organization=team-not-authorized",
+        },
+      }),
+    );
+    expect(unauthorizedScopeResponse.status).toBe(200);
+    expect((await unauthorizedScopeResponse.json()).selectedTeamId).toBe(
+      "team-a",
+    );
 
     const logoutResponse = await logoutRoute.POST(
       request("/api/subrouter/logout", { method: "POST" }),

--- a/web/tests/pricing-page.test.tsx
+++ b/web/tests/pricing-page.test.tsx
@@ -75,6 +75,17 @@ describe("localized pricing page", () => {
     expect(jaMessages.pricing.team.features).toEqual([
       "匿名の集計使用量・コスト分析付きチーム全体 CodeRouter",
     ]);
+    expect(
+      enMessages.pricing.compare.rows.map((row) => row.label),
+    ).not.toContain("Unified billing and seat management");
+    expect(
+      enMessages.pricing.compare.rows.map((row) => row.label),
+    ).not.toContain("Centralized admin and shared team rules");
+    expect(
+      enMessages.pricing.faq.items.at(-1)?.a,
+    ).toBe(
+      "Yes. Team is $35/user/mo, or $28/user/mo when billed annually, and adds shared CodeRouter with anonymous aggregate usage and cost analytics.",
+    );
   });
 
   beforeEach(() => {

--- a/web/tests/pricing-page.test.tsx
+++ b/web/tests/pricing-page.test.tsx
@@ -82,15 +82,31 @@ describe("localized pricing page", () => {
       enMessages.pricing.compare.rows.map((row) => row.label),
     ).not.toContain("Centralized admin and shared team rules");
     expect(
+      jaMessages.pricing.compare.rows.map((row) => row.label),
+    ).not.toContain("一元請求とシート管理");
+    expect(
+      jaMessages.pricing.compare.rows.map((row) => row.label),
+    ).not.toContain("一元管理と共有チームルール");
+    expect(
       enMessages.pricing.faq.items.at(-1)?.a,
     ).toBe(
       "Yes. Team is $35/user/mo, or $28/user/mo when billed annually, and adds shared CodeRouter with anonymous aggregate usage and cost analytics.",
+    );
+    expect(
+      jaMessages.pricing.faq.items.at(-1)?.a,
+    ).toBe(
+      "はい。Team は月払いで $35/ユーザー/月、年払いでは $28/ユーザー/月で、匿名の集計使用量・コスト分析付き共有 CodeRouter が追加されます。",
     );
     expect(
       enMessages.pricing.compare.rows.find(
         (row) => row.label === "Cloud agents on Cloud VMs",
       )?.team,
     ).toBe("20 hrs/mo, then usage-based");
+    expect(
+      jaMessages.pricing.compare.rows.find(
+        (row) => row.label === "Cloud VM 上のクラウドエージェント",
+      )?.team,
+    ).toBe("20時間/月、以降は従量課金");
   });
 
   beforeEach(() => {

--- a/web/tests/pricing-page.test.tsx
+++ b/web/tests/pricing-page.test.tsx
@@ -4,6 +4,7 @@ import { renderToStaticMarkup } from "react-dom/server";
 import { stripeSubscriptions } from "../db/schema";
 import enMessages from "../messages/en.json";
 import jaMessages from "../messages/ja.json";
+import { fallbackContentLocales } from "../i18n/locale-availability";
 import { createNextNavigationMock } from "./helpers/next-navigation-mock";
 import { withAccountMutationLeaseSupport } from
   "./helpers/account-mutation-db-mock";
@@ -68,6 +69,10 @@ mock.module("../db/client", () => ({
 const { default: PricingPage } = await import("../app/[locale]/pricing/page");
 
 describe("localized pricing page", () => {
+  test("publishes pricing only in its fully authored English and Japanese catalogs", () => {
+    expect(fallbackContentLocales).toEqual(["en", "ja"]);
+  });
+
   test("limits the Team-only benefit to aggregate CodeRouter for now", () => {
     expect(enMessages.pricing.team.features).toEqual([
       "Team-wide CodeRouter with anonymous aggregate usage and cost analytics",

--- a/web/tests/pricing-page.test.tsx
+++ b/web/tests/pricing-page.test.tsx
@@ -86,6 +86,11 @@ describe("localized pricing page", () => {
     ).toBe(
       "Yes. Team is $35/user/mo, or $28/user/mo when billed annually, and adds shared CodeRouter with anonymous aggregate usage and cost analytics.",
     );
+    expect(
+      enMessages.pricing.compare.rows.find(
+        (row) => row.label === "Cloud agents on Cloud VMs",
+      )?.team,
+    ).toBe("20 hrs/mo, then usage-based");
   });
 
   beforeEach(() => {

--- a/web/tests/pricing-page.test.tsx
+++ b/web/tests/pricing-page.test.tsx
@@ -3,6 +3,7 @@ import { renderToStaticMarkup } from "react-dom/server";
 
 import { stripeSubscriptions } from "../db/schema";
 import enMessages from "../messages/en.json";
+import jaMessages from "../messages/ja.json";
 import { createNextNavigationMock } from "./helpers/next-navigation-mock";
 import { withAccountMutationLeaseSupport } from
   "./helpers/account-mutation-db-mock";
@@ -67,6 +68,15 @@ mock.module("../db/client", () => ({
 const { default: PricingPage } = await import("../app/[locale]/pricing/page");
 
 describe("localized pricing page", () => {
+  test("limits the Team-only benefit to aggregate CodeRouter for now", () => {
+    expect(enMessages.pricing.team.features).toEqual([
+      "Team-wide CodeRouter with anonymous aggregate usage and cost analytics",
+    ]);
+    expect(jaMessages.pricing.team.features).toEqual([
+      "匿名の集計使用量・コスト分析付きチーム全体 CodeRouter",
+    ]);
+  });
+
   beforeEach(() => {
     process.env.CMUX_VAULT_ENABLED = "0";
     stackConfigured = false;

--- a/web/tests/pricing-page.test.tsx
+++ b/web/tests/pricing-page.test.tsx
@@ -107,6 +107,12 @@ describe("localized pricing page", () => {
         (row) => row.label === "Cloud VM 上のクラウドエージェント",
       )?.team,
     ).toBe("20時間/月、以降は従量課金");
+    expect(enMessages.dashboard.billing.free.upsellBody).toContain(
+      "shared CodeRouter with anonymous aggregate usage and cost analytics",
+    );
+    expect(jaMessages.dashboard.billing.free.upsellBody).toContain(
+      "匿名の集計使用量・コスト分析付き共有 CodeRouter",
+    );
   });
 
   beforeEach(() => {


### PR DESCRIPTION
## Summary
- add a direct bottom-left organization switcher filtered by authoritative CodeRouter permissions
- expose a CodeRouter organization catalog while preserving the legacy Subrouter compatibility route
- publish the v4 CLI organization endpoint contract
- make PostHog fixed-Endpoint failures alertable in Sentry without team identity or request content
- replace the account sign-out hard navigation with Next navigation

## Validation
- 1,238 web tests passed, 148 DB-gated skips, 0 failed
- Next.js production build passed
- instant-navigation Playwright passed
- focused ESLint and typecheck passed
- production Stack team invite and revoke flow verified through Aside Browser

## Companion CLI
- https://github.com/manaflow-ai/coderouter/pull/46

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/9882"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788919276&installation_model_id=21920&pr_number=9882&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F9882&signature=35895fc8d5014d9c12086c1df1590b0b3dc6f2963f010ba3b6a9663b8a303481"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk from new org-scoping cookie and team-resolution order affecting which team’s metrics and accounts load, plus expanded analytics failure reporting in production.
> 
> **Overview**
> Adds a **CodeRouter organization switcher** in the dashboard account menu (above the user menu), loading permission-filtered teams from **`/api/coderouter/organizations`** (alias of the Subrouter teams route). Switching writes a **dedicated cookie** (`cmux_coderouter_organization`) and navigates to **`/dashboard/coderouter?team=`** without changing Stack’s global selected team.
> 
> **Team selection** on the CodeRouter overview and in the org API now follows: URL `team` → cookie scope → Stack `selectedTeamId` → personal team fallback.
> 
> **CLI config** bumps to **v4** with **`organizationsUrl`**. **Team metrics** report privacy-safe **`analytics_query`** failures to Sentry (bounded reason/status only) and tighten PostHog endpoint parsing; ops docs add alerting for **`analytics_delivery`** and **`analytics_query`**.
> 
> **Pricing / i18n** narrows Team messaging to shared CodeRouter aggregate analytics (en/ja), aligns Team Cloud VM hours with Pro, and adds **`organizationSwitchError`** strings across locales. Sign-out uses Next **`router.replace`/`refresh`** and clears the org cookie; shell spacing adjusts for the extra switcher control.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d618afb77fb2498374cb583e6b5c19ae8b3112bc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Finishes the CodeRouter org switcher and analytics flow. The dashboard now persists a per-user CodeRouter org scope cookie and treats `?team=` as the source of truth without changing Stack’s global team; CLI config moves to v4 with `organizationsUrl`.

- New Features
  - Organization switcher above the account menu using `@stackframe/stack` `TeamSwitcher`. Loads `/api/coderouter/organizations` (alias of the Subrouter teams handler), permission-filtered, strictly validated, and cached via `@tanstack/react-query` (networkMode: "always", 15s timeout).
  - Switching persists a CodeRouter-only, per-user cookie scope (`cmux_coderouter_organization`), updates the local catalog cache, then pushes `?team=` and refreshes. Stack `selectedTeam` is unchanged.
  - Team resolution in the CodeRouter overview: URL `team` → cookie-scoped org → authenticated `selectedTeamId` → personal fallback. The API also honors the cookie and falls back safely.
  - CLI config: v4 with `organizationsUrl`. Pricing copy narrowed to shared CodeRouter aggregate analytics for Team; Team Cloud VM allowance aligned with Pro. Pricing content published only for `en` and `ja`.

- Bug Fixes
  - Organization switching: preserves cached orgs on background refetch errors; bounds loads; serializes switches; falls back to account settings when no permitted orgs; adjusts shell spacing so controls stay reachable; keeps URL scope authoritative during navigation; clears the cookie on sign‑out.
  - Analytics: strict endpoint JSON parsing and limits; privacy-safe `analytics_query` Sentry errors; ops docs instruct alerting on both `analytics_delivery` and `analytics_query`.
  - Account: sign‑out now uses Next `router.replace`/`refresh`.

<sup>Written for commit d618afb77fb2498374cb583e6b5c19ae8b3112bc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/9882?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added team and organization switching to the dashboard account menu.
  * Authorized and personal teams can be selected, with navigation to the chosen dashboard.
  * CLI configuration now includes the CodeRouter organizations endpoint.

* **Bug Fixes**
  * Improved sign-out and team-switching navigation.
  * Team metrics failures now return unavailable results with privacy-safe error details and clearer failure reporting.

* **Documentation**
  * Documented privacy-safe analytics errors and production alerting requirements.
  * Updated Team pricing information to clarify aggregate analytics, Cloud VM allowances, and included features.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->