### PR TITLE
Preserve iOS workspace search across detail navigation

### DIFF
--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListLayoutPreviewView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListLayoutPreviewView.swift
@@ -165,7 +165,8 @@ public struct WorkspaceListLayoutPreviewView: View {
     }
 
     @State private var fixtureRoute: FixtureWorkspaceRoute?
-    @State private var pendingSearchFixtureRoute: FixtureWorkspaceRoute?
+    @State private var searchFixtureRoute: FixtureWorkspaceRoute?
+    @State private var restoresSearchPresentationOnReturn = false
 
     private var scrollMetricsEnabled: Bool {
         ProcessInfo.processInfo.environment["CMUX_UITEST_SCROLL_METRICS"] == "1"
@@ -496,32 +497,10 @@ public struct WorkspaceListLayoutPreviewView: View {
                         workspaceListFixture(searchText: searchText)
                     }
                     .navigationDestination(item: $fixtureRoute) { route in
-                        VStack(spacing: 12) {
-                            Text(
-                                model.workspaces.first(where: { $0.id == route.id })?.name
-                                    ?? route.id.rawValue
-                            )
-                            .font(.title2)
-                            Text("Fixture workspace detail")
-                                .foregroundStyle(.secondary)
-                        }
-                        .accessibilityIdentifier("FixtureWorkspaceDetail")
-                        .toolbarVisibility(.hidden, for: .tabBar, .bottomBar)
-                        .navigationBarBackButtonHidden(true)
-                        .toolbar {
-                            ToolbarItem(placement: .topBarLeading) {
-                                WorkspaceBackButton(unreadCount: 0) {
-                                    fixtureRoute = nil
-                                }
-                            }
+                        fixtureWorkspaceDetail(route: route) {
+                            fixtureRoute = nil
                         }
                     }
-                }
-                .onAppear {
-                    consumePendingSearchFixtureNavigation()
-                }
-                .onChange(of: pendingSearchFixtureRoute) { _, _ in
-                    consumePendingSearchFixtureNavigation()
                 }
                 .overlay(alignment: .bottomTrailing) {
                     if scrollMetricsEnabled {
@@ -549,6 +528,15 @@ public struct WorkspaceListLayoutPreviewView: View {
                             ) { searchText in
                                 workspaceListFixture(searchText: searchText)
                             }
+                            .navigationDestination(item: $searchFixtureRoute) { route in
+                                fixtureWorkspaceDetail(route: route) {
+                                    searchFixtureRoute = nil
+                                }
+                            }
+                        }
+                        .onChange(of: searchFixtureRoute) { oldRoute, newRoute in
+                            guard oldRoute != nil, newRoute == nil else { return }
+                            restoreSearchPresentationIfNeeded()
                         }
                     } notificationSearch: {
                         Text("Notification feed fixture")
@@ -558,10 +546,6 @@ public struct WorkspaceListLayoutPreviewView: View {
                     workspaceListStack
                 }
             }
-        }
-        .onChange(of: primarySearchCoordinator.isPresented) { _, isPresented in
-            guard !isPresented else { return }
-            consumePendingSearchFixtureNavigation()
         }
         .overlay(alignment: .topLeading) {
             ZStack(alignment: .topLeading) {
@@ -601,19 +585,40 @@ public struct WorkspaceListLayoutPreviewView: View {
         let route = FixtureWorkspaceRoute(id: id)
         if showsTabScaffold,
            selectedPrimaryTab == .search || primarySearchCoordinator.isPresented {
-            pendingSearchFixtureRoute = route
-            transitionPrimaryTab(to: .workspaces)
+            restoresSearchPresentationOnReturn = primarySearchCoordinator.isPresented
+            searchFixtureRoute = route
         } else {
             fixtureRoute = route
         }
     }
 
-    private func consumePendingSearchFixtureNavigation() {
-        guard !primarySearchCoordinator.isPresented,
-              selectedPrimaryTab == .workspaces,
-              let route = pendingSearchFixtureRoute else { return }
-        pendingSearchFixtureRoute = nil
-        fixtureRoute = route
+    private func fixtureWorkspaceDetail(
+        route: FixtureWorkspaceRoute,
+        onBack: @escaping () -> Void
+    ) -> some View {
+        VStack(spacing: 12) {
+            Text(
+                model.workspaces.first(where: { $0.id == route.id })?.name
+                    ?? route.id.rawValue
+            )
+            .font(.title2)
+            Text("Fixture workspace detail")
+                .foregroundStyle(.secondary)
+        }
+        .accessibilityIdentifier("FixtureWorkspaceDetail")
+        .toolbarVisibility(.hidden, for: .tabBar, .bottomBar)
+        .navigationBarBackButtonHidden(true)
+        .toolbar {
+            ToolbarItem(placement: .topBarLeading) {
+                WorkspaceBackButton(unreadCount: 0, action: onBack)
+            }
+        }
+    }
+
+    private func restoreSearchPresentationIfNeeded() {
+        guard restoresSearchPresentationOnReturn else { return }
+        restoresSearchPresentationOnReturn = false
+        primarySearchCoordinator.setPresentation(true)
     }
 
     @discardableResult

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceShellView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceShellView.swift
@@ -167,7 +167,9 @@ struct WorkspaceShellView: View {
     #if os(iOS)
     @State private var selectedPrimaryTab: MobilePrimaryTab = .workspaces
     @State private var notificationNavigationPath: [MobileWorkspacePreview.ID] = []
+    @State private var workspaceSearchNavigationPath: [MobileWorkspacePreview.ID] = []
     @State private var notificationSearchNavigationPath: [MobileWorkspacePreview.ID] = []
+    @State private var restoreSearchOnDetailReturn = false
     @State private var pendingPrimarySearchWorkspaceNavigationID: MobileWorkspacePreview.ID?
     @State private var pendingPrimarySearchNotificationNavigationID: MobileWorkspacePreview.ID?
     @State private var showingRootSettings = false
@@ -344,7 +346,7 @@ struct WorkspaceShellView: View {
 
     private func workspaceSearchTabContent(canCreateWorkspaceForSelection: Bool) -> some View {
         workspaceActionToastOverlay {
-            NavigationStack {
+            NavigationStack(path: $workspaceSearchNavigationPath) {
                 MobilePrimaryWorkspaceSearchContentHost(
                     searchCoordinator: primarySearchCoordinator
                 ) { searchText in
@@ -360,8 +362,29 @@ struct WorkspaceShellView: View {
                     )
                 }
                 .toolbar {
-                    rootToolbarContent
+                    if workspaceSearchNavigationPath.isEmpty {
+                        rootToolbarContent
+                    }
                 }
+                .navigationDestination(for: MobileWorkspacePreview.ID.self) { workspaceID in
+                    workspaceDestination(
+                        for: workspaceID,
+                        createWorkspace: createWorkspaceInCompactStack,
+                        canCreateWorkspaceForSelection: canCreateWorkspaceForSelection,
+                        backButtonConfiguration: WorkspaceBackButtonConfiguration(
+                            unreadCount: unreadWorkspaceCount(excluding: workspaceID),
+                            badgeContrast: .darkBackground,
+                            action: popWorkspaceSearchStack
+                        )
+                    )
+                    .toolbarVisibility(.hidden, for: .tabBar, .bottomBar)
+                    .navigationBarBackButtonHidden(true)
+                    .background(InteractiveSwipeBackEnabler())
+                }
+            }
+            .onChange(of: workspaceSearchNavigationPath) { oldPath, newPath in
+                guard !oldPath.isEmpty, newPath.isEmpty else { return }
+                restoreWorkspaceSearchPresentationIfNeeded()
             }
         }
     }
@@ -482,6 +505,7 @@ struct WorkspaceShellView: View {
             }
         }
         .onChange(of: store.selectedWorkspaceID) { _, selectedWorkspaceID in
+            guard workspaceSearchNavigationPath.isEmpty else { return }
             if let createdPath = compactNavigationPolicy.pathForCreatedWorkspaceSelection(
                 currentPath: compactNavigationPath,
                 selectedWorkspaceID: selectedWorkspaceID,
@@ -900,8 +924,21 @@ struct WorkspaceShellView: View {
     }
 
     private func selectWorkspaceFromSearch(_ id: MobileWorkspacePreview.ID) {
-        pendingPrimarySearchWorkspaceNavigationID = id
-        transitionPrimaryTab(to: .workspaces)
+        restoreSearchOnDetailReturn = primarySearchCoordinator.isPresented
+        workspaceSearchNavigationPath = [id]
+        pendingCompactCreateNavigationWorkspaceIDs = nil
+        store.selectedWorkspaceID = id
+    }
+
+    private func popWorkspaceSearchStack() {
+        guard !workspaceSearchNavigationPath.isEmpty else { return }
+        workspaceSearchNavigationPath.removeLast()
+    }
+
+    private func restoreWorkspaceSearchPresentationIfNeeded() {
+        guard restoreSearchOnDetailReturn else { return }
+        restoreSearchOnDetailReturn = false
+        primarySearchCoordinator.setPresentation(true)
     }
 
     private func createWorkspaceFromSearch() {

--- a/ios/cmuxUITests/cmuxUITests.swift
+++ b/ios/cmuxUITests/cmuxUITests.swift
@@ -1146,7 +1146,7 @@ final class cmuxUITests: XCTestCase {
     }
 
     @MainActor
-    func testWorkspaceSearchIsMinimizedAndPreservesQueryAcrossRefresh() throws {
+    func testWorkspaceSearchRestoresPresentationQueryAndResultsAfterWorkspaceDetailAndRefresh() throws {
         guard #available(iOS 26.0, *) else {
             throw XCTSkip("The detached workspace search control requires iOS 26.")
         }
@@ -1220,7 +1220,19 @@ final class cmuxUITests: XCTestCase {
         tap(backButton, in: app)
         XCTAssertNotNil(waitForVisibleElement(in: workspaceListTables, app: app, timeout: 3))
         XCTAssertTrue(minimizedSearch.waitForExistence(timeout: 3))
-        XCTAssertTrue(waitForKeyboardDismissal(in: app))
+        XCTAssertTrue(
+            searchField.waitForExistence(timeout: 3),
+            "Returning from workspace detail must restore the expanded Search presentation."
+        )
+        XCTAssertEqual(
+            searchField.value as? String,
+            "Docs",
+            "Returning from workspace detail must restore the exact search query."
+        )
+        XCTAssertTrue(
+            app.keyboards.firstMatch.waitForExistence(timeout: 3),
+            "Returning from workspace detail must restore Search focus and its keyboard."
+        )
         XCTAssertTrue(waitForHittable(docsRow, timeout: 3))
         XCTAssertTrue(waitForNotHittable(mainRow, timeout: 3))
 
@@ -1228,7 +1240,7 @@ final class cmuxUITests: XCTestCase {
             NSPredicate(format: "identifier == %@", "MobileWorkspaceListPreviewRefresh")
         )
         guard let previewRefresh = waitForVisibleElement(in: previewRefreshButtons, app: app, timeout: 3) else {
-            XCTFail("Visible preview refresh trigger disappeared after leaving Search")
+            XCTFail("Visible preview refresh trigger disappeared after returning to Search")
             return
         }
         tap(previewRefresh, in: app)


### PR DESCRIPTION
Keep workspace-detail pushes inside the active Search tab navigation stack. Returning with Back or an edge swipe reopens the same search presentation, query, keyboard focus, filtered list, and retained list position.

The first commit adds the behavior-level XCUITest. The second implements the navigation ownership fix.

Stacked on https://github.com/manaflow-ai/cmux/pull/9859 so the verified toolbar checkpoint remains intact.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/9883"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788921707&installation_model_id=21920&pr_number=9883&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F9883&signature=b87cc51c7874c8127767bfab9c28f9880135a2142e52a4eaaea09742fd6f368e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes iOS primary-tab navigation ownership for search-to-workspace flows; behavior is covered by an expanded UI test but touches compact-stack coordination and search coordinator presentation.
> 
> **Overview**
> **Workspace detail from Search now pushes inside the Search tab’s navigation stack** instead of switching to the Workspaces tab and deferring navigation. `selectWorkspaceFromSearch` sets `workspaceSearchNavigationPath` and records whether expanded search was active so **Back or swipe-back** can call `restoreWorkspaceSearchPresentationIfNeeded()` and reopen search via `primarySearchCoordinator.setPresentation(true)`.
> 
> The Search tab `NavigationStack` gains `navigationDestination` for workspace IDs (custom back button, swipe-back enabler) and hides the root toolbar while detail is shown. **Compact-stack selection sync** skips updating `compactNavigationPath` while a search-stack detail is open.
> 
> The DEBUG list preview fixture mirrors the same pattern (`searchFixtureRoute`, shared `fixtureWorkspaceDetail`) and drops the old pending-route / tab-hop consumption logic.
> 
> **XCUITest** `testWorkspaceSearchRestoresPresentationQueryAndResultsAfterWorkspaceDetailAndRefresh` now asserts expanded search field, preserved query, keyboard focus, filtered rows, and stability after preview refresh—not only minimized search chrome.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c4704c01f9d22f3f11defd956d25d1812424bbee. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->