### PR TITLE
Remove terminal timing sleeps deterministically

### DIFF
--- a/Packages/macOS/CmuxTerminalBackendService/Sources/CmuxTerminalBackendService/BackendServiceReadinessDeadline.swift
+++ b/Packages/macOS/CmuxTerminalBackendService/Sources/CmuxTerminalBackendService/BackendServiceReadinessDeadline.swift
@@ -8,10 +8,10 @@ internal actor BackendServiceReadinessDeadline {
     private var state = State.pending
 
     /// Claims a completed handshake after sampling time inside this actor.
-    func complete(
-        clock: ContinuousClock,
-        before absoluteDeadline: ContinuousClock.Instant
-    ) -> Bool {
+    func complete<C: Clock>(
+        clock: C,
+        before absoluteDeadline: C.Instant
+    ) -> Bool where C.Duration == Duration {
         guard case .pending = state else { return false }
         guard clock.now < absoluteDeadline else { return false }
         state = .completed

--- a/Packages/macOS/CmuxTerminalBackendService/Sources/CmuxTerminalBackendService/BackendServiceReadinessProbe.swift
+++ b/Packages/macOS/CmuxTerminalBackendService/Sources/CmuxTerminalBackendService/BackendServiceReadinessProbe.swift
@@ -18,6 +18,7 @@ public struct BackendServiceReadinessProbe: BackendServiceReadinessChecking, Sen
     private let trustVerifierOverride: (any BackendPeerTrustVerifying)?
     private let trustVerificationScopeID: UUID
     private let transportFactory: @Sendable () -> any BackendPeerIdentityTransport
+    private let clock: any Clock<Duration>
 
     /// Creates a protocol readiness probe for one app-scoped backend.
     ///
@@ -34,6 +35,7 @@ public struct BackendServiceReadinessProbe: BackendServiceReadinessChecking, Sen
     ///     `nil` to use the current process identifier.
     ///   - trustVerifier: An injectable live-process code-signing verifier.
     ///   - transportFactory: An injectable credential-bearing transport factory.
+    ///   - clock: The cancellable monotonic clock used for deadlines and retries.
     public init(
         descriptor: BackendServiceDescriptor,
         runtimePaths: BackendServiceRuntimePaths,
@@ -43,7 +45,8 @@ public struct BackendServiceReadinessProbe: BackendServiceReadinessChecking, Sen
         expectedUserID: UInt32? = nil,
         clientProcessID: UInt32? = nil,
         trustVerifier: (any BackendPeerTrustVerifying)? = nil,
-        transportFactory: (@Sendable () -> any BackendPeerIdentityTransport)? = nil
+        transportFactory: (@Sendable () -> any BackendPeerIdentityTransport)? = nil,
+        clock: any Clock<Duration> = ContinuousClock()
     ) {
         precondition(timeout > .zero)
         expectedSession = descriptor.sessionName
@@ -57,6 +60,7 @@ public struct BackendServiceReadinessProbe: BackendServiceReadinessChecking, Sen
         self.transportFactory = transportFactory ?? {
             UnixBackendTransport(path: runtimePaths.socketURL.path)
         }
+        self.clock = clock
     }
 
     /// Connects, validates the negotiated authority, and closes the probe connection.
@@ -70,7 +74,14 @@ public struct BackendServiceReadinessProbe: BackendServiceReadinessChecking, Sen
     public func checkReadiness(
         trustedPair: BackendServiceInstalledPair
     ) async throws -> BackendServiceReadiness {
-        let clock = ContinuousClock()
+        let clock = clock
+        return try await checkReadiness(trustedPair: trustedPair, clock: clock)
+    }
+
+    private func checkReadiness<C: Clock>(
+        trustedPair: BackendServiceInstalledPair,
+        clock: C
+    ) async throws -> BackendServiceReadiness where C.Duration == Duration {
         let absoluteDeadline = clock.now.advanced(by: timeout)
         var retryDelay = retryPolicy.initialDelay
 
@@ -98,7 +109,7 @@ public struct BackendServiceReadinessProbe: BackendServiceReadinessChecking, Sen
                 }
 
                 let retryAt = min(clock.now.advanced(by: retryDelay), absoluteDeadline)
-                try await clock.sleep(until: retryAt)
+                try await clock.sleep(until: retryAt, tolerance: nil)
                 guard clock.now < absoluteDeadline else {
                     throw BackendServiceReadinessError.timedOut
                 }
@@ -107,12 +118,12 @@ public struct BackendServiceReadinessProbe: BackendServiceReadinessChecking, Sen
         }
     }
 
-    private func runAttempt(
+    private func runAttempt<C: Clock>(
         transport: any BackendPeerIdentityTransport,
         trustedPair: BackendServiceInstalledPair,
-        clock: ContinuousClock,
-        absoluteDeadline: ContinuousClock.Instant
-    ) async throws -> BackendServiceReadiness {
+        clock: C,
+        absoluteDeadline: C.Instant
+    ) async throws -> BackendServiceReadiness where C.Duration == Duration {
         let client = BackendProtocolClient(transport: transport)
         let deadline = BackendServiceReadinessDeadline()
 
@@ -195,7 +206,7 @@ public struct BackendServiceReadinessProbe: BackendServiceReadinessChecking, Sen
                 }
             }
             group.addTask {
-                try await clock.sleep(until: absoluteDeadline)
+                try await clock.sleep(until: absoluteDeadline, tolerance: nil)
                 guard await deadline.expire() else {
                     // The handshake already claimed success before the
                     // deadline. Its connection close may still be suspended,

--- a/Packages/macOS/CmuxTerminalBackendService/Tests/CmuxTerminalBackendServiceTests/BackendReadinessManualClock.swift
+++ b/Packages/macOS/CmuxTerminalBackendService/Tests/CmuxTerminalBackendServiceTests/BackendReadinessManualClock.swift
@@ -1,0 +1,103 @@
+import Foundation
+
+/// Thread safety: `lock` protects every mutable field and every continuation collection.
+final class BackendReadinessManualClock: Clock, @unchecked Sendable {
+    typealias Instant = BackendReadinessManualClockInstant
+
+    private let lock = NSLock()
+    private var currentInstant = Instant(offset: .zero)
+    private var sleepers: [UUID: BackendReadinessManualClockSleeper] = [:]
+    private var cancelledSleeperIDs: Set<UUID> = []
+    private var parkWaiters: [
+        UUID: (count: Int, continuation: CheckedContinuation<Void, any Error>)
+    ] = [:]
+
+    var now: Instant {
+        lock.lock()
+        defer { lock.unlock() }
+        return currentInstant
+    }
+
+    var minimumResolution: Duration { .zero }
+
+    func sleep(until deadline: Instant, tolerance: Duration?) async throws {
+        let identifier = UUID()
+        try await withTaskCancellationHandler {
+            try await withCheckedThrowingContinuation {
+                (continuation: CheckedContinuation<Void, any Error>) in
+                lock.lock()
+                if cancelledSleeperIDs.remove(identifier) != nil {
+                    lock.unlock()
+                    continuation.resume(throwing: CancellationError())
+                    return
+                }
+                if deadline <= currentInstant {
+                    lock.unlock()
+                    continuation.resume()
+                    return
+                }
+                sleepers[identifier] = BackendReadinessManualClockSleeper(
+                    deadline: deadline,
+                    continuation: continuation
+                )
+                let waiters = takeSatisfiedParkWaitersLocked()
+                lock.unlock()
+                for waiter in waiters { waiter.resume() }
+            }
+        } onCancel: {
+            lock.lock()
+            let sleeper = sleepers.removeValue(forKey: identifier)
+            if sleeper == nil { cancelledSleeperIDs.insert(identifier) }
+            lock.unlock()
+            sleeper?.continuation.resume(throwing: CancellationError())
+        }
+    }
+
+    func waitUntilSleepers(count: Int = 1) async throws {
+        let identifier = UUID()
+        try await withTaskCancellationHandler {
+            try await withCheckedThrowingContinuation {
+                (continuation: CheckedContinuation<Void, any Error>) in
+                lock.lock()
+                if Task.isCancelled {
+                    lock.unlock()
+                    continuation.resume(throwing: CancellationError())
+                } else if sleepers.count >= count {
+                    lock.unlock()
+                    continuation.resume()
+                } else {
+                    parkWaiters[identifier] = (count, continuation)
+                    lock.unlock()
+                }
+            }
+        } onCancel: {
+            lock.lock()
+            let waiter = parkWaiters.removeValue(forKey: identifier)
+            lock.unlock()
+            waiter?.continuation.resume(throwing: CancellationError())
+        }
+    }
+
+    func advance(by duration: Duration) {
+        lock.lock()
+        currentInstant = currentInstant.advanced(by: duration)
+        var due: [BackendReadinessManualClockSleeper] = []
+        for (identifier, sleeper) in sleepers where sleeper.deadline <= currentInstant {
+            sleepers[identifier] = nil
+            due.append(sleeper)
+        }
+        lock.unlock()
+        for sleeper in due.sorted(by: { $0.deadline < $1.deadline }) {
+            sleeper.continuation.resume()
+        }
+    }
+
+    private func takeSatisfiedParkWaitersLocked() -> [CheckedContinuation<Void, any Error>] {
+        let identifiers = parkWaiters.compactMap { identifier, waiter in
+            sleepers.count >= waiter.count ? identifier : nil
+        }
+        return identifiers.compactMap {
+            parkWaiters.removeValue(forKey: $0)?.continuation
+        }
+    }
+}

--- a/Packages/macOS/CmuxTerminalBackendService/Tests/CmuxTerminalBackendServiceTests/BackendReadinessManualClockInstant.swift
+++ b/Packages/macOS/CmuxTerminalBackendService/Tests/CmuxTerminalBackendServiceTests/BackendReadinessManualClockInstant.swift
@@ -1,0 +1,20 @@
+import Foundation
+
+struct BackendReadinessManualClockInstant: InstantProtocol, Sendable {
+    var offset: Duration
+
+    func advanced(by duration: Duration) -> BackendReadinessManualClockInstant {
+        BackendReadinessManualClockInstant(offset: offset + duration)
+    }
+
+    func duration(to other: BackendReadinessManualClockInstant) -> Duration {
+        other.offset - offset
+    }
+
+    static func < (
+        lhs: BackendReadinessManualClockInstant,
+        rhs: BackendReadinessManualClockInstant
+    ) -> Bool {
+        lhs.offset < rhs.offset
+    }
+}

--- a/Packages/macOS/CmuxTerminalBackendService/Tests/CmuxTerminalBackendServiceTests/BackendReadinessManualClockSleeper.swift
+++ b/Packages/macOS/CmuxTerminalBackendService/Tests/CmuxTerminalBackendServiceTests/BackendReadinessManualClockSleeper.swift
@@ -1,0 +1,6 @@
+import Foundation
+
+struct BackendReadinessManualClockSleeper {
+    let deadline: BackendReadinessManualClockInstant
+    let continuation: CheckedContinuation<Void, any Error>
+}

--- a/Packages/macOS/CmuxTerminalBackendService/Tests/CmuxTerminalBackendServiceTests/BackendServiceReadinessProbeTests.swift
+++ b/Packages/macOS/CmuxTerminalBackendService/Tests/CmuxTerminalBackendServiceTests/BackendServiceReadinessProbeTests.swift
@@ -282,7 +282,7 @@ struct BackendServiceReadinessProbeTests {
         }
 
         await transport.waitUntilCloseStarts()
-        await clock.waitUntilSleepers()
+        try await clock.waitUntilSleepers()
         clock.advance(by: .milliseconds(75))
         #expect(clock.now.offset == .milliseconds(75))
         await transport.releaseClose()
@@ -318,19 +318,19 @@ struct BackendServiceReadinessProbeTests {
         }
 
         let firstAttempt = Task { try await probe.checkReadiness() }
-        await clock.waitUntilSleepers()
+        try await clock.waitUntilSleepers()
         clock.advance(by: .milliseconds(100))
         await #expect(throws: BackendServiceReadinessError.timedOut) {
             _ = try await firstAttempt.value
         }
         let secondAttempt = Task { try await probe.checkReadiness() }
-        await clock.waitUntilSleepers()
+        try await clock.waitUntilSleepers()
         clock.advance(by: .milliseconds(100))
         await #expect(throws: BackendServiceReadinessError.timedOut) {
             _ = try await secondAttempt.value
         }
         let separatelyScopedAttempt = Task { try await separatelyScopedProbe.checkReadiness() }
-        await clock.waitUntilSleepers()
+        try await clock.waitUntilSleepers()
         clock.advance(by: .milliseconds(100))
         await #expect(throws: BackendServiceReadinessError.timedOut) {
             _ = try await separatelyScopedAttempt.value
@@ -483,105 +483,6 @@ struct BackendServiceReadinessProbeTests {
                 )
             )
         )
-    }
-}
-
-private final class BackendReadinessManualClock: Clock, @unchecked Sendable {
-    struct Instant: InstantProtocol, Sendable {
-        var offset: Duration
-
-        func advanced(by duration: Duration) -> Instant { Instant(offset: offset + duration) }
-        func duration(to other: Instant) -> Duration { other.offset - offset }
-        static func < (lhs: Instant, rhs: Instant) -> Bool { lhs.offset < rhs.offset }
-    }
-
-    private struct Sleeper {
-        let deadline: Instant
-        let continuation: CheckedContinuation<Void, any Error>
-    }
-
-    private let lock = NSLock()
-    private var currentInstant = Instant(offset: .zero)
-    private var sleepers: [UUID: Sleeper] = [:]
-    private var cancelledSleeperIDs: Set<UUID> = []
-    private var parkWaiters: [(Int, CheckedContinuation<Void, Never>)] = []
-
-    var now: Instant {
-        lock.lock()
-        defer { lock.unlock() }
-        return currentInstant
-    }
-    var minimumResolution: Duration { .zero }
-
-    func sleep(until deadline: Instant, tolerance: Duration?) async throws {
-        let identifier = UUID()
-        try await withTaskCancellationHandler {
-            try await withCheckedThrowingContinuation {
-                (continuation: CheckedContinuation<Void, any Error>) in
-                lock.lock()
-                if cancelledSleeperIDs.remove(identifier) != nil {
-                    lock.unlock()
-                    continuation.resume(throwing: CancellationError())
-                    return
-                }
-                if deadline <= currentInstant {
-                    lock.unlock()
-                    continuation.resume()
-                    return
-                }
-                sleepers[identifier] = Sleeper(
-                    deadline: deadline,
-                    continuation: continuation
-                )
-                let waiters = takeSatisfiedParkWaitersLocked()
-                lock.unlock()
-                for waiter in waiters { waiter.resume() }
-            }
-        } onCancel: {
-            lock.lock()
-            let sleeper = sleepers.removeValue(forKey: identifier)
-            if sleeper == nil { cancelledSleeperIDs.insert(identifier) }
-            lock.unlock()
-            sleeper?.continuation.resume(throwing: CancellationError())
-        }
-    }
-
-    func waitUntilSleepers(count: Int = 1) async {
-        await withCheckedContinuation {
-            (continuation: CheckedContinuation<Void, Never>) in
-            lock.lock()
-            if sleepers.count >= count {
-                lock.unlock()
-                continuation.resume()
-                return
-            }
-            parkWaiters.append((count, continuation))
-            lock.unlock()
-        }
-    }
-
-    func advance(by duration: Duration) {
-        lock.lock()
-        currentInstant = currentInstant.advanced(by: duration)
-        var due: [Sleeper] = []
-        for (identifier, sleeper) in sleepers where sleeper.deadline <= currentInstant {
-            sleepers[identifier] = nil
-            due.append(sleeper)
-        }
-        lock.unlock()
-        for sleeper in due.sorted(by: { $0.deadline < $1.deadline }) {
-            sleeper.continuation.resume()
-        }
-    }
-
-    private func takeSatisfiedParkWaitersLocked() -> [CheckedContinuation<Void, Never>] {
-        var satisfied: [CheckedContinuation<Void, Never>] = []
-        parkWaiters.removeAll { waiter in
-            guard sleepers.count >= waiter.0 else { return false }
-            satisfied.append(waiter.1)
-            return true
-        }
-        return satisfied
     }
 }
 

--- a/Packages/macOS/CmuxTerminalBackendService/Tests/CmuxTerminalBackendServiceTests/BackendServiceReadinessProbeTests.swift
+++ b/Packages/macOS/CmuxTerminalBackendService/Tests/CmuxTerminalBackendServiceTests/BackendServiceReadinessProbeTests.swift
@@ -268,16 +268,23 @@ struct BackendServiceReadinessProbeTests {
         #expect(await transport.isClosed())
     }
 
-    @Test("completion claimed before the deadline survives a blocked close")
+    @Test("completion claimed before the deadline survives a blocked close", .timeLimit(.minutes(1)))
     func completedHandshakeWinsWhileClosing() async throws {
         let transport = try makeTransport(blocksOnClose: true)
-        let probe = makeProbe(transport: transport, timeout: .milliseconds(50))
+        let clock = BackendReadinessManualClock()
+        let probe = makeProbe(
+            transport: transport,
+            timeout: .milliseconds(50),
+            clock: clock
+        )
         let readinessTask = Task {
             try await probe.checkReadiness()
         }
 
         await transport.waitUntilCloseStarts()
-        try await Task.sleep(for: .milliseconds(75))
+        await clock.waitUntilSleepers()
+        clock.advance(by: .milliseconds(75))
+        #expect(clock.now.offset == .milliseconds(75))
         await transport.releaseClose()
 
         let readiness = try await readinessTask.value
@@ -285,7 +292,7 @@ struct BackendServiceReadinessProbeTests {
         #expect(await transport.isClosed())
     }
 
-    @Test("a blocked trust verifier cannot extend deadlines or spawn followers")
+    @Test("a blocked trust verifier cannot extend deadlines or spawn followers", .timeLimit(.minutes(1)))
     func blockedTrustVerifierIsBounded() async throws {
         let firstTransport = try makeTransport()
         let secondTransport = try makeTransport()
@@ -293,38 +300,43 @@ struct BackendServiceReadinessProbeTests {
         let recoveredTransport = try makeTransport()
         let sequence = BackendServiceProbeTransportSequence([firstTransport, secondTransport])
         let trustVerifier = BlockingBackendPeerTrustVerifier()
+        let clock = BackendReadinessManualClock()
         let probe = makeProbe(
             transportFactory: { sequence.next() },
             timeout: .milliseconds(100),
-            trustVerifier: trustVerifier
+            trustVerifier: trustVerifier,
+            clock: clock
         )
         let separatelyScopedProbe = makeProbe(
             transport: queuedTransport,
             timeout: .milliseconds(100),
-            trustVerifier: trustVerifier
+            trustVerifier: trustVerifier,
+            clock: clock
         )
-        let failsafe = Task.detached {
-            try? await Task.sleep(for: .seconds(1))
-            trustVerifier.release()
-        }
         defer {
-            failsafe.cancel()
             trustVerifier.release()
         }
-        let clock = ContinuousClock()
-        let started = clock.now
 
+        let firstAttempt = Task { try await probe.checkReadiness() }
+        await clock.waitUntilSleepers()
+        clock.advance(by: .milliseconds(100))
         await #expect(throws: BackendServiceReadinessError.timedOut) {
-            _ = try await probe.checkReadiness()
+            _ = try await firstAttempt.value
         }
+        let secondAttempt = Task { try await probe.checkReadiness() }
+        await clock.waitUntilSleepers()
+        clock.advance(by: .milliseconds(100))
         await #expect(throws: BackendServiceReadinessError.timedOut) {
-            _ = try await probe.checkReadiness()
+            _ = try await secondAttempt.value
         }
+        let separatelyScopedAttempt = Task { try await separatelyScopedProbe.checkReadiness() }
+        await clock.waitUntilSleepers()
+        clock.advance(by: .milliseconds(100))
         await #expect(throws: BackendServiceReadinessError.timedOut) {
-            _ = try await separatelyScopedProbe.checkReadiness()
+            _ = try await separatelyScopedAttempt.value
         }
 
-        #expect(started.duration(to: clock.now) < .milliseconds(500))
+        #expect(clock.now.offset == .milliseconds(300))
         #expect(trustVerifier.invocationCount == 1)
         #expect(await firstTransport.isClosed())
         #expect(await secondTransport.isClosed())
@@ -359,7 +371,8 @@ struct BackendServiceReadinessProbeTests {
         transport: BackendServiceProbeTransport,
         timeout: Duration = .seconds(1),
         clientProcessID: UInt32 = 99,
-        trustVerifier: any BackendPeerTrustVerifying = FixedBackendPeerTrustVerifier()
+        trustVerifier: any BackendPeerTrustVerifying = FixedBackendPeerTrustVerifier(),
+        clock: any Clock<Duration> = ContinuousClock()
     ) -> BackendServiceReadinessProbe {
         let descriptor = BackendServiceDescriptor.production
         let paths = BackendServiceRuntimePaths(
@@ -374,7 +387,8 @@ struct BackendServiceReadinessProbeTests {
             expectedUserID: 501,
             clientProcessID: clientProcessID,
             trustVerifier: trustVerifier,
-            transportFactory: { transport }
+            transportFactory: { transport },
+            clock: clock
         )
     }
 
@@ -383,7 +397,8 @@ struct BackendServiceReadinessProbeTests {
         timeout: Duration = .seconds(1),
         retryPolicy: BackendServiceReadinessRetryPolicy = .launchdStartup,
         clientProcessID: UInt32 = 99,
-        trustVerifier: any BackendPeerTrustVerifying = FixedBackendPeerTrustVerifier()
+        trustVerifier: any BackendPeerTrustVerifying = FixedBackendPeerTrustVerifier(),
+        clock: any Clock<Duration> = ContinuousClock()
     ) -> BackendServiceReadinessProbe {
         let descriptor = BackendServiceDescriptor.production
         let paths = BackendServiceRuntimePaths(
@@ -399,7 +414,8 @@ struct BackendServiceReadinessProbeTests {
             expectedUserID: 501,
             clientProcessID: clientProcessID,
             trustVerifier: trustVerifier,
-            transportFactory: transportFactory
+            transportFactory: transportFactory,
+            clock: clock
         )
     }
 
@@ -467,6 +483,105 @@ struct BackendServiceReadinessProbeTests {
                 )
             )
         )
+    }
+}
+
+private final class BackendReadinessManualClock: Clock, @unchecked Sendable {
+    struct Instant: InstantProtocol, Sendable {
+        var offset: Duration
+
+        func advanced(by duration: Duration) -> Instant { Instant(offset: offset + duration) }
+        func duration(to other: Instant) -> Duration { other.offset - offset }
+        static func < (lhs: Instant, rhs: Instant) -> Bool { lhs.offset < rhs.offset }
+    }
+
+    private struct Sleeper {
+        let deadline: Instant
+        let continuation: CheckedContinuation<Void, any Error>
+    }
+
+    private let lock = NSLock()
+    private var currentInstant = Instant(offset: .zero)
+    private var sleepers: [UUID: Sleeper] = [:]
+    private var cancelledSleeperIDs: Set<UUID> = []
+    private var parkWaiters: [(Int, CheckedContinuation<Void, Never>)] = []
+
+    var now: Instant {
+        lock.lock()
+        defer { lock.unlock() }
+        return currentInstant
+    }
+    var minimumResolution: Duration { .zero }
+
+    func sleep(until deadline: Instant, tolerance: Duration?) async throws {
+        let identifier = UUID()
+        try await withTaskCancellationHandler {
+            try await withCheckedThrowingContinuation {
+                (continuation: CheckedContinuation<Void, any Error>) in
+                lock.lock()
+                if cancelledSleeperIDs.remove(identifier) != nil {
+                    lock.unlock()
+                    continuation.resume(throwing: CancellationError())
+                    return
+                }
+                if deadline <= currentInstant {
+                    lock.unlock()
+                    continuation.resume()
+                    return
+                }
+                sleepers[identifier] = Sleeper(
+                    deadline: deadline,
+                    continuation: continuation
+                )
+                let waiters = takeSatisfiedParkWaitersLocked()
+                lock.unlock()
+                for waiter in waiters { waiter.resume() }
+            }
+        } onCancel: {
+            lock.lock()
+            let sleeper = sleepers.removeValue(forKey: identifier)
+            if sleeper == nil { cancelledSleeperIDs.insert(identifier) }
+            lock.unlock()
+            sleeper?.continuation.resume(throwing: CancellationError())
+        }
+    }
+
+    func waitUntilSleepers(count: Int = 1) async {
+        await withCheckedContinuation {
+            (continuation: CheckedContinuation<Void, Never>) in
+            lock.lock()
+            if sleepers.count >= count {
+                lock.unlock()
+                continuation.resume()
+                return
+            }
+            parkWaiters.append((count, continuation))
+            lock.unlock()
+        }
+    }
+
+    func advance(by duration: Duration) {
+        lock.lock()
+        currentInstant = currentInstant.advanced(by: duration)
+        var due: [Sleeper] = []
+        for (identifier, sleeper) in sleepers where sleeper.deadline <= currentInstant {
+            sleepers[identifier] = nil
+            due.append(sleeper)
+        }
+        lock.unlock()
+        for sleeper in due.sorted(by: { $0.deadline < $1.deadline }) {
+            sleeper.continuation.resume()
+        }
+    }
+
+    private func takeSatisfiedParkWaitersLocked() -> [CheckedContinuation<Void, Never>] {
+        var satisfied: [CheckedContinuation<Void, Never>] = []
+        parkWaiters.removeAll { waiter in
+            guard sleepers.count >= waiter.0 else { return false }
+            satisfied.append(waiter.1)
+            return true
+        }
+        return satisfied
     }
 }
 

--- a/Sources/TerminalBackendClientCoordinator.swift
+++ b/Sources/TerminalBackendClientCoordinator.swift
@@ -289,6 +289,7 @@ actor TerminalBackendClientCoordinator:
     private let readinessProvider: ReadinessProvider
     private let sessionFactory: SessionFactory
     private let reconnectPolicy: TerminalBackendReconnectPolicy
+    private let recoveryClock: any Clock<Duration>
     private let compatibilityReporter: CompatibilityReporter
     private let screenTextLimiter = TerminalBackendScreenTextLimiter()
 
@@ -406,6 +407,9 @@ actor TerminalBackendClientCoordinator:
     private var frontendRecoveryStartCount = 0
     private let rendererWorkerExitMonitor: any TerminalBackendRendererWorkerExitMonitoring
     private var rendererWorkerExitLedger = TerminalBackendRendererWorkerExitLedger()
+    private var rendererWorkerExitCountWaiters: [
+        UUID: (expectedCount: Int, continuation: CheckedContinuation<Void, Never>)
+    ] = [:]
     private let monotonicNowNanoseconds: @Sendable () -> UInt64
 
     private static let terminalInputOwnerTTLMilliseconds: UInt64 = 30_000
@@ -417,6 +421,7 @@ actor TerminalBackendClientCoordinator:
         runtimePaths: BackendServiceRuntimePaths,
         registrationIdentity: BackendClientRegistrationIdentity,
         reconnectPolicy: TerminalBackendReconnectPolicy = .appStartup,
+        recoveryClock: any Clock<Duration> = ContinuousClock(),
         rendererWorkerExitMonitor: any TerminalBackendRendererWorkerExitMonitoring =
             TerminalBackendRendererWorkerExitMonitor(),
         compatibilityReporter: @escaping CompatibilityReporter = { _ in }
@@ -437,6 +442,7 @@ actor TerminalBackendClientCoordinator:
             )
         }
         self.reconnectPolicy = reconnectPolicy
+        self.recoveryClock = recoveryClock
         self.rendererWorkerExitMonitor = rendererWorkerExitMonitor
         self.compatibilityReporter = compatibilityReporter
         monotonicNowNanoseconds = { DispatchTime.now().uptimeNanoseconds }
@@ -446,6 +452,7 @@ actor TerminalBackendClientCoordinator:
         readinessProvider: @escaping ReadinessProvider,
         sessionFactory: @escaping SessionFactory,
         reconnectPolicy: TerminalBackendReconnectPolicy = .immediate,
+        recoveryClock: any Clock<Duration> = ContinuousClock(),
         rendererWorkerExitMonitor: any TerminalBackendRendererWorkerExitMonitoring =
             TerminalBackendRendererWorkerExitMonitor(),
         monotonicNowNanoseconds: @escaping @Sendable () -> UInt64 = {
@@ -456,6 +463,7 @@ actor TerminalBackendClientCoordinator:
         self.readinessProvider = readinessProvider
         self.sessionFactory = sessionFactory
         self.reconnectPolicy = reconnectPolicy
+        self.recoveryClock = recoveryClock
         self.rendererWorkerExitMonitor = rendererWorkerExitMonitor
         self.monotonicNowNanoseconds = monotonicNowNanoseconds
         self.compatibilityReporter = compatibilityReporter
@@ -2346,6 +2354,7 @@ actor TerminalBackendClientCoordinator:
                 return nil
             case .unverifiable:
                 rendererWorkerExitLedger.remove(identity)
+                resolveRendererWorkerExitCountWaiters()
                 throw BackendProtocolError.peerIdentityMismatch
             }
         case .existing:
@@ -2353,6 +2362,7 @@ actor TerminalBackendClientCoordinator:
         case .conflict:
             throw BackendProtocolError.peerIdentityMismatch
         }
+        resolveRendererWorkerExitCountWaiters()
         return rendererWorkerIsLive(identity) ? identity : nil
     }
 
@@ -2434,7 +2444,9 @@ actor TerminalBackendClientCoordinator:
     private func rendererWorkerDidExit(
         _ identity: TerminalBackendRendererWorkerProcessIdentity
     ) {
-        _ = rendererWorkerExitLedger.markExited(identity)
+        if rendererWorkerExitLedger.markExited(identity) {
+            resolveRendererWorkerExitCountWaiters()
+        }
     }
 
     private func rendererWorkerIsLive(
@@ -2455,6 +2467,27 @@ actor TerminalBackendClientCoordinator:
 
     var debugRendererWorkerExitWaiterCount: Int {
         rendererWorkerExitLedger.activeFenceCount
+    }
+
+    func debugWaitForRendererWorkerExitWaiterCount(_ expectedCount: Int) async {
+        guard rendererWorkerExitLedger.activeFenceCount != expectedCount else { return }
+        await withCheckedContinuation { continuation in
+            if rendererWorkerExitLedger.activeFenceCount == expectedCount {
+                continuation.resume()
+            } else {
+                rendererWorkerExitCountWaiters[UUID()] = (expectedCount, continuation)
+            }
+        }
+    }
+
+    private func resolveRendererWorkerExitCountWaiters() {
+        let currentCount = rendererWorkerExitLedger.activeFenceCount
+        let satisfied = rendererWorkerExitCountWaiters.filter {
+            $0.value.expectedCount == currentCount
+        }
+        for identifier in satisfied.keys {
+            rendererWorkerExitCountWaiters.removeValue(forKey: identifier)?.continuation.resume()
+        }
     }
 
     func debugRegisterRendererWorker(
@@ -3404,6 +3437,7 @@ actor TerminalBackendClientCoordinator:
         let supervisorID = UUID()
         connectionSupervisorID = supervisorID
         let recoveryCycleDelay = reconnectPolicy.recoveryCycleDelay
+        let recoveryClock = recoveryClock
         connectionSupervisorTask = Task { [weak self] in
             while !Task.isCancelled {
                 guard let step = await self?.beginConnectionSupervisorCycle(
@@ -3415,7 +3449,7 @@ actor TerminalBackendClientCoordinator:
                 case .retry:
                     do {
                         if recoveryCycleDelay > .zero {
-                            try await ContinuousClock().sleep(for: recoveryCycleDelay)
+                            try await recoveryClock.sleep(for: recoveryCycleDelay)
                         } else {
                             await Task.yield()
                         }
@@ -3665,11 +3699,13 @@ actor TerminalBackendClientCoordinator:
         let readinessProvider = readinessProvider
         let sessionFactory = sessionFactory
         let reconnectPolicy = reconnectPolicy
+        let recoveryClock = recoveryClock
         let task = Task {
             try await Self.connect(
                 readinessProvider: readinessProvider,
                 sessionFactory: sessionFactory,
-                reconnectPolicy: reconnectPolicy
+                reconnectPolicy: reconnectPolicy,
+                recoveryClock: recoveryClock
             )
         }
         connectionTask = task
@@ -4007,7 +4043,8 @@ actor TerminalBackendClientCoordinator:
     private static func connect(
         readinessProvider: ReadinessProvider,
         sessionFactory: SessionFactory,
-        reconnectPolicy: TerminalBackendReconnectPolicy
+        reconnectPolicy: TerminalBackendReconnectPolicy,
+        recoveryClock: any Clock<Duration>
     ) async throws -> TerminalBackendConnectedSession {
         var nextDelayIndex = 0
         while true {
@@ -4045,7 +4082,7 @@ actor TerminalBackendClientCoordinator:
                 nextDelayIndex += 1
                 if delay > .zero {
                     // This is the retry policy's bounded, cancellable backoff.
-                    try await ContinuousClock().sleep(for: delay)
+                    try await recoveryClock.sleep(for: delay)
                 }
             }
         }

--- a/Sources/TerminalBackendClientCoordinator.swift
+++ b/Sources/TerminalBackendClientCoordinator.swift
@@ -407,9 +407,6 @@ actor TerminalBackendClientCoordinator:
     private var frontendRecoveryStartCount = 0
     private let rendererWorkerExitMonitor: any TerminalBackendRendererWorkerExitMonitoring
     private var rendererWorkerExitLedger = TerminalBackendRendererWorkerExitLedger()
-    private var rendererWorkerExitCountWaiters: [
-        UUID: (expectedCount: Int, continuation: CheckedContinuation<Void, Never>)
-    ] = [:]
     private let monotonicNowNanoseconds: @Sendable () -> UInt64
 
     private static let terminalInputOwnerTTLMilliseconds: UInt64 = 30_000
@@ -2354,7 +2351,6 @@ actor TerminalBackendClientCoordinator:
                 return nil
             case .unverifiable:
                 rendererWorkerExitLedger.remove(identity)
-                resolveRendererWorkerExitCountWaiters()
                 throw BackendProtocolError.peerIdentityMismatch
             }
         case .existing:
@@ -2362,7 +2358,6 @@ actor TerminalBackendClientCoordinator:
         case .conflict:
             throw BackendProtocolError.peerIdentityMismatch
         }
-        resolveRendererWorkerExitCountWaiters()
         return rendererWorkerIsLive(identity) ? identity : nil
     }
 
@@ -2444,9 +2439,7 @@ actor TerminalBackendClientCoordinator:
     private func rendererWorkerDidExit(
         _ identity: TerminalBackendRendererWorkerProcessIdentity
     ) {
-        if rendererWorkerExitLedger.markExited(identity) {
-            resolveRendererWorkerExitCountWaiters()
-        }
+        _ = rendererWorkerExitLedger.markExited(identity)
     }
 
     private func rendererWorkerIsLive(
@@ -2467,27 +2460,6 @@ actor TerminalBackendClientCoordinator:
 
     var debugRendererWorkerExitWaiterCount: Int {
         rendererWorkerExitLedger.activeFenceCount
-    }
-
-    func debugWaitForRendererWorkerExitWaiterCount(_ expectedCount: Int) async {
-        guard rendererWorkerExitLedger.activeFenceCount != expectedCount else { return }
-        await withCheckedContinuation { continuation in
-            if rendererWorkerExitLedger.activeFenceCount == expectedCount {
-                continuation.resume()
-            } else {
-                rendererWorkerExitCountWaiters[UUID()] = (expectedCount, continuation)
-            }
-        }
-    }
-
-    private func resolveRendererWorkerExitCountWaiters() {
-        let currentCount = rendererWorkerExitLedger.activeFenceCount
-        let satisfied = rendererWorkerExitCountWaiters.filter {
-            $0.value.expectedCount == currentCount
-        }
-        for identifier in satisfied.keys {
-            rendererWorkerExitCountWaiters.removeValue(forKey: identifier)?.continuation.resume()
-        }
     }
 
     func debugRegisterRendererWorker(

--- a/cmux-tui/Cargo.lock
+++ b/cmux-tui/Cargo.lock
@@ -207,6 +207,7 @@ dependencies = [
  "toml",
  "unicode-width",
  "uuid",
+ "wait-timeout",
 ]
 
 [[package]]
@@ -1919,6 +1920,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d9b2acfb050df409c972a37d3b8e08cdea3bddb0c09db9d53137e504cfabed0"
 dependencies = [
  "utf8parse",
+]
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
+dependencies = [
+ "libc",
 ]
 
 [[package]]

--- a/cmux-tui/Cargo.toml
+++ b/cmux-tui/Cargo.toml
@@ -49,6 +49,7 @@ smallvec = "1"
 getrandom = "0.3"
 uuid = { version = "1", features = ["serde", "v4", "v5"] }
 fs2 = "0.4.3"
+wait-timeout = "0.2.1"
 
 [profile.release]
 lto = "thin"

--- a/cmux-tui/crates/cmux-tui-core/src/model.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/model.rs
@@ -80,12 +80,7 @@ impl Node {
                 let old = Node::Leaf(*id);
                 let new = Node::Leaf(new_pane);
                 let (a, b) = if insert_first { (new, old) } else { (old, new) };
-                *self = Node::Split {
-                    dir,
-                    ratio,
-                    a: Box::new(a),
-                    b: Box::new(b),
-                };
+                *self = Node::Split { dir, ratio, a: Box::new(a), b: Box::new(b) };
                 true
             }
             Node::Leaf(_) => false,
@@ -201,8 +196,7 @@ impl Node {
             }
         }
 
-        let (_, matched, changed) =
-            walk(self, target, dir, target_in_first, new_ratio);
+        let (_, matched, changed) = walk(self, target, dir, target_in_first, new_ratio);
         match (matched, changed) {
             (false, _) => ChangeState::Missing,
             (true, false) => ChangeState::Unchanged,

--- a/cmux-tui/crates/cmux-tui-core/src/mux.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/mux.rs
@@ -12525,13 +12525,21 @@ mod tests {
         let Some(marker) = std::env::var_os("CMUX_TEST_NON_READER_EXIT_MARKER") else {
             return;
         };
-        unsafe {
-            libc::signal(libc::SIGHUP, libc::SIG_IGN);
-        }
-        let original_parent = unsafe { libc::getppid() };
-        let deadline = Instant::now() + Duration::from_secs(10);
-        while unsafe { libc::getppid() } == original_parent && Instant::now() < deadline {
-            std::thread::sleep(Duration::from_millis(10));
+        let address = std::env::var("CMUX_TEST_PARENT_LIFETIME_ADDRESS").unwrap();
+        let mut lifetime = std::net::TcpStream::connect(address).unwrap();
+        lifetime.set_read_timeout(Some(Duration::from_secs(10))).unwrap();
+        let mut ready = [0_u8; 1];
+        std::io::Read::read_exact(&mut lifetime, &mut ready).unwrap();
+        assert_eq!(ready, [1]);
+        let mut end = [0_u8; 1];
+        match std::io::Read::read(&mut lifetime, &mut end) {
+            Ok(0) => {}
+            Err(error)
+                if matches!(
+                    error.kind(),
+                    std::io::ErrorKind::ConnectionReset | std::io::ErrorKind::BrokenPipe
+                ) => {}
+            result => panic!("parent lifetime channel stayed open: {result:?}"),
         }
         std::fs::write(marker, b"parent-exited").unwrap();
     }
@@ -12543,6 +12551,15 @@ mod tests {
         };
         let root = std::path::PathBuf::from(root);
         let target_exit_marker = root.join("target-exited");
+        let lifetime_listener = std::net::TcpListener::bind(("127.0.0.1", 0)).unwrap();
+        let lifetime_address = lifetime_listener.local_addr().unwrap();
+        std::thread::spawn(move || {
+            let (mut lifetime, _) = lifetime_listener.accept().unwrap();
+            std::io::Write::write_all(&mut lifetime, &[1]).unwrap();
+            loop {
+                std::thread::park();
+            }
+        });
         let store = StateStore::new(root.join("store"));
         let mux = Mux::recover_from_state_store("main", SurfaceOptions::default(), &store).unwrap();
         let executable = std::env::current_exe().unwrap();
@@ -12559,10 +12576,13 @@ mod tests {
                     "mux::tests::initial_input_non_reader_entrypoint".to_string(),
                     "--nocapture".to_string(),
                 ]),
-                env: vec![(
-                    "CMUX_TEST_NON_READER_EXIT_MARKER".to_string(),
-                    target_exit_marker.to_string_lossy().into_owned(),
-                )],
+                env: vec![
+                    (
+                        "CMUX_TEST_NON_READER_EXIT_MARKER".to_string(),
+                        target_exit_marker.to_string_lossy().into_owned(),
+                    ),
+                    ("CMUX_TEST_PARENT_LIFETIME_ADDRESS".to_string(), lifetime_address.to_string()),
+                ],
                 initial_input: Some(canonical_safe_initial_input(1024 * 1024)),
                 ..TerminalLaunchRequest::default()
             },
@@ -16222,14 +16242,23 @@ mod tests {
     }
 
     fn wait_for_surface_uuid(mux: &Mux, uuid: SurfaceUuid, present: bool) {
+        if mux.with_state(|state| state.surface_id_by_uuid(uuid).is_some()) == present {
+            return;
+        }
+        let subscription = topology_subscription(mux, mux.canonical_topology_revision());
+        if mux.with_state(|state| state.surface_id_by_uuid(uuid).is_some()) == present {
+            return;
+        }
         let deadline = Instant::now() + Duration::from_secs(5);
-        while Instant::now() < deadline {
+        loop {
+            let remaining = deadline.saturating_duration_since(Instant::now());
+            subscription.receiver.recv_timeout(remaining).unwrap_or_else(|error| {
+                panic!("surface {uuid} presence did not become {present}: {error}")
+            });
             if mux.with_state(|state| state.surface_id_by_uuid(uuid).is_some()) == present {
                 return;
             }
-            std::thread::sleep(Duration::from_millis(10));
         }
-        panic!("surface {uuid} presence did not become {present}");
     }
 
     #[test]

--- a/cmux-tui/crates/cmux-tui-core/src/mux.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/mux.rs
@@ -12525,6 +12525,9 @@ mod tests {
         let Some(marker) = std::env::var_os("CMUX_TEST_NON_READER_EXIT_MARKER") else {
             return;
         };
+        unsafe {
+            libc::signal(libc::SIGHUP, libc::SIG_IGN);
+        }
         let address = std::env::var("CMUX_TEST_PARENT_LIFETIME_ADDRESS").unwrap();
         let mut lifetime = std::net::TcpStream::connect(address).unwrap();
         lifetime.set_read_timeout(Some(Duration::from_secs(10))).unwrap();

--- a/cmux-tui/crates/cmux-tui/Cargo.toml
+++ b/cmux-tui/crates/cmux-tui/Cargo.toml
@@ -31,3 +31,4 @@ uuid.workspace = true
 
 [dev-dependencies]
 fs2.workspace = true
+wait-timeout.workspace = true

--- a/cmux-tui/crates/cmux-tui/tests/cli.rs
+++ b/cmux-tui/crates/cmux-tui/tests/cli.rs
@@ -6,6 +6,7 @@ use std::sync::mpsc;
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
 use cmux_tui_core::platform::transport;
+use wait_timeout::ChildExt;
 
 fn register_test_tui(writer: &mut impl Write, reader: &mut impl BufRead) {
     let client_uuid = uuid::Uuid::new_v4();
@@ -76,14 +77,10 @@ impl HeadlessServer {
     }
 
     fn wait_for_exit(&mut self) -> std::process::ExitStatus {
-        let deadline = Instant::now() + Duration::from_secs(10);
-        while Instant::now() < deadline {
-            if let Some(status) = self.child.try_wait().unwrap() {
-                return status;
-            }
-            std::thread::sleep(Duration::from_millis(25));
-        }
-        panic!("headless server did not exit after a fatal persistence failure");
+        self.child
+            .wait_timeout(Duration::from_secs(10))
+            .unwrap()
+            .expect("headless server did not exit after a fatal persistence failure")
     }
 
     fn read_stderr(&mut self) -> String {
@@ -437,6 +434,8 @@ fn assert_subscribe_topology_reports_revisioned_delta(server: &HeadlessServer) {
     let daemon = snapshot["daemon_instance_id"].as_str().unwrap();
     let session = snapshot["session_id"].as_str().unwrap();
     let revision = snapshot["revision"].as_u64().unwrap();
+    assert!(revision > 0, "topology replay requires a prior revision");
+    let replay_revision = revision - 1;
     let mut child = Command::new(bin())
         .args(["--socket"])
         .arg(&server.socket)
@@ -447,7 +446,7 @@ fn assert_subscribe_topology_reports_revisioned_delta(server: &HeadlessServer) {
             "--session-id",
             session,
             "--revision",
-            &revision.to_string(),
+            &replay_revision.to_string(),
         ])
         .env_remove("CMUX_TUI_SOCKET")
         .stdout(Stdio::piped())
@@ -465,28 +464,27 @@ fn assert_subscribe_topology_reports_revisioned_delta(server: &HeadlessServer) {
         }
     });
 
-    std::thread::sleep(Duration::from_millis(200));
+    let deadline = Instant::now() + Duration::from_secs(10);
+    let replay = rx
+        .recv_timeout(deadline.saturating_duration_since(Instant::now()))
+        .expect("subscribe-topology did not replay the prior topology delta");
+    let replay: serde_json::Value = serde_json::from_str(&replay).unwrap();
+    assert_eq!(replay["event"], "topology-delta");
+    assert_eq!(replay["base_revision"].as_u64(), Some(replay_revision));
+    assert_eq!(replay["revision"].as_u64(), Some(revision));
+
     assert_success(&cli(server, &["new-tab"]));
 
-    let deadline = Instant::now() + Duration::from_secs(10);
-    let mut lines = Vec::new();
-    while Instant::now() < deadline {
-        if let Ok(line) = rx.recv_timeout(Duration::from_millis(250)) {
-            lines.push(line.clone());
-            let value: serde_json::Value = serde_json::from_str(&line).unwrap();
-            if value["event"] == "topology-delta" {
-                assert_eq!(value["base_revision"].as_u64(), Some(revision));
-                assert_eq!(value["revision"].as_u64(), Some(revision + 1));
-                assert!(value["replacement"]["workspaces"].is_array());
-                let _ = child.kill();
-                let _ = child.wait();
-                return;
-            }
-        }
-    }
+    let line = rx
+        .recv_timeout(deadline.saturating_duration_since(Instant::now()))
+        .expect("subscribe-topology did not print the new topology delta");
+    let value: serde_json::Value = serde_json::from_str(&line).unwrap();
+    assert_eq!(value["event"], "topology-delta");
+    assert_eq!(value["base_revision"].as_u64(), Some(revision));
+    assert_eq!(value["revision"].as_u64(), Some(revision + 1));
+    assert!(value["replacement"]["workspaces"].is_array());
     let _ = child.kill();
     let _ = child.wait();
-    panic!("subscribe-topology did not print a topology delta; lines={lines:?}");
 }
 
 #[test]

--- a/cmuxTests/TerminalBackendTopologyCoordinatorTests.swift
+++ b/cmuxTests/TerminalBackendTopologyCoordinatorTests.swift
@@ -2914,8 +2914,9 @@ struct TerminalBackendTopologyCoordinatorTests {
                 projector: RecordingTopologyProjector()
             )
         }
+        defer { claimTask.cancel() }
 
-        await service.waitForActiveClaimCount(16)
+        try await service.waitForActiveClaimCount(16)
         #expect(await service.maximumConcurrentClaimCount() == 16)
         await service.releaseClaims()
         try await claimTask.value
@@ -4333,8 +4334,10 @@ private actor RecordingNativeBrowserService:
     private var activeClaimCount = 0
     private var maximumActiveClaimCount = 0
     private var blocksClaims = false
-    private var claimContinuations: [CheckedContinuation<Void, Never>] = []
-    private var activeClaimCountWaiters: [(Int, CheckedContinuation<Void, Never>)] = []
+    private var claimContinuations: [UUID: CheckedContinuation<Void, any Error>] = [:]
+    private var activeClaimCountWaiters: [
+        UUID: (count: Int, continuation: CheckedContinuation<Void, any Error>)
+    ] = [:]
     private var blocksFirstSourceUpdate = false
     private var firstSourceUpdateContinuation: CheckedContinuation<Void, Never>?
     private var failsSourceUpdates = false
@@ -4359,12 +4362,15 @@ private actor RecordingNativeBrowserService:
         ))
         activeClaimCount += 1
         maximumActiveClaimCount = max(maximumActiveClaimCount, activeClaimCount)
-        let satisfied = activeClaimCountWaiters.filter { $0.0 <= activeClaimCount }
-        activeClaimCountWaiters.removeAll { $0.0 <= activeClaimCount }
-        for waiter in satisfied { waiter.1.resume() }
+        let identifiers = activeClaimCountWaiters.compactMap { identifier, waiter in
+            waiter.count <= activeClaimCount ? identifier : nil
+        }
+        for identifier in identifiers {
+            activeClaimCountWaiters.removeValue(forKey: identifier)?.continuation.resume()
+        }
         defer { activeClaimCount -= 1 }
         if blocksClaims {
-            await withCheckedContinuation { claimContinuations.append($0) }
+            try await waitForClaimRelease()
         }
         let resolvedSource = retainedSources[surfaceID] ?? sourceURL
         if let resolvedSource {
@@ -4415,10 +4421,21 @@ private actor RecordingNativeBrowserService:
         blocksClaims = blocks
     }
 
-    func waitForActiveClaimCount(_ expectedCount: Int) async {
+    func waitForActiveClaimCount(_ expectedCount: Int) async throws {
         guard activeClaimCount < expectedCount else { return }
-        await withCheckedContinuation {
-            activeClaimCountWaiters.append((expectedCount, $0))
+        let identifier = UUID()
+        try await withTaskCancellationHandler {
+            try await withCheckedThrowingContinuation { continuation in
+                if Task.isCancelled {
+                    continuation.resume(throwing: CancellationError())
+                } else if activeClaimCount >= expectedCount {
+                    continuation.resume()
+                } else {
+                    activeClaimCountWaiters[identifier] = (expectedCount, continuation)
+                }
+            }
+        } onCancel: {
+            Task { await self.cancelActiveClaimCountWaiter(identifier) }
         }
     }
 
@@ -4426,7 +4443,36 @@ private actor RecordingNativeBrowserService:
         blocksClaims = false
         let continuations = claimContinuations
         claimContinuations.removeAll(keepingCapacity: false)
-        for continuation in continuations { continuation.resume() }
+        for continuation in continuations.values { continuation.resume() }
+    }
+
+    private func waitForClaimRelease() async throws {
+        let identifier = UUID()
+        try await withTaskCancellationHandler {
+            try await withCheckedThrowingContinuation { continuation in
+                if Task.isCancelled {
+                    continuation.resume(throwing: CancellationError())
+                } else if blocksClaims {
+                    claimContinuations[identifier] = continuation
+                } else {
+                    continuation.resume()
+                }
+            }
+        } onCancel: {
+            Task { await self.cancelClaimContinuation(identifier) }
+        }
+    }
+
+    private func cancelClaimContinuation(_ identifier: UUID) {
+        claimContinuations.removeValue(forKey: identifier)?.resume(
+            throwing: CancellationError()
+        )
+    }
+
+    private func cancelActiveClaimCountWaiter(_ identifier: UUID) {
+        activeClaimCountWaiters.removeValue(forKey: identifier)?.continuation.resume(
+            throwing: CancellationError()
+        )
     }
 
     func setBlocksFirstSourceUpdate(_ blocks: Bool) {

--- a/cmuxTests/TerminalBackendTopologyCoordinatorTests.swift
+++ b/cmuxTests/TerminalBackendTopologyCoordinatorTests.swift
@@ -2895,26 +2895,31 @@ struct TerminalBackendTopologyCoordinatorTests {
         #expect(await service.claimCallSnapshot().count == 1)
     }
 
-    @Test @MainActor
+    @Test(.timeLimit(.minutes(1))) @MainActor
     func nativeBrowserClaimsUseBoundedConcurrency() async throws {
         let authority = makeAuthority()
         let surfaceIDs = (0..<40).map { _ in SurfaceID(rawValue: UUID()) }
         let service = RecordingNativeBrowserService(authority: authority)
-        await service.setClaimDelay(nanoseconds: 10_000_000)
+        await service.setBlocksClaims(true)
         let runtime = TerminalBackendNativeBrowserRuntimeCoordinator(
             service: service,
             presentationRegistry: TerminalBackendNativeBrowserPresentationRegistry(),
             maximumConcurrentClaimCount: 16
         )
 
-        try await runtime.claimBeforeProjection(
-            authority: authority,
-            surfaceIDs: surfaceIDs,
-            projector: RecordingTopologyProjector()
-        )
+        let claimTask = Task {
+            try await runtime.claimBeforeProjection(
+                authority: authority,
+                surfaceIDs: surfaceIDs,
+                projector: RecordingTopologyProjector()
+            )
+        }
 
-        #expect(await service.claimCallSnapshot().count == surfaceIDs.count)
+        await service.waitForActiveClaimCount(16)
         #expect(await service.maximumConcurrentClaimCount() == 16)
+        await service.releaseClaims()
+        try await claimTask.value
+        #expect(await service.claimCallSnapshot().count == surfaceIDs.count)
     }
 
     @Test @MainActor
@@ -4327,7 +4332,9 @@ private actor RecordingNativeBrowserService:
     private var sourceUpdateCalls: [SourceUpdateCall] = []
     private var activeClaimCount = 0
     private var maximumActiveClaimCount = 0
-    private var claimDelayNanoseconds: UInt64 = 0
+    private var blocksClaims = false
+    private var claimContinuations: [CheckedContinuation<Void, Never>] = []
+    private var activeClaimCountWaiters: [(Int, CheckedContinuation<Void, Never>)] = []
     private var blocksFirstSourceUpdate = false
     private var firstSourceUpdateContinuation: CheckedContinuation<Void, Never>?
     private var failsSourceUpdates = false
@@ -4352,9 +4359,12 @@ private actor RecordingNativeBrowserService:
         ))
         activeClaimCount += 1
         maximumActiveClaimCount = max(maximumActiveClaimCount, activeClaimCount)
+        let satisfied = activeClaimCountWaiters.filter { $0.0 <= activeClaimCount }
+        activeClaimCountWaiters.removeAll { $0.0 <= activeClaimCount }
+        for waiter in satisfied { waiter.1.resume() }
         defer { activeClaimCount -= 1 }
-        if claimDelayNanoseconds > 0 {
-            try await Task.sleep(nanoseconds: claimDelayNanoseconds)
+        if blocksClaims {
+            await withCheckedContinuation { claimContinuations.append($0) }
         }
         let resolvedSource = retainedSources[surfaceID] ?? sourceURL
         if let resolvedSource {
@@ -4401,8 +4411,22 @@ private actor RecordingNativeBrowserService:
         )
     }
 
-    func setClaimDelay(nanoseconds: UInt64) {
-        claimDelayNanoseconds = nanoseconds
+    func setBlocksClaims(_ blocks: Bool) {
+        blocksClaims = blocks
+    }
+
+    func waitForActiveClaimCount(_ expectedCount: Int) async {
+        guard activeClaimCount < expectedCount else { return }
+        await withCheckedContinuation {
+            activeClaimCountWaiters.append((expectedCount, $0))
+        }
+    }
+
+    func releaseClaims() {
+        blocksClaims = false
+        let continuations = claimContinuations
+        claimContinuations.removeAll(keepingCapacity: false)
+        for continuation in continuations { continuation.resume() }
     }
 
     func setBlocksFirstSourceUpdate(_ blocks: Bool) {

--- a/cmuxTests/TerminalClientCompositionTests.swift
+++ b/cmuxTests/TerminalClientCompositionTests.swift
@@ -2121,7 +2121,7 @@ struct TerminalClientCompositionTests {
         #expect(Darwin.kill(firstDaemonPID, SIGKILL) == 0)
         firstDaemonProcess.waitUntilExit()
         await firstSession.disconnectEventStream()
-        await waitForEventSubscriptionCount(1, session: secondSession)
+        try await waitForEventSubscriptionCount(1, session: secondSession)
 
         let staleMetadata = try TerminalRenderFrameMetadata(
             daemonInstanceID: firstAuthority.daemonInstanceID.rawValue,
@@ -2159,13 +2159,23 @@ struct TerminalClientCompositionTests {
                 from: binding
             )
         }
-        await coordinator.debugWaitForRendererWorkerExitWaiterCount(1)
+        try await withReconnectTestTimeout(.seconds(5)) {
+            while await coordinator.debugRendererWorkerExitWaiterCount < 1 {
+                try Task.checkCancellation()
+                await Task.yield()
+            }
+        }
         #expect(rendererProcess.isRunning)
         #expect(await coordinator.debugRendererWorkerExitWaiterCount == 1)
 
         #expect(Darwin.kill(rendererPID, SIGCONT) == 0)
         #expect(Darwin.kill(rendererPID, SIGTERM) == 0)
-        await coordinator.debugWaitForRendererWorkerExitWaiterCount(0)
+        try await withReconnectTestTimeout(.seconds(5)) {
+            while await coordinator.debugRendererWorkerExitWaiterCount != 0 {
+                try Task.checkCancellation()
+                await Task.yield()
+            }
+        }
         try await releaseTask.value
         try await detachTask.value
         rendererProcess.waitUntilExit()
@@ -2273,13 +2283,22 @@ struct TerminalClientCompositionTests {
             }
             throw ReconnectSupervisorTestError.streamEnded
         }
-        await recoveryClock.waitUntilSleepers()
+        defer { recoveredRevisionTask.cancel() }
+        try await withReconnectTestTimeout(.seconds(5)) {
+            try await recoveryClock.waitUntilSleepers()
+        }
         recoveryClock.advance(by: .seconds(1))
-        await recoveryClock.waitUntilSleepers()
+        try await withReconnectTestTimeout(.seconds(5)) {
+            try await recoveryClock.waitUntilSleepers()
+        }
         recoveryClock.advance(by: .seconds(2))
-        await recoveryClock.waitUntilSleepers()
+        try await withReconnectTestTimeout(.seconds(5)) {
+            try await recoveryClock.waitUntilSleepers()
+        }
         recoveryClock.advance(by: .seconds(3))
-        let recoveredRevision = try await recoveredRevisionTask.value
+        let recoveredRevision = try await withReconnectTestTimeout(.seconds(5)) {
+            try await recoveredRevisionTask.value
+        }
 
         #expect(recoveredRevision == latestSnapshot.revision)
         #expect(await readiness.requestCount() >= 5)
@@ -2369,17 +2388,17 @@ struct TerminalClientCompositionTests {
         )
 
         await coordinator.start()
-        await waitForCompatibilityReportCount(1, reports: reports)
-        await waitForEventSubscriptionCount(1, session: firstSession)
+        try await waitForCompatibilityReportCount(1, reports: reports)
+        try await waitForEventSubscriptionCount(1, session: firstSession)
         #expect(await reports.recorded() == [readWrite])
 
         await firstSession.disconnectEventStream()
-        await waitForCompatibilityReportCount(3, reports: reports)
-        await waitForEventSubscriptionCount(1, session: secondSession)
+        try await waitForCompatibilityReportCount(3, reports: reports)
+        try await waitForEventSubscriptionCount(1, session: secondSession)
         #expect(await reports.recorded() == [readWrite, nil, readOnly])
 
         await coordinator.disconnectFrontend()
-        await waitForCompatibilityReportCount(4, reports: reports)
+        try await waitForCompatibilityReportCount(4, reports: reports)
         #expect(await reports.recorded() == [readWrite, nil, readOnly, nil])
         #expect(await firstSession.closeCount() == 1)
         #expect(await secondSession.closeCount() == 1)
@@ -2426,15 +2445,15 @@ struct TerminalClientCompositionTests {
         )
 
         await coordinator.start()
-        await waitForCompatibilityReportCount(1, reports: reports)
-        await waitForEventSubscriptionCount(1, session: session)
+        try await waitForCompatibilityReportCount(1, reports: reports)
+        try await waitForEventSubscriptionCount(1, session: session)
         #expect(await reports.recorded() == [readOnly])
         #expect(await session.connectCount() == 1)
         #expect(await session.closeCount() == 0)
         #expect(await lifecycle.activeIdentifiers() == ["diagnostic-only"])
 
         await coordinator.disconnectFrontend()
-        await waitForCompatibilityReportCount(2, reports: reports)
+        try await waitForCompatibilityReportCount(2, reports: reports)
         #expect(await reports.recorded() == [readOnly, nil])
         #expect(await session.closeCount() == 1)
         #expect(await lifecycle.activeIdentifiers().isEmpty)
@@ -2443,15 +2462,19 @@ struct TerminalClientCompositionTests {
     private func waitForCompatibilityReportCount(
         _ count: Int,
         reports: BackendCompatibilityReporterRecorder
-    ) async {
-        await reports.waitForCount(count)
+    ) async throws {
+        try await withReconnectTestTimeout(.seconds(5)) {
+            try await reports.waitForCount(count)
+        }
     }
 
     private func waitForEventSubscriptionCount(
         _ count: Int,
         session: OverflowingBackendSession
-    ) async {
-        await session.waitForEventSubscriptionCount(count)
+    ) async throws {
+        try await withReconnectTestTimeout(.seconds(5)) {
+            try await session.waitForEventSubscriptionCount(count)
+        }
     }
 
     @MainActor
@@ -3555,7 +3578,9 @@ private final class TerminalBackendManualClock: Clock, @unchecked Sendable {
     private var currentInstant = Instant(offset: .zero)
     private var sleepers: [UUID: Sleeper] = [:]
     private var cancelledSleeperIDs: Set<UUID> = []
-    private var parkWaiters: [(Int, CheckedContinuation<Void, Never>)] = []
+    private var parkWaiters: [
+        UUID: (count: Int, continuation: CheckedContinuation<Void, any Error>)
+    ] = [:]
 
     var now: Instant {
         lock.lock()
@@ -3598,17 +3623,28 @@ private final class TerminalBackendManualClock: Clock, @unchecked Sendable {
         }
     }
 
-    func waitUntilSleepers(count: Int = 1) async {
-        await withCheckedContinuation {
-            (continuation: CheckedContinuation<Void, Never>) in
-            lock.lock()
-            if sleepers.count >= count {
-                lock.unlock()
-                continuation.resume()
-                return
+    func waitUntilSleepers(count: Int = 1) async throws {
+        let identifier = UUID()
+        try await withTaskCancellationHandler {
+            try await withCheckedThrowingContinuation {
+                (continuation: CheckedContinuation<Void, any Error>) in
+                lock.lock()
+                if Task.isCancelled {
+                    lock.unlock()
+                    continuation.resume(throwing: CancellationError())
+                } else if sleepers.count >= count {
+                    lock.unlock()
+                    continuation.resume()
+                } else {
+                    parkWaiters[identifier] = (count, continuation)
+                    lock.unlock()
+                }
             }
-            parkWaiters.append((count, continuation))
+        } onCancel: {
+            lock.lock()
+            let waiter = parkWaiters.removeValue(forKey: identifier)
             lock.unlock()
+            waiter?.continuation.resume(throwing: CancellationError())
         }
     }
 
@@ -3626,19 +3662,38 @@ private final class TerminalBackendManualClock: Clock, @unchecked Sendable {
         }
     }
 
-    private func takeSatisfiedParkWaitersLocked() -> [CheckedContinuation<Void, Never>] {
-        var satisfied: [CheckedContinuation<Void, Never>] = []
-        parkWaiters.removeAll { waiter in
-            guard sleepers.count >= waiter.0 else { return false }
-            satisfied.append(waiter.1)
-            return true
+    private func takeSatisfiedParkWaitersLocked() -> [CheckedContinuation<Void, any Error>] {
+        let identifiers = parkWaiters.compactMap { identifier, waiter in
+            sleepers.count >= waiter.count ? identifier : nil
         }
-        return satisfied
+        return identifiers.compactMap {
+            parkWaiters.removeValue(forKey: $0)?.continuation
+        }
     }
 }
 
 private enum ReconnectSupervisorTestError: Error {
+    case timedOut
     case streamEnded
+}
+
+private func withReconnectTestTimeout<Value: Sendable>(
+    _ duration: Duration,
+    clock: ContinuousClock = ContinuousClock(),
+    operation: @escaping @Sendable () async throws -> Value
+) async throws -> Value {
+    try await withThrowingTaskGroup(of: Value.self) { group in
+        group.addTask(operation: operation)
+        group.addTask {
+            try await clock.sleep(for: duration)
+            throw ReconnectSupervisorTestError.timedOut
+        }
+        defer { group.cancelAll() }
+        guard let value = try await group.next() else {
+            throw ReconnectSupervisorTestError.streamEnded
+        }
+        return value
+    }
 }
 
 private actor ScriptedBackendReadiness {
@@ -3682,22 +3737,46 @@ private actor BackendSessionLifecycleRecorder {
 
 private actor BackendCompatibilityReporterRecorder {
     private var reports: [BackendCompatibilityResult?] = []
-    private var countWaiters: [(Int, CheckedContinuation<Void, Never>)] = []
+    private var countWaiters: [
+        UUID: (count: Int, continuation: CheckedContinuation<Void, any Error>)
+    ] = [:]
 
     func record(_ compatibility: BackendCompatibilityResult?) {
         reports.append(compatibility)
-        let satisfied = countWaiters.filter { $0.0 <= reports.count }
-        countWaiters.removeAll { $0.0 <= reports.count }
-        for waiter in satisfied { waiter.1.resume() }
+        let identifiers = countWaiters.compactMap { identifier, waiter in
+            waiter.count <= reports.count ? identifier : nil
+        }
+        for identifier in identifiers {
+            countWaiters.removeValue(forKey: identifier)?.continuation.resume()
+        }
     }
 
     func count() -> Int { reports.count }
 
     func recorded() -> [BackendCompatibilityResult?] { reports }
 
-    func waitForCount(_ expectedCount: Int) async {
+    func waitForCount(_ expectedCount: Int) async throws {
         guard reports.count < expectedCount else { return }
-        await withCheckedContinuation { countWaiters.append((expectedCount, $0)) }
+        let identifier = UUID()
+        try await withTaskCancellationHandler {
+            try await withCheckedThrowingContinuation { continuation in
+                if Task.isCancelled {
+                    continuation.resume(throwing: CancellationError())
+                } else if reports.count >= expectedCount {
+                    continuation.resume()
+                } else {
+                    countWaiters[identifier] = (expectedCount, continuation)
+                }
+            }
+        } onCancel: {
+            Task { await self.cancelCountWaiter(identifier) }
+        }
+    }
+
+    private func cancelCountWaiter(_ identifier: UUID) {
+        countWaiters.removeValue(forKey: identifier)?.continuation.resume(
+            throwing: CancellationError()
+        )
     }
 }
 
@@ -3891,7 +3970,9 @@ private actor OverflowingBackendSession: TerminalBackendSessionServing {
     private let rendererSerialization: RendererSerializationSessionHarness?
     private var stableContinuation: AsyncStream<BackendCanonicalSessionEvent>.Continuation?
     private var recordedEventSubscriptionCount = 0
-    private var eventSubscriptionCountWaiters: [(Int, CheckedContinuation<Void, Never>)] = []
+    private var eventSubscriptionCountWaiters: [
+        UUID: (count: Int, continuation: CheckedContinuation<Void, any Error>)
+    ] = [:]
     private var recordedConnectCount = 0
     private var recordedCloseCount = 0
     private var isOpen = false
@@ -3919,13 +4000,12 @@ private actor OverflowingBackendSession: TerminalBackendSessionServing {
 
     func events() -> AsyncStream<BackendCanonicalSessionEvent> {
         recordedEventSubscriptionCount += 1
-        let satisfied = eventSubscriptionCountWaiters.filter {
-            $0.0 <= recordedEventSubscriptionCount
+        let identifiers = eventSubscriptionCountWaiters.compactMap { identifier, waiter in
+            waiter.count <= recordedEventSubscriptionCount ? identifier : nil
         }
-        eventSubscriptionCountWaiters.removeAll {
-            $0.0 <= recordedEventSubscriptionCount
+        for identifier in identifiers {
+            eventSubscriptionCountWaiters.removeValue(forKey: identifier)?.continuation.resume()
         }
-        for waiter in satisfied { waiter.1.resume() }
         let pair = AsyncStream<BackendCanonicalSessionEvent>.makeStream(
             bufferingPolicy: .bufferingOldest(256)
         )
@@ -3960,11 +4040,28 @@ private actor OverflowingBackendSession: TerminalBackendSessionServing {
 
     func eventSubscriptionCount() -> Int { recordedEventSubscriptionCount }
 
-    func waitForEventSubscriptionCount(_ expectedCount: Int) async {
+    func waitForEventSubscriptionCount(_ expectedCount: Int) async throws {
         guard recordedEventSubscriptionCount < expectedCount else { return }
-        await withCheckedContinuation {
-            eventSubscriptionCountWaiters.append((expectedCount, $0))
+        let identifier = UUID()
+        try await withTaskCancellationHandler {
+            try await withCheckedThrowingContinuation { continuation in
+                if Task.isCancelled {
+                    continuation.resume(throwing: CancellationError())
+                } else if recordedEventSubscriptionCount >= expectedCount {
+                    continuation.resume()
+                } else {
+                    eventSubscriptionCountWaiters[identifier] = (expectedCount, continuation)
+                }
+            }
+        } onCancel: {
+            Task { await self.cancelEventSubscriptionCountWaiter(identifier) }
         }
+    }
+
+    private func cancelEventSubscriptionCountWaiter(_ identifier: UUID) {
+        eventSubscriptionCountWaiters.removeValue(forKey: identifier)?.continuation.resume(
+            throwing: CancellationError()
+        )
     }
 
     func connect() async throws -> TopologySnapshot? {

--- a/cmuxTests/TerminalClientCompositionTests.swift
+++ b/cmuxTests/TerminalClientCompositionTests.swift
@@ -2121,7 +2121,7 @@ struct TerminalClientCompositionTests {
         #expect(Darwin.kill(firstDaemonPID, SIGKILL) == 0)
         firstDaemonProcess.waitUntilExit()
         await firstSession.disconnectEventStream()
-        try await waitForEventSubscriptionCount(1, session: secondSession)
+        await waitForEventSubscriptionCount(1, session: secondSession)
 
         let staleMetadata = try TerminalRenderFrameMetadata(
             daemonInstanceID: firstAuthority.daemonInstanceID.rawValue,
@@ -2159,23 +2159,13 @@ struct TerminalClientCompositionTests {
                 from: binding
             )
         }
-        try await withReconnectTestTimeout(.seconds(5)) {
-            while await coordinator.debugRendererWorkerExitWaiterCount < 1 {
-                try Task.checkCancellation()
-                await Task.yield()
-            }
-        }
+        await coordinator.debugWaitForRendererWorkerExitWaiterCount(1)
         #expect(rendererProcess.isRunning)
         #expect(await coordinator.debugRendererWorkerExitWaiterCount == 1)
 
         #expect(Darwin.kill(rendererPID, SIGCONT) == 0)
         #expect(Darwin.kill(rendererPID, SIGTERM) == 0)
-        try await withReconnectTestTimeout(.seconds(5)) {
-            while await coordinator.debugRendererWorkerExitWaiterCount != 0 {
-                try Task.checkCancellation()
-                await Task.yield()
-            }
-        }
+        await coordinator.debugWaitForRendererWorkerExitWaiterCount(0)
         try await releaseTask.value
         try await detachTask.value
         rendererProcess.waitUntilExit()
@@ -2252,19 +2242,21 @@ struct TerminalClientCompositionTests {
                 revision: latestSnapshot.revision
             )),
         ])
+        let recoveryClock = TerminalBackendManualClock()
         let coordinator = TerminalBackendClientCoordinator(
             readinessProvider: { await readiness.next() },
             sessionFactory: { proof in
                 proof.processID == 41 ? firstSession : secondSession
             },
             reconnectPolicy: TerminalBackendReconnectPolicy(
-                delays: [.zero, .zero],
-                recoveryCycleDelay: .zero
-            )
+                delays: [.seconds(1), .seconds(2)],
+                recoveryCycleDelay: .seconds(3)
+            ),
+            recoveryClock: recoveryClock
         )
 
         let events = try await coordinator.canonicalTopologyEvents()
-        let recoveredRevision = try await withReconnectTestTimeout(.seconds(5)) {
+        let recoveredRevisionTask = Task { () throws -> UInt64 in
             for await event in events {
                 let revision: UInt64?
                 switch event {
@@ -2281,6 +2273,13 @@ struct TerminalClientCompositionTests {
             }
             throw ReconnectSupervisorTestError.streamEnded
         }
+        await recoveryClock.waitUntilSleepers()
+        recoveryClock.advance(by: .seconds(1))
+        await recoveryClock.waitUntilSleepers()
+        recoveryClock.advance(by: .seconds(2))
+        await recoveryClock.waitUntilSleepers()
+        recoveryClock.advance(by: .seconds(3))
+        let recoveredRevision = try await recoveredRevisionTask.value
 
         #expect(recoveredRevision == latestSnapshot.revision)
         #expect(await readiness.requestCount() >= 5)
@@ -2370,17 +2369,17 @@ struct TerminalClientCompositionTests {
         )
 
         await coordinator.start()
-        try await waitForCompatibilityReportCount(1, reports: reports)
-        try await waitForEventSubscriptionCount(1, session: firstSession)
+        await waitForCompatibilityReportCount(1, reports: reports)
+        await waitForEventSubscriptionCount(1, session: firstSession)
         #expect(await reports.recorded() == [readWrite])
 
         await firstSession.disconnectEventStream()
-        try await waitForCompatibilityReportCount(3, reports: reports)
-        try await waitForEventSubscriptionCount(1, session: secondSession)
+        await waitForCompatibilityReportCount(3, reports: reports)
+        await waitForEventSubscriptionCount(1, session: secondSession)
         #expect(await reports.recorded() == [readWrite, nil, readOnly])
 
         await coordinator.disconnectFrontend()
-        try await waitForCompatibilityReportCount(4, reports: reports)
+        await waitForCompatibilityReportCount(4, reports: reports)
         #expect(await reports.recorded() == [readWrite, nil, readOnly, nil])
         #expect(await firstSession.closeCount() == 1)
         #expect(await secondSession.closeCount() == 1)
@@ -2427,15 +2426,15 @@ struct TerminalClientCompositionTests {
         )
 
         await coordinator.start()
-        try await waitForCompatibilityReportCount(1, reports: reports)
-        try await waitForEventSubscriptionCount(1, session: session)
+        await waitForCompatibilityReportCount(1, reports: reports)
+        await waitForEventSubscriptionCount(1, session: session)
         #expect(await reports.recorded() == [readOnly])
         #expect(await session.connectCount() == 1)
         #expect(await session.closeCount() == 0)
         #expect(await lifecycle.activeIdentifiers() == ["diagnostic-only"])
 
         await coordinator.disconnectFrontend()
-        try await waitForCompatibilityReportCount(2, reports: reports)
+        await waitForCompatibilityReportCount(2, reports: reports)
         #expect(await reports.recorded() == [readOnly, nil])
         #expect(await session.closeCount() == 1)
         #expect(await lifecycle.activeIdentifiers().isEmpty)
@@ -2444,23 +2443,15 @@ struct TerminalClientCompositionTests {
     private func waitForCompatibilityReportCount(
         _ count: Int,
         reports: BackendCompatibilityReporterRecorder
-    ) async throws {
-        try await withReconnectTestTimeout(.seconds(5)) {
-            while await reports.count() < count {
-                await Task.yield()
-            }
-        }
+    ) async {
+        await reports.waitForCount(count)
     }
 
     private func waitForEventSubscriptionCount(
         _ count: Int,
         session: OverflowingBackendSession
-    ) async throws {
-        try await withReconnectTestTimeout(.seconds(5)) {
-            while await session.eventSubscriptionCount() < count {
-                await Task.yield()
-            }
-        }
+    ) async {
+        await session.waitForEventSubscriptionCount(count)
     }
 
     @MainActor
@@ -3546,27 +3537,108 @@ actor RecordingExternalTerminalService: TerminalBackendExternalTerminalServing,
     }
 }
 
-private enum ReconnectSupervisorTestError: Error {
-    case timedOut
-    case streamEnded
+private final class TerminalBackendManualClock: Clock, @unchecked Sendable {
+    struct Instant: InstantProtocol, Sendable {
+        var offset: Duration
+
+        func advanced(by duration: Duration) -> Instant { Instant(offset: offset + duration) }
+        func duration(to other: Instant) -> Duration { other.offset - offset }
+        static func < (lhs: Instant, rhs: Instant) -> Bool { lhs.offset < rhs.offset }
+    }
+
+    private struct Sleeper {
+        let deadline: Instant
+        let continuation: CheckedContinuation<Void, any Error>
+    }
+
+    private let lock = NSLock()
+    private var currentInstant = Instant(offset: .zero)
+    private var sleepers: [UUID: Sleeper] = [:]
+    private var cancelledSleeperIDs: Set<UUID> = []
+    private var parkWaiters: [(Int, CheckedContinuation<Void, Never>)] = []
+
+    var now: Instant {
+        lock.lock()
+        defer { lock.unlock() }
+        return currentInstant
+    }
+
+    var minimumResolution: Duration { .zero }
+
+    func sleep(until deadline: Instant, tolerance: Duration?) async throws {
+        let identifier = UUID()
+        try await withTaskCancellationHandler {
+            try await withCheckedThrowingContinuation {
+                (continuation: CheckedContinuation<Void, any Error>) in
+                lock.lock()
+                if cancelledSleeperIDs.remove(identifier) != nil {
+                    lock.unlock()
+                    continuation.resume(throwing: CancellationError())
+                    return
+                }
+                if deadline <= currentInstant {
+                    lock.unlock()
+                    continuation.resume()
+                    return
+                }
+                sleepers[identifier] = Sleeper(
+                    deadline: deadline,
+                    continuation: continuation
+                )
+                let waiters = takeSatisfiedParkWaitersLocked()
+                lock.unlock()
+                for waiter in waiters { waiter.resume() }
+            }
+        } onCancel: {
+            lock.lock()
+            let sleeper = sleepers.removeValue(forKey: identifier)
+            if sleeper == nil { cancelledSleeperIDs.insert(identifier) }
+            lock.unlock()
+            sleeper?.continuation.resume(throwing: CancellationError())
+        }
+    }
+
+    func waitUntilSleepers(count: Int = 1) async {
+        await withCheckedContinuation {
+            (continuation: CheckedContinuation<Void, Never>) in
+            lock.lock()
+            if sleepers.count >= count {
+                lock.unlock()
+                continuation.resume()
+                return
+            }
+            parkWaiters.append((count, continuation))
+            lock.unlock()
+        }
+    }
+
+    func advance(by duration: Duration) {
+        lock.lock()
+        currentInstant = currentInstant.advanced(by: duration)
+        var due: [Sleeper] = []
+        for (identifier, sleeper) in sleepers where sleeper.deadline <= currentInstant {
+            sleepers[identifier] = nil
+            due.append(sleeper)
+        }
+        lock.unlock()
+        for sleeper in due.sorted(by: { $0.deadline < $1.deadline }) {
+            sleeper.continuation.resume()
+        }
+    }
+
+    private func takeSatisfiedParkWaitersLocked() -> [CheckedContinuation<Void, Never>] {
+        var satisfied: [CheckedContinuation<Void, Never>] = []
+        parkWaiters.removeAll { waiter in
+            guard sleepers.count >= waiter.0 else { return false }
+            satisfied.append(waiter.1)
+            return true
+        }
+        return satisfied
+    }
 }
 
-private func withReconnectTestTimeout<Value: Sendable>(
-    _ duration: Duration,
-    operation: @escaping @Sendable () async throws -> Value
-) async throws -> Value {
-    try await withThrowingTaskGroup(of: Value.self) { group in
-        group.addTask(operation: operation)
-        group.addTask {
-            try await ContinuousClock().sleep(for: duration)
-            throw ReconnectSupervisorTestError.timedOut
-        }
-        defer { group.cancelAll() }
-        guard let value = try await group.next() else {
-            throw ReconnectSupervisorTestError.streamEnded
-        }
-        return value
-    }
+private enum ReconnectSupervisorTestError: Error {
+    case streamEnded
 }
 
 private actor ScriptedBackendReadiness {
@@ -3610,14 +3682,23 @@ private actor BackendSessionLifecycleRecorder {
 
 private actor BackendCompatibilityReporterRecorder {
     private var reports: [BackendCompatibilityResult?] = []
+    private var countWaiters: [(Int, CheckedContinuation<Void, Never>)] = []
 
     func record(_ compatibility: BackendCompatibilityResult?) {
         reports.append(compatibility)
+        let satisfied = countWaiters.filter { $0.0 <= reports.count }
+        countWaiters.removeAll { $0.0 <= reports.count }
+        for waiter in satisfied { waiter.1.resume() }
     }
 
     func count() -> Int { reports.count }
 
     func recorded() -> [BackendCompatibilityResult?] { reports }
+
+    func waitForCount(_ expectedCount: Int) async {
+        guard reports.count < expectedCount else { return }
+        await withCheckedContinuation { countWaiters.append((expectedCount, $0)) }
+    }
 }
 
 private actor RendererSerializationSessionHarness {
@@ -3810,6 +3891,7 @@ private actor OverflowingBackendSession: TerminalBackendSessionServing {
     private let rendererSerialization: RendererSerializationSessionHarness?
     private var stableContinuation: AsyncStream<BackendCanonicalSessionEvent>.Continuation?
     private var recordedEventSubscriptionCount = 0
+    private var eventSubscriptionCountWaiters: [(Int, CheckedContinuation<Void, Never>)] = []
     private var recordedConnectCount = 0
     private var recordedCloseCount = 0
     private var isOpen = false
@@ -3837,6 +3919,13 @@ private actor OverflowingBackendSession: TerminalBackendSessionServing {
 
     func events() -> AsyncStream<BackendCanonicalSessionEvent> {
         recordedEventSubscriptionCount += 1
+        let satisfied = eventSubscriptionCountWaiters.filter {
+            $0.0 <= recordedEventSubscriptionCount
+        }
+        eventSubscriptionCountWaiters.removeAll {
+            $0.0 <= recordedEventSubscriptionCount
+        }
+        for waiter in satisfied { waiter.1.resume() }
         let pair = AsyncStream<BackendCanonicalSessionEvent>.makeStream(
             bufferingPolicy: .bufferingOldest(256)
         )
@@ -3870,6 +3959,13 @@ private actor OverflowingBackendSession: TerminalBackendSessionServing {
     }
 
     func eventSubscriptionCount() -> Int { recordedEventSubscriptionCount }
+
+    func waitForEventSubscriptionCount(_ expectedCount: Int) async {
+        guard recordedEventSubscriptionCount < expectedCount else { return }
+        await withCheckedContinuation {
+            eventSubscriptionCountWaiters.append((expectedCount, $0))
+        }
+    }
 
     func connect() async throws -> TopologySnapshot? {
         recordedConnectCount += 1

--- a/tests/test_terminal_backend_versioned_install.sh
+++ b/tests/test_terminal_backend_versioned_install.sh
@@ -6,6 +6,7 @@ TEST_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/cmux-versioned-backend.XXXXXX")"
 BACKEND_PID=""
 WORKER_PID_FILE="$TEST_ROOT/worker.pid"
 RENDER_LOG="$TEST_ROOT/render.log"
+RENDER_EVENT_PIPE="$TEST_ROOT/render-event.pipe"
 BUILD_V1="1111111111111111111111111111111111111111111111111111111111111111"
 BUILD_V2="2222222222222222222222222222222222222222222222222222222222222222"
 VERSIONS="$TEST_ROOT/Application Support/cmux/terminal-backend/com.cmuxterm.test/versions"
@@ -20,6 +21,7 @@ stop_backend() {
 
 cleanup() {
   stop_backend
+  exec 9>&-
   rm -rf "$TEST_ROOT"
 }
 trap cleanup EXIT
@@ -49,6 +51,7 @@ BACKEND
   cat > "$directory/cmux-terminal-renderer" <<RENDERER
 #!/usr/bin/env bash
 printf '%s\n' '$version' >> "\$1"
+printf '%s\n' '$version' > "\$CMUX_TEST_RENDER_EVENT_PIPE"
 exec /usr/bin/tail -f /dev/null
 RENDERER
   printf '%s\n' "$build_id" > "$directory/cmux-terminal-backend.build-id"
@@ -77,6 +80,7 @@ start_descriptor() {
   local program
   program="$(/usr/libexec/PlistBuddy -c 'Print :Program' "$LAUNCH_PLIST")"
   CMUX_TEST_RENDER_LOG="$RENDER_LOG" \
+    CMUX_TEST_RENDER_EVENT_PIPE="$RENDER_EVENT_PIPE" \
     CMUX_TEST_WORKER_PID_FILE="$WORKER_PID_FILE" \
     "$program" &
   BACKEND_PID=$!
@@ -84,17 +88,14 @@ start_descriptor() {
 
 wait_for_render_count() {
   local expected="$1"
-  local count=0
-  for _ in {1..250}; do
-    count="$(wc -l < "$RENDER_LOG" 2>/dev/null || true)"
-    [[ "$count" -ge "$expected" ]] && return 0
-    kill -0 "$BACKEND_PID" 2>/dev/null || return 1
-    sleep 0.02
-  done
-  return 1
+  local event
+  IFS= read -r -t 5 -u 9 event || return 1
+  [[ "$(wc -l < "$RENDER_LOG")" -ge "$expected" ]]
 }
 
 mkdir -p "$VERSIONS"
+mkfifo "$RENDER_EVENT_PIPE"
+exec 9<> "$RENDER_EVENT_PIPE"
 : > "$RENDER_LOG"
 chmod 0700 "$TEST_ROOT/Application Support" "$TEST_ROOT/Application Support/cmux" \
   "$TEST_ROOT/Application Support/cmux/terminal-backend" \


### PR DESCRIPTION
## Summary

- Inject cancellable clocks into terminal backend recovery and readiness paths.
- Replace the nine designated test sleeps with deterministic events, manual time, or bounded process waits.
- Keep the proven 5-second and 10-second failure deadlines.

## Ownership

This branch is the exact remote head of https://github.com/manaflow-ai/cmux/pull/8378 plus the sleep removal and one mechanical rustfmt correction. It excludes all 134 unpublished commits and all uncommitted files in the protected worktree.

Main reconciliation is deferred until those 134 commits have a confirmed owner and remote branch.

## Verification

- Exact-head Swift run: https://github.com/manaflow-ai/cmux/actions/runs/31353904842
- Unchanged-parent Swift baseline: https://github.com/manaflow-ai/cmux/actions/runs/31355685942
- Exact-head macOS, Linux, and Windows run: https://github.com/manaflow-ai/cmux/actions/runs/31353157393
- GhosttyKit artifact build: https://github.com/manaflow-ai/cmux/actions/runs/31353541559
- GhosttyKit release: https://github.com/manaflow-ai/ghostty/releases/tag/xcframework-0e750d5d03807bbdf7c9e971f335629c61d94381-crashsubdir-cmux-crash-v1
- Local shell behavior test: `bash tests/test_terminal_backend_versioned_install.sh`
- `git diff --check`

Windows passes. The exact-head and unchanged-parent Swift runs both stop at the same parent errors in `UnixBackendTransport.swift:480` and `:502`. The tagged macOS build stops at the same errors, so it produced no app.

The macOS and Linux Rust jobs stop at 57 clippy errors in parent feature code before the tests. None of those errors is on a sleep-removal line. The Windows job compiles and passes with `wait-timeout`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are mostly test harness and optional clock injection with production defaults unchanged; reconnect/readiness timing behavior should match prior `ContinuousClock` usage.
> 
> **Overview**
> Replaces **real-time sleeps and poll loops** in terminal backend tests with **injectable `Clock<Duration>`** and deterministic advancement, while production paths still default to `ContinuousClock()`.
> 
> **Swift production/test plumbing:** `BackendServiceReadinessProbe`, `BackendServiceReadinessDeadline`, and `TerminalBackendClientCoordinator` take a clock for readiness deadlines, reconnect backoff, and recovery-cycle delays. New `BackendReadinessManualClock` (and a parallel test helper in client composition tests) lets tests `advance(by:)` and `waitUntilSleepers()` instead of `Task.sleep`. Readiness and reconnect supervisor tests drive bounded-deadline and trust-verifier scenarios with explicit time steps; native-browser concurrency tests block claims until release instead of artificial claim delays.
> 
> **Rust / shell tests:** CLI integration uses `wait-timeout` for process exit; topology subscribe tests wait on replay/delta events with bounded `recv_timeout`; mux persistence tests wait on topology subscriptions instead of sleeping; initial-input child tests use a parent **TCP lifetime channel** instead of polling `getppid()`. The versioned-backend shell script waits on a **FIFO render-event pipe** instead of polling the render log.
> 
> Minor formatting-only tweaks in `model.rs` are included.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c5be156aeed5641b68c77080eb74884c17a42f1f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->