### PR TITLE
Add valid Windows ConPTY resize coverage

### DIFF
--- a/.github/workflows/cmux-tui-build-package.yml
+++ b/.github/workflows/cmux-tui-build-package.yml
@@ -477,6 +477,13 @@ jobs:
           cd ../cmux-tui
           cargo build -p cmux-tui --bin cmux-tui --release --locked --target x86_64-pc-windows-gnu
 
+      - name: Verify Windows ConPTY resize
+        shell: bash
+        run: |
+          python -m pip install --disable-pip-version-check pywinpty
+          python cmux-tui/scripts/smoke-windows-conpty-resize.py \
+            --binary cmux-tui/target/x86_64-pc-windows-gnu/release/cmux-tui.exe
+
       - name: Verify remote commands fail clearly on Windows
         shell: bash
         run: |

--- a/.github/workflows/cmux-tui-build-package.yml
+++ b/.github/workflows/cmux-tui-build-package.yml
@@ -477,10 +477,16 @@ jobs:
           cd ../cmux-tui
           cargo build -p cmux-tui --bin cmux-tui --release --locked --target x86_64-pc-windows-gnu
 
+      - name: Set up Python for ConPTY verification
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
+        with:
+          python-version: "3.12.11"
+
       - name: Verify Windows ConPTY resize
         shell: bash
         run: |
-          python -m pip install --disable-pip-version-check pywinpty
+          python -m pip install --disable-pip-version-check --require-hashes \
+            -r cmux-tui/scripts/requirements-windows-conpty.txt
           python cmux-tui/scripts/smoke-windows-conpty-resize.py \
             --binary cmux-tui/target/x86_64-pc-windows-gnu/release/cmux-tui.exe
 

--- a/.github/workflows/cmux-tui-build-package.yml
+++ b/.github/workflows/cmux-tui-build-package.yml
@@ -492,7 +492,7 @@ jobs:
       - name: Set up Python for ConPTY verification
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
-          python-version: "3.12.11"
+          python-version: "3.12.10"
 
       - name: Verify Windows ConPTY resize
         shell: bash

--- a/cmux-tui/scripts/requirements-windows-conpty.txt
+++ b/cmux-tui/scripts/requirements-windows-conpty.txt
@@ -1,0 +1,2 @@
+pywinpty==3.0.5 \
+    --hash=sha256:d62946adf14b15b54c0b8d785f93fe18b04da23f4ad59e2e8c4612646e9abd23

--- a/cmux-tui/scripts/smoke-windows-conpty-resize.py
+++ b/cmux-tui/scripts/smoke-windows-conpty-resize.py
@@ -1,0 +1,197 @@
+#!/usr/bin/env python3
+"""Verify that a Windows ConPTY resize reaches the attached terminal."""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import json
+import os
+from pathlib import Path
+import queue
+import subprocess
+import tempfile
+import threading
+import time
+import uuid
+
+from winpty import PtyProcess
+
+
+TIMEOUT_SECONDS = 20.0
+CREATE_NEW_PROCESS_GROUP = 0x00000200
+
+
+def run_cli(binary: Path, socket_path: Path, env: dict[str, str], *args: str) -> subprocess.CompletedProcess[str]:
+    result = subprocess.run(
+        [str(binary), "--socket", str(socket_path), "--json", *args],
+        env=env,
+        stdin=subprocess.DEVNULL,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        timeout=TIMEOUT_SECONDS,
+        check=False,
+        creationflags=CREATE_NEW_PROCESS_GROUP,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(
+            f"cmux-tui command failed ({result.returncode}): {result.args!r}\n"
+            f"stdout: {result.stdout}\nstderr: {result.stderr}"
+        )
+    return result
+
+
+def wait_for_socket(server: subprocess.Popen[bytes], socket_path: Path) -> None:
+    deadline = time.monotonic() + TIMEOUT_SECONDS
+    while time.monotonic() < deadline:
+        if socket_path.exists():
+            return
+        code = server.poll()
+        if code is not None:
+            stdout, stderr = server.communicate()
+            raise RuntimeError(
+                f"server exited before socket publication with code {code}\n"
+                f"stdout:\n{stdout.decode('utf-8', errors='replace')}\n"
+                f"stderr:\n{stderr.decode('utf-8', errors='replace')}"
+            )
+        time.sleep(0.01)
+    raise TimeoutError(f"server did not publish {socket_path}")
+
+
+def wait_for_first_output(pty: PtyProcess) -> None:
+    events: queue.Queue[BaseException | None] = queue.Queue()
+
+    def read() -> None:
+        try:
+            chunk = pty.read(8192)
+            if not chunk:
+                raise RuntimeError("attach closed before it produced output")
+            events.put(None)
+            while pty.read(8192):
+                pass
+        except (EOFError, OSError):
+            return
+        except BaseException as error:
+            events.put(error)
+
+    threading.Thread(target=read, name="conpty-resize-reader", daemon=True).start()
+    result = events.get(timeout=TIMEOUT_SECONDS)
+    if result is not None:
+        raise result
+
+
+def wait_for_screen_size(
+    binary: Path,
+    socket_path: Path,
+    env: dict[str, str],
+    terminal: str,
+    cols: int,
+    rows: int,
+) -> None:
+    deadline = time.monotonic() + TIMEOUT_SECONDS
+    last_screen = None
+    while time.monotonic() < deadline:
+        screen = run_cli(binary, socket_path, env, "terminal", terminal, "screen", "read")
+        value = json.loads(screen.stdout)
+        if isinstance(value, dict):
+            value = value.get("value", value)
+        last_screen = value
+        if isinstance(value, dict) and value.get("cols") == cols and value.get("rows") == rows:
+            return
+        time.sleep(0.01)
+    raise TimeoutError(f"screen did not reach {cols}x{rows}: {last_screen!r}")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--binary", type=Path, required=True)
+    args = parser.parse_args()
+    binary = args.binary.resolve()
+
+    with tempfile.TemporaryDirectory(prefix="cmux-conpty-resize-") as temporary:
+        root = Path(temporary)
+        state = root / "state"
+        state.mkdir()
+        (state / "machine-id").write_bytes(f"machine_{uuid.uuid4().hex}\n".encode())
+        (state / "resource-effect-pepper").write_bytes(os.urandom(32))
+        socket_path = root / "server.sock"
+        config = root / "config.json"
+        config.write_text("{}\n", encoding="utf-8")
+        env = os.environ.copy()
+        env["CMUX_TUI_CONFIG"] = str(config)
+        server = subprocess.Popen(
+            [
+                str(binary),
+                "--headless",
+                "--session",
+                "windows-conpty-resize",
+                "--socket",
+                str(socket_path),
+                "--state",
+                str(state),
+            ],
+            env=env,
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            creationflags=CREATE_NEW_PROCESS_GROUP,
+        )
+        pty = None
+        try:
+            wait_for_socket(server, socket_path)
+            created = run_cli(binary, socket_path, env, "workspace", "create", "--name", "resize-check")
+            value = json.loads(created.stdout)
+            if isinstance(value, dict):
+                value = value.get("value", value)
+            terminal = value.get("terminal_id") if isinstance(value, dict) else None
+            if not isinstance(terminal, str):
+                raise RuntimeError(f"workspace creation had no terminal id: {created.stdout}")
+
+            pty = PtyProcess.spawn(
+                [str(binary), "attach", "--socket", str(socket_path), "--terminal", terminal],
+                cwd=str(root),
+                env=env,
+                dimensions=(24, 80),
+            )
+            wait_for_first_output(pty)
+            pty.setwinsize(33, 101)
+            wait_for_screen_size(binary, socket_path, env, terminal, 101, 33)
+            command = (
+                "Write-Output ('RESIZE_' + $Host.UI.RawUI.WindowSize.Width + "
+                "'x' + $Host.UI.RawUI.WindowSize.Height)\r"
+            )
+            encoded = base64.b64encode(command.encode("utf-8")).decode("ascii")
+            run_cli(binary, socket_path, env, "terminal", terminal, "write", "--bytes-base64", encoded)
+            run_cli(
+                binary,
+                socket_path,
+                env,
+                "terminal",
+                terminal,
+                "screen",
+                "wait",
+                "--pattern",
+                "RESIZE_101x33",
+                "--timeout-ms",
+                "10000",
+            )
+            screen = run_cli(binary, socket_path, env, "terminal", terminal, "screen", "read")
+            if "RESIZE_101x33" not in screen.stdout:
+                raise AssertionError(screen.stdout)
+        finally:
+            if pty is not None and pty.isalive():
+                pty.terminate(force=True)
+            if server.poll() is None:
+                try:
+                    run_cli(binary, socket_path, env, "session", "current", "shutdown")
+                    server.wait(timeout=TIMEOUT_SECONDS)
+                except Exception:
+                    server.kill()
+                    server.wait()
+
+
+if __name__ == "__main__":
+    main()

--- a/cmux-tui/scripts/smoke-windows-conpty-resize.py
+++ b/cmux-tui/scripts/smoke-windows-conpty-resize.py
@@ -44,18 +44,26 @@ def run_cli(binary: Path, socket_path: Path, env: dict[str, str], *args: str) ->
     return result
 
 
-def wait_for_socket(server: subprocess.Popen[bytes], socket_path: Path) -> None:
+def read_log(path: Path) -> str:
+    return path.read_text(encoding="utf-8", errors="replace")
+
+
+def server_diagnostics(stdout_path: Path, stderr_path: Path) -> str:
+    return f"server stdout:\n{read_log(stdout_path)}\nserver stderr:\n{read_log(stderr_path)}"
+
+
+def wait_for_socket(
+    server: subprocess.Popen[bytes], socket_path: Path, stdout_path: Path, stderr_path: Path
+) -> None:
     deadline = time.monotonic() + TIMEOUT_SECONDS
     while time.monotonic() < deadline:
         if socket_path.exists():
             return
         code = server.poll()
         if code is not None:
-            stdout, stderr = server.communicate()
             raise RuntimeError(
                 f"server exited before socket publication with code {code}\n"
-                f"stdout:\n{stdout.decode('utf-8', errors='replace')}\n"
-                f"stderr:\n{stderr.decode('utf-8', errors='replace')}"
+                f"{server_diagnostics(stdout_path, stderr_path)}"
             )
         time.sleep(0.01)
     raise TimeoutError(f"server did not publish {socket_path}")
@@ -65,15 +73,18 @@ def wait_for_first_output(pty: PtyProcess) -> None:
     events: queue.Queue[BaseException | None] = queue.Queue()
 
     def read() -> None:
+        ready = False
         try:
             chunk = pty.read(8192)
             if not chunk:
                 raise RuntimeError("attach closed before it produced output")
             events.put(None)
+            ready = True
             while pty.read(8192):
                 pass
-        except (EOFError, OSError):
-            return
+        except (EOFError, OSError) as error:
+            if not ready:
+                events.put(error)
         except BaseException as error:
             events.put(error)
 
@@ -119,78 +130,89 @@ def main() -> None:
         (state / "resource-effect-pepper").write_bytes(os.urandom(32))
         socket_path = root / "server.sock"
         config = root / "config.json"
+        stdout_path = root / "server.stdout.log"
+        stderr_path = root / "server.stderr.log"
         config.write_text("{}\n", encoding="utf-8")
         env = os.environ.copy()
         env["CMUX_TUI_CONFIG"] = str(config)
-        server = subprocess.Popen(
-            [
-                str(binary),
-                "--headless",
-                "--session",
-                "windows-conpty-resize",
-                "--socket",
-                str(socket_path),
-                "--state",
-                str(state),
-            ],
-            env=env,
-            stdin=subprocess.DEVNULL,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-            creationflags=CREATE_NEW_PROCESS_GROUP,
-        )
-        pty = None
-        try:
-            wait_for_socket(server, socket_path)
-            created = run_cli(binary, socket_path, env, "workspace", "create", "--name", "resize-check")
-            value = json.loads(created.stdout)
-            if isinstance(value, dict):
-                value = value.get("value", value)
-            terminal = value.get("terminal_id") if isinstance(value, dict) else None
-            if not isinstance(terminal, str):
-                raise RuntimeError(f"workspace creation had no terminal id: {created.stdout}")
-
-            pty = PtyProcess.spawn(
-                [str(binary), "attach", "--socket", str(socket_path), "--terminal", terminal],
-                cwd=str(root),
+        with stdout_path.open("wb") as server_stdout, stderr_path.open("wb") as server_stderr:
+            server = subprocess.Popen(
+                [
+                    str(binary),
+                    "--headless",
+                    "--session",
+                    "windows-conpty-resize",
+                    "--socket",
+                    str(socket_path),
+                    "--state",
+                    str(state),
+                ],
                 env=env,
-                dimensions=(24, 80),
+                stdin=subprocess.DEVNULL,
+                stdout=server_stdout,
+                stderr=server_stderr,
+                creationflags=CREATE_NEW_PROCESS_GROUP,
             )
-            wait_for_first_output(pty)
-            pty.setwinsize(33, 101)
-            wait_for_screen_size(binary, socket_path, env, terminal, 101, 33)
-            command = (
-                "Write-Output ('RESIZE_' + $Host.UI.RawUI.WindowSize.Width + "
-                "'x' + $Host.UI.RawUI.WindowSize.Height)\r"
-            )
-            encoded = base64.b64encode(command.encode("utf-8")).decode("ascii")
-            run_cli(binary, socket_path, env, "terminal", terminal, "write", "--bytes-base64", encoded)
-            run_cli(
-                binary,
-                socket_path,
-                env,
-                "terminal",
-                terminal,
-                "screen",
-                "wait",
-                "--pattern",
-                "RESIZE_101x33",
-                "--timeout-ms",
-                "10000",
-            )
-            screen = run_cli(binary, socket_path, env, "terminal", terminal, "screen", "read")
-            if "RESIZE_101x33" not in screen.stdout:
-                raise AssertionError(screen.stdout)
-        finally:
-            if pty is not None and pty.isalive():
-                pty.terminate(force=True)
-            if server.poll() is None:
-                try:
-                    run_cli(binary, socket_path, env, "session", "current", "shutdown")
-                    server.wait(timeout=TIMEOUT_SECONDS)
-                except Exception:
-                    server.kill()
-                    server.wait()
+            pty = None
+            try:
+                wait_for_socket(server, socket_path, stdout_path, stderr_path)
+                created = run_cli(
+                    binary, socket_path, env, "workspace", "create", "--name", "resize-check"
+                )
+                value = json.loads(created.stdout)
+                if isinstance(value, dict):
+                    value = value.get("value", value)
+                terminal = value.get("terminal_id") if isinstance(value, dict) else None
+                if not isinstance(terminal, str):
+                    raise RuntimeError(f"workspace creation had no terminal id: {created.stdout}")
+
+                pty = PtyProcess.spawn(
+                    [str(binary), "attach", "--socket", str(socket_path), "--terminal", terminal],
+                    cwd=str(root),
+                    env=env,
+                    dimensions=(24, 80),
+                )
+                wait_for_first_output(pty)
+                pty.setwinsize(33, 101)
+                wait_for_screen_size(binary, socket_path, env, terminal, 101, 33)
+                command = (
+                    "Write-Output ('RESIZE_' + $Host.UI.RawUI.WindowSize.Width + "
+                    "'x' + $Host.UI.RawUI.WindowSize.Height)\r"
+                )
+                encoded = base64.b64encode(command.encode("utf-8")).decode("ascii")
+                run_cli(
+                    binary, socket_path, env, "terminal", terminal, "write", "--bytes-base64", encoded
+                )
+                run_cli(
+                    binary,
+                    socket_path,
+                    env,
+                    "terminal",
+                    terminal,
+                    "screen",
+                    "wait",
+                    "--pattern",
+                    "RESIZE_101x33",
+                    "--timeout-ms",
+                    "10000",
+                )
+                screen = run_cli(binary, socket_path, env, "terminal", terminal, "screen", "read")
+                if "RESIZE_101x33" not in screen.stdout:
+                    raise AssertionError(screen.stdout)
+            except Exception as error:
+                raise RuntimeError(
+                    f"{error}\n{server_diagnostics(stdout_path, stderr_path)}"
+                ) from error
+            finally:
+                if pty is not None and pty.isalive():
+                    pty.terminate(force=True)
+                if server.poll() is None:
+                    try:
+                        run_cli(binary, socket_path, env, "session", "current", "shutdown")
+                        server.wait(timeout=TIMEOUT_SECONDS)
+                    except Exception:
+                        server.kill()
+                        server.wait()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Adds a Windows package regression that starts a headless server, attaches through a real ConPTY, resizes from 80x24 to 101x33, waits for cmux to publish the new size, and then verifies that PowerShell sees 101x33.

The supplied artifact did not reproduce a product defect. Its attach command put global options before the attach subcommand, so attach exited with an unknown-argument error. It also queried PowerShell before cmux processed the resize. Latest main passes after both test errors are removed.

Azure Windows exact-head check: passed at 9352051a73301cec6425a5d775aa50a767bfa6e0.

Native Windows SSH remains owned by https://github.com/manaflow-ai/cmux/pull/9682. This change does not modify SSH.

Merge authorization: Lawrence requested on 2026-08-09 that this PR be merged when production-ready. This authorization remains active until merge or explicit revocation.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/9904"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788933196&installation_model_id=21920&pr_number=9904&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F9904&signature=db67499e2a881c241453682d3793887c9a541509a3ebffc95dc380fc0fc70e07"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only additions (workflow, pip requirements, Python smoke script); no changes to cmux-tui product code or terminal handling logic.
> 
> **Overview**
> Adds **Windows package CI coverage** for ConPTY terminal resize: after the existing Windows smoke tests, the workflow installs Python 3.12.10, pins **`pywinpty==3.0.5`** via hash-locked requirements, and runs a new smoke script against the built `cmux-tui.exe`.
> 
> The new **`smoke-windows-conpty-resize.py`** boots a headless server, attaches through a real ConPTY, resizes from 80×24 to 101×33, waits for cmux to report the new screen size on the socket, then verifies PowerShell sees **101×33** via a screen wait pattern. No application/runtime code changes—only test assets and workflow steps.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a4d3865ee6bda900cbb857ce65681dcd68bee236. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a Windows ConPTY resize smoke test to `cmux-tui` CI to catch terminal-size regressions. It starts a headless server, attaches via a real ConPTY, resizes to 101x33, waits for socket publication/first output and for `cmux-tui` to report 101x33, then asserts PowerShell prints RESIZE_101x33.

CI runs it post-build using hosted Python 3.12.10, installs `pywinpty==3.0.5` from `requirements-windows-conpty.txt` with --require-hashes, and captures server logs for clear failures.

<sup>Written for commit a4d3865ee6bda900cbb857ce65681dcd68bee236. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/9904?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added Windows terminal validation for ConPTY resizing and updated screen dimensions.
  * Expanded Windows build checks to run the resize test against the packaged executable.
  * Added automatic setup and cleanup for test servers, terminals, temporary state, and terminal sessions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->