### PR TITLE
Fix Windows terminal exit publication

### DIFF
--- a/.github/workflows/cmux-tui-build-package.yml
+++ b/.github/workflows/cmux-tui-build-package.yml
@@ -477,6 +477,12 @@ jobs:
           cd ../cmux-tui
           cargo build -p cmux-tui --bin cmux-tui --release --locked --target x86_64-pc-windows-gnu
 
+      - name: Verify Windows terminal process exit
+        shell: bash
+        run: |
+          python cmux-tui/scripts/smoke-windows-process-wait.py \
+            --binary cmux-tui/target/x86_64-pc-windows-gnu/release/cmux-tui.exe
+
       - name: Verify remote commands fail clearly on Windows
         shell: bash
         run: |

--- a/cmux-tui/crates/cmux-tui-core/src/surface.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/surface.rs
@@ -1302,7 +1302,7 @@ pub struct PtyTerminalRuntime {
 enum PtyRuntime {
     Local {
         writer: Box<dyn Write + Send>,
-        master: Box<dyn MasterPty + Send>,
+        master: Option<Box<dyn MasterPty + Send>>,
         killer: Box<dyn ChildKiller + Send>,
     },
     #[cfg(unix)]
@@ -1814,6 +1814,23 @@ fn publish_local_exit_if_ready(surface: &Arc<Surface>) {
     }
 }
 
+#[cfg(windows)]
+fn close_local_terminal_master_after_exit(surface: &Arc<Surface>) {
+    let Some(pty) = surface.as_pty() else { return };
+    let master = {
+        let mut runtime = pty.runtime.lock().unwrap();
+        let PtyRuntime::Local { master, .. } = &mut *runtime;
+        master.take()
+    };
+    // portable-pty's ConPTY reader keeps a separate output handle. Closing
+    // the master closes the pseudoconsole, which lets that reader drain the
+    // final bytes and then observe EOF.
+    drop(master);
+}
+
+#[cfg(not(windows))]
+fn close_local_terminal_master_after_exit(_surface: &Arc<Surface>) {}
+
 fn terminal_public_id_from_resource_identity(
     identity: &TabResourceIdentity,
     invalid_context: &str,
@@ -2142,7 +2159,11 @@ impl Surface {
                 term: Mutex::new(Box::new(term)),
                 stream_progress: Box::new(TerminalStreamProgress::default()),
                 mouse_encoders: Mutex::new(Box::new(mouse_encoders)),
-                runtime: Mutex::new(PtyRuntime::Local { writer, master, killer }),
+                runtime: Mutex::new(PtyRuntime::Local {
+                    writer,
+                    master: Some(master),
+                    killer,
+                }),
                 lifetime,
                 supports_clear_history_key_fallback: AtomicBool::new(
                     supports_clear_history_key_fallback,
@@ -2293,6 +2314,7 @@ impl Surface {
                 if let Some(pty) = surface.as_pty() {
                     *pty.exit.lock().unwrap() = Some(exit);
                 }
+                close_local_terminal_master_after_exit(&surface);
                 publish_local_exit_if_ready(&surface);
             }
         })?;
@@ -3693,10 +3715,10 @@ impl Surface {
                 mouse_encoders: Mutex::new(Box::new(mouse_encoders)),
                 runtime: Mutex::new(PtyRuntime::Local {
                     writer: Box::new(std::io::sink()),
-                    master: Box::new(TestMasterPty {
+                    master: Some(Box::new(TestMasterPty {
                         size: Mutex::new(initial_pty_size),
                         control: test_master_control.clone(),
-                    }),
+                    })),
                     killer: Box::new(TestChildKiller),
                 }),
                 lifetime,
@@ -4400,12 +4422,13 @@ impl Surface {
                     let PtyRuntime::Local { writer, master, .. } = &mut *runtime else {
                         unreachable!("a local PTY runtime cannot become hosted")
                     };
+                    let Some(master) = master.as_deref() else {
+                        return Err(ClearHistoryFailure::known_not_delivered(anyhow::anyhow!(
+                            "terminal process has exited"
+                        )));
+                    };
                     drop(term);
-                    return write_clear_history_fallback(
-                        master.as_ref(),
-                        writer.as_mut(),
-                        &encoded,
-                    );
+                    return write_clear_history_fallback(master, writer.as_mut(), &encoded);
                 }
                 ClearHistoryTransition::Noop => return Ok(()),
                 ClearHistoryTransition::Cleared(clear) => {
@@ -4760,7 +4783,7 @@ impl Surface {
         let PtyRuntime::Local { master, .. } = &*runtime else {
             panic!("test PTY surface uses a local runtime");
         };
-        master.get_size().unwrap()
+        master.as_deref().expect("test PTY master is open").get_size().unwrap()
     }
 
     #[cfg(test)]
@@ -5906,7 +5929,7 @@ impl PtySurface {
         let mut term = self.term.lock().unwrap();
         let runtime = (!hosted_mirror).then(|| self.runtime.lock().unwrap());
         let master = match runtime.as_deref() {
-            Some(PtyRuntime::Local { master, .. }) => Some(master.as_ref()),
+            Some(PtyRuntime::Local { master, .. }) => master.as_deref(),
             #[cfg(unix)]
             Some(PtyRuntime::Hosted(_)) => None,
             #[cfg(unix)]
@@ -8327,10 +8350,10 @@ mod tests {
                 panic!("test surface unexpectedly uses a terminal host");
             };
             *writer = Box::new(write_end);
-            *master = Box::new(FdMasterPty {
+            *master = Some(Box::new(FdMasterPty {
                 file: master_file,
                 size: Mutex::new(PtySize { rows: 24, cols: 80, pixel_width: 0, pixel_height: 0 }),
-            });
+            }));
         }
 
         let input = KeyInput {

--- a/cmux-tui/scripts/smoke-windows-process-wait.py
+++ b/cmux-tui/scripts/smoke-windows-process-wait.py
@@ -1,0 +1,159 @@
+#!/usr/bin/env python3
+"""Verify that Windows reports a terminal's nonzero process exit."""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import json
+import os
+from pathlib import Path
+import subprocess
+import tempfile
+import time
+import uuid
+
+
+TIMEOUT_SECONDS = 20.0
+CREATE_NEW_PROCESS_GROUP = 0x00000200
+
+
+def run_cli(
+    binary: Path, socket_path: Path, env: dict[str, str], *args: str
+) -> subprocess.CompletedProcess[str]:
+    result = subprocess.run(
+        [str(binary), "--socket", str(socket_path), "--json", *args],
+        env=env,
+        stdin=subprocess.DEVNULL,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        timeout=TIMEOUT_SECONDS,
+        check=False,
+        creationflags=CREATE_NEW_PROCESS_GROUP,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(
+            f"cmux-tui command failed ({result.returncode}): {result.args!r}\n"
+            f"stdout: {result.stdout}\nstderr: {result.stderr}"
+        )
+    return result
+
+
+def result_value(result: subprocess.CompletedProcess[str]) -> dict[str, object]:
+    value = json.loads(result.stdout)
+    if isinstance(value, dict) and isinstance(value.get("value"), dict):
+        value = value["value"]
+    if not isinstance(value, dict):
+        raise RuntimeError(f"cmux-tui returned an unexpected result: {result.stdout}")
+    return value
+
+
+def wait_for_socket(server: subprocess.Popen[bytes], socket_path: Path) -> None:
+    deadline = time.monotonic() + TIMEOUT_SECONDS
+    while time.monotonic() < deadline:
+        if socket_path.exists():
+            return
+        code = server.poll()
+        if code is not None:
+            stdout, stderr = server.communicate()
+            raise RuntimeError(
+                f"server exited before socket publication with code {code}\n"
+                f"stdout:\n{stdout.decode('utf-8', errors='replace')}\n"
+                f"stderr:\n{stderr.decode('utf-8', errors='replace')}"
+            )
+        time.sleep(0.01)
+    raise TimeoutError(f"server did not publish {socket_path}")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--binary", type=Path, required=True)
+    args = parser.parse_args()
+    binary = args.binary.resolve()
+
+    with tempfile.TemporaryDirectory(prefix="cmux-process-wait-") as temporary:
+        root = Path(temporary)
+        state = root / "state"
+        state.mkdir()
+        (state / "machine-id").write_bytes(f"machine_{uuid.uuid4().hex}\n".encode())
+        (state / "resource-effect-pepper").write_bytes(os.urandom(32))
+        socket_path = root / "server.sock"
+        config = root / "config.json"
+        config.write_text("{}\n", encoding="utf-8")
+        env = os.environ.copy()
+        env["CMUX_TUI_CONFIG"] = str(config)
+        server = subprocess.Popen(
+            [
+                str(binary),
+                "--headless",
+                "--session",
+                "windows-process-wait",
+                "--socket",
+                str(socket_path),
+                "--state",
+                str(state),
+            ],
+            env=env,
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            creationflags=CREATE_NEW_PROCESS_GROUP,
+        )
+        try:
+            wait_for_socket(server, socket_path)
+            created = result_value(
+                run_cli(binary, socket_path, env, "workspace", "create", "--name", "wait-check")
+            )
+            terminal = created.get("terminal_id")
+            if not isinstance(terminal, str):
+                raise RuntimeError(f"workspace creation had no terminal id: {created!r}")
+
+            command = "Write-Output PROCESS_EXIT_READY; exit 7\r"
+            encoded = base64.b64encode(command.encode("utf-8")).decode("ascii")
+            run_cli(binary, socket_path, env, "terminal", terminal, "write", "--bytes-base64", encoded)
+            run_cli(
+                binary,
+                socket_path,
+                env,
+                "terminal",
+                terminal,
+                "screen",
+                "wait",
+                "--pattern",
+                "PROCESS_EXIT_READY",
+                "--timeout-ms",
+                "10000",
+            )
+            waited = result_value(
+                run_cli(
+                    binary,
+                    socket_path,
+                    env,
+                    "terminal",
+                    terminal,
+                    "process",
+                    "wait",
+                    "--timeout-ms",
+                    "10000",
+                )
+            )
+            if waited.get("state") != "exited" or waited.get("lifecycle") != "exited":
+                raise AssertionError(f"terminal process remained active: {waited!r}")
+            outcome = waited.get("outcome")
+            if not isinstance(outcome, dict) or outcome != {"kind": "exit", "code": 7}:
+                raise AssertionError(f"terminal process lost exit code 7: {waited!r}")
+        finally:
+            if server.poll() is None:
+                try:
+                    run_cli(binary, socket_path, env, "session", "current", "shutdown")
+                    server.wait(timeout=TIMEOUT_SECONDS)
+                except Exception:
+                    server.kill()
+                    server.wait()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Closes the local ConPTY master after the native child exits. The reader can then drain final output, observe EOF, and publish the durable exit outcome. The change keeps output before lifecycle publication.

Adds a Windows package regression that runs exit 7 and requires the public process-wait result to report a durable exit with code 7.

Azure Windows latest-main check: failed with lifecycle running and state pending. Exact-head check: passed at b3397436742b479d689a6ca59964de30910f7f8c.

Native Windows SSH remains owned by https://github.com/manaflow-ai/cmux/pull/9682. This change only changes the local terminal lifecycle.

Merge authorization: Lawrence requested on 2026-08-09 that this PR be merged when production-ready. This authorization remains active until merge or explicit revocation.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/9905"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788933198&installation_model_id=21920&pr_number=9905&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F9905&signature=b5e881274b1df0074a6668ea767d25ddaacbafec99d07ee8968dbadce2025b60"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit b3397436742b479d689a6ca59964de30910f7f8c. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Windows terminal exit handling by closing the local ConPTY master after the child exits so the reader drains output, sees EOF, and we publish a durable exit with the correct code. The public process-wait now returns the right exit code on Windows.

- Bug Fixes
  - Windows: Close the local terminal master after exit and make `PtyRuntime::Local.master` an `Option`, guarding all callers in `cmux-tui-core`. This preserves final output and reliably publishes the exit outcome.
  - CI: Add `cmux-tui/scripts/smoke-windows-process-wait.py` and a workflow step to assert a process exiting with code 7 is reported as a durable exit.

<sup>Written for commit b3397436742b479d689a6ca59964de30910f7f8c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/9905?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Windows terminal process handling so final output is delivered and process completion is reported reliably.
  * Prevented errors when terminal resources have already closed.

* **Tests**
  * Added automated Windows coverage for process termination, exit codes, lifecycle state, and final output.
  * Integrated the smoke test into the Windows release build workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->