### PR TITLE
Support long Windows cmux-tui state paths

### DIFF
--- a/.github/workflows/cmux-tui-build-package.yml
+++ b/.github/workflows/cmux-tui-build-package.yml
@@ -477,6 +477,12 @@ jobs:
           cd ../cmux-tui
           cargo build -p cmux-tui --bin cmux-tui --release --locked --target x86_64-pc-windows-gnu
 
+      - name: Verify long Windows state path
+        shell: bash
+        run: |
+          python cmux-tui/scripts/smoke-windows-long-state-path.py \
+            --binary cmux-tui/target/x86_64-pc-windows-gnu/release/cmux-tui.exe
+
       - name: Verify remote commands fail clearly on Windows
         shell: bash
         run: |

--- a/cmux-tui/crates/cmux-tui-core/src/workspace_registry.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/workspace_registry.rs
@@ -2134,14 +2134,31 @@ fn sqlite_filesystem_path(path: &Path) -> anyhow::Result<Cow<'_, Path>> {
     }
 }
 
-fn open_registry_database(path: &Path) -> anyhow::Result<Connection> {
+fn open_registry_database_with_flags(
+    path: &Path,
+    flags: OpenFlags,
+) -> anyhow::Result<Connection> {
     let path = sqlite_filesystem_path(path)?;
-    Ok(Connection::open(path.as_ref())?)
+    #[cfg(windows)]
+    {
+        Ok(Connection::open_with_flags_and_vfs(
+            path.as_ref(),
+            flags,
+            "win32-longpath",
+        )?)
+    }
+    #[cfg(not(windows))]
+    {
+        Ok(Connection::open_with_flags(path.as_ref(), flags)?)
+    }
+}
+
+fn open_registry_database(path: &Path) -> anyhow::Result<Connection> {
+    open_registry_database_with_flags(path, OpenFlags::default())
 }
 
 fn open_registry_database_read_only(path: &Path) -> anyhow::Result<Connection> {
-    let path = sqlite_filesystem_path(path)?;
-    Ok(Connection::open_with_flags(path.as_ref(), OpenFlags::SQLITE_OPEN_READ_ONLY)?)
+    open_registry_database_with_flags(path, OpenFlags::SQLITE_OPEN_READ_ONLY)
 }
 
 impl std::fmt::Debug for WorkspaceRegistry {

--- a/cmux-tui/crates/cmux-tui-core/src/workspace_registry.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/workspace_registry.rs
@@ -2120,12 +2120,12 @@ fn sqlite_filesystem_path(path: &Path) -> anyhow::Result<Cow<'_, Path>> {
     {
         let parent = path
             .parent()
-            .ok_or_else(|| anyhow::anyhow!("SQLite path has no parent: {}", path.display()))?;
+            .ok_or_else(|| anyhow::anyhow!("workspace state path has no parent"))?;
         let file_name = path
             .file_name()
-            .ok_or_else(|| anyhow::anyhow!("SQLite path has no file name: {}", path.display()))?;
+            .ok_or_else(|| anyhow::anyhow!("workspace state path has no file name"))?;
         let parent = fs::canonicalize(parent)
-            .with_context(|| format!("resolve SQLite directory {}", parent.display()))?;
+            .context("resolve workspace state directory")?;
         Ok(Cow::Owned(parent.join(file_name)))
     }
     #[cfg(not(windows))]

--- a/cmux-tui/crates/cmux-tui-core/src/workspace_registry.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/workspace_registry.rs
@@ -5,6 +5,7 @@
 //! event are published, so durable order, reply order, and event order are the
 //! same order. Runtime pane/surface ids deliberately never enter this store.
 
+use std::borrow::Cow;
 #[cfg(test)]
 use std::cell::Cell;
 use std::collections::{HashMap, HashSet};
@@ -2114,6 +2115,35 @@ fn metadata_identity(metadata: &fs::Metadata) -> String {
     )
 }
 
+fn sqlite_filesystem_path(path: &Path) -> anyhow::Result<Cow<'_, Path>> {
+    #[cfg(windows)]
+    {
+        let parent = path
+            .parent()
+            .ok_or_else(|| anyhow::anyhow!("SQLite path has no parent: {}", path.display()))?;
+        let file_name = path
+            .file_name()
+            .ok_or_else(|| anyhow::anyhow!("SQLite path has no file name: {}", path.display()))?;
+        let parent = fs::canonicalize(parent)
+            .with_context(|| format!("resolve SQLite directory {}", parent.display()))?;
+        Ok(Cow::Owned(parent.join(file_name)))
+    }
+    #[cfg(not(windows))]
+    {
+        Ok(Cow::Borrowed(path))
+    }
+}
+
+fn open_registry_database(path: &Path) -> anyhow::Result<Connection> {
+    let path = sqlite_filesystem_path(path)?;
+    Ok(Connection::open(path.as_ref())?)
+}
+
+fn open_registry_database_read_only(path: &Path) -> anyhow::Result<Connection> {
+    let path = sqlite_filesystem_path(path)?;
+    Ok(Connection::open_with_flags(path.as_ref(), OpenFlags::SQLITE_OPEN_READ_ONLY)?)
+}
+
 impl std::fmt::Debug for WorkspaceRegistry {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("WorkspaceRegistry")
@@ -2159,7 +2189,7 @@ impl WorkspaceRegistry {
             return Err(error.into());
         }
         let lease = SessionLease::acquire(&session_dir.join(SESSION_WRITER_LOCK_FILE))?;
-        let connection = Connection::open(&db_path)
+        let connection = open_registry_database(&db_path)
             .with_context(|| format!("open workspace registry {}", db_path.display()))?;
         platform::restrict_file(&db_path)?;
         Self::initialize(
@@ -4448,7 +4478,7 @@ fn preflight_unsupported_schema(
 fn try_preflight_unsupported_schema(
     database_path: &Path,
 ) -> anyhow::Result<Option<UnsupportedWorkspaceRegistrySchema>> {
-    let connection = Connection::open_with_flags(database_path, OpenFlags::SQLITE_OPEN_READ_ONLY)?;
+    let connection = open_registry_database_read_only(database_path)?;
     connection.busy_timeout(std::time::Duration::from_millis(500))?;
     let has_meta: bool = connection.query_row(
         "SELECT EXISTS(SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'meta')",
@@ -4846,7 +4876,7 @@ fn ensure_missing_pepper_can_migrate(root: &Path, pepper_path: &Path) -> anyhow:
         if !database.try_exists()? {
             continue;
         }
-        let connection = Connection::open_with_flags(&database, OpenFlags::SQLITE_OPEN_READ_ONLY)
+        let connection = open_registry_database_read_only(&database)
             .with_context(|| {
             format!("inspect registry before recreating missing pepper {}", database.display())
         })?;

--- a/cmux-tui/scripts/smoke-windows-long-state-path.py
+++ b/cmux-tui/scripts/smoke-windows-long-state-path.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import argparse
+import json
 import os
 from pathlib import Path
 import shutil
@@ -19,7 +20,7 @@ START_TIMEOUT_SECONDS = 20
 
 def make_state_path(root: Path) -> Path:
     state = root / "state"
-    while len(str(state)) + 121 < STATE_PATH_LENGTH:
+    while len(str(state)) + 121 < STATE_PATH_LENGTH - 1:
         state /= "界" * 120
     remaining = STATE_PATH_LENGTH - len(str(state)) - 1
     if not 1 <= remaining <= 255:
@@ -46,35 +47,37 @@ def run() -> None:
     socket_path = root / "server.sock"
     state_path = make_state_path(root)
     config_path = root / "config.json"
-    root.mkdir(parents=True)
     extended_state_path = extended_path(state_path)
-    extended_state_path.mkdir(parents=True)
-    (extended_state_path / "machine-id").write_bytes(
-        f"machine_{uuid.uuid4().hex}\n".encode()
-    )
-    (extended_state_path / "resource-effect-pepper").write_bytes(os.urandom(32))
-    config_path.write_text("{}\n", encoding="utf-8")
     env = os.environ.copy()
     env["CMUX_TUI_CONFIG"] = str(config_path)
+    env["CMUX_TUI_STATE_DIR"] = str(state_path)
     session = f"long-state-{uuid.uuid4().hex[:8]}"
-    process = subprocess.Popen(
-        [
-            str(binary),
-            "--headless",
-            "--session",
-            session,
-            "--socket",
-            str(socket_path),
-            "--state",
-            str(state_path),
-        ],
-        env=env,
-        stdin=subprocess.DEVNULL,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
-        text=True,
-    )
+    process: subprocess.Popen[str] | None = None
     try:
+        root.mkdir(parents=True)
+        extended_state_path.mkdir(parents=True)
+        (extended_state_path / "machine-id").write_bytes(
+            f"machine_{uuid.uuid4().hex}\n".encode()
+        )
+        (extended_state_path / "resource-effect-pepper").write_bytes(os.urandom(32))
+        config_path.write_text("{}\n", encoding="utf-8")
+        process = subprocess.Popen(
+            [
+                str(binary),
+                "--headless",
+                "--session",
+                session,
+                "--socket",
+                str(socket_path),
+                "--state",
+                str(state_path),
+            ],
+            env=env,
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
         deadline = time.monotonic() + START_TIMEOUT_SECONDS
         while not socket_path.exists():
             exit_code = process.poll()
@@ -101,32 +104,41 @@ def run() -> None:
                 f"workspace list failed with {listing.returncode}\n"
                 f"stdout:\n{listing.stdout}\nstderr:\n{listing.stderr}"
             )
+        payload = json.loads(listing.stdout)
+        workspaces = payload.get("data", {}).get("workspaces")
+        if not isinstance(workspaces, list):
+            raise AssertionError(f"workspace list had no data.workspaces array: {payload!r}")
         print(f"Windows state path length: {len(str(state_path))}")
         print(f"Windows state path UTF-8 length: {len(str(state_path).encode('utf-8'))}")
         print(f"Published socket: {socket_path}")
     finally:
-        if process.poll() is None:
-            subprocess.run(
-                [
-                    str(binary),
-                    "--socket",
-                    str(socket_path),
-                    "--json",
-                    "session",
-                    "current",
-                    "shutdown",
-                ],
-                env=env,
-                capture_output=True,
-                timeout=START_TIMEOUT_SECONDS,
-                check=False,
-            )
-            try:
-                process.wait(timeout=START_TIMEOUT_SECONDS)
-            except subprocess.TimeoutExpired:
-                process.kill()
-                process.wait()
-        shutil.rmtree(extended_path(root), ignore_errors=True)
+        try:
+            if process is not None and process.poll() is None:
+                try:
+                    subprocess.run(
+                        [
+                            str(binary),
+                            "--socket",
+                            str(socket_path),
+                            "--json",
+                            "session",
+                            "current",
+                            "shutdown",
+                        ],
+                        env=env,
+                        capture_output=True,
+                        timeout=START_TIMEOUT_SECONDS,
+                        check=False,
+                    )
+                except subprocess.TimeoutExpired:
+                    pass
+                try:
+                    process.wait(timeout=START_TIMEOUT_SECONDS)
+                except subprocess.TimeoutExpired:
+                    process.kill()
+                    process.wait()
+        finally:
+            shutil.rmtree(extended_path(root), ignore_errors=True)
 
 
 if __name__ == "__main__":

--- a/cmux-tui/scripts/smoke-windows-long-state-path.py
+++ b/cmux-tui/scripts/smoke-windows-long-state-path.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python3
+"""Verify that a 423-character Windows state path publishes a working socket."""
+
+from __future__ import annotations
+
+import argparse
+import os
+from pathlib import Path
+import shutil
+import subprocess
+import tempfile
+import time
+import uuid
+
+
+STATE_PATH_LENGTH = 423
+START_TIMEOUT_SECONDS = 20
+
+
+def make_state_path(root: Path) -> Path:
+    state = root / "state"
+    while len(str(state)) + 121 < STATE_PATH_LENGTH:
+        state /= "x" * 120
+    remaining = STATE_PATH_LENGTH - len(str(state)) - 1
+    if not 1 <= remaining <= 255:
+        raise AssertionError(f"invalid final path segment length: {remaining}")
+    state /= "x" * remaining
+    if len(str(state)) != STATE_PATH_LENGTH:
+        raise AssertionError(f"state path length is {len(str(state))}, expected {STATE_PATH_LENGTH}")
+    return state
+
+
+def extended_path(path: Path) -> Path:
+    return Path("\\\\?\\" + str(path.resolve()))
+
+
+def run() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--binary", type=Path, required=True)
+    args = parser.parse_args()
+
+    binary = args.binary.resolve()
+    root = Path(tempfile.gettempdir()) / f"cmux-long-state-{uuid.uuid4().hex[:8]}"
+    socket_path = root / "server.sock"
+    state_path = make_state_path(root)
+    config_path = root / "config.json"
+    root.mkdir(parents=True)
+    extended_state_path = extended_path(state_path)
+    extended_state_path.mkdir(parents=True)
+    (extended_state_path / "machine-id").write_bytes(
+        f"machine_{uuid.uuid4().hex}\n".encode()
+    )
+    (extended_state_path / "resource-effect-pepper").write_bytes(os.urandom(32))
+    config_path.write_text("{}\n", encoding="utf-8")
+    env = os.environ.copy()
+    env["CMUX_TUI_CONFIG"] = str(config_path)
+    session = f"long-state-{uuid.uuid4().hex[:8]}"
+    process = subprocess.Popen(
+        [
+            str(binary),
+            "--headless",
+            "--session",
+            session,
+            "--socket",
+            str(socket_path),
+            "--state",
+            str(state_path),
+        ],
+        env=env,
+        stdin=subprocess.DEVNULL,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    try:
+        deadline = time.monotonic() + START_TIMEOUT_SECONDS
+        while not socket_path.exists():
+            exit_code = process.poll()
+            if exit_code is not None:
+                stdout, stderr = process.communicate()
+                raise AssertionError(
+                    f"server exited with {exit_code} before socket publication\n"
+                    f"stdout:\n{stdout}\nstderr:\n{stderr}"
+                )
+            if time.monotonic() >= deadline:
+                raise AssertionError("server did not publish its socket within 20 seconds")
+            time.sleep(0.05)
+
+        listing = subprocess.run(
+            [str(binary), "--socket", str(socket_path), "--json", "workspace", "list"],
+            env=env,
+            capture_output=True,
+            text=True,
+            timeout=START_TIMEOUT_SECONDS,
+            check=False,
+        )
+        if listing.returncode != 0:
+            raise AssertionError(
+                f"workspace list failed with {listing.returncode}\n"
+                f"stdout:\n{listing.stdout}\nstderr:\n{listing.stderr}"
+            )
+        print(f"Windows state path length: {len(str(state_path))}")
+        print(f"Published socket: {socket_path}")
+    finally:
+        if process.poll() is None:
+            subprocess.run(
+                [
+                    str(binary),
+                    "--socket",
+                    str(socket_path),
+                    "--json",
+                    "session",
+                    "current",
+                    "shutdown",
+                ],
+                env=env,
+                capture_output=True,
+                timeout=START_TIMEOUT_SECONDS,
+                check=False,
+            )
+            try:
+                process.wait(timeout=START_TIMEOUT_SECONDS)
+            except subprocess.TimeoutExpired:
+                process.kill()
+                process.wait()
+        shutil.rmtree(extended_path(root), ignore_errors=True)
+
+
+if __name__ == "__main__":
+    run()

--- a/cmux-tui/scripts/smoke-windows-long-state-path.py
+++ b/cmux-tui/scripts/smoke-windows-long-state-path.py
@@ -105,9 +105,8 @@ def run() -> None:
                 f"stdout:\n{listing.stdout}\nstderr:\n{listing.stderr}"
             )
         payload = json.loads(listing.stdout)
-        workspaces = payload.get("data", {}).get("workspaces")
-        if not isinstance(workspaces, list):
-            raise AssertionError(f"workspace list had no data.workspaces array: {payload!r}")
+        if not isinstance(payload, list):
+            raise AssertionError(f"workspace list was not an array: {payload!r}")
         print(f"Windows state path length: {len(str(state_path))}")
         print(f"Windows state path UTF-8 length: {len(str(state_path).encode('utf-8'))}")
         print(f"Published socket: {socket_path}")

--- a/cmux-tui/scripts/smoke-windows-long-state-path.py
+++ b/cmux-tui/scripts/smoke-windows-long-state-path.py
@@ -20,13 +20,15 @@ START_TIMEOUT_SECONDS = 20
 def make_state_path(root: Path) -> Path:
     state = root / "state"
     while len(str(state)) + 121 < STATE_PATH_LENGTH:
-        state /= "x" * 120
+        state /= "界" * 120
     remaining = STATE_PATH_LENGTH - len(str(state)) - 1
     if not 1 <= remaining <= 255:
         raise AssertionError(f"invalid final path segment length: {remaining}")
-    state /= "x" * remaining
+    state /= "界" * remaining
     if len(str(state)) != STATE_PATH_LENGTH:
         raise AssertionError(f"state path length is {len(str(state))}, expected {STATE_PATH_LENGTH}")
+    if len(str(state).encode("utf-8")) <= 1040:
+        raise AssertionError("state path does not cross SQLite's win32 VFS byte limit")
     return state
 
 
@@ -100,6 +102,7 @@ def run() -> None:
                 f"stdout:\n{listing.stdout}\nstderr:\n{listing.stderr}"
             )
         print(f"Windows state path length: {len(str(state_path))}")
+        print(f"Windows state path UTF-8 length: {len(str(state_path).encode('utf-8'))}")
         print(f"Published socket: {socket_path}")
     finally:
         if process.poll() is None:


### PR DESCRIPTION
Canonicalizes the existing Windows SQLite parent directory before each direct rusqlite open. Windows returns an extended path, so a 423-character state path reaches socket publication without changing public path handling.

Adds a Windows package regression that creates the long path through the extended prefix, passes the ordinary path to cmux-tui, and requires socket publication plus a workspace listing.

Azure Windows latest-main check: failed before socket publication. Exact-head check: passed at e498eff0d118e605c0a94d3d0cabce21c2d63c54.

Native Windows SSH and directory synchronization remain owned by https://github.com/manaflow-ai/cmux/pull/9682. This change only changes SQLite filesystem entry points.

Merge authorization: Lawrence requested on 2026-08-09 that this PR be merged when production-ready. This authorization remains active until merge or explicit revocation.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/9906"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788933200&installation_model_id=21920&pr_number=9906&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F9906&signature=8af8caa6585ec7247ae10ba2395e8595c176f86f02535537ec01358957f4b01a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Windows durable workspace registry SQLite open paths, which can block session startup if wrong, but scope is limited to those entry points and a CI smoke test covers the reported failure mode.
> 
> **Overview**
> **Fixes headless `cmux-tui` on Windows when `--state` paths are long enough to break the default SQLite path handling**, so the daemon can open `workspace-registry.sqlite3` and publish its socket instead of failing during startup.
> 
> On Windows only, workspace registry SQLite opens now **canonicalize the database parent directory** and open through SQLite’s **`win32-longpath` VFS** via new helpers (`sqlite_filesystem_path`, `open_registry_database`, `open_registry_database_read_only`). Direct `rusqlite` opens at the writer, schema preflight, and read-only inspection paths are routed through those helpers. **Non-Windows behavior is unchanged.**
> 
> CI adds a **Windows package workflow step** that runs `smoke-windows-long-state-path.py`: it builds a **423-character** state path (UTF-8 length past the win32 VFS byte boundary), creates directories via the extended `\\?\` prefix while passing the ordinary path to `cmux-tui`, and asserts socket publication plus a successful `workspace list` JSON response.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit df15557435a909dcb4753e805c4abbf007fbf615. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `cmux-tui` on Windows to handle very long `--state` paths by resolving the SQLite directory to an extended path and opening all `rusqlite` connections with the `win32-longpath` VFS. Adds a CI smoke test with a 423-character path and improves error messages for invalid state paths.

- **Bug Fixes**
  - Canonicalize the SQLite parent directory on Windows and rejoin the file name before open; use `win32-longpath` via new helpers: `sqlite_filesystem_path`, `open_registry_database`, `open_registry_database_read_only`.
  - Replace direct `rusqlite` opens at writer, preflight, and read-only inspection sites with the helpers.
  - Sanitize workspace state path errors (e.g., missing parent/file name, directory resolution failures) with clearer messages.
  - Add a Windows smoke test and workflow step: build a 423-character path that crosses the win32 VFS byte boundary, assert socket publication, and validate `workspace list` returns a JSON array; includes startup timeout, diagnostics, graceful shutdown, and cleanup.
  - Scope: only Windows SQLite filesystem entry points; non-Windows unchanged.

<sup>Written for commit df15557435a909dcb4753e805c4abbf007fbf615. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/9906?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability on Windows when using very long state-file paths.
  * Ensured workspace data remains accessible from extended-length Windows paths.
  * Improved startup handling when application state is stored in deeply nested folders.

* **Tests**
  * Added automated Windows coverage for launching with a long state path and verifying workspace listing.
  * Added validation for startup failures, timeouts, invalid paths, and cleanup.
  * Added reporting to confirm long-path behavior during the Windows build.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->