### PR TITLE
Apply Rust formatting to Windows cmux-tui fixes

### DIFF
--- a/cmux-tui/crates/cmux-tui-core/src/surface.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/surface.rs
@@ -2159,11 +2159,7 @@ impl Surface {
                 term: Mutex::new(Box::new(term)),
                 stream_progress: Box::new(TerminalStreamProgress::default()),
                 mouse_encoders: Mutex::new(Box::new(mouse_encoders)),
-                runtime: Mutex::new(PtyRuntime::Local {
-                    writer,
-                    master: Some(master),
-                    killer,
-                }),
+                runtime: Mutex::new(PtyRuntime::Local { writer, master: Some(master), killer }),
                 lifetime,
                 supports_clear_history_key_fallback: AtomicBool::new(
                     supports_clear_history_key_fallback,

--- a/cmux-tui/crates/cmux-tui-core/src/workspace_registry.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/workspace_registry.rs
@@ -2118,14 +2118,12 @@ fn metadata_identity(metadata: &fs::Metadata) -> String {
 fn sqlite_filesystem_path(path: &Path) -> anyhow::Result<Cow<'_, Path>> {
     #[cfg(windows)]
     {
-        let parent = path
-            .parent()
-            .ok_or_else(|| anyhow::anyhow!("workspace state path has no parent"))?;
+        let parent =
+            path.parent().ok_or_else(|| anyhow::anyhow!("workspace state path has no parent"))?;
         let file_name = path
             .file_name()
             .ok_or_else(|| anyhow::anyhow!("workspace state path has no file name"))?;
-        let parent = fs::canonicalize(parent)
-            .context("resolve workspace state directory")?;
+        let parent = fs::canonicalize(parent).context("resolve workspace state directory")?;
         Ok(Cow::Owned(parent.join(file_name)))
     }
     #[cfg(not(windows))]
@@ -2134,18 +2132,11 @@ fn sqlite_filesystem_path(path: &Path) -> anyhow::Result<Cow<'_, Path>> {
     }
 }
 
-fn open_registry_database_with_flags(
-    path: &Path,
-    flags: OpenFlags,
-) -> anyhow::Result<Connection> {
+fn open_registry_database_with_flags(path: &Path, flags: OpenFlags) -> anyhow::Result<Connection> {
     let path = sqlite_filesystem_path(path)?;
     #[cfg(windows)]
     {
-        Ok(Connection::open_with_flags_and_vfs(
-            path.as_ref(),
-            flags,
-            "win32-longpath",
-        )?)
+        Ok(Connection::open_with_flags_and_vfs(path.as_ref(), flags, "win32-longpath")?)
     }
     #[cfg(not(windows))]
     {
@@ -4893,8 +4884,7 @@ fn ensure_missing_pepper_can_migrate(root: &Path, pepper_path: &Path) -> anyhow:
         if !database.try_exists()? {
             continue;
         }
-        let connection = open_registry_database_read_only(&database)
-            .with_context(|| {
+        let connection = open_registry_database_read_only(&database).with_context(|| {
             format!("inspect registry before recreating missing pepper {}", database.display())
         })?;
         let schema = meta_value(&connection, "schema_version")?


### PR DESCRIPTION
## Summary
- apply the exact rustfmt layout reported by the hosted Linux and macOS jobs
- keep the Windows lifecycle and long-path behavior unchanged

## Verification
- no local compile or Rust tool invocation
- exact-head hosted full gate will verify formatting, Linux, macOS, package builds, and Windows execution

Lawrence gave standing merge authorization for the Azure Windows correctness hardening series.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/9908"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788942556&installation_model_id=21920&pr_number=9908&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F9908&signature=2a29b540870927ced2ab1857f0286d19353b25b3e8c343644ca0f9985f19c429"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit fbb2a1c405f3e94af4788152e5cf6f6a06d236bb. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Apply `rustfmt` formatting to Windows-specific code in `cmux-tui` to match Linux/macOS CI output. No behavior changes; Windows lifecycle and SQLite long-path VFS (`win32-longpath`) remain unchanged and will be verified by the full CI gate.

<sup>Written for commit fbb2a1c405f3e94af4788152e5cf6f6a06d236bb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/9908?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

