### PR TITLE
Suppress Codex Ultra subagent completion spam

### DIFF
--- a/CLI/CMUXCLI+AgentHookPayload.swift
+++ b/CLI/CMUXCLI+AgentHookPayload.swift
@@ -364,6 +364,42 @@ extension CMUXCLI {
         }
     }
 
+    func readInitialTextFileLine(
+        path: String,
+        maxBytes: Int
+    ) -> String? {
+        guard maxBytes > 0 else { return nil }
+
+        let expandedPath = NSString(string: path).expandingTildeInPath
+        guard let handle = try? FileHandle(forReadingFrom: URL(fileURLWithPath: expandedPath)) else {
+            return nil
+        }
+        defer { try? handle.close() }
+
+        do {
+            guard let data = try handle.read(upToCount: maxBytes), !data.isEmpty else {
+                return nil
+            }
+
+            let lineData: Data
+            if let newline = data.firstIndex(of: 0x0A) {
+                lineData = Data(data[..<newline])
+            } else {
+                let size = try handle.seekToEnd()
+                guard size <= UInt64(maxBytes) else { return nil }
+                lineData = data
+            }
+
+            guard let line = String(data: lineData, encoding: .utf8) else {
+                return nil
+            }
+            let trimmed = line.trimmingCharacters(in: .whitespacesAndNewlines)
+            return trimmed.isEmpty ? nil : trimmed
+        } catch {
+            return nil
+        }
+    }
+
     func firstString(in object: [String: Any], keys: [String]) -> String? {
         for key in keys {
             guard let value = object[key] else { continue }

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -26874,7 +26874,7 @@ struct CMUXCLI {
         turnId: String?
     ) -> CodexTranscriptSubagentSignals {
         var signals = CodexTranscriptSubagentSignals()
-        if let firstLine = readInitialTextFileLine(path: path, maxBytes: 1024 * 1024),
+        if let firstLine = readInitialTextFileLine(path: path, maxBytes: 4 * 1024 * 1024),
            let data = firstLine.data(using: .utf8),
            let object = try? JSONSerialization.jsonObject(with: data, options: []) as? [String: Any],
            (object["type"] as? String) == "session_meta",

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -26873,12 +26873,20 @@ struct CMUXCLI {
         path: String,
         turnId: String?
     ) -> CodexTranscriptSubagentSignals {
-        guard let lines = readRecentTextFileLines(path: path, maxBytes: 512 * 1024) else {
-            return CodexTranscriptSubagentSignals()
+        var signals = CodexTranscriptSubagentSignals()
+        if let firstLine = readInitialTextFileLine(path: path, maxBytes: 1024 * 1024),
+           let data = firstLine.data(using: .utf8),
+           let object = try? JSONSerialization.jsonObject(with: data, options: []) as? [String: Any],
+           (object["type"] as? String) == "session_meta",
+           let payload = object["payload"] as? [String: Any],
+           codexTranscriptSessionMetaIsSubagent(payload) {
+            signals.isSubagentSession = true
         }
 
+        guard let lines = readRecentTextFileLines(path: path, maxBytes: 512 * 1024) else {
+            return signals
+        }
         let normalizedTurnId = normalizedHookValue(turnId)
-        var signals = CodexTranscriptSubagentSignals()
         var currentTurnId: String?
         var currentTurnRelevant = normalizedTurnId == nil
 

--- a/cmuxTests/CLINotifyProcessIntegrationRegressionTests.swift
+++ b/cmuxTests/CLINotifyProcessIntegrationRegressionTests.swift
@@ -3300,6 +3300,54 @@ final class CLINotifyProcessIntegrationRegressionTests: XCTestCase {
         )
     }
 
+    func testLargeCodexSubagentTranscriptDoesNotNotifyOrReplaceResumeBinding() throws {
+        let context = try makeClaudeHookContext(name: "codex-large-subagent-transcript")
+        defer { context.cleanup() }
+
+        let sessionId = "large-subagent-session"
+        let turnId = "child-turn"
+        let transcriptURL = context.root.appendingPathComponent("codex-large-subagent.jsonl")
+        let sessionMeta = #"{"type":"session_meta","payload":{"id":"\#(sessionId)","thread_source":"subagent","source":{"subagent":{"parent_thread_id":"parent-thread"}}}}"#
+        let filler = String(
+            repeating: #"{"type":"event_msg","payload":{"type":"token_count"}}"# + "\n",
+            count: 12_000
+        )
+        let terminalTurn = [
+            #"{"type":"turn_context","payload":{"turn_id":"\#(turnId)"}}"#,
+            #"{"type":"event_msg","payload":{"type":"task_complete","turn_id":"\#(turnId)","last_agent_message":"child done"}}"#,
+        ].joined(separator: "\n")
+        try (sessionMeta + "\n" + filler + terminalTurn)
+            .write(to: transcriptURL, atomically: true, encoding: .utf8)
+        XCTAssertGreaterThan(
+            try FileManager.default.attributesOfItem(atPath: transcriptURL.path)[.size] as? Int ?? 0,
+            512 * 1024
+        )
+
+        startAgentHookMockServerAccepting(context: context)
+        let result = runCodexHook(
+            context: context,
+            subcommand: "stop",
+            standardInput: #"{"session_id":"\#(sessionId)","turn_id":"\#(turnId)","cwd":"\#(context.root.path)","transcript_path":"\#(transcriptURL.path)","hook_event_name":"Stop","last_assistant_message":"child done"}"#,
+            extraEnvironment: codexLaunchEnvironment(context: context, sessionId: sessionId)
+        )
+
+        XCTAssertFalse(result.timedOut, result.stderr)
+        XCTAssertEqual(result.status, 0, result.stderr)
+        XCTAssertEqual(result.stdout, "{}\n")
+        XCTAssertTrue(
+            context.state.commands.contains { $0.contains(#""method":"feed.push""#) && $0.contains(#""hook_event_name":"Stop""#) },
+            "Large-transcript subagent Stop should remain Feed telemetry, saw \(context.state.commands)"
+        )
+        XCTAssertFalse(
+            context.state.commands.contains { self.jsonObject($0)?["method"] as? String == "surface.resume.set" },
+            "Large-transcript subagent Stop should not publish a child resume binding, saw \(context.state.commands)"
+        )
+        XCTAssertFalse(
+            context.state.commands.contains { $0.hasPrefix("notify_target") || $0.hasPrefix("set_status codex ") },
+            "Large-transcript subagent Stop should not notify or clobber visible status, saw \(context.state.commands)"
+        )
+    }
+
     func testCodexStopIgnoresStaleSubagentRelayFromCompletedTurnWithoutTurnId() throws {
         let context = try makeClaudeHookContext(name: "codex-stale-relay")
         defer { context.cleanup() }

--- a/cmuxTests/CLINotifyProcessIntegrationRegressionTests.swift
+++ b/cmuxTests/CLINotifyProcessIntegrationRegressionTests.swift
@@ -3307,7 +3307,10 @@ final class CLINotifyProcessIntegrationRegressionTests: XCTestCase {
         let sessionId = "large-subagent-session"
         let turnId = "child-turn"
         let transcriptURL = context.root.appendingPathComponent("codex-large-subagent.jsonl")
-        let sessionMeta = #"{"type":"session_meta","payload":{"id":"\#(sessionId)","thread_source":"subagent","source":{"subagent":{"parent_thread_id":"parent-thread"}}}}"#
+        let sessionMetaPadding = String(repeating: "m", count: 1_100_000)
+        let sessionMeta = #"{"type":"session_meta","payload":{"id":"\#(sessionId)","thread_source":"subagent","source":{"subagent":{"parent_thread_id":"parent-thread"}},"base_instructions":"\#(sessionMetaPadding)"}}"#
+        XCTAssertGreaterThan(sessionMeta.utf8.count, 1024 * 1024)
+        XCTAssertLessThanOrEqual(sessionMeta.utf8.count, 4 * 1024 * 1024)
         let filler = String(
             repeating: #"{"type":"event_msg","payload":{"type":"token_count"}}"# + "\n",
             count: 12_000
@@ -3339,8 +3342,17 @@ final class CLINotifyProcessIntegrationRegressionTests: XCTestCase {
             "Large-transcript subagent Stop should remain Feed telemetry, saw \(context.state.commands)"
         )
         XCTAssertFalse(
-            context.state.commands.contains { self.jsonObject($0)?["method"] as? String == "surface.resume.set" },
-            "Large-transcript subagent Stop should not publish a child resume binding, saw \(context.state.commands)"
+            context.state.commands.contains {
+                guard let method = self.jsonObject($0)?["method"] as? String else {
+                    return false
+                }
+                return method.hasPrefix("surface.resume.")
+            },
+            "Large-transcript subagent Stop should not mutate resume bindings, saw \(context.state.commands)"
+        )
+        XCTAssertFalse(
+            context.state.commands.contains { $0.hasPrefix("set_agent_lifecycle codex ") },
+            "Large-transcript subagent Stop should not mutate Codex lifecycle, saw \(context.state.commands)"
         )
         XCTAssertFalse(
             context.state.commands.contains { $0.hasPrefix("notify_target") || $0.hasPrefix("set_status codex ") },


### PR DESCRIPTION
## Summary

- Read Codex transcript `session_meta` from a bounded first-line window before scanning the recent event tail.
- Preserve sub-agent classification when Ultra workflows grow beyond the existing 512 KiB tail window, suppressing child completion notifications, resume bindings, lifecycle changes, and visible status mutations while retaining Feed telemetry.
- Add a greater-than-512-KiB regression transcript that reproduces the false top-level completion.

The existing tail-only scan lost immutable sub-agent metadata once long Ultra sessions appended enough events. cmux then treated a child stop as a top-level completion and notified the user.

## Testing

- Confirmed the test-only commit fails because the child stop emits `surface.resume.set`, `notify_target_async`, and visible idle status.
- Ran five focused `CLINotifyProcessIntegrationRegressionTests` covering large and ordinary sub-agent transcripts, stale relays, parent resume binding preservation, and parent completion notification: 5 passed, 0 failed.
- Built the committed HEAD with `./scripts/reload.sh --tag codex-ultra-notify`: succeeded.
- Verified the live notification setting is `never` in both app defaults and `cmux.json`.

## Demo Video

Not applicable: this changes Codex hook routing without adding or changing visual UI. The integration test captures the observable notification commands.

- Video URL or attachment: N/A

## Review Trigger (Copy/Paste as PR comment)

```text
@codex review
@coderabbitai review
@greptile-apps review
@cubic-dev-ai review
```

## Checklist

- [x] I tested the change locally
- [x] I added or updated tests for behavior changes
- [x] I updated docs/changelog if needed (not needed: no command, workflow, environment variable, or user-facing copy changed)
- [ ] I requested bot reviews after my latest commit (copy/paste block above or equivalent)
- [ ] All code review bot comments are resolved
- [ ] All human review comments are resolved

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/9910"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788953211&installation_model_id=21920&pr_number=9910&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F9910&signature=d955d14f6d0635f4353df332c80f37cd750baa7b19d297b8889614e0555a9363"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Codex Stop hook routing and transcript parsing; bounded I/O limits blast radius, but misclassification could still affect notifications and resume bindings.
> 
> **Overview**
> Codex hook handling now reads the transcript’s first `session_meta` line in a bounded window **before** scanning the 512 KiB tail, so long Ultra sessions still classify as sub-agent when immutable metadata has scrolled out of the tail.
> 
> **`readInitialTextFileLine`** supports that peek without loading the whole file. When `session_meta` marks a sub-agent session, child **Stop** events keep Feed telemetry but no longer emit top-level completion side effects (`surface.resume.set`, `notify_target`, visible idle status).
> 
> A regression test uses a transcript larger than 512 KiB with `session_meta` on line one to lock in that behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9f8a9c054b8b126e5934a6956fc83fd7e35ed21e. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of subagent sessions from transcript files.
  * Prevented large subagent transcripts from triggering incorrect resume bindings, notifications, or visible status changes.
  * Improved handling of unreadable, empty, invalid, or oversized transcript files.

* **Tests**
  * Added regression coverage for large Codex subagent transcripts and Stop hook behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->