### PR TITLE
Persist remote tmux sidebar groups and order across reconnect

### DIFF
--- a/Sources/RemoteTmuxController.swift
+++ b/Sources/RemoteTmuxController.swift
@@ -31,6 +31,17 @@ final class RemoteTmuxController {
     private var connectionsByHostSession: [String: RemoteTmuxControlConnection] = [:]
     private var connectionObserverTokensByHostSession: [String: RemoteTmuxControlConnection.ObserverToken] = [:]
 
+    /// Remembered sidebar group + order for mirrors, keyed by `connectionKey`.
+    /// Seeded from the session snapshot on restore and refreshed when a mirror
+    /// disconnects, so a reconnect returns the mirror to its prior placement
+    /// across reconnects and app restarts. See ``applySidebarPlacement`` /
+    /// ``captureSidebarPlacement`` at the end of this file.
+    var sidebarPlacementByConnectionKey: [String: RemoteTmuxSidebarPlacementSnapshot] = [:]
+    /// Maps an original (dissolved) group id to the group recreated for it during
+    /// reconnect, so multiple sessions from one mirror-only group rejoin a single
+    /// recreated group instead of each spawning its own.
+    var recreatedGroupIdByOriginalId: [UUID: UUID] = [:]
+
     init() {}
 
     /// Synchronous read of the `remoteTmux` beta flag for AppKit/socket paths
@@ -317,6 +328,7 @@ final class RemoteTmuxController {
             "CMUX_WORKSPACE_ID": workspace.id.uuidString,
             "CMUX_TAB_ID": workspace.id.uuidString,
         ])
+        workspace.remoteTmuxMirrorIdentity = key
         workspace.remoteTmuxWindowOrderSync = { [weak self, weak workspace] orderedPanelIds, verification in
             guard let self, let workspace else { return false }
             return self.handleMirrorWindowsReordered(
@@ -337,6 +349,8 @@ final class RemoteTmuxController {
                 workspaceID: workspace.id
             )
         )
+        // Return the reconnected mirror to its remembered sidebar group + order.
+        applySidebarPlacement(connectionKey: key, workspace: workspace, manager: tabManager)
         return true
     }
 
@@ -394,6 +408,13 @@ final class RemoteTmuxController {
                 sessionMirrors[newKey] = mirror
             }
 
+            // Keep the sidebar placement memory and the workspace stamp keyed to
+            // the renamed session so a later reconnect still finds the placement.
+            if var placement = sidebarPlacementByConnectionKey.removeValue(forKey: oldKey) {
+                placement.connectionKey = newKey
+                sidebarPlacementByConnectionKey[newKey] = placement
+            }
+            mirror.mirroredWorkspace?.remoteTmuxMirrorIdentity = newKey
         }
     }
 
@@ -612,6 +633,7 @@ final class RemoteTmuxController {
         let manager = mirrorWorkspace?.owningTabManager ?? AppDelegate.shared?.tabManagerFor(tabId: workspaceId)
         let workspace = mirrorWorkspace ?? manager?.tabs.first(where: { $0.id == workspaceId })
         if let manager, let workspace {
+            captureSidebarPlacement(connectionKey: key, workspace: workspace, manager: manager)
             switch reason {
             case .sessionEnded:
                 // Preserve a usable owning window when the remote disappears.
@@ -807,5 +829,86 @@ final class RemoteTmuxController {
     /// connection.
     static func connectionKey(host: RemoteTmuxHost, sessionName: String) -> String {
         "\(host.connectionHash)\u{1}\(sessionName)"
+    }
+}
+
+// MARK: - Sidebar placement memory (groups + order across reconnect / restart)
+
+extension RemoteTmuxController {
+    /// Seeds the placement memory from a restored session snapshot. Existing
+    /// in-session entries (from a live disconnect capture) take precedence.
+    func ingestPersistedSidebarPlacements(_ placements: [RemoteTmuxSidebarPlacementSnapshot]?) {
+        guard let placements else { return }
+        for placement in placements where sidebarPlacementByConnectionKey[placement.connectionKey] == nil {
+            sidebarPlacementByConnectionKey[placement.connectionKey] = placement
+        }
+    }
+
+    /// Records a mirror's current sidebar group + order before it leaves the
+    /// sidebar (disconnect/detach), keyed by the stable `connectionKey`.
+    func captureSidebarPlacement(connectionKey: String, workspace: Workspace, manager: TabManager) {
+        guard let sidebarIndex = manager.tabs.firstIndex(where: { $0.id == workspace.id }) else { return }
+        var group: RemoteTmuxSidebarGroupPlacementSnapshot?
+        if let gid = workspace.groupId,
+           let g = manager.workspaceGroups.first(where: { $0.id == gid }) {
+            let members = manager.tabs.filter { $0.groupId == gid }.map(\.id)
+            group = RemoteTmuxSidebarGroupPlacementSnapshot(
+                id: g.id,
+                name: g.name,
+                isCollapsed: g.isCollapsed,
+                isPinned: g.isPinned,
+                customColor: g.customColor,
+                iconSymbol: g.iconSymbol,
+                memberIndex: members.firstIndex(of: workspace.id) ?? 0,
+                groupOrderIndex: manager.workspaceGroups.firstIndex(where: { $0.id == gid })
+            )
+        }
+        sidebarPlacementByConnectionKey[connectionKey] = RemoteTmuxSidebarPlacementSnapshot(
+            connectionKey: connectionKey,
+            sidebarIndex: sidebarIndex,
+            group: group
+        )
+    }
+
+    /// Returns a reconnected mirror to its remembered group + sidebar order.
+    /// Rejoins the original group when it still exists, otherwise recreates a
+    /// dissolved (mirror-only) group once and remaps siblings onto it.
+    func applySidebarPlacement(connectionKey: String, workspace: Workspace, manager: TabManager) {
+        guard let placement = sidebarPlacementByConnectionKey[connectionKey] else { return }
+
+        if let groupPlacement = placement.group {
+            let liveGroupId = manager.workspaceGroups.first(where: { $0.id == groupPlacement.id })?.id
+                ?? recreatedGroupIdByOriginalId[groupPlacement.id].flatMap { recreatedId in
+                    manager.workspaceGroups.contains(where: { $0.id == recreatedId }) ? recreatedId : nil
+                }
+            if let groupId = liveGroupId {
+                manager.addWorkspaceToGroup(workspaceId: workspace.id, groupId: groupId)
+            } else if let newGroupId = manager.createWorkspaceGroup(
+                name: groupPlacement.name,
+                childWorkspaceIds: [workspace.id],
+                selectAnchor: false,
+                collapseSidebarSelection: false
+            ) {
+                recreatedGroupIdByOriginalId[groupPlacement.id] = newGroupId
+                if groupPlacement.isCollapsed {
+                    manager.setWorkspaceGroupCollapsed(groupId: newGroupId, isCollapsed: true)
+                }
+                if groupPlacement.isPinned == true {
+                    manager.setWorkspaceGroupPinned(groupId: newGroupId, isPinned: true)
+                }
+                if let color = groupPlacement.customColor {
+                    manager.setWorkspaceGroupColor(groupId: newGroupId, hex: color)
+                }
+                if let icon = groupPlacement.iconSymbol {
+                    _ = manager.setWorkspaceGroupIcon(groupId: newGroupId, symbol: icon)
+                }
+            }
+        }
+
+        // Best-effort absolute order: place the mirror back at its remembered
+        // index (clamped). Group-aware reordering keeps it within its section.
+        guard !manager.tabs.isEmpty else { return }
+        let clampedIndex = max(0, min(placement.sidebarIndex, manager.tabs.count - 1))
+        _ = manager.reorderWorkspace(tabId: workspace.id, toIndex: clampedIndex)
     }
 }

--- a/Sources/RemoteTmuxController.swift
+++ b/Sources/RemoteTmuxController.swift
@@ -656,13 +656,22 @@ final class RemoteTmuxController {
     func handleWindowWorkspacesClosed(workspaceIds: [UUID]) {
         let ids = Set(workspaceIds)
         var affectedHosts: [String: RemoteTmuxHost] = [:]
+        var capturesByManager: [ObjectIdentifier: (TabManager, [(String, Workspace)])] = [:]
+        for (key, mirror) in sessionMirrors {
+            guard let workspace = mirror.mirroredWorkspace,
+                  ids.contains(workspace.id),
+                  let manager = workspace.owningTabManager else { continue }
+            let managerId = ObjectIdentifier(manager)
+            var capture = capturesByManager[managerId] ?? (manager, [])
+            capture.1.append((key, workspace))
+            capturesByManager[managerId] = capture
+        }
+        for (manager, captures) in capturesByManager.values {
+            captureSidebarPlacements(captures, manager: manager)
+        }
         for (key, mirror) in sessionMirrors {
             guard let workspaceId = mirror.mirroredWorkspaceId, ids.contains(workspaceId) else { continue }
             affectedHosts[mirror.host.connectionHash] = mirror.host
-            if let workspace = mirror.mirroredWorkspace,
-               let manager = workspace.owningTabManager {
-                captureSidebarPlacement(connectionKey: key, workspace: workspace, manager: manager)
-            }
             mirror.detachObserver()
             sessionMirrors.removeValue(forKey: key)
             removeCachedConnection(forKey: key)?.stop()
@@ -851,27 +860,55 @@ extension RemoteTmuxController {
     /// Records a mirror's current sidebar group + order before it leaves the
     /// sidebar (disconnect/detach), keyed by the stable `connectionKey`.
     func captureSidebarPlacement(connectionKey: String, workspace: Workspace, manager: TabManager) {
-        guard let sidebarIndex = manager.tabs.firstIndex(where: { $0.id == workspace.id }) else { return }
-        var group: RemoteTmuxSidebarGroupPlacementSnapshot?
-        if let gid = workspace.groupId,
-           let g = manager.workspaceGroups.first(where: { $0.id == gid }) {
-            let members = manager.tabs.filter { $0.groupId == gid }.map(\.id)
-            group = RemoteTmuxSidebarGroupPlacementSnapshot(
-                id: g.id,
-                name: g.name,
-                isCollapsed: g.isCollapsed,
-                isPinned: g.isPinned,
-                customColor: g.customColor,
-                iconSymbol: g.iconSymbol,
-                memberIndex: members.firstIndex(of: workspace.id) ?? 0,
-                groupOrderIndex: manager.workspaceGroups.firstIndex(where: { $0.id == gid })
+        captureSidebarPlacements([(connectionKey, workspace)], manager: manager)
+    }
+
+    private func captureSidebarPlacements(
+        _ captures: [(connectionKey: String, workspace: Workspace)],
+        manager: TabManager
+    ) {
+        let sidebarIndexByWorkspaceId = Dictionary(
+            manager.tabs.enumerated().map { ($1.id, $0) },
+            uniquingKeysWith: { first, _ in first }
+        )
+        let groupById = Dictionary(
+            manager.workspaceGroups.map { ($0.id, $0) },
+            uniquingKeysWith: { first, _ in first }
+        )
+        let groupOrderIndexById = Dictionary(
+            manager.workspaceGroups.enumerated().map { ($1.id, $0) },
+            uniquingKeysWith: { first, _ in first }
+        )
+        var nextMemberIndexByGroupId: [UUID: Int] = [:]
+        var memberIndexByWorkspaceId: [UUID: Int] = [:]
+        for workspace in manager.tabs {
+            guard let groupId = workspace.groupId else { continue }
+            memberIndexByWorkspaceId[workspace.id] = nextMemberIndexByGroupId[groupId, default: 0]
+            nextMemberIndexByGroupId[groupId, default: 0] += 1
+        }
+
+        for (connectionKey, workspace) in captures {
+            guard let sidebarIndex = sidebarIndexByWorkspaceId[workspace.id] else { continue }
+            var group: RemoteTmuxSidebarGroupPlacementSnapshot?
+            if let groupId = workspace.groupId,
+               let liveGroup = groupById[groupId] {
+                group = RemoteTmuxSidebarGroupPlacementSnapshot(
+                    id: liveGroup.id,
+                    name: liveGroup.name,
+                    isCollapsed: liveGroup.isCollapsed,
+                    isPinned: liveGroup.isPinned,
+                    customColor: liveGroup.customColor,
+                    iconSymbol: liveGroup.iconSymbol,
+                    memberIndex: memberIndexByWorkspaceId[workspace.id] ?? 0,
+                    groupOrderIndex: groupOrderIndexById[groupId]
+                )
+            }
+            sidebarPlacementByConnectionKey[connectionKey] = RemoteTmuxSidebarPlacementSnapshot(
+                connectionKey: connectionKey,
+                sidebarIndex: sidebarIndex,
+                group: group
             )
         }
-        sidebarPlacementByConnectionKey[connectionKey] = RemoteTmuxSidebarPlacementSnapshot(
-            connectionKey: connectionKey,
-            sidebarIndex: sidebarIndex,
-            group: group
-        )
     }
 
     /// Returns a reconnected mirror to its remembered group + sidebar order.

--- a/Sources/RemoteTmuxController.swift
+++ b/Sources/RemoteTmuxController.swift
@@ -659,6 +659,10 @@ final class RemoteTmuxController {
         for (key, mirror) in sessionMirrors {
             guard let workspaceId = mirror.mirroredWorkspaceId, ids.contains(workspaceId) else { continue }
             affectedHosts[mirror.host.connectionHash] = mirror.host
+            if let workspace = mirror.mirroredWorkspace,
+               let manager = workspace.owningTabManager {
+                captureSidebarPlacement(connectionKey: key, workspace: workspace, manager: manager)
+            }
             mirror.detachObserver()
             sessionMirrors.removeValue(forKey: key)
             removeCachedConnection(forKey: key)?.stop()

--- a/Sources/SessionPersistence.swift
+++ b/Sources/SessionPersistence.swift
@@ -1893,10 +1893,41 @@ extension SessionWindowSnapshot {
     }
 }
 
+/// Persisted sidebar placement for a remote tmux mirror workspace, keyed by the
+/// controller's stable `connectionKey` (host connection hash + session name).
+/// Mirror workspaces themselves are not restorable (their SSH session can't be
+/// resumed cold), but this lightweight record lets a *reconnected* mirror return
+/// to its prior group and sidebar order across reconnects and app restarts.
+struct RemoteTmuxSidebarPlacementSnapshot: Codable, Sendable, Equatable {
+    var connectionKey: String
+    /// Absolute index among the window's workspaces at capture time.
+    var sidebarIndex: Int
+    /// Group membership + definition, present when the mirror was grouped.
+    var group: RemoteTmuxSidebarGroupPlacementSnapshot? = nil
+}
+
+struct RemoteTmuxSidebarGroupPlacementSnapshot: Codable, Sendable, Equatable {
+    /// Original group id; reused to rejoin the group if it still exists, or to
+    /// recreate a dissolved (mirror-only) group deterministically across siblings.
+    var id: UUID
+    var name: String
+    var isCollapsed: Bool
+    var isPinned: Bool? = nil
+    var customColor: String? = nil
+    var iconSymbol: String? = nil
+    /// 0-based index of this mirror among the group's members in tab order.
+    var memberIndex: Int
+    /// 0-based index of the group among all groups (sidebar section order).
+    var groupOrderIndex: Int? = nil
+}
+
 struct SessionTabManagerSnapshot: Codable, Sendable {
     var selectedWorkspaceIndex: Int?
     var workspaces: [SessionWorkspaceSnapshot]
     var workspaceGroups: [SessionWorkspaceGroupSnapshot]? = nil
+    /// Sidebar placement memory for remote tmux mirrors (groups/order lost on
+    /// reconnect). Optional-with-nil-default so older manifests decode cleanly.
+    var remoteTmuxSidebarPlacements: [RemoteTmuxSidebarPlacementSnapshot]? = nil
 }
 
 struct SessionWindowSnapshot: Codable, Sendable {

--- a/Sources/TabManager.swift
+++ b/Sources/TabManager.swift
@@ -5899,6 +5899,42 @@ extension TabManager {
             hasher.combine(group.customColor ?? "")
             hasher.combine(group.iconSymbol ?? "")
         }
+        let groupById = Dictionary(
+            workspaceGroups.map { ($0.id, $0) },
+            uniquingKeysWith: { first, _ in first }
+        )
+        let groupOrderIndexById = Dictionary(
+            workspaceGroups.enumerated().map { ($1.id, $0) },
+            uniquingKeysWith: { first, _ in first }
+        )
+        var nextMemberIndexByGroupId: [UUID: Int] = [:]
+        for (sidebarIndex, workspace) in tabs.enumerated() {
+            let memberIndex: Int?
+            if let groupId = workspace.groupId {
+                memberIndex = nextMemberIndexByGroupId[groupId, default: 0]
+                nextMemberIndexByGroupId[groupId, default: 0] += 1
+            } else {
+                memberIndex = nil
+            }
+            guard workspace.isRemoteTmuxMirror,
+                  let connectionKey = workspace.remoteTmuxMirrorIdentity else { continue }
+            hasher.combine(connectionKey)
+            hasher.combine(sidebarIndex)
+            guard let groupId = workspace.groupId,
+                  let group = groupById[groupId] else {
+                hasher.combine(false)
+                continue
+            }
+            hasher.combine(true)
+            hasher.combine(group.id)
+            hasher.combine(group.name)
+            hasher.combine(group.isCollapsed)
+            hasher.combine(group.isPinned)
+            hasher.combine(group.customColor ?? "")
+            hasher.combine(group.iconSymbol ?? "")
+            hasher.combine(memberIndex)
+            hasher.combine(groupOrderIndexById[groupId])
+        }
         for workspace in tabs.prefix(SessionPersistencePolicy.maxWorkspacesPerWindow) {
             hasher.combine(workspace.id)
             hasher.combine(workspace.groupId)
@@ -6215,17 +6251,27 @@ extension TabManager {
         // returns each mirror to its prior group and position. Read from the
         // UNFILTERED tabs since mirrors are excluded from `restorableTabs`.
         let remoteTmuxSidebarPlacements: [RemoteTmuxSidebarPlacementSnapshot]? = {
+            let groupById = Dictionary(
+                workspaceGroups.map { ($0.id, $0) },
+                uniquingKeysWith: { first, _ in first }
+            )
             let groupOrderIndexById = Dictionary(
                 workspaceGroups.enumerated().map { ($1.id, $0) },
                 uniquingKeysWith: { first, _ in first }
             )
+            var memberIdsByGroupId: [UUID: [UUID]] = [:]
+            for tab in tabs {
+                if let groupId = tab.groupId {
+                    memberIdsByGroupId[groupId, default: []].append(tab.id)
+                }
+            }
             var placements: [RemoteTmuxSidebarPlacementSnapshot] = []
             for (index, tab) in tabs.enumerated() where tab.isRemoteTmuxMirror {
                 guard let key = tab.remoteTmuxMirrorIdentity else { continue }
                 var group: RemoteTmuxSidebarGroupPlacementSnapshot?
                 if let gid = tab.groupId,
-                   let g = workspaceGroups.first(where: { $0.id == gid }) {
-                    let members = tabs.filter { $0.groupId == gid }.map(\.id)
+                   let g = groupById[gid] {
+                    let members = memberIdsByGroupId[gid] ?? []
                     group = RemoteTmuxSidebarGroupPlacementSnapshot(
                         id: g.id,
                         name: g.name,

--- a/Sources/TabManager.swift
+++ b/Sources/TabManager.swift
@@ -6259,10 +6259,12 @@ extension TabManager {
                 workspaceGroups.enumerated().map { ($1.id, $0) },
                 uniquingKeysWith: { first, _ in first }
             )
-            var memberIdsByGroupId: [UUID: [UUID]] = [:]
+            var nextMemberIndexByGroupId: [UUID: Int] = [:]
+            var memberIndexByWorkspaceId: [UUID: Int] = [:]
             for tab in tabs {
                 if let groupId = tab.groupId {
-                    memberIdsByGroupId[groupId, default: []].append(tab.id)
+                    memberIndexByWorkspaceId[tab.id] = nextMemberIndexByGroupId[groupId, default: 0]
+                    nextMemberIndexByGroupId[groupId, default: 0] += 1
                 }
             }
             var placements: [RemoteTmuxSidebarPlacementSnapshot] = []
@@ -6271,7 +6273,6 @@ extension TabManager {
                 var group: RemoteTmuxSidebarGroupPlacementSnapshot?
                 if let gid = tab.groupId,
                    let g = groupById[gid] {
-                    let members = memberIdsByGroupId[gid] ?? []
                     group = RemoteTmuxSidebarGroupPlacementSnapshot(
                         id: g.id,
                         name: g.name,
@@ -6279,7 +6280,7 @@ extension TabManager {
                         isPinned: g.isPinned,
                         customColor: g.customColor,
                         iconSymbol: g.iconSymbol,
-                        memberIndex: members.firstIndex(of: tab.id) ?? 0,
+                        memberIndex: memberIndexByWorkspaceId[tab.id] ?? 0,
                         groupOrderIndex: groupOrderIndexById[gid]
                     )
                 }

--- a/Sources/TabManager.swift
+++ b/Sources/TabManager.swift
@@ -6210,10 +6210,44 @@ extension TabManager {
                 }
             return snapshots.isEmpty ? nil : snapshots
         }()
+        // Remote tmux mirrors are NOT restorable, but we record their sidebar
+        // group + order (keyed by the stable connectionKey) so a later reconnect
+        // returns each mirror to its prior group and position. Read from the
+        // UNFILTERED tabs since mirrors are excluded from `restorableTabs`.
+        let remoteTmuxSidebarPlacements: [RemoteTmuxSidebarPlacementSnapshot]? = {
+            let groupOrderIndexById = Dictionary(
+                workspaceGroups.enumerated().map { ($1.id, $0) },
+                uniquingKeysWith: { first, _ in first }
+            )
+            var placements: [RemoteTmuxSidebarPlacementSnapshot] = []
+            for (index, tab) in tabs.enumerated() where tab.isRemoteTmuxMirror {
+                guard let key = tab.remoteTmuxMirrorIdentity else { continue }
+                var group: RemoteTmuxSidebarGroupPlacementSnapshot?
+                if let gid = tab.groupId,
+                   let g = workspaceGroups.first(where: { $0.id == gid }) {
+                    let members = tabs.filter { $0.groupId == gid }.map(\.id)
+                    group = RemoteTmuxSidebarGroupPlacementSnapshot(
+                        id: g.id,
+                        name: g.name,
+                        isCollapsed: g.isCollapsed,
+                        isPinned: g.isPinned,
+                        customColor: g.customColor,
+                        iconSymbol: g.iconSymbol,
+                        memberIndex: members.firstIndex(of: tab.id) ?? 0,
+                        groupOrderIndex: groupOrderIndexById[gid]
+                    )
+                }
+                placements.append(
+                    RemoteTmuxSidebarPlacementSnapshot(connectionKey: key, sidebarIndex: index, group: group)
+                )
+            }
+            return placements.isEmpty ? nil : placements
+        }()
         return SessionTabManagerSnapshot(
             selectedWorkspaceIndex: selectedWorkspaceIndex,
             workspaces: workspaceSnapshots,
-            workspaceGroups: groupSnapshots
+            workspaceGroups: groupSnapshots,
+            remoteTmuxSidebarPlacements: remoteTmuxSidebarPlacements
         )
     }
 
@@ -6281,6 +6315,12 @@ extension TabManager {
 
         isRestoringSessionSnapshot = true
         defer { isRestoringSessionSnapshot = false }
+        // Seed the remote-tmux sidebar placement memory so a reconnect after this
+        // restart returns each mirror to its remembered group + order. Mirrors are
+        // not restored here (their SSH session can't resume cold); only the
+        // placement metadata is loaded.
+        AppDelegate.shared?.remoteTmuxController
+            .ingestPersistedSidebarPlacements(snapshot.remoteTmuxSidebarPlacements)
         let previousTabs = tabs
         for tab in previousTabs {
             unwireClosedBrowserTracking(for: tab)

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -5862,6 +5862,13 @@ final class Workspace: Identifiable, ObservableObject, FilePreviewTabMetadataHos
     /// Bound action for this mirror's outbound window-order mutation boundary.
     var remoteTmuxWindowOrderSync: (([UUID], ((Bool) -> Void)?) -> Bool)?
 
+    /// Stable identity of the mirrored remote tmux session (the controller's
+    /// `connectionKey` = host connection hash + session name). Unlike `id`, this
+    /// survives disconnect/reconnect and app restarts, so it keys the persisted
+    /// sidebar group/placement memory that lets a reconnected mirror return to
+    /// its prior group and order. Nil for non-mirror workspaces.
+    var remoteTmuxMirrorIdentity: String?
+
     /// Per-window multi-pane renderers, keyed by mirrored window-tab panel id.
     private(set) var remoteTmuxWindowMirrors: [UUID: RemoteTmuxWindowMirror] = [:]
 


### PR DESCRIPTION
## Problem

Remote tmux mirror workspaces lose their sidebar **grouping and ordering** whenever you reconnect with `cmux ssh-tmux`. Regular workspaces keep their groups/order; remote tmux ones come back ungrouped at the bottom of the sidebar.

Root cause: mirror workspaces are excluded from session restore (`isRemoteTmuxMirror` short-circuits `isRestorableInSessionSnapshot`) and are destroyed on disconnect, so a reconnect calls `mirrorSession` → `addWorkspace`, minting a **fresh UUID, `groupId == nil`, appended at the end**. Nothing persisted or reapplied any prior placement keyed to a stable identity.

## Fix

Add a **sidebar placement memory keyed by the stable `connectionKey`** (`host.connectionHash` + tmux session name), which is deterministic across reconnects and app restarts — so quitting cmux and re-running `cmux ssh-tmux <same host/session>` reconstructs the same key and finds the saved placement.

- `Workspace.remoteTmuxMirrorIdentity` stamps the `connectionKey` on the mirror.
- `SessionPersistence` gains `RemoteTmuxSidebarPlacementSnapshot` (+ group placement) and a field on `SessionTabManagerSnapshot` (optional, back-compat nil default).
- `TabManager.sessionSnapshot` records each mirror's group definition + member index + sidebar order from the **unfiltered** tabs (mirrors stay non-restorable — only the placement metadata is saved).
- `RemoteTmuxController` seeds the memory on restore, captures on disconnect, and on reconnect **reapplies**: rejoins the original group when it still exists, else recreates a dissolved mirror-only group (name/color/icon/collapsed) and remaps siblings onto it, then restores sidebar order. Re-keys the memory + workspace stamp on session rename.

## Testing

Dogfooded the reported flow against live remote tmux sessions: group + order several mirrors, **quit cmux entirely**, reopen, run `cmux ssh-tmux` again → the mirrors return to their groups and original order. In-session reconnect (detach → reattach) restores placement too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/9912"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788971000&installation_model_id=21920&pr_number=9912&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F9912&signature=dcc0a8ace34faea2d20b48848b33f2c036b1f555796d9b3af0c2b3028a634166"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 4c69e61e0c4aab773be9a752104121ad93702f65. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Persist remote tmux mirror sidebar groups and order across reconnects and app restarts. Previously mirrors reconnected ungrouped at the bottom; now they return to their prior group and index without changing non-remote behavior.

- New Features
  - Add placement memory keyed by a stable connectionKey (host hash + tmux session name).
  - Capture placement on detach/close; persist in `SessionTabManagerSnapshot.remoteTmuxSidebarPlacements`; seed on restore; mirrors remain non-restorable.
  - On reconnect, rejoin the original group or recreate a dissolved group (name/color/icon/collapsed/pinned) and restore the saved index; siblings share one recreated group.
  - Batch placement capture per window to compute consistent sidebar and group-member indices.

<sup>Written for commit fc2edece97fc41d79dfe7793104dc560ad119c4e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/9912?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Remote tmux mirror sidebar placement, grouping, and ordering now persist across app restarts and reconnects.
  * Dissolved groups can be recreated with their previous organization.
  * Mirrored workspaces retain their identity when sessions are renamed or reconnected.
* **Bug Fixes**
  * Improved restoration of remote tmux mirror layouts from saved sessions.
  * Renamed sessions now correctly carry over saved sidebar placement data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->