### PR TITLE
Make Windows state sync portable and terminal close atomic

### DIFF
--- a/cmux-tui/crates/cmux-tui-core/src/mux.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/mux.rs
@@ -20736,8 +20736,8 @@ mod tests {
         let host = mux
             .resource_terminal_host_identity(&surface)
             .expect("test terminal has a host identity");
-        let public_id = match surface.resource_identity().unwrap().content_id {
-            ContentPublicId::Terminal(public_id) => public_id,
+        let public_id = match &surface.resource_identity().unwrap().content_id {
+            ContentPublicId::Terminal(public_id) => public_id.clone(),
             ContentPublicId::Browser(_) => panic!("workspace opened a browser"),
         };
         let mutation = WorkspaceMutation::new("lost-host-close-reply", "legacy-client").unwrap();
@@ -20781,8 +20781,8 @@ mod tests {
         let host = mux
             .resource_terminal_host_identity(&surface)
             .expect("test terminal has a host identity");
-        let public_id = match surface.resource_identity().unwrap().content_id {
-            ContentPublicId::Terminal(public_id) => public_id,
+        let public_id = match &surface.resource_identity().unwrap().content_id {
+            ContentPublicId::Terminal(public_id) => public_id.clone(),
             ContentPublicId::Browser(_) => panic!("workspace opened a browser"),
         };
         let host_close = mux

--- a/cmux-tui/crates/cmux-tui-core/src/mux.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/mux.rs
@@ -20775,6 +20775,73 @@ mod tests {
     }
 
     #[test]
+    fn replayed_resource_close_does_not_acquire_terminal_effects() {
+        let mux = test_mux();
+        let surface = mux.new_workspace(None, None).unwrap();
+        let host = mux
+            .resource_terminal_host_identity(&surface)
+            .expect("test terminal has a host identity");
+        let public_id = match surface.resource_identity().unwrap().content_id {
+            ContentPublicId::Terminal(public_id) => public_id,
+            ContentPublicId::Browser(_) => panic!("workspace opened a browser"),
+        };
+        let host_close = mux
+            .workspace_registry
+            .lock()
+            .unwrap()
+            .close_terminal(
+                &WorkspaceMutation::new("closed-host", "legacy-client").unwrap(),
+                None,
+                None,
+                &host.terminal_id,
+                Some(&host.incarnation),
+            )
+            .unwrap();
+        let mutation =
+            WorkspaceMutation::new("lost-resource-close-reply", "resource-client").unwrap();
+        let fingerprint = serde_json::json!({
+            "op":"close-terminal",
+            "terminal_id":host.terminal_id,
+            "incarnation":host.incarnation,
+        });
+        let resource_revision = mux.with_state(|state| state.resource_revision);
+        let resource_close = mux
+            .workspace_registry
+            .lock()
+            .unwrap()
+            .commit_resource_patch(
+                &mutation,
+                "terminal.close",
+                &fingerprint,
+                None,
+                Some(resource_revision),
+                &ResourcePatch { changes: Vec::new() },
+                &serde_json::json!({}),
+                &serde_json::json!([]),
+            )
+            .unwrap();
+
+        let retry = mux
+            .close_terminal_with_mutation(
+                &host.terminal_id,
+                Some(&host.incarnation),
+                None,
+                None,
+                &mutation,
+            )
+            .unwrap();
+
+        assert!(retry.already_closed);
+        assert_eq!(retry.terminal_revision, host_close.revision);
+        assert_eq!(mux.with_state(|state| state.resource_revision), resource_close.revision);
+        assert!(mux.surface(surface.id).is_some());
+        assert_eq!(
+            mux.workspace_registry.lock().unwrap().terminal_resource_id(&host.terminal_id).unwrap(),
+            Some(public_id)
+        );
+    }
+
+    #[test]
     fn failed_browser_surface_attach_kills_worker() {
         let mux = test_mux();
         let opts = mux.surface_options.lock().unwrap().clone();

--- a/cmux-tui/crates/cmux-tui-core/src/mux.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/mux.rs
@@ -7623,6 +7623,15 @@ impl Mux {
         if let Some(incarnation) = terminal_incarnation {
             validate_terminal_hex(incarnation, "invalid_terminal_incarnation")?;
         }
+        if let Some(result) = self.commit_legacy_terminal_close(
+            terminal_id,
+            terminal_incarnation,
+            expected_generation,
+            expected_revision,
+            mutation,
+        )? {
+            return Ok(result);
+        }
         let (commit, terminal_incarnation, public_id, notify_public_id) = {
             let mut registry = self.workspace_registry.lock().unwrap();
             let public_id = registry.terminal_resource_id(terminal_id)?;

--- a/cmux-tui/crates/cmux-tui-core/src/mux.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/mux.rs
@@ -20730,6 +20730,51 @@ mod tests {
     }
 
     #[test]
+    fn replayed_host_close_does_not_acquire_public_resource_effects() {
+        let mux = test_mux();
+        let surface = mux.new_workspace(None, None).unwrap();
+        let host = mux
+            .resource_terminal_host_identity(&surface)
+            .expect("test terminal has a host identity");
+        let public_id = match surface.resource_identity().unwrap().content_id {
+            ContentPublicId::Terminal(public_id) => public_id,
+            ContentPublicId::Browser(_) => panic!("workspace opened a browser"),
+        };
+        let mutation = WorkspaceMutation::new("lost-host-close-reply", "legacy-client").unwrap();
+        let resource_revision = mux.with_state(|state| state.resource_revision);
+
+        let host_close = mux
+            .workspace_registry
+            .lock()
+            .unwrap()
+            .close_terminal(&mutation, None, None, &host.terminal_id, Some(&host.incarnation))
+            .unwrap();
+        assert!(!host_close.replayed);
+        assert_eq!(
+            mux.workspace_registry.lock().unwrap().terminal_resource_id(&host.terminal_id).unwrap(),
+            Some(public_id.clone())
+        );
+
+        let retry = mux
+            .close_terminal_with_mutation(
+                &host.terminal_id,
+                Some(&host.incarnation),
+                None,
+                None,
+                &mutation,
+            )
+            .unwrap();
+
+        assert_eq!(retry.terminal_revision, host_close.revision);
+        assert_eq!(mux.with_state(|state| state.resource_revision), resource_revision);
+        assert!(mux.surface(surface.id).is_some());
+        assert_eq!(
+            mux.workspace_registry.lock().unwrap().terminal_resource_id(&host.terminal_id).unwrap(),
+            Some(public_id)
+        );
+    }
+
+    #[test]
     fn failed_browser_surface_attach_kills_worker() {
         let mux = test_mux();
         let opts = mux.surface_options.lock().unwrap().clone();

--- a/cmux-tui/crates/cmux-tui-core/src/mux/resource_topology.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/mux/resource_topology.rs
@@ -86,6 +86,10 @@ struct ResourceCloseEffects {
     empty_revision: Option<u64>,
 }
 
+fn terminal_close_state_error(detail: impl Into<String>) -> anyhow::Error {
+    anyhow::Error::msg(detail.into()).context("terminal close state is unavailable")
+}
+
 enum ResourceCloseTreePublication {
     PendingDelta(TreeDelta),
     PendingSnapshot,
@@ -2247,18 +2251,22 @@ impl Mux {
             return Ok(None);
         };
         let mut state = self.state.lock().unwrap();
-        let durable_host = registry
-            .terminal_host_id(&public_id)?
-            .with_context(|| format!("terminal {public_id} has no durable host"))?;
-        anyhow::ensure!(durable_host == terminal_id, "terminal resource changed hosts");
+        let durable_host = registry.terminal_host_id(&public_id)?.ok_or_else(|| {
+            terminal_close_state_error(format!("terminal {public_id} has no durable host"))
+        })?;
+        if durable_host != terminal_id {
+            return Err(terminal_close_state_error("terminal resource changed hosts"));
+        }
         let content_id = ContentPublicId::Terminal(public_id.clone());
         let (target, mut plan) = if let Some(runtime) =
             state.terminal_catalog.get(&public_id).cloned()
         {
-            let host = self
-                .resource_terminal_host_identity(&runtime)
-                .context("terminal runtime omitted its durable host identity")?;
-            anyhow::ensure!(host.terminal_id == terminal_id, "terminal resource changed hosts");
+            let host = self.resource_terminal_host_identity(&runtime).ok_or_else(|| {
+                terminal_close_state_error("terminal runtime omitted its durable host identity")
+            })?;
+            if host.terminal_id != terminal_id {
+                return Err(terminal_close_state_error("terminal resource changed hosts"));
+            }
             if let Some(expected) = expected_incarnation {
                 anyhow::ensure!(host.incarnation == expected, "terminal_incarnation_mismatch");
             }
@@ -2272,10 +2280,11 @@ impl Mux {
             )?;
             (target, plan)
         } else {
-            anyhow::ensure!(
-                state.placements_of_content(&content_id).is_empty(),
-                "live terminal resource {public_id} has views but no runtime owner"
-            );
+            if !state.placements_of_content(&content_id).is_empty() {
+                return Err(terminal_close_state_error(format!(
+                    "live terminal resource {public_id} has views but no runtime owner"
+                )));
+            }
             (
                 None,
                 ResourceClosePlan {
@@ -2293,14 +2302,17 @@ impl Mux {
         };
         let projection =
             self.resource_effect_projection_locked(&registry, &mut plan.state, json!({}))?;
-        anyhow::ensure!(
-            projection.patch.changes.iter().any(|change| matches!(
+        if !projection.patch.changes.iter().any(|change| {
+            matches!(
                 change,
                 ResourceChange::TombstoneTerminal { public_id: closing, .. }
                     if closing == &public_id
-            )),
-            "terminal close projection omitted {public_id}"
-        );
+            )
+        }) {
+            return Err(terminal_close_state_error(format!(
+                "terminal close projection omitted {public_id}"
+            )));
+        }
         #[cfg(test)]
         if let Some(hook) = self.resource_projection_before_commit.lock().unwrap().clone() {
             hook();

--- a/cmux-tui/crates/cmux-tui-core/src/mux/resource_topology.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/mux/resource_topology.rs
@@ -2228,6 +2228,21 @@ impl Mux {
         let _creation_fence = self.resource_creation_execution.lock().unwrap();
         let notifications = self.surface_notifications();
         let mut registry = self.workspace_registry.lock().unwrap();
+        if let Some(terminal) =
+            registry.replay_terminal_close(mutation, terminal_id, expected_incarnation)?
+        {
+            let result = TerminalCloseResult {
+                surface: None,
+                terminal_id: terminal_id.to_string(),
+                terminal_incarnation: terminal.result["incarnation"].as_str().map(str::to_string),
+                already_closed: terminal.result["already_closed"].as_bool().unwrap_or(false),
+                terminal_revision: terminal.revision,
+            };
+            drop(registry);
+            drop(_creation_fence);
+            drop(_creation_handoff);
+            return Ok(Some(result));
+        }
         let Some(public_id) = registry.terminal_resource_id(terminal_id)? else {
             return Ok(None);
         };

--- a/cmux-tui/crates/cmux-tui-core/src/mux/resource_topology.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/mux/resource_topology.rs
@@ -2329,7 +2329,7 @@ impl Mux {
             &projection.changes,
         )?;
         let (terminal, resource) = match committed {
-            TerminalResourceCloseCommit::TerminalReplay(terminal) => {
+            TerminalResourceCloseCommit::Replay(terminal) => {
                 let result = TerminalCloseResult {
                     surface: None,
                     terminal_id: terminal_id.to_string(),

--- a/cmux-tui/crates/cmux-tui-core/src/mux/resource_topology.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/mux/resource_topology.rs
@@ -2243,10 +2243,8 @@ impl Mux {
             anyhow::ensure!(host.incarnation == expected, "terminal_incarnation_mismatch");
         }
         let surface = runtime.id;
-        let target = state
-            .placements_of_content(&ContentPublicId::Terminal(public_id.clone()))
-            .first()
-            .copied();
+        let target =
+            state.placements_of_content(&ContentPublicId::Terminal(public_id)).first().copied();
         let mut plan = self.resource_close_plan_locked(
             ResourceOperation::TerminalClose,
             EffectSlots { workspace: None, screen: None, pane: None, tab: Some(surface) },

--- a/cmux-tui/crates/cmux-tui-core/src/mux/resource_topology.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/mux/resource_topology.rs
@@ -2300,7 +2300,7 @@ impl Mux {
                 },
             )
         };
-        let projection =
+        let mut projection =
             self.resource_effect_projection_locked(&registry, &mut plan.state, json!({}))?;
         if !projection.patch.changes.iter().any(|change| {
             matches!(
@@ -2309,9 +2309,27 @@ impl Mux {
                     if closing == &public_id
             )
         }) {
-            return Err(terminal_close_state_error(format!(
-                "terminal close projection omitted {public_id}"
-            )));
+            let incarnation = registry
+                .terminal_record(terminal_id)?
+                .ok_or_else(|| {
+                    terminal_close_state_error(format!(
+                        "terminal close projection omitted host {terminal_id}"
+                    ))
+                })?
+                .incarnation;
+            projection.patch.changes.push(ResourceChange::TombstoneTerminal {
+                public_id: public_id.clone(),
+                expected_incarnation: incarnation,
+            });
+            let changes = projection.changes.as_array_mut().ok_or_else(|| {
+                terminal_close_state_error("terminal close projection changes are not an array")
+            })?;
+            changes.push(json!({
+                "kind":"delete",
+                "sequence":changes.len(),
+                "resource":"terminal",
+                "id":public_id,
+            }));
         }
         #[cfg(test)]
         if let Some(hook) = self.resource_projection_before_commit.lock().unwrap().clone() {

--- a/cmux-tui/crates/cmux-tui-core/src/mux/resource_topology.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/mux/resource_topology.rs
@@ -2232,29 +2232,60 @@ impl Mux {
             return Ok(None);
         };
         let mut state = self.state.lock().unwrap();
-        let runtime =
-            state.terminal_catalog.get(&public_id).cloned().with_context(|| {
-                format!("live terminal resource {public_id} has no runtime owner")
-            })?;
-        let host = self
-            .resource_terminal_host_identity(&runtime)
-            .context("terminal runtime omitted its durable host identity")?;
-        anyhow::ensure!(host.terminal_id == terminal_id, "terminal resource changed hosts");
-        if let Some(expected) = expected_incarnation {
-            anyhow::ensure!(host.incarnation == expected, "terminal_incarnation_mismatch");
-        }
-        let surface = runtime.id;
-        let target =
-            state.placements_of_content(&ContentPublicId::Terminal(public_id)).first().copied();
-        let mut plan = self.resource_close_plan_locked(
-            ResourceOperation::TerminalClose,
-            EffectSlots { workspace: None, screen: None, pane: None, tab: Some(surface) },
-            &registry,
-            &state,
-            &notifications,
-        )?;
+        let durable_host = registry
+            .terminal_host_id(&public_id)?
+            .with_context(|| format!("terminal {public_id} has no durable host"))?;
+        anyhow::ensure!(durable_host == terminal_id, "terminal resource changed hosts");
+        let content_id = ContentPublicId::Terminal(public_id.clone());
+        let (target, mut plan) = if let Some(runtime) =
+            state.terminal_catalog.get(&public_id).cloned()
+        {
+            let host = self
+                .resource_terminal_host_identity(&runtime)
+                .context("terminal runtime omitted its durable host identity")?;
+            anyhow::ensure!(host.terminal_id == terminal_id, "terminal resource changed hosts");
+            if let Some(expected) = expected_incarnation {
+                anyhow::ensure!(host.incarnation == expected, "terminal_incarnation_mismatch");
+            }
+            let target = state.placements_of_content(&content_id).first().copied();
+            let plan = self.resource_close_plan_locked(
+                ResourceOperation::TerminalClose,
+                EffectSlots { workspace: None, screen: None, pane: None, tab: Some(runtime.id) },
+                &registry,
+                &state,
+                &notifications,
+            )?;
+            (target, plan)
+        } else {
+            anyhow::ensure!(
+                state.placements_of_content(&content_id).is_empty(),
+                "live terminal resource {public_id} has views but no runtime owner"
+            );
+            (
+                None,
+                ResourceClosePlan {
+                    state: state.clone(),
+                    removed: Vec::new(),
+                    terminal_runtime: None,
+                    closed_terminal_public_id: Some(public_id.clone()),
+                    terminal_batch: Vec::new(),
+                    workspace_close: None,
+                    delta: None,
+                    changed_screens: Vec::new(),
+                    selection_resync: false,
+                },
+            )
+        };
         let projection =
             self.resource_effect_projection_locked(&registry, &mut plan.state, json!({}))?;
+        anyhow::ensure!(
+            projection.patch.changes.iter().any(|change| matches!(
+                change,
+                ResourceChange::TombstoneTerminal { public_id: closing, .. }
+                    if closing == &public_id
+            )),
+            "terminal close projection omitted {public_id}"
+        );
         #[cfg(test)]
         if let Some(hook) = self.resource_projection_before_commit.lock().unwrap().clone() {
             hook();

--- a/cmux-tui/crates/cmux-tui-core/src/mux/resource_topology.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/mux/resource_topology.rs
@@ -15,6 +15,7 @@ use crate::server::MAX_CREATION_SELECTOR_FALLBACKS;
 use crate::workspace_registry::{
     RegistryPane, RegistryScreen, RegistryViewportColumn, ResourceCreationPreparation,
     ResourceCreationRecovery, ResourcePatchCommit, ResourceWorkspaceClose, TerminalLifecycle,
+    TerminalResourceCloseCommit,
 };
 use crate::{ResolvedResourcePath, ResourceSelectors, ResourceTarget, SurfaceKind};
 
@@ -2258,7 +2259,7 @@ impl Mux {
         if let Some(hook) = self.resource_projection_before_commit.lock().unwrap().clone() {
             hook();
         }
-        let (terminal, resource) = registry.close_terminal_with_resource_patch(
+        let committed = registry.close_terminal_with_resource_patch(
             mutation,
             expected_generation,
             expected_terminal_revision,
@@ -2269,6 +2270,25 @@ impl Mux {
             &projection.result,
             &projection.changes,
         )?;
+        let (terminal, resource) = match committed {
+            TerminalResourceCloseCommit::TerminalReplay(terminal) => {
+                let result = TerminalCloseResult {
+                    surface: None,
+                    terminal_id: terminal_id.to_string(),
+                    terminal_incarnation: terminal.result["incarnation"]
+                        .as_str()
+                        .map(str::to_string),
+                    already_closed: terminal.result["already_closed"].as_bool().unwrap_or(false),
+                    terminal_revision: terminal.revision,
+                };
+                drop(state);
+                drop(registry);
+                drop(_creation_fence);
+                drop(_creation_handoff);
+                return Ok(Some(result));
+            }
+            TerminalResourceCloseCommit::Committed { terminal, resource } => (terminal, resource),
+        };
         #[cfg(test)]
         if let Some(hook) = self.resource_close_after_commit.lock().unwrap().clone() {
             hook();

--- a/cmux-tui/crates/cmux-tui-core/src/mux/resource_topology.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/mux/resource_topology.rs
@@ -2211,6 +2211,88 @@ impl Mux {
         Ok(self.finish_resource_close(committed))
     }
 
+    /// Route the legacy host close through the same projected topology owner
+    /// as `terminal.close`. `None` means the host has no live public resource,
+    /// so the caller may use the host-only compatibility path.
+    #[allow(clippy::too_many_arguments)]
+    pub(super) fn commit_legacy_terminal_close(
+        &self,
+        terminal_id: &str,
+        expected_incarnation: Option<&str>,
+        expected_generation: Option<&str>,
+        expected_terminal_revision: Option<u64>,
+        mutation: &WorkspaceMutation,
+    ) -> anyhow::Result<Option<TerminalCloseResult>> {
+        let _creation_handoff = self.resource_creation_handoff.lock().unwrap();
+        let _creation_fence = self.resource_creation_execution.lock().unwrap();
+        let notifications = self.surface_notifications();
+        let mut registry = self.workspace_registry.lock().unwrap();
+        let Some(public_id) = registry.terminal_resource_id(terminal_id)? else {
+            return Ok(None);
+        };
+        let mut state = self.state.lock().unwrap();
+        let runtime =
+            state.terminal_catalog.get(&public_id).cloned().with_context(|| {
+                format!("live terminal resource {public_id} has no runtime owner")
+            })?;
+        let host = self
+            .resource_terminal_host_identity(&runtime)
+            .context("terminal runtime omitted its durable host identity")?;
+        anyhow::ensure!(host.terminal_id == terminal_id, "terminal resource changed hosts");
+        if let Some(expected) = expected_incarnation {
+            anyhow::ensure!(host.incarnation == expected, "terminal_incarnation_mismatch");
+        }
+        let surface = runtime.id;
+        let target = state
+            .placements_of_content(&ContentPublicId::Terminal(public_id.clone()))
+            .first()
+            .copied();
+        let mut plan = self.resource_close_plan_locked(
+            ResourceOperation::TerminalClose,
+            EffectSlots { workspace: None, screen: None, pane: None, tab: Some(surface) },
+            &registry,
+            &state,
+            &notifications,
+        )?;
+        let projection =
+            self.resource_effect_projection_locked(&registry, &mut plan.state, json!({}))?;
+        #[cfg(test)]
+        if let Some(hook) = self.resource_projection_before_commit.lock().unwrap().clone() {
+            hook();
+        }
+        let (terminal, resource) = registry.close_terminal_with_resource_patch(
+            mutation,
+            expected_generation,
+            expected_terminal_revision,
+            state.resource_revision,
+            terminal_id,
+            expected_incarnation,
+            &projection.patch,
+            &projection.result,
+            &projection.changes,
+        )?;
+        #[cfg(test)]
+        if let Some(hook) = self.resource_close_after_commit.lock().unwrap().clone() {
+            hook();
+        }
+        if !terminal.replayed && !terminal.result["already_closed"].as_bool().unwrap_or(false) {
+            self.emit_terminal_registry_changed(&registry, terminal.revision);
+        }
+        let effects = plan.install(&mut state, resource.revision, None);
+        drop(state);
+        drop(registry);
+        drop(_creation_fence);
+        drop(_creation_handoff);
+        self.finish_resource_close(CommittedResourceClose { commit: resource, effects });
+        Ok(Some(TerminalCloseResult {
+            surface: target,
+            terminal_id: terminal_id.to_string(),
+            terminal_incarnation: terminal.result["incarnation"].as_str().map(str::to_string),
+            already_closed: terminal.result["already_closed"].as_bool().unwrap_or(false),
+            terminal_revision: terminal.revision,
+        }))
+    }
+
     pub(super) fn terminal_exit_detach_projection_locked(
         &self,
         registry: &WorkspaceRegistry,

--- a/cmux-tui/crates/cmux-tui-core/src/workspace_registry.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/workspace_registry.rs
@@ -360,7 +360,7 @@ pub struct TerminalRegistryCommit {
 /// A host mutation replay cannot acquire a public-resource side effect that
 /// was not part of its original transaction.
 pub(crate) enum TerminalResourceCloseCommit {
-    TerminalReplay(TerminalRegistryCommit),
+    Replay(TerminalRegistryCommit),
     Committed { terminal: TerminalRegistryCommit, resource: ResourcePatchCommit },
 }
 
@@ -2984,6 +2984,32 @@ impl WorkspaceRegistry {
         let fingerprint = terminal_close_fingerprint(mutation, terminal_id, expected_incarnation)?;
         let resource_result_json = canonical_json(resource_result)?;
         let tx = self.connection.transaction()?;
+        if let Some(terminal) = terminal_replay(&tx, mutation, &fingerprint)? {
+            tx.commit()?;
+            return Ok(TerminalResourceCloseCommit::Replay(terminal));
+        }
+        if resource_store::resource_patch_replay(&tx, mutation, OPERATION, &fingerprint)?.is_some()
+        {
+            let terminal =
+                read_terminal(&tx, terminal_id)?.context("terminal close state is unavailable")?;
+            anyhow::ensure!(
+                terminal.lifecycle == TerminalLifecycle::Tombstoned,
+                "terminal close state is unavailable"
+            );
+            let revision = transaction_terminal_revision(&tx)?;
+            let result = serde_json::json!({
+                "terminal_id": terminal_id,
+                "incarnation": terminal.incarnation,
+                "closed": true,
+                "already_closed": true,
+            });
+            tx.commit()?;
+            return Ok(TerminalResourceCloseCommit::Replay(TerminalRegistryCommit {
+                revision,
+                result,
+                replayed: true,
+            }));
+        }
         let terminal = close_terminal_in_transaction(
             &tx,
             &self.generation,
@@ -2994,61 +3020,50 @@ impl WorkspaceRegistry {
             terminal_id,
             expected_incarnation,
         )?;
-        if terminal.replayed {
-            // The original mutation may predate the combined close path. Its
-            // durable reply is final, so do not apply a patch to whichever
-            // public resource currently owns this terminal ID.
-            tx.commit()?;
-            return Ok(TerminalResourceCloseCommit::TerminalReplay(terminal));
-        }
-        let resource = if let Some(replayed) =
-            resource_store::resource_patch_replay(&tx, mutation, OPERATION, &fingerprint)?
-        {
-            replayed
-        } else {
-            let previous_revision = transaction_resource_revision(&tx)?;
-            anyhow::ensure!(
-                previous_revision == expected_resource_revision,
-                "resource revision conflict: expected {expected_resource_revision}, current {previous_revision}"
-            );
-            let revision = previous_revision
-                .checked_add(1)
-                .ok_or_else(|| anyhow::anyhow!("resource revision exhausted"))?;
-            let sqlite_revision =
-                i64::try_from(revision).context("resource revision exceeds SQLite range")?;
-            apply_resource_patch(&tx, patch, sqlite_revision)?;
-            tx.execute(
-                "UPDATE meta SET value = ?1 WHERE key = 'resource_revision'",
-                [revision.to_string()],
-            )?;
-            tx.execute(
-                "INSERT INTO resource_mutations(
+        debug_assert!(!terminal.replayed);
+        let previous_revision = transaction_resource_revision(&tx)?;
+        anyhow::ensure!(
+            previous_revision == expected_resource_revision,
+            "resource revision conflict: expected {expected_resource_revision}, current {previous_revision}"
+        );
+        let revision = previous_revision
+            .checked_add(1)
+            .ok_or_else(|| anyhow::anyhow!("resource revision exhausted"))?;
+        let sqlite_revision =
+            i64::try_from(revision).context("resource revision exceeds SQLite range")?;
+        apply_resource_patch(&tx, patch, sqlite_revision)?;
+        tx.execute(
+            "UPDATE meta SET value = ?1 WHERE key = 'resource_revision'",
+            [revision.to_string()],
+        )?;
+        tx.execute(
+            "INSERT INTO resource_mutations(
                    origin, idempotency_key, operation, fingerprint, result_json,
                    committed_revision
                  ) VALUES(?1, ?2, ?3, ?4, ?5, ?6)",
-                params![
-                    mutation.origin,
-                    mutation.id,
-                    OPERATION,
-                    fingerprint,
-                    resource_result_json,
-                    sqlite_revision,
-                ],
-            )?;
-            append_resource_journal_record(
-                &tx,
-                revision,
-                previous_revision,
-                &mutation.origin,
-                &mutation.id,
+            params![
+                mutation.origin,
+                mutation.id,
                 OPERATION,
-                Some(patch),
-                resource_result,
-                resource_deltas,
-            )?;
-            resource_store::prune_resource_mutations(&tx)?;
-            ResourcePatchCommit { revision, result: resource_result.clone(), replayed: false }
-        };
+                fingerprint,
+                resource_result_json,
+                sqlite_revision,
+            ],
+        )?;
+        append_resource_journal_record(
+            &tx,
+            revision,
+            previous_revision,
+            &mutation.origin,
+            &mutation.id,
+            OPERATION,
+            Some(patch),
+            resource_result,
+            resource_deltas,
+        )?;
+        resource_store::prune_resource_mutations(&tx)?;
+        let resource =
+            ResourcePatchCommit { revision, result: resource_result.clone(), replayed: false };
         tx.commit()?;
         Ok(TerminalResourceCloseCommit::Committed { terminal, resource })
     }

--- a/cmux-tui/crates/cmux-tui-core/src/workspace_registry.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/workspace_registry.rs
@@ -5027,8 +5027,7 @@ fn load_or_create_resource_effect_pepper(root: &Path) -> anyhow::Result<Resource
                 .with_context(|| format!("write resource receipt pepper {}", path.display()))?;
             file.sync_all()
                 .with_context(|| format!("sync resource receipt pepper {}", path.display()))?;
-            File::open(root)
-                .and_then(|directory| directory.sync_all())
+            platform::sync_directory(root)
                 .with_context(|| format!("sync state root {}", root.display()))?;
             Ok(pepper)
         }
@@ -5107,8 +5106,7 @@ fn load_or_create_machine_id(root: &Path) -> anyhow::Result<MachinePublicId> {
                 .and_then(|()| file.write_all(b"\n"))
                 .with_context(|| format!("write machine identity {}", path.display()))?;
             file.sync_all().with_context(|| format!("sync machine identity {}", path.display()))?;
-            File::open(root)
-                .and_then(|directory| directory.sync_all())
+            platform::sync_directory(root)
                 .with_context(|| format!("sync state root {}", root.display()))?;
             Ok(id)
         }

--- a/cmux-tui/crates/cmux-tui-core/src/workspace_registry.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/workspace_registry.rs
@@ -72,8 +72,7 @@ use resource_store::{
     apply_resource_patch, create_resource_schema, initialize_resource_mutation_retention,
     migrate_resource_agent_projections, migrate_resource_browser_metadata,
     migrate_resource_mutations_to_session_scope, migrate_resource_tabs_to_multiview,
-    prune_resource_mutations, resource_patch_replay, resource_tabs_needs_multiview_normalization,
-    validate_resource_invariants, validate_resource_patch,
+    resource_tabs_needs_multiview_normalization, validate_resource_invariants,
 };
 pub use session_journal::{
     JournalAuthority, JournalClass, JournalProducer, JournalReplayPolicy, JournalSensitivity,
@@ -2964,7 +2963,7 @@ impl WorkspaceRegistry {
         const OPERATION: &str = "terminal.close";
 
         validate_identifier("resource operation", OPERATION)?;
-        validate_resource_patch(patch)?;
+        resource_store::validate_resource_patch(patch)?;
         let fingerprint = terminal_close_fingerprint(mutation, terminal_id, expected_incarnation)?;
         let resource_result_json = canonical_json(resource_result)?;
         let tx = self.connection.transaction()?;
@@ -2979,7 +2978,7 @@ impl WorkspaceRegistry {
             expected_incarnation,
         )?;
         let resource = if let Some(replayed) =
-            resource_patch_replay(&tx, mutation, OPERATION, &fingerprint)?
+            resource_store::resource_patch_replay(&tx, mutation, OPERATION, &fingerprint)?
         {
             replayed
         } else {
@@ -3023,7 +3022,7 @@ impl WorkspaceRegistry {
                 resource_result,
                 resource_deltas,
             )?;
-            prune_resource_mutations(&tx)?;
+            resource_store::prune_resource_mutations(&tx)?;
             ResourcePatchCommit { revision, result: resource_result.clone(), replayed: false }
         };
         tx.commit()?;

--- a/cmux-tui/crates/cmux-tui-core/src/workspace_registry.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/workspace_registry.rs
@@ -2951,6 +2951,16 @@ impl WorkspaceRegistry {
         Ok(commit)
     }
 
+    pub(crate) fn replay_terminal_close(
+        &self,
+        mutation: &WorkspaceMutation,
+        terminal_id: &str,
+        expected_incarnation: Option<&str>,
+    ) -> anyhow::Result<Option<TerminalRegistryCommit>> {
+        let fingerprint = terminal_close_fingerprint(mutation, terminal_id, expected_incarnation)?;
+        terminal_replay(&self.connection, mutation, &fingerprint)
+    }
+
     /// Commit the legacy host close and its public resource tombstone in one
     /// SQLite transaction. The mux installs the matching runtime projection
     /// only after this method returns successfully.

--- a/cmux-tui/crates/cmux-tui-core/src/workspace_registry.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/workspace_registry.rs
@@ -357,6 +357,13 @@ pub struct TerminalRegistryCommit {
     pub replayed: bool,
 }
 
+/// A host mutation replay cannot acquire a public-resource side effect that
+/// was not part of its original transaction.
+pub(crate) enum TerminalResourceCloseCommit {
+    TerminalReplay(TerminalRegistryCommit),
+    Committed { terminal: TerminalRegistryCommit, resource: ResourcePatchCommit },
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct TerminalBatchClose {
     pub revision: u64,
@@ -2959,7 +2966,7 @@ impl WorkspaceRegistry {
         patch: &ResourcePatch,
         resource_result: &Value,
         resource_deltas: &Value,
-    ) -> anyhow::Result<(TerminalRegistryCommit, ResourcePatchCommit)> {
+    ) -> anyhow::Result<TerminalResourceCloseCommit> {
         const OPERATION: &str = "terminal.close";
 
         validate_identifier("resource operation", OPERATION)?;
@@ -2977,6 +2984,13 @@ impl WorkspaceRegistry {
             terminal_id,
             expected_incarnation,
         )?;
+        if terminal.replayed {
+            // The original mutation may predate the combined close path. Its
+            // durable reply is final, so do not apply a patch to whichever
+            // public resource currently owns this terminal ID.
+            tx.commit()?;
+            return Ok(TerminalResourceCloseCommit::TerminalReplay(terminal));
+        }
         let resource = if let Some(replayed) =
             resource_store::resource_patch_replay(&tx, mutation, OPERATION, &fingerprint)?
         {
@@ -3026,7 +3040,7 @@ impl WorkspaceRegistry {
             ResourcePatchCommit { revision, result: resource_result.clone(), replayed: false }
         };
         tx.commit()?;
-        Ok((terminal, resource))
+        Ok(TerminalResourceCloseCommit::Committed { terminal, resource })
     }
 
     /// Tombstone every hosted tab in one pane/screen as one SQLite unit. All

--- a/cmux-tui/crates/cmux-tui-core/src/workspace_registry.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/workspace_registry.rs
@@ -72,7 +72,8 @@ use resource_store::{
     apply_resource_patch, create_resource_schema, initialize_resource_mutation_retention,
     migrate_resource_agent_projections, migrate_resource_browser_metadata,
     migrate_resource_mutations_to_session_scope, migrate_resource_tabs_to_multiview,
-    resource_tabs_needs_multiview_normalization, validate_resource_invariants,
+    prune_resource_mutations, resource_patch_replay, resource_tabs_needs_multiview_normalization,
+    validate_resource_invariants, validate_resource_patch,
 };
 pub use session_journal::{
     JournalAuthority, JournalClass, JournalProducer, JournalReplayPolicy, JournalSensitivity,
@@ -2928,119 +2929,105 @@ impl WorkspaceRegistry {
         terminal_id: &str,
         expected_incarnation: Option<&str>,
     ) -> anyhow::Result<TerminalRegistryCommit> {
-        validate_identifier("mutation id", &mutation.id)?;
-        validate_identifier("mutation origin", &mutation.origin)?;
-        validate_terminal_identity("terminal id", terminal_id)?;
-        if let Some(incarnation) = expected_incarnation {
-            validate_terminal_identity("terminal incarnation", incarnation)?;
-        }
-        let fingerprint_value = serde_json::json!({
-            "op": "close-terminal",
-            "terminal_id": terminal_id,
-            "incarnation": expected_incarnation,
-        });
-        let fingerprint = canonical_json(&fingerprint_value)?;
+        let fingerprint = terminal_close_fingerprint(mutation, terminal_id, expected_incarnation)?;
         let tx = self.connection.transaction()?;
-        if let Some(replay) = terminal_replay(&tx, mutation, &fingerprint)? {
-            return Ok(replay);
-        }
-        if let Some(expected) = expected_generation
-            && expected != self.generation
-        {
-            anyhow::bail!(
-                "terminal generation conflict: expected {expected}, current {}",
-                self.generation
-            );
-        }
-        let current_revision = transaction_terminal_revision(&tx)?;
-        if let Some(expected) = expected_revision
-            && expected != current_revision
-        {
-            anyhow::bail!(
-                "terminal revision conflict: expected {expected}, current {current_revision}"
-            );
-        }
-        let Some(terminal) = read_terminal(&tx, terminal_id)? else {
-            anyhow::bail!("unknown terminal {terminal_id}; it may not have been adopted yet");
-        };
-        if let Some(expected) = expected_incarnation
-            && terminal.incarnation.as_deref() != Some(expected)
-        {
-            anyhow::bail!("terminal_incarnation_mismatch");
-        }
+        let commit = close_terminal_in_transaction(
+            &tx,
+            &self.generation,
+            mutation,
+            &fingerprint,
+            expected_generation,
+            expected_revision,
+            terminal_id,
+            expected_incarnation,
+        )?;
+        tx.commit()?;
+        Ok(commit)
+    }
 
-        if terminal.lifecycle == TerminalLifecycle::Tombstoned {
-            let result = serde_json::json!({
-                "terminal_id": terminal_id,
-                "incarnation": terminal.incarnation,
-                "closed": true,
-                "already_closed": true,
-            });
-            let result_json = canonical_json(&result)?;
+    /// Commit the legacy host close and its public resource tombstone in one
+    /// SQLite transaction. The mux installs the matching runtime projection
+    /// only after this method returns successfully.
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn close_terminal_with_resource_patch(
+        &mut self,
+        mutation: &WorkspaceMutation,
+        expected_generation: Option<&str>,
+        expected_terminal_revision: Option<u64>,
+        expected_resource_revision: u64,
+        terminal_id: &str,
+        expected_incarnation: Option<&str>,
+        patch: &ResourcePatch,
+        resource_result: &Value,
+        resource_deltas: &Value,
+    ) -> anyhow::Result<(TerminalRegistryCommit, ResourcePatchCommit)> {
+        const OPERATION: &str = "terminal.close";
+
+        validate_identifier("resource operation", OPERATION)?;
+        validate_resource_patch(patch)?;
+        let fingerprint = terminal_close_fingerprint(mutation, terminal_id, expected_incarnation)?;
+        let resource_result_json = canonical_json(resource_result)?;
+        let tx = self.connection.transaction()?;
+        let terminal = close_terminal_in_transaction(
+            &tx,
+            &self.generation,
+            mutation,
+            &fingerprint,
+            expected_generation,
+            expected_terminal_revision,
+            terminal_id,
+            expected_incarnation,
+        )?;
+        let resource = if let Some(replayed) =
+            resource_patch_replay(&tx, mutation, OPERATION, &fingerprint)?
+        {
+            replayed
+        } else {
+            let previous_revision = transaction_resource_revision(&tx)?;
+            anyhow::ensure!(
+                previous_revision == expected_resource_revision,
+                "resource revision conflict: expected {expected_resource_revision}, current {previous_revision}"
+            );
+            let revision = previous_revision
+                .checked_add(1)
+                .ok_or_else(|| anyhow::anyhow!("resource revision exhausted"))?;
+            let sqlite_revision =
+                i64::try_from(revision).context("resource revision exceeds SQLite range")?;
+            apply_resource_patch(&tx, patch, sqlite_revision)?;
             tx.execute(
-                "INSERT INTO terminal_mutations(
-                   origin, mutation_id, fingerprint, result_json, committed_revision
-                 ) VALUES(?1, ?2, ?3, ?4, ?5)",
+                "UPDATE meta SET value = ?1 WHERE key = 'resource_revision'",
+                [revision.to_string()],
+            )?;
+            tx.execute(
+                "INSERT INTO resource_mutations(
+                   origin, idempotency_key, operation, fingerprint, result_json,
+                   committed_revision
+                 ) VALUES(?1, ?2, ?3, ?4, ?5, ?6)",
                 params![
                     mutation.origin,
                     mutation.id,
+                    OPERATION,
                     fingerprint,
-                    result_json,
-                    i64::try_from(current_revision)
-                        .context("terminal revision exceeds SQLite integer range")?,
+                    resource_result_json,
+                    sqlite_revision,
                 ],
             )?;
-            tx.commit()?;
-            return Ok(TerminalRegistryCommit {
-                revision: current_revision,
-                result,
-                replayed: false,
-            });
-        }
-
-        let revision = current_revision
-            .checked_add(1)
-            .ok_or_else(|| anyhow::anyhow!("terminal revision exhausted"))?;
-        let sqlite_revision =
-            i64::try_from(revision).context("terminal revision exceeds SQLite integer range")?;
-        let result = serde_json::json!({
-            "terminal_id": terminal_id,
-            "incarnation": terminal.incarnation,
-            "closed": true,
-            "already_closed": false,
-        });
-        let result_json = canonical_json(&result)?;
-        tx.execute(
-            "UPDATE terminal_hosts
-             SET lifecycle = 'tombstoned', updated_revision = ?1, deleted_revision = ?1
-             WHERE terminal_id = ?2",
-            params![sqlite_revision, terminal_id],
-        )?;
-        tx.execute(
-            "UPDATE meta SET value = ?1 WHERE key = 'terminal_revision'",
-            [revision.to_string()],
-        )?;
-        tx.execute(
-            "INSERT INTO terminal_mutations(
-               origin, mutation_id, fingerprint, result_json, committed_revision
-             ) VALUES(?1, ?2, ?3, ?4, ?5)",
-            params![mutation.origin, mutation.id, fingerprint, result_json, sqlite_revision],
-        )?;
-        tx.execute(
-            "INSERT INTO terminal_events(
-               revision, kind, terminal_id, workspace_key, origin, mutation_id, result_json
-             ) VALUES(?1, 'terminal-closed', ?2, ?3, ?4, ?5, ?6)",
-            params![
-                sqlite_revision,
-                terminal_id,
-                terminal.workspace_key,
-                mutation.origin,
-                mutation.id,
-                result_json,
-            ],
-        )?;
+            append_resource_journal_record(
+                &tx,
+                revision,
+                previous_revision,
+                &mutation.origin,
+                &mutation.id,
+                OPERATION,
+                Some(patch),
+                resource_result,
+                resource_deltas,
+            )?;
+            prune_resource_mutations(&tx)?;
+            ResourcePatchCommit { revision, result: resource_result.clone(), replayed: false }
+        };
         tx.commit()?;
-        Ok(TerminalRegistryCommit { revision, result, replayed: false })
+        Ok((terminal, resource))
     }
 
     /// Tombstone every hosted tab in one pane/screen as one SQLite unit. All
@@ -4209,6 +4196,128 @@ fn normalized_workspace_resource_deltas(
         push_delete("workspace", workspace.as_str());
     }
     Ok(Value::Array(deltas))
+}
+
+fn terminal_close_fingerprint(
+    mutation: &WorkspaceMutation,
+    terminal_id: &str,
+    expected_incarnation: Option<&str>,
+) -> anyhow::Result<String> {
+    validate_identifier("mutation id", &mutation.id)?;
+    validate_identifier("mutation origin", &mutation.origin)?;
+    validate_terminal_identity("terminal id", terminal_id)?;
+    if let Some(incarnation) = expected_incarnation {
+        validate_terminal_identity("terminal incarnation", incarnation)?;
+    }
+    canonical_json(&serde_json::json!({
+        "op": "close-terminal",
+        "terminal_id": terminal_id,
+        "incarnation": expected_incarnation,
+    }))
+}
+
+#[allow(clippy::too_many_arguments)]
+fn close_terminal_in_transaction(
+    transaction: &Transaction<'_>,
+    generation: &str,
+    mutation: &WorkspaceMutation,
+    fingerprint: &str,
+    expected_generation: Option<&str>,
+    expected_revision: Option<u64>,
+    terminal_id: &str,
+    expected_incarnation: Option<&str>,
+) -> anyhow::Result<TerminalRegistryCommit> {
+    if let Some(replay) = terminal_replay(transaction, mutation, fingerprint)? {
+        return Ok(replay);
+    }
+    if let Some(expected) = expected_generation
+        && expected != generation
+    {
+        anyhow::bail!("terminal generation conflict: expected {expected}, current {generation}");
+    }
+    let current_revision = transaction_terminal_revision(transaction)?;
+    if let Some(expected) = expected_revision
+        && expected != current_revision
+    {
+        anyhow::bail!(
+            "terminal revision conflict: expected {expected}, current {current_revision}"
+        );
+    }
+    let Some(terminal) = read_terminal(transaction, terminal_id)? else {
+        anyhow::bail!("unknown terminal {terminal_id}; it may not have been adopted yet");
+    };
+    if let Some(expected) = expected_incarnation
+        && terminal.incarnation.as_deref() != Some(expected)
+    {
+        anyhow::bail!("terminal_incarnation_mismatch");
+    }
+
+    if terminal.lifecycle == TerminalLifecycle::Tombstoned {
+        let result = serde_json::json!({
+            "terminal_id": terminal_id,
+            "incarnation": terminal.incarnation,
+            "closed": true,
+            "already_closed": true,
+        });
+        let result_json = canonical_json(&result)?;
+        transaction.execute(
+            "INSERT INTO terminal_mutations(
+               origin, mutation_id, fingerprint, result_json, committed_revision
+             ) VALUES(?1, ?2, ?3, ?4, ?5)",
+            params![
+                mutation.origin,
+                mutation.id,
+                fingerprint,
+                result_json,
+                i64::try_from(current_revision)
+                    .context("terminal revision exceeds SQLite integer range")?,
+            ],
+        )?;
+        return Ok(TerminalRegistryCommit { revision: current_revision, result, replayed: false });
+    }
+
+    let revision = current_revision
+        .checked_add(1)
+        .ok_or_else(|| anyhow::anyhow!("terminal revision exhausted"))?;
+    let sqlite_revision =
+        i64::try_from(revision).context("terminal revision exceeds SQLite integer range")?;
+    let result = serde_json::json!({
+        "terminal_id": terminal_id,
+        "incarnation": terminal.incarnation,
+        "closed": true,
+        "already_closed": false,
+    });
+    let result_json = canonical_json(&result)?;
+    transaction.execute(
+        "UPDATE terminal_hosts
+         SET lifecycle = 'tombstoned', updated_revision = ?1, deleted_revision = ?1
+         WHERE terminal_id = ?2",
+        params![sqlite_revision, terminal_id],
+    )?;
+    transaction.execute(
+        "UPDATE meta SET value = ?1 WHERE key = 'terminal_revision'",
+        [revision.to_string()],
+    )?;
+    transaction.execute(
+        "INSERT INTO terminal_mutations(
+           origin, mutation_id, fingerprint, result_json, committed_revision
+         ) VALUES(?1, ?2, ?3, ?4, ?5)",
+        params![mutation.origin, mutation.id, fingerprint, result_json, sqlite_revision],
+    )?;
+    transaction.execute(
+        "INSERT INTO terminal_events(
+           revision, kind, terminal_id, workspace_key, origin, mutation_id, result_json
+         ) VALUES(?1, 'terminal-closed', ?2, ?3, ?4, ?5, ?6)",
+        params![
+            sqlite_revision,
+            terminal_id,
+            terminal.workspace_key,
+            mutation.origin,
+            mutation.id,
+            result_json,
+        ],
+    )?;
+    Ok(TerminalRegistryCommit { revision, result, replayed: false })
 }
 
 fn validate_terminal_batch_close(


### PR DESCRIPTION
Fix two current-main blockers found by the exact startup benchmark.

- Route state-directory durability through the platform owner. Unix keeps open plus sync_all; Windows validates the directory and avoids an unsupported directory handle flush.
- Commit a legacy terminal host close and its public resource tombstone in one SQLite transaction. This removes the live-resource/tombstoned-host state that broke public snapshots after a detached terminal closed.
- Keep durable agent history, notification unlinking, terminal revisions, idempotency, and runtime cleanup behavior.

Static Rust formatting and whitespace checks pass. No local compile or test ran. Hosted validation is required.

## Demo video

Not applicable. This PR changes Rust persistence and terminal lifecycle behavior without a visible UI.

## Checklist

- [x] Static Rust formatting and whitespace checks pass.
- [x] Regression test precedes the replay fix.
- [x] Exact-head local autoreview is clean.
- [x] Exact-head hosted required paths pass. The only full-suite failure reproduces unchanged on the exact base and head on Linux and macOS.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes durable terminal lifecycle, SQLite transactions, and idempotency replay paths—areas that can leave inconsistent public snapshots if wrong; scope is focused but persistence-critical.
> 
> **Overview**
> Legacy **terminal host close** now goes through **`commit_legacy_terminal_close`** when a public resource exists, aligning with **`terminal.close`** topology and tombstoning the public resource in the **same SQLite transaction** via **`close_terminal_with_resource_patch`**. Retries after a lost reply **replay** without bumping resource revision or double-applying effects; separate tests cover host-only vs resource-side replays.
> 
> **Workspace registry** refactors close into **`close_terminal_in_transaction`** / **`terminal_close_fingerprint`**, and **`TerminalResourceCloseCommit`** distinguishes replay from a full host+resource commit.
> 
> **State directory durability** for resource receipt pepper and machine identity uses **`platform::sync_directory`** instead of opening the root and **`sync_all`**, avoiding unsupported directory flush on Windows while keeping Unix behavior via the platform owner.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1e1c83ecf0081a85a45e4e427286b5feb2e2d380. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved terminal closing reliability across current and legacy terminal workflows.
  * Prevented duplicate or repeated close actions from creating inconsistent state.
  * Ensured associated resources update atomically when a terminal closes.
  * Added validation to prevent stale or mismatched close operations.
  * Improved recovery and replay handling after interruptions.
  * Improved persistence and synchronization of terminal and resource state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->