### PR TITLE
Surface the Simulator feature at moments of intent on Mac and iOS

### DIFF
--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+SimulatorStream.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+SimulatorStream.swift
@@ -4,6 +4,16 @@ import Foundation
 
 @MainActor
 extension MobileShellComposite {
+    /// Permanently dismisses the workspace simulator hint banner. Called by
+    /// the banner's close button and by any successful simulator stream
+    /// selection, since organically opening one proves the hint is no longer
+    /// needed.
+    public func dismissSimulatorStreamHint() {
+        guard !simulatorStreamHintDismissed else { return }
+        simulatorStreamHintDismissed = true
+        simulatorStreamHintDismissalStore.markDismissed()
+    }
+
     /// Serializes start/stop transitions per panel through the composite-owned
     /// operation chain, so a foreground restart cannot overlap a still-running
     /// background stop against the Mac's single-controller ownership.

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
@@ -499,6 +499,12 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
     public private(set) var workspaceChangeChipsByWorkspaceID: [String: MobileWorkspaceChangesChip] = [:]
     /// Device-local persistence for the one-time workspace-changes hint.
     @ObservationIgnored var workspaceChangesHintDismissalStore: MobileWorkspaceChangesHintDismissalStore
+    /// Device-local persistence for the one-time simulator hint banner.
+    @ObservationIgnored var simulatorStreamHintDismissalStore: MobileSimulatorStreamHintDismissalStore
+    /// Observable mirror of the simulator hint dismissal, so every mounted
+    /// workspace view drops the banner the moment it is dismissed anywhere.
+    /// Written only by `dismissSimulatorStreamHint()`.
+    public internal(set) var simulatorStreamHintDismissed: Bool
 
     func setWorkspaceChangeChipsByWorkspaceID(
         _ chips: [String: MobileWorkspaceChangesChip]
@@ -1491,6 +1497,7 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         groupCollapseStore: MobileWorkspaceGroupCollapseStore = MobileWorkspaceGroupCollapseStore(),
         workspaceSortStore: MobileWorkspaceSortStore = MobileWorkspaceSortStore(),
         workspaceChangesHintDismissalStore: MobileWorkspaceChangesHintDismissalStore = MobileWorkspaceChangesHintDismissalStore(),
+        simulatorStreamHintDismissalStore: MobileSimulatorStreamHintDismissalStore = MobileSimulatorStreamHintDismissalStore(),
         workspaceChangesSchedulingClock: any Clock<Duration> = ContinuousClock(),
         controlPlaneSchedulingClock: any Clock<Duration> = ContinuousClock(),
         connectionHandoffDrainTimeoutNanoseconds: UInt64 = 3_000_000_000,
@@ -1508,6 +1515,8 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         self.workspaceSortMode = workspaceSortStore.mode
         self.workspaceComputerPriority = workspaceSortStore.computerPriority
         self.workspaceChangesHintDismissalStore = workspaceChangesHintDismissalStore
+        self.simulatorStreamHintDismissalStore = simulatorStreamHintDismissalStore
+        self.simulatorStreamHintDismissed = simulatorStreamHintDismissalStore.isDismissed
         self.workspaceChangesSchedulingClock = workspaceChangesSchedulingClock
         self.controlPlaneSchedulingClock = controlPlaneSchedulingClock
         self.connectionHandoffDrainTimeoutNanoseconds =

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileSimulatorStreamHintDismissalStore.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileSimulatorStreamHintDismissalStore.swift
@@ -1,0 +1,31 @@
+public import Foundation
+
+/// Persists the one-time dismissal of the workspace simulator hint banner in
+/// injected user defaults.
+///
+/// Global rather than per-workspace: the banner exists to teach that Mac
+/// Simulator panes can be opened from the surfaces menu. Once the user has
+/// dismissed it — or opened a simulator stream anywhere, which proves the
+/// lesson landed — it never shows again on any workspace.
+public struct MobileSimulatorStreamHintDismissalStore {
+    private static let dismissedKey = "cmux.mobile.simulatorStreamHint.dismissed"
+    private let defaults: UserDefaults
+
+    /// Creates a dismissal store backed by the supplied defaults domain.
+    ///
+    /// - Parameter defaults: The defaults domain; production uses `UserDefaults.standard`.
+    public init(defaults: UserDefaults = .standard) {
+        self.defaults = defaults
+    }
+
+    /// Whether the hint has been dismissed (explicitly or by opening a
+    /// simulator stream).
+    public var isDismissed: Bool {
+        defaults.bool(forKey: Self.dismissedKey)
+    }
+
+    /// Marks the hint as permanently dismissed.
+    public func markDismissed() {
+        defaults.set(true, forKey: Self.dismissedKey)
+    }
+}

--- a/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/MobileSimulatorStreamHintTests.swift
+++ b/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/MobileSimulatorStreamHintTests.swift
@@ -1,0 +1,42 @@
+import Foundation
+import Testing
+@testable import CmuxMobileShell
+
+@MainActor
+@Suite struct MobileSimulatorStreamHintTests {
+    @Test func dismissalPersistsAcrossStoreInstances() throws {
+        let suiteName = "simulator-hint-\(UUID().uuidString)"
+        let defaults = try #require(UserDefaults(suiteName: suiteName))
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        let store = MobileSimulatorStreamHintDismissalStore(defaults: defaults)
+        #expect(!store.isDismissed)
+        store.markDismissed()
+        #expect(store.isDismissed)
+        #expect(MobileSimulatorStreamHintDismissalStore(defaults: defaults).isDismissed)
+    }
+
+    /// The composite mirrors the persisted flag observably and writes through
+    /// on dismissal, so every mounted workspace view drops the banner at once
+    /// and it stays gone on the next launch.
+    @Test func compositeDismissalWritesThroughAndIsIdempotent() throws {
+        let suiteName = "simulator-hint-composite-\(UUID().uuidString)"
+        let defaults = try #require(UserDefaults(suiteName: suiteName))
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        let store = MobileSimulatorStreamHintDismissalStore(defaults: defaults)
+
+        let composite = MobileShellComposite(simulatorStreamHintDismissalStore: store)
+        #expect(!composite.simulatorStreamHintDismissed)
+
+        composite.dismissSimulatorStreamHint()
+        #expect(composite.simulatorStreamHintDismissed)
+        #expect(store.isDismissed)
+
+        composite.dismissSimulatorStreamHint()
+        #expect(composite.simulatorStreamHintDismissed)
+
+        // A fresh composite over the same defaults starts dismissed.
+        let relaunched = MobileShellComposite(simulatorStreamHintDismissalStore: store)
+        #expect(relaunched.simulatorStreamHintDismissed)
+    }
+}

--- a/Packages/iOS/CmuxMobileShellModel/Sources/CmuxMobileShellModel/MobileWorkspacePreview.swift
+++ b/Packages/iOS/CmuxMobileShellModel/Sources/CmuxMobileShellModel/MobileWorkspacePreview.swift
@@ -91,6 +91,15 @@ public struct MobileWorkspacePreview: Identifiable, Equatable, Sendable {
     public var terminals: [MobileTerminalPreview]
     /// The Simulator panes contained in the workspace, in display order.
     public var simulators: [MobileSimulatorPanelDescriptor]
+
+    /// Whether any of the workspace's Simulator panes currently has a booted
+    /// device, i.e. there is live content a phone could stream right now (vs
+    /// a pane whose device is shut down or not yet selected).
+    public var hasBootedSimulator: Bool {
+        simulators.contains { descriptor in
+            descriptor.selectedDeviceState?.caseInsensitiveCompare("Booted") == .orderedSame
+        }
+    }
     /// The owning Mac's DISTINCT color index in the aggregated list, stamped by
     /// ``MobileWorkspaceAggregation/derivedWorkspaces`` so same-Mac workspaces
     /// share one avatar color and different Macs are guaranteed distinct. `nil`

--- a/Packages/iOS/CmuxMobileShellModel/Tests/CmuxMobileShellModelTests/MobileWorkspacePreviewSimulatorTests.swift
+++ b/Packages/iOS/CmuxMobileShellModel/Tests/CmuxMobileShellModelTests/MobileWorkspacePreviewSimulatorTests.swift
@@ -1,0 +1,45 @@
+import CMUXMobileCore
+import Testing
+@testable import CmuxMobileShellModel
+
+@Suite struct MobileWorkspacePreviewSimulatorTests {
+    @Test func bootedSimulatorDetectionIsCaseInsensitiveAndStateDriven() {
+        #expect(!preview(simulators: []).hasBootedSimulator)
+        #expect(!preview(simulators: [descriptor(state: "Shutdown")]).hasBootedSimulator)
+        #expect(!preview(simulators: [descriptor(state: nil)]).hasBootedSimulator)
+        #expect(preview(simulators: [descriptor(state: "Booted")]).hasBootedSimulator)
+        #expect(preview(simulators: [descriptor(state: "booted")]).hasBootedSimulator)
+        #expect(preview(
+            simulators: [descriptor(state: "Shutdown"), descriptor(state: "Booted")]
+        ).hasBootedSimulator)
+    }
+
+    private func preview(
+        simulators: [MobileSimulatorPanelDescriptor]
+    ) -> MobileWorkspacePreview {
+        MobileWorkspacePreview(
+            id: MobileWorkspacePreview.ID(rawValue: "workspace-1"),
+            name: "Workspace",
+            terminals: [],
+            simulators: simulators
+        )
+    }
+
+    private func descriptor(state: String?) -> MobileSimulatorPanelDescriptor {
+        MobileSimulatorPanelDescriptor(
+            panelID: "sim-1",
+            workspaceID: "workspace-1",
+            title: "Simulator",
+            selectedDeviceName: "iPhone 17",
+            selectedDeviceState: state,
+            status: "streaming",
+            isReady: true,
+            supportsTouch: true,
+            supportsKeyboard: true,
+            supportsHardwareButtons: true,
+            supportsRotation: true,
+            ownerConnectionID: nil,
+            isOwnedByCurrentConnection: nil
+        )
+    }
+}

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/OnboardingFlowView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/OnboardingFlowView.swift
@@ -95,6 +95,8 @@ struct OnboardingFlowView: View {
         switch pageStage {
         case .agents:
             OnboardingAgentsView()
+        case .simulator:
+            OnboardingSimulatorView()
         case .notifications:
             OnboardingNotificationsView()
         case .connect:
@@ -110,8 +112,10 @@ struct OnboardingFlowView: View {
         switch stage {
         case .agents:
             break
-        case .notifications:
+        case .simulator:
             showAgents()
+        case .notifications:
+            showSimulator()
         case .connect:
             showNotifications()
         }
@@ -120,6 +124,8 @@ struct OnboardingFlowView: View {
     private func handlePrimary() {
         switch stage {
         case .agents:
+            showSimulator()
+        case .simulator:
             showNotifications()
         case .notifications:
             showConnection()
@@ -134,6 +140,10 @@ struct OnboardingFlowView: View {
 
     private func showAgents() {
         navigate(to: .agents)
+    }
+
+    private func showSimulator() {
+        navigate(to: .simulator)
     }
 
     private func showNotifications() {

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/OnboardingSceneChrome.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/OnboardingSceneChrome.swift
@@ -24,6 +24,12 @@ struct OnboardingSceneChrome: Equatable {
                 defaultValue: "Continue"
             )
             secondaryTitle = nil
+        case .simulator:
+            primaryTitle = L10n.string(
+                "mobile.onboarding.continue",
+                defaultValue: "Continue"
+            )
+            secondaryTitle = nil
         case .notifications:
             primaryTitle = L10n.string(
                 "mobile.onboarding.continue",

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/OnboardingScreenshot.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/OnboardingScreenshot.swift
@@ -9,6 +9,7 @@ import UIKit
 struct OnboardingScreenshot: View {
     enum Content: String, CaseIterable {
         case workspaces
+        case simulator
         case notifications
 
         var accessibilityIdentifier: String {

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/OnboardingSimulatorView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/OnboardingSimulatorView.swift
@@ -1,0 +1,35 @@
+#if os(iOS)
+import CmuxMobileSupport
+import SwiftUI
+
+struct OnboardingSimulatorView: View {
+    var body: some View {
+        ZStack {
+            Color.clear
+                .frame(width: 1, height: 1)
+                .accessibilityElement(children: .ignore)
+                .accessibilityLabel(title)
+                .accessibilityIdentifier("MobileOnboardingSimulatorScene")
+
+            OnboardingSceneContent(
+                title: title,
+                message: L10n.string(
+                    "mobile.onboarding.simulator.body",
+                    defaultValue: "Stream it live and tap, type, and swipe from your phone."
+                ),
+                visual: OnboardingScreenshot(
+                    content: .simulator,
+                    accessibilityLabel: title
+                )
+            )
+        }
+    }
+
+    private var title: String {
+        L10n.string(
+            "mobile.onboarding.simulator.title",
+            defaultValue: "Control your Mac's iOS Simulator"
+        )
+    }
+}
+#endif

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/OnboardingStage.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/OnboardingStage.swift
@@ -1,6 +1,7 @@
 #if os(iOS)
 enum OnboardingStage: Int, CaseIterable, Hashable, Sendable {
     case agents
+    case simulator
     case notifications
     case connect
 
@@ -9,6 +10,7 @@ enum OnboardingStage: Int, CaseIterable, Hashable, Sendable {
     var analyticsValue: String {
         switch self {
         case .agents: "agents"
+        case .simulator: "simulator"
         case .notifications: "notifications"
         case .connect: "connect"
         }

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/Resources/Localizable.xcstrings
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/Resources/Localizable.xcstrings
@@ -1354,6 +1354,91 @@
         "en" : { "stringUnit" : { "state" : "translated", "value" : "Unknown" } },
         "ja" : { "stringUnit" : { "state" : "translated", "value" : "不明" } }
       }
+    },
+    "workspace.simulator.chip.accessibility" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Simulator attached"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "シミュレータあり"
+          }
+        }
+      }
+    },
+    "workspace.simulator.chip.accessibility.booted" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Simulator running"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "シミュレータ起動中"
+          }
+        }
+      }
+    },
+    "workspace.simulator.hint.body" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tap to stream and control it from this phone. It also lives in the Terminals menu in the toolbar."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "タップするとこのスマートフォンからストリーミングして操作できます。ツールバーのターミナルメニューからも開けます。"
+          }
+        }
+      }
+    },
+    "workspace.simulator.hint.dismiss" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dismiss"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "閉じる"
+          }
+        }
+      }
+    },
+    "workspace.simulator.hint.title" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "This workspace has a Mac Simulator"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "このワークスペースにはMacのシミュレータがあります"
+          }
+        }
+      }
     }
   },
   "version" : "1.0"

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TerminalPickerMenu.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TerminalPickerMenu.swift
@@ -60,18 +60,32 @@ struct TerminalPickerMenu: View, Equatable {
             }
         }
 
-        if value.supportsSimulatorStream, !value.simulatorStreamRows.isEmpty {
+        if value.supportsSimulatorStream {
             Section(L10n.string("mobile.simulatorStream.menuTitle", defaultValue: "Mac Simulators")) {
-                ForEach(value.simulatorStreamRows) { panel in
-                    Button { actions.selectSimulatorStream(panel.id) } label: {
-                        Label(
-                            panel.label,
-                            systemImage: panel.id == value.activeSimulatorStreamPanelID
-                                ? "checkmark.circle.fill"
-                                : "iphone"
-                        )
+                if value.simulatorStreamRows.isEmpty {
+                    // Teaching empty state: the capability exists but this
+                    // workspace has no Simulator pane yet, so name the
+                    // Mac-side step instead of hiding the feature entirely.
+                    Label(
+                        L10n.string(
+                            "mobile.simulatorStream.emptyHint",
+                            defaultValue: "Attach a Simulator pane in cmux on your Mac to control it from here"
+                        ),
+                        systemImage: "iphone.badge.play"
+                    )
+                    .accessibilityIdentifier("SimulatorStreamEmptyHint")
+                } else {
+                    ForEach(value.simulatorStreamRows) { panel in
+                        Button { actions.selectSimulatorStream(panel.id) } label: {
+                            Label(
+                                panel.label,
+                                systemImage: panel.id == value.activeSimulatorStreamPanelID
+                                    ? "checkmark.circle.fill"
+                                    : "iphone"
+                            )
+                        }
+                        .accessibilityIdentifier("SimulatorStreamMenuItem-\(panel.id)")
                     }
-                    .accessibilityIdentifier("SimulatorStreamMenuItem-\(panel.id)")
                 }
             }
         }

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceDetailView+Surfaces.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceDetailView+Surfaces.swift
@@ -39,10 +39,19 @@ extension WorkspaceDetailView {
             }
         }
         .safeAreaInset(edge: .top, spacing: 0) {
+            // At most one hint banner at a time; the changes hint wins
+            // because it is tied to fresh agent activity.
+            // (Simulator hint eligibility lives in
+            // `simulatorStreamHintPanelID` below.)
             if workspaceChangesHint != nil {
                 WorkspaceChangesHintBanner(
                     openChanges: openWorkspaceChanges,
                     dismiss: dismissWorkspaceChangesHint
+                )
+            } else if let panelID = simulatorStreamHintPanelID {
+                WorkspaceSimulatorHintBanner(
+                    openSimulator: { selectSimulatorStreamFromToolbar(panelID) },
+                    dismiss: { store.dismissSimulatorStreamHint() }
                 )
             }
         }
@@ -164,4 +173,15 @@ extension WorkspaceDetailView {
         }
     }
     #endif
+
+    /// The panel the simulator hint banner would open, or `nil` when the hint
+    /// must not show: already dismissed (globally, once ever), host lacks the
+    /// capability, a simulator stream is already active, or the workspace has
+    /// no simulator panes.
+    var simulatorStreamHintPanelID: String? {
+        guard !store.simulatorStreamHintDismissed,
+              store.supportsSimulatorStream,
+              activeSimulatorStream == nil else { return nil }
+        return simulatorStreamStore.panels(in: workspace.rpcWorkspaceID.rawValue).first?.panelID
+    }
 }

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceDetailView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceDetailView.swift
@@ -929,8 +929,11 @@ struct WorkspaceDetailView: View {
         Task { await store.startMobileBrowserStream(panelID: panelID) }
     }
 
-    private func selectSimulatorStreamFromToolbar(_ panelID: String) {
+    func selectSimulatorStreamFromToolbar(_ panelID: String) {
         dismissTerminalKeyboardForChrome()
+        // Opening a simulator stream anywhere proves the discovery hint's
+        // lesson landed; retire the banner for good.
+        store.dismissSimulatorStreamHint()
         browserStore.closeBrowser(for: workspace.id.rawValue)
         stopActiveBrowserStream()
         let workspaceID = workspace.rpcWorkspaceID.rawValue

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceRow.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceRow.swift
@@ -80,9 +80,16 @@ struct WorkspaceRow: View {
                         .foregroundStyle(.secondary)
                         .lineLimit(previewLineLimit, reservesSpace: true)
 
-                    if let changesChip, changesChip.filesChanged > 0 {
+                    if hasTrailingChips {
                         Spacer(minLength: 8)
-                        changesChipView(changesChip)
+                        HStack(spacing: 4) {
+                            if !workspace.simulators.isEmpty {
+                                WorkspaceSimulatorChipLabel(workspace: workspace)
+                            }
+                            if let changesChip, changesChip.filesChanged > 0 {
+                                changesChipView(changesChip)
+                            }
+                        }
                     }
                 }
             }
@@ -109,6 +116,10 @@ struct WorkspaceRow: View {
             }
         }
         .contentShape(Rectangle())
+    }
+
+    private var hasTrailingChips: Bool {
+        !workspace.simulators.isEmpty || (changesChip?.filesChanged ?? 0) > 0
     }
 
     @ViewBuilder

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceSimulatorChipLabel.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceSimulatorChipLabel.swift
@@ -1,0 +1,42 @@
+import CmuxMobileShellModel
+import SwiftUI
+
+/// Compact workspace-row signifier that the workspace has a Mac Simulator
+/// pane the phone can stream. A green dot marks a booted device (live
+/// content right now). Passive label by design: tapping the row opens the
+/// workspace, where the simulator hint banner and the surface picker take
+/// over — the chip only makes the feature visible from the list.
+struct WorkspaceSimulatorChipLabel: View {
+    let workspace: MobileWorkspacePreview
+
+    var body: some View {
+        HStack(spacing: 4) {
+            Image(systemName: "iphone")
+                .font(.caption2.weight(.semibold))
+            if workspace.hasBootedSimulator {
+                Circle()
+                    .fill(.green)
+                    .frame(width: 5, height: 5)
+            }
+        }
+        .foregroundStyle(.secondary)
+        .padding(.horizontal, 6)
+        .padding(.vertical, 3)
+        .background(Capsule().fill(Color.secondary.opacity(0.12)))
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel(
+            workspace.hasBootedSimulator
+                ? String(
+                    localized: "workspace.simulator.chip.accessibility.booted",
+                    defaultValue: "Simulator running",
+                    bundle: .module
+                )
+                : String(
+                    localized: "workspace.simulator.chip.accessibility",
+                    defaultValue: "Simulator attached",
+                    bundle: .module
+                )
+        )
+        .accessibilityIdentifier("MobileSimulatorChip-\(workspace.rpcWorkspaceID.rawValue)")
+    }
+}

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceSimulatorHintBanner.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceSimulatorHintBanner.swift
@@ -1,0 +1,60 @@
+#if os(iOS)
+import SwiftUI
+
+/// One-time dismissable banner teaching that this workspace has a Mac
+/// Simulator pane the phone can stream, and where to open it. Tapping the
+/// body opens the simulator directly; the copy also names the surfaces menu
+/// so the user learns the durable path.
+struct WorkspaceSimulatorHintBanner: View {
+    let openSimulator: @MainActor () -> Void
+    let dismiss: @MainActor () -> Void
+
+    var body: some View {
+        HStack(alignment: .top, spacing: 10) {
+            Button(action: openSimulator) {
+                HStack(alignment: .top, spacing: 10) {
+                    Image(systemName: "iphone")
+                        .font(.subheadline.weight(.semibold))
+                        .foregroundStyle(Color.accentColor)
+                        .accessibilityHidden(true)
+                    VStack(alignment: .leading, spacing: 3) {
+                        Text(String(
+                            localized: "workspace.simulator.hint.title",
+                            defaultValue: "This workspace has a Mac Simulator",
+                            bundle: .module
+                        ))
+                        .font(.subheadline.weight(.semibold))
+                        Text(String(
+                            localized: "workspace.simulator.hint.body",
+                            defaultValue: "Tap to stream and control it from this phone. It also lives in the Terminals menu in the toolbar.",
+                            bundle: .module
+                        ))
+                        .font(.footnote)
+                        .foregroundStyle(.secondary)
+                    }
+                    .multilineTextAlignment(.leading)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                }
+                .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+
+            Button(action: dismiss) {
+                Image(systemName: "xmark")
+                    .font(.caption.weight(.semibold))
+                    .padding(5)
+            }
+            .buttonStyle(.plain)
+            .accessibilityLabel(String(
+                localized: "workspace.simulator.hint.dismiss",
+                defaultValue: "Dismiss",
+                bundle: .module
+            ))
+        }
+        .padding(12)
+        .background(.regularMaterial)
+        .overlay(alignment: .bottom) { Divider() }
+        .accessibilityIdentifier("MobileSimulatorHint")
+    }
+}
+#endif

--- a/Packages/macOS/CmuxSimulator/Sources/CmuxSimulatorUI/Views/SimulatorDeviceStage.swift
+++ b/Packages/macOS/CmuxSimulator/Sources/CmuxSimulatorUI/Views/SimulatorDeviceStage.swift
@@ -10,6 +10,7 @@ struct SimulatorDeviceStage: View {
     let allowsPointerInput: Bool
     let pointerEntryEventFilter: (@MainActor (NSEvent) -> Bool)?
     let onRequestPanelFocus: @MainActor () -> Void
+    var phoneControlTeaser: SimulatorPhoneControlTeaser? = nil
 
     var body: some View {
         ZStack {
@@ -89,6 +90,45 @@ struct SimulatorDeviceStage: View {
         .shadow(color: .black.opacity(0.28), radius: 18, y: 8)
         .padding(simulatorDeviceStagePadding)
         .accessibilityLabel(simulatorStrings.simulator)
+        .overlay(alignment: .bottom) {
+            if let phoneControlTeaser {
+                phoneControlTeaserChip(phoneControlTeaser)
+            }
+        }
+    }
+
+    /// One-time cross-device teaser shown only over a LIVE stage: the moment
+    /// a user first sees their Simulator streaming in a pane is the moment
+    /// the phone-control payoff is most believable.
+    private func phoneControlTeaserChip(
+        _ teaser: SimulatorPhoneControlTeaser
+    ) -> some View {
+        HStack(spacing: 10) {
+            Image(systemName: "iphone.radiowaves.left.and.right")
+                .foregroundStyle(.tint)
+                .accessibilityHidden(true)
+            Text(simulatorStrings.phoneControlTeaser)
+                .font(.callout)
+            Button(simulatorStrings.phoneControlTeaserAction) {
+                teaser.openPairing()
+            }
+            .buttonStyle(.borderedProminent)
+            .controlSize(.small)
+            Button {
+                teaser.dismiss()
+            } label: {
+                Image(systemName: "xmark")
+                    .font(.caption.weight(.semibold))
+                    .padding(3)
+            }
+            .buttonStyle(.plain)
+            .accessibilityLabel(simulatorStrings.phoneControlTeaserDismiss)
+        }
+        .padding(.horizontal, 14)
+        .padding(.vertical, 9)
+        .background(.regularMaterial, in: Capsule())
+        .padding(.bottom, 6)
+        .accessibilityIdentifier("SimulatorPhoneControlTeaser")
     }
 
     private func maximumDeviceSize(
@@ -142,12 +182,31 @@ struct SimulatorDeviceStage: View {
                 Button(simulatorStrings.reconnect) { coordinator.recover() }
             }
         default:
-            ContentUnavailableView(
-                simulatorStrings.selectToStart,
-                systemImage: "iphone",
-                description: nil
-            )
+            // Teaching empty state: name the next step and the payoff, and
+            // offer the fastest path — one click boots the most recently used
+            // device; the embedded picker is the same menu as the toolbar's.
+            ContentUnavailableView {
+                Label(simulatorStrings.selectToStart, systemImage: "iphone")
+            } description: {
+                Text(simulatorStrings.selectToStartHelp)
+            } actions: {
+                if let suggestion = quickStartDevice {
+                    Button(simulatorStrings.quickStart(suggestion.name)) {
+                        coordinator.selectDevice(id: suggestion.id)
+                    }
+                    .buttonStyle(.borderedProminent)
+                }
+                SimulatorDevicePicker(coordinator: coordinator)
+            }
         }
+    }
+
+    /// The one-click boot suggestion: the most recently booted available
+    /// device, falling back to the first available one.
+    private var quickStartDevice: SimulatorDevice? {
+        coordinator.devices
+            .filter(\.isAvailable)
+            .max(by: { ($0.lastBootedAt ?? .distantPast) < ($1.lastBootedAt ?? .distantPast) })
     }
 
     private func deviceCornerRadius(

--- a/Packages/macOS/CmuxSimulator/Sources/CmuxSimulatorUI/Views/SimulatorPaneView.swift
+++ b/Packages/macOS/CmuxSimulator/Sources/CmuxSimulatorUI/Views/SimulatorPaneView.swift
@@ -8,6 +8,7 @@ public struct SimulatorPaneView: View {
     private let allowsPointerInput: Bool
     private let pointerEntryEventFilter: (@MainActor (NSEvent) -> Bool)?
     private let onRequestPanelFocus: @MainActor () -> Void
+    private let phoneControlTeaser: SimulatorPhoneControlTeaser?
 
     /// Creates a native Simulator pane.
     /// - Parameters:
@@ -21,13 +22,15 @@ public struct SimulatorPaneView: View {
         backgroundColor: Color,
         allowsPointerInput: Bool,
         pointerEntryEventFilter: (@MainActor (NSEvent) -> Bool)? = nil,
-        onRequestPanelFocus: @escaping @MainActor () -> Void = {}
+        onRequestPanelFocus: @escaping @MainActor () -> Void = {},
+        phoneControlTeaser: SimulatorPhoneControlTeaser? = nil
     ) {
         self.coordinator = coordinator
         self.backgroundColor = backgroundColor
         self.allowsPointerInput = allowsPointerInput
         self.pointerEntryEventFilter = pointerEntryEventFilter
         self.onRequestPanelFocus = onRequestPanelFocus
+        self.phoneControlTeaser = phoneControlTeaser
     }
 
     /// The composed Simulator toolbar, live device stage, and tools inspector.
@@ -41,7 +44,8 @@ public struct SimulatorPaneView: View {
                     backgroundColor: backgroundColor,
                     allowsPointerInput: allowsPointerInput,
                     pointerEntryEventFilter: pointerEntryEventFilter,
-                    onRequestPanelFocus: onRequestPanelFocus
+                    onRequestPanelFocus: onRequestPanelFocus,
+                    phoneControlTeaser: phoneControlTeaser
                 )
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
                 if coordinator.showsTools {

--- a/Packages/macOS/CmuxSimulator/Sources/CmuxSimulatorUI/Views/SimulatorPhoneControlTeaser.swift
+++ b/Packages/macOS/CmuxSimulator/Sources/CmuxSimulatorUI/Views/SimulatorPhoneControlTeaser.swift
@@ -1,0 +1,22 @@
+import Foundation
+
+/// Host-provided one-time teaser pointing at iPhone control of this pane.
+///
+/// The package renders it as a dismissable chip over a live device stage; the
+/// HOST owns eligibility (feature flags, one-time persistence) and both
+/// actions, so the package stays free of pairing and defaults policy. A `nil`
+/// teaser renders nothing.
+public struct SimulatorPhoneControlTeaser {
+    /// Opens the host's phone-pairing flow (and retires the teaser).
+    public let openPairing: @MainActor () -> Void
+    /// Permanently dismisses the teaser without pairing.
+    public let dismiss: @MainActor () -> Void
+
+    public init(
+        openPairing: @escaping @MainActor () -> Void,
+        dismiss: @escaping @MainActor () -> Void
+    ) {
+        self.openPairing = openPairing
+        self.dismiss = dismiss
+    }
+}

--- a/Packages/macOS/CmuxSimulator/Sources/CmuxSimulatorUI/Views/SimulatorStrings.swift
+++ b/Packages/macOS/CmuxSimulator/Sources/CmuxSimulatorUI/Views/SimulatorStrings.swift
@@ -135,6 +135,40 @@ struct SimulatorStrings {
         bundle: .main,
         comment: "Idle text before a Simulator device is selected."
     )
+    let selectToStartHelp = LocalizedStringResource(
+        "simulator.status.selectToStart.help",
+        defaultValue: "Pick an iPhone or iPad and it boots automatically. Once running, you can control it from the cmux iOS app.",
+        bundle: .main,
+        comment: "Help text under the idle Simulator state, teaching the next step and the phone-control payoff."
+    )
+    let phoneControlTeaser = LocalizedStringResource(
+        "simulator.phoneControl.teaser",
+        defaultValue: "Control this Simulator from your iPhone",
+        bundle: .main,
+        comment: "One-time chip over a live Simulator stage pointing at phone control."
+    )
+    let phoneControlTeaserAction = LocalizedStringResource(
+        "simulator.phoneControl.teaser.action",
+        defaultValue: "Set Up",
+        bundle: .main,
+        comment: "Button on the phone-control teaser that opens Tailscale Pairing."
+    )
+    let phoneControlTeaserDismiss = LocalizedStringResource(
+        "simulator.phoneControl.teaser.dismiss",
+        defaultValue: "Dismiss",
+        bundle: .main,
+        comment: "Accessibility label for the phone-control teaser close button."
+    )
+    func quickStart(_ deviceName: String) -> String {
+        String(
+            format: String(
+                localized: "simulator.action.quickStart",
+                defaultValue: "Start %@",
+                comment: "Button that selects and boots the named Simulator device in one click."
+            ),
+            deviceName
+        )
+    }
     let device = LocalizedStringResource(
         "simulator.tools.device",
         defaultValue: "Device",

--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -225567,6 +225567,23 @@
         }
       }
     },
+    "simulator.action.quickStart": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Start %@"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@を起動"
+          }
+        }
+      }
+    },
     "simulator.action.refresh": {
       "extractionState": "manual",
       "localizations": {
@@ -230901,6 +230918,91 @@
           "stringUnit": {
             "state": "translated",
             "value": "処理中"
+          }
+        }
+      }
+    },
+    "simulator.status.selectToStart.help": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pick an iPhone or iPad and it boots automatically. Once running, you can control it from the cmux iOS app."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "iPhoneまたはiPadを選ぶと自動的に起動します。起動後はcmuxのiOSアプリから操作できます。"
+          }
+        }
+      }
+    },
+    "simulator.phoneControl.teaser": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Control this Simulator from your iPhone"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "このシミュレータをiPhoneから操作できます"
+          }
+        }
+      }
+    },
+    "simulator.phoneControl.teaser.action": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Set Up"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "設定"
+          }
+        }
+      }
+    },
+    "simulator.phoneControl.teaser.dismiss": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dismiss"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "閉じる"
+          }
+        }
+      }
+    },
+    "simulator.tabBar.bootedTooltip": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "A Simulator is booted — open it in a pane"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "シミュレータが起動中です — ペインで開けます"
           }
         }
       }

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -538,6 +538,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
     nonisolated(unsafe) static var shared: AppDelegate?
     /// Stateless control-socket syscall layer (CmuxControlSocket); composition-root owned.
     nonisolated let socketTransport = SocketTransport()
+    /// App-level booted-Simulator sampling that drives the contextual
+    /// New Simulator tab-bar button; composition-root owned.
+    let simulatorBootPresence = SimulatorBootPresence()
     /// Owns the About Titlebar Debug subsystem (CmuxAppKitSupportUI); composition-root
     /// owned and created lazily so the window-decoration seam can point back at `self`.
     lazy var debugWindowsCoordinator = CmuxDebugWindowsCoordinator(decorator: self)
@@ -1369,6 +1372,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
             telemetryEnabled: telemetryEnabled
         )
         let isRunningUnderXCTest = sentryStartupPolicy.isRunningUnderXCTest
+        if !isRunningUnderXCTest {
+            // Seed the contextual New Simulator affordance; throttled and
+            // flag-gated inside.
+            simulatorBootPresence.refresh()
+        }
         StartupBreadcrumbLog.append(
             "appDelegate.didFinish.begin",
             fields: [
@@ -1909,6 +1917,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
 
     func applicationDidBecomeActive(_ notification: Notification) {
         PortScanner.shared.setTrackedAgentScanningPaused(false)
+        // Cheap, throttled sample: a user who just booted a Simulator in
+        // Xcode switches to cmux next, which is exactly this moment.
+        simulatorBootPresence.refresh()
         let activationWindows = mainWindowsForVisibilityController()
         if mainWindowVisibilityController.finishPendingApplicationActivationRestore(windows: activationWindows, reason: .applicationDidBecomeActive) == nil, !hasVisibleMainTerminalWindow() {
             _ = mainWindowVisibilityController.restoreApplicationWindowsAfterActivation(windows: activationWindows, reason: .applicationDidBecomeActive)

--- a/Sources/Panels/SimulatorPanelView.swift
+++ b/Sources/Panels/SimulatorPanelView.swift
@@ -60,10 +60,13 @@ struct SimulatorPanelView: View {
               CmuxFeatureFlags.shared.isMobileConnectButtonEnabled else { return nil }
         return SimulatorPhoneControlTeaser(
             openPairing: {
-                phoneControlTeaserDismissed = true
-                _ = AppDelegate.shared?.performMobileConnectWorkspaceAction(
+                // Retire the teaser only when pairing actually opened, so a
+                // transient failure (no resolvable window) stays retryable.
+                if AppDelegate.shared?.performMobileConnectWorkspaceAction(
                     debugSource: "simulator.phoneControlTeaser"
-                )
+                ) != nil {
+                    phoneControlTeaserDismissed = true
+                }
             },
             dismiss: {
                 phoneControlTeaserDismissed = true

--- a/Sources/Panels/SimulatorPanelView.swift
+++ b/Sources/Panels/SimulatorPanelView.swift
@@ -11,6 +11,10 @@ struct SimulatorPanelView: View {
     let appearance: PanelAppearance
     let onRequestPanelFocus: () -> Void
     @State private var visibilityHostID = UUID()
+    /// One-time flag for the cross-device teaser; local dogfood resets it
+    /// with `defaults delete <bundle> cmux.simulator.phoneControlTeaser.dismissed`.
+    @AppStorage("cmux.simulator.phoneControlTeaser.dismissed")
+    private var phoneControlTeaserDismissed = false
 
     var body: some View {
         SimulatorPaneView(
@@ -18,7 +22,8 @@ struct SimulatorPanelView: View {
             backgroundColor: Color(nsColor: appearance.contentBackgroundColor),
             allowsPointerInput: allowsPointerInput,
             pointerEntryEventFilter: pointerEntryEventFilter,
-            onRequestPanelFocus: onRequestPanelFocus
+            onRequestPanelFocus: onRequestPanelFocus,
+            phoneControlTeaser: phoneControlTeaser
         )
             .background {
                 SimulatorFocusOwnershipBridge(panel: panel)
@@ -44,5 +49,25 @@ struct SimulatorPanelView: View {
                 panel.coordinator.releaseInputs()
                 panel.setVisibleInUI(false, hostID: visibilityHostID)
             }
+    }
+
+    /// The one-time "control from iPhone" teaser. `nil` (hidden) once
+    /// dismissed or when the pairing flow's feature flag is off, so the chip
+    /// can never advertise a dead path. The package renders it only over a
+    /// live device stage.
+    private var phoneControlTeaser: SimulatorPhoneControlTeaser? {
+        guard !phoneControlTeaserDismissed,
+              CmuxFeatureFlags.shared.isMobileConnectButtonEnabled else { return nil }
+        return SimulatorPhoneControlTeaser(
+            openPairing: {
+                phoneControlTeaserDismissed = true
+                _ = AppDelegate.shared?.performMobileConnectWorkspaceAction(
+                    debugSource: "simulator.phoneControlTeaser"
+                )
+            },
+            dismiss: {
+                phoneControlTeaserDismissed = true
+            }
+        )
     }
 }

--- a/Sources/SimulatorBootPresence.swift
+++ b/Sources/SimulatorBootPresence.swift
@@ -20,37 +20,53 @@ extension Notification.Name {
 @Observable
 final class SimulatorBootPresence {
     private(set) var hasBootedDevice = false
-    @ObservationIgnored private var lastRefreshAt: Date?
     @ObservationIgnored private var refreshTask: Task<Void, Never>?
-    @ObservationIgnored private let minimumRefreshInterval: TimeInterval
-    @ObservationIgnored private let now: () -> Date
+    @ObservationIgnored private var featureFlagsObserver: NSObjectProtocol?
     @ObservationIgnored private let discoverBootedDevice: @Sendable () async -> Bool
 
-    init(
-        minimumRefreshInterval: TimeInterval = 30,
-        now: @escaping () -> Date = Date.init,
-        discoverBootedDevice: @escaping @Sendable () async -> Bool = {
-            let devices = (try? await SimulatorControlService().discoverDevices()) ?? []
-            return devices.contains { $0.isAvailable && $0.state == .booted }
+    init(discoverBootedDevice: (@Sendable () async -> Bool)? = nil) {
+        if let discoverBootedDevice {
+            self.discoverBootedDevice = discoverBootedDevice
+        } else {
+            // One service reused across samples; discovery shells out to
+            // `simctl`, so per-refresh construction would rebuild its plumbing
+            // on every app activation.
+            let service = SimulatorControlService()
+            self.discoverBootedDevice = {
+                let devices = (try? await service.discoverDevices()) ?? []
+                return devices.contains { $0.isAvailable && $0.state == .booted }
+            }
         }
-    ) {
-        self.minimumRefreshInterval = minimumRefreshInterval
-        self.now = now
-        self.discoverBootedDevice = discoverBootedDevice
+        // The launch-time refresh runs before the remote flags load; when the
+        // simulator flag flips on afterward, sample immediately so the
+        // contextual button can appear without waiting for a reactivation.
+        featureFlagsObserver = NotificationCenter.default.addObserver(
+            forName: .cmuxFeatureFlagsDidChange,
+            object: CmuxFeatureFlags.shared,
+            queue: .main
+        ) { [weak self] _ in
+            Task { @MainActor [weak self] in
+                self?.refresh()
+            }
+        }
     }
 
-    /// Samples `simctl` unless a sufficiently fresh answer exists.
-    /// Single-flight and throttled, so activation churn cannot stack device
-    /// discoveries. Posts ``Notification/Name/cmuxSimulatorBootPresenceDidChange``
-    /// only when the answer flips.
+    deinit {
+        if let featureFlagsObserver {
+            NotificationCenter.default.removeObserver(featureFlagsObserver)
+        }
+    }
+
+    /// Samples `simctl` for a fresh authoritative answer. Single-flight so
+    /// activation churn cannot stack device discoveries, but never served
+    /// from a time-based cache: this is UI-enabling state, and a stale
+    /// `false` would hide the contextual button right after the user booted
+    /// a Simulator. Posts
+    /// ``Notification/Name/cmuxSimulatorBootPresenceDidChange`` only when
+    /// the answer flips.
     func refresh() {
         guard CmuxFeatureFlags.shared.isSimulatorEnabled else { return }
         guard refreshTask == nil else { return }
-        if let lastRefreshAt,
-           now().timeIntervalSince(lastRefreshAt) < minimumRefreshInterval {
-            return
-        }
-        lastRefreshAt = now()
         refreshTask = Task { @MainActor [discoverBootedDevice] in
             let booted = await discoverBootedDevice()
             refreshTask = nil

--- a/Sources/SimulatorBootPresence.swift
+++ b/Sources/SimulatorBootPresence.swift
@@ -1,0 +1,65 @@
+import CmuxSimulator
+import Foundation
+import Observation
+
+extension Notification.Name {
+    /// Posted by ``SimulatorBootPresence`` when the booted-device answer
+    /// flips, so each workspace can re-apply its surface tab-bar buttons.
+    static let cmuxSimulatorBootPresenceDidChange =
+        Notification.Name("cmux.simulatorBootPresenceDidChange")
+}
+
+/// App-level answer to "is any iPhone or iPad Simulator booted right now?".
+///
+/// Sampled at discrete UI moments (launch, app activation) instead of on a
+/// timer: a user who just booted a Simulator in Xcode reaches for cmux next,
+/// and that switch re-activates the app. The answer drives the contextual
+/// New Simulator tab-bar button, so the feature surfaces exactly while the
+/// user is doing iOS work and disappears when they are not.
+@MainActor
+@Observable
+final class SimulatorBootPresence {
+    private(set) var hasBootedDevice = false
+    @ObservationIgnored private var lastRefreshAt: Date?
+    @ObservationIgnored private var refreshTask: Task<Void, Never>?
+    @ObservationIgnored private let minimumRefreshInterval: TimeInterval
+    @ObservationIgnored private let now: () -> Date
+    @ObservationIgnored private let discoverBootedDevice: @Sendable () async -> Bool
+
+    init(
+        minimumRefreshInterval: TimeInterval = 30,
+        now: @escaping () -> Date = Date.init,
+        discoverBootedDevice: @escaping @Sendable () async -> Bool = {
+            let devices = (try? await SimulatorControlService().discoverDevices()) ?? []
+            return devices.contains { $0.isAvailable && $0.state == .booted }
+        }
+    ) {
+        self.minimumRefreshInterval = minimumRefreshInterval
+        self.now = now
+        self.discoverBootedDevice = discoverBootedDevice
+    }
+
+    /// Samples `simctl` unless a sufficiently fresh answer exists.
+    /// Single-flight and throttled, so activation churn cannot stack device
+    /// discoveries. Posts ``Notification/Name/cmuxSimulatorBootPresenceDidChange``
+    /// only when the answer flips.
+    func refresh() {
+        guard CmuxFeatureFlags.shared.isSimulatorEnabled else { return }
+        guard refreshTask == nil else { return }
+        if let lastRefreshAt,
+           now().timeIntervalSince(lastRefreshAt) < minimumRefreshInterval {
+            return
+        }
+        lastRefreshAt = now()
+        refreshTask = Task { @MainActor [discoverBootedDevice] in
+            let booted = await discoverBootedDevice()
+            refreshTask = nil
+            guard !Task.isCancelled, booted != hasBootedDevice else { return }
+            hasBootedDevice = booted
+            NotificationCenter.default.post(
+                name: .cmuxSimulatorBootPresenceDidChange,
+                object: self
+            )
+        }
+    }
+}

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -2286,6 +2286,7 @@ final class Workspace: Identifiable, ObservableObject {
     private var surfaceTabBarButtonGlobalConfigPath: String?
     private var surfaceTabBarButtonConfiguration: SurfaceTabBarButtonConfiguration?
     private var featureFlagsObserver: NSObjectProtocol?
+    private var simulatorBootPresenceObserver: NSObjectProtocol?
 
     /// The pane-tree sub-model (CmuxPanes): owns the panel registry, the
     /// surface-id mapping, and the pane-layout bookkeeping. The legacy
@@ -3492,6 +3493,15 @@ final class Workspace: Identifiable, ObservableObject {
                 self?.reapplySurfaceTabBarButtonsForFeatureFlags()
             }
         }
+        simulatorBootPresenceObserver = NotificationCenter.default.addObserver(
+            forName: .cmuxSimulatorBootPresenceDidChange,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            Task { @MainActor [weak self] in
+                self?.reapplySurfaceTabBarButtonsForFeatureFlags()
+            }
+        }
     }
 
     private var sharedLiveAgentIndexObserver: NSObjectProtocol?
@@ -3509,6 +3519,9 @@ final class Workspace: Identifiable, ObservableObject {
         }
         if let featureFlagsObserver {
             NotificationCenter.default.removeObserver(featureFlagsObserver)
+        }
+        if let simulatorBootPresenceObserver {
+            NotificationCenter.default.removeObserver(simulatorBootPresenceObserver)
         }
         activeRemoteSessionControllerID = nil
         remoteSessionTransitionTask?.cancel()
@@ -3553,12 +3566,32 @@ final class Workspace: Identifiable, ObservableObject {
             terminalCommandSourcePaths: terminalCommandSourcePaths,
             workspaceCommands: workspaceCommands
         )
-        let buttons = buttons.filter { button in
+        var buttons = buttons.filter { button in
             guard case .builtIn(let builtInAction) = button.action else { return true }
             if builtInAction == .mobileConnect { return CmuxFeatureFlags.shared.isMobileConnectButtonEnabled }
             if builtInAction == .newAgentChat { return CmuxFeatureFlags.shared.isAgentChatUIEnabled }
             if builtInAction == .newSimulator { return CmuxFeatureFlags.shared.isSimulatorEnabled }
             return true
+        }
+        // Contextual affordance: while any Simulator is booted, surface the
+        // New Simulator button even though it is not in the default set, so
+        // the feature shows up exactly when the user is doing iOS work and
+        // stays out of the way otherwise. A button already present (default
+        // or user-configured) wins; re-applied via
+        // `.cmuxSimulatorBootPresenceDidChange`.
+        if CmuxFeatureFlags.shared.isSimulatorEnabled,
+           AppDelegate.shared?.simulatorBootPresence.hasBootedDevice == true,
+           !buttons.contains(where: { button in
+               if case .builtIn(.newSimulator) = button.action { return true }
+               return false
+           }) {
+            buttons.append(.builtIn(
+                .newSimulator,
+                tooltip: String(
+                    localized: "simulator.tabBar.bootedTooltip",
+                    defaultValue: "A Simulator is booted — open it in a pane"
+                )
+            ))
         }
         let executableButtons = Dictionary(
             uniqueKeysWithValues: buttons.compactMap { button in

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -2064,6 +2064,7 @@ C0DE71B10000000000000001 /* AppDelegate+AgentChatNotifications.swift in Sources 
 		A6AC73330000000000000001 /* SidebarWorkspaceTrailingStatusSlot.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6AC73330000000000000002 /* SidebarWorkspaceTrailingStatusSlot.swift */; };
 		A6AC73340000000000000001 /* SidebarWorkspaceUnreadBadge.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6AC73340000000000000002 /* SidebarWorkspaceUnreadBadge.swift */; };
 		6707F00D6707F00D6707F00D /* SidebarWorkspaceWindowMoveTarget.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6707F00E6707F00E6707F00E /* SidebarWorkspaceWindowMoveTarget.swift */; };
+		C51B0B0000000000000000B1 /* SimulatorBootPresence.swift in Sources */ = {isa = PBXBuildFile; fileRef = C51B0B0000000000000000B2 /* SimulatorBootPresence.swift */; };
 		C51A720000000000000000A1 /* SimulatorCommandPaletteIntegration.swift in Sources */ = {isa = PBXBuildFile; fileRef = C51A720000000000000000A2 /* SimulatorCommandPaletteIntegration.swift */; };
 		C51A710000000000000000C3 /* SimulatorFeatureDisabledView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C51A710000000000000000C4 /* SimulatorFeatureDisabledView.swift */; };
 		C51A71F10000000000000002 /* SimulatorFocusOwnershipBridge.swift in Sources */ = {isa = PBXBuildFile; fileRef = C51A71F10000000000000001 /* SimulatorFocusOwnershipBridge.swift */; };
@@ -4733,6 +4734,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 		A6AC73330000000000000002 /* SidebarWorkspaceTrailingStatusSlot.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sidebar/SidebarWorkspaceTrailingStatusSlot.swift; sourceTree = "<group>"; };
 		A6AC73340000000000000002 /* SidebarWorkspaceUnreadBadge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sidebar/SidebarWorkspaceUnreadBadge.swift; sourceTree = "<group>"; };
 		6707F00E6707F00E6707F00E /* SidebarWorkspaceWindowMoveTarget.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarWorkspaceWindowMoveTarget.swift; sourceTree = "<group>"; };
+		C51B0B0000000000000000B2 /* SimulatorBootPresence.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SimulatorBootPresence.swift; sourceTree = "<group>"; };
 		C51A720000000000000000A2 /* SimulatorCommandPaletteIntegration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SimulatorCommandPaletteIntegration.swift; sourceTree = "<group>"; };
 		C51A710000000000000000C4 /* SimulatorFeatureDisabledView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/SimulatorFeatureDisabledView.swift; sourceTree = "<group>"; };
 		C51A71F10000000000000001 /* SimulatorFocusOwnershipBridge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/SimulatorFocusOwnershipBridge.swift; sourceTree = "<group>"; };
@@ -7172,6 +7174,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				C0DE43000000000000000004 /* CmuxSurfaceTabBarBuiltInAction+Codable.swift */,
 				C10D00040000000000000004 /* CmuxSurfaceTabBarBuiltInAction.swift */,
 				C51A720000000000000000A2 /* SimulatorCommandPaletteIntegration.swift */,
+				C51B0B0000000000000000B2 /* SimulatorBootPresence.swift */,
 				C51A720000000000000001A2 /* ContentView+CommandPaletteSurfaceMetadata.swift */,
 				A5FB120E /* Workspace+CustomLayout.swift */,
 				C57B00030000000000000002 /* Workspace+CustomSidebarPane.swift */,
@@ -9892,6 +9895,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				A6AC73330000000000000001 /* SidebarWorkspaceTrailingStatusSlot.swift in Sources */,
 				A6AC73340000000000000001 /* SidebarWorkspaceUnreadBadge.swift in Sources */,
 				6707F00D6707F00D6707F00D /* SidebarWorkspaceWindowMoveTarget.swift in Sources */,
+				C51B0B0000000000000000B1 /* SimulatorBootPresence.swift in Sources */,
 				C51A720000000000000000A1 /* SimulatorCommandPaletteIntegration.swift in Sources */,
 				C51A710000000000000000C3 /* SimulatorFeatureDisabledView.swift in Sources */,
 				C51A71F10000000000000002 /* SimulatorFocusOwnershipBridge.swift in Sources */,

--- a/ios/cmux/Resources/Localizable.xcstrings
+++ b/ios/cmux/Resources/Localizable.xcstrings
@@ -1089,6 +1089,23 @@
         }
       }
     },
+    "mobile.simulatorStream.emptyHint": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Attach a Simulator pane in cmux on your Mac to control it from here"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Macのcmuxでシミュレータペインを追加すると、ここから操作できます"
+          }
+        }
+      }
+    },
     "mobile.simulatorStream.home": {
       "extractionState": "manual",
       "localizations": {
@@ -4638,6 +4655,40 @@
           "stringUnit": {
             "state": "translated",
             "value": "ワークスペース"
+          }
+        }
+      }
+    },
+    "mobile.onboarding.simulator.body": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Stream it live and tap, type, and swipe from your phone."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ライブでストリーミングし、スマートフォンからタップ・入力・スワイプできます。"
+          }
+        }
+      }
+    },
+    "mobile.onboarding.simulator.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Control your Mac's iOS Simulator"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "MacのiOSシミュレータを操作"
           }
         }
       }


### PR DESCRIPTION
Simulator visibility was low on both platforms: the Mac pane hid behind config customization and the palette, and the phone showed nothing until a user already knew to open the surfaces menu inside a workspace. This PR adds moment-of-intent discovery on both ends, all copy EN+JA.

**Mac**
- Contextual tab-bar button: `New Simulator` appears while any Simulator is booted and disappears otherwise. Presence is sampled at launch and app activation through a throttled, single-flight `SimulatorBootPresence` (no timers); workspaces re-apply their tab-bar buttons on the flip, reusing the feature-flag re-apply path. A button already present (default or user-configured) wins.
- Teaching idle state: the "Select a device to start" pane now explains the next step and the phone-control payoff, offers a one-click **Start <most recent device>** boot, and embeds the same device picker menu as the toolbar.
- Cross-device teaser: a one-time dismissable chip over a live stage — "Control this Simulator from your iPhone" — opens Tailscale Pairing via the shared `performMobileConnectWorkspaceAction` path, gated on the mobile-connect flag so it can never advertise a dead path.

**iOS**
- Workspace rows show a Simulator chip (green dot when a device is booted), fed by the `simulators` payload already in the workspace list — no protocol change. Renders in both the SwiftUI and UIKit list pipelines via the shared `WorkspaceRow`.
- A one-time dismissable banner inside the workspace ("This workspace has a Mac Simulator") opens the stream directly and names the durable path (the Terminals menu). It retires permanently on dismissal or on opening a simulator stream any other way; the changes hint keeps priority so at most one banner shows.
- The surfaces menu keeps a "Mac Simulators" section when the capability exists but the workspace has no pane, teaching the Mac-side step instead of hiding the feature.
- Onboarding gains a simulator card (stage between agents and notifications); screenshots land with the dogfood build.

Everything gates on the existing `simulator-enabled-release` flag (and the teaser additionally on `mobile-connect-button-enabled-release`), so no surface can advertise a disabled feature.

**No analytics events**: every existing emit path attaches a persistent per-install id (iOS `client_id`, Mac PostHog anonymous distinct id), which fails the completely-anonymous requirement, so the funnel instrumentation was deliberately skipped.

Tests: booted-detection policy on `MobileWorkspacePreview`, hint-dismissal persistence and composite write-through, plus the existing simulator stream suites (15 green); `CmuxSimulator` package builds clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly UI/onboarding and UserDefaults persistence; Mac boot sampling is throttled and flag-gated with no auth or protocol changes.
> 
> **Overview**
> Adds **moment-of-intent discovery** for Mac Simulator streaming on both Mac and iOS, with EN+JA strings and feature-flag gating (`simulator-enabled-release`; Mac teaser also needs `mobile-connect-button-enabled-release`).
> 
> **iOS** adds workspace-list **Simulator chips** (green dot when `hasBootedSimulator`), a **one-time workspace banner** that opens the stream and names the Terminals menu, **global dismissal** via `MobileSimulatorStreamHintDismissalStore` / `dismissSimulatorStreamHint()` (also when opening any simulator stream), and an **empty-state** in the Mac Simulators menu when capability exists but no pane is attached. Onboarding inserts a **simulator stage** between agents and notifications.
> 
> **Mac** introduces throttled **`SimulatorBootPresence`** (launch + activation) to **inject a contextual New Simulator tab-bar button** while any device is booted, improves the **idle Simulator pane** with help text, quick-start, and embedded picker, and shows a **one-time phone-control teaser** on live stages that opens pairing through `performMobileConnectWorkspaceAction`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 93668ff50a02387a689b79da9421d707ba8b2704. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improves Simulator discovery on Mac and iOS with contextual UI, clear teaching moments, and one‑tap paths. Adds fresh boot sampling and a resilient pairing teaser so the feature shows up exactly when you’re doing iOS work.

- **New Features**
  - Mac: Adds a contextual New Simulator tab-bar button that appears when any Simulator is booted (sampled at launch, app activation, and on remote flag changes via `SimulatorBootPresence`) and hides otherwise. Refreshes are single‑flight and always fresh (no time‑based cache; one discovery service reused). The idle pane teaches the next step, offers one‑click Start <most recent device>, embeds the device picker, and shows a tooltip when booted. A one‑time “Control this Simulator from your iPhone” chip over a live stage opens pairing via `performMobileConnectWorkspaceAction`, stays retryable on failure, and can be dismissed.
  - iOS: Workspace rows show a Simulator chip (green dot when a device is booted) using the existing `simulators` payload. A one‑time banner in the workspace opens the stream and points to the durable path (Terminals menu); it retires globally on dismissal or when any simulator stream is opened (`dismissSimulatorStreamHint` write‑through). The surfaces menu keeps a “Mac Simulators” section with a teaching empty state when no pane exists. Onboarding adds a Simulator card. Includes case‑insensitive `hasBootedSimulator` detection and unit tests.
  - Flags & localization: All surfaces gated by `simulator-enabled-release`; the phone‑control teaser also by `mobile-connect-button-enabled-release`. Boot‑presence re‑samples when flags change. All copy localized in EN and JA. No analytics added.

<sup>Written for commit 3192c427a405c70c4ad08a637554fb16b7ccbfb4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/9918?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added iPhone and iPad Simulator onboarding for controlling a Mac’s Simulator from mobile.
  * Added Simulator workspace indicators, booted-status detection, quick-start actions, and improved empty states.
  * Added Simulator discovery banners and menu guidance with persistent dismissal options.
  * Added an optional phone-control pairing teaser in the Mac Simulator interface.
* **Improvements**
  * Automatically surfaces Simulator actions when supported and a device is booted.
  * Added English and Japanese localization for Simulator features and guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->