### PR TITLE
Test Iroh path selection without sleeps

### DIFF
--- a/.github/actions/setup-cmux-tui-rust/action.yml
+++ b/.github/actions/setup-cmux-tui-rust/action.yml
@@ -1,0 +1,57 @@
+name: Set up cmux-tui Rust
+description: Install the repository-pinned cmux-tui Rust toolchain.
+
+runs:
+  using: composite
+  steps:
+    - name: Install pinned Rust toolchain
+      shell: bash
+      env:
+        TOOLCHAIN_FILE: ${{ github.action_path }}/../../../cmux-tui/rust-toolchain.toml
+      run: |
+        if command -v python3 >/dev/null 2>&1; then
+          python_cmd=python3
+        elif command -v python >/dev/null 2>&1; then
+          python_cmd=python
+        else
+          echo "::error::Python is required to read the pinned Rust toolchain" >&2
+          exit 1
+        fi
+        "$python_cmd" <<'PY'
+        import os
+        import pathlib
+        import re
+        import subprocess
+
+        contents = pathlib.Path(os.environ["TOOLCHAIN_FILE"]).read_text(encoding="utf-8")
+
+        def value(name):
+            match = re.search(rf'^\s*{name}\s*=\s*"([^"]+)"', contents, re.MULTILINE)
+            if match is None:
+                raise SystemExit(f"missing {name} in cmux-tui/rust-toolchain.toml")
+            return match.group(1)
+
+        channel = value("channel")
+        profile = value("profile")
+        components_match = re.search(r"^\s*components\s*=\s*\[([^]]*)\]", contents, re.MULTILINE)
+        if components_match is None:
+            raise SystemExit("missing components in cmux-tui/rust-toolchain.toml")
+        components = re.findall(r'"([^"]+)"', components_match.group(1))
+
+        command = ["rustup", "toolchain", "install", channel, "--profile", profile]
+        for component in components:
+            command.extend(["--component", component])
+        subprocess.run(command, check=True)
+        subprocess.run(["rustup", "default", channel], check=True)
+
+        cargo = subprocess.run(
+            ["rustup", "which", "cargo"],
+            check=True,
+            capture_output=True,
+            text=True,
+        ).stdout.strip()
+        with open(os.environ["GITHUB_PATH"], "a", encoding="utf-8") as path_file:
+            print(pathlib.Path(cargo).parent, file=path_file)
+        PY
+        cargo --version
+        rustc --version

--- a/.github/scripts/run-cmux-tui-core-tests-isolated.py
+++ b/.github/scripts/run-cmux-tui-core-tests-isolated.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+"""Run each cmux-tui-core Rust test in a fresh process."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+import subprocess
+import sys
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("cargo_messages", type=Path)
+    parser.add_argument("core_root", type=Path)
+    return parser.parse_args()
+
+
+def is_below(path: Path, root: Path) -> bool:
+    try:
+        path.relative_to(root)
+    except ValueError:
+        return False
+    return True
+
+
+def test_binaries(cargo_messages: Path, core_root: Path) -> list[Path]:
+    binaries: dict[Path, set[str]] = {}
+    with cargo_messages.open(encoding="utf-8") as messages:
+        for line in messages:
+            try:
+                message = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            if message.get("reason") != "compiler-artifact":
+                continue
+            if not message.get("profile", {}).get("test"):
+                continue
+
+            target = message.get("target", {})
+            kinds = set(target.get("kind", []))
+            if not kinds.intersection({"lib", "test"}):
+                continue
+            source = target.get("src_path")
+            executable = message.get("executable")
+            if not source or not executable:
+                continue
+            if not is_below(Path(source).resolve(), core_root):
+                continue
+            binaries.setdefault(Path(executable).resolve(), set()).update(kinds)
+
+    library_binaries = [path for path, kinds in binaries.items() if "lib" in kinds]
+    if len(library_binaries) != 1:
+        raise SystemExit(
+            "expected one cmux-tui-core library test binary, "
+            f"found {len(library_binaries)}"
+        )
+    if not binaries:
+        raise SystemExit("cargo did not report any cmux-tui-core test binaries")
+    return sorted(binaries)
+
+
+def tests_in(binary: Path) -> list[str]:
+    result = subprocess.run(
+        [str(binary), "--list"],
+        check=True,
+        stdout=subprocess.PIPE,
+        text=True,
+    )
+    tests = []
+    for line in result.stdout.splitlines():
+        name, separator, kind = line.rpartition(": ")
+        if separator and kind == "test":
+            tests.append(name)
+    if not tests:
+        raise SystemExit(f"{binary.name} did not list any tests")
+    if len(tests) != len(set(tests)):
+        raise SystemExit(f"{binary.name} listed duplicate test names")
+    return tests
+
+
+def main() -> int:
+    args = parse_args()
+    core_root = args.core_root.resolve()
+    binaries = test_binaries(args.cargo_messages, core_root)
+    total = 0
+    for binary in binaries:
+        tests = tests_in(binary)
+        print(f"Running {len(tests)} tests from {binary.name} in fresh processes")
+        for index, test_name in enumerate(tests, start=1):
+            print(f"[{index}/{len(tests)}] {test_name}", flush=True)
+            subprocess.run(
+                [str(binary), test_name, "--exact", "--test-threads=1"],
+                check=True,
+            )
+            total += 1
+    print(f"Passed {total} isolated cmux-tui-core tests")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/workflows/cmux-tui-build-package.yml
+++ b/.github/workflows/cmux-tui-build-package.yml
@@ -27,6 +27,36 @@ on:
         required: false
         default: false
         type: boolean
+      target_set:
+        description: "Binary targets to build: all or macos-arm64"
+        required: false
+        default: all
+        type: string
+      build_cloudflare_relay:
+        description: "Build and verify the Cloudflare relay"
+        required: false
+        default: true
+        type: boolean
+      verify_linux_arm64:
+        description: "Run package entrypoint verification on native Linux ARM64"
+        required: false
+        default: true
+        type: boolean
+      macos_runner:
+        description: "Optional macOS runner label override"
+        required: false
+        default: ""
+        type: string
+      linux_runner:
+        description: "Optional Linux x64 runner label override"
+        required: false
+        default: ""
+        type: string
+      windows_runner:
+        description: "Optional Windows runner label override"
+        required: false
+        default: ""
+        type: string
       checkout_ref:
         description: "Optional git ref to build instead of the caller ref"
         required: false
@@ -35,44 +65,114 @@ on:
 
 permissions: {}
 
-env:
-  RUST_TOOLCHAIN: "1.95.0"
-
 jobs:
+  plan-build:
+    name: select binary targets
+    runs-on: ${{ inputs.linux_runner != '' && inputs.linux_runner || vars.LINUX_RUNNER || 'blacksmith-4vcpu-ubuntu-2404' }}
+    timeout-minutes: 5
+    outputs:
+      matrix: ${{ steps.targets.outputs.matrix }}
+      linux_package_matrix: ${{ steps.targets.outputs.linux_package_matrix }}
+    steps:
+      - name: Select binary targets
+        id: targets
+        env:
+          TARGET_SET: ${{ inputs.target_set }}
+          PACKAGE_NPM: ${{ inputs.package_npm }}
+          PACKAGE_PYPI: ${{ inputs.package_pypi }}
+          MACOS_RUNNER: ${{ inputs.macos_runner != '' && inputs.macos_runner || vars.MACOS_RUNNER_15 || 'blacksmith-6vcpu-macos-15' }}
+          LINUX_RUNNER: ${{ inputs.linux_runner != '' && inputs.linux_runner || vars.LINUX_RUNNER || 'blacksmith-4vcpu-ubuntu-2404' }}
+          LINUX_ARM64_RUNNER: ${{ vars.LINUX_ARM64_RUNNER || 'ubuntu-24.04-arm' }}
+          VERIFY_LINUX_ARM64: ${{ inputs.verify_linux_arm64 }}
+        shell: bash
+        run: |
+          python3 <<'PY' >> "$GITHUB_OUTPUT"
+          import json
+          import os
+
+          targets = [
+              {
+                  "target": "aarch64-apple-darwin",
+                  "build_target": "aarch64-apple-darwin",
+                  "runner": os.environ["MACOS_RUNNER"],
+                  "cross": False,
+                  "ext": "",
+                  "compatibility_target": "",
+              },
+              {
+                  "target": "x86_64-apple-darwin",
+                  "build_target": "x86_64-apple-darwin",
+                  "runner": os.environ["MACOS_RUNNER"],
+                  "cross": True,
+                  "ext": "",
+                  "compatibility_target": "",
+              },
+              {
+                  "target": "x86_64-unknown-linux-musl",
+                  "build_target": "x86_64-unknown-linux-musl",
+                  "runner": os.environ["LINUX_RUNNER"],
+                  "cross": True,
+                  "ext": "",
+                  "compatibility_target": "x86_64-unknown-linux-gnu",
+              },
+              {
+                  "target": "aarch64-unknown-linux-musl",
+                  "build_target": "aarch64-unknown-linux-musl",
+                  "runner": os.environ["LINUX_RUNNER"],
+                  "cross": True,
+                  "ext": "",
+                  "compatibility_target": "aarch64-unknown-linux-gnu",
+              },
+          ]
+          target_set = os.environ["TARGET_SET"]
+          if target_set == "all":
+              selected = targets
+          elif target_set == "macos-arm64":
+              selected = [
+                  target for target in targets
+                  if target["target"] == "aarch64-apple-darwin"
+              ]
+          else:
+              raise SystemExit(f"unsupported target_set: {target_set!r}")
+
+          packages_requested = (
+              os.environ["PACKAGE_NPM"] == "true"
+              or os.environ["PACKAGE_PYPI"] == "true"
+          )
+          if packages_requested and target_set != "all":
+              raise SystemExit("npm and PyPI packaging require target_set=all")
+
+          print("matrix=" + json.dumps({"include": selected}, separators=(",", ":")))
+
+          linux_package_targets = [
+              {
+                  "architecture": "x64",
+                  "runner": os.environ["LINUX_RUNNER"],
+              }
+          ]
+          if os.environ["VERIFY_LINUX_ARM64"] == "true":
+              linux_package_targets.append(
+                  {
+                      "architecture": "arm64",
+                      "runner": os.environ["LINUX_ARM64_RUNNER"],
+                  }
+              )
+          print(
+              "linux_package_matrix="
+              + json.dumps({"include": linux_package_targets}, separators=(",", ":"))
+          )
+          PY
+
   build:
     name: build ${{ matrix.target }}
+    needs: plan-build
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 60
     permissions:
       contents: read
     strategy:
       fail-fast: false
-      matrix:
-        include:
-          - target: aarch64-apple-darwin
-            build_target: aarch64-apple-darwin
-            runner: ${{ vars.MACOS_RUNNER_15 || 'blacksmith-6vcpu-macos-15' }}
-            cross: false
-            ext: ""
-            compatibility_target: ""
-          - target: x86_64-apple-darwin
-            build_target: x86_64-apple-darwin
-            runner: ${{ vars.MACOS_RUNNER_15 || 'blacksmith-6vcpu-macos-15' }}
-            cross: true
-            ext: ""
-            compatibility_target: ""
-          - target: x86_64-unknown-linux-musl
-            build_target: x86_64-unknown-linux-musl
-            runner: ${{ vars.LINUX_RUNNER || 'blacksmith-4vcpu-ubuntu-2404' }}
-            cross: true
-            ext: ""
-            compatibility_target: x86_64-unknown-linux-gnu
-          - target: aarch64-unknown-linux-musl
-            build_target: aarch64-unknown-linux-musl
-            runner: ${{ vars.LINUX_RUNNER || 'blacksmith-4vcpu-ubuntu-2404' }}
-            cross: true
-            ext: ""
-            compatibility_target: aarch64-unknown-linux-gnu
+      matrix: ${{ fromJSON(needs.plan-build.outputs.matrix) }}
     steps:
       - name: Checkout caller ref
         if: inputs.checkout_ref == ''
@@ -94,31 +194,37 @@ jobs:
         if: runner.os == 'Linux'
         run: |
           sudo apt-get update
-          sudo apt-get install -y binutils clang libclang-dev pkg-config
+          sudo apt-get install -y binutils clang libclang-dev musl-tools pkg-config
+
+      - name: Resolve Ghostty Zig version
+        id: ghostty-zig-version
+        shell: bash
+        run: |
+          version="$(bash ./scripts/ghostty-zig-version.sh)"
+          echo "version=$version" >> "$GITHUB_OUTPUT"
 
       - name: Install zig
         uses: mlugg/setup-zig@8d6198c65fb0feaa111df26e6b467fea8345e46f # v2.0.5
         with:
-          version: 0.15.2
+          version: ${{ steps.ghostty-zig-version.outputs.version }}
 
-      - name: Install Rust toolchain
-        shell: bash
-        run: |
-          rustup toolchain install "$RUST_TOOLCHAIN" --profile minimal
-          rustup default "$RUST_TOOLCHAIN"
-          rustc --version
+      - name: Set up pinned Rust
+        uses: ./.github/actions/setup-cmux-tui-rust
 
       - name: Install Rust target
         shell: bash
         run: rustup target add ${{ matrix.target }}
 
       - name: Install cargo-zigbuild
-        if: matrix.cross == true
+        if: matrix.cross == true && runner.os == 'Linux'
         shell: bash
         run: cargo install --locked cargo-zigbuild@0.20.0
 
       - name: Build cmux-tui (native)
         if: matrix.cross == false
+        env:
+          CMUX_TUI_DISTRIBUTION_VERSION: ${{ inputs.version }}
+          PACKAGE_NPM: ${{ inputs.package_npm }}
         working-directory: cmux-tui
         shell: bash
         run: |
@@ -127,17 +233,19 @@ jobs:
           unset CMUX_GHOSTTY_SRC
           CMUX_TUI_BUILD_COMMIT="$(git -C .. rev-parse HEAD)"
           CMUX_TUI_GHOSTTY_COMMIT="$(git -C ../ghostty rev-parse HEAD)"
-          CMUX_TUI_DISTRIBUTION_VERSION="${{ inputs.version }}"
           export CMUX_TUI_BUILD_COMMIT CMUX_TUI_GHOSTTY_COMMIT CMUX_TUI_DISTRIBUTION_VERSION
-          if [[ "${{ inputs.package_npm }}" == "true" ]]; then
-            CMUX_TUI_NPM_BOOTSTRAP_VERSION="${{ inputs.version }}"
+          if [[ "$PACKAGE_NPM" == "true" ]]; then
+            CMUX_TUI_NPM_BOOTSTRAP_VERSION="$CMUX_TUI_DISTRIBUTION_VERSION"
             export CMUX_TUI_NPM_BOOTSTRAP_VERSION
           fi
           cargo build -p cmux-tui --bin cmux-tui --release --locked --target ${{ matrix.build_target }}
           cargo build -p cmux-relay --bin cmux-relay --release --locked --target ${{ matrix.build_target }}
 
-      - name: Build cmux-tui (cross)
-        if: matrix.cross == true
+      - name: Build cmux-tui (Linux cross)
+        if: matrix.cross == true && runner.os == 'Linux'
+        env:
+          CMUX_TUI_DISTRIBUTION_VERSION: ${{ inputs.version }}
+          PACKAGE_NPM: ${{ inputs.package_npm }}
         working-directory: cmux-tui
         shell: bash
         run: |
@@ -146,14 +254,34 @@ jobs:
           unset CMUX_GHOSTTY_SRC
           CMUX_TUI_BUILD_COMMIT="$(git -C .. rev-parse HEAD)"
           CMUX_TUI_GHOSTTY_COMMIT="$(git -C ../ghostty rev-parse HEAD)"
-          CMUX_TUI_DISTRIBUTION_VERSION="${{ inputs.version }}"
           export CMUX_TUI_BUILD_COMMIT CMUX_TUI_GHOSTTY_COMMIT CMUX_TUI_DISTRIBUTION_VERSION
-          if [[ "${{ inputs.package_npm }}" == "true" ]]; then
-            CMUX_TUI_NPM_BOOTSTRAP_VERSION="${{ inputs.version }}"
+          if [[ "$PACKAGE_NPM" == "true" ]]; then
+            CMUX_TUI_NPM_BOOTSTRAP_VERSION="$CMUX_TUI_DISTRIBUTION_VERSION"
             export CMUX_TUI_NPM_BOOTSTRAP_VERSION
           fi
           cargo zigbuild -p cmux-tui --bin cmux-tui --release --locked --target ${{ matrix.build_target }}
           cargo zigbuild -p cmux-relay --bin cmux-relay --release --locked --target ${{ matrix.build_target }}
+
+      - name: Build cmux-tui (macOS cross)
+        if: matrix.cross == true && runner.os == 'macOS'
+        env:
+          CMUX_TUI_DISTRIBUTION_VERSION: ${{ inputs.version }}
+          PACKAGE_NPM: ${{ inputs.package_npm }}
+        working-directory: cmux-tui
+        shell: bash
+        run: |
+          # Xcode's macOS SDK natively supports cross-architecture builds.
+          # cargo-zigbuild cannot resolve SDK frameworks when the host is arm64.
+          unset CMUX_GHOSTTY_SRC
+          CMUX_TUI_BUILD_COMMIT="$(git -C .. rev-parse HEAD)"
+          CMUX_TUI_GHOSTTY_COMMIT="$(git -C ../ghostty rev-parse HEAD)"
+          export CMUX_TUI_BUILD_COMMIT CMUX_TUI_GHOSTTY_COMMIT CMUX_TUI_DISTRIBUTION_VERSION
+          if [[ "$PACKAGE_NPM" == "true" ]]; then
+            CMUX_TUI_NPM_BOOTSTRAP_VERSION="$CMUX_TUI_DISTRIBUTION_VERSION"
+            export CMUX_TUI_NPM_BOOTSTRAP_VERSION
+          fi
+          cargo build -p cmux-tui --bin cmux-tui --release --locked --target ${{ matrix.build_target }}
+          cargo build -p cmux-relay --bin cmux-relay --release --locked --target ${{ matrix.build_target }}
 
       - name: Stage binary
         shell: bash
@@ -223,10 +351,11 @@ jobs:
 
   cloudflare-relay:
     name: Cloudflare Durable Object relay
-    runs-on: ${{ vars.LINUX_RUNNER || 'blacksmith-4vcpu-ubuntu-2404' }}
+    if: inputs.build_cloudflare_relay
+    runs-on: ${{ inputs.linux_runner != '' && inputs.linux_runner || vars.LINUX_RUNNER || 'blacksmith-4vcpu-ubuntu-2404' }}
     timeout-minutes: 30
     env:
-      RUSTUP_TOOLCHAIN: "1.88.0"
+      RUSTUP_TOOLCHAIN: "1.91.0"
     permissions:
       contents: read
     defaults:
@@ -255,7 +384,7 @@ jobs:
 
       - name: Install pinned Rust toolchain and Worker builder
         run: |
-          rustup toolchain install 1.88.0 --profile minimal --component clippy --target wasm32-unknown-unknown
+          rustup toolchain install "$RUSTUP_TOOLCHAIN" --profile minimal --component clippy --target wasm32-unknown-unknown
           cargo install --locked worker-build@0.8.5
 
       - name: Install pinned npm dependencies
@@ -279,9 +408,8 @@ jobs:
   build-windows:
     name: build x86_64-pc-windows-gnu
     if: inputs.include_windows
-    runs-on: ${{ vars.WINDOWS_RUNNER || 'windows-latest' }}
+    runs-on: ${{ inputs.windows_runner != '' && inputs.windows_runner || vars.WINDOWS_RUNNER || 'windows-latest' }}
     timeout-minutes: 60
-    continue-on-error: true
     permissions:
       contents: read
     steps:
@@ -301,17 +429,20 @@ jobs:
       - name: Init ghostty submodule
         run: git submodule update --init --depth 1 ghostty
 
+      - name: Resolve Ghostty Zig version
+        id: ghostty-zig-version
+        shell: bash
+        run: |
+          version="$(bash ./scripts/ghostty-zig-version.sh)"
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+
       - name: Install zig
         uses: mlugg/setup-zig@8d6198c65fb0feaa111df26e6b467fea8345e46f # v2.0.5
         with:
-          version: 0.15.2
+          version: ${{ steps.ghostty-zig-version.outputs.version }}
 
-      - name: Install Rust toolchain
-        shell: bash
-        run: |
-          rustup toolchain install "$RUST_TOOLCHAIN" --profile minimal
-          rustup default "$RUST_TOOLCHAIN"
-          rustc --version
+      - name: Set up pinned Rust
+        uses: ./.github/actions/setup-cmux-tui-rust
 
       - name: Install Rust target
         shell: bash
@@ -320,6 +451,9 @@ jobs:
           printf '%s\n' 'C:\msys64\mingw64\bin' >> "$GITHUB_PATH"
 
       - name: Build libghostty-vt + cmux-tui (Windows GNU)
+        env:
+          CMUX_TUI_DISTRIBUTION_VERSION: ${{ inputs.version }}
+          PACKAGE_NPM: ${{ inputs.package_npm }}
         shell: bash
         run: |
           # Keep the manual Zig build and Cargo's build script on the same
@@ -327,10 +461,9 @@ jobs:
           unset CMUX_GHOSTTY_SRC
           CMUX_TUI_BUILD_COMMIT="$(git rev-parse HEAD)"
           CMUX_TUI_GHOSTTY_COMMIT="$(git -C ghostty rev-parse HEAD)"
-          CMUX_TUI_DISTRIBUTION_VERSION="${{ inputs.version }}"
           export CMUX_TUI_BUILD_COMMIT CMUX_TUI_GHOSTTY_COMMIT CMUX_TUI_DISTRIBUTION_VERSION
-          if [[ "${{ inputs.package_npm }}" == "true" ]]; then
-            CMUX_TUI_NPM_BOOTSTRAP_VERSION="${{ inputs.version }}"
+          if [[ "$PACKAGE_NPM" == "true" ]]; then
+            CMUX_TUI_NPM_BOOTSTRAP_VERSION="$CMUX_TUI_DISTRIBUTION_VERSION"
             export CMUX_TUI_NPM_BOOTSTRAP_VERSION
           fi
           cd ghostty
@@ -367,7 +500,7 @@ jobs:
     name: package distributions
     needs: build
     if: inputs.package_npm || inputs.package_pypi
-    runs-on: ${{ vars.LINUX_RUNNER || 'blacksmith-4vcpu-ubuntu-2404' }}
+    runs-on: ${{ inputs.linux_runner != '' && inputs.linux_runner || vars.LINUX_RUNNER || 'blacksmith-4vcpu-ubuntu-2404' }}
     timeout-minutes: 30
     permissions:
       contents: read
@@ -530,18 +663,17 @@ jobs:
 
   verify-linux-packages:
     name: verify Linux package entrypoints (${{ matrix.architecture }})
-    needs: package
+    needs:
+      - plan-build
+      - package
     if: ${{ inputs.package_npm || inputs.package_pypi }}
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.runner }}
     timeout-minutes: 30
     permissions:
       contents: read
     strategy:
       fail-fast: false
-      matrix:
-        architecture:
-          - x64
-          - arm64
+      matrix: ${{ fromJSON(needs.plan-build.outputs.linux_package_matrix) }}
     env:
       PYPI_VERSION: ${{ inputs.pypi_version != '' && inputs.pypi_version || inputs.version }}
     steps:
@@ -557,12 +689,6 @@ jobs:
         with:
           persist-credentials: false
           ref: ${{ inputs.checkout_ref }}
-
-      - name: Set up ARM64 emulation
-        if: matrix.architecture == 'arm64'
-        uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0
-        with:
-          platforms: arm64
 
       - name: Download npm package archive
         if: inputs.package_npm

--- a/.github/workflows/cmux-tui-sdks.yml
+++ b/.github/workflows/cmux-tui-sdks.yml
@@ -1,0 +1,539 @@
+name: cmux-tui SDKs
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "cmux-tui/**"
+      - ".github/actions/setup-cmux-tui-rust/**"
+      - ".github/workflows/cmux-tui-nightly.yml"
+      - ".github/workflows/cmux-tui-release-cut.yml"
+      - ".github/workflows/cmux-tui-release.yml"
+      - ".github/workflows/cmux-tui-sdks.yml"
+      - ".github/workflows/cmux-tui-spec.yml"
+      - ".github/workflows/sdk-bootstrap-crates.yml"
+      - ".github/workflows/sdk-bootstrap-npm.yml"
+      - ".github/workflows/sdk-bootstrap-pypi.yml"
+      - ".github/workflows/sdk-publish-crates.yml"
+      - ".github/workflows/sdk-publish-go.yml"
+      - ".github/workflows/sdk-publish-java.yml"
+      - ".github/workflows/sdk-publish-npm.yml"
+      - ".github/workflows/sdk-publish-python.yml"
+      - ".github/workflows/sdk-release-cut.yml"
+      - ".github/workflows/tui-publish-npm.yml"
+      - ".github/workflows/tui-publish-pypi.yml"
+      - "tests/test_tui_publish_workflow_security.py"
+  pull_request:
+    paths:
+      - "cmux-tui/**"
+      - ".github/actions/setup-cmux-tui-rust/**"
+      - ".github/workflows/cmux-tui-nightly.yml"
+      - ".github/workflows/cmux-tui-release-cut.yml"
+      - ".github/workflows/cmux-tui-release.yml"
+      - ".github/workflows/cmux-tui-sdks.yml"
+      - ".github/workflows/cmux-tui-spec.yml"
+      - ".github/workflows/sdk-bootstrap-crates.yml"
+      - ".github/workflows/sdk-bootstrap-npm.yml"
+      - ".github/workflows/sdk-bootstrap-pypi.yml"
+      - ".github/workflows/sdk-publish-crates.yml"
+      - ".github/workflows/sdk-publish-go.yml"
+      - ".github/workflows/sdk-publish-java.yml"
+      - ".github/workflows/sdk-publish-npm.yml"
+      - ".github/workflows/sdk-publish-python.yml"
+      - ".github/workflows/sdk-release-cut.yml"
+      - ".github/workflows/tui-publish-npm.yml"
+      - ".github/workflows/tui-publish-pypi.yml"
+      - "tests/test_tui_publish_workflow_security.py"
+  workflow_dispatch:
+
+concurrency:
+  group: cmux-tui-sdks-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  contract:
+    name: protocol contract
+    runs-on: ${{ vars.LINUX_RUNNER || 'blacksmith-4vcpu-ubuntu-2404' }}
+    timeout-minutes: 8
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Set up Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
+        with:
+          python-version: "3.12.8"
+
+      - name: Install workflow guard dependencies
+        run: |
+          python3 -m pip install \
+            --disable-pip-version-check \
+            "PyYAML==6.0.3"
+
+      - name: Test protocol inventory
+        run: python3 cmux-tui/scripts/test_check_spec_inventory.py
+
+      - name: Check protocol and TUI action inventory
+        run: python3 cmux-tui/scripts/check-spec-inventory.py
+
+      - name: Test SDK schema drift checker
+        run: python3 cmux-tui/scripts/test_check_sdk_schema.py
+
+      - name: Check SDK schema against runtime fields
+        run: python3 cmux-tui/scripts/check-sdk-schema.py
+
+      - name: Test public resource boundary checker
+        run: python3 cmux-tui/scripts/test_check_resource_api_boundary.py
+
+      - name: Check public resource API boundary
+        run: python3 cmux-tui/scripts/check-resource-api-boundary.py
+
+      - name: Test deterministic SDK generator
+        env:
+          PYTHONPATH: cmux-tui/bindings
+        run: python3 -m unittest discover -s cmux-tui/bindings/codegen/tests -v
+
+      - name: Check all generated SDK wire layers
+        run: python3 cmux-tui/bindings/codegen/generate.py --check
+
+      - name: Test package version guard
+        run: |
+          python3 -m unittest discover \
+            -s cmux-tui/bindings/tests \
+            -p 'test_*.py' \
+            -v
+
+      - name: Test SDK publishing workflow guards
+        run: python3 tests/test_tui_publish_workflow_security.py -v
+
+      - name: Check package versions
+        run: python3 cmux-tui/bindings/check-versions.py --published-only
+
+      - name: Test shared conformance runner
+        run: |
+          python3 -m unittest discover \
+            -s cmux-tui/bindings/conformance \
+            -p 'test_*.py' \
+            -v
+
+  packages:
+    name: ${{ matrix.language }} package
+    needs: contract
+    runs-on: ${{ vars.LINUX_RUNNER || 'blacksmith-4vcpu-ubuntu-2404' }}
+    timeout-minutes: 25
+    strategy:
+      fail-fast: false
+      matrix:
+        language:
+          - python
+          - typescript
+          - rust
+          - go
+          - java
+          - cpp
+          - zig
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Set up Python 3.9
+        if: matrix.language == 'python'
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
+        with:
+          python-version: "3.9"
+
+      - name: Set up Node.js
+        if: matrix.language == 'typescript'
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: "20.19.5"
+          cache: npm
+          cache-dependency-path: cmux-tui/bindings/typescript/package-lock.json
+
+      - name: Set up Rust 1.88
+        if: matrix.language == 'rust'
+        run: |
+          rustup toolchain install 1.88.0 --profile minimal --component clippy,rustfmt
+          cargo +1.88.0 --version
+          rustc +1.88.0 --version
+
+      - name: Set up Go
+        if: matrix.language == 'go'
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version: "1.22.12"
+          cache-dependency-path: cmux-tui/bindings/go/go.mod
+
+      - name: Select JDK 17
+        if: matrix.language == 'java'
+        run: |
+          test -x "$JAVA_HOME_17_X64/bin/java"
+          echo "$JAVA_HOME_17_X64/bin" >> "$GITHUB_PATH"
+          echo "JAVA_HOME=$JAVA_HOME_17_X64" >> "$GITHUB_ENV"
+          "$JAVA_HOME_17_X64/bin/java" -version
+          "$JAVA_HOME_17_X64/bin/javac" -version
+
+      - name: Select Clang C++20
+        if: matrix.language == 'cpp'
+        run: clang++ --version
+
+      - name: Set up Zig
+        if: matrix.language == 'zig'
+        uses: mlugg/setup-zig@8d6198c65fb0feaa111df26e6b467fea8345e46f # v2.0.5
+        with:
+          version: 0.15.2
+
+      - name: Test and install Python SDK
+        if: matrix.language == 'python'
+        env:
+          PYTHONPATH: cmux-tui/bindings/python
+        run: |
+          python3 -m pip install \
+            --disable-pip-version-check \
+            "setuptools==80.9.0"
+          python3 -m unittest discover -s cmux-tui/bindings/python/tests -v
+          python3 -m pip install \
+            --no-build-isolation \
+            --no-deps \
+            --target "$RUNNER_TEMP/cmux-python-package" \
+            ./cmux-tui/bindings/python
+          CMUX_PYTHON_PACKAGE="$RUNNER_TEMP/cmux-python-package" python3 - <<'PY'
+          import importlib.metadata
+          import os
+          import pathlib
+          import sys
+
+          package = pathlib.Path(os.environ["CMUX_PYTHON_PACKAGE"]).resolve()
+          sys.path.insert(0, str(package))
+          import cmux
+
+          assert pathlib.Path(cmux.__file__).resolve().is_relative_to(package)
+          distribution = next(
+              item
+              for item in importlib.metadata.distributions(path=[str(package)])
+              if item.metadata["Name"] == "cmux-sdk"
+          )
+          assert not distribution.requires
+          PY
+
+      - name: Test packed TypeScript SDK
+        if: matrix.language == 'typescript'
+        working-directory: cmux-tui/bindings/typescript
+        run: |
+          npm ci --no-audit --no-fund
+          npm test
+
+      - name: Test and package Rust SDKs
+        if: matrix.language == 'rust'
+        working-directory: cmux-tui
+        run: |
+          cargo +1.88.0 fmt -p cmux-sdk -p cmux-sidebar -- --check
+          cargo +1.88.0 test \
+            -p cmux-sdk \
+            -p cmux-sidebar \
+            --all-targets \
+            --locked
+          cargo +1.88.0 test \
+            -p cmux-sdk \
+            -p cmux-sidebar \
+            --doc \
+            --locked
+          cargo +1.88.0 clippy \
+            -p cmux-sdk \
+            -p cmux-sidebar \
+            --all-targets \
+            --locked \
+            -- -D warnings
+          RUSTDOCFLAGS="-D warnings" \
+            cargo +1.88.0 doc \
+              -p cmux-sdk \
+              -p cmux-sidebar \
+              --locked \
+              --no-deps
+          cargo +1.88.0 package -p cmux-sdk --locked
+          # Full sidebar packaging resolves its versioned crates.io dependency.
+          # Publish cmux-sdk first; CI still verifies the exact sidebar file set.
+          cargo +1.88.0 package -p cmux-sidebar --locked --list
+
+      - name: Test Go SDK
+        if: matrix.language == 'go'
+        working-directory: cmux-tui/bindings/go
+        run: |
+          go test ./...
+          go test -race ./...
+          go vet ./...
+
+      - name: Test external Java jar consumer
+        if: matrix.language == 'java'
+        working-directory: cmux-tui/bindings/java
+        run: bash scripts/test.sh
+
+      - name: Test installed C++ package consumer
+        if: matrix.language == 'cpp'
+        env:
+          CC: clang
+          CXX: clang++
+        run: |
+          cmake \
+            -S cmux-tui/bindings/cpp \
+            -B "$RUNNER_TEMP/cmux-cpp-sdk" \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_CXX_FLAGS="-Wall -Wextra -Wpedantic -Werror"
+          cmake --build "$RUNNER_TEMP/cmux-cpp-sdk" --parallel
+          ctest --test-dir "$RUNNER_TEMP/cmux-cpp-sdk" --output-on-failure
+
+      - name: Test Zig SDK
+        if: matrix.language == 'zig'
+        working-directory: cmux-tui/bindings/zig
+        run: |
+          test "$(zig version)" = "0.15.2"
+          zig fmt --check build.zig src examples
+          zig build test
+          zig build
+
+  consumers:
+    name: ${{ matrix.language }} consumer
+    needs: contract
+    runs-on: ${{ vars.LINUX_RUNNER || 'blacksmith-4vcpu-ubuntu-2404' }}
+    timeout-minutes: 25
+    strategy:
+      fail-fast: false
+      matrix:
+        language:
+          - python
+          - typescript
+          - rust
+          - go
+          - java
+          - cpp
+          - zig
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Set up Python 3.9
+        if: matrix.language == 'python'
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
+        with:
+          python-version: "3.9"
+
+      - name: Set up Node.js
+        if: matrix.language == 'typescript'
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: "20.19.5"
+          cache: npm
+          cache-dependency-path: |
+            cmux-tui/bindings/typescript/package-lock.json
+            cmux-tui/bindings/examples/typescript-browser-controller/package-lock.json
+
+      - name: Set up Rust 1.88
+        if: matrix.language == 'rust'
+        run: |
+          rustup toolchain install 1.88.0 --profile minimal --component clippy,rustfmt
+          cargo +1.88.0 --version
+          rustc +1.88.0 --version
+
+      - name: Set up Go
+        if: matrix.language == 'go'
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version: "1.22.12"
+          cache-dependency-path: |
+            cmux-tui/bindings/go/go.mod
+            cmux-tui/bindings/examples/go-terminal-bot/go.mod
+
+      - name: Select JDK 17
+        if: matrix.language == 'java'
+        run: |
+          test -x "$JAVA_HOME_17_X64/bin/java"
+          echo "$JAVA_HOME_17_X64/bin" >> "$GITHUB_PATH"
+          echo "JAVA_HOME=$JAVA_HOME_17_X64" >> "$GITHUB_ENV"
+          "$JAVA_HOME_17_X64/bin/java" -version
+          "$JAVA_HOME_17_X64/bin/javac" -version
+
+      - name: Select Clang C++20
+        if: matrix.language == 'cpp'
+        run: clang++ --version
+
+      - name: Set up Zig
+        if: matrix.language == 'zig'
+        uses: mlugg/setup-zig@8d6198c65fb0feaa111df26e6b467fea8345e46f # v2.0.5
+        with:
+          version: 0.15.2
+
+      - name: Test Python agent watchdog
+        if: matrix.language == 'python'
+        working-directory: cmux-tui/bindings/examples/python-agent-watchdog
+        env:
+          PYTHONPATH: ${{ github.workspace }}/cmux-tui/bindings/python
+        run: python3 -m unittest discover -s tests -v
+
+      - name: Test Python development orchestrator
+        if: matrix.language == 'python'
+        working-directory: cmux-tui/bindings/examples/python-dev-orchestrator
+        env:
+          PYTHONPATH: ${{ github.workspace }}/cmux-tui/bindings/python:${{ github.workspace }}/cmux-tui/bindings/examples/python-dev-orchestrator
+        run: python3 -m unittest discover -s tests -v
+
+      - name: Test TypeScript browser controller
+        if: matrix.language == 'typescript'
+        working-directory: cmux-tui/bindings/examples/typescript-browser-controller
+        run: |
+          npm ci --no-audit --no-fund
+          npm test
+
+      - name: Test Rust resource consumers
+        if: matrix.language == 'rust'
+        run: |
+          cargo +1.88.0 test \
+            --manifest-path cmux-tui/bindings/examples/rust-agent-dashboard/Cargo.toml \
+            --locked
+          cargo +1.88.0 clippy \
+            --manifest-path cmux-tui/bindings/examples/rust-agent-dashboard/Cargo.toml \
+            --locked \
+            --all-targets \
+            -- -D warnings
+          cargo +1.88.0 test \
+            --manifest-path cmux-tui/bindings/examples/rust-sidebar-monitor/Cargo.toml \
+            --locked \
+            --all-targets
+          cargo +1.88.0 clippy \
+            --manifest-path cmux-tui/bindings/examples/rust-sidebar-monitor/Cargo.toml \
+            --locked \
+            --all-targets \
+            -- -D warnings
+
+      - name: Test Go terminal bot
+        if: matrix.language == 'go'
+        working-directory: cmux-tui/bindings/examples/go-terminal-bot
+        run: |
+          go test ./...
+          go test -race ./...
+          go vet ./...
+
+      - name: Test Java CI orchestrator
+        if: matrix.language == 'java'
+        run: cmux-tui/bindings/examples/java-ci-orchestrator/scripts/test.sh
+
+      - name: Test installed C++ terminal frontend
+        if: matrix.language == 'cpp'
+        env:
+          CC: clang
+          CXX: clang++
+        run: |
+          cmake \
+            -S cmux-tui/bindings/cpp \
+            -B "$RUNNER_TEMP/cmux-cpp-install-build" \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DCMUX_BUILD_TESTS=OFF
+          cmake --build "$RUNNER_TEMP/cmux-cpp-install-build" --parallel
+          cmake \
+            --install "$RUNNER_TEMP/cmux-cpp-install-build" \
+            --prefix "$RUNNER_TEMP/cmux-cpp-install"
+          cmake \
+            -S cmux-tui/bindings/examples/cpp-terminal-frontend \
+            -B "$RUNNER_TEMP/cmux-cpp-frontend" \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DCMUX_CPP_SDK_DIR= \
+            -DCMAKE_PREFIX_PATH="$RUNNER_TEMP/cmux-cpp-install"
+          cmake --build "$RUNNER_TEMP/cmux-cpp-frontend" --parallel
+          ctest --test-dir "$RUNNER_TEMP/cmux-cpp-frontend" --output-on-failure
+
+      - name: Test Zig session supervisor
+        if: matrix.language == 'zig'
+        working-directory: cmux-tui/bindings/examples/zig-session-supervisor
+        run: |
+          test "$(zig version)" = "0.15.2"
+          zig fmt --check build.zig src tests
+          zig build test -Doptimize=Debug
+          zig build test -Doptimize=ReleaseSafe
+          zig build -Doptimize=Debug
+          zig build -Doptimize=ReleaseSafe
+
+  conformance:
+    name: seven-language live conformance
+    needs: contract
+    runs-on: ${{ vars.LINUX_RUNNER || 'blacksmith-8vcpu-ubuntu-2404' }}
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Initialize Ghostty protocol submodule
+        run: git submodule update --init --depth 1 ghostty
+
+      - name: Install Linux build dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y clang libclang-dev pkg-config
+
+      - name: Set up Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
+        with:
+          python-version: "3.12.8"
+
+      - name: Set up Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: "20.19.5"
+          cache: npm
+          cache-dependency-path: cmux-tui/bindings/typescript/package-lock.json
+
+      - name: Set up pinned cmux-tui Rust
+        uses: ./.github/actions/setup-cmux-tui-rust
+
+      - name: Set up Go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version: "1.22.12"
+          cache-dependency-path: cmux-tui/bindings/go/go.mod
+
+      - name: Select JDK 17
+        run: |
+          test -x "$JAVA_HOME_17_X64/bin/java"
+          echo "$JAVA_HOME_17_X64/bin" >> "$GITHUB_PATH"
+          echo "JAVA_HOME=$JAVA_HOME_17_X64" >> "$GITHUB_ENV"
+          "$JAVA_HOME_17_X64/bin/java" -version
+          "$JAVA_HOME_17_X64/bin/javac" -version
+
+      - name: Set up Zig for Ghostty
+        uses: mlugg/setup-zig@8d6198c65fb0feaa111df26e6b467fea8345e46f # v2.0.5
+        with:
+          version: 0.16.0
+
+      - name: Install TypeScript adapter build tools
+        working-directory: cmux-tui/bindings/typescript
+        run: npm ci --no-audit --no-fund
+
+      - name: Build exact headless cmux-tui
+        working-directory: cmux-tui
+        run: |
+          test "$(zig version)" = "0.16.0"
+          cargo build -p cmux-tui --bin cmux-tui --locked
+
+      - name: Set up Zig for SDK conformance
+        uses: mlugg/setup-zig@8d6198c65fb0feaa111df26e6b467fea8345e46f # v2.0.5
+        with:
+          version: 0.15.2
+
+      - name: Run shared fake and live protocol contract
+        env:
+          CC: clang
+          CXX: clang++
+          CMUX_ZIG: zig
+          NODE_OPTIONS: --experimental-websocket
+        run: |
+          test "$(zig version)" = "0.15.2"
+          test "$(node -p 'typeof WebSocket')" = "function"
+          python3 cmux-tui/bindings/conformance/runner.py \
+            --require python,typescript,rust,go,java,cpp,zig \
+            --cmux-tui-bin "$GITHUB_WORKSPACE/cmux-tui/target/debug/cmux-tui"

--- a/.github/workflows/cmux-tui.yml
+++ b/.github/workflows/cmux-tui.yml
@@ -1,24 +1,99 @@
 name: cmux-tui
+run-name: cmux-tui ${{ inputs.mode }} ${{ inputs.request_id }} @ ${{ inputs.commit }}
 
 on:
-  # Temporarily manual-only beginning 2026-07-13 to pause automatic CI.
   workflow_dispatch:
+    inputs:
+      commit:
+        description: "Exact pushed 40-character commit SHA to verify"
+        required: true
+        type: string
+      mode:
+        description: "Focused Rust tests or the full cross-platform merge gate"
+        required: true
+        type: choice
+        options:
+          - focused
+          - full
+      test_filter:
+        description: "Rust test-name substring; required in focused mode"
+        required: false
+        default: ""
+        type: string
+      request_id:
+        description: "Unique caller token used to find this run"
+        required: true
+        type: string
 
 concurrency:
-  group: cmux-tui-${{ github.workflow }}-${{ github.ref }}
+  # Every caller waits for one exact commit. A newer request must not cancel it.
+  group: cmux-tui-${{ inputs.request_id }}
   cancel-in-progress: true
 
 permissions:
   contents: read
 
 jobs:
+  validate-inputs:
+    name: validate exact commit request
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    timeout-minutes: 5
+    steps:
+      - name: Validate dispatch inputs
+        env:
+          EXACT_COMMIT: ${{ inputs.commit }}
+          WORKFLOW_COMMIT: ${{ github.sha }}
+          MODE: ${{ inputs.mode }}
+          TEST_FILTER: ${{ inputs.test_filter }}
+          REQUEST_ID: ${{ inputs.request_id }}
+        shell: bash
+        run: |
+          if [[ ! "$EXACT_COMMIT" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "::error::commit must be a lowercase 40-character SHA" >&2
+            exit 1
+          fi
+          if [[ "$WORKFLOW_COMMIT" != "$EXACT_COMMIT" ]]; then
+            echo "::error::workflow revision $WORKFLOW_COMMIT does not match requested commit $EXACT_COMMIT" >&2
+            exit 1
+          fi
+          if [[ ! "$REQUEST_ID" =~ ^[A-Za-z0-9._-]{1,100}$ ]]; then
+            echo "::error::request_id contains unsupported characters" >&2
+            exit 1
+          fi
+          case "$MODE" in
+            focused)
+              if [[ ! "$TEST_FILTER" =~ ^[A-Za-z0-9_][A-Za-z0-9_:.-]{0,199}$ ]]; then
+                echo "::error::focused mode needs one safe Rust test-name substring" >&2
+                exit 1
+              fi
+              ;;
+            full)
+              if [[ -n "$TEST_FILTER" ]]; then
+                echo "::error::full mode does not accept test_filter" >&2
+                exit 1
+              fi
+              ;;
+            *)
+              echo "::error::unsupported mode: $MODE" >&2
+              exit 1
+              ;;
+          esac
+
   web-frontend:
-    runs-on: ${{ vars.LINUX_RUNNER || 'blacksmith-4vcpu-ubuntu-2404' }}
+    needs: validate-inputs
+    if: inputs.mode == 'full'
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
+          ref: ${{ inputs.commit }}
+
+      - name: Require exact checkout
+        env:
+          EXACT_COMMIT: ${{ inputs.commit }}
+        run: test "$(git rev-parse HEAD)" = "$EXACT_COMMIT"
 
       - name: Set up Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
@@ -42,13 +117,28 @@ jobs:
           npm run build
           npm test
 
-  valgrind-leak-check:
-    runs-on: ${{ vars.LINUX_RUNNER || 'blacksmith-4vcpu-ubuntu-2404' }}
+  valgrind-leak-check-shard:
+    name: valgrind-leak-check (${{ matrix.shard }})
+    needs: validate-inputs
+    if: inputs.mode == 'full'
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    # Full behavior stays in the normal macOS and Linux suites. Valgrind owns
+    # the bounded startup parsers and terminal replay state only.
     timeout-minutes: 40
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [startup]
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
+          ref: ${{ inputs.commit }}
+
+      - name: Require exact checkout
+        env:
+          EXACT_COMMIT: ${{ inputs.commit }}
+        run: test "$(git rev-parse HEAD)" = "$EXACT_COMMIT"
 
       - name: Init ghostty submodule
         run: git submodule update --init --depth 1 ghostty
@@ -61,13 +151,8 @@ jobs:
       - name: Install zig
         run: ./scripts/install-zig-ci.sh
 
-      - name: Rust version
-        run: |
-          rustc --version || true
-          if ! command -v cargo >/dev/null; then
-            curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain stable
-            echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
-          fi
+      - name: Set up pinned Rust
+        uses: ./.github/actions/setup-cmux-tui-rust
 
       - name: Build test binaries
         working-directory: cmux-tui
@@ -76,70 +161,181 @@ jobs:
           # SIMD codegen stays within what valgrind's instruction emulation
           # supports (see crates/ghostty-vt-sys/build.rs).
           CMUX_GHOSTTY_VT_ZIG_CPU: baseline
+          VALGRIND_SHARD: ${{ matrix.shard }}
         run: |
           mkdir -p target
           cargo test --workspace --locked --no-run --message-format=json > target/cargo-test-binaries.jsonl
           python3 <<'PY'
           import json
+          import os
+          import re
           import sys
 
+          shard = os.environ["VALGRIND_SHARD"]
+          known_shards = {"startup"}
+          if shard not in known_shards:
+              raise SystemExit(f"unknown Valgrind shard: {shard}")
+
+          def shard_for(executable):
+              name = os.path.basename(executable)
+              if re.fullmatch(r"(?:cmux_tui|terminal)-[0-9a-f]+", name):
+                  return "startup"
+              return None
+
           seen = set()
+          selected = []
           with open("target/cargo-test-binaries.jsonl", "r", encoding="utf-8") as messages:
-              with open("target/valgrind-test-binaries.txt", "w", encoding="utf-8") as output:
-                  for line in messages:
-                      try:
-                          message = json.loads(line)
-                      except json.JSONDecodeError:
-                          continue
-                      if not message.get("profile", {}).get("test"):
-                          continue
-                      executable = message.get("executable")
-                      if not executable or executable in seen:
-                          continue
-                      seen.add(executable)
-                      print(executable, file=output)
+              for line in messages:
+                  try:
+                      message = json.loads(line)
+                  except json.JSONDecodeError:
+                      continue
+                  if not message.get("profile", {}).get("test"):
+                      continue
+                  executable = message.get("executable")
+                  if not executable or executable in seen:
+                      continue
+                  seen.add(executable)
+                  if shard_for(executable) == shard:
+                      selected.append(executable)
 
           if not seen:
               raise SystemExit("cargo did not report any test binaries")
-          print(f"Collected {len(seen)} test binaries", file=sys.stderr)
+          if not selected:
+              raise SystemExit(f"Valgrind shard {shard} selected no test binaries")
+
+          with open("target/valgrind-test-binaries.txt", "w", encoding="utf-8") as output:
+              for executable in selected:
+                  print(executable, file=output)
+
+          print(
+              f"Valgrind shard {shard} selected {len(selected)} of {len(seen)} test binaries",
+              file=sys.stderr,
+          )
           PY
+
+      - name: Verify baseline terminal replay behavior
+        if: matrix.shard == 'startup'
+        working-directory: cmux-tui
+        run: |
+          matches=0
+          while IFS= read -r bin; do
+            [ -n "$bin" ] || continue
+            case "$(basename "$bin")" in
+              terminal-*)
+                if ! "$bin" --list \
+                  | grep -Fqx 'pending_wrap_replay_preserves_cursor_with_origin_mode: test'; then
+                  echo "::error::terminal replay test binary does not contain the exact baseline test" >&2
+                  exit 1
+                fi
+                "$bin" pending_wrap_replay_preserves_cursor_with_origin_mode \
+                  --exact \
+                  --test-threads=1
+                matches=$((matches + 1))
+                ;;
+            esac
+          done < target/valgrind-test-binaries.txt
+          if [[ "$matches" -ne 1 ]]; then
+            echo "::error::expected one terminal integration test binary, found $matches" >&2
+            exit 1
+          fi
 
       - name: Run test binaries under valgrind
         working-directory: cmux-tui
-        env:
-          # Valgrind's ~30x slowdown breaks the 50ms ws-latency budget on an
-          # otherwise-correct build; the guarded regression (events serialized
-          # behind a 100ms read poll) inflates far past this bound anyway.
-          CMUX_TEST_WS_LATENCY_BUDGET_MS: "2000"
-          # Process-exit and PTY-reader tests also use bounded polling. Keep
-          # their normal deadlines strict while allowing for instrumentation.
-          CMUX_TEST_TIMEOUT_SCALE: "4"
         run: |
-          while IFS= read -r bin; do
-            [ -n "$bin" ] || continue
-            echo "Running valgrind for $bin"
-            if ! valgrind \
+          run_valgrind() {
+            local bin="$1"
+            shift
+            valgrind \
+              "${valgrind_args[@]}" \
               --error-exitcode=1 \
               --leak-check=full \
               --show-leak-kinds=definite \
               --errors-for-leak-kinds=definite \
-              --track-origins=yes \
-              -- "$bin"; then
-              echo "Valgrind failed for $bin" >&2
+              -- "$bin" "$@"
+          }
+
+          require_exact_test() {
+            local bin="$1"
+            local test_name="$2"
+            if ! "$bin" --list | grep -Fqx "$test_name: test"; then
+              echo "::error::$(basename "$bin") does not contain exact test '$test_name'" >&2
               exit 1
             fi
+          }
+
+          cmux_tui_bin=""
+          terminal_bin=""
+          while IFS= read -r bin; do
+            case "$(basename "$bin")" in
+              cmux_tui-*) cmux_tui_bin="$bin" ;;
+              terminal-*) terminal_bin="$bin" ;;
+            esac
           done < target/valgrind-test-binaries.txt
+          if [[ -z "$cmux_tui_bin" || -z "$terminal_bin" ]]; then
+            echo "::error::startup memory check did not find both test binaries" >&2
+            exit 1
+          fi
+
+          valgrind_args=(--track-origins=yes)
+          require_exact_test \
+            "$terminal_bin" \
+            pending_wrap_replay_preserves_cursor_with_origin_mode
+          run_valgrind \
+            "$terminal_bin" \
+            pending_wrap_replay_preserves_cursor_with_origin_mode \
+            --exact \
+            --test-threads=1
+
+          startup_tests=(
+            config::tests::load_uses_file_ghostty_defaults_without_invoking_external_resolver
+            config::tests::ghostty_file_reader_enforces_byte_limit_during_read
+            config::tests::ghostty_config_helper_output_reader_enforces_byte_limit
+          )
+          for test_name in "${startup_tests[@]}"; do
+            require_exact_test "$cmux_tui_bin" "$test_name"
+            run_valgrind \
+              "$cmux_tui_bin" \
+              "$test_name" \
+              --exact \
+              --test-threads=1
+          done
+
+  valgrind-leak-check:
+    name: valgrind-leak-check
+    if: always() && inputs.mode == 'full'
+    needs: valgrind-leak-check-shard
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    timeout-minutes: 2
+    steps:
+      - name: Require every Valgrind shard
+        env:
+          SHARD_RESULT: ${{ needs.valgrind-leak-check-shard.result }}
+        run: test "$SHARD_RESULT" = success
 
   test:
     name: test (${{ matrix.os }})
-    runs-on: ${{ matrix.os == 'macos' && (vars.MACOS_RUNNER_15 || 'blacksmith-6vcpu-macos-15') || 'ubuntu-latest' }}
+    needs: validate-inputs
+    runs-on: ${{ matrix.runner }}
     timeout-minutes: 40
     strategy:
       fail-fast: false
       matrix:
-        os: [macos, linux]
+        include:
+          - os: macos
+            runner: blacksmith-6vcpu-macos-15
+          - os: linux
+            runner: blacksmith-4vcpu-ubuntu-2404
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+          ref: ${{ inputs.commit }}
+
+      - name: Require exact checkout
+        env:
+          EXACT_COMMIT: ${{ inputs.commit }}
+        run: test "$(git rev-parse HEAD)" = "$EXACT_COMMIT"
 
       - name: Init ghostty submodule
         run: git submodule update --init --depth 1 ghostty
@@ -153,43 +349,93 @@ jobs:
       - name: Install zig
         run: ./scripts/install-zig-ci.sh
 
-      - name: Rust version
+      - name: Ghostty VT cursor replay checks
+        if: inputs.mode == 'full'
+        working-directory: ghostty
         run: |
-          rustc --version || true
-          if ! command -v cargo >/dev/null; then
-            curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain stable
-            echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
-          fi
+          "$CMUX_ZIG" build test-lib-vt -Dtest-filter="Terminal vt"
+
+      - name: Set up pinned Rust
+        uses: ./.github/actions/setup-cmux-tui-rust
 
       - name: cargo fmt
         working-directory: cmux-tui
         run: cargo fmt --check
 
       - name: cargo clippy
+        if: inputs.mode == 'full'
         working-directory: cmux-tui
         run: cargo clippy --workspace --all-targets --locked -- -D warnings
 
       - name: cargo test
         working-directory: cmux-tui
-        run: cargo test --workspace --locked
+        env:
+          MODE: ${{ inputs.mode }}
+          TEST_FILTER: ${{ inputs.test_filter }}
+        shell: bash
+        run: |
+          if [[ "$MODE" == "full" ]]; then
+            cargo test --workspace --exclude cmux-tui-core --locked
+            mkdir -p target
+            cargo test -p cmux-tui-core --locked --no-run --message-format=json \
+              > target/cmux-tui-core-test-binaries.jsonl
+            python3 ../.github/scripts/run-cmux-tui-core-tests-isolated.py \
+              target/cmux-tui-core-test-binaries.jsonl \
+              crates/cmux-tui-core
+            cargo test -p cmux-tui-core --doc --locked
+            exit 0
+          fi
+          cargo test --workspace --locked "$TEST_FILTER" -- --list \
+            | tee "$RUNNER_TEMP/cmux-tui-focused-tests.txt"
+          if ! grep -Eq ': test$' "$RUNNER_TEMP/cmux-tui-focused-tests.txt"; then
+            echo "::error::test_filter '$TEST_FILTER' selected no Rust tests" >&2
+            exit 1
+          fi
+          cargo test --workspace --locked "$TEST_FILTER"
+
+      - name: crossterm parser tests
+        if: inputs.mode == 'full'
+        working-directory: cmux-tui
+        run: cargo test --manifest-path vendor/crossterm/Cargo.toml --lib
 
       - name: TUI smoke test (scripted pty)
+        if: inputs.mode == 'full'
         working-directory: cmux-tui
         run: |
           cargo build -p cmux-tui
           python3 scripts/smoke-tui.py
 
       - name: Detach/reattach smoke test
+        if: inputs.mode == 'full'
         working-directory: cmux-tui
         run: python3 scripts/smoke-attach.py
 
   bindings-e2e:
-    runs-on: ${{ vars.LINUX_RUNNER || 'blacksmith-4vcpu-ubuntu-2404' }}
+    needs: validate-inputs
+    if: inputs.mode == 'full'
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     timeout-minutes: 40
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
+          ref: ${{ inputs.commit }}
+
+      - name: Require exact checkout
+        env:
+          EXACT_COMMIT: ${{ inputs.commit }}
+        run: test "$(git rev-parse HEAD)" = "$EXACT_COMMIT"
+
+      - name: Set up Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: "22.14.0"
+          cache: npm
+          cache-dependency-path: cmux-tui/bindings/typescript/package-lock.json
+
+      - name: Install TypeScript binding dependencies
+        working-directory: cmux-tui/bindings/typescript
+        run: npm ci --no-audit --no-fund
 
       - name: Init ghostty submodule
         run: git submodule update --init --depth 1 ghostty
@@ -202,13 +448,8 @@ jobs:
       - name: Install zig
         run: ./scripts/install-zig-ci.sh
 
-      - name: Rust version
-        run: |
-          rustc --version || true
-          if ! command -v cargo >/dev/null; then
-            curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain stable
-            echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
-          fi
+      - name: Set up pinned Rust
+        uses: ./.github/actions/setup-cmux-tui-rust
 
       - name: Java version
         run: |
@@ -222,41 +463,94 @@ jobs:
         working-directory: cmux-tui
         run: cargo build -p cmux-tui
 
+      - name: Resolve Zig SDK version
+        id: zig-sdk-version
+        shell: bash
+        run: |
+          version="$(
+            sed -nE 's/^[[:space:]]*\.minimum_zig_version[[:space:]]*=[[:space:]]*"([^"]+)".*/\1/p' \
+              cmux-tui/bindings/zig/build.zig.zon | head -1
+          )"
+          if [[ ! "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "Invalid Zig SDK version: $version" >&2
+            exit 1
+          fi
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+
+      - name: Install Zig for SDK conformance
+        env:
+          ZIG_REQUIRED: ${{ steps.zig-sdk-version.outputs.version }}
+          ZIG_FORCE_LOCAL_INSTALL: "1"
+        run: ./scripts/install-zig-ci.sh
+
       - name: Python conformance fixtures
-        run: python3 cmux-tui/bindings/conformance/runner.py
+        run: |
+          test "$("$CMUX_ZIG" version)" = "${{ steps.zig-sdk-version.outputs.version }}"
+          python3 cmux-tui/bindings/conformance/runner.py
 
       - name: Binding e2e
-        run: bash cmux-tui/bindings/conformance/e2e.sh --require python,typescript,rust,go,java
+        run: |
+          test "$("$CMUX_ZIG" version)" = "${{ steps.zig-sdk-version.outputs.version }}"
+          bash cmux-tui/bindings/conformance/e2e.sh --require python,typescript,rust,go,java
 
-  windows-experimental:
-    name: windows experimental (x86_64-gnu)
-    runs-on: windows-latest
-    timeout-minutes: 40
-    continue-on-error: true
+  build-artifacts:
+    name: release-path dogfood artifacts
+    needs: validate-inputs
+    permissions:
+      contents: read
+    uses: ./.github/workflows/cmux-tui-build-package.yml
+    with:
+      version: 0.0.0-nightly.19700101.0
+      pypi_version: 0.0.0.dev197001010
+      package_npm: ${{ inputs.mode == 'full' }}
+      package_pypi: ${{ inputs.mode == 'full' }}
+      include_windows: ${{ inputs.mode == 'full' }}
+      target_set: ${{ inputs.mode == 'full' && 'all' || 'macos-arm64' }}
+      build_cloudflare_relay: false
+      verify_linux_arm64: ${{ inputs.mode == 'full' }}
+      macos_runner: blacksmith-6vcpu-macos-15
+      linux_runner: blacksmith-4vcpu-ubuntu-2404
+      windows_runner: windows-latest
+      checkout_ref: ${{ inputs.commit }}
+
+  hosted-verification:
+    name: ${{ inputs.mode == 'full' && 'hosted verification' || 'focused hosted verification' }}
+    if: always()
+    needs:
+      - validate-inputs
+      - web-frontend
+      - valgrind-leak-check
+      - test
+      - bindings-e2e
+      - build-artifacts
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    timeout-minutes: 5
+    env:
+      MODE: ${{ inputs.mode }}
+      VALIDATE_RESULT: ${{ needs.validate-inputs.result }}
+      WEB_RESULT: ${{ needs.web-frontend.result }}
+      VALGRIND_RESULT: ${{ needs.valgrind-leak-check.result }}
+      TEST_RESULT: ${{ needs.test.result }}
+      BINDINGS_RESULT: ${{ needs.bindings-e2e.result }}
+      ARTIFACT_RESULT: ${{ needs.build-artifacts.result }}
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-
-      - name: Init ghostty submodule
-        run: git submodule update --init --depth 1 ghostty
-
-      - name: Install zig
-        uses: mlugg/setup-zig@8d6198c65fb0feaa111df26e6b467fea8345e46f # v2.0.5
-        with:
-          version: 0.15.2
-
-      - name: Install Rust GNU target
+      - name: Require selected verification jobs
         shell: bash
         run: |
-          rustup target add x86_64-pc-windows-gnu
-          printf '%s\n' 'C:\msys64\mingw64\bin' >> "$GITHUB_PATH"
+          require_success() {
+            local name="$1"
+            local result="$2"
+            if [[ "$result" != "success" ]]; then
+              echo "::error::$name finished with result '$result'" >&2
+              exit 1
+            fi
+          }
 
-      - name: Build libghostty-vt for Windows GNU
-        shell: bash
-        working-directory: ghostty
-        run: |
-          zig build -Demit-lib-vt=true -Demit-xcframework=false -Doptimize=ReleaseFast -Dtarget=x86_64-windows-gnu --prefix "$RUNNER_TEMP/ghostty-vt-win-gnu"
-          zig ar t "$RUNNER_TEMP/ghostty-vt-win-gnu/lib/ghostty-vt-static.lib" | head
-
-      - name: cargo build cmux-tui for Windows GNU
-        working-directory: cmux-tui
-        run: cargo build -p cmux-tui --target x86_64-pc-windows-gnu --locked
+          require_success "input validation" "$VALIDATE_RESULT"
+          require_success "Rust tests" "$TEST_RESULT"
+          require_success "dogfood artifact build" "$ARTIFACT_RESULT"
+          if [[ "$MODE" == "full" ]]; then
+            require_success "web frontend" "$WEB_RESULT"
+            require_success "Valgrind" "$VALGRIND_RESULT"
+            require_success "binding end-to-end tests" "$BINDINGS_RESULT"
+          fi

--- a/cmux-tui/AGENTS.md
+++ b/cmux-tui/AGENTS.md
@@ -1,0 +1,14 @@
+# cmux-tui agent instructions
+
+Do not run `cargo`, `rustc`, or Zig on Lawrence's Mac. Do not use a local build as a fallback. Commit and push the exact branch head, then use the hosted entry point from the repository root:
+
+```bash
+./scripts/verify-cmux-tui-hosted.sh --filter <rust-test-name>
+./scripts/verify-cmux-tui-hosted.sh --full
+```
+
+Use `--filter` during focused development. It accepts one Rust test-name substring and verifies that the filter selects at least one test on hosted Linux and macOS. Use `--full` for the merge gate. Full mode runs the complete Linux and macOS suites, package builds, and a Windows-hosted binary execution check.
+
+The script rejects dirty or unpushed work, verifies the exact commit in every hosted job, waits for completion, prints failed logs, and downloads the macOS arm64 binary to `cmux-tui/target/hosted/<commit>/cmux-tui`. Running that downloaded binary on the Mac is allowed.
+
+`rust-toolchain.toml` is the single Rust toolchain source for hosted TUI tests, package builds, and live conformance. Change that file instead of adding a workflow-specific Rust version.

--- a/cmux-tui/CLAUDE.md
+++ b/cmux-tui/CLAUDE.md
@@ -1,0 +1,3 @@
+# cmux-tui
+
+Read and follow `AGENTS.md` in this directory before you change or verify `cmux-tui`.

--- a/cmux-tui/crates/cmux-remote/tests/iroh_e2e.rs
+++ b/cmux-tui/crates/cmux-remote/tests/iroh_e2e.rs
@@ -55,20 +55,27 @@ async fn spawn_plaintext_relay() -> (Server, RelayUrl) {
 }
 
 /// The selected path is published once the carrier settles, which for a relayed
-/// connection happens after the first frames move. Polling keeps the assertion
-/// meaningful without making it a race.
+/// connection happens after the first frames move. Iroh owns this external
+/// state and exposes no path-change signal through `LinkGroup`, so probe it at a
+/// bounded cadence under one final deadline.
 async fn wait_for_path_kind(client: &ClientConnection, expected: TransportPathKind) {
-    let deadline = tokio::time::Instant::now() + Duration::from_secs(20);
+    let mut probes = tokio::time::interval(Duration::from_millis(50));
+    probes.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
     let mut last = None;
-    while tokio::time::Instant::now() < deadline {
-        let snapshot = client.snapshot().await;
-        last = snapshot.transport.selected_path.clone();
-        if last.as_ref().is_some_and(|path| path.kind == expected) {
-            return;
+    let selected = tokio::time::timeout(Duration::from_secs(20), async {
+        loop {
+            probes.tick().await;
+            let snapshot = client.snapshot().await;
+            last = snapshot.transport.selected_path.clone();
+            if last.as_ref().is_some_and(|path| path.kind == expected) {
+                return;
+            }
         }
-        tokio::time::sleep(Duration::from_millis(50)).await;
+    })
+    .await;
+    if selected.is_err() {
+        panic!("Iroh never selected a {expected:?} path; last published path was {last:?}");
     }
-    panic!("Iroh never selected a {expected:?} path; last published path was {last:?}");
 }
 
 async fn wait_for_output(events: &ProcessEventStream, transcript: &mut Vec<u8>, expected: &str) {

--- a/cmux-tui/rust-toolchain.toml
+++ b/cmux-tui/rust-toolchain.toml
@@ -1,0 +1,4 @@
+[toolchain]
+channel = "1.95.0"
+profile = "minimal"
+components = ["clippy", "rustfmt"]

--- a/scripts/verify-cmux-tui-hosted.sh
+++ b/scripts/verify-cmux-tui-hosted.sh
@@ -1,0 +1,224 @@
+#!/usr/bin/env bash
+# Verify the exact pushed HEAD on hosted runners and download its macOS arm64 TUI.
+set -euo pipefail
+
+REPO="manaflow-ai/cmux"
+WORKFLOW="cmux-tui.yml"
+
+usage() {
+  cat <<'EOF'
+Usage:
+  ./scripts/verify-cmux-tui-hosted.sh --filter <rust-test-name>
+  ./scripts/verify-cmux-tui-hosted.sh --full
+
+--filter runs matching Rust tests on hosted Linux and macOS.
+--full runs the cross-platform merge gate, including real Windows execution.
+Both modes build and download a macOS arm64 cmux-tui artifact from the exact pushed HEAD.
+EOF
+}
+
+mode=""
+test_filter=""
+case "${1:-}" in
+  --filter)
+    if [[ $# -ne 2 ]]; then
+      usage >&2
+      exit 2
+    fi
+    mode="focused"
+    test_filter="$2"
+    ;;
+  --full)
+    if [[ $# -ne 1 ]]; then
+      usage >&2
+      exit 2
+    fi
+    mode="full"
+    ;;
+  -h|--help)
+    usage
+    exit 0
+    ;;
+  *)
+    usage >&2
+    exit 2
+    ;;
+esac
+
+if [[ "$mode" == "focused" && ! "$test_filter" =~ ^[A-Za-z0-9_][A-Za-z0-9_:.-]{0,199}$ ]]; then
+  echo "error: --filter must be one Rust test-name substring without shell syntax" >&2
+  exit 2
+fi
+
+timeout_seconds="${CMUX_TUI_HOSTED_TIMEOUT_SECONDS:-7200}"
+if [[ ! "$timeout_seconds" =~ ^[1-9][0-9]*$ ]]; then
+  echo "error: hosted verification timeout must be a positive integer" >&2
+  exit 2
+fi
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(git -C "$script_dir" rev-parse --show-toplevel)"
+cd "$repo_root"
+
+if [[ -n "$(git status --porcelain --untracked-files=normal)" ]]; then
+  echo "error: commit all changes before hosted verification" >&2
+  git status --short >&2
+  exit 1
+fi
+
+branch="$(git symbolic-ref --quiet --short HEAD || true)"
+if [[ -z "$branch" ]]; then
+  echo "error: hosted verification requires a pushed branch, not detached HEAD" >&2
+  exit 1
+fi
+upstream="$(git rev-parse --abbrev-ref --symbolic-full-name '@{upstream}' 2>/dev/null || true)"
+if [[ "$upstream" == */* ]]; then
+  remote="${upstream%%/*}"
+  remote_branch="${upstream#*/}"
+else
+  remote="origin"
+  remote_branch="$branch"
+fi
+remote_ref="$remote/$remote_branch"
+remote_url="$(git remote get-url "$remote")"
+remote_matches_repo=false
+for expected_url in \
+  "https://github.com/$REPO" \
+  "https://github.com/$REPO.git" \
+  "git@github.com:$REPO" \
+  "git@github.com:$REPO.git" \
+  "ssh://git@github.com/$REPO" \
+  "ssh://git@github.com/$REPO.git"
+do
+  if [[ "$remote_url" == "$expected_url" ]]; then
+    remote_matches_repo=true
+    break
+  fi
+done
+if [[ "$remote_matches_repo" != true ]]; then
+  echo "error: upstream remote $remote does not target github.com/$REPO" >&2
+  exit 1
+fi
+
+commit="$(git rev-parse HEAD)"
+if [[ ! "$commit" =~ ^[0-9a-f]{40}$ ]]; then
+  echo "error: could not resolve an exact commit SHA" >&2
+  exit 1
+fi
+
+remote_commit="$(git ls-remote --heads "$remote" "refs/heads/$remote_branch" | awk 'NR == 1 { print $1 }')"
+if [[ -z "$remote_commit" ]]; then
+  echo "error: $remote_ref does not exist; push this branch first" >&2
+  exit 1
+fi
+if [[ "$remote_commit" != "$commit" ]]; then
+  echo "error: $remote_ref is $remote_commit, but local HEAD is $commit" >&2
+  echo "push the exact local HEAD before hosted verification" >&2
+  exit 1
+fi
+
+request_id="${commit:0:12}-$(date +%s)-$$"
+run_title="cmux-tui $mode $request_id @ $commit"
+
+echo "Dispatching $mode verification for $commit"
+gh workflow run "$WORKFLOW" \
+  --repo "$REPO" \
+  --ref "$remote_branch" \
+  -f "commit=$commit" \
+  -f "mode=$mode" \
+  -f "test_filter=$test_filter" \
+  -f "request_id=$request_id"
+
+run_id=""
+# The dispatch command does not return a run ID. Poll only until the uniquely
+# titled run appears, and then let GitHub CLI watch the run state.
+for _ in $(seq 1 60); do
+  run_query=""
+  if run_query="$(
+    gh run list \
+      --repo "$REPO" \
+      --workflow "$WORKFLOW" \
+      --branch "$remote_branch" \
+      --event workflow_dispatch \
+      --limit 100 \
+      --json databaseId,displayTitle,headSha \
+      --jq ".[] | select(.displayTitle == \"$run_title\" and .headSha == \"$commit\") | .databaseId"
+  )"; then
+    run_id="$(printf '%s\n' "$run_query" | sed -n '1p')"
+  else
+    echo "warning: run discovery query failed; retrying" >&2
+  fi
+  if [[ -n "$run_id" ]]; then
+    break
+  fi
+  sleep 2
+done
+
+if [[ -z "$run_id" ]]; then
+  echo "error: the dispatched workflow did not appear within 120 seconds" >&2
+  exit 1
+fi
+
+run_url="https://github.com/$REPO/actions/runs/$run_id"
+echo "Run: $run_url"
+echo "Waiting for hosted verification"
+verification_started="$(date +%s)"
+run_status=""
+run_conclusion=""
+while true; do
+  run_state=""
+  if run_state="$(
+    gh run view \
+      --repo "$REPO" \
+      "$run_id" \
+      --json status,conclusion \
+      --jq '[.status, .conclusion] | @tsv'
+  )"; then
+    IFS=$'\t' read -r run_status run_conclusion <<< "$run_state"
+    if [[ "$run_status" == "completed" ]]; then
+      break
+    fi
+  else
+    echo "warning: hosted run status query failed; retrying" >&2
+  fi
+
+  verification_now="$(date +%s)"
+  if (( verification_now - verification_started >= timeout_seconds )); then
+    echo "error: hosted verification did not complete within ${timeout_seconds}s: $run_url" >&2
+    exit 1
+  fi
+  sleep 10
+done
+
+if [[ "$run_conclusion" != "success" ]]; then
+  echo "Hosted verification failed: $run_url" >&2
+  gh run view --repo "$REPO" "$run_id" --log-failed || true
+  exit 1
+fi
+
+temp_dir="$(mktemp -d "${TMPDIR:-/tmp}/cmux-tui-hosted.XXXXXX")"
+cleanup() {
+  rm -rf -- "$temp_dir"
+}
+trap cleanup EXIT
+
+gh run download \
+  --repo "$REPO" \
+  "$run_id" \
+  --name cmux-tui-aarch64-apple-darwin \
+  --dir "$temp_dir"
+
+downloaded_binary="$(find "$temp_dir" -type f -name cmux-tui-aarch64-apple-darwin -print | sed -n '1p')"
+if [[ -z "$downloaded_binary" ]]; then
+  echo "error: the macOS arm64 artifact did not contain cmux-tui" >&2
+  exit 1
+fi
+
+artifact_dir="cmux-tui/target/hosted/$commit"
+artifact_binary="$artifact_dir/cmux-tui"
+mkdir -p "$artifact_dir"
+install -m 0755 "$downloaded_binary" "$artifact_binary"
+
+echo "Hosted verification passed: $run_url"
+echo "Artifact: $artifact_binary"
+echo "Dogfood: $artifact_binary --session verify-${commit:0:8}"


### PR DESCRIPTION
## Summary
- Replace the Iroh path-selection test sleep with a bounded readiness probe.
- Keep one final 20-second deadline and delay missed probes instead of catching up.

## Testing
- Hosted verification pending. No local compile or test run, as required by the timing-audit owner.

## Related
- Parent: https://github.com/manaflow-ai/cmux/pull/9237
- Audit row: cmux-tui/crates/cmux-remote/tests/iroh_e2e.rs:69

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large CI and workflow changes affect the merge gate and release-path builds; the Iroh test tweak is low risk but bundled with broad pipeline edits.
> 
> **Overview**
> **Replaces ad-hoc local `cargo` with a hosted verification gate** driven by `workflow_dispatch` on an exact 40-char SHA (`focused` test filter vs `full` merge gate), plus `scripts/verify-cmux-tui-hosted.sh` to dispatch, wait, and download a macOS arm64 binary.
> 
> **Centralizes Rust for cmux-tui** via `cmux-tui/rust-toolchain.toml` and `.github/actions/setup-cmux-tui-rust`, wired into package builds, SDK conformance, and the main TUI workflow.
> 
> **Expands CI behavior**: `cmux-tui-build-package.yml` adds target planning (`all` vs `macos-arm64`), runner overrides, Ghostty-derived Zig version, Linux vs macOS cross-build paths, and optional Cloudflare relay / native Linux ARM64 package checks. New `cmux-tui-sdks.yml` runs multi-language SDK contract, package, consumer, and live conformance jobs.
> 
> **Test execution changes** in `cmux-tui.yml`: Valgrind limited to a startup shard with exact tests; `cmux-tui-core` tests run one-per-process via `run-cmux-tui-core-tests-isolated.py`; full mode reuses the package workflow for dogfood artifacts.
> 
> **Iroh e2e** (`wait_for_path_kind`): drops fixed `sleep` polling for a 50ms `interval` with `MissedTickBehavior::Delay` inside a single 20s timeout.
> 
> Agent docs in `cmux-tui/AGENTS.md` document hosted-only verification on Lawrence's Mac.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9d2b381036b4c2394f945eb4550067f26c4a7a5f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the Iroh path-selection test deterministic and add an exact-head hosted verification path for `cmux-tui` with a pinned Rust toolchain. This reduces test flakiness and ensures CI runs the exact pushed commit across focused and full suites.

- **CI**
  - Add `cmux-tui.yml` and `scripts/verify-cmux-tui-hosted.sh` to run focused or full suites on hosted runners, require an exact commit, and publish a macOS arm64 artifact.
  - Pin Rust via `cmux-tui/rust-toolchain.toml` and a reusable setup action, and update build/package workflows to use target planning, Zig version resolution, and per-binary test isolation.

<sup>Written for commit 9d2b381036b4c2394f945eb4550067f26c4a7a5f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/9925?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

