### PR TITLE
test(tui): signal CDP reader shutdown

### DIFF
--- a/cmux-tui/crates/cmux-tui-cdp/src/client.rs
+++ b/cmux-tui/crates/cmux-tui-cdp/src/client.rs
@@ -96,6 +96,29 @@ impl ResolverTestGate {
 }
 
 #[cfg(test)]
+#[derive(Default)]
+struct ReaderStoppedSignal {
+    stopped: Mutex<bool>,
+    changed: Condvar,
+}
+
+#[cfg(test)]
+impl ReaderStoppedSignal {
+    fn mark(&self) {
+        let mut stopped = self.stopped.lock().unwrap();
+        *stopped = true;
+        self.changed.notify_all();
+    }
+
+    fn wait(&self, timeout: Duration) -> bool {
+        let stopped = self.stopped.lock().unwrap();
+        let (stopped, _) =
+            self.changed.wait_timeout_while(stopped, timeout, |stopped| !*stopped).unwrap();
+        *stopped
+    }
+}
+
+#[cfg(test)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 enum ResolverReaperTestEvent {
     Attempt(u32),
@@ -863,7 +886,7 @@ struct Inner {
     web_socket_url: Arc<str>,
     peer_addr: SocketAddr,
     #[cfg(test)]
-    reader_stopped: Arc<AtomicBool>,
+    reader_stopped: Arc<ReaderStoppedSignal>,
 }
 
 struct PendingCall {
@@ -1362,7 +1385,7 @@ impl CdpClient {
                 web_socket_url: Arc::from(web_socket_url),
                 peer_addr: addr,
                 #[cfg(test)]
-                reader_stopped: Arc::new(AtomicBool::new(false)),
+                reader_stopped: Arc::new(ReaderStoppedSignal::default()),
             }),
         };
         client.spawn_reader(ws, outbound_rx, events)?;
@@ -1381,7 +1404,7 @@ impl CdpClient {
         std::thread::Builder::new().name("cmux-tui-cdp-reader".into()).spawn(move || {
             reader_loop(&weak, ws, &outbound, &event_output);
             #[cfg(test)]
-            reader_stopped.store(true, Ordering::Release);
+            reader_stopped.mark();
         })?;
         Ok(())
     }
@@ -3064,7 +3087,7 @@ mod tests {
                 timeout: Duration::from_secs(1),
                 web_socket_url: Arc::from("ws://127.0.0.1:1/devtools/browser/test"),
                 peer_addr: "127.0.0.1:1".parse().unwrap(),
-                reader_stopped: Arc::new(AtomicBool::new(false)),
+                reader_stopped: Arc::new(ReaderStoppedSignal::default()),
             }),
             outbound_rx,
         )
@@ -4560,11 +4583,10 @@ mod tests {
         )
         .unwrap();
         drop(command);
-        let close_deadline = Instant::now() + Duration::from_secs(1);
-        while !client.inner.reader_stopped.load(Ordering::Acquire) {
-            assert!(Instant::now() < close_deadline, "initial CDP reader did not stop");
-            thread::yield_now();
-        }
+        assert!(
+            client.inner.reader_stopped.wait(Duration::from_secs(1)),
+            "initial CDP reader did not stop"
+        );
 
         let unused_gate = Arc::new(ResolverTestGate::default());
         *NEXT_RESOLVE_GATE.lock().unwrap() = Some(unused_gate.clone());
@@ -5138,11 +5160,10 @@ mod tests {
             CdpClient::connect(&format!("ws://{addr}/devtools/browser/fake"), event_tx).unwrap();
         server.join().unwrap();
 
-        let deadline = Instant::now() + Duration::from_millis(500);
-        while !client.inner.reader_stopped.load(Ordering::Acquire) {
-            assert!(Instant::now() < deadline, "CDP reader did not stop");
-            thread::yield_now();
-        }
+        assert!(
+            client.inner.reader_stopped.wait(Duration::from_millis(500)),
+            "CDP reader did not stop"
+        );
         assert!(matches!(event_rx.recv(), Ok(CdpEvent::Other { .. })));
 
         let shutdown = event_rx.recv_timeout(Duration::from_millis(500));


### PR DESCRIPTION
Summary:
- Replace CDP reader-stop spin polling with a condition-variable lifecycle signal.
- Keep timeout values only as failure bounds in the two existing behavior tests.

Testing:
- Local compile and tests skipped as required by cmux-tui/AGENTS.md.
- Focused hosted Linux and macOS verification pending.

Related: https://github.com/manaflow-ai/cmux/pull/8769

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are confined to test synchronization in `client.rs` under `#[cfg(test)]`; no production CDP transport or reader logic changes.
> 
> **Overview**
> **Test-only change** in `cmux-tui-cdp`: CDP reader shutdown is no longer detected by spinning on an `AtomicBool` in a few integration tests.
> 
> Adds **`ReaderStoppedSignal`** (mutex + condvar, same idea as existing `ResolverTestGate`). The reader thread calls **`mark()`** when `reader_loop` finishes; tests call **`wait(timeout)`** instead of `while !load { yield }` with a manual deadline.
> 
> The `Inner::reader_stopped` field stays behind **`#[cfg(test)]`**; production CDP client behavior is unchanged—only how tests synchronize on reader exit.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4205c81d378bbcaee00ce148ddbfd1d623d09e9d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaces AtomicBool spin polling with a test-only condition-variable signal (`ReaderStoppedSignal`) for CDP reader shutdown in `cmux-tui-cdp` tests, making shutdown detection deterministic and eliminating busy waits. Aligns with task-8769 for CDP test synchronization; timeouts remain only as failure bounds and production behavior is unchanged.

<sup>Written for commit 4205c81d378bbcaee00ce148ddbfd1d623d09e9d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/9926?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

