### PR TITLE
test(tui): require public close before terminal adoption

### DIFF
--- a/cmux-tui/crates/cmux-tui-core/src/mux.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/mux.rs
@@ -1893,6 +1893,8 @@ pub struct Mux {
     resource_close_after_commit: Mutex<Option<Arc<dyn Fn() + Send + Sync>>>,
     #[cfg(test)]
     resource_close_cleanup: Mutex<Option<Arc<dyn Fn() + Send + Sync>>>,
+    #[cfg(test)]
+    discovered_terminal_terminations: Mutex<Vec<(String, Option<String>)>>,
     browser_providers: Arc<BrowserProviderRegistry>,
     browser_runtime: Mutex<Option<Arc<BrowserRuntime>>>,
     active_render_attachments: Arc<AtomicUsize>,
@@ -2246,6 +2248,8 @@ impl Mux {
             resource_close_after_commit: Mutex::new(None),
             #[cfg(test)]
             resource_close_cleanup: Mutex::new(None),
+            #[cfg(test)]
+            discovered_terminal_terminations: Mutex::new(Vec::new()),
             browser_providers: Arc::new(BrowserProviderRegistry::default()),
             browser_runtime: Mutex::new(None),
             active_render_attachments: Arc::new(AtomicUsize::new(0)),
@@ -7778,6 +7782,11 @@ impl Mux {
         terminal_id: &str,
         incarnation: Option<&str>,
     ) {
+        #[cfg(test)]
+        self.discovered_terminal_terminations
+            .lock()
+            .unwrap()
+            .push((terminal_id.to_string(), incarnation.map(str::to_string)));
         #[cfg(unix)]
         {
             let root = self.surface_options.lock().unwrap().terminal_host_root.clone();
@@ -7799,6 +7808,23 @@ impl Mux {
         }
         #[cfg(not(unix))]
         let _ = (terminal_id, incarnation);
+    }
+
+    #[cfg(test)]
+    pub(crate) fn discovered_terminal_terminations_for_test(
+        &self,
+    ) -> Vec<(String, Option<String>)> {
+        self.discovered_terminal_terminations.lock().unwrap().clone()
+    }
+
+    #[cfg(all(test, unix))]
+    pub(crate) fn finish_terminal_adoption_for_test(
+        &self,
+        terminal_id: &str,
+        incarnation: &str,
+        surface: Arc<Surface>,
+    ) -> anyhow::Result<()> {
+        self.finish_terminal_adoption(terminal_id, incarnation, surface)
     }
 
     fn terminate_terminal_runtime(&self, runtime: &Arc<Surface>) {

--- a/cmux-tui/crates/cmux-tui-core/src/mux/resource_topology.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/mux/resource_topology.rs
@@ -67,6 +67,7 @@ struct ResourceCloseInputs {
 struct ResourceClosePlan {
     state: State,
     removed: Vec<Arc<Surface>>,
+    placement_ids: Vec<SurfaceId>,
     terminal_runtime: Option<Arc<Surface>>,
     closed_terminal_public_id: Option<TerminalPublicId>,
     terminal_batch: Vec<(String, Option<String>)>,
@@ -78,6 +79,7 @@ struct ResourceClosePlan {
 
 struct ResourceCloseEffects {
     removed: Vec<Arc<Surface>>,
+    placement_ids: Vec<SurfaceId>,
     terminal_runtime: Option<Arc<Surface>>,
     closed_terminal_public_id: Option<TerminalPublicId>,
     tree_publication: ResourceCloseTreePublication,
@@ -88,6 +90,111 @@ struct ResourceCloseEffects {
 
 fn terminal_close_state_error(detail: impl Into<String>) -> anyhow::Error {
     anyhow::Error::msg(detail.into()).context("terminal close state is unavailable")
+}
+
+fn ensure_terminal_close_projection(
+    terminal_public_id: &TerminalPublicId,
+    terminal_incarnation: Option<&str>,
+    projection: &mut ResourceEffectProjection,
+) -> anyhow::Result<()> {
+    let has_terminal_tombstone = projection.patch.changes.iter().any(|change| {
+        matches!(
+            change,
+            ResourceChange::TombstoneTerminal { public_id, .. }
+                if public_id == terminal_public_id
+        )
+    });
+    if !has_terminal_tombstone {
+        projection.patch.changes.push(ResourceChange::TombstoneTerminal {
+            public_id: terminal_public_id.clone(),
+            expected_incarnation: terminal_incarnation.map(str::to_string),
+        });
+        let changes = projection.changes.as_array_mut().ok_or_else(|| {
+            terminal_close_state_error("terminal close public changes are not an array")
+        })?;
+        changes.push(json!({
+            "kind":"delete",
+            "sequence":changes.len(),
+            "resource":"terminal",
+            "id":terminal_public_id,
+        }));
+    }
+    Ok(())
+}
+
+fn validate_terminal_close_projection(
+    terminal_public_id: &TerminalPublicId,
+    tab_ids: &[TabPublicId],
+    projection: &ResourceEffectProjection,
+) -> anyhow::Result<()> {
+    let terminal_tombstones = projection
+        .patch
+        .changes
+        .iter()
+        .filter(|change| {
+            matches!(
+                change,
+                ResourceChange::TombstoneTerminal { public_id, .. }
+                    if public_id == terminal_public_id
+            )
+        })
+        .count();
+    if terminal_tombstones != 1 {
+        return Err(terminal_close_state_error(format!(
+            "terminal close projected {terminal_tombstones} terminal tombstones"
+        )));
+    }
+    for tab_id in tab_ids {
+        let tombstones = projection
+            .patch
+            .changes
+            .iter()
+            .filter(|change| {
+                matches!(
+                    change,
+                    ResourceChange::TombstoneTab { tab_id: closing, close_content: true }
+                        if closing == tab_id
+                )
+            })
+            .count();
+        if tombstones != 1 {
+            return Err(terminal_close_state_error(format!(
+                "terminal close projected {tombstones} tombstones for tab {tab_id}"
+            )));
+        }
+    }
+    let public_changes = projection.changes.as_array().ok_or_else(|| {
+        terminal_close_state_error("terminal close public changes are not an array")
+    })?;
+    let terminal_deletes = public_changes
+        .iter()
+        .filter(|change| {
+            change["kind"] == "delete"
+                && change["resource"] == "terminal"
+                && change["id"].as_str() == Some(terminal_public_id.as_str())
+        })
+        .count();
+    if terminal_deletes != 1 {
+        return Err(terminal_close_state_error(format!(
+            "terminal close projected {terminal_deletes} public terminal deletes"
+        )));
+    }
+    for tab_id in tab_ids {
+        let deletes = public_changes
+            .iter()
+            .filter(|change| {
+                change["kind"] == "delete"
+                    && change["resource"] == "tab"
+                    && change["id"].as_str() == Some(tab_id.as_str())
+            })
+            .count();
+        if deletes != 1 {
+            return Err(terminal_close_state_error(format!(
+                "terminal close projected {deletes} public deletes for tab {tab_id}"
+            )));
+        }
+    }
+    Ok(())
 }
 
 enum ResourceCloseTreePublication {
@@ -121,6 +228,7 @@ impl ResourceClosePlan {
         *state = self.state;
         ResourceCloseEffects {
             removed: self.removed,
+            placement_ids: self.placement_ids,
             terminal_runtime: self.terminal_runtime,
             closed_terminal_public_id: self.closed_terminal_public_id,
             tree_publication: self.delta.map_or(
@@ -194,6 +302,13 @@ impl Drop for ResourceCreationActivity<'_> {
 }
 
 impl Mux {
+    pub(crate) fn live_terminal_host_for_resource(
+        &self,
+        terminal_public_id: &TerminalPublicId,
+    ) -> anyhow::Result<Option<String>> {
+        self.workspace_registry.lock().unwrap().live_terminal_host_id(terminal_public_id)
+    }
+
     #[cfg(test)]
     pub(crate) fn set_resource_terminal_reservation_hook_for_test(
         &self,
@@ -2190,30 +2305,140 @@ impl Mux {
 
     pub(crate) fn commit_resource_terminal_close_effect(
         &self,
-        surface: SurfaceId,
+        terminal_public_id: &TerminalPublicId,
         idempotency_key: &str,
         operation_name: &str,
         fingerprint: &Value,
     ) -> anyhow::Result<ResourcePatchCommit> {
         let _creation_handoff = self.resource_creation_handoff.lock().unwrap();
         let _creation_fence = self.resource_creation_execution.lock().unwrap();
-        let committed = self.commit_resource_close_with(
-            ResourceOperation::TerminalClose,
-            None,
+        let mut registry = self.workspace_registry.lock().unwrap();
+        let terminal_id = registry.live_terminal_host_id(terminal_public_id)?.ok_or_else(|| {
+            terminal_close_state_error(format!(
+                "terminal {terminal_public_id} disappeared before close"
+            ))
+        })?;
+        let terminal = registry.terminal_record(&terminal_id)?.ok_or_else(|| {
+            terminal_close_state_error(format!(
+                "terminal {terminal_public_id} has no durable host record"
+            ))
+        })?;
+        let terminal_incarnation = terminal.incarnation.clone();
+        let mut state = self.state.lock().unwrap();
+        let closing_tab_ids = state
+            .placements_of_content(&ContentPublicId::Terminal(terminal_public_id.clone()))
+            .iter()
+            .map(|surface| {
+                state.resource_indexes.tab_ids.get(surface).cloned().ok_or_else(|| {
+                    terminal_close_state_error(format!(
+                        "terminal {terminal_public_id} placement {surface} has no durable tab"
+                    ))
+                })
+            })
+            .collect::<anyhow::Result<Vec<_>>>()?;
+        let mut plan = self.resource_terminal_close_plan_locked(
+            terminal_public_id,
+            &terminal_id,
+            terminal_incarnation.as_deref(),
+            &state,
+        )?;
+        let mut projection =
+            self.resource_effect_projection_locked(&registry, &mut plan.state, json!({}))?;
+        ensure_terminal_close_projection(
+            terminal_public_id,
+            terminal_incarnation.as_deref(),
+            &mut projection,
+        )?;
+        validate_terminal_close_projection(terminal_public_id, &closing_tab_ids, &projection)?;
+        #[cfg(test)]
+        if let Some(hook) = self.resource_projection_before_commit.lock().unwrap().clone() {
+            hook();
+        }
+        let close = registry.commit_resource_close_patch(
             idempotency_key,
             operation_name,
             fingerprint,
-            move |state| {
-                anyhow::ensure!(
-                    state.terminal_runtime_by_id(surface).is_some(),
-                    "terminal disappeared"
-                );
-                Ok(EffectSlots { workspace: None, screen: None, pane: None, tab: Some(surface) })
-            },
+            &projection.patch,
+            &projection.result,
+            &projection.changes,
+            &plan.terminal_batch,
+            None,
         )?;
+        #[cfg(test)]
+        if let Some(hook) = self.resource_close_after_commit.lock().unwrap().clone() {
+            hook();
+        }
+        let had_runtime = plan.terminal_runtime.is_some();
+        let effects = plan.install(&mut state, close.resource.revision, close.workspace_revision);
+        drop(state);
+        if close.terminal_batch.closed != 0 {
+            self.emit_terminal_registry_changed(&registry, close.terminal_batch.revision);
+        }
+        drop(registry);
         drop(_creation_fence);
         drop(_creation_handoff);
-        Ok(self.finish_resource_close(committed))
+        let commit =
+            self.finish_resource_close(CommittedResourceClose { commit: close.resource, effects });
+        if !had_runtime {
+            self.terminate_discovered_terminal_host(&terminal_id, terminal_incarnation.as_deref());
+        }
+        Ok(commit)
+    }
+
+    /// Build the close plan from the durable public identity. The terminal
+    /// catalog owner is optional because restored views precede host adoption.
+    fn resource_terminal_close_plan_locked(
+        &self,
+        terminal_public_id: &TerminalPublicId,
+        terminal_id: &str,
+        terminal_incarnation: Option<&str>,
+        state: &State,
+    ) -> anyhow::Result<ResourceClosePlan> {
+        let content_id = ContentPublicId::Terminal(terminal_public_id.clone());
+        let placements = state.placements_of_content(&content_id).to_vec();
+        let changed_screens = unique_screen_ids(
+            placements.iter().filter_map(|surface| surface_screen_id(state, *surface)),
+        );
+        let selection_before = active_tree_selection(state);
+        let mut projected = state.clone();
+        let (terminal_runtime, removed, _) =
+            remove_terminal_content_from_state(self, &mut projected, terminal_public_id);
+        if let Some(runtime) = terminal_runtime.as_ref() {
+            let host = self.resource_terminal_host_identity(runtime).ok_or_else(|| {
+                terminal_close_state_error("terminal runtime omitted its durable host identity")
+            })?;
+            if host.terminal_id != terminal_id {
+                return Err(terminal_close_state_error("terminal resource changed hosts"));
+            }
+            if terminal_incarnation.is_some_and(|expected| host.incarnation != expected) {
+                return Err(terminal_close_state_error("terminal resource changed incarnations"));
+            }
+        }
+        if !projected.placements_of_content(&content_id).is_empty() {
+            return Err(terminal_close_state_error("terminal close retained a projected view"));
+        }
+        if projected.terminal_catalog.contains_key(terminal_public_id) {
+            return Err(terminal_close_state_error("terminal close retained its catalog runtime"));
+        }
+        let mut placement_ids = placements;
+        placement_ids.extend(removed.iter().map(|surface| surface.id));
+        placement_ids.sort_unstable();
+        placement_ids.dedup();
+        Ok(ResourceClosePlan {
+            selection_resync: selection_before != active_tree_selection(&projected),
+            state: projected,
+            removed,
+            placement_ids,
+            terminal_runtime,
+            closed_terminal_public_id: Some(terminal_public_id.clone()),
+            terminal_batch: vec![(
+                terminal_id.to_string(),
+                terminal_incarnation.map(str::to_string),
+            )],
+            workspace_close: None,
+            delta: None,
+            changed_screens,
+        })
     }
 
     /// Route the legacy host close through the same projected topology owner
@@ -2290,6 +2515,7 @@ impl Mux {
                 ResourceClosePlan {
                     state: state.clone(),
                     removed: Vec::new(),
+                    placement_ids: Vec::new(),
                     terminal_runtime: None,
                     closed_terminal_public_id: Some(public_id.clone()),
                     terminal_batch: Vec::new(),
@@ -2300,37 +2526,29 @@ impl Mux {
                 },
             )
         };
+        let closing_tab_ids = state
+            .placements_of_content(&ContentPublicId::Terminal(public_id.clone()))
+            .iter()
+            .map(|surface| {
+                state.resource_indexes.tab_ids.get(surface).cloned().ok_or_else(|| {
+                    terminal_close_state_error(format!(
+                        "terminal {public_id} placement {surface} has no durable tab"
+                    ))
+                })
+            })
+            .collect::<anyhow::Result<Vec<_>>>()?;
         let mut projection =
             self.resource_effect_projection_locked(&registry, &mut plan.state, json!({}))?;
-        if !projection.patch.changes.iter().any(|change| {
-            matches!(
-                change,
-                ResourceChange::TombstoneTerminal { public_id: closing, .. }
-                    if closing == &public_id
-            )
-        }) {
-            let incarnation = registry
-                .terminal_record(terminal_id)?
-                .ok_or_else(|| {
-                    terminal_close_state_error(format!(
-                        "terminal close projection omitted host {terminal_id}"
-                    ))
-                })?
-                .incarnation;
-            projection.patch.changes.push(ResourceChange::TombstoneTerminal {
-                public_id: public_id.clone(),
-                expected_incarnation: incarnation,
-            });
-            let changes = projection.changes.as_array_mut().ok_or_else(|| {
-                terminal_close_state_error("terminal close projection changes are not an array")
-            })?;
-            changes.push(json!({
-                "kind":"delete",
-                "sequence":changes.len(),
-                "resource":"terminal",
-                "id":public_id,
-            }));
-        }
+        let incarnation = registry
+            .terminal_record(terminal_id)?
+            .ok_or_else(|| {
+                terminal_close_state_error(format!(
+                    "terminal close projection omitted host {terminal_id}"
+                ))
+            })?
+            .incarnation;
+        ensure_terminal_close_projection(&public_id, incarnation.as_deref(), &mut projection)?;
+        validate_terminal_close_projection(&public_id, &closing_tab_ids, &projection)?;
         #[cfg(test)]
         if let Some(hook) = self.resource_projection_before_commit.lock().unwrap().clone() {
             hook();
@@ -2645,9 +2863,18 @@ impl Mux {
         Ok(CommittedResourceClose { commit: close.resource, effects })
     }
     fn finish_resource_close(&self, committed: CommittedResourceClose) -> ResourcePatchCommit {
-        let effects = committed.effects;
-        if let Some(terminal_id) = effects.closed_terminal_public_id {
-            self.notify_terminal_exit_waiters(Some(terminal_id));
+        let ResourceCloseEffects {
+            removed,
+            placement_ids,
+            terminal_runtime,
+            closed_terminal_public_id,
+            tree_publication,
+            changed_screens,
+            selection_resync,
+            empty_revision,
+        } = committed.effects;
+        if let Some(terminal_id) = closed_terminal_public_id.as_ref() {
+            self.notify_terminal_exit_waiters(Some(terminal_id.clone()));
         }
 
         #[cfg(test)]
@@ -2655,32 +2882,38 @@ impl Mux {
             hook();
         }
         self.publish_resource_event();
-        for surface in effects.removed {
-            self.purge_surface_side_tables(surface.id);
+        for placement in placement_ids {
+            self.purge_surface_side_tables(placement);
+        }
+        for surface in &removed {
             if surface.kind() == SurfaceKind::Browser {
                 surface.kill();
             }
         }
-        if let Some(runtime) = effects.terminal_runtime {
+        drop(removed);
+        if let Some(terminal_id) = closed_terminal_public_id.as_ref() {
+            self.purge_terminal_side_tables(terminal_id);
+        }
+        if let Some(runtime) = terminal_runtime {
             self.purge_terminal_runtime_side_tables(&runtime);
             self.terminate_terminal_runtime(&runtime);
         }
-        match effects.tree_publication {
+        match tree_publication {
             ResourceCloseTreePublication::PendingDelta(delta) => {
-                self.emit_tree_delta(delta, effects.selection_resync);
+                self.emit_tree_delta(delta, selection_resync);
             }
             ResourceCloseTreePublication::PendingSnapshot => {
                 self.emit(MuxEvent::TreeChanged);
-                if effects.selection_resync {
+                if selection_resync {
                     self.emit(MuxEvent::TreeSelectionChanged);
                 }
             }
             ResourceCloseTreePublication::Published => {}
         }
-        for screen in effects.changed_screens {
+        for screen in changed_screens {
             self.emit(MuxEvent::LayoutChanged(screen));
         }
-        self.emit_empty_if_current(effects.empty_revision);
+        self.emit_empty_if_current(empty_revision);
         committed.commit
     }
 
@@ -2820,9 +3053,9 @@ impl Mux {
             );
             removed = terminal_views;
             split_index_changed = changed;
-            for surface in surface_ids {
+            for surface in &surface_ids {
                 anyhow::ensure!(
-                    projected.pane_of(surface).is_none(),
+                    projected.pane_of(*surface).is_none(),
                     "close target surface {surface} remained attached"
                 );
             }
@@ -2832,10 +3065,10 @@ impl Mux {
                     removed.push(surface);
                 }
             }
-            for surface in surface_ids {
-                let (_, changed) = remove_surface(self, &mut projected, surface);
+            for surface in &surface_ids {
+                let (_, changed) = remove_surface(self, &mut projected, *surface);
                 anyhow::ensure!(
-                    projected.pane_of(surface).is_none(),
+                    projected.pane_of(*surface).is_none(),
                     "close target surface {surface} remained attached"
                 );
                 split_index_changed |= changed;
@@ -2887,9 +3120,14 @@ impl Mux {
         if let Some(delta) = &mut delta {
             delta.workspace_revision = None;
         }
+        let mut placement_ids = surface_ids;
+        placement_ids.extend(removed.iter().map(|surface| surface.id));
+        placement_ids.sort_unstable();
+        placement_ids.dedup();
         Ok(ResourceClosePlan {
             state: projected,
             removed,
+            placement_ids,
             terminal_runtime,
             closed_terminal_public_id: terminal_public_id,
             terminal_batch,

--- a/cmux-tui/crates/cmux-tui-core/src/mux/resource_topology.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/mux/resource_topology.rs
@@ -2323,7 +2323,7 @@ impl Mux {
                 "terminal {terminal_public_id} has no durable host record"
             ))
         })?;
-        let terminal_incarnation = terminal.incarnation.clone();
+        let terminal_incarnation = terminal.incarnation;
         let mut state = self.state.lock().unwrap();
         let closing_tab_ids = state
             .placements_of_content(&ContentPublicId::Terminal(terminal_public_id.clone()))

--- a/cmux-tui/crates/cmux-tui-core/src/resource_router/content.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/resource_router/content.rs
@@ -326,7 +326,11 @@ fn terminal_effect(mux: &Arc<Mux>, request: ParsedResourceRequest) -> Result<Val
     validate_terminal_effect_fields(&request)?;
     let fields = request.fields.clone();
     let preparation = effects::prepare(mux, &request, || {
-        let (terminal_id, _) = resolve_terminal_surface(mux, &request.selectors)?;
+        let terminal_id = if request.envelope.operation == ResourceOperation::TerminalClose {
+            resolve_terminal_close_id(mux, &request.selectors)?
+        } else {
+            resolve_terminal_surface(mux, &request.selectors)?.0
+        };
         Ok(json!({"terminal_id":terminal_id,"fields":fields}))
     })?;
     match preparation {
@@ -352,6 +356,15 @@ fn execute_terminal_effect(
         Ok(fields) => fields.clone(),
         Err(error) => return effects::commit_known_failure(mux, prepared, error),
     };
+    if prepared.operation == "terminal.close" {
+        let commit = mux.commit_resource_terminal_close_effect(
+            &terminal_id,
+            &prepared.idempotency_key,
+            &prepared.operation,
+            &prepared.fingerprint,
+        );
+        return finish_projection_commit(mux, prepared, commit);
+    }
     let Some(surface_id) = mux.resource_surface_for_terminal(&terminal_id) else {
         return effects::commit_known_failure(
             mux,
@@ -383,7 +396,6 @@ fn execute_terminal_effect(
             surface.clear_history().map_err(|error| ActionFailure::Indeterminate(error.to_string()))
         }
         "terminal.viewport.scroll" => terminal_scroll_viewport(mux, &surface, &fields),
-        "terminal.close" => Ok(()),
         operation => Err(ActionFailure::Known(ResourceError::operation_failed(
             operation,
             "stored terminal effect operation is invalid",
@@ -392,16 +404,6 @@ fn execute_terminal_effect(
     };
     if let Err(failure) = action {
         return finish_action_failure(mux, prepared, failure);
-    }
-
-    if prepared.operation == "terminal.close" {
-        let commit = mux.commit_resource_terminal_close_effect(
-            surface_id,
-            &prepared.idempotency_key,
-            &prepared.operation,
-            &prepared.fingerprint,
-        );
-        return finish_projection_commit(mux, prepared, commit);
     }
 
     debug_assert!(effects::receipt_only_operation(&prepared.operation));
@@ -1030,6 +1032,43 @@ fn resolve_terminal_surface(
     Ok((terminal_id, surface))
 }
 
+/// Resolve a close target from durable public topology. Close is the one
+/// terminal effect that does not require an adopted runtime: restored views
+/// are public before their host is attached to this daemon.
+fn resolve_terminal_close_id(
+    mux: &Arc<Mux>,
+    selectors: &ResourceSelectors,
+) -> Result<TerminalPublicId, ResourceError> {
+    match mux.resolve_resource_path(ResourceTarget::Terminal, selectors) {
+        Ok(path) => path.terminal.ok_or_else(|| ResourceError::not_found("terminal", "<resolved>")),
+        Err(error)
+            if error.code == "selector.not_found"
+                && error.details["scope"] == "terminal"
+                && selectors.workspace.is_none()
+                && selectors.screen.is_none()
+                && selectors.pane.is_none()
+                && selectors.tab.is_none() =>
+        {
+            let Some(selector) = selectors.terminal.as_deref() else {
+                return Err(error);
+            };
+            let Ok(terminal_id) = TerminalPublicId::parse(selector) else {
+                return Err(error);
+            };
+            if mux
+                .live_terminal_host_for_resource(&terminal_id)
+                .map_err(resource_operation_error)?
+                .is_some()
+            {
+                Ok(terminal_id)
+            } else {
+                Err(error)
+            }
+        }
+        Err(error) => Err(error),
+    }
+}
+
 fn resolve_browser_surface(
     mux: &Arc<Mux>,
     selectors: &ResourceSelectors,
@@ -1550,10 +1589,13 @@ fn finish_action_failure(
 
 #[cfg(test)]
 mod tests {
+    use std::sync::atomic::{AtomicBool, Ordering};
     use std::sync::mpsc;
 
     use super::*;
+    use crate::NotificationLevel;
     use crate::SurfaceOptions;
+    use crate::resource::NotificationPublicId;
 
     fn terminal_fixture(
         command: Option<Vec<String>>,
@@ -1844,21 +1886,80 @@ mod tests {
     fn terminal_listed_before_runtime_adoption_closes_by_public_id_atomically() {
         let (mux, surface, selectors) = terminal_fixture(None);
         let terminal_id = TerminalPublicId::parse(selectors.terminal.as_deref().unwrap()).unwrap();
-        let tab_id = mux.with_state(|state| state.resource_indexes.tab_ids[&surface.id].clone());
+        let initial = public_session_snapshot(&mux).unwrap();
+        let projected = dispatch(
+            &mux,
+            parsed_request(
+                "terminal.project",
+                &selectors,
+                json!({
+                    "destination_workspace":initial["workspaces"][0]["id"],
+                    "destination_screen":initial["screens"][0]["id"],
+                    "destination_pane":initial["panes"][0]["id"],
+                    "index":1,
+                    "name":"restored mirror",
+                }),
+                Some("project-terminal-before-adoption"),
+            ),
+        )
+        .unwrap();
+        let projected_tab = projected["value"]["id"].as_str().unwrap();
+        let placements = mux.with_state(|state| {
+            state.placements_of_content(&ContentPublicId::Terminal(terminal_id.clone())).to_vec()
+        });
+        assert_eq!(placements.len(), 2);
+        assert!(placements.contains(&surface.id));
+        let tab_ids = mux.with_state(|state| {
+            placements
+                .iter()
+                .map(|placement| state.resource_indexes.tab_ids[placement].clone())
+                .collect::<Vec<_>>()
+        });
+        assert!(tab_ids.iter().any(|tab| tab.as_str() == projected_tab));
+        for (index, placement) in placements.iter().enumerate() {
+            mux.post_resource_notification(
+                NotificationPublicId::random().unwrap(),
+                format!("placement {index}"),
+                String::new(),
+                NotificationLevel::Info,
+                Some(*placement),
+                None,
+                1,
+            );
+        }
+        mux.post_resource_notification(
+            NotificationPublicId::random().unwrap(),
+            "terminal".into(),
+            String::new(),
+            NotificationLevel::Info,
+            Some(surface.id),
+            Some(terminal_id.clone()),
+            2,
+        );
         let before_resource_revision = mux.with_state(|state| state.resource_revision);
         let before_terminal_revision = mux.terminal_registry_snapshot().unwrap().revision;
 
-        let removed_surface =
-            mux.remove_surface_runtime_for_test(surface.id).expect("fixture has a live view");
+        let removed_surfaces = placements
+            .iter()
+            .map(|placement| {
+                mux.remove_surface_runtime_for_test(*placement).expect("fixture has a live view")
+            })
+            .collect::<Vec<_>>();
         let removed_runtime = mux
             .remove_terminal_catalog_for_test(&terminal_id)
             .expect("fixture has a catalog runtime");
-        assert!(removed_surface.shares_terminal_runtime(&removed_runtime));
+        assert!(
+            removed_surfaces
+                .iter()
+                .all(|removed| removed.shares_terminal_runtime(&removed_runtime))
+        );
+        assert!(placements.iter().all(|placement| mux.surface_notification(*placement).is_some()));
+        assert!(mux.terminal_notification(&terminal_id).is_some());
         assert_eq!(
             mux.with_state(|state| state
                 .placements_of_content(&ContentPublicId::Terminal(terminal_id.clone()))
                 .to_vec()),
-            vec![surface.id],
+            placements,
             "pre-adoption fixture must retain its projected view"
         );
 
@@ -1875,7 +1976,23 @@ mod tests {
         assert_eq!(listed["ok"], true);
         assert_eq!(listed["result"].as_array().unwrap().len(), 1);
         assert_eq!(listed["result"][0]["id"], terminal_id.as_str());
-        assert_eq!(listed["result"][0]["tab_ids"], json!([tab_id]));
+        assert_eq!(listed["result"][0]["tab_ids"].as_array().unwrap().len(), 2);
+
+        let close_installed = Arc::new(AtomicBool::new(false));
+        mux.set_resource_close_cleanup_hook_for_test(Some(Arc::new({
+            let mux = Arc::downgrade(&mux);
+            let close_installed = close_installed.clone();
+            move || {
+                let installed = mux.upgrade().is_some_and(|mux| {
+                    mux.with_state(|state| state.resource_revision == before_resource_revision + 1)
+                        && mux
+                            .terminal_registry_snapshot()
+                            .is_ok_and(|snapshot| snapshot.revision == before_terminal_revision + 1)
+                        && mux.discovered_terminal_terminations_for_test().is_empty()
+                });
+                close_installed.store(installed, Ordering::Release);
+            }
+        })));
 
         let closed = super::super::handle_parsed_resource_request(
             &mux,
@@ -1892,6 +2009,8 @@ mod tests {
             panic!("a terminal returned by terminal.list was not closable: {closed}");
         }
         assert_eq!(closed["result"]["replayed"], false);
+        assert!(close_installed.load(Ordering::Acquire));
+        assert_eq!(mux.discovered_terminal_terminations_for_test().len(), 1);
 
         let after = super::super::handle_parsed_resource_request(
             &mux,
@@ -1903,6 +2022,8 @@ mod tests {
             state.placements_of_content(&ContentPublicId::Terminal(terminal_id.clone())).is_empty()
         }));
         assert!(mux.surface(surface.id).is_none());
+        assert!(placements.iter().all(|placement| mux.surface_notification(*placement).is_none()));
+        assert!(mux.terminal_notification(&terminal_id).is_none());
 
         let close_events = mux.resource_events_after(before_resource_revision).unwrap();
         assert_eq!(close_events.batches.len(), 1);
@@ -1918,17 +2039,19 @@ mod tests {
                 .count(),
             1
         );
-        assert_eq!(
-            changes
-                .iter()
-                .filter(|change| {
-                    change["kind"] == "delete"
-                        && change["resource"] == "tab"
-                        && change["id"] == tab_id.as_str()
-                })
-                .count(),
-            1
-        );
+        for tab_id in &tab_ids {
+            assert_eq!(
+                changes
+                    .iter()
+                    .filter(|change| {
+                        change["kind"] == "delete"
+                            && change["resource"] == "tab"
+                            && change["id"] == tab_id.as_str()
+                    })
+                    .count(),
+                1
+            );
+        }
         assert_eq!(mux.with_state(|state| state.resource_revision), before_resource_revision + 1);
         let (terminal_snapshot, terminal_events) =
             mux.terminal_registry_events_page(before_terminal_revision).unwrap();
@@ -1954,6 +2077,249 @@ mod tests {
             mux.terminal_registry_snapshot().unwrap().revision,
             before_terminal_revision + 1
         );
+        assert_eq!(mux.discovered_terminal_terminations_for_test().len(), 1);
+        mux.shutdown();
+    }
+
+    #[test]
+    fn terminal_close_before_adoption_preserves_topology_when_atomic_commit_fails() {
+        let (mux, surface, selectors) = terminal_fixture(None);
+        let terminal_id = TerminalPublicId::parse(selectors.terminal.as_deref().unwrap()).unwrap();
+        let before_resource_revision = mux.with_state(|state| state.resource_revision);
+        let before_terminal_revision = mux.terminal_registry_snapshot().unwrap().revision;
+
+        let removed_surface =
+            mux.remove_surface_runtime_for_test(surface.id).expect("fixture has a live view");
+        let removed_runtime = mux
+            .remove_terminal_catalog_for_test(&terminal_id)
+            .expect("fixture has a catalog runtime");
+        assert!(removed_surface.shares_terminal_runtime(&removed_runtime));
+        mux.set_resource_patch_failure_for_test(true);
+
+        let failed = super::super::handle_parsed_resource_request(
+            &mux,
+            parsed_request(
+                "terminal.close",
+                &selectors,
+                json!({}),
+                Some("close-terminal-before-adoption-failure"),
+            ),
+        )
+        .unwrap();
+        assert_eq!(failed["ok"], false);
+        assert_eq!(failed["error"]["code"], "mutation.indeterminate");
+        mux.set_resource_patch_failure_for_test(false);
+
+        assert_eq!(mux.with_state(|state| state.resource_revision), before_resource_revision);
+        assert_eq!(mux.terminal_registry_snapshot().unwrap().revision, before_terminal_revision);
+        assert!(mux.discovered_terminal_terminations_for_test().is_empty());
+        assert_eq!(
+            mux.with_state(|state| state
+                .placements_of_content(&ContentPublicId::Terminal(terminal_id.clone()))
+                .to_vec()),
+            vec![surface.id],
+            "failed close must retain the projected terminal view"
+        );
+
+        let retry = super::super::handle_parsed_resource_request(
+            &mux,
+            parsed_request(
+                "terminal.close",
+                &selectors,
+                json!({}),
+                Some("close-terminal-before-adoption-retry"),
+            ),
+        )
+        .unwrap();
+        assert_eq!(retry["ok"], true);
+        assert_eq!(retry["result"]["replayed"], false);
+        assert!(mux.with_state(|state| {
+            state.placements_of_content(&ContentPublicId::Terminal(terminal_id.clone())).is_empty()
+        }));
+        mux.shutdown();
+    }
+
+    #[test]
+    fn zero_view_terminal_closes_only_by_its_exact_unscoped_public_id() {
+        let (mux, surface, selectors) = terminal_fixture(None);
+        let terminal_id = TerminalPublicId::parse(selectors.terminal.as_deref().unwrap()).unwrap();
+        let snapshot = public_session_snapshot(&mux).unwrap();
+        let workspace_id = snapshot["workspaces"][0]["id"].as_str().unwrap().to_string();
+        let tab_id = snapshot["terminals"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .find(|terminal| terminal["id"] == terminal_id.as_str())
+            .unwrap()["tab_ids"][0]
+            .as_str()
+            .unwrap()
+            .to_string();
+        let pane_id = snapshot["tabs"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .find(|tab| tab["id"] == tab_id)
+            .unwrap()["pane_id"]
+            .as_str()
+            .unwrap()
+            .to_string();
+        super::super::topology::dispatch(
+            &mux,
+            parsed_request(
+                "tab.create_terminal",
+                &ResourceSelectors {
+                    machine: Some("current".into()),
+                    session: Some("current".into()),
+                    pane: Some(pane_id),
+                    ..ResourceSelectors::default()
+                },
+                json!({}),
+                Some("keep-zero-view-workspace-live"),
+            ),
+        )
+        .unwrap();
+        let tab_selectors = ResourceSelectors {
+            machine: Some("current".into()),
+            session: Some("current".into()),
+            tab: Some(tab_id),
+            ..ResourceSelectors::default()
+        };
+        super::super::topology::dispatch(
+            &mux,
+            parsed_request(
+                "tab.close",
+                &tab_selectors,
+                json!({}),
+                Some("detach-terminal-zero-view"),
+            ),
+        )
+        .unwrap();
+        assert!(mux.surface(surface.id).is_some(), "detaching the last view retains its runtime");
+        let removed_runtime = mux
+            .remove_terminal_catalog_for_test(&terminal_id)
+            .expect("detached terminal retains its catalog runtime");
+        assert!(removed_runtime.shares_terminal_runtime(&surface));
+        assert!(mux.with_state(|state| {
+            state.placements_of_content(&ContentPublicId::Terminal(terminal_id.clone())).is_empty()
+        }));
+        let listed = super::super::handle_parsed_resource_request(
+            &mux,
+            parsed_request(
+                "terminal.list",
+                &ResourceSelectors {
+                    machine: Some("current".into()),
+                    session: Some("current".into()),
+                    ..ResourceSelectors::default()
+                },
+                json!({}),
+                None,
+            ),
+        )
+        .unwrap();
+        let listed_terminal = listed["result"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .find(|terminal| terminal["id"] == terminal_id.as_str())
+            .expect("terminal.list retains the zero-view terminal");
+        assert_eq!(listed_terminal["tab_ids"], json!([]));
+
+        let scoped = ResourceSelectors { workspace: Some(workspace_id), ..selectors.clone() };
+        let scoped_close = super::super::handle_parsed_resource_request(
+            &mux,
+            parsed_request("terminal.close", &scoped, json!({}), Some("close-zero-view-scoped")),
+        )
+        .unwrap();
+        assert_eq!(scoped_close["ok"], false);
+        assert_eq!(scoped_close["error"]["code"], "selector.not_found");
+
+        let exact_close = super::super::handle_parsed_resource_request(
+            &mux,
+            parsed_request("terminal.close", &selectors, json!({}), Some("close-zero-view-exact")),
+        )
+        .unwrap();
+        assert_eq!(exact_close["ok"], true);
+        assert_eq!(exact_close["result"]["replayed"], false);
+        assert!(
+            public_session_snapshot(&mux).unwrap()["terminals"]
+                .as_array()
+                .unwrap()
+                .iter()
+                .all(|terminal| terminal["id"] != terminal_id.as_str())
+        );
+        mux.shutdown();
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn terminal_close_tombstone_wins_an_adoption_waiting_on_the_same_state_owner() {
+        let (mux, surface, selectors) = terminal_fixture(None);
+        let terminal_id = TerminalPublicId::parse(selectors.terminal.as_deref().unwrap()).unwrap();
+        let removed_surface =
+            mux.remove_surface_runtime_for_test(surface.id).expect("fixture has a live view");
+        let removed_runtime = mux
+            .remove_terminal_catalog_for_test(&terminal_id)
+            .expect("fixture has a catalog runtime");
+        assert!(removed_surface.shares_terminal_runtime(&removed_runtime));
+        let host = mux
+            .resource_terminal_host_identity(&removed_runtime)
+            .expect("fixture runtime has a durable host identity");
+        let commit_ready = Arc::new(std::sync::Barrier::new(2));
+        let allow_install = Arc::new(std::sync::Barrier::new(2));
+        mux.set_resource_close_after_commit_hook_for_test(Some(Arc::new({
+            let commit_ready = commit_ready.clone();
+            let allow_install = allow_install.clone();
+            move || {
+                commit_ready.wait();
+                allow_install.wait();
+            }
+        })));
+
+        let closing = {
+            let mux = mux.clone();
+            let selectors = selectors.clone();
+            std::thread::spawn(move || {
+                super::super::handle_parsed_resource_request(
+                    &mux,
+                    parsed_request(
+                        "terminal.close",
+                        &selectors,
+                        json!({}),
+                        Some("close-terminal-during-adoption"),
+                    ),
+                )
+            })
+        };
+        commit_ready.wait();
+        let (adoption_tx, adoption_rx) = mpsc::channel();
+        let adopting = {
+            let mux = mux.clone();
+            std::thread::spawn(move || {
+                let result = mux.finish_terminal_adoption_for_test(
+                    &host.terminal_id,
+                    &host.incarnation,
+                    removed_runtime,
+                );
+                adoption_tx.send(result).unwrap();
+            })
+        };
+        assert!(
+            adoption_rx.recv_timeout(Duration::from_millis(50)).is_err(),
+            "adoption entered while terminal close held registry and state ownership"
+        );
+        allow_install.wait();
+        let closed = closing.join().unwrap().unwrap();
+        assert_eq!(closed["ok"], true);
+        let adoption = adoption_rx.recv_timeout(Duration::from_secs(1)).unwrap();
+        assert!(adoption.is_err(), "a committed close tombstone must reject late adoption");
+        adopting.join().unwrap();
+        mux.set_resource_close_after_commit_hook_for_test(None);
+        assert!(mux.with_state(|state| {
+            !state.terminal_catalog.contains_key(&terminal_id)
+                && state
+                    .placements_of_content(&ContentPublicId::Terminal(terminal_id.clone()))
+                    .is_empty()
+        }));
         mux.shutdown();
     }
 

--- a/cmux-tui/crates/cmux-tui-core/src/resource_router/content.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/resource_router/content.rs
@@ -1841,6 +1841,123 @@ mod tests {
     }
 
     #[test]
+    fn terminal_listed_before_runtime_adoption_closes_by_public_id_atomically() {
+        let (mux, surface, selectors) = terminal_fixture(None);
+        let terminal_id = TerminalPublicId::parse(selectors.terminal.as_deref().unwrap()).unwrap();
+        let tab_id = mux.with_state(|state| state.resource_indexes.tab_ids[&surface.id].clone());
+        let before_resource_revision = mux.with_state(|state| state.resource_revision);
+        let before_terminal_revision = mux.terminal_registry_snapshot().unwrap().revision;
+
+        let removed_surface =
+            mux.remove_surface_runtime_for_test(surface.id).expect("fixture has a live view");
+        let removed_runtime = mux
+            .remove_terminal_catalog_for_test(&terminal_id)
+            .expect("fixture has a catalog runtime");
+        assert!(removed_surface.shares_terminal_runtime(&removed_runtime));
+        assert_eq!(
+            mux.with_state(|state| state
+                .placements_of_content(&ContentPublicId::Terminal(terminal_id.clone()))
+                .to_vec()),
+            vec![surface.id],
+            "pre-adoption fixture must retain its projected view"
+        );
+
+        let session_selectors = ResourceSelectors {
+            machine: Some("current".into()),
+            session: Some("current".into()),
+            ..ResourceSelectors::default()
+        };
+        let listed = super::super::handle_parsed_resource_request(
+            &mux,
+            parsed_request("terminal.list", &session_selectors, json!({}), None),
+        )
+        .unwrap();
+        assert_eq!(listed["ok"], true);
+        assert_eq!(listed["result"].as_array().unwrap().len(), 1);
+        assert_eq!(listed["result"][0]["id"], terminal_id.as_str());
+        assert_eq!(listed["result"][0]["tab_ids"], json!([tab_id]));
+
+        let closed = super::super::handle_parsed_resource_request(
+            &mux,
+            parsed_request(
+                "terminal.close",
+                &selectors,
+                json!({}),
+                Some("close-terminal-before-adoption"),
+            ),
+        )
+        .unwrap();
+        if closed["ok"] != true {
+            mux.shutdown();
+            panic!("a terminal returned by terminal.list was not closable: {closed}");
+        }
+        assert_eq!(closed["result"]["replayed"], false);
+
+        let after = super::super::handle_parsed_resource_request(
+            &mux,
+            parsed_request("terminal.list", &session_selectors, json!({}), None),
+        )
+        .unwrap();
+        assert_eq!(after["result"], json!([]));
+        assert!(mux.with_state(|state| {
+            state.placements_of_content(&ContentPublicId::Terminal(terminal_id.clone())).is_empty()
+        }));
+        assert!(mux.surface(surface.id).is_none());
+
+        let close_events = mux.resource_events_after(before_resource_revision).unwrap();
+        assert_eq!(close_events.batches.len(), 1);
+        let changes = close_events.batches[0].changes.as_array().unwrap();
+        assert_eq!(
+            changes
+                .iter()
+                .filter(|change| {
+                    change["kind"] == "delete"
+                        && change["resource"] == "terminal"
+                        && change["id"] == terminal_id.as_str()
+                })
+                .count(),
+            1
+        );
+        assert_eq!(
+            changes
+                .iter()
+                .filter(|change| {
+                    change["kind"] == "delete"
+                        && change["resource"] == "tab"
+                        && change["id"] == tab_id.as_str()
+                })
+                .count(),
+            1
+        );
+        assert_eq!(mux.with_state(|state| state.resource_revision), before_resource_revision + 1);
+        let (terminal_snapshot, terminal_events) =
+            mux.terminal_registry_events_page(before_terminal_revision).unwrap();
+        assert_eq!(terminal_snapshot.revision, before_terminal_revision + 1);
+        assert_eq!(terminal_events.len(), 1);
+        assert_eq!(terminal_events[0].kind, "terminal-closed");
+
+        let replay = super::super::handle_parsed_resource_request(
+            &mux,
+            parsed_request(
+                "terminal.close",
+                &selectors,
+                json!({}),
+                Some("close-terminal-before-adoption"),
+            ),
+        )
+        .unwrap();
+        assert_eq!(replay["ok"], true);
+        assert_eq!(replay["result"]["replayed"], true);
+        assert_eq!(replay["result"]["revision"], closed["result"]["revision"]);
+        assert_eq!(mux.resource_events_after(before_resource_revision).unwrap().batches.len(), 1);
+        assert_eq!(
+            mux.terminal_registry_snapshot().unwrap().revision,
+            before_terminal_revision + 1
+        );
+        mux.shutdown();
+    }
+
+    #[test]
     fn terminal_wait_coalesces_more_than_attach_capacity_without_losing_a_later_match() {
         let (mux, surface, selectors) = terminal_fixture(Some(vec!["fake-shell".into()]));
         let request = parsed_request(

--- a/cmux-tui/crates/cmux-tui-core/src/resource_router/content.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/resource_router/content.rs
@@ -2277,7 +2277,6 @@ mod tests {
 
         let closing = {
             let mux = mux.clone();
-            let selectors = selectors.clone();
             std::thread::spawn(move || {
                 super::super::handle_parsed_resource_request(
                     &mux,


### PR DESCRIPTION
## Summary

- Add a public behavior test for closing a durable terminal before runtime adoption.
- Keep the restored projected tab while the test removes the live surface and catalog owner.
- Check the atomic terminal, tab, event, revision, and replay results.

## Test plan

- Local compile and test execution omitted by instruction.
- Hosted red evidence must show the current `selector.not_found` result before the fix commit.

This is commit 1 of 2. Do not merge until commit 2 fixes the proven failure.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/9932"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788999735&installation_model_id=21920&pr_number=9932&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F9932&signature=e55c91bd556dc7e7ebdc16d7aa4f929c2e212b7c13cad7c7c3ce454494b21b79"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core resource topology commit, registry close, and terminal lifecycle ordering; mistakes could leave inconsistent tabs/terminals or break idempotent close.
> 
> **Overview**
> **`terminal.close`** no longer depends on a live surface or catalog runtime. The router resolves the target via **`resolve_terminal_close_id`** (durable topology / live host id), and **`commit_resource_terminal_close_effect`** now takes a **public terminal id** and commits through the workspace registry with projection tombstones for the terminal and every related tab.
> 
> Close planning adds **`resource_terminal_close_plan_locked`**, shared **`ensure_terminal_close_projection`** / **`validate_terminal_close_projection`** checks, and **`placement_ids`** so **`finish_resource_close`** purges all placement side tables and terminal side tables—not only removed surface runtimes. When there is no runtime, **`terminate_discovered_terminal_host`** still runs (with test hooks to record those calls).
> 
> Regression tests cover list-then-close before adoption, failed atomic commit, zero-view terminals (exact unscoped id only), and close winning over concurrent adoption.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 344f02b1fd3bae02a8dacb071258db8e193b1e8f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enables closing terminals by public ID before runtime adoption in `cmux-tui-core`. `terminal.close` now resolves from durable topology and commits atomically across terminal, tabs, and surfaces with correct events and cleanup.

- **Bug Fixes**
  - `terminal.close` resolves by public terminal ID and runs before surface/runtime resolution; commits via the workspace registry.
  - Adds projection helpers and validators to ensure a single terminal tombstone and matching tab deletes in both patch and public change streams; supports idempotent replay.
  - Purges all placement side tables and terminal side tables; terminates the runtime when present and records discovered-host cleanup otherwise.
  - Router adds `resolve_terminal_close_id`; zero-view terminals close only by exact unscoped public ID; a close tombstone wins over a concurrent adoption.

<sup>Written for commit 344f02b1fd3bae02a8dacb071258db8e193b1e8f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/9932?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reliability when closing terminals that were listed before runtime adoption, ensuring related terminal, tab, surface, and resource state is removed consistently.

- **Tests**
  - Added regression coverage for terminal listing and closure across runtime transitions.
  - Verified repeated close requests are idempotent and do not generate duplicate events.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->