### PR TITLE
test(tui): gate descendant fixture release

### DIFF
--- a/cmux-tui/crates/cmux-tui-core/src/journal_ingress.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/journal_ingress.rs
@@ -1914,6 +1914,7 @@ mod tests {
         ));
         let descendant_pid_path = root.join("descendant.pid");
         let release_gate_path = root.join("descendant.release");
+        let release_ready_path = root.join("descendant.release-ready");
         let mux = Mux::open_persistent(
             "terminal-descendant-shutdown",
             crate::SurfaceOptions::default(),
@@ -1943,10 +1944,11 @@ mod tests {
                 command: Some(vec![
                     "/bin/sh".into(),
                     "-c".into(),
-                    "stty -echo; printf input-ready; read ready; /bin/sh -c 'read release < \"$1\"' cmux-descendant \"$2\" & echo $! > \"$1\"; printf detached-ready; exit 0".into(),
+                    "stty -echo; printf input-ready; read ready; /bin/sh -c 'exec 3<\"$1\"; : > \"$2\"; read release <&3' cmux-descendant \"$2\" \"$3\" & echo $! > \"$1\"; printf detached-ready; exit 0".into(),
                     "cmux-shutdown-test".into(),
                     descendant_pid_path.to_string_lossy().into_owned(),
                     release_gate_path.to_string_lossy().into_owned(),
+                    release_ready_path.to_string_lossy().into_owned(),
                 ]),
                 ..crate::SurfaceOptions::default()
             },
@@ -1993,6 +1995,11 @@ mod tests {
             !std::fs::read_to_string(&descendant_pid_path).unwrap().trim().is_empty(),
             "descendant fixture did not publish its pid"
         );
+        let ready_deadline = Instant::now() + Duration::from_secs(5);
+        while !release_ready_path.exists() && Instant::now() < ready_deadline {
+            std::thread::yield_now();
+        }
+        assert!(release_ready_path.exists(), "descendant did not open the release gate");
 
         let started = Instant::now();
         mux.shutdown();

--- a/cmux-tui/crates/cmux-tui-core/src/journal_ingress.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/journal_ingress.rs
@@ -1920,9 +1920,9 @@ mod tests {
             &root,
         )
         .unwrap();
-        let release_gate_path_c = std::ffi::CString::new(
-            std::os::unix::ffi::OsStrExt::as_bytes(release_gate_path.as_os_str()),
-        )
+        let release_gate_path_c = std::ffi::CString::new(std::os::unix::ffi::OsStrExt::as_bytes(
+            release_gate_path.as_os_str(),
+        ))
         .unwrap();
         assert_eq!(
             unsafe { libc::mkfifo(release_gate_path_c.as_ptr(), 0o600) },
@@ -1935,10 +1935,8 @@ mod tests {
             .custom_flags(libc::O_NONBLOCK)
             .open(&release_gate_path)
             .unwrap();
-        let mut release_gate = std::fs::OpenOptions::new()
-            .write(true)
-            .open(&release_gate_path)
-            .unwrap();
+        let mut release_gate =
+            std::fs::OpenOptions::new().write(true).open(&release_gate_path).unwrap();
         let surface = crate::Surface::spawn(
             1,
             crate::SurfaceOptions {

--- a/cmux-tui/crates/cmux-tui-core/src/journal_ingress.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/journal_ingress.rs
@@ -1905,27 +1905,50 @@ mod tests {
     #[cfg(unix)]
     #[test]
     fn shutdown_is_bounded_when_a_descendant_keeps_the_pty_open() {
+        use std::os::unix::fs::OpenOptionsExt as _;
+
         let root = std::env::temp_dir().join(format!(
             "cmux-terminal-descendant-shutdown-{}-{}",
             std::process::id(),
             std::time::SystemTime::now().duration_since(std::time::UNIX_EPOCH).unwrap().as_nanos()
         ));
         let descendant_pid_path = root.join("descendant.pid");
+        let release_gate_path = root.join("descendant.release");
         let mux = Mux::open_persistent(
             "terminal-descendant-shutdown",
             crate::SurfaceOptions::default(),
             &root,
         )
         .unwrap();
+        let release_gate_path_c = std::ffi::CString::new(
+            std::os::unix::ffi::OsStrExt::as_bytes(release_gate_path.as_os_str()),
+        )
+        .unwrap();
+        assert_eq!(
+            unsafe { libc::mkfifo(release_gate_path_c.as_ptr(), 0o600) },
+            0,
+            "failed to create descendant release gate: {}",
+            io::Error::last_os_error()
+        );
+        let release_gate_reader = std::fs::OpenOptions::new()
+            .read(true)
+            .custom_flags(libc::O_NONBLOCK)
+            .open(&release_gate_path)
+            .unwrap();
+        let mut release_gate = std::fs::OpenOptions::new()
+            .write(true)
+            .open(&release_gate_path)
+            .unwrap();
         let surface = crate::Surface::spawn(
             1,
             crate::SurfaceOptions {
                 command: Some(vec![
                     "/bin/sh".into(),
                     "-c".into(),
-                    "stty -echo; printf input-ready; read ready; sleep 30 & echo $! > \"$1\"; printf detached-ready; exit 0".into(),
+                    "stty -echo; printf input-ready; read ready; /bin/sh -c 'read release < \"$1\"' cmux-descendant \"$2\" & echo $! > \"$1\"; printf detached-ready; exit 0".into(),
                     "cmux-shutdown-test".into(),
                     descendant_pid_path.to_string_lossy().into_owned(),
+                    release_gate_path.to_string_lossy().into_owned(),
                 ]),
                 ..crate::SurfaceOptions::default()
             },
@@ -1968,11 +1991,10 @@ mod tests {
                 "descendant fixture did not publish its pid"
             );
         }
-        let descendant_pid = std::fs::read_to_string(&descendant_pid_path)
-            .unwrap()
-            .trim()
-            .parse::<libc::pid_t>()
-            .unwrap();
+        assert!(
+            !std::fs::read_to_string(&descendant_pid_path).unwrap().trim().is_empty(),
+            "descendant fixture did not publish its pid"
+        );
 
         let started = Instant::now();
         mux.shutdown();
@@ -1981,16 +2003,12 @@ mod tests {
             "shutdown waited without a bound for a descendant-held PTY"
         );
 
-        if unsafe { libc::kill(descendant_pid, libc::SIGKILL) } != 0 {
-            assert_eq!(
-                io::Error::last_os_error().raw_os_error(),
-                Some(libc::ESRCH),
-                "descendant cleanup failed"
-            );
-        }
+        std::io::Write::write_all(&mut release_gate, b"release\n").unwrap();
+        drop(release_gate);
+        drop(release_gate_reader);
         assert!(
             surface.wait_for_terminal_reader_for_test(Instant::now() + Duration::from_secs(5)),
-            "terminal reader did not signal descendant cleanup"
+            "terminal reader did not finish after the descendant release"
         );
         assert!(surface.is_dead(), "terminal reader did not stop after descendant cleanup");
         drop(surface);


### PR DESCRIPTION
## Summary

- replace the 30-second descendant fixture with a named release gate
- publish descendant readiness before shutdown
- release the descendant after the bounded shutdown assertion

## Verification

- `git diff --check`
- hosted cmux-tui verification will run on this branch
- no local compile or test run, as required by the timing audit

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/9935"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789000462&installation_model_id=21920&pr_number=9935&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F9935&signature=665d0022764324fd2e7aea56e857dbdb398e270b48efde241973863714f12c44"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change in journal ingress shutdown coverage; no production shutdown or PTY handling logic is modified.
> 
> **Overview**
> Refactors **`shutdown_is_bounded_when_a_descendant_keeps_the_pty_open`** so the descendant no longer **`sleep 30`** to hold the PTY during **`mux.shutdown()`**.
> 
> The fixture now creates a FIFO **release gate** (`mkfifo`), spawns a descendant that blocks on a read from that pipe after publishing its PID, and still asserts shutdown completes within about three seconds while the PTY stays open. After that check, the test writes **`release\n`** to the gate and drops the FIFO handles instead of **`SIGKILL`**, then waits for the terminal reader to exit and the surface to die.
> 
> PID readiness is only checked as non-empty; the test no longer parses the descendant PID for kill-based cleanup.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9a57b0d430abfd3a4e378ed06b338c645c8c758d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaces the 30s sleep in `shutdown_is_bounded_when_a_descendant_keeps_the_pty_open` with a named FIFO release gate to make the test deterministic and faster. Synchronizes the release so the descendant opens the gate before asserting bounded shutdown; no production paths change.

- Creates the FIFO with `mkfifo`, opens a non-blocking read handle and a write handle to avoid open races, and keeps them until release.
- Descendant opens the FIFO for read, writes a release-ready marker, then blocks; the test asserts shutdown completes within ~3s while the PTY stays open.
- After the assertion, the test writes to the gate to release the descendant and waits for the terminal reader to finish.
- Removes SIGKILL-based cleanup and PID parsing; only checks that the published PID file is non-empty.

<sup>Written for commit ff5e9fa74ca4becec65858e01699eb8aaa951f2a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/9935?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved shutdown handling for detached processes on Unix systems.
  * Added more reliable coordination during shutdown, ensuring terminal reads complete correctly.
  * Removed the need for manual force-kill cleanup in shutdown scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->