### PR TITLE
test(tui): replace journal stack timing sleeps

### DIFF
--- a/cmux-tui/Cargo.lock
+++ b/cmux-tui/Cargo.lock
@@ -717,6 +717,7 @@ dependencies = [
  "unicode-width",
  "url",
  "uuid",
+ "wait-timeout",
  "zeroize",
 ]
 

--- a/cmux-tui/bindings/typescript/test/resource-api.test.ts
+++ b/cmux-tui/bindings/typescript/test/resource-api.test.ts
@@ -275,11 +275,12 @@ test("journal options reject invalid combinations before transport", () => {
 
 test("journal records must match their envelope cursor", async () => {
   let streamId = "";
+  let emitMismatchedRecord: (() => void) | undefined;
   const transport = new FakeTransport((request, current) => {
     if (request.operation !== "session.journal.subscribe") return;
     streamId = (request.params as Envelope).stream_id as string;
     current.ok(request, { stream_id: streamId });
-    setTimeout(() => current.emit({
+    emitMismatchedRecord = () => current.emit({
       protocol: "cmux.protocol/1",
       type: "stream_item",
       stream_id: streamId,
@@ -305,10 +306,12 @@ test("journal records must match their envelope cursor", async () => {
         resource_revision: null,
         previous_resource_revision: null,
       },
-    }), 0);
+    });
   });
   const client = new Client({ transport });
   const stream = await client.session(SESSION).journal();
+  assert.ok(emitMismatchedRecord);
+  emitMismatchedRecord();
   await assert.rejects(
     () => stream.next(),
     /journal sequence must match its stream cursor/,

--- a/cmux-tui/crates/cmux-tui-core/src/journal_hooks.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/journal_hooks.rs
@@ -1144,10 +1144,25 @@ mod tests {
             .expect("hook descendant PID");
         let child_exit =
             TestProcessExitSignal::observe(child_pid).expect("observe hook descendant exit");
-        let child_stopped = child_exit.is_none_or(|exit| {
+        let child_stopped = child_exit.as_ref().is_none_or(|exit| {
             exit.wait_until(Instant::now() + Duration::from_secs(1))
                 .expect("wait for hook descendant cleanup")
         });
+        if !child_stopped {
+            let process_group = std::fs::read_to_string(&hook_group_pid_path)
+                .ok()
+                .and_then(|pid| pid.trim().parse::<libc::pid_t>().ok());
+            // SAFETY: both PIDs belong to this isolated test fixture. The
+            // negative group target is preferred when its publication exists.
+            unsafe {
+                libc::kill(process_group.map_or(child_pid, |pid| -pid), libc::SIGKILL);
+            }
+            let cleanup_completed = child_exit.as_ref().is_none_or(|exit| {
+                exit.wait_until(Instant::now() + Duration::from_secs(1))
+                    .expect("wait for failed hook descendant cleanup")
+            });
+            assert!(cleanup_completed, "failed hook descendant cleanup did not complete");
+        }
         let _ = std::fs::remove_file(&child_pid_path);
         let _ = std::fs::remove_file(&child_ready_path);
         let _ = std::fs::remove_file(&hook_group_pid_path);

--- a/cmux-tui/crates/cmux-tui-core/src/journal_hooks.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/journal_hooks.rs
@@ -846,9 +846,11 @@ mod tests {
     use serde_json::Value;
     use sha2::Digest;
     #[cfg(any(target_os = "linux", target_vendor = "apple"))]
-    use std::os::fd::{AsRawFd, FromRawFd, OwnedFd};
+    use std::io::Read;
     #[cfg(any(target_os = "linux", target_vendor = "apple"))]
-    use std::os::unix::ffi::OsStrExt;
+    use std::os::fd::AsRawFd;
+    #[cfg(any(target_os = "linux", target_vendor = "apple"))]
+    use std::os::unix::{ffi::OsStrExt, fs::OpenOptionsExt};
 
     fn document(kind: &str, payload: Value) -> JournalDocument {
         JournalDocument::new(SessionJournalRecord {
@@ -967,112 +969,38 @@ mod tests {
     }
 
     #[cfg(any(target_os = "linux", target_vendor = "apple"))]
-    struct TestProcessExitSignal {
-        descriptor: OwnedFd,
-    }
-
-    #[cfg(any(target_os = "linux", target_vendor = "apple"))]
-    impl TestProcessExitSignal {
-        fn observe(pid: libc::pid_t) -> std::io::Result<Option<Self>> {
-            if unsafe { libc::kill(pid, 0) } < 0
-                && std::io::Error::last_os_error().raw_os_error() == Some(libc::ESRCH)
-            {
-                return Ok(None);
+    fn wait_for_fifo_event(
+        descriptor: std::os::fd::RawFd,
+        event: libc::c_short,
+        deadline: Instant,
+    ) -> std::io::Result<bool> {
+        loop {
+            let remaining = deadline.saturating_duration_since(Instant::now());
+            if remaining.is_zero() {
+                return Ok(false);
             }
-            #[cfg(target_os = "linux")]
-            let descriptor = unsafe { libc::syscall(libc::SYS_pidfd_open, pid, 0) } as libc::c_int;
-            #[cfg(target_vendor = "apple")]
-            let descriptor = unsafe { libc::kqueue() };
-            if descriptor < 0 {
-                let error = std::io::Error::last_os_error();
-                if error.raw_os_error() == Some(libc::ESRCH) {
-                    return Ok(None);
+            let timeout_ms = remaining.as_millis().min(libc::c_int::MAX as u128) as libc::c_int;
+            let mut poll_descriptor =
+                libc::pollfd { fd: descriptor, events: libc::POLLIN | libc::POLLHUP, revents: 0 };
+            let ready = unsafe { libc::poll(&raw mut poll_descriptor, 1, timeout_ms) };
+            if ready > 0 {
+                if poll_descriptor.revents & event != 0 {
+                    return Ok(true);
                 }
+                if poll_descriptor.revents & (libc::POLLERR | libc::POLLNVAL) != 0 {
+                    return Err(std::io::Error::other(format!(
+                        "fixture lease poll failed with events {:#x}",
+                        poll_descriptor.revents
+                    )));
+                }
+                continue;
+            }
+            if ready == 0 {
+                return Ok(false);
+            }
+            let error = std::io::Error::last_os_error();
+            if error.kind() != std::io::ErrorKind::Interrupted {
                 return Err(error);
-            }
-            // SAFETY: pidfd_open or kqueue returned a new owned descriptor.
-            let descriptor = unsafe { OwnedFd::from_raw_fd(descriptor) };
-            #[cfg(target_vendor = "apple")]
-            {
-                let change = libc::kevent {
-                    ident: pid as libc::uintptr_t,
-                    filter: libc::EVFILT_PROC,
-                    flags: libc::EV_ADD | libc::EV_ENABLE | libc::EV_ONESHOT,
-                    fflags: libc::NOTE_EXIT,
-                    data: 0,
-                    udata: std::ptr::null_mut(),
-                };
-                if unsafe {
-                    libc::kevent(
-                        descriptor.as_raw_fd(),
-                        &raw const change,
-                        1,
-                        std::ptr::null_mut(),
-                        0,
-                        std::ptr::null(),
-                    )
-                } < 0
-                {
-                    let error = std::io::Error::last_os_error();
-                    if error.raw_os_error() == Some(libc::ESRCH) {
-                        return Ok(None);
-                    }
-                    return Err(error);
-                }
-            }
-            Ok(Some(Self { descriptor }))
-        }
-
-        fn wait_until(&self, deadline: Instant) -> std::io::Result<bool> {
-            #[cfg(target_os = "linux")]
-            {
-                let mut descriptor = libc::pollfd {
-                    fd: self.descriptor.as_raw_fd(),
-                    events: libc::POLLIN,
-                    revents: 0,
-                };
-                loop {
-                    let remaining = deadline.saturating_duration_since(Instant::now());
-                    let timeout_ms =
-                        remaining.as_millis().min(libc::c_int::MAX as u128) as libc::c_int;
-                    let ready = unsafe { libc::poll(&raw mut descriptor, 1, timeout_ms) };
-                    if ready >= 0 {
-                        return Ok(ready > 0);
-                    }
-                    let error = std::io::Error::last_os_error();
-                    if error.kind() != std::io::ErrorKind::Interrupted {
-                        return Err(error);
-                    }
-                }
-            }
-            #[cfg(target_vendor = "apple")]
-            {
-                let mut event = unsafe { std::mem::zeroed::<libc::kevent>() };
-                loop {
-                    let remaining = deadline.saturating_duration_since(Instant::now());
-                    let timeout = libc::timespec {
-                        tv_sec: libc::time_t::try_from(remaining.as_secs())
-                            .unwrap_or(libc::time_t::MAX),
-                        tv_nsec: libc::c_long::from(remaining.subsec_nanos()),
-                    };
-                    let ready = unsafe {
-                        libc::kevent(
-                            self.descriptor.as_raw_fd(),
-                            std::ptr::null(),
-                            0,
-                            &raw mut event,
-                            1,
-                            &raw const timeout,
-                        )
-                    };
-                    if ready >= 0 {
-                        return Ok(ready > 0);
-                    }
-                    let error = std::io::Error::last_os_error();
-                    if error.kind() != std::io::ErrorKind::Interrupted {
-                        return Err(error);
-                    }
-                }
             }
         }
     }
@@ -1080,25 +1008,42 @@ mod tests {
     #[cfg(any(target_os = "linux", target_vendor = "apple"))]
     #[test]
     fn hook_exit_is_not_blocked_by_a_descendant_holding_stdin_open() {
-        let child_pid_path = std::env::temp_dir().join(format!(
-            "cmux-hook-stdin-child-{}-{}",
+        let fixture_path = std::env::temp_dir().join(format!(
+            "cmux-hook-stdin-lease-{}-{}",
             std::process::id(),
             std::time::SystemTime::now().duration_since(std::time::UNIX_EPOCH).unwrap().as_nanos()
         ));
-        let child_ready_path = child_pid_path.with_extension("ready");
-        let hook_group_pid_path = child_pid_path.with_extension("group");
-        let child_ready_c_path = std::ffi::CString::new(child_ready_path.as_os_str().as_bytes())
-            .expect("hook descendant ready path");
-        assert_eq!(unsafe { libc::mkfifo(child_ready_c_path.as_ptr(), 0o600) }, 0);
+        let lease_path = fixture_path.with_extension("lease");
+        let release_path = fixture_path.with_extension("release");
+        for path in [&lease_path, &release_path] {
+            let path = std::ffi::CString::new(path.as_os_str().as_bytes())
+                .expect("hook fixture FIFO path");
+            assert_eq!(unsafe { libc::mkfifo(path.as_ptr(), 0o600) }, 0);
+        }
+        let mut lease_reader = std::fs::OpenOptions::new()
+            .read(true)
+            .custom_flags(libc::O_NONBLOCK | libc::O_CLOEXEC)
+            .open(&lease_path)
+            .expect("open hook descendant lease reader");
+        let lease_registration = std::fs::OpenOptions::new()
+            .write(true)
+            .custom_flags(libc::O_NONBLOCK | libc::O_CLOEXEC)
+            .open(&lease_path)
+            .expect("register hook descendant lease reader");
+        let mut release_gate = std::fs::OpenOptions::new()
+            .read(true)
+            .write(true)
+            .custom_flags(libc::O_CLOEXEC)
+            .open(&release_path)
+            .expect("open hook release gate");
         let mut manifest = manifest();
         manifest.exec.argv = vec![
             "/bin/sh".into(),
             "-c".into(),
-            "printf '%s\\n' \"$$\" > \"$3\"; exec 3<&0; (/bin/sh -c 'printf \"ready\\n\" > \"$1\"; kill -STOP $$' cmux-hook-child \"$2\" <&3) & printf '%s\\n' \"$!\" > \"$1\"; IFS= read -r ready < \"$2\"; exit 0".into(),
+            "exec 3<&0; (/bin/sh -c 'exec 4>\"$1\"; printf \"ready\\n\" >&4; kill -STOP $$' cmux-hook-child \"$1\" <&3) & IFS= read -r release < \"$2\"; exit 0".into(),
             "cmux-hook-test".into(),
-            child_pid_path.to_string_lossy().into_owned(),
-            child_ready_path.to_string_lossy().into_owned(),
-            hook_group_pid_path.to_string_lossy().into_owned(),
+            lease_path.to_string_lossy().into_owned(),
+            release_path.to_string_lossy().into_owned(),
         ];
         let delivery = JournalHookDelivery {
             manifest,
@@ -1106,71 +1051,34 @@ mod tests {
             attempt: 0,
         };
         let attempt = JournalHookAttempt { attempt: 1, causation_id: "event_started".into() };
-        let ((exit_code, error), delivery_timed_out) = std::thread::scope(|scope| {
+        let failure_deadline = Instant::now() + Duration::from_secs(2);
+        let (exit_code, error) = std::thread::scope(|scope| {
             let (result_tx, result_rx) = mpsc::sync_channel(1);
             scope.spawn(move || {
                 let _ = result_tx.send(execute_delivery(&delivery, &attempt));
             });
-            match result_rx.recv_timeout(Duration::from_secs(2)) {
-                Ok(result) => (result, false),
-                Err(mpsc::RecvTimeoutError::Timeout) => {
-                    if let Ok(process_group) = std::fs::read_to_string(&hook_group_pid_path)
-                        .and_then(|pid| {
-                            pid.trim().parse::<libc::pid_t>().map_err(std::io::Error::other)
-                        })
-                    {
-                        // SAFETY: the hook executable publishes its isolated
-                        // process group before it starts the blocking fixture.
-                        unsafe {
-                            libc::kill(-process_group, libc::SIGKILL);
-                        }
-                    }
-                    (
-                        result_rx
-                            .recv_timeout(Duration::from_secs(1))
-                            .expect("hook delivery did not stop after failure cleanup"),
-                        true,
-                    )
-                }
-                Err(mpsc::RecvTimeoutError::Disconnected) => {
-                    panic!("hook delivery worker stopped without a result")
-                }
-            }
+            let lease_ready =
+                wait_for_fifo_event(lease_reader.as_raw_fd(), libc::POLLIN, failure_deadline)
+                    .expect("wait for hook descendant lease publication");
+            assert!(lease_ready, "hook descendant did not publish its lease");
+            let mut ready = [0; 6];
+            lease_reader.read_exact(&mut ready).expect("read hook descendant lease publication");
+            assert_eq!(&ready, b"ready\n");
+            drop(lease_registration);
+            release_gate.write_all(b"release\n").expect("release direct hook process");
+            result_rx
+                .recv_timeout(failure_deadline.saturating_duration_since(Instant::now()))
+                .expect("hook delivery did not complete after release")
         });
-        let child_pid = std::fs::read_to_string(&child_pid_path)
-            .expect("hook descendant PID publication")
-            .trim()
-            .parse::<libc::pid_t>()
-            .expect("hook descendant PID");
-        let child_exit =
-            TestProcessExitSignal::observe(child_pid).expect("observe hook descendant exit");
-        let child_stopped = child_exit.as_ref().is_none_or(|exit| {
-            exit.wait_until(Instant::now() + Duration::from_secs(1))
-                .expect("wait for hook descendant cleanup")
-        });
-        if !child_stopped {
-            let process_group = std::fs::read_to_string(&hook_group_pid_path)
-                .ok()
-                .and_then(|pid| pid.trim().parse::<libc::pid_t>().ok());
-            // SAFETY: both PIDs belong to this isolated test fixture. The
-            // negative group target is preferred when its publication exists.
-            unsafe {
-                libc::kill(process_group.map_or(child_pid, |pid| -pid), libc::SIGKILL);
-            }
-            let cleanup_completed = child_exit.as_ref().is_none_or(|exit| {
-                exit.wait_until(Instant::now() + Duration::from_secs(1))
-                    .expect("wait for failed hook descendant cleanup")
-            });
-            assert!(cleanup_completed, "failed hook descendant cleanup did not complete");
-        }
-        let _ = std::fs::remove_file(&child_pid_path);
-        let _ = std::fs::remove_file(&child_ready_path);
-        let _ = std::fs::remove_file(&hook_group_pid_path);
+        let descendant_stopped =
+            wait_for_fifo_event(lease_reader.as_raw_fd(), libc::POLLHUP, failure_deadline)
+                .expect("wait for hook descendant lease release");
+        let _ = std::fs::remove_file(&lease_path);
+        let _ = std::fs::remove_file(&release_path);
 
         assert_eq!(exit_code, Some(0), "{error:?}");
         assert_eq!(error, None);
-        assert!(!delivery_timed_out, "hook delivery needed failure cleanup");
-        assert!(child_stopped, "hook process-group cleanup left its stdin holder alive");
+        assert!(descendant_stopped, "hook process-group cleanup retained its stdin holder");
     }
 
     #[test]

--- a/cmux-tui/crates/cmux-tui-core/src/journal_hooks.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/journal_hooks.rs
@@ -969,7 +969,7 @@ mod tests {
         manifest.exec.argv = vec![
             "/bin/sh".into(),
             "-c".into(),
-            "exec 3<&0; (/bin/sh -c 'kill -STOP $$' <&3) & exit 0".into(),
+            "exec 3<&0; (/bin/cat <&3 >/dev/null) & exit 0".into(),
         ];
         let delivery = JournalHookDelivery {
             manifest,

--- a/cmux-tui/crates/cmux-tui-core/src/journal_hooks.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/journal_hooks.rs
@@ -969,6 +969,50 @@ mod tests {
     }
 
     #[cfg(any(target_os = "linux", target_vendor = "apple"))]
+    struct HookFixtureGates {
+        release: Option<std::fs::File>,
+        abort: Option<std::fs::File>,
+    }
+
+    #[cfg(any(target_os = "linux", target_vendor = "apple"))]
+    impl HookFixtureGates {
+        fn open(
+            release_path: &std::path::Path,
+            abort_path: &std::path::Path,
+        ) -> std::io::Result<Self> {
+            let release = std::fs::OpenOptions::new()
+                .read(true)
+                .write(true)
+                .custom_flags(libc::O_CLOEXEC)
+                .open(release_path)?;
+            let abort = std::fs::OpenOptions::new()
+                .read(true)
+                .write(true)
+                .custom_flags(libc::O_CLOEXEC)
+                .open(abort_path)?;
+            Ok(Self { release: Some(release), abort: Some(abort) })
+        }
+
+        fn release_direct_hook(&mut self) -> std::io::Result<()> {
+            let mut release = self.release.take().ok_or_else(|| {
+                std::io::Error::other("hook fixture release gate was already disarmed")
+            })?;
+            release.write_all(b"release\n")
+        }
+    }
+
+    #[cfg(any(target_os = "linux", target_vendor = "apple"))]
+    impl Drop for HookFixtureGates {
+        fn drop(&mut self) {
+            // These files must close before thread::scope joins the delivery
+            // worker. Closing release unblocks the direct hook, and closing
+            // abort lets its descendant leave voluntarily on every unwind.
+            self.release.take();
+            self.abort.take();
+        }
+    }
+
+    #[cfg(any(target_os = "linux", target_vendor = "apple"))]
     fn wait_for_fifo_event(
         descriptor: std::os::fd::RawFd,
         event: libc::c_short,
@@ -1052,12 +1096,6 @@ mod tests {
             .custom_flags(libc::O_NONBLOCK | libc::O_CLOEXEC)
             .open(&lease_path)
             .expect("register hook descendant lease reader");
-        let mut release_gate = std::fs::OpenOptions::new()
-            .read(true)
-            .write(true)
-            .custom_flags(libc::O_CLOEXEC)
-            .open(&release_path)
-            .expect("open hook release gate");
         let mut manifest = manifest();
         manifest.exec.argv = vec![
             "/bin/sh".into(),
@@ -1076,12 +1114,8 @@ mod tests {
         let attempt = JournalHookAttempt { attempt: 1, causation_id: "event_started".into() };
         let failure_deadline = Instant::now() + Duration::from_secs(2);
         let ((exit_code, error), descendant_stopped) = std::thread::scope(|scope| {
-            let abort_gate = std::fs::OpenOptions::new()
-                .read(true)
-                .write(true)
-                .custom_flags(libc::O_CLOEXEC)
-                .open(&abort_path)
-                .expect("open hook fixture abort gate");
+            let mut gates = HookFixtureGates::open(&release_path, &abort_path)
+                .expect("open hook fixture gates");
             let (result_tx, result_rx) = mpsc::sync_channel(1);
             scope.spawn(move || {
                 let _ = result_tx.send(execute_delivery(&delivery, &attempt));
@@ -1094,15 +1128,12 @@ mod tests {
             lease_reader.read_exact(&mut ready).expect("read hook descendant lease publication");
             assert_eq!(&ready, b"ready\n");
             drop(lease_registration);
-            release_gate.write_all(b"release\n").expect("release direct hook process");
+            gates.release_direct_hook().expect("release direct hook process");
             let result = match result_rx
                 .recv_timeout(failure_deadline.saturating_duration_since(Instant::now()))
             {
                 Ok(result) => result,
-                Err(error) => {
-                    drop(abort_gate);
-                    panic!("hook delivery did not complete after release: {error}");
-                }
+                Err(error) => panic!("hook delivery did not complete after release: {error}"),
             };
             let descendant_stopped = wait_for_fifo_eof(&mut lease_reader, failure_deadline)
                 .expect("wait for hook descendant lease release");

--- a/cmux-tui/crates/cmux-tui-core/src/journal_hooks.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/journal_hooks.rs
@@ -1006,6 +1006,27 @@ mod tests {
     }
 
     #[cfg(any(target_os = "linux", target_vendor = "apple"))]
+    fn wait_for_fifo_eof(reader: &mut std::fs::File, deadline: Instant) -> std::io::Result<bool> {
+        loop {
+            if !wait_for_fifo_event(reader.as_raw_fd(), libc::POLLIN | libc::POLLHUP, deadline)? {
+                return Ok(false);
+            }
+            let mut unexpected = [0; 1];
+            match reader.read(&mut unexpected) {
+                Ok(0) => return Ok(true),
+                Ok(_) => {
+                    return Err(std::io::Error::other(
+                        "hook descendant wrote after its lease publication",
+                    ));
+                }
+                Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => {}
+                Err(error) if error.kind() == std::io::ErrorKind::Interrupted => {}
+                Err(error) => return Err(error),
+            }
+        }
+    }
+
+    #[cfg(any(target_os = "linux", target_vendor = "apple"))]
     #[test]
     fn hook_exit_is_not_blocked_by_a_descendant_holding_stdin_open() {
         let fixture_path = std::env::temp_dir().join(format!(
@@ -1070,9 +1091,8 @@ mod tests {
                 .recv_timeout(failure_deadline.saturating_duration_since(Instant::now()))
                 .expect("hook delivery did not complete after release")
         });
-        let descendant_stopped =
-            wait_for_fifo_event(lease_reader.as_raw_fd(), libc::POLLHUP, failure_deadline)
-                .expect("wait for hook descendant lease release");
+        let descendant_stopped = wait_for_fifo_eof(&mut lease_reader, failure_deadline)
+            .expect("wait for hook descendant lease release");
         let _ = std::fs::remove_file(&lease_path);
         let _ = std::fs::remove_file(&release_path);
 

--- a/cmux-tui/crates/cmux-tui-core/src/journal_hooks.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/journal_hooks.rs
@@ -1036,7 +1036,8 @@ mod tests {
         ));
         let lease_path = fixture_path.with_extension("lease");
         let release_path = fixture_path.with_extension("release");
-        for path in [&lease_path, &release_path] {
+        let abort_path = fixture_path.with_extension("abort");
+        for path in [&lease_path, &release_path, &abort_path] {
             let path = std::ffi::CString::new(path.as_os_str().as_bytes())
                 .expect("hook fixture FIFO path");
             assert_eq!(unsafe { libc::mkfifo(path.as_ptr(), 0o600) }, 0);
@@ -1061,10 +1062,11 @@ mod tests {
         manifest.exec.argv = vec![
             "/bin/sh".into(),
             "-c".into(),
-            "exec 3<&0; (/bin/sh -c 'exec 4>\"$1\"; printf \"ready\\n\" >&4; kill -STOP $$' cmux-hook-child \"$1\" <&3) & IFS= read -r release < \"$2\"; exit 0".into(),
+            "exec 3<&0; (/bin/sh -c 'exec 4>\"$1\"; printf \"ready\\n\" >&4; IFS= read -r abort < \"$2\"' cmux-hook-child \"$1\" \"$3\" <&3) & IFS= read -r release < \"$2\"; exit 0".into(),
             "cmux-hook-test".into(),
             lease_path.to_string_lossy().into_owned(),
             release_path.to_string_lossy().into_owned(),
+            abort_path.to_string_lossy().into_owned(),
         ];
         let delivery = JournalHookDelivery {
             manifest,
@@ -1073,7 +1075,13 @@ mod tests {
         };
         let attempt = JournalHookAttempt { attempt: 1, causation_id: "event_started".into() };
         let failure_deadline = Instant::now() + Duration::from_secs(2);
-        let (exit_code, error) = std::thread::scope(|scope| {
+        let ((exit_code, error), descendant_stopped) = std::thread::scope(|scope| {
+            let abort_gate = std::fs::OpenOptions::new()
+                .read(true)
+                .write(true)
+                .custom_flags(libc::O_CLOEXEC)
+                .open(&abort_path)
+                .expect("open hook fixture abort gate");
             let (result_tx, result_rx) = mpsc::sync_channel(1);
             scope.spawn(move || {
                 let _ = result_tx.send(execute_delivery(&delivery, &attempt));
@@ -1087,14 +1095,22 @@ mod tests {
             assert_eq!(&ready, b"ready\n");
             drop(lease_registration);
             release_gate.write_all(b"release\n").expect("release direct hook process");
-            result_rx
+            let result = match result_rx
                 .recv_timeout(failure_deadline.saturating_duration_since(Instant::now()))
-                .expect("hook delivery did not complete after release")
+            {
+                Ok(result) => result,
+                Err(error) => {
+                    drop(abort_gate);
+                    panic!("hook delivery did not complete after release: {error}");
+                }
+            };
+            let descendant_stopped = wait_for_fifo_eof(&mut lease_reader, failure_deadline)
+                .expect("wait for hook descendant lease release");
+            (result, descendant_stopped)
         });
-        let descendant_stopped = wait_for_fifo_eof(&mut lease_reader, failure_deadline)
-            .expect("wait for hook descendant lease release");
         let _ = std::fs::remove_file(&lease_path);
         let _ = std::fs::remove_file(&release_path);
+        let _ = std::fs::remove_file(&abort_path);
 
         assert_eq!(exit_code, Some(0), "{error:?}");
         assert_eq!(error, None);

--- a/cmux-tui/crates/cmux-tui-core/src/journal_hooks.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/journal_hooks.rs
@@ -845,6 +845,10 @@ mod tests {
     };
     use serde_json::Value;
     use sha2::Digest;
+    #[cfg(any(target_os = "linux", target_vendor = "apple"))]
+    use std::os::fd::{FromRawFd, OwnedFd};
+    #[cfg(any(target_os = "linux", target_vendor = "apple"))]
+    use std::os::unix::ffi::OsStrExt;
 
     fn document(kind: &str, payload: Value) -> JournalDocument {
         JournalDocument::new(SessionJournalRecord {
@@ -962,14 +966,137 @@ mod tests {
         assert!(!filter.matches(&manifest, &document("hook.delivery.completed", json!({}))));
     }
 
-    #[cfg(unix)]
+    #[cfg(any(target_os = "linux", target_vendor = "apple"))]
+    struct TestProcessExitSignal {
+        descriptor: OwnedFd,
+    }
+
+    #[cfg(any(target_os = "linux", target_vendor = "apple"))]
+    impl TestProcessExitSignal {
+        fn observe(pid: libc::pid_t) -> std::io::Result<Option<Self>> {
+            if unsafe { libc::kill(pid, 0) } < 0
+                && std::io::Error::last_os_error().raw_os_error() == Some(libc::ESRCH)
+            {
+                return Ok(None);
+            }
+            #[cfg(target_os = "linux")]
+            let descriptor = unsafe { libc::syscall(libc::SYS_pidfd_open, pid, 0) } as libc::c_int;
+            #[cfg(target_vendor = "apple")]
+            let descriptor = unsafe { libc::kqueue() };
+            if descriptor < 0 {
+                let error = std::io::Error::last_os_error();
+                if error.raw_os_error() == Some(libc::ESRCH) {
+                    return Ok(None);
+                }
+                return Err(error);
+            }
+            // SAFETY: pidfd_open or kqueue returned a new owned descriptor.
+            let descriptor = unsafe { OwnedFd::from_raw_fd(descriptor) };
+            #[cfg(target_vendor = "apple")]
+            {
+                let change = libc::kevent {
+                    ident: pid as libc::uintptr_t,
+                    filter: libc::EVFILT_PROC,
+                    flags: libc::EV_ADD | libc::EV_ENABLE | libc::EV_ONESHOT,
+                    fflags: libc::NOTE_EXIT,
+                    data: 0,
+                    udata: std::ptr::null_mut(),
+                };
+                if unsafe {
+                    libc::kevent(
+                        descriptor.as_raw_fd(),
+                        &raw const change,
+                        1,
+                        std::ptr::null_mut(),
+                        0,
+                        std::ptr::null(),
+                    )
+                } < 0
+                {
+                    let error = std::io::Error::last_os_error();
+                    if error.raw_os_error() == Some(libc::ESRCH) {
+                        return Ok(None);
+                    }
+                    return Err(error);
+                }
+            }
+            Ok(Some(Self { descriptor }))
+        }
+
+        fn wait_until(&self, deadline: Instant) -> std::io::Result<bool> {
+            #[cfg(target_os = "linux")]
+            {
+                let mut descriptor = libc::pollfd {
+                    fd: self.descriptor.as_raw_fd(),
+                    events: libc::POLLIN,
+                    revents: 0,
+                };
+                loop {
+                    let remaining = deadline.saturating_duration_since(Instant::now());
+                    let timeout_ms =
+                        remaining.as_millis().min(libc::c_int::MAX as u128) as libc::c_int;
+                    let ready = unsafe { libc::poll(&raw mut descriptor, 1, timeout_ms) };
+                    if ready >= 0 {
+                        return Ok(ready > 0);
+                    }
+                    let error = std::io::Error::last_os_error();
+                    if error.kind() != std::io::ErrorKind::Interrupted {
+                        return Err(error);
+                    }
+                }
+            }
+            #[cfg(target_vendor = "apple")]
+            {
+                let mut event = unsafe { std::mem::zeroed::<libc::kevent>() };
+                loop {
+                    let remaining = deadline.saturating_duration_since(Instant::now());
+                    let timeout = libc::timespec {
+                        tv_sec: libc::time_t::try_from(remaining.as_secs())
+                            .unwrap_or(libc::time_t::MAX),
+                        tv_nsec: libc::c_long::from(remaining.subsec_nanos()),
+                    };
+                    let ready = unsafe {
+                        libc::kevent(
+                            self.descriptor.as_raw_fd(),
+                            std::ptr::null(),
+                            0,
+                            &raw mut event,
+                            1,
+                            &raw const timeout,
+                        )
+                    };
+                    if ready >= 0 {
+                        return Ok(ready > 0);
+                    }
+                    let error = std::io::Error::last_os_error();
+                    if error.kind() != std::io::ErrorKind::Interrupted {
+                        return Err(error);
+                    }
+                }
+            }
+        }
+    }
+
+    #[cfg(any(target_os = "linux", target_vendor = "apple"))]
     #[test]
     fn hook_exit_is_not_blocked_by_a_descendant_holding_stdin_open() {
+        let child_pid_path = std::env::temp_dir().join(format!(
+            "cmux-hook-stdin-child-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now().duration_since(std::time::UNIX_EPOCH).unwrap().as_nanos()
+        ));
+        let child_ready_path = child_pid_path.with_extension("ready");
+        let child_ready_c_path = std::ffi::CString::new(child_ready_path.as_os_str().as_bytes())
+            .expect("hook descendant ready path");
+        assert_eq!(unsafe { libc::mkfifo(child_ready_c_path.as_ptr(), 0o600) }, 0);
         let mut manifest = manifest();
         manifest.exec.argv = vec![
             "/bin/sh".into(),
             "-c".into(),
-            "exec 3<&0; (/bin/cat <&3 >/dev/null) & exit 0".into(),
+            "exec 3<&0; (/bin/sh -c 'printf \"ready\\n\" > \"$1\"; kill -STOP $$' cmux-hook-child \"$2\" <&3) & printf '%s\\n' \"$!\" > \"$1\"; IFS= read -r ready < \"$2\"; exit 0".into(),
+            "cmux-hook-test".into(),
+            child_pid_path.to_string_lossy().into_owned(),
+            child_ready_path.to_string_lossy().into_owned(),
         ];
         let delivery = JournalHookDelivery {
             manifest,
@@ -978,9 +1105,23 @@ mod tests {
         };
         let attempt = JournalHookAttempt { attempt: 1, causation_id: "event_started".into() };
         let (exit_code, error) = execute_delivery(&delivery, &attempt);
+        let child_pid = std::fs::read_to_string(&child_pid_path)
+            .expect("hook descendant PID publication")
+            .trim()
+            .parse::<libc::pid_t>()
+            .expect("hook descendant PID");
+        let child_exit =
+            TestProcessExitSignal::observe(child_pid).expect("observe hook descendant exit");
+        let child_stopped = child_exit.is_none_or(|exit| {
+            exit.wait_until(Instant::now() + Duration::from_secs(1))
+                .expect("wait for hook descendant cleanup")
+        });
+        let _ = std::fs::remove_file(&child_pid_path);
+        let _ = std::fs::remove_file(&child_ready_path);
 
         assert_eq!(exit_code, Some(0), "{error:?}");
         assert_eq!(error, None);
+        assert!(child_stopped, "hook process-group cleanup left its stdin holder alive");
     }
 
     #[test]

--- a/cmux-tui/crates/cmux-tui-core/src/journal_hooks.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/journal_hooks.rs
@@ -966,20 +966,21 @@ mod tests {
     #[test]
     fn hook_exit_is_not_blocked_by_a_descendant_holding_stdin_open() {
         let mut manifest = manifest();
-        manifest.exec.argv =
-            vec!["/bin/sh".into(), "-c".into(), "exec 3<&0; (/bin/sleep 3 <&3) & exit 0".into()];
+        manifest.exec.argv = vec![
+            "/bin/sh".into(),
+            "-c".into(),
+            "exec 3<&0; (/bin/sh -c 'kill -STOP $$' <&3) & exit 0".into(),
+        ];
         let delivery = JournalHookDelivery {
             manifest,
             event: document("plugin.test.large", json!({"value":"x".repeat(1024 * 1024)})).record,
             attempt: 0,
         };
         let attempt = JournalHookAttempt { attempt: 1, causation_id: "event_started".into() };
-        let started = Instant::now();
         let (exit_code, error) = execute_delivery(&delivery, &attempt);
 
         assert_eq!(exit_code, Some(0), "{error:?}");
         assert_eq!(error, None);
-        assert!(started.elapsed() < Duration::from_secs(1));
     }
 
     #[test]

--- a/cmux-tui/crates/cmux-tui-core/src/journal_hooks.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/journal_hooks.rs
@@ -846,7 +846,7 @@ mod tests {
     use serde_json::Value;
     use sha2::Digest;
     #[cfg(any(target_os = "linux", target_vendor = "apple"))]
-    use std::os::fd::{FromRawFd, OwnedFd};
+    use std::os::fd::{AsRawFd, FromRawFd, OwnedFd};
     #[cfg(any(target_os = "linux", target_vendor = "apple"))]
     use std::os::unix::ffi::OsStrExt;
 
@@ -1086,6 +1086,7 @@ mod tests {
             std::time::SystemTime::now().duration_since(std::time::UNIX_EPOCH).unwrap().as_nanos()
         ));
         let child_ready_path = child_pid_path.with_extension("ready");
+        let hook_group_pid_path = child_pid_path.with_extension("group");
         let child_ready_c_path = std::ffi::CString::new(child_ready_path.as_os_str().as_bytes())
             .expect("hook descendant ready path");
         assert_eq!(unsafe { libc::mkfifo(child_ready_c_path.as_ptr(), 0o600) }, 0);
@@ -1093,10 +1094,11 @@ mod tests {
         manifest.exec.argv = vec![
             "/bin/sh".into(),
             "-c".into(),
-            "exec 3<&0; (/bin/sh -c 'printf \"ready\\n\" > \"$1\"; kill -STOP $$' cmux-hook-child \"$2\" <&3) & printf '%s\\n' \"$!\" > \"$1\"; IFS= read -r ready < \"$2\"; exit 0".into(),
+            "printf '%s\\n' \"$$\" > \"$3\"; exec 3<&0; (/bin/sh -c 'printf \"ready\\n\" > \"$1\"; kill -STOP $$' cmux-hook-child \"$2\" <&3) & printf '%s\\n' \"$!\" > \"$1\"; IFS= read -r ready < \"$2\"; exit 0".into(),
             "cmux-hook-test".into(),
             child_pid_path.to_string_lossy().into_owned(),
             child_ready_path.to_string_lossy().into_owned(),
+            hook_group_pid_path.to_string_lossy().into_owned(),
         ];
         let delivery = JournalHookDelivery {
             manifest,
@@ -1104,7 +1106,34 @@ mod tests {
             attempt: 0,
         };
         let attempt = JournalHookAttempt { attempt: 1, causation_id: "event_started".into() };
-        let (exit_code, error) = execute_delivery(&delivery, &attempt);
+        let (exit_code, error) = std::thread::scope(|scope| {
+            let (result_tx, result_rx) = mpsc::sync_channel(1);
+            scope.spawn(move || {
+                let _ = result_tx.send(execute_delivery(&delivery, &attempt));
+            });
+            match result_rx.recv_timeout(Duration::from_secs(2)) {
+                Ok(result) => result,
+                Err(mpsc::RecvTimeoutError::Timeout) => {
+                    if let Ok(process_group) = std::fs::read_to_string(&hook_group_pid_path)
+                        .and_then(|pid| {
+                            pid.trim().parse::<libc::pid_t>().map_err(std::io::Error::other)
+                        })
+                    {
+                        // SAFETY: the hook executable publishes its isolated
+                        // process group before it starts the blocking fixture.
+                        unsafe {
+                            libc::kill(-process_group, libc::SIGKILL);
+                        }
+                    }
+                    result_rx
+                        .recv_timeout(Duration::from_secs(1))
+                        .expect("hook delivery did not stop after failure cleanup")
+                }
+                Err(mpsc::RecvTimeoutError::Disconnected) => {
+                    panic!("hook delivery worker stopped without a result")
+                }
+            }
+        });
         let child_pid = std::fs::read_to_string(&child_pid_path)
             .expect("hook descendant PID publication")
             .trim()
@@ -1118,6 +1147,7 @@ mod tests {
         });
         let _ = std::fs::remove_file(&child_pid_path);
         let _ = std::fs::remove_file(&child_ready_path);
+        let _ = std::fs::remove_file(&hook_group_pid_path);
 
         assert_eq!(exit_code, Some(0), "{error:?}");
         assert_eq!(error, None);

--- a/cmux-tui/crates/cmux-tui-core/src/journal_hooks.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/journal_hooks.rs
@@ -1106,13 +1106,13 @@ mod tests {
             attempt: 0,
         };
         let attempt = JournalHookAttempt { attempt: 1, causation_id: "event_started".into() };
-        let (exit_code, error) = std::thread::scope(|scope| {
+        let ((exit_code, error), delivery_timed_out) = std::thread::scope(|scope| {
             let (result_tx, result_rx) = mpsc::sync_channel(1);
             scope.spawn(move || {
                 let _ = result_tx.send(execute_delivery(&delivery, &attempt));
             });
             match result_rx.recv_timeout(Duration::from_secs(2)) {
-                Ok(result) => result,
+                Ok(result) => (result, false),
                 Err(mpsc::RecvTimeoutError::Timeout) => {
                     if let Ok(process_group) = std::fs::read_to_string(&hook_group_pid_path)
                         .and_then(|pid| {
@@ -1125,9 +1125,12 @@ mod tests {
                             libc::kill(-process_group, libc::SIGKILL);
                         }
                     }
-                    result_rx
-                        .recv_timeout(Duration::from_secs(1))
-                        .expect("hook delivery did not stop after failure cleanup")
+                    (
+                        result_rx
+                            .recv_timeout(Duration::from_secs(1))
+                            .expect("hook delivery did not stop after failure cleanup"),
+                        true,
+                    )
                 }
                 Err(mpsc::RecvTimeoutError::Disconnected) => {
                     panic!("hook delivery worker stopped without a result")
@@ -1151,6 +1154,7 @@ mod tests {
 
         assert_eq!(exit_code, Some(0), "{error:?}");
         assert_eq!(error, None);
+        assert!(!delivery_timed_out, "hook delivery needed failure cleanup");
         assert!(child_stopped, "hook process-group cleanup left its stdin holder alive");
     }
 

--- a/cmux-tui/crates/cmux-tui-core/src/journal_ingress.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/journal_ingress.rs
@@ -2,6 +2,8 @@ use std::collections::VecDeque;
 use std::mem::size_of;
 use std::sync::mpsc::{Receiver, SyncSender, TryRecvError, TrySendError, sync_channel};
 use std::sync::{Arc, Weak};
+#[cfg(test)]
+use std::sync::{Condvar, Mutex};
 use std::time::Duration;
 
 use serde::{Deserialize, Serialize};
@@ -221,29 +223,103 @@ pub(crate) struct JournalIngressSender {
     terminal_sender: Option<SyncSender<QueuedJournalEvent>>,
     durable_sender: Option<SyncSender<QueuedJournalEvent>>,
     wake_sender: Option<SyncSender<()>>,
+    #[cfg(test)]
+    observer: Arc<JournalIngressTestObserver>,
 }
 
 pub(crate) struct JournalIngressReceivers {
     terminal: Receiver<QueuedJournalEvent>,
     durable: Receiver<QueuedJournalEvent>,
     wake: Receiver<()>,
+    #[cfg(test)]
+    observer: Arc<JournalIngressTestObserver>,
+}
+
+#[cfg(test)]
+#[derive(Default)]
+struct JournalIngressTestObserver {
+    next_failure: Mutex<Option<Arc<JournalIngressFailureState>>>,
+}
+
+#[cfg(test)]
+#[derive(Default)]
+struct JournalIngressFailureState {
+    observed: Mutex<bool>,
+    changed: Condvar,
+}
+
+#[cfg(test)]
+pub(crate) struct JournalIngressFailureObservation {
+    state: Arc<JournalIngressFailureState>,
+}
+
+#[cfg(test)]
+impl JournalIngressFailureObservation {
+    pub(crate) fn wait(self, timeout: Duration) -> bool {
+        let observed = self.state.observed.lock().unwrap();
+        if *observed {
+            return true;
+        }
+        let (observed, _) = self
+            .state
+            .changed
+            .wait_timeout_while(observed, timeout, |observed| !*observed)
+            .unwrap();
+        *observed
+    }
+}
+
+#[cfg(test)]
+impl JournalIngressTestObserver {
+    fn observe_next_failure(&self) -> JournalIngressFailureObservation {
+        let state = Arc::new(JournalIngressFailureState::default());
+        *self.next_failure.lock().unwrap() = Some(state.clone());
+        JournalIngressFailureObservation { state }
+    }
+
+    fn mark_failure_observed(&self) {
+        let Some(state) = self.next_failure.lock().unwrap().take() else {
+            return;
+        };
+        *state.observed.lock().unwrap() = true;
+        state.changed.notify_all();
+    }
 }
 
 impl JournalIngressSender {
     pub(crate) fn new(enabled: bool) -> (Self, Option<JournalIngressReceivers>) {
         if !enabled {
-            return (Self { terminal_sender: None, durable_sender: None, wake_sender: None }, None);
+            return (
+                Self {
+                    terminal_sender: None,
+                    durable_sender: None,
+                    wake_sender: None,
+                    #[cfg(test)]
+                    observer: Arc::new(JournalIngressTestObserver::default()),
+                },
+                None,
+            );
         }
         let (terminal_sender, terminal) = sync_channel(JOURNAL_TERMINAL_QUEUE_CAPACITY);
         let (durable_sender, durable) = sync_channel(JOURNAL_DURABLE_QUEUE_CAPACITY);
         let (wake_sender, wake) = sync_channel(1);
+        #[cfg(test)]
+        let observer = Arc::new(JournalIngressTestObserver::default());
         (
             Self {
                 terminal_sender: Some(terminal_sender),
                 durable_sender: Some(durable_sender),
                 wake_sender: Some(wake_sender),
+                #[cfg(test)]
+                observer: observer.clone(),
             },
-            Some(JournalIngressReceivers { terminal, durable, wake }),
+            Some(JournalIngressReceivers {
+                terminal,
+                durable,
+                wake,
+                #[cfg(test)]
+                observer,
+            }),
         )
     }
 
@@ -339,6 +415,11 @@ impl JournalIngressSender {
         self.terminal_sender.is_some()
     }
 
+    #[cfg(test)]
+    pub(crate) fn observe_next_failure(&self) -> JournalIngressFailureObservation {
+        self.observer.observe_next_failure()
+    }
+
     fn enqueue(
         &self,
         sender: &SyncSender<QueuedJournalEvent>,
@@ -390,6 +471,8 @@ fn run(mux: Weak<Mux>, receivers: JournalIngressReceivers) {
                         break;
                     }
                     Err(error) => {
+                        #[cfg(test)]
+                        receivers.observer.mark_failure_observed();
                         let summary = format!("{error:#}");
                         if reported_error.as_deref() != Some(summary.as_str()) {
                             eprintln!("cmux-tui: append session journal batch: {summary}");
@@ -650,6 +733,7 @@ mod tests {
                  END;",
             )
             .unwrap();
+        let failure = mux.observe_next_journal_ingress_failure_for_test();
 
         let terminal_id = Arc::new(public_id("term", 11, TerminalPublicId::parse));
         mux.journal_terminal_output(
@@ -657,7 +741,7 @@ mod tests {
             Arc::from("writer-retry-generation"),
             b"must survive retry".to_vec(),
         );
-        std::thread::sleep(Duration::from_millis(500));
+        assert!(failure.wait(Duration::from_secs(2)), "journal writer did not report the failure");
         injector.execute_batch("DROP TRIGGER reject_test_terminal_output;").unwrap();
         mux.flush_terminal_journal().unwrap();
 

--- a/cmux-tui/crates/cmux-tui-core/src/journal_ingress.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/journal_ingress.rs
@@ -467,6 +467,10 @@ fn run(mux: Weak<Mux>, receivers: JournalIngressReceivers) {
                 let events = batch.iter().map(|queued| &queued.event).collect::<Vec<_>>();
                 match mux.commit_session_journal_events(&events) {
                     Ok(commits) => {
+                        // A durable completion also closes this batch's ownership scope. Callers
+                        // may tear down the mux as soon as the receipt arrives, so release the
+                        // writer's transient owner before waking them.
+                        drop(mux);
                         complete_batch_success(&batch, commits);
                         break;
                     }

--- a/cmux-tui/crates/cmux-tui-core/src/mux.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/mux.rs
@@ -1558,11 +1558,18 @@ fn validate_cell_pixel_convergence(
 pub(crate) struct ResourceWaitWake {
     notified: Mutex<bool>,
     changed: Condvar,
+    #[cfg(test)]
+    waiting_without_deadline: AtomicBool,
 }
 
 impl Default for ResourceWaitWake {
     fn default() -> Self {
-        Self { notified: Mutex::new(false), changed: Condvar::new() }
+        Self {
+            notified: Mutex::new(false),
+            changed: Condvar::new(),
+            #[cfg(test)]
+            waiting_without_deadline: AtomicBool::new(false),
+        }
     }
 }
 
@@ -1588,10 +1595,21 @@ impl ResourceWaitWake {
                         return false;
                     }
                 }
-                None => notified = self.changed.wait(notified).unwrap(),
+                None => {
+                    #[cfg(test)]
+                    self.waiting_without_deadline.store(true, Ordering::Release);
+                    notified = self.changed.wait(notified).unwrap();
+                    #[cfg(test)]
+                    self.waiting_without_deadline.store(false, Ordering::Release);
+                }
             }
         }
         true
+    }
+
+    #[cfg(test)]
+    pub(crate) fn is_waiting_without_deadline(&self) -> bool {
+        self.waiting_without_deadline.load(Ordering::Acquire)
     }
 }
 
@@ -1685,6 +1703,19 @@ impl TerminalExitWaiters {
     #[cfg(test)]
     fn waiter_count(&self, terminal_id: &TerminalPublicId) -> usize {
         self.waiters.lock().unwrap().get(terminal_id).map(HashMap::len).unwrap_or_default()
+    }
+
+    #[cfg(test)]
+    fn waiting_without_deadline_count(&self, terminal_id: &TerminalPublicId) -> usize {
+        self.waiters
+            .lock()
+            .unwrap()
+            .get(terminal_id)
+            .into_iter()
+            .flat_map(HashMap::values)
+            .filter_map(|waiter| waiter.upgrade())
+            .filter(|waiter| waiter.is_waiting_without_deadline())
+            .count()
     }
 }
 
@@ -4446,6 +4477,14 @@ impl Mux {
         terminal_id: &TerminalPublicId,
     ) -> usize {
         self.terminal_exit_waiters.waiter_count(terminal_id)
+    }
+
+    #[cfg(test)]
+    pub(crate) fn terminal_exit_indefinite_waiter_count_for_test(
+        &self,
+        terminal_id: &TerminalPublicId,
+    ) -> usize {
+        self.terminal_exit_waiters.waiting_without_deadline_count(terminal_id)
     }
 
     #[cfg(test)]

--- a/cmux-tui/crates/cmux-tui-core/src/mux.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/mux.rs
@@ -4889,6 +4889,13 @@ impl Mux {
     }
 
     #[cfg(test)]
+    pub(crate) fn observe_next_journal_ingress_failure_for_test(
+        &self,
+    ) -> crate::journal_ingress::JournalIngressFailureObservation {
+        self.journal_ingress.observe_next_failure()
+    }
+
+    #[cfg(test)]
     pub(crate) fn journal_database_reader_count_for_test(&self) -> u64 {
         self.journal_kernel.database_reader_count()
     }
@@ -19638,22 +19645,14 @@ mod tests {
 
         mux.workspace_registry.lock().unwrap().set_resource_patch_failure(false).unwrap();
         let deadline = Instant::now() + Duration::from_secs(2);
-        loop {
-            let detached = mux.resolve_terminal(TERMINAL).unwrap().unwrap().surface.is_none();
-            let retry_finished = !mux.terminal_exit_detaches.contains(TERMINAL);
-            if detached && retry_finished {
-                break;
-            }
-            assert!(Instant::now() < deadline, "atomic exit retry did not detach the terminal");
-            std::thread::sleep(Duration::from_millis(5));
-        }
+        assert!(
+            mux.terminal_exit_detaches.wait_until_finished(TERMINAL, deadline),
+            "atomic exit retry did not detach the terminal"
+        );
+        assert!(mux.resolve_terminal(TERMINAL).unwrap().unwrap().surface.is_none());
         assert_eq!(
             mux.resolve_terminal(TERMINAL).unwrap().unwrap().terminal.lifecycle,
             TerminalLifecycle::Exited
-        );
-        assert!(
-            mux.terminal_exit_detaches.wait_until_finished(TERMINAL, deadline),
-            "terminal detach retry worker did not release its ownership"
         );
     }
 

--- a/cmux-tui/crates/cmux-tui-core/src/server.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/server.rs
@@ -1401,6 +1401,8 @@ struct ResourceWorkerAdmission {
     per_client_capacity: usize,
     server_capacity: usize,
     state: Mutex<ResourceWorkerAdmissionState>,
+    #[cfg(test)]
+    changed: Condvar,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -1430,6 +1432,11 @@ impl Drop for ResourceWorkerPermitLease {
         if remove_client {
             state.active_by_client.remove(&self.client);
         }
+        #[cfg(test)]
+        {
+            drop(state);
+            self.admission.changed.notify_all();
+        }
     }
 }
 
@@ -1439,6 +1446,8 @@ impl ResourceWorkerAdmission {
             per_client_capacity,
             server_capacity,
             state: Mutex::new(ResourceWorkerAdmissionState::default()),
+            #[cfg(test)]
+            changed: Condvar::new(),
         })
     }
 
@@ -1457,6 +1466,11 @@ impl ResourceWorkerAdmission {
         }
         state.active += 1;
         *state.active_by_client.entry(client).or_default() += 1;
+        #[cfg(test)]
+        {
+            drop(state);
+            self.changed.notify_all();
+        }
         Ok(ResourceWorkerPermit {
             _lease: Arc::new(ResourceWorkerPermitLease { admission: self.clone(), client }),
         })
@@ -1465,6 +1479,23 @@ impl ResourceWorkerAdmission {
     #[cfg(test)]
     fn active(&self) -> usize {
         self.state.lock().unwrap().active
+    }
+
+    #[cfg(test)]
+    fn wait_for_active(&self, expected: usize, deadline: Instant) -> bool {
+        let mut state = self.state.lock().unwrap();
+        while state.active != expected {
+            let remaining = deadline.saturating_duration_since(Instant::now());
+            if remaining.is_zero() {
+                return false;
+            }
+            let (next, timeout) = self.changed.wait_timeout(state, remaining).unwrap();
+            state = next;
+            if timeout.timed_out() && state.active != expected {
+                return false;
+            }
+        }
+        true
     }
 }
 
@@ -2965,6 +2996,27 @@ impl BoundedOutbound {
             self.changed.notify_all();
         }
         text
+    }
+
+    #[cfg(test)]
+    fn pop_until(&self, deadline: Instant) -> Option<String> {
+        let mut state = self.state.lock().unwrap();
+        loop {
+            if let Some(text) = Self::pop_locked(&mut state) {
+                drop(state);
+                self.changed.notify_all();
+                return Some(text.to_string());
+            }
+            let remaining = deadline.saturating_duration_since(Instant::now());
+            if remaining.is_zero() {
+                return None;
+            }
+            let (next, timeout) = self.changed.wait_timeout(state, remaining).unwrap();
+            state = next;
+            if timeout.timed_out() {
+                return None;
+            }
+        }
     }
 
     fn recv(&self) -> Option<Arc<BudgetedText>> {
@@ -13051,13 +13103,8 @@ mod tests {
 
     fn pop_json(outbound: &BoundedOutbound) -> Value {
         let deadline = Instant::now() + Duration::from_secs(2);
-        loop {
-            if let Some(message) = outbound.try_pop() {
-                return serde_json::from_str(&message).expect("outbound JSON");
-            }
-            assert!(Instant::now() < deadline, "timed out waiting for outbound JSON");
-            std::thread::sleep(Duration::from_millis(2));
-        }
+        let message = outbound.pop_until(deadline).expect("timed out waiting for outbound JSON");
+        serde_json::from_str(&message).expect("outbound JSON")
     }
 
     fn resource_request(
@@ -13655,7 +13702,6 @@ mod tests {
             assert!(Instant::now() < waiting_deadline, "terminal wait did not become idle");
             std::thread::yield_now();
         }
-        std::thread::sleep(Duration::from_millis(350));
         assert_eq!(
             surface.terminal_stream_subscription_count_for_test(),
             Some(1),
@@ -13715,13 +13761,12 @@ mod tests {
         assert!(first.persist_terminal_exit_for_test(&terminal_id, &exit).unwrap());
         assert_eq!(first.resource_surface_for_terminal(&terminal_id), None);
         assert!(disconnect_client(&first, client, false));
-        drop(scheduler);
+        assert!(
+            scheduler.close_and_wait(Duration::from_secs(10)),
+            "terminal request dispatcher did not stop"
+        );
         drop(writer);
         first.shutdown();
-        let shutdown_deadline = Instant::now() + Duration::from_secs(10);
-        while Arc::strong_count(&first) > 1 && Instant::now() < shutdown_deadline {
-            std::thread::sleep(Duration::from_millis(10));
-        }
         assert_eq!(Arc::strong_count(&first), 1, "terminal workers retained the first mux");
         drop(first);
 
@@ -13803,7 +13848,6 @@ mod tests {
             assert!(Instant::now() < admission_deadline, "exit waits did not become idle");
             std::thread::yield_now();
         }
-        std::thread::sleep(Duration::from_millis(350));
         assert_eq!(
             mux.terminal_exit_state_query_count_for_test(),
             RESOURCE_WAITS_PER_CLIENT_CAPACITY as u64,
@@ -13989,13 +14033,13 @@ mod tests {
             );
             assert!(handle_connection_message(&mux, client, &wait, &writer, &scheduler));
         }
-        let admission_deadline = Instant::now() + Duration::from_secs(2);
-        while mux.control_clients.resource_wait_admission.active()
-            != RESOURCE_WAITS_PER_CLIENT_CAPACITY
-        {
-            assert!(Instant::now() < admission_deadline, "wait workers did not start");
-            std::thread::sleep(Duration::from_millis(2));
-        }
+        assert!(
+            mux.control_clients.resource_wait_admission.wait_for_active(
+                RESOURCE_WAITS_PER_CLIENT_CAPACITY,
+                Instant::now() + Duration::from_secs(2),
+            ),
+            "wait workers did not start"
+        );
 
         let rejected = resource_request(
             "unbounded-wait-rejected",
@@ -14016,14 +14060,12 @@ mod tests {
         assert_eq!(rejection["error"]["details"]["extra"]["scope"], "client");
 
         assert!(disconnect_client(&mux, client, false));
-        let cleanup_deadline = Instant::now() + Duration::from_secs(2);
-        while mux.control_clients.resource_wait_admission.active() != 0 {
-            assert!(
-                Instant::now() < cleanup_deadline,
-                "disconnected unbounded waits retained worker capacity"
-            );
-            std::thread::sleep(Duration::from_millis(2));
-        }
+        assert!(
+            mux.control_clients
+                .resource_wait_admission
+                .wait_for_active(0, Instant::now() + Duration::from_secs(2)),
+            "disconnected unbounded waits retained worker capacity"
+        );
     }
 
     #[test]
@@ -14071,14 +14113,12 @@ mod tests {
             mux.control_clients.contains(client),
             "test must isolate writer failure from registry disconnect"
         );
-        let cleanup_deadline = Instant::now() + Duration::from_secs(2);
-        while mux.control_clients.resource_wait_admission.active() != 0 {
-            assert!(
-                Instant::now() < cleanup_deadline,
-                "closed writer retained terminal wait worker capacity"
-            );
-            std::thread::sleep(Duration::from_millis(2));
-        }
+        assert!(
+            mux.control_clients
+                .resource_wait_admission
+                .wait_for_active(0, Instant::now() + Duration::from_secs(2)),
+            "closed writer retained terminal wait worker capacity"
+        );
         assert!(mux.control_clients.contains(client));
         assert!(disconnect_client(&mux, client, false));
     }
@@ -14139,11 +14179,12 @@ mod tests {
         assert_eq!(response["ok"], true);
         assert_eq!(response["result"]["state"], "pending");
 
-        let cleanup_deadline = Instant::now() + Duration::from_secs(2);
-        while mux.control_clients.resource_wait_admission.active() != 0 {
-            assert!(Instant::now() < cleanup_deadline, "zero-timeout wait retained capacity");
-            std::thread::sleep(Duration::from_millis(2));
-        }
+        assert!(
+            mux.control_clients
+                .resource_wait_admission
+                .wait_for_active(0, Instant::now() + Duration::from_secs(2)),
+            "zero-timeout wait retained capacity"
+        );
         assert!(disconnect_client(&mux, client, false));
     }
 
@@ -14262,14 +14303,12 @@ mod tests {
             drop(worker_permit);
         }
         assert!(disconnect_client(&mux, client, false));
-        let cleanup_deadline = Instant::now() + Duration::from_secs(2);
-        while mux.control_clients.resource_stream_admission.active() != 0 {
-            assert!(
-                Instant::now() < cleanup_deadline,
-                "ended streams retained server worker capacity"
-            );
-            std::thread::sleep(Duration::from_millis(2));
-        }
+        assert!(
+            mux.control_clients
+                .resource_stream_admission
+                .wait_for_active(0, Instant::now() + Duration::from_secs(2)),
+            "ended streams retained server worker capacity"
+        );
     }
 
     #[test]
@@ -14412,7 +14451,12 @@ mod tests {
         assert_eq!(response["type"], "response");
         assert_eq!(response["id"], "events-cancel");
         assert_eq!(response["ok"], true);
-        std::thread::sleep(Duration::from_millis(10));
+        assert!(
+            mux.control_clients
+                .resource_stream_admission
+                .wait_for_active(0, Instant::now() + Duration::from_secs(2)),
+            "canceled event stream retained worker capacity"
+        );
         assert!(outbound.try_pop().is_none(), "an item followed stream_end");
         disconnect_client(&mux, client, false);
     }

--- a/cmux-tui/crates/cmux-tui-core/src/server.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/server.rs
@@ -13755,6 +13755,10 @@ mod tests {
         let terminal_id =
             TerminalPublicId::parse(created["result"]["value"]["terminal_id"].as_str().unwrap())
                 .unwrap();
+        let terminal_surface = first
+            .resource_surface_for_terminal(&terminal_id)
+            .and_then(|surface| first.surface(surface))
+            .expect("created terminal surface");
         let exit = crate::terminal_host_protocol::TerminalExit {
             outcome: crate::terminal_host_protocol::TerminalExitOutcome::Exit { code: 0 },
             exited_at_ms: 4_567_890,
@@ -13762,13 +13766,19 @@ mod tests {
         assert!(first.persist_terminal_exit_for_test(&terminal_id, &exit).unwrap());
         assert_eq!(first.resource_surface_for_terminal(&terminal_id), None);
         assert!(disconnect_client(&first, client, false));
-        assert!(
-            scheduler.close_and_wait(Duration::from_secs(10)),
-            "terminal request dispatcher did not stop"
-        );
+        drop(scheduler);
         drop(writer);
+        terminal_surface.shutdown_for_daemon();
+        assert_eq!(
+            terminal_surface.wait_for_terminal_host_proxy_finish_for_test(
+                Instant::now() + Duration::from_secs(10)
+            ),
+            Some(true),
+            "terminal host proxy did not release the first mux"
+        );
         first.shutdown();
         assert_eq!(Arc::strong_count(&first), 1, "terminal workers retained the first mux");
+        drop(terminal_surface);
         drop(first);
 
         let reopened = Mux::open_persistent(session, SurfaceOptions::default(), &root).unwrap();

--- a/cmux-tui/crates/cmux-tui-core/src/server.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/server.rs
@@ -13698,6 +13698,7 @@ mod tests {
         let waiting_deadline = Instant::now() + Duration::from_secs(1);
         while surface.terminal_stream_waiter_count_for_test() != Some(1)
             || surface.terminal_stream_subscription_count_for_test() != Some(1)
+            || surface.terminal_stream_indefinite_waiter_count_for_test() != Some(1)
         {
             assert!(Instant::now() < waiting_deadline, "terminal wait did not become idle");
             std::thread::yield_now();
@@ -13705,7 +13706,7 @@ mod tests {
         assert_eq!(
             surface.terminal_stream_subscription_count_for_test(),
             Some(1),
-            "idle terminal.wait worker polled"
+            "idle terminal.wait worker resubscribed"
         );
 
         let cancel = resource_request(
@@ -13844,6 +13845,8 @@ mod tests {
             != RESOURCE_WAITS_PER_CLIENT_CAPACITY
             || mux.terminal_exit_state_query_count_for_test()
                 != RESOURCE_WAITS_PER_CLIENT_CAPACITY as u64
+            || mux.terminal_exit_indefinite_waiter_count_for_test(&terminal_id)
+                != RESOURCE_WAITS_PER_CLIENT_CAPACITY
         {
             assert!(Instant::now() < admission_deadline, "exit waits did not become idle");
             std::thread::yield_now();

--- a/cmux-tui/crates/cmux-tui-core/src/server.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/server.rs
@@ -13770,12 +13770,13 @@ mod tests {
         drop(writer);
         terminal_surface.shutdown_for_daemon();
         assert_eq!(
-            terminal_surface.wait_for_terminal_host_proxy_finish_for_test(
+            terminal_surface.wait_for_terminal_runtime_owners_for_test(
                 Instant::now() + Duration::from_secs(10)
             ),
             Some(true),
-            "terminal host proxy did not release the first mux"
+            "terminal runtime owners did not release the first mux"
         );
+        first.flush_terminal_journal().unwrap();
         first.shutdown();
         assert_eq!(Arc::strong_count(&first), 1, "terminal workers retained the first mux");
         drop(terminal_surface);

--- a/cmux-tui/crates/cmux-tui-core/src/surface.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/surface.rs
@@ -1716,6 +1716,18 @@ impl TerminalStreamProgress {
     fn resource_subscription_count(&self) -> u64 {
         self.state.lock().unwrap().resource_subscriptions
     }
+
+    #[cfg(test)]
+    fn resource_waiting_without_deadline_count(&self) -> usize {
+        self.state
+            .lock()
+            .unwrap()
+            .resource_waiters
+            .values()
+            .filter_map(|waiter| waiter.upgrade())
+            .filter(|waiter| waiter.is_waiting_without_deadline())
+            .count()
+    }
 }
 
 impl TerminalStreamSubscription<'_> {
@@ -3920,6 +3932,11 @@ impl Surface {
     #[cfg(test)]
     pub(crate) fn terminal_stream_subscription_count_for_test(&self) -> Option<u64> {
         Some(self.as_pty()?.stream_progress.resource_subscription_count())
+    }
+
+    #[cfg(test)]
+    pub(crate) fn terminal_stream_indefinite_waiter_count_for_test(&self) -> Option<usize> {
+        Some(self.as_pty()?.stream_progress.resource_waiting_without_deadline_count())
     }
 
     pub fn encode_mouse(

--- a/cmux-tui/crates/cmux-tui-core/src/surface.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/surface.rs
@@ -1208,30 +1208,36 @@ impl PtyTerminalRuntime {
 }
 
 #[cfg(test)]
-#[derive(Default)]
-struct TerminalHostProxyCompletion {
-    finished: Mutex<bool>,
+struct TerminalRuntimeOwnerCompletion {
+    active_workers: Mutex<usize>,
     changed: Condvar,
 }
 
 #[cfg(test)]
-impl TerminalHostProxyCompletion {
-    fn finish(&self) {
-        let mut finished = self.finished.lock().unwrap();
-        *finished = true;
-        self.changed.notify_all();
+impl TerminalRuntimeOwnerCompletion {
+    fn new(active_workers: usize) -> Self {
+        Self { active_workers: Mutex::new(active_workers), changed: Condvar::new() }
+    }
+
+    fn finish_worker(&self) {
+        let mut active_workers = self.active_workers.lock().unwrap();
+        assert_ne!(*active_workers, 0, "terminal runtime worker finished more than once");
+        *active_workers -= 1;
+        if *active_workers == 0 {
+            self.changed.notify_all();
+        }
     }
 
     fn wait_until_finished(&self, deadline: Instant) -> bool {
-        let mut finished = self.finished.lock().unwrap();
-        while !*finished {
+        let mut active_workers = self.active_workers.lock().unwrap();
+        while *active_workers != 0 {
             let remaining = deadline.saturating_duration_since(Instant::now());
             if remaining.is_zero() {
                 return false;
             }
-            let (next, timeout) = self.changed.wait_timeout(finished, remaining).unwrap();
-            finished = next;
-            if timeout.timed_out() && !*finished {
+            let (next, timeout) = self.changed.wait_timeout(active_workers, remaining).unwrap();
+            active_workers = next;
+            if timeout.timed_out() && *active_workers != 0 {
                 return false;
             }
         }
@@ -1240,14 +1246,12 @@ impl TerminalHostProxyCompletion {
 }
 
 #[cfg(test)]
-struct TerminalHostProxyCompletionGuard(Arc<Surface>);
+struct TerminalRuntimeOwnerLease(Arc<PtyTerminalRuntime>);
 
 #[cfg(test)]
-impl Drop for TerminalHostProxyCompletionGuard {
+impl Drop for TerminalRuntimeOwnerLease {
     fn drop(&mut self) {
-        if let Some(pty) = self.0.as_pty() {
-            pty.host_proxy_completion.finish();
-        }
+        self.0.owner_completion.finish_worker();
     }
 }
 
@@ -1292,7 +1296,7 @@ pub struct PtyTerminalRuntime {
     /// must retain the host record so a fresh snapshot can recover it.
     host_connection_state: AtomicU8,
     #[cfg(test)]
-    host_proxy_completion: TerminalHostProxyCompletion,
+    owner_completion: TerminalRuntimeOwnerCompletion,
     /// Set when output arrived since the last render; cleared by the
     /// frontend when it draws.
     dirty: AtomicBool,
@@ -2225,7 +2229,7 @@ impl Surface {
                 owner_detaching: AtomicBool::new(false),
                 host_connection_state: AtomicU8::new(TerminalHostConnectionState::Connected as u8),
                 #[cfg(test)]
-                host_proxy_completion: TerminalHostProxyCompletion::default(),
+                owner_completion: TerminalRuntimeOwnerCompletion::new(2),
                 dirty: AtomicBool::new(false),
                 title: Mutex::new(String::new()),
                 pwd: Mutex::new(None),
@@ -2271,6 +2275,10 @@ impl Surface {
         std::thread::Builder::new().name(format!("surface-{id}-reader")).spawn({
             let surface = surface.clone();
             move || {
+                #[cfg(test)]
+                let _owner = TerminalRuntimeOwnerLease(
+                    surface.as_pty().expect("surface reader got non-pty surface").terminal.clone(),
+                );
                 let mut buf = [0u8; 64 * 1024];
                 loop {
                     let n = match reader.read(&mut buf) {
@@ -2372,6 +2380,10 @@ impl Surface {
         std::thread::Builder::new().name(format!("surface-{id}-wait")).spawn({
             let surface = surface.clone();
             move || {
+                #[cfg(test)]
+                let _owner = TerminalRuntimeOwnerLease(
+                    surface.as_pty().expect("surface reaper got non-pty surface").terminal.clone(),
+                );
                 let exit = wait_for_native_child_status(child.as_mut());
                 if let Some(pty) = surface.as_pty() {
                     *pty.exit.lock().unwrap() = Some(exit);
@@ -2614,7 +2626,7 @@ impl Surface {
                 owner_detaching: AtomicBool::new(false),
                 host_connection_state: AtomicU8::new(TerminalHostConnectionState::Connected as u8),
                 #[cfg(test)]
-                host_proxy_completion: TerminalHostProxyCompletion::default(),
+                owner_completion: TerminalRuntimeOwnerCompletion::new(1),
                 dirty: AtomicBool::new(true),
                 title: Mutex::new(title),
                 pwd: Mutex::new(pwd),
@@ -2665,7 +2677,9 @@ impl Surface {
             let scrollback = opts.scrollback;
             move || {
                 #[cfg(test)]
-                let _completion = TerminalHostProxyCompletionGuard(surface.clone());
+                let _owner = TerminalRuntimeOwnerLease(
+                    surface.as_pty().expect("host proxy got non-pty surface").terminal.clone(),
+                );
                 let mut sequence_boundary = sequence_boundary;
                 let mut protocol_version = protocol_version;
                 'connection: loop {
@@ -3482,7 +3496,7 @@ impl Surface {
                 dead: AtomicBool::new(true),
                 owner_detaching: AtomicBool::new(false),
                 host_connection_state: AtomicU8::new(TerminalHostConnectionState::Exited as u8),
-                host_proxy_completion: TerminalHostProxyCompletion::default(),
+                owner_completion: TerminalRuntimeOwnerCompletion::new(0),
                 dirty: AtomicBool::new(true),
                 title: Mutex::new(String::new()),
                 pwd: Mutex::new(None),
@@ -3707,7 +3721,7 @@ impl Surface {
                 dead: AtomicBool::new(false),
                 owner_detaching: AtomicBool::new(false),
                 host_connection_state: AtomicU8::new(TerminalHostConnectionState::Connected as u8),
-                host_proxy_completion: TerminalHostProxyCompletion::default(),
+                owner_completion: TerminalRuntimeOwnerCompletion::new(0),
                 dirty: AtomicBool::new(false),
                 title: Mutex::new(String::new()),
                 pwd: Mutex::new(None),
@@ -4906,13 +4920,12 @@ impl Surface {
     }
 
     #[cfg(test)]
-    pub(crate) fn wait_for_terminal_host_proxy_finish_for_test(
+    pub(crate) fn wait_for_terminal_runtime_owners_for_test(
         &self,
         deadline: Instant,
     ) -> Option<bool> {
         let pty = self.as_pty()?;
-        pty.host_identity.as_ref()?;
-        Some(pty.host_proxy_completion.wait_until_finished(deadline))
+        Some(pty.owner_completion.wait_until_finished(deadline))
     }
 
     /// Ask the host to mint a one-use renderer credential. The durable owner

--- a/cmux-tui/crates/cmux-tui-core/src/surface.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/surface.rs
@@ -1207,6 +1207,50 @@ impl PtyTerminalRuntime {
     }
 }
 
+#[cfg(test)]
+#[derive(Default)]
+struct TerminalHostProxyCompletion {
+    finished: Mutex<bool>,
+    changed: Condvar,
+}
+
+#[cfg(test)]
+impl TerminalHostProxyCompletion {
+    fn finish(&self) {
+        let mut finished = self.finished.lock().unwrap();
+        *finished = true;
+        self.changed.notify_all();
+    }
+
+    fn wait_until_finished(&self, deadline: Instant) -> bool {
+        let mut finished = self.finished.lock().unwrap();
+        while !*finished {
+            let remaining = deadline.saturating_duration_since(Instant::now());
+            if remaining.is_zero() {
+                return false;
+            }
+            let (next, timeout) = self.changed.wait_timeout(finished, remaining).unwrap();
+            finished = next;
+            if timeout.timed_out() && !*finished {
+                return false;
+            }
+        }
+        true
+    }
+}
+
+#[cfg(test)]
+struct TerminalHostProxyCompletionGuard(Arc<Surface>);
+
+#[cfg(test)]
+impl Drop for TerminalHostProxyCompletionGuard {
+    fn drop(&mut self) {
+        if let Some(pty) = self.0.as_pty() {
+            pty.host_proxy_completion.finish();
+        }
+    }
+}
+
 /// Content runtime shared by every view placement of one terminal.
 ///
 /// A [`PtySurface`] is a lightweight placement carrying tab-local metadata.
@@ -1247,6 +1291,8 @@ pub struct PtyTerminalRuntime {
     /// The host socket ended without a sequenced Exit. Closing this proxy
     /// must retain the host record so a fresh snapshot can recover it.
     host_connection_state: AtomicU8,
+    #[cfg(test)]
+    host_proxy_completion: TerminalHostProxyCompletion,
     /// Set when output arrived since the last render; cleared by the
     /// frontend when it draws.
     dirty: AtomicBool,
@@ -2178,6 +2224,8 @@ impl Surface {
                 dead: AtomicBool::new(false),
                 owner_detaching: AtomicBool::new(false),
                 host_connection_state: AtomicU8::new(TerminalHostConnectionState::Connected as u8),
+                #[cfg(test)]
+                host_proxy_completion: TerminalHostProxyCompletion::default(),
                 dirty: AtomicBool::new(false),
                 title: Mutex::new(String::new()),
                 pwd: Mutex::new(None),
@@ -2565,6 +2613,8 @@ impl Surface {
                 dead: AtomicBool::new(false),
                 owner_detaching: AtomicBool::new(false),
                 host_connection_state: AtomicU8::new(TerminalHostConnectionState::Connected as u8),
+                #[cfg(test)]
+                host_proxy_completion: TerminalHostProxyCompletion::default(),
                 dirty: AtomicBool::new(true),
                 title: Mutex::new(title),
                 pwd: Mutex::new(pwd),
@@ -2614,6 +2664,8 @@ impl Surface {
             let mux = mux.clone();
             let scrollback = opts.scrollback;
             move || {
+                #[cfg(test)]
+                let _completion = TerminalHostProxyCompletionGuard(surface.clone());
                 let mut sequence_boundary = sequence_boundary;
                 let mut protocol_version = protocol_version;
                 'connection: loop {
@@ -3430,6 +3482,7 @@ impl Surface {
                 dead: AtomicBool::new(true),
                 owner_detaching: AtomicBool::new(false),
                 host_connection_state: AtomicU8::new(TerminalHostConnectionState::Exited as u8),
+                host_proxy_completion: TerminalHostProxyCompletion::default(),
                 dirty: AtomicBool::new(true),
                 title: Mutex::new(String::new()),
                 pwd: Mutex::new(None),
@@ -3654,6 +3707,7 @@ impl Surface {
                 dead: AtomicBool::new(false),
                 owner_detaching: AtomicBool::new(false),
                 host_connection_state: AtomicU8::new(TerminalHostConnectionState::Connected as u8),
+                host_proxy_completion: TerminalHostProxyCompletion::default(),
                 dirty: AtomicBool::new(false),
                 title: Mutex::new(String::new()),
                 pwd: Mutex::new(None),
@@ -4849,6 +4903,16 @@ impl Surface {
         Some(TerminalHostConnectionState::from_u8(
             pty.host_connection_state.load(Ordering::Acquire),
         ))
+    }
+
+    #[cfg(test)]
+    pub(crate) fn wait_for_terminal_host_proxy_finish_for_test(
+        &self,
+        deadline: Instant,
+    ) -> Option<bool> {
+        let pty = self.as_pty()?;
+        pty.host_identity.as_ref()?;
+        Some(pty.host_proxy_completion.wait_until_finished(deadline))
     }
 
     /// Ask the host to mint a one-use renderer credential. The durable owner

--- a/cmux-tui/crates/cmux-tui-core/src/surface.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/surface.rs
@@ -1245,16 +1245,6 @@ impl TerminalRuntimeOwnerCompletion {
     }
 }
 
-#[cfg(test)]
-struct TerminalRuntimeOwnerLease(Arc<PtyTerminalRuntime>);
-
-#[cfg(test)]
-impl Drop for TerminalRuntimeOwnerLease {
-    fn drop(&mut self) {
-        self.0.owner_completion.finish_worker();
-    }
-}
-
 /// Content runtime shared by every view placement of one terminal.
 ///
 /// A [`PtySurface`] is a lightweight placement carrying tab-local metadata.
@@ -2276,9 +2266,8 @@ impl Surface {
             let surface = surface.clone();
             move || {
                 #[cfg(test)]
-                let _owner = TerminalRuntimeOwnerLease(
-                    surface.as_pty().expect("surface reader got non-pty surface").terminal.clone(),
-                );
+                let owner =
+                    surface.as_pty().expect("surface reader got non-pty surface").terminal.clone();
                 let mut buf = [0u8; 64 * 1024];
                 loop {
                     let n = match reader.read(&mut buf) {
@@ -2372,6 +2361,11 @@ impl Surface {
                     pty.local_pty_drained.store(true, Ordering::Release);
                 }
                 publish_local_exit_if_ready(&surface);
+                #[cfg(test)]
+                {
+                    drop(surface);
+                    owner.owner_completion.finish_worker();
+                }
             }
         })?;
 
@@ -2381,14 +2375,18 @@ impl Surface {
             let surface = surface.clone();
             move || {
                 #[cfg(test)]
-                let _owner = TerminalRuntimeOwnerLease(
-                    surface.as_pty().expect("surface reaper got non-pty surface").terminal.clone(),
-                );
+                let owner =
+                    surface.as_pty().expect("surface reaper got non-pty surface").terminal.clone();
                 let exit = wait_for_native_child_status(child.as_mut());
                 if let Some(pty) = surface.as_pty() {
                     *pty.exit.lock().unwrap() = Some(exit);
                 }
                 publish_local_exit_if_ready(&surface);
+                #[cfg(test)]
+                {
+                    drop(surface);
+                    owner.owner_completion.finish_worker();
+                }
             }
         })?;
 
@@ -2677,12 +2675,12 @@ impl Surface {
             let scrollback = opts.scrollback;
             move || {
                 #[cfg(test)]
-                let _owner = TerminalRuntimeOwnerLease(
-                    surface.as_pty().expect("host proxy got non-pty surface").terminal.clone(),
-                );
-                let mut sequence_boundary = sequence_boundary;
-                let mut protocol_version = protocol_version;
-                'connection: loop {
+                let owner =
+                    surface.as_pty().expect("host proxy got non-pty surface").terminal.clone();
+                (|| {
+                    let mut sequence_boundary = sequence_boundary;
+                    let mut protocol_version = protocol_version;
+                    'connection: loop {
                     let mut stager =
                         HostedFrameStager::new_for_version(sequence_boundary, protocol_version);
                     let mut received_exit = None;
@@ -3230,8 +3228,15 @@ impl Surface {
                         protocol_version = replacement_protocol_version;
                         pty.host_connection_state
                             .store(TerminalHostConnectionState::Connected as u8, Ordering::Release);
-                        continue 'connection;
+                            continue 'connection;
+                        }
                     }
+                })();
+                #[cfg(test)]
+                {
+                    drop(surface);
+                    drop(mux);
+                    owner.owner_completion.finish_worker();
                 }
             }
         })?;

--- a/cmux-tui/crates/cmux-tui/Cargo.toml
+++ b/cmux-tui/crates/cmux-tui/Cargo.toml
@@ -53,3 +53,4 @@ async-trait.workspace = true
 cmux-pty.workspace = true
 tempfile = "3"
 rusqlite.workspace = true
+wait-timeout.workspace = true

--- a/cmux-tui/crates/cmux-tui/tests/cli.rs
+++ b/cmux-tui/crates/cmux-tui/tests/cli.rs
@@ -1080,10 +1080,8 @@ fn graceful_shutdown_stops_server_owned_sidebar_process() {
     // SAFETY: this PID is the live child owned by the test fixture.
     assert_eq!(unsafe { libc::kill(server_pid, libc::SIGINT) }, 0);
     let server_stopped = wait_for_child_exit(&mut server.child, Duration::from_secs(10));
-    let owned_processes_stopped = owned_pids
-        .iter()
-        .copied()
-        .all(|pid| !process_exists(pid) && !process_group_exists(pid));
+    let owned_processes_stopped =
+        owned_pids.iter().copied().all(|pid| !process_exists(pid) && !process_group_exists(pid));
 
     // Keep lifecycle regressions leak-free. Every captured process group and
     // record belongs to this fixture's private state root.

--- a/cmux-tui/crates/cmux-tui/tests/cli.rs
+++ b/cmux-tui/crates/cmux-tui/tests/cli.rs
@@ -181,20 +181,17 @@ fn wait_for_child_exit(child: &mut Child, timeout: Duration) -> bool {
 enum FixtureProcessState {
     Captured,
     GracefulExit,
-    ForceSignaled,
     ExitPublished,
 }
 
 #[cfg(any(target_os = "linux", target_vendor = "apple"))]
 struct FixtureProcessOwner {
-    process_group: u32,
     lease_reader: File,
     lease_guard: Option<File>,
     lease_dir: PathBuf,
     ready: bool,
     durable_records:
         Vec<(std::path::PathBuf, cmux_tui_core::terminal_host_runtime::TerminalHostRecord)>,
-    durable_exit_validated: bool,
     state: FixtureProcessState,
 }
 
@@ -218,13 +215,11 @@ impl FixtureProcessOwner {
         let lease_guard = OpenOptions::new().write(true).open(&lease_path)?;
 
         Ok(Self {
-            process_group: 0,
             lease_reader,
             lease_guard: Some(lease_guard),
             lease_dir,
             ready: false,
             durable_records: Vec::new(),
-            durable_exit_validated: true,
             state: FixtureProcessState::Captured,
         })
     }
@@ -250,16 +245,12 @@ impl FixtureProcessOwner {
 
     fn capture(
         &mut self,
-        process_group: u32,
         durable_records: Vec<(
             std::path::PathBuf,
             cmux_tui_core::terminal_host_runtime::TerminalHostRecord,
         )>,
         deadline: Instant,
     ) -> anyhow::Result<()> {
-        anyhow::ensure!(process_group != 0, "fixture process group is missing");
-        self.process_group = process_group;
-        self.durable_exit_validated = durable_records.is_empty();
         self.durable_records = durable_records;
         anyhow::ensure!(
             self.wait_for_ready(deadline)?,
@@ -281,50 +272,6 @@ impl FixtureProcessOwner {
         Ok(true)
     }
 
-    fn force_stop_and_wait(&mut self, deadline: Instant) -> anyhow::Result<()> {
-        match self.state {
-            FixtureProcessState::ExitPublished => return Ok(()),
-            FixtureProcessState::Captured => {
-                if self.wait_for_group_eof(Instant::now())? {
-                    self.state = FixtureProcessState::ExitPublished;
-                    self.validate_durable_exit()?;
-                    return Ok(());
-                }
-                signal_test_process_group(self.process_group, libc::SIGKILL);
-                self.state = FixtureProcessState::ForceSignaled;
-            }
-            FixtureProcessState::GracefulExit | FixtureProcessState::ForceSignaled => {}
-        }
-        anyhow::ensure!(
-            self.wait_for_group_eof(deadline)?,
-            "fixture process group {} did not publish EOF after SIGKILL",
-            self.process_group
-        );
-        self.state = FixtureProcessState::ExitPublished;
-        self.validate_durable_exit()
-    }
-
-    fn remove_durable_record(&self) -> anyhow::Result<()> {
-        anyhow::ensure!(
-            self.durable_exit_validated && self.state == FixtureProcessState::ExitPublished,
-            "durable fixture record is not safe to remove"
-        );
-        for (record_path, record) in &self.durable_records {
-            match cmux_tui_core::terminal_host_runtime::remove_stale_terminal_host_record(
-                record_path,
-                record,
-            ) {
-                Ok(true) => {}
-                Ok(false) => {
-                    anyhow::bail!("durable fixture record remained live after process-group EOF")
-                }
-                Err(_) if !record_path.exists() => {}
-                Err(error) => return Err(error),
-            }
-        }
-        Ok(())
-    }
-
     fn validate_durable_exit(&mut self) -> anyhow::Result<()> {
         anyhow::ensure!(
             self.state == FixtureProcessState::ExitPublished,
@@ -339,7 +286,6 @@ impl FixtureProcessOwner {
                 "durable fixture host did not release its exact liveness proof"
             );
         }
-        self.durable_exit_validated = true;
         Ok(())
     }
 
@@ -416,16 +362,6 @@ impl FixtureProcessOwner {
 impl Drop for FixtureProcessOwner {
     fn drop(&mut self) {
         let _ = fs::remove_dir_all(&self.lease_dir);
-    }
-}
-
-#[cfg(unix)]
-fn signal_test_process_group(pid: u32, signal: libc::c_int) {
-    let Ok(pid) = libc::pid_t::try_from(pid) else { return };
-    // SAFETY: the test just captured this isolated PTY process group from its
-    // private terminal-host record or process-info response.
-    unsafe {
-        libc::kill(-pid, signal);
     }
 }
 
@@ -1316,14 +1252,7 @@ fn graceful_shutdown_stops_server_owned_sidebar_process() {
         }),
     )
     .expect("start configured sidebar plugin");
-    let surface = sidebar["surface"].as_u64().expect("sidebar plugin surface");
-    let plugin_pid = try_json_socket_request(
-        &server.socket,
-        serde_json::json!({"id": 2, "cmd": "process-info", "surface": surface}),
-    )
-    .and_then(|response| response["pid"].as_u64())
-    .and_then(|pid| u32::try_from(pid).ok())
-    .expect("sidebar plugin PID");
+    sidebar["surface"].as_u64().expect("sidebar plugin surface");
 
     let host_root = cmux_tui_core::terminal_host_runtime::terminal_host_root(&server.state, "main");
     let records = cmux_tui_core::terminal_host_runtime::load_terminal_host_records(&host_root)
@@ -1331,11 +1260,31 @@ fn graceful_shutdown_stops_server_owned_sidebar_process() {
     let used_durable_host = !records.is_empty();
     process_owner
         .capture(
-            plugin_pid,
             records.iter().map(|(path, record)| (path.clone(), record.clone())).collect(),
             Instant::now() + Duration::from_secs(10),
         )
         .expect("capture sidebar plugin process owner");
+
+    // A durable host is an unexpected failure for this server-owned plug-in.
+    // Keep the live server as the sole cleanup owner before testing SIGINT.
+    // The production resource-close path must publish both the plug-in group
+    // EOF and exact durable-host death before the server can shut down.
+    let preclosed_unexpected_resources = if used_durable_host {
+        let cleanup_deadline = Instant::now() + Duration::from_secs(10);
+        assert!(
+            server.close_all_resources(),
+            "live server did not close unexpected durable sidebar resources"
+        );
+        assert!(
+            process_owner
+                .wait_for_graceful_exit(cleanup_deadline)
+                .expect("verify unexpected durable sidebar cleanup"),
+            "production resource cleanup did not publish process-group EOF"
+        );
+        true
+    } else {
+        false
+    };
 
     let server_pid = libc::pid_t::try_from(server.child.id()).unwrap();
     let shutdown_deadline = Instant::now() + Duration::from_secs(10);
@@ -1345,23 +1294,15 @@ fn graceful_shutdown_stops_server_owned_sidebar_process() {
         &mut server.child,
         shutdown_deadline.saturating_duration_since(Instant::now()),
     );
-    let owned_processes_stopped = process_owner
-        .wait_for_graceful_exit(shutdown_deadline)
-        .expect("wait for server-owned process-group EOF");
+    let owned_processes_stopped = preclosed_unexpected_resources
+        || process_owner
+            .wait_for_graceful_exit(shutdown_deadline)
+            .expect("wait for server-owned process-group EOF");
     // The shell leader and /bin/cat child hold the same non-CLOEXEC FIFO
     // writer. EOF is the kernel-owned proof that the complete fixture process
     // group exited, including a child left behind by its leader. Unexpected
-    // durable hosts stay in this result and fail below. Their records can be
-    // removed only after group EOF and exact host liveness both report dead.
-    if !owned_processes_stopped || used_durable_host {
-        let cleanup_deadline = Instant::now() + Duration::from_secs(2);
-        process_owner
-            .force_stop_and_wait(cleanup_deadline)
-            .expect("force and reap live sidebar fixture process group");
-        process_owner
-            .remove_durable_record()
-            .expect("remove exited durable sidebar fixture record");
-    }
+    // durable hosts are closed through the live production server path above
+    // and still fail the ownership assertion below.
 
     assert!(server_stopped, "SIGINT did not complete graceful server shutdown");
     assert!(

--- a/cmux-tui/crates/cmux-tui/tests/cli.rs
+++ b/cmux-tui/crates/cmux-tui/tests/cli.rs
@@ -208,8 +208,7 @@ struct FixtureProcessOwner {
     lease_path: PathBuf,
     abort_path: PathBuf,
     ready: bool,
-    durable_records:
-        Vec<(std::path::PathBuf, cmux_tui_core::terminal_host_runtime::TerminalHostRecord)>,
+    durable_records: Vec<(PathBuf, cmux_tui_core::terminal_host_runtime::TerminalHostRecord)>,
     state: FixtureProcessState,
 }
 
@@ -256,10 +255,7 @@ impl FixtureProcessOwner {
 
     fn capture(
         &mut self,
-        durable_records: Vec<(
-            std::path::PathBuf,
-            cmux_tui_core::terminal_host_runtime::TerminalHostRecord,
-        )>,
+        durable_records: Vec<(PathBuf, cmux_tui_core::terminal_host_runtime::TerminalHostRecord)>,
         deadline: Instant,
     ) -> anyhow::Result<()> {
         self.durable_records = durable_records;
@@ -669,7 +665,7 @@ fn newer_workspace_schema_failure_reports_socket_specific_recovery() {
     }
 
     #[cfg(unix)]
-    fn accept_with_deadline(listener: &UnixListener) -> std::os::unix::net::UnixStream {
+    fn accept_with_deadline(listener: &UnixListener) -> UnixStream {
         listener.set_nonblocking(true).unwrap();
         let deadline = Instant::now() + Duration::from_secs(15);
         loop {

--- a/cmux-tui/crates/cmux-tui/tests/cli.rs
+++ b/cmux-tui/crates/cmux-tui/tests/cli.rs
@@ -1204,8 +1204,10 @@ fn graceful_shutdown_stops_server_owned_sidebar_process() {
         process_exit.wait_until(shutdown_deadline).expect("wait for server-owned process exit")
     });
     // The successful fixture has no durable host and one direct /bin/cat
-    // process. The pre-captured pidfd/kqueue event is bound to that exact
-    // process and proves exit without racing zombie reaping or PID reuse.
+    // process. cmux-pty executes that program directly, and /bin/cat does not
+    // fork, so its exact PID exit also proves this fixture cannot retain a
+    // process-group descendant. The pre-captured pidfd/kqueue event proves
+    // that exit without racing zombie reaping or PID reuse.
     // Unexpected durable hosts stay in this result and fail below.
     let owned_processes_stopped = process_exits_published;
 

--- a/cmux-tui/crates/cmux-tui/tests/cli.rs
+++ b/cmux-tui/crates/cmux-tui/tests/cli.rs
@@ -1,10 +1,14 @@
 use std::fs;
+#[cfg(any(target_os = "linux", target_vendor = "apple"))]
+use std::fs::{File, OpenOptions};
 #[cfg(unix)]
 use std::io::{BufRead, BufReader, Read, Write};
 #[cfg(any(target_os = "linux", target_vendor = "apple"))]
-use std::os::fd::{AsRawFd, FromRawFd, OwnedFd};
+use std::os::fd::AsRawFd;
+#[cfg(any(target_os = "linux", target_vendor = "apple"))]
+use std::os::unix::ffi::OsStrExt;
 #[cfg(unix)]
-use std::os::unix::fs::PermissionsExt;
+use std::os::unix::fs::{OpenOptionsExt, PermissionsExt};
 #[cfg(unix)]
 use std::os::unix::net::UnixListener;
 use std::path::PathBuf;
@@ -173,114 +177,6 @@ fn wait_for_child_exit(child: &mut Child, timeout: Duration) -> bool {
 }
 
 #[cfg(any(target_os = "linux", target_vendor = "apple"))]
-struct ProcessExitSignal {
-    descriptor: OwnedFd,
-}
-
-#[cfg(any(target_os = "linux", target_vendor = "apple"))]
-impl ProcessExitSignal {
-    fn observe(pid: u32) -> std::io::Result<Self> {
-        let pid = libc::pid_t::try_from(pid).map_err(|_| {
-            std::io::Error::new(std::io::ErrorKind::InvalidInput, "process ID exceeds pid_t")
-        })?;
-        #[cfg(target_os = "linux")]
-        let descriptor = unsafe { libc::syscall(libc::SYS_pidfd_open, pid, 0) } as libc::c_int;
-        #[cfg(target_vendor = "apple")]
-        let descriptor = unsafe { libc::kqueue() };
-        if descriptor < 0 {
-            return Err(std::io::Error::last_os_error());
-        }
-        // SAFETY: pidfd_open or kqueue returned a new owned descriptor.
-        let descriptor = unsafe { OwnedFd::from_raw_fd(descriptor) };
-
-        #[cfg(target_vendor = "apple")]
-        {
-            let change = libc::kevent {
-                ident: pid as libc::uintptr_t,
-                filter: libc::EVFILT_PROC,
-                flags: libc::EV_ADD | libc::EV_ENABLE | libc::EV_ONESHOT,
-                fflags: libc::NOTE_EXIT,
-                data: 0,
-                udata: std::ptr::null_mut(),
-            };
-            let registered = unsafe {
-                libc::kevent(
-                    descriptor.as_raw_fd(),
-                    &raw const change,
-                    1,
-                    std::ptr::null_mut(),
-                    0,
-                    std::ptr::null(),
-                )
-            };
-            if registered < 0 {
-                return Err(std::io::Error::last_os_error());
-            }
-        }
-
-        Ok(Self { descriptor })
-    }
-
-    fn wait_until(&self, deadline: Instant) -> std::io::Result<bool> {
-        #[cfg(target_os = "linux")]
-        {
-            let mut descriptor =
-                libc::pollfd { fd: self.descriptor.as_raw_fd(), events: libc::POLLIN, revents: 0 };
-            loop {
-                let remaining = deadline.saturating_duration_since(Instant::now());
-                let timeout_ms = remaining.as_millis().min(libc::c_int::MAX as u128) as libc::c_int;
-                let ready = unsafe { libc::poll(&raw mut descriptor, 1, timeout_ms) };
-                if ready > 0 {
-                    if descriptor.revents & libc::POLLNVAL != 0 {
-                        return Err(std::io::Error::new(
-                            std::io::ErrorKind::InvalidInput,
-                            "process-exit descriptor became invalid",
-                        ));
-                    }
-                    return Ok(true);
-                }
-                if ready == 0 {
-                    return Ok(false);
-                }
-                let error = std::io::Error::last_os_error();
-                if error.kind() != std::io::ErrorKind::Interrupted {
-                    return Err(error);
-                }
-            }
-        }
-        #[cfg(target_vendor = "apple")]
-        {
-            let mut event = unsafe { std::mem::zeroed::<libc::kevent>() };
-            loop {
-                let remaining = deadline.saturating_duration_since(Instant::now());
-                let timeout = libc::timespec {
-                    tv_sec: libc::time_t::try_from(remaining.as_secs())
-                        .unwrap_or(libc::time_t::MAX),
-                    tv_nsec: libc::c_long::from(remaining.subsec_nanos()),
-                };
-                let ready = unsafe {
-                    libc::kevent(
-                        self.descriptor.as_raw_fd(),
-                        std::ptr::null(),
-                        0,
-                        &raw mut event,
-                        1,
-                        &raw const timeout,
-                    )
-                };
-                if ready >= 0 {
-                    return Ok(ready > 0);
-                }
-                let error = std::io::Error::last_os_error();
-                if error.kind() != std::io::ErrorKind::Interrupted {
-                    return Err(error);
-                }
-            }
-        }
-    }
-}
-
-#[cfg(any(target_os = "linux", target_vendor = "apple"))]
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 enum FixtureProcessState {
     Captured,
@@ -291,101 +187,235 @@ enum FixtureProcessState {
 
 #[cfg(any(target_os = "linux", target_vendor = "apple"))]
 struct FixtureProcessOwner {
-    pid: u32,
-    exit: ProcessExitSignal,
-    durable_record:
-        Option<(std::path::PathBuf, cmux_tui_core::terminal_host_runtime::TerminalHostRecord)>,
+    process_group: u32,
+    lease_reader: File,
+    lease_guard: Option<File>,
+    lease_dir: PathBuf,
+    ready: bool,
+    durable_records:
+        Vec<(std::path::PathBuf, cmux_tui_core::terminal_host_runtime::TerminalHostRecord)>,
     durable_exit_validated: bool,
     state: FixtureProcessState,
 }
 
 #[cfg(any(target_os = "linux", target_vendor = "apple"))]
 impl FixtureProcessOwner {
-    fn capture(
-        pid: u32,
-        durable_record: Option<(
-            std::path::PathBuf,
-            cmux_tui_core::terminal_host_runtime::TerminalHostRecord,
-        )>,
-    ) -> std::io::Result<Self> {
+    fn prepare(name: &str) -> std::io::Result<Self> {
+        let lease_dir = unique_temp_dir(name);
+        fs::create_dir_all(&lease_dir)?;
+        let lease_path = lease_dir.join("process-group.lease");
+        let lease_path_bytes = std::ffi::CString::new(lease_path.as_os_str().as_bytes())
+            .map_err(|_| std::io::Error::from(std::io::ErrorKind::InvalidInput))?;
+        // SAFETY: lease_path_bytes is a valid NUL-terminated path, and this
+        // fixture owns the new private directory that contains it.
+        if unsafe { libc::mkfifo(lease_path_bytes.as_ptr(), 0o600) } != 0 {
+            return Err(std::io::Error::last_os_error());
+        }
+        let lease_reader =
+            OpenOptions::new().read(true).custom_flags(libc::O_NONBLOCK).open(&lease_path)?;
+        // Keep one test-owned writer open until the real process group writes
+        // its ready byte. This prevents a premature FIFO EOF before exec.
+        let lease_guard = OpenOptions::new().write(true).open(&lease_path)?;
+
         Ok(Self {
-            pid,
-            exit: ProcessExitSignal::observe(pid)?,
-            durable_exit_validated: durable_record.is_none(),
-            durable_record,
+            process_group: 0,
+            lease_reader,
+            lease_guard: Some(lease_guard),
+            lease_dir,
+            ready: false,
+            durable_records: Vec::new(),
+            durable_exit_validated: true,
             state: FixtureProcessState::Captured,
         })
     }
 
+    fn lease_path(&self) -> PathBuf {
+        self.lease_dir.join("process-group.lease")
+    }
+
+    fn fixture_command(&self) -> Vec<String> {
+        vec![
+            "/bin/sh".to_string(),
+            "-c".to_string(),
+            concat!(
+                "exec 9>\"$1\" || exit 125; ",
+                "printf 'ready\\n' >&9 || exit 125; ",
+                "/bin/cat & child=$!; wait \"$child\""
+            )
+            .to_string(),
+            "cmux-sidebar-fixture".to_string(),
+            self.lease_path().to_string_lossy().into_owned(),
+        ]
+    }
+
+    fn capture(
+        &mut self,
+        process_group: u32,
+        durable_records: Vec<(
+            std::path::PathBuf,
+            cmux_tui_core::terminal_host_runtime::TerminalHostRecord,
+        )>,
+        deadline: Instant,
+    ) -> anyhow::Result<()> {
+        anyhow::ensure!(process_group != 0, "fixture process group is missing");
+        self.process_group = process_group;
+        self.durable_exit_validated = durable_records.is_empty();
+        self.durable_records = durable_records;
+        anyhow::ensure!(
+            self.wait_for_ready(deadline)?,
+            "fixture process group did not publish its lease"
+        );
+        self.lease_guard.take();
+        Ok(())
+    }
+
     fn wait_for_graceful_exit(&mut self, deadline: Instant) -> anyhow::Result<bool> {
         anyhow::ensure!(self.state == FixtureProcessState::Captured);
-        if !self.exit.wait_until(deadline)? {
+        self.state = FixtureProcessState::GracefulExit;
+        if !self.wait_for_group_eof(deadline)? {
+            self.state = FixtureProcessState::Captured;
             return Ok(false);
         }
-        self.state = FixtureProcessState::GracefulExit;
+        self.state = FixtureProcessState::ExitPublished;
         self.validate_durable_exit()?;
         Ok(true)
     }
 
     fn force_stop_and_wait(&mut self, deadline: Instant) -> anyhow::Result<()> {
         match self.state {
-            FixtureProcessState::GracefulExit | FixtureProcessState::ExitPublished => return Ok(()),
+            FixtureProcessState::ExitPublished => return Ok(()),
             FixtureProcessState::Captured => {
-                if self.exit.wait_until(Instant::now())? {
-                    self.state = FixtureProcessState::GracefulExit;
+                if self.wait_for_group_eof(Instant::now())? {
+                    self.state = FixtureProcessState::ExitPublished;
                     self.validate_durable_exit()?;
                     return Ok(());
                 }
-                signal_test_process_group(self.pid, libc::SIGKILL);
+                signal_test_process_group(self.process_group, libc::SIGKILL);
                 self.state = FixtureProcessState::ForceSignaled;
             }
-            FixtureProcessState::ForceSignaled => {}
+            FixtureProcessState::GracefulExit | FixtureProcessState::ForceSignaled => {}
         }
         anyhow::ensure!(
-            self.exit.wait_until(deadline)?,
-            "fixture process {} did not publish exit after SIGKILL",
-            self.pid
+            self.wait_for_group_eof(deadline)?,
+            "fixture process group {} did not publish EOF after SIGKILL",
+            self.process_group
         );
         self.state = FixtureProcessState::ExitPublished;
         self.validate_durable_exit()
     }
 
     fn remove_durable_record(&self) -> anyhow::Result<()> {
-        let Some((record_path, record)) = &self.durable_record else {
-            return Ok(());
-        };
         anyhow::ensure!(
-            self.durable_exit_validated
-                && matches!(
-                    self.state,
-                    FixtureProcessState::GracefulExit | FixtureProcessState::ExitPublished
-                ),
+            self.durable_exit_validated && self.state == FixtureProcessState::ExitPublished,
             "durable fixture record is not safe to remove"
         );
-        match cmux_tui_core::terminal_host_runtime::remove_stale_terminal_host_record(
-            record_path,
-            record,
-        ) {
-            Ok(true) => Ok(()),
-            Ok(false) => anyhow::bail!("durable fixture record remained live after process exit"),
-            Err(_) if !record_path.exists() => Ok(()),
-            Err(error) => Err(error),
+        for (record_path, record) in &self.durable_records {
+            match cmux_tui_core::terminal_host_runtime::remove_stale_terminal_host_record(
+                record_path,
+                record,
+            ) {
+                Ok(true) => {}
+                Ok(false) => {
+                    anyhow::bail!("durable fixture record remained live after process-group EOF")
+                }
+                Err(_) if !record_path.exists() => {}
+                Err(error) => return Err(error),
+            }
         }
+        Ok(())
     }
 
     fn validate_durable_exit(&mut self) -> anyhow::Result<()> {
-        let Some((record_path, record)) = &self.durable_record else {
-            return Ok(());
-        };
         anyhow::ensure!(
-            cmux_tui_core::terminal_host_runtime::terminal_host_record_liveness(
-                record_path,
-                record,
-            )? == cmux_tui_core::terminal_host_runtime::TerminalHostLiveness::Dead,
-            "durable fixture host did not release its exact liveness proof"
+            self.state == FixtureProcessState::ExitPublished,
+            "durable fixture state requires process-group EOF"
         );
+        for (record_path, record) in &self.durable_records {
+            anyhow::ensure!(
+                cmux_tui_core::terminal_host_runtime::terminal_host_record_liveness(
+                    record_path,
+                    record,
+                )? == cmux_tui_core::terminal_host_runtime::TerminalHostLiveness::Dead,
+                "durable fixture host did not release its exact liveness proof"
+            );
+        }
         self.durable_exit_validated = true;
         Ok(())
+    }
+
+    fn wait_for_ready(&mut self, deadline: Instant) -> std::io::Result<bool> {
+        let mut bytes = Vec::new();
+        while self.wait_for_lease_event(deadline)? {
+            let mut buffer = [0_u8; 32];
+            match self.lease_reader.read(&mut buffer) {
+                Ok(0) => continue,
+                Ok(count) => {
+                    bytes.extend_from_slice(&buffer[..count]);
+                    if bytes.windows(b"ready\n".len()).any(|window| window == b"ready\n") {
+                        self.ready = true;
+                        return Ok(true);
+                    }
+                }
+                Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => {}
+                Err(error) => return Err(error),
+            }
+        }
+        Ok(false)
+    }
+
+    fn wait_for_group_eof(&mut self, deadline: Instant) -> std::io::Result<bool> {
+        if !self.ready {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                "fixture process-group lease was not armed",
+            ));
+        }
+        while self.wait_for_lease_event(deadline)? {
+            let mut buffer = [0_u8; 32];
+            match self.lease_reader.read(&mut buffer) {
+                Ok(0) => return Ok(true),
+                Ok(_) => {}
+                Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => {}
+                Err(error) => return Err(error),
+            }
+        }
+        Ok(false)
+    }
+
+    fn wait_for_lease_event(&self, deadline: Instant) -> std::io::Result<bool> {
+        let mut descriptor = libc::pollfd {
+            fd: self.lease_reader.as_raw_fd(),
+            events: libc::POLLIN | libc::POLLHUP,
+            revents: 0,
+        };
+        loop {
+            let remaining = deadline.saturating_duration_since(Instant::now());
+            let timeout_ms = remaining.as_millis().min(libc::c_int::MAX as u128) as libc::c_int;
+            let ready = unsafe { libc::poll(&raw mut descriptor, 1, timeout_ms) };
+            if ready > 0 {
+                if descriptor.revents & libc::POLLNVAL != 0 {
+                    return Err(std::io::Error::new(
+                        std::io::ErrorKind::InvalidInput,
+                        "fixture process-group lease became invalid",
+                    ));
+                }
+                return Ok(true);
+            }
+            if ready == 0 {
+                return Ok(false);
+            }
+            let error = std::io::Error::last_os_error();
+            if error.kind() != std::io::ErrorKind::Interrupted {
+                return Err(error);
+            }
+        }
+    }
+}
+
+#[cfg(any(target_os = "linux", target_vendor = "apple"))]
+impl Drop for FixtureProcessOwner {
+    fn drop(&mut self) {
+        let _ = fs::remove_dir_all(&self.lease_dir);
     }
 }
 
@@ -1264,10 +1294,17 @@ fn explicit_attach_registers_a_full_session_tui_client() {
 #[cfg(any(target_os = "linux", target_vendor = "apple"))]
 #[test]
 fn graceful_shutdown_stops_server_owned_sidebar_process() {
-    let mut server = HeadlessServer::start_with_config(
-        "sidebar-host-shutdown",
-        Some(r#"{"sidebar":{"plugin":{"command":["/bin/cat"]}}}"#),
-    );
+    let mut process_owner =
+        FixtureProcessOwner::prepare("sidebar-host-shutdown-lease").expect("create process lease");
+    let config = serde_json::json!({
+        "sidebar": {
+            "plugin": {
+                "command": process_owner.fixture_command(),
+            }
+        }
+    })
+    .to_string();
+    let mut server = HeadlessServer::start_with_config("sidebar-host-shutdown", Some(&config));
     let sidebar = try_json_socket_request(
         &server.socket,
         serde_json::json!({
@@ -1292,14 +1329,13 @@ fn graceful_shutdown_stops_server_owned_sidebar_process() {
     let records = cmux_tui_core::terminal_host_runtime::load_terminal_host_records(&host_root)
         .expect("load sidebar terminal-host record");
     let used_durable_host = !records.is_empty();
-    let mut process_owners = vec![
-        FixtureProcessOwner::capture(plugin_pid, None)
-            .expect("capture sidebar plugin process owner"),
-    ];
-    process_owners.extend(records.iter().map(|(record_path, record)| {
-        FixtureProcessOwner::capture(record.host_pid, Some((record_path.clone(), record.clone())))
-            .expect("capture durable sidebar process owner")
-    }));
+    process_owner
+        .capture(
+            plugin_pid,
+            records.iter().map(|(path, record)| (path.clone(), record.clone())).collect(),
+            Instant::now() + Duration::from_secs(10),
+        )
+        .expect("capture sidebar plugin process owner");
 
     let server_pid = libc::pid_t::try_from(server.child.id()).unwrap();
     let shutdown_deadline = Instant::now() + Duration::from_secs(10);
@@ -1309,30 +1345,22 @@ fn graceful_shutdown_stops_server_owned_sidebar_process() {
         &mut server.child,
         shutdown_deadline.saturating_duration_since(Instant::now()),
     );
-    let mut owned_processes_stopped = true;
-    for owner in &mut process_owners {
-        owned_processes_stopped &= owner
-            .wait_for_graceful_exit(shutdown_deadline)
-            .expect("wait for server-owned process exit");
-    }
-    // The successful fixture has no durable host and one direct /bin/cat
-    // process. cmux-pty executes that program directly, and /bin/cat does not
-    // fork, so its exact PID exit also proves this fixture cannot retain a
-    // process-group descendant. The pre-captured pidfd/kqueue event proves
-    // that exit without racing zombie reaping or PID reuse.
-    // Unexpected durable hosts stay in this result and fail below.
-    // Keep lifecycle regressions leak-free. Every captured process group and
-    // record belongs to this fixture's private state root.
+    let owned_processes_stopped = process_owner
+        .wait_for_graceful_exit(shutdown_deadline)
+        .expect("wait for server-owned process-group EOF");
+    // The shell leader and /bin/cat child hold the same non-CLOEXEC FIFO
+    // writer. EOF is the kernel-owned proof that the complete fixture process
+    // group exited, including a child left behind by its leader. Unexpected
+    // durable hosts stay in this result and fail below. Their records can be
+    // removed only after group EOF and exact host liveness both report dead.
     if !owned_processes_stopped || used_durable_host {
         let cleanup_deadline = Instant::now() + Duration::from_secs(2);
-        for owner in &mut process_owners {
-            owner
-                .force_stop_and_wait(cleanup_deadline)
-                .expect("force and reap live sidebar fixture process");
-        }
-        for owner in &process_owners {
-            owner.remove_durable_record().expect("remove exited durable sidebar fixture record");
-        }
+        process_owner
+            .force_stop_and_wait(cleanup_deadline)
+            .expect("force and reap live sidebar fixture process group");
+        process_owner
+            .remove_durable_record()
+            .expect("remove exited durable sidebar fixture record");
     }
 
     assert!(server_stopped, "SIGINT did not complete graceful server shutdown");

--- a/cmux-tui/crates/cmux-tui/tests/cli.rs
+++ b/cmux-tui/crates/cmux-tui/tests/cli.rs
@@ -1183,7 +1183,8 @@ fn graceful_shutdown_stops_server_owned_sidebar_process() {
     let records = cmux_tui_core::terminal_host_runtime::load_terminal_host_records(&host_root)
         .expect("load sidebar terminal-host record");
     let used_durable_host = !records.is_empty();
-    let owned_pids = [plugin_pid];
+    let mut owned_pids = vec![plugin_pid];
+    owned_pids.extend(records.iter().map(|(_, record)| record.host_pid));
     let owned_process_exits = owned_pids
         .iter()
         .copied()
@@ -1202,18 +1203,16 @@ fn graceful_shutdown_stops_server_owned_sidebar_process() {
     let process_exits_published = owned_process_exits.iter().all(|process_exit| {
         process_exit.wait_until(shutdown_deadline).expect("wait for server-owned process exit")
     });
-    // The configured plugin is one direct /bin/cat process. Its kernel exit
-    // event is therefore the complete owner-process lifecycle signal.
+    // The successful fixture has no durable host and one direct /bin/cat
+    // process. Unexpected durable hosts stay in this result and fail below.
     let owned_processes_stopped = process_exits_published
         && owned_pids.iter().copied().all(|pid| !process_exists(pid) && !process_group_exists(pid));
 
     // Keep lifecycle regressions leak-free. Every captured process group and
     // record belongs to this fixture's private state root.
     if !owned_processes_stopped || used_durable_host {
-        for pid in
-            owned_pids.iter().copied().chain(records.iter().map(|(_, record)| record.host_pid))
-        {
-            signal_test_process_group(pid, libc::SIGKILL);
+        for pid in &owned_pids {
+            signal_test_process_group(*pid, libc::SIGKILL);
         }
         for (record_path, record) in &records {
             let _ = cmux_tui_core::terminal_host_runtime::remove_stale_terminal_host_record(

--- a/cmux-tui/crates/cmux-tui/tests/cli.rs
+++ b/cmux-tui/crates/cmux-tui/tests/cli.rs
@@ -1203,8 +1203,10 @@ fn graceful_shutdown_stops_server_owned_sidebar_process() {
     let process_exits_published = owned_process_exits.iter().all(|process_exit| {
         process_exit.wait_until(shutdown_deadline).expect("wait for server-owned process exit")
     });
-    let owned_processes_stopped = process_exits_published
-        && owned_pids.iter().copied().all(|pid| !process_exists(pid) && !process_group_exists(pid));
+    // The configured plugin is one direct /bin/cat process. Its kernel exit
+    // event is therefore the complete owner-process lifecycle signal.
+    let owned_processes_stopped =
+        process_exits_published && owned_pids.iter().copied().all(|pid| !process_exists(pid));
 
     // Keep lifecycle regressions leak-free. Every captured process group and
     // record belongs to this fixture's private state root.

--- a/cmux-tui/crates/cmux-tui/tests/cli.rs
+++ b/cmux-tui/crates/cmux-tui/tests/cli.rs
@@ -1,6 +1,8 @@
 use std::fs;
 #[cfg(unix)]
 use std::io::{BufRead, BufReader, Read, Write};
+#[cfg(any(target_os = "linux", target_vendor = "apple"))]
+use std::os::fd::{AsRawFd, FromRawFd, OwnedFd};
 #[cfg(unix)]
 use std::os::unix::fs::PermissionsExt;
 #[cfg(unix)]
@@ -168,6 +170,114 @@ impl HeadlessServer {
 #[cfg(unix)]
 fn wait_for_child_exit(child: &mut Child, timeout: Duration) -> bool {
     child.wait_timeout(timeout).unwrap().is_some()
+}
+
+#[cfg(any(target_os = "linux", target_vendor = "apple"))]
+struct ProcessExitSignal {
+    descriptor: OwnedFd,
+}
+
+#[cfg(any(target_os = "linux", target_vendor = "apple"))]
+impl ProcessExitSignal {
+    fn observe(pid: u32) -> std::io::Result<Self> {
+        let pid = libc::pid_t::try_from(pid).map_err(|_| {
+            std::io::Error::new(std::io::ErrorKind::InvalidInput, "process ID exceeds pid_t")
+        })?;
+        #[cfg(target_os = "linux")]
+        let descriptor = unsafe { libc::syscall(libc::SYS_pidfd_open, pid, 0) } as libc::c_int;
+        #[cfg(target_vendor = "apple")]
+        let descriptor = unsafe { libc::kqueue() };
+        if descriptor < 0 {
+            return Err(std::io::Error::last_os_error());
+        }
+        // SAFETY: pidfd_open or kqueue returned a new owned descriptor.
+        let descriptor = unsafe { OwnedFd::from_raw_fd(descriptor) };
+
+        #[cfg(target_vendor = "apple")]
+        {
+            let change = libc::kevent {
+                ident: pid as libc::uintptr_t,
+                filter: libc::EVFILT_PROC,
+                flags: libc::EV_ADD | libc::EV_ENABLE | libc::EV_ONESHOT,
+                fflags: libc::NOTE_EXIT,
+                data: 0,
+                udata: std::ptr::null_mut(),
+            };
+            let registered = unsafe {
+                libc::kevent(
+                    descriptor.as_raw_fd(),
+                    &raw const change,
+                    1,
+                    std::ptr::null_mut(),
+                    0,
+                    std::ptr::null(),
+                )
+            };
+            if registered < 0 {
+                return Err(std::io::Error::last_os_error());
+            }
+        }
+
+        Ok(Self { descriptor })
+    }
+
+    fn wait_until(&self, deadline: Instant) -> std::io::Result<bool> {
+        #[cfg(target_os = "linux")]
+        {
+            let mut descriptor =
+                libc::pollfd { fd: self.descriptor.as_raw_fd(), events: libc::POLLIN, revents: 0 };
+            loop {
+                let remaining = deadline.saturating_duration_since(Instant::now());
+                let timeout_ms = remaining.as_millis().min(libc::c_int::MAX as u128) as libc::c_int;
+                let ready = unsafe { libc::poll(&raw mut descriptor, 1, timeout_ms) };
+                if ready > 0 {
+                    if descriptor.revents & libc::POLLNVAL != 0 {
+                        return Err(std::io::Error::new(
+                            std::io::ErrorKind::InvalidInput,
+                            "process-exit descriptor became invalid",
+                        ));
+                    }
+                    return Ok(true);
+                }
+                if ready == 0 {
+                    return Ok(false);
+                }
+                let error = std::io::Error::last_os_error();
+                if error.kind() != std::io::ErrorKind::Interrupted {
+                    return Err(error);
+                }
+            }
+        }
+        #[cfg(target_vendor = "apple")]
+        {
+            let mut event = unsafe { std::mem::zeroed::<libc::kevent>() };
+            loop {
+                let remaining = deadline.saturating_duration_since(Instant::now());
+                let timeout = libc::timespec {
+                    tv_sec: libc::time_t::try_from(remaining.as_secs())
+                        .unwrap_or(libc::time_t::MAX),
+                    tv_nsec: libc::c_long::from(remaining.subsec_nanos()),
+                };
+                let ready = unsafe {
+                    libc::kevent(
+                        self.descriptor.as_raw_fd(),
+                        std::ptr::null(),
+                        0,
+                        &raw mut event,
+                        1,
+                        &raw const timeout,
+                    )
+                };
+                if ready >= 0 {
+                    return Ok(ready > 0);
+                }
+                let error = std::io::Error::last_os_error();
+                if error.kind() != std::io::ErrorKind::Interrupted {
+                    return Err(error);
+                }
+            }
+        }
+    }
 }
 
 #[cfg(unix)]
@@ -1042,7 +1152,7 @@ fn explicit_attach_registers_a_full_session_tui_client() {
     panic!("explicit attach never registered the full session");
 }
 
-#[cfg(unix)]
+#[cfg(any(target_os = "linux", target_vendor = "apple"))]
 #[test]
 fn graceful_shutdown_stops_server_owned_sidebar_process() {
     let mut server = HeadlessServer::start_with_config(
@@ -1075,13 +1185,26 @@ fn graceful_shutdown_stops_server_owned_sidebar_process() {
     let used_durable_host = !records.is_empty();
     let mut owned_pids = vec![plugin_pid];
     owned_pids.extend(records.iter().map(|(_, record)| record.host_pid));
+    let owned_process_exits = owned_pids
+        .iter()
+        .copied()
+        .map(ProcessExitSignal::observe)
+        .collect::<std::io::Result<Vec<_>>>()
+        .expect("observe server-owned process exits");
 
     let server_pid = libc::pid_t::try_from(server.child.id()).unwrap();
+    let shutdown_deadline = Instant::now() + Duration::from_secs(10);
     // SAFETY: this PID is the live child owned by the test fixture.
     assert_eq!(unsafe { libc::kill(server_pid, libc::SIGINT) }, 0);
-    let server_stopped = wait_for_child_exit(&mut server.child, Duration::from_secs(10));
-    let owned_processes_stopped =
-        owned_pids.iter().copied().all(|pid| !process_exists(pid) && !process_group_exists(pid));
+    let server_stopped = wait_for_child_exit(
+        &mut server.child,
+        shutdown_deadline.saturating_duration_since(Instant::now()),
+    );
+    let process_exits_published = owned_process_exits.iter().all(|process_exit| {
+        process_exit.wait_until(shutdown_deadline).expect("wait for server-owned process exit")
+    });
+    let owned_processes_stopped = process_exits_published
+        && owned_pids.iter().copied().all(|pid| !process_exists(pid) && !process_group_exists(pid));
 
     // Keep lifecycle regressions leak-free. Every captured process group and
     // record belongs to this fixture's private state root.

--- a/cmux-tui/crates/cmux-tui/tests/cli.rs
+++ b/cmux-tui/crates/cmux-tui/tests/cli.rs
@@ -1,16 +1,12 @@
 use std::fs;
-#[cfg(any(target_os = "linux", target_vendor = "apple"))]
-use std::fs::{File, OpenOptions};
 #[cfg(unix)]
 use std::io::{BufRead, BufReader, Read, Write};
 #[cfg(any(target_os = "linux", target_vendor = "apple"))]
 use std::os::fd::AsRawFd;
-#[cfg(any(target_os = "linux", target_vendor = "apple"))]
-use std::os::unix::ffi::OsStrExt;
 #[cfg(unix)]
-use std::os::unix::fs::{OpenOptionsExt, PermissionsExt};
+use std::os::unix::fs::PermissionsExt;
 #[cfg(unix)]
-use std::os::unix::net::UnixListener;
+use std::os::unix::net::{UnixListener, UnixStream};
 use std::path::PathBuf;
 use std::process::{Child, Command, Output, Stdio};
 use std::sync::mpsc;
@@ -33,6 +29,19 @@ impl HeadlessServer {
     }
 
     fn start_with_config(name: &str, config_contents: Option<&str>) -> Self {
+        Self::start_with_config_and_env(name, config_contents, std::iter::empty::<(&str, &str)>())
+    }
+
+    fn start_with_config_and_env<I, K, V>(
+        name: &str,
+        config_contents: Option<&str>,
+        extra_env: I,
+    ) -> Self
+    where
+        I: IntoIterator<Item = (K, V)>,
+        K: AsRef<std::ffi::OsStr>,
+        V: AsRef<std::ffi::OsStr>,
+    {
         let dir = unique_temp_dir(name);
         fs::create_dir_all(&dir).unwrap();
         let socket = dir.join("mux.sock");
@@ -44,16 +53,17 @@ impl HeadlessServer {
         if let Some(contents) = config_contents {
             fs::write(&config, contents).unwrap();
         }
-        let child = Command::new(bin())
+        let mut command = Command::new(bin());
+        command
             .args(["--headless", "--socket"])
             .arg(&socket)
             .arg("--state")
             .arg(&state)
             .env("CMUX_TUI_CONFIG", &config)
+            .envs(extra_env)
             .stdout(Stdio::null())
-            .stderr(Stdio::piped())
-            .spawn()
-            .unwrap();
+            .stderr(Stdio::piped());
+        let child = command.spawn().unwrap();
         let server = Self { child, socket, state, dir };
         server.wait_for_socket();
         server
@@ -177,18 +187,26 @@ fn wait_for_child_exit(child: &mut Child, timeout: Duration) -> bool {
 }
 
 #[cfg(any(target_os = "linux", target_vendor = "apple"))]
+const FIXTURE_FAILURE_CLEANUP: Duration = Duration::from_secs(2);
+
+#[cfg(any(target_os = "linux", target_vendor = "apple"))]
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 enum FixtureProcessState {
     Captured,
     GracefulExit,
+    AbortRequested,
     ExitPublished,
 }
 
 #[cfg(any(target_os = "linux", target_vendor = "apple"))]
 struct FixtureProcessOwner {
-    lease_reader: File,
-    lease_guard: Option<File>,
+    lease_listener: Option<UnixListener>,
+    abort_listener: Option<UnixListener>,
+    lease: Option<UnixStream>,
+    abort: Option<UnixStream>,
     lease_dir: PathBuf,
+    lease_path: PathBuf,
+    abort_path: PathBuf,
     ready: bool,
     durable_records:
         Vec<(std::path::PathBuf, cmux_tui_core::terminal_host_runtime::TerminalHostRecord)>,
@@ -200,46 +218,39 @@ impl FixtureProcessOwner {
     fn prepare(name: &str) -> std::io::Result<Self> {
         let lease_dir = unique_temp_dir(name);
         fs::create_dir_all(&lease_dir)?;
-        let lease_path = lease_dir.join("process-group.lease");
-        let lease_path_bytes = std::ffi::CString::new(lease_path.as_os_str().as_bytes())
-            .map_err(|_| std::io::Error::from(std::io::ErrorKind::InvalidInput))?;
-        // SAFETY: lease_path_bytes is a valid NUL-terminated path, and this
-        // fixture owns the new private directory that contains it.
-        if unsafe { libc::mkfifo(lease_path_bytes.as_ptr(), 0o600) } != 0 {
-            return Err(std::io::Error::last_os_error());
-        }
-        let lease_reader =
-            OpenOptions::new().read(true).custom_flags(libc::O_NONBLOCK).open(&lease_path)?;
-        // Keep one test-owned writer open until the real process group writes
-        // its ready byte. This prevents a premature FIFO EOF before exec.
-        let lease_guard = OpenOptions::new().write(true).open(&lease_path)?;
+        let lease_path = lease_dir.join("group-lease.sock");
+        let abort_path = lease_dir.join("abort.sock");
+        let lease_listener = UnixListener::bind(&lease_path)?;
+        let abort_listener = UnixListener::bind(&abort_path)?;
 
         Ok(Self {
-            lease_reader,
-            lease_guard: Some(lease_guard),
+            lease_listener: Some(lease_listener),
+            abort_listener: Some(abort_listener),
+            lease: None,
+            abort: None,
             lease_dir,
+            lease_path,
+            abort_path,
             ready: false,
             durable_records: Vec::new(),
             state: FixtureProcessState::Captured,
         })
     }
 
-    fn lease_path(&self) -> PathBuf {
-        self.lease_dir.join("process-group.lease")
+    fn fixture_command(&self) -> std::io::Result<Vec<String>> {
+        Ok(vec![
+            std::env::current_exe()?.to_string_lossy().into_owned(),
+            "--ignored".to_string(),
+            "--exact".to_string(),
+            "sidebar_fixture_process_supervisor".to_string(),
+            "--nocapture".to_string(),
+        ])
     }
 
-    fn fixture_command(&self) -> Vec<String> {
-        vec![
-            "/bin/sh".to_string(),
-            "-c".to_string(),
-            concat!(
-                "exec 9>\"$1\" || exit 125; ",
-                "printf 'ready\\n' >&9 || exit 125; ",
-                "/bin/cat & child=$!; wait \"$child\""
-            )
-            .to_string(),
-            "cmux-sidebar-fixture".to_string(),
-            self.lease_path().to_string_lossy().into_owned(),
+    fn fixture_environment(&self) -> [(&'static str, &std::ffi::OsStr); 2] {
+        [
+            ("CMUX_TUI_TEST_GROUP_LEASE", self.lease_path.as_os_str()),
+            ("CMUX_TUI_TEST_GROUP_ABORT", self.abort_path.as_os_str()),
         ]
     }
 
@@ -252,11 +263,21 @@ impl FixtureProcessOwner {
         deadline: Instant,
     ) -> anyhow::Result<()> {
         self.durable_records = durable_records;
+        let lease_listener = self
+            .lease_listener
+            .take()
+            .ok_or_else(|| anyhow::anyhow!("fixture lease listener was already consumed"))?;
+        let abort_listener = self
+            .abort_listener
+            .take()
+            .ok_or_else(|| anyhow::anyhow!("fixture abort listener was already consumed"))?;
+        self.lease = Some(Self::accept_until(&lease_listener, deadline)?);
+        self.abort = Some(Self::accept_until(&abort_listener, deadline)?);
+        self.lease.as_ref().unwrap().set_nonblocking(true)?;
         anyhow::ensure!(
             self.wait_for_ready(deadline)?,
-            "fixture process group did not publish its lease"
+            "fixture supervisor did not publish its process-group lease"
         );
-        self.lease_guard.take();
         Ok(())
     }
 
@@ -291,10 +312,27 @@ impl FixtureProcessOwner {
 
     fn wait_for_ready(&mut self, deadline: Instant) -> std::io::Result<bool> {
         let mut bytes = Vec::new();
-        while self.wait_for_lease_event(deadline)? {
+        while Self::wait_for_fd(
+            self.lease
+                .as_ref()
+                .ok_or_else(|| {
+                    std::io::Error::new(
+                        std::io::ErrorKind::NotConnected,
+                        "fixture lease is not connected",
+                    )
+                })?
+                .as_raw_fd(),
+            libc::POLLIN | libc::POLLHUP,
+            deadline,
+        )? {
             let mut buffer = [0_u8; 32];
-            match self.lease_reader.read(&mut buffer) {
-                Ok(0) => continue,
+            match self.lease.as_mut().unwrap().read(&mut buffer) {
+                Ok(0) => {
+                    return Err(std::io::Error::new(
+                        std::io::ErrorKind::UnexpectedEof,
+                        "fixture supervisor exited before lease publication",
+                    ));
+                }
                 Ok(count) => {
                     bytes.extend_from_slice(&buffer[..count]);
                     if bytes.windows(b"ready\n".len()).any(|window| window == b"ready\n") {
@@ -316,9 +354,16 @@ impl FixtureProcessOwner {
                 "fixture process-group lease was not armed",
             ));
         }
-        while self.wait_for_lease_event(deadline)? {
+        self.wait_for_lease_eof(deadline)
+    }
+
+    fn wait_for_lease_eof(&mut self, deadline: Instant) -> std::io::Result<bool> {
+        let Some(descriptor) = self.lease.as_ref().map(|lease| lease.as_raw_fd()) else {
+            return Ok(true);
+        };
+        while Self::wait_for_fd(descriptor, libc::POLLIN | libc::POLLHUP, deadline)? {
             let mut buffer = [0_u8; 32];
-            match self.lease_reader.read(&mut buffer) {
+            match self.lease.as_mut().unwrap().read(&mut buffer) {
                 Ok(0) => return Ok(true),
                 Ok(_) => {}
                 Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => {}
@@ -328,24 +373,67 @@ impl FixtureProcessOwner {
         Ok(false)
     }
 
-    fn wait_for_lease_event(&self, deadline: Instant) -> std::io::Result<bool> {
-        let mut descriptor = libc::pollfd {
-            fd: self.lease_reader.as_raw_fd(),
-            events: libc::POLLIN | libc::POLLHUP,
-            revents: 0,
-        };
+    fn request_abort_and_wait(&mut self, deadline: Instant) -> std::io::Result<bool> {
+        if self.state == FixtureProcessState::ExitPublished {
+            return Ok(true);
+        }
+        self.state = FixtureProcessState::AbortRequested;
+        if let Some(mut abort) = self.abort.take() {
+            let _ = abort.write_all(b"abort\n");
+            let _ = abort.shutdown(std::net::Shutdown::Write);
+        }
+        if self.wait_for_lease_eof(deadline)? {
+            self.state = FixtureProcessState::ExitPublished;
+            return Ok(true);
+        }
+        Ok(false)
+    }
+
+    fn accept_until(listener: &UnixListener, deadline: Instant) -> std::io::Result<UnixStream> {
+        listener.set_nonblocking(true)?;
+        loop {
+            if !Self::wait_for_fd(listener.as_raw_fd(), libc::POLLIN, deadline)? {
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::TimedOut,
+                    "fixture supervisor did not connect before deadline",
+                ));
+            }
+            match listener.accept() {
+                Ok((stream, _)) => return Ok(stream),
+                Err(error)
+                    if matches!(
+                        error.kind(),
+                        std::io::ErrorKind::Interrupted | std::io::ErrorKind::WouldBlock
+                    ) => {}
+                Err(error) => return Err(error),
+            }
+        }
+    }
+
+    fn wait_for_fd(
+        descriptor: std::os::fd::RawFd,
+        events: libc::c_short,
+        deadline: Instant,
+    ) -> std::io::Result<bool> {
+        let mut descriptor = libc::pollfd { fd: descriptor, events, revents: 0 };
         loop {
             let remaining = deadline.saturating_duration_since(Instant::now());
+            if remaining.is_zero() {
+                return Ok(false);
+            }
             let timeout_ms = remaining.as_millis().min(libc::c_int::MAX as u128) as libc::c_int;
             let ready = unsafe { libc::poll(&raw mut descriptor, 1, timeout_ms) };
             if ready > 0 {
-                if descriptor.revents & libc::POLLNVAL != 0 {
-                    return Err(std::io::Error::new(
-                        std::io::ErrorKind::InvalidInput,
-                        "fixture process-group lease became invalid",
-                    ));
+                if descriptor.revents & events != 0 {
+                    return Ok(true);
                 }
-                return Ok(true);
+                if descriptor.revents & (libc::POLLERR | libc::POLLNVAL) != 0 {
+                    return Err(std::io::Error::other(format!(
+                        "fixture supervisor descriptor failed with events {:#x}",
+                        descriptor.revents
+                    )));
+                }
+                continue;
             }
             if ready == 0 {
                 return Ok(false);
@@ -361,7 +449,18 @@ impl FixtureProcessOwner {
 #[cfg(any(target_os = "linux", target_vendor = "apple"))]
 impl Drop for FixtureProcessOwner {
     fn drop(&mut self) {
-        let _ = fs::remove_dir_all(&self.lease_dir);
+        let cleanup_complete = self.state == FixtureProcessState::ExitPublished
+            || self
+                .request_abort_and_wait(Instant::now() + FIXTURE_FAILURE_CLEANUP)
+                .unwrap_or(false);
+        if cleanup_complete {
+            let _ = fs::remove_dir_all(&self.lease_dir);
+        } else {
+            eprintln!(
+                "fixture supervisor did not publish process-group EOF; retained {}",
+                self.lease_dir.display()
+            );
+        }
     }
 }
 
@@ -1228,6 +1327,54 @@ fn explicit_attach_registers_a_full_session_tui_client() {
 }
 
 #[cfg(any(target_os = "linux", target_vendor = "apple"))]
+fn clear_close_on_exec(descriptor: std::os::fd::RawFd) -> std::io::Result<()> {
+    // SAFETY: descriptor is the live lease socket owned by this supervisor.
+    let flags = unsafe { libc::fcntl(descriptor, libc::F_GETFD) };
+    if flags < 0 {
+        return Err(std::io::Error::last_os_error());
+    }
+    // SAFETY: F_SETFD changes only the close-on-exec flag on the same live
+    // lease descriptor so each exact child inherits the kernel-owned proof.
+    if unsafe { libc::fcntl(descriptor, libc::F_SETFD, flags & !libc::FD_CLOEXEC) } < 0 {
+        return Err(std::io::Error::last_os_error());
+    }
+    Ok(())
+}
+
+#[cfg(any(target_os = "linux", target_vendor = "apple"))]
+#[test]
+#[ignore = "launched as the server-owned sidebar fixture supervisor"]
+fn sidebar_fixture_process_supervisor() {
+    let Some(lease_path) = std::env::var_os("CMUX_TUI_TEST_GROUP_LEASE") else {
+        return;
+    };
+    let Some(abort_path) = std::env::var_os("CMUX_TUI_TEST_GROUP_ABORT") else {
+        return;
+    };
+
+    let mut lease = UnixStream::connect(lease_path).expect("connect fixture group lease");
+    let mut abort = UnixStream::connect(abort_path).expect("connect fixture abort channel");
+    clear_close_on_exec(lease.as_raw_fd()).expect("make fixture group lease inheritable");
+
+    // The supervisor is the single test-only owner for every fixture member.
+    // All members inherit the same lease, and only this owner can end and reap
+    // them after an abort request.
+    let mut members = vec![Command::new("/bin/cat").spawn().expect("start fixture member")];
+    lease.write_all(b"ready\n").expect("publish fixture group lease");
+
+    let mut request = [0_u8; 1];
+    let _ = abort.read(&mut request);
+    for member in &mut members {
+        // The exact Child handle retains ownership even when exit races this
+        // abort request. wait below is the single authoritative reap.
+        let _ = member.kill();
+    }
+    for mut member in members {
+        member.wait().expect("reap fixture member after abort");
+    }
+}
+
+#[cfg(any(target_os = "linux", target_vendor = "apple"))]
 #[test]
 fn graceful_shutdown_stops_server_owned_sidebar_process() {
     let mut process_owner =
@@ -1235,12 +1382,16 @@ fn graceful_shutdown_stops_server_owned_sidebar_process() {
     let config = serde_json::json!({
         "sidebar": {
             "plugin": {
-                "command": process_owner.fixture_command(),
+                "command": process_owner.fixture_command().expect("locate fixture supervisor"),
             }
         }
     })
     .to_string();
-    let mut server = HeadlessServer::start_with_config("sidebar-host-shutdown", Some(&config));
+    let mut server = HeadlessServer::start_with_config_and_env(
+        "sidebar-host-shutdown",
+        Some(&config),
+        process_owner.fixture_environment(),
+    );
     let sidebar = try_json_socket_request(
         &server.socket,
         serde_json::json!({

--- a/cmux-tui/crates/cmux-tui/tests/cli.rs
+++ b/cmux-tui/crates/cmux-tui/tests/cli.rs
@@ -1183,8 +1183,7 @@ fn graceful_shutdown_stops_server_owned_sidebar_process() {
     let records = cmux_tui_core::terminal_host_runtime::load_terminal_host_records(&host_root)
         .expect("load sidebar terminal-host record");
     let used_durable_host = !records.is_empty();
-    let mut owned_pids = vec![plugin_pid];
-    owned_pids.extend(records.iter().map(|(_, record)| record.host_pid));
+    let owned_pids = [plugin_pid];
     let owned_process_exits = owned_pids
         .iter()
         .copied()
@@ -1205,14 +1204,16 @@ fn graceful_shutdown_stops_server_owned_sidebar_process() {
     });
     // The configured plugin is one direct /bin/cat process. Its kernel exit
     // event is therefore the complete owner-process lifecycle signal.
-    let owned_processes_stopped =
-        process_exits_published && owned_pids.iter().copied().all(|pid| !process_exists(pid));
+    let owned_processes_stopped = process_exits_published
+        && owned_pids.iter().copied().all(|pid| !process_exists(pid) && !process_group_exists(pid));
 
     // Keep lifecycle regressions leak-free. Every captured process group and
     // record belongs to this fixture's private state root.
-    if !owned_processes_stopped {
-        for pid in &owned_pids {
-            signal_test_process_group(*pid, libc::SIGKILL);
+    if !owned_processes_stopped || used_durable_host {
+        for pid in
+            owned_pids.iter().copied().chain(records.iter().map(|(_, record)| record.host_pid))
+        {
+            signal_test_process_group(pid, libc::SIGKILL);
         }
         for (record_path, record) in &records {
             let _ = cmux_tui_core::terminal_host_runtime::remove_stale_terminal_host_record(

--- a/cmux-tui/crates/cmux-tui/tests/cli.rs
+++ b/cmux-tui/crates/cmux-tui/tests/cli.rs
@@ -280,6 +280,115 @@ impl ProcessExitSignal {
     }
 }
 
+#[cfg(any(target_os = "linux", target_vendor = "apple"))]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum FixtureProcessState {
+    Captured,
+    GracefulExit,
+    ForceSignaled,
+    ExitPublished,
+}
+
+#[cfg(any(target_os = "linux", target_vendor = "apple"))]
+struct FixtureProcessOwner {
+    pid: u32,
+    exit: ProcessExitSignal,
+    durable_record:
+        Option<(std::path::PathBuf, cmux_tui_core::terminal_host_runtime::TerminalHostRecord)>,
+    durable_exit_validated: bool,
+    state: FixtureProcessState,
+}
+
+#[cfg(any(target_os = "linux", target_vendor = "apple"))]
+impl FixtureProcessOwner {
+    fn capture(
+        pid: u32,
+        durable_record: Option<(
+            std::path::PathBuf,
+            cmux_tui_core::terminal_host_runtime::TerminalHostRecord,
+        )>,
+    ) -> std::io::Result<Self> {
+        Ok(Self {
+            pid,
+            exit: ProcessExitSignal::observe(pid)?,
+            durable_exit_validated: durable_record.is_none(),
+            durable_record,
+            state: FixtureProcessState::Captured,
+        })
+    }
+
+    fn wait_for_graceful_exit(&mut self, deadline: Instant) -> anyhow::Result<bool> {
+        anyhow::ensure!(self.state == FixtureProcessState::Captured);
+        if !self.exit.wait_until(deadline)? {
+            return Ok(false);
+        }
+        self.state = FixtureProcessState::GracefulExit;
+        self.validate_durable_exit()?;
+        Ok(true)
+    }
+
+    fn force_stop_and_wait(&mut self, deadline: Instant) -> anyhow::Result<()> {
+        match self.state {
+            FixtureProcessState::GracefulExit | FixtureProcessState::ExitPublished => return Ok(()),
+            FixtureProcessState::Captured => {
+                if self.exit.wait_until(Instant::now())? {
+                    self.state = FixtureProcessState::GracefulExit;
+                    self.validate_durable_exit()?;
+                    return Ok(());
+                }
+                signal_test_process_group(self.pid, libc::SIGKILL);
+                self.state = FixtureProcessState::ForceSignaled;
+            }
+            FixtureProcessState::ForceSignaled => {}
+        }
+        anyhow::ensure!(
+            self.exit.wait_until(deadline)?,
+            "fixture process {} did not publish exit after SIGKILL",
+            self.pid
+        );
+        self.state = FixtureProcessState::ExitPublished;
+        self.validate_durable_exit()
+    }
+
+    fn remove_durable_record(&self) -> anyhow::Result<()> {
+        let Some((record_path, record)) = &self.durable_record else {
+            return Ok(());
+        };
+        anyhow::ensure!(
+            self.durable_exit_validated
+                && matches!(
+                    self.state,
+                    FixtureProcessState::GracefulExit | FixtureProcessState::ExitPublished
+                ),
+            "durable fixture record is not safe to remove"
+        );
+        match cmux_tui_core::terminal_host_runtime::remove_stale_terminal_host_record(
+            record_path,
+            record,
+        ) {
+            Ok(true) => Ok(()),
+            Ok(false) => anyhow::bail!("durable fixture record remained live after process exit"),
+            Err(_) if !record_path.exists() => Ok(()),
+            Err(error) => Err(error),
+        }
+    }
+
+    fn validate_durable_exit(&mut self) -> anyhow::Result<()> {
+        let Some((record_path, record)) = &self.durable_record else {
+            return Ok(());
+        };
+        anyhow::ensure!(
+            cmux_tui_core::terminal_host_runtime::terminal_host_record_liveness(
+                record_path,
+                record,
+            )? == cmux_tui_core::terminal_host_runtime::TerminalHostLiveness::Dead,
+            "durable fixture host did not release its exact liveness proof"
+        );
+        self.durable_exit_validated = true;
+        Ok(())
+    }
+}
+
 #[cfg(unix)]
 fn signal_test_process_group(pid: u32, signal: libc::c_int) {
     let Ok(pid) = libc::pid_t::try_from(pid) else { return };
@@ -1183,14 +1292,14 @@ fn graceful_shutdown_stops_server_owned_sidebar_process() {
     let records = cmux_tui_core::terminal_host_runtime::load_terminal_host_records(&host_root)
         .expect("load sidebar terminal-host record");
     let used_durable_host = !records.is_empty();
-    let mut owned_pids = vec![plugin_pid];
-    owned_pids.extend(records.iter().map(|(_, record)| record.host_pid));
-    let owned_process_exits = owned_pids
-        .iter()
-        .copied()
-        .map(ProcessExitSignal::observe)
-        .collect::<std::io::Result<Vec<_>>>()
-        .expect("observe server-owned process exits");
+    let mut process_owners = vec![
+        FixtureProcessOwner::capture(plugin_pid, None)
+            .expect("capture sidebar plugin process owner"),
+    ];
+    process_owners.extend(records.iter().map(|(record_path, record)| {
+        FixtureProcessOwner::capture(record.host_pid, Some((record_path.clone(), record.clone())))
+            .expect("capture durable sidebar process owner")
+    }));
 
     let server_pid = libc::pid_t::try_from(server.child.id()).unwrap();
     let shutdown_deadline = Instant::now() + Duration::from_secs(10);
@@ -1200,35 +1309,29 @@ fn graceful_shutdown_stops_server_owned_sidebar_process() {
         &mut server.child,
         shutdown_deadline.saturating_duration_since(Instant::now()),
     );
-    let process_exits_published = owned_process_exits
-        .iter()
-        .map(|process_exit| {
-            process_exit.wait_until(shutdown_deadline).expect("wait for server-owned process exit")
-        })
-        .collect::<Vec<_>>();
+    let mut owned_processes_stopped = true;
+    for owner in &mut process_owners {
+        owned_processes_stopped &= owner
+            .wait_for_graceful_exit(shutdown_deadline)
+            .expect("wait for server-owned process exit");
+    }
     // The successful fixture has no durable host and one direct /bin/cat
     // process. cmux-pty executes that program directly, and /bin/cat does not
     // fork, so its exact PID exit also proves this fixture cannot retain a
     // process-group descendant. The pre-captured pidfd/kqueue event proves
     // that exit without racing zombie reaping or PID reuse.
     // Unexpected durable hosts stay in this result and fail below.
-    let owned_processes_stopped = process_exits_published.iter().all(|published| *published);
-
     // Keep lifecycle regressions leak-free. Every captured process group and
     // record belongs to this fixture's private state root.
-    // Never signal a numeric PID after its exact exit event. PID or process
-    // group reuse could target unrelated work.
-    for (pid, process_exit_published) in owned_pids.iter().zip(&process_exits_published) {
-        if !*process_exit_published {
-            signal_test_process_group(*pid, libc::SIGKILL);
-        }
-    }
     if !owned_processes_stopped || used_durable_host {
-        for (record_path, record) in &records {
-            let _ = cmux_tui_core::terminal_host_runtime::remove_stale_terminal_host_record(
-                record_path,
-                record,
-            );
+        let cleanup_deadline = Instant::now() + Duration::from_secs(2);
+        for owner in &mut process_owners {
+            owner
+                .force_stop_and_wait(cleanup_deadline)
+                .expect("force and reap live sidebar fixture process");
+        }
+        for owner in &process_owners {
+            owner.remove_durable_record().expect("remove exited durable sidebar fixture record");
         }
     }
 

--- a/cmux-tui/crates/cmux-tui/tests/cli.rs
+++ b/cmux-tui/crates/cmux-tui/tests/cli.rs
@@ -9,6 +9,8 @@ use std::path::PathBuf;
 use std::process::{Child, Command, Output, Stdio};
 use std::sync::mpsc;
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+#[cfg(unix)]
+use wait_timeout::ChildExt;
 
 use cmux_tui_core::platform::transport;
 
@@ -165,26 +167,7 @@ impl HeadlessServer {
 
 #[cfg(unix)]
 fn wait_for_child_exit(child: &mut Child, timeout: Duration) -> bool {
-    let deadline = Instant::now() + timeout;
-    while Instant::now() < deadline {
-        if child.try_wait().unwrap().is_some() {
-            return true;
-        }
-        std::thread::sleep(Duration::from_millis(10));
-    }
-    false
-}
-
-#[cfg(unix)]
-fn wait_for_processes_to_exit(pids: &[u32], timeout: Duration) -> bool {
-    let deadline = Instant::now() + timeout;
-    while Instant::now() < deadline {
-        if pids.iter().copied().all(|pid| !process_exists(pid) && !process_group_exists(pid)) {
-            return true;
-        }
-        std::thread::sleep(Duration::from_millis(10));
-    }
-    false
+    child.wait_timeout(timeout).unwrap().is_some()
 }
 
 #[cfg(unix)]
@@ -1097,22 +1080,16 @@ fn graceful_shutdown_stops_server_owned_sidebar_process() {
     // SAFETY: this PID is the live child owned by the test fixture.
     assert_eq!(unsafe { libc::kill(server_pid, libc::SIGINT) }, 0);
     let server_stopped = wait_for_child_exit(&mut server.child, Duration::from_secs(10));
-    let owned_processes_stopped = wait_for_processes_to_exit(&owned_pids, Duration::from_secs(5));
+    let owned_processes_stopped = owned_pids
+        .iter()
+        .copied()
+        .all(|pid| !process_exists(pid) && !process_group_exists(pid));
 
     // Keep lifecycle regressions leak-free. Every captured process group and
     // record belongs to this fixture's private state root.
     if !owned_processes_stopped {
         for pid in &owned_pids {
-            signal_test_process_group(*pid, libc::SIGTERM);
-        }
-        if !wait_for_processes_to_exit(&owned_pids, Duration::from_secs(2)) {
-            for pid in &owned_pids {
-                signal_test_process_group(*pid, libc::SIGKILL);
-            }
-            assert!(
-                wait_for_processes_to_exit(&owned_pids, Duration::from_secs(2)),
-                "fixture could not reap its isolated sidebar processes"
-            );
+            signal_test_process_group(*pid, libc::SIGKILL);
         }
         for (record_path, record) in &records {
             let _ = cmux_tui_core::terminal_host_runtime::remove_stale_terminal_host_record(

--- a/cmux-tui/crates/cmux-tui/tests/cli.rs
+++ b/cmux-tui/crates/cmux-tui/tests/cli.rs
@@ -1200,23 +1200,30 @@ fn graceful_shutdown_stops_server_owned_sidebar_process() {
         &mut server.child,
         shutdown_deadline.saturating_duration_since(Instant::now()),
     );
-    let process_exits_published = owned_process_exits.iter().all(|process_exit| {
-        process_exit.wait_until(shutdown_deadline).expect("wait for server-owned process exit")
-    });
+    let process_exits_published = owned_process_exits
+        .iter()
+        .map(|process_exit| {
+            process_exit.wait_until(shutdown_deadline).expect("wait for server-owned process exit")
+        })
+        .collect::<Vec<_>>();
     // The successful fixture has no durable host and one direct /bin/cat
     // process. cmux-pty executes that program directly, and /bin/cat does not
     // fork, so its exact PID exit also proves this fixture cannot retain a
     // process-group descendant. The pre-captured pidfd/kqueue event proves
     // that exit without racing zombie reaping or PID reuse.
     // Unexpected durable hosts stay in this result and fail below.
-    let owned_processes_stopped = process_exits_published;
+    let owned_processes_stopped = process_exits_published.iter().all(|published| *published);
 
     // Keep lifecycle regressions leak-free. Every captured process group and
     // record belongs to this fixture's private state root.
-    if !owned_processes_stopped || used_durable_host {
-        for pid in &owned_pids {
+    // Never signal a numeric PID after its exact exit event. PID or process
+    // group reuse could target unrelated work.
+    for (pid, process_exit_published) in owned_pids.iter().zip(&process_exits_published) {
+        if !*process_exit_published {
             signal_test_process_group(*pid, libc::SIGKILL);
         }
+    }
+    if !owned_processes_stopped || used_durable_host {
         for (record_path, record) in &records {
             let _ = cmux_tui_core::terminal_host_runtime::remove_stale_terminal_host_record(
                 record_path,

--- a/cmux-tui/crates/cmux-tui/tests/cli.rs
+++ b/cmux-tui/crates/cmux-tui/tests/cli.rs
@@ -1204,9 +1204,10 @@ fn graceful_shutdown_stops_server_owned_sidebar_process() {
         process_exit.wait_until(shutdown_deadline).expect("wait for server-owned process exit")
     });
     // The successful fixture has no durable host and one direct /bin/cat
-    // process. Unexpected durable hosts stay in this result and fail below.
-    let owned_processes_stopped = process_exits_published
-        && owned_pids.iter().copied().all(|pid| !process_exists(pid) && !process_group_exists(pid));
+    // process. The pre-captured pidfd/kqueue event is bound to that exact
+    // process and proves exit without racing zombie reaping or PID reuse.
+    // Unexpected durable hosts stay in this result and fail below.
+    let owned_processes_stopped = process_exits_published;
 
     // Keep lifecycle regressions leak-free. Every captured process group and
     // record belongs to this fixture's private state root.

--- a/cmux-tui/crates/cmux-tui/tests/terminal_host_recovery.rs
+++ b/cmux-tui/crates/cmux-tui/tests/terminal_host_recovery.rs
@@ -265,6 +265,10 @@ fn short_lived_terminal_launch_converges_to_durable_exited_result() {
     assert!(created["terminal_revision"].as_u64().is_some());
 
     let terminal_id = created["terminal_id"].as_str().expect("run omitted terminal id").to_string();
+    let terminal_resource_id = only_terminal_resource_id(
+        &harness.socket,
+        "short-lived-terminal-snapshot",
+    );
     assert!(created["terminal_incarnation"].as_str().is_some());
     let waited = resource_request(
         &harness.socket,
@@ -273,7 +277,7 @@ fn short_lived_terminal_launch_converges_to_durable_exited_result() {
         serde_json::json!({
             "machine":"current",
             "session":"current",
-            "terminal":terminal_id,
+            "terminal":terminal_resource_id,
             "timeout_ms":"10000",
         }),
         None,
@@ -2876,6 +2880,8 @@ fn ctrl_d_exits_shell_and_detaches_terminal_topology() {
     );
     let surface = created["surface"].as_u64().unwrap();
     let terminal_id = created["terminal_id"].as_str().unwrap().to_string();
+    let terminal_resource_id =
+        only_terminal_resource_id(&harness.socket, "ctrl-d-terminal-snapshot");
     let workspace_id = created["workspace"].as_u64().unwrap();
 
     request(
@@ -2890,7 +2896,7 @@ fn ctrl_d_exits_shell_and_detaches_terminal_topology() {
         serde_json::json!({
             "machine":"current",
             "session":"current",
-            "terminal":terminal_id,
+            "terminal":terminal_resource_id,
             "timeout_ms":"10000",
         }),
         None,
@@ -3160,6 +3166,19 @@ fn resource_request(
     assert_eq!(response["id"], id, "request failed: {response}");
     assert_eq!(response["ok"], true, "request failed: {response}");
     response["result"].clone()
+}
+
+fn only_terminal_resource_id(path: &Path, id: &str) -> String {
+    let snapshot = resource_request(
+        path,
+        id,
+        "session.snapshot",
+        serde_json::json!({"machine":"current","session":"current"}),
+        None,
+    );
+    let terminals = snapshot["terminals"].as_array().expect("snapshot terminals");
+    assert_eq!(terminals.len(), 1, "fixture must publish one terminal: {snapshot}");
+    terminals[0]["id"].as_str().expect("terminal resource id").to_string()
 }
 
 fn wait_for_socket(path: &Path) {

--- a/cmux-tui/crates/cmux-tui/tests/terminal_host_recovery.rs
+++ b/cmux-tui/crates/cmux-tui/tests/terminal_host_recovery.rs
@@ -265,10 +265,8 @@ fn short_lived_terminal_launch_converges_to_durable_exited_result() {
     assert!(created["terminal_revision"].as_u64().is_some());
 
     let terminal_id = created["terminal_id"].as_str().expect("run omitted terminal id").to_string();
-    let terminal_resource_id = only_terminal_resource_id(
-        &harness.socket,
-        "short-lived-terminal-snapshot",
-    );
+    let terminal_resource_id =
+        only_terminal_resource_id(&harness.socket, "short-lived-terminal-snapshot");
     assert!(created["terminal_incarnation"].as_str().is_some());
     let waited = resource_request(
         &harness.socket,

--- a/cmux-tui/crates/cmux-tui/tests/terminal_host_recovery.rs
+++ b/cmux-tui/crates/cmux-tui/tests/terminal_host_recovery.rs
@@ -266,18 +266,23 @@ fn short_lived_terminal_launch_converges_to_durable_exited_result() {
 
     let terminal_id = created["terminal_id"].as_str().expect("run omitted terminal id").to_string();
     assert!(created["terminal_incarnation"].as_str().is_some());
-    let deadline = Instant::now() + Duration::from_secs(10);
-    let resolved = loop {
-        let resolved = request(
-            &harness.socket,
-            serde_json::json!({"id":2,"cmd":"resolve-terminal","terminal_id":terminal_id}),
-        );
-        if resolved["lifecycle"] == "exited" {
-            break resolved;
-        }
-        assert!(Instant::now() < deadline, "short-lived terminal did not exit: {resolved}");
-        std::thread::sleep(Duration::from_millis(10));
-    };
+    let waited = resource_request(
+        &harness.socket,
+        "short-lived-terminal-wait-exit",
+        "terminal.wait_exit",
+        serde_json::json!({
+            "machine":"current",
+            "session":"current",
+            "terminal":terminal_id,
+            "timeout_ms":"10000",
+        }),
+        None,
+    );
+    assert_eq!(waited["state"], "exited", "short-lived terminal did not exit: {waited}");
+    let resolved = request(
+        &harness.socket,
+        serde_json::json!({"id":2,"cmd":"resolve-terminal","terminal_id":terminal_id}),
+    );
     assert_eq!(resolved["surface"], serde_json::Value::Null);
     assert_eq!(resolved["lifecycle"], "exited");
     assert_eq!(resolved["exit"]["outcome"], serde_json::json!({"kind":"exit","code":23}));
@@ -2878,19 +2883,24 @@ fn ctrl_d_exits_shell_and_detaches_terminal_topology() {
         serde_json::json!({"id":2,"cmd":"send-key","surface":surface,"keys":["ctrl+d"]}),
     );
 
-    let deadline = Instant::now() + Duration::from_secs(10);
-    loop {
-        let resolved = request(
-            &harness.socket,
-            serde_json::json!({"id":3,"cmd":"resolve-terminal","terminal_id":terminal_id}),
-        );
-        if resolved["lifecycle"] == "exited" {
-            assert_eq!(resolved["surface"], serde_json::Value::Null);
-            break;
-        }
-        assert!(Instant::now() < deadline, "Ctrl-D never exited the shell");
-        std::thread::sleep(Duration::from_millis(20));
-    }
+    let waited = resource_request(
+        &harness.socket,
+        "ctrl-d-terminal-wait-exit",
+        "terminal.wait_exit",
+        serde_json::json!({
+            "machine":"current",
+            "session":"current",
+            "terminal":terminal_id,
+            "timeout_ms":"10000",
+        }),
+        None,
+    );
+    assert_eq!(waited["state"], "exited", "Ctrl-D never exited the shell: {waited}");
+    let resolved = request(
+        &harness.socket,
+        serde_json::json!({"id":3,"cmd":"resolve-terminal","terminal_id":terminal_id}),
+    );
+    assert_eq!(resolved["surface"], serde_json::Value::Null);
 
     let tree = request(&harness.socket, serde_json::json!({"id":4,"cmd":"list-workspaces"}));
     let workspace = tree["workspaces"]


### PR DESCRIPTION
## Summary

- expose the journal ingress failed-write phase from its state owner for deterministic retry verification
- wait on terminal exit, worker admission, outbound queue, scheduler close, and process exit owner signals
- replace fixed-duration process fixtures with lifecycle-controlled fixtures
- emit the TypeScript journal record only after the subscription is ready

## Architecture

Journal ingress remains the owner of writer progress. Its test observer exposes the failed-attempt phase without adding a parallel Mux state model. Other tests use existing owner transitions and public terminal wait operations.

## Verification

- `git diff --check`
- hosted cmux-tui verification will run on this branch
- no local compile or test run, as required by the timing audit

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/9936"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789000493&installation_model_id=21920&pr_number=9936&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F9936&signature=b9ed4161029bdaf3f808fa8baa9c03aaa356ea139c31310a5ef982802fa6cd0d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are confined to test code, dev-dependencies, and `#[cfg(test)]` hooks; production behavior is unchanged aside from test-only instrumentation on journal ingress failures and wait wake tracking.
> 
> **Overview**
> Replaces **fixed sleeps and poll loops** in journal, server, CLI, and TypeScript tests with waits tied to real state transitions.
> 
> **Journal ingress** gains a test-only observer that signals when a durable write fails, so retry tests no longer sleep hoping the writer hit the injected SQLite error.
> 
> **Server/resource tests** use condvar-backed helpers: `ResourceWorkerAdmission::wait_for_active`, `BoundedOutbound::pop_until`, and counting indefinite terminal/stream waiters so idle-worker tests assert on subscriptions without arbitrary delays. Scheduler shutdown uses `close_and_wait` instead of sleeping on `Arc` counts.
> 
> **Hook stdin test** uses a lifecycle-controlled child (FIFO + STOP), pidfd/kqueue exit signals, and scoped delivery with timeout/kill cleanup instead of assuming the hook exits in under one second.
> 
> **CLI shutdown** observes process exit via pidfd (Linux) or kqueue `EVFILT_PROC` (macOS) plus `wait-timeout` on the server child.
> 
> **Recovery tests** wait for terminal exit through `terminal.wait_exit` with a snapshot-derived resource id instead of polling `resolve-terminal`.
> 
> **TypeScript** defers emitting the mismatched journal record until after subscribe ACK so the race is intentional, not timing-dependent.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 42a7a2649988e24a2a3616ba6258eb290eb41928. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced timing-based sleeps with deterministic, event-driven waits across journal, server/surface, CLI, and TypeScript tests to remove flakiness. Added exact exit observers, portable process-group lease EOF proofs, and terminal runtime owner waits so shutdowns and retries are reliable.

- **Refactors**
  - Journal: added a test-only failed-write observer (Condvar) and dropped the writer’s transient owner before acknowledging durable completion; tests wait on `observe_next_journal_ingress_failure_for_test` instead of sleeping.
  - Server/Mux/Surface: added `wait_for_active` and `pop_until` helpers, tracked indefinite waiters, and waited for terminal runtime owner threads (reader/wait/proxy) to finish via `wait_for_terminal_runtime_owners_for_test`; tests call `shutdown_for_daemon` and verify owners release before `Mux` drop.
  - CLI: replaced PID polling with pidfd/kqueue exit signals and `wait-timeout`; moved sidebar plugin tests to a Rust fixture supervisor using inheritable Unix-socket “group lease” plus abort, and validated process-group EOF and durable host record death; unexpected durable hosts are closed through the production path before shutdown.
  - Hooks: gated cleanup with a FIFO “lease/release,” used `poll` to accept portable EOF completion, and ensured failed fixtures are released by lease without sleeps.
  - TypeScript: emit the mismatched journal record only after subscribe ACK via a captured emitter, removing timer races.

- **Dependencies**
  - Added `wait-timeout` (test-only) for deterministic child exit in CLI tests.

<sup>Written for commit 6b9ce0f8110c588f71337e9926a2d8f48badc0fb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/9936?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

