### PR TITLE
Replace terminal timing polls with owner signals

### DIFF
--- a/cmux-tui/apps/macos/TerminalBytesDemo/Sources/TerminalBytesDemo/TerminalModel.swift
+++ b/cmux-tui/apps/macos/TerminalBytesDemo/Sources/TerminalBytesDemo/TerminalModel.swift
@@ -51,6 +51,43 @@ struct ConnectedHandle: Sendable {
 
 typealias TerminalConnector = @Sendable (String, String) -> ConnectedHandle
 
+struct TerminalModelClock: Sendable {
+    private let currentTime: @Sendable () -> Duration
+    private let sleepUntilTime: @Sendable (Duration, Duration?) async throws -> Void
+
+    init(
+        now: @escaping @Sendable () -> Duration,
+        sleepUntil: @escaping @Sendable (Duration, Duration?) async throws -> Void
+    ) {
+        currentTime = now
+        sleepUntilTime = sleepUntil
+    }
+
+    var now: Duration { currentTime() }
+
+    func sleep(for delay: Duration) async throws {
+        try await sleep(until: now + delay)
+    }
+
+    func sleep(until deadline: Duration, tolerance: Duration? = nil) async throws {
+        try await sleepUntilTime(deadline, tolerance)
+    }
+
+    static func continuous() -> TerminalModelClock {
+        let clock = ContinuousClock()
+        let origin = clock.now
+        return TerminalModelClock(
+            now: { origin.duration(to: clock.now) },
+            sleepUntil: { deadline, tolerance in
+                try await clock.sleep(
+                    until: origin.advanced(by: deadline),
+                    tolerance: tolerance
+                )
+            }
+        )
+    }
+}
+
 private let terminalConnectionTimeoutError = "terminal connection timed out"
 private let terminalConnectionTimeoutMilliseconds: UInt64 = 15_000
 
@@ -546,6 +583,7 @@ final class TerminalModel {
     @ObservationIgnored private var resizeRetryExhausted = false
     @ObservationIgnored private var geometryDelivery = GeometryDeliveryState()
     @ObservationIgnored private let connectClient: TerminalConnector
+    @ObservationIgnored private let clock: TerminalModelClock
     @ObservationIgnored private let shouldAutoConnect: Bool
     @ObservationIgnored private var didAttemptAutoConnect = false
     @ObservationIgnored private var isShuttingDown = false
@@ -555,7 +593,8 @@ final class TerminalModel {
         configuration: DemoLaunchConfiguration = .processEnvironment(),
         retainedClient: TerminalClientHandle? = nil,
         initiallyConnected: Bool = false,
-        connectClient: TerminalConnector? = nil
+        connectClient: TerminalConnector? = nil,
+        clock: TerminalModelClock = .continuous()
     ) {
         let inputWake = AsyncStream.makeStream(
             of: Void.self,
@@ -566,6 +605,7 @@ final class TerminalModel {
         invitation = configuration.invitation
         terminalID = configuration.terminalID
         self.connectClient = connectClient ?? defaultTerminalConnector
+        self.clock = clock
         shouldAutoConnect = configuration.autoConnect
         client = retainedClient
         let retainedInvitation = configuration.invitation.trimmingCharacters(
@@ -872,7 +912,7 @@ final class TerminalModel {
         resizeRetryAttempt += 1
         resizeRetryTask = Task {
             do {
-                try await ContinuousClock().sleep(for: delay)
+                try await clock.sleep(for: delay)
             } catch {
                 return
             }
@@ -896,7 +936,6 @@ final class TerminalModel {
         updateTask?.cancel()
         updateTask = Task { [weak self] in
             let updates = await client.updates()
-            let clock = ContinuousClock()
             var nextRender = clock.now
             for await _ in updates.stream {
                 guard !Task.isCancelled else { break }

--- a/cmux-tui/apps/macos/TerminalBytesDemo/Sources/TerminalBytesDemo/TerminalModel.swift
+++ b/cmux-tui/apps/macos/TerminalBytesDemo/Sources/TerminalBytesDemo/TerminalModel.swift
@@ -934,14 +934,18 @@ final class TerminalModel {
 
     private func beginUpdates(from client: TerminalClientHandle, operation: UInt64) {
         updateTask?.cancel()
+        let renderClock = clock
         updateTask = Task { [weak self] in
             let updates = await client.updates()
-            var nextRender = clock.now
+            var nextRender = renderClock.now
             for await _ in updates.stream {
                 guard !Task.isCancelled else { break }
-                if clock.now < nextRender {
+                if renderClock.now < nextRender {
                     do {
-                        try await clock.sleep(until: nextRender, tolerance: .milliseconds(2))
+                        try await renderClock.sleep(
+                            until: nextRender,
+                            tolerance: .milliseconds(2)
+                        )
                     } catch {
                         break
                     }
@@ -952,7 +956,7 @@ final class TerminalModel {
                     !self.isShuttingDown
                 else { break }
                 self.apply(snapshot, from: client)
-                nextRender = clock.now.advanced(by: .milliseconds(33))
+                nextRender = renderClock.now.advanced(by: .milliseconds(33))
             }
             await client.stopUpdates(generation: updates.generation)
         }

--- a/cmux-tui/apps/macos/TerminalBytesDemo/Tests/TerminalBytesDemoTests/TerminalBytesLogicTests.swift
+++ b/cmux-tui/apps/macos/TerminalBytesDemo/Tests/TerminalBytesDemoTests/TerminalBytesLogicTests.swift
@@ -1,8 +1,113 @@
 import AppKit
 import Foundation
+import Observation
 import Testing
 
 @testable import TerminalBytesDemo
+
+private final class TestProgress: @unchecked Sendable {
+    static let shared = TestProgress()
+
+    private let lock = NSLock()
+    private var generationStorage: UInt64 = 0
+    private var waiters: [(UInt64, CheckedContinuation<Void, Never>)] = []
+
+    var generation: UInt64 {
+        lock.lock()
+        defer { lock.unlock() }
+        return generationStorage
+    }
+
+    func signal() {
+        lock.lock()
+        generationStorage &+= 1
+        let ready = waiters
+        waiters.removeAll()
+        lock.unlock()
+        for (_, continuation) in ready {
+            continuation.resume()
+        }
+    }
+
+    func wait(after observedGeneration: UInt64) async {
+        await withCheckedContinuation { continuation in
+            lock.lock()
+            if generationStorage != observedGeneration {
+                lock.unlock()
+                continuation.resume()
+            } else {
+                waiters.append((observedGeneration, continuation))
+                lock.unlock()
+            }
+        }
+    }
+}
+
+private final class ManualTerminalClock: @unchecked Sendable {
+    private let lock = NSLock()
+    private var time: Duration = .zero
+    private let ticks: AsyncStream<Void>
+    private let tickContinuation: AsyncStream<Void>.Continuation
+    private let sleepRequests: AsyncStream<Duration>
+    private let requestContinuation: AsyncStream<Duration>.Continuation
+
+    init() {
+        let tickEvents = AsyncStream.makeStream(
+            of: Void.self,
+            bufferingPolicy: .bufferingNewest(1)
+        )
+        ticks = tickEvents.stream
+        tickContinuation = tickEvents.continuation
+        let requests = AsyncStream.makeStream(
+            of: Duration.self,
+            bufferingPolicy: .unbounded
+        )
+        sleepRequests = requests.stream
+        requestContinuation = requests.continuation
+    }
+
+    var clock: TerminalModelClock {
+        TerminalModelClock(
+            now: { [self] in now },
+            sleepUntil: { [self] deadline, _ in
+                try await sleep(until: deadline)
+            }
+        )
+    }
+
+    var now: Duration {
+        lock.lock()
+        defer { lock.unlock() }
+        return time
+    }
+
+    func advance(by duration: Duration) {
+        lock.lock()
+        time += duration
+        lock.unlock()
+        tickContinuation.yield()
+    }
+
+    func nextSleepDeadline() async -> Duration {
+        for await deadline in sleepRequests {
+            return deadline
+        }
+        Issue.record("The manual clock stopped before receiving a sleep request.")
+        return .zero
+    }
+
+    private func sleep(until deadline: Duration) async throws {
+        requestContinuation.yield(deadline)
+        var iterator = ticks.makeAsyncIterator()
+        while now < deadline {
+            guard await iterator.next() != nil else {
+                try Task.checkCancellation()
+                throw CancellationError()
+            }
+            try Task.checkCancellation()
+        }
+    }
+}
 
 private final class LockedFlag: @unchecked Sendable {
     // NSLock protects every access to storage, including calls from injected
@@ -20,6 +125,7 @@ private final class LockedFlag: @unchecked Sendable {
         lock.lock()
         storage = true
         lock.unlock()
+        TestProgress.shared.signal()
     }
 }
 
@@ -38,6 +144,7 @@ private final class LockedCounter: @unchecked Sendable {
         lock.lock()
         storage += 1
         lock.unlock()
+        TestProgress.shared.signal()
     }
 }
 
@@ -54,9 +161,11 @@ private final class LockedInputs: @unchecked Sendable {
     @discardableResult
     func record(_ value: String) -> Int {
         lock.lock()
-        defer { lock.unlock() }
         storage.append(value)
-        return storage.count
+        let count = storage.count
+        lock.unlock()
+        TestProgress.shared.signal()
+        return count
     }
 }
 
@@ -167,11 +276,17 @@ struct TerminalBytesLogicTests {
     private func waitUntil(
         _ predicate: @escaping @MainActor () -> Bool
     ) async -> Bool {
-        for _ in 0..<100 {
-            if predicate() { return true }
-            try? await Task.sleep(for: .milliseconds(10))
+        while true {
+            let generation = TestProgress.shared.generation
+            var satisfied = false
+            withObservationTracking {
+                satisfied = predicate()
+            } onChange: {
+                TestProgress.shared.signal()
+            }
+            if satisfied { return true }
+            await TestProgress.shared.wait(after: generation)
         }
-        return predicate()
     }
 
     @Test
@@ -398,6 +513,48 @@ struct TerminalBytesLogicTests {
         await Task.yield()
         #expect(attempts.value == 4)
         model.shutdown()
+    }
+
+    @Test @MainActor
+    func rejectedResizeRetryUsesTheInjectedClockAndCancelsOnShutdown() async throws {
+        let attempts = LockedCounter()
+        let clock = ManualTerminalClock()
+        let handle = TerminalClientHandle(
+            rawAddress: 11,
+            attachClient: { _, _, _, _, _ in true },
+            destroyClient: { _ in },
+            detachClient: { _ in },
+            setUpdateCallback: { _, _, _ in },
+            resizeClient: { _, _, _ in
+                attempts.increment()
+                return false
+            },
+            copyFrameClient: { _, _, _ in 0 },
+            copyDiagnosticsClient: { _, _, _ in 0 }
+        )
+        let model = TerminalModel(
+            configuration: DemoLaunchConfiguration(
+                invitation: "",
+                terminalID: "term_0123456789abcdef0123456789abcdef",
+                autoConnect: false
+            ),
+            retainedClient: handle,
+            initiallyConnected: true,
+            clock: clock.clock
+        )
+
+        model.resize(to: TerminalGeometry(cols: 120, rows: 40))
+        #expect(await waitUntil { attempts.value == 1 })
+        #expect(await clock.nextSleepDeadline() == .milliseconds(50))
+
+        clock.advance(by: .milliseconds(50))
+        #expect(await waitUntil { attempts.value == 2 })
+        #expect(await clock.nextSleepDeadline() == .milliseconds(150))
+
+        model.shutdown()
+        clock.advance(by: .seconds(1))
+        await Task.yield()
+        #expect(attempts.value == 2)
     }
 
     @Test @MainActor

--- a/cmux-tui/apps/macos/TerminalBytesDemo/Tests/TerminalBytesDemoTests/TerminalBytesLogicTests.swift
+++ b/cmux-tui/apps/macos/TerminalBytesDemo/Tests/TerminalBytesDemoTests/TerminalBytesLogicTests.swift
@@ -194,6 +194,61 @@ private final class LockedInputs: @unchecked Sendable {
     }
 }
 
+private final class LockedString: @unchecked Sendable {
+    private let lock = NSLock()
+    private var storage = ""
+
+    var value: String {
+        lock.lock()
+        defer { lock.unlock() }
+        return storage
+    }
+
+    func set(_ value: String) {
+        lock.lock()
+        storage = value
+        lock.unlock()
+    }
+}
+
+private final class LockedUpdateCallback: @unchecked Sendable {
+    private let lock = NSLock()
+    private let registration = TestSignal()
+    private var callback: TerminalUpdateCallback?
+    private var context: UnsafeMutableRawPointer?
+
+    func set(_ callback: TerminalUpdateCallback?, context: UnsafeMutableRawPointer?) {
+        lock.lock()
+        self.callback = callback
+        self.context = context
+        lock.unlock()
+        registration.signal()
+    }
+
+    private var isRegistered: Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        return callback != nil
+    }
+
+    func waitUntilRegistered() async {
+        while !isRegistered {
+            let generation = registration.generation
+            if !isRegistered {
+                await registration.wait(after: generation)
+            }
+        }
+    }
+
+    func send() {
+        lock.lock()
+        let callback = callback
+        let context = context
+        lock.unlock()
+        callback?(context)
+    }
+}
+
 @MainActor
 private func makeBlockingInputHarness() -> (
     model: TerminalModel,
@@ -587,6 +642,50 @@ struct TerminalBytesLogicTests {
         clock.advance(by: .seconds(1))
         await Task.yield()
         #expect(attempts.value == 2)
+    }
+
+    @Test @MainActor
+    func renderThrottleUsesTheInjectedClockAndStopsOnShutdown() async throws {
+        let updates = LockedUpdateCallback()
+        let frame = LockedString()
+        let clock = ManualTerminalClock()
+        let handle = TerminalClientHandle(
+            rawAddress: 12,
+            attachClient: { _, _, _, _, _ in true },
+            destroyClient: { _ in },
+            detachClient: { _ in },
+            setUpdateCallback: { _, callback, context in
+                updates.set(callback, context: context)
+            },
+            copyFrameClient: { _, buffer, capacity in
+                copyTestCString(frame.value, buffer: buffer, capacity: capacity)
+            },
+            copyDiagnosticsClient: { _, _, _ in 0 }
+        )
+        let model = TerminalModel(
+            configuration: DemoLaunchConfiguration(
+                invitation: "",
+                terminalID: "term_0123456789abcdef0123456789abcdef",
+                autoConnect: false
+            ),
+            retainedClient: handle,
+            clock: clock.clock
+        )
+
+        model.connect()
+        await updates.waitUntilRegistered()
+        frame.set("first")
+        updates.send()
+        await waitUntilObserved { model.frame == "first" }
+
+        frame.set("second")
+        updates.send()
+        #expect(await clock.nextSleepDeadline() == .milliseconds(33))
+        #expect(model.frame == "first")
+
+        clock.advance(by: .milliseconds(33))
+        await waitUntilObserved { model.frame == "second" }
+        model.shutdown()
     }
 
     @Test @MainActor

--- a/cmux-tui/apps/macos/TerminalBytesDemo/Tests/TerminalBytesDemoTests/TerminalBytesLogicTests.swift
+++ b/cmux-tui/apps/macos/TerminalBytesDemo/Tests/TerminalBytesDemoTests/TerminalBytesLogicTests.swift
@@ -5,12 +5,10 @@ import Testing
 
 @testable import TerminalBytesDemo
 
-private final class TestProgress: @unchecked Sendable {
-    static let shared = TestProgress()
-
+private final class TestSignal: @unchecked Sendable {
     private let lock = NSLock()
     private var generationStorage: UInt64 = 0
-    private var waiters: [(UInt64, CheckedContinuation<Void, Never>)] = []
+    private var waiters: [CheckedContinuation<Void, Never>] = []
 
     var generation: UInt64 {
         lock.lock()
@@ -24,7 +22,7 @@ private final class TestProgress: @unchecked Sendable {
         let ready = waiters
         waiters.removeAll()
         lock.unlock()
-        for (_, continuation) in ready {
+        for continuation in ready {
             continuation.resume()
         }
     }
@@ -36,7 +34,7 @@ private final class TestProgress: @unchecked Sendable {
                 lock.unlock()
                 continuation.resume()
             } else {
-                waiters.append((observedGeneration, continuation))
+                waiters.append(continuation)
                 lock.unlock()
             }
         }
@@ -113,6 +111,7 @@ private final class LockedFlag: @unchecked Sendable {
     // NSLock protects every access to storage, including calls from injected
     // C-operation closures that the compiler must treat as concurrent.
     private let lock = NSLock()
+    private let signal = TestSignal()
     private var storage = false
 
     var value: Bool {
@@ -125,13 +124,22 @@ private final class LockedFlag: @unchecked Sendable {
         lock.lock()
         storage = true
         lock.unlock()
-        TestProgress.shared.signal()
+        signal.signal()
+    }
+
+    func waitUntilSet() async {
+        while !value {
+            let generation = signal.generation
+            if value { return }
+            await signal.wait(after: generation)
+        }
     }
 }
 
 private final class LockedCounter: @unchecked Sendable {
     // NSLock protects every access from injected concurrent client operations.
     private let lock = NSLock()
+    private let signal = TestSignal()
     private var storage = 0
 
     var value: Int {
@@ -144,12 +152,21 @@ private final class LockedCounter: @unchecked Sendable {
         lock.lock()
         storage += 1
         lock.unlock()
-        TestProgress.shared.signal()
+        signal.signal()
+    }
+
+    func wait(until predicate: @Sendable (Int) -> Bool) async {
+        while !predicate(value) {
+            let generation = signal.generation
+            if predicate(value) { return }
+            await signal.wait(after: generation)
+        }
     }
 }
 
 private final class LockedInputs: @unchecked Sendable {
     private let lock = NSLock()
+    private let signal = TestSignal()
     private var storage: [String] = []
 
     var values: [String] {
@@ -164,8 +181,16 @@ private final class LockedInputs: @unchecked Sendable {
         storage.append(value)
         let count = storage.count
         lock.unlock()
-        TestProgress.shared.signal()
+        signal.signal()
         return count
+    }
+
+    func wait(until predicate: @Sendable ([String]) -> Bool) async {
+        while !predicate(values) {
+            let generation = signal.generation
+            if predicate(values) { return }
+            await signal.wait(after: generation)
+        }
     }
 }
 
@@ -273,19 +298,26 @@ private final class LockedClientCalls: @unchecked Sendable {
 @Suite
 struct TerminalBytesLogicTests {
     @MainActor
-    private func waitUntil(
+    private func waitUntilObserved(
         _ predicate: @escaping @MainActor () -> Bool
-    ) async -> Bool {
+    ) async {
         while true {
-            let generation = TestProgress.shared.generation
             var satisfied = false
-            withObservationTracking {
+            let changes = AsyncStream.makeStream(
+                of: Void.self,
+                bufferingPolicy: .bufferingNewest(1)
+            )
+            withObservationTracking({
                 satisfied = predicate()
-            } onChange: {
-                TestProgress.shared.signal()
+            }, onChange: {
+                changes.continuation.yield()
+                changes.continuation.finish()
+            })
+            if satisfied {
+                changes.continuation.finish()
+                return
             }
-            if satisfied { return true }
-            await TestProgress.shared.wait(after: generation)
+            for await _ in changes.stream { break }
         }
     }
 
@@ -505,11 +537,11 @@ struct TerminalBytesLogicTests {
         )
 
         model.resize(to: TerminalGeometry(cols: 120, rows: 40))
-        #expect(await waitUntil { attempts.value > 0 })
+        await attempts.wait { $0 > 0 }
         for _ in 0..<100 {
             model.resize(to: TerminalGeometry(cols: 120, rows: 40))
         }
-        #expect(await waitUntil { attempts.value >= 4 })
+        await attempts.wait { $0 >= 4 }
         await Task.yield()
         #expect(attempts.value == 4)
         model.shutdown()
@@ -544,11 +576,11 @@ struct TerminalBytesLogicTests {
         )
 
         model.resize(to: TerminalGeometry(cols: 120, rows: 40))
-        #expect(await waitUntil { attempts.value == 1 })
+        await attempts.wait { $0 == 1 }
         #expect(await clock.nextSleepDeadline() == .milliseconds(50))
 
         clock.advance(by: .milliseconds(50))
-        #expect(await waitUntil { attempts.value == 2 })
+        await attempts.wait { $0 == 2 }
         #expect(await clock.nextSleepDeadline() == .milliseconds(150))
 
         model.shutdown()
@@ -644,14 +676,14 @@ struct TerminalBytesLogicTests {
         )
 
         model.submit(.bytes(Data("0".utf8)))
-        #expect(await waitUntil { firstStarted.value })
+        await firstStarted.waitUntilSet()
         for value in 1...300 {
             model.submit(.bytes(Data(String(value).utf8)))
         }
         #expect(!model.errorMessage.isEmpty)
 
         releaseFirst.signal()
-        #expect(await waitUntil { inputs.values.count == 257 })
+        await inputs.wait { $0.count == 257 }
         #expect(inputs.values == (0...256).map(String.init))
         model.shutdown()
     }
@@ -660,7 +692,7 @@ struct TerminalBytesLogicTests {
     func terminalInputRejectsAnOversizedPayloadBeforeTheEntryLimit() async throws {
         let harness = makeBlockingInputHarness()
         harness.model.submit(.bytes(Data("blocked".utf8)))
-        #expect(await waitUntil { harness.firstStarted.value })
+        await harness.firstStarted.waitUntilSet()
 
         harness.model.submit(.bytes(Data(repeating: 0x61, count: 1_048_577)))
         #expect(!harness.model.errorMessage.isEmpty)
@@ -673,7 +705,7 @@ struct TerminalBytesLogicTests {
     func terminalInputRejectsAggregateBytesBeforeTheEntryLimit() async throws {
         let harness = makeBlockingInputHarness()
         harness.model.submit(.bytes(Data("blocked".utf8)))
-        #expect(await waitUntil { harness.firstStarted.value })
+        await harness.firstStarted.waitUntilSet()
 
         let chunk = Data(repeating: 0x61, count: 1_048_576)
         for _ in 0..<5 {
@@ -714,11 +746,11 @@ struct TerminalBytesLogicTests {
 
         model.connect()
         #expect(model.isConnecting)
-        #expect(await waitUntil { attachStarted.value })
+        await attachStarted.waitUntilSet()
         #expect(model.isConnecting)
 
         releaseAttach.signal()
-        #expect(await waitUntil { model.isConnected && !model.isConnecting })
+        await waitUntilObserved { model.isConnected && !model.isConnecting }
         model.shutdown()
     }
 
@@ -738,11 +770,13 @@ struct TerminalBytesLogicTests {
         )
 
         model.connect()
-        #expect(await waitUntil { attempts.value == 1 && !model.isConnecting })
+        await attempts.wait { $0 == 1 }
+        await waitUntilObserved { !model.isConnecting }
         #expect(!model.errorMessage.isEmpty)
 
         model.connect()
-        #expect(await waitUntil { attempts.value == 2 && !model.isConnecting })
+        await attempts.wait { $0 == 2 }
+        await waitUntilObserved { !model.isConnecting }
         #expect(!model.errorMessage.isEmpty)
         model.shutdown()
     }
@@ -778,15 +812,13 @@ struct TerminalBytesLogicTests {
         )
 
         model.connect()
-        #expect(await waitUntil { timeouts.values == ["15000"] && !model.isConnecting })
+        await timeouts.wait { $0 == ["15000"] }
+        await waitUntilObserved { !model.isConnecting }
         #expect(!model.errorMessage.isEmpty)
 
         model.connect()
-        #expect(
-            await waitUntil {
-                timeouts.values == ["15000", "15000"] && !model.isConnecting
-            }
-        )
+        await timeouts.wait { $0 == ["15000", "15000"] }
+        await waitUntilObserved { !model.isConnecting }
         #expect(!model.errorMessage.isEmpty)
         model.shutdown()
     }
@@ -825,12 +857,9 @@ struct TerminalBytesLogicTests {
         model.invitation = "cmux://enroll/new"
         model.connect()
 
-        #expect(
-            await waitUntil {
-                invitations.values == ["cmux://enroll/new"] && destroyed.value
-                    && !model.isConnecting
-            }
-        )
+        await invitations.wait { $0 == ["cmux://enroll/new"] }
+        await destroyed.waitUntilSet()
+        await waitUntilObserved { !model.isConnecting }
         #expect(!attached.value)
         model.shutdown()
     }
@@ -864,11 +893,11 @@ struct TerminalBytesLogicTests {
         model.disconnect()
         #expect(!model.isConnected)
         #expect(model.isConnecting)
-        #expect(await waitUntil { detachStarted.value })
+        await detachStarted.waitUntilSet()
         #expect(model.isConnecting)
 
         releaseDetach.signal()
-        #expect(await waitUntil { !model.isConnecting })
+        await waitUntilObserved { !model.isConnecting }
         model.shutdown()
     }
 
@@ -901,7 +930,7 @@ struct TerminalBytesLogicTests {
         )
 
         model.connect()
-        #expect(await waitUntil { model.frame == "terminal A" })
+        await waitUntilObserved { model.frame == "terminal A" }
         model.disconnect()
         #expect(model.frame.isEmpty)
         model.shutdown()
@@ -943,7 +972,7 @@ struct TerminalBytesLogicTests {
         )
 
         model.connect()
-        #expect(await waitUntil { model.diagnostics == exitedDiagnostics })
+        await waitUntilObserved { model.diagnostics == exitedDiagnostics }
         #expect(!model.isConnected)
         model.submit(.bytes(Data("x".utf8)))
         #expect(model.errorMessage.isEmpty)

--- a/cmux-tui/crates/cmux-terminal-client/src/lib.rs
+++ b/cmux-tui/crates/cmux-terminal-client/src/lib.rs
@@ -2700,11 +2700,8 @@ mod tests {
             let (shutdown, mut shutdown_events) =
                 tokio::sync::watch::channel(TerminalTaskPhase::Running);
             let waiter = tokio::spawn(async move {
-                wait_for_reconnect_backoff(
-                    &mut shutdown_events,
-                    std::time::Duration::from_secs(60),
-                )
-                .await
+                wait_for_reconnect_backoff(&mut shutdown_events, std::time::Duration::from_secs(60))
+                    .await
             });
             tokio::task::yield_now().await;
             shutdown.send_replace(TerminalTaskPhase::Stopped);

--- a/cmux-tui/crates/cmux-terminal-client/src/lib.rs
+++ b/cmux-tui/crates/cmux-terminal-client/src/lib.rs
@@ -2629,4 +2629,26 @@ mod tests {
             daemon.shutdown().await;
         });
     }
+
+    #[test]
+    fn reconnect_backoff_stops_when_terminal_shutdown_is_published() {
+        let runtime = Runtime::new().unwrap();
+        runtime.block_on(async {
+            let (shutdown, mut shutdown_events) = tokio::sync::watch::channel(false);
+            let waiter = tokio::spawn(async move {
+                wait_for_reconnect_backoff(
+                    &mut shutdown_events,
+                    std::time::Duration::from_secs(60),
+                )
+                .await
+            });
+            tokio::task::yield_now().await;
+            shutdown.send_replace(true);
+            let completed = tokio::time::timeout(std::time::Duration::from_secs(1), waiter)
+                .await
+                .expect("shutdown did not wake reconnect backoff")
+                .expect("reconnect backoff task panicked");
+            assert!(!completed, "shutdown must cancel reconnect backoff");
+        });
+    }
 }

--- a/cmux-tui/crates/cmux-terminal-client/src/lib.rs
+++ b/cmux-tui/crates/cmux-terminal-client/src/lib.rs
@@ -360,6 +360,12 @@ struct ClientUpdates {
     test_events: tokio::sync::watch::Sender<u64>,
 }
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum TerminalTaskPhase {
+    Running,
+    Stopped,
+}
+
 impl Default for ClientUpdates {
     fn default() -> Self {
         #[cfg(test)]
@@ -404,7 +410,7 @@ impl ClientUpdates {
 struct ActiveTerminal {
     streams: tokio::sync::watch::Sender<Option<Arc<ServiceStream>>>,
     closed: Arc<AtomicBool>,
-    shutdown: tokio::sync::watch::Sender<bool>,
+    shutdown: tokio::sync::watch::Sender<TerminalTaskPhase>,
     command_sender: tokio::sync::mpsc::Sender<Bytes>,
     receiver_task: tokio::task::JoinHandle<()>,
     command_task: tokio::task::JoinHandle<()>,
@@ -413,7 +419,7 @@ struct ActiveTerminal {
 impl ActiveTerminal {
     async fn close(self) {
         self.closed.store(true, Ordering::Release);
-        self.shutdown.send_replace(true);
+        self.shutdown.send_replace(TerminalTaskPhase::Stopped);
         self.receiver_task.abort();
         self.command_task.abort();
         let stream = self.streams.send_replace(None);
@@ -1217,7 +1223,7 @@ async fn supervise_terminal_stream(
     initial_stream: Arc<ServiceStream>,
     streams: tokio::sync::watch::Sender<Option<Arc<ServiceStream>>>,
     closed: Arc<AtomicBool>,
-    shutdown: tokio::sync::watch::Sender<bool>,
+    shutdown: tokio::sync::watch::Sender<TerminalTaskPhase>,
     state: Arc<Mutex<ClientState>>,
     updates: Arc<ClientUpdates>,
 ) {
@@ -1231,7 +1237,7 @@ async fn supervise_terminal_stream(
         }
         if outcome == StreamOutcome::Stop {
             closed.store(true, Ordering::Release);
-            shutdown.send_replace(true);
+            shutdown.send_replace(TerminalTaskPhase::Stopped);
             return;
         }
         if closed.load(Ordering::Acquire) {
@@ -1269,15 +1275,17 @@ async fn supervise_terminal_stream(
 }
 
 async fn wait_for_reconnect_backoff(
-    shutdown: &mut tokio::sync::watch::Receiver<bool>,
+    shutdown: &mut tokio::sync::watch::Receiver<TerminalTaskPhase>,
     delay: std::time::Duration,
 ) -> bool {
-    if *shutdown.borrow() {
+    if *shutdown.borrow() == TerminalTaskPhase::Stopped {
         return false;
     }
     tokio::select! {
         _ = tokio::time::sleep(delay) => true,
-        changed = shutdown.changed() => changed.is_ok() && !*shutdown.borrow(),
+        changed = shutdown.changed() => {
+            changed.is_ok() && *shutdown.borrow() == TerminalTaskPhase::Running
+        },
     }
 }
 
@@ -1290,7 +1298,7 @@ fn start_terminal_tasks(
     updates: Arc<ClientUpdates>,
 ) -> ActiveTerminal {
     let closed = Arc::new(AtomicBool::new(false));
-    let (shutdown, _) = tokio::sync::watch::channel(false);
+    let (shutdown, _) = tokio::sync::watch::channel(TerminalTaskPhase::Running);
     let (streams, mut command_streams) = tokio::sync::watch::channel(Some(stream.clone()));
     let receiver_task = runtime.spawn(supervise_terminal_stream(
         multiplexer,
@@ -2661,10 +2669,14 @@ mod tests {
 
             let mut shutdown = active.shutdown.subscribe();
             tokio::time::timeout(std::time::Duration::from_secs(3), async {
-                if !*shutdown.borrow() {
+                if *shutdown.borrow() == TerminalTaskPhase::Running {
                     shutdown.changed().await.expect("terminal shutdown stream closed");
                 }
-                assert!(*shutdown.borrow(), "terminal exit must publish shutdown");
+                assert_eq!(
+                    *shutdown.borrow(),
+                    TerminalTaskPhase::Stopped,
+                    "terminal exit must publish shutdown"
+                );
             })
             .await
             .expect("terminal exit did not close the smart client input path");
@@ -2685,7 +2697,8 @@ mod tests {
     fn reconnect_backoff_stops_when_terminal_shutdown_is_published() {
         let runtime = Runtime::new().unwrap();
         runtime.block_on(async {
-            let (shutdown, mut shutdown_events) = tokio::sync::watch::channel(false);
+            let (shutdown, mut shutdown_events) =
+                tokio::sync::watch::channel(TerminalTaskPhase::Running);
             let waiter = tokio::spawn(async move {
                 wait_for_reconnect_backoff(
                     &mut shutdown_events,
@@ -2694,7 +2707,7 @@ mod tests {
                 .await
             });
             tokio::task::yield_now().await;
-            shutdown.send_replace(true);
+            shutdown.send_replace(TerminalTaskPhase::Stopped);
             let completed = tokio::time::timeout(std::time::Duration::from_secs(1), waiter)
                 .await
                 .expect("shutdown did not wake reconnect backoff")

--- a/cmux-tui/crates/cmux-terminal-client/src/lib.rs
+++ b/cmux-tui/crates/cmux-terminal-client/src/lib.rs
@@ -354,9 +354,22 @@ struct UpdateCallbackRegistration {
     context: usize,
 }
 
-#[derive(Default)]
 struct ClientUpdates {
     callback: Mutex<Option<UpdateCallbackRegistration>>,
+    #[cfg(test)]
+    test_events: tokio::sync::watch::Sender<u64>,
+}
+
+impl Default for ClientUpdates {
+    fn default() -> Self {
+        #[cfg(test)]
+        let (test_events, _) = tokio::sync::watch::channel(0);
+        Self {
+            callback: Mutex::new(None),
+            #[cfg(test)]
+            test_events,
+        }
+    }
 }
 
 impl ClientUpdates {
@@ -378,12 +391,20 @@ impl ClientUpdates {
             // holds this same mutex across invocation and synchronous removal.
             unsafe { (registered.callback)(registered.context as *mut c_void) };
         }
+        #[cfg(test)]
+        self.test_events.send_modify(|generation| *generation = generation.wrapping_add(1));
+    }
+
+    #[cfg(test)]
+    fn subscribe(&self) -> tokio::sync::watch::Receiver<u64> {
+        self.test_events.subscribe()
     }
 }
 
 struct ActiveTerminal {
     streams: tokio::sync::watch::Sender<Option<Arc<ServiceStream>>>,
     closed: Arc<AtomicBool>,
+    shutdown: tokio::sync::watch::Sender<bool>,
     command_sender: tokio::sync::mpsc::Sender<Bytes>,
     receiver_task: tokio::task::JoinHandle<()>,
     command_task: tokio::task::JoinHandle<()>,
@@ -392,6 +413,7 @@ struct ActiveTerminal {
 impl ActiveTerminal {
     async fn close(self) {
         self.closed.store(true, Ordering::Release);
+        self.shutdown.send_replace(true);
         self.receiver_task.abort();
         self.command_task.abort();
         let stream = self.streams.send_replace(None);
@@ -1195,9 +1217,11 @@ async fn supervise_terminal_stream(
     initial_stream: Arc<ServiceStream>,
     streams: tokio::sync::watch::Sender<Option<Arc<ServiceStream>>>,
     closed: Arc<AtomicBool>,
+    shutdown: tokio::sync::watch::Sender<bool>,
     state: Arc<Mutex<ClientState>>,
     updates: Arc<ClientUpdates>,
 ) {
+    let mut shutdown_events = shutdown.subscribe();
     let mut stream = initial_stream;
     loop {
         let outcome = receive_frames(stream.clone(), state.clone(), updates.clone()).await;
@@ -1207,6 +1231,7 @@ async fn supervise_terminal_stream(
         }
         if outcome == StreamOutcome::Stop {
             closed.store(true, Ordering::Release);
+            shutdown.send_replace(true);
             return;
         }
         if closed.load(Ordering::Acquire) {
@@ -1229,10 +1254,30 @@ async fn supervise_terminal_stream(
                 }
                 Err(error) => {
                     set_client_status(&state, &updates, format!("reconnect: {error}"));
-                    tokio::time::sleep(std::time::Duration::from_millis(250)).await;
+                    if !wait_for_reconnect_backoff(
+                        &mut shutdown_events,
+                        std::time::Duration::from_millis(250),
+                    )
+                    .await
+                    {
+                        return;
+                    }
                 }
             }
         }
+    }
+}
+
+async fn wait_for_reconnect_backoff(
+    shutdown: &mut tokio::sync::watch::Receiver<bool>,
+    delay: std::time::Duration,
+) -> bool {
+    if *shutdown.borrow() {
+        return false;
+    }
+    tokio::select! {
+        _ = tokio::time::sleep(delay) => true,
+        changed = shutdown.changed() => changed.is_ok() && !*shutdown.borrow(),
     }
 }
 
@@ -1245,6 +1290,7 @@ fn start_terminal_tasks(
     updates: Arc<ClientUpdates>,
 ) -> ActiveTerminal {
     let closed = Arc::new(AtomicBool::new(false));
+    let (shutdown, _) = tokio::sync::watch::channel(false);
     let (streams, mut command_streams) = tokio::sync::watch::channel(Some(stream.clone()));
     let receiver_task = runtime.spawn(supervise_terminal_stream(
         multiplexer,
@@ -1252,6 +1298,7 @@ fn start_terminal_tasks(
         stream,
         streams.clone(),
         closed.clone(),
+        shutdown.clone(),
         state.clone(),
         updates.clone(),
     ));
@@ -1301,7 +1348,7 @@ fn start_terminal_tasks(
             }
         }
     });
-    ActiveTerminal { streams, closed, command_sender, receiver_task, command_task }
+    ActiveTerminal { streams, closed, shutdown, command_sender, receiver_task, command_task }
 }
 
 impl CmuxTerminalClient {
@@ -2528,13 +2575,15 @@ mod tests {
             let state = Arc::new(Mutex::new(
                 ClientState::new("test".into(), "memory".into(), 1, terminal_id.clone()).unwrap(),
             ));
+            let updates = Arc::new(ClientUpdates::default());
+            let mut update_events = updates.subscribe();
             let active = start_terminal_tasks(
                 runtime.handle(),
                 stream,
                 client.clone(),
                 terminal_id,
                 state.clone(),
-                Arc::new(ClientUpdates::default()),
+                updates,
             );
 
             tokio::time::timeout(std::time::Duration::from_secs(3), async {
@@ -2549,7 +2598,7 @@ mod tests {
                     if recovered {
                         break;
                     }
-                    tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+                    update_events.changed().await.expect("client update stream closed");
                 }
             })
             .await
@@ -2610,10 +2659,12 @@ mod tests {
                 Arc::new(ClientUpdates::default()),
             );
 
+            let mut shutdown = active.shutdown.subscribe();
             tokio::time::timeout(std::time::Duration::from_secs(3), async {
-                while !active.closed.load(Ordering::Acquire) {
-                    tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+                if !*shutdown.borrow() {
+                    shutdown.changed().await.expect("terminal shutdown stream closed");
                 }
+                assert!(*shutdown.borrow(), "terminal exit must publish shutdown");
             })
             .await
             .expect("terminal exit did not close the smart client input path");

--- a/cmux-tui/crates/cmux-tui-core/src/mux.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/mux.rs
@@ -1706,9 +1706,7 @@ impl TerminalExitDetachSignal {
         let state = self.state.lock().unwrap();
         let (state, _) = self
             .changed
-            .wait_timeout_while(state, timeout, |state| {
-                state.generation == observed_generation
-            })
+            .wait_timeout_while(state, timeout, |state| state.generation == observed_generation)
             .unwrap();
         state.generation
     }

--- a/cmux-tui/crates/cmux-tui-core/src/mux.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/mux.rs
@@ -1653,6 +1653,7 @@ pub struct Mux {
     resource_creation_active: AtomicBool,
     terminal_adoptions: Mutex<HashSet<String>>,
     terminal_exit_detaches: Mutex<HashSet<String>>,
+    terminal_exit_detach_signal: Arc<TerminalExitDetachSignal>,
     terminal_adoption_insert_failures: AtomicU64,
     /// Fences the interval between accepting a browser daemon-handoff request
     /// and queueing its acknowledgement. ClientRegistry consults this under
@@ -1665,6 +1666,61 @@ pub struct Mux {
     #[cfg(test)]
     test_surface_runtime: bool,
     pub session: String,
+}
+
+#[derive(Default)]
+struct TerminalExitDetachSignal {
+    state: Mutex<TerminalExitDetachSignalState>,
+    changed: Condvar,
+}
+
+#[derive(Default)]
+struct TerminalExitDetachSignalState {
+    generation: u64,
+    active_workers: usize,
+}
+
+impl TerminalExitDetachSignal {
+    fn register_worker(&self) {
+        self.state.lock().unwrap().active_workers += 1;
+    }
+
+    fn finish_worker(&self) {
+        let mut state = self.state.lock().unwrap();
+        state.active_workers = state.active_workers.saturating_sub(1);
+        self.changed.notify_all();
+    }
+
+    fn snapshot(&self) -> u64 {
+        self.state.lock().unwrap().generation
+    }
+
+    fn notify(&self) {
+        let mut state = self.state.lock().unwrap();
+        state.generation = state.generation.wrapping_add(1);
+        self.changed.notify_all();
+    }
+
+    fn wait(&self, observed_generation: u64, timeout: Duration) -> u64 {
+        let state = self.state.lock().unwrap();
+        let (state, _) = self
+            .changed
+            .wait_timeout_while(state, timeout, |state| {
+                state.generation == observed_generation
+            })
+            .unwrap();
+        state.generation
+    }
+
+    #[cfg(test)]
+    fn wait_for_idle(&self, timeout: Duration) -> bool {
+        let state = self.state.lock().unwrap();
+        let (state, _) = self
+            .changed
+            .wait_timeout_while(state, timeout, |state| state.active_workers > 0)
+            .unwrap();
+        state.active_workers == 0
+    }
 }
 
 #[derive(Clone)]
@@ -1980,6 +2036,7 @@ impl Mux {
             resource_creation_active: AtomicBool::new(false),
             terminal_adoptions: Mutex::new(HashSet::new()),
             terminal_exit_detaches: Mutex::new(HashSet::new()),
+            terminal_exit_detach_signal: Arc::new(TerminalExitDetachSignal::default()),
             terminal_adoption_insert_failures: AtomicU64::new(
                 std::env::var("CMUX_TUI_TEST_ADOPTION_INSERT_FAILURES")
                     .ok()
@@ -6666,6 +6723,7 @@ impl Mux {
 
     pub fn shutdown(&self) {
         self.shutting_down.store(true, Ordering::Release);
+        self.terminal_exit_detach_signal.notify();
         let surfaces = self.state.lock().unwrap().surfaces.values().cloned().collect::<Vec<_>>();
         for surface in surfaces {
             surface.disconnect_for_daemon_shutdown();
@@ -6711,6 +6769,7 @@ impl Mux {
     /// and remain available for the replacement daemon to adopt.
     pub fn request_daemon_shutdown(&self) {
         self.shutting_down.store(true, Ordering::Release);
+        self.terminal_exit_detach_signal.notify();
     }
 
     pub fn daemon_shutdown_requested(&self) -> bool {
@@ -10810,12 +10869,15 @@ impl Mux {
         let cleanup_id = terminal_id.clone();
         let mux = Arc::downgrade(self);
         let surface = Arc::downgrade(surface);
+        let retry_signal = self.terminal_exit_detach_signal.clone();
+        retry_signal.register_worker();
         let spawn_result = std::thread::Builder::new()
             .name(format!("terminal-exit-detach-{terminal_id}"))
             .spawn(move || {
                 let mut delay = Duration::from_millis(25);
+                let mut generation = retry_signal.snapshot();
                 loop {
-                    std::thread::sleep(delay);
+                    generation = retry_signal.wait(generation, delay);
                     let Some(mux) = mux.upgrade() else {
                         break;
                     };
@@ -10842,8 +10904,10 @@ impl Mux {
                         }
                     }
                 }
+                retry_signal.finish_worker();
             });
         if let Err(error) = spawn_result {
+            self.terminal_exit_detach_signal.finish_worker();
             self.terminal_exit_detaches.lock().unwrap().remove(&cleanup_id);
             self.emit(MuxEvent::Status(format!(
                 "could not schedule exited terminal {cleanup_id} detach: {error}"

--- a/cmux-tui/crates/cmux-tui-core/src/mux.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/mux.rs
@@ -10882,12 +10882,13 @@ impl Mux {
         let surface = Arc::downgrade(surface);
         let retry_signal = self.terminal_exit_detach_signal.clone();
         retry_signal.register_worker();
+        let retry_generation = retry_signal.snapshot();
         let spawn_result = std::thread::Builder::new()
             .name(format!("terminal-exit-detach-{terminal_id}"))
             .spawn(move || {
                 let _worker = TerminalExitDetachWorkerGuard { signal: retry_signal.clone() };
                 let mut delay = Duration::from_millis(25);
-                let mut generation = retry_signal.snapshot();
+                let mut generation = retry_generation;
                 loop {
                     generation = retry_signal.wait(generation, delay);
                     let Some(mux) = mux.upgrade() else {

--- a/cmux-tui/crates/cmux-tui-core/src/mux.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/mux.rs
@@ -1687,7 +1687,8 @@ impl TerminalExitDetachSignal {
 
     fn finish_worker(&self) {
         let mut state = self.state.lock().unwrap();
-        state.active_workers = state.active_workers.saturating_sub(1);
+        debug_assert!(state.active_workers > 0, "detach worker registration underflow");
+        state.active_workers -= 1;
         self.changed.notify_all();
     }
 
@@ -1720,6 +1721,16 @@ impl TerminalExitDetachSignal {
             .wait_timeout_while(state, timeout, |state| state.active_workers > 0)
             .unwrap();
         state.active_workers == 0
+    }
+}
+
+struct TerminalExitDetachWorkerGuard {
+    signal: Arc<TerminalExitDetachSignal>,
+}
+
+impl Drop for TerminalExitDetachWorkerGuard {
+    fn drop(&mut self) {
+        self.signal.finish_worker();
     }
 }
 
@@ -10874,6 +10885,7 @@ impl Mux {
         let spawn_result = std::thread::Builder::new()
             .name(format!("terminal-exit-detach-{terminal_id}"))
             .spawn(move || {
+                let _worker = TerminalExitDetachWorkerGuard { signal: retry_signal.clone() };
                 let mut delay = Duration::from_millis(25);
                 let mut generation = retry_signal.snapshot();
                 loop {
@@ -10904,7 +10916,6 @@ impl Mux {
                         }
                     }
                 }
-                retry_signal.finish_worker();
             });
         if let Err(error) = spawn_result {
             self.terminal_exit_detach_signal.finish_worker();

--- a/cmux-tui/crates/cmux-tui-core/src/mux.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/mux.rs
@@ -22121,16 +22121,14 @@ mod tests {
         mux.surface_exited(surface);
 
         assert!(mux.terminal_exit_detaches.lock().unwrap().contains(TERMINAL));
+        mux.shutdown();
+        assert!(
+            mux.terminal_exit_detach_signal.wait_for_idle(Duration::from_secs(1)),
+            "detach retry did not stop after mux shutdown"
+        );
         let weak = Arc::downgrade(&mux);
         drop(mux);
-        let deadline = Instant::now() + Duration::from_secs(1);
-        while weak.upgrade().is_some() {
-            assert!(
-                Instant::now() < deadline,
-                "detach retry retained the mux after its owner left"
-            );
-            std::thread::sleep(Duration::from_millis(1));
-        }
+        assert!(weak.upgrade().is_none(), "stopped detach retry retained the mux owner");
     }
 
     #[cfg(unix)]

--- a/cmux-tui/crates/cmux-tui-core/src/server.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/server.rs
@@ -11353,13 +11353,13 @@ mod tests {
         assert!(first.persist_terminal_exit_for_test(&terminal_id, &exit).unwrap());
         assert_eq!(first.resource_surface_for_terminal(&terminal_id), None);
         assert!(disconnect_client(&first, client, false));
+        assert!(
+            scheduler.close_and_wait(Duration::from_secs(10)),
+            "connection dispatcher did not release the first mux"
+        );
         drop(scheduler);
         drop(writer);
         first.shutdown();
-        let shutdown_deadline = Instant::now() + Duration::from_secs(10);
-        while Arc::strong_count(&first) > 1 && Instant::now() < shutdown_deadline {
-            std::thread::sleep(Duration::from_millis(10));
-        }
         assert_eq!(Arc::strong_count(&first), 1, "terminal workers retained the first mux");
         drop(first);
 

--- a/cmux-tui/crates/cmux-tui-core/src/terminal_host_runtime.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/terminal_host_runtime.rs
@@ -2754,6 +2754,8 @@ mod unix {
         /// resize keeps this lock until all prior parser commands drain, which
         /// gives both the host and smart clients the same output/resize order.
         source_order_lock: Mutex<()>,
+        #[cfg(test)]
+        exit_after_source_order: Mutex<Option<Arc<dyn Fn() + Send + Sync>>>,
         parser_commands: SyncSender<ParserCommand>,
         parser_budget: ParserBudget,
         /// Generation advanced after each parser write. Snapshot admission
@@ -3821,6 +3823,10 @@ mod unix {
             )?;
             if let Some(exit) = exit {
                 let _source_order = self.source_order_lock.lock().unwrap();
+                #[cfg(test)]
+                if let Some(hook) = self.exit_after_source_order.lock().unwrap().clone() {
+                    hook();
+                }
                 // Snapshot capture keeps `term` held from the dead check
                 // through smart subscription. Publish Exit under that same
                 // lock so an attach either joins before Exit or observes dead.
@@ -4258,6 +4264,8 @@ mod unix {
             sequence: AtomicU64::new(0),
             smart: SmartStreamState::new(),
             source_order_lock: Mutex::new(()),
+            #[cfg(test)]
+            exit_after_source_order: Mutex::new(None),
             parser_commands,
             parser_budget: ParserBudget::new(MAX_HOST_PARSER_QUEUED_BYTES),
             parser_progress: (Mutex::new(0), Condvar::new()),
@@ -5496,6 +5504,7 @@ mod unix {
                 sequence: AtomicU64::new(0),
                 smart: SmartStreamState::new(),
                 source_order_lock: Mutex::new(()),
+                exit_after_source_order: Mutex::new(None),
                 parser_commands,
                 parser_budget: ParserBudget::new(1),
                 parser_progress: (Mutex::new(0), Condvar::new()),
@@ -5584,6 +5593,7 @@ mod unix {
                 sequence: AtomicU64::new(0),
                 smart: SmartStreamState::new(),
                 source_order_lock: Mutex::new(()),
+                exit_after_source_order: Mutex::new(None),
                 parser_commands,
                 parser_budget: ParserBudget::new(1),
                 parser_progress: (Mutex::new(0), Condvar::new()),
@@ -6723,16 +6733,39 @@ mod unix {
             let server = thread::spawn(move || -> anyhow::Result<bool> {
                 let accept_before = |deadline: Instant| -> anyhow::Result<Option<UnixStream>> {
                     loop {
+                        let now = Instant::now();
+                        if now >= deadline {
+                            return Ok(None);
+                        }
+                        let timeout_ms = deadline
+                            .saturating_duration_since(now)
+                            .as_millis()
+                            .clamp(1, i32::MAX as u128) as i32;
+                        let mut poll_fd = libc::pollfd {
+                            fd: listener.as_raw_fd(),
+                            events: libc::POLLIN | libc::POLLHUP | libc::POLLERR,
+                            revents: 0,
+                        };
+                        // SAFETY: poll_fd is initialized and listener owns the
+                        // descriptor for the complete poll call.
+                        let ready = unsafe { libc::poll(&mut poll_fd, 1, timeout_ms) };
+                        if ready == 0 {
+                            return Ok(None);
+                        }
+                        if ready < 0 {
+                            let error = std::io::Error::last_os_error();
+                            if error.kind() == std::io::ErrorKind::Interrupted {
+                                continue;
+                            }
+                            return Err(error.into());
+                        }
                         match listener.accept() {
                             Ok((stream, _)) => {
                                 stream.set_nonblocking(false)?;
                                 return Ok(Some(stream));
                             }
                             Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => {
-                                if Instant::now() >= deadline {
-                                    return Ok(None);
-                                }
-                                thread::sleep(Duration::from_millis(2));
+                                continue;
                             }
                             Err(error) => return Err(error.into()),
                         }
@@ -7258,36 +7291,24 @@ mod unix {
             assert!(!host.dead.load(Ordering::Acquire));
 
             let (started_tx, started_rx) = std::sync::mpsc::channel();
+            let (ordered_tx, ordered_rx) = std::sync::mpsc::channel();
+            let (release_tx, release_rx) = std::sync::mpsc::channel();
+            let release_rx = Arc::new(Mutex::new(release_rx));
+            *host.exit_after_source_order.lock().unwrap() = Some(Arc::new(move || {
+                ordered_tx.send(()).unwrap();
+                release_rx.lock().unwrap().recv().unwrap();
+            }));
             let exit = thread::spawn(move || {
                 started_tx.send(()).unwrap();
                 exit_host.persist_and_publish_exit_if_drained().unwrap();
             });
             started_rx.recv_timeout(Duration::from_secs(1)).unwrap();
-            let deadline = Instant::now() + Duration::from_secs(5);
-            loop {
-                match host.source_order_lock.try_lock() {
-                    Ok(source_order) => {
-                        drop(source_order);
-                        assert!(Instant::now() < deadline, "Exit did not reach publication");
-                        thread::yield_now();
-                    }
-                    Err(TryLockError::WouldBlock) => break,
-                    Err(TryLockError::Poisoned(error)) => panic!("{error}"),
-                }
-            }
-            // Once Exit owns source ordering, the old implementation is
-            // runnable and only a few uncontended operations from `dead =
-            // true`. Give it a generous scheduling window so this regression
-            // cannot pass merely because that thread was preempted after the
-            // lock probe. The fixed implementation remains blocked on `term`.
-            let transition_deadline = Instant::now() + Duration::from_secs(1);
-            while !host.dead.load(Ordering::Acquire) && Instant::now() < transition_deadline {
-                thread::sleep(Duration::from_millis(1));
-            }
+            ordered_rx.recv_timeout(Duration::from_secs(1)).unwrap();
             assert!(
                 !host.dead.load(Ordering::Acquire),
                 "Exit bypassed the terminal snapshot lock after the attach dead check"
             );
+            release_tx.send(()).unwrap();
 
             drop(smart_publication);
             let (host_socket, _client_socket) = UnixStream::pair().unwrap();

--- a/cmux-tui/crates/cmux-tui-core/src/terminal_host_runtime.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/terminal_host_runtime.rs
@@ -3217,7 +3217,7 @@ mod unix {
                 let master = self.master.lock().unwrap();
                 if let Err(error) = master.resize(next_size) {
                     self.smart.close_failed_transition(source_cursor);
-                    return Err(error.into());
+                    return Err(error);
                 }
                 if let Err(error) =
                     term.resize(size.0, size.1, u32::from(next.0), u32::from(next.1))

--- a/cmux-tui/crates/cmux-tui-core/src/terminal_host_runtime.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/terminal_host_runtime.rs
@@ -6740,7 +6740,8 @@ mod unix {
                         let timeout_ms = deadline
                             .saturating_duration_since(now)
                             .as_millis()
-                            .clamp(1, i32::MAX as u128) as i32;
+                            .clamp(1, i32::MAX as u128)
+                            as i32;
                         let mut poll_fd = libc::pollfd {
                             fd: listener.as_raw_fd(),
                             events: libc::POLLIN | libc::POLLHUP | libc::POLLERR,


### PR DESCRIPTION
## Summary

- Inject the monotonic clock used by TerminalModel retry and render deadlines.
- Replace terminal client retry sleep with lifecycle-owned cancellation.
- Replace mux detach sleep with a worker registration and cancellation condition.
- Replace test polling with update, shutdown, scheduler, socket, and critical-section owner signals.

## Architecture and behavior coverage

- TerminalModel owns its clock. Tests advance resize retry and render throttle deadlines and verify shutdown cancellation.
- ActiveTerminal publishes Running and Stopped phases. A behavior test proves shutdown wakes the reconnect backoff.
- Mux registers each detach worker before spawn. A guard publishes worker completion, and shutdown wakes the retry condition.
- Terminal host tests wait on socket readiness and a publication hook. Scheduler tests wait for dispatcher closure.

This change is stacked on https://github.com/manaflow-ai/cmux/pull/9647.

## Verification

Hosted cmux-tui verification is pending.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/9939"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789000649&installation_model_id=21920&pr_number=9939&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F9939&signature=40cdf02b5d631315789588a54f0dbee9e3d9837c837cfca656c27e811c82f14d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes terminal reconnect backoff, mux shutdown/detach threading, and exit publication ordering—lifecycle-critical paths—but intent is cancellation and test determinism with added regression tests rather than new user-facing behavior.
> 
> **Overview**
> Replaces **sleep-and-poll** timing across the terminal stack with **owner signals** and an **injectable monotonic clock**, so shutdown and tests can cancel or advance work deterministically.
> 
> **macOS `TerminalModel`** gains `TerminalModelClock` (production default wraps `ContinuousClock`). Resize retries and ~33ms render throttling use the injected clock; demo tests drive deadlines via `ManualTerminalClock` and wait on observation/`TestSignal` instead of fixed `Task.sleep` loops.
> 
> **`cmux-terminal-client`** publishes `TerminalTaskPhase` (`Running`/`Stopped`) on `ActiveTerminal`; reconnect backoff waits with `tokio::select!` on that watch so **shutdown cancels** the sleep. Tests subscribe to client update generations instead of polling.
> 
> **Mux exit-detach retries** register workers on `TerminalExitDetachSignal`; `shutdown` / `request_daemon_shutdown` bump a generation and wake condvar waiters so retries stop without holding the mux. A test waits for idle workers via the signal instead of timing out on `Arc` strong counts.
> 
> **Host and server tests** swap blind sleeps for **poll(2)** on accept, **scheduler `close_and_wait`**, and a test-only **exit-after-source-order** hook for the smart-attach vs exit race.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 917249550500e53fc664cc8d5bc0df131cb99dff. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced sleep-based polling with lifecycle signals and an injectable clock across the terminal stack. Shutdown now cancels reconnect backoff and exit-detach retries, and render/resize timing and tests are deterministic.

- **New Features - New features added**
  - Injected `TerminalModelClock` into `TerminalModel`; added a controllable `ManualTerminalClock` for tests.
  - Replaced test polling with owner signals for client update generations (watch channel), socket readiness via poll(2), scheduler closure, and a source-order exit hook.

- **Bug Fixes - Bug fixes implemented**
  - Stopped reconnect backoff on shutdown via a `TerminalTaskPhase` watch; `ActiveTerminal` now publishes Running/Stopped and tests assert the publication.
  - Woke and stopped exit-detach retries on mux shutdown; registered workers before spawn and guarded completion to release owners in `cmux-tui-core`.
  - Used the injected clock for resize retries and render throttling; the throttle captures the clock by value and cancels on shutdown.

<sup>Written for commit 917249550500e53fc664cc8d5bc0df131cb99dff. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/9939?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

