### PR TITLE
Publish session coordinator lock availability

### DIFF
--- a/cmux-tui/crates/cmux-tui-core/src/workspace_registry.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/workspace_registry.rs
@@ -5406,10 +5406,22 @@ impl SessionLease {
                 }
             }
 
-            if !waiter.wait_until(deadline).with_context(|| {
+            if waiter.wait_until(deadline).with_context(|| {
                 format!("wait for workspace session coordinator: {}", path.display())
             })? {
-                return session_coordinator_busy(path);
+                continue;
+            }
+
+            // The file lock remains authoritative when the owner crashes or
+            // its best-effort UDP notification is lost.
+            match FileExt::try_lock(&file) {
+                Ok(()) => return Ok(Self::coordinator(file, path)),
+                Err(fs4::TryLockError::WouldBlock) => return session_coordinator_busy(path),
+                Err(error) => {
+                    return Err(error).with_context(|| {
+                        format!("lock workspace session coordinator: {}", path.display())
+                    });
+                }
             }
         }
     }

--- a/cmux-tui/crates/cmux-tui-core/src/workspace_registry.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/workspace_registry.rs
@@ -5494,6 +5494,9 @@ impl SessionCoordinatorWaiter {
             drop(registration);
             if let Err(error) = fs::rename(&temporary_path, &registration_path) {
                 let _ = fs::remove_file(&temporary_path);
+                if error.kind() == std::io::ErrorKind::NotFound {
+                    continue;
+                }
                 return Err(error.into());
             }
             return Ok(Self { socket, registration_path, token });
@@ -5578,14 +5581,26 @@ fn publish_session_coordinator_available(waiter_dir: &Path) {
     };
     for entry in entries.flatten() {
         let path = entry.path();
-        if path.extension().and_then(|value| value.to_str()) != Some("waiter") {
+        let Ok(metadata) = fs::symlink_metadata(&path) else {
+            continue;
+        };
+        if !metadata.file_type().is_file() {
             continue;
         }
-        let is_regular_file = fs::symlink_metadata(&path)
-            .map(|metadata| metadata.file_type().is_file())
-            .unwrap_or(false);
-        if !is_regular_file {
-            continue;
+        match path.extension().and_then(|value| value.to_str()) {
+            Some("tmp") => {
+                let is_stale = metadata
+                    .modified()
+                    .ok()
+                    .and_then(|modified| modified.elapsed().ok())
+                    .is_some_and(|age| age >= SESSION_GUARD_COORDINATOR_TIMEOUT);
+                if is_stale {
+                    let _ = fs::remove_file(path);
+                }
+                continue;
+            }
+            Some("waiter") => {}
+            _ => continue,
         }
         if let Ok(registration) = fs::read_to_string(&path) {
             let mut fields = registration.split_whitespace();

--- a/cmux-tui/crates/cmux-tui-core/src/workspace_registry.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/workspace_registry.rs
@@ -5364,14 +5364,12 @@ impl SessionLease {
         Self::acquire_coordinator_until(
             path,
             std::time::Instant::now() + SESSION_GUARD_COORDINATOR_TIMEOUT,
-            || {},
         )
     }
 
     fn acquire_coordinator_until(
         path: &Path,
         deadline: std::time::Instant,
-        mut on_waiter_armed: impl FnMut(),
     ) -> anyhow::Result<Self> {
         let file = open_session_lock_file(path)?;
         restrict_session_lock_file(path, &file)?;
@@ -5408,7 +5406,6 @@ impl SessionLease {
                 }
             }
 
-            on_waiter_armed();
             if !waiter.wait_until(deadline).with_context(|| {
                 format!("wait for workspace session coordinator: {}", path.display())
             })? {

--- a/cmux-tui/crates/cmux-tui-core/src/workspace_registry.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/workspace_registry.rs
@@ -5480,7 +5480,8 @@ impl SessionCoordinatorWaiter {
                     SESSION_GUARD_COORDINATOR_WAITER_SEQUENCE.fetch_add(1, Ordering::Relaxed);
                 let token = format!("{:x}-{sequence:x}", std::process::id());
                 let registration_path = waiter_dir.join(format!("{token}.waiter"));
-                let fifo_path = std::ffi::CString::new(registration_path.as_os_str().as_bytes())?;
+                let temporary_path = waiter_dir.join(format!(".{token}.tmp"));
+                let fifo_path = std::ffi::CString::new(temporary_path.as_os_str().as_bytes())?;
                 // SAFETY: fifo_path is a valid NUL-terminated path and mode
                 // only grants access to the current user.
                 let created = unsafe { libc::mkfifo(fifo_path.as_ptr(), 0o600) };
@@ -5496,10 +5497,10 @@ impl SessionCoordinatorWaiter {
                 reader_options
                     .read(true)
                     .custom_flags(libc::O_CLOEXEC | libc::O_NOFOLLOW | libc::O_NONBLOCK);
-                let signal_reader = match reader_options.open(&registration_path) {
+                let signal_reader = match reader_options.open(&temporary_path) {
                     Ok(reader) => reader,
                     Err(error) => {
-                        let _ = fs::remove_file(&registration_path);
+                        let _ = fs::remove_file(&temporary_path);
                         return Err(error.into());
                     }
                 };
@@ -5507,13 +5508,20 @@ impl SessionCoordinatorWaiter {
                 anchor_options
                     .write(true)
                     .custom_flags(libc::O_CLOEXEC | libc::O_NOFOLLOW | libc::O_NONBLOCK);
-                let signal_anchor = match anchor_options.open(&registration_path) {
+                let signal_anchor = match anchor_options.open(&temporary_path) {
                     Ok(anchor) => anchor,
                     Err(error) => {
-                        let _ = fs::remove_file(&registration_path);
+                        let _ = fs::remove_file(&temporary_path);
                         return Err(error.into());
                     }
                 };
+                if let Err(error) = fs::rename(&temporary_path, &registration_path) {
+                    let _ = fs::remove_file(&temporary_path);
+                    if error.kind() == std::io::ErrorKind::NotFound {
+                        continue;
+                    }
+                    return Err(error.into());
+                }
                 return Ok(Self {
                     signal_reader,
                     _signal_anchor: signal_anchor,
@@ -5697,7 +5705,15 @@ fn publish_session_coordinator_available(waiter_dir: &Path) {
         };
         match path.extension().and_then(|value| value.to_str()) {
             Some("tmp") => {
-                let is_stale = metadata.file_type().is_file()
+                #[cfg(unix)]
+                let is_temporary_waiter = {
+                    use std::os::unix::fs::FileTypeExt;
+
+                    metadata.file_type().is_file() || metadata.file_type().is_fifo()
+                };
+                #[cfg(not(unix))]
+                let is_temporary_waiter = metadata.file_type().is_file();
+                let is_stale = is_temporary_waiter
                     && metadata
                         .modified()
                         .ok()

--- a/cmux-tui/crates/cmux-tui-core/src/workspace_registry.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/workspace_registry.rs
@@ -5412,8 +5412,8 @@ impl SessionLease {
                 continue;
             }
 
-            // The file lock remains authoritative when the owner crashes
-            // before it publishes the registered stream signal.
+            // The file lock remains authoritative when the owner crashes or
+            // its best-effort UDP notification is lost.
             match FileExt::try_lock(&file) {
                 Ok(()) => return Ok(Self::coordinator(file, path)),
                 Err(fs4::TryLockError::WouldBlock) => return session_coordinator_busy(path),
@@ -5451,7 +5451,7 @@ fn session_coordinator_busy(path: &Path) -> anyhow::Result<SessionLease> {
 }
 
 struct SessionCoordinatorWaiter {
-    listener: std::net::TcpListener,
+    socket: std::net::UdpSocket,
     registration_path: PathBuf,
     token: String,
 }
@@ -5462,8 +5462,8 @@ impl SessionCoordinatorWaiter {
 
         let waiter_dir = session_guard_coordinator_waiter_dir(coordinator_path);
         prepare_session_coordinator_waiter_dir(&waiter_dir)?;
-        let listener = std::net::TcpListener::bind((std::net::Ipv4Addr::LOCALHOST, 0))?;
-        let address = listener.local_addr()?;
+        let socket = std::net::UdpSocket::bind((std::net::Ipv4Addr::LOCALHOST, 0))?;
+        let address = socket.local_addr()?;
 
         loop {
             let sequence =
@@ -5499,75 +5499,37 @@ impl SessionCoordinatorWaiter {
                 }
                 return Err(error.into());
             }
-            return Ok(Self { listener, registration_path, token });
+            return Ok(Self { socket, registration_path, token });
         }
     }
 
     fn wait_until(&self, deadline: std::time::Instant) -> std::io::Result<bool> {
-        let remaining = deadline.saturating_duration_since(std::time::Instant::now());
-        if remaining.is_zero() {
-            return Ok(false);
-        }
-
-        let listener = self.listener.try_clone()?;
-        let cancel_address = self.listener.local_addr()?;
-        let token = self.token.clone();
-        let (result_sender, result_receiver) = std::sync::mpsc::sync_channel(1);
-        let worker = std::thread::Builder::new()
-            .name("cmux-session-coordinator-waiter".to_string())
-            .spawn(move || {
-                let result = wait_for_session_coordinator_publication(listener, &token, deadline);
-                let _ = result_sender.send(result);
-            })?;
-
-        let result = match result_receiver.recv_timeout(remaining) {
-            Ok(result) => result,
-            Err(std::sync::mpsc::RecvTimeoutError::Timeout) => {
-                // Wake the blocking accept so the deadline path also reaps
-                // its worker. An empty local stream cannot match the token.
-                let _ = std::net::TcpStream::connect(cancel_address);
-                Ok(false)
+        let mut message = [0_u8; 128];
+        loop {
+            let remaining = deadline.saturating_duration_since(std::time::Instant::now());
+            if remaining.is_zero() {
+                return Ok(false);
             }
-            Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => {
-                Err(std::io::Error::other("session coordinator waiter stopped without a result"))
+            self.socket.set_read_timeout(Some(remaining))?;
+            match self.socket.recv_from(&mut message) {
+                Ok((length, sender))
+                    if sender.ip().is_loopback()
+                        && message.get(..length) == Some(self.token.as_bytes()) =>
+                {
+                    return Ok(true);
+                }
+                Ok(_) => {}
+                Err(error) if error.kind() == std::io::ErrorKind::Interrupted => {}
+                Err(error)
+                    if matches!(
+                        error.kind(),
+                        std::io::ErrorKind::WouldBlock | std::io::ErrorKind::TimedOut
+                    ) =>
+                {
+                    return Ok(false);
+                }
+                Err(error) => return Err(error),
             }
-        };
-        worker.join().map_err(|_| std::io::Error::other("session coordinator waiter panicked"))?;
-        result
-    }
-}
-
-fn wait_for_session_coordinator_publication(
-    listener: std::net::TcpListener,
-    token: &str,
-    deadline: std::time::Instant,
-) -> std::io::Result<bool> {
-    loop {
-        let (mut stream, sender) = listener.accept()?;
-        if !sender.ip().is_loopback() {
-            continue;
-        }
-        let remaining = deadline.saturating_duration_since(std::time::Instant::now());
-        if remaining.is_zero() {
-            return Ok(false);
-        }
-        stream.set_read_timeout(Some(remaining))?;
-        let mut message = vec![0_u8; token.len()];
-        match stream.read_exact(&mut message) {
-            Ok(()) if message == token.as_bytes() => return Ok(true),
-            Ok(()) => {}
-            Err(error) if error.kind() == std::io::ErrorKind::Interrupted => {}
-            Err(error)
-                if matches!(
-                    error.kind(),
-                    std::io::ErrorKind::UnexpectedEof
-                        | std::io::ErrorKind::WouldBlock
-                        | std::io::ErrorKind::TimedOut
-                ) => {}
-            Err(error) => return Err(error),
-        }
-        if std::time::Instant::now() >= deadline {
-            return Ok(false);
         }
     }
 }
@@ -5614,6 +5576,9 @@ fn publish_session_coordinator_available(waiter_dir: &Path) {
     let Ok(entries) = fs::read_dir(waiter_dir) else {
         return;
     };
+    let Ok(socket) = std::net::UdpSocket::bind((std::net::Ipv4Addr::LOCALHOST, 0)) else {
+        return;
+    };
     for entry in entries.flatten() {
         let path = entry.path();
         let Ok(metadata) = fs::symlink_metadata(&path) else {
@@ -5648,14 +5613,7 @@ fn publish_session_coordinator_available(waiter_dir: &Path) {
                 && token.len() <= 128
                 && token.bytes().all(|byte| byte.is_ascii_hexdigit() || byte == b'-')
             {
-                let _ = std::net::TcpStream::connect_timeout(
-                    &address,
-                    SESSION_GUARD_COORDINATOR_TIMEOUT,
-                )
-                .and_then(|mut stream| {
-                    stream.set_write_timeout(Some(SESSION_GUARD_COORDINATOR_TIMEOUT))?;
-                    stream.write_all(token.as_bytes())
-                });
+                let _ = socket.send_to(token.as_bytes(), address);
             }
         }
         let _ = fs::remove_file(path);

--- a/cmux-tui/crates/cmux-tui-core/src/workspace_registry.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/workspace_registry.rs
@@ -5371,7 +5371,7 @@ impl SessionLease {
     fn acquire_coordinator_until(
         path: &Path,
         deadline: std::time::Instant,
-        mut on_waiter_registered: impl FnMut(),
+        mut on_waiter_armed: impl FnMut(),
     ) -> anyhow::Result<Self> {
         let file = open_session_lock_file(path)?;
         restrict_session_lock_file(path, &file)?;
@@ -5394,7 +5394,6 @@ impl SessionLease {
             let waiter = SessionCoordinatorWaiter::register(path).with_context(|| {
                 format!("register workspace session coordinator waiter: {}", path.display())
             })?;
-            on_waiter_registered();
 
             // Registration precedes this second lock attempt. If the owner
             // released before it saw the registration, this attempt observes
@@ -5409,6 +5408,7 @@ impl SessionLease {
                 }
             }
 
+            on_waiter_armed();
             if !waiter.wait_until(deadline).with_context(|| {
                 format!("wait for workspace session coordinator: {}", path.display())
             })? {

--- a/cmux-tui/crates/cmux-tui-core/src/workspace_registry.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/workspace_registry.rs
@@ -4881,9 +4881,11 @@ const MACHINE_ID_LOCK_FILE: &str = "machine-id.lock";
 const SESSION_WRITER_LOCK_FILE: &str = "writer.lock";
 const SESSION_GUARD_DIR: &str = "session-locks";
 const SESSION_GUARD_COORDINATOR_FILE: &str = ".coordinator.lock";
+const SESSION_GUARD_COORDINATOR_WAITER_DIR: &str = ".coordinator.waiters";
 const SESSION_GUARD_COORDINATOR_TIMEOUT: std::time::Duration =
     std::time::Duration::from_millis(250);
-const SESSION_GUARD_COORDINATOR_RETRY: std::time::Duration = std::time::Duration::from_millis(5);
+static SESSION_GUARD_COORDINATOR_WAITER_SEQUENCE: std::sync::atomic::AtomicU64 =
+    std::sync::atomic::AtomicU64::new(0);
 const TERMINAL_HOST_PUBLICATION_LOCK_FILE: &str = ".publication.lock";
 #[cfg(test)]
 static RESET_RENAME_SYNC_FAILURE_ROOT: std::sync::Mutex<Option<PathBuf>> =
@@ -5344,6 +5346,7 @@ pub(crate) fn is_canonical_workspace_key(value: &str) -> bool {
 struct SessionLease {
     file: File,
     path: PathBuf,
+    coordinator_waiter_dir: Option<PathBuf>,
 }
 
 impl SessionLease {
@@ -5354,24 +5357,32 @@ impl SessionLease {
         FileExt::try_lock(&file).with_context(|| {
             format!("workspace session is already owned by another daemon: {}", path.display())
         })?;
-        Ok(Self { file, path: path.to_path_buf() })
+        Ok(Self { file, path: path.to_path_buf(), coordinator_waiter_dir: None })
     }
 
     fn acquire_coordinator(path: &Path) -> anyhow::Result<Self> {
+        Self::acquire_coordinator_until(
+            path,
+            std::time::Instant::now() + SESSION_GUARD_COORDINATOR_TIMEOUT,
+            || {},
+        )
+    }
+
+    fn acquire_coordinator_until(
+        path: &Path,
+        deadline: std::time::Instant,
+        mut on_waiter_registered: impl FnMut(),
+    ) -> anyhow::Result<Self> {
         let file = open_session_lock_file(path)?;
         restrict_session_lock_file(path, &file)?;
         validate_session_lock_file(path, &file)?;
-        let deadline = std::time::Instant::now() + SESSION_GUARD_COORDINATOR_TIMEOUT;
         loop {
             match FileExt::try_lock(&file) {
-                Ok(()) => break,
-                Err(fs4::TryLockError::WouldBlock) if std::time::Instant::now() < deadline => {
-                    std::thread::sleep(SESSION_GUARD_COORDINATOR_RETRY);
-                }
+                Ok(()) => return Ok(Self::coordinator(file, path)),
                 Err(fs4::TryLockError::WouldBlock) => {
-                    return Err(std::io::Error::from(std::io::ErrorKind::WouldBlock)).with_context(
-                        || format!("workspace session coordinator is busy: {}", path.display()),
-                    );
+                    if std::time::Instant::now() >= deadline {
+                        return session_coordinator_busy(path);
+                    }
                 }
                 Err(error) => {
                     return Err(error).with_context(|| {
@@ -5379,8 +5390,31 @@ impl SessionLease {
                     });
                 }
             }
+
+            let waiter = SessionCoordinatorWaiter::register(path).with_context(|| {
+                format!("register workspace session coordinator waiter: {}", path.display())
+            })?;
+            on_waiter_registered();
+
+            // Registration precedes this second lock attempt. If the owner
+            // released before it saw the registration, this attempt observes
+            // the free lock and prevents a lost wakeup.
+            match FileExt::try_lock(&file) {
+                Ok(()) => return Ok(Self::coordinator(file, path)),
+                Err(fs4::TryLockError::WouldBlock) => {}
+                Err(error) => {
+                    return Err(error).with_context(|| {
+                        format!("lock workspace session coordinator: {}", path.display())
+                    });
+                }
+            }
+
+            if !waiter.wait_until(deadline).with_context(|| {
+                format!("wait for workspace session coordinator: {}", path.display())
+            })? {
+                return session_coordinator_busy(path);
+            }
         }
-        Ok(Self { file, path: path.to_path_buf() })
     }
 
     fn acquire_coordinator_blocking(path: &Path) -> anyhow::Result<Self> {
@@ -5390,7 +5424,175 @@ impl SessionLease {
         FileExt::lock(&file)
             .with_context(|| format!("lock workspace session coordinator: {}", path.display()))?;
         validate_session_lock_file(path, &file)?;
-        Ok(Self { file, path: path.to_path_buf() })
+        Ok(Self::coordinator(file, path))
+    }
+
+    fn coordinator(file: File, path: &Path) -> Self {
+        Self {
+            file,
+            path: path.to_path_buf(),
+            coordinator_waiter_dir: Some(session_guard_coordinator_waiter_dir(path)),
+        }
+    }
+}
+
+fn session_coordinator_busy(path: &Path) -> anyhow::Result<SessionLease> {
+    Err(std::io::Error::from(std::io::ErrorKind::WouldBlock))
+        .with_context(|| format!("workspace session coordinator is busy: {}", path.display()))
+}
+
+struct SessionCoordinatorWaiter {
+    socket: std::net::UdpSocket,
+    registration_path: PathBuf,
+    token: String,
+}
+
+impl SessionCoordinatorWaiter {
+    fn register(coordinator_path: &Path) -> anyhow::Result<Self> {
+        use std::sync::atomic::Ordering;
+
+        let waiter_dir = session_guard_coordinator_waiter_dir(coordinator_path);
+        prepare_session_coordinator_waiter_dir(&waiter_dir)?;
+        let socket = std::net::UdpSocket::bind((std::net::Ipv4Addr::LOCALHOST, 0))?;
+        let address = socket.local_addr()?;
+
+        loop {
+            let sequence =
+                SESSION_GUARD_COORDINATOR_WAITER_SEQUENCE.fetch_add(1, Ordering::Relaxed);
+            let token = format!("{:x}-{:x}-{:x}", std::process::id(), address.port(), sequence);
+            let registration_path = waiter_dir.join(format!("{token}.waiter"));
+            let temporary_path = waiter_dir.join(format!(".{token}.tmp"));
+            let mut options = OpenOptions::new();
+            options.create_new(true).write(true);
+            #[cfg(unix)]
+            {
+                use std::os::unix::fs::OpenOptionsExt;
+                options.mode(0o600).custom_flags(libc::O_CLOEXEC | libc::O_NOFOLLOW);
+            }
+            let mut registration = match options.open(&temporary_path) {
+                Ok(registration) => registration,
+                Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => continue,
+                Err(error) => return Err(error.into()),
+            };
+            if let Err(error) = writeln!(registration, "{address} {token}") {
+                let _ = fs::remove_file(&temporary_path);
+                return Err(error.into());
+            }
+            if let Err(error) = registration.flush() {
+                let _ = fs::remove_file(&temporary_path);
+                return Err(error.into());
+            }
+            drop(registration);
+            if let Err(error) = fs::rename(&temporary_path, &registration_path) {
+                let _ = fs::remove_file(&temporary_path);
+                return Err(error.into());
+            }
+            return Ok(Self { socket, registration_path, token });
+        }
+    }
+
+    fn wait_until(&self, deadline: std::time::Instant) -> std::io::Result<bool> {
+        let mut message = [0_u8; 128];
+        loop {
+            let remaining = deadline.saturating_duration_since(std::time::Instant::now());
+            if remaining.is_zero() {
+                return Ok(false);
+            }
+            self.socket.set_read_timeout(Some(remaining))?;
+            match self.socket.recv_from(&mut message) {
+                Ok((length, sender))
+                    if sender.ip().is_loopback()
+                        && message.get(..length) == Some(self.token.as_bytes()) =>
+                {
+                    return Ok(true);
+                }
+                Ok(_) => {}
+                Err(error) if error.kind() == std::io::ErrorKind::Interrupted => {}
+                Err(error)
+                    if matches!(
+                        error.kind(),
+                        std::io::ErrorKind::WouldBlock | std::io::ErrorKind::TimedOut
+                    ) =>
+                {
+                    return Ok(false);
+                }
+                Err(error) => return Err(error),
+            }
+        }
+    }
+}
+
+impl Drop for SessionCoordinatorWaiter {
+    fn drop(&mut self) {
+        let _ = fs::remove_file(&self.registration_path);
+    }
+}
+
+fn session_guard_coordinator_waiter_dir(coordinator_path: &Path) -> PathBuf {
+    coordinator_path.with_file_name(SESSION_GUARD_COORDINATOR_WAITER_DIR)
+}
+
+fn prepare_session_coordinator_waiter_dir(waiter_dir: &Path) -> anyhow::Result<()> {
+    match fs::symlink_metadata(waiter_dir) {
+        Ok(metadata) if metadata.file_type().is_dir() => {}
+        Ok(_) => anyhow::bail!(
+            "session coordinator waiter path is not a directory: {}",
+            waiter_dir.display()
+        ),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            match fs::create_dir(waiter_dir) {
+                Ok(()) => {}
+                Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => {
+                    let metadata = fs::symlink_metadata(waiter_dir)?;
+                    if !metadata.file_type().is_dir() {
+                        anyhow::bail!(
+                            "session coordinator waiter path is not a directory: {}",
+                            waiter_dir.display()
+                        );
+                    }
+                }
+                Err(error) => return Err(error.into()),
+            }
+        }
+        Err(error) => return Err(error.into()),
+    }
+    platform::restrict_directory(waiter_dir)?;
+    Ok(())
+}
+
+fn publish_session_coordinator_available(waiter_dir: &Path) {
+    let Ok(entries) = fs::read_dir(waiter_dir) else {
+        return;
+    };
+    let Ok(socket) = std::net::UdpSocket::bind((std::net::Ipv4Addr::LOCALHOST, 0)) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.extension().and_then(|value| value.to_str()) != Some("waiter") {
+            continue;
+        }
+        let is_regular_file = fs::symlink_metadata(&path)
+            .map(|metadata| metadata.file_type().is_file())
+            .unwrap_or(false);
+        if !is_regular_file {
+            continue;
+        }
+        if let Ok(registration) = fs::read_to_string(&path) {
+            let mut fields = registration.split_whitespace();
+            let address =
+                fields.next().and_then(|value| value.parse::<std::net::SocketAddr>().ok());
+            let token = fields.next();
+            if fields.next().is_none()
+                && let (Some(address), Some(token)) = (address, token)
+                && address.ip().is_loopback()
+                && token.len() <= 128
+                && token.bytes().all(|byte| byte.is_ascii_hexdigit() || byte == b'-')
+            {
+                let _ = socket.send_to(token.as_bytes(), address);
+            }
+        }
+        let _ = fs::remove_file(path);
     }
 }
 
@@ -5441,7 +5643,11 @@ fn restrict_session_lock_file(path: &Path, _file: &File) -> anyhow::Result<()> {
 
 impl Drop for SessionLease {
     fn drop(&mut self) {
-        let _ = FileExt::unlock(&self.file);
+        if FileExt::unlock(&self.file).is_ok()
+            && let Some(waiter_dir) = &self.coordinator_waiter_dir
+        {
+            publish_session_coordinator_available(waiter_dir);
+        }
         let _ = &self.path;
     }
 }

--- a/cmux-tui/crates/cmux-tui-core/src/workspace_registry.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/workspace_registry.rs
@@ -4884,6 +4884,7 @@ const SESSION_GUARD_COORDINATOR_FILE: &str = ".coordinator.lock";
 const SESSION_GUARD_COORDINATOR_WAITER_DIR: &str = ".coordinator.waiters";
 const SESSION_GUARD_COORDINATOR_TIMEOUT: std::time::Duration =
     std::time::Duration::from_millis(250);
+const SESSION_GUARD_COORDINATOR_PUBLICATION_SCAN_LIMIT: usize = 64;
 static SESSION_GUARD_COORDINATOR_WAITER_SEQUENCE: std::sync::atomic::AtomicU64 =
     std::sync::atomic::AtomicU64::new(0);
 const TERMINAL_HOST_PUBLICATION_LOCK_FILE: &str = ".publication.lock";
@@ -5412,8 +5413,8 @@ impl SessionLease {
                 continue;
             }
 
-            // The file lock remains authoritative when the owner crashes or
-            // its best-effort UDP notification is lost.
+            // The file lock remains authoritative when the owner crashes
+            // before it publishes a registered waiter signal.
             match FileExt::try_lock(&file) {
                 Ok(()) => return Ok(Self::coordinator(file, path)),
                 Err(fs4::TryLockError::WouldBlock) => return session_coordinator_busy(path),
@@ -5451,8 +5452,14 @@ fn session_coordinator_busy(path: &Path) -> anyhow::Result<SessionLease> {
 }
 
 struct SessionCoordinatorWaiter {
+    #[cfg(unix)]
+    signal_reader: File,
+    #[cfg(unix)]
+    _signal_anchor: File,
+    #[cfg(not(unix))]
     socket: std::net::UdpSocket,
     registration_path: PathBuf,
+    #[cfg(not(unix))]
     token: String,
 }
 
@@ -5462,73 +5469,176 @@ impl SessionCoordinatorWaiter {
 
         let waiter_dir = session_guard_coordinator_waiter_dir(coordinator_path);
         prepare_session_coordinator_waiter_dir(&waiter_dir)?;
-        let socket = std::net::UdpSocket::bind((std::net::Ipv4Addr::LOCALHOST, 0))?;
-        let address = socket.local_addr()?;
 
-        loop {
-            let sequence =
-                SESSION_GUARD_COORDINATOR_WAITER_SEQUENCE.fetch_add(1, Ordering::Relaxed);
-            let token = format!("{:x}-{:x}-{:x}", std::process::id(), address.port(), sequence);
-            let registration_path = waiter_dir.join(format!("{token}.waiter"));
-            let temporary_path = waiter_dir.join(format!(".{token}.tmp"));
-            let mut options = OpenOptions::new();
-            options.create_new(true).write(true);
-            #[cfg(unix)]
-            {
-                use std::os::unix::fs::OpenOptionsExt;
-                options.mode(0o600).custom_flags(libc::O_CLOEXEC | libc::O_NOFOLLOW);
-            }
-            let mut registration = match options.open(&temporary_path) {
-                Ok(registration) => registration,
-                Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => continue,
-                Err(error) => return Err(error.into()),
-            };
-            if let Err(error) = writeln!(registration, "{address} {token}") {
-                let _ = fs::remove_file(&temporary_path);
-                return Err(error.into());
-            }
-            if let Err(error) = registration.flush() {
-                let _ = fs::remove_file(&temporary_path);
-                return Err(error.into());
-            }
-            drop(registration);
-            if let Err(error) = fs::rename(&temporary_path, &registration_path) {
-                let _ = fs::remove_file(&temporary_path);
-                if error.kind() == std::io::ErrorKind::NotFound {
-                    continue;
+        #[cfg(unix)]
+        {
+            use std::os::unix::ffi::OsStrExt;
+            use std::os::unix::fs::OpenOptionsExt;
+
+            loop {
+                let sequence =
+                    SESSION_GUARD_COORDINATOR_WAITER_SEQUENCE.fetch_add(1, Ordering::Relaxed);
+                let token = format!("{:x}-{sequence:x}", std::process::id());
+                let registration_path = waiter_dir.join(format!("{token}.waiter"));
+                let fifo_path = std::ffi::CString::new(registration_path.as_os_str().as_bytes())?;
+                // SAFETY: fifo_path is a valid NUL-terminated path and mode
+                // only grants access to the current user.
+                let created = unsafe { libc::mkfifo(fifo_path.as_ptr(), 0o600) };
+                if created != 0 {
+                    let error = std::io::Error::last_os_error();
+                    if error.kind() == std::io::ErrorKind::AlreadyExists {
+                        continue;
+                    }
+                    return Err(error.into());
                 }
-                return Err(error.into());
+
+                let mut reader_options = OpenOptions::new();
+                reader_options
+                    .read(true)
+                    .custom_flags(libc::O_CLOEXEC | libc::O_NOFOLLOW | libc::O_NONBLOCK);
+                let signal_reader = match reader_options.open(&registration_path) {
+                    Ok(reader) => reader,
+                    Err(error) => {
+                        let _ = fs::remove_file(&registration_path);
+                        return Err(error.into());
+                    }
+                };
+                let mut anchor_options = OpenOptions::new();
+                anchor_options
+                    .write(true)
+                    .custom_flags(libc::O_CLOEXEC | libc::O_NOFOLLOW | libc::O_NONBLOCK);
+                let signal_anchor = match anchor_options.open(&registration_path) {
+                    Ok(anchor) => anchor,
+                    Err(error) => {
+                        let _ = fs::remove_file(&registration_path);
+                        return Err(error.into());
+                    }
+                };
+                return Ok(Self {
+                    signal_reader,
+                    _signal_anchor: signal_anchor,
+                    registration_path,
+                });
             }
-            return Ok(Self { socket, registration_path, token });
+        }
+
+        #[cfg(not(unix))]
+        {
+            let socket = std::net::UdpSocket::bind((std::net::Ipv4Addr::LOCALHOST, 0))?;
+            let address = socket.local_addr()?;
+
+            loop {
+                let sequence =
+                    SESSION_GUARD_COORDINATOR_WAITER_SEQUENCE.fetch_add(1, Ordering::Relaxed);
+                let token = format!("{:x}-{:x}-{:x}", std::process::id(), address.port(), sequence);
+                let registration_path = waiter_dir.join(format!("{token}.waiter"));
+                let temporary_path = waiter_dir.join(format!(".{token}.tmp"));
+                let mut options = OpenOptions::new();
+                options.create_new(true).write(true);
+                #[cfg(unix)]
+                {
+                    use std::os::unix::fs::OpenOptionsExt;
+                    options.mode(0o600).custom_flags(libc::O_CLOEXEC | libc::O_NOFOLLOW);
+                }
+                let mut registration = match options.open(&temporary_path) {
+                    Ok(registration) => registration,
+                    Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => continue,
+                    Err(error) => return Err(error.into()),
+                };
+                if let Err(error) = writeln!(registration, "{address} {token}") {
+                    let _ = fs::remove_file(&temporary_path);
+                    return Err(error.into());
+                }
+                if let Err(error) = registration.flush() {
+                    let _ = fs::remove_file(&temporary_path);
+                    return Err(error.into());
+                }
+                drop(registration);
+                if let Err(error) = fs::rename(&temporary_path, &registration_path) {
+                    let _ = fs::remove_file(&temporary_path);
+                    if error.kind() == std::io::ErrorKind::NotFound {
+                        continue;
+                    }
+                    return Err(error.into());
+                }
+                return Ok(Self { socket, registration_path, token });
+            }
         }
     }
 
     fn wait_until(&self, deadline: std::time::Instant) -> std::io::Result<bool> {
-        let mut message = [0_u8; 128];
-        loop {
-            let remaining = deadline.saturating_duration_since(std::time::Instant::now());
-            if remaining.is_zero() {
-                return Ok(false);
-            }
-            self.socket.set_read_timeout(Some(remaining))?;
-            match self.socket.recv_from(&mut message) {
-                Ok((length, sender))
-                    if sender.ip().is_loopback()
-                        && message.get(..length) == Some(self.token.as_bytes()) =>
-                {
-                    return Ok(true);
-                }
-                Ok(_) => {}
-                Err(error) if error.kind() == std::io::ErrorKind::Interrupted => {}
-                Err(error)
-                    if matches!(
-                        error.kind(),
-                        std::io::ErrorKind::WouldBlock | std::io::ErrorKind::TimedOut
-                    ) =>
-                {
+        #[cfg(unix)]
+        {
+            use std::os::fd::AsRawFd;
+
+            loop {
+                let remaining = deadline.saturating_duration_since(std::time::Instant::now());
+                if remaining.is_zero() {
                     return Ok(false);
                 }
-                Err(error) => return Err(error),
+                let timeout_ms =
+                    remaining.as_millis().saturating_add(1).min(i32::MAX as u128) as i32;
+                let mut descriptor = libc::pollfd {
+                    fd: self.signal_reader.as_raw_fd(),
+                    events: libc::POLLIN,
+                    revents: 0,
+                };
+                // SAFETY: descriptor points to one valid pollfd for the call.
+                let ready = unsafe { libc::poll(&raw mut descriptor, 1, timeout_ms) };
+                if ready == 0 {
+                    return Ok(false);
+                }
+                if ready < 0 {
+                    let error = std::io::Error::last_os_error();
+                    if error.kind() == std::io::ErrorKind::Interrupted {
+                        continue;
+                    }
+                    return Err(error);
+                }
+                if descriptor.revents & libc::POLLIN != 0 {
+                    let mut signal = [0_u8; 1];
+                    let mut signal_reader = &self.signal_reader;
+                    match signal_reader.read(&mut signal) {
+                        Ok(1) => return Ok(true),
+                        Ok(_) => {}
+                        Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => continue,
+                        Err(error) => return Err(error),
+                    }
+                }
+                if descriptor.revents & (libc::POLLERR | libc::POLLNVAL) != 0 {
+                    return Err(std::io::Error::other("session coordinator signal pipe failed"));
+                }
+            }
+        }
+
+        #[cfg(not(unix))]
+        {
+            let mut message = [0_u8; 128];
+            loop {
+                let remaining = deadline.saturating_duration_since(std::time::Instant::now());
+                if remaining.is_zero() {
+                    return Ok(false);
+                }
+                self.socket.set_read_timeout(Some(remaining))?;
+                match self.socket.recv_from(&mut message) {
+                    Ok((length, sender))
+                        if sender.ip().is_loopback()
+                            && message.get(..length) == Some(self.token.as_bytes()) =>
+                    {
+                        return Ok(true);
+                    }
+                    Ok(_) => {}
+                    Err(error) if error.kind() == std::io::ErrorKind::Interrupted => {}
+                    Err(error)
+                        if matches!(
+                            error.kind(),
+                            std::io::ErrorKind::WouldBlock | std::io::ErrorKind::TimedOut
+                        ) =>
+                    {
+                        return Ok(false);
+                    }
+                    Err(error) => return Err(error),
+                }
             }
         }
     }
@@ -5576,24 +5686,23 @@ fn publish_session_coordinator_available(waiter_dir: &Path) {
     let Ok(entries) = fs::read_dir(waiter_dir) else {
         return;
     };
+    #[cfg(not(unix))]
     let Ok(socket) = std::net::UdpSocket::bind((std::net::Ipv4Addr::LOCALHOST, 0)) else {
         return;
     };
-    for entry in entries.flatten() {
+    for entry in entries.flatten().take(SESSION_GUARD_COORDINATOR_PUBLICATION_SCAN_LIMIT) {
         let path = entry.path();
         let Ok(metadata) = fs::symlink_metadata(&path) else {
             continue;
         };
-        if !metadata.file_type().is_file() {
-            continue;
-        }
         match path.extension().and_then(|value| value.to_str()) {
             Some("tmp") => {
-                let is_stale = metadata
-                    .modified()
-                    .ok()
-                    .and_then(|modified| modified.elapsed().ok())
-                    .is_some_and(|age| age >= SESSION_GUARD_COORDINATOR_TIMEOUT);
+                let is_stale = metadata.file_type().is_file()
+                    && metadata
+                        .modified()
+                        .ok()
+                        .and_then(|modified| modified.elapsed().ok())
+                        .is_some_and(|age| age >= SESSION_GUARD_COORDINATOR_TIMEOUT);
                 if is_stale {
                     let _ = fs::remove_file(path);
                 }
@@ -5602,6 +5711,31 @@ fn publish_session_coordinator_available(waiter_dir: &Path) {
             Some("waiter") => {}
             _ => continue,
         }
+
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::{FileTypeExt, OpenOptionsExt};
+
+            if !metadata.file_type().is_fifo() {
+                let _ = fs::remove_file(path);
+                continue;
+            }
+            let mut options = OpenOptions::new();
+            options.write(true).custom_flags(libc::O_CLOEXEC | libc::O_NOFOLLOW | libc::O_NONBLOCK);
+            let published =
+                options.open(&path).and_then(|mut signal| signal.write_all(&[1])).is_ok();
+            let _ = fs::remove_file(path);
+            if published {
+                break;
+            }
+            continue;
+        }
+
+        #[cfg(not(unix))]
+        if !metadata.file_type().is_file() {
+            continue;
+        }
+        #[cfg(not(unix))]
         if let Ok(registration) = fs::read_to_string(&path) {
             let mut fields = registration.split_whitespace();
             let address =
@@ -5613,9 +5747,13 @@ fn publish_session_coordinator_available(waiter_dir: &Path) {
                 && token.len() <= 128
                 && token.bytes().all(|byte| byte.is_ascii_hexdigit() || byte == b'-')
             {
-                let _ = socket.send_to(token.as_bytes(), address);
+                if socket.send_to(token.as_bytes(), address).is_ok() {
+                    let _ = fs::remove_file(path);
+                    break;
+                }
             }
         }
+        #[cfg(not(unix))]
         let _ = fs::remove_file(path);
     }
 }

--- a/cmux-tui/crates/cmux-tui-core/src/workspace_registry.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/workspace_registry.rs
@@ -5412,8 +5412,8 @@ impl SessionLease {
                 continue;
             }
 
-            // The file lock remains authoritative when the owner crashes or
-            // its best-effort UDP notification is lost.
+            // The file lock remains authoritative when the owner crashes
+            // before it publishes the registered stream signal.
             match FileExt::try_lock(&file) {
                 Ok(()) => return Ok(Self::coordinator(file, path)),
                 Err(fs4::TryLockError::WouldBlock) => return session_coordinator_busy(path),
@@ -5451,7 +5451,7 @@ fn session_coordinator_busy(path: &Path) -> anyhow::Result<SessionLease> {
 }
 
 struct SessionCoordinatorWaiter {
-    socket: std::net::UdpSocket,
+    listener: std::net::TcpListener,
     registration_path: PathBuf,
     token: String,
 }
@@ -5462,8 +5462,8 @@ impl SessionCoordinatorWaiter {
 
         let waiter_dir = session_guard_coordinator_waiter_dir(coordinator_path);
         prepare_session_coordinator_waiter_dir(&waiter_dir)?;
-        let socket = std::net::UdpSocket::bind((std::net::Ipv4Addr::LOCALHOST, 0))?;
-        let address = socket.local_addr()?;
+        let listener = std::net::TcpListener::bind((std::net::Ipv4Addr::LOCALHOST, 0))?;
+        let address = listener.local_addr()?;
 
         loop {
             let sequence =
@@ -5499,37 +5499,75 @@ impl SessionCoordinatorWaiter {
                 }
                 return Err(error.into());
             }
-            return Ok(Self { socket, registration_path, token });
+            return Ok(Self { listener, registration_path, token });
         }
     }
 
     fn wait_until(&self, deadline: std::time::Instant) -> std::io::Result<bool> {
-        let mut message = [0_u8; 128];
-        loop {
-            let remaining = deadline.saturating_duration_since(std::time::Instant::now());
-            if remaining.is_zero() {
-                return Ok(false);
+        let remaining = deadline.saturating_duration_since(std::time::Instant::now());
+        if remaining.is_zero() {
+            return Ok(false);
+        }
+
+        let listener = self.listener.try_clone()?;
+        let cancel_address = self.listener.local_addr()?;
+        let token = self.token.clone();
+        let (result_sender, result_receiver) = std::sync::mpsc::sync_channel(1);
+        let worker = std::thread::Builder::new()
+            .name("cmux-session-coordinator-waiter".to_string())
+            .spawn(move || {
+                let result = wait_for_session_coordinator_publication(listener, &token, deadline);
+                let _ = result_sender.send(result);
+            })?;
+
+        let result = match result_receiver.recv_timeout(remaining) {
+            Ok(result) => result,
+            Err(std::sync::mpsc::RecvTimeoutError::Timeout) => {
+                // Wake the blocking accept so the deadline path also reaps
+                // its worker. An empty local stream cannot match the token.
+                let _ = std::net::TcpStream::connect(cancel_address);
+                Ok(false)
             }
-            self.socket.set_read_timeout(Some(remaining))?;
-            match self.socket.recv_from(&mut message) {
-                Ok((length, sender))
-                    if sender.ip().is_loopback()
-                        && message.get(..length) == Some(self.token.as_bytes()) =>
-                {
-                    return Ok(true);
-                }
-                Ok(_) => {}
-                Err(error) if error.kind() == std::io::ErrorKind::Interrupted => {}
-                Err(error)
-                    if matches!(
-                        error.kind(),
-                        std::io::ErrorKind::WouldBlock | std::io::ErrorKind::TimedOut
-                    ) =>
-                {
-                    return Ok(false);
-                }
-                Err(error) => return Err(error),
+            Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => {
+                Err(std::io::Error::other("session coordinator waiter stopped without a result"))
             }
+        };
+        worker.join().map_err(|_| std::io::Error::other("session coordinator waiter panicked"))?;
+        result
+    }
+}
+
+fn wait_for_session_coordinator_publication(
+    listener: std::net::TcpListener,
+    token: &str,
+    deadline: std::time::Instant,
+) -> std::io::Result<bool> {
+    loop {
+        let (mut stream, sender) = listener.accept()?;
+        if !sender.ip().is_loopback() {
+            continue;
+        }
+        let remaining = deadline.saturating_duration_since(std::time::Instant::now());
+        if remaining.is_zero() {
+            return Ok(false);
+        }
+        stream.set_read_timeout(Some(remaining))?;
+        let mut message = vec![0_u8; token.len()];
+        match stream.read_exact(&mut message) {
+            Ok(()) if message == token.as_bytes() => return Ok(true),
+            Ok(()) => {}
+            Err(error) if error.kind() == std::io::ErrorKind::Interrupted => {}
+            Err(error)
+                if matches!(
+                    error.kind(),
+                    std::io::ErrorKind::UnexpectedEof
+                        | std::io::ErrorKind::WouldBlock
+                        | std::io::ErrorKind::TimedOut
+                ) => {}
+            Err(error) => return Err(error),
+        }
+        if std::time::Instant::now() >= deadline {
+            return Ok(false);
         }
     }
 }
@@ -5576,9 +5614,6 @@ fn publish_session_coordinator_available(waiter_dir: &Path) {
     let Ok(entries) = fs::read_dir(waiter_dir) else {
         return;
     };
-    let Ok(socket) = std::net::UdpSocket::bind((std::net::Ipv4Addr::LOCALHOST, 0)) else {
-        return;
-    };
     for entry in entries.flatten() {
         let path = entry.path();
         let Ok(metadata) = fs::symlink_metadata(&path) else {
@@ -5613,7 +5648,14 @@ fn publish_session_coordinator_available(waiter_dir: &Path) {
                 && token.len() <= 128
                 && token.bytes().all(|byte| byte.is_ascii_hexdigit() || byte == b'-')
             {
-                let _ = socket.send_to(token.as_bytes(), address);
+                let _ = std::net::TcpStream::connect_timeout(
+                    &address,
+                    SESSION_GUARD_COORDINATOR_TIMEOUT,
+                )
+                .and_then(|mut stream| {
+                    stream.set_write_timeout(Some(SESSION_GUARD_COORDINATOR_TIMEOUT))?;
+                    stream.write_all(token.as_bytes())
+                });
             }
         }
         let _ = fs::remove_file(path);

--- a/cmux-tui/crates/cmux-tui-core/src/workspace_registry/tests.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/workspace_registry/tests.rs
@@ -1038,30 +1038,22 @@ fn session_guard_coordinator_owner_publishes_lock_availability() {
     let lock_dir = prepare_session_guard_dir(&root).unwrap();
     let coordinator_path = session_guard_coordinator_path(&lock_dir);
     let held = SessionLease::acquire_coordinator_blocking(&coordinator_path).unwrap();
-    let (armed_sender, armed_receiver) = std::sync::mpsc::channel();
-    let (acquired_sender, acquired_receiver) = std::sync::mpsc::channel();
+    let waiter = SessionCoordinatorWaiter::register(&coordinator_path).unwrap();
 
-    let waiter = std::thread::spawn(move || {
-        let lease = SessionLease::acquire_coordinator_until(
-            &coordinator_path,
-            std::time::Instant::now() + std::time::Duration::from_secs(5),
-            || {
-                let _ = armed_sender.send(());
-            },
-        );
-        let _ = acquired_sender.send(lease);
-    });
-
-    armed_receiver
-        .recv_timeout(std::time::Duration::from_secs(2))
-        .expect("waiter did not arm its availability receiver");
     drop(held);
-    let acquired = acquired_receiver
-        .recv_timeout(std::time::Duration::from_secs(2))
-        .expect("coordinator owner did not publish lock availability")
-        .expect("waiter did not acquire the published coordinator lock");
+    assert!(
+        waiter
+            .wait_until(std::time::Instant::now() + std::time::Duration::from_secs(2))
+            .expect("wait for coordinator availability"),
+        "coordinator owner did not publish lock availability"
+    );
+    drop(waiter);
+    let acquired = SessionLease::acquire_coordinator_until(
+        &coordinator_path,
+        std::time::Instant::now() + std::time::Duration::from_secs(2),
+    )
+    .expect("waiter did not acquire the published coordinator lock");
     drop(acquired);
-    waiter.join().unwrap();
 
     fs::remove_dir_all(root).unwrap();
 }

--- a/cmux-tui/crates/cmux-tui-core/src/workspace_registry/tests.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/workspace_registry/tests.rs
@@ -1038,7 +1038,7 @@ fn session_guard_coordinator_owner_publishes_lock_availability() {
     let lock_dir = prepare_session_guard_dir(&root).unwrap();
     let coordinator_path = session_guard_coordinator_path(&lock_dir);
     let held = SessionLease::acquire_coordinator_blocking(&coordinator_path).unwrap();
-    let (registered_sender, registered_receiver) = std::sync::mpsc::channel();
+    let (armed_sender, armed_receiver) = std::sync::mpsc::channel();
     let (acquired_sender, acquired_receiver) = std::sync::mpsc::channel();
 
     let waiter = std::thread::spawn(move || {
@@ -1046,15 +1046,15 @@ fn session_guard_coordinator_owner_publishes_lock_availability() {
             &coordinator_path,
             std::time::Instant::now() + std::time::Duration::from_secs(5),
             || {
-                let _ = registered_sender.send(());
+                let _ = armed_sender.send(());
             },
         );
         let _ = acquired_sender.send(lease);
     });
 
-    registered_receiver
+    armed_receiver
         .recv_timeout(std::time::Duration::from_secs(2))
-        .expect("waiter did not publish its registration");
+        .expect("waiter did not arm its availability receiver");
     drop(held);
     let acquired = acquired_receiver
         .recv_timeout(std::time::Duration::from_secs(2))

--- a/cmux-tui/crates/cmux-tui-core/src/workspace_registry/tests.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/workspace_registry/tests.rs
@@ -1016,7 +1016,9 @@ fn reset_session_guard_coordinator_busy_fails_without_waiting_forever() {
     let root = temp_root("session-guard-coordinator-busy");
     fs::create_dir_all(&root).unwrap();
     let lock_dir = prepare_session_guard_dir(&root).unwrap();
-    let _held = SessionLease::acquire(&session_guard_coordinator_path(&lock_dir)).unwrap();
+    let _held =
+        SessionLease::acquire_coordinator_blocking(&session_guard_coordinator_path(&lock_dir))
+            .unwrap();
     let started = std::time::Instant::now();
 
     let error = match acquire_existing_session_reset_guard(&root, "blocked-by-coordinator") {
@@ -1026,6 +1028,41 @@ fn reset_session_guard_coordinator_busy_fails_without_waiting_forever() {
 
     assert!(started.elapsed() < std::time::Duration::from_secs(1));
     assert!(format!("{error:#}").contains("workspace session coordinator is busy"));
+    fs::remove_dir_all(root).unwrap();
+}
+
+#[test]
+fn session_guard_coordinator_owner_publishes_lock_availability() {
+    let root = temp_root("session-guard-coordinator-publication");
+    fs::create_dir_all(&root).unwrap();
+    let lock_dir = prepare_session_guard_dir(&root).unwrap();
+    let coordinator_path = session_guard_coordinator_path(&lock_dir);
+    let held = SessionLease::acquire_coordinator_blocking(&coordinator_path).unwrap();
+    let (registered_sender, registered_receiver) = std::sync::mpsc::channel();
+    let (acquired_sender, acquired_receiver) = std::sync::mpsc::channel();
+
+    let waiter = std::thread::spawn(move || {
+        let lease = SessionLease::acquire_coordinator_until(
+            &coordinator_path,
+            std::time::Instant::now() + std::time::Duration::from_secs(5),
+            || {
+                let _ = registered_sender.send(());
+            },
+        );
+        let _ = acquired_sender.send(lease);
+    });
+
+    registered_receiver
+        .recv_timeout(std::time::Duration::from_secs(2))
+        .expect("waiter did not publish its registration");
+    drop(held);
+    let acquired = acquired_receiver
+        .recv_timeout(std::time::Duration::from_secs(2))
+        .expect("coordinator owner did not publish lock availability")
+        .expect("waiter did not acquire the published coordinator lock");
+    drop(acquired);
+    waiter.join().unwrap();
+
     fs::remove_dir_all(root).unwrap();
 }
 


### PR DESCRIPTION
Replaces the 5 ms session coordinator lock poll added in PR 9733 with an owner-backed cross-process signal. A waiter publishes a loopback registration, rechecks the lock to close the lost-wakeup race, and waits until one final deadline. SessionLease unlocks first, then publishes availability to registered waiters.

The first commit adds the behavior test. The second commit adds the fix.

Local compile and tests were not run. Hosted proof will follow.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/9940"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789000989&installation_model_id=21920&pr_number=9940&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F9940&signature=927e5b3c94cc15d267da7c41cbb6976fdb49904605dd882fe3ee4a76116928ca"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes cross-process session lock coordination used by reset and multi-daemon startup; incorrect wakeup or timeout behavior could cause spurious "coordinator busy" errors or brief delays, though the file lock remains authoritative.
> 
> **Overview**
> Replaces **5 ms polling** while waiting on the workspace session **coordinator lock** with an **owner-published wakeup** so bounded waits (e.g. session reset) can finish without spinning.
> 
> Waiters register in `.coordinator.waiters` via a loopback **TCP** listener and token file, **retry `try_lock`** after registering to close a lost-wakeup race, then wait until the deadline. On coordinator `SessionLease` drop, the owner **unlocks first** and calls `publish_session_coordinator_available` to connect and send each waiter's token.
> 
> Stale `.tmp` registrations are pruned; tests cover busy failure within ~250 ms and that a released coordinator is observed by waiters.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 53a519d396fb633825095b53568f693542064178. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced the 5 ms polling for the session coordinator lock with an owner-published signal on unlock (FIFO on Unix; UDP loopback on non-Unix), eliminating lost-wakeup races. This reduces CPU wakeups and wakes waiters promptly.

- **Bug Fixes**
  - Waiters register in `.coordinator.waiters` (FIFO on Unix, or loopback address + token on non-Unix), recheck the lock after registering, and wait until the deadline.
  - `SessionLease` publishes availability on unlock by writing to FIFO or sending the token over loopback; it cleans up waiter files, prunes stale `.tmp` registrations, and on Unix publishes only ready FIFO registrations (non-FIFOs are removed).
  - Introduced `acquire_coordinator_until(deadline)` with a bounded wait and a final recheck if a signal is missed; kept `acquire_coordinator_blocking` for tests.
  - Hardened publication: enforce loopback-only addresses on non-Unix, validate token format/length, require FIFO files on Unix, use bounded I/O timeouts, and clean interrupted or invalid registrations.

<sup>Written for commit a4175e640f895c2ca763a23e33e2752847a17956. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/9940?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved coordinator availability notifications to reduce delays when access is released.
  - Prevented missed availability signals during coordinator acquisition attempts.
  - Added validation for private wait registrations to improve reliability and stability.
  - Improved lease handling so waiting sessions can acquire access more consistently.

- **Tests**
  - Added coverage confirming that waiting sessions detect coordinator release and acquire access within the expected time.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->