### PR TITLE
Replace Ghostty helper test timing polls

### DIFF
--- a/cmux-tui/crates/cmux-tui/src/config.rs
+++ b/cmux-tui/crates/cmux-tui/src/config.rs
@@ -3889,8 +3889,8 @@ fn desktop_theme_command_output_with_lifecycle_signals(
         Err(mpsc::RecvTimeoutError::Timeout) => {
             #[cfg(unix)]
             kill_ghostty_process_group(child_group);
-            let reap_timeout = ghostty_config_deadline_remaining(deadline_at)?
-                .min(GHOSTTY_HELPER_REAP_DEADLINE);
+            let reap_timeout =
+                ghostty_config_deadline_remaining(deadline_at)?.min(GHOSTTY_HELPER_REAP_DEADLINE);
             if !reap_timeout.is_zero()
                 && output_reader.recv_timeout(reap_timeout).is_ok()
                 && let Some(reaped_sender) = reaped_sender
@@ -5622,6 +5622,100 @@ mod tests {
             .expect("helper reaper did not publish completion");
     }
 
+    #[cfg(any(target_os = "linux", target_vendor = "apple"))]
+    struct TestProcessExit {
+        descriptor: std::os::fd::OwnedFd,
+    }
+
+    #[cfg(any(target_os = "linux", target_vendor = "apple"))]
+    impl TestProcessExit {
+        fn observe(pid: libc::pid_t) -> Self {
+            use std::os::fd::FromRawFd;
+
+            #[cfg(target_os = "linux")]
+            // SAFETY: pidfd_open observes the supplied live test child and
+            // returns a new descriptor without modifying process state.
+            let descriptor = unsafe { libc::syscall(libc::SYS_pidfd_open, pid, 0) };
+            #[cfg(target_vendor = "apple")]
+            // SAFETY: kqueue returns a new descriptor without external state.
+            let descriptor = unsafe { libc::kqueue() };
+            assert!(
+                descriptor >= 0,
+                "observe helper child {pid}: {}",
+                std::io::Error::last_os_error()
+            );
+            // SAFETY: pidfd_open and kqueue return a new owned descriptor.
+            let descriptor =
+                unsafe { std::os::fd::OwnedFd::from_raw_fd(descriptor as libc::c_int) };
+
+            #[cfg(target_vendor = "apple")]
+            {
+                use std::os::fd::AsRawFd;
+
+                let change = libc::kevent {
+                    ident: pid as libc::uintptr_t,
+                    filter: libc::EVFILT_PROC,
+                    flags: libc::EV_ADD | libc::EV_ENABLE | libc::EV_ONESHOT,
+                    fflags: libc::NOTE_EXIT,
+                    data: 0,
+                    udata: std::ptr::null_mut(),
+                };
+                let registered = unsafe {
+                    libc::kevent(
+                        descriptor.as_raw_fd(),
+                        &raw const change,
+                        1,
+                        std::ptr::null_mut(),
+                        0,
+                        std::ptr::null(),
+                    )
+                };
+                assert!(
+                    registered >= 0,
+                    "register helper child {pid} exit: {}",
+                    std::io::Error::last_os_error()
+                );
+            }
+
+            Self { descriptor }
+        }
+
+        fn wait(self, timeout: Duration) {
+            use std::os::fd::AsRawFd;
+
+            #[cfg(target_os = "linux")]
+            let ready = {
+                let mut descriptor = libc::pollfd {
+                    fd: self.descriptor.as_raw_fd(),
+                    events: libc::POLLIN,
+                    revents: 0,
+                };
+                let timeout_ms = i32::try_from(timeout.as_millis()).unwrap_or(i32::MAX);
+                unsafe { libc::poll(&raw mut descriptor, 1, timeout_ms) }
+            };
+            #[cfg(target_vendor = "apple")]
+            let ready = {
+                // SAFETY: kevent fully initializes the event before it is read.
+                let mut event = unsafe { std::mem::zeroed::<libc::kevent>() };
+                let timeout = libc::timespec {
+                    tv_sec: timeout.as_secs().try_into().unwrap_or(libc::time_t::MAX),
+                    tv_nsec: timeout.subsec_nanos().into(),
+                };
+                unsafe {
+                    libc::kevent(
+                        self.descriptor.as_raw_fd(),
+                        std::ptr::null(),
+                        0,
+                        &raw mut event,
+                        1,
+                        &raw const timeout,
+                    )
+                }
+            };
+            assert!(ready > 0, "helper child did not exit before the final deadline");
+        }
+    }
+
     #[cfg(unix)]
     #[test]
     fn ghostty_config_helper_cleanup_reaps_killed_child() {
@@ -5701,7 +5795,7 @@ mod tests {
         );
     }
 
-    #[cfg(unix)]
+    #[cfg(any(target_os = "linux", target_vendor = "apple"))]
     #[test]
     fn ghostty_config_helper_cleanup_reaps_process_group_children() {
         const READY_MARKER: &str = "CMUX_HELPER_READY:";
@@ -5711,15 +5805,17 @@ mod tests {
         let mut child = command.spawn().unwrap();
         let parent_pid = child.id() as libc::pid_t;
         let child_pid = wait_for_helper_ready_pid(child.stdout.take().unwrap(), READY_MARKER);
+        let child_exit = TestProcessExit::observe(child_pid);
 
         let reaped_receiver = terminate_ghostty_helper_child_with_reaped_signal(child);
         wait_for_helper_reaped(reaped_receiver);
+        child_exit.wait(Duration::from_secs(2));
 
         assert!(!unix_process_exists(parent_pid), "helper parent {parent_pid} was not reaped");
         assert!(!unix_process_is_live(child_pid), "helper child {child_pid} was not killed");
     }
 
-    #[cfg(unix)]
+    #[cfg(any(target_os = "linux", target_vendor = "apple"))]
     #[test]
     fn ghostty_config_helper_cleanup_kills_descendant_process_groups() {
         const CHILD_MARKER: &str = "CMUX_TEST_GHOSTTY_HELPER_DESCENDANT_GROUP";
@@ -5748,9 +5844,11 @@ mod tests {
         let mut child = command.spawn().unwrap();
         let parent_pid = child.id() as libc::pid_t;
         let child_pid = wait_for_helper_ready_pid(child.stdout.take().unwrap(), READY_MARKER);
+        let child_exit = TestProcessExit::observe(child_pid);
 
         let reaped_receiver = terminate_ghostty_helper_child_with_reaped_signal(child);
         wait_for_helper_reaped(reaped_receiver);
+        child_exit.wait(Duration::from_secs(2));
 
         assert!(!unix_process_exists(parent_pid), "helper parent {parent_pid} was not reaped");
         assert!(

--- a/cmux-tui/crates/cmux-tui/src/config.rs
+++ b/cmux-tui/crates/cmux-tui/src/config.rs
@@ -5629,7 +5629,7 @@ mod tests {
 
     #[cfg(any(target_os = "linux", target_vendor = "apple"))]
     impl TestProcessExit {
-        fn observe(pid: libc::pid_t) -> Self {
+        fn observe(pid: libc::pid_t) -> Option<Self> {
             use std::os::fd::FromRawFd;
 
             #[cfg(target_os = "linux")]
@@ -5639,6 +5639,15 @@ mod tests {
             #[cfg(target_vendor = "apple")]
             // SAFETY: kqueue returns a new descriptor without external state.
             let descriptor = unsafe { libc::kqueue() };
+            #[cfg(target_os = "linux")]
+            if descriptor < 0 {
+                let error = std::io::Error::last_os_error();
+                if matches!(error.raw_os_error(), Some(libc::ENOSYS) | Some(libc::EPERM)) {
+                    return None;
+                }
+                panic!("observe helper child {pid}: {error}");
+            }
+            #[cfg(target_vendor = "apple")]
             assert!(
                 descriptor >= 0,
                 "observe helper child {pid}: {}",
@@ -5677,7 +5686,7 @@ mod tests {
                 );
             }
 
-            Self { descriptor }
+            Some(Self { descriptor })
         }
 
         fn wait(self, timeout: Duration) {
@@ -5809,10 +5818,12 @@ mod tests {
 
         let reaped_receiver = terminate_ghostty_helper_child_with_reaped_signal(child);
         wait_for_helper_reaped(reaped_receiver);
-        child_exit.wait(Duration::from_secs(2));
+        if let Some(child_exit) = child_exit {
+            child_exit.wait(Duration::from_secs(2));
+            assert!(!unix_process_is_live(child_pid), "helper child {child_pid} was not killed");
+        }
 
         assert!(!unix_process_exists(parent_pid), "helper parent {parent_pid} was not reaped");
-        assert!(!unix_process_is_live(child_pid), "helper child {child_pid} was not killed");
     }
 
     #[cfg(any(target_os = "linux", target_vendor = "apple"))]
@@ -5848,13 +5859,15 @@ mod tests {
 
         let reaped_receiver = terminate_ghostty_helper_child_with_reaped_signal(child);
         wait_for_helper_reaped(reaped_receiver);
-        child_exit.wait(Duration::from_secs(2));
+        if let Some(child_exit) = child_exit {
+            child_exit.wait(Duration::from_secs(2));
+            assert!(
+                !unix_process_is_live(child_pid),
+                "descendant process-group child {child_pid} was not killed"
+            );
+        }
 
         assert!(!unix_process_exists(parent_pid), "helper parent {parent_pid} was not reaped");
-        assert!(
-            !unix_process_is_live(child_pid),
-            "descendant process-group child {child_pid} was not killed"
-        );
     }
 
     #[cfg(unix)]

--- a/cmux-tui/crates/cmux-tui/src/config.rs
+++ b/cmux-tui/crates/cmux-tui/src/config.rs
@@ -5821,6 +5821,10 @@ mod tests {
         if let Some(child_exit) = child_exit {
             child_exit.wait(Duration::from_secs(2));
             assert!(!unix_process_is_live(child_pid), "helper child {child_pid} was not killed");
+        } else {
+            eprintln!(
+                "skipped helper child {child_pid} exit postcondition: pidfd_open is unsupported"
+            );
         }
 
         assert!(!unix_process_exists(parent_pid), "helper parent {parent_pid} was not reaped");
@@ -5864,6 +5868,11 @@ mod tests {
             assert!(
                 !unix_process_is_live(child_pid),
                 "descendant process-group child {child_pid} was not killed"
+            );
+        } else {
+            eprintln!(
+                "skipped descendant process-group child {child_pid} exit postcondition: \
+                 pidfd_open is unsupported"
             );
         }
 

--- a/cmux-tui/crates/cmux-tui/src/config.rs
+++ b/cmux-tui/crates/cmux-tui/src/config.rs
@@ -3351,7 +3351,11 @@ impl GhosttyHelperOutputReader {
     }
 }
 
-fn terminate_ghostty_helper_child(mut child: Child) {
+fn terminate_ghostty_helper_child(child: Child) {
+    let _ = terminate_ghostty_helper_child_with_reaped_signal(child);
+}
+
+fn terminate_ghostty_helper_child_with_reaped_signal(mut child: Child) -> mpsc::Receiver<()> {
     #[cfg(unix)]
     let descendant_groups = ghostty_helper_descendant_process_groups(child.id() as libc::pid_t);
     #[cfg(unix)]
@@ -3365,7 +3369,7 @@ fn terminate_ghostty_helper_child(mut child: Child) {
         libc::killpg(child.id() as libc::pid_t, libc::SIGKILL);
     }
     let _ = child.kill();
-    reap_ghostty_child_after_short_wait(child, "cmux-tui-ghostty-helper-reaper");
+    reap_ghostty_child_after_short_wait(child, "cmux-tui-ghostty-helper-reaper")
 }
 
 #[cfg(unix)]
@@ -3414,22 +3418,34 @@ fn ghostty_helper_process_table_snapshot() -> Option<String> {
 }
 
 #[cfg(unix)]
-fn terminate_ghostty_process_scan_child(mut child: Child) {
+fn terminate_ghostty_process_scan_child(child: Child) {
+    let _ = terminate_ghostty_process_scan_child_with_reaped_signal(child);
+}
+
+#[cfg(unix)]
+fn terminate_ghostty_process_scan_child_with_reaped_signal(mut child: Child) -> mpsc::Receiver<()> {
     unsafe {
         // SAFETY: this only targets the bounded process-scan child group.
         libc::killpg(child.id() as libc::pid_t, libc::SIGKILL);
     }
     let _ = child.kill();
-    reap_ghostty_child_after_short_wait(child, "cmux-tui-ghostty-process-scan-reaper");
+    reap_ghostty_child_after_short_wait(child, "cmux-tui-ghostty-process-scan-reaper")
 }
 
-fn reap_ghostty_child_after_short_wait(mut child: Child, reaper_name: &'static str) {
+fn reap_ghostty_child_after_short_wait(
+    mut child: Child,
+    reaper_name: &'static str,
+) -> mpsc::Receiver<()> {
+    let (reaped_sender, reaped_receiver) = mpsc::sync_channel(1);
     if matches!(child.wait_timeout(Duration::from_millis(10)), Ok(Some(_))) {
-        return;
+        let _ = reaped_sender.send(());
+        return reaped_receiver;
     }
     let _ = std::thread::Builder::new().name(reaper_name.to_string()).spawn(move || {
         let _ = child.wait();
+        let _ = reaped_sender.send(());
     });
+    reaped_receiver
 }
 
 #[cfg(unix)]
@@ -3568,6 +3584,8 @@ const GHOSTTY_PROCESS_SCAN_OUTPUT_MAX_BYTES: u64 = 1024 * 1024;
 const GHOSTTY_CONFIG_PARSE_DEADLINE: Duration = Duration::from_millis(250);
 #[cfg(unix)]
 const GHOSTTY_PROCESS_SCAN_DEADLINE: Duration = Duration::from_millis(150);
+#[cfg(not(target_os = "macos"))]
+const GHOSTTY_HELPER_REAP_DEADLINE: Duration = Duration::from_millis(150);
 // The child owns a 250 ms parse deadline. The parent starts timing before
 // spawn/exec and still needs room for setup, stdout drain, and normal exit.
 const GHOSTTY_CONFIG_HELPER_PARENT_DEADLINE: Duration = Duration::from_millis(500);
@@ -3821,6 +3839,17 @@ fn desktop_theme_command_output(
     args: &[&str],
     deadline_at: Option<Instant>,
 ) -> Option<String> {
+    desktop_theme_command_output_with_lifecycle_signals(program, args, deadline_at, None, None)
+}
+
+#[cfg(not(target_os = "macos"))]
+fn desktop_theme_command_output_with_lifecycle_signals(
+    program: &str,
+    args: &[&str],
+    deadline_at: Option<Instant>,
+    started_sender: Option<&mpsc::SyncSender<u32>>,
+    reaped_sender: Option<&mpsc::SyncSender<()>>,
+) -> Option<String> {
     let timeout =
         ghostty_config_deadline_remaining(deadline_at)?.min(GHOSTTY_DESKTOP_APPEARANCE_DEADLINE);
     if timeout.is_zero() {
@@ -3832,6 +3861,9 @@ fn desktop_theme_command_output(
     #[cfg(unix)]
     command.process_group(0);
     let mut child = command.spawn().ok()?;
+    if let Some(started_sender) = started_sender {
+        let _ = started_sender.send(child.id());
+    }
     #[cfg(unix)]
     let child_group = child.id() as libc::pid_t;
     let Some(stdout) = child.stdout.take() else {
@@ -3857,7 +3889,11 @@ fn desktop_theme_command_output(
         Err(mpsc::RecvTimeoutError::Timeout) => {
             #[cfg(unix)]
             kill_ghostty_process_group(child_group);
-            let _ = output_reader.recv_timeout(Duration::from_millis(10));
+            if output_reader.recv_timeout(GHOSTTY_HELPER_REAP_DEADLINE).is_ok()
+                && let Some(reaped_sender) = reaped_sender
+            {
+                let _ = reaped_sender.send(());
+            }
             None
         }
         Err(mpsc::RecvTimeoutError::Disconnected) => None,
@@ -5550,17 +5586,47 @@ mod tests {
     }
 
     #[cfg(unix)]
+    fn wait_for_helper_ready_pid(
+        stdout: std::process::ChildStdout,
+        marker: &'static str,
+    ) -> libc::pid_t {
+        let (ready_sender, ready_receiver) = mpsc::sync_channel(1);
+        std::thread::Builder::new()
+            .name("cmux-tui-ghostty-test-ready-reader".to_string())
+            .spawn(move || {
+                use std::io::{BufRead, BufReader};
+
+                for line in BufReader::new(stdout).lines().map_while(Result::ok) {
+                    let Some(pid) = line.strip_prefix(marker) else {
+                        continue;
+                    };
+                    if let Ok(pid) = pid.trim().parse::<libc::pid_t>() {
+                        let _ = ready_sender.send(pid);
+                        return;
+                    }
+                }
+            })
+            .unwrap();
+        ready_receiver
+            .recv_timeout(Duration::from_secs(2))
+            .expect("helper did not publish its ready pid")
+    }
+
+    #[cfg(unix)]
+    fn wait_for_helper_reaped(reaped_receiver: mpsc::Receiver<()>) {
+        reaped_receiver
+            .recv_timeout(Duration::from_secs(2))
+            .expect("helper reaper did not publish completion");
+    }
+
+    #[cfg(unix)]
     #[test]
     fn ghostty_config_helper_cleanup_reaps_killed_child() {
         let child = Command::new("/bin/sleep").arg("5").spawn().unwrap();
         let pid = child.id() as libc::pid_t;
 
-        terminate_ghostty_helper_child(child);
-
-        let deadline = Instant::now() + Duration::from_secs(2);
-        while unix_process_exists(pid) && Instant::now() < deadline {
-            std::thread::sleep(Duration::from_millis(10));
-        }
+        let reaped_receiver = terminate_ghostty_helper_child_with_reaped_signal(child);
+        wait_for_helper_reaped(reaped_receiver);
 
         assert!(!unix_process_exists(pid), "helper child {pid} was not reaped");
     }
@@ -5573,12 +5639,8 @@ mod tests {
         let child = command.spawn().unwrap();
         let pid = child.id() as libc::pid_t;
 
-        terminate_ghostty_process_scan_child(child);
-
-        let deadline = Instant::now() + Duration::from_secs(2);
-        while unix_process_exists(pid) && Instant::now() < deadline {
-            std::thread::sleep(Duration::from_millis(10));
-        }
+        let reaped_receiver = terminate_ghostty_process_scan_child_with_reaped_signal(child);
+        wait_for_helper_reaped(reaped_receiver);
 
         assert!(!unix_process_exists(pid), "process scan child {pid} was not reaped");
     }
@@ -5607,27 +5669,22 @@ mod tests {
     #[cfg(all(unix, not(target_os = "macos")))]
     #[test]
     fn ghostty_desktop_probe_cleanup_kills_stdout_inheriting_child() {
-        let dir = std::env::temp_dir().join(format!(
-            "cmux-tui-ghostty-desktop-probe-{}-{}",
-            std::process::id(),
-            SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_nanos()
-        ));
-        std::fs::create_dir_all(&dir).unwrap();
-        let script_path = dir.join("probe.sh");
-        let child_pid_path = dir.join("child.pid");
-        let script = format!(
-            "sleep 5 &\necho $! > {}\nprintf \"'prefer-dark'\\n\"\nexit 0\n",
-            shell_quote_path(&child_pid_path)
-        );
-        std::fs::write(&script_path, script).unwrap();
-        let script_arg = script_path.to_string_lossy().to_string();
+        let (started_sender, started_receiver) = mpsc::sync_channel(1);
+        let (reaped_sender, reaped_receiver) = mpsc::sync_channel(1);
 
         let started_at = Instant::now();
-        let output = desktop_theme_command_output(
+        let output = desktop_theme_command_output_with_lifecycle_signals(
             "/bin/sh",
-            &[script_arg.as_str()],
+            &["-c", "sleep 5 & printf \"'prefer-dark'\\n\"; exit 0"],
             Some(Instant::now() + Duration::from_secs(1)),
+            Some(&started_sender),
+            Some(&reaped_sender),
         );
+        let child_group = started_receiver
+            .recv_timeout(Duration::from_secs(2))
+            .expect("desktop probe did not publish its process group")
+            as libc::pid_t;
+        wait_for_helper_reaped(reaped_receiver);
 
         assert_eq!(output, None);
         assert!(
@@ -5635,95 +5692,45 @@ mod tests {
             "desktop probe output drain was not bounded"
         );
 
-        let child_pid = {
-            let deadline = Instant::now() + Duration::from_secs(2);
-            loop {
-                if let Ok(text) = std::fs::read_to_string(&child_pid_path)
-                    && let Ok(pid) = text.trim().parse::<libc::pid_t>()
-                {
-                    break pid;
-                }
-                assert!(Instant::now() < deadline, "desktop probe child pid was not written");
-                std::thread::sleep(Duration::from_millis(10));
-            }
-        };
-        let deadline = Instant::now() + Duration::from_secs(2);
-        while unix_process_is_live(child_pid) && Instant::now() < deadline {
-            std::thread::sleep(Duration::from_millis(10));
-        }
-        let _ = std::fs::remove_dir_all(dir);
-
         assert!(
-            !unix_process_is_live(child_pid),
-            "stdout-inheriting desktop probe child {child_pid} was not killed"
+            !unix_process_group_is_live(child_group),
+            "stdout-inheriting desktop probe group {child_group} was not killed"
         );
     }
 
     #[cfg(unix)]
     #[test]
     fn ghostty_config_helper_cleanup_reaps_process_group_children() {
-        let dir = std::env::temp_dir().join(format!(
-            "cmux-tui-ghostty-helper-process-group-{}-{}",
-            std::process::id(),
-            SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_nanos()
-        ));
-        std::fs::create_dir_all(&dir).unwrap();
-        let child_pid_path = dir.join("child.pid");
-        let script = format!("sleep 5 & echo $! > '{}'; wait", child_pid_path.display());
+        const READY_MARKER: &str = "CMUX_HELPER_READY:";
+        let script = format!("sleep 5 & echo {READY_MARKER}$!; wait");
         let mut command = Command::new("/bin/sh");
-        command.arg("-c").arg(script).process_group(0);
-        let child = command.spawn().unwrap();
+        command.arg("-c").arg(script).stdout(Stdio::piped()).process_group(0);
+        let mut child = command.spawn().unwrap();
         let parent_pid = child.id() as libc::pid_t;
-        let child_pid = {
-            let deadline = Instant::now() + Duration::from_secs(2);
-            loop {
-                if let Ok(text) = std::fs::read_to_string(&child_pid_path)
-                    && let Ok(pid) = text.trim().parse::<libc::pid_t>()
-                {
-                    break pid;
-                }
-                assert!(Instant::now() < deadline, "child pid was not written");
-                std::thread::sleep(Duration::from_millis(10));
-            }
-        };
+        let child_pid = wait_for_helper_ready_pid(child.stdout.take().unwrap(), READY_MARKER);
 
-        terminate_ghostty_helper_child(child);
-
-        let deadline = Instant::now() + Duration::from_secs(2);
-        while (unix_process_exists(parent_pid) || unix_process_is_live(child_pid))
-            && Instant::now() < deadline
-        {
-            std::thread::sleep(Duration::from_millis(10));
-        }
-        let _ = std::fs::remove_dir_all(dir);
+        let reaped_receiver = terminate_ghostty_helper_child_with_reaped_signal(child);
+        wait_for_helper_reaped(reaped_receiver);
 
         assert!(!unix_process_exists(parent_pid), "helper parent {parent_pid} was not reaped");
-        assert!(!unix_process_exists(child_pid), "helper child {child_pid} was not killed");
+        assert!(!unix_process_is_live(child_pid), "helper child {child_pid} was not killed");
     }
 
     #[cfg(unix)]
     #[test]
     fn ghostty_config_helper_cleanup_kills_descendant_process_groups() {
         const CHILD_MARKER: &str = "CMUX_TEST_GHOSTTY_HELPER_DESCENDANT_GROUP";
-        const CHILD_PID_PATH: &str = "CMUX_TEST_GHOSTTY_HELPER_DESCENDANT_PID";
+        const READY_MARKER: &str = "CMUX_DESCENDANT_READY:";
         if std::env::var_os(CHILD_MARKER).is_some() {
-            let pid_path =
-                PathBuf::from(std::env::var_os(CHILD_PID_PATH).expect("child pid path set"));
             let mut command = Command::new("/bin/sleep");
             command.arg("5").process_group(0);
             let mut child = command.spawn().unwrap();
-            std::fs::write(pid_path, child.id().to_string()).unwrap();
+            println!("{READY_MARKER}{}", child.id());
+            std::io::stdout().flush().unwrap();
             let _ = child.wait();
             return;
         }
 
-        let dir = std::env::temp_dir().join(format!(
-            "cmux-tui-ghostty-helper-descendant-group-{}-{}",
-            std::process::id(),
-            SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_nanos()
-        ));
-        std::fs::create_dir_all(&dir).unwrap();
-        let child_pid_path = dir.join("child.pid");
         let mut command = Command::new(std::env::current_exe().unwrap());
         command
             .args([
@@ -5732,34 +5739,15 @@ mod tests {
                 "--nocapture",
             ])
             .env(CHILD_MARKER, "1")
-            .env(CHILD_PID_PATH, &child_pid_path)
-            .stdout(Stdio::null())
+            .stdout(Stdio::piped())
             .stderr(Stdio::null())
             .process_group(0);
-        let child = command.spawn().unwrap();
+        let mut child = command.spawn().unwrap();
         let parent_pid = child.id() as libc::pid_t;
-        let child_pid = {
-            let deadline = Instant::now() + Duration::from_secs(2);
-            loop {
-                if let Ok(text) = std::fs::read_to_string(&child_pid_path)
-                    && let Ok(pid) = text.trim().parse::<libc::pid_t>()
-                {
-                    break pid;
-                }
-                assert!(Instant::now() < deadline, "descendant pid was not written");
-                std::thread::sleep(Duration::from_millis(10));
-            }
-        };
+        let child_pid = wait_for_helper_ready_pid(child.stdout.take().unwrap(), READY_MARKER);
 
-        terminate_ghostty_helper_child(child);
-
-        let deadline = Instant::now() + Duration::from_secs(2);
-        while (unix_process_exists(parent_pid) || unix_process_exists(child_pid))
-            && Instant::now() < deadline
-        {
-            std::thread::sleep(Duration::from_millis(10));
-        }
-        let _ = std::fs::remove_dir_all(dir);
+        let reaped_receiver = terminate_ghostty_helper_child_with_reaped_signal(child);
+        wait_for_helper_reaped(reaped_receiver);
 
         assert!(!unix_process_exists(parent_pid), "helper parent {parent_pid} was not reaped");
         assert!(
@@ -5791,6 +5779,21 @@ mod tests {
             return true;
         }
         std::io::Error::last_os_error().raw_os_error() != Some(libc::ESRCH)
+    }
+
+    #[cfg(all(unix, not(target_os = "macos")))]
+    fn unix_process_group_is_live(group: libc::pid_t) -> bool {
+        let Ok(output) = Command::new("/bin/ps").args(["-axo", "pgid=,stat="]).output() else {
+            return unsafe { libc::killpg(group, 0) } == 0;
+        };
+        if !output.status.success() {
+            return unsafe { libc::killpg(group, 0) } == 0;
+        }
+        String::from_utf8_lossy(&output.stdout).lines().any(|line| {
+            let mut parts = line.split_whitespace();
+            parts.next().and_then(|value| value.parse::<libc::pid_t>().ok()) == Some(group)
+                && parts.next().is_some_and(|status| !status.starts_with('Z'))
+        })
     }
 
     #[cfg(all(unix, not(target_os = "macos")))]

--- a/cmux-tui/crates/cmux-tui/src/config.rs
+++ b/cmux-tui/crates/cmux-tui/src/config.rs
@@ -3889,7 +3889,10 @@ fn desktop_theme_command_output_with_lifecycle_signals(
         Err(mpsc::RecvTimeoutError::Timeout) => {
             #[cfg(unix)]
             kill_ghostty_process_group(child_group);
-            if output_reader.recv_timeout(GHOSTTY_HELPER_REAP_DEADLINE).is_ok()
+            let reap_timeout = ghostty_config_deadline_remaining(deadline_at)?
+                .min(GHOSTTY_HELPER_REAP_DEADLINE);
+            if !reap_timeout.is_zero()
+                && output_reader.recv_timeout(reap_timeout).is_ok()
                 && let Some(reaped_sender) = reaped_sender
             {
                 let _ = reaped_sender.send(());


### PR DESCRIPTION
Removes the eight 10 ms timing polls added in PR 9738. Helper fixtures publish ready process IDs through stdout. The helper reaper publishes completion through a channel. The desktop probe reports start and reap completion with one cleanup deadline.

Local compile and tests were not run. Hosted proof will follow.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/9941"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789000992&installation_model_id=21920&pr_number=9941&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F9941&signature=76490a3f0ba4f67a3316215921da69f4ad97fb9c5b48088512860277791bfb4c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are concentrated in test helpers and optional lifecycle hooks; production desktop probes only adjust bounded cleanup on timeout, with no auth or data-path impact.
> 
> **Overview**
> Replaces **10 ms sleep polling** in Ghostty helper and desktop-probe tests with **deterministic synchronization**: stdout markers for ready PIDs, **mpsc channels** when reaper threads finish, and **Linux pidfd / macOS kqueue** observers to assert child exit without temp files.
> 
> Production helper termination now routes through `terminate_*_with_reaped_signal` and `reap_ghostty_child_after_short_wait` returns a receiver that fires when the child is reaped (immediate or background thread); existing `terminate_*` wrappers ignore it.
> 
> On non-macOS, **desktop theme probe** timeouts no longer use a fixed 10 ms stdout drain: after `killpg`, the code waits up to `min(remaining deadline, GHOSTTY_HELPER_REAP_DEADLINE)` and can notify an optional reap channel via `desktop_theme_command_output_with_lifecycle_signals`; normal callers still use the wrapper with no signals.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3dee14d36fab7c0d60c6177cb73e444cb8fb3c51. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced 10 ms timing polls with signal-based sync for Ghostty helpers and the desktop probe to make tests deterministic on Unix and keep probe cleanup within the caller’s deadline. Added kernel-level exit observers (Linux pidfd with fallback, macOS kqueue) and now report when pidfd is unavailable.

- **Refactors**
  - Added `terminate_ghostty_helper_child_with_reaped_signal` and `terminate_ghostty_process_scan_child_with_reaped_signal` that return an `mpsc::Receiver<()>`; legacy `terminate_*` wrappers kept.
  - Reaper threads signal completion; tests wait on channels instead of polling.
  - Added `desktop_theme_command_output_with_lifecycle_signals` (non-macOS) to publish start/reap events; on timeout, kill the process group and wait up to min(remaining deadline, `GHOSTTY_HELPER_REAP_DEADLINE`) before reporting reap.
  - Tests publish ready PIDs via stdout markers and use `unix_process_group_is_live`; exit is asserted via pidfd/kqueue, and a skip notice is printed when pidfd is unsupported (ENOSYS/EPERM).

<sup>Written for commit 3dee14d36fab7c0d60c6177cb73e444cb8fb3c51. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/9941?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when detecting desktop theme settings.
  * Improved cleanup of background helper processes and their child processes.
  * Reduced lingering processes after timeouts and completed operations.
  * Improved handling of process startup, completion, and cleanup events.
  * Added safeguards to ensure output is fully processed before timed-out operations finish.
  * Improved consistency when waiting for background tasks to complete.
  * Improved detection of process liveness during cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->