### PR TITLE
fix(tui): remove duplicate sidebar width type

### DIFF
--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -6775,13 +6775,6 @@ const MIN_CONTENT_WIDTH: u16 = 40;
 const MIN_TABBED_PANE_HEIGHT: u16 = 3;
 const RAIL_REVEAL_HYSTERESIS: u16 = 4;
 
-#[derive(Clone, Copy, Default)]
-struct SidebarWidthOverrides {
-    workspace: Option<u16>,
-    machine: Option<u16>,
-    tabs: Option<u16>,
-}
-
 fn clamp_rail_width(desired: u16, configured_max: u16, available: u16) -> Option<u16> {
     let configured_max = if configured_max > 0 { configured_max } else { u16::MAX };
     let effective_max = available.min(configured_max);


### PR DESCRIPTION
Remove the duplicate SidebarWidthOverrides declaration introduced by stacked history. The remaining declaration is identical and continues to serve the existing sidebar layout tests.

Verification: hosted full cmux-tui gate only. No local Cargo, Rust, Zig, compile, or test command was run.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/9943"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789000997&installation_model_id=21920&pr_number=9943&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F9943&signature=34ff9116f89da2924fc2834cc888c00c6fedb4a512a3f51e08cebc8095bbd6b1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Duplicate type removal only; no behavior change to sidebar layout logic.
> 
> **Overview**
> Removes a **duplicate** `SidebarWidthOverrides` struct in `app.rs` that was left from stacked merge history. The single remaining definition is unchanged and still drives `sidebar_layout_for` and sidebar layout tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e57e23f873964527c089ce96e319f7a7c7f7a082. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->