### PR TITLE
test(tui): cover detached cleanup identity

### DIFF
--- a/cmux-tui/crates/cmux-tui-core/src/mux.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/mux.rs
@@ -29704,6 +29704,91 @@ mod tests {
 
     #[cfg(unix)]
     #[test]
+    fn detached_terminal_close_rejects_stale_cleanup_identity_before_commit() {
+        use std::os::unix::fs::{MetadataExt, PermissionsExt};
+
+        const TERMINAL: &str = "0000000000004000800000000000000d";
+        const INCARNATION: &str = "1000000000004000800000000000000d";
+        const OTHER_INCARNATION: &str = "1000000000004000800000000000000e";
+        let root = std::env::temp_dir().join(format!(
+            "cmux-mux-detached-cleanup-{}",
+            crate::workspace_registry::new_uuid_v4()
+        ));
+        let host_root = crate::terminal_host_runtime::terminal_host_root(&root, "detached-cleanup");
+        let options = SurfaceOptions {
+            terminal_host_root: Some(host_root.clone()),
+            ..SurfaceOptions::default()
+        };
+        let mux = Mux::new_for_test("detached-cleanup", options);
+        let workspace =
+            mux.create_empty_workspace(Some("detached-cleanup".into()), None, None).unwrap();
+        let surface =
+            mux.seed_running_terminal_for_test(TERMINAL, INCARNATION, &workspace.key).unwrap();
+        let terminal =
+            mux.workspace_registry.lock().unwrap().terminal_resource_id(TERMINAL).unwrap().unwrap();
+        assert!(
+            mux.persist_terminal_exit_for_test(
+                &terminal,
+                &TerminalExit {
+                    outcome: crate::terminal_host_protocol::TerminalExitOutcome::Exit { code: 0 },
+                    exited_at_ms: 1,
+                },
+            )
+            .unwrap()
+        );
+        mux.surface_exited(surface);
+        let detached = mux.resolve_terminal(TERMINAL).unwrap().unwrap();
+        assert_eq!(detached.surface, None);
+        assert_eq!(detached.terminal.lifecycle, TerminalLifecycle::Exited);
+
+        mux.terminal_adoption_coordinator.state.lock().unwrap().stopping = true;
+        std::fs::create_dir_all(&host_root).unwrap();
+        let uid = std::fs::metadata(&host_root).unwrap().uid();
+        let host_record = crate::terminal_host_runtime::TerminalHostRecord {
+            record_version: 1,
+            terminal_id: TERMINAL.into(),
+            incarnation: OTHER_INCARNATION.into(),
+            endpoint: format!("/tmp/cmux-th-{uid}/{TERMINAL}.sock"),
+            owner_token: "01".repeat(crate::terminal_host::CAPABILITY_TOKEN_LEN),
+            host_pid: 0,
+            host_start_nonce: String::new(),
+            workspace_key: workspace.key,
+            supports_set_defaults: false,
+            supports_terminate_only: false,
+            supports_terminate_ack: false,
+            supports_clear_history: false,
+        };
+        let host_record_path = host_root.join(format!("{TERMINAL}.json"));
+        std::fs::write(&host_record_path, serde_json::to_vec(&host_record).unwrap()).unwrap();
+        let mut permissions = std::fs::metadata(&host_record_path).unwrap().permissions();
+        permissions.set_mode(0o600);
+        std::fs::set_permissions(&host_record_path, permissions).unwrap();
+
+        let error = mux
+            .close_terminal(TERMINAL, INCARNATION)
+            .expect_err("detached terminal close accepted a different host incarnation");
+        assert!(format!("{error:#}").contains("terminal-host incarnation changed"));
+        assert_eq!(
+            mux.resolve_terminal(TERMINAL).unwrap().unwrap().terminal.lifecycle,
+            TerminalLifecycle::Exited,
+            "rejected host cleanup changed the detached terminal lifecycle"
+        );
+
+        std::fs::remove_file(host_record_path).unwrap();
+        let closed = mux.close_terminal(TERMINAL, INCARNATION).unwrap();
+        assert_eq!(closed.surface, None);
+        assert_eq!(
+            mux.resolve_terminal(TERMINAL).unwrap().unwrap().terminal.lifecycle,
+            TerminalLifecycle::Tombstoned
+        );
+        mux.terminal_adoption_coordinator.state.lock().unwrap().stopping = false;
+        mux.shutdown().unwrap();
+        drop(mux);
+        std::fs::remove_dir_all(root).unwrap();
+    }
+
+    #[cfg(unix)]
+    #[test]
     fn hosted_terminal_exit_removes_sole_surface_but_preserves_exact_wait_result() {
         const TERMINAL: &str = "0000000000004000800000000000003c";
         const INCARNATION: &str = "1000000000004000800000000000003c";


### PR DESCRIPTION
Production fix 8c0257750b2e0940a3e8c67e71035324fc180464 landed directly on feat-tui-server-upgrade. This child adds the missing behavior proof.

- reject detached terminal cleanup when the host record has a different incarnation
- keep the terminal Exited after rejection
- remove the conflicting record and prove the exact close succeeds
- retain terminal-host recovery during restart

Local Rust compile and tests were skipped by repository policy. Hosted macOS and Linux verification will run on the exact head. Isolated gpt-5.6-sol xhigh review is clean with no findings.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change with no production logic modified; low risk.
> 
> **Overview**
> Adds a **unix-only** integration test in `mux.rs` for detached terminal close when a stale terminal-host JSON record carries a different `incarnation` than the receipt.
> 
> The test seeds an exited detached terminal, writes a conflicting host record on disk, and asserts `close_terminal` fails with **terminal-host incarnation changed** while lifecycle stays **Exited**. After removing that record, the same close tombstones the receipt as expected.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4ee231b5728dbf2c6470910dc7b911f964ed13f9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a Unix-only test that rejects detached terminal cleanup when a stale terminal-host record has a different `incarnation`. Verifies `close_terminal` errors with "terminal-host incarnation changed", the terminal remains Exited, and after removing the conflicting record the close succeeds and tombstones the terminal.

<sup>Written for commit 4ee231b5728dbf2c6470910dc7b911f964ed13f9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/9945?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

