### PR TITLE
fix(tui): project restored terminal tabs

### DIFF
--- a/cmux-tui/bindings/conformance/runner.py
+++ b/cmux-tui/bindings/conformance/runner.py
@@ -1568,7 +1568,7 @@ def run_live_case(
     adapter: Adapter,
     binary: Path,
     constants: Mapping[str, str],
-) -> tuple[str, ...]:
+) -> dict[str, str]:
     try:
         exact_binary = binary.expanduser().resolve(strict=True)
     except FileNotFoundError as error:
@@ -1593,6 +1593,7 @@ def run_live_case(
     process: subprocess.Popen[str] | None = None
     setup: dict[str, tuple[str, list[str]]] = {}
     creation: dict[str, LiveCreationEvidence] = {}
+    failures: dict[str, str] = {}
     try:
         process, websocket_url = start_live_server(
             exact_binary,
@@ -1656,57 +1657,65 @@ def run_live_case(
             websocket_token,
         )
         for transport in transports:
-            stable_id, duplicate_ids = setup[transport]
-            evidence = creation[transport]
-            workspace_name = f"{base_name}-{transport}"
-            payload = live_payload(
-                identifier=f"live-{transport}-exit-restart",
-                operation="live-exit-restart",
-                transport=transport,
-                socket_path=socket_path,
-                websocket_url=websocket_url,
-                websocket_token=websocket_token,
-                constants=constants,
-                workspace_name=workspace_name,
-                key_prefix=transport,
-            )
-            payload.update(
-                {
-                    "expected_created_path": evidence.created_path,
-                    "expected_correlation_key": evidence.correlation_key,
-                    "expected_creation_generation": (
-                        evidence.creation_generation
-                    ),
-                    "expected_creation_revision": evidence.creation_revision,
-                    "expected_exited_at": evidence.exited_at,
-                    "expected_exit_revision": evidence.exit_revision,
-                    "exit_timeout_ms": "0",
-                    "expected_exit_code": 17,
-                }
-            )
-            validate_live_exit_restart(
-                adapter.request(payload, timeout=45),
-                transport,
-                evidence,
-            )
-            payload = live_payload(
-                identifier=f"live-{transport}-restart",
-                operation="live-restart",
-                transport=transport,
-                socket_path=socket_path,
-                websocket_url=websocket_url,
-                websocket_token=websocket_token,
-                constants=constants,
-                workspace_name=workspace_name,
-                key_prefix=transport,
-            )
-            payload["expected_stable_id"] = stable_id
-            payload["expected_duplicate_ids"] = duplicate_ids
-            validate_live_restart(
-                adapter.request(payload, timeout=45),
-                transport,
-            )
-        return transports
+            try:
+                stable_id, duplicate_ids = setup[transport]
+                evidence = creation[transport]
+                workspace_name = f"{base_name}-{transport}"
+                payload = live_payload(
+                    identifier=f"live-{transport}-exit-restart",
+                    operation="live-exit-restart",
+                    transport=transport,
+                    socket_path=socket_path,
+                    websocket_url=websocket_url,
+                    websocket_token=websocket_token,
+                    constants=constants,
+                    workspace_name=workspace_name,
+                    key_prefix=transport,
+                )
+                payload.update(
+                    {
+                        "expected_created_path": evidence.created_path,
+                        "expected_correlation_key": evidence.correlation_key,
+                        "expected_creation_generation": (
+                            evidence.creation_generation
+                        ),
+                        "expected_creation_revision": (
+                            evidence.creation_revision
+                        ),
+                        "expected_exited_at": evidence.exited_at,
+                        "expected_exit_revision": evidence.exit_revision,
+                        "exit_timeout_ms": "0",
+                        "expected_exit_code": 17,
+                    }
+                )
+                validate_live_exit_restart(
+                    adapter.request(payload, timeout=45),
+                    transport,
+                    evidence,
+                )
+                payload = live_payload(
+                    identifier=f"live-{transport}-restart",
+                    operation="live-restart",
+                    transport=transport,
+                    socket_path=socket_path,
+                    websocket_url=websocket_url,
+                    websocket_token=websocket_token,
+                    constants=constants,
+                    workspace_name=workspace_name,
+                    key_prefix=transport,
+                )
+                payload["expected_stable_id"] = stable_id
+                payload["expected_duplicate_ids"] = duplicate_ids
+                validate_live_restart(
+                    adapter.request(payload, timeout=45),
+                    transport,
+                )
+            except BaseException as error:
+                # A failed transport must not be reported as evidence that a
+                # later transport ran. Keep the shared restart state and
+                # exercise every supported transport independently.
+                failures[transport] = str(error)
+        return failures
     finally:
         if process is not None:
             stop_live_server(process, socket_path)
@@ -1798,7 +1807,9 @@ def main(argv: Sequence[str] | None = None) -> int:
         if not args.fake_only and args.cmux_tui_bin is not None:
             transports = live_transports(language)
             try:
-                run_live_case(adapter, args.cmux_tui_bin, constants)
+                failures = run_live_case(
+                    adapter, args.cmux_tui_bin, constants
+                )
             except BaseException as error:
                 for transport in transports:
                     results.append(
@@ -1811,11 +1822,13 @@ def main(argv: Sequence[str] | None = None) -> int:
                     )
             else:
                 for transport in transports:
+                    detail = failures.get(transport)
                     results.append(
                         CaseResult(
                             language,
                             f"live-creation-exit-restart-{transport}",
-                            "PASS",
+                            "FAIL" if detail is not None else "PASS",
+                            detail or "",
                         )
                     )
 

--- a/cmux-tui/bindings/conformance/test_runner.py
+++ b/cmux-tui/bindings/conformance/test_runner.py
@@ -305,8 +305,8 @@ class LiveOrchestrationTests(unittest.TestCase):
                 (object(), "ws://127.0.0.1:41001"),
                 (object(), "ws://127.0.0.1:41002"),
             ]
-            transports = run_live_case(adapter, Path(sys.executable), {})
-            self.assertEqual(transports, ("unix", "websocket"))
+            failures = run_live_case(adapter, Path(sys.executable), {})
+            self.assertEqual(failures, {})
             return adapter, start, stop
 
     def test_live_orchestration_orders_creation_exit_and_cleanup(self) -> None:

--- a/cmux-tui/bindings/conformance/test_runner.py
+++ b/cmux-tui/bindings/conformance/test_runner.py
@@ -126,6 +126,17 @@ class FakeLiveAdapter:
         }
 
 
+class UnixRestartFailureAdapter(FakeLiveAdapter):
+    def request(self, payload: dict, *, timeout: float = 45.0) -> dict:
+        if (
+            payload["transport"] == "unix"
+            and payload["op"] == "live-exit-restart"
+        ):
+            self.requests.append(json.loads(json.dumps(payload)))
+            raise ConformanceFailure("unix restart failed")
+        return super().request(payload, timeout=timeout)
+
+
 class ContractTests(unittest.TestCase):
     @classmethod
     def setUpClass(cls) -> None:
@@ -360,6 +371,30 @@ class LiveOrchestrationTests(unittest.TestCase):
             self.assertEqual(
                 restarted[transport]["expected_exited_at"], "1001"
             )
+
+    def test_unix_restart_failure_does_not_skip_websocket_restart(self) -> None:
+        adapter = UnixRestartFailureAdapter()
+        with (
+            patch("runner.start_live_server") as start,
+            patch("runner.stop_live_server"),
+        ):
+            start.side_effect = [
+                (object(), "ws://127.0.0.1:41001"),
+                (object(), "ws://127.0.0.1:41002"),
+            ]
+            failures = run_live_case(adapter, Path(sys.executable), {})
+
+        self.assertEqual(failures, {"unix": "unix restart failed"})
+        websocket_restart_operations = [
+            payload["op"]
+            for payload in adapter.requests
+            if payload["transport"] == "websocket"
+            and payload["op"] in {"live-exit-restart", "live-restart"}
+        ]
+        self.assertEqual(
+            websocket_restart_operations,
+            ["live-exit-restart", "live-restart"],
+        )
 
 
 class EnvelopeServerTests(unittest.TestCase):

--- a/cmux-tui/crates/cmux-tui-core/src/mux/resource_content.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/mux/resource_content.rs
@@ -732,17 +732,7 @@ impl Mux {
                         // must preserve those durable views instead of making
                         // unrelated host adoption a precondition.
                         let surface = state.surfaces.get(surface_slot);
-                        let identity = surface
-                            .and_then(|surface| surface.resource_identity().cloned())
-                            .or_else(|| {
-                                Some(TabResourceIdentity::new(
-                                    state.resource_indexes.tab_ids.get(surface_slot)?.clone(),
-                                    state.resource_indexes.content_ids.get(surface_slot)?.clone(),
-                                ))
-                            })
-                            .with_context(|| {
-                                format!("pane surface {surface_slot} has no resource identity")
-                            })?;
+                        let identity = projected_tab_identity(state, *surface_slot)?;
                         let before_tab = before_tabs.get(&identity.tab_id);
                         live_tabs.insert(identity.tab_id.clone());
                         tab_order.push(identity.tab_id.clone());
@@ -1078,13 +1068,7 @@ fn ordered_terminal_tab_ids(
     let mut tabs = Vec::new();
     for pane in state.panes.values() {
         for (position, surface_slot) in pane.tabs.iter().enumerate() {
-            let surface = state
-                .surfaces
-                .get(surface_slot)
-                .with_context(|| format!("pane references missing surface {surface_slot}"))?;
-            let identity = surface
-                .resource_identity()
-                .with_context(|| format!("pane surface {surface_slot} has no resource identity"))?;
+            let identity = projected_tab_identity(state, *surface_slot)?;
             if let ContentPublicId::Terminal(terminal_id) = &identity.content_id {
                 tabs.push((
                     terminal_id.clone(),
@@ -1096,6 +1080,31 @@ fn ordered_terminal_tab_ids(
         }
     }
     Ok(terminal_tab_ids_in_canonical_order(tabs))
+}
+
+/// Resolve the durable placement identity without making runtime adoption a
+/// projection precondition. Restart restores these indexes before it installs
+/// terminal surfaces, and every projection phase must accept that state.
+fn projected_tab_identity(
+    state: &State,
+    surface_slot: crate::SurfaceId,
+) -> anyhow::Result<TabResourceIdentity> {
+    if let Some(identity) =
+        state.surfaces.get(&surface_slot).and_then(|surface| surface.resource_identity())
+    {
+        return Ok(identity.clone());
+    }
+    let tab_id = state
+        .resource_indexes
+        .tab_ids
+        .get(&surface_slot)
+        .cloned()
+        .with_context(|| format!("pane surface {surface_slot} has no durable tab identity"))?;
+    let content_id =
+        state.resource_indexes.content_ids.get(&surface_slot).cloned().with_context(|| {
+            format!("pane surface {surface_slot} has no durable content identity")
+        })?;
+    Ok(TabResourceIdentity::new(tab_id, content_id))
 }
 
 fn registry_screen_from_live(


### PR DESCRIPTION
Cause: restart restores pane tabs and durable indexes before terminal surfaces are adopted. The projection ordered-tab phase required a live surface even though the main phase already accepted the durable restored identity.

Changes:
- use one live-or-durable tab identity resolver in every projection phase
- record Unix and WebSocket restart failures independently so both paths run
- retain the existing behavior test for projection before surface adoption and add orchestration coverage for transport isolation

Verification:
- no local compile or test, per task constraint
- hosted exact-SHA proof will be attached before merge

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/9948"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789003338&installation_model_id=21920&pr_number=9948&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F9948&signature=45f216649d1209b637b8310faa6898a38c18b30d3cb7f1b5e5e1cbb8c920afac"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 3f5bf1c1e7e5b3e2bd043e787ba1d7c1042a486f. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes terminal tab projection after restart when surfaces aren't adopted yet. Tabs now restore using durable indexes, and restart tests isolate Unix and WebSocket paths so one failure doesn't hide the other.

- **Bug Fixes**
  - Added a single live-or-durable tab identity resolver used in all projection phases (`projected_tab_identity`).
  - Ordered terminal tabs now derive identity from durable indexes when no live surface exists.
  - Conformance runner records Unix and WebSocket restart failures independently and continues running both transports.
  - Added a test to confirm a Unix restart failure does not skip WebSocket restart.

<sup>Written for commit 3f5bf1c1e7e5b3e2bd043e787ba1d7c1042a486f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/9948?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

