### PR TITLE
Fix journal owner branch CI

### DIFF
--- a/cmux-tui/bindings/rust/src/resource/model.rs
+++ b/cmux-tui/bindings/rust/src/resource/model.rs
@@ -534,12 +534,12 @@ impl<'de> Deserialize<'de> for TerminalSnapshot {
                 return Err(serde::de::Error::custom("terminal tab_ids must be an array"));
             }
             (legacy, Some(Some(tab_ids))) => {
-                if let Some(legacy) = legacy {
-                    if legacy.as_ref() != tab_ids.first() {
-                        return Err(serde::de::Error::custom(
-                            "terminal tab_id must be the first tab_ids item",
-                        ));
-                    }
+                if let Some(legacy) = legacy
+                    && legacy.as_ref() != tab_ids.first()
+                {
+                    return Err(serde::de::Error::custom(
+                        "terminal tab_id must be the first tab_ids item",
+                    ));
                 }
                 tab_ids
             }

--- a/cmux-tui/crates/cmux-tui-core/src/journal_checkpoint.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/journal_checkpoint.rs
@@ -28,6 +28,7 @@ const RESOURCE_COLLECTIONS: [&str; 10] = [
     "sidebar_views",
 ];
 
+#[derive(Debug)]
 pub(crate) struct CapturedCheckpoint {
     pub(crate) source_sequence: u64,
     pub(crate) state: Value,

--- a/cmux-tui/crates/cmux-tui-core/src/mux.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/mux.rs
@@ -15666,6 +15666,7 @@ mod tests {
     use crate::workspace_registry::{
         RegistryPane, RegistryScreen, RegistryViewportColumn, ResourceChange, ResourcePatch,
     };
+    use serde_json::json;
 
     fn test_mux() -> Arc<Mux> {
         Mux::new_for_test("test", SurfaceOptions::default())


### PR DESCRIPTION
## Summary

- import the JSON macro used by the owner-branch mux test
- make captured checkpoints debuggable for `expect_err`
- satisfy the owner branch's denied collapsible-if lint

## Verification

- failures reproduced by hosted diagnostic run 31449493968
- full hosted cmux-tui gate will run on this branch
- no local compile or test run

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/9951"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789004217&installation_model_id=21920&pr_number=9951&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F9951&signature=73feff711727ebe35e0e1b9acea5f462743379fb2e6d31ace24184454ea760e7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 24c65b6c0f179dbb800b616a4cb74173aa957d30. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restore owner-branch CI for the journal tests by importing `serde_json::json`, making checkpoints debuggable, and fixing a lint in the deserializer.

- **Bug Fixes**
  - Import `serde_json::json` in mux tests used by the owner branch.
  - Derive `Debug` for `CapturedCheckpoint` to improve `expect_err` diagnostics.
  - Simplify `TerminalSnapshot` deserialization check with an `if let` chain to satisfy the denied collapsible-if lint.

<sup>Written for commit afe9394c9295009d388b808a659c46bade6ca2ac. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/9951?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

