### PR TITLE
Fix iOS 27 keyboard dock tracking

### DIFF
--- a/Packages/iOS/CmuxMobileSupport/Sources/CmuxMobileSupport/UITestConfig.swift
+++ b/Packages/iOS/CmuxMobileSupport/Sources/CmuxMobileSupport/UITestConfig.swift
@@ -79,6 +79,16 @@ public struct UITestConfig {
         #endif
     }
 
+    /// Forces the iOS 27 keyboard-dock compatibility path on an older simulator.
+    /// DEBUG-only so production selection remains tied exclusively to the OS version.
+    public static var forceIOS27KeyboardDockWorkaround: Bool {
+        #if DEBUG
+        return ProcessInfo.processInfo.environment["CMUX_UITEST_FORCE_IOS27_KEYBOARD_DOCK"] == "1"
+        #else
+        return false
+        #endif
+    }
+
     /// Whether the standalone workspace-list layout preview is enabled.
     ///
     /// When `CMUX_UITEST_WORKSPACE_LIST_PREVIEW=1`, the root view renders a

--- a/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceHostView.swift
+++ b/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceHostView.swift
@@ -1,7 +1,7 @@
 #if canImport(UIKit)
 import UIKit
 
-/// Plain UIKit root that owns the terminal's keyboard guide and bottom dock.
+/// Plain UIKit root that owns the terminal's bottom dock and keyboard geometry.
 ///
 /// `GhosttySurfaceView` is an aggressively relaid-out `CAMetalLayer` renderer. Keeping
 /// the keyboard constraint on this separate, layout-passive root prevents renderer

--- a/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView.swift
+++ b/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView.swift
@@ -12,6 +12,32 @@ import os
 
 private let log = Logger(subsystem: "ai.manaflow.cmux.ios", category: "ghostty.surface")
 
+/// iOS 27 beta can leave `UIKeyboardLayoutGuide` seated at the screen bottom while
+/// the keyboard is visible. Keep the existing system-guide architecture everywhere
+/// else and use the keyboard notification's end frame only on that OS major.
+private enum KeyboardDockGeometrySource: Equatable {
+    case systemLayoutGuide
+    case keyboardNotifications
+
+    static var current: Self {
+        #if DEBUG
+        if UITestConfig.forceIOS27KeyboardDockWorkaround {
+            return .keyboardNotifications
+        }
+        #endif
+        return ProcessInfo.processInfo.operatingSystemVersion.majorVersion == 27
+            ? .keyboardNotifications
+            : .systemLayoutGuide
+    }
+
+    var debugName: String {
+        switch self {
+        case .systemLayoutGuide: "layoutGuide"
+        case .keyboardNotifications: "notification"
+        }
+    }
+}
+
 public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
     /// The surface whose terminal proxy or composer currently owns input.
     ///
@@ -362,6 +388,7 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
         let keyboardTransitionID = bottomDockTransitionInFlight ? 1 : -1
         let keyboardTransitionTarget = pointValue(keyboardHeight)
         let keyboardGuideTop = pointValue(keyboardGuideFrameInSurface.minY)
+        let keyboardDockTargetTop = pointValue(keyboardDockTargetTopInSurface)
         return [
             "chromeHidden=\(chromeHidden ? 1 : 0)",
             "composerActive=\(composerActive ? 1 : 0)",
@@ -381,6 +408,8 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
             "dockMaxInternalPresentationGap=\(maximumInternalPresentationGap)",
             "bottomSafeArea=\(pointValue(safeAreaInsetsBottom))",
             "keyboardGuideTop=\(keyboardGuideTop)",
+            "keyboardDockSource=\(keyboardDockGeometrySource.debugName)",
+            "keyboardDockTargetTop=\(keyboardDockTargetTop)",
             "keyboardTransitionID=\(keyboardTransitionID)",
             "keyboardTransitionTarget=\(keyboardTransitionTarget)",
             "bandMounted=\(composerContainer.subviews.isEmpty ? 0 : 1)",
@@ -513,17 +542,19 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
     }
     private var viewportCoordinator = TerminalViewportCoordinator()
     /// The toolbar/composer use Auto Layout; the Ghostty renderer does not. This bit
-    /// keeps its display-link viewport updates alive until the guide-constrained
-    /// toolbar's presentation frame reaches its model frame.
+    /// keeps display-link viewport updates alive until the dock's presentation frame
+    /// reaches its model frame.
     private var bottomDockTransitionObserved = false
+    private let keyboardDockGeometrySource = KeyboardDockGeometrySource.current
+    private var keyboardNotificationTransitionGeneration: UInt64 = 0
     private var bottomDockToKeyboardConstraint: NSLayoutConstraint?
+    private var bottomDockManualConstraint: NSLayoutConstraint?
     private var bottomDockHostConstraints: [NSLayoutConstraint] = []
     private weak var bottomDockHostView: UIView?
     private var composerHeightConstraint: NSLayoutConstraint?
     private var toolbarHeightConstraint: NSLayoutConstraint?
     #if DEBUG
     private var keyboardHeightOverrideForTesting: CGFloat?
-    private var bottomDockForTestingConstraint: NSLayoutConstraint?
     private var maximumInternalDockPresentationGap: CGFloat = 0
     #endif
 
@@ -822,6 +853,14 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
             name: UIResponder.keyboardWillChangeFrameNotification,
             object: nil
         )
+        if keyboardDockGeometrySource == .keyboardNotifications {
+            NotificationCenter.default.addObserver(
+                self,
+                selector: #selector(handleKeyboardWillChangeFrame(_:)),
+                name: UIResponder.keyboardDidChangeFrameNotification,
+                object: nil
+            )
+        }
     }
 
     @objc private func handleAppWillResignActive() {
@@ -907,9 +946,9 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
     /// toolbar's live top edge equal to the viewport edge; any whole-cell render
     /// remainder stays inside the terminal viewport instead of becoming toolbar fill.
     private static let persistentToolbarHeight: CGFloat = TerminalInputTextView.dockedButtonRowHeight
-    /// The single visual dock translated by UIKit's keyboard guide. The Shortcut and
-    /// Composer bars are children of this view, so an interrupted keyboard animation
-    /// cannot leave their presentation layers on different translation timelines.
+    /// The single visual dock translated by the selected keyboard geometry source.
+    /// The Shortcut and Composer bars are children of this view, so an interrupted
+    /// animation cannot leave their presentation layers on different timelines.
     private let bottomDockContainer = UIView()
     /// The docked accessory bar. It is the upper child of ``bottomDockContainer``;
     /// the composer is the lower child nearest the keyboard.
@@ -990,16 +1029,61 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
         // and its text stays; tapping it refocuses and re-raises the keyboard. The
         // composer is dismissed only by its chevron or the toolbar composer button.
         //
-        // This notification owns responder-facing VISIBILITY only. UIKit's
-        // `keyboardLayoutGuide` owns all dock and viewport geometry, including safe-area
-        // fallback and interrupted keyboard motion. Keeping those responsibilities
-        // separate prevents a stale notification frame from becoming a second layout
-        // authority while preserving hardware/floating keyboard visibility semantics.
+        // This notification always owns responder-facing visibility. On iOS 27 it
+        // also owns dock geometry because that beta can leave `keyboardLayoutGuide`
+        // stale; every other OS keeps the existing guide as its only geometry source.
         updateDockedToolbarVisibility()
-        setNeedsLayout()
+        switch keyboardDockGeometrySource {
+        case .systemLayoutGuide:
+            setNeedsLayout()
+        case .keyboardNotifications:
+            let durationOverride: TimeInterval? = notification.name
+                == UIResponder.keyboardDidChangeFrameNotification ? 0 : nil
+            applyNotificationDrivenKeyboardTransition(
+                transition,
+                durationOverride: durationOverride
+            )
+        }
     }
 
-    /// Keep the renderer clipped to UIKit's live keyboard guide during animation.
+    /// Drives the iOS 27 compatibility constraint from UIKit's keyboard frame.
+    /// This is the sole dock geometry authority on that OS, so the broken layout
+    /// guide never competes with the notification-derived target.
+    private func applyNotificationDrivenKeyboardTransition(
+        _ transition: MobileKeyboardTransition,
+        durationOverride: TimeInterval?
+    ) {
+        let owner = bottomDockHostView ?? self
+        let targetOverlap = transition.overlap(in: owner)
+        let animationDuration = durationOverride ?? transition.duration
+
+        owner.layoutIfNeeded()
+        keyboardHeight = targetOverlap
+        updateNotificationDrivenDockConstraint()
+        #if DEBUG
+        maximumInternalDockPresentationGap = 0
+        #endif
+        keyboardNotificationTransitionGeneration &+= 1
+        let generation = keyboardNotificationTransitionGeneration
+        bottomDockTransitionObserved = animationDuration > 0
+        setNeedsGeometrySync()
+
+        transition.animate(durationOverride: durationOverride) { [weak self, weak owner] in
+            guard let self, let owner else { return }
+            owner.layoutIfNeeded()
+            self.layoutRenderedTerminalForCurrentViewport()
+            self.layoutZoomOverlay()
+        } completion: { [weak self] _ in
+            guard let self,
+                  self.keyboardNotificationTransitionGeneration == generation else { return }
+            self.bottomDockTransitionObserved = false
+            self.layoutRenderedTerminalForCurrentViewport()
+            self.layoutZoomOverlay()
+            self.setNeedsGeometrySync()
+        }
+    }
+
+    /// Keep the renderer clipped to the dock's live presentation during animation.
     ///
     /// The constrained toolbar/composer already follow the guide automatically. The
     /// terminal renderer is not Auto Layout-backed, so its display-link pass reads the
@@ -1018,11 +1102,41 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
         }
     }
 
-    /// Installs the system keyboard guide as the only production keyboard geometry source.
+    /// Configures the system keyboard guide used by every OS except iOS 27.
     private func configureKeyboardLayoutGuide(on owner: UIView? = nil) {
+        guard keyboardDockGeometrySource == .systemLayoutGuide else { return }
         let guide = (owner ?? self).keyboardLayoutGuide
         guide.followsUndockedKeyboard = true
         guide.usesBottomSafeArea = true
+    }
+
+    /// Builds the one active dock-bottom constraint for the selected OS policy.
+    private func makeBottomDockConstraint(on owner: UIView) -> NSLayoutConstraint {
+        switch keyboardDockGeometrySource {
+        case .systemLayoutGuide:
+            configureKeyboardLayoutGuide(on: owner)
+            return bottomDockContainer.bottomAnchor.constraint(
+                equalTo: owner.keyboardLayoutGuide.topAnchor
+            )
+        case .keyboardNotifications:
+            let constraint = bottomDockContainer.bottomAnchor.constraint(
+                equalTo: owner.bottomAnchor
+            )
+            bottomDockManualConstraint = constraint
+            updateNotificationDrivenDockConstraint(constraint)
+            return constraint
+        }
+    }
+
+    private func updateNotificationDrivenDockConstraint(
+        _ constraint: NSLayoutConstraint? = nil
+    ) {
+        guard keyboardDockGeometrySource == .keyboardNotifications,
+              let constraint = constraint ?? bottomDockManualConstraint else { return }
+        constraint.constant = -TerminalLetterboxGeometry.keyboardOccupancy(
+            keyboardHeight: keyboardHeight,
+            bottomSafeAreaInset: safeAreaInsetsBottom
+        )
     }
 
     private func installBottomDockContainer() {
@@ -1032,17 +1146,15 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
         addSubview(bottomDockContainer)
     }
 
-    /// Pins one dock container to Apple's keyboard guide. Keyboard motion therefore
-    /// translates one layer; child height constraints only arrange the bars internally.
+    /// Pins one dock container to the selected keyboard geometry source. Keyboard
+    /// motion translates one layer; child constraints arrange the bars internally.
     private func installBottomDockConstraints() {
         guard let dockedToolbar else { return }
         bottomDockContainer.translatesAutoresizingMaskIntoConstraints = false
         dockedToolbar.translatesAutoresizingMaskIntoConstraints = false
         composerContainer.translatesAutoresizingMaskIntoConstraints = false
 
-        let dockBottom = bottomDockContainer.bottomAnchor.constraint(
-            equalTo: keyboardLayoutGuide.topAnchor
-        )
+        let dockBottom = makeBottomDockConstraint(on: self)
         let composerHeight = composerContainer.heightAnchor.constraint(equalToConstant: 0)
         let toolbarHeight = dockedToolbar.heightAnchor.constraint(equalToConstant: 0)
         bottomDockToKeyboardConstraint = dockBottom
@@ -1072,17 +1184,15 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
     }
 
     /// Moves the visual dock out of the renderer and into a layout-passive host.
-    /// The host's keyboard guide is then the sole owner of the dock's presentation.
+    /// The selected OS policy then owns the dock's presentation on that host.
     func moveBottomDock(to host: UIView) {
         guard host !== self, bottomDockHostView !== host else { return }
-        configureKeyboardLayoutGuide(on: host)
         NSLayoutConstraint.deactivate(bottomDockHostConstraints)
         bottomDockContainer.removeFromSuperview()
         host.addSubview(bottomDockContainer)
 
-        let dockBottom = bottomDockContainer.bottomAnchor.constraint(
-            equalTo: host.keyboardLayoutGuide.topAnchor
-        )
+        bottomDockManualConstraint = nil
+        let dockBottom = makeBottomDockConstraint(on: host)
         let hostConstraints = [
             bottomDockContainer.leadingAnchor.constraint(equalTo: host.leadingAnchor),
             bottomDockContainer.trailingAnchor.constraint(equalTo: host.trailingAnchor),
@@ -1098,6 +1208,7 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
     /// Updates the renderer's overlap model from the guide's target top edge.
     @discardableResult
     private func synchronizeKeyboardGeometryFromLayoutGuide() -> Bool {
+        guard keyboardDockGeometrySource == .systemLayoutGuide else { return false }
         let nextHeight = keyboardOverlapFromLayoutGuide
         guard abs(nextHeight - keyboardHeight) > 0.25 else { return false }
         keyboardHeight = nextHeight
@@ -1137,7 +1248,21 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
         return owner.convert(owner.keyboardLayoutGuide.layoutFrame, to: self)
     }
 
-    /// Whether UIKit is still animating the guide-constrained dock toward its target.
+    private var keyboardDockTargetTopInSurface: CGFloat {
+        switch keyboardDockGeometrySource {
+        case .systemLayoutGuide:
+            return keyboardGuideFrameInSurface.minY
+        case .keyboardNotifications:
+            let owner = bottomDockHostView ?? self
+            let target = CGPoint(
+                x: owner.bounds.minX,
+                y: owner.bounds.maxY - keyboardOccupancyInBounds
+            )
+            return owner.convert(target, to: self).y
+        }
+    }
+
+    /// Whether UIKit is still animating the constrained dock toward its target.
     private var bottomDockTransitionInFlight: Bool {
         #if DEBUG
         if keyboardHeightOverrideForTesting != nil { return false }
@@ -1159,17 +1284,18 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
         bottomDockTransitionObserved = false
 
         bottomDockToKeyboardConstraint?.isActive = false
-        if bottomDockForTestingConstraint == nil {
-            let owner = bottomDockHostView ?? self
-            bottomDockForTestingConstraint = bottomDockContainer.bottomAnchor.constraint(
-                equalTo: owner.bottomAnchor
-            )
-        }
-        bottomDockForTestingConstraint?.constant = -TerminalLetterboxGeometry.keyboardOccupancy(
+        bottomDockManualConstraint?.isActive = false
+        let owner = bottomDockHostView ?? self
+        let constraint = bottomDockContainer.bottomAnchor.constraint(
+            equalTo: owner.bottomAnchor
+        )
+        constraint.constant = -TerminalLetterboxGeometry.keyboardOccupancy(
             keyboardHeight: clamped,
             bottomSafeAreaInset: safeAreaInsetsBottom
         )
-        bottomDockForTestingConstraint?.isActive = true
+        constraint.isActive = true
+        bottomDockManualConstraint = constraint
+        bottomDockToKeyboardConstraint = constraint
     }
     #endif
 
@@ -2283,6 +2409,7 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
     public override func layoutSubviews() {
         super.layoutSubviews()
         synchronizeKeyboardGeometryFromLayoutGuide()
+        updateNotificationDrivenDockConstraint()
         let snapshot = viewportSnapshot()
         layoutBottomDock(using: snapshot)
         layoutRenderedTerminalForCurrentViewport(using: snapshot)
@@ -2318,6 +2445,7 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
         }
         #endif
         synchronizeKeyboardGeometryFromLayoutGuide()
+        updateNotificationDrivenDockConstraint()
         let snapshot = viewportSnapshot()
         layoutBottomDock(using: snapshot)
         layoutRenderedTerminalForCurrentViewport(using: snapshot)
@@ -2791,8 +2919,8 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
     /// Resigns this surface's hidden text input.
     public func resignInput() {
         resignCurrentInput()
-        // Geometry follows `keyboardLayoutGuide`; responder release only decides
-        // whether UIKit should dismiss the software keyboard.
+        // Dock geometry follows the OS-selected source; responder release only
+        // decides whether UIKit should dismiss the software keyboard.
     }
 
     /// Stops user-visible and accessibility output from a surface SwiftUI has removed.

--- a/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView.swift
+++ b/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView.swift
@@ -1002,7 +1002,12 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
 
     @objc private func handleKeyboardWillChangeFrame(_ notification: Notification) {
         guard let transition = MobileKeyboardTransition(notification: notification) else { return }
+        #if DEBUG
+        let willBeVisible = keyboardHeightOverrideForTesting.map { $0 > 0 }
+            ?? transition.isVisible(in: self)
+        #else
         let willBeVisible = transition.isVisible(in: self)
+        #endif
         let wasVisible = keyboardVisible
         #if DEBUG
         // The composer-up/keyboard-down desync can be reached WITHOUT the dismiss
@@ -1054,6 +1059,16 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
         durationOverride: TimeInterval?
     ) {
         let owner = bottomDockHostView ?? self
+        #if DEBUG
+        if let keyboardHeightOverrideForTesting {
+            keyboardHeight = max(0, keyboardHeightOverrideForTesting)
+            bottomDockTransitionObserved = false
+            updateNotificationDrivenDockConstraint()
+            setNeedsGeometrySync()
+            setNeedsLayout()
+            return
+        }
+        #endif
         let targetOverlap = transition.overlap(in: owner)
         let animationDuration = durationOverride ?? transition.duration
 

--- a/ios/cmuxUITests/cmuxUITests.swift
+++ b/ios/cmuxUITests/cmuxUITests.swift
@@ -7990,8 +7990,8 @@ final class cmuxUITests: XCTestCase {
     }
 
     /// Verify the built app's two-part keyboard contract at steady state:
-    /// UIKit's keyboard guide resolves to the real software-keyboard edge, and the
-    /// visible composer/toolbar stack resolves to that same guide edge.
+    /// the OS-selected geometry source resolves to the real software-keyboard edge,
+    /// and the visible composer/toolbar stack resolves to that same target.
     @MainActor
     private func assertTerminalDockPinnedToSoftwareKeyboard(
         _ dock: [String: String],
@@ -8001,12 +8001,12 @@ final class cmuxUITests: XCTestCase {
         file: StaticString = #filePath,
         line: UInt = #line
     ) {
-        guard let guideTop = dock["keyboardGuideTop"].flatMap(Double.init),
+        guard let source = dock["keyboardDockSource"],
               let composerMinY = dock["composerMinY"].flatMap(Double.init),
               let composerMaxY = dock["composerMaxY"].flatMap(Double.init),
               let toolbarMaxY = dock["toolbarMaxY"].flatMap(Double.init) else {
             XCTFail(
-                "Missing keyboard-guide dock geometry for \(context). dock=\(dock)",
+                "Missing keyboard dock geometry for \(context). dock=\(dock)",
                 file: file,
                 line: line
             )
@@ -8014,19 +8014,49 @@ final class cmuxUITests: XCTestCase {
         }
 
         let dockEdge = composerMaxY - composerMinY > 0.5 ? composerMaxY : toolbarMaxY
+        let targetTop: Double
+        switch source {
+        case "notification":
+            guard let notificationTop = dock["keyboardDockTargetTop"].flatMap(Double.init) else {
+                XCTFail(
+                    "Missing notification keyboard target for \(context). dock=\(dock)",
+                    file: file,
+                    line: line
+                )
+                return
+            }
+            targetTop = notificationTop
+        case "layoutGuide":
+            guard let guideTop = dock["keyboardGuideTop"].flatMap(Double.init) else {
+                XCTFail(
+                    "Missing keyboard-guide target for \(context). dock=\(dock)",
+                    file: file,
+                    line: line
+                )
+                return
+            }
+            targetTop = guideTop
+        default:
+            XCTFail(
+                "Unknown keyboard dock source for \(context). dock=\(dock)",
+                file: file,
+                line: line
+            )
+            return
+        }
         XCTAssertEqual(
             dockEdge,
-            guideTop,
+            targetTop,
             accuracy: 1,
-            "Dock must terminate at UIKeyboardLayoutGuide.topAnchor for \(context). dock=\(dock)",
+            "Dock must terminate at its selected keyboard target for \(context). dock=\(dock)",
             file: file,
             line: line
         )
         XCTAssertEqual(
-            Double(surface.frame.minY) + guideTop,
+            Double(surface.frame.minY) + targetTop,
             Double(keyboard.frame.minY),
             accuracy: 2,
-            "UIKeyboardLayoutGuide must resolve to the visible keyboard edge for "
+            "Selected keyboard geometry must resolve to the visible keyboard edge for "
                 + "\(context). keyboard=\(keyboard) surface=\(surface.frame) dock=\(dock)",
             file: file,
             line: line

--- a/ios/cmuxUITests/cmuxUITests.swift
+++ b/ios/cmuxUITests/cmuxUITests.swift
@@ -5816,11 +5816,15 @@ final class cmuxUITests: XCTestCase {
     }
 
     @MainActor
-    private func launchConnectedApp(port: UInt16, assertStatusRows: Bool = true) throws -> XCUIApplication {
+    private func launchConnectedApp(
+        port: UInt16,
+        assertStatusRows: Bool = true,
+        environment: [String: String] = [:]
+    ) throws -> XCUIApplication {
         let attachURL = try attachURL(port: port)
-        let app = launchApp(mockData: true, environment: [
-            "CMUX_UITEST_ATTACH_URL": attachURL.absoluteString,
-        ])
+        var launchEnvironment = environment
+        launchEnvironment["CMUX_UITEST_ATTACH_URL"] = attachURL.absoluteString
+        let app = launchApp(mockData: true, environment: launchEnvironment)
         waitForWorkspaceShell(in: app)
         try openSelectedWorkspaceIfNeeded(app)
         if assertStatusRows {
@@ -8479,6 +8483,63 @@ final class cmuxUITests: XCTestCase {
                 "Shortcut and Composer bars separated during rapid reversal \(cycle). dock=\(dock)"
             )
         }
+    }
+
+    /// iOS 27 falls back to notification-driven keyboard geometry because its
+    /// keyboard layout guide can remain seated at the screen bottom. Force that
+    /// runtime policy on the CI simulator and prove the visible dock follows the
+    /// real software-keyboard edge through the production composer path.
+    @MainActor
+    func testIOS27KeyboardDockWorkaroundPinsComposerToKeyboard() async throws {
+        let server = try MobileSyncMockHostServer()
+        let port = try await server.start()
+        defer { server.stop() }
+
+        let app = try launchConnectedApp(port: port, environment: [
+            "CMUX_UITEST_FORCE_IOS27_KEYBOARD_DOCK": "1",
+        ])
+        let surface = app.otherElements["MobileTerminalSurface"]
+        XCTAssertTrue(surface.waitForExistence(timeout: 8))
+
+        let composerField = app.descendants(matching: .any)[Composer.field]
+        XCTAssertTrue(composerField.waitForExistence(timeout: 4))
+        composerField.tap()
+
+        guard let keyboard = waitForSoftwareKeyboardKeyPlane(
+            in: app,
+            minimumOverlap: 120,
+            timeout: 4
+        ) else { return }
+        let dock = waitForDock(in: app, describe: "iOS 27 notification fallback tracks keyboard") {
+            $0["keyboardDockSource"] == "notification"
+                && ($0["keyboardHeight"].flatMap(Double.init) ?? 0) > 120
+        }
+
+        guard let dockTargetTop = dock["keyboardDockTargetTop"].flatMap(Double.init),
+              let composerMinY = dock["composerMinY"].flatMap(Double.init),
+              let composerMaxY = dock["composerMaxY"].flatMap(Double.init),
+              let toolbarMaxY = dock["toolbarMaxY"].flatMap(Double.init) else {
+            XCTFail("Missing iOS 27 keyboard-dock fallback geometry. dock=\(dock)")
+            return
+        }
+
+        let dockEdge = composerMaxY - composerMinY > 0.5 ? composerMaxY : toolbarMaxY
+        XCTAssertEqual(
+            dockEdge,
+            dockTargetTop,
+            accuracy: 1,
+            "The iOS 27 fallback must terminate the dock at its notification-derived target. dock=\(dock)"
+        )
+        XCTAssertEqual(
+            Double(surface.frame.minY) + dockTargetTop,
+            Double(keyboard.frame.minY),
+            accuracy: 2,
+            "The iOS 27 fallback must pin the composer to the visible software keyboard. keyboard=\(keyboard) dock=\(dock)"
+        )
+        assertTerminalRenderBottomAttachedToViewport(
+            dock,
+            context: "iOS 27 notification fallback"
+        )
     }
 
     @MainActor


### PR DESCRIPTION
iOS 27 beta can leave the host keyboard layout guide at the screen bottom while the keyboard is visible. On OS major 27 only, the existing host-owned dock now uses keyboard frame notifications to update one bottom constraint with UIKit animation timing. Every other OS keeps the current layout-guide path. The focused UI test forces the iOS 27 policy on the hosted simulator, enters the production composer, and checks the dock and terminal viewport against the visible software keyboard.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how keyboard height drives terminal chrome layout on iOS 27 only, with regression coverage; non-27 behavior remains on the layout-guide path.
> 
> **Overview**
> On **iOS 27**, where `UIKeyboardLayoutGuide` can stay at the screen bottom while the software keyboard is visible, the terminal bottom dock (composer/toolbar) now follows **keyboard frame notifications** instead of the layout guide. A single manual bottom constraint is updated from notification overlap, animated with UIKit’s keyboard timing (including `keyboardDidChangeFrame` with zero duration when needed), and the terminal viewport stays aligned during the transition.
> 
> **All other OS versions** keep pinning the dock to `keyboardLayoutGuide.topAnchor`; layout-guide sync is skipped on the notification path so the stale guide does not compete.
> 
> **DEBUG / tests:** `UITestConfig.forceIOS27KeyboardDockWorkaround` (`CMUX_UITEST_FORCE_IOS27_KEYBOARD_DOCK=1`) forces the iOS 27 path on older simulators. Dock debug snapshots add `keyboardDockSource` and `keyboardDockTargetTop`; UI tests assert the dock edge against the active source, and a new test opens the production composer under the forced policy and checks alignment with the visible keyboard.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e99c3d851865e5afc329869d1bafb8664156d025. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes keyboard dock tracking on iOS 27 by bypassing the broken `UIKeyboardLayoutGuide` and driving the dock with keyboard frame notifications. Other iOS versions keep the layout-guide path; animations and the terminal viewport stay in sync.

- **Bug Fixes**
  - On iOS 27 only, drive the dock from keyboard frame notifications with UIKit-matched animations; keep the `keyboardLayoutGuide` path on other iOS.
  - Add a DEBUG-only toggle `UITestConfig.forceIOS27KeyboardDockWorkaround` (env: `CMUX_UITEST_FORCE_IOS27_KEYBOARD_DOCK=1`) to force the iOS 27 path in CI.
  - Extend the surface debug snapshot with `keyboardDockSource` and `keyboardDockTargetTop` to validate geometry in tests.
  - Update UI tests to assert against the selected geometry source (layout guide vs notification), pass launch env to the app, and add a focused test that forces the policy, opens the composer, and verifies the dock and terminal viewport follow the visible keyboard.

<sup>Written for commit e99c3d851865e5afc329869d1bafb8664156d025. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/9958?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved keyboard and composer dock positioning on iOS 27.
  * Preserved compatible keyboard layout behavior across other supported iOS versions.
  * Improved alignment between the terminal viewport, composer, and toolbar when the keyboard appears.

* **Bug Fixes**
  * Resolved keyboard-driven dock movement issues during transitions on iOS 27.

* **Testing**
  * Added coverage for keyboard docking, terminal viewport alignment, and configurable test launch environments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->