### PR TITLE
Fix iOS compatibility with legacy Mac releases

### DIFF
--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileMacBuildCompatibilityPolicy.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileMacBuildCompatibilityPolicy.swift
@@ -46,6 +46,23 @@ public enum MobileMacBuildCompatibilityPolicy: Equatable, Sendable {
         }
     }
 
+    /// Returns whether an authenticated host status belongs to this policy.
+    ///
+    /// Official Mac releases before instance tags shipped report no tag. They
+    /// remain compatible after RPC authentication, while tagged discovery and
+    /// every development build continue to fail closed through ``allows(instanceTag:)``.
+    /// The caller still enforces device and route authority for the response.
+    ///
+    /// - Parameter instanceTag: The tag reported by authenticated host status.
+    /// - Returns: `true` for a compatible tagged host or a tagless legacy host
+    ///   used by an official iOS build.
+    func allowsAuthenticatedHostStatus(instanceTag: String?) -> Bool {
+        if case .official = self, Self.normalized(instanceTag) == nil {
+            return true
+        }
+        return allows(instanceTag: instanceTag)
+    }
+
     /// Wraps a paired-Mac store so every read and mutation follows this policy.
     ///
     /// - Parameter store: The underlying persistence implementation.

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+BuildCompatibility.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+BuildCompatibility.swift
@@ -5,7 +5,8 @@ internal import Foundation
 extension MobileShellComposite {
     /// Whether authenticated host status belongs to this iOS build's audience.
     func macBuildIsCompatible(instanceTag: String?) -> Bool {
-        buildCompatibilityPolicy?.allows(instanceTag: instanceTag) ?? true
+        buildCompatibilityPolicy?
+            .allowsAuthenticatedHostStatus(instanceTag: instanceTag) ?? true
     }
 
     /// Removes registry app instances this iOS build is not allowed to use.

--- a/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/MobileMacBuildCompatibilityPolicyTests.swift
+++ b/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/MobileMacBuildCompatibilityPolicyTests.swift
@@ -30,6 +30,19 @@ import Testing
         #expect(!policy.allows(instanceTag: nil))
     }
 
+    @MainActor
+    @Test func authenticatedOfficialHostAcceptsLegacyMacWithoutInstanceTag() {
+        let officialShell = MobileShellComposite(
+            buildCompatibilityPolicy: .official
+        )
+        let developmentShell = MobileShellComposite(
+            buildCompatibilityPolicy: .development(expectedInstanceTag: "icap")
+        )
+
+        #expect(officialShell.macBuildIsCompatible(instanceTag: nil))
+        #expect(!developmentShell.macBuildIsCompatible(instanceTag: nil))
+    }
+
     @Test func scopedStoreHidesAndRejectsIncompatibleRows() async throws {
         let directory = FileManager.default.temporaryDirectory
             .appendingPathComponent(UUID().uuidString, isDirectory: true)


### PR DESCRIPTION
Fixes the iOS regression that rejected cmux 0.64.14 through 0.64.17 when authenticated host status omitted mac_instance_tag.

Mechanism:
- Keep registry and presence discovery fail-closed.
- Accept a missing tag only on authenticated host status for official iOS builds.
- Preserve exact-tag isolation for development builds and tag-bearing hosts.

Verification:
- Red-then-green MobileMacBuildCompatibilityPolicyTests regression, 9 passed.
- MobileMacInstanceConnectionAuthorityTests, 9 passed.
- MobileTerminalDTODecodeTests, 23 passed.
- IrohReconnectRouteSelectionTests, 26 passed.
- Hosted E2E passed: https://github.com/manaflow-ai/cmux/actions/runs/31455262509
- Tagged macOS legmac build succeeded.
- Isolated iOS simulator build signed in, paired, listed the Mac workspace, and streamed its terminal.
- Signed iPhone build succeeded and is queued for Aziz because the phone is unavailable.

Compatibility boundary:
- Restores core terminal compatibility for current official iOS with Mac 0.64.14 through 0.64.17.
- Discovery remains strict, development builds still require exact tags, and capabilities added after those Mac releases remain unavailable by design.