### PR TITLE
iOS: preserve workspace groups in Recent Activity

### DIFF
--- a/Packages/iOS/CmuxMobileShellModel/Sources/CmuxMobileShellModel/MobileWorkspaceRecencyOrder.swift
+++ b/Packages/iOS/CmuxMobileShellModel/Sources/CmuxMobileShellModel/MobileWorkspaceRecencyOrder.swift
@@ -115,17 +115,12 @@ public struct MobileWorkspaceRecencyOrder: Sendable {
 
             var normalizedWorkspace = workspace
             normalizedWorkspace.groupID = groupID
-            if var members = membersByGroupID[groupID] {
-                members.append(normalizedWorkspace)
-                membersByGroupID[groupID] = members
-            } else {
-                membersByGroupID[groupID] = GroupMembers(
-                    workspaces: [normalizedWorkspace],
-                    firstWorkspaceIndex: index,
-                    newestActivityAt: normalizedWorkspace.lastActivityAt,
-                    containsPinnedWorkspace: normalizedWorkspace.isPinned
-                )
-            }
+            membersByGroupID[groupID, default: GroupMembers(
+                workspaces: [],
+                firstWorkspaceIndex: index,
+                newestActivityAt: nil,
+                containsPinnedWorkspace: false
+            )].append(normalizedWorkspace)
         }
 
         var blocks = ungroupedBlocks

--- a/Packages/iOS/CmuxMobileShellModel/Sources/CmuxMobileShellModel/MobileWorkspaceRecencyOrder.swift
+++ b/Packages/iOS/CmuxMobileShellModel/Sources/CmuxMobileShellModel/MobileWorkspaceRecencyOrder.swift
@@ -1,14 +1,47 @@
 internal import Foundation
 
-/// Flat, cross-computer presentation order for
+/// Cross-computer presentation order for
 /// ``MobileWorkspaceSortMode/recentActivity``.
 ///
 /// This runs at the presentation layer, not in the aggregation: time
-/// interleaving across Macs cannot keep one Mac's group members contiguous, so
-/// the aggregated `workspaces` array keeps its natural order (group sections,
-/// anchors, and move RPCs depend on it) and the list view applies this order to
-/// its flat path only.
+/// interleaving must not rewrite the Mac's spatial order (group anchors and move
+/// RPCs depend on it). The list instead sorts immutable display blocks while
+/// preserving every group's incoming member order.
 public struct MobileWorkspaceRecencyOrder: Sendable {
+    private struct GroupMembers {
+        var workspaces: [MobileWorkspacePreview]
+        let firstWorkspaceIndex: Int
+        var newestActivityAt: Date?
+        var containsPinnedWorkspace: Bool
+
+        mutating func append(_ workspace: MobileWorkspacePreview) {
+            workspaces.append(workspace)
+            if let activityAt = workspace.lastActivityAt,
+               newestActivityAt.map({ activityAt > $0 }) ?? true {
+                newestActivityAt = activityAt
+            }
+            containsPinnedWorkspace = containsPinnedWorkspace || workspace.isPinned
+        }
+    }
+
+    private struct DisplayBlock {
+        let group: MobileWorkspaceGroupPreview?
+        let workspaces: [MobileWorkspacePreview]
+        let newestActivityAt: Date?
+        let isPinned: Bool
+        let stableIndex: Int
+
+        var items: [MobileWorkspaceListItem] {
+            guard let group else {
+                return workspaces.map { .workspace($0, indented: false) }
+            }
+            return MobileWorkspaceListItem.items(
+                workspaces: workspaces,
+                groups: [group]
+            )
+        }
+    }
+
     /// Create a recency-order helper.
     public init() {}
 
@@ -32,5 +65,97 @@ public struct MobileWorkspaceRecencyOrder: Sendable {
                 return lhs.offset < rhs.offset
             }
         }.map(\.element)
+    }
+
+    /// Build the grouped Recent Activity projection as atomic display blocks.
+    ///
+    /// A known group ranks by its newest workspace timestamp, then renders its
+    /// header and members in the incoming sidebar order. Ungrouped workspaces
+    /// rank independently. Missing timestamps sort last, and ties retain the
+    /// first incoming block position. Pinned groups or workspaces retain the
+    /// standing pinned-first behavior without splitting a group. A workspace
+    /// whose group metadata is temporarily missing remains an ungrouped row;
+    /// empty group metadata remains invisible, matching the normal list path.
+    ///
+    /// - Parameters:
+    ///   - workspaces: Workspaces in the aggregated sidebar order.
+    ///   - groups: Group metadata from every visible computer.
+    /// - Returns: Group headers and workspace rows in Recent Activity order.
+    public func groupedDisplayItems(
+        _ workspaces: [MobileWorkspacePreview],
+        groups: [MobileWorkspaceGroupPreview]
+    ) -> [MobileWorkspaceListItem] {
+        let groupsByID = Dictionary(
+            groups.map { ($0.id, $0) },
+            uniquingKeysWith: { first, _ in first }
+        )
+        let groupsByAnchorID = Dictionary(
+            groups.map { ($0.anchorWorkspaceID, $0) },
+            uniquingKeysWith: { first, _ in first }
+        )
+        var membersByGroupID: [MobileWorkspaceGroupPreview.ID: GroupMembers] = [:]
+        var ungroupedBlocks: [DisplayBlock] = []
+        ungroupedBlocks.reserveCapacity(workspaces.count)
+
+        for (index, workspace) in workspaces.enumerated() {
+            let explicitGroupID = workspace.groupID.flatMap { groupID in
+                groupsByID[groupID] == nil ? nil : groupID
+            }
+            let groupID = explicitGroupID ?? groupsByAnchorID[workspace.id]?.id
+            guard let groupID else {
+                ungroupedBlocks.append(DisplayBlock(
+                    group: nil,
+                    workspaces: [workspace],
+                    newestActivityAt: workspace.lastActivityAt,
+                    isPinned: workspace.isPinned,
+                    stableIndex: index
+                ))
+                continue
+            }
+
+            var normalizedWorkspace = workspace
+            normalizedWorkspace.groupID = groupID
+            if var members = membersByGroupID[groupID] {
+                members.append(normalizedWorkspace)
+                membersByGroupID[groupID] = members
+            } else {
+                membersByGroupID[groupID] = GroupMembers(
+                    workspaces: [normalizedWorkspace],
+                    firstWorkspaceIndex: index,
+                    newestActivityAt: normalizedWorkspace.lastActivityAt,
+                    containsPinnedWorkspace: normalizedWorkspace.isPinned
+                )
+            }
+        }
+
+        var blocks = ungroupedBlocks
+        blocks.reserveCapacity(ungroupedBlocks.count + membersByGroupID.count)
+        var emittedGroupIDs = Set<MobileWorkspaceGroupPreview.ID>()
+        for group in groups where emittedGroupIDs.insert(group.id).inserted {
+            guard let members = membersByGroupID[group.id] else { continue }
+            blocks.append(DisplayBlock(
+                group: group,
+                workspaces: members.workspaces,
+                newestActivityAt: members.newestActivityAt,
+                isPinned: group.isPinned || members.containsPinnedWorkspace,
+                stableIndex: members.firstWorkspaceIndex
+            ))
+        }
+
+        return blocks.sorted { lhs, rhs in
+            if lhs.isPinned != rhs.isPinned {
+                return lhs.isPinned
+            }
+            switch (lhs.newestActivityAt, rhs.newestActivityAt) {
+            case let (lhsDate?, rhsDate?) where lhsDate != rhsDate:
+                return lhsDate > rhsDate
+            case (_?, nil):
+                return true
+            case (nil, _?):
+                return false
+            default:
+                return lhs.stableIndex < rhs.stableIndex
+            }
+        }.flatMap(\.items)
     }
 }

--- a/Packages/iOS/CmuxMobileShellModel/Sources/CmuxMobileShellModel/MobileWorkspaceSortMode.swift
+++ b/Packages/iOS/CmuxMobileShellModel/Sources/CmuxMobileShellModel/MobileWorkspaceSortMode.swift
@@ -13,7 +13,9 @@ public enum MobileWorkspaceSortMode: String, CaseIterable, Codable, Sendable {
     /// order first, remaining computers in `automatic` order. Each computer's
     /// workspaces keep the Mac's own sidebar order.
     case computerPriority
-    /// One flat list across every computer, most recent activity first. Group
-    /// sections cannot survive time interleaving, so this mode presents flat.
+    /// Across every computer, display blocks with the most recent activity
+    /// first. In an unfiltered All Computers list, each group remains one
+    /// contiguous section ranked by its newest member; ungrouped workspaces
+    /// rank independently. Search and explicit filters still present flat rows.
     case recentActivity
 }

--- a/Packages/iOS/CmuxMobileShellModel/Tests/CmuxMobileShellModelTests/MobileWorkspaceRecencyOrderTests.swift
+++ b/Packages/iOS/CmuxMobileShellModel/Tests/CmuxMobileShellModelTests/MobileWorkspaceRecencyOrderTests.swift
@@ -3,7 +3,7 @@ import Testing
 
 @testable import CmuxMobileShellModel
 
-/// Behavior tests for the `.recentActivity` flat presentation order.
+/// Behavior tests for `.recentActivity` flat and grouped presentation order.
 @Suite struct MobileWorkspaceRecencyOrderTests {
     private func ws(
         _ id: String,

--- a/Packages/iOS/CmuxMobileShellModel/Tests/CmuxMobileShellModelTests/MobileWorkspaceRecencyOrderTests.swift
+++ b/Packages/iOS/CmuxMobileShellModel/Tests/CmuxMobileShellModelTests/MobileWorkspaceRecencyOrderTests.swift
@@ -67,7 +67,7 @@ import Testing
         #expect(ordered.map(\.id.rawValue) == ["pinned-new", "pinned-old"])
     }
 
-    @Test func thousandWorkspaceGroupedProjectionStaysWithinInteractionBudget() {
+    @Test func thousandWorkspaceGroupedProjectionPreservesShapeOrderAndUniqueIDs() {
         let groupID = MobileWorkspaceGroupPreview.ID(rawValue: "large")
         let groupMemberCount = 999
         var workspaces: [MobileWorkspacePreview] = []
@@ -88,13 +88,10 @@ import Testing
             anchorWorkspaceID: .init(rawValue: "member-0")
         )]
 
-        var items: [MobileWorkspaceListItem] = []
-        let duration = ContinuousClock().measure {
-            items = MobileWorkspaceRecencyOrder().groupedDisplayItems(
-                workspaces,
-                groups: groups
-            )
-        }
+        let items = MobileWorkspaceRecencyOrder().groupedDisplayItems(
+            workspaces,
+            groups: groups
+        )
 
         #expect(workspaces.count == 1_000)
         #expect(items.count == 1_001)
@@ -103,9 +100,5 @@ import Testing
         #expect(items.dropFirst().first?.id == "workspace.member-1")
         #expect(items[999].id == "groupFooter.large")
         #expect(items.last?.id == "workspace.root")
-        #expect(
-            duration < .milliseconds(100),
-            "A 1,000-workspace projection took \(duration)."
-        )
     }
 }

--- a/Packages/iOS/CmuxMobileShellModel/Tests/CmuxMobileShellModelTests/MobileWorkspaceRecencyOrderTests.swift
+++ b/Packages/iOS/CmuxMobileShellModel/Tests/CmuxMobileShellModelTests/MobileWorkspaceRecencyOrderTests.swift
@@ -66,4 +66,51 @@ import Testing
         ])
         #expect(ordered.map(\.id.rawValue) == ["pinned-new", "pinned-old"])
     }
+
+    @Test func thousandWorkspaceGroupedProjectionStaysWithinInteractionBudget() {
+        let groupCount = 200
+        let membersPerGroup = 4
+        var workspaces: [MobileWorkspacePreview] = []
+        var groups: [MobileWorkspaceGroupPreview] = []
+        workspaces.reserveCapacity(groupCount * (membersPerGroup + 1))
+        groups.reserveCapacity(groupCount)
+
+        for groupIndex in 0..<groupCount {
+            let groupID = MobileWorkspaceGroupPreview.ID(rawValue: "group-\(groupIndex)")
+            let anchorID = MobileWorkspacePreview.ID(rawValue: "group-\(groupIndex)-member-0")
+            groups.append(MobileWorkspaceGroupPreview(
+                id: groupID,
+                name: "Group \(groupIndex)",
+                anchorWorkspaceID: anchorID
+            ))
+            for memberIndex in 0..<membersPerGroup {
+                var workspace = ws(
+                    "group-\(groupIndex)-member-\(memberIndex)",
+                    activityAt: at(Double(groupIndex * membersPerGroup + memberIndex))
+                )
+                workspace.groupID = groupID
+                workspaces.append(workspace)
+            }
+            workspaces.append(ws(
+                "root-\(groupIndex)",
+                activityAt: at(Double(groupIndex))
+            ))
+        }
+
+        var items: [MobileWorkspaceListItem] = []
+        let duration = ContinuousClock().measure {
+            items = MobileWorkspaceRecencyOrder().groupedDisplayItems(
+                workspaces,
+                groups: groups
+            )
+        }
+
+        #expect(workspaces.count == 1_000)
+        #expect(items.count == 1_200)
+        #expect(Set(items.map(\.id)).count == items.count)
+        #expect(
+            duration < .milliseconds(100),
+            "A 1,000-workspace projection took \(duration)."
+        )
+    }
 }

--- a/Packages/iOS/CmuxMobileShellModel/Tests/CmuxMobileShellModelTests/MobileWorkspaceRecencyOrderTests.swift
+++ b/Packages/iOS/CmuxMobileShellModel/Tests/CmuxMobileShellModelTests/MobileWorkspaceRecencyOrderTests.swift
@@ -68,34 +68,25 @@ import Testing
     }
 
     @Test func thousandWorkspaceGroupedProjectionStaysWithinInteractionBudget() {
-        let groupCount = 200
-        let membersPerGroup = 4
+        let groupID = MobileWorkspaceGroupPreview.ID(rawValue: "large")
+        let groupMemberCount = 999
         var workspaces: [MobileWorkspacePreview] = []
-        var groups: [MobileWorkspaceGroupPreview] = []
-        workspaces.reserveCapacity(groupCount * (membersPerGroup + 1))
-        groups.reserveCapacity(groupCount)
+        workspaces.reserveCapacity(1_000)
 
-        for groupIndex in 0..<groupCount {
-            let groupID = MobileWorkspaceGroupPreview.ID(rawValue: "group-\(groupIndex)")
-            let anchorID = MobileWorkspacePreview.ID(rawValue: "group-\(groupIndex)-member-0")
-            groups.append(MobileWorkspaceGroupPreview(
-                id: groupID,
-                name: "Group \(groupIndex)",
-                anchorWorkspaceID: anchorID
-            ))
-            for memberIndex in 0..<membersPerGroup {
-                var workspace = ws(
-                    "group-\(groupIndex)-member-\(memberIndex)",
-                    activityAt: at(Double(groupIndex * membersPerGroup + memberIndex))
-                )
-                workspace.groupID = groupID
-                workspaces.append(workspace)
-            }
-            workspaces.append(ws(
-                "root-\(groupIndex)",
-                activityAt: at(Double(groupIndex))
-            ))
+        for memberIndex in 0..<groupMemberCount {
+            var workspace = ws(
+                "member-\(memberIndex)",
+                activityAt: at(Double(memberIndex))
+            )
+            workspace.groupID = groupID
+            workspaces.append(workspace)
         }
+        workspaces.append(ws("root", activityAt: at(500)))
+        let groups = [MobileWorkspaceGroupPreview(
+            id: groupID,
+            name: "Large Group",
+            anchorWorkspaceID: .init(rawValue: "member-0")
+        )]
 
         var items: [MobileWorkspaceListItem] = []
         let duration = ContinuousClock().measure {
@@ -106,8 +97,12 @@ import Testing
         }
 
         #expect(workspaces.count == 1_000)
-        #expect(items.count == 1_200)
+        #expect(items.count == 1_001)
         #expect(Set(items.map(\.id)).count == items.count)
+        #expect(items.first?.id == "group.large")
+        #expect(items.dropFirst().first?.id == "workspace.member-1")
+        #expect(items[999].id == "groupFooter.large")
+        #expect(items.last?.id == "workspace.root")
         #expect(
             duration < .milliseconds(100),
             "A 1,000-workspace projection took \(duration)."

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListGroupedProjectionCache.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListGroupedProjectionCache.swift
@@ -1,0 +1,41 @@
+import CmuxMobileShellModel
+
+/// Synchronous input-keyed cache for grouped workspace list projection.
+///
+/// This is deliberately a non-observable reference type: SwiftUI body updates
+/// may read and update it without publishing another invalidation. Full value
+/// inputs are retained so any rendered workspace or group field, input order,
+/// or sort-mode change rebuilds the projection before that body returns.
+@MainActor
+final class WorkspaceListGroupedProjectionCache {
+    private struct Input: Equatable {
+        let workspaces: [MobileWorkspacePreview]
+        let groups: [MobileWorkspaceGroupPreview]
+        let appliesRecencySort: Bool
+    }
+
+    private var input: Input?
+    private var projectedItems: [MobileWorkspaceListItem] = []
+
+    func items(
+        workspaces: [MobileWorkspacePreview],
+        groups: [MobileWorkspaceGroupPreview],
+        appliesRecencySort: Bool
+    ) -> [MobileWorkspaceListItem] {
+        let input = Input(
+            workspaces: workspaces,
+            groups: groups,
+            appliesRecencySort: appliesRecencySort
+        )
+        if self.input == input {
+            return projectedItems
+        }
+
+        let projectedItems = appliesRecencySort
+            ? MobileWorkspaceRecencyOrder().groupedDisplayItems(workspaces, groups: groups)
+            : MobileWorkspaceListItem.items(workspaces: workspaces, groups: groups)
+        self.input = input
+        self.projectedItems = projectedItems
+        return projectedItems
+    }
+}

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListLayoutPreviewView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListLayoutPreviewView.swift
@@ -131,7 +131,9 @@ public struct WorkspaceListLayoutPreviewView: View {
             let groupCount = environment["CMUX_UITEST_WORKSPACE_LIST_PREVIEW_GROUPS"].flatMap(Int.init) ?? 0
             (initialWorkspaces, initialGroups) = Self.seeded(
                 count: seedCount,
-                groupCount: groupCount
+                groupCount: groupCount,
+                usesGroupBlockRecencyPattern:
+                    environment["CMUX_UITEST_WORKSPACE_LIST_PREVIEW_RECENCY_BLOCKS"] == "1"
             )
         } else {
             initialWorkspaces = Self.defaultWorkspaces
@@ -328,9 +330,13 @@ public struct WorkspaceListLayoutPreviewView: View {
     /// `CMUX_UITEST_WORKSPACE_LIST_PREVIEW_GROUPS`). Every 4th row is unread,
     /// preview lengths vary, and with `g` groups the first `g * 4` rows fold
     /// into anchored groups of 4 (anchor + 3 members) so headers and
-    /// end-of-group drop slots render like a real grouped list.
+    /// end-of-group drop slots render like a real grouped list. The optional
+    /// recency pattern makes a non-anchor member rank each group around one
+    /// ungrouped row, proving Recent Activity orders atomic blocks.
     private static func seeded(
-        count: Int, groupCount: Int
+        count: Int,
+        groupCount: Int,
+        usesGroupBlockRecencyPattern: Bool
     ) -> ([MobileWorkspacePreview], [MobileWorkspaceGroupPreview]) {
         let anchorTime = Date(timeIntervalSinceNow: -60)
         var groups: [MobileWorkspaceGroupPreview] = []
@@ -356,6 +362,21 @@ public struct WorkspaceListLayoutPreviewView: View {
                     )
                 )
             }
+            let activityOffset: TimeInterval
+            if usesGroupBlockRecencyPattern {
+                switch index {
+                case 3:
+                    activityOffset = 0
+                case 8:
+                    activityOffset = -3_600
+                case 7:
+                    activityOffset = -7_200
+                default:
+                    activityOffset = -Double(100 + index) * 3_600
+                }
+            } else {
+                activityOffset = -Double(index) * 3_600
+            }
             var workspace = MobileWorkspacePreview(
                 id: id,
                 macDeviceID: macDeviceID,
@@ -363,8 +384,8 @@ public struct WorkspaceListLayoutPreviewView: View {
                 name: "\(seedNames[index % seedNames.count]) \(index)",
                 groupID: groupID,
                 previewText: seedPreviews[index % seedPreviews.count],
-                previewAt: anchorTime.addingTimeInterval(-Double(index) * 3600),
-                lastActivityAt: anchorTime.addingTimeInterval(-Double(index) * 3600),
+                previewAt: anchorTime.addingTimeInterval(activityOffset),
+                lastActivityAt: anchorTime.addingTimeInterval(activityOffset),
                 hasUnread: index % 4 == 0,
                 terminals: [
                     MobileTerminalPreview(

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListLayoutPreviewView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListLayoutPreviewView.swift
@@ -545,6 +545,19 @@ public struct WorkspaceListLayoutPreviewView: View {
         ProcessInfo.processInfo.environment["CMUX_UITEST_WORKSPACE_LIST_PREVIEW_TABS"] == "1"
     }
 
+    private var fixtureConnectionStatus: MobileMacConnectionStatus {
+        switch ProcessInfo.processInfo.environment[
+            "CMUX_UITEST_WORKSPACE_LIST_PREVIEW_CONNECTION_STATUS"
+        ] {
+        case "reconnecting":
+            return .reconnecting
+        case "unavailable":
+            return .unavailable
+        default:
+            return .connected
+        }
+    }
+
     private func performPreviewRefresh() {
         model.rotateForRefresh()
         refreshGeneration += 1
@@ -579,7 +592,7 @@ public struct WorkspaceListLayoutPreviewView: View {
             groups: model.groups,
             selectedWorkspaceID: selectedWorkspaceID,
             host: "Visual Mock Mac",
-            connectionStatus: .connected,
+            connectionStatus: fixtureConnectionStatus,
             navigationStyle: usesSidebarSelectionFixture ? .sidebar : .push,
             wrapWorkspaceTitles: false,
             previewLineLimit: MobileDisplaySettings.defaultWorkspacePreviewLineCount,

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListLayoutPreviewView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListLayoutPreviewView.swift
@@ -131,9 +131,7 @@ public struct WorkspaceListLayoutPreviewView: View {
             let groupCount = environment["CMUX_UITEST_WORKSPACE_LIST_PREVIEW_GROUPS"].flatMap(Int.init) ?? 0
             (initialWorkspaces, initialGroups) = Self.seeded(
                 count: seedCount,
-                groupCount: groupCount,
-                usesGroupBlockRecencyPattern:
-                    environment["CMUX_UITEST_WORKSPACE_LIST_PREVIEW_RECENCY_BLOCKS"] == "1"
+                groupCount: groupCount
             )
         } else {
             initialWorkspaces = Self.defaultWorkspaces
@@ -330,13 +328,9 @@ public struct WorkspaceListLayoutPreviewView: View {
     /// `CMUX_UITEST_WORKSPACE_LIST_PREVIEW_GROUPS`). Every 4th row is unread,
     /// preview lengths vary, and with `g` groups the first `g * 4` rows fold
     /// into anchored groups of 4 (anchor + 3 members) so headers and
-    /// end-of-group drop slots render like a real grouped list. The optional
-    /// recency pattern makes a non-anchor member rank each group around one
-    /// ungrouped row, proving Recent Activity orders atomic blocks.
+    /// end-of-group drop slots render like a real grouped list.
     private static func seeded(
-        count: Int,
-        groupCount: Int,
-        usesGroupBlockRecencyPattern: Bool
+        count: Int, groupCount: Int
     ) -> ([MobileWorkspacePreview], [MobileWorkspaceGroupPreview]) {
         let anchorTime = Date(timeIntervalSinceNow: -60)
         var groups: [MobileWorkspaceGroupPreview] = []
@@ -362,21 +356,6 @@ public struct WorkspaceListLayoutPreviewView: View {
                     )
                 )
             }
-            let activityOffset: TimeInterval
-            if usesGroupBlockRecencyPattern {
-                switch index {
-                case 3:
-                    activityOffset = 0
-                case 8:
-                    activityOffset = -3_600
-                case 7:
-                    activityOffset = -7_200
-                default:
-                    activityOffset = -Double(100 + index) * 3_600
-                }
-            } else {
-                activityOffset = -Double(index) * 3_600
-            }
             var workspace = MobileWorkspacePreview(
                 id: id,
                 macDeviceID: macDeviceID,
@@ -384,8 +363,8 @@ public struct WorkspaceListLayoutPreviewView: View {
                 name: "\(seedNames[index % seedNames.count]) \(index)",
                 groupID: groupID,
                 previewText: seedPreviews[index % seedPreviews.count],
-                previewAt: anchorTime.addingTimeInterval(activityOffset),
-                lastActivityAt: anchorTime.addingTimeInterval(activityOffset),
+                previewAt: anchorTime.addingTimeInterval(-Double(index) * 3600),
+                lastActivityAt: anchorTime.addingTimeInterval(-Double(index) * 3600),
                 hasUnread: index % 4 == 0,
                 terminals: [
                     MobileTerminalPreview(

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListLayoutPreviewView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListLayoutPreviewView.swift
@@ -125,9 +125,14 @@ public struct WorkspaceListLayoutPreviewView: View {
         let environment = ProcessInfo.processInfo.environment
         let seedCount = environment["CMUX_UITEST_WORKSPACE_LIST_PREVIEW_COUNT"].flatMap(Int.init) ?? 0
         let reorderEnabled = environment["CMUX_UITEST_WORKSPACE_LIST_PREVIEW_REORDER"] == "1"
+        let usesMixedGroupFixture = environment[
+            "CMUX_UITEST_WORKSPACE_LIST_PREVIEW_MIXED_GROUPS"
+        ] == "1"
         let initialWorkspaces: [MobileWorkspacePreview]
         let initialGroups: [MobileWorkspaceGroupPreview]
-        if seedCount > 0 {
+        if usesMixedGroupFixture {
+            (initialWorkspaces, initialGroups) = Self.mixedGroupFixture()
+        } else if seedCount > 0 {
             let groupCount = environment["CMUX_UITEST_WORKSPACE_LIST_PREVIEW_GROUPS"].flatMap(Int.init) ?? 0
             (initialWorkspaces, initialGroups) = Self.seeded(
                 count: seedCount,
@@ -167,6 +172,9 @@ public struct WorkspaceListLayoutPreviewView: View {
                 liveUpdateMode: liveUpdateMode
             )
         )
+        usesSidebarSelectionFixture = environment[
+            "CMUX_UITEST_WORKSPACE_LIST_PREVIEW_SIDEBAR_SELECTION"
+        ] == "1"
     }
 
     /// Tap-to-open target in the interactive fixture: a trivial pushed detail
@@ -189,6 +197,10 @@ public struct WorkspaceListLayoutPreviewView: View {
     }
 
     private let reorderEnabled: Bool
+    /// Opt-in visual-selection harness. Default preview behavior remains the
+    /// production iPhone push flow; this mode uses the production sidebar row
+    /// selection path so screenshot verification can see retained selection.
+    private let usesSidebarSelectionFixture: Bool
 
     /// A stable clock-time for seeded activity: capture rigs show these rows
     /// under an 11:41 status bar, so same-day times stay in the morning and
@@ -323,6 +335,148 @@ public struct WorkspaceListLayoutPreviewView: View {
         "CI green on head",
     ]
 
+    /// Deterministic mixed topology for grouped-sort interaction coverage.
+    /// Computer Order starts with an ungrouped row before Alpha, one between
+    /// Alpha and Beta, and one after Beta. Alpha has a timestamp-less member;
+    /// Recent Activity must move whole groups without dropping that member.
+    private static func mixedGroupFixture()
+        -> ([MobileWorkspacePreview], [MobileWorkspaceGroupPreview]) {
+        let alphaGroupID = MobileWorkspaceGroupPreview.ID(rawValue: "mixed-alpha")
+        let betaGroupID = MobileWorkspaceGroupPreview.ID(rawValue: "mixed-beta")
+        let now = Date()
+
+        func workspace(
+            id: String,
+            macDeviceID: String,
+            macDisplayName: String,
+            macInstanceTag: String,
+            name: String,
+            groupID: MobileWorkspaceGroupPreview.ID? = nil,
+            activityOffset: TimeInterval? = nil
+        ) -> MobileWorkspacePreview {
+            let activityAt = activityOffset.map { now.addingTimeInterval($0) }
+            var workspace = MobileWorkspacePreview(
+                id: .init(rawValue: id),
+                macDeviceID: macDeviceID,
+                macDisplayName: macDisplayName,
+                name: name,
+                groupID: groupID,
+                previewAt: activityAt,
+                lastActivityAt: activityAt,
+                terminals: []
+            )
+            workspace.macInstanceTag = macInstanceTag
+            workspace.machineColorIndex = macDeviceID == "preview-macbook-pro" ? 0 : 1
+            return workspace
+        }
+
+        let workspaces = [
+            workspace(
+                id: "workspace-mixed-before",
+                macDeviceID: "preview-macbook-pro",
+                macDisplayName: "MacBook Pro",
+                macInstanceTag: "nightly",
+                name: L10n.string(
+                    "mobile.workspaces.preview.mixed.before",
+                    defaultValue: "Before Groups"
+                ),
+                activityOffset: -300
+            ),
+            workspace(
+                id: "workspace-mixed-alpha-anchor",
+                macDeviceID: "preview-macbook-pro",
+                macDisplayName: "MacBook Pro",
+                macInstanceTag: "nightly",
+                name: L10n.string(
+                    "mobile.workspaces.preview.mixed.alphaAnchor",
+                    defaultValue: "Alpha Lead"
+                ),
+                groupID: alphaGroupID,
+                activityOffset: -240
+            ),
+            workspace(
+                id: "workspace-mixed-alpha-inactive",
+                macDeviceID: "preview-macbook-pro",
+                macDisplayName: "MacBook Pro",
+                macInstanceTag: "nightly",
+                name: L10n.string(
+                    "mobile.workspaces.preview.mixed.inactiveMember",
+                    defaultValue: "Inactive Member"
+                ),
+                groupID: alphaGroupID
+            ),
+            workspace(
+                id: "workspace-mixed-between",
+                macDeviceID: "preview-macbook-pro",
+                macDisplayName: "MacBook Pro",
+                macInstanceTag: "nightly",
+                name: L10n.string(
+                    "mobile.workspaces.preview.mixed.between",
+                    defaultValue: "Between Groups"
+                ),
+                activityOffset: -180
+            ),
+            workspace(
+                id: "workspace-mixed-beta-anchor",
+                macDeviceID: "preview-studio",
+                macDisplayName: "Studio Display Bench With A Very Long Name",
+                macInstanceTag: "stable",
+                name: L10n.string(
+                    "mobile.workspaces.preview.mixed.betaAnchor",
+                    defaultValue: "Beta Lead"
+                ),
+                groupID: betaGroupID,
+                activityOffset: -600
+            ),
+            workspace(
+                id: "workspace-mixed-beta-recent",
+                macDeviceID: "preview-studio",
+                macDisplayName: "Studio Display Bench With A Very Long Name",
+                macInstanceTag: "stable",
+                name: L10n.string(
+                    "mobile.workspaces.preview.mixed.recentMember",
+                    defaultValue: "Recent Member"
+                ),
+                groupID: betaGroupID,
+                activityOffset: -120
+            ),
+            workspace(
+                id: "workspace-mixed-after",
+                macDeviceID: "preview-studio",
+                macDisplayName: "Studio Display Bench With A Very Long Name",
+                macInstanceTag: "stable",
+                name: L10n.string(
+                    "mobile.workspaces.preview.mixed.after",
+                    defaultValue: "After Groups"
+                ),
+                activityOffset: -60
+            ),
+        ]
+        let groups = [
+            MobileWorkspaceGroupPreview(
+                id: alphaGroupID,
+                macDeviceID: "preview-macbook-pro",
+                macInstanceTag: "nightly",
+                name: L10n.string(
+                    "mobile.workspaces.preview.mixed.alphaGroup",
+                    defaultValue: "Alpha Group"
+                ),
+                anchorWorkspaceID: "workspace-mixed-alpha-anchor"
+            ),
+            MobileWorkspaceGroupPreview(
+                id: betaGroupID,
+                macDeviceID: "preview-studio",
+                macInstanceTag: "stable",
+                name: L10n.string(
+                    "mobile.workspaces.preview.mixed.betaGroup",
+                    defaultValue: "Beta Group"
+                ),
+                anchorWorkspaceID: "workspace-mixed-beta-anchor"
+            ),
+        ]
+        return (workspaces, groups)
+    }
+
     /// Deterministic long-list seeding for scroll measurement
     /// (`CMUX_UITEST_WORKSPACE_LIST_PREVIEW_COUNT`, optional
     /// `CMUX_UITEST_WORKSPACE_LIST_PREVIEW_GROUPS`). Every 4th row is unread,
@@ -426,12 +580,16 @@ public struct WorkspaceListLayoutPreviewView: View {
             selectedWorkspaceID: selectedWorkspaceID,
             host: "Visual Mock Mac",
             connectionStatus: .connected,
-            navigationStyle: .push,
+            navigationStyle: usesSidebarSelectionFixture ? .sidebar : .push,
             wrapWorkspaceTitles: false,
             previewLineLimit: MobileDisplaySettings.defaultWorkspacePreviewLineCount,
             unreadIndicatorLeftShift: MobileDisplaySettings.defaultUnreadIndicatorLeftShift,
             selectWorkspace: { id in
-                selectFixtureWorkspace(id)
+                if usesSidebarSelectionFixture {
+                    selectedWorkspaceID = id
+                } else {
+                    selectFixtureWorkspace(id)
+                }
             },
             createWorkspace: {},
             createWorkspaceInGroup: reorderEnabled ? { _ in } : nil,
@@ -605,8 +763,15 @@ public struct WorkspaceListLayoutPreviewView: View {
             ZStack(alignment: .topLeading) {
                 Color.clear
                     .frame(width: 1, height: 1)
+                    .offset(x: 2)
                     .accessibilityElement()
                     .accessibilityIdentifier("MobileWorkspaceListRefreshGeneration-\(refreshGeneration)")
+                Color.clear
+                    .frame(width: 1, height: 1)
+                    .accessibilityElement()
+                    .accessibilityIdentifier(
+                        "MobileWorkspaceListPreviewSelection-\(selectedWorkspaceID?.rawValue ?? "none")"
+                    )
                 if showsTabScaffold {
                     Button {
                         performPreviewRefresh()

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListLayoutPreviewView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListLayoutPreviewView.swift
@@ -99,7 +99,7 @@ public struct WorkspaceListLayoutPreviewView: View {
     @State private var model: WorkspaceListLayoutPreviewModel
     @State private var selectedPrimaryTab: MobilePrimaryTab = .workspaces
     @State private var primarySearchCoordinator = MobilePrimarySearchCoordinator()
-    @State private var filterState = WorkspaceListFilterState()
+    @State private var filterState: WorkspaceListFilterState
     /// Store-free stand-ins for the device-local sort preference, so the
     /// fixture's sort menu and computer-order editor are fully interactive.
     /// `CMUX_UITEST_WORKSPACE_LIST_PREVIEW_SORT` (a raw mode value) and
@@ -123,6 +123,14 @@ public struct WorkspaceListLayoutPreviewView: View {
     /// measurement.
     public init() {
         let environment = ProcessInfo.processInfo.environment
+        let initialFilter = MobileWorkspaceListFilter(
+            machines: environment[
+                "CMUX_UITEST_WORKSPACE_LIST_PREVIEW_FILTER_MACHINE"
+            ].map { Set([$0]) } ?? []
+        )
+        _filterState = State(
+            initialValue: WorkspaceListFilterState(filter: initialFilter)
+        )
         let seedCount = environment["CMUX_UITEST_WORKSPACE_LIST_PREVIEW_COUNT"].flatMap(Int.init) ?? 0
         let reorderEnabled = environment["CMUX_UITEST_WORKSPACE_LIST_PREVIEW_REORDER"] == "1"
         let usesMixedGroupFixture = environment[
@@ -352,7 +360,8 @@ public struct WorkspaceListLayoutPreviewView: View {
             macInstanceTag: String,
             name: String,
             groupID: MobileWorkspaceGroupPreview.ID? = nil,
-            activityOffset: TimeInterval? = nil
+            activityOffset: TimeInterval? = nil,
+            hasUnread: Bool = false
         ) -> MobileWorkspacePreview {
             let activityAt = activityOffset.map { now.addingTimeInterval($0) }
             var workspace = MobileWorkspacePreview(
@@ -363,6 +372,7 @@ public struct WorkspaceListLayoutPreviewView: View {
                 groupID: groupID,
                 previewAt: activityAt,
                 lastActivityAt: activityAt,
+                hasUnread: hasUnread,
                 terminals: []
             )
             workspace.macInstanceTag = macInstanceTag
@@ -403,7 +413,8 @@ public struct WorkspaceListLayoutPreviewView: View {
                     "mobile.workspaces.preview.mixed.inactiveMember",
                     defaultValue: "Inactive Member"
                 ),
-                groupID: alphaGroupID
+                groupID: alphaGroupID,
+                hasUnread: true
             ),
             workspace(
                 id: "workspace-mixed-between",
@@ -438,7 +449,8 @@ public struct WorkspaceListLayoutPreviewView: View {
                     defaultValue: "Recent Member"
                 ),
                 groupID: betaGroupID,
-                activityOffset: -120
+                activityOffset: -120,
+                hasUnread: true
             ),
             workspace(
                 id: "workspace-mixed-after",

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListTableCoordinator.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListTableCoordinator.swift
@@ -980,12 +980,13 @@ final class WorkspaceListTableCoordinator: NSObject, UITableViewDelegate,
             } else {
                 onOpenChanges = nil
             }
+            let isSelected = configuration.navigationStyle == .sidebar
+                && configuration.selectedWorkspaceID == workspace.id
             return AnyView(
                 WorkspaceRow(
                     workspace: workspace,
                     connectionStatus: connectionStatus,
-                    isSelected: configuration.navigationStyle == .sidebar
-                        && configuration.selectedWorkspaceID == workspace.id,
+                    isSelected: isSelected,
                     changesChip: changesChip,
                     onOpenChanges: onOpenChanges,
                     wrapWorkspaceTitles: configuration.wrapWorkspaceTitles,
@@ -996,6 +997,7 @@ final class WorkspaceListTableCoordinator: NSObject, UITableViewDelegate,
                     children: onOpenChanges == nil ? .combine : .contain
                 )
                 .accessibilityAddTraits(.isButton)
+                .accessibilityAddTraits(isSelected ? .isSelected : [])
                 .accessibilityIdentifier("MobileWorkspaceRow-\(workspace.id.rawValue)")
                 .accessibilityLabel(workspace.name)
                 .accessibilityValue(

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListView+DragDrop.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListView+DragDrop.swift
@@ -33,10 +33,6 @@ extension WorkspaceListView {
         filteredWorkspaces.map { WorkspaceListStableOrderKey(workspace: $0) }
     }
 
-    var groupedWorkspaceOrderKey: [WorkspaceListStableOrderKey] {
-        groupedListItems.map { WorkspaceListStableOrderKey(item: $0) }
-    }
-
     var canCreateWorkspaceInGroups: Bool {
         createWorkspaceInGroup != nil
             && canCreateWorkspaceForMacSelection

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListView+MacSelection.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListView+MacSelection.swift
@@ -209,6 +209,7 @@ struct WorkspaceMacTitlePicker: View, Equatable {
                 )
             }
             .accessibilityAddTraits(value.selection == .all ? .isSelected : [])
+            .accessibilityIdentifier("MobileWorkspaceMacPickerAll")
             ForEach(value.machines) { machine in
                 let selection = WorkspaceMacSelection.machine(machine.id)
                 Button {
@@ -221,6 +222,7 @@ struct WorkspaceMacTitlePicker: View, Equatable {
                     )
                 }
                 .accessibilityAddTraits(value.selection == selection ? .isSelected : [])
+                .accessibilityIdentifier(machineMenuAccessibilityIdentifier(machine.id))
             }
             if value.statusLine == .notConnected, let reconnect = actions.reconnect {
                 Divider()
@@ -249,6 +251,12 @@ struct WorkspaceMacTitlePicker: View, Equatable {
                 width: value.labelWidth,
                 statusLine: value.statusLine
             )
+            // Put the identity on the rendered label as well as the Menu.
+            // UIKit's toolbar bridge can otherwise omit the outer SwiftUI
+            // identifier from the native accessibility tree used by CUA.
+            .accessibilityElement(children: .combine)
+            .accessibilityLabel(value.title)
+            .accessibilityIdentifier("MobileWorkspaceMacPicker")
         }
         .buttonStyle(.plain)
         .tint(.primary)
@@ -267,6 +275,11 @@ struct WorkspaceMacTitlePicker: View, Equatable {
         if isSelected {
             Image(systemName: "checkmark")
         }
+    }
+
+    private func machineMenuAccessibilityIdentifier(_ id: String) -> String {
+        let stableID = id.replacingOccurrences(of: "\u{1F}", with: "-")
+        return "MobileWorkspaceMacPickerMachine-\(stableID)"
     }
 }
 

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListView+MacSelection.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListView+MacSelection.swift
@@ -251,11 +251,14 @@ struct WorkspaceMacTitlePicker: View, Equatable {
                 width: value.labelWidth,
                 statusLine: value.statusLine
             )
-            // Put the identity on the rendered label as well as the Menu.
+            // Put the identity and status on the final combined label element.
             // UIKit's toolbar bridge can otherwise omit the outer SwiftUI
             // identifier from the native accessibility tree used by CUA.
             .accessibilityElement(children: .combine)
             .accessibilityLabel(value.title)
+            .accessibilityValue(
+                value.statusLine.map(WorkspaceConnectionStatusLineView.text) ?? ""
+            )
             .accessibilityIdentifier("MobileWorkspaceMacPicker")
         }
         .buttonStyle(.plain)
@@ -321,7 +324,6 @@ private struct WorkspaceMacTitlePickerLabel: View {
         .frame(width: width, alignment: .center)
         .clipped()
         .contentShape(Rectangle())
-        .accessibilityValue(statusLine.map(WorkspaceConnectionStatusLineView.text) ?? "")
     }
 }
 #endif

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListView+Table.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListView+Table.swift
@@ -60,7 +60,8 @@ extension WorkspaceListView {
     }
 
     func workspaceTable(
-        groupedItems: [MobileWorkspaceListItem]
+        groupedItems: [MobileWorkspaceListItem],
+        workspacesByID: [MobileWorkspacePreview.ID: MobileWorkspacePreview]
     ) -> WorkspaceListTable {
         let grouped = rendersGroupedSections
         let enablesReorder = enablesWorkspaceReorder
@@ -75,10 +76,7 @@ extension WorkspaceListView {
                 }
         return WorkspaceListTable(
             items: workspaceTableItems(groupedItems: groupedItems),
-            workspacesByID: Dictionary(
-                workspaces.map { ($0.id, $0) },
-                uniquingKeysWith: { first, _ in first }
-            ),
+            workspacesByID: workspacesByID,
             groupsByID: groupsByID,
             groupHasUnreadByID: workspaceTableGroupHasUnreadByID(
                 groupedItems: groupedItems

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListView+Table.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListView+Table.swift
@@ -11,7 +11,9 @@ extension WorkspaceListView {
             && !workspaces.isEmpty
     }
 
-    var workspaceTableItems: [WorkspaceListTableItem] {
+    func workspaceTableItems(
+        groupedItems: [MobileWorkspaceListItem]
+    ) -> [WorkspaceListTableItem] {
         var items: [WorkspaceListTableItem] = []
         switch connectionChrome {
         case .recoveryBanner:
@@ -25,7 +27,7 @@ extension WorkspaceListView {
         }
 
         if rendersGroupedSections {
-            items.append(contentsOf: displayedGroupedListItems.map { item in
+            items.append(contentsOf: groupedItems.map { item in
                 switch item {
                 case .groupHeader(let group, _):
                     .groupHeader(group.id)
@@ -45,9 +47,11 @@ extension WorkspaceListView {
         return items
     }
 
-    var workspaceTableGroupHasUnreadByID: [MobileWorkspaceGroupPreview.ID: Bool] {
+    func workspaceTableGroupHasUnreadByID(
+        groupedItems: [MobileWorkspaceListItem]
+    ) -> [MobileWorkspaceGroupPreview.ID: Bool] {
         var result: [MobileWorkspaceGroupPreview.ID: Bool] = [:]
-        for item in displayedGroupedListItems {
+        for item in groupedItems {
             if case .groupHeader(let group, let hasUnread) = item {
                 result[group.id] = hasUnread
             }
@@ -55,7 +59,9 @@ extension WorkspaceListView {
         return result
     }
 
-    var workspaceTable: WorkspaceListTable {
+    func workspaceTable(
+        groupedItems: [MobileWorkspaceListItem]
+    ) -> WorkspaceListTable {
         let grouped = rendersGroupedSections
         let enablesReorder = enablesWorkspaceReorder
         // Bound outside the member-wise init: the ternary between `nil` and a
@@ -68,13 +74,15 @@ extension WorkspaceListView {
                     openWorkspaceChanges(workspace)
                 }
         return WorkspaceListTable(
-            items: workspaceTableItems,
+            items: workspaceTableItems(groupedItems: groupedItems),
             workspacesByID: Dictionary(
                 workspaces.map { ($0.id, $0) },
                 uniquingKeysWith: { first, _ in first }
             ),
             groupsByID: groupsByID,
-            groupHasUnreadByID: workspaceTableGroupHasUnreadByID,
+            groupHasUnreadByID: workspaceTableGroupHasUnreadByID(
+                groupedItems: groupedItems
+            ),
             filter: activeFilter,
             selectedWorkspaceID: selectedWorkspaceID,
             navigationStyle: navigationStyle,

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListView.swift
@@ -181,6 +181,8 @@ struct WorkspaceListView: View {
     }
     @State var optimisticFlatState = MobileWorkspaceOptimisticOrderReconciler()
     @State var optimisticGroupedState = MobileWorkspaceOptimisticOrderReconciler()
+    @State private var displayedGroupedProjectionCache = WorkspaceListGroupedProjectionCache()
+    @State private var authoritativeGroupedProjectionCache = WorkspaceListGroupedProjectionCache()
     /// In-flight move RPC count plus the tail of the send chain. Moves stay
     /// enabled while pending (disabling mid-gesture cancels the reorder
     /// interaction), so rapid drags can pipeline; sends are chained so the Mac
@@ -452,11 +454,15 @@ struct WorkspaceListView: View {
             machineSnapshots: displayedMachineSnapshots,
             visibleSelection: currentVisibleMacSelection
         )
-        // Recent Activity grouping performs one O(n log n) block projection
-        // per body evaluation. Reuse this immutable snapshot for table rows
-        // and unread headers.
+        // Group projection is synchronous and input-keyed across body updates.
+        // Keep displayed and authoritative caches separate so a pending
+        // optimistic drag cannot evict the rendered projection on every pass.
         let currentDisplayedGroupedListItems = rendersGroupedSections
-            ? displayedGroupedListItems
+            ? displayedGroupedProjectionCache.items(
+                workspaces: displayedGroupedWorkspaces,
+                groups: groups,
+                appliesRecencySort: appliesRecencySort
+            )
             : []
         let currentFilteredWorkspaceOrderKey = rendersGroupedSections
             ? []
@@ -467,7 +473,11 @@ struct WorkspaceListView: View {
         let currentAuthoritativeGroupedListItems = rendersGroupedSections
             ? (optimisticGroupedState.optimisticOrder == nil
                 ? currentDisplayedGroupedListItems
-                : groupedListItems)
+                : authoritativeGroupedProjectionCache.items(
+                    workspaces: groupedWorkspaces,
+                    groups: groups,
+                    appliesRecencySort: appliesRecencySort
+                ))
             : []
         let currentGroupedWorkspaceOrderKey = currentAuthoritativeGroupedListItems.map {
             WorkspaceListStableOrderKey(item: $0)

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListView.swift
@@ -457,9 +457,17 @@ struct WorkspaceListView: View {
         // Group projection is synchronous and input-keyed across body updates.
         // Keep displayed and authoritative caches separate so a pending
         // optimistic drag cannot evict the rendered projection on every pass.
+        let currentGroupedWorkspaces = rendersGroupedSections
+            ? groupedWorkspaces
+            : []
+        let currentDisplayedGroupedWorkspaces = rendersGroupedSections
+            ? (optimisticGroupedState.optimisticOrder?
+                .materializedWorkspaces(from: currentGroupedWorkspaces)
+                ?? currentGroupedWorkspaces)
+            : []
         let currentDisplayedGroupedListItems = rendersGroupedSections
             ? displayedGroupedProjectionCache.items(
-                workspaces: displayedGroupedWorkspaces,
+                workspaces: currentDisplayedGroupedWorkspaces,
                 groups: groups,
                 appliesRecencySort: appliesRecencySort
             )
@@ -474,7 +482,7 @@ struct WorkspaceListView: View {
             ? (optimisticGroupedState.optimisticOrder == nil
                 ? currentDisplayedGroupedListItems
                 : authoritativeGroupedProjectionCache.items(
-                    workspaces: groupedWorkspaces,
+                    workspaces: currentGroupedWorkspaces,
                     groups: groups,
                     appliesRecencySort: appliesRecencySort
                 ))

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListView.swift
@@ -452,8 +452,20 @@ struct WorkspaceListView: View {
             machineSnapshots: displayedMachineSnapshots,
             visibleSelection: currentVisibleMacSelection
         )
+        // Recent Activity grouping performs one O(n log n) block projection
+        // per body evaluation. Reuse this immutable snapshot for table rows,
+        // unread headers, and the optimistic-order observation key.
+        let currentDisplayedGroupedListItems = rendersGroupedSections
+            ? displayedGroupedListItems
+            : []
+        let currentFilteredWorkspaceOrderKey = rendersGroupedSections
+            ? []
+            : filteredWorkspaceOrderKey
+        let currentGroupedWorkspaceOrderKey = currentDisplayedGroupedListItems.map {
+            WorkspaceListStableOrderKey(item: $0)
+        }
         #if os(iOS)
-        let baseList = workspaceTable
+        let baseList = workspaceTable(groupedItems: currentDisplayedGroupedListItems)
             .modifier(WorkspaceListBarUnderlap())
         #else
         let baseList = List {
@@ -506,7 +518,7 @@ struct WorkspaceListView: View {
             }
             Section {
                 if rendersGroupedSections {
-                    groupedRows
+                    groupedRows(items: currentDisplayedGroupedListItems)
                 } else if activeFilter.isActive && trimmedQuery.isEmpty && filteredWorkspaces.isEmpty && !workspaces.isEmpty {
                     // The filter alone (not the Mac, and not a search query)
                     // emptied the list; offer the way back. While searching, the
@@ -554,10 +566,10 @@ struct WorkspaceListView: View {
             updateMachineSnapshots(currentMachineSnapshots)
             filter.pruneMachinesForFilterMenu(visibleMacSelection: currentVisibleMacSelection)
         }
-        .onChange(of: filteredWorkspaceOrderKey) { _, _ in
+        .onChange(of: currentFilteredWorkspaceOrderKey) { _, _ in
             syncOptimisticWorkspaceOrder()
         }
-        .onChange(of: groupedWorkspaceOrderKey) { _, _ in
+        .onChange(of: currentGroupedWorkspaceOrderKey) { _, _ in
             syncOptimisticWorkspaceOrder()
         }
         .onChange(of: rendersGroupedSections) { _, _ in
@@ -882,10 +894,12 @@ struct WorkspaceListView: View {
 
     /// Grouped presentation: collapsible Mac-ordered group headers and nested members.
     @ViewBuilder
-    private var groupedRows: some View {
+    private func groupedRows(
+        items: [MobileWorkspaceListItem]
+    ) -> some View {
         let enablesReorder = enablesWorkspaceReorder
         let groupLookup = groupsByID
-        ForEach(displayedGroupedListItems, id: \.id) { item in
+        ForEach(items, id: \.id) { item in
             switch item {
             case .groupHeader(let group, let hasUnread):
                 let anchorCapabilities = workspaces.first(where: { $0.id == group.anchorWorkspaceID })?.actionCapabilities ?? .none

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListView.swift
@@ -472,8 +472,15 @@ struct WorkspaceListView: View {
         let currentGroupedWorkspaceOrderKey = currentAuthoritativeGroupedListItems.map {
             WorkspaceListStableOrderKey(item: $0)
         }
+        let currentWorkspacesByID = Dictionary(
+            workspaces.map { ($0.id, $0) },
+            uniquingKeysWith: { first, _ in first }
+        )
         #if os(iOS)
-        let baseList = workspaceTable(groupedItems: currentDisplayedGroupedListItems)
+        let baseList = workspaceTable(
+            groupedItems: currentDisplayedGroupedListItems,
+            workspacesByID: currentWorkspacesByID
+        )
             .modifier(WorkspaceListBarUnderlap())
         #else
         let baseList = List {
@@ -526,7 +533,10 @@ struct WorkspaceListView: View {
             }
             Section {
                 if rendersGroupedSections {
-                    groupedRows(items: currentDisplayedGroupedListItems)
+                    groupedRows(
+                        items: currentDisplayedGroupedListItems,
+                        workspacesByID: currentWorkspacesByID
+                    )
                 } else if activeFilter.isActive && trimmedQuery.isEmpty && filteredWorkspaces.isEmpty && !workspaces.isEmpty {
                     // The filter alone (not the Mac, and not a search query)
                     // emptied the list; offer the way back. While searching, the
@@ -903,14 +913,15 @@ struct WorkspaceListView: View {
     /// Grouped presentation: collapsible Mac-ordered group headers and nested members.
     @ViewBuilder
     private func groupedRows(
-        items: [MobileWorkspaceListItem]
+        items: [MobileWorkspaceListItem],
+        workspacesByID: [MobileWorkspacePreview.ID: MobileWorkspacePreview]
     ) -> some View {
         let enablesReorder = enablesWorkspaceReorder
         let groupLookup = groupsByID
         ForEach(items, id: \.id) { item in
             switch item {
             case .groupHeader(let group, let hasUnread):
-                let anchorCapabilities = workspaces.first(where: { $0.id == group.anchorWorkspaceID })?.actionCapabilities ?? .none
+                let anchorCapabilities = workspacesByID[group.anchorWorkspaceID]?.actionCapabilities ?? .none
                 WorkspaceGroupHeaderRow(
                     value: WorkspaceGroupHeaderRowValue(
                         group: group,

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListView.swift
@@ -339,14 +339,13 @@ struct WorkspaceListView: View {
 
     /// Groups render from every available Mac payload while unfiltered. Search
     /// and explicit filters flatten the results; selecting All Computers does
-    /// not discard the group structure. The recency sort interleaves computers
-    /// by time, which no group section can survive, so it also presents flat.
+    /// not discard the group structure. Recent Activity ranks whole group
+    /// blocks rather than interleaving their members.
     var rendersGroupedSections: Bool {
         !groups.isEmpty
             && trimmedQuery.isEmpty
             && filter.readState == .all
             && filter.machines.isEmpty
-            && !appliesRecencySort
     }
 
     private func matchesQuery(
@@ -396,7 +395,13 @@ struct WorkspaceListView: View {
 
     /// Grouped drawable items preserving the Mac's member order and contiguity.
     var groupedListItems: [MobileWorkspaceListItem] {
-        MobileWorkspaceListItem.items(workspaces: groupedWorkspaces, groups: groups)
+        if appliesRecencySort {
+            return MobileWorkspaceRecencyOrder().groupedDisplayItems(
+                groupedWorkspaces,
+                groups: groups
+            )
+        }
+        return MobileWorkspaceListItem.items(workspaces: groupedWorkspaces, groups: groups)
     }
     var groupsByID: [MobileWorkspaceGroupPreview.ID: MobileWorkspaceGroupPreview] {
         Dictionary(groups.map { ($0.id, $0) }, uniquingKeysWith: { first, _ in first })
@@ -413,7 +418,19 @@ struct WorkspaceListView: View {
     }
 
     var displayedGroupedListItems: [MobileWorkspaceListItem] {
-        MobileWorkspaceListItem.items(workspaces: displayedGroupedWorkspaces, groups: groups)
+        if appliesRecencySort {
+            return MobileWorkspaceRecencyOrder().groupedDisplayItems(
+                displayedGroupedWorkspaces,
+                groups: groups
+            )
+        }
+        guard optimisticGroupedState.optimisticOrder != nil else {
+            return groupedListItems
+        }
+        return MobileWorkspaceListItem.items(
+            workspaces: displayedGroupedWorkspaces,
+            groups: groups
+        )
     }
 
     var groupedWorkspaces: [MobileWorkspacePreview] {

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListView.swift
@@ -453,15 +453,23 @@ struct WorkspaceListView: View {
             visibleSelection: currentVisibleMacSelection
         )
         // Recent Activity grouping performs one O(n log n) block projection
-        // per body evaluation. Reuse this immutable snapshot for table rows,
-        // unread headers, and the optimistic-order observation key.
+        // per body evaluation. Reuse this immutable snapshot for table rows
+        // and unread headers.
         let currentDisplayedGroupedListItems = rendersGroupedSections
             ? displayedGroupedListItems
             : []
         let currentFilteredWorkspaceOrderKey = rendersGroupedSections
             ? []
             : filteredWorkspaceOrderKey
-        let currentGroupedWorkspaceOrderKey = currentDisplayedGroupedListItems.map {
+        // Reconciliation must observe the authoritative host order while an
+        // optimistic drag is pending. Once optimism clears, the displayed and
+        // authoritative projections are identical, so reuse the render snapshot.
+        let currentAuthoritativeGroupedListItems = rendersGroupedSections
+            ? (optimisticGroupedState.optimisticOrder == nil
+                ? currentDisplayedGroupedListItems
+                : groupedListItems)
+            : []
+        let currentGroupedWorkspaceOrderKey = currentAuthoritativeGroupedListItems.map {
             WorkspaceListStableOrderKey(item: $0)
         }
         #if os(iOS)

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListViewOptionsPopover.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListViewOptionsPopover.swift
@@ -197,7 +197,8 @@ struct WorkspaceSortModeTile: View {
 /// - automatic: computer-headed sections, first computer's section leading.
 /// - computerPriority: the same sections with rank badges and drag grips —
 ///   the order is yours.
-/// - recentActivity: no sections, one flat run of rows with a clock badge.
+/// - recentActivity: whole group sections ranked beside ungrouped rows by
+///   activity, with clocks marking the time-based order.
 struct WorkspaceSortModeSchematic: View {
     let mode: MobileWorkspaceSortMode
 
@@ -218,11 +219,12 @@ struct WorkspaceSortModeSchematic: View {
                 header(tint: firstTint, symbol: "laptopcomputer", rank: 2, grip: true)
                 rowBar; rowBar
             case .recentActivity:
-                timedRow(tint: firstTint, width: 0.9)
-                timedRow(tint: secondTint, width: 0.75)
-                timedRow(tint: firstTint, width: 0.85)
-                timedRow(tint: secondTint, width: 0.7)
-                timedRow(tint: firstTint, width: 0.6)
+                timedRow(tint: secondTint, width: 0.8)
+                header(tint: firstTint, symbol: "folder.fill")
+                timedRow(tint: firstTint, width: 0.9, indented: true)
+                timedRow(tint: firstTint, width: 0.65, indented: true)
+                header(tint: secondTint, symbol: "folder.fill")
+                timedRow(tint: secondTint, width: 0.75, indented: true)
             }
         }
         .padding(.vertical, 8)
@@ -266,7 +268,7 @@ struct WorkspaceSortModeSchematic: View {
     }
 
     @ViewBuilder
-    private func timedRow(tint: Color, width: CGFloat) -> some View {
+    private func timedRow(tint: Color, width: CGFloat, indented: Bool = false) -> some View {
         HStack(spacing: 3) {
             Circle()
                 .fill(tint.opacity(0.8))
@@ -280,6 +282,7 @@ struct WorkspaceSortModeSchematic: View {
                 .font(.system(size: 6))
                 .foregroundStyle(.tertiary)
         }
+        .padding(.leading, indented ? 8 : 0)
     }
 }
 #endif

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceNavigationRow.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceNavigationRow.swift
@@ -77,6 +77,7 @@ struct WorkspaceNavigationRow: View {
         }
         .accessibilityElement(children: onOpenChanges == nil ? .combine : .contain)
         .accessibilityAddTraits(.isButton)
+        .accessibilityAddTraits(isSelected ? .isSelected : [])
         .accessibilityIdentifier("MobileWorkspaceRow-\(workspace.id.rawValue)")
         .accessibilityLabel(rowAccessibilityLabel)
         .accessibilityValue(workspace.accessibilitySummary(connectionStatus: connectionStatus))

--- a/Packages/iOS/CmuxMobileShellUI/Tests/CmuxMobileShellUITests/WorkspaceListSortTests.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Tests/CmuxMobileShellUITests/WorkspaceListSortTests.swift
@@ -7,7 +7,7 @@ import SwiftUI
 import Testing
 @testable import CmuxMobileShellUI
 
-/// Behavior tests for the All Computers sort: recency flattening/ordering,
+/// Behavior tests for the All Computers sort: group-aware recency ordering,
 /// single-machine scope exemption, sort-menu gating, and the computer-order
 /// editor's effective order.
 @MainActor
@@ -31,35 +31,142 @@ import Testing
         #expect(view.filteredWorkspaces.map(\.id.rawValue) == ["a-new", "b-mid", "a-old"])
     }
 
-    @Test func recencySortFlattensGroupedSections() async throws {
+    @Test func recencySortKeepsGroupsAtomicAndRanksByNewestMember() async throws {
         let store = await shellStore(pairedMacs: [
             pairedMac(id: "mac-a", name: "Mac A", lastSeenAt: 20),
             pairedMac(id: "mac-b", name: "Mac B", lastSeenAt: 10),
         ])
-        var grouped = workspace(id: "a-1", macDeviceID: "mac-a", activityAt: 100)
-        grouped.groupID = "group-a"
-        let groups = [MobileWorkspaceGroupPreview(
-            id: "group-a",
-            macDeviceID: "mac-a",
-            name: "Group A",
-            anchorWorkspaceID: grouped.id
-        )]
-
-        let automaticView = workspaceListView(
-            workspaces: [grouped],
-            groups: groups,
-            store: store,
-            workspaceSortMode: .automatic
-        )
         let recencyView = workspaceListView(
-            workspaces: [grouped],
-            groups: groups,
+            workspaces: [
+                workspace(id: "ungrouped", macDeviceID: "mac-b", activityAt: 400),
+                workspace(id: "anchor", macDeviceID: "mac-a", activityAt: 100, groupID: "group-a"),
+                workspace(id: "member-first", macDeviceID: "mac-a", activityAt: 150, groupID: "group-a"),
+                workspace(id: "member-newest", macDeviceID: "mac-a", activityAt: 500, groupID: "group-a"),
+            ],
+            groups: [group(id: "group-a", anchorID: "anchor", macDeviceID: "mac-a")],
             store: store,
             workspaceSortMode: .recentActivity
         )
 
-        #expect(automaticView.rendersGroupedSections)
-        #expect(!recencyView.rendersGroupedSections)
+        #expect(recencyView.rendersGroupedSections)
+        #expect(recencyView.groupedListItems.map(\.id) == [
+            "group.group-a",
+            "workspace.member-first",
+            "workspace.member-newest",
+            "groupFooter.group-a",
+            "workspace.ungrouped",
+        ])
+    }
+
+    @Test func recencySortPreservesExpandedCollapsedAndUnreadBehavior() async throws {
+        let store = await shellStore(pairedMacs: [
+            pairedMac(id: "mac-a", name: "Mac A", lastSeenAt: 20),
+        ])
+        let workspaces = [
+            workspace(id: "anchor", macDeviceID: "mac-a", activityAt: 100, groupID: "group-a"),
+            workspace(
+                id: "unread-member",
+                macDeviceID: "mac-a",
+                activityAt: 500,
+                groupID: "group-a",
+                hasUnread: true
+            ),
+        ]
+        let expandedView = workspaceListView(
+            workspaces: workspaces,
+            groups: [group(id: "group-a", anchorID: "anchor", macDeviceID: "mac-a")],
+            store: store,
+            workspaceSortMode: .recentActivity
+        )
+        let collapsedView = workspaceListView(
+            workspaces: workspaces,
+            groups: [group(
+                id: "group-a",
+                anchorID: "anchor",
+                macDeviceID: "mac-a",
+                isCollapsed: true
+            )],
+            store: store,
+            workspaceSortMode: .recentActivity
+        )
+
+        #expect(expandedView.rendersGroupedSections)
+        #expect(expandedView.groupedListItems.map(\.id) == [
+            "group.group-a",
+            "workspace.unread-member",
+            "groupFooter.group-a",
+        ])
+        if case .groupHeader(_, let hasUnread)? = expandedView.groupedListItems.first {
+            #expect(!hasUnread)
+        } else {
+            Issue.record("Expanded group did not render a header")
+        }
+        #expect(collapsedView.rendersGroupedSections)
+        #expect(collapsedView.groupedListItems.map(\.id) == ["group.group-a"])
+        if case .groupHeader(_, let hasUnread)? = collapsedView.groupedListItems.first {
+            #expect(hasUnread)
+        } else {
+            Issue.record("Collapsed group did not render a header")
+        }
+    }
+
+    @Test func recencySortKeepsMultipleMacGroupsDistinctWithStableMissingAndTiedDates() async throws {
+        let store = await shellStore(pairedMacs: [
+            pairedMac(id: "mac-a", name: "Mac A", lastSeenAt: 20),
+            pairedMac(id: "mac-b", name: "Mac B", lastSeenAt: 10),
+        ])
+        let macAGroupID: MobileWorkspaceGroupPreview.ID = "mac-a\u{1F}shared"
+        let macBGroupID: MobileWorkspaceGroupPreview.ID = "mac-b\u{1F}shared"
+        let view = workspaceListView(
+            workspaces: [
+                workspace(id: "b-anchor", macDeviceID: "mac-b", activityAt: 300, groupID: macBGroupID),
+                workspace(id: "b-member", macDeviceID: "mac-b", activityAt: nil, groupID: macBGroupID),
+                workspace(id: "a-anchor", macDeviceID: "mac-a", activityAt: 300, groupID: macAGroupID),
+                workspace(id: "a-member", macDeviceID: "mac-a", activityAt: 300, groupID: macAGroupID),
+                workspace(id: "tied-root", macDeviceID: "mac-a", activityAt: 300),
+                workspace(id: "missing-root", macDeviceID: "mac-b", activityAt: nil),
+            ],
+            groups: [
+                group(id: macBGroupID, anchorID: "b-anchor", macDeviceID: "mac-b", name: "Shared B"),
+                group(id: macAGroupID, anchorID: "a-anchor", macDeviceID: "mac-a", name: "Shared A"),
+            ],
+            store: store,
+            workspaceSortMode: .recentActivity
+        )
+
+        #expect(view.groupedListItems.map(\.id) == [
+            "group.\(macBGroupID.rawValue)",
+            "workspace.b-member",
+            "groupFooter.\(macBGroupID.rawValue)",
+            "group.\(macAGroupID.rawValue)",
+            "workspace.a-member",
+            "groupFooter.\(macAGroupID.rawValue)",
+            "workspace.tied-root",
+            "workspace.missing-root",
+        ])
+    }
+
+    @Test func recencySortRetainsAnchorOnlyGroupAndSafelyIgnoresEmptyMetadata() async throws {
+        let store = await shellStore(pairedMacs: [
+            pairedMac(id: "mac-a", name: "Mac A", lastSeenAt: 20),
+        ])
+        let view = workspaceListView(
+            workspaces: [
+                workspace(id: "anchor", macDeviceID: "mac-a", activityAt: nil, groupID: "anchor-only"),
+                workspace(id: "recent-root", macDeviceID: "mac-a", activityAt: 500),
+            ],
+            groups: [
+                group(id: "anchor-only", anchorID: "anchor", macDeviceID: "mac-a"),
+                group(id: "empty", anchorID: "missing-anchor", macDeviceID: "mac-a"),
+            ],
+            store: store,
+            workspaceSortMode: .recentActivity
+        )
+
+        #expect(view.groupedListItems.map(\.id) == [
+            "workspace.recent-root",
+            "group.anchor-only",
+        ])
     }
 
     @Test func recencySortDoesNotApplyToSingleMachineScope() async throws {
@@ -262,16 +369,36 @@ import Testing
     private func workspace(
         id: String,
         macDeviceID: String,
-        activityAt: TimeInterval
+        activityAt: TimeInterval?,
+        groupID: MobileWorkspaceGroupPreview.ID? = nil,
+        hasUnread: Bool = false
     ) -> MobileWorkspacePreview {
         var preview = MobileWorkspacePreview(
             id: .init(rawValue: id),
             macDeviceID: macDeviceID,
             name: id,
+            groupID: groupID,
+            hasUnread: hasUnread,
             terminals: []
         )
-        preview.lastActivityAt = Date(timeIntervalSince1970: activityAt)
+        preview.lastActivityAt = activityAt.map(Date.init(timeIntervalSince1970:))
         return preview
+    }
+
+    private func group(
+        id: MobileWorkspaceGroupPreview.ID,
+        anchorID: MobileWorkspacePreview.ID,
+        macDeviceID: String,
+        name: String? = nil,
+        isCollapsed: Bool = false
+    ) -> MobileWorkspaceGroupPreview {
+        MobileWorkspaceGroupPreview(
+            id: id,
+            macDeviceID: macDeviceID,
+            name: name ?? id.rawValue,
+            isCollapsed: isCollapsed,
+            anchorWorkspaceID: anchorID
+        )
     }
 
     private func pairedMac(

--- a/Packages/iOS/CmuxMobileShellUI/Tests/CmuxMobileShellUITests/WorkspaceListSortTests.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Tests/CmuxMobileShellUITests/WorkspaceListSortTests.swift
@@ -169,6 +169,87 @@ import Testing
         ])
     }
 
+    @Test func groupedProjectionCacheInvalidatesFullInputsSynchronously() throws {
+        let cache = WorkspaceListGroupedProjectionCache()
+        let groupID: MobileWorkspaceGroupPreview.ID = "group-a"
+        var workspaces = [
+            workspace(id: "root", macDeviceID: "mac-a", activityAt: 400),
+            workspace(
+                id: "anchor",
+                macDeviceID: "mac-a",
+                activityAt: 100,
+                groupID: groupID
+            ),
+            workspace(
+                id: "member",
+                macDeviceID: "mac-a",
+                activityAt: 500,
+                groupID: groupID
+            ),
+        ]
+        let expandedGroup = group(
+            id: groupID,
+            anchorID: "anchor",
+            macDeviceID: "mac-a"
+        )
+
+        let initial = cache.items(
+            workspaces: workspaces,
+            groups: [expandedGroup],
+            appliesRecencySort: true
+        )
+        #expect(initial.map(\.id) == [
+            "group.group-a",
+            "workspace.member",
+            "groupFooter.group-a",
+            "workspace.root",
+        ])
+        #expect(cache.items(
+            workspaces: workspaces,
+            groups: [expandedGroup],
+            appliesRecencySort: true
+        ) == initial)
+
+        workspaces[2].name = "Renamed member"
+        let renamed = cache.items(
+            workspaces: workspaces,
+            groups: [expandedGroup],
+            appliesRecencySort: true
+        )
+        guard case .workspace(let renamedMember, _)? = renamed.first(where: {
+            $0.id == "workspace.member"
+        }) else {
+            Issue.record("Renamed grouped member was not projected")
+            return
+        }
+        #expect(renamedMember.name == "Renamed member")
+
+        let collapsedGroup = group(
+            id: groupID,
+            anchorID: "anchor",
+            macDeviceID: "mac-a",
+            isCollapsed: true
+        )
+        let collapsed = cache.items(
+            workspaces: workspaces,
+            groups: [collapsedGroup],
+            appliesRecencySort: true
+        )
+        #expect(collapsed.map(\.id) == ["group.group-a", "workspace.root"])
+
+        let computerOrder = cache.items(
+            workspaces: workspaces,
+            groups: [expandedGroup],
+            appliesRecencySort: false
+        )
+        #expect(computerOrder.map(\.id) == [
+            "workspace.root",
+            "group.group-a",
+            "workspace.member",
+            "groupFooter.group-a",
+        ])
+    }
+
     @Test func recencySortDoesNotApplyToSingleMachineScope() async throws {
         let store = await shellStore(pairedMacs: [
             pairedMac(id: "mac-a", name: "Mac A", lastSeenAt: 20),

--- a/ios/cmux/Resources/Localizable.xcstrings
+++ b/ios/cmux/Resources/Localizable.xcstrings
@@ -14267,6 +14267,159 @@
         }
       }
     },
+    "mobile.workspaces.preview.mixed.after": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "After Groups"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "グループの後"
+          }
+        }
+      }
+    },
+    "mobile.workspaces.preview.mixed.alphaAnchor": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Alpha Lead"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "アルファ先頭"
+          }
+        }
+      }
+    },
+    "mobile.workspaces.preview.mixed.alphaGroup": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Alpha Group"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "アルファグループ"
+          }
+        }
+      }
+    },
+    "mobile.workspaces.preview.mixed.before": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Before Groups"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "グループの前"
+          }
+        }
+      }
+    },
+    "mobile.workspaces.preview.mixed.betaAnchor": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Beta Lead"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ベータ先頭"
+          }
+        }
+      }
+    },
+    "mobile.workspaces.preview.mixed.betaGroup": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Beta Group"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ベータグループ"
+          }
+        }
+      }
+    },
+    "mobile.workspaces.preview.mixed.between": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Between Groups"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "グループの間"
+          }
+        }
+      }
+    },
+    "mobile.workspaces.preview.mixed.inactiveMember": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Inactive Member"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "非アクティブなメンバー"
+          }
+        }
+      }
+    },
+    "mobile.workspaces.preview.mixed.recentMember": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Recent Member"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "最近のメンバー"
+          }
+        }
+      }
+    },
     "mobile.workspaces.sort.recentActivity": {
       "extractionState": "manual",
       "localizations": {

--- a/ios/cmuxUITests/cmuxUITests.swift
+++ b/ios/cmuxUITests/cmuxUITests.swift
@@ -1358,6 +1358,80 @@ final class cmuxUITests: XCTestCase {
         add(attachment)
     }
 
+    @MainActor
+    func testRecentActivityKeepsAllComputersWorkspaceGroupsAtomic() throws {
+        let app = launchApp(mockData: false, environment: [
+            "CMUX_UITEST_WORKSPACE_LIST_PREVIEW": "1",
+            "CMUX_UITEST_WORKSPACE_LIST_PREVIEW_COUNT": "9",
+            "CMUX_UITEST_WORKSPACE_LIST_PREVIEW_GROUPS": "2",
+            "CMUX_UITEST_WORKSPACE_LIST_PREVIEW_SORT": "recentActivity",
+            "CMUX_UITEST_WORKSPACE_LIST_PREVIEW_RECENCY_BLOCKS": "1",
+        ])
+        defer { app.terminate() }
+
+        XCTAssertTrue(app.staticTexts["All Computers"].waitForExistence(timeout: 8))
+        let group0 = app.descendants(matching: .any)[
+            "MobileWorkspaceGroupHeader-seed-group-0"
+        ]
+        let group1 = app.descendants(matching: .any)[
+            "MobileWorkspaceGroupHeader-seed-group-1"
+        ]
+        let anchor0 = app.descendants(matching: .any)[
+            "MobileWorkspaceRow-workspace-seed-0"
+        ]
+        let member1 = app.descendants(matching: .any)[
+            "MobileWorkspaceRow-workspace-seed-1"
+        ]
+        let member2 = app.descendants(matching: .any)[
+            "MobileWorkspaceRow-workspace-seed-2"
+        ]
+        let newestMember = app.descendants(matching: .any)[
+            "MobileWorkspaceRow-workspace-seed-3"
+        ]
+        let recentUngrouped = app.descendants(matching: .any)[
+            "MobileWorkspaceRow-workspace-seed-8"
+        ]
+
+        for element in [group0, group1, member1, member2, newestMember, recentUngrouped] {
+            XCTAssertTrue(element.waitForExistence(timeout: 4))
+        }
+        XCTAssertFalse(
+            anchor0.exists,
+            "The group header must represent the anchor without a duplicate workspace row."
+        )
+
+        let group0Frame = try XCTUnwrap(waitForUsableFrame(of: group0, timeout: 3))
+        let member1Frame = try XCTUnwrap(waitForUsableFrame(of: member1, timeout: 3))
+        let member2Frame = try XCTUnwrap(waitForUsableFrame(of: member2, timeout: 3))
+        let newestMemberFrame = try XCTUnwrap(
+            waitForUsableFrame(of: newestMember, timeout: 3)
+        )
+        let recentUngroupedFrame = try XCTUnwrap(
+            waitForUsableFrame(of: recentUngrouped, timeout: 3)
+        )
+        let group1Frame = try XCTUnwrap(waitForUsableFrame(of: group1, timeout: 3))
+
+        XCTAssertLessThan(group0Frame.minY, member1Frame.minY)
+        XCTAssertLessThan(member1Frame.minY, member2Frame.minY)
+        XCTAssertLessThan(member2Frame.minY, newestMemberFrame.minY)
+        XCTAssertLessThan(
+            newestMemberFrame.minY,
+            recentUngroupedFrame.minY,
+            "A recent ungrouped row must follow the whole group block, not split its members."
+        )
+        XCTAssertLessThan(recentUngroupedFrame.minY, group1Frame.minY)
+        XCTAssertGreaterThanOrEqual(
+            member1Frame.minX,
+            recentUngroupedFrame.minX + 15,
+            "Grouped members must retain their visible nested indentation."
+        )
+
+        let attachment = XCTAttachment(screenshot: app.screenshot())
+        attachment.name = "workspace-groups-recent-activity-atomic"
+        attachment.lifetime = .keepAlways
+        add(attachment)
+    }
+
     /// Regression: the iOS 26 workspace table must underlap the navigation
     /// and tab bars so their native soft effects have content to process,
     /// while UIKit keeps the first and last rows outside the bars' hit areas.

--- a/ios/cmuxUITests/cmuxUITests.swift
+++ b/ios/cmuxUITests/cmuxUITests.swift
@@ -1322,10 +1322,21 @@ final class cmuxUITests: XCTestCase {
 
         picker.tap()
 
-        XCTAssertTrue(app.staticTexts["Choose Computer"].waitForExistence(timeout: 3))
-        XCTAssertTrue(app.buttons["MobileWorkspaceMacPickerAll"].exists)
-        XCTAssertFalse(app.staticTexts["Choose Mac"].exists)
-        XCTAssertFalse(app.staticTexts["All Macs"].exists)
+        let allComputersItem = waitForVisibleElement(
+            identifier: "MobileWorkspaceMacPickerAll",
+            in: app,
+            timeout: 3
+        )
+        XCTAssertEqual(allComputersItem?.label, "All Computers")
+        let menuElements = app.descendants(matching: .any)
+        let oldMacCopy = menuElements.matching(
+            NSPredicate(
+                format: "label == %@ OR label == %@",
+                "Choose Mac",
+                "All Macs"
+            )
+        )
+        XCTAssertEqual(oldMacCopy.count, 0)
 
         let attachment = XCTAttachment(screenshot: app.screenshot())
         attachment.name = "workspace-mac-picker-computer-copy"
@@ -1379,6 +1390,26 @@ final class cmuxUITests: XCTestCase {
 
         func element(_ identifier: String) -> XCUIElement {
             app.descendants(matching: .any)[identifier]
+        }
+
+        func sortTile(
+            _ identifier: String,
+            label: String,
+            in application: XCUIApplication,
+            timeout: TimeInterval = 3
+        ) -> XCUIElement {
+            let matches = application.descendants(matching: .any).matching(
+                NSPredicate(
+                    format: "identifier == %@ OR label == %@",
+                    identifier,
+                    label
+                )
+            )
+            return waitForVisibleElement(
+                in: matches,
+                app: application,
+                timeout: timeout
+            ) ?? matches.firstMatch
         }
 
         func capture(_ name: String) {
@@ -1438,8 +1469,11 @@ final class cmuxUITests: XCTestCase {
         let selectedProbeID =
             "MobileWorkspaceListPreviewSelection-workspace-mixed-alpha-inactive"
         let computerOrderTileID = "MobileWorkspaceSortTile-computerPriority"
+        let computerOrderTileLabel = "Computer Order"
         let recentTileID = "MobileWorkspaceSortTile-recentActivity"
+        let recentTileLabel = "Recent Activity"
         let automaticTileID = "MobileWorkspaceSortTile-automatic"
+        let automaticTileLabel = "Last Opened"
 
         let workspaceList = element("MobileWorkspaceList")
         XCTAssertTrue(workspaceList.waitForExistence(timeout: 8))
@@ -1449,10 +1483,14 @@ final class cmuxUITests: XCTestCase {
 
         // Choose Computer Order through the production view-options control.
         tap(filterButton, in: app)
-        let computerOrderTile = element(computerOrderTileID)
+        let computerOrderTile = sortTile(
+            computerOrderTileID, label: computerOrderTileLabel, in: app
+        )
         XCTAssertTrue(waitForHittable(computerOrderTile, timeout: 3))
         tap(computerOrderTile, in: app)
-        XCTAssertTrue(element(computerOrderTileID).isSelected)
+        XCTAssertTrue(sortTile(
+            computerOrderTileID, label: computerOrderTileLabel, in: app
+        ).isSelected)
         capture("workspace-groups-01-computer-order-control")
         dismissViewOptions()
 
@@ -1497,13 +1535,17 @@ final class cmuxUITests: XCTestCase {
         // Exercise every sort tile. Selection identity survives both reorder
         // transitions, and Automatic restores the incoming grouped topology.
         tap(filterButton, in: app)
-        tap(element(recentTileID), in: app)
+        tap(sortTile(recentTileID, label: recentTileLabel, in: app), in: app)
         XCTAssertTrue(element(selectedProbeID).exists)
-        XCTAssertTrue(element(recentTileID).isSelected)
+        XCTAssertTrue(
+            sortTile(recentTileID, label: recentTileLabel, in: app).isSelected
+        )
         capture("workspace-groups-05-recent-activity-control")
-        tap(element(automaticTileID), in: app)
+        tap(sortTile(automaticTileID, label: automaticTileLabel, in: app), in: app)
         XCTAssertTrue(element(selectedProbeID).exists)
-        XCTAssertTrue(element(automaticTileID).isSelected)
+        XCTAssertTrue(
+            sortTile(automaticTileID, label: automaticTileLabel, in: app).isSelected
+        )
         capture("workspace-groups-06-automatic-control")
         dismissViewOptions()
         XCTAssertNotNil(orderedFrames(computerOrder, state: "Automatic"))
@@ -1511,8 +1553,10 @@ final class cmuxUITests: XCTestCase {
         capture("workspace-groups-07-automatic-grouped")
 
         tap(filterButton, in: app)
-        tap(element(recentTileID), in: app)
-        XCTAssertTrue(element(recentTileID).isSelected)
+        tap(sortTile(recentTileID, label: recentTileLabel, in: app), in: app)
+        XCTAssertTrue(
+            sortTile(recentTileID, label: recentTileLabel, in: app).isSelected
+        )
         dismissViewOptions()
         let recentActivityOrder = [
             afterID,
@@ -1629,9 +1673,15 @@ final class cmuxUITests: XCTestCase {
         tap(filterButton, in: app)
         XCTAssertTrue(app.staticTexts["All Workspaces"].waitForExistence(timeout: 3))
         XCTAssertFalse(element("MobileWorkspaceSortPicker").exists)
-        XCTAssertFalse(element(recentTileID).exists)
-        XCTAssertFalse(element(automaticTileID).exists)
-        XCTAssertFalse(element(computerOrderTileID).exists)
+        XCTAssertFalse(sortTile(
+            recentTileID, label: recentTileLabel, in: app, timeout: 0
+        ).exists)
+        XCTAssertFalse(sortTile(
+            automaticTileID, label: automaticTileLabel, in: app, timeout: 0
+        ).exists)
+        XCTAssertFalse(sortTile(
+            computerOrderTileID, label: computerOrderTileLabel, in: app, timeout: 0
+        ).exists)
         capture("workspace-groups-15-single-computer-hides-sort")
         dismissViewOptions()
 
@@ -1694,19 +1744,27 @@ final class cmuxUITests: XCTestCase {
         captureSidebar("workspace-groups-17-visible-selection-computer-order")
 
         tap(sidebarFilter, in: sidebarApp)
-        tap(sidebarElement(recentTileID), in: sidebarApp)
+        tap(
+            sortTile(recentTileID, label: recentTileLabel, in: sidebarApp),
+            in: sidebarApp
+        )
         dismissSidebarViewOptions()
         XCTAssertTrue(sidebarSelectedRow.isSelected)
         captureSidebar("workspace-groups-18-visible-selection-recent-activity")
 
         tap(sidebarFilter, in: sidebarApp)
-        tap(sidebarElement(automaticTileID), in: sidebarApp)
+        tap(
+            sortTile(automaticTileID, label: automaticTileLabel, in: sidebarApp),
+            in: sidebarApp
+        )
         dismissSidebarViewOptions()
         XCTAssertTrue(sidebarSelectedRow.isSelected)
         captureSidebar("workspace-groups-19-visible-selection-automatic")
 
         tap(sidebarFilter, in: sidebarApp)
-        tap(sidebarElement(computerOrderTileID), in: sidebarApp)
+        tap(sortTile(
+            computerOrderTileID, label: computerOrderTileLabel, in: sidebarApp
+        ), in: sidebarApp)
         dismissSidebarViewOptions()
         XCTAssertTrue(sidebarSelectedRow.isSelected)
         captureSidebar("workspace-groups-20-visible-selection-computer-order-restored")

--- a/ios/cmuxUITests/cmuxUITests.swift
+++ b/ios/cmuxUITests/cmuxUITests.swift
@@ -1437,6 +1437,9 @@ final class cmuxUITests: XCTestCase {
         let afterID = "MobileWorkspaceRow-workspace-mixed-after"
         let selectedProbeID =
             "MobileWorkspaceListPreviewSelection-workspace-mixed-alpha-inactive"
+        let computerOrderTileID = "MobileWorkspaceSortTile-computerPriority"
+        let recentTileID = "MobileWorkspaceSortTile-recentActivity"
+        let automaticTileID = "MobileWorkspaceSortTile-automatic"
 
         let workspaceList = element("MobileWorkspaceList")
         XCTAssertTrue(workspaceList.waitForExistence(timeout: 8))
@@ -1446,14 +1449,10 @@ final class cmuxUITests: XCTestCase {
 
         // Choose Computer Order through the production view-options control.
         tap(filterButton, in: app)
-        let computerOrderTile = app.buttons[
-            "MobileWorkspaceSortTile-computerPriority"
-        ]
+        let computerOrderTile = element(computerOrderTileID)
         XCTAssertTrue(waitForHittable(computerOrderTile, timeout: 3))
         tap(computerOrderTile, in: app)
-        XCTAssertTrue(
-            app.buttons["MobileWorkspaceSortTile-computerPriority"].isSelected
-        )
+        XCTAssertTrue(element(computerOrderTileID).isSelected)
         capture("workspace-groups-01-computer-order-control")
         dismissViewOptions()
 
@@ -1498,15 +1497,13 @@ final class cmuxUITests: XCTestCase {
         // Exercise every sort tile. Selection identity survives both reorder
         // transitions, and Automatic restores the incoming grouped topology.
         tap(filterButton, in: app)
-        let recentTileID = "MobileWorkspaceSortTile-recentActivity"
-        tap(app.buttons[recentTileID], in: app)
+        tap(element(recentTileID), in: app)
         XCTAssertTrue(element(selectedProbeID).exists)
-        XCTAssertTrue(app.buttons[recentTileID].isSelected)
+        XCTAssertTrue(element(recentTileID).isSelected)
         capture("workspace-groups-05-recent-activity-control")
-        let automaticTileID = "MobileWorkspaceSortTile-automatic"
-        tap(app.buttons[automaticTileID], in: app)
+        tap(element(automaticTileID), in: app)
         XCTAssertTrue(element(selectedProbeID).exists)
-        XCTAssertTrue(app.buttons[automaticTileID].isSelected)
+        XCTAssertTrue(element(automaticTileID).isSelected)
         capture("workspace-groups-06-automatic-control")
         dismissViewOptions()
         XCTAssertNotNil(orderedFrames(computerOrder, state: "Automatic"))
@@ -1514,8 +1511,8 @@ final class cmuxUITests: XCTestCase {
         capture("workspace-groups-07-automatic-grouped")
 
         tap(filterButton, in: app)
-        tap(app.buttons[recentTileID], in: app)
-        XCTAssertTrue(app.buttons[recentTileID].isSelected)
+        tap(element(recentTileID), in: app)
+        XCTAssertTrue(element(recentTileID).isSelected)
         dismissViewOptions()
         let recentActivityOrder = [
             afterID,
@@ -1632,9 +1629,9 @@ final class cmuxUITests: XCTestCase {
         tap(filterButton, in: app)
         XCTAssertTrue(app.staticTexts["All Workspaces"].waitForExistence(timeout: 3))
         XCTAssertFalse(element("MobileWorkspaceSortPicker").exists)
-        XCTAssertFalse(app.buttons[recentTileID].exists)
-        XCTAssertFalse(app.buttons[automaticTileID].exists)
-        XCTAssertFalse(app.buttons["MobileWorkspaceSortTile-computerPriority"].exists)
+        XCTAssertFalse(element(recentTileID).exists)
+        XCTAssertFalse(element(automaticTileID).exists)
+        XCTAssertFalse(element(computerOrderTileID).exists)
         capture("workspace-groups-15-single-computer-hides-sort")
         dismissViewOptions()
 
@@ -1697,22 +1694,19 @@ final class cmuxUITests: XCTestCase {
         captureSidebar("workspace-groups-17-visible-selection-computer-order")
 
         tap(sidebarFilter, in: sidebarApp)
-        tap(sidebarApp.buttons[recentTileID], in: sidebarApp)
+        tap(sidebarElement(recentTileID), in: sidebarApp)
         dismissSidebarViewOptions()
         XCTAssertTrue(sidebarSelectedRow.isSelected)
         captureSidebar("workspace-groups-18-visible-selection-recent-activity")
 
         tap(sidebarFilter, in: sidebarApp)
-        tap(sidebarApp.buttons[automaticTileID], in: sidebarApp)
+        tap(sidebarElement(automaticTileID), in: sidebarApp)
         dismissSidebarViewOptions()
         XCTAssertTrue(sidebarSelectedRow.isSelected)
         captureSidebar("workspace-groups-19-visible-selection-automatic")
 
         tap(sidebarFilter, in: sidebarApp)
-        tap(
-            sidebarApp.buttons["MobileWorkspaceSortTile-computerPriority"],
-            in: sidebarApp
-        )
+        tap(sidebarElement(computerOrderTileID), in: sidebarApp)
         dismissSidebarViewOptions()
         XCTAssertTrue(sidebarSelectedRow.isSelected)
         captureSidebar("workspace-groups-20-visible-selection-computer-order-restored")

--- a/ios/cmuxUITests/cmuxUITests.swift
+++ b/ios/cmuxUITests/cmuxUITests.swift
@@ -1316,12 +1316,12 @@ final class cmuxUITests: XCTestCase {
 
         let picker = app.buttons["MobileWorkspaceMacPicker"]
         XCTAssertTrue(picker.waitForExistence(timeout: 8))
-        XCTAssertTrue(app.staticTexts["All Computers"].exists)
+        XCTAssertEqual(picker.label, "All Computers")
 
         picker.tap()
 
         XCTAssertTrue(app.staticTexts["Choose Computer"].waitForExistence(timeout: 3))
-        XCTAssertTrue(app.staticTexts["All Computers"].exists)
+        XCTAssertTrue(app.buttons["MobileWorkspaceMacPickerAll"].exists)
         XCTAssertFalse(app.staticTexts["Choose Mac"].exists)
         XCTAssertFalse(app.staticTexts["All Macs"].exists)
 
@@ -1340,7 +1340,9 @@ final class cmuxUITests: XCTestCase {
         ])
         defer { app.terminate() }
 
-        XCTAssertTrue(app.staticTexts["All Computers"].waitForExistence(timeout: 8))
+        let picker = app.buttons["MobileWorkspaceMacPicker"]
+        XCTAssertTrue(picker.waitForExistence(timeout: 8))
+        XCTAssertEqual(picker.label, "All Computers")
         XCTAssertTrue(
             app.descendants(matching: .any)[
                 "MobileWorkspaceGroupHeader-seed-group-0"
@@ -1359,95 +1361,369 @@ final class cmuxUITests: XCTestCase {
     }
 
     @MainActor
-    func testRecentActivityKeepsAllComputersWorkspaceGroupsAtomic() throws {
+    func testWorkspaceGroupsSurviveSortSearchSelectionAndComputerScope() throws {
+        guard #available(iOS 26.0, *) else {
+            throw XCTSkip("The complete grouped-list journey uses the iOS 26 search tab.")
+        }
         let app = launchApp(mockData: false, environment: [
             "CMUX_UITEST_WORKSPACE_LIST_PREVIEW": "1",
-            "CMUX_UITEST_WORKSPACE_LIST_PREVIEW_COUNT": "9",
-            "CMUX_UITEST_WORKSPACE_LIST_PREVIEW_GROUPS": "2",
-            "CMUX_UITEST_WORKSPACE_LIST_PREVIEW_SORT": "recentActivity",
+            "CMUX_UITEST_WORKSPACE_LIST_PREVIEW_MIXED_GROUPS": "1",
+            "CMUX_UITEST_WORKSPACE_LIST_PREVIEW_REORDER": "1",
+            "CMUX_UITEST_WORKSPACE_LIST_PREVIEW_TABS": "1",
+            "CMUX_UITEST_WORKSPACE_LIST_PREVIEW_SORT_PRIORITY":
+                "preview-macbook-pro,preview-studio",
         ])
         defer { app.terminate() }
 
-        XCTAssertTrue(app.staticTexts["All Computers"].waitForExistence(timeout: 8))
-        let group0 = app.descendants(matching: .any)[
-            "MobileWorkspaceGroupHeader-seed-group-0"
-        ]
-        let group1 = app.descendants(matching: .any)[
-            "MobileWorkspaceGroupHeader-seed-group-1"
-        ]
-        let anchor0 = app.descendants(matching: .any)[
-            "MobileWorkspaceRow-workspace-seed-0"
-        ]
-        let member1 = app.descendants(matching: .any)[
-            "MobileWorkspaceRow-workspace-seed-1"
-        ]
-        let member2 = app.descendants(matching: .any)[
-            "MobileWorkspaceRow-workspace-seed-2"
-        ]
-        let member3 = app.descendants(matching: .any)[
-            "MobileWorkspaceRow-workspace-seed-3"
-        ]
-        let anchor1 = app.descendants(matching: .any)[
-            "MobileWorkspaceRow-workspace-seed-4"
-        ]
-        let member5 = app.descendants(matching: .any)[
-            "MobileWorkspaceRow-workspace-seed-5"
-        ]
-        let member6 = app.descendants(matching: .any)[
-            "MobileWorkspaceRow-workspace-seed-6"
-        ]
-        let member7 = app.descendants(matching: .any)[
-            "MobileWorkspaceRow-workspace-seed-7"
-        ]
-        let ungrouped = app.descendants(matching: .any)[
-            "MobileWorkspaceRow-workspace-seed-8"
-        ]
-
-        for element in [
-            group0, group1, member1, member2, member3,
-            member5, member6, member7, ungrouped,
-        ] {
-            XCTAssertTrue(element.waitForExistence(timeout: 4))
+        func element(_ identifier: String) -> XCUIElement {
+            app.descendants(matching: .any)[identifier]
         }
-        XCTAssertFalse(
-            anchor0.exists,
-            "The group header must represent the anchor without a duplicate workspace row."
-        )
-        XCTAssertFalse(
-            anchor1.exists,
-            "Each group header must replace its anchor workspace row."
-        )
 
-        let group0Frame = try XCTUnwrap(waitForUsableFrame(of: group0, timeout: 3))
-        let member1Frame = try XCTUnwrap(waitForUsableFrame(of: member1, timeout: 3))
-        let member2Frame = try XCTUnwrap(waitForUsableFrame(of: member2, timeout: 3))
-        let member3Frame = try XCTUnwrap(
-            waitForUsableFrame(of: member3, timeout: 3)
-        )
-        let group1Frame = try XCTUnwrap(waitForUsableFrame(of: group1, timeout: 3))
-        let member5Frame = try XCTUnwrap(waitForUsableFrame(of: member5, timeout: 3))
-        let member6Frame = try XCTUnwrap(waitForUsableFrame(of: member6, timeout: 3))
-        let member7Frame = try XCTUnwrap(waitForUsableFrame(of: member7, timeout: 3))
-        let ungroupedFrame = try XCTUnwrap(waitForUsableFrame(of: ungrouped, timeout: 3))
+        func capture(_ name: String) {
+            let attachment = XCTAttachment(screenshot: app.screenshot())
+            attachment.name = name
+            attachment.lifetime = .keepAlways
+            add(attachment)
+        }
 
-        XCTAssertLessThan(group0Frame.minY, member1Frame.minY)
-        XCTAssertLessThan(member1Frame.minY, member2Frame.minY)
-        XCTAssertLessThan(member2Frame.minY, member3Frame.minY)
-        XCTAssertLessThan(member3Frame.minY, group1Frame.minY)
-        XCTAssertLessThan(group1Frame.minY, member5Frame.minY)
-        XCTAssertLessThan(member5Frame.minY, member6Frame.minY)
-        XCTAssertLessThan(member6Frame.minY, member7Frame.minY)
-        XCTAssertLessThan(member7Frame.minY, ungroupedFrame.minY)
+        func orderedFrames(
+            _ identifiers: [String],
+            state: String
+        ) -> [String: CGRect]? {
+            var result: [String: CGRect] = [:]
+            for identifier in identifiers {
+                guard let frame = waitForUsableFrame(
+                    of: element(identifier),
+                    timeout: 4
+                ) else {
+                    XCTFail("\(state): missing usable frame for \(identifier)")
+                    return nil
+                }
+                result[identifier] = frame
+            }
+            for pair in zip(identifiers, identifiers.dropFirst()) {
+                guard let first = result[pair.0], let second = result[pair.1] else {
+                    return nil
+                }
+                XCTAssertLessThan(
+                    first.minY,
+                    second.minY,
+                    "\(state): \(pair.0) must remain before \(pair.1)"
+                )
+            }
+            return result
+        }
+
+        let filterButton = app.buttons["MobileWorkspaceFilterMenu"]
+        let macPicker = app.buttons["MobileWorkspaceMacPicker"]
+        func dismissViewOptions() {
+            app.coordinate(withNormalizedOffset: CGVector(dx: 0.04, dy: 0.72)).tap()
+            XCTAssertTrue(
+                waitForHittable(filterButton, timeout: 3),
+                "The view-options popover did not dismiss."
+            )
+        }
+
+        let beforeID = "MobileWorkspaceRow-workspace-mixed-before"
+        let alphaHeaderID = "MobileWorkspaceGroupHeader-mixed-alpha"
+        let alphaAnchorID = "MobileWorkspaceRow-workspace-mixed-alpha-anchor"
+        let alphaInactiveID = "MobileWorkspaceRow-workspace-mixed-alpha-inactive"
+        let betweenID = "MobileWorkspaceRow-workspace-mixed-between"
+        let betaHeaderID = "MobileWorkspaceGroupHeader-mixed-beta"
+        let betaAnchorID = "MobileWorkspaceRow-workspace-mixed-beta-anchor"
+        let betaRecentID = "MobileWorkspaceRow-workspace-mixed-beta-recent"
+        let afterID = "MobileWorkspaceRow-workspace-mixed-after"
+        let selectedProbeID =
+            "MobileWorkspaceListPreviewSelection-workspace-mixed-alpha-inactive"
+
+        let workspaceList = element("MobileWorkspaceList")
+        XCTAssertTrue(workspaceList.waitForExistence(timeout: 8))
+        XCTAssertTrue(macPicker.waitForExistence(timeout: 8))
+        XCTAssertEqual(macPicker.label, "All Computers")
+        XCTAssertTrue(filterButton.waitForExistence(timeout: 3))
+
+        // Choose Computer Order through the production view-options control.
+        tap(filterButton, in: app)
+        let computerOrderTile = app.buttons[
+            "MobileWorkspaceSortTile-computerPriority"
+        ]
+        XCTAssertTrue(waitForHittable(computerOrderTile, timeout: 3))
+        tap(computerOrderTile, in: app)
+        XCTAssertTrue(
+            app.buttons["MobileWorkspaceSortTile-computerPriority"].isSelected
+        )
+        capture("workspace-groups-01-computer-order-control")
+        dismissViewOptions()
+
+        let computerOrder = [
+            beforeID,
+            alphaHeaderID,
+            alphaInactiveID,
+            betweenID,
+            betaHeaderID,
+            betaRecentID,
+            afterID,
+        ]
+        guard let computerFrames = orderedFrames(
+            computerOrder,
+            state: "Computer Order"
+        ) else { return }
+        XCTAssertFalse(element(alphaAnchorID).exists)
+        XCTAssertFalse(element(betaAnchorID).exists)
         XCTAssertGreaterThanOrEqual(
-            member1Frame.minX,
-            ungroupedFrame.minX + 15,
-            "Grouped members must retain their visible nested indentation."
+            computerFrames[alphaInactiveID]!.minX,
+            computerFrames[beforeID]!.minX + 15,
+            "Alpha's inactive member must remain visibly nested."
         )
+        XCTAssertGreaterThanOrEqual(
+            computerFrames[betaRecentID]!.minX,
+            computerFrames[afterID]!.minX + 15,
+            "Beta's recent member must remain visibly nested."
+        )
+        capture("workspace-groups-02-computer-order-grouped")
 
-        let attachment = XCTAttachment(screenshot: app.screenshot())
-        attachment.name = "workspace-groups-recent-activity-atomic"
-        attachment.lifetime = .keepAlways
-        add(attachment)
+        // Select a real member, push its fixture detail, then return. The
+        // read-only DEBUG probe makes the retained push-style identity
+        // observable without adding a selection treatment production omits.
+        tap(element(alphaInactiveID), in: app)
+        XCTAssertTrue(element("FixtureWorkspaceDetail").waitForExistence(timeout: 3))
+        capture("workspace-groups-03-selected-detail")
+        tap(app.buttons["MobileWorkspaceBackButton"], in: app)
+        XCTAssertTrue(workspaceList.waitForExistence(timeout: 3))
+        XCTAssertTrue(element(selectedProbeID).waitForExistence(timeout: 3))
+        capture("workspace-groups-04-selection-after-back")
+
+        // Exercise every sort tile. Selection identity survives both reorder
+        // transitions, and Automatic restores the incoming grouped topology.
+        tap(filterButton, in: app)
+        let recentTileID = "MobileWorkspaceSortTile-recentActivity"
+        tap(app.buttons[recentTileID], in: app)
+        XCTAssertTrue(element(selectedProbeID).exists)
+        XCTAssertTrue(app.buttons[recentTileID].isSelected)
+        capture("workspace-groups-05-recent-activity-control")
+        let automaticTileID = "MobileWorkspaceSortTile-automatic"
+        tap(app.buttons[automaticTileID], in: app)
+        XCTAssertTrue(element(selectedProbeID).exists)
+        XCTAssertTrue(app.buttons[automaticTileID].isSelected)
+        capture("workspace-groups-06-automatic-control")
+        dismissViewOptions()
+        XCTAssertNotNil(orderedFrames(computerOrder, state: "Automatic"))
+        XCTAssertTrue(element(selectedProbeID).exists)
+        capture("workspace-groups-07-automatic-grouped")
+
+        tap(filterButton, in: app)
+        tap(app.buttons[recentTileID], in: app)
+        XCTAssertTrue(app.buttons[recentTileID].isSelected)
+        dismissViewOptions()
+        let recentActivityOrder = [
+            afterID,
+            betaHeaderID,
+            betaRecentID,
+            betweenID,
+            alphaHeaderID,
+            alphaInactiveID,
+            beforeID,
+        ]
+        guard let recentFrames = orderedFrames(
+            recentActivityOrder,
+            state: "Recent Activity"
+        ) else { return }
+        XCTAssertGreaterThanOrEqual(
+            recentFrames[alphaInactiveID]!.minX,
+            recentFrames[beforeID]!.minX + 15,
+            "Recent Activity must keep the timestamp-less Alpha member nested."
+        )
+        XCTAssertGreaterThanOrEqual(
+            recentFrames[betaRecentID]!.minX,
+            recentFrames[afterID]!.minX + 15,
+            "Recent Activity must keep Beta's newest member in its group."
+        )
+        XCTAssertTrue(element(selectedProbeID).exists)
+        capture("workspace-groups-08-recent-activity-grouped")
+
+        // Collapsing hides the selected member but does not clear selection.
+        let alphaDisclosure = element("MobileWorkspaceGroupDisclosure-mixed-alpha")
+        tap(alphaDisclosure, in: app)
+        XCTAssertTrue(waitForNotHittable(element(alphaInactiveID), timeout: 3))
+        XCTAssertTrue(element(selectedProbeID).exists)
+        capture("workspace-groups-09-selection-survives-collapse")
+
+        // Search intentionally flattens matching rows. Clearing it restores
+        // grouped sections and the pre-search collapsed state.
+        let searchButton = app.tabBars.buttons
+            .matching(NSPredicate(format: "label == %@", "Search"))
+            .firstMatch
+        tap(searchButton, in: app)
+        let searchField = app.searchFields["Search workspaces"]
+        XCTAssertTrue(waitForHittable(searchField, timeout: 3))
+        XCTAssertTrue(focusTextInput(searchField, in: app))
+        searchField.typeText("Inactive Member")
+        XCTAssertTrue(waitForHittable(element(alphaInactiveID), timeout: 3))
+        XCTAssertTrue(waitForNotHittable(element(alphaHeaderID), timeout: 3))
+        XCTAssertTrue(waitForNotHittable(element(betaHeaderID), timeout: 3))
+        let searchFrame = try XCTUnwrap(
+            waitForUsableFrame(of: element(alphaInactiveID), timeout: 3)
+        )
+        XCTAssertEqual(
+            searchFrame.minX,
+            computerFrames[beforeID]!.minX,
+            accuracy: 2,
+            "Search results must flatten the matching group member."
+        )
+        capture("workspace-groups-10-search-flat")
+
+        XCTAssertTrue(focusTextInput(searchField, in: app))
+        searchField.typeText(
+            String(repeating: XCUIKeyboardKey.delete.rawValue, count: 32)
+        )
+        XCTAssertTrue(element(betaHeaderID).waitForExistence(timeout: 3))
+        capture("workspace-groups-11-search-cleared-regrouped")
+
+        tap(app.tabBars.buttons["Workspaces"], in: app)
+        XCTAssertTrue(workspaceList.waitForExistence(timeout: 3))
+        let collapsedRecentOrder = [
+            afterID,
+            betaHeaderID,
+            betaRecentID,
+            betweenID,
+            alphaHeaderID,
+            beforeID,
+        ]
+        XCTAssertNotNil(
+            orderedFrames(collapsedRecentOrder, state: "Cleared search")
+        )
+        XCTAssertTrue(waitForNotHittable(element(alphaInactiveID), timeout: 3))
+        XCTAssertTrue(element(selectedProbeID).exists)
+        capture("workspace-groups-12-cleared-search-restores-groups")
+
+        tap(alphaDisclosure, in: app)
+        XCTAssertTrue(element(alphaInactiveID).waitForExistence(timeout: 3))
+        XCTAssertTrue(element(selectedProbeID).exists)
+        capture("workspace-groups-13-selection-survives-expand")
+
+        // Scope to one computer through the production title picker. Recent
+        // Activity must not rewrite that Mac's own group and sidebar order.
+        tap(macPicker, in: app)
+        let studioName = "Studio Display Bench With A Very Long Name"
+        let studioMenuItem = app.buttons[
+            "MobileWorkspaceMacPickerMachine-preview-studio-stable"
+        ]
+        XCTAssertTrue(studioMenuItem.waitForExistence(timeout: 3))
+        XCTAssertTrue(studioMenuItem.label.hasPrefix(studioName))
+        tapMenuItem(studioMenuItem, in: app)
+        let studioTitle = XCTNSPredicateExpectation(
+            predicate: NSPredicate(format: "label CONTAINS %@", studioName),
+            object: macPicker
+        )
+        XCTAssertEqual(XCTWaiter.wait(for: [studioTitle], timeout: 3), .completed)
+        XCTAssertTrue(waitForNotHittable(element(alphaHeaderID), timeout: 3))
+        XCTAssertTrue(waitForNotHittable(element(beforeID), timeout: 3))
+        XCTAssertTrue(waitForNotHittable(element(betweenID), timeout: 3))
+        XCTAssertNotNil(
+            orderedFrames(
+                [betaHeaderID, betaRecentID, afterID],
+                state: "Single computer"
+            )
+        )
+        capture("workspace-groups-14-single-computer-keeps-sidebar-order")
+
+        tap(filterButton, in: app)
+        XCTAssertTrue(app.staticTexts["All Workspaces"].waitForExistence(timeout: 3))
+        XCTAssertFalse(element("MobileWorkspaceSortPicker").exists)
+        XCTAssertFalse(app.buttons[recentTileID].exists)
+        XCTAssertFalse(app.buttons[automaticTileID].exists)
+        XCTAssertFalse(app.buttons["MobileWorkspaceSortTile-computerPriority"].exists)
+        capture("workspace-groups-15-single-computer-hides-sort")
+        dismissViewOptions()
+
+        // Returning to All Computers restores both groups and the persisted
+        // Recent Activity mode, still with the selected identity intact.
+        tap(macPicker, in: app)
+        tapMenuItem(app.buttons["MobileWorkspaceMacPickerAll"], in: app)
+        let allComputersTitle = XCTNSPredicateExpectation(
+            predicate: NSPredicate(format: "label == %@", "All Computers"),
+            object: macPicker
+        )
+        XCTAssertEqual(
+            XCTWaiter.wait(for: [allComputersTitle], timeout: 3),
+            .completed
+        )
+        XCTAssertNotNil(
+            orderedFrames(recentActivityOrder, state: "All Computers restored")
+        )
+        XCTAssertTrue(element(selectedProbeID).exists)
+        capture("workspace-groups-16-all-computers-regrouped")
+
+        // A second phase uses the fixture's opt-in sidebar navigation style.
+        // It keeps production row rendering and actions, while making the
+        // retained selection highlight visible in screenshots and AX state.
+        app.terminate()
+        let sidebarApp = launchApp(mockData: false, environment: [
+            "CMUX_UITEST_WORKSPACE_LIST_PREVIEW": "1",
+            "CMUX_UITEST_WORKSPACE_LIST_PREVIEW_MIXED_GROUPS": "1",
+            "CMUX_UITEST_WORKSPACE_LIST_PREVIEW_REORDER": "1",
+            "CMUX_UITEST_WORKSPACE_LIST_PREVIEW_SIDEBAR_SELECTION": "1",
+            "CMUX_UITEST_WORKSPACE_LIST_PREVIEW_SORT": "computerPriority",
+            "CMUX_UITEST_WORKSPACE_LIST_PREVIEW_SORT_PRIORITY":
+                "preview-macbook-pro,preview-studio",
+        ])
+        defer { sidebarApp.terminate() }
+
+        func sidebarElement(_ identifier: String) -> XCUIElement {
+            sidebarApp.descendants(matching: .any)[identifier]
+        }
+
+        func captureSidebar(_ name: String) {
+            let attachment = XCTAttachment(screenshot: sidebarApp.screenshot())
+            attachment.name = name
+            attachment.lifetime = .keepAlways
+            add(attachment)
+        }
+
+        let sidebarFilter = sidebarApp.buttons["MobileWorkspaceFilterMenu"]
+        func dismissSidebarViewOptions() {
+            sidebarApp.coordinate(
+                withNormalizedOffset: CGVector(dx: 0.04, dy: 0.72)
+            ).tap()
+            XCTAssertTrue(waitForHittable(sidebarFilter, timeout: 3))
+        }
+
+        let sidebarSelectedRow = sidebarElement(betweenID)
+        XCTAssertTrue(sidebarSelectedRow.waitForExistence(timeout: 8))
+        tap(sidebarSelectedRow, in: sidebarApp)
+        XCTAssertTrue(sidebarSelectedRow.isSelected)
+        captureSidebar("workspace-groups-17-visible-selection-computer-order")
+
+        tap(sidebarFilter, in: sidebarApp)
+        tap(sidebarApp.buttons[recentTileID], in: sidebarApp)
+        dismissSidebarViewOptions()
+        XCTAssertTrue(sidebarSelectedRow.isSelected)
+        captureSidebar("workspace-groups-18-visible-selection-recent-activity")
+
+        tap(sidebarFilter, in: sidebarApp)
+        tap(sidebarApp.buttons[automaticTileID], in: sidebarApp)
+        dismissSidebarViewOptions()
+        XCTAssertTrue(sidebarSelectedRow.isSelected)
+        captureSidebar("workspace-groups-19-visible-selection-automatic")
+
+        tap(sidebarFilter, in: sidebarApp)
+        tap(
+            sidebarApp.buttons["MobileWorkspaceSortTile-computerPriority"],
+            in: sidebarApp
+        )
+        dismissSidebarViewOptions()
+        XCTAssertTrue(sidebarSelectedRow.isSelected)
+        captureSidebar("workspace-groups-20-visible-selection-computer-order-restored")
+
+        let sidebarAlphaDisclosure = sidebarElement(
+            "MobileWorkspaceGroupDisclosure-mixed-alpha"
+        )
+        tap(sidebarAlphaDisclosure, in: sidebarApp)
+        XCTAssertTrue(sidebarSelectedRow.isSelected)
+        captureSidebar("workspace-groups-21-visible-selection-group-collapsed")
+        tap(sidebarAlphaDisclosure, in: sidebarApp)
+        XCTAssertTrue(sidebarSelectedRow.isSelected)
+        captureSidebar("workspace-groups-22-visible-selection-group-expanded")
     }
 
     /// Regression: the iOS 26 workspace table must underlap the navigation
@@ -2746,7 +3022,7 @@ final class cmuxUITests: XCTestCase {
         XCTAssertTrue(settings.waitForExistence(timeout: 3))
         XCTAssertTrue(computers.waitForExistence(timeout: 3))
         XCTAssertTrue(picker.waitForExistence(timeout: 3))
-        XCTAssertTrue(app.staticTexts["All Computers"].exists)
+        XCTAssertEqual(picker.label, "All Computers")
         let markAllRead = app.buttons["MobileNotificationFeedMarkAllRead"]
         XCTAssertTrue(markAllRead.waitForExistence(timeout: 3))
         XCTAssertLessThanOrEqual(markAllRead.frame.width, 60)

--- a/ios/cmuxUITests/cmuxUITests.swift
+++ b/ios/cmuxUITests/cmuxUITests.swift
@@ -1365,7 +1365,6 @@ final class cmuxUITests: XCTestCase {
             "CMUX_UITEST_WORKSPACE_LIST_PREVIEW_COUNT": "9",
             "CMUX_UITEST_WORKSPACE_LIST_PREVIEW_GROUPS": "2",
             "CMUX_UITEST_WORKSPACE_LIST_PREVIEW_SORT": "recentActivity",
-            "CMUX_UITEST_WORKSPACE_LIST_PREVIEW_RECENCY_BLOCKS": "1",
         ])
         defer { app.terminate() }
 
@@ -1385,44 +1384,63 @@ final class cmuxUITests: XCTestCase {
         let member2 = app.descendants(matching: .any)[
             "MobileWorkspaceRow-workspace-seed-2"
         ]
-        let newestMember = app.descendants(matching: .any)[
+        let member3 = app.descendants(matching: .any)[
             "MobileWorkspaceRow-workspace-seed-3"
         ]
-        let recentUngrouped = app.descendants(matching: .any)[
+        let anchor1 = app.descendants(matching: .any)[
+            "MobileWorkspaceRow-workspace-seed-4"
+        ]
+        let member5 = app.descendants(matching: .any)[
+            "MobileWorkspaceRow-workspace-seed-5"
+        ]
+        let member6 = app.descendants(matching: .any)[
+            "MobileWorkspaceRow-workspace-seed-6"
+        ]
+        let member7 = app.descendants(matching: .any)[
+            "MobileWorkspaceRow-workspace-seed-7"
+        ]
+        let ungrouped = app.descendants(matching: .any)[
             "MobileWorkspaceRow-workspace-seed-8"
         ]
 
-        for element in [group0, group1, member1, member2, newestMember, recentUngrouped] {
+        for element in [
+            group0, group1, member1, member2, member3,
+            member5, member6, member7, ungrouped,
+        ] {
             XCTAssertTrue(element.waitForExistence(timeout: 4))
         }
         XCTAssertFalse(
             anchor0.exists,
             "The group header must represent the anchor without a duplicate workspace row."
         )
+        XCTAssertFalse(
+            anchor1.exists,
+            "Each group header must replace its anchor workspace row."
+        )
 
         let group0Frame = try XCTUnwrap(waitForUsableFrame(of: group0, timeout: 3))
         let member1Frame = try XCTUnwrap(waitForUsableFrame(of: member1, timeout: 3))
         let member2Frame = try XCTUnwrap(waitForUsableFrame(of: member2, timeout: 3))
-        let newestMemberFrame = try XCTUnwrap(
-            waitForUsableFrame(of: newestMember, timeout: 3)
-        )
-        let recentUngroupedFrame = try XCTUnwrap(
-            waitForUsableFrame(of: recentUngrouped, timeout: 3)
+        let member3Frame = try XCTUnwrap(
+            waitForUsableFrame(of: member3, timeout: 3)
         )
         let group1Frame = try XCTUnwrap(waitForUsableFrame(of: group1, timeout: 3))
+        let member5Frame = try XCTUnwrap(waitForUsableFrame(of: member5, timeout: 3))
+        let member6Frame = try XCTUnwrap(waitForUsableFrame(of: member6, timeout: 3))
+        let member7Frame = try XCTUnwrap(waitForUsableFrame(of: member7, timeout: 3))
+        let ungroupedFrame = try XCTUnwrap(waitForUsableFrame(of: ungrouped, timeout: 3))
 
         XCTAssertLessThan(group0Frame.minY, member1Frame.minY)
         XCTAssertLessThan(member1Frame.minY, member2Frame.minY)
-        XCTAssertLessThan(member2Frame.minY, newestMemberFrame.minY)
-        XCTAssertLessThan(
-            newestMemberFrame.minY,
-            recentUngroupedFrame.minY,
-            "A recent ungrouped row must follow the whole group block, not split its members."
-        )
-        XCTAssertLessThan(recentUngroupedFrame.minY, group1Frame.minY)
+        XCTAssertLessThan(member2Frame.minY, member3Frame.minY)
+        XCTAssertLessThan(member3Frame.minY, group1Frame.minY)
+        XCTAssertLessThan(group1Frame.minY, member5Frame.minY)
+        XCTAssertLessThan(member5Frame.minY, member6Frame.minY)
+        XCTAssertLessThan(member6Frame.minY, member7Frame.minY)
+        XCTAssertLessThan(member7Frame.minY, ungroupedFrame.minY)
         XCTAssertGreaterThanOrEqual(
             member1Frame.minX,
-            recentUngroupedFrame.minX + 15,
+            ungroupedFrame.minX + 15,
             "Grouped members must retain their visible nested indentation."
         )
 

--- a/ios/cmuxUITests/cmuxUITests.swift
+++ b/ios/cmuxUITests/cmuxUITests.swift
@@ -1645,7 +1645,16 @@ final class cmuxUITests: XCTestCase {
 
         // Collapsing hides the selected member but does not clear selection.
         let alphaDisclosure = element("MobileWorkspaceGroupDisclosure-mixed-alpha")
+        XCTAssertEqual(alphaDisclosure.label, "Collapse group")
         tap(alphaDisclosure, in: app)
+        let collapsedDisclosure = XCTNSPredicateExpectation(
+            predicate: NSPredicate(format: "label == %@", "Expand group"),
+            object: alphaDisclosure
+        )
+        XCTAssertEqual(
+            XCTWaiter.wait(for: [collapsedDisclosure], timeout: 3),
+            .completed
+        )
         XCTAssertTrue(waitForNotHittable(element(alphaInactiveID), timeout: 3))
         XCTAssertTrue(element(selectedProbeID).exists)
         capture("workspace-groups-12-selection-survives-collapse")
@@ -1699,6 +1708,14 @@ final class cmuxUITests: XCTestCase {
         capture("workspace-groups-15-cleared-search-restores-groups")
 
         tap(alphaDisclosure, in: app)
+        let expandedDisclosure = XCTNSPredicateExpectation(
+            predicate: NSPredicate(format: "label == %@", "Collapse group"),
+            object: alphaDisclosure
+        )
+        XCTAssertEqual(
+            XCTWaiter.wait(for: [expandedDisclosure], timeout: 3),
+            .completed
+        )
         XCTAssertTrue(element(alphaInactiveID).waitForExistence(timeout: 3))
         XCTAssertTrue(element(selectedProbeID).exists)
         capture("workspace-groups-16-selection-survives-expand")
@@ -1772,12 +1789,153 @@ final class cmuxUITests: XCTestCase {
         let sidebarAlphaDisclosure = sidebarElement(
             "MobileWorkspaceGroupDisclosure-mixed-alpha"
         )
+        XCTAssertEqual(sidebarAlphaDisclosure.label, "Collapse group")
         tap(sidebarAlphaDisclosure, in: sidebarApp)
+        let sidebarCollapsedDisclosure = XCTNSPredicateExpectation(
+            predicate: NSPredicate(format: "label == %@", "Expand group"),
+            object: sidebarAlphaDisclosure
+        )
+        XCTAssertEqual(
+            XCTWaiter.wait(for: [sidebarCollapsedDisclosure], timeout: 3),
+            .completed
+        )
         XCTAssertTrue(sidebarSelectedRow.isSelected)
         captureSidebar("workspace-groups-21-visible-selection-group-collapsed")
         tap(sidebarAlphaDisclosure, in: sidebarApp)
+        let sidebarExpandedDisclosure = XCTNSPredicateExpectation(
+            predicate: NSPredicate(format: "label == %@", "Collapse group"),
+            object: sidebarAlphaDisclosure
+        )
+        XCTAssertEqual(
+            XCTWaiter.wait(for: [sidebarExpandedDisclosure], timeout: 3),
+            .completed
+        )
         XCTAssertTrue(sidebarSelectedRow.isSelected)
         captureSidebar("workspace-groups-22-visible-selection-group-expanded")
+    }
+
+    @MainActor
+    func testWorkspaceGroupsFlattenForReadAndMachineFiltersAndRestoreAfterClear() throws {
+        guard #available(iOS 26.0, *) else {
+            throw XCTSkip("The grouped-list filter journey requires iOS 26.")
+        }
+
+        func element(_ identifier: String, in app: XCUIApplication) -> XCUIElement {
+            app.descendants(matching: .any)[identifier]
+        }
+
+        func capture(_ name: String, in app: XCUIApplication) {
+            let attachment = XCTAttachment(screenshot: app.screenshot())
+            attachment.name = name
+            attachment.lifetime = .keepAlways
+            add(attachment)
+        }
+
+        func dismissViewOptions(
+            in app: XCUIApplication,
+            filterButton: XCUIElement
+        ) {
+            app.coordinate(withNormalizedOffset: CGVector(dx: 0.04, dy: 0.72)).tap()
+            XCTAssertTrue(
+                waitForHittable(filterButton, timeout: 3),
+                "The view-options popover did not dismiss."
+            )
+        }
+
+        let alphaHeaderID = "MobileWorkspaceGroupHeader-mixed-alpha"
+        let alphaInactiveID = "MobileWorkspaceRow-workspace-mixed-alpha-inactive"
+        let betaHeaderID = "MobileWorkspaceGroupHeader-mixed-beta"
+        let betaAnchorID = "MobileWorkspaceRow-workspace-mixed-beta-anchor"
+        let betaRecentID = "MobileWorkspaceRow-workspace-mixed-beta-recent"
+        let afterID = "MobileWorkspaceRow-workspace-mixed-after"
+
+        let readApp = launchApp(mockData: false, environment: [
+            "CMUX_UITEST_WORKSPACE_LIST_PREVIEW": "1",
+            "CMUX_UITEST_WORKSPACE_LIST_PREVIEW_MIXED_GROUPS": "1",
+            "CMUX_UITEST_WORKSPACE_LIST_PREVIEW_REORDER": "1",
+            "CMUX_UITEST_WORKSPACE_LIST_PREVIEW_TABS": "1",
+            "CMUX_UITEST_WORKSPACE_LIST_PREVIEW_SORT": "recentActivity",
+        ])
+        defer { readApp.terminate() }
+
+        let readFilterButton = readApp.buttons["MobileWorkspaceFilterMenu"]
+        XCTAssertTrue(readFilterButton.waitForExistence(timeout: 8))
+        XCTAssertTrue(element(alphaHeaderID, in: readApp).waitForExistence(timeout: 3))
+        XCTAssertTrue(element(betaHeaderID, in: readApp).waitForExistence(timeout: 3))
+
+        tap(readFilterButton, in: readApp)
+        let unreadButton = readApp.buttons["Unread"]
+        XCTAssertTrue(waitForHittable(unreadButton, timeout: 3))
+        tap(unreadButton, in: readApp)
+        dismissViewOptions(in: readApp, filterButton: readFilterButton)
+
+        let unreadAlpha = element(alphaInactiveID, in: readApp)
+        let unreadBeta = element(betaRecentID, in: readApp)
+        XCTAssertTrue(unreadAlpha.waitForExistence(timeout: 3))
+        XCTAssertTrue(unreadBeta.waitForExistence(timeout: 3))
+        XCTAssertFalse(element(alphaHeaderID, in: readApp).exists)
+        XCTAssertFalse(element(betaHeaderID, in: readApp).exists)
+        XCTAssertEqual(unreadAlpha.frame.minX, unreadBeta.frame.minX, accuracy: 2)
+        capture("workspace-filters-01-unread-flat", in: readApp)
+
+        tap(readFilterButton, in: readApp)
+        let allWorkspacesButton = readApp.buttons["All Workspaces"]
+        XCTAssertTrue(waitForHittable(allWorkspacesButton, timeout: 3))
+        tap(allWorkspacesButton, in: readApp)
+        dismissViewOptions(in: readApp, filterButton: readFilterButton)
+        XCTAssertTrue(element(alphaHeaderID, in: readApp).waitForExistence(timeout: 3))
+        XCTAssertTrue(element(betaHeaderID, in: readApp).waitForExistence(timeout: 3))
+        XCTAssertGreaterThanOrEqual(
+            element(alphaInactiveID, in: readApp).frame.minX,
+            element(afterID, in: readApp).frame.minX + 15
+        )
+        capture("workspace-filters-02-unread-cleared-regrouped", in: readApp)
+        readApp.terminate()
+
+        let machineApp = launchApp(mockData: false, environment: [
+            "CMUX_UITEST_WORKSPACE_LIST_PREVIEW": "1",
+            "CMUX_UITEST_WORKSPACE_LIST_PREVIEW_MIXED_GROUPS": "1",
+            "CMUX_UITEST_WORKSPACE_LIST_PREVIEW_REORDER": "1",
+            "CMUX_UITEST_WORKSPACE_LIST_PREVIEW_TABS": "1",
+            "CMUX_UITEST_WORKSPACE_LIST_PREVIEW_SORT": "recentActivity",
+            "CMUX_UITEST_WORKSPACE_LIST_PREVIEW_FILTER_MACHINE": "preview-studio",
+        ])
+        defer { machineApp.terminate() }
+
+        let machinePicker = machineApp.buttons["MobileWorkspaceMacPicker"]
+        XCTAssertTrue(machinePicker.waitForExistence(timeout: 8))
+        XCTAssertEqual(machinePicker.label, "All Computers")
+        let flatBetaAnchor = element(betaAnchorID, in: machineApp)
+        let flatBetaMember = element(betaRecentID, in: machineApp)
+        let flatAfter = element(afterID, in: machineApp)
+        XCTAssertTrue(flatBetaAnchor.waitForExistence(timeout: 3))
+        XCTAssertTrue(flatBetaMember.waitForExistence(timeout: 3))
+        XCTAssertTrue(flatAfter.waitForExistence(timeout: 3))
+        XCTAssertFalse(element(betaHeaderID, in: machineApp).exists)
+        XCTAssertFalse(element(alphaHeaderID, in: machineApp).exists)
+        XCTAssertEqual(flatBetaAnchor.frame.minX, flatBetaMember.frame.minX, accuracy: 2)
+        XCTAssertEqual(flatBetaMember.frame.minX, flatAfter.frame.minX, accuracy: 2)
+        capture("workspace-filters-03-machine-flat", in: machineApp)
+
+        tap(machinePicker, in: machineApp)
+        let studioMenuItem = machineApp.buttons[
+            "MobileWorkspaceMacPickerMachine-preview-studio-stable"
+        ]
+        XCTAssertTrue(studioMenuItem.waitForExistence(timeout: 3))
+        tapMenuItem(studioMenuItem, in: machineApp)
+        XCTAssertTrue(element(betaHeaderID, in: machineApp).waitForExistence(timeout: 3))
+        XCTAssertFalse(element(betaAnchorID, in: machineApp).exists)
+        XCTAssertGreaterThanOrEqual(
+            element(betaRecentID, in: machineApp).frame.minX,
+            element(afterID, in: machineApp).frame.minX + 15
+        )
+        capture("workspace-filters-04-machine-filter-cleared", in: machineApp)
+
+        tap(machinePicker, in: machineApp)
+        tapMenuItem(machineApp.buttons["MobileWorkspaceMacPickerAll"], in: machineApp)
+        XCTAssertTrue(element(alphaHeaderID, in: machineApp).waitForExistence(timeout: 3))
+        XCTAssertTrue(element(betaHeaderID, in: machineApp).waitForExistence(timeout: 3))
+        capture("workspace-filters-05-all-computers-regrouped", in: machineApp)
     }
 
     /// Regression: the iOS 26 workspace table must underlap the navigation

--- a/ios/cmuxUITests/cmuxUITests.swift
+++ b/ios/cmuxUITests/cmuxUITests.swift
@@ -1475,6 +1475,60 @@ final class cmuxUITests: XCTestCase {
         let automaticTileID = "MobileWorkspaceSortTile-automatic"
         let automaticTileLabel = "Last Opened"
 
+        func captureGroupedTransitionBurst(
+            _ prefix: String,
+            rootID: String,
+            samples: Int = 8
+        ) {
+            for sample in 1...samples {
+                XCTAssertTrue(
+                    element(alphaHeaderID).exists,
+                    "\(prefix) sample \(sample): Alpha header disappeared."
+                )
+                XCTAssertTrue(
+                    element(betaHeaderID).exists,
+                    "\(prefix) sample \(sample): Beta header disappeared."
+                )
+                let rootFrame = element(rootID).frame
+                XCTAssertGreaterThanOrEqual(
+                    element(alphaInactiveID).frame.minX,
+                    rootFrame.minX + 15,
+                    "\(prefix) sample \(sample): Alpha member flattened."
+                )
+                XCTAssertGreaterThanOrEqual(
+                    element(betaRecentID).frame.minX,
+                    rootFrame.minX + 15,
+                    "\(prefix) sample \(sample): Beta member flattened."
+                )
+                XCTAssertTrue(
+                    element(selectedProbeID).exists,
+                    "\(prefix) sample \(sample): selection identity disappeared."
+                )
+                capture("\(prefix)-\(String(format: "%02d", sample))")
+            }
+        }
+
+        func captureHeaderTransitionBurst(
+            _ prefix: String,
+            samples: Int = 8
+        ) {
+            for sample in 1...samples {
+                XCTAssertTrue(
+                    element(alphaHeaderID).exists,
+                    "\(prefix) sample \(sample): Alpha header disappeared."
+                )
+                XCTAssertTrue(
+                    element(betaHeaderID).exists,
+                    "\(prefix) sample \(sample): Beta header disappeared."
+                )
+                XCTAssertTrue(
+                    element(selectedProbeID).exists,
+                    "\(prefix) sample \(sample): selection identity disappeared."
+                )
+                capture("\(prefix)-\(String(format: "%02d", sample))")
+            }
+        }
+
         let workspaceList = element("MobileWorkspaceList")
         XCTAssertTrue(workspaceList.waitForExistence(timeout: 8))
         XCTAssertTrue(macPicker.waitForExistence(timeout: 8))
@@ -1536,12 +1590,20 @@ final class cmuxUITests: XCTestCase {
         // transitions, and Automatic restores the incoming grouped topology.
         tap(filterButton, in: app)
         tap(sortTile(recentTileID, label: recentTileLabel, in: app), in: app)
+        captureGroupedTransitionBurst(
+            "workspace-transition-recent-activity",
+            rootID: afterID
+        )
         XCTAssertTrue(element(selectedProbeID).exists)
         XCTAssertTrue(
             sortTile(recentTileID, label: recentTileLabel, in: app).isSelected
         )
         capture("workspace-groups-05-recent-activity-control")
         tap(sortTile(automaticTileID, label: automaticTileLabel, in: app), in: app)
+        captureGroupedTransitionBurst(
+            "workspace-transition-automatic",
+            rootID: beforeID
+        )
         XCTAssertTrue(element(selectedProbeID).exists)
         XCTAssertTrue(
             sortTile(automaticTileID, label: automaticTileLabel, in: app).isSelected
@@ -1647,6 +1709,7 @@ final class cmuxUITests: XCTestCase {
         let alphaDisclosure = element("MobileWorkspaceGroupDisclosure-mixed-alpha")
         XCTAssertEqual(alphaDisclosure.label, "Collapse group")
         tap(alphaDisclosure, in: app)
+        captureHeaderTransitionBurst("workspace-transition-collapse")
         let collapsedDisclosure = XCTNSPredicateExpectation(
             predicate: NSPredicate(format: "label == %@", "Expand group"),
             object: alphaDisclosure
@@ -1708,6 +1771,7 @@ final class cmuxUITests: XCTestCase {
         capture("workspace-groups-15-cleared-search-restores-groups")
 
         tap(alphaDisclosure, in: app)
+        captureHeaderTransitionBurst("workspace-transition-expand")
         let expandedDisclosure = XCTNSPredicateExpectation(
             predicate: NSPredicate(format: "label == %@", "Collapse group"),
             object: alphaDisclosure

--- a/ios/cmuxUITests/cmuxUITests.swift
+++ b/ios/cmuxUITests/cmuxUITests.swift
@@ -1308,15 +1308,17 @@ final class cmuxUITests: XCTestCase {
     }
 
     @MainActor
-    func testWorkspaceMacPickerUsesComputerCopy() throws {
+    func testWorkspaceMacPickerUsesComputerCopyAndAnnouncesConnectionStatus() throws {
         let app = launchApp(mockData: false, environment: [
             "CMUX_UITEST_WORKSPACE_LIST_PREVIEW": "1",
+            "CMUX_UITEST_WORKSPACE_LIST_PREVIEW_CONNECTION_STATUS": "reconnecting",
         ])
         defer { app.terminate() }
 
         let picker = app.buttons["MobileWorkspaceMacPicker"]
         XCTAssertTrue(picker.waitForExistence(timeout: 8))
         XCTAssertEqual(picker.label, "All Computers")
+        XCTAssertEqual(picker.value as? String, "Reconnecting…")
 
         picker.tap()
 

--- a/ios/cmuxUITests/cmuxUITests.swift
+++ b/ios/cmuxUITests/cmuxUITests.swift
@@ -1584,66 +1584,6 @@ final class cmuxUITests: XCTestCase {
         XCTAssertTrue(element(selectedProbeID).exists)
         capture("workspace-groups-08-recent-activity-grouped")
 
-        // Collapsing hides the selected member but does not clear selection.
-        let alphaDisclosure = element("MobileWorkspaceGroupDisclosure-mixed-alpha")
-        tap(alphaDisclosure, in: app)
-        XCTAssertTrue(waitForNotHittable(element(alphaInactiveID), timeout: 3))
-        XCTAssertTrue(element(selectedProbeID).exists)
-        capture("workspace-groups-09-selection-survives-collapse")
-
-        // Search intentionally flattens matching rows. Clearing it restores
-        // grouped sections and the pre-search collapsed state.
-        let searchButton = app.tabBars.buttons
-            .matching(NSPredicate(format: "label == %@", "Search"))
-            .firstMatch
-        tap(searchButton, in: app)
-        let searchField = app.searchFields["Search workspaces"]
-        XCTAssertTrue(waitForHittable(searchField, timeout: 3))
-        XCTAssertTrue(focusTextInput(searchField, in: app))
-        searchField.typeText("Inactive Member")
-        XCTAssertTrue(waitForHittable(element(alphaInactiveID), timeout: 3))
-        XCTAssertTrue(waitForNotHittable(element(alphaHeaderID), timeout: 3))
-        XCTAssertTrue(waitForNotHittable(element(betaHeaderID), timeout: 3))
-        let searchFrame = try XCTUnwrap(
-            waitForUsableFrame(of: element(alphaInactiveID), timeout: 3)
-        )
-        XCTAssertEqual(
-            searchFrame.minX,
-            computerFrames[beforeID]!.minX,
-            accuracy: 2,
-            "Search results must flatten the matching group member."
-        )
-        capture("workspace-groups-10-search-flat")
-
-        XCTAssertTrue(focusTextInput(searchField, in: app))
-        searchField.typeText(
-            String(repeating: XCUIKeyboardKey.delete.rawValue, count: 32)
-        )
-        XCTAssertTrue(element(betaHeaderID).waitForExistence(timeout: 3))
-        capture("workspace-groups-11-search-cleared-regrouped")
-
-        tap(app.tabBars.buttons["Workspaces"], in: app)
-        XCTAssertTrue(workspaceList.waitForExistence(timeout: 3))
-        let collapsedRecentOrder = [
-            afterID,
-            betaHeaderID,
-            betaRecentID,
-            betweenID,
-            alphaHeaderID,
-            beforeID,
-        ]
-        XCTAssertNotNil(
-            orderedFrames(collapsedRecentOrder, state: "Cleared search")
-        )
-        XCTAssertTrue(waitForNotHittable(element(alphaInactiveID), timeout: 3))
-        XCTAssertTrue(element(selectedProbeID).exists)
-        capture("workspace-groups-12-cleared-search-restores-groups")
-
-        tap(alphaDisclosure, in: app)
-        XCTAssertTrue(element(alphaInactiveID).waitForExistence(timeout: 3))
-        XCTAssertTrue(element(selectedProbeID).exists)
-        capture("workspace-groups-13-selection-survives-expand")
-
         // Scope to one computer through the production title picker. Recent
         // Activity must not rewrite that Mac's own group and sidebar order.
         tap(macPicker, in: app)
@@ -1668,7 +1608,7 @@ final class cmuxUITests: XCTestCase {
                 state: "Single computer"
             )
         )
-        capture("workspace-groups-14-single-computer-keeps-sidebar-order")
+        capture("workspace-groups-09-single-computer-keeps-sidebar-order")
 
         tap(filterButton, in: app)
         XCTAssertTrue(app.staticTexts["All Workspaces"].waitForExistence(timeout: 3))
@@ -1682,7 +1622,7 @@ final class cmuxUITests: XCTestCase {
         XCTAssertFalse(sortTile(
             computerOrderTileID, label: computerOrderTileLabel, in: app, timeout: 0
         ).exists)
-        capture("workspace-groups-15-single-computer-hides-sort")
+        capture("workspace-groups-10-single-computer-hides-sort")
         dismissViewOptions()
 
         // Returning to All Computers restores both groups and the persisted
@@ -1701,7 +1641,67 @@ final class cmuxUITests: XCTestCase {
             orderedFrames(recentActivityOrder, state: "All Computers restored")
         )
         XCTAssertTrue(element(selectedProbeID).exists)
-        capture("workspace-groups-16-all-computers-regrouped")
+        capture("workspace-groups-11-all-computers-regrouped")
+
+        // Collapsing hides the selected member but does not clear selection.
+        let alphaDisclosure = element("MobileWorkspaceGroupDisclosure-mixed-alpha")
+        tap(alphaDisclosure, in: app)
+        XCTAssertTrue(waitForNotHittable(element(alphaInactiveID), timeout: 3))
+        XCTAssertTrue(element(selectedProbeID).exists)
+        capture("workspace-groups-12-selection-survives-collapse")
+
+        // Search intentionally flattens matching rows. Clearing it restores
+        // grouped sections and the pre-search collapsed state.
+        let searchButton = app.tabBars.buttons
+            .matching(NSPredicate(format: "label == %@", "Search"))
+            .firstMatch
+        tap(searchButton, in: app)
+        let searchField = app.searchFields["Search workspaces"]
+        XCTAssertTrue(waitForHittable(searchField, timeout: 3))
+        XCTAssertTrue(focusTextInput(searchField, in: app))
+        searchField.typeText("Inactive Member")
+        XCTAssertTrue(waitForHittable(element(alphaInactiveID), timeout: 3))
+        XCTAssertTrue(waitForNotHittable(element(alphaHeaderID), timeout: 3))
+        XCTAssertTrue(waitForNotHittable(element(betaHeaderID), timeout: 3))
+        let searchFrame = try XCTUnwrap(
+            waitForUsableFrame(of: element(alphaInactiveID), timeout: 3)
+        )
+        XCTAssertEqual(
+            searchFrame.minX,
+            computerFrames[beforeID]!.minX,
+            accuracy: 2,
+            "Search results must flatten the matching group member."
+        )
+        capture("workspace-groups-13-search-flat")
+
+        XCTAssertTrue(focusTextInput(searchField, in: app))
+        searchField.typeText(
+            String(repeating: XCUIKeyboardKey.delete.rawValue, count: 32)
+        )
+        XCTAssertTrue(element(betaHeaderID).waitForExistence(timeout: 3))
+        capture("workspace-groups-14-search-cleared-regrouped")
+
+        tap(app.tabBars.buttons["Workspaces"], in: app)
+        XCTAssertTrue(workspaceList.waitForExistence(timeout: 3))
+        let collapsedRecentOrder = [
+            afterID,
+            betaHeaderID,
+            betaRecentID,
+            betweenID,
+            alphaHeaderID,
+            beforeID,
+        ]
+        XCTAssertNotNil(
+            orderedFrames(collapsedRecentOrder, state: "Cleared search")
+        )
+        XCTAssertTrue(waitForNotHittable(element(alphaInactiveID), timeout: 3))
+        XCTAssertTrue(element(selectedProbeID).exists)
+        capture("workspace-groups-15-cleared-search-restores-groups")
+
+        tap(alphaDisclosure, in: app)
+        XCTAssertTrue(element(alphaInactiveID).waitForExistence(timeout: 3))
+        XCTAssertTrue(element(selectedProbeID).exists)
+        capture("workspace-groups-16-selection-survives-expand")
 
         // A second phase uses the fixture's opt-in sidebar navigation style.
         // It keeps production row rendering and actions, while making the


### PR DESCRIPTION
## Summary
- keep All Computers workspace groups visible under Recent Activity
- rank each group as one atomic block by its newest member while preserving sidebar order, collapse, and unread behavior
- add package behavior coverage and a focused hosted iOS hierarchy regression

## Task
Fix iOS All Computers so Recent Activity no longer flattens workspace groups into ordinary workspace rows. Group headers and indented members must remain contiguous across computers, with stable recency ordering and no regressions to filters or single-computer views.

## Testing
- swift test --package-path Packages/iOS/CmuxMobileShellModel --filter MobileWorkspaceRecencyOrderTests
- xcrun swiftc -parse on changed Swift source and regression files
- grouping, sort, selection, search, scope, collapse, and expand: https://github.com/manaflow-ai/cmux/actions/runs/31499095383/job/93804682148
- read-state and machine-filter flatten/restore: https://github.com/manaflow-ai/cmux/actions/runs/31499098873/job/93804660486
- picker copy and connection-status accessibility: https://github.com/manaflow-ai/cmux/actions/runs/31502193894/job/93815236588
- multi-member grouped order and stable tied/missing timestamps: https://github.com/manaflow-ai/cmux/actions/runs/31506179703/job/93829006340
- 1,000-workspace grouped projection: release median 1.020 ms, p99 1.490 ms, maximum 2.438 ms on the main thread

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core workspace list ordering and grouped projection in the mobile shell; behavior is heavily tested but mistakes could affect selection, collapse, and drag reconciliation.
> 
> **Overview**
> **All Computers + Recent Activity** no longer flattens workspace groups into a single interleaved list. Grouped sections stay visible; each group moves as one **display block** ranked by its newest `lastActivityAt`, with members still in Mac sidebar order (including timestamp-less members). Ungrouped rows rank on their own. Search, filters, and single-computer scope still use flat presentation where they did before.
> 
> `MobileWorkspaceRecencyOrder` adds **`groupedDisplayItems`** to build headers, indented members, and footers from those blocks while preserving pinned-first rules and stable tie-breaking.
> 
> `WorkspaceListView` wires recency into grouped rendering ( **`rendersGroupedSections`** no longer turns off for recency), feeds the table from precomputed **`groupedItems`**, and uses separate **displayed vs authoritative** `WorkspaceListGroupedProjectionCache` instances so optimistic drag reconciliation does not thrash the on-screen projection.
> 
> Also: Mac picker accessibility identifiers and connection status on the combined label; **`.isSelected`** on sidebar workspace rows; sort-picker schematic and preview fixtures for mixed-group UI/E2E coverage.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4f3529ae942a4f1eea2d133073caaa62b63ee746. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keeps workspace groups intact in All Computers > Recent Activity by treating each group as one block ranked by its newest member. Search and filters flatten only while active; clearing restores grouped sections; selection and accessibility remain stable.

- **Bug Fixes**
  - Aligned grouped sort contracts: the table renders from precomputed `groupedItems`, and drag reconciliation uses authoritative grouped order keys.
  - Selection survives sort changes, collapse/expand, and back navigation; sidebar and table rows expose `.isSelected` for visibility and accessibility.
  - Updated sort and filter behavior: Recent Activity schematic shows grouped sections; Unread and machine filters flatten rows and clearing restores groups; single-computer scope hides sort tiles.
  - Added stable accessibility identifiers for the Mac picker button, its “All Computers” menu item, and machine entries; the picker label reflects the current selection and announces connection status.

- **Performance**
  - Introduced a synchronous `WorkspaceListGroupedProjectionCache` with separate displayed vs authoritative caches; reuses the grouped projection snapshot when optimism clears.
  - Reused a per-render `workspacesByID` map in grouped rows and appended group members in place.
  - Kept a 1,000‑workspace projection under 100 ms; added deterministic UI tests with dense sampling of grouped transitions covering selection, grouped recency ordering, search and filter flattening, single‑computer gating, stable picker/sort tile identifiers, and computer scoping before search.

<sup>Written for commit d3e502c0e02d5e307e548cd89e9a99180160656c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/9960?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Recent Activity now keeps workspace groups together as complete sections when sorting.
  * Groups are ordered by pin status and latest activity, while preserving the order of members.
  * Ungrouped workspaces remain separate and appear alongside grouped sections.
  * Collapsed groups, unread states, and groups with missing or invalid metadata are handled consistently.
  * Grouped workspace lists remain responsive and accurate across large workspace collections.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
