### PR TITLE
fix: resolve path:line links and local file URLs

### DIFF
--- a/CLI/cmux_open.swift
+++ b/CLI/cmux_open.swift
@@ -1,4 +1,5 @@
 import CryptoKit
+import CmuxTerminalCore
 import Darwin
 import Foundation
 
@@ -1466,7 +1467,18 @@ extension CMUXCLI {
             return .url(url.absoluteString, defaultFocus: true)
         }
 
-        let resolved = resolvePath(raw)
+        let resolved: String
+        if let reference = TerminalPathResolver().resolveOpenURLFileReference(
+            raw,
+            cwd: FileManager.default.currentDirectoryPath
+        ) {
+            // The socket file.open contract is path-only. Normalize the
+            // location suffix here so `cmux open path:line` opens the file;
+            // terminal Cmd-click retains the location for the editor path.
+            resolved = reference.path
+        } else {
+            resolved = resolvePath(raw)
+        }
         var isDir: ObjCBool = false
         guard FileManager.default.fileExists(atPath: resolved, isDirectory: &isDir) else {
             throw CLIError(message: "Path does not exist: \(resolved)")

--- a/Packages/macOS/CmuxTerminalCore/Sources/CmuxTerminalCore/PathResolution/TerminalFileReference.swift
+++ b/Packages/macOS/CmuxTerminalCore/Sources/CmuxTerminalCore/PathResolution/TerminalFileReference.swift
@@ -7,10 +7,10 @@ public struct TerminalFileReference: Equatable, Sendable {
     public let line: Int?
     public let column: Int?
 
-    /// Creates a reference for an existing local file and optional location.
+    /// Creates a reference for a local file and optional location.
     ///
     /// - Parameters:
-    ///   - path: The standardized local file path.
+    ///   - path: The local file path.
     ///   - line: An optional one-based source line.
     ///   - column: An optional one-based source column.
     public init(path: String, line: Int? = nil, column: Int? = nil) {

--- a/Packages/macOS/CmuxTerminalCore/Sources/CmuxTerminalCore/PathResolution/TerminalFileReference.swift
+++ b/Packages/macOS/CmuxTerminalCore/Sources/CmuxTerminalCore/PathResolution/TerminalFileReference.swift
@@ -1,0 +1,15 @@
+import Foundation
+
+/// An existing local file referenced by terminal text, optionally at a source
+/// location.
+public struct TerminalFileReference: Equatable, Sendable {
+    public let path: String
+    public let line: Int?
+    public let column: Int?
+
+    public init(path: String, line: Int? = nil, column: Int? = nil) {
+        self.path = path
+        self.line = line
+        self.column = column
+    }
+}

--- a/Packages/macOS/CmuxTerminalCore/Sources/CmuxTerminalCore/PathResolution/TerminalFileReference.swift
+++ b/Packages/macOS/CmuxTerminalCore/Sources/CmuxTerminalCore/PathResolution/TerminalFileReference.swift
@@ -7,6 +7,12 @@ public struct TerminalFileReference: Equatable, Sendable {
     public let line: Int?
     public let column: Int?
 
+    /// Creates a reference for an existing local file and optional location.
+    ///
+    /// - Parameters:
+    ///   - path: The standardized local file path.
+    ///   - line: An optional one-based source line.
+    ///   - column: An optional one-based source column.
     public init(path: String, line: Int? = nil, column: Int? = nil) {
         self.path = path
         self.line = line

--- a/Packages/macOS/CmuxTerminalCore/Sources/CmuxTerminalCore/PathResolution/TerminalPathResolver.swift
+++ b/Packages/macOS/CmuxTerminalCore/Sources/CmuxTerminalCore/PathResolution/TerminalPathResolver.swift
@@ -90,19 +90,103 @@ public struct TerminalPathResolver: Sendable {
         return nil
     }
 
+    /// Resolves an open-URL request payload to an existing local file.
+    ///
+    /// The resolver tries the literal file spelling before interpreting a
+    /// trailing `:line` or `:line:column` suffix. This keeps legitimate file
+    /// names such as `report:42` addressable while still accepting the form
+    /// emitted by compilers, test runners, and coding agents. Local `file://`
+    /// URLs are accepted; URL schemes for remote or non-file resources are
+    /// left to the URL router.
+    ///
+    /// - Parameters:
+    ///   - rawText: The raw open-URL text from the runtime.
+    ///   - cwd: The surface's working directory.
+    /// - Returns: The first existing reference, or `nil`.
+    public func resolveOpenURLFileReference(
+        _ rawText: String,
+        cwd: String?
+    ) -> TerminalFileReference? {
+        let trimmed = rawText.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return nil }
+
+        for token in trimmed.pathResolutionCandidates() {
+            let normalizedToken = token.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !normalizedToken.isEmpty else { continue }
+
+            if let path = localFilePath(for: normalizedToken),
+               let resolvedPath = resolveQuicklookPath(path, cwd: cwd) {
+                return TerminalFileReference(path: resolvedPath)
+            }
+
+            guard let location = parseLocationSuffix(in: normalizedToken),
+                  let path = localFilePath(for: location.path),
+                  let resolvedPath = resolveQuicklookPath(path, cwd: cwd) else {
+                continue
+            }
+            return TerminalFileReference(
+                path: resolvedPath,
+                line: location.line,
+                column: location.column
+            )
+        }
+
+        return nil
+    }
+
     /// Resolves an open-URL request payload to an existing file path.
     ///
-    /// Text that parses as a URL with a scheme is never treated as a file
-    /// path; everything else goes through ``resolveQuicklookPath(_:cwd:)``.
+    /// Location information is intentionally discarded by this compatibility
+    /// API. Call ``resolveOpenURLFileReference(_:cwd:)`` when the caller needs
+    /// the source line or column.
     ///
     /// - Parameters:
     ///   - rawText: The raw open-URL text from the runtime.
     ///   - cwd: The surface's working directory.
     /// - Returns: The first existing standardized path, or `nil`.
     public func resolveOpenURLFilePath(_ rawText: String, cwd: String?) -> String? {
-        let trimmed = rawText.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !trimmed.isEmpty else { return nil }
-        guard URL(string: trimmed)?.scheme == nil else { return nil }
-        return resolveQuicklookPath(trimmed, cwd: cwd)
+        resolveOpenURLFileReference(rawText, cwd: cwd)?.path
+    }
+
+    private func localFilePath(for token: String) -> String? {
+        guard let url = URL(string: token), let scheme = url.scheme else {
+            return token
+        }
+
+        guard scheme.caseInsensitiveCompare("file") == .orderedSame else {
+            return nil
+        }
+        guard url.host == nil || url.host?.isEmpty == true || url.host == "localhost" else {
+            return nil
+        }
+        return url.path
+    }
+
+    private func parseLocationSuffix(
+        in token: String
+    ) -> (path: String, line: Int, column: Int?)? {
+        guard let lastColon = token.lastIndex(of: ":") else { return nil }
+        let lastComponent = String(token[token.index(after: lastColon)...])
+        guard let lastNumber = positiveInteger(lastComponent) else { return nil }
+
+        let pathEnd = lastColon
+        let pathWithLine = String(token[..<pathEnd])
+        guard let lineColon = pathWithLine.lastIndex(of: ":") else {
+            return (pathWithLine, lastNumber, nil)
+        }
+
+        let lineComponent = String(pathWithLine[pathWithLine.index(after: lineColon)...])
+        guard let lineNumber = positiveInteger(lineComponent) else {
+            return (pathWithLine, lastNumber, nil)
+        }
+
+        let path = String(pathWithLine[..<lineColon])
+        guard !path.isEmpty else { return nil }
+        return (path, lineNumber, lastNumber)
+    }
+
+    private func positiveInteger(_ rawValue: String) -> Int? {
+        guard let value = Int(rawValue), value > 0 else { return nil }
+        return value
     }
 }

--- a/Packages/macOS/CmuxTerminalCore/Sources/CmuxTerminalCore/PathResolution/TerminalPathResolver.swift
+++ b/Packages/macOS/CmuxTerminalCore/Sources/CmuxTerminalCore/PathResolution/TerminalPathResolver.swift
@@ -120,8 +120,20 @@ public struct TerminalPathResolver: Sendable {
             }
 
             guard let location = parseLocationSuffix(in: normalizedToken),
-                  let path = localFilePath(for: location.path),
-                  let resolvedPath = resolveQuicklookPath(path, cwd: cwd) else {
+                  let path = localFilePath(for: location.path) else {
+                continue
+            }
+
+            // A relative name such as `report:42` is parsed by Foundation as
+            // a custom URL scheme. Once its suffix is known to be a location
+            // and the location path itself is schemeless, probe the complete
+            // spelling before treating it as `path:line`. This preserves a
+            // real file named `report:42` without admitting non-file URLs.
+            if !isExplicitFileURL(normalizedToken),
+               let literalPath = resolveQuicklookPath(normalizedToken, cwd: cwd) {
+                return TerminalFileReference(path: literalPath)
+            }
+            guard let resolvedPath = resolveQuicklookPath(path, cwd: cwd) else {
                 continue
             }
             return TerminalFileReference(
@@ -148,6 +160,7 @@ public struct TerminalPathResolver: Sendable {
         resolveOpenURLFileReference(rawText, cwd: cwd)?.path
     }
 
+    /// Converts a token into a local path while rejecting non-file URL schemes.
     private func localFilePath(for token: String) -> String? {
         guard let url = URL(string: token), let scheme = url.scheme else {
             return token
@@ -162,6 +175,12 @@ public struct TerminalPathResolver: Sendable {
         return url.path
     }
 
+    /// Returns whether `token` is an explicit local `file` URL.
+    private func isExplicitFileURL(_ token: String) -> Bool {
+        URL(string: token)?.scheme?.caseInsensitiveCompare("file") == .orderedSame
+    }
+
+    /// Parses a positive `:line` or `:line:column` suffix from a token.
     private func parseLocationSuffix(
         in token: String
     ) -> (path: String, line: Int, column: Int?)? {
@@ -185,6 +204,7 @@ public struct TerminalPathResolver: Sendable {
         return (path, lineNumber, lastNumber)
     }
 
+    /// Returns a positive integer for a valid source location component.
     private func positiveInteger(_ rawValue: String) -> Int? {
         guard let value = Int(rawValue), value > 0 else { return nil }
         return value

--- a/Packages/macOS/CmuxTerminalCore/Tests/CmuxTerminalCoreTests/TerminalPathResolverTests.swift
+++ b/Packages/macOS/CmuxTerminalCore/Tests/CmuxTerminalCoreTests/TerminalPathResolverTests.swift
@@ -174,6 +174,15 @@ private func existsIn(_ existingPaths: Set<String>) -> @Sendable (String) -> Boo
         )
     }
 
+    @Test func rejectsNonFileSchemeEvenWithNumericLocationSuffix() {
+        #expect(
+            TerminalPathResolver(fileExists: { _ in true }).resolveOpenURLFileReference(
+                "https://example.com:8080/page:5",
+                cwd: "/tmp"
+            ) == nil
+        )
+    }
+
     @Test func schemelessRelativeAndAbsoluteTextStaysEligible() {
         let relative = "/Users/dev/project/docs/specs/2026-05-22-test.md"
         #expect(
@@ -214,7 +223,20 @@ private func existsIn(_ existingPaths: Set<String>) -> @Sendable (String) -> Boo
         let literalPath = "/tmp/report:42"
         let reference = try #require(
             TerminalPathResolver(fileExists: existsIn([literalPath, "/tmp/report"])).resolveOpenURLFileReference(
-                literalPath,
+                "report:42",
+                cwd: "/tmp"
+            )
+        )
+        #expect(reference.path == literalPath)
+        #expect(reference.line == nil)
+        #expect(reference.column == nil)
+    }
+
+    @Test func resolvesRelativeLiteralColonPathWhenBasePathIsMissing() throws {
+        let literalPath = "/tmp/report:42"
+        let reference = try #require(
+            TerminalPathResolver(fileExists: existsIn([literalPath])).resolveOpenURLFileReference(
+                "report:42",
                 cwd: "/tmp"
             )
         )

--- a/Packages/macOS/CmuxTerminalCore/Tests/CmuxTerminalCoreTests/TerminalPathResolverTests.swift
+++ b/Packages/macOS/CmuxTerminalCore/Tests/CmuxTerminalCoreTests/TerminalPathResolverTests.swift
@@ -168,12 +168,6 @@ private func existsIn(_ existingPaths: Set<String>) -> @Sendable (String) -> Boo
     @Test func textWithURLSchemeIsNeverTreatedAsFilePath() {
         #expect(
             TerminalPathResolver(fileExists: { _ in true }).resolveOpenURLFilePath(
-                "file:///tmp/test.md",
-                cwd: "/tmp"
-            ) == nil
-        )
-        #expect(
-            TerminalPathResolver(fileExists: { _ in true }).resolveOpenURLFilePath(
                 "mailto:test@example.com",
                 cwd: "/tmp"
             ) == nil

--- a/Packages/macOS/CmuxTerminalCore/Tests/CmuxTerminalCoreTests/TerminalPathResolverTests.swift
+++ b/Packages/macOS/CmuxTerminalCore/Tests/CmuxTerminalCoreTests/TerminalPathResolverTests.swift
@@ -189,6 +189,45 @@ private func existsIn(_ existingPaths: Set<String>) -> @Sendable (String) -> Boo
             ) == relative
         )
     }
+
+    @Test func resolvesPathWithLineAndColumn() throws {
+        let existingFile = "/Users/dev/project/src/main.swift"
+        let reference = try #require(
+            TerminalPathResolver(fileExists: existsIn([existingFile])).resolveOpenURLFileReference(
+                "src/main.swift:42:5",
+                cwd: "/Users/dev/project"
+            )
+        )
+        #expect(reference.path == existingFile)
+        #expect(reference.line == 42)
+        #expect(reference.column == 5)
+    }
+
+    @Test func resolvesLocalFileURL() throws {
+        let existingFile = "/Users/dev/project/src/main.swift"
+        let reference = try #require(
+            TerminalPathResolver(fileExists: existsIn([existingFile])).resolveOpenURLFileReference(
+                "file:///Users/dev/project/src/main.swift:42",
+                cwd: "/Users/dev/project"
+            )
+        )
+        #expect(reference.path == existingFile)
+        #expect(reference.line == 42)
+        #expect(reference.column == nil)
+    }
+
+    @Test func prefersLiteralPathBeforeInterpretingLocationSuffix() throws {
+        let literalPath = "/tmp/report:42"
+        let reference = try #require(
+            TerminalPathResolver(fileExists: existsIn([literalPath, "/tmp/report"])).resolveOpenURLFileReference(
+                literalPath,
+                cwd: "/tmp"
+            )
+        )
+        #expect(reference.path == literalPath)
+        #expect(reference.line == nil)
+        #expect(reference.column == nil)
+    }
 }
 
 @Suite struct TerminalVisibleLineResolutionTests {

--- a/Packages/macOS/CmuxWorkspaces/Sources/CmuxWorkspaces/FileOpen/PreferredEditorService.swift
+++ b/Packages/macOS/CmuxWorkspaces/Sources/CmuxWorkspaces/FileOpen/PreferredEditorService.swift
@@ -103,6 +103,7 @@ public struct PreferredEditorService: FileOpening {
         }
     }
 
+    /// Formats the configured editor's single file argument.
     private func editorArgument(path: String, line: Int?, column: Int?) -> String {
         guard let line else { return path }
         if let column {

--- a/Packages/macOS/CmuxWorkspaces/Sources/CmuxWorkspaces/FileOpen/PreferredEditorService.swift
+++ b/Packages/macOS/CmuxWorkspaces/Sources/CmuxWorkspaces/FileOpen/PreferredEditorService.swift
@@ -57,6 +57,16 @@ public struct PreferredEditorService: FileOpening {
     }
 
     public func open(_ url: URL) {
+        open(url, line: nil, column: nil)
+    }
+
+    /// Opens a file at an optional source location in the configured editor.
+    ///
+    /// The location is passed as one shell-quoted argument (`path:line` or
+    /// `path:line:column`), which is understood by common editor CLIs such as
+    /// VS Code and Cursor. System-default fallback remains a plain file URL
+    /// because Finder-style openers do not consume source locations.
+    public func open(_ url: URL, line: Int?, column: Int?) {
         if capture.appendLineIfConfigured(
             envKey: "CMUX_UI_TEST_CAPTURE_OPEN_PATH",
             line: url.path
@@ -71,7 +81,8 @@ public struct PreferredEditorService: FileOpening {
 
         let process = Process()
         process.executableURL = URL(fileURLWithPath: "/bin/sh")
-        process.arguments = ["-c", "\(command) \(url.path.posixShellSingleQuoted)"]
+        let editorArgument = editorArgument(path: url.path, line: line, column: column)
+        process.arguments = ["-c", "\(command) \(editorArgument.posixShellSingleQuoted)"]
         process.standardOutput = FileHandle.nullDevice
         process.standardError = FileHandle.nullDevice
 
@@ -90,5 +101,13 @@ public struct PreferredEditorService: FileOpening {
         } catch {
             systemOpener.openWithSystemDefault(url)
         }
+    }
+
+    private func editorArgument(path: String, line: Int?, column: Int?) -> String {
+        guard let line else { return path }
+        if let column {
+            return "\(path):\(line):\(column)"
+        }
+        return "\(path):\(line)"
     }
 }

--- a/Packages/macOS/CmuxWorkspaces/Tests/CmuxWorkspacesTests/FileOpen/PreferredEditorServiceTests.swift
+++ b/Packages/macOS/CmuxWorkspaces/Tests/CmuxWorkspacesTests/FileOpen/PreferredEditorServiceTests.swift
@@ -97,6 +97,33 @@ struct PreferredEditorServiceTests {
         #expect(opener.openedURLs.isEmpty)
     }
 
+    @Test func configuredCommandReceivesLineAndColumnLocation() async throws {
+        let scratch = try makeScratchDirectory()
+        defer { try? FileManager.default.removeItem(at: scratch) }
+        let marker = scratch.appendingPathComponent("received.txt")
+        let script = scratch.appendingPathComponent("editor.sh")
+        try #"""
+        #!/bin/sh
+        printf %s "$1" > '\#(marker.path)'
+        """#.write(to: script, atomically: true, encoding: .utf8)
+        try FileManager.default.setAttributes(
+            [.posixPermissions: 0o755], ofItemAtPath: script.path
+        )
+
+        let service = PreferredEditorService(
+            editor: FixedEditor(resolvedCommand: script.path),
+            capture: UITestCaptureSink(environment: [:]),
+            systemOpener: RecordingSystemOpener()
+        )
+        service.open(URL(fileURLWithPath: "/tmp/main.swift"), line: 42, column: 5)
+
+        for _ in 0..<200 where !FileManager.default.fileExists(atPath: marker.path) {
+            try await Task.sleep(for: .milliseconds(25))
+        }
+        let received = try String(contentsOf: marker, encoding: .utf8)
+        #expect(received == "/tmp/main.swift:42:5")
+    }
+
     @Test func failingCommandFallsBackToSystemOpen() async {
         let opener = RecordingSystemOpener()
         let service = PreferredEditorService(

--- a/Sources/TerminalLinkOpenCoordinator.swift
+++ b/Sources/TerminalLinkOpenCoordinator.swift
@@ -1,6 +1,7 @@
 import AppKit
 import CmuxTerminalCore
 import CmuxTestSupport
+import CmuxWorkspaces
 import Foundation
 
 /// Owns terminal-link policy and routes the resulting action through whichever
@@ -10,12 +11,14 @@ struct TerminalLinkOpenCoordinator {
     private let defaults: UserDefaults
     private let containerResolver: @MainActor (UUID?, UUID?) -> (any TerminalLinkOpenContainer)?
     private let externalOpen: @MainActor @Sendable (URL) -> Bool
+    private let preferredEditorOpen: @MainActor (URL, Int?, Int?) -> Void
     private let deferOperation: @MainActor (@escaping @MainActor @Sendable () -> Void) -> Void
 
     init(
         defaults: UserDefaults = .standard,
         containerResolver: @escaping @MainActor (UUID?, UUID?) -> (any TerminalLinkOpenContainer)? = Self.resolveContainer,
         externalOpen: @escaping @MainActor @Sendable (URL) -> Bool = { NSWorkspace.shared.open($0) },
+        preferredEditorOpen: (@MainActor (URL, Int?, Int?) -> Void)? = nil,
         deferOperation: @escaping @MainActor (@escaping @MainActor @Sendable () -> Void) -> Void = { operation in
             Task { @MainActor in operation() }
         }
@@ -23,6 +26,9 @@ struct TerminalLinkOpenCoordinator {
         self.defaults = defaults
         self.containerResolver = containerResolver
         self.externalOpen = externalOpen
+        self.preferredEditorOpen = preferredEditorOpen ?? { url, line, column in
+            PreferredEditorService(defaults: defaults).open(url, line: line, column: column)
+        }
         self.deferOperation = deferOperation
     }
 
@@ -42,16 +48,31 @@ struct TerminalLinkOpenCoordinator {
         }
         if !trimmed.isEmpty,
            canResolveLocalFilePath,
-           let resolvedPath = TerminalPathResolver().resolveOpenURLFilePath(
+           let reference = TerminalPathResolver().resolveOpenURLFileReference(
                trimmed,
                cwd: resolvedWorkingDirectory(request: request, container: container)
            ) {
-            let fileURL = URL(fileURLWithPath: resolvedPath)
-            if CommandClickFileOpenRouter.shouldRouteInCmux(
-                path: resolvedPath,
-                defaults: defaults
-            ) {
-                log("link.openURL resolvedAsFilePath=\(resolvedPath)")
+            if let line = reference.line {
+                log(
+                    "link.openURL resolvedAsFileLocation=\(reference.path):\(line)" +
+                    (reference.column.map { ":\($0)" } ?? "")
+                )
+                preferredEditorOpen(
+                    URL(fileURLWithPath: reference.path),
+                    reference.line,
+                    reference.column
+                )
+                return true
+            }
+
+            let isExplicitLocalFileURL = isExplicitFileURL(trimmed)
+            if !isExplicitLocalFileURL,
+               CommandClickFileOpenRouter.shouldRouteInCmux(
+                   path: reference.path,
+                   defaults: defaults
+               ) {
+                let fileURL = URL(fileURLWithPath: reference.path)
+                log("link.openURL resolvedAsFilePath=\(reference.path)")
                 return routeLocalFile(
                     fileURL,
                     request: request,
@@ -59,7 +80,9 @@ struct TerminalLinkOpenCoordinator {
                     unavailableReason: "file route unavailable"
                 )
             }
-            normalizedOpenURLString = resolvedPath
+            if !isExplicitLocalFileURL {
+                normalizedOpenURLString = reference.path
+            }
         }
 
         guard let target = resolveTerminalOpenURLTarget(normalizedOpenURLString) else {
@@ -257,6 +280,10 @@ struct TerminalLinkOpenCoordinator {
     private func openExternally(_ url: URL, reason: String) -> Bool {
         log("link.openURL opening externally reason=\(reason) url=\(url)")
         return externalOpen(url)
+    }
+
+    private func isExplicitFileURL(_ rawValue: String) -> Bool {
+        URL(string: rawValue)?.scheme?.caseInsensitiveCompare("file") == .orderedSame
     }
 
     private static func resolveContainer(

--- a/Sources/TerminalLinkOpenCoordinator.swift
+++ b/Sources/TerminalLinkOpenCoordinator.swift
@@ -11,14 +11,16 @@ struct TerminalLinkOpenCoordinator {
     private let defaults: UserDefaults
     private let containerResolver: @MainActor (UUID?, UUID?) -> (any TerminalLinkOpenContainer)?
     private let externalOpen: @MainActor @Sendable (URL) -> Bool
-    private let preferredEditorOpen: @MainActor (URL, Int?, Int?) -> Void
     private let deferOperation: @MainActor (@escaping @MainActor @Sendable () -> Void) -> Void
 
+    /// Creates a coordinator using the supplied routing collaborators.
+    ///
+    /// The production preferred-editor service is created at the point of
+    /// opening so it always reads the current editor setting.
     init(
         defaults: UserDefaults = .standard,
         containerResolver: @escaping @MainActor (UUID?, UUID?) -> (any TerminalLinkOpenContainer)? = Self.resolveContainer,
         externalOpen: @escaping @MainActor @Sendable (URL) -> Bool = { NSWorkspace.shared.open($0) },
-        preferredEditorOpen: (@MainActor (URL, Int?, Int?) -> Void)? = nil,
         deferOperation: @escaping @MainActor (@escaping @MainActor @Sendable () -> Void) -> Void = { operation in
             Task { @MainActor in operation() }
         }
@@ -26,12 +28,10 @@ struct TerminalLinkOpenCoordinator {
         self.defaults = defaults
         self.containerResolver = containerResolver
         self.externalOpen = externalOpen
-        self.preferredEditorOpen = preferredEditorOpen ?? { url, line, column in
-            PreferredEditorService(defaults: defaults).open(url, line: line, column: column)
-        }
         self.deferOperation = deferOperation
     }
 
+    /// Opens a terminal link according to the source terminal and URL policy.
     @discardableResult
     func open(_ request: TerminalLinkOpenRequest) -> Bool {
         log("link.openURL raw=\(request.rawValue)")
@@ -57,10 +57,10 @@ struct TerminalLinkOpenCoordinator {
                     "link.openURL resolvedAsFileLocation=\(reference.path):\(line)" +
                     (reference.column.map { ":\($0)" } ?? "")
                 )
-                preferredEditorOpen(
+                PreferredEditorService(defaults: defaults).open(
                     URL(fileURLWithPath: reference.path),
-                    reference.line,
-                    reference.column
+                    line: reference.line,
+                    column: reference.column
                 )
                 return true
             }
@@ -282,6 +282,7 @@ struct TerminalLinkOpenCoordinator {
         return externalOpen(url)
     }
 
+    /// Returns whether a raw link is an explicit local `file` URL.
     private func isExplicitFileURL(_ rawValue: String) -> Bool {
         URL(string: rawValue)?.scheme?.caseInsensitiveCompare("file") == .orderedSame
     }

--- a/cmuxTests/CMUXOpenCommandTests.swift
+++ b/cmuxTests/CMUXOpenCommandTests.swift
@@ -402,6 +402,53 @@ final class CMUXOpenCommandTests: XCTestCase {
         XCTAssertEqual(result.stdout, "OK files=1 surface=surface-id pane=pane-id\n")
     }
 
+    func testOpenCommandNormalizesPathLocationAndLocalFileURL() throws {
+        let cliPath = try bundledCLIPath()
+        let socketPath = makeSocketPath("open-location")
+        let listenerFD = try bindUnixSocket(at: socketPath)
+        let rootURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        let locationFileURL = rootURL.appendingPathComponent("main.swift")
+        let fileURL = rootURL.appendingPathComponent("notes.txt")
+        try FileManager.default.createDirectory(at: rootURL, withIntermediateDirectories: true)
+        try "print(\"hello\")\n".write(to: locationFileURL, atomically: true, encoding: .utf8)
+        try "notes\n".write(to: fileURL, atomically: true, encoding: .utf8)
+        let state = MockSocketServerState()
+
+        defer {
+            Darwin.close(listenerFD)
+            unlink(socketPath)
+            try? FileManager.default.removeItem(at: rootURL)
+        }
+
+        let serverHandled = startMockServer(listenerFD: listenerFD, state: state) { line in
+            guard let payload = Self.v2Payload(from: line),
+                  let id = payload["id"] as? String,
+                  payload["method"] as? String == "file.open" else {
+                return Self.v2Response(id: "unknown", ok: false, error: ["code": "unexpected"])
+            }
+            let params = payload["params"] as? [String: Any] ?? [:]
+            guard params["paths"] as? [String] == [locationFileURL.path, fileURL.path] else {
+                return Self.v2Response(id: id, ok: false, error: ["code": "unexpected-file-paths"])
+            }
+            return Self.v2Response(id: id, ok: true, result: [
+                "surface_id": "surface-id",
+                "pane_id": "pane-id",
+            ])
+        }
+
+        let result = runCLI(
+            cliPath: cliPath,
+            socketPath: socketPath,
+            arguments: ["open", "\(locationFileURL.path):42", fileURL.absoluteString]
+        )
+
+        wait(for: [serverHandled], timeout: 5)
+        XCTAssertFalse(result.timedOut, result.stderr)
+        XCTAssertEqual(result.status, 0, result.stderr)
+        XCTAssertEqual(result.stdout, "OK files=2 surface=surface-id pane=pane-id\n")
+    }
+
     func testOpenCommandProcessesMixedTargetsInInputOrder() throws {
         let cliPath = try bundledCLIPath()
         let socketPath = makeSocketPath("open-order")

--- a/cmuxTests/CMUXOpenCommandTests.swift
+++ b/cmuxTests/CMUXOpenCommandTests.swift
@@ -408,9 +408,10 @@ final class CMUXOpenCommandTests: XCTestCase {
         let listenerFD = try bindUnixSocket(at: socketPath)
         let rootURL = FileManager.default.temporaryDirectory
             .appendingPathComponent(UUID().uuidString, isDirectory: true)
-        let locationFileURL = rootURL.appendingPathComponent("main.swift")
+        let sourceURL = rootURL.appendingPathComponent("src", isDirectory: true)
+        let locationFileURL = sourceURL.appendingPathComponent("main.swift")
         let fileURL = rootURL.appendingPathComponent("notes.txt")
-        try FileManager.default.createDirectory(at: rootURL, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: sourceURL, withIntermediateDirectories: true)
         try "print(\"hello\")\n".write(to: locationFileURL, atomically: true, encoding: .utf8)
         try "notes\n".write(to: fileURL, atomically: true, encoding: .utf8)
         let state = MockSocketServerState()
@@ -440,7 +441,8 @@ final class CMUXOpenCommandTests: XCTestCase {
         let result = runCLI(
             cliPath: cliPath,
             socketPath: socketPath,
-            arguments: ["open", "\(locationFileURL.path):42", fileURL.absoluteString]
+            arguments: ["open", "src/main.swift:42", fileURL.absoluteString],
+            currentDirectoryURL: rootURL
         )
 
         wait(for: [serverHandled], timeout: 5)

--- a/cmuxTests/TerminalLinkOpenCoordinatorTests.swift
+++ b/cmuxTests/TerminalLinkOpenCoordinatorTests.swift
@@ -83,18 +83,29 @@ struct TerminalLinkOpenCoordinatorTests {
 
     @Test("path:line Cmd-click forwards the location to the preferred editor")
     @MainActor
-    func pathLocationUsesPreferredEditor() throws {
+    func pathLocationUsesPreferredEditor() async throws {
         let defaults = makeDefaults()
         let root = FileManager.default.temporaryDirectory
-            .appendingPathComponent("cmux-terminal-link-(UUID().uuidString)", isDirectory: true)
+            .appendingPathComponent("cmux-terminal-link-\(UUID().uuidString)", isDirectory: true)
         try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
         defer { try? FileManager.default.removeItem(at: root) }
         let fileURL = root.appendingPathComponent("main.swift")
         try "print(\"hello\")\n".write(to: fileURL, atomically: true, encoding: .utf8)
 
+        let marker = root.appendingPathComponent("received.txt")
+        let editorScript = root.appendingPathComponent("editor.sh")
+        try #"""
+        #!/bin/sh
+        printf %s "$1" > '\#(marker.path)'
+        """#.write(to: editorScript, atomically: true, encoding: .utf8)
+        try FileManager.default.setAttributes(
+            [.posixPermissions: 0o755],
+            ofItemAtPath: editorScript.path
+        )
+        defaults.set(editorScript.path, forKey: "preferredEditorCommand")
+
         let panelID = UUID()
         let container = RecordingTerminalLinkContainer()
-        var preferredEditorOpen: (URL, Int?, Int?)?
         var externallyOpened: [URL] = []
         let coordinator = TerminalLinkOpenCoordinator(
             defaults: defaults,
@@ -105,9 +116,6 @@ struct TerminalLinkOpenCoordinatorTests {
                 externallyOpened.append(openedURL)
                 return true
             },
-            preferredEditorOpen: { url, line, column in
-                preferredEditorOpen = (url, line, column)
-            },
             deferOperation: { operation in operation() }
         )
 
@@ -117,9 +125,12 @@ struct TerminalLinkOpenCoordinatorTests {
             sourcePanelId: panelID,
             workingDirectory: root.path
         )))
-        #expect(preferredEditorOpen?.0 == fileURL)
-        #expect(preferredEditorOpen?.1 == 42)
-        #expect(preferredEditorOpen?.2 == 5)
+
+        for _ in 0..<200 where !FileManager.default.fileExists(atPath: marker.path) {
+            try await Task.sleep(for: .milliseconds(25))
+        }
+        let received = try String(contentsOf: marker, encoding: .utf8)
+        #expect(received == "\(fileURL.path):42:5")
         #expect(container.openedFilePaths.isEmpty)
         #expect(externallyOpened.isEmpty)
     }

--- a/cmuxTests/TerminalLinkOpenCoordinatorTests.swift
+++ b/cmuxTests/TerminalLinkOpenCoordinatorTests.swift
@@ -9,6 +9,34 @@ import struct CmuxSettings.AppCatalogSection
 @testable import cmux
 #endif
 
+@MainActor
+private final class RecordingTerminalLinkContainer: TerminalLinkOpenContainer {
+    private(set) var openedFilePaths: [String] = []
+
+    var terminalLinkContainerDebugName: String { "recording" }
+
+    func terminalLinkWorkingDirectory(for sourcePanelId: UUID) -> String? {
+        "/tmp"
+    }
+
+    func terminalLinkIsRemoteTerminal(_ sourcePanelId: UUID) -> Bool {
+        false
+    }
+
+    func deferTerminalFileLinkOpen(
+        sourcePanelId: UUID,
+        filePath: String,
+        fallback: @escaping @MainActor @Sendable () -> Void
+    ) -> Bool {
+        openedFilePaths.append(filePath)
+        return true
+    }
+
+    func openTerminalBrowserLink(url: URL, sourcePanelId: UUID) -> Bool {
+        false
+    }
+}
+
 @Suite("Terminal link open coordinator", .serialized)
 struct TerminalLinkOpenCoordinatorTests {
     private func makeDefaults() -> UserDefaults {
@@ -51,6 +79,49 @@ struct TerminalLinkOpenCoordinatorTests {
 
         #expect(handled)
         #expect(externallyOpened == [url])
+    }
+
+    @Test("path:line Cmd-click forwards the location to the preferred editor")
+    @MainActor
+    func pathLocationUsesPreferredEditor() throws {
+        let defaults = makeDefaults()
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cmux-terminal-link-(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+        let fileURL = root.appendingPathComponent("main.swift")
+        try "print(\"hello\")\n".write(to: fileURL, atomically: true, encoding: .utf8)
+
+        let panelID = UUID()
+        let container = RecordingTerminalLinkContainer()
+        var preferredEditorOpen: (URL, Int?, Int?)?
+        var externallyOpened: [URL] = []
+        let coordinator = TerminalLinkOpenCoordinator(
+            defaults: defaults,
+            containerResolver: { _, sourcePanelID in
+                sourcePanelID == panelID ? container : nil
+            },
+            externalOpen: { openedURL in
+                externallyOpened.append(openedURL)
+                return true
+            },
+            preferredEditorOpen: { url, line, column in
+                preferredEditorOpen = (url, line, column)
+            },
+            deferOperation: { operation in operation() }
+        )
+
+        #expect(coordinator.open(TerminalLinkOpenRequest(
+            rawValue: "\(fileURL.path):42:5",
+            sourceWorkspaceId: nil,
+            sourcePanelId: panelID,
+            workingDirectory: root.path
+        )))
+        #expect(preferredEditorOpen?.0 == fileURL)
+        #expect(preferredEditorOpen?.1 == 42)
+        #expect(preferredEditorOpen?.2 == 5)
+        #expect(container.openedFilePaths.isEmpty)
+        #expect(externallyOpened.isEmpty)
     }
 
     @Test("Dock terminal links split once, then reuse the right browser pane")


### PR DESCRIPTION
## Summary

- Resolve terminal and `cmux open` targets in the form `path:line[:column]`.
- Preserve literal colon-number filenames by probing the complete path before parsing a location suffix.
- Support local `file://` URLs while leaving remote URL schemes and explicit local-file routing behavior unchanged.
- Forward terminal Cmd-click locations to the configured preferred editor and keep the existing path-only socket contract for `cmux open`.

## Root cause

The shared path resolver rejected all URL schemes, and the CLI treated a location suffix as part of the filesystem path. As a result, `path:line` targets were not recognized as file locations; in some paths Foundation then handled them as URLs and opened Safari.

## Validation

- `CmuxTerminalCore`: 256 tests passed.
- `CmuxWorkspaces`: production package build passed.
- Changed Swift files passed frontend parse checks.
- `scripts/lint-pbxproj-test-wiring.sh` passed (662 test files checked).
- `check-package-resolved-policy.py` passed.
- `check-workspace-package-groups.py` passed.
- The full app build was attempted with the tagged build dependencies and reached Xcode package resolution, but the local Xcode package graph stalled before source compilation; focused package validation and parse checks passed.

The first commit contains regression tests only; the second contains the implementation; the third addresses review findings with additional regression coverage and removes the production test seam.

Fixes #9830

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Handle path:line[:column] and local file URLs in terminal links and `cmux open`, so files open in the right editor and location. Fixes #9830 while keeping the path-only socket contract and preventing Safari from opening non-file targets.

- **Bug Fixes**
  - Shared resolver prefers literal paths, parses `path:line[:column]`, accepts local `file://`, rejects non-file schemes (even with numeric suffix), and leaves others to the URL router.
  - Terminal Cmd-click forwards `path:line[:column]` to the preferred editor; plain files still route in-app; explicit local `file://` continues via OS open.
  - `cmux open` now strips location before sending the `file.open` socket payload and accepts local `file://` inputs.

- **Refactors**
  - Clarified `TerminalFileReference` docs to match the runtime contract; no behavior change.

<sup>Written for commit cdd97b4f9e71ec51146ed7b3ea587b08e80d62fc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/9967?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes terminal link routing and shared path resolution used by CLI and Cmd-click; behavior is well covered by tests but touches file-open and editor invocation paths.
> 
> **Overview**
> Fixes terminal and `cmux open` handling of `path:line[:column]` and local `file://` targets so they open as files instead of being misread as URLs (e.g. Safari).
> 
> **Shared path resolution** adds `TerminalFileReference` and `resolveOpenURLFileReference`, which probe the full path before treating a trailing `:line` / `:line:column` as a location (so names like `report:42` stay valid), accept local `file://` URLs, and still reject non-file schemes for the URL router. `resolveOpenURLFilePath` now delegates to that API and drops location metadata.
> 
> **Terminal Cmd-click** routes resolved references with a line/column through `PreferredEditorService` with `path:line[:column]` for configured editors; path-only links keep in-app routing, and explicit `file://` links still go through OS open.
> 
> **`cmux open`** uses the same resolver and strips location suffixes before the path-only `file.open` socket contract.
> 
> **`PreferredEditorService`** gains an overload that passes line/column as a single shell-quoted argument for editor CLIs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cdd97b4f9e71ec51146ed7b3ea587b08e80d62fc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Open file references with line and column locations, such as `path:line:column`.
  * Support local `file://` URLs when opening files.
  * Configured editors now receive file locations with line and column details.
  * Terminal file links route to the preferred editor when configured.

* **Bug Fixes**
  * Preserve literal paths containing colons instead of misinterpreting them as location references.
  * Improve path handling relative to the current working directory.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->