### PR TITLE
Restore Zig SDK conformance toolchain boundary

### DIFF
--- a/.github/workflows/cmux-tui.yml
+++ b/.github/workflows/cmux-tui.yml
@@ -231,15 +231,39 @@ jobs:
         with:
           version: 0.15.2
 
-      - name: Python conformance fixtures
-        env:
-          CMUX_ZIG: zig
+      - name: Enter SDK conformance toolchain phase
+        shell: bash
         run: |
+          sdk_zig="$(command -v zig)"
+          case "$sdk_zig" in
+            /*) ;;
+            *) echo "Zig executable is not an absolute path: $sdk_zig" >&2; exit 1 ;;
+          esac
+          test "$("$sdk_zig" version)" = "0.15.2"
+          sdk_zig_lib_dir="$("$sdk_zig" env | python3 -c 'import json, sys; print(json.load(sys.stdin)["lib_dir"])')"
+          case "$sdk_zig_lib_dir" in
+            /*) ;;
+            *) echo "Zig library directory is not an absolute path: $sdk_zig_lib_dir" >&2; exit 1 ;;
+          esac
+          test -d "$sdk_zig_lib_dir"
+          echo "CMUX_ZIG=$sdk_zig" >> "$GITHUB_ENV"
+          echo "CMUX_ZIG_LIB_DIR=$sdk_zig_lib_dir" >> "$GITHUB_ENV"
+
+      - name: Python conformance fixtures
+        shell: bash
+        run: |
+          test "$(command -v zig)" = "$CMUX_ZIG"
           test "$("$CMUX_ZIG" version)" = "0.15.2"
+          test "$("$CMUX_ZIG" env | python3 -c 'import json, sys; print(json.load(sys.stdin)["lib_dir"])')" = "$CMUX_ZIG_LIB_DIR"
           python3 cmux-tui/bindings/conformance/runner.py
 
       - name: Binding e2e
-        run: bash cmux-tui/bindings/conformance/e2e.sh --require python,typescript,rust,go,java
+        shell: bash
+        run: |
+          test "$(command -v zig)" = "$CMUX_ZIG"
+          test "$("$CMUX_ZIG" version)" = "0.15.2"
+          test "$("$CMUX_ZIG" env | python3 -c 'import json, sys; print(json.load(sys.stdin)["lib_dir"])')" = "$CMUX_ZIG_LIB_DIR"
+          bash cmux-tui/bindings/conformance/e2e.sh --require python,typescript,rust,go,java
 
   windows-experimental:
     name: windows experimental (x86_64-gnu)

--- a/.github/workflows/cmux-tui.yml
+++ b/.github/workflows/cmux-tui.yml
@@ -240,7 +240,7 @@ jobs:
             *) echo "Zig executable is not an absolute path: $sdk_zig" >&2; exit 1 ;;
           esac
           test "$("$sdk_zig" version)" = "0.15.2"
-          sdk_zig_lib_dir="$("$sdk_zig" env | python3 -c 'import json, sys; print(json.load(sys.stdin)["lib_dir"])')"
+          sdk_zig_lib_dir="$("$sdk_zig" env | sed -n 's/^[[:space:]]*\.lib_dir = "\(.*\)",$/\1/p')"
           case "$sdk_zig_lib_dir" in
             /*) ;;
             *) echo "Zig library directory is not an absolute path: $sdk_zig_lib_dir" >&2; exit 1 ;;
@@ -254,7 +254,7 @@ jobs:
         run: |
           test "$(command -v zig)" = "$CMUX_ZIG"
           test "$("$CMUX_ZIG" version)" = "0.15.2"
-          test "$("$CMUX_ZIG" env | python3 -c 'import json, sys; print(json.load(sys.stdin)["lib_dir"])')" = "$CMUX_ZIG_LIB_DIR"
+          test "$("$CMUX_ZIG" env | sed -n 's/^[[:space:]]*\.lib_dir = "\(.*\)",$/\1/p')" = "$CMUX_ZIG_LIB_DIR"
           python3 cmux-tui/bindings/conformance/runner.py
 
       - name: Binding e2e
@@ -262,7 +262,7 @@ jobs:
         run: |
           test "$(command -v zig)" = "$CMUX_ZIG"
           test "$("$CMUX_ZIG" version)" = "0.15.2"
-          test "$("$CMUX_ZIG" env | python3 -c 'import json, sys; print(json.load(sys.stdin)["lib_dir"])')" = "$CMUX_ZIG_LIB_DIR"
+          test "$("$CMUX_ZIG" env | sed -n 's/^[[:space:]]*\.lib_dir = "\(.*\)",$/\1/p')" = "$CMUX_ZIG_LIB_DIR"
           bash cmux-tui/bindings/conformance/e2e.sh --require python,typescript,rust,go,java
 
   windows-experimental:

--- a/.github/workflows/cmux-tui.yml
+++ b/.github/workflows/cmux-tui.yml
@@ -226,8 +226,15 @@ jobs:
         working-directory: cmux-tui
         run: cargo build -p cmux-tui
 
+      - name: Set up Zig for SDK conformance
+        uses: mlugg/setup-zig@8d6198c65fb0feaa111df26e6b467fea8345e46f # v2.0.5
+        with:
+          version: 0.15.2
+
       - name: Python conformance fixtures
-        run: python3 cmux-tui/bindings/conformance/runner.py
+        run: |
+          test "$(zig version)" = "0.15.2"
+          python3 cmux-tui/bindings/conformance/runner.py
 
       - name: Binding e2e
         run: bash cmux-tui/bindings/conformance/e2e.sh --require python,typescript,rust,go,java

--- a/.github/workflows/cmux-tui.yml
+++ b/.github/workflows/cmux-tui.yml
@@ -232,8 +232,10 @@ jobs:
           version: 0.15.2
 
       - name: Python conformance fixtures
+        env:
+          CMUX_ZIG: zig
         run: |
-          test "$(zig version)" = "0.15.2"
+          test "$("$CMUX_ZIG" version)" = "0.15.2"
           python3 cmux-tui/bindings/conformance/runner.py
 
       - name: Binding e2e


### PR DESCRIPTION
## Summary
- keep Zig 0.16 for the Ghostty and headless cmux-tui build
- install and assert Zig 0.15.2 before the public SDK conformance adapter

## Testing
- actionlint .github/workflows/cmux-tui.yml
- git diff --check
- isolated gpt-5.6-sol xhigh review, clean at b20b2c75d9d3e4bd707570db8a03f24fee15d699

## Red evidence
- Base-only bindings failure: https://github.com/manaflow-ai/cmux/actions/runs/31459241082/job/93679275138

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only workflow changes with no runtime or application code impact; risk is limited to bindings-e2e job behavior if Zig path parsing or version pinning drifts.
> 
> **Overview**
> The **bindings-e2e** job still builds `cmux-tui` with the existing CI Zig install (Ghostty/0.16 path), then **switches toolchain** for public SDK conformance only.
> 
> It adds **Zig 0.15.2** via `mlugg/setup-zig`, a phase step that records absolute **`CMUX_ZIG`** and **`CMUX_ZIG_LIB_DIR`** from `zig env`, and **pre-flight checks** on the Python conformance runner and binding e2e script so PATH `zig`, version, and lib dir all match those env vars—restoring the boundary that stopped conformance from running against the wrong Zig.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 951598e46c768f173de5c970d1c6b95ad717593c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores the Zig toolchain boundary in `cmux-tui` CI. Keeps Zig 0.16 for Ghostty/headless builds and pins SDK conformance to Zig 0.15.2 to prevent binding failures.

- **Bug Fixes**
  - Install SDK Zig 0.15.2 with `mlugg/setup-zig@v2.0.5`; export absolute `CMUX_ZIG` and `CMUX_ZIG_LIB_DIR` parsed from `zig env`, and validate both.
  - Before Python fixtures and binding e2e, assert PATH `zig` equals `$CMUX_ZIG`, version is `0.15.2`, and parsed `.lib_dir` matches `$CMUX_ZIG_LIB_DIR`.

<sup>Written for commit 951598e46c768f173de5c970d1c6b95ad717593c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/9968?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

