### PR TITLE
test(tui): await sidebar overflow cancellation

### DIFF
--- a/cmux-tui/bindings/rust-sidebar/tests/runtime.rs
+++ b/cmux-tui/bindings/rust-sidebar/tests/runtime.rs
@@ -336,6 +336,7 @@ fn runtime_remains_attached_across_idle_request_timeout_and_accepts_late_snapsho
 fn bounded_queue_overflow_cancels_and_reports_recovery() {
     let path = socket_path();
     let listener = UnixListener::bind(&path).unwrap();
+    let (overflow_observed_tx, overflow_observed_rx) = std::sync::mpsc::channel();
     let server = thread::spawn(move || {
         let (control, _) = listener.accept().unwrap();
         let (mut stream, _) = listener.accept().unwrap();
@@ -350,6 +351,7 @@ fn bounded_queue_overflow_cancels_and_reports_recovery() {
         assert_eq!(cancel["operation"], "stream.cancel");
         success(&mut stream, &cancel, json!({}));
         end_canceled(&mut stream, &stream_id);
+        overflow_observed_tx.send(()).unwrap();
         drop(control);
     });
 
@@ -364,7 +366,9 @@ fn bounded_queue_overflow_cancels_and_reports_recovery() {
         SidebarConfig { queue_capacity: 1, ..SidebarConfig::default() },
     )
     .unwrap();
-    thread::sleep(Duration::from_millis(50));
+    overflow_observed_rx
+        .recv_timeout(Duration::from_secs(2))
+        .expect("sidebar worker did not cancel the overflowing stream");
     let deadline = Instant::now() + Duration::from_secs(2);
     loop {
         runtime.poll_updates();


### PR DESCRIPTION
## Summary

- wait for the sidebar stream fixture to observe `stream.cancel` before polling updates
- remove the fixed 50 ms pre-poll dwell
- keep the owner wait bounded by `recv_timeout`

## Cause

Valgrind slows the stream worker past the fixed dwell. Early `poll_updates()` can then drain the capacity-one queue before it overflows, so the test deadline controls progress instead of only failure reporting.

The fixture now confirms that the queue owner sent `stream.cancel` before the observer polls. This preserves the production protocol and makes overflow creation deterministic.

Red evidence: [Valgrind job 93679275185](https://github.com/manaflow-ai/cmux/actions/runs/31459241082/job/93679275185)

## Verification

- local build and tests not run, per task constraint
- `git diff --check` passed
- isolated gpt-5.6-sol xhigh review passed
- exact hosted cmux-tui Valgrind and full gate pending

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 90190934b7303dfd1e24c55487361786d2131696. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the sidebar overflow test deterministic under Valgrind by waiting for the cancel signal before polling. This removes the fixed sleep and prevents early polling from draining the capacity-one queue.

- **Bug Fixes**
  - Wait for `stream.cancel` via a channel before calling `poll_updates()`.
  - Replace the 50 ms sleep with a `recv_timeout`-bounded wait (2s) to preserve protocol order and stabilize the test.

<sup>Written for commit 90190934b7303dfd1e24c55487361786d2131696. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/9969?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

