### PR TITLE
test(tui): stage hook launcher fixtures

### DIFF
--- a/tests/test_tui_package_launchers.py
+++ b/tests/test_tui_package_launchers.py
@@ -4,6 +4,7 @@ import os
 import platform
 import runpy
 import shutil
+import stat
 import subprocess
 import sys
 import zipfile
@@ -159,6 +160,10 @@ def test_pypi_launcher_preserves_uvx_invocation(tmp_path: Path) -> None:
             binaries / f"cmux-tui-{target}",
             "printf '%s\\n' \"$CMUX_TUI_LAUNCHER_COMMAND\"",
         )
+        write_executable(
+            binaries / f"cmux-tui-hook-{target}",
+            "exit 0",
+        )
 
     wheels = tmp_path / "wheels"
     packaged = run(
@@ -178,7 +183,10 @@ def test_pypi_launcher_preserves_uvx_invocation(tmp_path: Path) -> None:
     wheel = wheels / f"cmux-1.2.3-py3-none-{wheel_tag}.whl"
     installed = tmp_path / "installed"
     with zipfile.ZipFile(wheel) as archive:
+        hook = archive.getinfo("cmux_tui/bin/cmux-tui-hook")
+        assert hook.external_attr >> 16 & stat.S_IXUSR
         archive.extractall(installed)
+    assert (installed / "cmux_tui/bin/cmux-tui-hook").is_file()
     (installed / "cmux_tui/bin/cmux-tui").chmod(0o755)
 
     environment = os.environ.copy()


### PR DESCRIPTION
The PyPI launcher fixture created cmux-tui binaries only. The production packager now requires a matching cmux-tui-hook binary for every Rust target, so the workflow guard stopped before it tested uvx launch behavior.

This change stages both executable fixtures, verifies that the built wheel contains an executable hook, and preserves the npm and uvx launcher assertions.

Red proof: https://github.com/manaflow-ai/cmux/actions/runs/31461409212

Local compile and tests were not run, per the hosted-only verification rule. Exact hosted workflow-guard proof will follow.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/9970"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789018400&installation_model_id=21920&pr_number=9970&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F9970&signature=bda67e9f1739c04a6f8015677745577d1b86bb80722fdb7bb58fdee0fe27cac2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes with no production code paths; low risk aside from CI coverage for PyPI wheel hook packaging.
> 
> **Overview**
> Updates **`test_pypi_launcher_preserves_uvx_invocation`** so PyPI wheel packaging tests match production: the packager now requires a **`cmux-tui-hook-<rust-target>`** fixture alongside each **`cmux-tui-<rust-target>`** binary.
> 
> After building the wheel, the test asserts the archive includes an executable **`cmux_tui/bin/cmux-tui-hook`** (via zip **`external_attr`** / **`stat.S_IXUSR`**) and that the extracted hook file exists, while keeping the existing **`uvx`** launcher assertion unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 35186a696ee081c94315dbdb6ec10e685d3dcbb8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated the PyPI launcher test to stage `cmux-tui-hook` alongside `cmux-tui` for each Rust target and verify the wheel includes an executable hook. This unblocks the workflow guard and keeps `npm` and `uvx` launcher assertions intact.

<sup>Written for commit 35186a696ee081c94315dbdb6ec10e685d3dcbb8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/9970?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

