### PR TITLE
test(tui): make connect poll ownership deterministic

### DIFF
--- a/cmux-tui/bindings/rust/src/codec.rs
+++ b/cmux-tui/bindings/rust/src/codec.rs
@@ -15,6 +15,7 @@ thread_local! {
     static FORCE_PENDING_CONNECT: std::cell::Cell<bool> = const { std::cell::Cell::new(false) };
     static FORCED_CONNECT_ATTEMPTS: std::cell::Cell<usize> = const { std::cell::Cell::new(0) };
     static FORCED_CONNECT_POLLS: std::cell::Cell<usize> = const { std::cell::Cell::new(0) };
+    static FORCED_CONNECT_POLL_LIMIT: std::cell::Cell<usize> = const { std::cell::Cell::new(0) };
 }
 
 #[cfg(test)]
@@ -28,7 +29,15 @@ impl ForcedPendingConnectProbe {
         });
         FORCED_CONNECT_ATTEMPTS.with(|attempts| attempts.set(0));
         FORCED_CONNECT_POLLS.with(|polls| polls.set(0));
+        FORCED_CONNECT_POLL_LIMIT.with(|limit| limit.set(0));
         Self
+    }
+
+    pub(crate) fn install_with_poll_limit(limit: usize) -> Self {
+        assert!(limit > 0, "a pending-connect poll limit must be positive");
+        let probe = Self::install();
+        FORCED_CONNECT_POLL_LIMIT.with(|configured| configured.set(limit));
+        probe
     }
 
     pub(crate) fn attempts(&self) -> usize {
@@ -46,6 +55,7 @@ impl Drop for ForcedPendingConnectProbe {
         FORCE_PENDING_CONNECT.with(|forced| forced.set(false));
         FORCED_CONNECT_ATTEMPTS.with(|attempts| attempts.set(0));
         FORCED_CONNECT_POLLS.with(|polls| polls.set(0));
+        FORCED_CONNECT_POLL_LIMIT.with(|limit| limit.set(0));
     }
 }
 
@@ -275,7 +285,17 @@ fn connect_unix_with_poll_checks(
             if now >= deadline {
                 return Err(connect_timeout_error(socket_path));
             }
-            FORCED_CONNECT_POLLS.with(|polls| polls.set(polls.get() + 1));
+            let reached_poll_limit = FORCED_CONNECT_POLLS.with(|polls| {
+                let count = polls.get().saturating_add(1);
+                polls.set(count);
+                FORCED_CONNECT_POLL_LIMIT.with(|limit| {
+                    let limit = limit.get();
+                    limit > 0 && count >= limit
+                })
+            });
+            if reached_poll_limit {
+                return Err(connect_timeout_error(socket_path));
+            }
             std::thread::sleep(deadline.saturating_duration_since(now).min(poll_interval));
         }
     }

--- a/cmux-tui/bindings/rust/src/resource/client.rs
+++ b/cmux-tui/bindings/rust/src/resource/client.rs
@@ -973,10 +973,10 @@ mod tests {
 
     #[test]
     fn cancellable_connect_reuses_one_socket_across_poll_slices() {
-        let probe = crate::codec::ForcedPendingConnectProbe::install();
+        let probe = crate::codec::ForcedPendingConnectProbe::install_with_poll_limit(3);
         let cancellation = super::super::options::CancellationToken::new();
         let options = RequestOptions::new()
-            .with_timeout(Duration::from_millis(35))
+            .with_timeout(Duration::from_secs(1))
             .unwrap()
             .with_cancellation(cancellation);
         let budget = CallBudget::new(options, Duration::from_secs(1)).unwrap();
@@ -986,7 +986,7 @@ mod tests {
             connect_with_budget(&config, ops::SESSION_LIST, &budget),
             Err(Error::Timeout(_))
         ));
-        assert!(probe.polls() >= 2, "the connect should span several cancellation polls");
+        assert_eq!(probe.polls(), 3, "the connect should span the configured poll slices");
         assert_eq!(
             probe.attempts(),
             1,


### PR DESCRIPTION
## Summary

- let the forced pending-socket fixture own an exact three-poll completion limit
- assert one socket attempt across those three observed poll slices
- keep the one-second timeout only as a final failure bound

## Cause

The test used a 35 ms wall-clock deadline to create multiple cancellation poll slices. On a loaded macOS runner, the first 10 ms sleep could consume the full deadline, so the test observed one poll without a product defect.

The forced socket owner now ends the fixture after its third recorded poll. Elapsed time no longer controls progress.

Failure evidence: [macOS job 93685556753](https://github.com/manaflow-ai/cmux/actions/runs/31461437871/job/93685556753)

## Verification

- `git diff --check` passed
- isolated gpt-5.6-sol xhigh review passed
- no local build or test run

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/9973"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789019417&installation_model_id=21920&pr_number=9973&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F9973&signature=8b04f2dc4444c6ff0c9f07a88e73395388919da2e521201305cf463e9ad6159e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 190b6559400c37da6f6a1cb9429d7d589e7e5445. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make connect poll ownership deterministic in `cmux-tui` tests by adding a fixed poll limit and ending after three polls. This removes timing-based flakiness on macOS runners while keeping a 1s final timeout bound.

- **Bug Fixes**
  - Added `FORCED_CONNECT_POLL_LIMIT` and `install_with_poll_limit(limit)` to `ForcedPendingConnectProbe`.
  - `connect_unix_with_poll_checks` stops and returns a timeout once the poll limit is reached.
  - Updated `cancellable_connect_reuses_one_socket_across_poll_slices` to use a 3-poll limit, assert `polls()==3`, and confirm a single socket attempt; kept a 1s timeout as the final bound.

<sup>Written for commit 190b6559400c37da6f6a1cb9429d7d589e7e5445. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/9973?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

