### PR TITLE
fix(vt): restore DECOM replay cursor coordinates

### DIFF
--- a/cmux-tui/crates/ghostty-vt/src/terminal.rs
+++ b/cmux-tui/crates/ghostty-vt/src/terminal.rs
@@ -2,8 +2,8 @@ use std::borrow::Cow;
 use std::collections::{BTreeMap, BTreeSet, HashMap};
 use std::ffi::c_void;
 use std::ptr;
-use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Arc, Mutex};
 
 use base64::Engine as _;
 use ghostty_vt_sys as sys;
@@ -3045,6 +3045,7 @@ impl Terminal {
         max_bytes: usize,
         include_palette: bool,
     ) -> Result<VtReplay> {
+        let cursor_plan = self.vt_replay_cursor_plan()?;
         let inflight = self.kitty_inflight.replay_prefix_checked(max_bytes)?;
         let remaining = max_bytes.checked_sub(inflight.len()).ok_or(Error::OutOfSpace)?;
         let mut pixel_cache = std::mem::take(&mut self.kitty_replay_pixel_cache.0);
@@ -3064,6 +3065,7 @@ impl Terminal {
             catalog.placement_rows(),
             active_start,
             include_palette,
+            &cursor_plan,
         )?;
         let visible_cost =
             active_text.range.map(|range| catalog.visible_cost(range, remaining)).unwrap_or(0);
@@ -3074,6 +3076,7 @@ impl Terminal {
             catalog.placement_rows(),
             active_start,
             include_palette,
+            &cursor_plan,
         )?;
         let graphics_budget = remaining.saturating_sub(text.bytes.len());
         let graphics = catalog.plan(text.range, graphics_budget, false);
@@ -3117,6 +3120,7 @@ impl Terminal {
         placement_rows: &KittyReplayRowIndex,
         minimum_start: Option<u64>,
         include_palette: bool,
+        cursor_plan: &ReplayCursorPlan,
     ) -> Result<ReplayText> {
         let Some(scrollbar) = self.scrollbar() else {
             return Ok(ReplayText::minimal(max_bytes));
@@ -3147,6 +3151,7 @@ impl Terminal {
                 placement_rows,
                 max_bytes,
                 include_palette,
+                cursor_plan,
             )? {
                 if tail_rows == scrollbar.total {
                     return Ok(replay);
@@ -3158,6 +3163,7 @@ impl Terminal {
                         placement_rows,
                         max_bytes,
                         include_palette,
+                        cursor_plan,
                     );
                 }
                 best = Some(replay);
@@ -3176,6 +3182,7 @@ impl Terminal {
                     placement_rows,
                     max_bytes,
                     include_palette,
+                    cursor_plan,
                 );
             }
             if tail_rows <= minimum_rows {
@@ -3198,6 +3205,7 @@ impl Terminal {
         placement_rows: &KittyReplayRowIndex,
         max_bytes: usize,
         include_palette: bool,
+        cursor_plan: &ReplayCursorPlan,
     ) -> Result<ReplayText> {
         let Some(best_range) = best.range else {
             return Ok(best);
@@ -3217,6 +3225,7 @@ impl Terminal {
                 placement_rows,
                 max_bytes,
                 include_palette,
+                cursor_plan,
             )? {
                 best = replay;
                 high = middle;
@@ -3233,14 +3242,13 @@ impl Terminal {
         placement_rows: &KittyReplayRowIndex,
         max_bytes: usize,
         include_palette: bool,
+        cursor_plan: &ReplayCursorPlan,
     ) -> Result<Option<ReplayText>> {
         let cols = self.cols();
         if cols == 0 || range.start > range.end {
             return Err(Error::InvalidValue);
         }
-        let suffix = self.cursor_position_escape()?;
-        let suffix_len = suffix.as_ref().map_or(0, Vec::len);
-        let Some(format_max_bytes) = max_bytes.checked_sub(suffix_len) else {
+        let Some(format_max_bytes) = max_bytes.checked_sub(cursor_plan.bytes.len()) else {
             return Ok(None);
         };
         let insert_at_start = placement_rows.overlaps(range.start);
@@ -3314,9 +3322,7 @@ impl Terminal {
                 bytes.extend_from_slice(b"\r\n");
             }
         }
-        if let Some(suffix) = suffix {
-            bytes.extend_from_slice(&suffix);
-        }
+        bytes.extend_from_slice(&cursor_plan.bytes);
         Ok(Some(ReplayText { bytes, range: Some(range), insertion_offsets }))
     }
 
@@ -3337,19 +3343,16 @@ impl Terminal {
         })
     }
 
-    fn cursor_position_escape(&mut self) -> Result<Option<Vec<u8>>> {
-        let Some((x, y)) = self.cursor_position() else { return Ok(None) };
+    fn vt_replay_cursor_plan(&mut self) -> Result<ReplayCursorPlan> {
+        let (x, y) = self.cursor_position().ok_or(Error::InvalidValue)?;
         let origin_mode = self.mode(6, false);
+        let (row, column) = if origin_mode {
+            self.cursor_position_report()?
+        } else {
+            (u32::from(y) + 1, u32::from(x) + 1)
+        };
         if !self.get::<bool>(sys::GHOSTTY_TERMINAL_DATA_CURSOR_PENDING_WRAP).unwrap_or(false) {
-            // The formatter already emits the cursor. An appended CUP would
-            // reinterpret active-area coordinates relative to the scrolling
-            // region while DECOM is enabled.
-            if origin_mode {
-                return Ok(None);
-            }
-            return Ok(Some(
-                format!("\x1b[{};{}H", u32::from(y) + 1, u32::from(x) + 1).into_bytes(),
-            ));
+            return Ok(ReplayCursorPlan { bytes: format!("\x1b[{row};{column}H").into_bytes() });
         }
 
         // No standard cursor-positioning sequence can restore pending wrap:
@@ -3400,21 +3403,42 @@ impl Terminal {
             },
             selection: &selection,
         };
-        let mut suffix = if origin_mode {
-            // The main formatter leaves the cursor at the authoritative cell.
-            // Move only to a wide glyph's lead cell, using a relative motion
-            // whose meaning is independent of the scrolling-region origin.
-            let columns_left = x.saturating_sub(start_x);
-            if columns_left == 0 {
-                Vec::new()
-            } else {
-                format!("\x1b[{}D", u32::from(columns_left)).into_bytes()
-            }
-        } else {
-            format!("\x1b[{};{}H", u32::from(y) + 1, u32::from(start_x) + 1).into_bytes()
-        };
+        let start_column =
+            column.checked_sub(u32::from(x.saturating_sub(start_x))).ok_or(Error::InvalidValue)?;
+        let mut suffix = format!("\x1b[{row};{start_column}H").into_bytes();
         suffix.extend_from_slice(&self.format(opts)?);
-        Ok(Some(suffix))
+        Ok(ReplayCursorPlan { bytes: suffix })
+    }
+
+    fn cursor_position_report(&mut self) -> Result<(u32, u32)> {
+        if !self.vt_stream_is_ground() {
+            return Err(Error::InvalidValue);
+        }
+
+        let report = Arc::new(Mutex::new(Vec::new()));
+        let captured = Arc::clone(&report);
+        let original_callback = self.callbacks.on_pty_write.replace(Box::new(move |bytes| {
+            captured.lock().unwrap().extend_from_slice(bytes);
+        }));
+        // This is an internal state query, not process output. Feed it only to
+        // Ghostty so replay tracking still describes the real PTY stream.
+        let query = b"\x1b[6n";
+        unsafe { sys::ghostty_terminal_vt_write(self.raw, query.as_ptr(), query.len()) };
+        self.callbacks.on_pty_write = original_callback;
+
+        let report = report.lock().map_err(|_| Error::InvalidValue)?;
+        let report = std::str::from_utf8(&report).map_err(|_| Error::InvalidValue)?;
+        let body = report
+            .strip_prefix("\x1b[")
+            .and_then(|value| value.strip_suffix('R'))
+            .ok_or(Error::InvalidValue)?;
+        let (row, column) = body.split_once(';').ok_or(Error::InvalidValue)?;
+        let row = row.parse::<u32>().map_err(|_| Error::InvalidValue)?;
+        let column = column.parse::<u32>().map_err(|_| Error::InvalidValue)?;
+        if row == 0 || column == 0 {
+            return Err(Error::InvalidValue);
+        }
+        Ok((row, column))
     }
 
     fn vt_replay_segment_options(
@@ -3430,7 +3454,7 @@ impl Terminal {
         options.extra.tabstops = last;
         options.extra.pwd = last;
         options.extra.keyboard = last;
-        options.extra.screen.cursor = last;
+        options.extra.screen.cursor = false;
         options.extra.screen.style = last;
         options.extra.screen.hyperlink = last;
         options.extra.screen.protection = last;
@@ -3591,6 +3615,10 @@ fn minimal_vt_replay(max_bytes: usize) -> Vec<u8> {
 struct ReplayRowRange {
     start: u64,
     end: u64,
+}
+
+struct ReplayCursorPlan {
+    bytes: Vec<u8>,
 }
 
 #[derive(Default)]
@@ -4836,12 +4864,14 @@ mod tests {
         let snapshot = source.kitty_graphics_snapshot().unwrap();
         let image = snapshot.images.first().unwrap();
         let max_bytes = kitty_replay_image_len(image).unwrap() + b"\x1bc".len();
+        let cursor_plan = source.vt_replay_cursor_plan().unwrap();
         let text = source
             .vt_replay_text_layout_bounded(
                 max_bytes,
                 &super::KittyReplayRowIndex::default(),
                 None,
                 false,
+                &cursor_plan,
             )
             .unwrap();
         assert_eq!(text.range, None, "fixture did not reach the minimal reset fallback");
@@ -4882,8 +4912,15 @@ mod tests {
         let anchor_row = scrollbar.total - 12;
         let placement_rows = [anchor_row].into_iter().collect();
         let anchor_range = super::ReplayRowRange { start: anchor_row, end: scrollbar.total - 1 };
+        let cursor_plan = source.vt_replay_cursor_plan().unwrap();
         let anchor_bytes = source
-            .vt_replay_text_range_bounded(anchor_range, &placement_rows, usize::MAX, true)
+            .vt_replay_text_range_bounded(
+                anchor_range,
+                &placement_rows,
+                usize::MAX,
+                true,
+                &cursor_plan,
+            )
             .unwrap()
             .unwrap()
             .bytes
@@ -4892,7 +4929,13 @@ mod tests {
             super::ReplayRowRange { start: scrollbar.total - 16, end: scrollbar.total - 1 };
         assert!(
             source
-                .vt_replay_text_range_bounded(older_range, &placement_rows, anchor_bytes, true)
+                .vt_replay_text_range_bounded(
+                    older_range,
+                    &placement_rows,
+                    anchor_bytes,
+                    true,
+                    &cursor_plan,
+                )
                 .unwrap()
                 .is_none(),
             "fixture must put the anchor between a fitting and oversized geometric window"
@@ -4904,6 +4947,7 @@ mod tests {
                 &placement_rows,
                 Some(scrollbar.total - scrollbar.len),
                 true,
+                &cursor_plan,
             )
             .unwrap();
 
@@ -5011,8 +5055,15 @@ mod tests {
             anchors: [(placement.key, anchor)].into_iter().collect(),
         };
         let catalog = KittyReplayCatalog::new(&snapshot, (10, 20), 4);
+        let cursor_plan = source.vt_replay_cursor_plan().unwrap();
         let text = source
-            .vt_replay_text_range_bounded(range, catalog.placement_rows(), usize::MAX, true)
+            .vt_replay_text_range_bounded(
+                range,
+                catalog.placement_rows(),
+                usize::MAX,
+                true,
+                &cursor_plan,
+            )
             .unwrap()
             .unwrap();
         let graphics = catalog.plan(Some(range), usize::MAX, false);

--- a/cmux-tui/crates/ghostty-vt/src/terminal.rs
+++ b/cmux-tui/crates/ghostty-vt/src/terminal.rs
@@ -3344,7 +3344,9 @@ impl Terminal {
     }
 
     fn vt_replay_cursor_plan(&mut self) -> Result<ReplayCursorPlan> {
-        let (x, y) = self.cursor_position().ok_or(Error::InvalidValue)?;
+        let Some((x, y)) = self.cursor_position() else {
+            return Ok(ReplayCursorPlan { bytes: Vec::new() });
+        };
         let origin_mode = self.mode(6, false);
         let (row, column) = if origin_mode {
             let (origin_x, origin_y) = self.scrolling_region_origin(x, y)?;

--- a/cmux-tui/crates/ghostty-vt/src/terminal.rs
+++ b/cmux-tui/crates/ghostty-vt/src/terminal.rs
@@ -2,8 +2,8 @@ use std::borrow::Cow;
 use std::collections::{BTreeMap, BTreeSet, HashMap};
 use std::ffi::c_void;
 use std::ptr;
+use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
-use std::sync::{Arc, Mutex};
 
 use base64::Engine as _;
 use ghostty_vt_sys as sys;
@@ -3347,7 +3347,8 @@ impl Terminal {
         let (x, y) = self.cursor_position().ok_or(Error::InvalidValue)?;
         let origin_mode = self.mode(6, false);
         let (row, column) = if origin_mode {
-            self.cursor_position_report()?
+            let (origin_x, origin_y) = self.scrolling_region_origin(x, y)?;
+            (u32::from(y).saturating_sub(origin_y) + 1, u32::from(x).saturating_sub(origin_x) + 1)
         } else {
             (u32::from(y) + 1, u32::from(x) + 1)
         };
@@ -3410,35 +3411,31 @@ impl Terminal {
         Ok(ReplayCursorPlan { bytes: suffix })
     }
 
-    fn cursor_position_report(&mut self) -> Result<(u32, u32)> {
-        if !self.vt_stream_is_ground() {
-            return Err(Error::InvalidValue);
-        }
-
-        let report = Arc::new(Mutex::new(Vec::new()));
-        let captured = Arc::clone(&report);
-        let original_callback = self.callbacks.on_pty_write.replace(Box::new(move |bytes| {
-            captured.lock().unwrap().extend_from_slice(bytes);
-        }));
-        // This is an internal state query, not process output. Feed it only to
-        // Ghostty so replay tracking still describes the real PTY stream.
-        let query = b"\x1b[6n";
-        unsafe { sys::ghostty_terminal_vt_write(self.raw, query.as_ptr(), query.len()) };
-        self.callbacks.on_pty_write = original_callback;
-
-        let report = report.lock().map_err(|_| Error::InvalidValue)?;
-        let report = std::str::from_utf8(&report).map_err(|_| Error::InvalidValue)?;
-        let body = report
-            .strip_prefix("\x1b[")
-            .and_then(|value| value.strip_suffix('R'))
+    fn scrolling_region_origin(&mut self, x: u16, y: u16) -> Result<(u32, u32)> {
+        let cursor_ref = self
+            .grid_ref(sys::GHOSTTY_POINT_TAG_ACTIVE, x, u64::from(y))
             .ok_or(Error::InvalidValue)?;
-        let (row, column) = body.split_once(';').ok_or(Error::InvalidValue)?;
-        let row = row.parse::<u32>().map_err(|_| Error::InvalidValue)?;
-        let column = column.parse::<u32>().map_err(|_| Error::InvalidValue)?;
-        if row == 0 || column == 0 {
-            return Err(Error::InvalidValue);
-        }
-        Ok((row, column))
+        let selection = sys::GhosttySelection {
+            size: size_of::<sys::GhosttySelection>(),
+            start: cursor_ref,
+            end: cursor_ref,
+            rectangle: false,
+        };
+        let mut options = Self::vt_replay_options(Some(&selection), false);
+        options.extra.modes = false;
+        options.extra.tabstops = false;
+        options.extra.pwd = false;
+        options.extra.keyboard = false;
+        options.extra.screen.cursor = false;
+        options.extra.screen.style = false;
+        options.extra.screen.hyperlink = false;
+        options.extra.screen.protection = false;
+        options.extra.screen.kitty_keyboard = false;
+        options.extra.screen.charsets = false;
+        let cols = self.cols();
+        let rows = self.rows();
+        let fragment = self.format(options)?;
+        scrolling_region_origin_from_vt(&fragment, cols, rows)
     }
 
     fn vt_replay_segment_options(
@@ -3619,6 +3616,61 @@ struct ReplayRowRange {
 
 struct ReplayCursorPlan {
     bytes: Vec<u8>,
+}
+
+fn scrolling_region_origin_from_vt(bytes: &[u8], cols: u16, rows: u16) -> Result<(u32, u32)> {
+    let mut origin_x = 0;
+    let mut origin_y = 0;
+    let mut index = 0;
+    while index + 2 < bytes.len() {
+        if bytes[index..].starts_with(b"\x1b[") {
+            let body_start = index + 2;
+            let Some(final_offset) =
+                bytes[body_start..].iter().position(|byte| matches!(byte, 0x40..=0x7e))
+            else {
+                break;
+            };
+            let final_index = body_start + final_offset;
+            let final_byte = bytes[final_index];
+            if matches!(final_byte, b'r' | b's') {
+                let (start, end) = parse_csi_decimal_pair(&bytes[body_start..final_index])
+                    .ok_or(Error::InvalidValue)?;
+                let limit = u32::from(if final_byte == b'r' { rows } else { cols });
+                if start == 0 || start > end || end > limit {
+                    return Err(Error::InvalidValue);
+                }
+                if final_byte == b'r' {
+                    origin_y = start - 1;
+                } else {
+                    origin_x = start - 1;
+                }
+            }
+            index = final_index + 1;
+        } else {
+            index += 1;
+        }
+    }
+    Ok((origin_x, origin_y))
+}
+
+fn parse_csi_decimal_pair(bytes: &[u8]) -> Option<(u32, u32)> {
+    let separator = bytes.iter().position(|byte| *byte == b';')?;
+    if bytes[separator + 1..].contains(&b';') {
+        return None;
+    }
+    Some((parse_csi_decimal(&bytes[..separator])?, parse_csi_decimal(&bytes[separator + 1..])?))
+}
+
+fn parse_csi_decimal(bytes: &[u8]) -> Option<u32> {
+    if bytes.is_empty() {
+        return None;
+    }
+    bytes.iter().try_fold(0_u32, |value, byte| {
+        if !byte.is_ascii_digit() {
+            return None;
+        }
+        value.checked_mul(10)?.checked_add(u32::from(*byte - b'0'))
+    })
 }
 
 #[derive(Default)]

--- a/cmux-tui/crates/ghostty-vt/tests/terminal.rs
+++ b/cmux-tui/crates/ghostty-vt/tests/terminal.rs
@@ -342,6 +342,35 @@ fn vt_replay_restores_cursor_position_after_tabstops() {
     }
 }
 
+#[test]
+fn vt_replay_restores_cursor_inside_origin_mode_scrolling_region() {
+    let mut source = Terminal::new(12, 8, 0, Callbacks::default()).unwrap();
+    source.vt_write(b"screen contents");
+    source.vt_write(b"\x1b[?69h\x1b[3;7r\x1b[4;10s\x1b[?6h\x1b[2;3H");
+    let expected = source.cursor_position().unwrap();
+    assert_eq!(expected, (5, 3));
+
+    let full = source.vt_replay_bytes().unwrap();
+    let bounded = source.vt_replay_bounded_bytes(8 * 1024 * 1024).unwrap();
+    for replay in [&full, &bounded] {
+        let mut mirror = Terminal::new(12, 8, 0, Callbacks::default()).unwrap();
+        mirror.vt_write(replay);
+        assert!(mirror.mode(6, false), "replay lost DECOM");
+        assert_eq!(
+            mirror.cursor_position().unwrap(),
+            expected,
+            "mirror cursor diverged inside the scrolling region"
+        );
+
+        mirror.vt_write(b"\x1b[1;1H");
+        assert_eq!(
+            mirror.cursor_position().unwrap(),
+            (3, 2),
+            "replay lost the DECOM scrolling-region origin"
+        );
+    }
+}
+
 fn assert_theme_portable_replay_boundaries(
     label: &str,
     transcript: &[u8],

--- a/cmux-tui/crates/ghostty-vt/tests/terminal.rs
+++ b/cmux-tui/crates/ghostty-vt/tests/terminal.rs
@@ -371,6 +371,44 @@ fn vt_replay_restores_cursor_inside_origin_mode_scrolling_region() {
     }
 }
 
+#[test]
+fn vt_replay_restores_cursor_inside_origin_mode_with_incomplete_sequence() {
+    let mut source = Terminal::new(12, 8, 0, Callbacks::default()).unwrap();
+    source.vt_write(b"screen contents");
+    source.vt_write(b"\x1b[?69h\x1b[3;7r\x1b[4;10s\x1b[?6h\x1b[2;3H");
+    let expected = source.cursor_position().unwrap();
+    assert_eq!(expected, (5, 3));
+
+    source.vt_write(b"\x1b]0;incomplete title");
+    assert!(!source.vt_stream_is_ground());
+
+    let full = source.vt_replay_bytes().unwrap();
+    assert!(!source.vt_stream_is_ground(), "replay changed the live parser boundary");
+    let bounded = source.vt_replay_bounded_bytes(8 * 1024 * 1024).unwrap();
+    assert!(!source.vt_stream_is_ground(), "bounded replay changed the live parser boundary");
+
+    for replay in [&full, &bounded] {
+        let mut mirror = Terminal::new(12, 8, 0, Callbacks::default()).unwrap();
+        mirror.vt_write(replay);
+        assert!(mirror.mode(6, false), "replay lost DECOM");
+        assert_eq!(
+            mirror.cursor_position().unwrap(),
+            expected,
+            "mirror cursor diverged while the source parser held a partial OSC"
+        );
+
+        mirror.vt_write(b"\x1b[1;1H");
+        assert_eq!(
+            mirror.cursor_position().unwrap(),
+            (3, 2),
+            "replay lost the DECOM scrolling-region origin"
+        );
+    }
+
+    source.vt_write(b"\x07");
+    assert!(source.vt_stream_is_ground(), "replay corrupted the live partial OSC");
+}
+
 fn assert_theme_portable_replay_boundaries(
     label: &str,
     transcript: &[u8],


### PR DESCRIPTION
Ghostty formats the cursor before it restores DECOM scrolling regions and tab stops. The receiver can therefore finish at a different cursor.

This change captures one Ghostty cursor-position report in receiver coordinates, disables the earlier formatter cursor, and appends one final cursor plan. Pending wrap uses the same plan before it restores the cursor cell.

Commit c7c8a9821f43a9f2833314aec880da74aeeb2361 adds the behavior regression. Commit 057f14a66143b03ba10beed1c252109ac575734d adds the fix.

Hosted red proof: https://github.com/manaflow-ai/cmux/actions/runs/31463263242
Hosted final proof: https://github.com/manaflow-ai/cmux/actions/runs/31463573078

Local compile and test were intentionally not run. Hosted macOS, Linux, and Valgrind proof validate the exact head.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes attach/mirror replay cursor restoration in DECOM and pending-wrap cases; incorrect CPR handling or byte budgeting around the plan could misplace the cursor after replay.
> 
> **Overview**
> **VT replay** now builds a single **`ReplayCursorPlan`** up front and appends it at the end of formatted text instead of mixing formatter-emitted cursor state with scrolling-region / tab-stop restoration. Replay segment formatting turns off **`screen.cursor`** so the cursor is restored only through that plan.
> 
> When **DECOM** (origin mode) is active, cursor coordinates for the final **CUP** come from an internal **CPR** (`\x1b[6n`) answered via a temporary **`on_pty_write`** hook—receiver coordinates that stay correct after the formatter restores regions and modes. **Pending wrap** still uses a one-cell reprint path, but row/column in that suffix use the same reported coordinates.
> 
> Adds integration coverage that full and bounded replay keep DECOM, scrolling-region origin, and cursor position inside the region.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3667f81fc73305841f845ca0c418dc2f1fc7ce35. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->