### PR TITLE
test: restore snapshot resume command assertion

### DIFF
--- a/cmuxTests/PiVaultAgentPersistenceTests.swift
+++ b/cmuxTests/PiVaultAgentPersistenceTests.swift
@@ -1108,7 +1108,7 @@ final class PiVaultAgentPersistenceTests: XCTestCase {
         XCTAssertEqual(loadedAgent.kind.rawValue, "pi")
         XCTAssertEqual(loadedAgent.sessionId, sessionPath)
         XCTAssertEqual(
-            loadedAgent.copyResumeCommand,
+            loadedAgent.resumeCommand,
             TerminalStartupWorkingDirectoryPrefix.prefix(
                 "'env' 'PI_CODING_AGENT_SESSION_DIR=\(tempDir.path)' '/opt/homebrew/bin/pi' '--session' '\(sessionPath)' '--session-dir' '\(tempDir.path)'",
                 workingDirectory: "/tmp/pi repo"


### PR DESCRIPTION
Fixes the base test compile failure introduced by 7c866e496c.

The persisted-agent round-trip test creates a SessionRestorableAgentSnapshot. It now checks that type's resumeCommand API. copyResumeCommand belongs to SessionEntry and never existed on the snapshot.

Behavior coverage: the existing round-trip test still verifies that persistence preserves the exact targeted Pi resume command and working-directory prefix.

Red evidence: https://github.com/manaflow-ai/cmux/actions/runs/31463289556/job/93691570713

No local compile or tests were run. Hosted proof will follow.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit e8a1bf96dc8f1a908efb139c1edd92a1695892ea. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix test compile error by asserting `resumeCommand` on `SessionRestorableAgentSnapshot` instead of `copyResumeCommand`. Keeps the persisted-agent round-trip test verifying the exact Pi resume command and working-directory prefix.

<sup>Written for commit e8a1bf96dc8f1a908efb139c1edd92a1695892ea. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/9976?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

