### PR TITLE
Fix iOS workspace selection after Iroh reconnect

### DIFF
--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
@@ -1167,6 +1167,20 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
     /// recovery-scoped UI attributes flags to the exact pairing being
     /// redialed, never a healthy sibling build on the same physical Mac.
     private(set) var recoveryTargetInstanceTag: String?
+    /// The foreground pairing that a new connection attempt replaces. During
+    /// recovery the live identity is intentionally cleared before redial, so
+    /// the retained target remains the ownership authority for distinguishing
+    /// a same-Mac reconnect from a real Mac switch.
+    private var foregroundOrRecoveryMacKey: MacPairingKey {
+        guard foregroundMacDeviceID == nil,
+              let recoveryTargetMacDeviceID else {
+            return foregroundMacKey
+        }
+        return MacPairingKey(
+            macDeviceID: recoveryTargetMacDeviceID,
+            instanceTag: recoveryTargetInstanceTag
+        )
+    }
     /// Compatibility view over registry entries whose role is `.control`.
     var secondaryMacSubscriptions: MobileMacConnectionRegistry.ControlSubscriptions {
         macConnectionRegistry.controlSubscriptions
@@ -8020,7 +8034,7 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
             .trimmingCharacters(in: .whitespacesAndNewlines)
         let requestedMacDeviceID = pairedMacDeviceID
             ?? (ticketMacDeviceID.isEmpty ? nil : ticketMacDeviceID)
-        let previousForegroundKeyBeforeConnect = foregroundMacKey
+        let previousForegroundKeyBeforeConnect = foregroundOrRecoveryMacKey
         let currentFocusedConnection: MacConnection? =
             foregroundMacDeviceID.flatMap { macID in
                 guard let connection = connections[macID],

--- a/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/IrohConnectionRecoveryOwnerTests.swift
+++ b/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/IrohConnectionRecoveryOwnerTests.swift
@@ -34,6 +34,30 @@ extension ReconnectRouteSelectionTests {
         #expect(attemptedKinds.allSatisfy { $0 == .iroh })
     }
 
+    @Test func sameMacEventStreamRecoveryPreservesSelectedWorkspace() async throws {
+        let fixture = try await makeRecoveryOwnerFixture()
+        defer { fixture.release() }
+        await fixture.router.setWorkspaceIDs(["cmux-master", "hevy-cli"])
+
+        #expect(await fixture.store.reconnectActiveMacIfAvailable(stackUserID: "user-1"))
+        #expect(await fixture.router.waitForCount(of: "mobile.events.subscribe", atLeast: 1))
+        let firstClient = try #require(fixture.store.remoteClient)
+        let hevyWorkspace = try #require(
+            fixture.store.workspaces.first { $0.rpcWorkspaceID.rawValue == "hevy-cli" }
+        )
+        fixture.store.selectedWorkspaceID = hevyWorkspace.id
+        let firstTransport = try #require(fixture.box.get())
+
+        await firstTransport.close()
+
+        #expect(try await pollUntil {
+            guard let replacement = fixture.store.remoteClient else { return false }
+            return replacement !== firstClient
+                && fixture.store.connectionState == .connected
+        })
+        #expect(fixture.store.selectedWorkspace?.rpcWorkspaceID.rawValue == "hevy-cli")
+    }
+
     @Test func recoveryWaitsForOldPhysicalTransportBeforeRedialing() async throws {
         let closeGate = LivenessTransportCloseGate()
         let fixture = try await makeRecoveryOwnerFixture(

--- a/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/MobileShellRenderGridLivenessTestSupport.swift
+++ b/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/MobileShellRenderGridLivenessTestSupport.swift
@@ -81,6 +81,7 @@ actor LivenessHostRouter {
     private var macInstanceTag: String? = "default"
     private var macDisplayName: String? = "Test Mac"
     private var workspaceListResponseHook: (@Sendable () -> Void)?
+    private var workspaceIDs = ["live-workspace"]
     private var workspaceListTitles: [String] = []
     /// FIFO of scripted `mobile.sync.fetch` results (state sync v2 tests).
     private var syncFetchResults: [[String: Any]] = []
@@ -336,6 +337,10 @@ actor LivenessHostRouter {
         workspaceListTitles.append(contentsOf: titles)
     }
 
+    func setWorkspaceIDs(_ workspaceIDs: [String]) {
+        self.workspaceIDs = workspaceIDs
+    }
+
     func scriptNotificationFeedRevisions(_ revisions: [Int]) {
         notificationFeedRevisions.append(contentsOf: revisions)
     }
@@ -483,24 +488,27 @@ actor LivenessHostRouter {
                     message: "scripted workspace list failure"
                 )
             }
-            return try? Self.resultFrame(id: id, result: [
-                "workspaces": [
-                    [
-                        "id": "live-workspace",
-                        "title": workspaceTitle,
-                        "current_directory": "/Users/test/project",
-                        "is_selected": true,
-                        "terminals": [
-                            [
-                                "id": "live-terminal",
-                                "title": "Terminal",
-                                "current_directory": "/Users/test/project",
-                                "is_ready": true,
-                                "is_focused": true,
-                            ],
+            let workspaces: [[String: Any]] = workspaceIDs.enumerated().map { index, workspaceID in
+                [
+                    "id": workspaceID,
+                    "title": index == 0 ? workspaceTitle : workspaceID,
+                    "current_directory": "/Users/test/project",
+                    "is_selected": index == 0,
+                    "terminals": [
+                        [
+                            "id": workspaceID == "live-workspace"
+                                ? "live-terminal"
+                                : "\(workspaceID)-terminal",
+                            "title": "Terminal",
+                            "current_directory": "/Users/test/project",
+                            "is_ready": true,
+                            "is_focused": true,
                         ],
                     ],
-                ],
+                ]
+            }
+            return try? Self.resultFrame(id: id, result: [
+                "workspaces": workspaces,
             ])
         case "mobile.host.status":
             hostStatusRequestCount += 1


### PR DESCRIPTION
## Summary

- Preserve the selected iOS workspace when an Iroh event stream reconnects to the same Mac and build.
- Connection teardown cleared the live foreground Mac identity before redial, so recovery looked like a Mac switch and selected the first workspace. The reconnect now compares against the retained recovery pairing key, including the build tag. Real Mac or build switches still reset selection.

## Testing

- Test-only commit reproduced `hevy-cli` changing to `cmux-master`: https://github.com/manaflow-ai/cmux/actions/runs/31466803835
- Focused `sameMacEventStreamRecoveryPreservesSelectedWorkspace` test passed on the AWS M4 Pro.
- Package conventions lint and the requested iPad routing job passed: https://github.com/manaflow-ai/cmux/actions/runs/31467488901
- The same workflow's package and iPhone jobs reached the ten-minute job limit and were canceled, so its aggregate job failed without a test assertion failure.
- Cloud macOS and iOS builds succeeded. The isolated iOS simulator paired and rendered both `cmux-master` and `Hevy CLI`. The exact reconnect UI path remains unverified because Computer Use could not safely target this Simulator window while another agent's Simulator window was focused.

## Demo Video

- No video. This is a state-management change with no UI changes, and the exact simulator reconnect path could not be safely driven under the current shared Simulator window state.

## Review Trigger (Copy/Paste as PR comment)

```text
@codex review
@coderabbitai review
@greptile-apps review
@cubic-dev-ai review
```

## Checklist

- [ ] I tested the change locally. Local cmux test runs are prohibited; the focused test ran on the AWS M4 Pro.
- [x] I added or updated tests for behavior changes.
- [x] I updated docs/changelog if needed. No user-facing behavior or configuration documentation changed.
- [ ] I requested bot reviews after my latest commit. No manual review trigger was sent; CodeRabbit and Cursor ran automatically.
- [x] All code review bot comments are resolved. Automatic reviews reported no actionable comments.
- [x] All human review comments are resolved. No human review comments exist.
