### PR TITLE
test(tui): preserve exact journal subject marker

### DIFF
--- a/cmux-tui/crates/cmux-tui-core/src/server.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/server.rs
@@ -15060,7 +15060,7 @@ mod tests {
             Arc::new(ConnectionSurfaceScheduler::new(mux.surface_operation_admission.clone()));
 
         for index in 0..32_u128 {
-            let marker = format!("subject-head-marker-{index}");
+            let marker = format!("subject-head-child-{index}");
             let ingress = crate::agent_hook_journal_ingress(
                 "codex",
                 "SubagentStop",
@@ -15069,8 +15069,8 @@ mod tests {
                     "session_id":"subject-head-root",
                     "root_session_id":"subject-head-root",
                     "parent_session_id":"subject-head-root",
-                    "child_agent_id":format!("subject-head-child-{index}"),
-                    "message":marker,
+                    "child_agent_id":marker.clone(),
+                    "message":"complete",
                 }),
             )
             .unwrap();


### PR DESCRIPTION
This test-only correction keeps the journal subject-head marker in child_agent_id, which the adapter preserves as structural data. The former message marker is redacted before journal storage, so its exact payload filter cannot match.

Exact main red proof: https://github.com/manaflow-ai/cmux/actions/runs/31470355079
Exact PR 9840 red proof: https://github.com/manaflow-ai/cmux/actions/runs/31470352875

No production code changes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit b46724685d937502689b6c205e973f33fce459dc. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix tests in `cmux-tui-core` to preserve the journal subject-head marker by storing it in child_agent_id and setting message to "complete". This matches the adapter’s redaction of message payloads and prevents false negatives in the journal filter.

<sup>Written for commit b46724685d937502689b6c205e973f33fce459dc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/9982?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

