### PR TITLE
Fix Ghostty VT build script Clippy errors

### DIFF
--- a/cmux-tui/crates/ghostty-vt-sys/build.rs
+++ b/cmux-tui/crates/ghostty-vt-sys/build.rs
@@ -1,5 +1,5 @@
 use std::env;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::process::Command;
 
 fn main() {
@@ -72,13 +72,13 @@ fn main() {
 /// Build libghostty-vt.a with zig. ReleaseFast regardless of the cargo
 /// profile: the VT parser is on the PTY hot path and a debug zig build is an
 /// order of magnitude slower.
-fn build_libghostty_vt(ghostty_dir: &PathBuf, out_dir: &PathBuf, target: &str) -> PathBuf {
+fn build_libghostty_vt(ghostty_dir: &Path, out_dir: &Path, target: &str) -> PathBuf {
     let zig = env::var("ZIG").unwrap_or_else(|_| "zig".to_string());
     let prefix = out_dir.join("ghostty-vt");
     let host = env::var("HOST").unwrap();
     let mut command = Command::new(&zig);
     command
-        .current_dir(&ghostty_dir)
+        .current_dir(ghostty_dir)
         .arg("build")
         .arg("-Demit-lib-vt=true")
         .arg("-Demit-xcframework=false")
@@ -108,7 +108,7 @@ fn build_libghostty_vt(ghostty_dir: &PathBuf, out_dir: &PathBuf, target: &str) -
 
 /// Generate Rust bindings from the public C header. This needs the ghostty
 /// sources but no zig, so it runs the same way for a prebuilt archive.
-fn generate_bindings(ghostty_dir: &PathBuf, out_dir: &PathBuf, _target: &str) {
+fn generate_bindings(ghostty_dir: &Path, out_dir: &Path, _target: &str) {
     let include_dir = ghostty_dir.join("include");
     let bindings = bindgen::Builder::default()
         .header(include_dir.join("ghostty/vt.h").to_str().unwrap().to_string())


### PR DESCRIPTION
Rust 1.95 Clippy rejects borrowed PathBuf parameters and an extra borrow in the Ghostty VT build script.

This one-file repair accepts Path references and passes the existing borrow directly. Runtime behavior is unchanged.

Exact base red proof: PR9952 hosted run 31479592663, Linux job 93741282966.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 272fbd8e8be64f0e6922f3457ee4833b4ba08c12. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix Clippy errors in the `ghostty-vt-sys` build script on Rust 1.95 by switching function params from `&PathBuf` to `&Path` and removing an extra borrow. Unblocks CI with no runtime behavior change.

<sup>Written for commit 272fbd8e8be64f0e6922f3457ee4833b4ba08c12. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/9986?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

