### PR TITLE
Remove obsolete TUI shell quote test helper

### DIFF
--- a/cmux-tui/crates/cmux-tui/src/config.rs
+++ b/cmux-tui/crates/cmux-tui/src/config.rs
@@ -5919,11 +5919,6 @@ mod tests {
         })
     }
 
-    #[cfg(all(unix, not(target_os = "macos")))]
-    fn shell_quote_path(path: &Path) -> String {
-        format!("'{}'", path.to_string_lossy().replace('\'', "'\\''"))
-    }
-
     #[test]
     fn ghostty_config_helper_output_reader_drains_large_palette() {
         let mut output = String::new();


### PR DESCRIPTION
Removes a test-only helper that became unused after the hosted process-liveness cleanup.

Red proof: PR 9840 full hosted run 31479870146 fails cargo clippy because shell_quote_path is dead code. The fix has no runtime effect. No local compiler ran.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 8eea0590ed27e8345da973111f4f600292e86260. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the unused test helper `shell_quote_path` from `cmux-tui` to clear a cargo clippy dead-code warning. No runtime effect.

<sup>Written for commit 8eea0590ed27e8345da973111f4f600292e86260. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/9987?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed an internal test helper; no user-facing behavior has changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->