### PR TITLE
Fix cross-platform workspace mode Clippy lint

### DIFF
--- a/cmux-tui/crates/cmux-remote/src/workspace/files.rs
+++ b/cmux-tui/crates/cmux-remote/src/workspace/files.rs
@@ -1009,18 +1009,20 @@ impl RawEntryState {
     }
 
     fn is_regular(&self) -> bool {
-        self.mode & normalize_stat_value(libc::S_IFMT) == normalize_stat_value(libc::S_IFREG)
+        self.mode & normalize_stat_value::<_, u32>(libc::S_IFMT)
+            == normalize_stat_value::<_, u32>(libc::S_IFREG)
     }
 
     fn is_symlink(&self) -> bool {
-        self.mode & normalize_stat_value(libc::S_IFMT) == normalize_stat_value(libc::S_IFLNK)
+        self.mode & normalize_stat_value::<_, u32>(libc::S_IFMT)
+            == normalize_stat_value::<_, u32>(libc::S_IFLNK)
     }
 
     fn same_object(&self, other: &Self) -> bool {
         self.dev == other.dev
             && self.ino == other.ino
-            && self.mode & normalize_stat_value(libc::S_IFMT)
-                == other.mode & normalize_stat_value(libc::S_IFMT)
+            && self.mode & normalize_stat_value::<_, u32>(libc::S_IFMT)
+                == other.mode & normalize_stat_value::<_, u32>(libc::S_IFMT)
     }
 
     fn matches_snapshot(&self, other: &Self) -> bool {

--- a/cmux-tui/crates/cmux-remote/src/workspace/files.rs
+++ b/cmux-tui/crates/cmux-remote/src/workspace/files.rs
@@ -1009,17 +1009,18 @@ impl RawEntryState {
     }
 
     fn is_regular(&self) -> bool {
-        self.mode & libc::S_IFMT as u32 == libc::S_IFREG as u32
+        self.mode & normalize_stat_value(libc::S_IFMT) == normalize_stat_value(libc::S_IFREG)
     }
 
     fn is_symlink(&self) -> bool {
-        self.mode & libc::S_IFMT as u32 == libc::S_IFLNK as u32
+        self.mode & normalize_stat_value(libc::S_IFMT) == normalize_stat_value(libc::S_IFLNK)
     }
 
     fn same_object(&self, other: &Self) -> bool {
         self.dev == other.dev
             && self.ino == other.ino
-            && self.mode & libc::S_IFMT as u32 == other.mode & libc::S_IFMT as u32
+            && self.mode & normalize_stat_value(libc::S_IFMT)
+                == other.mode & normalize_stat_value(libc::S_IFMT)
     }
 
     fn matches_snapshot(&self, other: &Self) -> bool {


### PR DESCRIPTION
Rust 1.95 rejects mode_t casts that are redundant on Linux. Apple mode_t remains narrower. This one-file repair uses the existing checked stat-value normalization on both platforms.

Exact red proof: run 31480558906, Linux job 93744308807.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit da80cca79a4cbf49ff65dd01b34c4b6cfb353201. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Normalize file mode comparisons to fix a Rust 1.95 Clippy lint and keep behavior consistent on Linux and macOS. Replaced `as u32` casts with `normalize_stat_value::<_, u32>` in workspace file checks.

- **Bug Fixes**
  - Use `normalize_stat_value::<_, u32>` with `libc::S_IFMT`, `libc::S_IFREG`, and `libc::S_IFLNK` in `is_regular`, `is_symlink`, and `same_object`.
  - Explicitly normalize to `u32` to match `self.mode`, removing redundant `mode_t` casts on Linux and handling narrower `mode_t` on Apple.

<sup>Written for commit 4b5f2e0e35c76fbfcf02c006951fe11228c7b403. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/9988?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

