### PR TITLE
Fix bounded journal replay sensitivity fixture

### DIFF
--- a/cmux-tui/crates/cmux-tui-core/src/server.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/server.rs
@@ -15169,7 +15169,10 @@ mod tests {
                 "stream_id":stream_id,
                 "start":"beginning",
                 "follow":false,
-                "filter":{"kinds":["workspace.*"]},
+                "filter":{
+                    "kinds":["workspace.*"],
+                    "max_sensitivity":"sensitive",
+                },
             }),
             None,
         );


### PR DESCRIPTION
The bounded replay test requests workspace.create records, which are classified sensitive. Set the matching filter ceiling explicitly.

Red proof: exact-main hosted run 31477453158 fails this test because the metadata ceiling correctly omits the record. This is test-only. No local compiler ran.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/9989"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789036339&installation_model_id=21920&pr_number=9989&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F9989&signature=48be83fa1226d32548b46001c1c9cfe49719aaa074ccea59b30b47389f85e61c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test fixture only; no runtime or security logic changes.
> 
> **Overview**
> Updates the **journal-bounded-open** integration test so the subscribe filter explicitly sets **`max_sensitivity` to `sensitive`**.
> 
> Without that ceiling, replay correctly omits **`workspace.create`** events (they are sensitive), which broke expectations that the bounded stream still delivers that record and completes with **`stream_end`**. This is a **test-only** alignment with journal sensitivity filtering—no production behavior change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ebae1456ce2fba3f65c22e32680ba98ce54c6597. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix the bounded journal replay test by explicitly requesting sensitive workspace events. Set filter.max_sensitivity to sensitive so workspace.create records are returned and the test no longer fails; test-only, no production impact.

<sup>Written for commit ebae1456ce2fba3f65c22e32680ba98ce54c6597. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/9989?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Workspace event streams now include events marked as sensitive, improving event coverage for supported workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->