### PR TITLE
fix(scripts): use xcrun dwarfdump in diff sidecar verification

### DIFF
--- a/scripts/verify-diff-sidecar-artifact.sh
+++ b/scripts/verify-diff-sidecar-artifact.sh
@@ -56,7 +56,12 @@ for arch in $ARCHS; do
   fi
 done
 
-DEBUG_INFO="$(dwarfdump --debug-info "$BINARY" 2>&1)"
+# Resolve dwarfdump through xcrun so the Xcode toolchain's LLVM build is used.
+# Homebrew's dwarfutils installs a libdwarf dwarfdump at /opt/homebrew/bin,
+# which build-diff-sidecar.sh puts ahead of /usr/bin on PATH. That binary
+# rejects --debug-info, and under `set -e` the failing command substitution
+# aborts this script with no diagnostic at all.
+DEBUG_INFO="$(xcrun dwarfdump --debug-info "$BINARY" 2>&1)"
 if [[ "$DEBUG_INFO" == *"DW_TAG_"* ]]; then
   echo "error: diff sidecar retains embedded DWARF debug information" >&2
   exit 1


### PR DESCRIPTION
## Problem

On a machine that has Homebrew's `dwarfutils` installed, `./scripts/reload.sh` fails with:

```
Command PhaseScriptExecution failed with a nonzero exit code
** BUILD FAILED **

The following build commands failed:
	PhaseScriptExecution Build\ Diff\ Sidecar ...
(2 failures)
```

No error message is printed anywhere — not by the script, not in the Xcode log. The Rust crate itself compiles fine (`Finished release profile [optimized] target(s)`), and the failure happens immediately after.

## Root cause

`scripts/verify-diff-sidecar-artifact.sh` calls bare `dwarfdump`:

```sh
DEBUG_INFO="$(dwarfdump --debug-info "$BINARY" 2>&1)"
```

`dwarfutils` installs a libdwarf-based `dwarfdump` at `/opt/homebrew/bin/dwarfdump`, and `scripts/build-diff-sidecar.sh` explicitly prepends `/opt/homebrew/bin` to `PATH`:

```sh
export PATH="${CARGO_HOME:-${HOME}/.cargo}/bin:/opt/homebrew/bin:/usr/local/bin:${PATH}"
```

so the libdwarf binary always shadows Xcode's LLVM `dwarfdump` inside that build phase. libdwarf's version does not accept `--debug-info`:

```
ERROR: invalid long option '--debug-info'
dwarfdump option error.
```

It exits non-zero. Because the result is captured in a command substitution under `set -euo pipefail`, that non-zero status terminates the script immediately — before the `if` that would have inspected the output, and before any `echo` could report anything. Hence exit 65 with zero diagnostics.

Verified with `bash -x`:

```
+ /path/to/scripts/verify-diff-sidecar-artifact.sh /path/to/cmux-diff-sidecar --archs arm64
(script exits 1, no output)
```

## Fix

Route the call through `xcrun` so the Xcode toolchain's `dwarfdump` is selected regardless of `PATH` ordering. This matches how the rest of the build phase expects Apple tooling to resolve, and is a no-op on machines without `dwarfutils`.

## Testing

- macOS 26.6, Xcode 26.6, `dwarfutils 2.3.2` installed via Homebrew
- Before: `./scripts/build-diff-sidecar.sh` exits 1 silently; `reload.sh` fails with exit 65
- After: `diff sidecar: 638432 bytes, architectures: arm64, minimum macOS: 14.0, signed` and `reload.sh` proceeds past the phase
- The `DW_TAG_` check still works as intended — `xcrun dwarfdump --debug-info` produces the same output the check was written against

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/9990"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789041443&installation_model_id=21920&pr_number=9990&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F9990&signature=96addc0bf0f3c7730a615933468ba662888a356d12c1f29fe822552302305abe"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line tooling resolution change in a verification script; no product runtime or security impact.
> 
> **Overview**
> **Fixes silent failure** of diff sidecar verification when Homebrew `dwarfutils` shadows Xcode’s LLVM `dwarfdump` on `PATH`.
> 
> `verify-diff-sidecar-artifact.sh` now runs **`xcrun dwarfdump --debug-info`** instead of bare `dwarfdump`. The libdwarf binary from `/opt/homebrew/bin` rejects `--debug-info`, exits non-zero, and under `set -e` the command substitution aborts the script with no message—breaking `reload.sh` / the Build Diff Sidecar phase. Routing through `xcrun` picks the toolchain build regardless of `PATH`; the existing `DW_TAG_` DWARF check is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 17af47737cfe0ee86fd5cceec00b2caa0c8ecadf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Use `xcrun dwarfdump` in `scripts/verify-diff-sidecar-artifact.sh` to force Xcode’s toolchain and avoid Homebrew’s `dwarfutils` binary that rejects `--debug-info`. This stops the diff sidecar build phase (and `reload.sh`) from failing silently on machines with `dwarfutils` installed.

- **Bug Fixes**
  - Route `dwarfdump` calls through `xcrun` to avoid PATH shadowing by `/opt/homebrew/bin/dwarfdump` (libdwarf).
  - Keeps the `DW_TAG_` check working; no other behavior changes.

<sup>Written for commit 17af47737cfe0ee86fd5cceec00b2caa0c8ecadf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/9990?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved artifact verification by using the Xcode toolchain’s compatible inspection utility.
  * Avoided potential conflicts caused by alternate tool installations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->