### PR TITLE
Drop into a collapsed group by releasing on its header row

### DIFF
--- a/Packages/macOS/CmuxFoundation/Sources/CmuxFoundation/SidebarDrop/SidebarWorkspaceReorderDropResolver.swift
+++ b/Packages/macOS/CmuxFoundation/Sources/CmuxFoundation/SidebarDrop/SidebarWorkspaceReorderDropResolver.swift
@@ -167,6 +167,18 @@ public struct SidebarWorkspaceReorderDropResolver: Sendable {
                     guard !target.isGroupHeader else { return nil }
                     return (groupId, false)
                 case .bottom:
+                    // A group header's lower half is the group's own adopt
+                    // zone, so hovering it plans a drop *into* the group
+                    // whether or not the group's rows are visible underneath.
+                    // A collapsed group (and one whose only member is its
+                    // anchor) has no member row below the header, and reading
+                    // that as a group/root boundary sent the drop through the
+                    // horizontal lane rule below — where the left half planned
+                    // a root slot beside the group and the group looked
+                    // undroppable, because the gap that would have accepted the
+                    // workspace is exactly the one the collapse is hiding.
+                    // Only member rows can sit on a real group/root boundary.
+                    guard !target.isGroupHeader else { return (groupId, false) }
                     let nextIsSameGroup = context.nextTarget?.groupId == groupId
                     return (groupId, !nextIsSameGroup)
                 }

--- a/cmuxTests/SidebarWorkspaceDropPlannerTests.swift
+++ b/cmuxTests/SidebarWorkspaceDropPlannerTests.swift
@@ -222,7 +222,7 @@ private func require<T>(_ value: T?, _ message: String? = nil) throws -> T {
         expectEqual(explicitGroupId, fixture.groupId)
     }
 
-    @Test func CollapsedGroupHeaderLeftHalfPlansRootSlotAfterGroup() throws {
+    @Test func CollapsedGroupHeaderLeftHalfPlansFirstSlotInsideGroup() throws {
         let fixture = collapsedGroupReorderFixture()
 
         let plan = try require(SidebarWorkspaceReorderDropResolver().plan(
@@ -236,8 +236,66 @@ private func require<T>(_ value: T?, _ message: String? = nil) throws -> T {
             return
         }
         expectEqual(targetIndex, 2)
+        expectFalse(usesTopLevelRows)
+        expectEqual(explicitGroupId, fixture.groupId)
+    }
+
+    @Test func CollapsedGroupHeaderBottomEdgeAdoptsIntoGroupFromEitherLane() throws {
+        let fixture = collapsedGroupReorderFixture()
+
+        let leftLanePlan = try require(SidebarWorkspaceReorderDropResolver().plan(
+            for: fixture.request(point: CGPoint(x: 2, y: 70))
+        ))
+        let rightLanePlan = try require(SidebarWorkspaceReorderDropResolver().plan(
+            for: fixture.request(point: CGPoint(x: 120, y: 70))
+        ))
+
+        expectEqual(leftLanePlan, rightLanePlan)
+        expectEqual(leftLanePlan.indicator, SidebarDropIndicator(tabId: fixture.anchor, edge: .bottom))
+        expectEqual(leftLanePlan.indicatorScope, SidebarWorkspaceReorderDropIndicatorScope.group(fixture.groupId))
+        guard case .reorder(let targetIndex, let usesTopLevelRows, let explicitGroupId) = leftLanePlan.action else {
+            Issue.record("Expected local reorder plan")
+            return
+        }
+        expectEqual(targetIndex, 2)
+        expectFalse(usesTopLevelRows)
+        expectEqual(explicitGroupId, fixture.groupId)
+    }
+
+    @Test func CollapsedGroupHeaderTopHalfStillPlansRootSlotBeforeGroup() throws {
+        let fixture = collapsedGroupReorderFixture()
+
+        let plan = try require(SidebarWorkspaceReorderDropResolver().plan(
+            for: fixture.request(point: CGPoint(x: 2, y: 50))
+        ))
+
+        expectEqual(plan.indicator, SidebarDropIndicator(tabId: fixture.anchor, edge: .top))
+        expectEqual(plan.indicatorScope, SidebarWorkspaceReorderDropIndicatorScope.topLevel)
+        guard case .reorder(let targetIndex, let usesTopLevelRows, let explicitGroupId) = plan.action else {
+            Issue.record("Expected local reorder plan")
+            return
+        }
+        expectEqual(targetIndex, 1)
         expectTrue(usesTopLevelRows)
         #expect(explicitGroupId == nil)
+    }
+
+    @Test func EmptyGroupHeaderBottomEdgeAdoptsIntoGroupFromLeftLane() throws {
+        let fixture = emptyGroupReorderFixture()
+
+        let plan = try require(SidebarWorkspaceReorderDropResolver().plan(
+            for: fixture.request(point: CGPoint(x: 2, y: 56))
+        ))
+
+        expectEqual(plan.indicator, SidebarDropIndicator(tabId: fixture.anchor, edge: .bottom))
+        expectEqual(plan.indicatorScope, SidebarWorkspaceReorderDropIndicatorScope.group(fixture.groupId))
+        guard case .reorder(let targetIndex, let usesTopLevelRows, let explicitGroupId) = plan.action else {
+            Issue.record("Expected local reorder plan")
+            return
+        }
+        expectEqual(targetIndex, 2)
+        expectFalse(usesTopLevelRows)
+        expectEqual(explicitGroupId, fixture.groupId)
     }
 
     @Test func RootLaneOverExpandedGroupHeaderTopUsesGroupBlockBoundary() throws {
@@ -858,8 +916,64 @@ private func require<T>(_ value: T?, _ message: String? = nil) throws -> T {
         }
     }
 
+    /// A group whose only member is its anchor, so the header row is the whole
+    /// group block and no member gap is ever visible below it.
+    private struct EmptyGroupReorderFixture {
+        let rootBefore = UUID()
+        let anchor = UUID()
+        let rootAfter = UUID()
+        let dragged = UUID()
+        let groupId = UUID()
+
+        func request(point: CGPoint) -> SidebarWorkspaceReorderDropRequest {
+            SidebarWorkspaceReorderDropRequest(
+                point: point,
+                draggedWorkspaceId: dragged,
+                workspaces: [
+                    SidebarWorkspaceReorderWorkspaceSnapshot(id: rootBefore, isPinned: false, groupId: nil),
+                    SidebarWorkspaceReorderWorkspaceSnapshot(id: anchor, isPinned: false, groupId: groupId),
+                    SidebarWorkspaceReorderWorkspaceSnapshot(id: rootAfter, isPinned: false, groupId: nil),
+                    SidebarWorkspaceReorderWorkspaceSnapshot(id: dragged, isPinned: false, groupId: nil)
+                ],
+                groups: [
+                    SidebarWorkspaceReorderGroupSnapshot(id: groupId, anchorWorkspaceId: anchor, isPinned: false)
+                ],
+                targets: [
+                    SidebarWorkspaceReorderDropTarget(
+                        workspaceId: rootBefore,
+                        groupId: nil,
+                        isGroupHeader: false,
+                        frame: CGRect(x: 0, y: 0, width: 180, height: 32)
+                    ),
+                    SidebarWorkspaceReorderDropTarget(
+                        workspaceId: anchor,
+                        groupId: groupId,
+                        isGroupHeader: true,
+                        frame: CGRect(x: 0, y: 40, width: 180, height: 32)
+                    ),
+                    SidebarWorkspaceReorderDropTarget(
+                        workspaceId: rootAfter,
+                        groupId: nil,
+                        isGroupHeader: false,
+                        frame: CGRect(x: 0, y: 80, width: 180, height: 32)
+                    ),
+                    SidebarWorkspaceReorderDropTarget(
+                        workspaceId: dragged,
+                        groupId: nil,
+                        isGroupHeader: false,
+                        frame: CGRect(x: 0, y: 120, width: 180, height: 32)
+                    )
+                ]
+            )
+        }
+    }
+
     private func reorderFixture() -> ReorderFixture {
         ReorderFixture()
+    }
+
+    private func emptyGroupReorderFixture() -> EmptyGroupReorderFixture {
+        EmptyGroupReorderFixture()
     }
 
     private func multiChildReorderFixture() -> MultiChildReorderFixture {


### PR DESCRIPTION
## Problem

Dropping a workspace into a group requires landing on an insertion gap that belongs to the group's row scope. A **collapsed** group hides exactly those gaps, and a group whose only member is its anchor never has one.

`SidebarWorkspaceReorderDropResolver.groupScopeCandidate` confirmed the group scope on a header's bottom edge by checking whether the next visible row belonged to the same group. With no member row underneath that check failed, the position was marked ambiguous, and the drop fell through to the group/root horizontal lane rule — so the left half of the header planned a root slot beside the group. Releasing on a collapsed group silently dropped the session next to it, with no discoverable way in.

## Fix

Treat a group header as an unambiguous group target on its bottom edge and stop consulting the next visible row there. Only member rows can sit on a real group/root boundary.

- Expanded groups are unaffected: the next visible row was already the first member, so the branch resolved the same way.
- The header's top half still plans the root slot before the group, so inserting above a leading group keeps working.
- The boundary below the last visible member keeps its existing lane rule.

It lands in the shared `CmuxFoundation` resolver, so the AppKit table, the SwiftUI overlay, and the mobile move-intent resolver all pick it up from one path.

## Tests

Two commits per the regression policy — tests first (red), then the fix (green).

In `cmuxTests/SidebarWorkspaceDropPlannerTests.swift`:

- `CollapsedGroupHeaderLeftHalfPlansFirstSlotInsideGroup` — rewritten from `CollapsedGroupHeaderLeftHalfPlansRootSlotAfterGroup`, which encoded the bug
- `CollapsedGroupHeaderBottomEdgeAdoptsIntoGroupFromEitherLane`
- `CollapsedGroupHeaderTopHalfStillPlansRootSlotBeforeGroup` — guards the root escape hatch
- `EmptyGroupHeaderBottomEdgeAdoptsIntoGroupFromLeftLane` — new fixture, group whose only member is its anchor

## Verification status

**These tests have not been run.** Authored on Windows, so `xcodebuild` was unavailable, and this repo's Swift workflows (`ci.yml`, `test-depot.yml`) are `workflow_dispatch`-only, so nothing ran on the PR either. The expected values were derived by hand against the pure resolver and its fixtures. Someone with a Mac or dispatch access should run the suite before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
