### PR TITLE
Make initial route timeout tests owner-driven

### DIFF
--- a/cmux-tui/crates/cmux-tui/src/remote_runtime.rs
+++ b/cmux-tui/crates/cmux-tui/src/remote_runtime.rs
@@ -532,13 +532,23 @@ async fn run_client(
 
 async fn connect_first_available(
     options: &ClientRuntimeOptions,
+    shutdown: watch::Receiver<bool>,
+) -> anyhow::Result<(Arc<ClientConnection>, String)> {
+    let deadline_owner = InitialAttemptDeadlineOwner::default();
+    connect_first_available_with_deadline_owner(options, shutdown, &deadline_owner).await
+}
+
+async fn connect_first_available_with_deadline_owner(
+    options: &ClientRuntimeOptions,
     mut shutdown: watch::Receiver<bool>,
+    deadline_owner: &InitialAttemptDeadlineOwner,
 ) -> anyhow::Result<(Arc<ClientConnection>, String)> {
     let mut attempts = 0_u32;
     let mut delay = options.reconnect.initial_delay;
     loop {
         attempts = attempts.saturating_add(1);
-        let mut attempt = RuntimeInitialRouteAttempt { options, shutdown: shutdown.clone() };
+        let mut attempt =
+            RuntimeInitialRouteAttempt { options, shutdown: shutdown.clone(), deadline_owner };
         match select_initial_route(
             &options.routes,
             options.session,
@@ -566,6 +576,85 @@ async fn connect_first_available(
                 delay = (delay * 2).min(options.reconnect.maximum_delay);
             }
             Err(error) => return Err(error.error),
+        }
+    }
+}
+
+#[derive(Clone, Default)]
+struct InitialAttemptDeadlineOwner {
+    #[cfg(test)]
+    manual: Option<Arc<ManualInitialAttemptDeadlines>>,
+}
+
+impl InitialAttemptDeadlineOwner {
+    fn begin(&self, _endpoint: &Url, timeout: Duration) -> InitialAttemptDeadline {
+        #[cfg(test)]
+        if let Some(manual) = &self.manual {
+            let (expired, receiver) = watch::channel(false);
+            manual.deadlines.lock().unwrap().insert(_endpoint.as_str().to_owned(), expired);
+            return InitialAttemptDeadline::Manual(receiver);
+        }
+
+        InitialAttemptDeadline::Realtime(tokio::time::Instant::now() + timeout)
+    }
+
+    #[cfg(test)]
+    fn manual() -> Self {
+        Self { manual: Some(Arc::new(ManualInitialAttemptDeadlines::default())) }
+    }
+
+    #[cfg(test)]
+    fn expire(&self, endpoint: &Url) {
+        let manual = self.manual.as_ref().expect("deadline owner is not manual");
+        let expired = manual
+            .deadlines
+            .lock()
+            .unwrap()
+            .get(endpoint.as_str())
+            .cloned()
+            .expect("initial route did not create its deadline");
+        expired.send_replace(true);
+    }
+}
+
+#[cfg(test)]
+#[derive(Default)]
+struct ManualInitialAttemptDeadlines {
+    deadlines: std::sync::Mutex<BTreeMap<String, watch::Sender<bool>>>,
+}
+
+enum InitialAttemptDeadline {
+    Realtime(tokio::time::Instant),
+    #[cfg(test)]
+    Manual(watch::Receiver<bool>),
+}
+
+impl InitialAttemptDeadline {
+    async fn timeout<F>(&mut self, future: F) -> Result<F::Output, ()>
+    where
+        F: std::future::Future,
+    {
+        match self {
+            Self::Realtime(deadline) => {
+                tokio::time::timeout_at(*deadline, future).await.map_err(|_| ())
+            }
+            #[cfg(test)]
+            Self::Manual(expired) => {
+                tokio::pin!(future);
+                tokio::select! {
+                    result = &mut future => Ok(result),
+                    _ = wait_for_manual_deadline(expired) => Err(()),
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+async fn wait_for_manual_deadline(expired: &mut watch::Receiver<bool>) {
+    while !*expired.borrow() {
+        if expired.changed().await.is_err() {
+            std::future::pending::<()>().await;
         }
     }
 }
@@ -686,6 +775,7 @@ async fn select_initial_route<T: Send>(
 struct RuntimeInitialRouteAttempt<'a> {
     options: &'a ClientRuntimeOptions,
     shutdown: watch::Receiver<bool>,
+    deadline_owner: &'a InitialAttemptDeadlineOwner,
 }
 
 #[async_trait]
@@ -716,11 +806,10 @@ impl InitialRouteAttempt<(Arc<ClientConnection>, String)> for RuntimeInitialRout
     ) -> Result<(Arc<ClientConnection>, String), InitialRouteAttemptError> {
         let display_endpoint = sanitized_route(&request.endpoint);
         let timeout = self.options.reconnect.attempt_timeout;
-        let deadline = tokio::time::Instant::now() + timeout;
+        let mut deadline = self.deadline_owner.begin(&request.endpoint, timeout);
         let mut shutdown = self.shutdown.clone();
         let group = tokio::select! {
-            result = tokio::time::timeout_at(
-                deadline,
+            result = deadline.timeout(
                 self.options
                     .providers
                     .connect(request, client_auth_kind(&self.options.auth)),
@@ -751,8 +840,7 @@ impl InitialRouteAttempt<(Arc<ClientConnection>, String)> for RuntimeInitialRout
             ));
         let mut shutdown = self.shutdown.clone();
         let connection = tokio::select! {
-            result = tokio::time::timeout_at(
-                deadline,
+            result = deadline.timeout(
                 ClientConnection::connect_with_reconnect_groups(
                     group.clone(),
                     ClientConnectionConfig {
@@ -1630,6 +1718,7 @@ mod tests {
 
     struct HangingStartupProvider {
         calls: Arc<AtomicUsize>,
+        started: Arc<tokio::sync::Notify>,
     }
 
     #[async_trait]
@@ -1651,12 +1740,14 @@ mod tests {
             _request: ConnectRequest,
         ) -> Result<Arc<dyn LinkGroup>, ProviderError> {
             self.calls.fetch_add(1, Ordering::AcqRel);
+            self.started.notify_one();
             std::future::pending().await
         }
     }
 
     struct HangingOpenProvider {
         close_calls: Arc<AtomicUsize>,
+        started: Arc<tokio::sync::Notify>,
     }
 
     #[async_trait]
@@ -1677,12 +1768,16 @@ mod tests {
             &self,
             _request: ConnectRequest,
         ) -> Result<Arc<dyn LinkGroup>, ProviderError> {
-            Ok(Arc::new(HangingOpenGroup { close_calls: self.close_calls.clone() }))
+            Ok(Arc::new(HangingOpenGroup {
+                close_calls: self.close_calls.clone(),
+                started: self.started.clone(),
+            }))
         }
     }
 
     struct HangingOpenGroup {
         close_calls: Arc<AtomicUsize>,
+        started: Arc<tokio::sync::Notify>,
     }
 
     #[async_trait]
@@ -1703,6 +1798,7 @@ mod tests {
             &self,
             _request: cmux_remote::provider::LinkRequest,
         ) -> Result<Box<dyn cmux_remote::link::FrameLink>, ProviderError> {
+            self.started.notify_one();
             std::future::pending().await
         }
 
@@ -2445,11 +2541,18 @@ mod tests {
         let server = serve_unix(daemon, &unix_path, MAX_CARRIER_FRAME_BYTES).await.unwrap();
 
         let calls = Arc::new(AtomicUsize::new(0));
+        let started = Arc::new(tokio::sync::Notify::new());
         let mut providers = cmux_remote::provider::ProviderRegistry::default();
-        providers.register(Arc::new(HangingStartupProvider { calls: calls.clone() })).unwrap();
+        providers
+            .register(Arc::new(HangingStartupProvider {
+                calls: calls.clone(),
+                started: started.clone(),
+            }))
+            .unwrap();
         providers.register(Arc::new(UnixProvider::new(MAX_CARRIER_FRAME_BYTES))).unwrap();
         let providers = Arc::new(providers);
-        let routes = [Url::parse("hanging-startup://daemon").unwrap(), unix_test_route(&unix_path)]
+        let hanging_route = Url::parse("hanging-startup://daemon").unwrap();
+        let routes = [hanging_route.clone(), unix_test_route(&unix_path)]
             .into_iter()
             .map(|route| {
                 ResolvedRouteCandidate::resolve(route, BTreeMap::new(), &providers).unwrap()
@@ -2462,14 +2565,26 @@ mod tests {
         options.reconnect.attempt_timeout = Duration::from_millis(20);
         options.reconnect.full_jitter = false;
         let (_shutdown_tx, shutdown_rx) = watch::channel(false);
+        let deadline_owner = InitialAttemptDeadlineOwner::manual();
 
-        let (connection, selected) = tokio::time::timeout(
-            Duration::from_millis(500),
-            connect_first_available(&options, shutdown_rx),
-        )
-        .await
-        .expect("a stalled provider monopolized initial route selection")
-        .expect("the next initial route did not connect");
+        let ((connection, selected), ()) =
+            tokio::time::timeout(Duration::from_millis(500), async {
+                tokio::try_join!(
+                    connect_first_available_with_deadline_owner(
+                        &options,
+                        shutdown_rx,
+                        &deadline_owner,
+                    ),
+                    async {
+                        started.notified().await;
+                        deadline_owner.expire(&hanging_route);
+                        Ok::<(), anyhow::Error>(())
+                    },
+                )
+            })
+            .await
+            .expect("a stalled provider monopolized initial route selection")
+            .expect("the next initial route did not connect");
 
         assert_eq!(calls.load(Ordering::Acquire), 1);
         assert_eq!(selected, format!("unix://{}", unix_path.display()));
@@ -2489,13 +2604,18 @@ mod tests {
         let server = serve_unix(daemon, &unix_path, MAX_CARRIER_FRAME_BYTES).await.unwrap();
 
         let close_calls = Arc::new(AtomicUsize::new(0));
+        let started = Arc::new(tokio::sync::Notify::new());
         let mut providers = cmux_remote::provider::ProviderRegistry::default();
         providers
-            .register(Arc::new(HangingOpenProvider { close_calls: close_calls.clone() }))
+            .register(Arc::new(HangingOpenProvider {
+                close_calls: close_calls.clone(),
+                started: started.clone(),
+            }))
             .unwrap();
         providers.register(Arc::new(UnixProvider::new(MAX_CARRIER_FRAME_BYTES))).unwrap();
         let providers = Arc::new(providers);
-        let routes = [Url::parse("hanging-open://daemon").unwrap(), unix_test_route(&unix_path)]
+        let hanging_route = Url::parse("hanging-open://daemon").unwrap();
+        let routes = [hanging_route.clone(), unix_test_route(&unix_path)]
             .into_iter()
             .map(|route| {
                 ResolvedRouteCandidate::resolve(route, BTreeMap::new(), &providers).unwrap()
@@ -2508,14 +2628,26 @@ mod tests {
         options.reconnect.attempt_timeout = Duration::from_millis(20);
         options.reconnect.full_jitter = false;
         let (_shutdown_tx, shutdown_rx) = watch::channel(false);
+        let deadline_owner = InitialAttemptDeadlineOwner::manual();
 
-        let (connection, selected) = tokio::time::timeout(
-            Duration::from_millis(500),
-            connect_first_available(&options, shutdown_rx),
-        )
-        .await
-        .expect("a stalled physical link monopolized initial route selection")
-        .expect("the next initial route did not connect");
+        let ((connection, selected), ()) =
+            tokio::time::timeout(Duration::from_millis(500), async {
+                tokio::try_join!(
+                    connect_first_available_with_deadline_owner(
+                        &options,
+                        shutdown_rx,
+                        &deadline_owner,
+                    ),
+                    async {
+                        started.notified().await;
+                        deadline_owner.expire(&hanging_route);
+                        Ok::<(), anyhow::Error>(())
+                    },
+                )
+            })
+            .await
+            .expect("a stalled physical link monopolized initial route selection")
+            .expect("the next initial route did not connect");
 
         assert_eq!(close_calls.load(Ordering::Acquire), 1);
         assert_eq!(selected, format!("unix://{}", unix_path.display()));


### PR DESCRIPTION
Tests for initial route fallback used the same 20 ms wall-clock deadline for the hanging route and the valid Unix fallback. Under Valgrind, the fallback also expired.

This change injects a test-only deadline owner. Each test waits for the hanging provider or link to start, expires only that route, and awaits Unix selection under one final watchdog. Production still uses one absolute Tokio deadline across provider and link setup.

Red evidence: https://github.com/manaflow-ai/cmux/actions/runs/31498625744

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/9993"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789050971&installation_model_id=21920&pr_number=9993&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F9993&signature=c615d86041f5b020055aaa2d46aec4829b9316b915ca0e22582395b4ba29592e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes initial-route timeout tests owner-driven to fix Valgrind flakes. Tests now expire only the hanging route and reliably fall back to Unix, while production behavior stays the same.

- Bug Fixes
  - Added `InitialAttemptDeadlineOwner` with a manual test mode to control per-route timeouts.
  - Introduced `connect_first_available_with_deadline_owner` and used it in tests.
  - Updated tests to wait for the hanging provider/link to start, then expire that route and select the Unix fallback; production still uses a single absolute `tokio` deadline.

<sup>Written for commit 9bce672591e1e84a2c4b93ef3cf7fb1609cfcb05. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/9993?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

