### PR TITLE
test(tui): await configured server exit event

### DIFF
--- a/cmux-tui/crates/cmux-tui/tests/cli.rs
+++ b/cmux-tui/crates/cmux-tui/tests/cli.rs
@@ -4061,17 +4061,12 @@ fn configured_websocket_server_does_not_attach_to_existing_session() {
         &["--socket", server.socket.to_str().unwrap()],
         &[("CMUX_TUI_CONFIG", config.as_os_str())],
     );
-    let deadline = Instant::now() + Duration::from_secs(10);
-
-    while Instant::now() < deadline {
-        if let Some(status) = tui.child.try_wait().unwrap() {
-            assert!(!status.success(), "server launch unexpectedly succeeded");
-            return;
-        }
-        std::thread::sleep(Duration::from_millis(50));
-    }
-
-    panic!("configured WebSocket server attached instead of preserving server mode");
+    let status = wait_for_child_exit(
+        native_pty_child(tui.child.as_mut()),
+        Duration::from_secs(10),
+        "configured WebSocket server attached instead of preserving server mode",
+    );
+    assert!(!status.success(), "server launch unexpectedly succeeded");
 }
 
 #[cfg(unix)]


### PR DESCRIPTION
## Summary
- replace the last live PR8769 CLI timing identity with the existing child-exit event observer
- keep the 10-second bound only as a failure deadline
- preserve behavior coverage in the configured WebSocket server-mode test

## Testing
- git diff --check
- exact gpt-5.6-sol xhigh review: clean
- local compile and tests not run, per cmux-tui policy

## Ledger
- directly closes 1 of 28 CLI slice keys
- proves 27 identities already removed by PR8769 root commit 40e37424db886ce42fb3fcc38cc7c8987e260b97
- all 28 remain root-deferred until PR8769 enters main

## Related
- https://github.com/manaflow-ai/cmux/pull/8769

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/9995"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789054255&installation_model_id=21920&pr_number=9995&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F9995&signature=d5265ebd3f8559a8e6d157f2b12631b89d0dab1ff1b8b1db311c057ca0858d98"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stabilized the configured WebSocket server test by waiting for the child process exit event instead of polling. Keeps a 10s deadline only as a failure bound and still asserts the launch does not succeed.

- Refactors
  - Replaced the manual polling loop with an exit-event wait using the existing helper.
  - Preserved behavior: fail with the same message on timeout/attach and assert a non-success status.

<sup>Written for commit e7aee14311aec48b564c9424f2021bfe33d73115. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/9995?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

