### PR TITLE
Test SSH bootstrap shutdown at its child owner

### DIFF
--- a/cmux-tui/crates/cmux-remote/src/ssh_bootstrap.rs
+++ b/cmux-tui/crates/cmux-remote/src/ssh_bootstrap.rs
@@ -95,12 +95,92 @@ pub enum BootstrapOutcome {
 
 pub struct SshBootstrapper {
     config: SshBootstrapConfig,
+    cancellation: Option<SshBootstrapCancellation>,
+    #[cfg(test)]
+    lifecycle_events: Option<tokio::sync::mpsc::UnboundedSender<SshBootstrapLifecycleEvent>>,
+}
+
+#[derive(Clone)]
+pub struct SshBootstrapCancellation {
+    registration_open: std::sync::Arc<std::sync::Mutex<bool>>,
+    cancelled: tokio::sync::watch::Sender<bool>,
+    active_attempts: tokio::sync::watch::Sender<usize>,
+}
+
+impl SshBootstrapCancellation {
+    pub async fn cancel_and_wait(&self) {
+        let mut active_attempts = {
+            let mut registration_open = self.registration_open.lock().unwrap();
+            *registration_open = false;
+            self.cancelled.send_replace(true);
+            self.active_attempts.subscribe()
+        };
+        while *active_attempts.borrow() != 0 {
+            if active_attempts.changed().await.is_err() {
+                break;
+            }
+        }
+    }
+
+    fn begin_attempt(&self) -> Result<SshBootstrapAttemptRegistration, BootstrapError> {
+        let registration_open = self.registration_open.lock().unwrap();
+        if !*registration_open {
+            return Err(BootstrapError::Io(std::io::Error::new(
+                std::io::ErrorKind::Interrupted,
+                "SSH bootstrap was cancelled",
+            )));
+        }
+        self.active_attempts.send_modify(|active| *active += 1);
+        Ok(SshBootstrapAttemptRegistration { active_attempts: self.active_attempts.clone() })
+    }
+
+    fn subscribe(&self) -> tokio::sync::watch::Receiver<bool> {
+        self.cancelled.subscribe()
+    }
+}
+
+struct SshBootstrapAttemptRegistration {
+    active_attempts: tokio::sync::watch::Sender<usize>,
+}
+
+impl Drop for SshBootstrapAttemptRegistration {
+    fn drop(&mut self) {
+        self.active_attempts.send_modify(|active| *active = active.saturating_sub(1));
+    }
 }
 
 impl SshBootstrapper {
     pub fn new(config: SshBootstrapConfig) -> Result<Self, BootstrapError> {
         config.validate()?;
-        Ok(Self { config })
+        Ok(Self {
+            config,
+            cancellation: None,
+            #[cfg(test)]
+            lifecycle_events: None,
+        })
+    }
+
+    pub fn with_cancellation(mut self) -> (Self, SshBootstrapCancellation) {
+        let (cancelled, receiver) = tokio::sync::watch::channel(false);
+        drop(receiver);
+        let (active_attempts, receiver) = tokio::sync::watch::channel(0);
+        drop(receiver);
+        let cancellation = SshBootstrapCancellation {
+            registration_open: std::sync::Arc::new(std::sync::Mutex::new(true)),
+            cancelled,
+            active_attempts,
+        };
+        self.cancellation = Some(cancellation.clone());
+        (self, cancellation)
+    }
+
+    #[cfg(test)]
+    fn with_lifecycle_events(
+        mut self,
+        lifecycle_events: tokio::sync::mpsc::UnboundedSender<SshBootstrapLifecycleEvent>,
+    ) -> Self {
+        self.lifecycle_events = Some(lifecycle_events);
+        self
     }
 
     pub async fn probe(&self) -> Result<Option<RemoteProbe>, BootstrapError> {
@@ -253,6 +333,8 @@ impl SshBootstrapper {
         &self,
         remote_arguments: [&str; N],
     ) -> Result<RemoteOutput, BootstrapError> {
+        let mut attempt_registration =
+            self.cancellation.as_ref().map(SshBootstrapCancellation::begin_attempt).transpose()?;
         let mut command = Command::new(&self.config.ssh_binary);
         command.arg("-T");
         if let Some(port) = self.config.port {
@@ -287,6 +369,16 @@ impl SshBootstrapper {
                 )));
             }
         };
+        #[cfg(not(test))]
+        let mut child =
+            BootstrapChildOwner::new(child, self.cancellation.clone(), attempt_registration.take());
+        #[cfg(test)]
+        let mut child = BootstrapChildOwner::new(
+            child,
+            self.cancellation.clone(),
+            attempt_registration.take(),
+            self.lifecycle_events.clone(),
+        );
         let completion = tokio::time::timeout(self.config.timeout, async {
             // Drain both pipes concurrently so either stream can fill without
             // blocking the other stream or the child exit observation.
@@ -300,16 +392,135 @@ impl SshBootstrapper {
         let (stdout, stderr, status) = match completion {
             Ok(Ok(result)) => result,
             Ok(Err(error)) => {
-                terminate_and_reap(&mut child).await;
+                child.cancel_and_reap().await;
                 return Err(error);
             }
             Err(_) => {
-                terminate_and_reap(&mut child).await;
+                child.cancel_and_reap().await;
                 return Err(BootstrapError::Timeout);
             }
         };
         Ok(RemoteOutput { status: status.code().unwrap_or(255), stdout, stderr })
     }
+}
+
+struct BootstrapChildOwner {
+    cancel: Option<tokio::sync::oneshot::Sender<()>>,
+    task: Option<tokio::task::JoinHandle<std::io::Result<std::process::ExitStatus>>>,
+}
+
+impl BootstrapChildOwner {
+    #[cfg(not(test))]
+    fn new(
+        child: Child,
+        cancellation: Option<SshBootstrapCancellation>,
+        registration: Option<SshBootstrapAttemptRegistration>,
+    ) -> Self {
+        let (cancel, cancelled) = tokio::sync::oneshot::channel();
+        let external_cancellation = cancellation.as_ref().map(SshBootstrapCancellation::subscribe);
+        let task = tokio::spawn(async move {
+            let result =
+                wait_for_child_or_cancellation(child, cancelled, external_cancellation).await;
+            drop(registration);
+            result
+        });
+        Self { cancel: Some(cancel), task: Some(task) }
+    }
+
+    #[cfg(test)]
+    fn new(
+        child: Child,
+        cancellation: Option<SshBootstrapCancellation>,
+        registration: Option<SshBootstrapAttemptRegistration>,
+        lifecycle_events: Option<tokio::sync::mpsc::UnboundedSender<SshBootstrapLifecycleEvent>>,
+    ) -> Self {
+        let pid = child.id();
+        if let (Some(events), Some(pid)) = (&lifecycle_events, pid) {
+            let _ = events.send(SshBootstrapLifecycleEvent::Spawned(pid));
+        }
+        let (cancel, cancelled) = tokio::sync::oneshot::channel();
+        let external_cancellation = cancellation.as_ref().map(SshBootstrapCancellation::subscribe);
+        let task = tokio::spawn(async move {
+            let result =
+                wait_for_child_or_cancellation(child, cancelled, external_cancellation).await;
+            if result.is_ok()
+                && let (Some(events), Some(pid)) = (lifecycle_events, pid)
+            {
+                let _ = events.send(SshBootstrapLifecycleEvent::Reaped(pid));
+            }
+            drop(registration);
+            result
+        });
+        Self { cancel: Some(cancel), task: Some(task) }
+    }
+
+    async fn wait(&mut self) -> std::io::Result<std::process::ExitStatus> {
+        let result = match self.task.as_mut() {
+            Some(task) => task.await,
+            None => {
+                return Err(std::io::Error::other("SSH child owner was already awaited"));
+            }
+        };
+        self.task.take();
+        self.cancel.take();
+        result.map_err(|error| std::io::Error::other(format!("SSH child owner failed: {error}")))?
+    }
+
+    async fn cancel_and_reap(&mut self) {
+        if let Some(cancel) = self.cancel.take() {
+            let _ = cancel.send(());
+        }
+        if self.task.is_some() {
+            let _ = self.wait().await;
+        }
+    }
+}
+
+impl Drop for BootstrapChildOwner {
+    fn drop(&mut self) {
+        if let Some(cancel) = self.cancel.take() {
+            let _ = cancel.send(());
+        }
+    }
+}
+
+async fn wait_for_child_or_cancellation(
+    mut child: Child,
+    mut cancelled: tokio::sync::oneshot::Receiver<()>,
+    mut external_cancellation: Option<tokio::sync::watch::Receiver<bool>>,
+) -> std::io::Result<std::process::ExitStatus> {
+    tokio::select! {
+        result = child.wait() => result,
+        _ = &mut cancelled => {
+            let _ = child.start_kill();
+            child.wait().await
+        }
+        _ = wait_for_external_cancellation(&mut external_cancellation) => {
+            let _ = child.start_kill();
+            child.wait().await
+        }
+    }
+}
+
+async fn wait_for_external_cancellation(
+    cancellation: &mut Option<tokio::sync::watch::Receiver<bool>>,
+) {
+    let Some(cancelled) = cancellation else {
+        std::future::pending::<()>().await;
+        return;
+    };
+    while !*cancelled.borrow() {
+        if cancelled.changed().await.is_err() {
+            std::future::pending::<()>().await;
+        }
+    }
+}
+
+#[cfg(test)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum SshBootstrapLifecycleEvent {
+    Spawned(u32),
+    Reaped(u32),
 }
 
 async fn read_bounded(
@@ -532,6 +743,81 @@ mod tests {
             error,
             BootstrapError::PackageUnavailable(version) if version == "0.0.0-r2.test"
         ));
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn cancelled_bootstrap_reaps_the_spawned_ssh_child() {
+        use std::fs;
+        use std::os::unix::fs::PermissionsExt;
+
+        let directory = tempfile::tempdir().unwrap();
+        let script = directory.path().join("ssh");
+        fs::write(&script, "#!/bin/sh\nexec /usr/bin/tail -f /dev/null\n").unwrap();
+        fs::set_permissions(&script, fs::Permissions::from_mode(0o755)).unwrap();
+
+        let mut config = SshBootstrapConfig::defaults("host");
+        config.ssh_binary = script.to_string_lossy().into_owned();
+        let (lifecycle_tx, mut lifecycle_rx) = tokio::sync::mpsc::unbounded_channel();
+        let (bootstrapper, cancellation) = SshBootstrapper::new(config)
+            .unwrap()
+            .with_lifecycle_events(lifecycle_tx)
+            .with_cancellation();
+
+        tokio::time::timeout(Duration::from_secs(5), async {
+            let mut bootstrap = Box::pin(bootstrapper.probe());
+            let pid = tokio::select! {
+                event = lifecycle_rx.recv() => match event {
+                    Some(SshBootstrapLifecycleEvent::Spawned(pid)) => pid,
+                    Some(event) => panic!("unexpected SSH bootstrap event: {event:?}"),
+                    None => panic!("SSH bootstrap lifecycle ended before spawn"),
+                },
+                result = &mut bootstrap => {
+                    panic!("SSH bootstrap ended before cancellation: {result:?}")
+                }
+            };
+
+            cancellation.cancel_and_wait().await;
+            assert_eq!(lifecycle_rx.recv().await, Some(SshBootstrapLifecycleEvent::Reaped(pid)));
+            drop(bootstrap);
+        })
+        .await
+        .expect("cancelled SSH bootstrap did not reap its child");
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn deadline_reaps_the_spawned_ssh_child_before_returning() {
+        use std::fs;
+        use std::os::unix::fs::PermissionsExt;
+
+        let directory = tempfile::tempdir().unwrap();
+        let script = directory.path().join("ssh");
+        fs::write(&script, "#!/bin/sh\nexec /usr/bin/tail -f /dev/null\n").unwrap();
+        fs::set_permissions(&script, fs::Permissions::from_mode(0o755)).unwrap();
+
+        let mut config = SshBootstrapConfig::defaults("host");
+        config.ssh_binary = script.to_string_lossy().into_owned();
+        config.timeout = Duration::from_millis(20);
+        let (lifecycle_tx, mut lifecycle_rx) = tokio::sync::mpsc::unbounded_channel();
+        let bootstrapper =
+            SshBootstrapper::new(config).unwrap().with_lifecycle_events(lifecycle_tx);
+
+        tokio::time::timeout(Duration::from_secs(5), async {
+            let error = bootstrapper.probe().await.unwrap_err();
+            assert!(matches!(error, BootstrapError::Timeout));
+            let spawned = lifecycle_rx.recv().await;
+            let reaped = lifecycle_rx.recv().await;
+            assert!(matches!(
+                (spawned, reaped),
+                (
+                    Some(SshBootstrapLifecycleEvent::Spawned(spawned_pid)),
+                    Some(SshBootstrapLifecycleEvent::Reaped(reaped_pid))
+                ) if spawned_pid == reaped_pid
+            ));
+        })
+        .await
+        .expect("SSH bootstrap deadline did not reap its child");
     }
 
     #[cfg(unix)]

--- a/cmux-tui/crates/cmux-tui/src/remote_runtime.rs
+++ b/cmux-tui/crates/cmux-tui/src/remote_runtime.rs
@@ -4,6 +4,7 @@
 use std::collections::BTreeMap;
 use std::fmt;
 use std::fs;
+use std::future::Future;
 use std::net::SocketAddr;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
@@ -632,7 +633,7 @@ enum InitialAttemptDeadline {
 impl InitialAttemptDeadline {
     async fn timeout<F>(&mut self, future: F) -> Result<F::Output, ()>
     where
-        F: std::future::Future,
+        F: Future,
     {
         match self {
             Self::Realtime(deadline) => {
@@ -927,10 +928,10 @@ async fn bootstrap_initial_ssh_route(
 }
 
 async fn wait_for_ssh_bootstrap_or_shutdown(
-    bootstrap_work: impl std::future::Future<
+    bootstrap_work: impl Future<
         Output = Result<Result<(), BootstrapError>, tokio::time::error::Elapsed>,
     >,
-    cleanup: impl std::future::Future<Output = ()>,
+    cleanup: impl Future<Output = ()>,
     shutdown: Option<watch::Receiver<bool>>,
 ) -> anyhow::Result<()> {
     tokio::pin!(bootstrap_work);

--- a/cmux-tui/crates/cmux-tui/src/remote_runtime.rs
+++ b/cmux-tui/crates/cmux-tui/src/remote_runtime.rs
@@ -912,23 +912,46 @@ async fn bootstrap_initial_ssh_route(
     config.extra_args = ssh.extra_args.clone();
     config.auto_install = options.auto_install;
     config.timeout = options.attempt_timeout;
-    let bootstrap = SshBootstrapper::new(config)?;
-    tokio::select! {
-        result = tokio::time::timeout(options.attempt_timeout, async {
-            if upgrade {
-                bootstrap.install_verified().await?;
-                bootstrap
-                    .stop_daemon(&ssh.remote_session, ssh.remote_state_dir.as_deref())
-                    .await?;
-            } else {
-                bootstrap.ensure_installed().await?;
-            }
-            Ok::<(), BootstrapError>(())
-        }) => {
-            result.map_err(|_| BootstrapError::Timeout)??;
-            Ok(())
+    let (bootstrap, cancellation) = SshBootstrapper::new(config)?.with_cancellation();
+    let bootstrap_work = tokio::time::timeout(options.attempt_timeout, async {
+        if upgrade {
+            bootstrap.install_verified().await?;
+            bootstrap.stop_daemon(&ssh.remote_session, ssh.remote_state_dir.as_deref()).await?;
+        } else {
+            bootstrap.ensure_installed().await?;
         }
-        () = wait_for_shutdown_request(shutdown) => Err(anyhow!("SSH bootstrap interrupted")),
+        Ok::<(), BootstrapError>(())
+    });
+    wait_for_ssh_bootstrap_or_shutdown(bootstrap_work, cancellation.cancel_and_wait(), shutdown)
+        .await
+}
+
+async fn wait_for_ssh_bootstrap_or_shutdown(
+    bootstrap_work: impl std::future::Future<
+        Output = Result<Result<(), BootstrapError>, tokio::time::error::Elapsed>,
+    >,
+    cleanup: impl std::future::Future<Output = ()>,
+    shutdown: Option<watch::Receiver<bool>>,
+) -> anyhow::Result<()> {
+    tokio::pin!(bootstrap_work);
+    tokio::pin!(cleanup);
+    tokio::select! {
+        result = &mut bootstrap_work => {
+            match result {
+                Ok(result) => {
+                    result?;
+                    Ok(())
+                }
+                Err(_) => {
+                    cleanup.as_mut().await;
+                    Err(BootstrapError::Timeout.into())
+                }
+            }
+        }
+        () = wait_for_shutdown_request(shutdown) => {
+            cleanup.as_mut().await;
+            Err(anyhow!("SSH bootstrap interrupted"))
+        }
     }
 }
 
@@ -2252,158 +2275,51 @@ mod tests {
         );
     }
 
-    #[cfg(unix)]
-    #[test]
-    fn client_shutdown_cancels_reconnect_ssh_bootstrap_and_kills_child() {
-        use std::os::unix::fs::PermissionsExt;
+    #[tokio::test]
+    async fn ssh_bootstrap_shutdown_waits_for_owner_cleanup() {
+        tokio::time::timeout(Duration::from_secs(5), async {
+            let (bootstrap_started_tx, bootstrap_started_rx) = tokio::sync::oneshot::channel();
+            let bootstrap_work = async move {
+                let _ = bootstrap_started_tx.send(());
+                std::future::pending::<
+                    Result<Result<(), BootstrapError>, tokio::time::error::Elapsed>,
+                >()
+                .await
+            };
+            let (cleanup_started_tx, cleanup_started_rx) = tokio::sync::oneshot::channel();
+            let (cleanup_release_tx, cleanup_release_rx) = tokio::sync::oneshot::channel();
+            let cleanup = async move {
+                let _ = cleanup_started_tx.send(());
+                let _ = cleanup_release_rx.await;
+            };
+            let (shutdown_tx, shutdown_rx) = watch::channel(false);
+            let mut lifecycle = Box::pin(wait_for_ssh_bootstrap_or_shutdown(
+                bootstrap_work,
+                cleanup,
+                Some(shutdown_rx),
+            ));
 
-        let directory = tempfile::tempdir().unwrap();
-        let daemon_root = directory.path().join("daemon");
-        let daemon_link = daemon_root.join("link.sock");
-        let proxy_link = directory.path().join("proxy-link.sock");
-        let daemon = start_daemon_runtime(
-            directory.path().join("missing-mux.sock"),
-            DaemonRuntimeOptions {
-                session: "shutdown-cancel".into(),
-                state_dir: Some(daemon_root.clone()),
-                link_socket: Some(daemon_link.clone()),
-                admin_socket: Some(daemon_root.join("admin.sock")),
-                direct_websocket: None,
-                allow_insecure_non_loopback: false,
-                relays: Vec::new(),
-                iroh: false,
-                advertised_routes: Vec::new(),
-                resume_lease: Duration::from_secs(2),
-                replaceable_sidecar: false,
-            },
-        )
-        .unwrap();
-        let proxy_listener = std::os::unix::net::UnixListener::bind(&proxy_link).unwrap();
-        proxy_listener.set_nonblocking(true).unwrap();
-        let (cut_tx, cut_rx) = tokio::sync::oneshot::channel();
-        let proxy = thread::spawn(move || {
-            let runtime = build_remote_runtime("cmux-remote-carrier-cut-test").unwrap();
-            runtime.block_on(async move {
-                let listener = tokio::net::UnixListener::from_std(proxy_listener).unwrap();
-                let (mut client_stream, _) = listener.accept().await.unwrap();
-                let mut daemon_stream = tokio::net::UnixStream::connect(daemon_link).await.unwrap();
-                tokio::select! {
-                    _ = cut_rx => {}
-                    result = tokio::io::copy_bidirectional(
-                        &mut client_stream,
-                        &mut daemon_stream,
-                    ) => {
-                        result.unwrap();
-                    }
-                }
-            });
-        });
+            tokio::select! {
+                result = &mut lifecycle => panic!("SSH bootstrap ended before startup: {result:?}"),
+                result = bootstrap_started_rx => result.unwrap(),
+            }
+            shutdown_tx.send_replace(true);
+            tokio::select! {
+                result = &mut lifecycle => panic!("SSH bootstrap returned before cleanup: {result:?}"),
+                result = cleanup_started_rx => result.unwrap(),
+            }
+            tokio::select! {
+                biased;
+                result = &mut lifecycle => panic!("SSH bootstrap returned before cleanup release: {result:?}"),
+                _ = tokio::task::yield_now() => {}
+            }
 
-        let script = directory.path().join("ssh");
-        let pid_file = directory.path().join("ssh.pid");
-        fs::write(
-            &script,
-            format!(
-                "#!/bin/sh\nprintf '%s' \"$$\" > '{}'\nexec /bin/sleep 30\n",
-                pid_file.display()
-            ),
-        )
-        .unwrap();
-        fs::set_permissions(&script, fs::Permissions::from_mode(0o755)).unwrap();
-        let ssh = SshProviderConfig {
-            ssh_binary: script.to_string_lossy().into_owned(),
-            ..SshProviderConfig::default()
-        };
-        let providers = Arc::new(
-            client_provider_registry(ssh.clone(), None, BTreeMap::new(), IrohPathMode::Auto)
-                .unwrap(),
-        );
-        let mut unix_route = Url::parse("unix:///").unwrap();
-        unix_route.set_path(proxy_link.to_str().unwrap());
-        let routes = [unix_route, Url::parse("ssh://fallback.example").unwrap()]
-            .into_iter()
-            .map(|endpoint| {
-                ResolvedRouteCandidate::resolve(endpoint, BTreeMap::new(), &providers).unwrap()
-            })
-            .collect();
-        let client = start_client_runtime(ClientRuntimeOptions {
-            routes,
-            providers,
-            identity: StaticIdentity::generate().unwrap(),
-            expected_daemon: None,
-            auth: ClientAuthMode::Carrier,
-            device_name: "shutdown-cancel-test".into(),
-            session: SessionId([21; 16]),
-            lane_policy: LanePolicy::Single,
-            reconnect: ReconnectPolicy {
-                initial_delay: Duration::from_millis(10),
-                maximum_delay: Duration::from_millis(10),
-                attempt_timeout: Duration::from_millis(50),
-                full_jitter: false,
-                heartbeat_interval: Some(Duration::from_millis(10)),
-                heartbeat_timeout: Duration::from_millis(10),
-                maximum_attempts: None,
-            },
-            startup_timeout: Duration::from_secs(5),
-            state_dir: directory.path().join("client"),
-            local_socket: Some(directory.path().join("client.sock")),
-            ssh,
-            ssh_bootstrap: SshBootstrapOptions {
-                auto_install: true,
-                upgrade: false,
-                attempt_timeout: Duration::from_secs(10),
-            },
+            cleanup_release_tx.send(()).unwrap();
+            let error = lifecycle.await.unwrap_err();
+            assert_eq!(error.to_string(), "SSH bootstrap interrupted");
         })
-        .unwrap();
-
-        cut_tx.send(()).unwrap();
-        proxy.join().unwrap();
-        let deadline = std::time::Instant::now() + Duration::from_secs(3);
-        let pid = loop {
-            if let Ok(value) = fs::read_to_string(&pid_file)
-                && let Ok(pid) = value.parse::<libc::pid_t>()
-            {
-                break pid;
-            }
-            assert!(
-                std::time::Instant::now() < deadline,
-                "client did not enter reconnect SSH bootstrap"
-            );
-            thread::sleep(Duration::from_millis(10));
-        };
-
-        let (done_tx, done_rx) = mpsc::sync_channel(1);
-        thread::spawn(move || {
-            let _ = done_tx.send(client.shutdown());
-        });
-        let completed_promptly = match done_rx.recv_timeout(Duration::from_millis(500)) {
-            Ok(result) => {
-                result.unwrap();
-                true
-            }
-            Err(_) => {
-                unsafe {
-                    libc::kill(pid, libc::SIGKILL);
-                }
-                done_rx
-                    .recv_timeout(Duration::from_secs(3))
-                    .expect("client shutdown stayed blocked after SSH cleanup")
-                    .unwrap();
-                false
-            }
-        };
-        assert!(
-            completed_promptly,
-            "client shutdown waited for the reconnect SSH bootstrap timeout"
-        );
-
-        let deadline = std::time::Instant::now() + Duration::from_secs(2);
-        while unsafe { libc::kill(pid, 0) } == 0 && std::time::Instant::now() < deadline {
-            thread::sleep(Duration::from_millis(10));
-        }
-        assert_eq!(unsafe { libc::kill(pid, 0) }, -1, "cancelled SSH child is still alive");
-        assert_eq!(std::io::Error::last_os_error().raw_os_error(), Some(libc::ESRCH));
-        daemon.shutdown().unwrap();
+        .await
+        .expect("SSH bootstrap shutdown lifecycle did not complete");
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary
- register each SSH command with one cancellation owner before spawn
- wait for the owned child to be killed and reaped on shutdown and final deadline
- replace the indirect reconnect timing test with direct lifecycle and production-selector coverage

## Verification
- static rustfmt and diff checks only, per task constraint
- isolated gpt-5.6-sol xhigh review: clean
- hosted exact proof follows

Timing ledger effect: 0.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/9996"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789055556&installation_model_id=21920&pr_number=9996&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F9996&signature=c70767f11e7f8051e87554de7ffce9c06b6a6b0f5c4b737bbd277bd8ebe6bb3a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes SSH bootstrap cancellation reliable by owning the SSH child and reaping it on cancel, shutdown, or timeout. Client shutdown now waits for bootstrap cleanup to finish before returning.

- **Bug Fixes**
  - SSH bootstrap registers each attempt with a cancellation owner and kills/reaps the SSH child on cancel, shutdown, or timeout.
  - Fixed `Future` bounds in `remote_runtime` to satisfy pinned Clippy.

- **Refactors**
  - Added `SshBootstrapCancellation` and `BootstrapChildOwner`, integrated into `SshBootstrapper`.
  - Extracted `wait_for_ssh_bootstrap_or_shutdown` and replaced timing-based tests with lifecycle tests that assert spawn/reap and shutdown cleanup ordering.

<sup>Written for commit 92e21a554c3a608a652d315dc9c9bef51c4b1268. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/9996?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

