### PR TITLE
Fix NativeMuxDemo empty placement dictionary

### DIFF
--- a/cmux-tui/apps/macos/NativeMuxDemo/Sources/NativeMuxDemo/FrontendModel.swift
+++ b/cmux-tui/apps/macos/NativeMuxDemo/Sources/NativeMuxDemo/FrontendModel.swift
@@ -598,7 +598,7 @@ final class FrontendModel {
                   let screenID = selectedScreenID,
                   let screen = next.screens.first(where: {
                       $0.id == screenID && $0.workspaceID == workspaceID
-                  }) else { return [] }
+                  }) else { return [:] }
             return next.visibleTerminalPlacements(in: screen)
         }()
         let removed = terminalControllers.compactMap { paneID, controller in


### PR DESCRIPTION
Fix the NativeMuxDemo package compile failure exposed by the PR9938 exact hosted gate.

Red proof: https://github.com/manaflow-ai/cmux/actions/runs/31509792332/job/93840468514

The closure returns a String-to-String dictionary, so its empty result must use the dictionary literal. This PR changes only that literal.

Static proof: swiftc parse and git diff check passed. Exact-head xhigh review is clean with confidence 0.99.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/9997"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789058815&installation_model_id=21920&pr_number=9997&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F9997&signature=684847c79531fbf6612ef31c899b7df297fff66aee8ed108af59fa8bd1afd17a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix compile failure in `NativeMuxDemo` by returning an empty dictionary literal for terminal placements when no matching screen is found. This matches the closure’s dictionary return type and unblocks the exact-hosted gate build.

<sup>Written for commit 9c63c13129c9b34bb70037649931497ec9fbc08c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/9997?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

