### PR TITLE
Fix NativeMuxDemo mutating require test

### DIFF
--- a/cmux-tui/apps/macos/NativeMuxDemo/Tests/NativeMuxDemoTests/NativeMuxDemoTests.swift
+++ b/cmux-tui/apps/macos/NativeMuxDemo/Tests/NativeMuxDemoTests/NativeMuxDemoTests.swift
@@ -151,7 +151,8 @@ func decodesEveryNativeLayoutShape() async throws {
     var sawTitle = false
     var sawTopology = false
     for change in delta.changes {
-        switch try #require(snapshot.apply(change)) {
+        let applied = snapshot.apply(change)
+        switch try #require(applied) {
         case .terminalTitle(let id, let title):
             sawTitle = id == "term_88888888888888888888888888888888"
                 && title == "updated"


### PR DESCRIPTION
Fix the NativeMuxDemo test compile failure exposed after PR9997 repaired the package source.

Red proof: https://github.com/manaflow-ai/cmux/actions/runs/31514205923/job/93855206903

Call the mutating snapshot operation before the Testing macro, then require only its immutable result. This PR changes one test file.

Static Swift parse and diff checks passed. Exact-head xhigh review is clean with confidence 0.99.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/9999"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789061700&installation_model_id=21920&pr_number=9999&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F9999&signature=53a13d672da1bf118580584dc5bdd14a7e45714e4bbdd149458ef7ce2569543f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a compile error in the NativeMuxDemo test by applying the mutating snapshot change before using the `#require` macro. We now assign `let applied = snapshot.apply(change)` and switch on `try #require(applied)` so the macro operates on an immutable value.

<sup>Written for commit 197d48f9715eef50fb5c5b374e8355f01a353371. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/9999?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

