### PR TITLE
Export terminal copy limit for Swift

### DIFF
--- a/cmux-tui/apps/macos/NativeMuxDemo/Sources/NativeMuxDemo/FrontendService.swift
+++ b/cmux-tui/apps/macos/NativeMuxDemo/Sources/NativeMuxDemo/FrontendService.swift
@@ -705,7 +705,7 @@ struct TerminalRenderEventBatch: Sendable {
 
 func drainTerminalRenderEvents(
   maximumEvents: Int = 16,
-  maximumEventBytes: Int = Int(CMUX_TERMINAL_CLIENT_COPY_MAX_BYTES),
+  maximumEventBytes: Int = Int(CMUX_TERMINAL_CLIENT_COPY_MAX_BYTES_VALUE),
   maximumBytesEventBytes: Int = 65_536,
   maximumBytes: Int = 262_144,
   discard: () -> Void = {},

--- a/cmux-tui/apps/macos/NativeMuxDemo/Tests/NativeMuxDemoTests/NativeMuxDemoTests.swift
+++ b/cmux-tui/apps/macos/NativeMuxDemo/Tests/NativeMuxDemoTests/NativeMuxDemoTests.swift
@@ -883,7 +883,7 @@ func renderDrainAcceptsResetAboveFormerFrontendLimit() {
         return true
     }
 
-    #expect(payloadLength < Int(CMUX_TERMINAL_CLIENT_COPY_MAX_BYTES))
+    #expect(payloadLength < Int(CMUX_TERMINAL_CLIENT_COPY_MAX_BYTES_VALUE))
     #expect(batch.events.count == 1)
     #expect(batch.events.first?.kind == .reset)
     #expect(batch.events.first?.payload.count == payloadLength)

--- a/cmux-tui/crates/cmux-terminal-client/include/cmux_terminal_client.h
+++ b/cmux-tui/crates/cmux-terminal-client/include/cmux_terminal_client.h
@@ -266,7 +266,7 @@ bool cmux_terminal_client_last_resize_ack(
 // The producer owns the snapshot and may change it between calls. Callers must
 // bound two-pass retries and treat a returned length >= capacity as a truncated
 // snapshot. Returned pointers are never borrowed from client storage.
-#define CMUX_TERMINAL_CLIENT_COPY_MAX_BYTES (16u * 1024u * 1024u)
+extern const size_t CMUX_TERMINAL_CLIENT_COPY_MAX_BYTES;
 size_t cmux_terminal_client_copy_frame(
     const CmuxTerminalClient *client,
     char *buffer,

--- a/cmux-tui/crates/cmux-terminal-client/include/cmux_terminal_client.h
+++ b/cmux-tui/crates/cmux-terminal-client/include/cmux_terminal_client.h
@@ -266,7 +266,9 @@ bool cmux_terminal_client_last_resize_ack(
 // The producer owns the snapshot and may change it between calls. Callers must
 // bound two-pass retries and treat a returned length >= capacity as a truncated
 // snapshot. Returned pointers are never borrowed from client storage.
-extern const size_t CMUX_TERMINAL_CLIENT_COPY_MAX_BYTES;
+#define CMUX_TERMINAL_CLIENT_COPY_MAX_BYTES (16u * 1024u * 1024u)
+// Typed view for FFI importers that do not import expression macros.
+extern const size_t CMUX_TERMINAL_CLIENT_COPY_MAX_BYTES_VALUE;
 size_t cmux_terminal_client_copy_frame(
     const CmuxTerminalClient *client,
     char *buffer,

--- a/cmux-tui/crates/cmux-terminal-client/src/lib.rs
+++ b/cmux-tui/crates/cmux-terminal-client/src/lib.rs
@@ -39,6 +39,10 @@ const TERMINAL_RECONNECT_INITIAL_DELAY: StdDuration = StdDuration::from_millis(2
 const TERMINAL_RECONNECT_MAX_DELAY: StdDuration = StdDuration::from_secs(4);
 const MAX_NATIVE_RENDER_EVENT_BYTES: usize = 32 * 1024 * 1024;
 const MAX_NATIVE_RENDER_EVENTS: usize = 4096;
+
+#[unsafe(no_mangle)]
+pub static CMUX_TERMINAL_CLIENT_COPY_MAX_BYTES: usize = MAX_FRAME_PAYLOAD;
+
 const MAX_NATIVE_RENDER_BYTES_EVENT_BYTES: usize = 64 * 1024;
 
 #[derive(Clone, PartialEq, Eq)]
@@ -2325,6 +2329,11 @@ mod tests {
     use tokio::sync::{Mutex as AsyncMutex, mpsc, watch};
 
     use super::*;
+
+    #[test]
+    fn c_copy_limit_matches_the_protocol_payload_limit() {
+        assert_eq!(CMUX_TERMINAL_CLIENT_COPY_MAX_BYTES, MAX_FRAME_PAYLOAD);
+    }
 
     fn test_terminal_id() -> TerminalPublicId {
         TerminalPublicId::parse("term_0123456789abcdef0123456789abcdef").unwrap()

--- a/cmux-tui/crates/cmux-terminal-client/src/lib.rs
+++ b/cmux-tui/crates/cmux-terminal-client/src/lib.rs
@@ -41,7 +41,7 @@ const MAX_NATIVE_RENDER_EVENT_BYTES: usize = 32 * 1024 * 1024;
 const MAX_NATIVE_RENDER_EVENTS: usize = 4096;
 
 #[unsafe(no_mangle)]
-pub static CMUX_TERMINAL_CLIENT_COPY_MAX_BYTES: usize = MAX_FRAME_PAYLOAD;
+pub static CMUX_TERMINAL_CLIENT_COPY_MAX_BYTES_VALUE: usize = MAX_FRAME_PAYLOAD;
 
 const MAX_NATIVE_RENDER_BYTES_EVENT_BYTES: usize = 64 * 1024;
 
@@ -2332,7 +2332,7 @@ mod tests {
 
     #[test]
     fn c_copy_limit_matches_the_protocol_payload_limit() {
-        assert_eq!(CMUX_TERMINAL_CLIENT_COPY_MAX_BYTES, MAX_FRAME_PAYLOAD);
+        assert_eq!(CMUX_TERMINAL_CLIENT_COPY_MAX_BYTES_VALUE, MAX_FRAME_PAYLOAD);
     }
 
     fn test_terminal_id() -> TerminalPublicId {


### PR DESCRIPTION
Fix the C-to-Swift copy-limit boundary exposed by the NativeMuxDemo package gate.

Red proof: https://github.com/manaflow-ai/cmux/actions/runs/31518304312/job/93868901331

The public numeric macro remains unchanged for C constant-expression compatibility. Rust now exports a separate typed size_t value derived from the protocol MAX_FRAME_PAYLOAD owner. Swift uses that typed symbol because Clang cannot import the expression macro. A Rust ABI test requires equality with the protocol owner.

Static Swift parse and diff checks passed. Exact-head xhigh review is clean with confidence 0.95.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Export a typed terminal copy-limit constant for Swift and align it with the protocol payload limit. Keeps the C macro unchanged while fixing Swift’s import and preventing mismatches.

- **Bug Fixes**
  - In `cmux-terminal-client`, add `CMUX_TERMINAL_CLIENT_COPY_MAX_BYTES_VALUE` (typed `size_t`) derived from `MAX_FRAME_PAYLOAD`; keep `CMUX_TERMINAL_CLIENT_COPY_MAX_BYTES` macro for C.
  - Update `NativeMuxDemo` Swift code and tests to use the typed constant.
  - Add Rust test to assert the exported value equals the protocol `MAX_FRAME_PAYLOAD`.

<sup>Written for commit 463006a9cdbea7a8f966aa6dd072dea6354cc89b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/10002?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

