### PR TITLE
Coalesce iOS presence recovery during startup reconnect

### DIFF
--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+ConnectionRecovery.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+ConnectionRecovery.swift
@@ -83,6 +83,24 @@ extension MobileShellComposite {
             pendingInactiveRecoveryTrigger = trigger
             return
         }
+        // Launch and explicit stored-Mac restores claim their reconnect
+        // generation before awaiting the transport. Starting a recovery owner
+        // beside that operation would immediately start a nested restore,
+        // advance the generation, and cancel the dial already in flight.
+        // Automatic wake-ups are satisfied by the active restore. Manual retry
+        // and connection-method changes remain explicit replacements.
+        if isReconnectingStoredMac, !connectionRecoveryOwner.isActive {
+            switch trigger {
+            case .manual, .connectionMethodChanged:
+                break
+            default:
+                MobileDebugLog.anchormux(
+                    "connection.recovery coalesced trigger=\(trigger.description) "
+                        + "storedMacGeneration=\(storedMacReconnectGeneration)"
+                )
+                return
+            }
+        }
         if let accountID = identityProvider?.currentUserID {
             switch trigger {
             case .manual, .networkChange, .foreground, .connectionMethodChanged:

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+ConnectionRecovery.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+ConnectionRecovery.swift
@@ -93,7 +93,9 @@ extension MobileShellComposite {
             switch trigger {
             case .manual, .connectionMethodChanged:
                 break
-            default:
+            case .networkChange, .presencePush, .foreground, .liveness,
+                 .eventStreamEnded, .subscriptionStartFailed,
+                 .transportWriteTimedOut, .automaticBackoffExpired:
                 MobileDebugLog.anchormux(
                     "connection.recovery coalesced trigger=\(trigger.description) "
                         + "storedMacGeneration=\(storedMacReconnectGeneration)"

--- a/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/IrohConnectionRecoveryOwnerTests.swift
+++ b/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/IrohConnectionRecoveryOwnerTests.swift
@@ -114,6 +114,30 @@ extension ReconnectRouteSelectionTests {
         #expect(fixture.factory.attemptedKinds() == [.iroh, .iroh])
     }
 
+    @Test func presenceDuringStartupReconnectDoesNotSupersedeTheActiveDial() async throws {
+        let fixture = try await makeRecoveryOwnerFixture(heldConnectAttempts: [1])
+        defer { fixture.release() }
+
+        let startupReconnect = Task {
+            await fixture.store.reconnectActiveMacIfAvailable(stackUserID: "user-1")
+        }
+        #expect(await fixture.factory.waitForAttemptCount(1))
+        let startupGeneration = fixture.store.storedMacReconnectGeneration
+        #expect(fixture.store.isReconnectingStoredMac)
+
+        fixture.store.recoverMobileConnection(trigger: .presencePush)
+
+        #expect(!fixture.store.connectionRecoveryOwner.isActive)
+        #expect(fixture.store.storedMacReconnectGeneration == startupGeneration)
+        #expect(fixture.factory.attemptedKinds() == [.iroh])
+
+        fixture.factory.releaseHeldConnects()
+        #expect(await startupReconnect.value)
+        #expect(fixture.store.connectionState == .connected)
+        #expect(fixture.store.storedMacReconnectGeneration == startupGeneration)
+        #expect(fixture.factory.attemptedKinds() == [.iroh])
+    }
+
     @Test func staleRecoveryCleanupCannotClearNewerAttempt() async throws {
         let owner = MobileConnectionRecoveryOwner()
         defer { owner.cancel() }

--- a/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/IrohConnectionRecoveryOwnerTests.swift
+++ b/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/IrohConnectionRecoveryOwnerTests.swift
@@ -138,6 +138,14 @@ extension ReconnectRouteSelectionTests {
         #expect(fixture.factory.attemptedKinds() == [.iroh])
     }
 
+    @Test func manualRetryDuringStartupReconnectReplacesTheActiveDial() async throws {
+        try await expectExplicitRecoveryToReplaceStartupDial(trigger: .manual)
+    }
+
+    @Test func connectionMethodChangeDuringStartupReconnectReplacesTheActiveDial() async throws {
+        try await expectExplicitRecoveryToReplaceStartupDial(trigger: .connectionMethodChanged)
+    }
+
     @Test func staleRecoveryCleanupCannotClearNewerAttempt() async throws {
         let owner = MobileConnectionRecoveryOwner()
         defer { owner.cancel() }
@@ -658,6 +666,36 @@ extension ReconnectRouteSelectionTests {
             diagnosticLog: diagnosticLog,
             directory: directory
         )
+    }
+
+    private func expectExplicitRecoveryToReplaceStartupDial(
+        trigger: MobileShellComposite.RecoveryTrigger
+    ) async throws {
+        let fixture = try await makeRecoveryOwnerFixture(heldConnectAttempts: [1])
+        defer { fixture.release() }
+
+        let startupReconnect = Task {
+            await fixture.store.reconnectActiveMacIfAvailable(stackUserID: "user-1")
+        }
+        #expect(await fixture.factory.waitForAttemptCount(1))
+        let startupGeneration = fixture.store.storedMacReconnectGeneration
+        #expect(fixture.store.isReconnectingStoredMac)
+
+        fixture.store.recoverMobileConnection(trigger: trigger)
+
+        #expect(fixture.store.connectionRecoveryOwner.isActive)
+        #expect(fixture.store.connectionRecoveryOwner.activeAttempt?.trigger == trigger.description)
+        #expect(await fixture.factory.waitForAttemptCount(2))
+        #expect(fixture.store.storedMacReconnectGeneration > startupGeneration)
+        #expect(fixture.factory.attemptedKinds() == [.iroh, .iroh])
+        #expect(try await pollUntil {
+            fixture.store.connectionState == .connected
+        })
+
+        fixture.factory.releaseHeldConnects()
+        #expect(!(await startupReconnect.value))
+        #expect(fixture.store.connectionState == .connected)
+        #expect(fixture.factory.attemptedKinds() == [.iroh, .iroh])
     }
 }
 


### PR DESCRIPTION
Mark’s beta logs showed an authenticated presence snapshot starting a second Iroh recovery while launch reconnect was already dialing. The nested reconnect advanced the stored-Mac generation, canceled launch, and retried the same route.

This coalesces automatic recovery triggers into the active startup restore while keeping manual retry and connection-method changes as explicit replacements. It also logs the coalesced trigger for future diagnostics.

Regression history:
- Test-only commit reproduces owner takeover, generation 1 → 2, and two Iroh dials: https://github.com/manaflow-ai/cmux/actions/runs/31522370508
- Fix verification: https://github.com/manaflow-ai/cmux/actions/runs/31523800884

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/10005"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789065548&installation_model_id=21920&pr_number=10005&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F10005&signature=eb652b778858f617380e2e8b1953d9862810f1ba6b8c3d655fdbc7f29a0bb3a3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent nested reconnects during iOS startup by coalescing automatic recovery triggers into the active stored‑Mac restore. This avoids canceling the in‑flight dial, stops generation churn, and prevents duplicate Iroh dials.

- **Bug Fixes**
  - Coalesce automatic triggers (e.g., presence push) during `isReconnectingStoredMac`; keep `manual` retry and connection‑method changes as explicit replacements.
  - Log coalesced triggers via `MobileDebugLog.anchormux` with the current stored‑Mac generation.
  - Add tests covering presence coalescing and explicit startup replacements (manual retry and connection‑method change).

<sup>Written for commit 9c2d258dc746d3bd5bb09a76cd63dac20e618db8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/10005?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved automatic connection recovery to avoid duplicate reconnect attempts while one is already in progress.
  * Preserved the active startup connection attempt when presence updates occur during recovery.
  * Manual retries and connection-method changes now reliably replace the active attempt and start a fresh recovery operation.
  * Improved recovery handling so the latest connection attempt remains active after an earlier attempt fails.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->