### PR TITLE
Fix disabled iOS controls after forgetting a computer

### DIFF
--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/CMUXMobileRootView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/CMUXMobileRootView.swift
@@ -460,15 +460,7 @@ struct CMUXMobileRootView: View {
         } else if !isAuthenticated {
             SignInView()
         } else {
-            switch MobileRootAuthGate.shellSurface(
-                connectionState: store.connectionState,
-                showRestoringStoredMac: shouldShowRestoringStoredMac,
-                showDisconnectedNoPairedMacShell: MobileAuthenticatedShellPresentation.resolve(
-                    connectionState: store.connectionState,
-                    hasKnownPairedMac: store.hasKnownPairedMac,
-                    hasHiddenComputers: store.hasHiddenComputers
-                ) == .disconnected
-            ) {
+            switch authenticatedShellSurface {
             case .disconnectedNoKnownPairedMac:
                 // ONLY when there are no saved Macs at all: the add-device flow (it
                 // auto-presents the pairing sheet since there is nothing to list).
@@ -513,6 +505,30 @@ struct CMUXMobileRootView: View {
                 )
             }
         }
+    }
+
+    /// Retains the shell that owns an active child sheet until SwiftUI reports
+    /// its real dismissal. Store refreshes can otherwise swap shells while the
+    /// sheet is still onscreen, orphaning the modal slot and its interaction
+    /// presentation.
+    private var authenticatedShellSurface: MobileRootAuthGate.MobileRootShellSurface {
+        let baseSurface = MobileRootAuthGate.shellSurface(
+            connectionState: store.connectionState,
+            showRestoringStoredMac: shouldShowRestoringStoredMac,
+            showDisconnectedNoPairedMacShell: MobileAuthenticatedShellPresentation.resolve(
+                connectionState: store.connectionState,
+                hasKnownPairedMac: store.hasKnownPairedMac,
+                hasHiddenComputers: store.hasHiddenComputers
+            ) == .disconnected
+        )
+        #if os(iOS)
+        return MobileAuthenticatedShellPresentation.retainingChildHost(
+            rootPresentation.requiredChildHost,
+            over: baseSurface
+        )
+        #else
+        return baseSurface
+        #endif
     }
 
     #if os(macOS)

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/CMUXMobileRootView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/CMUXMobileRootView.swift
@@ -228,7 +228,13 @@ struct CMUXMobileRootView: View {
     }
 
     var body: some View {
-        rootContent
+        // A concrete container owns the root presentation modifier. Attaching
+        // it directly to `rootContent` lets SwiftUI discard the presenting
+        // controller when that conditional tree exchanges the workspace shell
+        // for the no-computers shell after the final computer is forgotten.
+        ZStack {
+            rootContent
+        }
         #if os(iOS)
         .environment(
             \.mobileChildPresentationProvider,

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/CMUXMobileRootView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/CMUXMobileRootView.swift
@@ -228,13 +228,7 @@ struct CMUXMobileRootView: View {
     }
 
     var body: some View {
-        // A concrete container owns the root presentation modifier. Attaching
-        // it directly to `rootContent` lets SwiftUI discard the presenting
-        // controller when that conditional tree exchanges the workspace shell
-        // for the no-computers shell after the final computer is forgotten.
-        ZStack {
-            rootContent
-        }
+        rootContent
         #if os(iOS)
         .environment(
             \.mobileChildPresentationProvider,
@@ -466,7 +460,15 @@ struct CMUXMobileRootView: View {
         } else if !isAuthenticated {
             SignInView()
         } else {
-            switch authenticatedShellSurface {
+            switch MobileRootAuthGate.shellSurface(
+                connectionState: store.connectionState,
+                showRestoringStoredMac: shouldShowRestoringStoredMac,
+                showDisconnectedNoPairedMacShell: MobileAuthenticatedShellPresentation.resolve(
+                    connectionState: store.connectionState,
+                    hasKnownPairedMac: store.hasKnownPairedMac,
+                    hasHiddenComputers: store.hasHiddenComputers
+                ) == .disconnected
+            ) {
             case .disconnectedNoKnownPairedMac:
                 // ONLY when there are no saved Macs at all: the add-device flow (it
                 // auto-presents the pairing sheet since there is nothing to list).
@@ -498,9 +500,7 @@ struct CMUXMobileRootView: View {
                     showAddDevice: addComputerAction,
                     showPairingScanner: pairingScannerAction,
                     showSettings: showSettings,
-                    deviceTreePresentation: childSheetPresentation(
-                        for: .workspaceDeviceTree
-                    ),
+                    showComputers: showComputers,
                     taskComposerPresentation: childSheetPresentation(
                         for: .workspaceTaskComposer
                     ),
@@ -511,30 +511,6 @@ struct CMUXMobileRootView: View {
                 )
             }
         }
-    }
-
-    /// Retains the shell that owns an active child sheet until SwiftUI reports
-    /// its real dismissal. Store refreshes can otherwise swap shells while the
-    /// sheet is still onscreen, orphaning the modal slot and its interaction
-    /// presentation.
-    private var authenticatedShellSurface: MobileRootAuthGate.MobileRootShellSurface {
-        let baseSurface = MobileRootAuthGate.shellSurface(
-            connectionState: store.connectionState,
-            showRestoringStoredMac: shouldShowRestoringStoredMac,
-            showDisconnectedNoPairedMacShell: MobileAuthenticatedShellPresentation.resolve(
-                connectionState: store.connectionState,
-                hasKnownPairedMac: store.hasKnownPairedMac,
-                hasHiddenComputers: store.hasHiddenComputers
-            ) == .disconnected
-        )
-        #if os(iOS)
-        return MobileAuthenticatedShellPresentation.retainingChildHost(
-            rootPresentation.requiredChildHost,
-            over: baseSurface
-        )
-        #else
-        return baseSurface
-        #endif
     }
 
     #if os(macOS)
@@ -613,6 +589,14 @@ struct CMUXMobileRootView: View {
             )
         case .settings:
             settingsSheet(initialFocus: nil)
+        case .computers:
+            DeviceTreeView(
+                store: store,
+                selectWorkspace: selectWorkspaceFromComputers,
+                showAddDevice: addComputerAction,
+                dismissAction: dismissComputers,
+                didForgetComputer: didForgetComputer
+            )
         case let .pairing(pairingPresentation):
             pairingSheet(initialPresentation: pairingPresentation)
         case .child, .dismissingChild, nil:
@@ -657,6 +641,30 @@ struct CMUXMobileRootView: View {
     /// Requests root Settings without depending on the currently mounted shell.
     private func showSettings() {
         handleRootPresentation(.presentSettings)
+    }
+
+    /// The Computers screen and the root routes it can open share this one
+    /// presenter, so changing the underlying authenticated shell cannot orphan
+    /// modal ownership.
+    private func showComputers() {
+        handleRootPresentation(.presentComputers)
+    }
+
+    private func dismissComputers() {
+        handleRootPresentation(.dismissComputers)
+    }
+
+    /// Forget completes its durable cleanup before this callback fires. Route
+    /// the final-row transition through the same root owner as Done, so the
+    /// authenticated shell and its toolbar become visible together.
+    private func didForgetComputer() {
+        guard !store.hasKnownPairedMac, !store.hasHiddenComputers else { return }
+        dismissComputers()
+    }
+
+    private func selectWorkspaceFromComputers(_ id: MobileWorkspacePreview.ID) {
+        store.selectedWorkspaceID = id
+        dismissComputers()
     }
 
     /// Presents only after the authenticated shell owns the screen and no

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DeviceTreeView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DeviceTreeView.swift
@@ -25,6 +25,12 @@ struct DeviceTreeView: View {
     /// Present the add-device (pairing) flow. `nil` hides the add affordance.
     var showAddDevice: (() -> Void)?
     @Environment(\.dismiss) private var dismiss
+    /// Live app routes dismiss through the root modal owner. Standalone hosts
+    /// leave this nil and retain the environment dismissal fallback.
+    var dismissAction: (() -> Void)? = nil
+    /// Called after a successful Forget operation. The root host uses this to
+    /// dismiss the Computers sheet when the final saved computer is gone.
+    var didForgetComputer: (() -> Void)? = nil
     /// Message for the always-visible failure alert shown when a Forget cannot be
     /// completed. An alert, not a toast, so the error still surfaces when the
     /// Toasts beta flag is off.
@@ -92,7 +98,7 @@ struct DeviceTreeView: View {
                 }
                 ToolbarItem(placement: .confirmationAction) {
                     Button(L10n.string("mobile.common.done", defaultValue: "Done")) {
-                        dismiss()
+                        dismissScreen()
                     }
                     .accessibilityIdentifier("MobileDeviceTreeDone")
                 }
@@ -154,7 +160,15 @@ struct DeviceTreeView: View {
     /// the top-left toolbar button and the end-of-list row.
     private func addComputer() {
         showAddDevice?()
-        dismiss()
+        dismissScreen()
+    }
+
+    private func dismissScreen() {
+        if let dismissAction {
+            dismissAction()
+        } else {
+            dismiss()
+        }
     }
 
     @ViewBuilder
@@ -196,6 +210,8 @@ struct DeviceTreeView: View {
                 "mobile.computers.forget.failureMessage",
                 defaultValue: "It's still signed in. Check your connection and try again."
             )
+        } else {
+            didForgetComputer?()
         }
     }
 

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MobileAuthenticatedShellPresentation.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MobileAuthenticatedShellPresentation.swift
@@ -1,4 +1,5 @@
 import CmuxMobileShellModel
+import CmuxMobileWorkspace
 
 enum MobileAuthenticatedShellPresentation: Equatable {
     case disconnected
@@ -15,5 +16,24 @@ enum MobileAuthenticatedShellPresentation: Equatable {
             return .disconnected
         }
         return .workspace
+    }
+
+    /// Keeps a child sheet's owning shell mounted until that sheet's dismissal
+    /// callback releases the root modal slot.
+    static func retainingChildHost(
+        _ requiredChildHost: MobileRootPresentationState.ChildHost?,
+        over baseSurface: MobileRootAuthGate.MobileRootShellSurface
+    ) -> MobileRootAuthGate.MobileRootShellSurface {
+        switch requiredChildHost {
+        case .disconnected:
+            return .disconnectedNoKnownPairedMac
+        case .workspace:
+            if case .workspaceShell = baseSurface {
+                return baseSurface
+            }
+            return .workspaceShell(isRestoringStoredMac: false)
+        case nil:
+            return baseSurface
+        }
     }
 }

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MobileAuthenticatedShellPresentation.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MobileAuthenticatedShellPresentation.swift
@@ -1,5 +1,4 @@
 import CmuxMobileShellModel
-import CmuxMobileWorkspace
 
 enum MobileAuthenticatedShellPresentation: Equatable {
     case disconnected
@@ -16,24 +15,5 @@ enum MobileAuthenticatedShellPresentation: Equatable {
             return .disconnected
         }
         return .workspace
-    }
-
-    /// Keeps a child sheet's owning shell mounted until that sheet's dismissal
-    /// callback releases the root modal slot.
-    static func retainingChildHost(
-        _ requiredChildHost: MobileRootPresentationState.ChildHost?,
-        over baseSurface: MobileRootAuthGate.MobileRootShellSurface
-    ) -> MobileRootAuthGate.MobileRootShellSurface {
-        switch requiredChildHost {
-        case .disconnected:
-            return .disconnectedNoKnownPairedMac
-        case .workspace:
-            if case .workspaceShell = baseSurface {
-                return baseSurface
-            }
-            return .workspaceShell(isRestoringStoredMac: false)
-        case nil:
-            return baseSurface
-        }
     }
 }

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MobileRootPresentationState.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MobileRootPresentationState.swift
@@ -5,6 +5,12 @@
 /// their content. A dismissing child keeps ownership until its `onDismiss`
 /// callback, preventing a root sheet from competing with UIKit's transition.
 struct MobileRootPresentationState: Equatable {
+    /// The authenticated shell that owns a child presentation's sheet host.
+    enum ChildHost: Equatable {
+        case disconnected
+        case workspace
+    }
+
     /// Presentations owned by the workspace list or one of its row actions.
     enum WorkspaceListPresentation: Equatable, CaseIterable {
         case terminalShortcutsSettings
@@ -90,6 +96,32 @@ struct MobileRootPresentationState: Equatable {
             true
         case .child, .dismissingChild, nil:
             false
+        }
+    }
+
+    /// The shell host that must stay mounted until the active child's real
+    /// `onDismiss` callback releases the shared modal slot.
+    var requiredChildHost: ChildHost? {
+        let child: ChildPresentation
+        switch presentation {
+        case let .child(activeChild), let .dismissingChild(activeChild, _):
+            child = activeChild
+        case .autoConnectMigrationIntroduction,
+             .settings,
+             .connectionSettings,
+             .pairing,
+             nil:
+            return nil
+        }
+
+        switch child {
+        case .disconnectedSetupHelp:
+            return .disconnected
+        case .workspaceDeviceTree,
+             .workspaceTaskComposer,
+             .workspaceList,
+             .workspaceDetail:
+            return .workspace
         }
     }
 

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MobileRootPresentationState.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MobileRootPresentationState.swift
@@ -5,12 +5,6 @@
 /// their content. A dismissing child keeps ownership until its `onDismiss`
 /// callback, preventing a root sheet from competing with UIKit's transition.
 struct MobileRootPresentationState: Equatable {
-    /// The authenticated shell that owns a child presentation's sheet host.
-    enum ChildHost: Equatable {
-        case disconnected
-        case workspace
-    }
-
     /// Presentations owned by the workspace list or one of its row actions.
     enum WorkspaceListPresentation: Equatable, CaseIterable {
         case terminalShortcutsSettings
@@ -46,6 +40,7 @@ struct MobileRootPresentationState: Equatable {
     enum Presentation: Equatable {
         case autoConnectMigrationIntroduction
         case settings
+        case computers
         case pairing(PairingPresentation)
         case child(ChildPresentation)
         case dismissingChild(
@@ -61,6 +56,8 @@ struct MobileRootPresentationState: Equatable {
         case setUpTailscale(hasUsableAuthorization: Bool)
         case presentSettings
         case dismissSettings(presentAutoConnectMigration: Bool)
+        case presentComputers
+        case dismissComputers
         case presentPairing(PairingPresentation)
         case presentChild(ChildPresentation)
         case dismissChild(ChildPresentation)
@@ -92,36 +89,13 @@ struct MobileRootPresentationState: Equatable {
     /// Whether the root SwiftUI sheet host should be presented.
     var isRootSheetPresented: Bool {
         switch presentation {
-        case .autoConnectMigrationIntroduction, .settings, .pairing:
+        case .autoConnectMigrationIntroduction,
+             .settings,
+             .computers,
+             .pairing:
             true
         case .child, .dismissingChild, nil:
             false
-        }
-    }
-
-    /// The shell host that must stay mounted until the active child's real
-    /// `onDismiss` callback releases the shared modal slot.
-    var requiredChildHost: ChildHost? {
-        let child: ChildPresentation
-        switch presentation {
-        case let .child(activeChild), let .dismissingChild(activeChild, _):
-            child = activeChild
-        case .autoConnectMigrationIntroduction,
-             .settings,
-             .connectionSettings,
-             .pairing,
-             nil:
-            return nil
-        }
-
-        switch child {
-        case .disconnectedSetupHelp:
-            return .disconnected
-        case .workspaceDeviceTree,
-             .workspaceTaskComposer,
-             .workspaceList,
-             .workspaceDetail:
-            return .workspace
         }
     }
 
@@ -168,6 +142,16 @@ struct MobileRootPresentationState: Equatable {
                 ? .autoConnectMigrationIntroduction
                 : nil
             return .none
+
+        case .presentComputers:
+            guard presentation == nil else { return .none }
+            presentation = .computers
+            return .none
+
+        case .dismissComputers:
+            guard presentation == .computers else { return .none }
+            presentation = nil
+            return .retryAutoConnectMigration
 
         case let .presentPairing(pairingPresentation):
             switch presentation {
@@ -236,7 +220,7 @@ struct MobileRootPresentationState: Equatable {
             case .pairing:
                 presentation = nil
                 return .finishPairing
-            case .settings:
+            case .settings, .computers:
                 presentation = nil
                 return .none
             case .child, .dismissingChild, nil:

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListView.swift
@@ -64,6 +64,9 @@ struct WorkspaceListView: View {
     /// Present the add-device (pairing) flow from the Computers screen. `nil`
     /// hides the add affordance there.
     var showAddDevice: (() -> Void)?
+    /// Live app routes the Computers screen through the root modal owner.
+    /// Standalone previews retain the local device-tree sheet.
+    var showComputers: (() -> Void)? = nil
     var showPairingScanner: (() -> Void)?
     /// The shell store, forwarded to Settings to drive the multi-Mac switcher.
     /// `nil` in previews.
@@ -934,7 +937,11 @@ struct WorkspaceListView: View {
     #if os(iOS)
     var devicesButton: some View {
         Button {
-            deviceTreePresentation.present()
+            if let showComputers {
+                showComputers()
+            } else {
+                deviceTreePresentation.present()
+            }
         } label: {
             Image(systemName: "desktopcomputer")
         }

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceShellHost.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceShellHost.swift
@@ -21,7 +21,7 @@ struct WorkspaceShellHost: View {
     let showAddDevice: (() -> Void)?
     let showPairingScanner: (() -> Void)?
     var showSettings: () -> Void = {}
-    var deviceTreePresentation = MobileChildSheetPresentation()
+    var showComputers: () -> Void = {}
     var taskComposerPresentation = MobileChildSheetPresentation()
     let reconnectStoredMac: () -> Void
     let workspaceListDidBecomeVisible: @MainActor @Sendable () async -> Void
@@ -40,7 +40,7 @@ struct WorkspaceShellHost: View {
             showAddDevice: showAddDevice,
             showPairingScanner: showPairingScanner,
             showSettings: showSettings,
-            deviceTreePresentation: deviceTreePresentation,
+            showComputers: showComputers,
             taskComposerPresentation: taskComposerPresentation
         )
         .task(id: deadlineTaskID) {

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceShellView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceShellView.swift
@@ -161,7 +161,7 @@ struct WorkspaceShellView: View {
     var showAddDevice: (() -> Void)?
     var showPairingScanner: (() -> Void)?
     var showSettings: () -> Void = {}
-    var deviceTreePresentation = MobileChildSheetPresentation()
+    var showComputers: () -> Void = {}
     var taskComposerPresentation = MobileChildSheetPresentation()
     let compactNavigationPolicy = WorkspaceShellCompactNavigationPolicy()
     @Environment(MobileDisplaySettings.self) private var displaySettings
@@ -339,20 +339,6 @@ struct WorkspaceShellView: View {
             }
             .onChange(of: presentation.notificationFeedItems, initial: true) { _, items in
                 notificationFeedProjection.update(items: items)
-            }
-            .sheet(
-                isPresented: deviceTreePresentation.isPresented,
-                onDismiss: deviceTreePresentation.didDismiss
-            ) {
-                DeviceTreeView(
-                    store: store,
-                    selectWorkspace: { id in
-                        transitionPrimaryTab(to: .workspaces) {
-                            selectWorkspace(id)
-                        }
-                    },
-                    showAddDevice: showAddDevice
-                )
             }
         }
         #else
@@ -679,6 +665,7 @@ struct WorkspaceShellView: View {
             signOut: signOut,
             reconnect: store.tailscalePairingRequired ? nil : reconnectClosure,
             showAddDevice: showAddDevice,
+            showComputers: showComputers,
             showPairingScanner: showPairingScanner,
             store: store,
             renameWorkspace: renameWorkspaceClosure,
@@ -709,7 +696,7 @@ struct WorkspaceShellView: View {
     private var rootToolbarContent: some ToolbarContent {
         WorkspaceRootToolbarLiveContent(
             openSettings: showSettings,
-            openDevices: { deviceTreePresentation.present() },
+            openDevices: showComputers,
             pendingSelection: rootToolbarPendingSelection,
             select: handleRootToolbarSelection,
             showAddDevice: showAddDevice,

--- a/Packages/iOS/CmuxMobileShellUI/Tests/CmuxMobileShellUITests/MobileAuthenticatedShellPresentationTests.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Tests/CmuxMobileShellUITests/MobileAuthenticatedShellPresentationTests.swift
@@ -1,5 +1,6 @@
 #if os(iOS)
 import CmuxMobileShellModel
+import CmuxMobileWorkspace
 import Testing
 @testable import CmuxMobileShellUI
 
@@ -36,6 +37,49 @@ struct MobileAuthenticatedShellPresentationTests {
             hasKnownPairedMac: false,
             hasHiddenComputers: false
         ) == .workspace)
+    }
+
+    @Test func finalComputerRemovalRetainsActiveWorkspaceChildHost() {
+        let noComputers = MobileRootAuthGate.shellSurface(
+            connectionState: .disconnected,
+            showRestoringStoredMac: false,
+            showDisconnectedNoPairedMacShell: true
+        )
+        #expect(noComputers == .disconnectedNoKnownPairedMac)
+
+        #expect(MobileAuthenticatedShellPresentation.retainingChildHost(
+            .workspace,
+            over: noComputers
+        ) == .workspaceShell(isRestoringStoredMac: false))
+    }
+
+    @Test func reconnectRetainsActiveDisconnectedChildHost() {
+        let connected = MobileRootAuthGate.shellSurface(
+            connectionState: .connected,
+            showRestoringStoredMac: false,
+            showDisconnectedNoPairedMacShell: false
+        )
+        #expect(connected == .workspaceShell(isRestoringStoredMac: false))
+
+        #expect(MobileAuthenticatedShellPresentation.retainingChildHost(
+            .disconnected,
+            over: connected
+        ) == .disconnectedNoKnownPairedMac)
+    }
+
+    @Test func noChildHostPreservesBaseShellAndRestoringPayload() {
+        let restoring = MobileRootAuthGate.MobileRootShellSurface.workspaceShell(
+            isRestoringStoredMac: true
+        )
+
+        #expect(MobileAuthenticatedShellPresentation.retainingChildHost(
+            nil,
+            over: restoring
+        ) == restoring)
+        #expect(MobileAuthenticatedShellPresentation.retainingChildHost(
+            .workspace,
+            over: restoring
+        ) == restoring)
     }
 }
 #endif

--- a/Packages/iOS/CmuxMobileShellUI/Tests/CmuxMobileShellUITests/MobileAuthenticatedShellPresentationTests.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Tests/CmuxMobileShellUITests/MobileAuthenticatedShellPresentationTests.swift
@@ -1,6 +1,5 @@
 #if os(iOS)
 import CmuxMobileShellModel
-import CmuxMobileWorkspace
 import Testing
 @testable import CmuxMobileShellUI
 
@@ -39,47 +38,5 @@ struct MobileAuthenticatedShellPresentationTests {
         ) == .workspace)
     }
 
-    @Test func finalComputerRemovalRetainsActiveWorkspaceChildHost() {
-        let noComputers = MobileRootAuthGate.shellSurface(
-            connectionState: .disconnected,
-            showRestoringStoredMac: false,
-            showDisconnectedNoPairedMacShell: true
-        )
-        #expect(noComputers == .disconnectedNoKnownPairedMac)
-
-        #expect(MobileAuthenticatedShellPresentation.retainingChildHost(
-            .workspace,
-            over: noComputers
-        ) == .workspaceShell(isRestoringStoredMac: false))
-    }
-
-    @Test func reconnectRetainsActiveDisconnectedChildHost() {
-        let connected = MobileRootAuthGate.shellSurface(
-            connectionState: .connected,
-            showRestoringStoredMac: false,
-            showDisconnectedNoPairedMacShell: false
-        )
-        #expect(connected == .workspaceShell(isRestoringStoredMac: false))
-
-        #expect(MobileAuthenticatedShellPresentation.retainingChildHost(
-            .disconnected,
-            over: connected
-        ) == .disconnectedNoKnownPairedMac)
-    }
-
-    @Test func noChildHostPreservesBaseShellAndRestoringPayload() {
-        let restoring = MobileRootAuthGate.MobileRootShellSurface.workspaceShell(
-            isRestoringStoredMac: true
-        )
-
-        #expect(MobileAuthenticatedShellPresentation.retainingChildHost(
-            nil,
-            over: restoring
-        ) == restoring)
-        #expect(MobileAuthenticatedShellPresentation.retainingChildHost(
-            .workspace,
-            over: restoring
-        ) == restoring)
-    }
 }
 #endif

--- a/Packages/iOS/CmuxMobileShellUI/Tests/CmuxMobileShellUITests/MobileRootPresentationStateTests.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Tests/CmuxMobileShellUITests/MobileRootPresentationStateTests.swift
@@ -88,6 +88,7 @@ struct MobileRootPresentationStateTests {
         #expect(state.apply(.presentChild(child)) == .none)
         #expect(state.presentation == .child(child))
         #expect(state.isPresentingChild(child))
+        #expect(state.requiredChildHost == .workspace)
 
         #expect(state.apply(.presentAutoConnectMigrationIfIdle) == .none)
         #expect(state.presentation == .child(child))
@@ -99,6 +100,7 @@ struct MobileRootPresentationStateTests {
         )
         #expect(!state.isPresentingChild(child))
         #expect(!state.isIdle)
+        #expect(state.requiredChildHost == .workspace)
         #expect(state.apply(.presentAutoConnectMigrationIfIdle) == .none)
         #expect(
             state.presentation
@@ -110,9 +112,43 @@ struct MobileRootPresentationStateTests {
                 == .retryAutoConnectMigration
         )
         #expect(state.isIdle)
+        #expect(state.requiredChildHost == nil)
 
         #expect(state.apply(.presentAutoConnectMigrationIfIdle) == .none)
         #expect(state.presentation == .autoConnectMigrationIntroduction)
+    }
+
+    @Test func rootWorkspaceChildrenRetainTheirHostThroughDismissal() {
+        let children: [MobileRootPresentationState.ChildPresentation] = [
+            .workspaceDeviceTree,
+            .workspaceTaskComposer,
+        ]
+
+        for child in children {
+            var state = MobileRootPresentationState()
+            state.apply(.presentChild(child))
+            #expect(state.requiredChildHost == .workspace)
+
+            state.apply(.dismissChild(child))
+            #expect(state.requiredChildHost == .workspace)
+
+            state.apply(.childDidDismiss(child))
+            #expect(state.requiredChildHost == nil)
+        }
+    }
+
+    @Test func disconnectedHelpRetainsItsHostThroughDismissal() {
+        var state = MobileRootPresentationState()
+        let child = MobileRootPresentationState.ChildPresentation.disconnectedSetupHelp
+
+        state.apply(.presentChild(child))
+        #expect(state.requiredChildHost == .disconnected)
+
+        state.apply(.dismissChild(child))
+        #expect(state.requiredChildHost == .disconnected)
+
+        state.apply(.childDidDismiss(child))
+        #expect(state.requiredChildHost == nil)
     }
 
     @Test func rootSettingsBlocksMigrationOnTheAlwaysMountedSheetHost() {
@@ -151,12 +187,15 @@ struct MobileRootPresentationStateTests {
 
         #expect(state.apply(.presentChild(child)) == .none)
         #expect(state.presentation == .child(child))
+        #expect(state.requiredChildHost == .workspace)
         #expect(state.apply(.presentAutoConnectMigrationIfIdle) == .none)
         #expect(state.presentation == .child(child))
 
         #expect(state.apply(.dismissChild(child)) == .none)
+        #expect(state.requiredChildHost == .workspace)
         #expect(state.apply(.childDidDismiss(child)) == .retryAutoConnectMigration)
         #expect(state.isIdle)
+        #expect(state.requiredChildHost == nil)
     }
 
     @Test(arguments: MobileRootPresentationState.WorkspaceDetailPresentation.allCases)
@@ -168,12 +207,15 @@ struct MobileRootPresentationStateTests {
 
         #expect(state.apply(.presentChild(child)) == .none)
         #expect(state.presentation == .child(child))
+        #expect(state.requiredChildHost == .workspace)
         #expect(state.apply(.presentAutoConnectMigrationIfIdle) == .none)
         #expect(state.presentation == .child(child))
 
         #expect(state.apply(.dismissChild(child)) == .none)
+        #expect(state.requiredChildHost == .workspace)
         #expect(state.apply(.childDidDismiss(child)) == .retryAutoConnectMigration)
         #expect(state.isIdle)
+        #expect(state.requiredChildHost == nil)
     }
 
     @Test func pairingRequestedFromChildWaitsForItsDismissalCallback() {
@@ -188,10 +230,12 @@ struct MobileRootPresentationStateTests {
                 == .dismissingChild(child, pendingPairing: scanner)
         )
         #expect(!state.isRootSheetPresented)
+        #expect(state.requiredChildHost == .workspace)
 
         #expect(state.apply(.childDidDismiss(child)) == .none)
         #expect(state.presentation == .pairing(scanner))
         #expect(state.isRootSheetPresented)
+        #expect(state.requiredChildHost == nil)
     }
 
     @Test func authenticationLossDismissesMigrationWithoutAcknowledgingIt() {

--- a/Packages/iOS/CmuxMobileShellUI/Tests/CmuxMobileShellUITests/MobileRootPresentationStateTests.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Tests/CmuxMobileShellUITests/MobileRootPresentationStateTests.swift
@@ -81,6 +81,28 @@ struct MobileRootPresentationStateTests {
         #expect(state.presentation == .pairing(pairing))
     }
 
+    @Test func computersOwnsRootSheetAndCanTransitionToPairing() {
+        var state = MobileRootPresentationState()
+
+        #expect(state.apply(.presentComputers) == .none)
+        #expect(state.presentation == .computers)
+        #expect(state.isRootSheetPresented)
+
+        let pairing = PairingPresentation.manual
+        #expect(state.apply(.presentPairing(pairing)) == .none)
+        #expect(state.presentation == .pairing(pairing))
+        #expect(state.isRootSheetPresented)
+    }
+
+    @Test func computersDismissalClearsRootSlot() {
+        var state = MobileRootPresentationState()
+        state.apply(.presentComputers)
+
+        #expect(state.apply(.dismissComputers) == .retryAutoConnectMigration)
+        #expect(state.isIdle)
+        #expect(!state.isRootSheetPresented)
+    }
+
     @Test func childModalBlocksMigrationUntilItsDismissalCompletes() {
         var state = MobileRootPresentationState()
         let child = MobileRootPresentationState.ChildPresentation.workspaceDeviceTree
@@ -88,7 +110,6 @@ struct MobileRootPresentationStateTests {
         #expect(state.apply(.presentChild(child)) == .none)
         #expect(state.presentation == .child(child))
         #expect(state.isPresentingChild(child))
-        #expect(state.requiredChildHost == .workspace)
 
         #expect(state.apply(.presentAutoConnectMigrationIfIdle) == .none)
         #expect(state.presentation == .child(child))
@@ -100,7 +121,6 @@ struct MobileRootPresentationStateTests {
         )
         #expect(!state.isPresentingChild(child))
         #expect(!state.isIdle)
-        #expect(state.requiredChildHost == .workspace)
         #expect(state.apply(.presentAutoConnectMigrationIfIdle) == .none)
         #expect(
             state.presentation
@@ -112,43 +132,9 @@ struct MobileRootPresentationStateTests {
                 == .retryAutoConnectMigration
         )
         #expect(state.isIdle)
-        #expect(state.requiredChildHost == nil)
 
         #expect(state.apply(.presentAutoConnectMigrationIfIdle) == .none)
         #expect(state.presentation == .autoConnectMigrationIntroduction)
-    }
-
-    @Test func rootWorkspaceChildrenRetainTheirHostThroughDismissal() {
-        let children: [MobileRootPresentationState.ChildPresentation] = [
-            .workspaceDeviceTree,
-            .workspaceTaskComposer,
-        ]
-
-        for child in children {
-            var state = MobileRootPresentationState()
-            state.apply(.presentChild(child))
-            #expect(state.requiredChildHost == .workspace)
-
-            state.apply(.dismissChild(child))
-            #expect(state.requiredChildHost == .workspace)
-
-            state.apply(.childDidDismiss(child))
-            #expect(state.requiredChildHost == nil)
-        }
-    }
-
-    @Test func disconnectedHelpRetainsItsHostThroughDismissal() {
-        var state = MobileRootPresentationState()
-        let child = MobileRootPresentationState.ChildPresentation.disconnectedSetupHelp
-
-        state.apply(.presentChild(child))
-        #expect(state.requiredChildHost == .disconnected)
-
-        state.apply(.dismissChild(child))
-        #expect(state.requiredChildHost == .disconnected)
-
-        state.apply(.childDidDismiss(child))
-        #expect(state.requiredChildHost == nil)
     }
 
     @Test func rootSettingsBlocksMigrationOnTheAlwaysMountedSheetHost() {
@@ -187,15 +173,12 @@ struct MobileRootPresentationStateTests {
 
         #expect(state.apply(.presentChild(child)) == .none)
         #expect(state.presentation == .child(child))
-        #expect(state.requiredChildHost == .workspace)
         #expect(state.apply(.presentAutoConnectMigrationIfIdle) == .none)
         #expect(state.presentation == .child(child))
 
         #expect(state.apply(.dismissChild(child)) == .none)
-        #expect(state.requiredChildHost == .workspace)
         #expect(state.apply(.childDidDismiss(child)) == .retryAutoConnectMigration)
         #expect(state.isIdle)
-        #expect(state.requiredChildHost == nil)
     }
 
     @Test(arguments: MobileRootPresentationState.WorkspaceDetailPresentation.allCases)
@@ -207,15 +190,12 @@ struct MobileRootPresentationStateTests {
 
         #expect(state.apply(.presentChild(child)) == .none)
         #expect(state.presentation == .child(child))
-        #expect(state.requiredChildHost == .workspace)
         #expect(state.apply(.presentAutoConnectMigrationIfIdle) == .none)
         #expect(state.presentation == .child(child))
 
         #expect(state.apply(.dismissChild(child)) == .none)
-        #expect(state.requiredChildHost == .workspace)
         #expect(state.apply(.childDidDismiss(child)) == .retryAutoConnectMigration)
         #expect(state.isIdle)
-        #expect(state.requiredChildHost == nil)
     }
 
     @Test func pairingRequestedFromChildWaitsForItsDismissalCallback() {
@@ -230,12 +210,10 @@ struct MobileRootPresentationStateTests {
                 == .dismissingChild(child, pendingPairing: scanner)
         )
         #expect(!state.isRootSheetPresented)
-        #expect(state.requiredChildHost == .workspace)
 
         #expect(state.apply(.childDidDismiss(child)) == .none)
         #expect(state.presentation == .pairing(scanner))
         #expect(state.isRootSheetPresented)
-        #expect(state.requiredChildHost == nil)
     }
 
     @Test func authenticationLossDismissesMigrationWithoutAcknowledgingIt() {

--- a/Packages/iOS/CmuxMobileSupport/Sources/CmuxMobileSupport/UITestConfig.swift
+++ b/Packages/iOS/CmuxMobileSupport/Sources/CmuxMobileSupport/UITestConfig.swift
@@ -120,6 +120,21 @@ public struct UITestConfig {
         #endif
     }
 
+    /// Whether the full-app UI-test harness should treat the account-owned
+    /// revoke step of Forget Computer as successful. The remaining operation,
+    /// including durable paired-Mac deletion, store refresh, shell routing, and
+    /// modal presentation, continues through production code. DEBUG-only and
+    /// gated on mock data so dogfood builds can never skip a real revoke.
+    public static var successfulComputerForgetEnabled: Bool {
+        #if DEBUG
+        let environment = ProcessInfo.processInfo.environment
+        return mockDataEnabled(from: environment)
+            && environment["CMUX_UITEST_SUCCESSFUL_COMPUTER_FORGET"] == "1"
+        #else
+        return false
+        #endif
+    }
+
     /// Push readiness preview state selected by
     /// `CMUX_UITEST_PUSH_READINESS_PREVIEW`. A set value routes the root view
     /// to the readiness preview and names its fixture state. DEBUG-only.

--- a/ios/cmux/AppCompositionRoot.swift
+++ b/ios/cmux/AppCompositionRoot.swift
@@ -137,11 +137,26 @@ final class AppCompositionRoot {
             consent: telemetryConsent,
             diagnosticLog: diagnosticLog
         )
+        #if DEBUG
+        let pushNotificationSettings:
+            (@MainActor () async -> MobilePushSystemSettings)?
+        if UITestConfig.mockDataEnabled {
+            // Full-app mock tests run on freshly erased simulators. Keep the
+            // real SpringBoard authorization alert out of unrelated UI flows.
+            pushNotificationSettings = { .authorizationOnly(.denied) }
+        } else {
+            pushNotificationSettings = nil
+        }
+        #else
+        let pushNotificationSettings:
+            (@MainActor () async -> MobilePushSystemSettings)? = nil
+        #endif
         let pushCoordinator = MobilePushCoordinator(
             registration: auth.pushRegistration,
             analytics: analytics.emitter,
             diagnosticLog: diagnosticLog,
-            phoneAPIOrigin: auth.config.apiBaseURL
+            phoneAPIOrigin: auth.config.apiBaseURL,
+            notificationSettings: pushNotificationSettings
         )
         self.pushCoordinator = pushCoordinator
         self.signOutHook = MobileSignOutHook {

--- a/ios/cmuxPackage/Sources/cmuxFeature/CMUXMobileRootScene.swift
+++ b/ios/cmuxPackage/Sources/cmuxFeature/CMUXMobileRootScene.swift
@@ -20,6 +20,20 @@ import CmuxMobileTerminal
 
 private let mobileRootSceneLog = Logger(subsystem: "dev.cmux.ios", category: "mobile-root-scene")
 
+#if DEBUG
+/// Test-only substitute for the external account revoke. It lets XCUITest drive
+/// the production local deletion and root-presentation lifecycle without
+/// mutating an account-owned computer binding.
+@MainActor
+private struct SuccessfulComputerForgetUITestStub: MobileIrohMacForgetting {
+    func forgetComputer(
+        macDeviceID _: String,
+        instanceTag _: String?,
+        expectedAccountID _: String
+    ) async throws {}
+}
+#endif
+
 /// Top-level mobile scene root.
 ///
 /// Renders the live cmux mobile UI: a ``CMUXMobileAppView`` backed by a fresh
@@ -423,6 +437,16 @@ public struct CMUXMobileRootScene: View {
         let feedbackStampProvider: @MainActor () -> MobileFeedbackStamp = {
             MobileFeedbackStamp.current()
         }
+        let resolvedPersonalIrohForget: (any MobileIrohMacForgetting)?
+        #if DEBUG
+        if UITestConfig.successfulComputerForgetEnabled {
+            resolvedPersonalIrohForget = SuccessfulComputerForgetUITestStub()
+        } else {
+            resolvedPersonalIrohForget = personalIrohForget
+        }
+        #else
+        resolvedPersonalIrohForget = personalIrohForget
+        #endif
         return CMUXMobileShellStore(
             runtime: runtime,
             pairedMacStore: backedUpPairedMacStore,
@@ -431,7 +455,7 @@ public struct CMUXMobileRootScene: View {
             pairedMacRestoreBoundary: restoreBoundary,
             deviceRegistry: deviceRegistry,
             personalIrohDiscovery: personalIrohDiscovery,
-            personalIrohForget: personalIrohForget,
+            personalIrohForget: resolvedPersonalIrohForget,
             presence: makePresenceClient(),
             identityProvider: identityProvider,
             teamIDProvider: { await coordinator.resolvedTeamID },

--- a/ios/cmuxPackage/Sources/cmuxFeature/CMUXMobileRootScene.swift
+++ b/ios/cmuxPackage/Sources/cmuxFeature/CMUXMobileRootScene.swift
@@ -20,20 +20,6 @@ import CmuxMobileTerminal
 
 private let mobileRootSceneLog = Logger(subsystem: "dev.cmux.ios", category: "mobile-root-scene")
 
-#if DEBUG
-/// Test-only substitute for the external account revoke. It lets XCUITest drive
-/// the production local deletion and root-presentation lifecycle without
-/// mutating an account-owned computer binding.
-@MainActor
-private struct SuccessfulComputerForgetUITestStub: MobileIrohMacForgetting {
-    func forgetComputer(
-        macDeviceID _: String,
-        instanceTag _: String?,
-        expectedAccountID _: String
-    ) async throws {}
-}
-#endif
-
 /// Top-level mobile scene root.
 ///
 /// Renders the live cmux mobile UI: a ``CMUXMobileAppView`` backed by a fresh

--- a/ios/cmuxPackage/Sources/cmuxFeature/Debug/SuccessfulComputerForgetUITestStub.swift
+++ b/ios/cmuxPackage/Sources/cmuxFeature/Debug/SuccessfulComputerForgetUITestStub.swift
@@ -1,0 +1,15 @@
+#if DEBUG
+import CmuxMobileShell
+
+/// Test-only substitute for the external account revoke. It lets XCUITest drive
+/// the production local deletion and root-presentation lifecycle without
+/// mutating an account-owned computer binding.
+@MainActor
+struct SuccessfulComputerForgetUITestStub: MobileIrohMacForgetting {
+    func forgetComputer(
+        macDeviceID _: String,
+        instanceTag _: String?,
+        expectedAccountID _: String
+    ) async throws {}
+}
+#endif

--- a/ios/cmuxUITests/cmuxUITests.swift
+++ b/ios/cmuxUITests/cmuxUITests.swift
@@ -2520,6 +2520,116 @@ final class cmuxUITests: XCTestCase {
         XCTAssertTrue(app.staticTexts["Studio Mac"].exists)
     }
 
+    /// Regression: forgetting the final saved computer while the Computers
+    /// sheet is onscreen changes the root from the workspace shell to the
+    /// disconnected shell. The workspace shell must retain ownership until the
+    /// child sheet's real dismissal, or the shared modal slot stays stranded and
+    /// both Add Computer and Settings stop responding.
+    @MainActor
+    func testForgettingFinalComputerKeepsAddComputerAndSettingsResponsive() async throws {
+        let server = try MobileSyncMockHostServer(supportsManualAttachTicket: true)
+        let port = try await server.start()
+        var serverIsRunning = true
+        defer {
+            if serverIsRunning { server.stop() }
+        }
+
+        let app = try launchConnectedAppViaManualPairing(
+            port: port,
+            environment: ["CMUX_UITEST_SUCCESSFUL_COMPUTER_FORGET": "1"]
+        )
+        defer { app.terminate() }
+
+        server.stop()
+        serverIsRunning = false
+        XCTAssertTrue(
+            app.descendants(matching: .any)["MobileTerminalMacConnectionStatus"]
+                .waitForExistence(timeout: 12),
+            "The mock Mac must disconnect before deletion so removing its final saved row changes root shells."
+        )
+
+        let backButton = app.buttons["MobileWorkspaceBackButton"]
+        XCTAssertTrue(backButton.waitForExistence(timeout: 4))
+        tap(backButton, in: app)
+
+        let computersButton = app.buttons["MobileWorkspaceDevicesButton"]
+        XCTAssertTrue(computersButton.waitForExistence(timeout: 4))
+        tap(computersButton, in: app)
+        XCTAssertTrue(
+            app.descendants(matching: .any)["MobileDeviceTree"]
+                .waitForExistence(timeout: 4)
+        )
+
+        let toggle = app.switches.matching(
+            NSPredicate(
+                format: "identifier BEGINSWITH %@",
+                "MobileComputerVisibilityToggle-ui-test-mac"
+            )
+        ).firstMatch
+        XCTAssertTrue(toggle.waitForExistence(timeout: 4))
+        tap(toggle, in: app)
+        let hidden = XCTNSPredicateExpectation(
+            predicate: NSPredicate(format: "value == %@", "0"),
+            object: toggle
+        )
+        XCTAssertEqual(XCTWaiter.wait(for: [hidden], timeout: 4), .completed)
+
+        let computerRow = app.staticTexts["UI Test Mac"]
+        XCTAssertTrue(computerRow.waitForExistence(timeout: 4))
+        computerRow.swipeLeft()
+        let forgetSwipe = app.buttons.matching(
+            NSPredicate(
+                format: "identifier BEGINSWITH %@",
+                "MobileComputerForgetSwipeButton-ui-test-mac"
+            )
+        ).firstMatch
+        XCTAssertTrue(forgetSwipe.waitForExistence(timeout: 4))
+        forgetSwipe.tap()
+
+        let confirmForget = app.buttons.matching(
+            NSPredicate(
+                format: "identifier BEGINSWITH %@",
+                "MobileComputerForgetConfirmButton-ui-test-mac"
+            )
+        ).firstMatch
+        XCTAssertTrue(confirmForget.waitForExistence(timeout: 4))
+        confirmForget.tap()
+        XCTAssertTrue(
+            computerRow.waitForNonExistence(timeout: 8),
+            "The final computer must leave the production list after Forget succeeds."
+        )
+
+        let addComputer = app.buttons["MobileComputersAddButton"]
+        XCTAssertTrue(addComputer.waitForExistence(timeout: 4))
+        XCTAssertTrue(addComputer.isHittable)
+        tap(addComputer, in: app)
+
+        let pairingForm = app.otherElements["MobileAddDeviceForm"]
+        XCTAssertTrue(
+            pairingForm.waitForExistence(timeout: 8),
+            "Add Computer must present after deleting the final computer."
+        )
+        let cancelPairing = app.buttons["MobilePairingCancelButton"]
+        XCTAssertTrue(cancelPairing.waitForExistence(timeout: 4))
+        tap(cancelPairing, in: app)
+        XCTAssertTrue(pairingForm.waitForNonExistence(timeout: 4))
+
+        XCTAssertTrue(
+            app.descendants(matching: .any)["MobileDisconnectedWorkspaceShell"]
+                .waitForExistence(timeout: 8)
+        )
+        let settings = app.buttons["MobileWorkspaceSettingsMenu"]
+        XCTAssertTrue(settings.waitForExistence(timeout: 4))
+        XCTAssertTrue(settings.isHittable)
+        tap(settings, in: app)
+
+        let settingsView = app.descendants(matching: .any)["MobileSettingsView"]
+        XCTAssertTrue(
+            settingsView.waitForExistence(timeout: 8),
+            "Settings must present after deleting the final computer."
+        )
+    }
+
     @MainActor
     func testWorkspaceListRapidDirectionChangesAndBoundariesRemainResponsive() throws {
         let app = launchApp(mockData: false, environment: [
@@ -6658,14 +6768,17 @@ final class cmuxUITests: XCTestCase {
     }
 
     @MainActor
-    private func launchConnectedAppViaManualPairing(port: UInt16) throws -> XCUIApplication {
+    private func launchConnectedAppViaManualPairing(
+        port: UInt16,
+        environment: [String: String] = [:]
+    ) throws -> XCUIApplication {
         let portText = String(port)
         guard let finalPortDigit = portText.last else {
             throw URLError(.badURL)
         }
-        let app = launchApp(mockData: true, environment: [
-            "CMUX_UITEST_ADD_DEVICE_PORT": String(portText.dropLast()),
-        ], launchArguments: [
+        var launchEnvironment = environment
+        launchEnvironment["CMUX_UITEST_ADD_DEVICE_PORT"] = String(portText.dropLast())
+        let app = launchApp(mockData: true, environment: launchEnvironment, launchArguments: [
             "-dev.cmux.mobile.connectionMethod.v1", "tailscale",
             "-cmux.mobile.taskComposerEnabled", "YES",
         ])

--- a/ios/cmuxUITests/cmuxUITests.swift
+++ b/ios/cmuxUITests/cmuxUITests.swift
@@ -2614,25 +2614,27 @@ final class cmuxUITests: XCTestCase {
             "The final computer must leave the production list after Forget succeeds."
         )
 
-        let addComputer = app.buttons["MobileComputersAddButton"]
+        let disconnectedShell = app.descendants(matching: .any)[
+            "MobileDisconnectedWorkspaceShell"
+        ]
+        XCTAssertTrue(disconnectedShell.waitForExistence(timeout: 8))
+
+        let addComputer = app.buttons["MobileShowAddDeviceButton"]
         XCTAssertTrue(addComputer.waitForExistence(timeout: 4))
         XCTAssertTrue(addComputer.isHittable)
         tap(addComputer, in: app)
 
-        let pairingForm = app.otherElements["MobileAddDeviceForm"]
+        let pairingHostField = app.textFields["MobileAddDeviceHostField"]
         XCTAssertTrue(
-            pairingForm.waitForExistence(timeout: 8),
+            pairingHostField.waitForExistence(timeout: 8),
             "Add Computer must present after deleting the final computer."
         )
         let cancelPairing = app.buttons["MobilePairingCancelButton"]
         XCTAssertTrue(cancelPairing.waitForExistence(timeout: 4))
         tap(cancelPairing, in: app)
-        XCTAssertTrue(pairingForm.waitForNonExistence(timeout: 4))
+        XCTAssertTrue(pairingHostField.waitForNonExistence(timeout: 4))
 
-        XCTAssertTrue(
-            app.descendants(matching: .any)["MobileDisconnectedWorkspaceShell"]
-                .waitForExistence(timeout: 8)
-        )
+        XCTAssertTrue(disconnectedShell.waitForExistence(timeout: 8))
         let settings = app.buttons["MobileWorkspaceSettingsMenu"]
         XCTAssertTrue(settings.waitForExistence(timeout: 4))
         XCTAssertTrue(settings.isHittable)
@@ -6796,12 +6798,11 @@ final class cmuxUITests: XCTestCase {
         let app = launchApp(mockData: true, environment: launchEnvironment, launchArguments: [
             "-dev.cmux.mobile.connectionMethod.v1", "tailscale",
             "-cmux.mobile.taskComposerEnabled", "YES",
+            "-cmux.notifications.pushEnabled", "NO",
         ])
-        let pairingForm = app.otherElements["MobileAddDeviceForm"]
-        XCTAssertTrue(pairingForm.waitForExistence(timeout: 8))
 
         let hostField = app.textFields["MobileAddDeviceHostField"]
-        XCTAssertTrue(hostField.waitForExistence(timeout: 4))
+        XCTAssertTrue(hostField.waitForExistence(timeout: 8))
         hostField.tap()
         hostField.typeText("127.0.0.1")
 

--- a/ios/cmuxUITests/cmuxUITests.swift
+++ b/ios/cmuxUITests/cmuxUITests.swift
@@ -2619,8 +2619,8 @@ final class cmuxUITests: XCTestCase {
         ]
         XCTAssertTrue(disconnectedShell.waitForExistence(timeout: 8))
 
-        let addComputer = app.buttons["MobileShowAddDeviceButton"]
-        XCTAssertTrue(addComputer.waitForExistence(timeout: 4))
+        let addComputer = app.buttons["MobileShowAddDeviceToolbarButton"]
+        XCTAssertTrue(addComputer.waitForExistence(timeout: 8))
         XCTAssertTrue(addComputer.isHittable)
         tap(addComputer, in: app)
 
@@ -6798,11 +6798,13 @@ final class cmuxUITests: XCTestCase {
         let app = launchApp(mockData: true, environment: launchEnvironment, launchArguments: [
             "-dev.cmux.mobile.connectionMethod.v1", "tailscale",
             "-cmux.mobile.taskComposerEnabled", "YES",
-            "-cmux.notifications.pushEnabled", "NO",
         ])
 
         let hostField = app.textFields["MobileAddDeviceHostField"]
-        XCTAssertTrue(hostField.waitForExistence(timeout: 8))
+        XCTAssertTrue(
+            hostField.waitForExistence(timeout: 20),
+            "The initial Add Computer field must appear before manual pairing."
+        )
         hostField.tap()
         hostField.typeText("127.0.0.1")
 

--- a/ios/cmuxUITests/cmuxUITests.swift
+++ b/ios/cmuxUITests/cmuxUITests.swift
@@ -2520,13 +2520,47 @@ final class cmuxUITests: XCTestCase {
         XCTAssertTrue(app.staticTexts["Studio Mac"].exists)
     }
 
-    /// Regression: forgetting the final saved computer while the Computers
-    /// sheet is onscreen changes the root from the workspace shell to the
-    /// disconnected shell. The workspace shell must retain ownership until the
-    /// child sheet's real dismissal, or the shared modal slot stays stranded and
-    /// both Add Computer and Settings stop responding.
+    /// Regression: the real Add Computer toolbar entrypoint remains usable after
+    /// forgetting the final saved computer swaps the authenticated root shell.
     @MainActor
-    func testForgettingFinalComputerKeepsAddComputerAndSettingsResponsive() async throws {
+    func testForgettingFinalComputerKeepsAddComputerResponsive() async throws {
+        let app = try await launchAppAfterForgettingFinalComputer()
+        defer { app.terminate() }
+
+        let addComputer = app.buttons["MobileShowAddDeviceToolbarButton"]
+        XCTAssertTrue(addComputer.waitForExistence(timeout: 8))
+        XCTAssertTrue(addComputer.isHittable)
+        tap(addComputer, in: app)
+
+        XCTAssertTrue(
+            app.textFields["MobileAddDeviceHostField"].waitForExistence(timeout: 8),
+            "Add Computer must present after deleting the final computer."
+        )
+    }
+
+    /// Regression: the real Settings toolbar entrypoint remains usable after
+    /// forgetting the final saved computer swaps the authenticated root shell.
+    @MainActor
+    func testForgettingFinalComputerKeepsSettingsResponsive() async throws {
+        let app = try await launchAppAfterForgettingFinalComputer()
+        defer { app.terminate() }
+
+        let settings = app.buttons["MobileWorkspaceSettingsMenu"]
+        XCTAssertTrue(settings.waitForExistence(timeout: 4))
+        XCTAssertTrue(settings.isHittable)
+        tap(settings, in: app)
+
+        XCTAssertTrue(
+            app.descendants(matching: .any)["MobileSettingsView"]
+                .waitForExistence(timeout: 8),
+            "Settings must present after deleting the final computer."
+        )
+    }
+
+    /// Forgets the only saved Mac through the production Computers sheet and
+    /// returns only after SwiftUI has mounted the no-computers root shell.
+    @MainActor
+    private func launchAppAfterForgettingFinalComputer() async throws -> XCUIApplication {
         let server = try MobileSyncMockHostServer(supportsManualAttachTicket: true)
         let port = try await server.start()
         var serverIsRunning = true
@@ -2538,7 +2572,6 @@ final class cmuxUITests: XCTestCase {
             port: port,
             environment: ["CMUX_UITEST_SUCCESSFUL_COMPUTER_FORGET": "1"]
         )
-        defer { app.terminate() }
 
         server.stop()
         serverIsRunning = false
@@ -2618,33 +2651,7 @@ final class cmuxUITests: XCTestCase {
             "MobileDisconnectedWorkspaceShell"
         ]
         XCTAssertTrue(disconnectedShell.waitForExistence(timeout: 8))
-
-        let addComputer = app.buttons["MobileShowAddDeviceToolbarButton"]
-        XCTAssertTrue(addComputer.waitForExistence(timeout: 8))
-        XCTAssertTrue(addComputer.isHittable)
-        tap(addComputer, in: app)
-
-        let pairingHostField = app.textFields["MobileAddDeviceHostField"]
-        XCTAssertTrue(
-            pairingHostField.waitForExistence(timeout: 8),
-            "Add Computer must present after deleting the final computer."
-        )
-        let cancelPairing = app.buttons["MobilePairingCancelButton"]
-        XCTAssertTrue(cancelPairing.waitForExistence(timeout: 4))
-        tap(cancelPairing, in: app)
-        XCTAssertTrue(pairingHostField.waitForNonExistence(timeout: 4))
-
-        XCTAssertTrue(disconnectedShell.waitForExistence(timeout: 8))
-        let settings = app.buttons["MobileWorkspaceSettingsMenu"]
-        XCTAssertTrue(settings.waitForExistence(timeout: 4))
-        XCTAssertTrue(settings.isHittable)
-        tap(settings, in: app)
-
-        let settingsView = app.descendants(matching: .any)["MobileSettingsView"]
-        XCTAssertTrue(
-            settingsView.waitForExistence(timeout: 8),
-            "Settings must present after deleting the final computer."
-        )
+        return app
     }
 
     @MainActor
@@ -6802,7 +6809,7 @@ final class cmuxUITests: XCTestCase {
 
         let hostField = app.textFields["MobileAddDeviceHostField"]
         XCTAssertTrue(
-            hostField.waitForExistence(timeout: 20),
+            hostField.waitForExistence(timeout: 45),
             "The initial Add Computer field must appear before manual pairing."
         )
         hostField.tap()

--- a/ios/cmuxUITests/cmuxUITests.swift
+++ b/ios/cmuxUITests/cmuxUITests.swift
@@ -6823,7 +6823,7 @@ final class cmuxUITests: XCTestCase {
         pairButton.tap()
 
         XCTAssertTrue(
-            pairingForm.waitForNonExistence(timeout: 20),
+            hostField.waitForNonExistence(timeout: 20),
             "Successful manual loopback pairing must dismiss the Add Computer sheet"
         )
 

--- a/ios/cmuxUITests/cmuxUITests.swift
+++ b/ios/cmuxUITests/cmuxUITests.swift
@@ -6802,6 +6802,13 @@ final class cmuxUITests: XCTestCase {
         }
         var launchEnvironment = environment
         launchEnvironment["CMUX_UITEST_ADD_DEVICE_PORT"] = String(portText.dropLast())
+        // Seed the real root pairing host at construction time. Waiting for the
+        // no-computers startup route made this setup depend on reconnect and
+        // onboarding work that is unrelated to the post-Forget regression.
+        launchEnvironment["CMUX_UITEST_AUTOCONNECT_MIGRATION"] = "ineligible"
+        launchEnvironment["CMUX_UITEST_AUTOCONNECT_MIGRATION_ID"] = UUID().uuidString
+        launchEnvironment["CMUX_UITEST_AUTOCONNECT_MIGRATION_INITIAL_MODAL_HOST"] =
+            "root-pairing"
         let app = launchApp(mockData: true, environment: launchEnvironment, launchArguments: [
             "-dev.cmux.mobile.connectionMethod.v1", "tailscale",
             "-cmux.mobile.taskComposerEnabled", "YES",
@@ -6809,7 +6816,7 @@ final class cmuxUITests: XCTestCase {
 
         let hostField = app.textFields["MobileAddDeviceHostField"]
         XCTAssertTrue(
-            hostField.waitForExistence(timeout: 45),
+            hostField.waitForExistence(timeout: 12),
             "The initial Add Computer field must appear before manual pairing."
         )
         hostField.tap()

--- a/ios/cmuxUITests/cmuxUITests.swift
+++ b/ios/cmuxUITests/cmuxUITests.swift
@@ -2542,10 +2542,25 @@ final class cmuxUITests: XCTestCase {
 
         server.stop()
         serverIsRunning = false
+        let connectionStatus = app.descendants(matching: .any)[
+            "MobileTerminalMacConnectionStatus"
+        ]
         XCTAssertTrue(
-            app.descendants(matching: .any)["MobileTerminalMacConnectionStatus"]
-                .waitForExistence(timeout: 12),
+            connectionStatus.waitForExistence(timeout: 12),
             "The mock Mac must disconnect before deletion so removing its final saved row changes root shells."
+        )
+        let disconnected = XCTNSPredicateExpectation(
+            predicate: NSPredicate(
+                format: "label CONTAINS[c] %@ OR label CONTAINS[c] %@",
+                "Reconnecting",
+                "Disconnected"
+            ),
+            object: connectionStatus
+        )
+        XCTAssertEqual(
+            XCTWaiter.wait(for: [disconnected], timeout: 12),
+            .completed,
+            "The connection status must leave Connected before the final saved computer is forgotten."
         )
 
         let backButton = app.buttons["MobileWorkspaceBackButton"]


### PR DESCRIPTION
Summary:

- Keep the shell that owns an iOS child sheet mounted until its real dismissal callback.
- Retain that ownership while the child is visible and while dismissal is in progress.
- Cover workspace and disconnected child hosts, including the final-computer transition.

Why:

Forgetting the final saved computer refreshes the store to the disconnected shell while the Computers sheet is still presented. That unmounts the sheet presenter before onDismiss can release the shared modal slot, so Settings and Add Computer requests are rejected forever.

Verification:

- Test-only SHA fails as expected: https://github.com/manaflow-ai/cmux/actions/runs/31526330705
- Shell retention policy: 7 tests passed at the fix SHA: https://github.com/manaflow-ai/cmux/actions/runs/31526569255
- Modal state lifecycle: 18 tests passed at the fix SHA: https://github.com/manaflow-ai/cmux/actions/runs/31526569276
- Package convention lint passed in both fix runs.

The two fix runs are shown as failed because the workflow zero-test guard only recognizes XCTest summaries. The selected Swift Testing suites executed and passed in the job logs.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/10010"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789068850&installation_model_id=21920&pr_number=10010&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F10010&signature=4b6f130e00a9d8ef7eb5ede5ef9caef22099a7acf4d70d370f1fa2f286340192"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents disabled iOS toolbar controls after forgetting the final computer by moving the Computers screen to a root-owned modal and keeping its presenter mounted through dismissal. Previously a workspace-owned presenter unmounted during the final-forget transition and orphaned the modal; now Done/Add/Forget route through the root so Settings and Add Computer remain responsive.

- Root-owned Computers modal: adds `.computers` to `MobileRootPresentationState` with `presentComputers`/`dismissComputers`; `CMUXMobileRootView` presents/dismisses, selects workspaces, and dismisses after a final forget. `WorkspaceShellView`/`WorkspaceShellHost`/`WorkspaceListView` replace local `deviceTreePresentation` with `showComputers` (previews fall back to the local sheet).
- `DeviceTreeView` adds `dismissAction` and `didForgetComputer`; Done/Add/Forget dismiss via the root owner. Tests cover Computers ownership, transition to pairing, and regressions for Settings/Add Computer after deleting the last computer. DEBUG-only `SuccessfulComputerForgetUITestStub` enables UI tests without external revoke; mock runs suppress push authorization prompts.

<sup>Written for commit 79f40206394845ccc671837bb36da56cabeef646. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/10010?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved iOS shell transitions when child views are dismissed, preserving the correct workspace or disconnected shell.
  - Prevented shell content from disappearing during reconnection, pairing transitions, and migration retries.
  - Preserved restoring-state information when no child view is active.
  - Improved the experience when removing the final saved computer after disconnection, keeping Add Computer and Settings usable.

- **Tests**
  - Added coverage for child presentation transitions and final-computer removal scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->