### PR TITLE
ci: pin reload-build simulator leg to arm64

### DIFF
--- a/.github/workflows/reload-build.yml
+++ b/.github/workflows/reload-build.yml
@@ -182,12 +182,15 @@ jobs:
           # Keep Blacksmith device reloads equivalent to the fleet path: one
           # build supplies both the unsigned phone archive and the exact same
           # source revision for an isolated Simulator verification.
+          # GhosttyKit.xcframework ships an arm64-only simulator slice, so an
+          # unpinned generic simulator build also links x86_64 and dies at ld.
           xcodebuild build \
             -workspace ios/cmux.xcworkspace \
             -scheme cmux-ios \
             -configuration Debug \
             -destination 'generic/platform=iOS Simulator' \
             -derivedDataPath "$RUNNER_TEMP/cmux-ios-dd" \
+            ARCHS=arm64 \
             PRODUCT_BUNDLE_IDENTIFIER="$bundle_id" \
             PRODUCT_DISPLAY_NAME="$display_name" \
             CMUX_GIT_SHA="$(git rev-parse --short HEAD)" \


### PR DESCRIPTION
The reload-build ios job's simulator step builds `generic/platform=iOS Simulator` with no ARCHS override, so xcodebuild also links x86_64. GhosttyKit.xcframework ships an arm64-only simulator slice, so that link dies with `ld: symbol(s) not found for architecture x86_64` (ghostty_surface_* symbols). Today this failed the ios lane for rroll (https://github.com/manaflow-ai/cmux/actions/runs/31535436193, https://github.com/manaflow-ai/cmux/actions/runs/31539046963), netchk (https://github.com/manaflow-ai/cmux/actions/runs/31523040920), and phand1. Pinning ARCHS=arm64 matches the fleet-path fix (cmuxterm-hq PR 247) and the arm64-only simulators the sim leg installs to.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Set ARCHS=arm64 for the generic iOS Simulator build in the reload-build CI workflow to stop x86_64 linking and ld errors with arm64-only `GhosttyKit.xcframework`. This matches the fleet path and the arm64-only simulators we install.

<sup>Written for commit 082ddaa90c9bd5528cc99e55ba16cae5a4499c58. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/10014?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated iOS Simulator verification builds to target arm64, improving compatibility with arm64-only simulator environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->