### PR TITLE
dispatch-e2e validation + agent time discipline rules

### DIFF
--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -1,5 +1,5 @@
 name: E2E test with video recording
-run-name: ${{ inputs.test_filter }} on ${{ (!inputs.runner || inputs.runner == 'auto') && (vars.MACOS_RUNNER_15 || 'blacksmith-6vcpu-macos-15') || inputs.runner }} @ ${{ inputs.ref || github.ref_name }}
+run-name: ${{ inputs.test_filter }} on ${{ (!inputs.runner || inputs.runner == 'auto') && (vars.MACOS_RUNNER_15 || 'blacksmith-6vcpu-macos-15') || inputs.runner }} @ ${{ inputs.ref || github.ref_name }}${{ inputs.dispatch_id != '' && format(' [{0}]', inputs.dispatch_id) || '' }}
 
 on:
   workflow_dispatch:
@@ -11,6 +11,10 @@ on:
       test_filter:
         description: "Test class or class/method; optionally target-qualified as cmuxUITests/Class or cmuxTests/Class"
         required: true
+      dispatch_id:
+        description: "Optional caller-generated id echoed into the run name so dispatchers can resolve their exact run"
+        required: false
+        default: ""
       test_timeout:
         description: "Per-test timeout in seconds"
         required: false

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -74,6 +74,8 @@ Dispatch hosted UI/E2E runs through the validated wrapper. It checks every filte
 gh workflow run test-e2e.yml --repo manaflow-ai/cmux -f ref=<branch-or-sha> -f test_filter="<Class or Class/method>"
 ```
 
+At most one dispatch per dogfood round. A red run means root-cause locally or on a fleet simulator first; never loop dispatch-fix-redispatch. A new XCUITest needs one green hosted run before the task is done; nothing else does.
+
 ## Agent time discipline
 
 Every poll slice pays a full model reasoning pass, so waiting is where agent hours disappear.
@@ -82,12 +84,13 @@ Every poll slice pays a full model reasoning pass, so waiting is where agent hou
 - **One build dispatch per need.** The cloud reload waits internally for a builder slot; never cycle `RELOAD_CLOUD_BUILDER` or re-dispatch a build that is already queued.
 - **Batch fixes per rebuild.** Accumulate a dogfood round's fixes, preflight with focused tests, then do one tagged rebuild for the round. Never rebuild per one-line fix.
 - **Locked or offline iPhone: probe once, then queue.** One reachability probe, enqueue in the install queue, notify, and end the turn with "queued; unlock to receive". Never write unlock/ready watcher scripts or repeat devicectl probes.
+- **CI is advisory.** Never block a handoff on bot checks, and never re-dispatch a failing hosted run without a local root cause.
 
 ## First pass, then dogfood
 
 A first pass ends when the change is implemented, the tagged build succeeded on the pushed HEAD, focused tests ran, and the PR is open (for `web/` PRs, also the live Vercel preview URL). Then hand off to the user. Do not sit in the main conversation watching CI or running speculative review passes after that point.
 
-Do not launch a background review agent (`$autoreview`, `codex review`, `claude review`, or a judge loop) by default. Second-model review is explicit user opt-in in the current conversation; an implementation request, open PR, CI failure, closeout, or handoff is not that opt-in. Let required GitHub checks and the automatic review bots run asynchronously, then return to address only concrete check failures and actionable findings before merge.
+Do not launch a background review agent (`$autoreview`, `codex review`, `claude review`, or a judge loop) by default. Second-model review is explicit user opt-in in the current conversation; an implementation request, open PR, CI failure, closeout, or handoff is not that opt-in. PR checks are advisory review bots only; there are no required status checks. Let them run asynchronously and return only for actionable findings. Merge validation happens at merge time via the merge gate, not by watching PR checks.
 
 The main agent owns dogfood, approval, mergeability, and every pushed fix. Merging app/runtime/UI changes requires the user's explicit approval after dogfood; if a fix changes runtime behavior mid-dogfood, rebuild the tag and re-notify, since the earlier verdict covers only the build the user tested.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,13 +68,13 @@ Dispatch hosted UI/E2E runs through the validated wrapper. It checks every filte
 ./scripts/dispatch-e2e.sh --ref <branch-or-sha> --filter "<Class or Class/method>[,more]" --watch
 ```
 
-`--dry-run` validates and prints the `gh` command without dispatching; `--runner`, `--record-video`, `--timeout` (per-test seconds), and `--job-timeout` (minutes) pass through. Raw fallback:
+`--dry-run` validates and prints the `gh` command without dispatching; `--runner`, `--record-video`, `--timeout` (per-test seconds), and `--job-timeout` (minutes) pass through. Validation reads the current checkout, so run it from a checkout of the same ref you dispatch. Raw fallback:
 
 ```bash
 gh workflow run test-e2e.yml --repo manaflow-ai/cmux -f ref=<branch-or-sha> -f test_filter="<Class or Class/method>"
 ```
 
-At most one dispatch per dogfood round. A red run means root-cause locally or on a fleet simulator first; never loop dispatch-fix-redispatch. A new XCUITest needs one green hosted run before the task is done; nothing else does.
+At most one dispatch per dogfood round; each comma-separated filter item becomes its own hosted run, so a multi-item filter spends the round's budget in one command. A red run means root-cause locally or on a fleet simulator first; never loop dispatch-fix-redispatch. A new XCUITest needs one green hosted run before the task is done; nothing else does.
 
 ## Agent time discipline
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,6 +60,29 @@ If the iPhone is unreachable at build time, the reload still completes: the sign
 
 Two commits, so CI proves the test catches the bug: commit 1 adds the failing test only (CI red), commit 2 adds the fix (CI green). This is visible in the PR Commits tab.
 
+## Hosted E2E dispatch
+
+Dispatch hosted UI/E2E runs through the validated wrapper. It checks every filter item against the local test sources and refuses to dispatch a filter that matches zero tests, which otherwise wastes a full dispatch+watch cycle before the run fails:
+
+```bash
+./scripts/dispatch-e2e.sh --ref <branch-or-sha> --filter "<Class or Class/method>[,more]" --watch
+```
+
+`--dry-run` validates and prints the `gh` command without dispatching; `--runner`, `--record-video`, `--timeout` (per-test seconds), and `--job-timeout` (minutes) pass through. Raw fallback:
+
+```bash
+gh workflow run test-e2e.yml --repo manaflow-ai/cmux -f ref=<branch-or-sha> -f test_filter="<Class or Class/method>"
+```
+
+## Agent time discipline
+
+Every poll slice pays a full model reasoning pass, so waiting is where agent hours disappear.
+
+- **Park on one blocking command per wait**: `gh run watch <id> --exit-status`, `./scripts/dispatch-e2e.sh --watch`, or `gh pr checks --watch`. Never 30-60s poll slices, sleep-and-recheck chains, or PTY heartbeat polls.
+- **One build dispatch per need.** The cloud reload waits internally for a builder slot; never cycle `RELOAD_CLOUD_BUILDER` or re-dispatch a build that is already queued.
+- **Batch fixes per rebuild.** Accumulate a dogfood round's fixes, preflight with focused tests, then do one tagged rebuild for the round. Never rebuild per one-line fix.
+- **Locked or offline iPhone: probe once, then queue.** One reachability probe, enqueue in the install queue, notify, and end the turn with "queued; unlock to receive". Never write unlock/ready watcher scripts or repeat devicectl probes.
+
 ## First pass, then dogfood
 
 A first pass ends when the change is implemented, the tagged build succeeded on the pushed HEAD, focused tests ran, and the PR is open (for `web/` PRs, also the live Vercel preview URL). Then hand off to the user. Do not sit in the main conversation watching CI or running speculative review passes after that point.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,7 +58,7 @@ If the iPhone is unreachable at build time, the reload still completes: the sign
 
 ## Regression test commits
 
-Two commits, so CI proves the test catches the bug: commit 1 adds the failing test only (CI red), commit 2 adds the fix (CI green). This is visible in the PR Commits tab.
+Two commits, so the history proves the test catches the bug: commit 1 adds the failing test only, commit 2 adds the fix. When red/green proof is wanted, dispatch the hosted run once against commit 1 and once against the head.
 
 ## Hosted E2E dispatch
 
@@ -94,7 +94,7 @@ Do not launch a background review agent (`$autoreview`, `codex review`, `claude 
 
 The main agent owns dogfood, approval, mergeability, and every pushed fix. Merging app/runtime/UI changes requires the user's explicit approval after dogfood; if a fix changes runtime behavior mid-dogfood, rebuild the tag and re-notify, since the earlier verdict covers only the build the user tested.
 
-Notify through `cmux notify` so the user can leave and return. Handoff: `--title "Dogfood ready: <short task>" --subtitle "<branch> · <tag>" --body "Was: <prior bad behavior>. Now: <expected behavior>. <concrete check>. PR: <pr-url>"`. Later closeout notifications use `"CI green: <branch>"` or `"CI blocked: <branch>"` with a one-line cause and the next decision. Titles carry outcome and branch, bodies carry the single next action. Skip notify if there is no cmux socket.
+Notify through `cmux notify` so the user can leave and return. Handoff: `--title "Dogfood ready: <short task>" --subtitle "<branch> · <tag>" --body "Was: <prior bad behavior>. Now: <expected behavior>. <concrete check>. PR: <pr-url>"`. Later closeout notifications use `"Merge gate green: <branch>"` or `"Merge gate blocked: <branch>"` with a one-line cause and the next decision. Titles carry outcome and branch, bodies carry the single next action. Skip notify if there is no cmux socket.
 
 ## Pitfalls
 

--- a/scripts/dispatch-e2e.sh
+++ b/scripts/dispatch-e2e.sh
@@ -240,6 +240,12 @@ validate_item() {
 
   if [ -n "$method" ]; then
     local method_bare="${method%()}"
+    # XCTest only discovers parameterless instance methods named test*; any
+    # other func would make the hosted -only-testing filter run zero tests.
+    if [[ "$method_bare" != test* ]]; then
+      echo "error: '$method_bare' is not an XCTest test method (must start with 'test'); the hosted filter would run zero tests" >&2
+      exit 2
+    fi
     local -a scope_files=()
     local file
     while IFS= read -r file; do
@@ -249,8 +255,9 @@ validate_item() {
     scoped="$(class_scoped_lines "$cls" "${scope_files[@]}")"
     local found=0
     # grep must read the full stream (no -q): under pipefail, -q's early exit
-    # SIGPIPEs printf and fails the pipeline even on a match.
-    if printf '%s\n' "$scoped" | grep -E "func[[:space:]]+${method_bare}\b" >/dev/null; then
+    # SIGPIPEs printf and fails the pipeline even on a match. Empty parens
+    # required: XCTest skips test methods that take parameters.
+    if printf '%s\n' "$scoped" | grep -E "func[[:space:]]+${method_bare}[[:space:]]*\(\)" >/dev/null; then
       found=1
     fi
     if [ "$found" -eq 0 ]; then

--- a/scripts/dispatch-e2e.sh
+++ b/scripts/dispatch-e2e.sh
@@ -1,0 +1,345 @@
+#!/usr/bin/env bash
+# Validated dispatcher for the hosted E2E workflow (test-e2e.yml).
+#
+# A test_filter that matches zero tests still costs a full CI dispatch+watch
+# cycle before the run fails with "executed 0 tests". This wrapper validates
+# every filter item against the local checkout first and refuses to dispatch
+# on a miss, printing the nearest candidate classes instead.
+#
+# Usage:
+#   scripts/dispatch-e2e.sh --ref <branch-or-sha> --filter "<Class or Class/method>[,more]" \
+#     [--runner <runner>] [--record-video true|false] [--timeout <seconds>] \
+#     [--job-timeout <minutes>] [--watch] [--dry-run]
+#
+# Filter items are comma-separated; each item dispatches its own workflow run.
+# A bare "Class" or "Class/method" targets cmuxUITests (the workflow's
+# back-compat default). Target-qualified "cmuxTests/Class[/method]" or
+# "cmuxUITests/Class[/method]" is validated against that target's directory.
+#
+# Validation reads THIS checkout's test sources, so run it from the worktree
+# that matches the ref you dispatch.
+#
+# Exit codes:
+#   0  dispatched (and, with --watch, all runs passed)
+#   1  usage error, dispatch failure, or watched run failed
+#   2  validation failed (class or method not found)
+
+set -euo pipefail
+
+REPO="manaflow-ai/cmux"
+WORKFLOW="test-e2e.yml"
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+usage() {
+  sed -n '2,26p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
+}
+
+die() {
+  echo "error: $*" >&2
+  exit 1
+}
+
+REF=""
+FILTERS_RAW=""
+RUNNER=""
+RECORD_VIDEO=""
+TEST_TIMEOUT=""
+JOB_TIMEOUT=""
+WATCH=0
+DRY_RUN=0
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --ref)
+      [ $# -ge 2 ] || die "--ref needs a value"
+      REF="$2"
+      shift 2
+      ;;
+    --filter)
+      [ $# -ge 2 ] || die "--filter needs a value"
+      FILTERS_RAW="$2"
+      shift 2
+      ;;
+    --runner)
+      [ $# -ge 2 ] || die "--runner needs a value"
+      RUNNER="$2"
+      shift 2
+      ;;
+    --record-video)
+      [ $# -ge 2 ] || die "--record-video needs true or false"
+      RECORD_VIDEO="$2"
+      shift 2
+      ;;
+    --timeout)
+      [ $# -ge 2 ] || die "--timeout needs a value (per-test seconds)"
+      TEST_TIMEOUT="$2"
+      shift 2
+      ;;
+    --job-timeout)
+      [ $# -ge 2 ] || die "--job-timeout needs a value (job minutes)"
+      JOB_TIMEOUT="$2"
+      shift 2
+      ;;
+    --watch)
+      WATCH=1
+      shift
+      ;;
+    --dry-run)
+      DRY_RUN=1
+      shift
+      ;;
+    -h | --help)
+      usage
+      exit 0
+      ;;
+    *)
+      die "unknown argument: $1 (see --help)"
+      ;;
+  esac
+done
+
+[ -n "$REF" ] || die "--ref is required"
+[ -n "$FILTERS_RAW" ] || die "--filter is required"
+if [ -n "$RECORD_VIDEO" ] && [ "$RECORD_VIDEO" != "true" ] && [ "$RECORD_VIDEO" != "false" ]; then
+  die "--record-video must be true or false"
+fi
+if [ -n "$TEST_TIMEOUT" ] && ! [[ "$TEST_TIMEOUT" =~ ^[0-9]+$ ]]; then
+  die "--timeout must be an integer (seconds)"
+fi
+if [ -n "$JOB_TIMEOUT" ] && ! [[ "$JOB_TIMEOUT" =~ ^[0-9]+$ ]]; then
+  die "--job-timeout must be an integer (minutes)"
+fi
+
+# --- validation -------------------------------------------------------------
+
+# All class names declared under a test target directory.
+list_classes() {
+  local dir="$1"
+  grep -rhoE '\bclass[[:space:]]+[A-Za-z_][A-Za-z0-9_]*' --include='*.swift' "$dir" 2>/dev/null |
+    awk '{print $2}' | sort -u
+}
+
+# Files declaring the given class.
+class_files() {
+  local dir="$1" cls="$2"
+  grep -rlE "class[[:space:]]+${cls}\b" --include='*.swift' "$dir" 2>/dev/null || true
+}
+
+# Nearest candidates for a missed name, best first.
+suggest_names() {
+  local query="$1"
+  shift
+  [ $# -gt 0 ] || return 0
+  if command -v python3 >/dev/null 2>&1; then
+    python3 - "$query" "$@" <<'PY'
+import difflib
+import sys
+
+query = sys.argv[1]
+names = sys.argv[2:]
+ranked = difflib.get_close_matches(query, names, n=5, cutoff=0.3)
+q = query.lower()
+for name in names:
+    if name in ranked:
+        continue
+    n = name.lower()
+    if q in n or n in q:
+        ranked.append(name)
+print("\n".join(ranked[:5]))
+PY
+  else
+    printf '%s\n' "$@" | grep -i -- "$query" | head -5 || true
+  fi
+}
+
+validate_item() {
+  local item="$1"
+  local target_dir="$ROOT/cmuxUITests"
+  local target_name="cmuxUITests"
+  local rest="$item"
+
+  case "$item" in
+    cmuxTests/*)
+      target_dir="$ROOT/cmuxTests"
+      target_name="cmuxTests"
+      rest="${item#cmuxTests/}"
+      ;;
+    cmuxUITests/*)
+      rest="${item#cmuxUITests/}"
+      ;;
+  esac
+
+  local cls="${rest%%/*}"
+  local method=""
+  if [ "$rest" != "$cls" ]; then
+    method="${rest#*/}"
+  fi
+
+  if ! [[ "$cls" =~ ^[A-Za-z_][A-Za-z0-9_]*$ ]]; then
+    die "invalid class name in filter item '$item'"
+  fi
+  if [ -n "$method" ] && ! [[ "$method" =~ ^[A-Za-z_][A-Za-z0-9_]*(\(\))?$ ]]; then
+    die "invalid method name in filter item '$item'"
+  fi
+  [ -d "$target_dir" ] || die "test directory not found: $target_dir"
+
+  local files
+  files="$(class_files "$target_dir" "$cls")"
+  if [ -z "$files" ]; then
+    echo "error: no 'class $cls' found under $target_name/ for filter item '$item'" >&2
+    local -a all_classes=()
+    while IFS= read -r name; do
+      if [ -n "$name" ]; then
+        all_classes+=("$name")
+      fi
+    done < <(list_classes "$target_dir")
+    local suggestions=""
+    if [ "${#all_classes[@]}" -gt 0 ]; then
+      suggestions="$(suggest_names "$cls" "${all_classes[@]}")"
+    fi
+    if [ -n "$suggestions" ]; then
+      echo "nearest candidates:" >&2
+      printf '%s\n' "$suggestions" | sed 's/^/  /' >&2
+    fi
+    exit 2
+  fi
+
+  if [ -n "$method" ]; then
+    local method_bare="${method%()}"
+    local found=0
+    local file
+    while IFS= read -r file; do
+      if grep -qE "func[[:space:]]+${method_bare}\b" "$file"; then
+        found=1
+        break
+      fi
+    done <<<"$files"
+    if [ "$found" -eq 0 ]; then
+      echo "error: no 'func $method_bare' found in class $cls for filter item '$item'" >&2
+      local -a all_methods=()
+      while IFS= read -r name; do
+        if [ -n "$name" ]; then
+          all_methods+=("$name")
+        fi
+      done < <(
+        while IFS= read -r f; do
+          [ -n "$f" ] || continue
+          grep -hoE 'func[[:space:]]+test[A-Za-z0-9_]*' "$f" 2>/dev/null || true
+        done <<<"$files" | awk '{print $2}' | sort -u
+      )
+      local suggestions=""
+      if [ "${#all_methods[@]}" -gt 0 ]; then
+        suggestions="$(suggest_names "$method_bare" "${all_methods[@]}")"
+      fi
+      if [ -n "$suggestions" ]; then
+        echo "nearest candidates:" >&2
+        printf '%s\n' "$suggestions" | sed 's/^/  /' >&2
+      fi
+      exit 2
+    fi
+  fi
+
+  echo "ok: $item (class $cls${method:+, method ${method%()}} in $target_name/)"
+}
+
+# --- dispatch ---------------------------------------------------------------
+
+dispatch_args_for() {
+  local filter="$1"
+  DISPATCH_ARGS=(workflow run "$WORKFLOW" --repo "$REPO" -f "ref=$REF" -f "test_filter=$filter")
+  if [ -n "$RUNNER" ]; then
+    DISPATCH_ARGS+=(-f "runner=$RUNNER")
+  fi
+  if [ -n "$RECORD_VIDEO" ]; then
+    DISPATCH_ARGS+=(-f "record_video=$RECORD_VIDEO")
+  fi
+  if [ -n "$TEST_TIMEOUT" ]; then
+    DISPATCH_ARGS+=(-f "test_timeout=$TEST_TIMEOUT")
+  fi
+  if [ -n "$JOB_TIMEOUT" ]; then
+    DISPATCH_ARGS+=(-f "job_timeout=$JOB_TIMEOUT")
+  fi
+}
+
+# Run ids that exist before dispatch, so the new run can be told apart.
+existing_run_ids() {
+  gh run list --repo "$REPO" --workflow "$WORKFLOW" --limit 30 \
+    --json databaseId --jq '.[].databaseId' 2>/dev/null || true
+}
+
+# The workflow's run-name starts with the test_filter, so match on that
+# among runs that did not exist before dispatch.
+resolve_run_id() {
+  local filter="$1" pre_ids="$2"
+  local attempt id title
+  for attempt in $(seq 1 15); do
+    while IFS=$'\t' read -r id title; do
+      [ -n "$id" ] || continue
+      if printf '%s\n' "$pre_ids" | grep -qx "$id"; then
+        continue
+      fi
+      case "$title" in
+        "$filter on "*)
+          echo "$id"
+          return 0
+          ;;
+      esac
+    done < <(gh run list --repo "$REPO" --workflow "$WORKFLOW" --limit 30 \
+      --json databaseId,displayTitle --jq '.[] | [.databaseId, .displayTitle] | @tsv' 2>/dev/null || true)
+    if [ "$attempt" -lt 15 ]; then
+      sleep 2
+    fi
+  done
+  return 1
+}
+
+IFS=',' read -r -a FILTER_ITEMS <<<"$FILTERS_RAW"
+CLEAN_ITEMS=()
+for raw_item in "${FILTER_ITEMS[@]}"; do
+  item="$(echo "$raw_item" | sed 's/^[[:space:]]*//; s/[[:space:]]*$//')"
+  [ -n "$item" ] || continue
+  CLEAN_ITEMS+=("$item")
+done
+[ "${#CLEAN_ITEMS[@]}" -gt 0 ] || die "--filter contained no filter items"
+
+for item in "${CLEAN_ITEMS[@]}"; do
+  validate_item "$item"
+done
+
+if [ "$DRY_RUN" -eq 1 ]; then
+  echo "dry run: validation passed; would dispatch:"
+  for item in "${CLEAN_ITEMS[@]}"; do
+    dispatch_args_for "$item"
+    printf 'gh'
+    printf ' %q' "${DISPATCH_ARGS[@]}"
+    printf '\n'
+  done
+  exit 0
+fi
+
+RUN_IDS=()
+for item in "${CLEAN_ITEMS[@]}"; do
+  dispatch_args_for "$item"
+  pre_ids="$(existing_run_ids)"
+  echo "dispatching: $item @ $REF"
+  gh "${DISPATCH_ARGS[@]}"
+  if run_id="$(resolve_run_id "$item" "$pre_ids")"; then
+    RUN_IDS+=("$run_id")
+    echo "run: https://github.com/$REPO/actions/runs/$run_id"
+  else
+    echo "warning: dispatched but could not resolve the new run id for '$item'." >&2
+    echo "  gh run list --repo $REPO --workflow $WORKFLOW --limit 5" >&2
+  fi
+done
+
+if [ "$WATCH" -eq 1 ]; then
+  [ "${#RUN_IDS[@]}" -gt 0 ] || die "--watch requested but no run ids were resolved"
+  FAILED=0
+  for run_id in "${RUN_IDS[@]}"; do
+    echo "watching run $run_id..."
+    if ! gh run watch "$run_id" --repo "$REPO" --exit-status; then
+      FAILED=1
+    fi
+  done
+  exit "$FAILED"
+fi

--- a/scripts/dispatch-e2e.sh
+++ b/scripts/dispatch-e2e.sh
@@ -125,6 +125,40 @@ class_files() {
   grep -rlE "class[[:space:]]+${cls}\b" --include='*.swift' "$dir" 2>/dev/null || true
 }
 
+# Files declaring the class OR an extension of it (methods may live in either).
+related_files() {
+  local dir="$1" cls="$2"
+  grep -rlE "(class|extension)[[:space:]]+${cls}\b" --include='*.swift' "$dir" 2>/dev/null || true
+}
+
+# Lines inside `class <cls>` / `extension <cls>` blocks across the given files,
+# tracked by brace depth, so a same-file helper or sibling class cannot satisfy
+# a Class/method filter that XCTest would resolve to zero tests.
+class_scoped_lines() {
+  local cls="$1"
+  shift
+  [ $# -gt 0 ] || return 0
+  awk -v cls="$cls" '
+    FNR == 1 { inside = 0; depth = 0; seen_open = 0 }
+    {
+      if (!inside) {
+        if ($0 ~ ("(^|[^A-Za-z0-9_])(class|extension)[[:space:]]+" cls "([^A-Za-z0-9_]|$)")) {
+          inside = 1; depth = 0; seen_open = 0
+        } else {
+          next
+        }
+      }
+      print
+      line = $0
+      o = gsub(/{/, "", line)
+      c = gsub(/}/, "", line)
+      depth += o - c
+      if (o > 0) seen_open = 1
+      if (seen_open && depth <= 0) inside = 0
+    }
+  ' "$@"
+}
+
 # Nearest candidates for a missed name, best first.
 suggest_names() {
   local query="$1"
@@ -206,14 +240,19 @@ validate_item() {
 
   if [ -n "$method" ]; then
     local method_bare="${method%()}"
-    local found=0
+    local -a scope_files=()
     local file
     while IFS= read -r file; do
-      if grep -qE "func[[:space:]]+${method_bare}\b" "$file"; then
-        found=1
-        break
-      fi
-    done <<<"$files"
+      [ -n "$file" ] && scope_files+=("$file")
+    done < <(related_files "$target_dir" "$cls")
+    local scoped
+    scoped="$(class_scoped_lines "$cls" "${scope_files[@]}")"
+    local found=0
+    # grep must read the full stream (no -q): under pipefail, -q's early exit
+    # SIGPIPEs printf and fails the pipeline even on a match.
+    if printf '%s\n' "$scoped" | grep -E "func[[:space:]]+${method_bare}\b" >/dev/null; then
+      found=1
+    fi
     if [ "$found" -eq 0 ]; then
       echo "error: no 'func $method_bare' found in class $cls for filter item '$item'" >&2
       local -a all_methods=()
@@ -222,10 +261,7 @@ validate_item() {
           all_methods+=("$name")
         fi
       done < <(
-        while IFS= read -r f; do
-          [ -n "$f" ] || continue
-          grep -hoE 'func[[:space:]]+test[A-Za-z0-9_]*' "$f" 2>/dev/null || true
-        done <<<"$files" | awk '{print $2}' | sort -u
+        printf '%s\n' "$scoped" | grep -oE 'func[[:space:]]+test[A-Za-z0-9_]*' | awk '{print $2}' | sort -u
       )
       local suggestions=""
       if [ "${#all_methods[@]}" -gt 0 ]; then
@@ -318,6 +354,7 @@ if [ "$DRY_RUN" -eq 1 ]; then
 fi
 
 RUN_IDS=()
+UNRESOLVED=0
 for item in "${CLEAN_ITEMS[@]}"; do
   dispatch_args_for "$item"
   pre_ids="$(existing_run_ids)"
@@ -327,6 +364,7 @@ for item in "${CLEAN_ITEMS[@]}"; do
     RUN_IDS+=("$run_id")
     echo "run: https://github.com/$REPO/actions/runs/$run_id"
   else
+    UNRESOLVED=$((UNRESOLVED + 1))
     echo "warning: dispatched but could not resolve the new run id for '$item'." >&2
     echo "  gh run list --repo $REPO --workflow $WORKFLOW --limit 5" >&2
   fi
@@ -341,5 +379,14 @@ if [ "$WATCH" -eq 1 ]; then
       FAILED=1
     fi
   done
+  if [ "$UNRESOLVED" -gt 0 ]; then
+    # A watch that silently omits an unresolved run must not report success.
+    echo "error: $UNRESOLVED dispatched run(s) could not be resolved and were not watched" >&2
+    exit 1
+  fi
   exit "$FAILED"
+fi
+
+if [ "$UNRESOLVED" -gt 0 ]; then
+  echo "note: dispatch succeeded for all items; $UNRESOLVED run URL(s) could not be resolved" >&2
 fi

--- a/scripts/dispatch-e2e.sh
+++ b/scripts/dispatch-e2e.sh
@@ -131,9 +131,11 @@ related_files() {
   grep -rlE "(class|extension)[[:space:]]+${cls}\b" --include='*.swift' "$dir" 2>/dev/null || true
 }
 
-# Lines inside `class <cls>` / `extension <cls>` blocks across the given files,
-# tracked by brace depth, so a same-file helper or sibling class cannot satisfy
-# a Class/method filter that XCTest would resolve to zero tests.
+# Direct-member lines of `class <cls>` / `extension <cls>` blocks across the
+# given files, tracked by brace depth. Only depth-1 lines are emitted, so a
+# same-file sibling class, a nested type's methods, or a function nested in a
+# method body cannot satisfy a Class/method filter that XCTest would resolve
+# to zero tests.
 class_scoped_lines() {
   local cls="$1"
   shift
@@ -148,7 +150,7 @@ class_scoped_lines() {
           next
         }
       }
-      print
+      if (seen_open && depth == 1) print
       line = $0
       o = gsub(/{/, "", line)
       c = gsub(/}/, "", line)
@@ -158,6 +160,11 @@ class_scoped_lines() {
     }
   ' "$@"
 }
+
+# XCTest discovers only parameterless INSTANCE methods named test*; a static,
+# class, private, or fileprivate func is never discovered and would dispatch a
+# zero-test hosted run.
+NON_INSTANCE_MODIFIERS='(^|[[:space:]])(static|private|fileprivate)[[:space:]]|class[[:space:]]+func'
 
 # Nearest candidates for a missed name, best first.
 suggest_names() {
@@ -257,7 +264,9 @@ validate_item() {
     # grep must read the full stream (no -q): under pipefail, -q's early exit
     # SIGPIPEs printf and fails the pipeline even on a match. Empty parens
     # required: XCTest skips test methods that take parameters.
-    if printf '%s\n' "$scoped" | grep -E "func[[:space:]]+${method_bare}[[:space:]]*\(\)" >/dev/null; then
+    if printf '%s\n' "$scoped" |
+      grep -E "func[[:space:]]+${method_bare}[[:space:]]*\(\)" |
+      grep -vE "$NON_INSTANCE_MODIFIERS" >/dev/null; then
       found=1
     fi
     if [ "$found" -eq 0 ]; then
@@ -268,7 +277,8 @@ validate_item() {
           all_methods+=("$name")
         fi
       done < <(
-        printf '%s\n' "$scoped" | grep -oE 'func[[:space:]]+test[A-Za-z0-9_]*' | awk '{print $2}' | sort -u
+        printf '%s\n' "$scoped" | grep -vE "$NON_INSTANCE_MODIFIERS" |
+          grep -oE 'func[[:space:]]+test[A-Za-z0-9_]*' | awk '{print $2}' | sort -u
       )
       local suggestions=""
       if [ "${#all_methods[@]}" -gt 0 ]; then
@@ -288,8 +298,11 @@ validate_item() {
 # --- dispatch ---------------------------------------------------------------
 
 dispatch_args_for() {
-  local filter="$1"
+  local filter="$1" nonce="${2:-}"
   DISPATCH_ARGS=(workflow run "$WORKFLOW" --repo "$REPO" -f "ref=$REF" -f "test_filter=$filter")
+  if [ -n "$nonce" ]; then
+    DISPATCH_ARGS+=(-f "dispatch_id=$nonce")
+  fi
   if [ -n "$RUNNER" ]; then
     DISPATCH_ARGS+=(-f "runner=$RUNNER")
   fi
@@ -310,14 +323,25 @@ existing_run_ids() {
     --json databaseId --jq '.[].databaseId' 2>/dev/null || true
 }
 
-# The workflow's run-name starts with the test_filter, so match on that
-# among runs that did not exist before dispatch.
+# Resolve the just-dispatched run. When the workflow on main supports the
+# dispatch_id input, the nonce is echoed into the run name and matching is
+# exact. Otherwise fall back to the heuristic: a run that did not exist
+# before dispatch whose run-name starts with the test_filter.
 resolve_run_id() {
-  local filter="$1" pre_ids="$2"
+  local filter="$1" pre_ids="$2" nonce="${3:-}"
   local attempt id title
   for attempt in $(seq 1 15); do
     while IFS=$'\t' read -r id title; do
       [ -n "$id" ] || continue
+      if [ -n "$nonce" ]; then
+        case "$title" in
+          *"[$nonce]"*)
+            echo "$id"
+            return 0
+            ;;
+        esac
+        continue
+      fi
       if printf '%s\n' "$pre_ids" | grep -qx "$id"; then
         continue
       fi
@@ -362,12 +386,27 @@ fi
 
 RUN_IDS=()
 UNRESOLVED=0
+DISPATCH_SEQ=0
 for item in "${CLEAN_ITEMS[@]}"; do
-  dispatch_args_for "$item"
+  DISPATCH_SEQ=$((DISPATCH_SEQ + 1))
+  nonce="d$(date +%s)-$$-$DISPATCH_SEQ"
+  dispatch_args_for "$item" "$nonce"
   pre_ids="$(existing_run_ids)"
   echo "dispatching: $item @ $REF"
-  gh "${DISPATCH_ARGS[@]}"
-  if run_id="$(resolve_run_id "$item" "$pre_ids")"; then
+  if ! dispatch_err="$(gh "${DISPATCH_ARGS[@]}" 2>&1)"; then
+    # The workflow definition on main may predate the dispatch_id input;
+    # gh rejects unknown inputs with 422. Retry once without the nonce and
+    # fall back to heuristic run resolution.
+    if printf '%s' "$dispatch_err" | grep -qi "unexpected inputs"; then
+      nonce=""
+      dispatch_args_for "$item"
+      gh "${DISPATCH_ARGS[@]}"
+    else
+      printf '%s\n' "$dispatch_err" >&2
+      die "workflow dispatch failed for '$item'"
+    fi
+  fi
+  if run_id="$(resolve_run_id "$item" "$pre_ids" "$nonce")"; then
     RUN_IDS+=("$run_id")
     echo "run: https://github.com/$REPO/actions/runs/$run_id"
   else

--- a/skills/cmux-testing/references/local-vs-ci-validation.md
+++ b/skills/cmux-testing/references/local-vs-ci-validation.md
@@ -17,7 +17,7 @@ For `cmuxApp` or `AppDelegate` churn, add the repo's GlobalISel workaround flag 
 
 ## E2E and UI tests
 
-Run through GitHub Actions or the VM. Use `./scripts/dispatch-e2e.sh --ref <branch> --filter "<Class or Class/method>"`; it validates the filter against local test sources and refuses zero-test dispatches. Raw fallback: `gh workflow run test-e2e.yml`. Dispatch at most once per dogfood round, and root-cause a red run locally or on a fleet simulator instead of looping dispatch-fix-redispatch. Never launch an untagged app locally to satisfy socket or UI tests.
+Run through GitHub Actions or the VM. Use `./scripts/dispatch-e2e.sh --ref <branch> --filter "<Class or Class/method>"`; it validates the filter against local test sources and refuses zero-test dispatches. Raw fallback: `gh workflow run test-e2e.yml --repo manaflow-ai/cmux -f ref=<branch-or-sha> -f test_filter="<Class>"` (`test_filter` is required; an empty one is rejected). Dispatch at most once per dogfood round, and root-cause a red run locally or on a fleet simulator instead of looping dispatch-fix-redispatch. Never launch an untagged app locally to satisfy socket or UI tests.
 
 ## Python socket tests
 

--- a/skills/cmux-testing/references/local-vs-ci-validation.md
+++ b/skills/cmux-testing/references/local-vs-ci-validation.md
@@ -17,7 +17,7 @@ For `cmuxApp` or `AppDelegate` churn, add the repo's GlobalISel workaround flag 
 
 ## E2E and UI tests
 
-Run through GitHub Actions or the VM. Use `./scripts/dispatch-e2e.sh --ref <branch> --filter "<Class or Class/method>"`; it validates the filter against local test sources and refuses zero-test dispatches. Raw fallback: `gh workflow run test-e2e.yml`. Never launch an untagged app locally to satisfy socket or UI tests.
+Run through GitHub Actions or the VM. Use `./scripts/dispatch-e2e.sh --ref <branch> --filter "<Class or Class/method>"`; it validates the filter against local test sources and refuses zero-test dispatches. Raw fallback: `gh workflow run test-e2e.yml`. Dispatch at most once per dogfood round, and root-cause a red run locally or on a fleet simulator instead of looping dispatch-fix-redispatch. Never launch an untagged app locally to satisfy socket or UI tests.
 
 ## Python socket tests
 

--- a/skills/cmux-testing/references/local-vs-ci-validation.md
+++ b/skills/cmux-testing/references/local-vs-ci-validation.md
@@ -17,7 +17,7 @@ For `cmuxApp` or `AppDelegate` churn, add the repo's GlobalISel workaround flag 
 
 ## E2E and UI tests
 
-Run through GitHub Actions or the VM: `gh workflow run test-e2e.yml`. Never launch an untagged app locally to satisfy socket or UI tests.
+Run through GitHub Actions or the VM. Use `./scripts/dispatch-e2e.sh --ref <branch> --filter "<Class or Class/method>"`; it validates the filter against local test sources and refuses zero-test dispatches. Raw fallback: `gh workflow run test-e2e.yml`. Never launch an untagged app locally to satisfy socket or UI tests.
 
 ## Python socket tests
 


### PR DESCRIPTION
An audit of 23 agent sessions found hosted test-e2e dispatches whose test_filter matched zero tests, each wasting a full dispatch+watch cycle before re-dispatch, plus hours lost to poll-slice waiting, re-dispatched builds, per-one-line-fix rebuilds, and iPhone unlock watchers.

`scripts/dispatch-e2e.sh` is a validated dispatcher for `test-e2e.yml`. Before dispatching it requires each filter item's class to exist under `cmuxUITests/` (or `cmuxTests/` when target-qualified) and, for `Class/method`, the method to exist in that class's files. On a miss it refuses to dispatch, exits 2, and prints the nearest candidate names. Comma-separated filters dispatch one run each. `--dry-run` stops after validation and prints the gh command; `--watch` blocks on `gh run watch --exit-status`; `--runner`, `--record-video`, `--timeout`, and `--job-timeout` pass through to the workflow inputs. Shellcheck clean.

CLAUDE.md now documents the wrapper as the E2E entrypoint (raw `gh workflow run` kept as fallback, also updated in the cmux-testing skill reference) and adds an agent time discipline section: park on one blocking command per wait instead of poll slices, one build dispatch per need, batch a dogfood round's fixes into one tagged rebuild, and for a locked or offline iPhone probe once, enqueue, notify, and end the turn.

Docs and CI tooling only, no runtime change, so no tagged build.

Validation transcripts:

```
$ ./scripts/dispatch-e2e.sh --ref main --filter "FeedSidebarUITests" --dry-run
ok: FeedSidebarUITests (class FeedSidebarUITests in cmuxUITests/)
gh workflow run test-e2e.yml --repo manaflow-ai/cmux -f ref=main -f test_filter=FeedSidebarUITests
(exit 0)

$ ./scripts/dispatch-e2e.sh --ref main --filter "FeedSidebarUITest" --dry-run
error: no 'class FeedSidebarUITest' found under cmuxUITests/ ...
nearest candidates: FeedSidebarUITests, SidebarResizeUITests, ...
(exit 2)

$ ./scripts/dispatch-e2e.sh --ref main --filter "FeedSidebarUITests/testDoesNotExistAnywhere" --dry-run
error: no 'func testDoesNotExistAnywhere' found in class FeedSidebarUITests ...
nearest candidates: testDockTerminalRerendersAfterRightSidebarHideShow, testFeedReceivesAndResolvesPermissionRequest
(exit 2)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Validates hosted E2E dispatches and enforces time‑discipline to prevent zero‑test runs and silent watch passes. Previously a `test_filter` with no matches still dispatched and `--watch` could succeed after omitting unresolved runs; now the wrapper validates selectors scoped to the class or its extensions, accepts only parameterless instance `test*` methods, resolves runs exactly via a per-dispatch `dispatch_id`, and fails `--watch` if any run id cannot be resolved. No runtime changes.

- Use: `./scripts/dispatch-e2e.sh --ref <branch-or-sha> --filter "<Class or Class/method>[,more]" [--watch] [--dry-run] [--runner] [--record-video] [--timeout] [--job-timeout]`; run it from a checkout of the same ref you dispatch.
- Exact run resolution: `test-e2e.yml` adds optional `dispatch_id`; the wrapper passes a nonce and, if the workflow on main rejects unknown inputs, retries once without it and falls back to a pre‑existing‑ids heuristic.
- Each comma-separated item dispatches its own run; cap to one dispatch per dogfood round.
- Raw fallback: `gh workflow run test-e2e.yml --repo manaflow-ai/cmux -f ref=<branch-or-sha> -f test_filter="<Class or Class/method>"` (required, non-empty).
- Do not dispatch‑fix‑redispatch; root‑cause red runs locally or on a fleet simulator. PR checks are advisory only; merge validation happens via the merge gate.

<sup>Written for commit b91b7ee451f6586d4da50be79620f2d4932962e8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/10024?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added guided dispatch for hosted end-to-end tests with selectable test filters.
  * Added validation for invalid or empty test selections, including suggested close matches.
  * Added dry-run previews, optional run monitoring, clear failure reporting, and support for individual test groups.
  * Retained a raw workflow fallback for hosted test execution.

* **Documentation**
  * Updated testing guidance for hosted runs, virtual machine execution, and fallback workflows.
  * Clarified dispatch limits, wait practices, asynchronous checks, and merge-gate handoff procedures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->