### PR TITLE
Await published browser tab state in TUI smoke test

### DIFF
--- a/cmux-tui/scripts/smoke-tui.py
+++ b/cmux-tui/scripts/smoke-tui.py
@@ -578,9 +578,9 @@ text = render_text_snapshot(output)
 assert "example.com" in text, text[-800:]
 os.write(fd, b"\x1b")
 drain(0.5)
-# Close the browser TAB. prefix-X since the tmux-alignment flip: x kills the
-# pane (which here is the only pane and would end the session), X the tab.
-os.write(fd, b"\x02X")
+# Close the browser tab. Lowercase x owns CloseTab; uppercase X owns
+# ClosePane, which would remove this only pane and leave the screen empty.
+os.write(fd, b"\x02x")
 screen0 = wait_for_active_screen(
     lambda screen: bool(screen.get("panes"))
     and len(screen["panes"][0]["tabs"]) == before_tabs,

--- a/cmux-tui/scripts/smoke-tui.py
+++ b/cmux-tui/scripts/smoke-tui.py
@@ -240,6 +240,29 @@ def drain(seconds):
             except OSError:
                 break
 
+def wait_for_active_screen(predicate, description, seconds=15):
+    deadline = time.monotonic() + seconds
+    last = []
+    while True:
+        last = tree()
+        screen = next(
+            (
+                screen
+                for workspace in last
+                if workspace.get("active")
+                for screen in workspace.get("screens", [])
+                if screen.get("active")
+            ),
+            None,
+        )
+        if screen is not None and predicate(screen):
+            return screen
+
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            raise AssertionError(f"{description}; last workspace tree: {last}")
+        drain(min(0.2, remaining))
+
 def wait_screen_contains(surface_id, needle, seconds=15):
     deadline = time.time() + seconds
     last = ""
@@ -540,8 +563,12 @@ drain(0.4)
 # omnibar. The dead CDP endpoint keeps this Chrome-free and fast.
 before_tabs = len(panes[0]["tabs"])
 os.write(fd, b"\x02B")
-drain(0.8)
-screen0 = active_screen(tree()[0])
+screen0 = wait_for_active_screen(
+    lambda screen: bool(screen.get("panes"))
+    and len(screen["panes"][0]["tabs"]) == before_tabs + 1
+    and screen["panes"][0]["tabs"][-1]["kind"] == "browser",
+    "browser tab was not published as active",
+)
 tabs = screen0["panes"][0]["tabs"]
 assert len(tabs) == before_tabs + 1, screen0
 assert tabs[-1]["kind"] == "browser", tabs
@@ -554,8 +581,11 @@ drain(0.5)
 # Close the browser TAB. prefix-X since the tmux-alignment flip: x kills the
 # pane (which here is the only pane and would end the session), X the tab.
 os.write(fd, b"\x02X")
-drain(0.8)
-screen0 = active_screen(tree()[0])
+screen0 = wait_for_active_screen(
+    lambda screen: bool(screen.get("panes"))
+    and len(screen["panes"][0]["tabs"]) == before_tabs,
+    "browser tab close was not published",
+)
 assert len(screen0["panes"][0]["tabs"]) == before_tabs, screen0
 print("prefix-B browser omnibar focuses, Esc blurs, and close works ok")
 


### PR DESCRIPTION
## Summary
- replace fixed prefix-B and close delays with one final-deadline readiness probe
- observe the active workspace, active screen, and requested browser-tab count
- report the final workspace tree if publication never completes

## Evidence
- red: PR9952 hosted run 31551446482 sampled list-workspaces before an active screen was published
- static: diff check passed
- local xhigh review: clean, 0.96
- local compile/tests: not run by instruction

Ledger effect: 0

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/10026"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789091092&installation_model_id=21920&pr_number=10026&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F10026&signature=b512044f71cfe00ced2688b5b497443ef6df3459f88a2e1748c8a21948a2a41c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the TUI smoke test wait for the published active screen and browser tab state, removing flakiness when opening and closing the browser tab.

- **Bug Fixes**
  - Added wait_for_active_screen(predicate, description, seconds) to poll the workspace tree until the active screen matches the expected tab count/kind.
  - Replaced fixed delays in the browser open/close paths with the readiness probe, and switched to the CloseTab owner action (`prefix-x`) to avoid closing the pane.
  - On timeout, fail with the last workspace tree to aid debugging.

<sup>Written for commit c144d292056bcb745af6bf6408d1f33439fa174c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/10026?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

