### PR TITLE
Replay the launcher PATH into remote Claude Teams teammate panes

### DIFF
--- a/daemon/remote/cmd/cmuxd-remote/agent_launch.go
+++ b/daemon/remote/cmd/cmuxd-remote/agent_launch.go
@@ -68,6 +68,14 @@ func runClaudeTeamsRelay(socketPath string, args []string, refreshAddr func() st
 		configureClaudeNodeOptions(restoreModulePath)
 	}
 
+	// Record the fully configured launch environment last, so teammate respawns
+	// replay the PATH this process actually execs claude with.
+	if encoded := encodeClaudeTeamsRespawnEnvironment(os.Environ()); encoded != "" {
+		os.Setenv(claudeTeamsRespawnEnvironmentKey, encoded)
+	} else {
+		os.Unsetenv(claudeTeamsRespawnEnvironmentKey)
+	}
+
 	launchArgs := claudeTeamsLaunchArgs(args)
 
 	argv := append([]string{claudePath}, launchArgs...)
@@ -455,6 +463,18 @@ func configureAgentEnvironment(cfg agentConfig) {
 	// Preserve COLORTERM for truecolor support in subagent panes.
 	if os.Getenv("COLORTERM") == "" {
 		os.Setenv("COLORTERM", "truecolor")
+	}
+
+	// Drop launch state inherited from an enclosing claude-teams process tree: its
+	// PATH must not replace this agent's own in a respawn, and its trust-prompt
+	// bypass must not waive this agent's own prompt. cfg.extraEnv is applied after
+	// this, and runClaudeTeamsRelay records its own transport once this returns.
+	for _, key := range []string{
+		"CLAUDE_CODE_SANDBOXED",
+		"CMUX_CLAUDE_TEAMS_SANDBOXED",
+		claudeTeamsRespawnEnvironmentKey,
+	} {
+		os.Unsetenv(key)
 	}
 
 	// Publish only the socket-validated inherited routing identity. Invalid or

--- a/daemon/remote/cmd/cmuxd-remote/agent_launch_context_test.go
+++ b/daemon/remote/cmd/cmuxd-remote/agent_launch_context_test.go
@@ -131,6 +131,9 @@ func TestConfigureAgentEnvironmentClearsRejectedRoutingIdentity(t *testing.T) {
 		"COLORTERM",
 		"CMUX_AGENT_LAUNCH_TEST_BIN",
 		"CMUX_AGENT_LAUNCH_TEST_TERM",
+		"CLAUDE_CODE_SANDBOXED",
+		"CMUX_CLAUDE_TEAMS_SANDBOXED",
+		claudeTeamsRespawnEnvironmentKey,
 	} {
 		t.Setenv(key, os.Getenv(key))
 	}

--- a/daemon/remote/cmd/cmuxd-remote/claude_teams_respawn_env.go
+++ b/daemon/remote/cmd/cmuxd-remote/claude_teams_respawn_env.go
@@ -1,0 +1,60 @@
+package main
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"strings"
+)
+
+// claudeTeamsRespawnEnvironmentKey carries the encoded launcher environment from
+// the claude-teams relay to the `__tmux-compat` process that respawns a teammate
+// pane. Same key and wire format as the Swift
+// ClaudeTeamsRespawnEnvironmentTransport, so either end can produce the value.
+const claudeTeamsRespawnEnvironmentKey = "CMUX_CLAUDE_TEAMS_RESPAWN_ENV_B64"
+
+// claudeTeamsRespawnEnvironmentAllowlist is deliberately narrower than the Swift
+// AgentLaunchEnvironmentPolicy: PATH is the only value a remote teammate needs
+// replayed, and a second hand-copied allowlist would drift from the Swift one.
+var claudeTeamsRespawnEnvironmentAllowlist = []string{"PATH"}
+
+// encodeClaudeTeamsRespawnEnvironment encodes the replay-safe subset of a
+// launcher environment as base64 JSON, or "" when there is nothing to replay.
+func encodeClaudeTeamsRespawnEnvironment(environ []string) string {
+	environment, _ := envMapWithOrder(environ)
+	selected := selectClaudeTeamsRespawnEnvironment(environment)
+	if len(selected) == 0 {
+		return ""
+	}
+	// json.Marshal sorts map keys, matching the Swift encoder's .sortedKeys.
+	encoded, err := json.Marshal(selected)
+	if err != nil {
+		return ""
+	}
+	return base64.StdEncoding.EncodeToString(encoded)
+}
+
+// decodeClaudeTeamsRespawnEnvironment decodes a transport value and reapplies the
+// allowlist, so a forged value cannot promote arbitrary variables into a teammate
+// pane. Invalid data yields no values rather than a partial environment.
+func decodeClaudeTeamsRespawnEnvironment(encoded string) map[string]string {
+	data, err := base64.StdEncoding.DecodeString(strings.TrimSpace(encoded))
+	if err != nil {
+		return nil
+	}
+	var transported map[string]string
+	if err := json.Unmarshal(data, &transported); err != nil {
+		return nil
+	}
+	return selectClaudeTeamsRespawnEnvironment(transported)
+}
+
+func selectClaudeTeamsRespawnEnvironment(environment map[string]string) map[string]string {
+	selected := make(map[string]string, len(claudeTeamsRespawnEnvironmentAllowlist))
+	for _, key := range claudeTeamsRespawnEnvironmentAllowlist {
+		// An empty value would emit `export PATH=''` and leave the pane worse off.
+		if value := environment[key]; value != "" {
+			selected[key] = value
+		}
+	}
+	return selected
+}

--- a/daemon/remote/cmd/cmuxd-remote/claude_teams_respawn_env_test.go
+++ b/daemon/remote/cmd/cmuxd-remote/claude_teams_respawn_env_test.go
@@ -1,0 +1,165 @@
+package main
+
+import (
+	"encoding/base64"
+	"os"
+	"testing"
+)
+
+func TestEncodeClaudeTeamsRespawnEnvironmentRoundTripsPath(t *testing.T) {
+	encoded := encodeClaudeTeamsRespawnEnvironment([]string{
+		"PATH=/opt/homebrew/bin:/usr/bin:/bin",
+		"HOME=/home/user",
+	})
+	if encoded == "" {
+		t.Fatal("encode returned empty for an environment containing PATH")
+	}
+
+	decoded := decodeClaudeTeamsRespawnEnvironment(encoded)
+	if got := decoded["PATH"]; got != "/opt/homebrew/bin:/usr/bin:/bin" {
+		t.Errorf("PATH = %q, want the launcher PATH", got)
+	}
+	if len(decoded) != 1 {
+		t.Errorf("decoded = %v, want PATH only", decoded)
+	}
+}
+
+func TestEncodeClaudeTeamsRespawnEnvironmentDropsNonAllowlistedKeys(t *testing.T) {
+	encoded := encodeClaudeTeamsRespawnEnvironment([]string{
+		"PATH=/usr/bin",
+		"ANTHROPIC_API_KEY=secret",
+		"CMUX_SURFACE_ID=surface-1",
+		"malformed-entry-without-separator",
+	})
+
+	decoded := decodeClaudeTeamsRespawnEnvironment(encoded)
+	for _, key := range []string{"ANTHROPIC_API_KEY", "CMUX_SURFACE_ID"} {
+		if _, ok := decoded[key]; ok {
+			t.Errorf("%s crossed the respawn boundary", key)
+		}
+	}
+	if decoded["PATH"] != "/usr/bin" {
+		t.Errorf("PATH = %q, want /usr/bin", decoded["PATH"])
+	}
+}
+
+func TestEncodeClaudeTeamsRespawnEnvironmentWithoutPathEncodesNothing(t *testing.T) {
+	for _, environ := range [][]string{
+		{"HOME=/home/user"},
+		{"PATH="},
+		nil,
+	} {
+		if got := encodeClaudeTeamsRespawnEnvironment(environ); got != "" {
+			t.Errorf("encode(%v) = %q, want empty", environ, got)
+		}
+	}
+}
+
+// A forged or truncated transport value must yield nothing, never a partial or
+// attacker-chosen environment.
+func TestDecodeClaudeTeamsRespawnEnvironmentFailsClosed(t *testing.T) {
+	tests := []struct {
+		name    string
+		encoded string
+	}{
+		{"empty", ""},
+		{"not base64", "!!!not-base64!!!"},
+		{"base64 of non-JSON", base64.StdEncoding.EncodeToString([]byte("PATH=/usr/bin"))},
+		{"base64 of a JSON array", base64.StdEncoding.EncodeToString([]byte(`["PATH"]`))},
+		{"base64 of a JSON string", base64.StdEncoding.EncodeToString([]byte(`"PATH"`))},
+		{"non-string JSON values", base64.StdEncoding.EncodeToString([]byte(`{"PATH":42}`))},
+		{"allowlisted key absent", base64.StdEncoding.EncodeToString([]byte(`{"LD_PRELOAD":"/tmp/evil.so"}`))},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if decoded := decodeClaudeTeamsRespawnEnvironment(tc.encoded); len(decoded) != 0 {
+				t.Errorf("decoded = %v, want no values", decoded)
+			}
+		})
+	}
+}
+
+func TestTmuxClaudeTeamsRespawnEnvironmentReplaysTransportedPath(t *testing.T) {
+	encoded := encodeClaudeTeamsRespawnEnvironment([]string{"PATH=/opt/homebrew/bin:/usr/bin"})
+	t.Setenv(claudeTeamsRespawnEnvironmentKey, encoded)
+	t.Setenv("CMUX_CLAUDE_TEAMS_SANDBOXED", "")
+
+	pairs := tmuxClaudeTeamsRespawnEnvironment()
+	want := []tmuxEnvPair{{key: "PATH", value: "/opt/homebrew/bin:/usr/bin"}}
+	if len(pairs) != len(want) || pairs[0] != want[0] {
+		t.Errorf("pairs = %v, want %v", pairs, want)
+	}
+}
+
+func TestTmuxClaudeTeamsRespawnEnvironmentOrdersKeysDeterministically(t *testing.T) {
+	t.Setenv(claudeTeamsRespawnEnvironmentKey, encodeClaudeTeamsRespawnEnvironment([]string{"PATH=/usr/bin"}))
+	t.Setenv("CMUX_CLAUDE_TEAMS_SANDBOXED", "1")
+
+	pairs := tmuxClaudeTeamsRespawnEnvironment()
+	want := []tmuxEnvPair{
+		{key: "CLAUDE_CODE_SANDBOXED", value: "1"},
+		{key: "PATH", value: "/usr/bin"},
+	}
+	if len(pairs) != len(want) {
+		t.Fatalf("pairs = %v, want %v", pairs, want)
+	}
+	for i := range want {
+		if pairs[i] != want[i] {
+			t.Errorf("pairs[%d] = %v, want %v", i, pairs[i], want[i])
+		}
+	}
+}
+
+func TestTmuxClaudeTeamsRespawnEnvironmentWithoutOptInOrTransportIsEmpty(t *testing.T) {
+	t.Setenv(claudeTeamsRespawnEnvironmentKey, "garbage")
+	t.Setenv("CMUX_CLAUDE_TEAMS_SANDBOXED", "")
+
+	if pairs := tmuxClaudeTeamsRespawnEnvironment(); pairs != nil {
+		t.Errorf("pairs = %v, want nil", pairs)
+	}
+}
+
+// `cmux omc`/`omo`/`omx` launched from inside a claude-teams process tree must
+// not replay the lead's PATH into its own pane respawns.
+func TestConfigureAgentEnvironmentClearsInheritedRespawnTransport(t *testing.T) {
+	for _, key := range []string{
+		"PATH",
+		"TMUX",
+		"TMUX_PANE",
+		"TERM",
+		"CMUX_SOCKET_PATH",
+		"CMUX_SOCKET",
+		"TERM_PROGRAM",
+		"COLORTERM",
+		"CMUX_WORKSPACE_ID",
+		"CMUX_SURFACE_ID",
+		"CMUX_PANEL_ID",
+		"CMUX_TAB_ID",
+		"CMUX_PANE_ID",
+		"CMUX_RESPAWN_TRANSPORT_TEST_BIN",
+		"CMUX_RESPAWN_TRANSPORT_TEST_TERM",
+	} {
+		t.Setenv(key, os.Getenv(key))
+	}
+	t.Setenv("PATH", "/omc/own/bin:/usr/bin")
+	t.Setenv("CMUX_CLAUDE_TEAMS_SANDBOXED", "")
+	t.Setenv(claudeTeamsRespawnEnvironmentKey,
+		encodeClaudeTeamsRespawnEnvironment([]string{"PATH=/claude-teams/lead/bin"}))
+
+	configureAgentEnvironment(agentConfig{
+		shimDir:        t.TempDir(),
+		socketPath:     "/tmp/cmux-respawn-transport-test.sock",
+		launchContext:  nil,
+		tmuxPathPrefix: "cmux-omc",
+		cmuxBinEnvVar:  "CMUX_RESPAWN_TRANSPORT_TEST_BIN",
+		termEnvVar:     "CMUX_RESPAWN_TRANSPORT_TEST_TERM",
+		extraEnv:       map[string]string{},
+	})
+
+	if value, present := os.LookupEnv(claudeTeamsRespawnEnvironmentKey); present {
+		t.Errorf("%s survived as %q", claudeTeamsRespawnEnvironmentKey, value)
+	}
+	if pairs := tmuxClaudeTeamsRespawnEnvironment(); pairs != nil {
+		t.Errorf("pairs = %v, want nil", pairs)
+	}
+}

--- a/daemon/remote/cmd/cmuxd-remote/tmux_compat.go
+++ b/daemon/remote/cmd/cmuxd-remote/tmux_compat.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"sort"
 	"strings"
 	"time"
 )
@@ -1754,17 +1755,38 @@ func tmuxRespawnStartCommand(command string, prependEnv []tmuxEnvPair) string {
 }
 
 // tmuxClaudeTeamsRespawnEnvironment re-supplies the environment a
-// claude-teams teammate pane must start with. CLAUDE_CODE_SANDBOXED
-// short-circuits Claude Code's interactive trust prompt, which a teammate
-// pane can never answer. It is only set when the claude-teams launcher
-// recorded the user's explicit opt-in (CMUX_CLAUDE_TEAMS_SANDBOXED=1),
-// propagated to this process by the tmux shim. Mirrors the Swift
-// tmuxClaudeTeamsRespawnEnvironment; see that for the full rationale.
+// claude-teams teammate pane must start with. The pane is spawned by the
+// relay rather than by the launcher, so it does not inherit the launcher's
+// PATH; runClaudeTeamsRelay records that PATH in the respawn transport and
+// this replays it, keeping teammate executable discovery identical to the
+// lead's. CLAUDE_CODE_SANDBOXED short-circuits Claude Code's interactive
+// trust prompt, which a teammate pane can never answer. It is only set when
+// the claude-teams launcher recorded the user's explicit opt-in
+// (CMUX_CLAUDE_TEAMS_SANDBOXED=1), propagated to this process by the tmux
+// shim. Narrower than the Swift tmuxClaudeTeamsRespawnEnvironment, which also
+// replays AgentLaunchEnvironmentPolicy.safeEnvironmentKeys; this replays PATH
+// only.
 func tmuxClaudeTeamsRespawnEnvironment() []tmuxEnvPair {
-	if strings.TrimSpace(os.Getenv("CMUX_CLAUDE_TEAMS_SANDBOXED")) != "1" {
+	environment := decodeClaudeTeamsRespawnEnvironment(os.Getenv(claudeTeamsRespawnEnvironmentKey))
+	if strings.TrimSpace(os.Getenv("CMUX_CLAUDE_TEAMS_SANDBOXED")) == "1" {
+		if environment == nil {
+			environment = map[string]string{}
+		}
+		environment["CLAUDE_CODE_SANDBOXED"] = "1"
+	}
+	if len(environment) == 0 {
 		return nil
 	}
-	return []tmuxEnvPair{{key: "CLAUDE_CODE_SANDBOXED", value: "1"}}
+	keys := make([]string, 0, len(environment))
+	for key := range environment {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	pairs := make([]tmuxEnvPair, 0, len(keys))
+	for _, key := range keys {
+		pairs = append(pairs, tmuxEnvPair{key: key, value: environment[key]})
+	}
+	return pairs
 }
 
 func tmuxSendKeys(rc *rpcContext, args []string) error {

--- a/daemon/remote/cmd/cmuxd-remote/tmux_compat_test.go
+++ b/daemon/remote/cmd/cmuxd-remote/tmux_compat_test.go
@@ -417,6 +417,8 @@ func TestConfigureAgentEnvironment(t *testing.T) {
 		"TERM", "CMUX_SOCKET_PATH", "TERM_PROGRAM",
 		"CMUX_WORKSPACE_ID", "CMUX_SURFACE_ID", "CMUX_PANEL_ID", "CMUX_TAB_ID", "CMUX_PANE_ID",
 		"CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS", "COLORTERM",
+		"CLAUDE_CODE_SANDBOXED", "CMUX_CLAUDE_TEAMS_SANDBOXED",
+		claudeTeamsRespawnEnvironmentKey,
 	}
 	saved := make(map[string]string)
 	for _, k := range envKeys {

--- a/daemon/remote/cmd/cmuxd-remote/tmux_corpus_behavior_test.go
+++ b/daemon/remote/cmd/cmuxd-remote/tmux_corpus_behavior_test.go
@@ -333,6 +333,9 @@ func TestTmuxCorpusNewSessionAndNewWindowCommandsDispatchShellText(t *testing.T)
 // respawn-pane" and Claude Code fell back to headless for the session.
 func TestTmuxCorpusRespawnPaneDispatchesSurfaceRespawn(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
+	// The respawn dispatch reads both from the ambient environment; pin them for every subtest.
+	t.Setenv("CMUX_CLAUDE_TEAMS_SANDBOXED", "")
+	t.Setenv(claudeTeamsRespawnEnvironmentKey, "")
 
 	const paneTarget = "%33333333-3333-4333-8333-333333333333"
 	const wantSurface = "44444444-4444-4444-8444-444444444444"
@@ -504,6 +507,53 @@ func TestTmuxCorpusRespawnPaneDispatchesSurfaceRespawn(t *testing.T) {
 		}
 		if got := params["tmux_start_command"]; got != "claude --resume" {
 			t.Errorf("tmux_start_command = %q (must stay raw for persistence)", got)
+		}
+	})
+
+	t.Run("claude-teams respawn transport prepends the launcher PATH", func(t *testing.T) {
+		t.Setenv(claudeTeamsRespawnEnvironmentKey, encodeClaudeTeamsRespawnEnvironment(
+			[]string{"PATH=/opt/homebrew/bin:/usr/bin:/bin"},
+		))
+		recorder := startTmuxCorpusRPCRecorder(t)
+		rc := &rpcContext{socketPath: recorder.socketPath}
+
+		err := dispatchTmuxCommand(rc, "respawn-pane", []string{
+			"-k", "-t", paneTarget, "claude --agent-id teammate-1",
+		})
+		if err != nil {
+			t.Fatalf("respawn-pane: %v", err)
+		}
+		requests := recorder.requestsFor("surface.respawn")
+		if len(requests) != 1 {
+			t.Fatalf("surface.respawn requests = %d, want 1", len(requests))
+		}
+		params := requests[0].Params
+		want := `/bin/sh -c 'export PATH='"'"'/opt/homebrew/bin:/usr/bin:/bin'"'"'; claude --agent-id teammate-1'`
+		if got := params["command"]; got != want {
+			t.Errorf("command = %q, want %q", got, want)
+		}
+		if got := params["tmux_start_command"]; got != "claude --agent-id teammate-1" {
+			t.Errorf("tmux_start_command = %q (must stay raw for persistence)", got)
+		}
+	})
+
+	t.Run("claude-teams respawn ignores an unreadable transport value", func(t *testing.T) {
+		t.Setenv(claudeTeamsRespawnEnvironmentKey, "!!!not-base64!!!")
+		recorder := startTmuxCorpusRPCRecorder(t)
+		rc := &rpcContext{socketPath: recorder.socketPath}
+
+		err := dispatchTmuxCommand(rc, "respawn-pane", []string{
+			"-k", "-t", paneTarget, "claude --agent-id teammate-1",
+		})
+		if err != nil {
+			t.Fatalf("respawn-pane: %v", err)
+		}
+		requests := recorder.requestsFor("surface.respawn")
+		if len(requests) != 1 {
+			t.Fatalf("surface.respawn requests = %d, want 1", len(requests))
+		}
+		if got := requests[0].Params["command"]; got != `/bin/sh -c 'claude --agent-id teammate-1'` {
+			t.Errorf("command = %q, want no exports", got)
 		}
 	})
 


### PR DESCRIPTION
## Summary

- **What changed?** Ports the respawn-environment transport from #9731 to the remote daemon's tmux-compat twin, so a Claude Teams teammate pane in an SSH/remote cmux workspace starts with the same `PATH` the `cmux claude-teams` lead was launched with. Go only — no Swift, no app-target, no `CLI/cmux.swift` diff.
- **Why?** #9731 fixed this for the local macOS path but touched no `.go` file. The remote daemon carries a deliberate line-by-line twin of that Swift path: `daemon/remote/cmd/cmuxd-remote/tmux_compat.go:1677` already calls `tmuxRespawnStartCommand(commandText, tmuxClaudeTeamsRespawnEnvironment())`, but `tmuxClaudeTeamsRespawnEnvironment` returned at most `CLAUDE_CODE_SANDBOXED` and never read `CMUX_CLAUDE_TEAMS_RESPAWN_ENV_B64`. A remote teammate therefore got no launcher `PATH` at all — the #7240 / #9150 symptom on the remote path.

Four small pieces:

1. **`claude_teams_respawn_env.go` (new)** — Go twin of `ClaudeTeamsRespawnEnvironmentTransport` on the same wire: base64 of a sorted-key JSON string map under the same `CMUX_CLAUDE_TEAMS_RESPAWN_ENV_B64` key (`json.Marshal` sorts map keys, matching Swift's `.sortedKeys`). Decode reapplies the allowlist and fails closed — bad base64, bad JSON, a JSON array/string, non-string values, or a non-allowlisted key all yield nothing rather than a partial environment.
2. **`agent_launch.go` → `runClaudeTeamsRelay`** — encodes its own fully configured environment at the same seam the Swift launcher's `defer` uses: after `configureAgentEnvironment` and `configureClaudeNodeOptions`, immediately before `syscall.Exec`.
3. **`agent_launch.go` → `configureAgentEnvironment`** — unsets the transport key **and the two inherited trust-bypass keys (`CLAUDE_CODE_SANDBOXED`, `CMUX_CLAUDE_TEAMS_SANDBOXED`)** for *every* relay, so `cmux omo` / `omx` / `omc` launched from inside a claude-teams process tree cannot inherit the lead's value and replay the lead's `PATH` — or the lead's trust-prompt waiver — into their own pane respawns. `tmux_compat.go:1678` is a single shared respawn dispatch for every agent shim, so without this an inherited value would override the pane `PATH` built by `ws_pty.go:757` and make `tmux` resolve to `~/.cmuxterm/claude-teams-bin` instead of that agent's own shim dir. This mirrors `clearInheritedClaudeLaunchEnvironment()` (`CLI/CMUXCLI+ExecutableResolution.swift:306-312`), which the Swift side calls from both the claude-teams launcher and the omc launcher — as far as the Go side has the concepts: it clears `inheritedTrustBypassKeys` + the transport, and does not clear `inheritedSessionIdentityKeys` or `CMUX_CLAUDE_TEAMS_WRAPPER_LAUNCH`, neither of which the remote daemon reads or writes anywhere. The clear runs before `cfg.extraEnv` is applied, matching the Swift order (`clearInheritedClaudeLaunchEnvironment()` → `claudeTeamsExtraEnvVars`). Placing it in the shared `configureAgentEnvironment` covers all four relays in one block; `runClaudeTeamsRelay` records its own value afterwards.
4. **`tmux_compat.go`** — `tmuxClaudeTeamsRespawnEnvironment` decodes the transport, overlays the existing `CLAUDE_CODE_SANDBOXED` opt-in exactly as before, and emits pairs in sorted key order, matching the Swift emitter's key-ordering rule.

**The Go allowlist is deliberately `PATH`-only, and this is a real narrowing versus Swift — not parity.** Swift's `tmuxClaudeTeamsRespawnEnvironment` also replays `AgentLaunchEnvironmentPolicy.safeEnvironmentKeys` (`Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/AgentLaunchEnvironmentPolicy.swift:58-119`: `CLAUDE_CONFIG_DIR`, `CLAUDE_SECURESTORAGE_CONFIG_DIR`, `ANTHROPIC_BASE_URL`/`MODEL`, `NODE_OPTIONS`, …). The Go side replays `PATH` and nothing else, so the emitted command string matches the Swift one only in key ordering and quoting, not in content whenever a policy key is set. The narrowing is stated at the pointer in the code rather than claimed as a mirror. Rationale: `AgentLaunchEnvironmentPolicy.swift` is hand-written (`scripts/generate-claude-launch-environment-policy.py` emits only `ClaudeSessionEnvironmentPolicy+Generated.swift` and the TypeScript/wrapper outputs, from a manifest whose only keys are `inheritedSessionIdentityKeys` and `inheritedTrustBypassKeys`), so a hand-copied second allowlist in Go would silently drift from it. `PATH` is the only value a remote teammate needs replayed. If you'd prefer full policy parity, the right move is extending the generator to emit Go — a larger cross-cutting change I did not make unasked. Happy to do it if you want it.

No new precedence logic, no synthesized or home-relative directories, no two-tier resolution: the lead's `PATH` is copied verbatim, so a repaired remote teammate resolves exactly what the lead resolves.

### Relationship to #7240 / #9150 / #9731

- **#9731** (merged, closes #9150) fixed the local macOS teammate path. I traced it end to end on `main` and it works: encode at `CLI/cmux.swift:20758-20766` → tmux shim → decode at `CLI/CMUXCLI+TmuxCompatSupport.swift:152-164` → exports at `:109-120` → pane process at `Sources/Workspace.swift:8444`. **This PR does not re-fix that**, and does not claim the local path is still broken.
- **#7240** is the broader "cmux.app runs on launchd's bare `PATH`" issue. This PR does **not** address that root cause — ordinary panes and other app-spawned subprocesses are untouched. It closes one specific remaining hole of the same shape.

### Verified repro evidence (for the symptom, on a build that predates #9731)

Reproduced on cmux 0.64.17 build 97 (a June build, before #9731):

- `ps eww` on the app pid: cmux.app runs with launchd's bare `PATH=/usr/bin:/bin:/usr/sbin:/sbin`.
- A teammate pane spawned mid-session via the lead's Agent tool (lead itself started by `cmux claude-teams` from a full-env terminal) got `PATH=<TMPDIR>/cmux-cli-shims/<uuid>:/Applications/cmux.app/Contents/Resources/bin:/usr/bin:/bin:/usr/sbin:/sbin`. `gh`, `go`, `node`, `npm`, `task` all exited 127 inside it; `git`/`jq` resolved only as Apple `/usr/bin` stubs.
- Spawn chain observed live: `/usr/bin/login -flp <user> /bin/bash --noprofile --norc -c exec -l /bin/sh -c '<abs path to claude> --agent-id … --agent-name …'` — no login shell, so dotfiles cannot repair it.
- The lead session was unaffected (it inherits the launching terminal's env).

**This is evidence for the symptom's shape, not evidence that `main` is still broken locally** — on `main`, #9731 fixes that scenario. The remote gap this PR closes is code-traced and unit-tested, **not** runtime-reproduced (see Testing).

### Deliberately left alone (disclosed, not overlooked)

- The Go relay still never *grants* the trust-prompt bypass: it has no `--dangerously-skip-permissions` argv check, so unlike the Swift launcher it never sets `CLAUDE_CODE_SANDBOXED` / `CMUX_CLAUDE_TEAMS_SANDBOXED` itself. Widening a trust-prompt bypass is your call, not a contributor's — this PR does not change that. What it does change is *inheritance*: `configureAgentEnvironment` now clears both keys alongside the transport, completing the mirror of `clearInheritedClaudeLaunchEnvironment()`, so a value inherited from an enclosing claude-teams process tree can no longer waive a different agent's prompt. The clear runs before `cfg.extraEnv` is applied, matching the Swift order, so a caller that ever does grant the opt-in still wins.
- The transport is still not persisted into session restore (intentional per #9731's rationale); a teammate still cannot spawn a teammate; command-carrying `split-window` / `new-window` / `new-session` remain uninjected, which keeps the whole mechanism coupled to Claude Code's current split-then-respawn sequence.

## Testing

Run in `daemon/remote` with go1.26.5 darwin/arm64.

- `gofmt -l ./cmd/cmuxd-remote` — clean (no files listed).
- `go build ./...` — passes.
- `go vet ./...` — passes.
- **`go test ./...` (the exact CI command, `.github/workflows/ci.yml:313-315`)** — `ok github.com/manaflow-ai/cmux/daemon/remote/cmd/cmuxd-remote 5.180s`. Green on `main` before the change and green after.
- Transport unit tests: encode→decode round-trips `PATH`; a non-allowlisted key (`ANTHROPIC_API_KEY`, `CMUX_SURFACE_ID`) never crosses the boundary; an environment without `PATH` encodes nothing; and seven fail-closed decode cases (empty, non-base64, base64-of-non-JSON, JSON array, JSON string, non-string values, non-allowlisted key) each yield no values.
- **`TestConfigureAgentEnvironmentClearsInheritedRespawnTransport`** — pins piece 3: with a lead's transport value in the ambient environment, `configureAgentEnvironment` for an omc-shaped config leaves the key unset and `tmuxClaudeTeamsRespawnEnvironment()` returns no pairs. Without the fix it fails with `pairs = [{PATH /claude-teams/lead/bin}]` — the lead's `PATH` leaking into another agent's respawn.
- Behavior tests added to the existing `TestTmuxCorpusRespawnPaneDispatchesSurfaceRespawn` table, in the style of the neighboring `claude-teams sandbox opt-in prepends env export` case. They assert the **full** `command` param that the production dispatch path actually sends over `surface.respawn` — not a substring, so any change to the emitted quoting is caught:
  - valid transport → ``/bin/sh -c 'export PATH='"'"'/opt/homebrew/bin:/usr/bin:/bin'"'"'; claude --agent-id teammate-1'``, with `tmux_start_command` still raw for persistence;
  - garbage transport → no exports at all.
- **Negative checks that the tests pin the real contract**, both re-run against the final tree: (a) restoring `tmux_compat.go` from `origin/main` fails `…ReplaysTransportedPath`, `…OrdersKeysDeterministically` and `…/claude-teams_respawn_transport_prepends_the_launcher_PATH`; (b) removing just the added unset block in `configureAgentEnvironment` fails `TestConfigureAgentEnvironmentClearsInheritedRespawnTransport`. Both pass again once restored. The tests exercise the production path rather than re-implementing its ordering.
- `-race` scoped to the touched tests passes 3/3 consecutive runs. A wider `-race -run 'TestTmuxCorpus'` intermittently fails `TestTmuxCorpusPRLaneSourcesExerciseRuntimeBehavior/regress/session-group-resize.sh` — **I ran that same command 4× on unmodified `origin/main` and it failed on 2 of 4 runs on the identical subtest**, so it is a pre-existing flake in a PTY-driving corpus test this PR does not touch. CI runs plain `go test ./...`, not `-race`.

**Test-isolation note worth knowing — this change widens it:** `TestTmuxCorpusRespawnPaneDispatchesSurfaceRespawn` takes part of its input from the ambient environment, and this PR takes that sensitivity **from one variable to two**. The pre-existing one is `CMUX_CLAUDE_TEAMS_SANDBOXED`: on unmodified `main`, running the suite from inside a `cmux claude-teams` pane — where it leaks in as `1` — already fails 4 of that test's subtests. This PR adds a second variable with the same blast radius, `CMUX_CLAUDE_TEAMS_RESPAWN_ENV_B64`: with a lead's transport value in the environment those subtests would see an unexpected `export PATH=…` prepended to the command. So the pin is at the parent test rather than per-subtest — `TestTmuxCorpusRespawnPaneDispatchesSurfaceRespawn` now pins **both** variables once with `t.Setenv` at the top, which makes every one of its subtests immune to whatever launched the suite. The tests added here pin both as well, and the two pre-existing tests that call `configureAgentEnvironment` now save/restore all three keys that block clears, so the new production `os.Unsetenv` cannot leak process-wide into later tests. Verified: the package passes with `CMUX_CLAUDE_TEAMS_SANDBOXED=1` in the environment, and with a valid `CMUX_CLAUDE_TEAMS_RESPAWN_ENV_B64` in the environment.

**What I could not verify:** I have no SSH/remote cmux workspace, so I never observed a real remote teammate pane before/after. The claim "a remote claude-teams teammate gets no launcher `PATH`" rests on reading `tmux_compat.go:1677` + `:1763-1769` and `agent_launch.go:26-76` / `:407-417`, plus `gh pr view 9731 --json files` showing no `.go` file in #9731. **This PR does not claim to have fixed anyone's observed remote failure.** Please sanity-check one remote claude-teams session before merging.

**Which targets compiled locally:** only `daemon/remote` (the sole module this PR touches) — built, vetted and fully tested here. No macOS app or Swift package target was compiled: this machine has Swift 6.3.2 CommandLineTools with no Xcode, so `xcodebuild` is unavailable. Since the diff is Go-only, no Swift target is affected; the Swift/app CI jobs will exercise unchanged code.

## Demo Video

**Not produced — I could not record one.** Two reasons, both hard blockers on the authoring machine: the macOS app target cannot be built (Swift 6.3.2 CommandLineTools, no Xcode/`xcodebuild`), and I have no SSH/remote host to run a remote `claude-teams` session against, which is the only place this change is observable.

In its place, the verifiable evidence is:

1. The exact emitted command string, asserted in full by a test that drives the production dispatch path:
   ```
   /bin/sh -c 'export PATH='"'"'/opt/homebrew/bin:/usr/bin:/bin'"'"'; claude --agent-id teammate-1'
   ```
2. The two negative checks above, showing those tests fail against the unpatched production code and pass with it — including the leak output `pairs = [{PATH /claude-teams/lead/bin}]` for the cross-agent case.
3. The full `go test ./...` output from the exact CI command.

## Review Trigger (Copy/Paste as PR comment)

```text
@codex review
@coderabbitai review
@greptile-apps review
@cubic-dev-ai review
```

## Checklist

- [x] I tested the change locally — `gofmt`, `go build`, `go vet`, and `go test ./...` (the exact CI command) in `daemon/remote`, plus two negative checks that the new tests fail without the production change. Not tested against a live remote host; see Testing.
- [x] I added or updated tests for behavior changes — unit tests for the transport (round-trip, allowlist, seven fail-closed cases), a test that an inherited transport does not survive into a non-claude-teams agent's respawn, and two subtests on the existing corpus table that assert the full command string the production path emits.
- [ ] I updated docs/changelog if needed — no docs or changelog entry; this is an internal parity fix in the remote daemon with no user-facing surface or configuration change. Happy to add one if you'd like.
- [x] I requested bot reviews after my latest commit — the trigger block above is posted as the PR's first comment.
- [ ] All code review bot comments are resolved — none yet.
- [ ] All human review comments are resolved — none yet.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/10042"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789134292&installation_model_id=21920&pr_number=10042&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F10042&signature=f8b1b6f2608c19b18740273b714db91db1a4197baed7e2e2b19922b2634e55ba"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replays the launcher PATH in remote Claude Teams teammate panes so tools resolve exactly like the lead session. Ports the respawn-environment transport to the remote Go daemon and prevents env leaks across agents.

- **Bug Fixes**
  - Ported PATH replay to the remote `tmux`-compat path; teammate panes now export the lead `PATH`.
  - `runClaudeTeamsRelay` records `CMUX_CLAUDE_TEAMS_RESPAWN_ENV_B64` (base64 JSON); `tmuxClaudeTeamsRespawnEnvironment` decodes it, preserves `CLAUDE_CODE_SANDBOXED` when opted-in, and emits env pairs in deterministic order.
  - `configureAgentEnvironment` unsets the transport and trust-bypass keys (`CLAUDE_CODE_SANDBOXED`, `CMUX_CLAUDE_TEAMS_SANDBOXED`) for all relays to avoid cross-agent PATH/trust leaks.
  - Go allowlist is intentionally PATH-only (narrower than Swift policy) to avoid drift; only PATH is replayed.
  - Added tests for transport round-trip and fail-closed cases, cross-agent isolation, and full `surface.respawn` command assertions.
  - Completes the remote half of the fix from #9731; addresses the teammate PATH gap without changing the broader PATH behavior tracked in #7240.

<sup>Written for commit d1b74ddc04a50e7a38e435fff8982e8b08d33858. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/10042?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved teammate respawns by preserving the required launcher environment, including `PATH`.
  - Added safeguards to isolate agent environments and prevent inherited sandbox or respawn settings.
  - Respawn commands now handle environment data consistently and deterministically.

- **Bug Fixes**
  - Invalid or incomplete environment data is safely ignored.
  - Prevented stale configuration from affecting newly launched agents.

- **Tests**
  - Added coverage for environment transport, filtering, cleanup, ordering, and respawn behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->