### PR TITLE
Include app version in GitHub PR poller User-Agent

### DIFF
--- a/Packages/macOS/CmuxGit/Sources/CmuxGit/Probe/GitHubPullRequestRequestCoordinator.swift
+++ b/Packages/macOS/CmuxGit/Sources/CmuxGit/Probe/GitHubPullRequestRequestCoordinator.swift
@@ -16,6 +16,34 @@ public actor GitHubPullRequestRequestCoordinator {
     private static let maximumConcurrentTransportCount = 3
     private static let maximumRateLimitIdentityCount = 32
 
+    /// Product token that identifies cmux's pull-request poller in the GitHub `User-Agent` header.
+    private static let userAgentProductToken = "cmux-workspace-pr-poller"
+
+    /// `User-Agent` sent with every pull-request probe, formatted as `Product/Version`.
+    ///
+    /// The version is resolved once from the host app bundle's
+    /// `CFBundleShortVersionString`, so it always reflects the shipped release
+    /// without any manual update. Formatting is factored into
+    /// `userAgentValue(appVersion:)` so it can be unit-tested without depending
+    /// on the bundle.
+    private static let userAgentHeaderValue = userAgentValue(
+        appVersion: Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String
+    )
+
+    /// Builds the poller `User-Agent`, appending the app version when available.
+    ///
+    /// The product token is always emitted as the leading component so
+    /// server-side matching on `cmux-workspace-pr-poller` keeps working. When no
+    /// version is available the token is paired with `unknown` to preserve the
+    /// `Product/Version` shape.
+    static func userAgentValue(appVersion: String?) -> String {
+        let version = appVersion?.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard let version, !version.isEmpty else {
+            return "\(userAgentProductToken)/unknown"
+        }
+        return "\(userAgentProductToken)/\(version)"
+    }
+
     internal struct RequestKey: Hashable, Sendable {
         let endpoint: String
         let authorizationFingerprint: Data
@@ -173,7 +201,7 @@ public actor GitHubPullRequestRequestCoordinator {
         var request = URLRequest(url: url)
         request.httpMethod = "GET"
         request.setValue("application/vnd.github+json", forHTTPHeaderField: "Accept")
-        request.setValue("cmux-workspace-pr-poller", forHTTPHeaderField: "User-Agent")
+        request.setValue(Self.userAgentHeaderValue, forHTTPHeaderField: "User-Agent")
         request.setValue(authHeader, forHTTPHeaderField: "Authorization")
         let cachedResponse = cachedResponseByRequestKey[requestKey]
         if let cachedResponse {

--- a/Packages/macOS/CmuxGit/Tests/CmuxGitTests/GitHubPullRequestRequestTests.swift
+++ b/Packages/macOS/CmuxGit/Tests/CmuxGitTests/GitHubPullRequestRequestTests.swift
@@ -420,4 +420,43 @@ struct GitHubPullRequestRequestTests {
         #expect(await survivor.value?.statusCode == 200)
         #expect(GitHubPullRequestStubURLProtocol.capturedRequests().count == 1)
     }
+
+    @Test func userAgentValueAppendsAppVersion() {
+        #expect(
+            GitHubPullRequestRequestCoordinator.userAgentValue(appVersion: "1.2.3")
+                == "cmux-workspace-pr-poller/1.2.3"
+        )
+    }
+
+    @Test func userAgentValueTrimsSurroundingWhitespace() {
+        #expect(
+            GitHubPullRequestRequestCoordinator.userAgentValue(appVersion: "  0.64.21  ")
+                == "cmux-workspace-pr-poller/0.64.21"
+        )
+    }
+
+    @Test func userAgentValueFallsBackWhenVersionMissing() {
+        #expect(
+            GitHubPullRequestRequestCoordinator.userAgentValue(appVersion: nil)
+                == "cmux-workspace-pr-poller/unknown"
+        )
+        #expect(
+            GitHubPullRequestRequestCoordinator.userAgentValue(appVersion: "   ")
+                == "cmux-workspace-pr-poller/unknown"
+        )
+    }
+
+    @Test func pollerRequestSendsProductTokenUserAgent() async {
+        GitHubPullRequestStubURLProtocol.reset(stubs: [
+            .init(statusCode: 200, data: Data("[]".utf8)),
+        ])
+        let coordinator = GitHubPullRequestRequestCoordinator(session: makeSession())
+
+        _ = await coordinator.response(endpoint: endpoint, authHeader: "******")
+
+        let userAgent = GitHubPullRequestStubURLProtocol.capturedRequests()
+            .first?
+            .value(forHTTPHeaderField: "User-Agent")
+        #expect(userAgent?.hasPrefix("cmux-workspace-pr-poller/") == true)
+    }
 }

--- a/Packages/macOS/CmuxGit/Tests/CmuxGitTests/GitHubPullRequestRequestTests.swift
+++ b/Packages/macOS/CmuxGit/Tests/CmuxGitTests/GitHubPullRequestRequestTests.swift
@@ -457,6 +457,10 @@ struct GitHubPullRequestRequestTests {
         let userAgent = GitHubPullRequestStubURLProtocol.capturedRequests()
             .first?
             .value(forHTTPHeaderField: "User-Agent")
+        let expected = GitHubPullRequestRequestCoordinator.userAgentValue(
+            appVersion: Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String
+        )
+        #expect(userAgent == expected)
         #expect(userAgent?.hasPrefix("cmux-workspace-pr-poller/") == true)
     }
 }


### PR DESCRIPTION
## Summary

The GitHub pull-request poller sends a fixed `User-Agent` of `cmux-workspace-pr-poller` with no version, so requests from different cmux releases are indistinguishable server-side. That makes it hard to attribute request behavior — including conditional-request (`If-None-Match` / ETag) revalidation and rate-limit usage — to a specific release.

This change appends the app version to the header, formatted as `cmux-workspace-pr-poller/<CFBundleShortVersionString>`:

- The version is resolved once from the host app bundle's `CFBundleShortVersionString`, so it always reflects the shipped release with **no manual update** required.
- The existing product token `cmux-workspace-pr-poller` is preserved as the leading component, so any server-side matching on it keeps working.
- A `/unknown` fallback preserves the `Product/Version` shape when a version isn't available (e.g. under `swift test`, where `Bundle.main` is the test runner).
- Formatting is factored into a small pure helper `userAgentValue(appVersion:)` so it can be unit-tested without depending on the bundle.

Closes #10044

## Testing

Added `swift-testing` cases in `GitHubPullRequestRequestTests.swift`:

- `userAgentValueAppendsAppVersion` — version appended as `cmux-workspace-pr-poller/1.2.3`.
- `userAgentValueTrimsSurroundingWhitespace` — surrounding whitespace trimmed.
- `userAgentValueFallsBackWhenVersionMissing` — `nil` and blank both fall back to `/unknown`.
- `pollerRequestSendsProductTokenUserAgent` — the outgoing request's `User-Agent` starts with `cmux-workspace-pr-poller/`.

> Note: this change was authored on a non-macOS machine, so it was **not** built/run locally (cmux's Swift/Xcode toolchain is macOS-only). CI is authoritative for build + tests here.

## Demo Video

N/A — no user-facing UI or behavior change (outbound request header metadata only).

## Review Trigger

@codex review
@coderabbitai review
@greptile-apps review
@cubic-dev-ai review

## Checklist

- [ ] I tested the change locally _(not possible on a non-macOS machine; relying on CI)_
- [x] I added tests
- [ ] I updated docs / changelog _(no user-facing docs affected)_
- [x] I requested bot reviews
- [ ] I resolved bot comments
- [ ] I resolved human comments

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/10046"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789140466&installation_model_id=21920&pr_number=10046&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F10046&signature=eb128995054aa923391b83bc2176f7d7171f2aff74dfee617c62f940fe955da0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Includes the app version in the GitHub PR poller’s User-Agent to attribute request behavior by release. Previously we sent "cmux-workspace-pr-poller"; now we send "cmux-workspace-pr-poller/<CFBundleShortVersionString>", falling back to "/unknown" when the version is unavailable.

- Builds the value once from `CFBundleShortVersionString` via `userAgentValue(appVersion:)`; no manual bumps.
- Sets a static `userAgentHeaderValue` in `GitHubPullRequestRequestCoordinator`; keeps the product token first; request semantics are unchanged.
- Tests verify formatting and whitespace trimming, the `/unknown` fallback, and assert the full `User-Agent` equals the value from `userAgentValue(appVersion:)` (not just the prefix).

<sup>Written for commit 1542e6d457d0793683c7b8fb7332e567b238645c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/10046?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * GitHub pull-request requests now identify the app with its current version.
  * Requests use a fallback identifier when the app version is unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->