### PR TITLE
resume: hookless directory-scoped continue bindings for remote agents (#7989)

### DIFF
--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -4794,8 +4794,27 @@ struct CMUXCLI {
                     defaultValue: "[cmux] remote session was lost; starting a new shell."
                 )
                 cliWriteStderr(Data((notice + "\n").utf8))
+                var respawnArgs = stableAttachArgs.filter { $0 != "--require-existing" }
+                // Hookless remote resume (#7989): the app can synthesize a
+                // directory-scoped continue command from the daemon's
+                // foreground tombstone for the session that just died. Any
+                // failure degrades to the plain replacement shell.
+                if let resumeCommand = sessionLostResumeRemoteCommand(
+                    client: client,
+                    attachArgs: stableAttachArgs
+                ) {
+                    let resumeNotice = String(
+                        localized: "cli.sshPtyAttach.remoteSessionLostResume",
+                        defaultValue: "[cmux] resuming the agent that was running in the lost session."
+                    )
+                    cliWriteStderr(Data((resumeNotice + "\n").utf8))
+                    respawnArgs = replacingSSHPTYAttachCommandB64(
+                        in: respawnArgs,
+                        with: Data(resumeCommand.utf8).base64EncodedString()
+                    )
+                }
                 try runSSHPTYAttach(
-                    commandArgs: stableAttachArgs.filter { $0 != "--require-existing" },
+                    commandArgs: respawnArgs,
                     client: client,
                     explicitPassword: socketPasswordArg
                 )
@@ -12799,6 +12818,67 @@ struct CMUXCLI {
             throw CLIError(message: "\(commandName): workspace not found")
         }
         return ["workspace_id": workspaceId]
+    }
+
+    /// Asks the app for a hookless remote continue command (#7989) after the
+    /// wrapper confirmed the persistent session was lost. The daemon's
+    /// foreground tombstone supplies the facts; binding precedence,
+    /// auto-resume, and approval policy stay in the app. Every failure —
+    /// older app, no tombstone, policy says attach plain — returns nil so the
+    /// respawn degrades to the existing replacement-shell behavior.
+    private func sessionLostResumeRemoteCommand(
+        client: SocketClient,
+        attachArgs: [String]
+    ) -> String? {
+        let (workspaceOpt, _) = parseOption(attachArgs, name: "--workspace")
+        let (sessionIDOpt, _) = parseOption(attachArgs, name: "--session-id")
+        let (attachmentIDOpt, _) = parseOption(attachArgs, name: "--attachment-id")
+        let environmentSurfaceID = Self.normalizedEnvValue(
+            ProcessInfo.processInfo.environment["CMUX_SURFACE_ID"]
+        )
+        let surfaceID = environmentSurfaceID
+            ?? Self.normalizedEnvValue(attachmentIDOpt).flatMap { UUID(uuidString: $0) == nil ? nil : $0 }
+        guard let workspaceID = Self.normalizedEnvValue(workspaceOpt)
+            ?? Self.normalizedEnvValue(ProcessInfo.processInfo.environment["CMUX_WORKSPACE_ID"]),
+            let sessionID = Self.normalizedEnvValue(sessionIDOpt),
+            let surfaceID else {
+            return nil
+        }
+        // The app-side handler deliberately outwaits the coordinator's daemon
+        // bootstrap (bounded at 20s), so this call must outlast it.
+        guard let payload = try? client.sendV2(
+            method: "workspace.remote.pty_session_lost_resume",
+            params: [
+                "workspace_id": workspaceID,
+                "surface_id": surfaceID,
+                "session_id": sessionID,
+            ],
+            responseTimeout: 30
+        ) else {
+            return nil
+        }
+        guard let command = payload["command"] as? String,
+              !command.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            return nil
+        }
+        return command
+    }
+
+    /// Returns `args` with any `--command-b64 <value>` pair replaced by the
+    /// synthesized resume payload.
+    private func replacingSSHPTYAttachCommandB64(in args: [String], with base64: String) -> [String] {
+        var result: [String] = []
+        var index = 0
+        while index < args.count {
+            if args[index] == "--command-b64", index + 1 < args.count {
+                index += 2
+                continue
+            }
+            result.append(args[index])
+            index += 1
+        }
+        result.append(contentsOf: ["--command-b64", base64])
+        return result
     }
 
     private func runSSHPTYAttach(commandArgs: [String], client: SocketClient, explicitPassword: String?) throws {

--- a/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Wire/ControlCommandExecutionPolicy.swift
+++ b/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Wire/ControlCommandExecutionPolicy.swift
@@ -125,6 +125,14 @@ public enum ControlCommandExecutionPolicy: Sendable, Equatable {
         // lane like the other workspace reads below.
         "workspace.env",
         "workspace.remote.pty_sessions",
+        // `workspace.remote.pty_session_lost_resume` deliberately outwaits the
+        // workspace coordinator's daemon bootstrap (bounded, signal-driven) and
+        // then queries the daemon's ended-session tombstones over the tunnel
+        // (#7989), so it must never hold the main actor; policy and binding
+        // registration take one `v2MainSync` hop. Without this entry the
+        // policy routes it to the main-actor processV2Command switch, which
+        // lacks the case, and the control socket returns method_not_found.
+        "workspace.remote.pty_session_lost_resume",
         "workspace.remote.pty_close",
         "workspace.remote.pty_detach",
         "workspace.remote.pty_bridge",

--- a/Packages/macOS/CmuxControlSocket/Tests/CmuxControlSocketTests/ControlCommandExecutionPolicyTests.swift
+++ b/Packages/macOS/CmuxControlSocket/Tests/CmuxControlSocketTests/ControlCommandExecutionPolicyTests.swift
@@ -32,6 +32,9 @@ struct ControlCommandExecutionPolicyTests {
             "feed.push", "browser.download.wait", "system.top", "system.memory",
             "workspace.remote.pty_bridge", "workspace.env", "sidebar.custom.reload",
             "sidebar.custom.open",
+            // Tombstone-backed hookless resume outwaits daemon bootstrap and
+            // queries the tunnel; it must never hold the main actor (#7989).
+            "workspace.remote.pty_session_lost_resume",
             "debug.sidebar.simulate_drag", "debug.mobile.transport.disconnect",
             "debug.window.screenshot", "mobile.attach_ticket.create",
             "mobile.terminal.set_font", "mobile.task.models.list",

--- a/Packages/macOS/CmuxRemoteDaemon/Sources/CmuxRemoteDaemon/Client/RemoteDaemonRPCClient+RPC.swift
+++ b/Packages/macOS/CmuxRemoteDaemon/Sources/CmuxRemoteDaemon/Client/RemoteDaemonRPCClient+RPC.swift
@@ -264,6 +264,15 @@ extension RemoteDaemonRPCClient {
         return result["sessions"] as? [[String: Any]] ?? []
     }
 
+    /// Lists ended persistent PTY sessions that retained a foreground-process
+    /// tombstone (`pty.list` → `ended_sessions`): the last agent command the
+    /// daemon sampled before the session died (#7989). Older daemons omit the
+    /// key; absence decodes as no tombstones.
+    public func listEndedPTY() throws -> [[String: Any]] {
+        let result = try call(method: "pty.list", params: [:], timeout: 8.0)
+        return result["ended_sessions"] as? [[String: Any]] ?? []
+    }
+
     /// Drops a local PTY subscription without telling the daemon.
     public func unregisterPTY(sessionID: String, attachmentID: String, attachmentToken: String? = nil) {
         let key = Self.ptySubscriptionKey(

--- a/Packages/macOS/CmuxRemoteSession/Sources/CmuxRemoteSession/Session/RemoteSessionCoordinator+PTYBridge.swift
+++ b/Packages/macOS/CmuxRemoteSession/Sources/CmuxRemoteSession/Session/RemoteSessionCoordinator+PTYBridge.swift
@@ -23,6 +23,19 @@ extension RemoteSessionCoordinator {
         }
     }
 
+    /// Lists the daemon's ended-session foreground tombstones (#7989) as raw
+    /// wire dictionaries; same blocking contract as ``listPTYSessions(timeout:)``.
+    public func listEndedPTYSessions(timeout: TimeInterval = 8.0) throws -> [[String: Any]] {
+        try runOnControllerQueue(timeout: timeout) {
+            guard self.daemonReady, self.proxyLease != nil else {
+                throw NSError(domain: "cmux.remote.pty", code: 1, userInfo: [
+                    NSLocalizedDescriptionKey: "remote daemon is not ready",
+                ])
+            }
+            return try self.proxyBroker.listEndedPTY(configuration: self.configuration)
+        }
+    }
+
     /// Closes one persistent PTY session by ID; same blocking contract as
     /// ``listPTYSessions(timeout:)``.
     public func closePTYSession(sessionID: String, timeout: TimeInterval = 8.0) throws {

--- a/Packages/macOS/CmuxRemoteWorkspace/Sources/CmuxRemoteWorkspace/Broker/RemoteProxyBroker.swift
+++ b/Packages/macOS/CmuxRemoteWorkspace/Sources/CmuxRemoteWorkspace/Broker/RemoteProxyBroker.swift
@@ -115,6 +115,13 @@ public final class RemoteProxyBroker: @unchecked Sendable {
         }
     }
 
+    /// Lists ended-session foreground tombstones through the ready tunnel (#7989).
+    public func listEndedPTY(configuration: WorkspaceRemoteConfiguration) throws -> [[String: Any]] {
+        try withReadyTunnel(configuration: configuration) { tunnel in
+            try tunnel.listEndedPTY()
+        }
+    }
+
     /// Closes a persistent PTY session through the ready tunnel.
     ///
     /// The broker queue is used only to pin the tunnel; the potentially

--- a/Packages/macOS/CmuxRemoteWorkspace/Sources/CmuxRemoteWorkspace/Broker/RemoteProxyBrokering.swift
+++ b/Packages/macOS/CmuxRemoteWorkspace/Sources/CmuxRemoteWorkspace/Broker/RemoteProxyBrokering.swift
@@ -30,6 +30,10 @@ public protocol RemoteProxyBrokering: AnyObject, Sendable {
     /// `configuration`; throws when no tunnel is ready.
     func listPTY(configuration: WorkspaceRemoteConfiguration) throws -> [[String: Any]]
 
+    /// Lists ended-session foreground tombstones through the ready tunnel for
+    /// `configuration` (#7989); throws when no tunnel is ready.
+    func listEndedPTY(configuration: WorkspaceRemoteConfiguration) throws -> [[String: Any]]
+
     /// Closes a persistent PTY session through the ready tunnel before `deadline`.
     ///
     /// - Parameters:
@@ -194,4 +198,9 @@ extension RemoteProxyBrokering {
             wasCurrent: wasCurrent
         )
     }
+
+    /// Foreground tombstones are an optional daemon capability; brokers that
+    /// predate it (and test fakes) report none. ``RemoteProxyBroker``
+    /// overrides this with the ready-tunnel query.
+    public func listEndedPTY(configuration: WorkspaceRemoteConfiguration) throws -> [[String: Any]] { [] }
 }

--- a/Packages/macOS/CmuxRemoteWorkspace/Sources/CmuxRemoteWorkspace/Broker/RemoteProxyTunneling.swift
+++ b/Packages/macOS/CmuxRemoteWorkspace/Sources/CmuxRemoteWorkspace/Broker/RemoteProxyTunneling.swift
@@ -33,6 +33,10 @@ public protocol RemoteProxyTunneling: AnyObject {
     /// shape pinned).
     func listPTY() throws -> [[String: Any]]
 
+    /// Lists ended persistent PTY sessions whose foreground-process tombstone
+    /// the daemon retained (#7989). Raw JSON objects, wire shape pinned.
+    func listEndedPTY() throws -> [[String: Any]]
+
     /// Closes a persistent PTY session on the daemon before `deadline`.
     ///
     /// - Parameters:
@@ -65,4 +69,10 @@ public protocol RemoteProxyTunneling: AnyObject {
         requireExisting: Bool,
         onLifecycleEnded: @escaping @Sendable () -> Void
     ) throws -> RemotePTYBridgeServer.Endpoint
+}
+
+public extension RemoteProxyTunneling {
+    /// Foreground tombstones are an optional daemon capability; tunnels that
+    /// predate it (and test doubles) report none.
+    func listEndedPTY() throws -> [[String: Any]] { [] }
 }

--- a/Packages/macOS/CmuxRemoteWorkspace/Sources/CmuxRemoteWorkspace/Tunnel/RemoteDaemonProxyTunnel.swift
+++ b/Packages/macOS/CmuxRemoteWorkspace/Sources/CmuxRemoteWorkspace/Tunnel/RemoteDaemonProxyTunnel.swift
@@ -163,6 +163,21 @@ public final class RemoteDaemonProxyTunnel: @unchecked Sendable {
         }
     }
 
+    /// Lists the daemon's ended-session foreground tombstones (#7989).
+    ///
+    /// Same wire-shape contract as ``listPTY()``; older daemons simply omit
+    /// the key and decode as empty.
+    public func listEndedPTY() throws -> [[String: Any]] {
+        try queue.sync {
+            guard let rpcClient, !isStopped else {
+                throw NSError(domain: "cmux.remote.pty", code: 30, userInfo: [
+                    NSLocalizedDescriptionKey: "remote daemon tunnel is not ready",
+                ])
+            }
+            return try rpcClient.listEndedPTY()
+        }
+    }
+
     /// Resizes a PTY attachment.
     public func resizePTY(sessionID: String, attachmentID: String, attachmentToken: String, cols: Int, rows: Int) throws {
         try queue.sync {

--- a/Packages/macOS/CmuxRemoteWorkspace/Sources/CmuxRemoteWorkspace/Tunnel/RemotePTYLifecycleRPCClient.swift
+++ b/Packages/macOS/CmuxRemoteWorkspace/Sources/CmuxRemoteWorkspace/Tunnel/RemotePTYLifecycleRPCClient.swift
@@ -4,7 +4,14 @@ internal import Foundation
 /// Testable PTY-only seam used by the tunnel's lifecycle and bridge operations.
 protocol RemotePTYLifecycleRPCClient: RemotePTYBridgeRPCClient {
     func listPTY() throws -> [[String: Any]]
+    func listEndedPTY() throws -> [[String: Any]]
     func closePTY(sessionID: String, timeout: TimeInterval) throws
     func resizePTY(sessionID: String, attachmentID: String, attachmentToken: String, cols: Int, rows: Int) throws
     func detachPTYChecked(sessionID: String, attachmentID: String, attachmentToken: String) throws
+}
+
+extension RemotePTYLifecycleRPCClient {
+    /// Foreground tombstones are an optional daemon capability; clients that
+    /// predate it (and test doubles) report none.
+    func listEndedPTY() throws -> [[String: Any]] { [] }
 }

--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -54821,6 +54821,23 @@
         }
       }
     },
+    "cli.sshPtyAttach.remoteSessionLostResume": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "[cmux] resuming the agent that was running in the lost session."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "[cmux] 失われたセッションで実行されていたエージェントを再開します。"
+          }
+        }
+      }
+    },
     "cli.sshSessionList.remoteStateUnavailable": {
       "extractionState": "manual",
       "localizations": {

--- a/Sources/ControlSurfaceResumeTarget.swift
+++ b/Sources/ControlSurfaceResumeTarget.swift
@@ -343,6 +343,11 @@ extension TerminalController {
         guard let binding else { return nil }
         let trimmedKind = binding.kind?.trimmingCharacters(in: .whitespacesAndNewlines)
         let normalizedKind = trimmedKind.flatMap { $0.isEmpty ? nil : $0 } ?? "command"
+        // Remote-synthesized bindings (#7989) intentionally map to `.direct`:
+        // they carry no session checkpoint, so `cmux surface resume show`
+        // presents the stored directory-level continue command verbatim under
+        // the agent kind instead of a typed `cmux restore <kind> <checkpoint>`
+        // selector.
         let mode: AgentRestoreRequestMode = binding.isAgentHookBinding
             ? .resumeAgent
             : .direct

--- a/Sources/RemoteAgentContinueSynthesizer.swift
+++ b/Sources/RemoteAgentContinueSynthesizer.swift
@@ -1,0 +1,87 @@
+import Foundation
+
+/// Synthesizes a hookless, directory-scoped resume binding for a remote agent
+/// (issue #7989, Tier 1).
+///
+/// A remote host without cmux agent hooks never reports a session checkpoint,
+/// so the strongest honest restore signal is "agent `<kind>` was running in
+/// `<directory>`". This synthesizer turns that pair into a conservative
+/// `cd <dir> && <agent> --continue || <agent>` command bound to the panel's
+/// persistent-SSH PTY, mirroring how `TmuxResumeParser` turns a locally
+/// observed tmux client into a `process-detected` binding.
+///
+/// Known limitation (accepted for hookless remotes): a directory-scoped
+/// continue command resumes whatever conversation the agent considers most
+/// recent for that directory. When several sessions of the same agent share
+/// one working directory, the wrong conversation can be continued.
+enum RemoteAgentContinueSynthesizer {
+    /// `SurfaceResumeBindingSnapshot.source` value for synthesized bindings;
+    /// must match `SurfaceResumeBindingSnapshot.isRemoteSynthesized`.
+    static let source = "remote-synthesized"
+
+    /// Builds a directory-scoped continue binding, or nil when the agent kind
+    /// has no trustworthy sessionless continue invocation or the remote
+    /// working directory is unknown.
+    static func binding(
+        kind: RestorableAgentKind,
+        remoteWorkingDirectory: String?,
+        remoteContext: SurfaceResumeRemoteContext,
+        updatedAt: TimeInterval = Date().timeIntervalSince1970
+    ) -> SurfaceResumeBindingSnapshot? {
+        guard let workingDirectory = normalized(remoteWorkingDirectory),
+              let continueCommand = directoryScopedContinueCommand(for: kind) else {
+            return nil
+        }
+        // Same cd guard as every other startup command
+        // (`TerminalStartupWorkingDirectoryPrefix`): tolerate a deleted saved
+        // directory instead of failing before the agent launches. The command
+        // runs on the remote host, so the local claude/codex wrapper-resolver
+        // tokens are deliberately not used here — mirroring
+        // `SurfaceResumeBindingSnapshot.remoteStartupInput()`, which renders
+        // remote commands with `repairPortableAgentExecutable: false`.
+        let command = TerminalStartupWorkingDirectoryPrefix.prefix(
+            continueCommand,
+            workingDirectory: workingDirectory
+        )
+        return SurfaceResumeBindingSnapshot(
+            name: "\(kind.displayName) continue",
+            kind: kind.rawValue,
+            command: command,
+            cwd: workingDirectory,
+            source: source,
+            autoResume: true,
+            launchFlavor: .persistentSSH(remoteContext),
+            updatedAt: updatedAt
+        )
+    }
+
+    /// Sessionless continue templates. Deliberately conservative: only agents
+    /// with a documented directory-level continue invocation are covered; the
+    /// per-session commands in `docs/agent-hooks.md` all need a checkpoint id
+    /// that a hookless remote cannot provide. The `|| <agent>` fallback starts
+    /// a fresh session when the agent has nothing to continue in that
+    /// directory, so restore never dead-ends on a continue error.
+    private static func directoryScopedContinueCommand(
+        for kind: RestorableAgentKind
+    ) -> String? {
+        switch kind {
+        case .claude:
+            // Continues the most recent conversation recorded for the current
+            // working directory (claude's session store is cwd-keyed).
+            return "claude --continue || claude"
+        case .codex:
+            // Resumes the most recently used codex session.
+            return "codex resume --last || codex"
+        default:
+            return nil
+        }
+    }
+
+    private static func normalized(_ value: String?) -> String? {
+        guard let trimmed = value?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !trimmed.isEmpty else {
+            return nil
+        }
+        return trimmed
+    }
+}

--- a/Sources/SessionPersistence.swift
+++ b/Sources/SessionPersistence.swift
@@ -363,6 +363,12 @@ struct SurfaceResumeBindingSnapshot: Codable, Equatable, Sendable {
         source == "cli"
     }
 
+    /// A directory-scoped continue binding synthesized by
+    /// `RemoteAgentContinueSynthesizer` for a hookless remote agent (#7989).
+    var isRemoteSynthesized: Bool {
+        source == "remote-synthesized"
+    }
+
     var allowsAutomaticResume: Bool {
         autoResume == true
     }

--- a/Sources/SurfaceResumeApprovalSigningSecretCache.swift
+++ b/Sources/SurfaceResumeApprovalSigningSecretCache.swift
@@ -391,7 +391,14 @@ extension SurfaceResumeApprovalStore {
     private static func trustedBinding(
         from binding: SurfaceResumeBindingSnapshot
     ) -> SurfaceResumeBindingSnapshot? {
-        if binding.isProcessDetected {
+        if binding.isProcessDetected || binding.isRemoteSynthesized {
+            // Both sources are cmux's own observations rather than proposals
+            // from an arbitrary process: process-detected comes from scanning
+            // live local processes, and remote-synthesized commands are built
+            // exclusively from `RemoteAgentContinueSynthesizer`'s inline
+            // directory-level continue templates (no caller-supplied
+            // arguments), so they share the same trust tier and bypass the
+            // signed approval store.
             var trustedBinding = binding
             trustedBinding.autoResume = true
             trustedBinding.approvalPolicy = .auto

--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -1451,6 +1451,8 @@ class TerminalController {
             return v2Result(id: request.id, v2WorkspaceEnv(params: request.params))
         case "workspace.remote.pty_sessions":
             return v2Result(id: request.id, v2WorkspaceRemotePTYSessions(params: request.params))
+        case "workspace.remote.pty_session_lost_resume":
+            return v2Result(id: request.id, v2WorkspaceRemotePTYSessionLostResume(params: request.params))
         case "workspace.remote.pty_close":
             return v2Result(id: request.id, v2WorkspaceRemotePTYClose(params: request.params))
         case "workspace.remote.pty_detach":
@@ -2721,7 +2723,8 @@ class TerminalController {
             "workspace.remote.reconnect",
             "workspace.remote.disconnect",
             "workspace.remote.status",
-            "workspace.remote.pty_sessions", "workspace.remote.pty_close", "workspace.remote.pty_detach",
+            "workspace.remote.pty_sessions", "workspace.remote.pty_session_lost_resume",
+            "workspace.remote.pty_close", "workspace.remote.pty_detach",
             "workspace.remote.pty_bridge", "workspace.remote.pty_resize", "workspace.remote.pty_attach_end",
             "workspace.remote.terminal_session_launching",
             "workspace.remote.terminal_session_connected", "workspace.remote.terminal_session_end",
@@ -4214,6 +4217,16 @@ class TerminalController {
         remotePTYControllerAvailabilityCondition.unlock()
     }
 
+    /// Blocks the calling (socket) thread until the next remote-PTY
+    /// availability signal or `deadline`, whichever comes first. Companion to
+    /// ``v2ResolveRemotePTYTargetWaitingForController`` for callers that must
+    /// also outwait a coordinator whose daemon link is still bootstrapping.
+    private nonisolated func waitForRemotePTYControllerAvailabilitySignal(until deadline: Date) {
+        remotePTYControllerAvailabilityCondition.lock()
+        _ = remotePTYControllerAvailabilityCondition.wait(until: deadline)
+        remotePTYControllerAvailabilityCondition.unlock()
+    }
+
     private nonisolated func v2ResolveRemotePTYTargetWaitingForController(
         params: [String: Any],
         requestedWorkspaceId: UUID?,
@@ -4448,6 +4461,90 @@ class TerminalController {
         payload["workspace_ref"] = target.workspaceRef
         payload["workspace_title"] = target.workspaceTitle
         return payload
+    }
+
+    /// Synthesizes a hookless remote continue command after the
+    /// ssh-pty-attach wrapper confirmed a persistent session died (#7989).
+    /// The daemon's ended-session foreground tombstone supplies the facts
+    /// (agent executable + working directory); `Workspace` applies binding
+    /// precedence, auto-resume, and approval policy. `command` is null when
+    /// the replacement session should start a plain shell.
+    ///
+    /// The wrapper reaches this method during restore, racing the workspace
+    /// coordinator's daemon bootstrap (its session-lost verdict travels the
+    /// shared tunnel's lifecycle channel, which can settle first), so both
+    /// the controller resolution and the tombstone query wait — bounded and
+    /// signal-driven on the shared availability condition — instead of
+    /// degrading to a plain shell on a transient "daemon is not ready".
+    private nonisolated func v2WorkspaceRemotePTYSessionLostResume(params: [String: Any]) -> V2CallResult {
+        let workspaceSelection = v2RequestedRemotePTYWorkspaceID(params: params)
+        if let error = workspaceSelection.error { return error }
+        let surfaceSelection = v2RequestedRemotePTYSurfaceID(params: params)
+        if let error = surfaceSelection.error { return error }
+        guard let surfaceId = surfaceSelection.surfaceId else {
+            return .err(code: "invalid_params", message: "Missing or invalid surface_id", data: nil)
+        }
+        guard let sessionID = v2RawString(params, "session_id")?
+            .trimmingCharacters(in: .whitespacesAndNewlines),
+              !sessionID.isEmpty else {
+            return .err(code: "invalid_params", message: "Missing or invalid session_id", data: nil)
+        }
+        let deadline = Date().addingTimeInterval(20)
+        let resolved = v2ResolveRemotePTYTargetWaitingForController(
+            params: params,
+            requestedWorkspaceId: workspaceSelection.workspaceId,
+            preferredSurfaceId: surfaceId,
+            deadline: deadline
+        )
+        if let error = resolved.error { return error }
+        guard let target = resolved.target else {
+            return .err(code: "not_found", message: "Workspace not found", data: nil)
+        }
+        guard let controller = target.controller else {
+            return .err(
+                code: "remote_pty_error",
+                message: "remote connection is not active",
+                data: ["workspace_id": target.workspaceId.uuidString, "workspace_ref": target.workspaceRef]
+            )
+        }
+        // Daemon-side facts: the last foreground process sampled before the
+        // session died. An error is a not-yet-ready daemon and retries until
+        // the deadline; an empty list is the authoritative "no tombstones"
+        // (older daemon, no agent, sampling never ran) and does not. Either
+        // way an existing binding still resolves; only synthesis needs facts.
+        var endedSessions: [[String: Any]] = []
+        while true {
+            do {
+                endedSessions = try controller.listEndedPTYSessions()
+                break
+            } catch {
+                guard Date() < deadline else { break }
+                waitForRemotePTYControllerAvailabilitySignal(
+                    until: min(deadline, Date().addingTimeInterval(1))
+                )
+            }
+        }
+        let tombstone = endedSessions.first {
+            ($0["session_id"] as? String)?.trimmingCharacters(in: .whitespacesAndNewlines) == sessionID
+        }
+        var command: String?
+        v2MainSync {
+            guard let owner = AppDelegate.shared?.tabManagerFor(tabId: target.workspaceId),
+                  let workspace = owner.tabs.first(where: { $0.id == target.workspaceId }) else {
+                return
+            }
+            command = workspace.remoteContinueResumeCommandAfterSessionLoss(
+                panelId: surfaceId,
+                persistentPTYSessionID: sessionID,
+                foregroundCommand: tombstone?["foreground_command"] as? String,
+                foregroundCwd: tombstone?["foreground_cwd"] as? String
+            )
+        }
+        var payload = v2RemotePTYTargetPayload(target)
+        payload["session_id"] = sessionID
+        payload["surface_id"] = surfaceId.uuidString
+        payload["command"] = command ?? NSNull()
+        return .ok(payload)
     }
 
     private nonisolated func v2WorkspaceRemotePTYClose(params: [String: Any]) -> V2CallResult {

--- a/Sources/Workspace+PersistentRemotePTYReattach.swift
+++ b/Sources/Workspace+PersistentRemotePTYReattach.swift
@@ -79,10 +79,16 @@ extension Workspace {
                         )
                     }
                     : nil
+                // An ended session with no binding keeps `--require-existing`:
+                // the replacement wrapper then confirms the loss itself and
+                // owns the tombstone-backed hookless synthesis (#7989) before
+                // degrading to the same replacement shell. Only a binding the
+                // app can already inject skips that round trip.
+                let delegatesSessionLossToWrapper = sessionEnded && injectableResumeCommand == nil
                 command = remotePTYAttachStartupCommand(
                     sessionID: sessionID,
                     remoteCommand: injectableResumeCommand ?? restartedShellCommand,
-                    requireExisting: !sessionEnded
+                    requireExisting: !sessionEnded || delegatesSessionLossToWrapper
                 )
             } else {
                 guard let startupCommand = effectiveRemoteTerminalStartupCommand(from: configuration) else {

--- a/Sources/Workspace+PersistentRemotePTYReattach.swift
+++ b/Sources/Workspace+PersistentRemotePTYReattach.swift
@@ -63,6 +63,14 @@ extension Workspace {
                     panelID: panelId,
                     persistentPTYSessionID: sessionID
                 )
+                // A synthesized directory-level continue command (#7989) has no
+                // session checkpoint the remote once-guard could reconcile
+                // against, so only inject it once the PTY is confirmed ended;
+                // a live PTY is attach-only.
+                let injectableResumeCommand =
+                    resumeBinding?.isRemoteSynthesized == true && !sessionEnded
+                        ? nil
+                        : approvedResumeCommand
                 let restartedShellCommand = sessionEnded
                     ? configuration.relayPort.map {
                         SSHPTYAttachStartupCommandBuilder.restoredRemoteShellCommand(
@@ -73,7 +81,7 @@ extension Workspace {
                     : nil
                 command = remotePTYAttachStartupCommand(
                     sessionID: sessionID,
-                    remoteCommand: approvedResumeCommand ?? restartedShellCommand,
+                    remoteCommand: injectableResumeCommand ?? restartedShellCommand,
                     requireExisting: !sessionEnded
                 )
             } else {

--- a/Sources/Workspace+RemoteSurfaceResumeBinding.swift
+++ b/Sources/Workspace+RemoteSurfaceResumeBinding.swift
@@ -99,4 +99,70 @@ extension Workspace {
             persistentPTYSessionID: persistentPTYSessionID
         )
     }
+
+    /// Synthesizes (and registers) a hookless directory-scoped continue
+    /// binding after the daemon confirmed a persistent PTY session died
+    /// (#7989), using the foreground tombstone the daemon sampled before the
+    /// death. Returns the remote shell command the replacement session must
+    /// run to resume the agent, or nil when facts or policy say plain shell:
+    /// an existing binding always wins (its approved command is returned),
+    /// the tombstone must name a known agent executable (shells never
+    /// resume), and the result passes the same approval and auto-resume
+    /// gates as every other persistent-SSH resume command.
+    func remoteContinueResumeCommandAfterSessionLoss(
+        panelId: UUID,
+        persistentPTYSessionID: String,
+        foregroundCommand: String?,
+        foregroundCwd: String?
+    ) -> String? {
+        let sessionID = persistentPTYSessionID.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !sessionID.isEmpty,
+              let configuration = remoteConfiguration,
+              configuration.transport == .ssh,
+              configuration.preserveAfterTerminalExit,
+              !configuration.skipDaemonBootstrap,
+              configuration.persistentDaemonSlot != nil else {
+            return nil
+        }
+        // An existing binding (agent-hook / cli / process-detected /
+        // previously synthesized) always wins; synthesis only fills the gap.
+        if let existing = surfaceResumeBindingsByPanelId[panelId] {
+            return approvedPersistentSSHResumeCommand(
+                for: existing,
+                panelID: panelId,
+                persistentPTYSessionID: sessionID
+            )
+        }
+        guard let executable = Self.normalizedForegroundExecutableName(foregroundCommand),
+              !TerminalForegroundCommandCapture.isShellProcessName(executable),
+              let kindRawValue = TerminalForegroundCommandCapture.knownAgentKind(forExecutableName: executable),
+              let kind = RestorableAgentKind(rawValue: kindRawValue),
+              let binding = RemoteAgentContinueSynthesizer.binding(
+                  kind: kind,
+                  remoteWorkingDirectory: foregroundCwd,
+                  remoteContext: SurfaceResumeRemoteContext(
+                      workspaceID: id,
+                      surfaceID: panelId,
+                      persistentPTYSessionID: sessionID
+                  )
+              ),
+              let command = approvedPersistentSSHResumeCommand(
+                  for: binding,
+                  panelID: panelId,
+                  persistentPTYSessionID: sessionID
+              ) else {
+            return nil
+        }
+        surfaceResumeBindingsByPanelId[panelId] = binding
+        return command
+    }
+
+    /// Basename of the daemon-sampled foreground command, or nil when empty.
+    private static func normalizedForegroundExecutableName(_ raw: String?) -> String? {
+        guard let raw = raw?.trimmingCharacters(in: .whitespacesAndNewlines), !raw.isEmpty else {
+            return nil
+        }
+        let basename = (raw as NSString).lastPathComponent
+        return basename.isEmpty ? nil : basename
+    }
 }

--- a/Sources/Workspace+RemoteSurfaceResumeBinding.swift
+++ b/Sources/Workspace+RemoteSurfaceResumeBinding.swift
@@ -84,7 +84,7 @@ extension Workspace {
         ) else {
             return nil
         }
-        if effectiveBinding.isAgentHookBinding,
+        if effectiveBinding.isAgentHookBinding || effectiveBinding.isRemoteSynthesized,
            !AgentSessionAutoResumeSettings.isEnabled(defaults: agentSessionAutoResumeDefaults) {
             return nil
         }

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -5773,6 +5773,16 @@ final class Workspace: Identifiable, ObservableObject, FilePreviewTabMetadataHos
         return try controller.listPTYSessions()
     }
 
+    /// Lists the remote daemon's ended-session foreground tombstones (#7989).
+    func listEndedRemotePTYSessions() throws -> [[String: Any]] {
+        guard let controller = remoteSessionController else {
+            throw NSError(domain: "cmux.remote.pty", code: 10, userInfo: [
+                NSLocalizedDescriptionKey: "remote connection is not active",
+            ])
+        }
+        return try controller.listEndedPTYSessions()
+    }
+
     func closeRemotePTYSession(sessionID: String) throws {
         guard let controller = remoteSessionController else {
             throw NSError(domain: "cmux.remote.pty", code: 11, userInfo: [

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -1411,13 +1411,46 @@ extension Workspace {
                 persistentPTYSessionID: restoredRemotePTYSessionID,
                 restoresRemoteTerminal: restoresRemoteWorkspaceTerminalSnapshot
             )
+            // Tier-1 hookless remote resume (#7989): a remote agent without
+            // relayed hooks leaves no resume binding, so a persistent-SSH
+            // restore reattaches the PTY but never resumes the agent when the
+            // PTY is gone. When the snapshot still knows the agent kind and
+            // remote working directory, synthesize a directory-scoped
+            // continue binding. An existing binding (agent-hook / cli /
+            // process-detected) always wins; the synthesized one only fills
+            // the gap.
+            let synthesizedRemoteContinueBinding: SurfaceResumeBindingSnapshot? = {
+                guard locatedResumeBinding == nil,
+                      restoresRemoteWorkspaceTerminalSnapshot,
+                      shouldAutoResumeAgent,
+                      let restoredRemotePTYSessionID,
+                      let restorableAgent else {
+                    return nil
+                }
+                return RemoteAgentContinueSynthesizer.binding(
+                    kind: restorableAgent.kind,
+                    remoteWorkingDirectory: restorableAgent.workingDirectory
+                        ?? restorableAgent.launchCommand?.workingDirectory
+                        ?? (restoresUntrustedSavedDirectory ? nil : snapshot.terminal?.workingDirectory),
+                    remoteContext: SurfaceResumeRemoteContext(
+                        workspaceID: restoredResumeSnapshotWorkspaceID,
+                        surfaceID: snapshot.id,
+                        persistentPTYSessionID: restoredRemotePTYSessionID
+                    )
+                )
+            }()
             let resumeBinding = Self.resumeBindingForSessionRestore(
-                locatedResumeBinding,
+                locatedResumeBinding ?? synthesizedRemoteContinueBinding,
                 restorableAgent: restorableAgent
             )
             let resumeBindingForStartup =
                 restoredHibernation != nil ||
-                (resumeBinding?.isProcessDetected == true && resumeBinding?.autoResume != true)
+                (resumeBinding?.isProcessDetected == true && resumeBinding?.autoResume != true) ||
+                // A synthesized continue binding is only as fresh as the
+                // wasAgentRunning evidence captured with the snapshot; once
+                // the remote agent exited (or auto-resume is disabled), a
+                // previously persisted synthesized binding must not replay.
+                (resumeBinding?.isRemoteSynthesized == true && !shouldAutoResumeAgent)
                     ? nil
                     : resumeBinding
             let effectiveResumeBindingForStartup = sessionRestorePolicy.approvedSurfaceResumeBinding(
@@ -1582,7 +1615,8 @@ extension Workspace {
                 localWorkingDirectory ?? hostShellWorkingDirectory
             let restoredAgentWillRunStartupCommand =
                 restoredPersistentSSHResumeCommand != nil &&
-                resumeBinding?.isAgentHookBinding == true
+                (resumeBinding?.isAgentHookBinding == true ||
+                    resumeBinding?.isRemoteSynthesized == true)
             let restoredAgentWillRunStartupInput =
                 restoredAgentResumeLaunch?.initialInput != nil ||
                 (restoredBindingLaunch?.initialInput != nil && resumeBinding?.isAgentHookBinding == true)

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -1882,6 +1882,7 @@ C0DE71B10000000000000001 /* AppDelegate+AgentChatNotifications.swift in Sources 
 		C65930020000000000000002 /* SessionPersistencePolicy+CrashStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = C65930020000000000000001 /* SessionPersistencePolicy+CrashStorage.swift */; };
 		F6572002A1B2C3D4E5F60718 /* SessionPersistenceResumeBindingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6572003A1B2C3D4E5F60718 /* SessionPersistenceResumeBindingTests.swift */; };
 		9DCE2D1C84A5FB5D00BF4437 /* RemoteAgentContinueSynthesizerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 72D87115779C1B5E4B9ADB2C /* RemoteAgentContinueSynthesizerTests.swift */; };
+		5BA8D26CDC2D1569CA382E1E /* RemoteSessionLossResumeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F712A646D87A7AF51BAB57BD /* RemoteSessionLossResumeTests.swift */; };
 		F5000000A1B2C3D4E5F60718 /* SessionPersistenceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5000001A1B2C3D4E5F60718 /* SessionPersistenceTests.swift */; };
 		812600000000000000000003 /* SessionRemoteWorkspaceMoshRestoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 812600000000000000000004 /* SessionRemoteWorkspaceMoshRestoreTests.swift */; };
 		E30780000000000000000014 /* SessionRemoteWorkspaceSnapshot+Restore.swift in Sources */ = {isa = PBXBuildFile; fileRef = E30780000000000000000013 /* SessionRemoteWorkspaceSnapshot+Restore.swift */; };
@@ -4635,6 +4636,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 		C65930020000000000000001 /* SessionPersistencePolicy+CrashStorage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SessionPersistencePolicy+CrashStorage.swift"; sourceTree = "<group>"; };
 		F6572003A1B2C3D4E5F60718 /* SessionPersistenceResumeBindingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionPersistenceResumeBindingTests.swift; sourceTree = "<group>"; };
 		72D87115779C1B5E4B9ADB2C /* RemoteAgentContinueSynthesizerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteAgentContinueSynthesizerTests.swift; sourceTree = "<group>"; };
+		F712A646D87A7AF51BAB57BD /* RemoteSessionLossResumeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteSessionLossResumeTests.swift; sourceTree = "<group>"; };
 		F5000001A1B2C3D4E5F60718 /* SessionPersistenceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionPersistenceTests.swift; sourceTree = "<group>"; };
 		812600000000000000000004 /* SessionRemoteWorkspaceMoshRestoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionRemoteWorkspaceMoshRestoreTests.swift; sourceTree = "<group>"; };
 		E30780000000000000000013 /* SessionRemoteWorkspaceSnapshot+Restore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SessionRemoteWorkspaceSnapshot+Restore.swift"; sourceTree = "<group>"; };
@@ -7753,6 +7755,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 					B79500320000000000000002 /* PortScannerIdentityContinuityTests.swift */,
 					F6572003A1B2C3D4E5F60718 /* SessionPersistenceResumeBindingTests.swift */,
 					72D87115779C1B5E4B9ADB2C /* RemoteAgentContinueSynthesizerTests.swift */,
+					F712A646D87A7AF51BAB57BD /* RemoteSessionLossResumeTests.swift */,
 					7989A0027989A0027989A002 /* RemoteResumeBindingTests.swift */,
 				812600000000000000000004 /* SessionRemoteWorkspaceMoshRestoreTests.swift */,
 					F6572013A1B2C3D4E5F60718 /* SurfaceResumeBindingCodexUpdateCheckTests.swift */,
@@ -11380,6 +11383,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				8A3392FE64E0605D942213D1 /* SessionIndexViewTests.swift in Sources */,
 				F6572002A1B2C3D4E5F60718 /* SessionPersistenceResumeBindingTests.swift in Sources */,
 				9DCE2D1C84A5FB5D00BF4437 /* RemoteAgentContinueSynthesizerTests.swift in Sources */,
+				5BA8D26CDC2D1569CA382E1E /* RemoteSessionLossResumeTests.swift in Sources */,
 				F5000000A1B2C3D4E5F60718 /* SessionPersistenceTests.swift in Sources */,
 				812600000000000000000003 /* SessionRemoteWorkspaceMoshRestoreTests.swift in Sources */,
 				806600000000000000000002 /* SessionRestorableAgentSnapshotPermissionModeTests.swift in Sources */,

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -1881,6 +1881,7 @@ C0DE71B10000000000000001 /* AppDelegate+AgentChatNotifications.swift in Sources 
 		A74770010000000000000009 /* SessionPersistencePolicy+ConfigFrames.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7477001000000000000000A /* SessionPersistencePolicy+ConfigFrames.swift */; };
 		C65930020000000000000002 /* SessionPersistencePolicy+CrashStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = C65930020000000000000001 /* SessionPersistencePolicy+CrashStorage.swift */; };
 		F6572002A1B2C3D4E5F60718 /* SessionPersistenceResumeBindingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6572003A1B2C3D4E5F60718 /* SessionPersistenceResumeBindingTests.swift */; };
+		9DCE2D1C84A5FB5D00BF4437 /* RemoteAgentContinueSynthesizerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 72D87115779C1B5E4B9ADB2C /* RemoteAgentContinueSynthesizerTests.swift */; };
 		F5000000A1B2C3D4E5F60718 /* SessionPersistenceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5000001A1B2C3D4E5F60718 /* SessionPersistenceTests.swift */; };
 		812600000000000000000003 /* SessionRemoteWorkspaceMoshRestoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 812600000000000000000004 /* SessionRemoteWorkspaceMoshRestoreTests.swift */; };
 		E30780000000000000000014 /* SessionRemoteWorkspaceSnapshot+Restore.swift in Sources */ = {isa = PBXBuildFile; fileRef = E30780000000000000000013 /* SessionRemoteWorkspaceSnapshot+Restore.swift */; };
@@ -2186,6 +2187,7 @@ C0DE71B10000000000000001 /* AppDelegate+AgentChatNotifications.swift in Sources 
 		842300000000000000000001 /* SurfaceResumeExitedAgentLivenessTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 842300000000000000000002 /* SurfaceResumeExitedAgentLivenessTests.swift */; };
 		7989B0027989B0027989B002 /* SurfaceResumeLaunchFlavor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7989B1027989B1027989B102 /* SurfaceResumeLaunchFlavor.swift */; };
 		7989B0037989B0037989B003 /* SurfaceResumeRemoteContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7989B1037989B1037989B103 /* SurfaceResumeRemoteContext.swift */; };
+		55385DA3BD1729F18132159B /* RemoteAgentContinueSynthesizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 447566488217DA11300AADDE /* RemoteAgentContinueSynthesizer.swift */; };
 		F27B00000000000000000001 /* SurfaceResumeRunPromptBatch.swift in Sources */ = {isa = PBXBuildFile; fileRef = F27B00000000000000000002 /* SurfaceResumeRunPromptBatch.swift */; };
 		A5001303 /* SurfaceSearchOverlay.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001301 /* SurfaceSearchOverlay.swift */; };
 		C51A73B40000000000000002 /* SurfaceTabBarButtonConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = C51A73B40000000000000001 /* SurfaceTabBarButtonConfiguration.swift */; };
@@ -4632,6 +4634,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 		A7477001000000000000000A /* SessionPersistencePolicy+ConfigFrames.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SessionPersistencePolicy+ConfigFrames.swift"; sourceTree = "<group>"; };
 		C65930020000000000000001 /* SessionPersistencePolicy+CrashStorage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SessionPersistencePolicy+CrashStorage.swift"; sourceTree = "<group>"; };
 		F6572003A1B2C3D4E5F60718 /* SessionPersistenceResumeBindingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionPersistenceResumeBindingTests.swift; sourceTree = "<group>"; };
+		72D87115779C1B5E4B9ADB2C /* RemoteAgentContinueSynthesizerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteAgentContinueSynthesizerTests.swift; sourceTree = "<group>"; };
 		F5000001A1B2C3D4E5F60718 /* SessionPersistenceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionPersistenceTests.swift; sourceTree = "<group>"; };
 		812600000000000000000004 /* SessionRemoteWorkspaceMoshRestoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionRemoteWorkspaceMoshRestoreTests.swift; sourceTree = "<group>"; };
 		E30780000000000000000013 /* SessionRemoteWorkspaceSnapshot+Restore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SessionRemoteWorkspaceSnapshot+Restore.swift"; sourceTree = "<group>"; };
@@ -4930,6 +4933,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 		842300000000000000000002 /* SurfaceResumeExitedAgentLivenessTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SurfaceResumeExitedAgentLivenessTests.swift; sourceTree = "<group>"; };
 		7989B1027989B1027989B102 /* SurfaceResumeLaunchFlavor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SurfaceResumeLaunchFlavor.swift; sourceTree = "<group>"; };
 		7989B1037989B1037989B103 /* SurfaceResumeRemoteContext.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SurfaceResumeRemoteContext.swift; sourceTree = "<group>"; };
+		447566488217DA11300AADDE /* RemoteAgentContinueSynthesizer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteAgentContinueSynthesizer.swift; sourceTree = "<group>"; };
 		F27B00000000000000000002 /* SurfaceResumeRunPromptBatch.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SurfaceResumeRunPromptBatch.swift; sourceTree = "<group>"; };
 		A5001301 /* SurfaceSearchOverlay.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Find/SurfaceSearchOverlay.swift; sourceTree = "<group>"; };
 		C51A73B40000000000000001 /* SurfaceTabBarButtonConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SurfaceTabBarButtonConfiguration.swift; sourceTree = "<group>"; };
@@ -7259,6 +7263,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				7989B1017989B1017989B101 /* SurfaceResumeBindingSnapshot+Remote.swift */,
 				7989B1027989B1027989B102 /* SurfaceResumeLaunchFlavor.swift */,
 				7989B1037989B1037989B103 /* SurfaceResumeRemoteContext.swift */,
+				447566488217DA11300AADDE /* RemoteAgentContinueSynthesizer.swift */,
 				A74770010000000000000006 /* SessionConfigFrameEntry.swift */,
 				A74770010000000000000008 /* SessionConfigFrameRing.swift */,
 				A74770010000000000000004 /* SessionDisplaySnapshot.swift */,
@@ -7747,6 +7752,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 					F83620010000000000000002 /* PortScannerTTYFreshnessTests.swift */,
 					B79500320000000000000002 /* PortScannerIdentityContinuityTests.swift */,
 					F6572003A1B2C3D4E5F60718 /* SessionPersistenceResumeBindingTests.swift */,
+					72D87115779C1B5E4B9ADB2C /* RemoteAgentContinueSynthesizerTests.swift */,
 					7989A0027989A0027989A002 /* RemoteResumeBindingTests.swift */,
 				812600000000000000000004 /* SessionRemoteWorkspaceMoshRestoreTests.swift */,
 					F6572013A1B2C3D4E5F60718 /* SurfaceResumeBindingCodexUpdateCheckTests.swift */,
@@ -10214,6 +10220,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				F6572000A1B2C3D4E5F60718 /* SurfaceResumeCommandCanonicalizer+PortableAgentExecutable.swift in Sources */,
 				7989B0027989B0027989B002 /* SurfaceResumeLaunchFlavor.swift in Sources */,
 				7989B0037989B0037989B003 /* SurfaceResumeRemoteContext.swift in Sources */,
+				55385DA3BD1729F18132159B /* RemoteAgentContinueSynthesizer.swift in Sources */,
 				F27B00000000000000000001 /* SurfaceResumeRunPromptBatch.swift in Sources */,
 				A5001303 /* SurfaceSearchOverlay.swift in Sources */,
 				C51A73B40000000000000002 /* SurfaceTabBarButtonConfiguration.swift in Sources */,
@@ -11372,6 +11379,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				850000000000000000000002 /* SessionIndexTableViewportTests.swift in Sources */,
 				8A3392FE64E0605D942213D1 /* SessionIndexViewTests.swift in Sources */,
 				F6572002A1B2C3D4E5F60718 /* SessionPersistenceResumeBindingTests.swift in Sources */,
+				9DCE2D1C84A5FB5D00BF4437 /* RemoteAgentContinueSynthesizerTests.swift in Sources */,
 				F5000000A1B2C3D4E5F60718 /* SessionPersistenceTests.swift in Sources */,
 				812600000000000000000003 /* SessionRemoteWorkspaceMoshRestoreTests.swift in Sources */,
 				806600000000000000000002 /* SessionRestorableAgentSnapshotPermissionModeTests.swift in Sources */,

--- a/cmuxTests/RemoteAgentContinueSynthesizerTests.swift
+++ b/cmuxTests/RemoteAgentContinueSynthesizerTests.swift
@@ -1,0 +1,351 @@
+import Foundation
+import Testing
+
+#if canImport(cmux_DEV)
+@testable import cmux_DEV
+#elseif canImport(cmux)
+@testable import cmux
+#endif
+
+/// Unit coverage for the Tier-1 hookless remote resume binding synthesis
+/// (issue #7989): `RemoteAgentContinueSynthesizer`, the
+/// `isRemoteSynthesized` source predicate, the approval-store trust tier,
+/// the session-restore reconcile pass-through, and Codable persistence of
+/// synthesized bindings.
+@Suite struct RemoteAgentContinueSynthesizerTests {
+    private static func remoteContext(
+        persistentPTYSessionID: String = "pty-session-1"
+    ) -> SurfaceResumeRemoteContext {
+        SurfaceResumeRemoteContext(
+            workspaceID: UUID(uuidString: "11111111-2222-3333-4444-555555555555")!,
+            surfaceID: UUID(uuidString: "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee")!,
+            persistentPTYSessionID: persistentPTYSessionID
+        )
+    }
+
+    // MARK: - Command synthesis
+
+    @Test func claudeBindingUsesCdGuardedDirectoryScopedContinueWithFreshSessionFallback() throws {
+        let binding = try #require(RemoteAgentContinueSynthesizer.binding(
+            kind: .claude,
+            remoteWorkingDirectory: "/home/user/proj",
+            remoteContext: Self.remoteContext(),
+            updatedAt: 123
+        ))
+
+        #expect(
+            binding.command
+                == "cd -- '/home/user/proj' 2>/dev/null || [ ! -d '/home/user/proj' ] && claude --continue || claude"
+        )
+        #expect(binding.name == "Claude Code continue")
+        #expect(binding.kind == "claude")
+        #expect(binding.cwd == "/home/user/proj")
+        #expect(binding.source == "remote-synthesized")
+        #expect(binding.isRemoteSynthesized)
+        #expect(binding.autoResume == true)
+        #expect(binding.allowsAutomaticResume)
+        #expect(binding.updatedAt == 123)
+        // A synthesized binding carries no checkpoint, hook environment, or
+        // launch capture: `cmux surface resume show` must map it to `.direct`
+        // (not `.resumeAgent`) and the command must replay verbatim.
+        #expect(binding.checkpointId == nil)
+        #expect(binding.environment == nil)
+        #expect(binding.launchCommand == nil)
+        #expect(!binding.isAgentHookBinding)
+    }
+
+    @Test func codexBindingUsesResumeLastWithFreshSessionFallback() throws {
+        let binding = try #require(RemoteAgentContinueSynthesizer.binding(
+            kind: .codex,
+            remoteWorkingDirectory: "/srv/app",
+            remoteContext: Self.remoteContext()
+        ))
+
+        #expect(
+            binding.command
+                == "cd -- '/srv/app' 2>/dev/null || [ ! -d '/srv/app' ] && codex resume --last || codex"
+        )
+        #expect(binding.name == "Codex continue")
+        #expect(binding.kind == "codex")
+        #expect(binding.source == "remote-synthesized")
+        #expect(binding.autoResume == true)
+    }
+
+    @Test func bindingIsScopedToThePersistentSSHSessionThatOwnsIt() throws {
+        let context = Self.remoteContext(persistentPTYSessionID: "pty-abc")
+        let binding = try #require(RemoteAgentContinueSynthesizer.binding(
+            kind: .claude,
+            remoteWorkingDirectory: "/home/user/proj",
+            remoteContext: context
+        ))
+
+        #expect(binding.launchFlavor == .persistentSSH(context))
+        #expect(binding.launchFlavor.remoteContext == context)
+        #expect(binding.launchFlavor.executionLocationRawValue == "remote_ssh")
+        #expect(!binding.usesLocalRestoreVerb)
+    }
+
+    @Test(arguments: [
+        RestorableAgentKind.grok, .pi, .amp, .cursor, .gemini, .kiro,
+        .antigravity, .opencode, .rovodev, .hermesAgent, .copilot,
+        .codebuddy, .factory, .qoder, .kimi, .ollama, .custom("acme-agent"),
+    ])
+    func kindsWithoutASessionlessContinueInvocationSynthesizeNothing(
+        kind: RestorableAgentKind
+    ) {
+        #expect(RemoteAgentContinueSynthesizer.binding(
+            kind: kind,
+            remoteWorkingDirectory: "/home/user/proj",
+            remoteContext: Self.remoteContext()
+        ) == nil)
+    }
+
+    @Test(arguments: [String?.none, "", "   ", "\n\t"])
+    func missingOrBlankRemoteWorkingDirectorySynthesizesNothing(cwd: String?) {
+        #expect(RemoteAgentContinueSynthesizer.binding(
+            kind: .claude,
+            remoteWorkingDirectory: cwd,
+            remoteContext: Self.remoteContext()
+        ) == nil)
+    }
+
+    @Test func workingDirectoryIsTrimmedBeforeSynthesis() throws {
+        let binding = try #require(RemoteAgentContinueSynthesizer.binding(
+            kind: .claude,
+            remoteWorkingDirectory: "  /home/user/proj \n",
+            remoteContext: Self.remoteContext()
+        ))
+
+        #expect(binding.cwd == "/home/user/proj")
+        #expect(binding.command.hasPrefix("cd -- '/home/user/proj' 2>/dev/null"))
+    }
+
+    // MARK: - Quoting safety
+
+    @Test func workingDirectoryWithSpacesIsSingleQuoted() throws {
+        let binding = try #require(RemoteAgentContinueSynthesizer.binding(
+            kind: .claude,
+            remoteWorkingDirectory: "/tmp/my project",
+            remoteContext: Self.remoteContext()
+        ))
+
+        #expect(
+            binding.command
+                == "cd -- '/tmp/my project' 2>/dev/null || [ ! -d '/tmp/my project' ] && claude --continue || claude"
+        )
+    }
+
+    @Test func workingDirectoryWithSingleQuoteCannotEscapeTheQuoting() throws {
+        let binding = try #require(RemoteAgentContinueSynthesizer.binding(
+            kind: .codex,
+            remoteWorkingDirectory: "/tmp/it's here",
+            remoteContext: Self.remoteContext()
+        ))
+
+        let quoted = #"'/tmp/it'\''s here'"#
+        #expect(
+            binding.command
+                == "cd -- \(quoted) 2>/dev/null || [ ! -d \(quoted) ] && codex resume --last || codex"
+        )
+    }
+
+    @Test func nonASCIIWorkingDirectoryUsesASCIIPrintfSubstitution() throws {
+        let cwd = "/tmp/项目"
+        let binding = try #require(RemoteAgentContinueSynthesizer.binding(
+            kind: .claude,
+            remoteWorkingDirectory: cwd,
+            remoteContext: Self.remoteContext()
+        ))
+
+        // The shared quoter renders non-ASCII paths as an ASCII-only
+        // `"$(printf '\ooo…')"` substitution so the command survives any
+        // remote locale; the raw bytes must not appear in the command.
+        let quoted = TerminalStartupShellQuoting.singleQuoted(cwd)
+        #expect(quoted.hasPrefix(#""$(printf '"#))
+        #expect(
+            binding.command
+                == "cd -- \(quoted) 2>/dev/null || [ ! -d \(quoted) ] && claude --continue || claude"
+        )
+        #expect(!binding.command.contains("项目"))
+        #expect(binding.cwd == cwd, "cwd stores the raw path; only the command is quoted")
+    }
+
+    // MARK: - Source predicate
+
+    @Test func isRemoteSynthesizedMatchesTheSynthesizerSourceExactly() {
+        #expect(RemoteAgentContinueSynthesizer.source == "remote-synthesized")
+
+        func snapshot(source: String?) -> SurfaceResumeBindingSnapshot {
+            SurfaceResumeBindingSnapshot(command: "claude --continue || claude", source: source)
+        }
+
+        #expect(snapshot(source: "remote-synthesized").isRemoteSynthesized)
+        // Snapshot init trims the source before storing it.
+        #expect(snapshot(source: " remote-synthesized \n").isRemoteSynthesized)
+        #expect(!snapshot(source: "Remote-Synthesized").isRemoteSynthesized)
+        #expect(!snapshot(source: "remote-synthesized-2").isRemoteSynthesized)
+        #expect(!snapshot(source: nil).isRemoteSynthesized)
+    }
+
+    @Test(arguments: ["agent-hook", "process-detected", "cli", "remote-synthesized"])
+    func sourcePredicatesAreMutuallyExclusive(source: String) {
+        let binding = SurfaceResumeBindingSnapshot(
+            command: "claude --continue || claude",
+            source: source
+        )
+
+        let predicates = [
+            binding.isAgentHookBinding,
+            binding.isProcessDetected,
+            binding.isCLIBinding,
+            binding.isRemoteSynthesized,
+        ]
+        #expect(predicates.filter { $0 }.count == 1, "exactly one predicate matches \(source)")
+        #expect(binding.isRemoteSynthesized == (source == "remote-synthesized"))
+    }
+
+    // MARK: - Approval trust tier
+
+    @Test func remoteSynthesizedBindingResolvesTrustWithoutSigningSecret() throws {
+        let binding = try #require(RemoteAgentContinueSynthesizer.binding(
+            kind: .claude,
+            remoteWorkingDirectory: "/home/user/proj",
+            remoteContext: Self.remoteContext()
+        ))
+
+        // Same tier as process-detected: cmux's own observation, never a
+        // proposal from an arbitrary process, so approval must resolve
+        // even while the Keychain signing secret is still pending.
+        let result = SurfaceResumeApprovalStore.approvalProposalContext(
+            for: binding,
+            signingSecretResolution: .pending
+        )
+        guard case let .resolved(context) = result else {
+            Issue.record("remote-synthesized must not depend on the signing secret")
+            return
+        }
+        #expect(context.effectiveBinding.allowsAutomaticResume)
+        #expect(context.effectiveBinding.approvalPolicy == .auto)
+        #expect(context.effectiveBinding.approvalRecordId == nil)
+        #expect(context.existingRecord == nil)
+        #expect(context.effectiveBinding.command == binding.command)
+    }
+
+    @Test func remoteSynthesizedTrustForcesAutoResumeEvenWhenUnsetOnTheBinding() {
+        let binding = SurfaceResumeBindingSnapshot(
+            kind: "claude",
+            command: "claude --continue || claude",
+            cwd: "/home/user/proj",
+            source: "remote-synthesized",
+            autoResume: nil,
+            launchFlavor: .persistentSSH(Self.remoteContext())
+        )
+
+        let effective = SurfaceResumeApprovalStore.bindingWithoutStoredApproval(to: binding)
+        #expect(effective.allowsAutomaticResume)
+        #expect(effective.approvalPolicy == .auto)
+        #expect(effective.approvalRecordId == nil)
+    }
+
+    @Test func untrustedSourcesStillRequireStoredApproval() {
+        let binding = SurfaceResumeBindingSnapshot(
+            kind: "claude",
+            command: "claude --continue || claude",
+            cwd: "/home/user/proj",
+            source: "cli",
+            autoResume: true,
+            approvalRecordId: "unverified-record",
+            launchFlavor: .persistentSSH(Self.remoteContext())
+        )
+
+        // Widening the trust tier to remote-synthesized must not loosen the
+        // gate for any other source: without a verified record, a cli
+        // proposal is demoted to manual.
+        let effective = SurfaceResumeApprovalStore.bindingWithoutStoredApproval(to: binding)
+        #expect(!effective.allowsAutomaticResume)
+        #expect(effective.approvalPolicy == .manual)
+        #expect(effective.approvalRecordId == nil)
+    }
+
+    // MARK: - Session-restore reconcile
+
+    @Test func sessionRestoreReconcilePassesSynthesizedBindingsThroughUntouched() throws {
+        let binding = try #require(RemoteAgentContinueSynthesizer.binding(
+            kind: .claude,
+            remoteWorkingDirectory: "/home/user/proj",
+            remoteContext: Self.remoteContext()
+        ))
+        let restorableAgent = SessionRestorableAgentSnapshot(
+            kind: .claude,
+            sessionId: "a22293b7-bcef-4707-8439-2f538c8517a4",
+            workingDirectory: "/somewhere/else",
+            launchCommand: nil
+        )
+
+        // The checkpoint-based cwd retargeting in resumeBindingForSessionRestore
+        // is agent-hook-only; a synthesized binding has no checkpoint to
+        // reconcile against and must keep its own directory and command.
+        let reconciled = Workspace.resumeBindingForSessionRestore(
+            binding,
+            restorableAgent: restorableAgent
+        )
+        #expect(reconciled == binding)
+    }
+
+    @Test func sessionRestoreReconcileDoesNotInventABindingFromAgentEvidenceAlone() {
+        let restorableAgent = SessionRestorableAgentSnapshot(
+            kind: .claude,
+            sessionId: "a22293b7-bcef-4707-8439-2f538c8517a4",
+            workingDirectory: "/home/user/proj",
+            launchCommand: nil
+        )
+
+        // Synthesis happens upstream (createPanel) and only when no binding
+        // was located; the reconcile helper itself must stay nil-preserving.
+        #expect(Workspace.resumeBindingForSessionRestore(
+            nil,
+            restorableAgent: restorableAgent
+        ) == nil)
+    }
+
+    // MARK: - Remote startup input
+
+    @Test func remoteStartupInputReplaysTheSynthesizedCommandVerbatim() throws {
+        let binding = try #require(RemoteAgentContinueSynthesizer.binding(
+            kind: .codex,
+            remoteWorkingDirectory: "/srv/app",
+            remoteContext: Self.remoteContext()
+        ))
+
+        // The command runs on the remote host: no local restore-CLI verb, no
+        // wrapper-shim environment, no /usr/bin/env prefix — the stored
+        // command plus a trailing newline is the whole PTY input.
+        #expect(binding.remoteStartupInput() == binding.command + "\n")
+    }
+
+    // MARK: - Codable persistence
+
+    @Test func synthesizedBindingRoundTripsThroughPersistence() throws {
+        let context = Self.remoteContext(persistentPTYSessionID: "pty-roundtrip")
+        let binding = try #require(RemoteAgentContinueSynthesizer.binding(
+            kind: .codex,
+            remoteWorkingDirectory: "/srv/app with 'quotes'",
+            remoteContext: context,
+            updatedAt: 42
+        ))
+
+        let decoded = try JSONDecoder().decode(
+            SurfaceResumeBindingSnapshot.self,
+            from: JSONEncoder().encode(binding)
+        )
+
+        #expect(decoded == binding)
+        #expect(decoded.isRemoteSynthesized)
+        #expect(decoded.launchFlavor == .persistentSSH(context))
+        #expect(decoded.launchFlavor.remoteContext?.persistentPTYSessionID == "pty-roundtrip")
+        #expect(!decoded.wasDecodedWithoutLaunchFlavor)
+        #expect(decoded.command == binding.command)
+        #expect(decoded.autoResume == true)
+        #expect(decoded.updatedAt == 42)
+    }
+}

--- a/cmuxTests/RemoteSessionLossResumeTests.swift
+++ b/cmuxTests/RemoteSessionLossResumeTests.swift
@@ -1,0 +1,310 @@
+import AppKit
+import CmuxCore
+import Foundation
+import Testing
+
+#if canImport(cmux_DEV)
+@testable import cmux_DEV
+#elseif canImport(cmux)
+@testable import cmux
+#endif
+
+/// `Workspace.remoteContinueResumeCommandAfterSessionLoss` (#7989): the
+/// policy seam that turns a daemon foreground tombstone into a hookless
+/// directory-scoped continue command after a persistent-SSH session died.
+/// Every case is hermetic — value-injected `remoteConfiguration`, private
+/// defaults suites, no sockets, no subprocesses, no shared fixtures.
+@Suite
+@MainActor
+struct RemoteSessionLossResumeTests {
+    private let relayPort = 64_121
+
+    @Test
+    func sessionLossSynthesizesContinueFromDaemonForegroundTombstone() throws {
+        let suiteName = "cmux-session-loss-resume-\(UUID().uuidString)"
+        let defaults = try #require(UserDefaults(suiteName: suiteName))
+        defaults.set(true, forKey: AgentSessionAutoResumeSettings.autoResumeAgentSessionsKey)
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        let workspace = Workspace(agentSessionAutoResumeDefaults: defaults)
+        let panel = try #require(workspace.focusedTerminalPanel)
+        workspace.remoteConfiguration = remoteConfiguration().scopedToOwnerWorkspace(workspace.id)
+        let sessionID = Workspace.defaultSSHPTYSessionID(workspaceId: workspace.id, panelId: panel.id)
+
+        let command = try #require(workspace.remoteContinueResumeCommandAfterSessionLoss(
+            panelId: panel.id,
+            persistentPTYSessionID: sessionID,
+            foregroundCommand: "/home/dev/.local/bin/claude",
+            foregroundCwd: "/home/dev/resume lab"
+        ))
+
+        #expect(command.contains("export CMUX_SOCKET_PATH=127.0.0.1:\(relayPort)"), "\(command)")
+        let initialCommand = try decodedInitialCommand(from: command)
+        #expect(initialCommand.contains("claude --continue || claude"), "\(initialCommand)")
+        #expect(initialCommand.contains("resume lab"), "\(initialCommand)")
+
+        let binding = try #require(workspace.surfaceResumeBinding(panelId: panel.id))
+        #expect(binding.isRemoteSynthesized)
+        #expect(binding.kind == "claude")
+        #expect(binding.cwd == "/home/dev/resume lab")
+        guard case .persistentSSH(let context) = binding.launchFlavor else {
+            Issue.record("expected a persistentSSH launch flavor, got \(binding.launchFlavor)")
+            return
+        }
+        #expect(context.matches(
+            workspaceID: workspace.id,
+            surfaceID: panel.id,
+            persistentPTYSessionID: sessionID
+        ))
+    }
+
+    @Test
+    func sessionLossSynthesizesCodexResumeFromDaemonForegroundTombstone() throws {
+        let suiteName = "cmux-session-loss-codex-\(UUID().uuidString)"
+        let defaults = try #require(UserDefaults(suiteName: suiteName))
+        defaults.set(true, forKey: AgentSessionAutoResumeSettings.autoResumeAgentSessionsKey)
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        let workspace = Workspace(agentSessionAutoResumeDefaults: defaults)
+        let panel = try #require(workspace.focusedTerminalPanel)
+        workspace.remoteConfiguration = remoteConfiguration().scopedToOwnerWorkspace(workspace.id)
+
+        let command = try #require(workspace.remoteContinueResumeCommandAfterSessionLoss(
+            panelId: panel.id,
+            persistentPTYSessionID: "ssh-session-codex",
+            foregroundCommand: "codex",
+            foregroundCwd: "/srv/codex work"
+        ))
+
+        let initialCommand = try decodedInitialCommand(from: command)
+        #expect(initialCommand.contains("codex resume --last || codex"), "\(initialCommand)")
+        let binding = try #require(workspace.surfaceResumeBinding(panelId: panel.id))
+        #expect(binding.kind == "codex")
+        #expect(binding.isRemoteSynthesized)
+    }
+
+    @Test(arguments: ["zsh", "bash", "-zsh", "vim", "python3", ""])
+    func sessionLossNeverSynthesizesForNonAgentForegrounds(foreground: String) throws {
+        let suiteName = "cmux-session-loss-nonagent-\(UUID().uuidString)"
+        let defaults = try #require(UserDefaults(suiteName: suiteName))
+        defaults.set(true, forKey: AgentSessionAutoResumeSettings.autoResumeAgentSessionsKey)
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        let workspace = Workspace(agentSessionAutoResumeDefaults: defaults)
+        let panel = try #require(workspace.focusedTerminalPanel)
+        workspace.remoteConfiguration = remoteConfiguration().scopedToOwnerWorkspace(workspace.id)
+
+        let command = workspace.remoteContinueResumeCommandAfterSessionLoss(
+            panelId: panel.id,
+            persistentPTYSessionID: "ssh-session-nonagent",
+            foregroundCommand: foreground,
+            foregroundCwd: "/home/dev"
+        )
+
+        #expect(command == nil, "\(foreground) must not synthesize a resume command")
+        #expect(workspace.surfaceResumeBinding(panelId: panel.id) == nil)
+    }
+
+    @Test
+    func sessionLossSynthesisHonorsAutoResumeSetting() throws {
+        let suiteName = "cmux-session-loss-autoresume-\(UUID().uuidString)"
+        let defaults = try #require(UserDefaults(suiteName: suiteName))
+        defaults.set(false, forKey: AgentSessionAutoResumeSettings.autoResumeAgentSessionsKey)
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        let workspace = Workspace(agentSessionAutoResumeDefaults: defaults)
+        let panel = try #require(workspace.focusedTerminalPanel)
+        workspace.remoteConfiguration = remoteConfiguration().scopedToOwnerWorkspace(workspace.id)
+
+        let command = workspace.remoteContinueResumeCommandAfterSessionLoss(
+            panelId: panel.id,
+            persistentPTYSessionID: "ssh-session-autoresume-off",
+            foregroundCommand: "claude",
+            foregroundCwd: "/home/dev/project"
+        )
+
+        #expect(command == nil)
+        #expect(workspace.surfaceResumeBinding(panelId: panel.id) == nil)
+    }
+
+    @Test
+    func sessionLossSynthesisRequiresPersistentSSHConfiguration() throws {
+        let suiteName = "cmux-session-loss-nonpersistent-\(UUID().uuidString)"
+        let defaults = try #require(UserDefaults(suiteName: suiteName))
+        defaults.set(true, forKey: AgentSessionAutoResumeSettings.autoResumeAgentSessionsKey)
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        let workspace = Workspace(agentSessionAutoResumeDefaults: defaults)
+        let panel = try #require(workspace.focusedTerminalPanel)
+        workspace.remoteConfiguration = remoteConfiguration(persistentDaemonSlot: nil)
+            .scopedToOwnerWorkspace(workspace.id)
+
+        let command = workspace.remoteContinueResumeCommandAfterSessionLoss(
+            panelId: panel.id,
+            persistentPTYSessionID: "ssh-session-nonpersistent",
+            foregroundCommand: "claude",
+            foregroundCwd: "/home/dev/project"
+        )
+
+        #expect(command == nil)
+        #expect(workspace.surfaceResumeBinding(panelId: panel.id) == nil)
+    }
+
+    @Test
+    func sessionLossSynthesisNeverOverwritesAnExistingBinding() throws {
+        let suiteName = "cmux-session-loss-precedence-\(UUID().uuidString)"
+        let defaults = try #require(UserDefaults(suiteName: suiteName))
+        defaults.set(true, forKey: AgentSessionAutoResumeSettings.autoResumeAgentSessionsKey)
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        let workspace = Workspace(agentSessionAutoResumeDefaults: defaults)
+        let panel = try #require(workspace.focusedTerminalPanel)
+        workspace.remoteConfiguration = remoteConfiguration().scopedToOwnerWorkspace(workspace.id)
+        let existing = try legacyLocalBinding()
+        workspace.surfaceResumeBindingsByPanelId[panel.id] = existing
+
+        // A local-flavor binding is not injectable into a persistent-SSH
+        // respawn, so the answer is a plain shell — but the tombstone must
+        // never displace the more precise existing binding.
+        let command = workspace.remoteContinueResumeCommandAfterSessionLoss(
+            panelId: panel.id,
+            persistentPTYSessionID: "ssh-session-precedence",
+            foregroundCommand: "claude",
+            foregroundCwd: "/home/dev/project"
+        )
+
+        #expect(command == nil)
+        let retained = try #require(workspace.surfaceResumeBinding(panelId: panel.id))
+        #expect(retained.source == existing.source)
+        #expect(!retained.isRemoteSynthesized)
+    }
+
+    @Test
+    func endedSessionWithoutBindingDelegatesLossToTheWrapper() throws {
+        let suiteName = "cmux-session-loss-delegate-\(UUID().uuidString)"
+        let defaults = try #require(UserDefaults(suiteName: suiteName))
+        defaults.set(true, forKey: AgentSessionAutoResumeSettings.autoResumeAgentSessionsKey)
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        let workspace = Workspace(agentSessionAutoResumeDefaults: defaults)
+        let panel = try #require(workspace.focusedTerminalPanel)
+        workspace.remoteConfiguration = remoteConfiguration().scopedToOwnerWorkspace(workspace.id)
+        let sessionID = Workspace.defaultSSHPTYSessionID(workspaceId: workspace.id, panelId: panel.id)
+
+        _ = workspace.markRemotePTYAttachEnded(surfaceId: panel.id, sessionID: sessionID)
+        workspace.markPersistentRemotePTYAttachFailed(surfaceId: panel.id)
+        let restarted = workspace.reattachPersistentRemotePTYPanels(
+            requestedSurfaceId: panel.id,
+            restartEndedSessions: true
+        )
+        #expect(restarted == [panel.id])
+
+        // With no binding to inject, the replacement wrapper keeps
+        // `--require-existing` so its session-lost path owns the
+        // tombstone-backed synthesis (#7989) instead of silently starting a
+        // plain shell.
+        let command = try #require(workspace.terminalPanel(for: panel.id)?.surface.debugInitialCommand())
+        #expect(command.contains("--require-existing"), "\(command)")
+        #expect(command.contains(sessionID), "\(command)")
+    }
+
+    @Test
+    func endedSessionWithSynthesizedBindingInjectsWithoutRequireExisting() throws {
+        let suiteName = "cmux-session-loss-inject-\(UUID().uuidString)"
+        let defaults = try #require(UserDefaults(suiteName: suiteName))
+        defaults.set(true, forKey: AgentSessionAutoResumeSettings.autoResumeAgentSessionsKey)
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        let workspace = Workspace(agentSessionAutoResumeDefaults: defaults)
+        let panel = try #require(workspace.focusedTerminalPanel)
+        workspace.remoteConfiguration = remoteConfiguration().scopedToOwnerWorkspace(workspace.id)
+        let sessionID = Workspace.defaultSSHPTYSessionID(workspaceId: workspace.id, panelId: panel.id)
+        _ = try #require(workspace.remoteContinueResumeCommandAfterSessionLoss(
+            panelId: panel.id,
+            persistentPTYSessionID: sessionID,
+            foregroundCommand: "claude",
+            foregroundCwd: "/home/dev/inject lab"
+        ))
+
+        _ = workspace.markRemotePTYAttachEnded(surfaceId: panel.id, sessionID: sessionID)
+        workspace.markPersistentRemotePTYAttachFailed(surfaceId: panel.id)
+        let restarted = workspace.reattachPersistentRemotePTYPanels(
+            requestedSurfaceId: panel.id,
+            restartEndedSessions: true
+        )
+        #expect(restarted == [panel.id])
+
+        let command = try #require(workspace.terminalPanel(for: panel.id)?.surface.debugInitialCommand())
+        #expect(!command.contains("--require-existing"), "\(command)")
+        let bootstrap = try decodedWrapperRemoteCommand(from: command)
+        let initialCommand = try decodedInitialCommand(from: bootstrap)
+        #expect(initialCommand.contains("claude --continue || claude"), "\(initialCommand)")
+        #expect(initialCommand.contains("inject lab"), "\(initialCommand)")
+    }
+
+    private func remoteConfiguration(
+        transport: WorkspaceRemoteTransport = .ssh,
+        terminalTransport: WorkspaceRemoteTerminalTransport = .ssh,
+        preserveAfterTerminalExit: Bool = true,
+        persistentDaemonSlot: String? = "ssh-issue-7989-loss",
+        skipDaemonBootstrap: Bool = false
+    ) -> WorkspaceRemoteConfiguration {
+        WorkspaceRemoteConfiguration(
+            transport: transport,
+            terminalTransport: terminalTransport,
+            destination: "dev@example.com",
+            port: 22,
+            identityFile: nil,
+            sshOptions: ["StrictHostKeyChecking=accept-new"],
+            localProxyPort: nil,
+            relayPort: relayPort,
+            relayID: "relay-issue-7989-loss",
+            relayToken: String(repeating: "a", count: 64),
+            localSocketPath: "/tmp/cmux-issue-7989-loss.sock",
+            terminalStartupCommand: SSHPTYAttachStartupCommandBuilder.command(requireExisting: false),
+            preserveAfterTerminalExit: preserveAfterTerminalExit,
+            persistentDaemonSlot: persistentDaemonSlot,
+            skipDaemonBootstrap: skipDaemonBootstrap
+        )
+    }
+
+    private func legacyLocalBinding() throws -> SurfaceResumeBindingSnapshot {
+        let object: [String: Any] = [
+            "name": "Codex",
+            "kind": "codex",
+            "command": "codex resume legacy-session",
+            "cwd": "/tmp/legacy-project",
+            "checkpointId": "legacy-session",
+            "source": "agent-hook",
+            "autoResume": true,
+            "updatedAt": 10.0,
+        ]
+        return try JSONDecoder().decode(
+            SurfaceResumeBindingSnapshot.self,
+            from: JSONSerialization.data(withJSONObject: object)
+        )
+    }
+
+    private func decodedInitialCommand(from bootstrap: String) throws -> String {
+        let payloadLine = try #require(bootstrap.split(separator: "\n").first { line in
+            line.contains("printf %s '") && line.contains("> \"$cmux_initial_command_tmp\"")
+        })
+        let prefixRange = try #require(payloadLine.range(of: "printf %s '"))
+        let encodedSuffix = payloadLine[prefixRange.upperBound...]
+        let closingQuote = try #require(encodedSuffix.firstIndex(of: "'"))
+        let encodedCommand = String(encodedSuffix[..<closingQuote])
+        let data = try #require(Data(base64Encoded: encodedCommand))
+        return try #require(String(data: data, encoding: .utf8))
+    }
+
+    private func decodedWrapperRemoteCommand(from startupCommand: String) throws -> String {
+        let words = TerminalStartupWorkingDirectoryPrefix.shellWordRanges(startupCommand).map(\.value)
+        let script = try #require(words.dropFirst(2).first)
+        let range = try #require(
+            script.range(of: #"--command-b64 [A-Za-z0-9+/=]+"#, options: .regularExpression)
+        )
+        let encoded = String(script[range]).split(separator: " ", maxSplits: 1).last.map(String.init)
+        let data = try #require(encoded.flatMap { Data(base64Encoded: $0) })
+        return try #require(String(data: data, encoding: .utf8))
+    }
+}

--- a/daemon/remote/README.md
+++ b/daemon/remote/README.md
@@ -41,7 +41,7 @@ When invoked as `cmux` (via wrapper/symlink installed during bootstrap), the bin
 16. `pty.resize`
 17. `pty.detach`
 18. `pty.close`
-19. `pty.list`
+19. `pty.list` (session snapshots include the sampled `foreground_command`/`foreground_cwd`; the response also carries `ended_sessions`, bounded tombstones of finished persistent sessions whose foreground process had been sampled, for restore after a remote agent dies)
 
 Current integration in cmux:
 1. `workspace.remote.configure` now bootstraps this binary over SSH when missing.

--- a/daemon/remote/cmd/cmuxd-remote/main.go
+++ b/daemon/remote/cmd/cmuxd-remote/main.go
@@ -2804,7 +2804,8 @@ func (s *rpcServer) handlePTYList(req rpcRequest) rpcResponse {
 			ID: req.ID,
 			OK: true,
 			Result: map[string]any{
-				"sessions": []map[string]any{},
+				"sessions":       []map[string]any{},
+				"ended_sessions": []map[string]any{},
 			},
 		}
 	}
@@ -2812,7 +2813,8 @@ func (s *rpcServer) handlePTYList(req rpcRequest) rpcResponse {
 		ID: req.ID,
 		OK: true,
 		Result: map[string]any{
-			"sessions": s.ptyHub.sessionSnapshots(),
+			"sessions":       s.ptyHub.sessionSnapshots(),
+			"ended_sessions": s.ptyHub.endedSessionSnapshots(),
 		},
 	}
 }

--- a/daemon/remote/cmd/cmuxd-remote/main_test.go
+++ b/daemon/remote/cmd/cmuxd-remote/main_test.go
@@ -2490,6 +2490,20 @@ func TestPTYRPCSessionReattachListAndClose(t *testing.T) {
 	if len(emptySessions) != 0 {
 		t.Fatalf("pty.list after close sessions = %v, want none", emptyResult["sessions"])
 	}
+	// The close races with the pump's foreground sample, so the session may or
+	// may not have left a tombstone; pin the response shape and ownership.
+	emptyEnded, ok := emptyResult["ended_sessions"].([]map[string]any)
+	if !ok {
+		t.Fatalf(
+			"pty.list after close ended_sessions = %v (%T), want an array",
+			emptyResult["ended_sessions"], emptyResult["ended_sessions"],
+		)
+	}
+	for _, entry := range emptyEnded {
+		if entry["session_id"] != "pty-rpc" {
+			t.Fatalf("pty.list after close ended_sessions = %v, want only pty-rpc entries", emptyEnded)
+		}
+	}
 }
 
 func TestPTYRPCCommandUsesPOSIXShellForConfiguredLoginShell(t *testing.T) {

--- a/daemon/remote/cmd/cmuxd-remote/ws_pty.go
+++ b/daemon/remote/cmd/cmuxd-remote/ws_pty.go
@@ -114,6 +114,8 @@ const (
 	defaultPTYExitDrainTimeout                = time.Second
 	maxConcurrentPTYSessionStartOwnersPerHub  = 16
 	maxConcurrentPTYSessionStartWaitersPerHub = 64
+	maxEndedPTYSessionTombstones              = 64
+	foregroundSampleInterval                  = 5 * time.Second
 	standardExecutablePath                    = "/usr/local/bin:/usr/bin:/bin:/usr/local/sbin:/usr/sbin:/sbin"
 )
 
@@ -217,6 +219,10 @@ type wsPTYSession struct {
 	// initialClaims counts the start owner and live joiners that must consume
 	// this exact generation rather than interpreting an early exit as absence.
 	initialClaims int
+	// foregroundCommand and foregroundCwd hold the most recent foreground
+	// process sampled from the PTY (guarded by hub mu).
+	foregroundCommand string
+	foregroundCwd     string
 }
 
 type wsPTYSessionStart struct {
@@ -238,6 +244,11 @@ type wsPTYSessionStartWaiter struct {
 type wsPTYHub struct {
 	mu       sync.Mutex
 	sessions map[wsPTYSessionKey]*wsPTYSession
+	// endedSessions retains the last sampled foreground process for persistent
+	// sessions that already left `sessions`, so a later restore can resume an
+	// agent the daemon watched die (#7989). Bounded FIFO; guarded by mu.
+	endedSessions     map[string]wsPTYEndedSession
+	endedSessionOrder []string
 	// startingSessions reserves a session key while PTY allocation and process
 	// startup run without mu. Callers for the same key join that start; callers
 	// for healthy or unrelated sessions never wait behind it.
@@ -273,6 +284,14 @@ type wsPTYHub struct {
 // slave (tty) ends. The production implementation is creack/pty.Open.
 type ptyOpener func() (ptmx *os.File, tty *os.File, err error)
 
+// wsPTYEndedSession is the tombstone left behind by a finished persistent
+// session whose foreground process had been sampled.
+type wsPTYEndedSession struct {
+	foregroundCommand string
+	foregroundCwd     string
+	endedAt           time.Time
+}
+
 func newWebSocketPTYHub(cfg wsPTYServerConfig, stderr io.Writer) *wsPTYHub {
 	limit := cfg.ScrollbackLimit
 	if limit <= 0 {
@@ -284,6 +303,7 @@ func newWebSocketPTYHub(cfg wsPTYServerConfig, stderr io.Writer) *wsPTYHub {
 	}
 	return &wsPTYHub{
 		sessions:                map[wsPTYSessionKey]*wsPTYSession{},
+		endedSessions:           map[string]wsPTYEndedSession{},
 		startingSessions:        map[wsPTYSessionKey]*wsPTYSessionStart{},
 		sessionStartSlots:       make(chan struct{}, maxConcurrentPTYSessionStartOwnersPerHub),
 		sessionStartWaiterSlots: make(chan struct{}, maxConcurrentPTYSessionStartWaitersPerHub),
@@ -1119,6 +1139,9 @@ func (h *wsPTYHub) prepareAttachmentWithReservation(
 					claimedSession = startedSession
 					ownsInitialClaim = true
 				}
+				if sessionKey.kind == wsPTYPersistentSession {
+					h.deleteEndedSessionLocked(sessionKey.sessionID)
+				}
 				h.sessions[sessionKey] = startedSession
 				h.scheduleIdleReapLocked(startedSession)
 				start.session = startedSession
@@ -1707,6 +1730,69 @@ func (h *wsPTYHub) sessionSnapshots() []map[string]any {
 	return snapshots
 }
 
+func (h *wsPTYHub) endedSessionSnapshots() []map[string]any {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	ids := make([]string, 0, len(h.endedSessions))
+	for id := range h.endedSessions {
+		ids = append(ids, id)
+	}
+	sort.Strings(ids)
+
+	snapshots := make([]map[string]any, 0, len(ids))
+	for _, id := range ids {
+		entry := h.endedSessions[id]
+		snapshots = append(snapshots, map[string]any{
+			"session_id":         id,
+			"foreground_command": entry.foregroundCommand,
+			"foreground_cwd":     entry.foregroundCwd,
+			"ended_at":           entry.endedAt.Unix(),
+		})
+	}
+	return snapshots
+}
+
+// recordEndedSessionLocked keeps the last sampled foreground process of a
+// persistent session that is leaving sessions. A session that never sampled
+// a foreground command carries no restore signal and leaves no tombstone.
+func (h *wsPTYHub) recordEndedSessionLocked(session *wsPTYSession) {
+	if session.key.kind != wsPTYPersistentSession || session.foregroundCommand == "" {
+		return
+	}
+	entry := wsPTYEndedSession{
+		foregroundCommand: session.foregroundCommand,
+		foregroundCwd:     session.foregroundCwd,
+		endedAt:           time.Now(),
+	}
+	if _, exists := h.endedSessions[session.id]; exists {
+		h.endedSessions[session.id] = entry
+		return
+	}
+	h.endedSessions[session.id] = entry
+	h.endedSessionOrder = append(h.endedSessionOrder, session.id)
+	for len(h.endedSessionOrder) > maxEndedPTYSessionTombstones {
+		oldest := h.endedSessionOrder[0]
+		delete(h.endedSessions, oldest)
+		h.endedSessionOrder = append(h.endedSessionOrder[:0], h.endedSessionOrder[1:]...)
+	}
+}
+
+// deleteEndedSessionLocked drops a tombstone once the same session id starts
+// a fresh generation; the live session supersedes the ended record.
+func (h *wsPTYHub) deleteEndedSessionLocked(sessionID string) {
+	if _, exists := h.endedSessions[sessionID]; !exists {
+		return
+	}
+	delete(h.endedSessions, sessionID)
+	for i, id := range h.endedSessionOrder {
+		if id == sessionID {
+			h.endedSessionOrder = append(h.endedSessionOrder[:i], h.endedSessionOrder[i+1:]...)
+			break
+		}
+	}
+}
+
 func (h *wsPTYHub) attachmentByID(sessionID string, attachmentID string, attachmentToken string) *wsPTYAttachment {
 	sessionID = strings.TrimSpace(sessionID)
 	attachmentID = strings.TrimSpace(attachmentID)
@@ -1748,13 +1834,15 @@ func (h *wsPTYHub) sessionSnapshotLocked(session *wsPTYSession) map[string]any {
 	}
 
 	return map[string]any{
-		"session_id":       session.id,
-		"attachments":      attachments,
-		"effective_cols":   session.effectiveCols,
-		"effective_rows":   session.effectiveRows,
-		"last_known_cols":  session.lastKnownCols,
-		"last_known_rows":  session.lastKnownRows,
-		"scrollback_bytes": len(session.scrollback),
+		"session_id":         session.id,
+		"attachments":        attachments,
+		"effective_cols":     session.effectiveCols,
+		"effective_rows":     session.effectiveRows,
+		"last_known_cols":    session.lastKnownCols,
+		"last_known_rows":    session.lastKnownRows,
+		"scrollback_bytes":   len(session.scrollback),
+		"foreground_command": session.foregroundCommand,
+		"foreground_cwd":     session.foregroundCwd,
 	}
 }
 
@@ -1801,26 +1889,30 @@ func (session *wsPTYSession) closePTYFiles() {
 	session.closePTYFile()
 }
 
+// ptyForegroundProcessGroup reads the PTY's foreground process group with
+// TIOCGPGRP. Callers must not hold h.mu; the ioctl reaches into the kernel.
+func ptyForegroundProcessGroup(ptyFile *os.File) int {
+	rawConn, err := ptyFile.SyscallConn()
+	if err != nil {
+		return 0
+	}
+	var foregroundGroup int32
+	var ioctlErr syscall.Errno
+	if err := rawConn.Control(func(fd uintptr) {
+		_, _, ioctlErr = syscall.Syscall(
+			syscall.SYS_IOCTL,
+			fd,
+			uintptr(syscall.TIOCGPGRP),
+			uintptr(unsafe.Pointer(&foregroundGroup)),
+		)
+	}); err != nil || ioctlErr != 0 {
+		return 0
+	}
+	return int(foregroundGroup)
+}
+
 func (session *wsPTYSession) terminateProcesses() {
-	session.terminateProcessesWithForegroundGroupLookup(func(ptyFile *os.File) int {
-		rawConn, err := ptyFile.SyscallConn()
-		if err != nil {
-			return 0
-		}
-		var foregroundGroup int32
-		var ioctlErr syscall.Errno
-		if err := rawConn.Control(func(fd uintptr) {
-			_, _, ioctlErr = syscall.Syscall(
-				syscall.SYS_IOCTL,
-				fd,
-				uintptr(syscall.TIOCGPGRP),
-				uintptr(unsafe.Pointer(&foregroundGroup)),
-			)
-		}); err != nil || ioctlErr != 0 {
-			return 0
-		}
-		return int(foregroundGroup)
-	})
+	session.terminateProcessesWithForegroundGroupLookup(ptyForegroundProcessGroup)
 }
 
 func (session *wsPTYSession) terminateProcessesWithForegroundGroupLookup(lookup func(*os.File) int) {
@@ -1851,6 +1943,41 @@ func (session *wsPTYSession) terminateProcessesWithForegroundGroupLookup(lookup 
 			_ = session.cmd.Process.Kill()
 		}
 	})
+}
+
+// sampleSessionForeground records the PTY's current foreground process so a
+// tombstone can describe what was running when the session ends (#7989).
+func (h *wsPTYHub) sampleSessionForeground(session *wsPTYSession) {
+	h.sampleSessionForegroundWithLookups(session, ptyForegroundProcessGroup, foregroundProcessInfo)
+}
+
+// sampleSessionForegroundWithLookups reads the ioctl and the process table
+// outside h.mu per the lock ordering rule; the result is published under h.mu
+// only after re-checking that the session is still current. A missing
+// foreground group or unreadable process keeps the last known values: a dying
+// PTY often has no foreground precisely when its tombstone matters.
+func (h *wsPTYHub) sampleSessionForegroundWithLookups(
+	session *wsPTYSession,
+	pgidLookup func(*os.File) int,
+	infoLookup func(int) (string, string, bool),
+) {
+	foregroundGroup := 0
+	session.withPTYFileLocked(func(ptyFile *os.File) {
+		foregroundGroup = pgidLookup(ptyFile)
+	})
+	if foregroundGroup <= 0 {
+		return
+	}
+	command, cwd, ok := infoLookup(foregroundGroup)
+	if !ok || command == "" {
+		return
+	}
+	h.mu.Lock()
+	if h.sessions[session.key] == session && !session.closed {
+		session.foregroundCommand = command
+		session.foregroundCwd = cwd
+	}
+	h.mu.Unlock()
 }
 
 func terminatePTYSessionMembers(sessionID int) {
@@ -1953,12 +2080,17 @@ func (h *wsPTYHub) pumpSession(session *wsPTYSession) {
 		return
 	}
 	buffer := make([]byte, 32768)
+	var lastForegroundSample time.Time
 	for {
 		n, err := ptyFile.Read(buffer)
 		if n > 0 {
 			chunk := append([]byte(nil), buffer[:n]...)
 			h.recordAndBroadcast(session, chunk)
 			h.confirmPTYSizeAfterOutput(session)
+			if now := time.Now(); now.Sub(lastForegroundSample) >= foregroundSampleInterval {
+				lastForegroundSample = now
+				h.sampleSessionForeground(session)
+			}
 		}
 		if err != nil {
 			return
@@ -1976,6 +2108,7 @@ func (h *wsPTYHub) finishSession(session *wsPTYSession) {
 	session.closePTYFiles()
 
 	h.mu.Lock()
+	h.recordEndedSessionLocked(session)
 	if session.initialPhase == wsPTYSessionAwaitingInitialAttachment {
 		session.initialPhase = wsPTYSessionFinishedBeforeInitialAttachment
 		session.closed = true

--- a/daemon/remote/cmd/cmuxd-remote/ws_pty_foreground_darwin.go
+++ b/daemon/remote/cmd/cmuxd-remote/ws_pty_foreground_darwin.go
@@ -1,0 +1,26 @@
+//go:build darwin
+
+// The production remote daemon runs on Linux; this darwin implementation is a
+// degraded fallback for local development. It resolves only the command name
+// via ps and cannot report a working directory.
+
+package main
+
+import (
+	"os/exec"
+	"path"
+	"strconv"
+	"strings"
+)
+
+func foregroundProcessInfo(pgid int) (string, string, bool) {
+	output, err := exec.Command("/bin/ps", "-o", "comm=", "-p", strconv.Itoa(pgid)).Output()
+	if err != nil {
+		return "", "", false
+	}
+	command := strings.TrimSpace(string(output))
+	if command == "" {
+		return "", "", false
+	}
+	return path.Base(command), "", true
+}

--- a/daemon/remote/cmd/cmuxd-remote/ws_pty_foreground_linux.go
+++ b/daemon/remote/cmd/cmuxd-remote/ws_pty_foreground_linux.go
@@ -1,0 +1,31 @@
+//go:build linux
+
+// The production remote daemon runs on Linux, so this is the authoritative
+// foreground-process probe; the darwin sibling is a degraded fallback for
+// local development.
+
+package main
+
+import (
+	"os"
+	"strconv"
+	"strings"
+)
+
+// foregroundProcessInfo resolves the command name and working directory of a
+// foreground process group leader from /proc. /proc races (the process
+// exiting between reads) are tolerated silently, like ptySessionMemberPIDs:
+// an unreadable comm reports ok=false and an unreadable cwd stays empty.
+func foregroundProcessInfo(pgid int) (string, string, bool) {
+	pid := strconv.Itoa(pgid)
+	comm, err := os.ReadFile("/proc/" + pid + "/comm")
+	if err != nil {
+		return "", "", false
+	}
+	command := strings.TrimRight(string(comm), "\n")
+	cwd, err := os.Readlink("/proc/" + pid + "/cwd")
+	if err != nil {
+		cwd = ""
+	}
+	return command, cwd, true
+}

--- a/daemon/remote/cmd/cmuxd-remote/ws_pty_test.go
+++ b/daemon/remote/cmd/cmuxd-remote/ws_pty_test.go
@@ -3252,3 +3252,270 @@ func (h *wsPTYHub) sessionPTYSize(sessionID string) (cols int, rows int, ok bool
 	}
 	return int(size.Cols), int(size.Rows), true, nil
 }
+
+func TestSampleSessionForegroundRecordsLastKnownAgent(t *testing.T) {
+	ptyFile, err := os.Open(os.DevNull)
+	if err != nil {
+		t.Fatalf("open PTY stand-in: %v", err)
+	}
+	t.Cleanup(func() { _ = ptyFile.Close() })
+
+	hub := newWebSocketPTYHub(wsPTYServerConfig{}, io.Discard)
+	t.Cleanup(hub.closeAll)
+	session := &wsPTYSession{
+		id:          "fg-sample",
+		key:         persistentPTYSessionKey("fg-sample"),
+		ptyFile:     ptyFile,
+		attachments: map[string]*wsPTYAttachment{},
+		done:        make(chan struct{}),
+	}
+	hub.sessions[session.key] = session
+
+	hub.sampleSessionForegroundWithLookups(
+		session,
+		func(*os.File) int { return 42 },
+		func(pgid int) (string, string, bool) {
+			if pgid != 42 {
+				t.Fatalf("info lookup pgid = %d, want 42", pgid)
+			}
+			return "claude", "/work/agent", true
+		},
+	)
+	if session.foregroundCommand != "claude" || session.foregroundCwd != "/work/agent" {
+		t.Fatalf(
+			"sampled foreground = %q %q, want claude /work/agent",
+			session.foregroundCommand, session.foregroundCwd,
+		)
+	}
+
+	hub.sampleSessionForegroundWithLookups(
+		session,
+		func(*os.File) int { return 0 },
+		func(int) (string, string, bool) {
+			t.Fatal("info lookup ran for a missing foreground group")
+			return "", "", false
+		},
+	)
+	if session.foregroundCommand != "claude" || session.foregroundCwd != "/work/agent" {
+		t.Fatalf(
+			"missing foreground group cleared the last known agent: %q %q",
+			session.foregroundCommand, session.foregroundCwd,
+		)
+	}
+
+	hub.mu.Lock()
+	delete(hub.sessions, session.key)
+	hub.mu.Unlock()
+	hub.sampleSessionForegroundWithLookups(
+		session,
+		func(*os.File) int { return 42 },
+		func(int) (string, string, bool) { return "vim", "/tmp", true },
+	)
+	if session.foregroundCommand != "claude" || session.foregroundCwd != "/work/agent" {
+		t.Fatalf(
+			"sample wrote to a session no longer registered in the hub: %q %q",
+			session.foregroundCommand, session.foregroundCwd,
+		)
+	}
+}
+
+func TestFinishSessionRecordsEndedForegroundTombstone(t *testing.T) {
+	hub := newWebSocketPTYHub(wsPTYServerConfig{}, io.Discard)
+	t.Cleanup(hub.closeAll)
+
+	finish := func(id string, key wsPTYSessionKey, command string, cwd string) {
+		t.Helper()
+		master, slave, err := os.Pipe()
+		if err != nil {
+			t.Fatalf("open fake PTY pipe: %v", err)
+		}
+		_ = slave.Close()
+		session := &wsPTYSession{
+			id:                id,
+			key:               key,
+			ptyFile:           master,
+			attachments:       map[string]*wsPTYAttachment{},
+			done:              make(chan struct{}),
+			foregroundCommand: command,
+			foregroundCwd:     cwd,
+		}
+		hub.mu.Lock()
+		hub.sessions[key] = session
+		hub.mu.Unlock()
+
+		go hub.pumpSession(session)
+		select {
+		case <-session.done:
+		case <-time.After(5 * time.Second):
+			t.Fatalf("session %q did not finish after PTY EOF", id)
+		}
+	}
+
+	finish("ended-agent", persistentPTYSessionKey("ended-agent"), "claude", "/work/agent")
+	finish("ended-idle", persistentPTYSessionKey("ended-idle"), "", "")
+	finish("ended-anon", anonymousPTYSessionKey("ended-anon", 1), "claude", "/work/agent")
+
+	hub.mu.Lock()
+	defer hub.mu.Unlock()
+	entry, ok := hub.endedSessions["ended-agent"]
+	if !ok {
+		t.Fatal("persistent session with a sampled foreground left no tombstone")
+	}
+	if entry.foregroundCommand != "claude" || entry.foregroundCwd != "/work/agent" {
+		t.Fatalf("tombstone = %+v, want claude /work/agent", entry)
+	}
+	if entry.endedAt.Unix() <= 0 {
+		t.Fatalf("tombstone ended_at = %v, want a positive unix time", entry.endedAt)
+	}
+	if _, exists := hub.endedSessions["ended-idle"]; exists {
+		t.Fatal("session without a sampled foreground left a tombstone")
+	}
+	if _, exists := hub.endedSessions["ended-anon"]; exists {
+		t.Fatal("anonymous session left a tombstone")
+	}
+	if len(hub.endedSessionOrder) != 1 || hub.endedSessionOrder[0] != "ended-agent" {
+		t.Fatalf("ended session order = %v, want exactly the persistent agent", hub.endedSessionOrder)
+	}
+}
+
+func TestEndedSessionTombstonesEvictOldest(t *testing.T) {
+	hub := newWebSocketPTYHub(wsPTYServerConfig{}, io.Discard)
+	t.Cleanup(hub.closeAll)
+
+	const recorded = maxEndedPTYSessionTombstones + 6
+	hub.mu.Lock()
+	for i := 0; i < recorded; i++ {
+		id := "ended-" + strconv.Itoa(i)
+		hub.recordEndedSessionLocked(&wsPTYSession{
+			id:                id,
+			key:               persistentPTYSessionKey(id),
+			foregroundCommand: "agent-" + strconv.Itoa(i),
+		})
+	}
+	defer hub.mu.Unlock()
+
+	if len(hub.endedSessions) != maxEndedPTYSessionTombstones ||
+		len(hub.endedSessionOrder) != maxEndedPTYSessionTombstones {
+		t.Fatalf(
+			"tombstones = %d entries / %d order, want %d",
+			len(hub.endedSessions), len(hub.endedSessionOrder), maxEndedPTYSessionTombstones,
+		)
+	}
+	for i := 0; i < recorded-maxEndedPTYSessionTombstones; i++ {
+		if _, exists := hub.endedSessions["ended-"+strconv.Itoa(i)]; exists {
+			t.Fatalf("oldest tombstone ended-%d survived eviction", i)
+		}
+	}
+	if hub.endedSessionOrder[0] != "ended-"+strconv.Itoa(recorded-maxEndedPTYSessionTombstones) {
+		t.Fatalf("eviction did not keep FIFO order: %v", hub.endedSessionOrder[0])
+	}
+	newest := "ended-" + strconv.Itoa(recorded-1)
+	if entry := hub.endedSessions[newest]; entry.foregroundCommand != "agent-"+strconv.Itoa(recorded-1) {
+		t.Fatalf("newest tombstone = %+v, want agent-%d", entry, recorded-1)
+	}
+}
+
+func TestSessionRestartClearsEndedTombstone(t *testing.T) {
+	hub := newWebSocketPTYHub(wsPTYServerConfig{Shell: "/bin/sh"}, io.Discard)
+	t.Cleanup(hub.closeAll)
+
+	hub.mu.Lock()
+	hub.endedSessions["restarted"] = wsPTYEndedSession{
+		foregroundCommand: "claude",
+		foregroundCwd:     "/work/agent",
+		endedAt:           time.Now(),
+	}
+	hub.endedSessionOrder = append(hub.endedSessionOrder, "restarted")
+	hub.mu.Unlock()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+	if _, _, _, err := hub.prepareAttachment(
+		ctx, nil, "restarted", "a1", 80, 24, true, "", "tok-restart", false, false,
+	); err != nil {
+		t.Fatalf("start restarted session: %v", err)
+	}
+
+	hub.mu.Lock()
+	_, exists := hub.endedSessions["restarted"]
+	orderLen := len(hub.endedSessionOrder)
+	hub.mu.Unlock()
+	if exists || orderLen != 0 {
+		t.Fatal("starting a new generation did not clear the ended-session tombstone")
+	}
+}
+
+func TestPTYListIncludesForegroundAndEndedSessions(t *testing.T) {
+	hub := newWebSocketPTYHub(wsPTYServerConfig{}, io.Discard)
+	t.Cleanup(hub.closeAll)
+	server := &rpcServer{ptyHub: hub}
+
+	master, slave, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("open fake PTY pipe: %v", err)
+	}
+	_ = slave.Close()
+	session := &wsPTYSession{
+		id:                "list-agent",
+		key:               persistentPTYSessionKey("list-agent"),
+		ptyFile:           master,
+		attachments:       map[string]*wsPTYAttachment{},
+		done:              make(chan struct{}),
+		foregroundCommand: "claude",
+		foregroundCwd:     "/work/agent",
+	}
+	hub.sessions[session.key] = session
+
+	liveResp := server.handlePTYList(rpcRequest{ID: 1, Method: "pty.list"})
+	if !liveResp.OK {
+		t.Fatalf("pty.list failed: %+v", liveResp)
+	}
+	liveResult, _ := liveResp.Result.(map[string]any)
+	liveSessions, _ := liveResult["sessions"].([]map[string]any)
+	if len(liveSessions) != 1 {
+		t.Fatalf("pty.list sessions = %v, want one", liveResult["sessions"])
+	}
+	if liveSessions[0]["foreground_command"] != "claude" || liveSessions[0]["foreground_cwd"] != "/work/agent" {
+		t.Fatalf("live snapshot foreground = %v, want claude /work/agent", liveSessions[0])
+	}
+	if ended, ok := liveResult["ended_sessions"].([]map[string]any); !ok || len(ended) != 0 {
+		t.Fatalf("pty.list ended_sessions before close = %v, want an empty array", liveResult["ended_sessions"])
+	}
+
+	go hub.pumpSession(session)
+	select {
+	case <-session.done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("session did not finish after PTY EOF")
+	}
+
+	endedResp := server.handlePTYList(rpcRequest{ID: 2, Method: "pty.list"})
+	if !endedResp.OK {
+		t.Fatalf("pty.list after finish failed: %+v", endedResp)
+	}
+	endedResult, _ := endedResp.Result.(map[string]any)
+	endedSessions, ok := endedResult["ended_sessions"].([]map[string]any)
+	if !ok || len(endedSessions) != 1 {
+		t.Fatalf("pty.list ended_sessions after finish = %v, want one", endedResult["ended_sessions"])
+	}
+	entry := endedSessions[0]
+	if entry["session_id"] != "list-agent" ||
+		entry["foreground_command"] != "claude" ||
+		entry["foreground_cwd"] != "/work/agent" {
+		t.Fatalf("ended session snapshot = %v, want list-agent claude /work/agent", entry)
+	}
+	if endedAt, _ := entry["ended_at"].(int64); endedAt <= 0 {
+		t.Fatalf("ended session ended_at = %v, want a positive unix time", entry["ended_at"])
+	}
+
+	nilHubServer := &rpcServer{}
+	nilResp := nilHubServer.handlePTYList(rpcRequest{ID: 3, Method: "pty.list"})
+	if !nilResp.OK {
+		t.Fatalf("nil-hub pty.list failed: %+v", nilResp)
+	}
+	nilResult, _ := nilResp.Result.(map[string]any)
+	nilEnded, ok := nilResult["ended_sessions"].([]map[string]any)
+	if !ok || nilEnded == nil || len(nilEnded) != 0 {
+		t.Fatalf("nil-hub ended_sessions = %v, want an empty non-nil array", nilResult["ended_sessions"])
+	}
+}


### PR DESCRIPTION
Implements the Tier-1 flavor proposed in [#7989's discussion](https://github.com/manaflow-ai/cmux/issues/7989#issuecomment-5263284712): synthesize a directory-scoped continue binding for remote agents that never published a hook binding, so a persistent-SSH restore can resume the agent after the remote PTY is genuinely gone — without requiring `cmux hooks setup` on every remote host.

## Problem

Local process discovery can't see agents on the SSH host, and hook-published bindings require per-host, per-agent installation — a real adoption cliff for multi-host users. Result: restore reattaches the PTY, but a genuinely-gone PTY leaves the agent unresumed (`resume_binding: null`).

## Approach

When the snapshot still records the agent kind + remote working directory (and `wasAgentRunning`), `RemoteAgentContinueSynthesizer` builds a binding from inline templates:

| kind | command |
|---|---|
| claude | `cd -- '<dir>' … && claude --continue \|\| claude` |
| codex | `cd -- '<dir>' … && codex resume --last \|\| codex` |
| all others | nothing (no trustworthy sessionless continue invocation) |

Design points, mapped to the issue's acceptance criteria:

- **Live PTY → attach-only, never a duplicate agent** (criterion 2): rides the existing `requireExisting` pipeline; the synthesized command is additionally hard-gated in `reattachPersistentRemotePTYPanels` to inject only once the PTY is confirmed ended. A directory-scoped continue has no session checkpoint the remote once-guard could reconcile against, so this gate is stricter than for hook bindings.
- **Gone PTY → command executes on the remote host, never locally** (criterion 3): binding carries `.persistentSSH(SurfaceResumeRemoteContext)` — the existing flavor, no new Codable case — and enters through the SSH persistent-session machinery via `remotePTYAttachStartupCommand`. No wrapper-resolver tokens (they resolve local Mac paths), mirroring `remoteStartupInput()`'s `repairPortableAgentExecutable: false` convention.
- **Trust model**: new source `remote-synthesized` shares the process-detected tier (bypasses the signed approval store) because the command is built exclusively from cmux's own inline templates with no caller-supplied arguments — an observation-grade artifact, not a proposal from an arbitrary process. The gate for every other source is unchanged (covered by a regression test).
- **Precedence**: agent-hook / cli / process-detected bindings always win; synthesis only fills the gap, and respects the auto-resume setting.

## Known limitations (documented in code + tests)

- Directory-scoped continue resumes the *most recent* session in that directory: a directory shared by same-kind agents can continue the wrong conversation. Hook bindings (Tier 2, this issue's original design) remain the precise path and always take precedence — the two tiers compose rather than compete.
- Persistent-SSH workspaces only; plain SSH panes have no reattach seam to hang the liveness gate on.
- Dock restore path has no remote-PTY seam today; left as follow-up rather than duplicating workspace machinery.

## Tests

`RemoteAgentContinueSynthesizerTests` (15 cases, Swift Testing): exact command form per kind, nil for the 16 uncovered kinds + custom (parameterized), cwd guards, single-quote splice injection safety, non-ASCII printf-octal quoting, `isRemoteSynthesized` predicate + mutual exclusion across all four sources (parameterized), trust-tier resolution with a `.pending` signing secret, cli-source demotion regression guard, reconcile pass-through, `remoteStartupInput()` verbatim replay, Codable round-trip with quote-bearing cwd.

## Caveats

- Developed on Linux against `main`; every call was verified against the callee's source, but **I could not compile or run the app locally**. Happy to iterate on anything the macOS build or the full restore matrix surfaces.
- `xcodeproj` wiring for the 2 new files is included (lint-pbxproj-test-wiring passes).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/10049"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789144407&installation_model_id=21920&pr_number=10049&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F10049&signature=42b7711328a3c19cf98f2632f56a421f8a5f981167bccaddbb2890b052b60be5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Resumes hookless remote agents in persistent-SSH workspaces after a lost session by synthesizing a directory-scoped continue command from daemon-sampled foreground “tombstones.” Previously, restore reattached the PTY but left the agent unresumed once the PTY had ended.

- Daemon: `cmuxd-remote` samples the PTY foreground process (Linux: TIOCGPGRP → `/proc/<pgid>/{comm,cwd}`; macOS dev: `ps` for command only), annotates live `pty.list` entries with `foreground_command`/`foreground_cwd`, and returns a bounded `ended_sessions` FIFO (64) for finished persistent sessions.
- App/CLI path: new RPC `workspace.remote.pty_session_lost_resume` (non–main-actor lane) waits for the daemon link, reads tombstones, applies policy, and returns a remote command or null. The CLI `ssh-pty-attach` wrapper calls it when it confirms session loss and injects the payload by replacing `--command-b64`; otherwise it degrades to the plain replacement shell.
- Synthesis: supports only `claude` and `codex`
  - `claude`: “claude --continue || claude”
  - `codex`: “codex resume --last || codex”
  The binding uses `.persistentSSH(SurfaceResumeRemoteContext)` and `.direct` mode, runs on the remote host, and is stored with source `remote-synthesized`.
- Precedence and liveness: an existing agent-hook/CLI/process-detected binding always wins. Inject a synthesized command only after the PTY is confirmed ended; a live PTY is attach-only. If an ended session has no injectable binding, the replacement attach keeps `--require-existing` so the wrapper owns tombstone-backed synthesis.
- Policy: honors the auto-resume setting and does not replay previously persisted synthesized bindings when auto-resume is off.
- Trust: `remote-synthesized` shares the process-detected tier and bypasses the signed approval store; other sources are unchanged.
- Limits and compatibility: directory-scoped continue may pick the wrong conversation when multiple same-kind agents share a cwd. Works in persistent-SSH workspaces only (plain SSH panes and Dock restore unchanged). Older daemons omit `ended_sessions`; the path degrades to a plain shell.

<sup>Written for commit 97647cde9fcfe01743d1fc6ffdaf0c94adfeacad. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/10049?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Remote terminal sessions can automatically resume supported Claude and Codex sessions after SSH or PTY loss.
  * Resume commands remain scoped to the correct working directory and persistent SSH session.
  * Recent ended-session details support reliable restoration.
  * Live sessions attach without injecting duplicate resume commands.

* **Bug Fixes**
  * Automatic resume settings are consistently honored.
  * Improved handling for ended sessions, unavailable directories, and unsupported agents.
  * Remote-synthesized resume bindings are trusted and restored consistently.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->