### PR TITLE
Add manual Sleep for agent panels (draft: not yet compiled)

### DIFF
--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -240913,6 +240913,40 @@
         }
       }
     },
+    "terminal.agentSleep.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sleeping"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "スリープ中"
+          }
+        }
+      }
+    },
+    "terminal.agentSleep.wake": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wake"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "復帰"
+          }
+        }
+      }
+    },
     "terminal.notification.action.show": {
       "extractionState": "manual",
       "localizations": {
@@ -241269,6 +241303,23 @@
           "stringUnit": {
             "state": "translated",
             "value": "重新連線窗格"
+          }
+        }
+      }
+    },
+    "terminalContextMenu.sleepAgent": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sleep"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "スリープ"
           }
         }
       }

--- a/Sources/AgentHibernation/AgentHibernationPanelState.swift
+++ b/Sources/AgentHibernation/AgentHibernationPanelState.swift
@@ -4,6 +4,25 @@ struct AgentHibernationPanelState {
     let agent: SessionRestorableAgentSnapshot
     let hibernatedAt: Date
     let lastActivityAt: Date
+    /// True when the user asked for this teardown (Sleep) rather than the
+    /// routine idle/limit planner or critical memory pressure. Manual sleep is
+    /// explicit-wake: the panel keeps showing the placeholder even once it
+    /// becomes visible, where an automatically hibernated panel auto-resumes on
+    /// visit. It is also excluded from the planner's live-terminal count so
+    /// parking work by hand does not change how the automatic policy behaves.
+    let isManual: Bool
+
+    init(
+        agent: SessionRestorableAgentSnapshot,
+        hibernatedAt: Date,
+        lastActivityAt: Date,
+        isManual: Bool = false
+    ) {
+        self.agent = agent
+        self.hibernatedAt = hibernatedAt
+        self.lastActivityAt = lastActivityAt
+        self.isManual = isManual
+    }
 
     var agentDisplayName: String {
         agent.agentDisplayName

--- a/Sources/App/AgentHibernationController+ManualSleep.swift
+++ b/Sources/App/AgentHibernationController+ManualSleep.swift
@@ -1,0 +1,55 @@
+import Foundation
+
+extension AppDelegate {
+    /// Finds a workspace by id across every window's tab manager, mirroring the
+    /// traversal `agentHibernationRecords(index:...)` uses.
+    func workspace(forId workspaceId: UUID) -> Workspace? {
+        for context in mainWindowContexts.values {
+            if let match = context.tabManager.tabs.first(where: { $0.id == workspaceId }) {
+                return match
+            }
+        }
+        return tabManager?.tabs.first { $0.id == workspaceId }
+    }
+}
+
+extension AgentHibernationController {
+    /// Whether Sleep should be offered for this panel. Resolves the owning
+    /// workspace so menu code holding only ids can ask without reaching for a
+    /// `Workspace` reference of its own.
+    func canSleepPanel(key: AgentHibernationPanelKey) -> Bool {
+        guard let workspace = AppDelegate.shared?.workspace(forId: key.workspaceId) else {
+            return false
+        }
+        return workspace.canSleepAgentPanel(panelId: key.panelId)
+    }
+
+    /// Puts the named panels to sleep on the user's behalf.
+    ///
+    /// This is the single shared action path behind every Sleep entrypoint, so
+    /// new surfaces (command palette, CLI, a bindable shortcut) attach here
+    /// rather than duplicating selection or teardown logic.
+    ///
+    /// The existing hibernation lifecycle remains the sole teardown owner. A
+    /// manual request only changes *selection* (the user picked the panels) and
+    /// *timing* (no idle settle window); transcript protection, process
+    /// revalidation, and scoped termination are unchanged. Panels whose
+    /// transcript cannot currently be protected are still skipped.
+    @discardableResult
+    func sleepPanels(keys: Set<AgentHibernationPanelKey>) -> Bool {
+        guard !keys.isEmpty else { return false }
+        Task { @MainActor [weak self] in
+            guard let self else { return }
+            let index = await RestorableAgentSessionIndex
+                .loadIncludingProcessDetectedSnapshots()
+            guard !Task.isCancelled else { return }
+            self.evaluate(
+                index: index,
+                settings: AgentHibernationSettings.values(),
+                now: .now,
+                trigger: .manual(keys)
+            )
+        }
+        return true
+    }
+}

--- a/Sources/App/AgentHibernationController+ProcessTermination.swift
+++ b/Sources/App/AgentHibernationController+ProcessTermination.swift
@@ -350,7 +350,8 @@ extension AgentHibernationController {
                 )
                 terminalPanel?.beginAgentHibernationTermination(
                     agent: agent,
-                    lastActivityAt: lastActivityAt
+                    lastActivityAt: lastActivityAt,
+                    isManual: request.trigger.isManual
                 )
             }
         )

--- a/Sources/App/AgentHibernationController.swift
+++ b/Sources/App/AgentHibernationController.swift
@@ -269,10 +269,10 @@ final class AgentHibernationController {
         now: TimeInterval,
         trigger: AgentHibernationReclaimTrigger
     ) -> ConfirmedTeardownRequest? {
-        guard record.lifecycle.allowsHibernation,
-              !record.hasUnconfirmedTerminalInput,
-              !record.isProtected,
-              (trigger == .systemMemoryPressure || !record.hasLiveProcess),
+        guard trigger.isManual || record.lifecycle.allowsHibernation,
+              trigger.isManual || !record.hasUnconfirmedTerminalInput,
+              trigger.isManual || !record.isProtected,
+              (trigger == .systemMemoryPressure || trigger.isManual || !record.hasLiveProcess),
               trigger != .systemMemoryPressure || record.hasPressureSafeProcessEvidence,
               record.terminalPanel.surface.hasLiveSurface,
               !record.terminalPanel.isAgentHibernated else {
@@ -281,6 +281,41 @@ final class AgentHibernationController {
             return nil
         }
         if teardownInFlightByPanel[record.key] != nil { confirmations.removeValue(forKey: record.key); return nil }
+
+        // Manual sleep skips the idle settle window. That window exists to
+        // catch an agent that only looks idle and is about to resume on its
+        // own; when the user asks for sleep, waiting ~60s before anything
+        // happens reads as a broken command. The transcript-protection marker
+        // below and the full teardown safety (process revalidation, transcript
+        // guard, safe commit) still apply.
+        if trigger.isManual {
+            guard let fingerprint = hibernationFingerprint(for: record) else { return nil }
+            if let marker = unableToProtectByPanel[record.key],
+               Self.unableToProtectMarkerStillApplies(
+                   marker,
+                   fingerprint: fingerprint,
+                   lastActivityAt: effectiveLastActivityAt,
+                   now: now
+               ) {
+                return nil
+            }
+            unableToProtectByPanel.removeValue(forKey: record.key)
+            confirmations.removeValue(forKey: record.key)
+            let requestID = UUID()
+            teardownInFlightByPanel[record.key] = InFlightTeardown(
+                requestID: requestID,
+                trigger: trigger
+            )
+            return ConfirmedTeardownRequest(
+                record: record,
+                confirmationFingerprint: fingerprint,
+                effectiveLastActivityAt: effectiveLastActivityAt,
+                requestID: requestID,
+                epoch: teardownValidationEpochByPanel[record.key] ?? 0,
+                generation: teardownValidationGeneration,
+                trigger: trigger
+            )
+        }
 
         if let confirmation = confirmations[record.key],
            confirmation.trigger == trigger {

--- a/Sources/App/AgentHibernationPlanner.swift
+++ b/Sources/App/AgentHibernationPlanner.swift
@@ -4,6 +4,15 @@ import Foundation
 enum AgentHibernationReclaimTrigger: Equatable, Sendable {
     case scheduled
     case systemMemoryPressure
+    /// User asked for these exact panels to sleep. Unlike the other triggers
+    /// this carries its own selection, so the planner does not choose victims:
+    /// it confirms the request is still safe to act on.
+    case manual(Set<AgentHibernationPanelKey>)
+
+    var isManual: Bool {
+        if case .manual = self { return true }
+        return false
+    }
 }
 
 enum AgentHibernationPlanner {
@@ -25,6 +34,19 @@ enum AgentHibernationPlanner {
                 liveRestorable.count,
                 TerminalSurfaceRuntimeTeardownCoordinator
                     .maximumIsolatedHibernationTeardownCount
+            )
+        case .manual(let requestedKeys):
+            // The user named these panels, so none of the routine gates apply:
+            // not the enabled flag, not `maxLiveTerminals`, not `idleSeconds`,
+            // and not `isProtected` (that means "currently visible", which is
+            // the common case when someone sleeps the pane in front of them).
+            // The transcript-protection marker is the one gate kept, because it
+            // signals cmux could not snapshot the agent transcript and tearing
+            // down anyway risks losing it.
+            return Set(
+                liveRestorable
+                    .filter { requestedKeys.contains($0.key) && !$0.isTemporarilyUnableToProtect }
+                    .map(\.key)
             )
         }
         guard excess > 0 else { return [] }

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -5141,6 +5141,32 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
         )
     }
 
+    // MARK: - Sleep
+
+    /// Only offer Sleep on panels the hibernation path can actually reclaim, so
+    /// the item never appears on a plain shell that has no agent to resume.
+    private func canSleepThisAgentPanel() -> Bool {
+        guard let terminalSurface else { return false }
+        return AgentHibernationController.shared.canSleepPanel(
+            key: AgentHibernationPanelKey(
+                workspaceId: terminalSurface.tabId,
+                panelId: terminalSurface.id
+            )
+        )
+    }
+
+    @IBAction func sleepAgentPanel(_ sender: Any?) {
+        guard let terminalSurface else { return }
+        AgentHibernationController.shared.sleepPanels(
+            keys: [
+                AgentHibernationPanelKey(
+                    workspaceId: terminalSurface.tabId,
+                    panelId: terminalSurface.id
+                )
+            ]
+        )
+    }
+
     // MARK: - Clipboard paste
 
     @IBAction func paste(_ sender: Any?) {
@@ -7348,6 +7374,22 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
             systemSymbolName: "rectangle.righthalf.inset.filled",
             accessibilityDescription: nil
         )
+        if canSleepThisAgentPanel() {
+            menu.addItem(.separator())
+            let sleepItem = menu.addItem(
+                withTitle: String(
+                    localized: "terminalContextMenu.sleepAgent",
+                    defaultValue: "Sleep"
+                ),
+                action: #selector(sleepAgentPanel(_:)),
+                keyEquivalent: ""
+            )
+            sleepItem.target = self
+            sleepItem.image = NSImage(
+                systemSymbolName: "moon.zzz",
+                accessibilityDescription: nil
+            )
+        }
         appendCurrentSurfaceContextMenuItems(to: menu)
         let resetTerminalItem = menu.addItem(
             withTitle: String(localized: "terminalContextMenu.resetTerminal", defaultValue: "Reset Terminal"),

--- a/Sources/Panels/AgentHibernationPlaceholderMode.swift
+++ b/Sources/Panels/AgentHibernationPlaceholderMode.swift
@@ -1,5 +1,9 @@
 enum AgentHibernationPlaceholderMode: Equatable {
     case hibernated
+    /// User-initiated sleep. Distinct from `hibernated` because it is shown
+    /// even while the panel is visible: manual sleep waits for an explicit
+    /// wake instead of resuming on visit.
+    case sleeping
     case recovering
     case failed
 }

--- a/Sources/Panels/TerminalPanel+AgentHibernation.swift
+++ b/Sources/Panels/TerminalPanel+AgentHibernation.swift
@@ -21,6 +21,13 @@ extension TerminalPanel {
         agentHibernationPhase.state
     }
 
+    /// True while this panel is asleep because the user asked for it. Drives
+    /// explicit-wake rendering and keeps the panel out of the automatic
+    /// planner's live-terminal accounting.
+    var isManuallySlept: Bool {
+        agentHibernationPhase.state?.isManual ?? false
+    }
+
     @discardableResult
     func enterAgentHibernation(
         agent: SessionRestorableAgentSnapshot,
@@ -47,14 +54,16 @@ extension TerminalPanel {
     func beginAgentHibernationTermination(
         agent: SessionRestorableAgentSnapshot,
         lastActivityAt: Date,
-        committedAt: Date = .now
+        committedAt: Date = .now,
+        isManual: Bool = false
     ) -> Bool {
         guard case .live = agentHibernationPhase else { return false }
         onRequestAgentHibernationTerminationRetry = nil
         let state = AgentHibernationPanelState(
             agent: agent,
             hibernatedAt: committedAt,
-            lastActivityAt: lastActivityAt
+            lastActivityAt: lastActivityAt,
+            isManual: isManual
         )
         guard suspendRuntimeForAgentHibernation(
             reason: "agentHibernation.terminating"

--- a/Sources/Panels/TerminalPanelView.swift
+++ b/Sources/Panels/TerminalPanelView.swift
@@ -67,7 +67,18 @@ struct TerminalPanelView: View {
 
     @ViewBuilder
     private func hibernationBody(_ hibernationState: AgentHibernationPanelState) -> some View {
-        if isVisibleInUI {
+        if hibernationState.isManual {
+            // Explicit-wake: the user asked for this sleep, so becoming visible
+            // must not resume it. Waking goes through the same action as the
+            // context menu.
+            AgentHibernationPlaceholderView(
+                state: hibernationState,
+                appearance: appearance,
+                mode: AgentHibernationPlaceholderMode.sleeping,
+                onAction: onResumeAgentHibernation
+            )
+            .id("slept-\(panel.id.uuidString)")
+        } else if isVisibleInUI {
             Color(nsColor: appearance.contentBackgroundColor)
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
                 .id("hibernated-resuming-\(panel.id.uuidString)")
@@ -263,6 +274,11 @@ private struct AgentHibernationPlaceholderView: View {
                 localized: "terminal.agentHibernation.title",
                 defaultValue: "Agent hibernated"
             )
+        case .sleeping:
+            String(
+                localized: "terminal.agentSleep.title",
+                defaultValue: "Sleeping"
+            )
         case .recovering:
             String(
                 localized: "terminal.agentHibernation.finishing",
@@ -280,6 +296,8 @@ private struct AgentHibernationPlaceholderView: View {
         switch mode {
         case .hibernated:
             String(localized: "terminal.agentHibernation.resume", defaultValue: "Resume")
+        case .sleeping:
+            String(localized: "terminal.agentSleep.wake", defaultValue: "Wake")
         case .recovering:
             nil
         case .failed:
@@ -305,6 +323,9 @@ private struct AgentHibernationPlaceholderView: View {
                     .accessibilityIdentifier("AgentHibernationTerminationRecoveryProgress")
             case .hibernated:
                 CmuxSystemSymbolImage(magnified: "pause.circle", pointSize: 34, weight: .regular)
+                    .foregroundStyle(.secondary)
+            case .sleeping:
+                CmuxSystemSymbolImage(magnified: "moon.zzz", pointSize: 34, weight: .regular)
                     .foregroundStyle(.secondary)
             case .failed:
                 CmuxSystemSymbolImage(

--- a/Sources/Workspace+AgentSleep.swift
+++ b/Sources/Workspace+AgentSleep.swift
@@ -1,0 +1,86 @@
+import Foundation
+
+/// User-initiated Sleep for agent panels.
+///
+/// Sleep is manual entry into the existing Agent Hibernation teardown: it frees
+/// the agent process now, regardless of the routine idle/limit policy, and the
+/// panel stays asleep until the user explicitly wakes it. Every entrypoint
+/// (panel context menu, sidebar workspace row) funnels through the methods here
+/// so selection, eligibility, and wake behavior have one implementation.
+extension Workspace {
+    /// Panels this workspace can put to sleep right now.
+    ///
+    /// A panel qualifies when it is a terminal with a tracked agent process and
+    /// is not already asleep. Plain shells are excluded: they have no resume
+    /// identity, so waking one could only mean a fresh shell with the scrollback
+    /// gone, which is not what a reversible-sounding "Sleep" should do.
+    func sleepableAgentPanelIds() -> [UUID] {
+        // Remote workspaces run their agents on the far side of the transport,
+        // where this teardown path has no process to reclaim.
+        guard !isRemoteWorkspace else { return [] }
+        return panels.keys
+            .filter { canSleepAgentPanel(panelId: $0) }
+            .sorted { $0.uuidString < $1.uuidString }
+    }
+
+    func canSleepAgentPanel(panelId: UUID) -> Bool {
+        guard !isRemoteWorkspace,
+              let terminalPanel = panels[panelId] as? TerminalPanel,
+              !terminalPanel.isAgentHibernated,
+              !terminalPanel.isAgentHibernationCommitPending else {
+            return false
+        }
+        return !(agentPIDKeysByPanelId[panelId] ?? []).isEmpty
+    }
+
+    /// True when any of `panelIds` holds an agent that is mid-turn or waiting on
+    /// the user. Callers use this to confirm before sleeping, since tearing down
+    /// here interrupts work in progress rather than reclaiming an idle process.
+    func agentSleepNeedsConfirmation(panelIds: [UUID]) -> Bool {
+        panelIds.contains { panelId in
+            let lifecycle = agentHibernationLifecycleState(panelId: panelId, fallback: nil)
+            return lifecycle == .running || lifecycle == .needsInput
+        }
+    }
+
+    @discardableResult
+    func sleepAgentPanel(panelId: UUID) -> Bool {
+        guard canSleepAgentPanel(panelId: panelId) else { return false }
+        return AgentHibernationController.shared.sleepPanels(
+            keys: [AgentHibernationPanelKey(workspaceId: id, panelId: panelId)]
+        )
+    }
+
+    /// Sleeps every eligible agent panel in this workspace in one request, so
+    /// the controller tears them down as a single batch.
+    @discardableResult
+    func sleepWorkspaceAgents() -> Bool {
+        let panelIds = sleepableAgentPanelIds()
+        guard !panelIds.isEmpty else { return false }
+        let keys = Set(
+            panelIds.map { AgentHibernationPanelKey(workspaceId: id, panelId: $0) }
+        )
+        return AgentHibernationController.shared.sleepPanels(keys: keys)
+    }
+
+    /// Panels currently asleep by user request. Drives Wake menu visibility.
+    func manuallySleptPanelIds() -> [UUID] {
+        panels.keys
+            .filter { (panels[$0] as? TerminalPanel)?.isManuallySlept == true }
+            .sorted { $0.uuidString < $1.uuidString }
+    }
+
+    @discardableResult
+    func wakeAgentPanel(panelId: UUID, focus: Bool = true) -> Bool {
+        resumeAgentHibernation(panelId: panelId, focus: focus)
+    }
+
+    @discardableResult
+    func wakeWorkspaceAgents() -> Bool {
+        var didWake = false
+        for panelId in manuallySleptPanelIds() {
+            didWake = wakeAgentPanel(panelId: panelId, focus: false) || didWake
+        }
+        return didWake
+    }
+}

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -60,6 +60,7 @@
 		F65760100000000000000001 /* AgentHibernationController+Confirmation.swift in Sources */ = {isa = PBXBuildFile; fileRef = F65760100000000000000002 /* AgentHibernationController+Confirmation.swift */; };
 		8740B0018740B0018740B001 /* AgentHibernationController+EvaluationScheduling.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8740A0018740A0018740A001 /* AgentHibernationController+EvaluationScheduling.swift */; };
 		F65760110000000000000001 /* AgentHibernationController+InFlightTeardown.swift in Sources */ = {isa = PBXBuildFile; fileRef = F65760110000000000000002 /* AgentHibernationController+InFlightTeardown.swift */; };
+		A6AC73020000000000009003 /* AgentHibernationController+ManualSleep.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6AC73020000000000009004 /* AgentHibernationController+ManualSleep.swift */; };
 		8997C0018997C0018997C001 /* AgentHibernationController+MemoryPressure.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8997D0018997D0018997D001 /* AgentHibernationController+MemoryPressure.swift */; };
 		8997C0068997C0068997C006 /* AgentHibernationController+PanelLifecycle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8997D0068997D0068997D006 /* AgentHibernationController+PanelLifecycle.swift */; };
 		F65760120000000000000001 /* AgentHibernationController+PostSnapshotValidationIndexTask.swift in Sources */ = {isa = PBXBuildFile; fileRef = F65760120000000000000002 /* AgentHibernationController+PostSnapshotValidationIndexTask.swift */; };
@@ -2487,6 +2488,7 @@ C0DE71B10000000000000001 /* AppDelegate+AgentChatNotifications.swift in Sources 
 		D7632B13A1B2C3D4E5F60718 /* WKWebView+CmuxPrintOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7632B14A1B2C3D4E5F60718 /* WKWebView+CmuxPrintOperation.swift */; };
 		C0DE43000000000000000007 /* Workspace+AgentChat.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE43000000000000000008 /* Workspace+AgentChat.swift */; };
 		A6AC73020000000000000001 /* Workspace+AgentLifecycle.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6AC73020000000000000002 /* Workspace+AgentLifecycle.swift */; };
+		A6AC73020000000000009001 /* Workspace+AgentSleep.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6AC73020000000000009002 /* Workspace+AgentSleep.swift */; };
 		8777E0018777E0018777E001 /* Workspace+AttentionFlashRouting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8777E0028777E0028777E002 /* Workspace+AttentionFlashRouting.swift */; };
 		CA52B0150000000000000000 /* Workspace+CanvasLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA52C0150000000000000000 /* Workspace+CanvasLayout.swift */; };
 		C54860020000000000000001 /* Workspace+CmuxNavigationDescriptor.swift in Sources */ = {isa = PBXBuildFile; fileRef = C54860020000000000000002 /* Workspace+CmuxNavigationDescriptor.swift */; };
@@ -2791,6 +2793,7 @@ C0DE71B10000000000000001 /* AppDelegate+AgentChatNotifications.swift in Sources 
 		F65760100000000000000002 /* AgentHibernationController+Confirmation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "App/AgentHibernationController+Confirmation.swift"; sourceTree = "<group>"; };
 		8740A0018740A0018740A001 /* AgentHibernationController+EvaluationScheduling.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "App/AgentHibernationController+EvaluationScheduling.swift"; sourceTree = "<group>"; };
 		F65760110000000000000002 /* AgentHibernationController+InFlightTeardown.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "App/AgentHibernationController+InFlightTeardown.swift"; sourceTree = "<group>"; };
+		A6AC73020000000000009004 /* AgentHibernationController+ManualSleep.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "App/AgentHibernationController+ManualSleep.swift"; sourceTree = "<group>"; };
 		8997D0018997D0018997D001 /* AgentHibernationController+MemoryPressure.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "App/AgentHibernationController+MemoryPressure.swift"; sourceTree = "<group>"; };
 		8997D0068997D0068997D006 /* AgentHibernationController+PanelLifecycle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "App/AgentHibernationController+PanelLifecycle.swift"; sourceTree = "<group>"; };
 		F65760120000000000000002 /* AgentHibernationController+PostSnapshotValidationIndexTask.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "App/AgentHibernationController+PostSnapshotValidationIndexTask.swift"; sourceTree = "<group>"; };
@@ -5121,6 +5124,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 		D7632B14A1B2C3D4E5F60718 /* WKWebView+CmuxPrintOperation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Panels/WKWebView+CmuxPrintOperation.swift"; sourceTree = "<group>"; };
 		C0DE43000000000000000008 /* Workspace+AgentChat.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Workspace+AgentChat.swift"; sourceTree = "<group>"; };
 		A6AC73020000000000000002 /* Workspace+AgentLifecycle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Workspace+AgentLifecycle.swift"; sourceTree = "<group>"; };
+		A6AC73020000000000009002 /* Workspace+AgentSleep.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Workspace+AgentSleep.swift"; sourceTree = "<group>"; };
 		8777E0028777E0028777E002 /* Workspace+AttentionFlashRouting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Workspace+AttentionFlashRouting.swift"; sourceTree = "<group>"; };
 		CA52C0150000000000000000 /* Workspace+CanvasLayout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Workspace+CanvasLayout.swift"; sourceTree = "<group>"; };
 		C54860020000000000000002 /* Workspace+CmuxNavigationDescriptor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Workspace+CmuxNavigationDescriptor.swift"; sourceTree = "<group>"; };
@@ -5849,6 +5853,8 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				8740A0018740A0018740A001 /* AgentHibernationController+EvaluationScheduling.swift */,
 				F65760150000000000000002 /* AgentHibernationController+UnableToProtectMarker.swift */,
 				8997D0018997D0018997D001 /* AgentHibernationController+MemoryPressure.swift */,
+				A6AC73020000000000009004 /* AgentHibernationController+ManualSleep.swift */,
+				A6AC73020000000000009002 /* Workspace+AgentSleep.swift */,
 				8997D0028997D0028997D002 /* AgentHibernationMemoryPressureResponder.swift */,
 				D36A00010000000000000002 /* AgentHibernationController.swift */,
 				F65760160000000000000002 /* AgentHibernationPlanner.swift */,
@@ -8612,6 +8618,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				F65760100000000000000001 /* AgentHibernationController+Confirmation.swift in Sources */,
 				8740B0018740B0018740B001 /* AgentHibernationController+EvaluationScheduling.swift in Sources */,
 				F65760110000000000000001 /* AgentHibernationController+InFlightTeardown.swift in Sources */,
+				A6AC73020000000000009003 /* AgentHibernationController+ManualSleep.swift in Sources */,
 				8997C0018997C0018997C001 /* AgentHibernationController+MemoryPressure.swift in Sources */,
 				8997C0068997C0068997C006 /* AgentHibernationController+PanelLifecycle.swift in Sources */,
 				F65760120000000000000001 /* AgentHibernationController+PostSnapshotValidationIndexTask.swift in Sources */,
@@ -10150,6 +10157,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				D7632B13A1B2C3D4E5F60718 /* WKWebView+CmuxPrintOperation.swift in Sources */,
 				C0DE43000000000000000007 /* Workspace+AgentChat.swift in Sources */,
 				A6AC73020000000000000001 /* Workspace+AgentLifecycle.swift in Sources */,
+				A6AC73020000000000009001 /* Workspace+AgentSleep.swift in Sources */,
 				8777E0018777E0018777E001 /* Workspace+AttentionFlashRouting.swift in Sources */,
 				CA52B0150000000000000000 /* Workspace+CanvasLayout.swift in Sources */,
 				C54860020000000000000001 /* Workspace+CmuxNavigationDescriptor.swift in Sources */,


### PR DESCRIPTION
Closes #9873.

> [!WARNING]
> **This has not been compiled.** I do not have Xcode on the machine I wrote this on, only Command Line Tools, so `xcodebuild` could not run. What I did verify: `swiftc -parse` on every changed Swift file, `Localizable.xcstrings` still parses and gained exactly the three new keys, and `scripts/check-pbxproj.sh` passes after `normalize-pbxproj.py`. That is syntax and wiring only - **zero type checking, no tests run, no dogfood.** Opening as a draft for design feedback rather than as a merge candidate. Expect type errors. Happy to close if you would rather this arrive already-built.

## Why

Agent Hibernation is entirely policy-driven: it fires only when over `maxLiveTerminals`, only on background panels, only after an idle plus confirmation window, and it auto-resumes the moment the pane becomes visible. There is no way to say "this one, now, and stay asleep."

Concretely it misses:

- Being done with a workspace for the afternoon while under the live-terminal limit, so nothing hibernates and its RAM/CPU keeps being paid.
- Routine hibernation being opt-in and off by default, so most users get no reclamation without enabling a global policy they may not want.
- Wanting to *look at* a parked agent's pane without waking it. Today visiting the tab resumes it immediately.

This adds a user-driven entry into the machinery that already ships, rather than new teardown machinery.

## What changed

**A `.manual(keys)` reclaim trigger** (`AgentHibernationPlanner.swift`). It carries its own selection, so the planner confirms a request instead of choosing victims. It bypasses the gates that do not apply to an explicit request: the `enabled` flag, `maxLiveTerminals`, `idleSeconds`, and `isProtected` - that last one means "currently visible," which is the common case when you sleep the pane in front of you.

**No idle settle window for manual requests** (`AgentHibernationController.evaluateConfirmation`). That window exists to catch an agent that only looks idle and is about to resume on its own; waiting ~60s after an explicit command reads as a broken menu item. Everything downstream is untouched - transcript protection, process revalidation, scoped termination, safe commit - and a panel whose transcript cannot currently be protected is still skipped.

**`AgentHibernationPanelState.isManual`** drives explicit-wake rendering. A manually slept panel keeps showing the placeholder when it becomes visible instead of auto-resuming (`TerminalPanelView.hibernationBody`), and wakes through the placeholder's own button - the same action the automatic path already uses.

**Entry point**: the terminal right-click menu, offered only when the panel has a tracked agent. There is deliberately no Wake item in that menu: a slept panel renders the placeholder rather than the terminal, so the terminal menu is not reachable while asleep and Wake belongs on the placeholder.

Per the shared-behavior policy, selection and eligibility live in one path (`Workspace+AgentSleep.swift`, `AgentHibernationController.sleepPanels`) so a command palette entry, a CLI verb, or a bindable shortcut can attach there instead of duplicating logic.

## Scope

Agent panels only. Plain shells stay live: they have no resume identity, so waking one could only mean a fresh shell with the scrollback gone, which is not what a reversible-sounding "Sleep" should do. Remote (ssh-tmux) workspaces are excluded - their processes live server-side, where this teardown path has nothing to reclaim.

## Deliberately not in this PR

- **Tests.** The repo requires behavior-level coverage and I agree it needs it - `AgentHibernationPlanner.selectedPanelKeys` under `.manual` and the explicit-wake branch are the two obvious targets. I left them out rather than commit tests I cannot execute. Tell me the shape you want and I will add them.
- **Confirmation when the agent is mid-turn.** `AgentHibernationLifecycleState` already tracks `running`/`needsInput`, and `Workspace.agentSleepNeedsConfirmation(panelIds:)` is in this diff unused, ready to gate a dialog. Teardown safety does not depend on it.
- **Sidebar workspace-row Sleep**, command palette, CLI, and a bindable shortcut. `sleepWorkspaceAgents()` / `wakeWorkspaceAgents()` exist for the workspace-level case; only the panel menu is wired.
- **Persisting `isManual` across relaunch.** A slept panel restores as an ordinary hibernated one today, so it would auto-resume on visit after a restart. `SessionAgentHibernationSnapshot` is where the flag would go.

## Relationship to existing issues

This is the smaller, complementary half of two open requests, not a third copy:

- #4927 (park a workspace) wants the deep version - terminate everything including PTYs, surfaces and watchers, serialize the workspace, restore weeks later. That needs new persistence and restore surface area; this needs none. Its snapshot could reuse `SessionWorkspaceSnapshot` and its restore the closed-item path in `AppDelegate+ClosedItemHistory.swift`.
- #4261 (snooze/hide a workspace) wants the sidebar-organization side, which is where slept and parked workspaces would naturally be listed.

If you would rather this land as a scoped first step inside #4927, say so and I will refile it that way.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/10053"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789156328&installation_model_id=21920&pr_number=10053&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F10053&signature=4b4639e1d25a222b1960472b1bc2985e854efb66be7a9c5a679ea69b54404d62"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a manual Sleep action for agent panels so users can hibernate a specific panel immediately and keep it asleep until explicitly woken. Previously hibernation was policy-driven and auto-resumed on visibility; now manual sleeps bypass routine gates and require an explicit Wake.

- Adds `.manual(keys)` trigger in the planner. It bypasses the enabled flag, `maxLiveTerminals`, `idleSeconds`, and `isProtected`. It still skips panels whose transcripts cannot be protected.
- Manual requests skip the idle-settle window. Teardown safety (process revalidation, transcript guard, scoped termination, safe commit) is unchanged.
- Introduces `AgentHibernationPanelState.isManual`. Manually slept panels render a persistent placeholder with “Wake” and do not auto-resume when visible. They are excluded from live-terminal accounting.
- UI: a “Sleep” item appears in the terminal context menu only when a tracked agent is present. Wake is via the placeholder button. New localized strings are added.
- Shared entry points: `Workspace+AgentSleep` and `AgentHibernationController.sleepPanels` centralize selection and eligibility for future command palette/CLI/shortcut hooks.
- Scope/eligibility: agent panels only. Plain shells and remote workspaces are excluded.
- Draft status: not compiled or type-checked; no tests included.

<sup>Written for commit dbb5e7d9b376711b4465230b99fec7793328aca4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/10053?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

