### PR TITLE
Hide notification rows for deleted workspaces

### DIFF
--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+NotificationFeed.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+NotificationFeed.swift
@@ -95,26 +95,30 @@ extension MobileShellComposite {
     }
 
     /// Builds a computer-picker-scoped feed from the retained source snapshots
-    /// before applying the global row cap. Filtering the already-capped global
-    /// feed can hide an entire Mac when another Mac owns the newest retained
-    /// rows.
+    /// before applying the global row cap. Rows whose current navigation target
+    /// is absent from the live workspace snapshot stay retained but are not
+    /// presented. Filtering the already-capped global feed can hide valid older
+    /// rows when newer retained rows are no longer navigable.
     public func notificationFeedItems(
         scopedTo macDeviceIDs: Set<String>?
     ) -> [MobileNotificationFeedItem] {
-        guard let macDeviceIDs, !macDeviceIDs.isEmpty else {
-            return notificationFeedItems
-        }
         // Scope entries are bare device ids or pairing ids. Matching happens
         // per ITEM (each carries its stamped tag) so a build-scoped selection
         // excludes the sibling's rows even inside the foreground's
         // device-keyed snapshot.
-        let parsedScopeEntries =
-            MobileWorkspaceListFilter.parsedMachineEntries(macDeviceIDs)
+        let parsedScopeEntries = macDeviceIDs.flatMap { ids in
+            ids.isEmpty ? nil : MobileWorkspaceListFilter.parsedMachineEntries(ids)
+        }
+        let targetIndex = NotificationFeedWorkspaceTargetIndex(workspaces: workspaces)
         let projected = notificationFeedSnapshotsByMac.compactMap {
             entry -> MobileNotificationFeedSourceSnapshot? in
             let ownerKey = entry.key
             let items = entry.value.items.filter { item in
-                parsedScopeEntries.contains {
+                guard targetIndex.workspaceID(for: item) != nil else {
+                    return false
+                }
+                guard let parsedScopeEntries else { return true }
+                return parsedScopeEntries.contains {
                     $0.matches(deviceID: item.macDeviceID, rowTag: item.macInstanceTag)
                 }
             }
@@ -253,24 +257,7 @@ extension MobileShellComposite {
                 instanceTag: item.macInstanceTag
             ) else { return }
         }
-        // Sibling builds share the device id and can reuse Mac-local
-        // workspace/surface ids: match by the item's exact pairing.
-        let capturedWorkspaceID = rowWorkspaceID(
-            forRemoteWorkspaceID: MobileWorkspacePreview.ID(rawValue: item.remoteWorkspaceID),
-            macDeviceID: item.macDeviceID,
-            instanceTag: item.macInstanceTag
-        )
-        let targetWorkspaceID: MobileWorkspacePreview.ID?
-        if item.retargetsToLiveSurfaceOwner, let surfaceID = item.remoteSurfaceID {
-            targetWorkspaceID = workspaceID(
-                forTerminalID: surfaceID,
-                macDeviceID: item.macDeviceID,
-                instanceTag: item.macInstanceTag
-            )
-        } else {
-            targetWorkspaceID = capturedWorkspaceID
-        }
-        guard let workspaceID = targetWorkspaceID else {
+        guard let workspaceID = notificationFeedTargetWorkspaceID(for: item) else {
             notificationFeedLog.error(
                 "open target unavailable mac=\(item.macDeviceID, privacy: .public) notification=\(item.notificationID, privacy: .public)"
             )
@@ -284,6 +271,16 @@ extension MobileShellComposite {
             selectTerminal(MobileTerminalPreview.ID(rawValue: surfaceID))
         }
         await markNotificationFeedItemRead(item)
+    }
+
+    /// Resolves the same live destination used by feed visibility and opening.
+    /// Sibling builds share Mac-local ids, so every lookup includes the item's
+    /// exact pairing identity.
+    private func notificationFeedTargetWorkspaceID(
+        for item: MobileNotificationFeedItem
+    ) -> MobileWorkspacePreview.ID? {
+        NotificationFeedWorkspaceTargetIndex(workspaces: workspaces)
+            .workspaceID(for: item)
     }
 
     /// Handles a revision-only feed invalidation from one specific Mac.

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/NotificationFeedWorkspaceLookupKey.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/NotificationFeedWorkspaceLookupKey.swift
@@ -1,0 +1,4 @@
+struct NotificationFeedWorkspaceLookupKey: Hashable, Sendable {
+    let macDeviceID: String
+    let targetID: String
+}

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/NotificationFeedWorkspaceTarget.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/NotificationFeedWorkspaceTarget.swift
@@ -1,0 +1,35 @@
+import CmuxMobileShellModel
+
+struct NotificationFeedWorkspaceTarget: Sendable {
+    private var rowIDs: Set<MobileWorkspacePreview.ID> = []
+    private var exactRowIDsByInstanceTag: [String: Set<MobileWorkspacePreview.ID>] = [:]
+    private var owners: Set<MacPairingKey> = []
+    private var ownerDevices: Set<String> = []
+
+    mutating func insert(
+        rowID: MobileWorkspacePreview.ID,
+        macDeviceID: String,
+        instanceTag: String?
+    ) {
+        rowIDs.insert(rowID)
+        if let instanceTag, !instanceTag.isEmpty {
+            exactRowIDsByInstanceTag[instanceTag, default: []].insert(rowID)
+        }
+        let owner = MacPairingKey(
+            macDeviceID: macDeviceID,
+            instanceTag: instanceTag
+        )
+        owners.insert(owner)
+        ownerDevices.insert(owner.canonicalMacDeviceID)
+    }
+
+    func rowID(instanceTag: String?) -> MobileWorkspacePreview.ID? {
+        if let instanceTag, !instanceTag.isEmpty {
+            guard let exactRowIDs = exactRowIDsByInstanceTag[instanceTag],
+                  exactRowIDs.count == 1 else { return nil }
+            return exactRowIDs.first
+        }
+        guard owners.count <= ownerDevices.count, rowIDs.count == 1 else { return nil }
+        return rowIDs.first
+    }
+}

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/NotificationFeedWorkspaceTargetIndex.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/NotificationFeedWorkspaceTargetIndex.swift
@@ -8,8 +8,8 @@ struct NotificationFeedWorkspaceTargetIndex: Sendable {
     }
 
     private struct Target: Sendable {
-        var firstRowID: MobileWorkspacePreview.ID?
-        var exactRowsByInstanceTag: [String: MobileWorkspacePreview.ID] = [:]
+        var rowIDs: Set<MobileWorkspacePreview.ID> = []
+        var exactRowIDsByInstanceTag: [String: Set<MobileWorkspacePreview.ID>] = [:]
         var owners: Set<MacPairingKey> = []
         var ownerDevices: Set<String> = []
 
@@ -18,12 +18,9 @@ struct NotificationFeedWorkspaceTargetIndex: Sendable {
             macDeviceID: String,
             instanceTag: String?
         ) {
-            if firstRowID == nil {
-                firstRowID = rowID
-            }
-            if let instanceTag, !instanceTag.isEmpty,
-               exactRowsByInstanceTag[instanceTag] == nil {
-                exactRowsByInstanceTag[instanceTag] = rowID
+            rowIDs.insert(rowID)
+            if let instanceTag, !instanceTag.isEmpty {
+                exactRowIDsByInstanceTag[instanceTag, default: []].insert(rowID)
             }
             let owner = MacPairingKey(
                 macDeviceID: macDeviceID,
@@ -35,10 +32,12 @@ struct NotificationFeedWorkspaceTargetIndex: Sendable {
 
         func rowID(instanceTag: String?) -> MobileWorkspacePreview.ID? {
             if let instanceTag, !instanceTag.isEmpty {
-                return exactRowsByInstanceTag[instanceTag]
+                guard let exactRowIDs = exactRowIDsByInstanceTag[instanceTag],
+                      exactRowIDs.count == 1 else { return nil }
+                return exactRowIDs.first
             }
-            guard owners.count <= ownerDevices.count else { return nil }
-            return firstRowID
+            guard owners.count <= ownerDevices.count, rowIDs.count == 1 else { return nil }
+            return rowIDs.first
         }
     }
 

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/NotificationFeedWorkspaceTargetIndex.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/NotificationFeedWorkspaceTargetIndex.swift
@@ -1,0 +1,92 @@
+import CmuxMobileShellModel
+
+/// Resolves notification destinations from one immutable workspace snapshot.
+struct NotificationFeedWorkspaceTargetIndex: Sendable {
+    private struct LookupKey: Hashable, Sendable {
+        let macDeviceID: String
+        let targetID: String
+    }
+
+    private struct Target: Sendable {
+        var firstRowID: MobileWorkspacePreview.ID?
+        var exactRowsByInstanceTag: [String: MobileWorkspacePreview.ID] = [:]
+        var owners: Set<MacPairingKey> = []
+        var ownerDevices: Set<String> = []
+
+        mutating func insert(
+            rowID: MobileWorkspacePreview.ID,
+            macDeviceID: String,
+            instanceTag: String?
+        ) {
+            if firstRowID == nil {
+                firstRowID = rowID
+            }
+            if let instanceTag, !instanceTag.isEmpty,
+               exactRowsByInstanceTag[instanceTag] == nil {
+                exactRowsByInstanceTag[instanceTag] = rowID
+            }
+            let owner = MacPairingKey(
+                macDeviceID: macDeviceID,
+                instanceTag: instanceTag
+            )
+            owners.insert(owner)
+            ownerDevices.insert(owner.canonicalMacDeviceID)
+        }
+
+        func rowID(instanceTag: String?) -> MobileWorkspacePreview.ID? {
+            if let instanceTag, !instanceTag.isEmpty {
+                return exactRowsByInstanceTag[instanceTag]
+            }
+            guard owners.count <= ownerDevices.count else { return nil }
+            return firstRowID
+        }
+    }
+
+    private var workspacesByRemoteID: [LookupKey: Target] = [:]
+    private var workspacesBySurfaceID: [LookupKey: Target] = [:]
+
+    init(workspaces: [MobileWorkspacePreview]) {
+        for workspace in workspaces {
+            guard let macDeviceID = workspace.macDeviceID, !macDeviceID.isEmpty else {
+                continue
+            }
+            let workspaceKey = LookupKey(
+                macDeviceID: macDeviceID,
+                targetID: workspace.rpcWorkspaceID.rawValue
+            )
+            workspacesByRemoteID[workspaceKey, default: Target()].insert(
+                rowID: workspace.id,
+                macDeviceID: macDeviceID,
+                instanceTag: workspace.macInstanceTag
+            )
+            for terminal in workspace.terminals {
+                let surfaceKey = LookupKey(
+                    macDeviceID: macDeviceID,
+                    targetID: terminal.id.rawValue
+                )
+                workspacesBySurfaceID[surfaceKey, default: Target()].insert(
+                    rowID: workspace.id,
+                    macDeviceID: macDeviceID,
+                    instanceTag: workspace.macInstanceTag
+                )
+            }
+        }
+    }
+
+    func workspaceID(
+        for item: MobileNotificationFeedItem
+    ) -> MobileWorkspacePreview.ID? {
+        let targetID: String
+        let targets: [LookupKey: Target]
+        if item.retargetsToLiveSurfaceOwner, let surfaceID = item.remoteSurfaceID {
+            targetID = surfaceID
+            targets = workspacesBySurfaceID
+        } else {
+            targetID = item.remoteWorkspaceID
+            targets = workspacesByRemoteID
+        }
+        return targets[
+            LookupKey(macDeviceID: item.macDeviceID, targetID: targetID)
+        ]?.rowID(instanceTag: item.macInstanceTag)
+    }
+}

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/NotificationFeedWorkspaceTargetIndex.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/NotificationFeedWorkspaceTargetIndex.swift
@@ -2,68 +2,29 @@ import CmuxMobileShellModel
 
 /// Resolves notification destinations from one immutable workspace snapshot.
 struct NotificationFeedWorkspaceTargetIndex: Sendable {
-    private struct LookupKey: Hashable, Sendable {
-        let macDeviceID: String
-        let targetID: String
-    }
-
-    private struct Target: Sendable {
-        var rowIDs: Set<MobileWorkspacePreview.ID> = []
-        var exactRowIDsByInstanceTag: [String: Set<MobileWorkspacePreview.ID>] = [:]
-        var owners: Set<MacPairingKey> = []
-        var ownerDevices: Set<String> = []
-
-        mutating func insert(
-            rowID: MobileWorkspacePreview.ID,
-            macDeviceID: String,
-            instanceTag: String?
-        ) {
-            rowIDs.insert(rowID)
-            if let instanceTag, !instanceTag.isEmpty {
-                exactRowIDsByInstanceTag[instanceTag, default: []].insert(rowID)
-            }
-            let owner = MacPairingKey(
-                macDeviceID: macDeviceID,
-                instanceTag: instanceTag
-            )
-            owners.insert(owner)
-            ownerDevices.insert(owner.canonicalMacDeviceID)
-        }
-
-        func rowID(instanceTag: String?) -> MobileWorkspacePreview.ID? {
-            if let instanceTag, !instanceTag.isEmpty {
-                guard let exactRowIDs = exactRowIDsByInstanceTag[instanceTag],
-                      exactRowIDs.count == 1 else { return nil }
-                return exactRowIDs.first
-            }
-            guard owners.count <= ownerDevices.count, rowIDs.count == 1 else { return nil }
-            return rowIDs.first
-        }
-    }
-
-    private var workspacesByRemoteID: [LookupKey: Target] = [:]
-    private var workspacesBySurfaceID: [LookupKey: Target] = [:]
+    private var workspacesByRemoteID: [NotificationFeedWorkspaceLookupKey: NotificationFeedWorkspaceTarget] = [:]
+    private var workspacesBySurfaceID: [NotificationFeedWorkspaceLookupKey: NotificationFeedWorkspaceTarget] = [:]
 
     init(workspaces: [MobileWorkspacePreview]) {
         for workspace in workspaces {
             guard let macDeviceID = workspace.macDeviceID, !macDeviceID.isEmpty else {
                 continue
             }
-            let workspaceKey = LookupKey(
+            let workspaceKey = NotificationFeedWorkspaceLookupKey(
                 macDeviceID: macDeviceID,
                 targetID: workspace.rpcWorkspaceID.rawValue
             )
-            workspacesByRemoteID[workspaceKey, default: Target()].insert(
+            workspacesByRemoteID[workspaceKey, default: NotificationFeedWorkspaceTarget()].insert(
                 rowID: workspace.id,
                 macDeviceID: macDeviceID,
                 instanceTag: workspace.macInstanceTag
             )
             for terminal in workspace.terminals {
-                let surfaceKey = LookupKey(
+                let surfaceKey = NotificationFeedWorkspaceLookupKey(
                     macDeviceID: macDeviceID,
                     targetID: terminal.id.rawValue
                 )
-                workspacesBySurfaceID[surfaceKey, default: Target()].insert(
+                workspacesBySurfaceID[surfaceKey, default: NotificationFeedWorkspaceTarget()].insert(
                     rowID: workspace.id,
                     macDeviceID: macDeviceID,
                     instanceTag: workspace.macInstanceTag
@@ -76,7 +37,7 @@ struct NotificationFeedWorkspaceTargetIndex: Sendable {
         for item: MobileNotificationFeedItem
     ) -> MobileWorkspacePreview.ID? {
         let targetID: String
-        let targets: [LookupKey: Target]
+        let targets: [NotificationFeedWorkspaceLookupKey: NotificationFeedWorkspaceTarget]
         if item.retargetsToLiveSurfaceOwner, let surfaceID = item.remoteSurfaceID {
             targetID = surfaceID
             targets = workspacesBySurfaceID
@@ -85,7 +46,7 @@ struct NotificationFeedWorkspaceTargetIndex: Sendable {
             targets = workspacesByRemoteID
         }
         return targets[
-            LookupKey(macDeviceID: item.macDeviceID, targetID: targetID)
+            NotificationFeedWorkspaceLookupKey(macDeviceID: item.macDeviceID, targetID: targetID)
         ]?.rowID(instanceTag: item.macInstanceTag)
     }
 }

--- a/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/MobileShellNotificationFeedStateTests.swift
+++ b/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/MobileShellNotificationFeedStateTests.swift
@@ -141,6 +141,37 @@ struct MobileShellNotificationFeedStateTests {
         #expect(scopedItems.allSatisfy { $0.macDeviceID == "mac-b" })
     }
 
+    @Test("Visible feed omits notifications whose workspace no longer exists")
+    func visibleFeedOmitsDeletedWorkspaceNotifications() throws {
+        var liveWorkspace = MobileWorkspacePreview(
+            id: "live-workspace-row",
+            macDeviceID: "mac",
+            name: "Live workspace",
+            terminals: []
+        )
+        liveWorkspace.remoteWorkspaceID = "live-workspace"
+        let store = MobileShellComposite(workspaces: [liveWorkspace])
+        let response = try MobileNotificationFeedListResponse.decode(Data(
+            """
+            {"revision":1,"notifications":[
+            {"id":"deleted","workspace_id":"deleted-workspace","title":"Deleted","body":"Orphaned","created_at":200,"is_read":false},
+            {"id":"live","workspace_id":"live-workspace","title":"Live","body":"Reachable","created_at":100,"is_read":false}
+            ]}
+            """.utf8
+        ))
+
+        #expect(store.applyNotificationFeedSnapshot(
+            response,
+            macDeviceID: "mac",
+            displayName: "Mac"
+        ))
+        #expect(store.notificationFeedItems.map(\.notificationID) == ["deleted", "live"])
+
+        let visibleItems = store.notificationFeedItems(scopedTo: nil)
+
+        #expect(visibleItems.map(\.notificationID) == ["live"])
+    }
+
     @Test("Mark All targets all selected Macs before applying the visible feed cap")
     func markAllTargetsSelectedMacsBeforeVisibleFeedCap() async throws {
         let store = MobileShellComposite()

--- a/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/MobileShellNotificationFeedStateTests.swift
+++ b/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/MobileShellNotificationFeedStateTests.swift
@@ -186,6 +186,36 @@ struct MobileShellNotificationFeedStateTests {
         #expect(visibleItems.map(\.notificationID) == ["live"])
     }
 
+    @Test("Visible feed fails closed when one pairing exposes duplicate target rows")
+    func visibleFeedOmitsAmbiguousDuplicateWorkspaceTargets() throws {
+        var firstWorkspace = MobileWorkspacePreview(
+            id: "first-row",
+            macDeviceID: "mac",
+            name: "First",
+            terminals: []
+        )
+        firstWorkspace.macInstanceTag = "norph"
+        firstWorkspace.remoteWorkspaceID = "workspace"
+        var secondWorkspace = MobileWorkspacePreview(
+            id: "second-row",
+            macDeviceID: "mac",
+            name: "Second",
+            terminals: []
+        )
+        secondWorkspace.macInstanceTag = "norph"
+        secondWorkspace.remoteWorkspaceID = "workspace"
+        let store = MobileShellComposite(workspaces: [firstWorkspace, secondWorkspace])
+
+        #expect(store.applyNotificationFeedSnapshot(
+            try response(revision: 1, id: "ambiguous", createdAt: 100),
+            macDeviceID: "mac\u{1F}norph",
+            displayName: "Mac"
+        ))
+
+        #expect(store.notificationFeedItems.map(\.notificationID) == ["ambiguous"])
+        #expect(store.notificationFeedItems(scopedTo: nil).isEmpty)
+    }
+
     @Test("Mark All targets all selected Macs before applying the visible feed cap")
     func markAllTargetsSelectedMacsBeforeVisibleFeedCap() async throws {
         let store = MobileShellComposite()

--- a/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/MobileShellNotificationFeedStateTests.swift
+++ b/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/MobileShellNotificationFeedStateTests.swift
@@ -105,7 +105,21 @@ struct MobileShellNotificationFeedStateTests {
 
     @Test("Computer-scoped feeds aggregate before the global feed cap")
     func computerScopedFeedsAggregateBeforeGlobalCap() throws {
-        let store = MobileShellComposite()
+        var macAWorkspace = MobileWorkspacePreview(
+            id: "mac-a-workspace-row",
+            macDeviceID: "mac-a",
+            name: "A",
+            terminals: []
+        )
+        macAWorkspace.remoteWorkspaceID = "workspace"
+        var macBWorkspace = MobileWorkspacePreview(
+            id: "mac-b-workspace-row",
+            macDeviceID: "mac-b",
+            name: "B",
+            terminals: []
+        )
+        macBWorkspace.remoteWorkspaceID = "workspace"
+        let store = MobileShellComposite(workspaces: [macAWorkspace, macBWorkspace])
         let cap = MobileNotificationFeedAggregation.maxItemCount
         let macAEntries = (0..<cap).map { offset in
             NotificationResponseEntry(

--- a/ios/cmuxUITests/cmuxUITests.swift
+++ b/ios/cmuxUITests/cmuxUITests.swift
@@ -3612,7 +3612,7 @@ final class cmuxUITests: XCTestCase {
         XCTAssertTrue(app.tabBars.buttons["Notifications"].exists)
         XCTAssertTrue(app.descendants(matching: .any)["MobileNotificationFeedDayToday"].exists)
         XCTAssertTrue(app.descendants(matching: .any)["MobileNotificationFeedDayYesterday"].exists)
-        XCTAssertTrue(app.staticTexts["Build Mac"].exists)
+        XCTAssertTrue(app.staticTexts["Build Mac"].waitForExistence(timeout: 3))
 
         let approvalTitle = app.staticTexts["Codex needs approval"]
         let approvalWorkspace = app.staticTexts["cmux iOS"]


### PR DESCRIPTION
Deleted workspaces can leave retained notification history behind. The iOS feed rendered those records as “Unknown workspace” even though opening them had no valid target.

This change indexes the current workspace and terminal snapshot once, filters visible feed rows through that live target index before applying the feed cap, and uses the same resolver when opening a row. Retained history stays intact, so a restored target can become visible again. This is principled because visibility follows navigability without deleting historical state.

Regression structure:
- eecfb3ab1e adds the failing behavioral test.
- 22f5768f86 adds the production fix.

Verified locally:
- swift test --package-path Packages/iOS/CmuxMobileShell --filter MobileShellNotificationFeedStateTests, 17 tests passed.
- No user-facing strings changed, so no localization catalog update is needed.

Residual risk: correctness depends on the workspace snapshot being current. Existing snapshot updates already drive the feed projection, and the resolver fails closed during transient gaps.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/10055"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789159686&installation_model_id=21920&pr_number=10055&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F10055&signature=7a0fbebc5a52b54e373928db6519d09e7affe1fc4b046c9cf0f25207aa66be8f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hide notification feed rows whose workspace or terminal is missing, and fail closed on ambiguous Mac‑local targets. Previously we showed “Unknown workspace” rows that could not open or could misnavigate; now we omit them from the visible feed while retaining history so items reappear if the target is restored.

- Build a live target index from the current `workspaces` snapshot to filter visible rows before the global cap and to resolve open targets through the same resolver. Retargeted-to-surface items map to the live surface owner; ambiguous duplicate matches are excluded.
- Validate targets before machine-scoped filtering; nil or empty scope shows all valid rows.
- Split target resolution into NotificationFeedWorkspaceTargetIndex, NotificationFeedWorkspaceTarget, and NotificationFeedWorkspaceLookupKey; add tests for orphaned and ambiguous rows and make the UI test wait for the feed preview projection.
- No API, persistence, or string changes. Visibility depends on snapshot freshness; the resolver fails closed during transient gaps.

<sup>Written for commit c95cd14de8a5ce35170fb51533507c9c1b606a59. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/10055?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Notification feeds now hide entries linked to workspaces that are no longer available.
  - Notifications open in the correct live workspace, including cases with shared workspace identifiers.
  - Empty or unspecified scopes now show all valid notification entries.
  - Ambiguous workspace matches are safely excluded to prevent notifications from opening in the wrong destination.
- **Tests**
  - Improved notification-feed UI test reliability by waiting for content to appear.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->