### PR TITLE
Make Tailscale setup banner dismissible

### DIFF
--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+ReconnectRoutes.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+ReconnectRoutes.swift
@@ -9,6 +9,17 @@ private let reconnectRouteLog = Logger(
     category: "MobileReconnectRoutes"
 )
 
+/// Readiness of the selected Tailscale connection method.
+///
+/// Keeping the load phase explicit prevents presentation code from treating a
+/// not-yet-loaded authorization as either confirmed or missing.
+public enum MobileTailscaleSetupStatus: Equatable, Sendable {
+    case notSelected
+    case loadingAuthorization
+    case pairingRequired
+    case authorized
+}
+
 /// Canonical identity for one locally authorized legacy Tailscale endpoint.
 private nonisolated struct MobileTailscaleAuthorizationEndpoint:
     Hashable, Sendable
@@ -178,11 +189,23 @@ extension MobileShellComposite {
         return hasStoredUsableTailscaleAuthorization
     }
 
+    /// Readiness of the selected Tailscale method and its local endpoint grant.
+    public var tailscaleSetupStatus: MobileTailscaleSetupStatus {
+        guard connectionMethodStore?.method == .tailscale else {
+            return .notSelected
+        }
+        if hasUsableTailscaleAuthorization {
+            return .authorized
+        }
+        if pairedMacLoadState == .notLoaded, hasKnownPairedMac {
+            return .loadingAuthorization
+        }
+        return .pairingRequired
+    }
+
     /// Whether the selected Tailscale method still needs its one-time pairing grant.
     public var tailscalePairingRequired: Bool {
-        connectionMethodStore?.method == .tailscale
-            && (pairedMacLoadState != .notLoaded || !hasKnownPairedMac)
-            && !hasUsableTailscaleAuthorization
+        tailscaleSetupStatus == .pairingRequired
     }
 
     /// The strict Tailscale policy for one paired Mac: only exact grant routes

--- a/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/ReconnectRouteSelectionTests.swift
+++ b/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/ReconnectRouteSelectionTests.swift
@@ -666,6 +666,7 @@ import Testing
 
         #expect(store.pairedMacLoadState == .notLoaded)
         #expect(!store.hasKnownPairedMac)
+        #expect(store.tailscaleSetupStatus == .pairingRequired)
         #expect(store.tailscalePairingRequired)
     }
 
@@ -689,8 +690,10 @@ import Testing
             pairingHintDefaults: pairingDefaults
         )
 
+        #expect(store.tailscaleSetupStatus == .loadingAuthorization)
         #expect(!store.tailscalePairingRequired)
         store.pairedMacLoadState = .failed
+        #expect(store.tailscaleSetupStatus == .pairingRequired)
         #expect(store.tailscalePairingRequired)
     }
 

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/CMUXMobileRootView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/CMUXMobileRootView.swift
@@ -444,13 +444,13 @@ struct CMUXMobileRootView: View {
                     hasKnownPairedMac: store.hasKnownPairedMac,
                     showAddDevice: addComputerAction,
                     showPairingScanner: pairingScannerAction,
+                    signOut: signOut,
+                    setupHelpHighlight: disconnectedSetupHelpHighlight,
+                    store: store,
                     isTailscalePairingBannerDismissed: isTailscalePairingBannerDismissed,
                     dismissTailscalePairingBanner: {
                         isTailscalePairingBannerDismissed = true
                     },
-                    signOut: signOut,
-                    setupHelpHighlight: disconnectedSetupHelpHighlight,
-                    store: store,
                     showSettings: showSettings,
                     setupHelpPresentation: childSheetPresentation(
                         for: .disconnectedSetupHelp

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/CMUXMobileRootView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/CMUXMobileRootView.swift
@@ -27,7 +27,7 @@ struct CMUXMobileRootView: View {
     /// Optional environment models do not reliably invalidate this root when a
     /// child sheet mutates them. Mirror the store's existing change stream so
     /// capability closures are rebuilt for the newly selected method.
-    @State private var observedConnectionMethod: MobileConnectionMethod?
+    @State private var connectionMethodObservationToken: MobileConnectionMethod?
     @Environment(\.dogfoodAttachPreparation) private var dogfoodAttachPreparation
     private let signOutHook: MobileSignOutHook
     private let startupConnectionCoordinator: MobileStartupConnectionCoordinator
@@ -46,10 +46,9 @@ struct CMUXMobileRootView: View {
     @State private var pendingAttachURL: String?
     @State private var didAuthenticateWithAttachTicket = false
     @State private var didExceedStartupRestoringGate = false
-    /// Session-only dismissal for the setup reminder. Pairing and Settings
-    /// remain available, and a fresh launch can remind the user again until the
-    /// required local authorization is complete.
-    @State private var isTailscalePairingBannerDismissed = false
+    /// One owner for the setup reminder's loading, required, and dismissed
+    /// presentation phases. Durable readiness remains in the shell store.
+    @State private var tailscaleSetupPrompt = MobileTailscaleSetupPromptState()
     #if os(macOS)
     @State private var isShowingAddDeviceSheet = false
     @State private var pairingPresentation: PairingPresentation = .manual
@@ -271,12 +270,15 @@ struct CMUXMobileRootView: View {
         }
         .task(id: connectionMethodStore.map(ObjectIdentifier.init)) {
             guard let connectionMethodStore else {
-                observedConnectionMethod = nil
+                connectionMethodObservationToken = nil
                 return
             }
             for await method in connectionMethodStore.changes() {
-                observedConnectionMethod = method
+                connectionMethodObservationToken = method
             }
+        }
+        .onChange(of: store.tailscaleSetupStatus, initial: true) { _, status in
+            tailscaleSetupPrompt.apply(.shellStatusChanged(status))
         }
         .onDisappear {
             cancelInjectedAttachTask(retryLaunchRoute: true)
@@ -400,7 +402,6 @@ struct CMUXMobileRootView: View {
         }
         .onChange(of: store.connectionState) { _, connectionState in
             if connectionState == .connected {
-                isTailscalePairingBannerDismissed = false
                 #if os(iOS)
                 handleRootPresentation(.dismissPairing)
                 #else
@@ -414,11 +415,6 @@ struct CMUXMobileRootView: View {
             #endif
         }
         #if os(iOS)
-        .onChange(of: store.tailscalePairingRequired) { _, isRequired in
-            if !isRequired {
-                isTailscalePairingBannerDismissed = false
-            }
-        }
         .onChange(of: authManager.currentUser?.id) { _, _ in
             // Account identity can in principle change without an
             // isAuthenticated or team edge; re-key the keep-alive so a stale
@@ -489,7 +485,7 @@ struct CMUXMobileRootView: View {
                     signOut: signOut,
                     setupHelpHighlight: disconnectedSetupHelpHighlight,
                     store: store,
-                    isTailscalePairingBannerDismissed: isTailscalePairingBannerDismissed,
+                    showsTailscalePairingBanner: tailscaleSetupPrompt.showsBanner,
                     dismissTailscalePairingBanner: dismissTailscalePairingBanner,
                     showSettings: showSettings,
                     setupHelpPresentation: childSheetPresentation(
@@ -511,7 +507,7 @@ struct CMUXMobileRootView: View {
                     signOut: signOut,
                     showAddDevice: addComputerAction,
                     showPairingScanner: pairingScannerAction,
-                    isTailscalePairingBannerDismissed: isTailscalePairingBannerDismissed,
+                    showsTailscalePairingBanner: tailscaleSetupPrompt.showsBanner,
                     dismissTailscalePairingBanner: dismissTailscalePairingBanner,
                     showSettings: showSettings,
                     showComputers: showComputers,
@@ -528,7 +524,7 @@ struct CMUXMobileRootView: View {
     }
 
     private func dismissTailscalePairingBanner() {
-        isTailscalePairingBannerDismissed = true
+        tailscaleSetupPrompt.apply(.dismiss)
     }
 
     #if os(macOS)
@@ -749,8 +745,11 @@ struct CMUXMobileRootView: View {
         case .useAutoConnect:
             connectionMethodStore?.method = .automatic
             autoConnectMigrationStore?.acknowledge()
-        case .setUpTailscale:
+        case let .setUpTailscale(requiresPairing):
             connectionMethodStore?.method = .tailscale
+            tailscaleSetupPrompt.apply(
+                .selectedTailscale(requiresPairing: requiresPairing)
+            )
             autoConnectMigrationStore?.acknowledge()
         case .finishPairing:
             finishPairingPresentation()
@@ -1042,14 +1041,13 @@ struct CMUXMobileRootView: View {
 
     private var allowsManualPairing: Bool {
         #if os(iOS)
-        // The pairing-required signal is derived from the source-of-truth
-        // method store. It can become true before the observation stream has
-        // delivered its next value after the migration sheet closes, so use it
-        // to keep the recovery scanner available during that transition.
-        store.tailscalePairingRequired
-            || (observedConnectionMethod ?? connectionMethodStore?.method) == .tailscale
+        // The stream value is only an invalidation token. Read the authoritative
+        // store synchronously so the migration transition can expose pairing in
+        // the same render that selects Tailscale.
+        _ = connectionMethodObservationToken
+        return connectionMethodStore?.method == .tailscale
         #else
-        true
+        return true
         #endif
     }
 

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/CMUXMobileRootView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/CMUXMobileRootView.swift
@@ -953,7 +953,12 @@ struct CMUXMobileRootView: View {
 
     private var allowsManualPairing: Bool {
         #if os(iOS)
-        (observedConnectionMethod ?? connectionMethodStore?.method) == .tailscale
+        // The pairing-required signal is derived from the source-of-truth
+        // method store. It can become true before the observation stream has
+        // delivered its next value after the migration sheet closes, so use it
+        // to keep the recovery scanner available during that transition.
+        store.tailscalePairingRequired
+            || (observedConnectionMethod ?? connectionMethodStore?.method) == .tailscale
         #else
         true
         #endif

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/CMUXMobileRootView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/CMUXMobileRootView.swift
@@ -45,6 +45,10 @@ struct CMUXMobileRootView: View {
     @State private var pendingAttachURL: String?
     @State private var didAuthenticateWithAttachTicket = false
     @State private var didExceedStartupRestoringGate = false
+    /// Session-only dismissal for the setup reminder. Pairing and Settings
+    /// remain available, and a fresh launch can remind the user again until the
+    /// required local authorization is complete.
+    @State private var isTailscalePairingBannerDismissed = false
     #if os(macOS)
     @State private var isShowingAddDeviceSheet = false
     @State private var pairingPresentation: PairingPresentation = .manual
@@ -354,6 +358,7 @@ struct CMUXMobileRootView: View {
         }
         .onChange(of: store.connectionState) { _, connectionState in
             if connectionState == .connected {
+                isTailscalePairingBannerDismissed = false
                 #if os(iOS)
                 handleRootPresentation(.dismissPairing)
                 #else
@@ -367,6 +372,11 @@ struct CMUXMobileRootView: View {
             #endif
         }
         #if os(iOS)
+        .onChange(of: store.tailscalePairingRequired) { _, isRequired in
+            if !isRequired {
+                isTailscalePairingBannerDismissed = false
+            }
+        }
         .onChange(of: authManager.currentUser?.id) { _, _ in
             // Account identity can in principle change without an
             // isAuthenticated or team edge; re-key the keep-alive so a stale
@@ -434,6 +444,10 @@ struct CMUXMobileRootView: View {
                     hasKnownPairedMac: store.hasKnownPairedMac,
                     showAddDevice: addComputerAction,
                     showPairingScanner: pairingScannerAction,
+                    isTailscalePairingBannerDismissed: isTailscalePairingBannerDismissed,
+                    dismissTailscalePairingBanner: {
+                        isTailscalePairingBannerDismissed = true
+                    },
                     signOut: signOut,
                     setupHelpHighlight: disconnectedSetupHelpHighlight,
                     store: store,
@@ -457,6 +471,10 @@ struct CMUXMobileRootView: View {
                     signOut: signOut,
                     showAddDevice: addComputerAction,
                     showPairingScanner: pairingScannerAction,
+                    isTailscalePairingBannerDismissed: isTailscalePairingBannerDismissed,
+                    dismissTailscalePairingBanner: {
+                        isTailscalePairingBannerDismissed = true
+                    },
                     showSettings: showSettings,
                     deviceTreePresentation: childSheetPresentation(
                         for: .workspaceDeviceTree

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/CMUXMobileRootView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/CMUXMobileRootView.swift
@@ -596,7 +596,7 @@ struct CMUXMobileRootView: View {
                 },
                 setUpTailscale: {
                     handleRootPresentation(.setUpTailscale(
-                        hasUsableAuthorization: store.hasUsableTailscaleAuthorization
+                        status: store.tailscaleSetupStatus
                     ))
                 },
                 showsLayoutProbe: showsAutoConnectMigrationLayoutProbe

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/CMUXMobileRootView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/CMUXMobileRootView.swift
@@ -448,9 +448,7 @@ struct CMUXMobileRootView: View {
                     setupHelpHighlight: disconnectedSetupHelpHighlight,
                     store: store,
                     isTailscalePairingBannerDismissed: isTailscalePairingBannerDismissed,
-                    dismissTailscalePairingBanner: {
-                        isTailscalePairingBannerDismissed = true
-                    },
+                    dismissTailscalePairingBanner: dismissTailscalePairingBanner,
                     showSettings: showSettings,
                     setupHelpPresentation: childSheetPresentation(
                         for: .disconnectedSetupHelp
@@ -472,9 +470,7 @@ struct CMUXMobileRootView: View {
                     showAddDevice: addComputerAction,
                     showPairingScanner: pairingScannerAction,
                     isTailscalePairingBannerDismissed: isTailscalePairingBannerDismissed,
-                    dismissTailscalePairingBanner: {
-                        isTailscalePairingBannerDismissed = true
-                    },
+                    dismissTailscalePairingBanner: dismissTailscalePairingBanner,
                     showSettings: showSettings,
                     deviceTreePresentation: childSheetPresentation(
                         for: .workspaceDeviceTree
@@ -489,6 +485,10 @@ struct CMUXMobileRootView: View {
                 )
             }
         }
+    }
+
+    private func dismissTailscalePairingBanner() {
+        isTailscalePairingBannerDismissed = true
     }
 
     #if os(macOS)

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DisconnectedWorkspaceShellView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DisconnectedWorkspaceShellView.swift
@@ -28,9 +28,8 @@ struct DisconnectedWorkspaceShellView: View {
     /// (this screen is the terminal not-connected state, reached after a stored
     /// Mac reconnect fails). `nil` in previews.
     var store: CMUXMobileShellStore?
-    /// Hides the setup banner for the current shell session without changing
-    /// the selected connection method or pairing state.
-    var isTailscalePairingBannerDismissed = false
+    /// Whether the root setup-prompt coordinator currently presents its banner.
+    var showsTailscalePairingBanner = false
     var dismissTailscalePairingBanner: () -> Void = {}
     var showSettings: () -> Void = {}
     var setupHelpPresentation = MobileChildSheetPresentation()
@@ -48,9 +47,7 @@ struct DisconnectedWorkspaceShellView: View {
         NavigationStack {
             content
                 .safeAreaInset(edge: .top, spacing: 0) {
-                    if store?.tailscalePairingRequired == true,
-                       !isTailscalePairingBannerDismissed,
-                       let showPairingScanner {
+                    if showsTailscalePairingBanner, let showPairingScanner {
                         MobileTailscalePairingRequiredBanner(
                             scanPairingCode: showPairingScanner,
                             dismiss: dismissTailscalePairingBanner
@@ -240,7 +237,7 @@ struct DisconnectedWorkspaceShellView: View {
     /// in that case the newer attempt is still in flight or has already
     /// connected, and alerting "couldn't connect" would be wrong — skip it.
     private func connect(to computer: MacComputerSnapshot) {
-        if store?.tailscalePairingRequired == true {
+        if showsTailscalePairingBanner {
             showPairingScanner?()
             return
         }

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DisconnectedWorkspaceShellView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DisconnectedWorkspaceShellView.swift
@@ -28,6 +28,10 @@ struct DisconnectedWorkspaceShellView: View {
     /// (this screen is the terminal not-connected state, reached after a stored
     /// Mac reconnect fails). `nil` in previews.
     var store: CMUXMobileShellStore?
+    /// Hides the setup banner for the current shell session without changing
+    /// the selected connection method or pairing state.
+    var isTailscalePairingBannerDismissed = false
+    var dismissTailscalePairingBanner: () -> Void = {}
     var showSettings: () -> Void = {}
     var setupHelpPresentation = MobileChildSheetPresentation()
 
@@ -45,9 +49,11 @@ struct DisconnectedWorkspaceShellView: View {
             content
                 .safeAreaInset(edge: .top, spacing: 0) {
                     if store?.tailscalePairingRequired == true,
+                       !isTailscalePairingBannerDismissed,
                        let showPairingScanner {
                         MobileTailscalePairingRequiredBanner(
-                            scanPairingCode: showPairingScanner
+                            scanPairingCode: showPairingScanner,
+                            dismiss: dismissTailscalePairingBanner
                         )
                     }
                 }

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MobileRootPresentationState.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MobileRootPresentationState.swift
@@ -73,7 +73,7 @@ struct MobileRootPresentationState: Equatable {
         case none
         case acknowledgeAutoConnectMigration
         case useAutoConnect
-        case setUpTailscale
+        case setUpTailscale(requiresPairing: Bool)
         case finishPairing
         case retryAutoConnectMigration
     }
@@ -127,7 +127,7 @@ struct MobileRootPresentationState: Equatable {
             presentation = hasUsableAuthorization
                 ? nil
                 : .pairing(.scanner(entry: .autoConnectMigration))
-            return .setUpTailscale
+            return .setUpTailscale(requiresPairing: !hasUsableAuthorization)
 
         case .presentSettings:
             guard presentation == nil else { return .none }

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MobileRootPresentationState.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MobileRootPresentationState.swift
@@ -53,7 +53,7 @@ struct MobileRootPresentationState: Equatable {
     enum Action: Equatable {
         case presentAutoConnectMigrationIfIdle
         case useAutoConnect
-        case setUpTailscale(hasUsableAuthorization: Bool)
+        case setUpTailscale(status: MobileTailscaleSetupStatus)
         case presentSettings
         case dismissSettings(presentAutoConnectMigration: Bool)
         case presentComputers
@@ -122,12 +122,20 @@ struct MobileRootPresentationState: Equatable {
             presentation = nil
             return .useAutoConnect
 
-        case let .setUpTailscale(hasUsableAuthorization):
+        case let .setUpTailscale(status):
             guard presentation == .autoConnectMigrationIntroduction else { return .none }
-            presentation = hasUsableAuthorization
-                ? nil
-                : .pairing(.scanner(entry: .autoConnectMigration))
-            return .setUpTailscale(requiresPairing: !hasUsableAuthorization)
+            switch status {
+            case .pairingRequired:
+                presentation = .pairing(.scanner(entry: .autoConnectMigration))
+                return .setUpTailscale(requiresPairing: true)
+            case .authorized, .loadingAuthorization, .notSelected:
+                // Selecting Tailscale while authorization is still being
+                // resolved must not open a scanner based on a stale false
+                // authorization flag. The shell will promote the setup banner
+                // if the authoritative result later requires pairing.
+                presentation = nil
+                return .setUpTailscale(requiresPairing: false)
+            }
 
         case .presentSettings:
             guard presentation == nil else { return .none }

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MobileTailscalePairingRequiredBanner.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MobileTailscalePairingRequiredBanner.swift
@@ -1,20 +1,35 @@
 import CmuxMobileSupport
 import SwiftUI
 
-/// Persistent recovery chrome for a Tailscale selection with no local endpoint grant.
+/// Recovery chrome for a Tailscale selection with no local endpoint grant.
 struct MobileTailscalePairingRequiredBanner: View {
     let scanPairingCode: () -> Void
+    let dismiss: () -> Void
 
     var body: some View {
         VStack(alignment: .leading, spacing: 10) {
-            Label(
-                L10n.string(
-                    "mobile.tailscalePairingRequired.title",
-                    defaultValue: "Finish Tailscale setup"
-                ),
-                systemImage: "qrcode.viewfinder"
-            )
-            .font(.headline)
+            HStack(alignment: .top, spacing: 10) {
+                Label(
+                    L10n.string(
+                        "mobile.tailscalePairingRequired.title",
+                        defaultValue: "Finish Tailscale setup"
+                    ),
+                    systemImage: "qrcode.viewfinder"
+                )
+                .font(.headline)
+
+                Spacer(minLength: 8)
+
+                Button(action: dismiss) {
+                    Image(systemName: "xmark")
+                        .font(.body.weight(.semibold))
+                        .frame(width: 44, height: 44)
+                }
+                .buttonStyle(.plain)
+                .contentShape(Rectangle())
+                .accessibilityLabel(L10n.string("mobile.common.dismiss", defaultValue: "Dismiss"))
+                .accessibilityIdentifier("MobileTailscalePairingRequiredDismiss")
+            }
 
             Text(MobilePairingScannerSheet.guidanceText)
             .font(.subheadline)

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MobileTailscaleSetupPromptState.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MobileTailscaleSetupPromptState.swift
@@ -1,0 +1,50 @@
+import CmuxMobileShell
+
+/// Session presentation state for the Tailscale setup reminder.
+///
+/// The shell owns durable setup readiness. This state only latches a requirement
+/// already known by the migration route and remembers a dismissal until setup
+/// readiness changes away from requiring pairing.
+struct MobileTailscaleSetupPromptState: Equatable {
+    enum Presentation: Equatable {
+        case followsShell
+        case required
+        case dismissed
+    }
+
+    enum Action: Equatable {
+        case selectedTailscale(requiresPairing: Bool)
+        case shellStatusChanged(MobileTailscaleSetupStatus)
+        case dismiss
+    }
+
+    private(set) var presentation: Presentation = .followsShell
+
+    var showsBanner: Bool {
+        presentation == .required
+    }
+
+    mutating func apply(_ action: Action) {
+        switch action {
+        case let .selectedTailscale(requiresPairing):
+            presentation = requiresPairing ? .required : .followsShell
+
+        case let .shellStatusChanged(status):
+            switch status {
+            case .notSelected, .authorized:
+                presentation = .followsShell
+            case .loadingAuthorization:
+                break
+            case .pairingRequired:
+                if presentation == .followsShell {
+                    presentation = .required
+                }
+            }
+
+        case .dismiss:
+            if presentation == .required {
+                presentation = .dismissed
+            }
+        }
+    }
+}

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListView.swift
@@ -61,6 +61,9 @@ struct WorkspaceListView: View {
     var signOut: (() -> Void)?
     /// Manual reconnect for the offline status row. `nil` in previews.
     var reconnect: (() -> Void)?
+    /// Hides the Tailscale setup banner for the current shell session.
+    var isTailscalePairingBannerDismissed = false
+    var dismissTailscalePairingBanner: () -> Void = {}
     /// Present the add-device (pairing) flow from the Computers screen. `nil`
     /// hides the add affordance there.
     var showAddDevice: (() -> Void)?
@@ -502,9 +505,11 @@ struct WorkspaceListView: View {
             .modifier(WorkspaceListBarUnderlap())
             .safeAreaInset(edge: .top, spacing: 0) {
                 if connectionChrome == .tailscalePairingRequired,
+                   !isTailscalePairingBannerDismissed,
                    let showPairingScanner {
                     MobileTailscalePairingRequiredBanner(
-                        scanPairingCode: showPairingScanner
+                        scanPairingCode: showPairingScanner,
+                        dismiss: dismissTailscalePairingBanner
                     )
                 }
             }
@@ -525,10 +530,11 @@ struct WorkspaceListView: View {
                     }
                 }
             case .tailscalePairingRequired:
-                if let showPairingScanner {
+                if !isTailscalePairingBannerDismissed, let showPairingScanner {
                     Section {
                         MobileTailscalePairingRequiredBanner(
-                            scanPairingCode: showPairingScanner
+                            scanPairingCode: showPairingScanner,
+                            dismiss: dismissTailscalePairingBanner
                         )
                         .listRowInsets(EdgeInsets(top: 8, leading: 12, bottom: 8, trailing: 12))
                         .listRowSeparator(.hidden)

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListView.swift
@@ -61,8 +61,8 @@ struct WorkspaceListView: View {
     var signOut: (() -> Void)?
     /// Manual reconnect for the offline status row. `nil` in previews.
     var reconnect: (() -> Void)?
-    /// Hides the Tailscale setup banner for the current shell session.
-    var isTailscalePairingBannerDismissed = false
+    /// Whether the root setup-prompt coordinator currently presents its banner.
+    var showsTailscalePairingBanner = false
     var dismissTailscalePairingBanner: () -> Void = {}
     /// Present the add-device (pairing) flow from the Computers screen. `nil`
     /// hides the add affordance there.
@@ -508,7 +508,6 @@ struct WorkspaceListView: View {
             .modifier(WorkspaceListBarUnderlap())
             .safeAreaInset(edge: .top, spacing: 0) {
                 if connectionChrome == .tailscalePairingRequired,
-                   !isTailscalePairingBannerDismissed,
                    let showPairingScanner {
                     MobileTailscalePairingRequiredBanner(
                         scanPairingCode: showPairingScanner,
@@ -533,7 +532,7 @@ struct WorkspaceListView: View {
                     }
                 }
             case .tailscalePairingRequired:
-                if !isTailscalePairingBannerDismissed, let showPairingScanner {
+                if let showPairingScanner {
                     Section {
                         MobileTailscalePairingRequiredBanner(
                             scanPairingCode: showPairingScanner,
@@ -917,7 +916,7 @@ struct WorkspaceListView: View {
             connectionRecoveryFailed: store?.connectionRecoveryFailed ?? false,
             isRecoveringConnection: store?.isRecoveringConnection ?? false,
             connectionStatus: connectionStatus,
-            tailscalePairingRequired: store?.tailscalePairingRequired ?? false,
+            tailscalePairingRequired: showsTailscalePairingBanner,
             isInitialConnectionLoading: isInitialConnectionLoading,
             initialConnectionTimedOut: initialConnectionTimedOut
         )

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceShellHost.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceShellHost.swift
@@ -20,6 +20,8 @@ struct WorkspaceShellHost: View {
     let signOut: @MainActor @Sendable () -> Void
     let showAddDevice: (() -> Void)?
     let showPairingScanner: (() -> Void)?
+    var isTailscalePairingBannerDismissed = false
+    var dismissTailscalePairingBanner: () -> Void = {}
     var showSettings: () -> Void = {}
     var deviceTreePresentation = MobileChildSheetPresentation()
     var taskComposerPresentation = MobileChildSheetPresentation()
@@ -39,6 +41,8 @@ struct WorkspaceShellHost: View {
             retryInitialConnection: retry,
             showAddDevice: showAddDevice,
             showPairingScanner: showPairingScanner,
+            isTailscalePairingBannerDismissed: isTailscalePairingBannerDismissed,
+            dismissTailscalePairingBanner: dismissTailscalePairingBanner,
             showSettings: showSettings,
             deviceTreePresentation: deviceTreePresentation,
             taskComposerPresentation: taskComposerPresentation

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceShellHost.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceShellHost.swift
@@ -20,7 +20,7 @@ struct WorkspaceShellHost: View {
     let signOut: @MainActor @Sendable () -> Void
     let showAddDevice: (() -> Void)?
     let showPairingScanner: (() -> Void)?
-    var isTailscalePairingBannerDismissed = false
+    var showsTailscalePairingBanner = false
     var dismissTailscalePairingBanner: () -> Void = {}
     var showSettings: () -> Void = {}
     var showComputers: () -> Void = {}
@@ -41,7 +41,7 @@ struct WorkspaceShellHost: View {
             retryInitialConnection: retry,
             showAddDevice: showAddDevice,
             showPairingScanner: showPairingScanner,
-            isTailscalePairingBannerDismissed: isTailscalePairingBannerDismissed,
+            showsTailscalePairingBanner: showsTailscalePairingBanner,
             dismissTailscalePairingBanner: dismissTailscalePairingBanner,
             showSettings: showSettings,
             showComputers: showComputers,

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceShellView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceShellView.swift
@@ -160,8 +160,8 @@ struct WorkspaceShellView: View {
     /// hides the add affordance.
     var showAddDevice: (() -> Void)?
     var showPairingScanner: (() -> Void)?
-    /// Hides the Tailscale setup banner for the current shell session.
-    var isTailscalePairingBannerDismissed = false
+    /// Whether the root setup-prompt coordinator currently presents its banner.
+    var showsTailscalePairingBanner = false
     var dismissTailscalePairingBanner: () -> Void = {}
     var showSettings: () -> Void = {}
     var showComputers: () -> Void = {}
@@ -666,8 +666,8 @@ struct WorkspaceShellView: View {
             cancelMacSwitch: cancelMacSwitchFromWorkspacePicker,
             refresh: refreshWorkspacesClosure,
             signOut: signOut,
-            reconnect: store.tailscalePairingRequired ? nil : reconnectClosure,
-            isTailscalePairingBannerDismissed: isTailscalePairingBannerDismissed,
+            reconnect: showsTailscalePairingBanner ? nil : reconnectClosure,
+            showsTailscalePairingBanner: showsTailscalePairingBanner,
             dismissTailscalePairingBanner: dismissTailscalePairingBanner,
             showAddDevice: showAddDevice,
             showComputers: showComputers,
@@ -705,7 +705,7 @@ struct WorkspaceShellView: View {
             pendingSelection: rootToolbarPendingSelection,
             select: handleRootToolbarSelection,
             showAddDevice: showAddDevice,
-            reconnect: store.tailscalePairingRequired ? nil : reconnectClosure
+            reconnect: showsTailscalePairingBanner ? nil : reconnectClosure
         )
     }
 
@@ -720,7 +720,7 @@ struct WorkspaceShellView: View {
             connectionRecoveryFailed: store.connectionRecoveryFailed,
             isRecoveringConnection: store.isRecoveringConnection,
             connectionStatus: listConnectionStatus,
-            tailscalePairingRequired: store.tailscalePairingRequired,
+            tailscalePairingRequired: showsTailscalePairingBanner,
             isInitialConnectionLoading: isInitialConnectionLoading,
             initialConnectionTimedOut: initialConnectionTimedOut
         ).statusLine

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceShellView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceShellView.swift
@@ -160,6 +160,9 @@ struct WorkspaceShellView: View {
     /// hides the add affordance.
     var showAddDevice: (() -> Void)?
     var showPairingScanner: (() -> Void)?
+    /// Hides the Tailscale setup banner for the current shell session.
+    var isTailscalePairingBannerDismissed = false
+    var dismissTailscalePairingBanner: () -> Void = {}
     var showSettings: () -> Void = {}
     var deviceTreePresentation = MobileChildSheetPresentation()
     var taskComposerPresentation = MobileChildSheetPresentation()
@@ -665,6 +668,8 @@ struct WorkspaceShellView: View {
             refresh: refreshWorkspacesClosure,
             signOut: signOut,
             reconnect: store.tailscalePairingRequired ? nil : reconnectClosure,
+            isTailscalePairingBannerDismissed: isTailscalePairingBannerDismissed,
+            dismissTailscalePairingBanner: dismissTailscalePairingBanner,
             showAddDevice: showAddDevice,
             showPairingScanner: showPairingScanner,
             store: store,

--- a/Packages/iOS/CmuxMobileShellUI/Tests/CmuxMobileShellUITests/MobileRootPresentationStateTests.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Tests/CmuxMobileShellUITests/MobileRootPresentationStateTests.swift
@@ -22,7 +22,7 @@ struct MobileRootPresentationStateTests {
 
         let scanner = PairingPresentation.scanner(entry: .autoConnectMigration)
         #expect(
-            state.apply(.setUpTailscale(hasUsableAuthorization: false))
+            state.apply(.setUpTailscale(status: .pairingRequired))
                 == .setUpTailscale(requiresPairing: true)
         )
         #expect(state.presentation == .pairing(scanner))
@@ -34,7 +34,18 @@ struct MobileRootPresentationStateTests {
         state.apply(.presentAutoConnectMigrationIfIdle)
 
         #expect(
-            state.apply(.setUpTailscale(hasUsableAuthorization: true))
+            state.apply(.setUpTailscale(status: .authorized))
+                == .setUpTailscale(requiresPairing: false)
+        )
+        #expect(state.isIdle)
+    }
+
+    @Test func introductionWaitsForLoadingTailscaleAuthorizationBeforePairing() {
+        var state = MobileRootPresentationState()
+        state.apply(.presentAutoConnectMigrationIfIdle)
+
+        #expect(
+            state.apply(.setUpTailscale(status: .loadingAuthorization))
                 == .setUpTailscale(requiresPairing: false)
         )
         #expect(state.isIdle)

--- a/Packages/iOS/CmuxMobileShellUI/Tests/CmuxMobileShellUITests/MobileRootPresentationStateTests.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Tests/CmuxMobileShellUITests/MobileRootPresentationStateTests.swift
@@ -1,4 +1,5 @@
 import Testing
+import CmuxMobileShell
 
 @testable import CmuxMobileShellUI
 
@@ -21,7 +22,8 @@ struct MobileRootPresentationStateTests {
 
         let scanner = PairingPresentation.scanner(entry: .autoConnectMigration)
         #expect(
-            state.apply(.setUpTailscale(hasUsableAuthorization: false)) == .setUpTailscale
+            state.apply(.setUpTailscale(hasUsableAuthorization: false))
+                == .setUpTailscale(requiresPairing: true)
         )
         #expect(state.presentation == .pairing(scanner))
         #expect(state.isRootSheetPresented)
@@ -32,9 +34,42 @@ struct MobileRootPresentationStateTests {
         state.apply(.presentAutoConnectMigrationIfIdle)
 
         #expect(
-            state.apply(.setUpTailscale(hasUsableAuthorization: true)) == .setUpTailscale
+            state.apply(.setUpTailscale(hasUsableAuthorization: true))
+                == .setUpTailscale(requiresPairing: false)
         )
         #expect(state.isIdle)
+    }
+
+    @Test func tailscalePromptLatchesMigrationRequirementAcrossShellLoading() {
+        var state = MobileTailscaleSetupPromptState()
+
+        state.apply(.selectedTailscale(requiresPairing: true))
+        #expect(state.showsBanner)
+
+        state.apply(.shellStatusChanged(.loadingAuthorization))
+        #expect(state.showsBanner)
+
+        state.apply(.dismiss)
+        #expect(!state.showsBanner)
+        #expect(state.presentation == .dismissed)
+
+        state.apply(.shellStatusChanged(.pairingRequired))
+        #expect(!state.showsBanner)
+        #expect(state.presentation == .dismissed)
+    }
+
+    @Test func tailscalePromptFollowsDurableReadinessAcrossLaunches() {
+        var state = MobileTailscaleSetupPromptState()
+
+        state.apply(.shellStatusChanged(.loadingAuthorization))
+        #expect(!state.showsBanner)
+
+        state.apply(.shellStatusChanged(.pairingRequired))
+        #expect(state.showsBanner)
+
+        state.apply(.shellStatusChanged(.authorized))
+        #expect(!state.showsBanner)
+        #expect(state.presentation == .followsShell)
     }
 
     @Test func interactiveIntroductionDismissalRequestsAcknowledgement() {

--- a/ios/cmuxUITests/cmuxUITests.swift
+++ b/ios/cmuxUITests/cmuxUITests.swift
@@ -580,6 +580,13 @@ final class cmuxUITests: XCTestCase {
         ]
         XCTAssertTrue(pairingRequiredBanner.waitForExistence(timeout: 4))
         XCTAssertTrue(app.buttons["MobileTailscalePairingRequiredScan"].isHittable)
+        let dismissPairingRequiredBanner = app.buttons[
+            "MobileTailscalePairingRequiredDismiss"
+        ]
+        XCTAssertTrue(dismissPairingRequiredBanner.waitForExistence(timeout: 4))
+        XCTAssertTrue(dismissPairingRequiredBanner.isHittable)
+        dismissPairingRequiredBanner.tap()
+        XCTAssertTrue(pairingRequiredBanner.waitForNonExistence(timeout: 4))
         app.terminate()
 
         let relaunched = launchApp(mockData: true, environment: environment)


### PR DESCRIPTION
Adds a close control to the iOS Tailscale setup banner.

- Shares session-scoped dismissal across workspace and disconnected shell presentations.
- Keeps pairing and Settings available, and re-prompts after a fresh launch while setup is incomplete.
- Covers the rendered close action with an accessibility identifier in the migration UI test.

The first commit is the red behavior test; the second commit implements the fix.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/10057"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789162393&installation_model_id=21920&pr_number=10057&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F10057&signature=7959471fc29b1001ce490983ed40241d2853007b11f6c88d07cfdee965e0c34a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes the iOS Tailscale setup banner dismissible and defers opening the pairing scanner until authorization status is known. Previously the banner always persisted and migration could open pairing too early; now users can dismiss it for the session, it returns on relaunch until local authorization succeeds, and reconnect is suppressed while pairing is required.

- Adds a close control with accessibility identifier `MobileTailscalePairingRequiredDismiss`; `MobileTailscalePairingRequiredBanner` now requires a `dismiss` action.
- Introduces `MobileTailscaleSetupStatus` (`notSelected`, `loadingAuthorization`, `pairingRequired`, `authorized`) and derives `tailscalePairingRequired` from it.
- Adds session-scoped `MobileTailscaleSetupPromptState` in `CMUXMobileRootView` to track loading/required/authorized and dismissal; latches “required” when selecting Tailscale during migration and follows shell status changes.
- Changes migration action to `setUpTailscale(status: MobileTailscaleSetupStatus)`; only opens the scanner when `status == .pairingRequired` to avoid pairing while authorization is still loading.
- Hoists prompt state and threads `showsTailscalePairingBanner`/`dismissTailscalePairingBanner` through `WorkspaceShellHost`, `WorkspaceShellView`, `WorkspaceListView`, and `DisconnectedWorkspaceShellView` to gate reconnect while keeping pairing/Settings available without flicker.
- Updates tests for route selection, prompt transitions, and UI dismissal.

<sup>Written for commit f6354398f000be571f1515d77964f51bb0e41715. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/10057?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a dismiss option to the Tailscale pairing-required banner.
  * Dismissed banners remain hidden during the current session.
  * The banner reappears when connection status or pairing requirements change.
  * Manual pairing remains available when required.
  * Reconnect actions are disabled while pairing setup is required.
  * Added accessibility support for the banner’s close control.

* **Tests**
  * Added coverage for banner dismissal, migration prompts, loading states, and authorized setup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->