### PR TITLE
Fix stale control-socket rebind and restore startup race

### DIFF
--- a/CLI/SocketClient+StartupWait.swift
+++ b/CLI/SocketClient+StartupWait.swift
@@ -1,0 +1,65 @@
+import CmuxControlSocket
+import Foundation
+
+extension SocketClient {
+    static func waitForConnectableSocket(path: String, timeout: TimeInterval) throws -> SocketClient {
+        try waitForConnectableSocket(resolvePath: { path }, timeout: timeout)
+    }
+
+    /// Waits for a socket selected by `resolvePath` to become connectable.
+    ///
+    /// ``SocketStartupWaiter`` owns the shared deadline, path re-resolution,
+    /// vnode wakeups, and backoff. This adapter owns CLI connection creation and
+    /// classifies transport failures so permanent path conflicts surface
+    /// immediately while startup races remain retryable.
+    static func waitForConnectableSocket(
+        resolvePath: () -> String,
+        timeout: TimeInterval
+    ) throws -> SocketClient {
+        do {
+            return try SocketStartupWaiter().wait(
+                timeout: timeout,
+                resolvePath: resolvePath
+            ) { path, remainingTime in
+                let client = SocketClient(path: path)
+                do {
+                    // Use the remaining total budget as the connect deadline so
+                    // a full listen backlog cannot extend the bounded startup wait.
+                    try client.connectWithoutRetry(
+                        responseTimeout: max(remainingTime, 0.001)
+                    )
+                    if client.isRelayBacked {
+                        client.close()
+                    }
+                    return client
+                } catch {
+                    client.close()
+                    guard shouldRetrySocketStartup(error) else {
+                        throw error
+                    }
+                    return nil
+                }
+            }
+        } catch let startupTimeout as SocketStartupWaitTimeout {
+            throw startupSocketTimeout(path: startupTimeout.path)
+        }
+    }
+
+    static func isSocketStartupTimeout(_ error: Error) -> Bool {
+        (error as? CLIError)?.socketFailureKind == .startupTimeout
+    }
+
+    private static func shouldRetrySocketStartup(_ error: Error) -> Bool {
+        if shouldRetryConnect(error) {
+            return true
+        }
+        return (error as? CLIError)?.socketFailureKind == .pathMissing
+    }
+
+    private static func startupSocketTimeout(path: String) -> CLIError {
+        CLIError(
+            message: "cmux app did not start in time (socket not found at \(path))",
+            socketFailureKind: .startupTimeout
+        )
+    }
+}

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -2215,12 +2215,12 @@ final class SocketClient {
         throw SocketConnectError(path: path, errnoValue: connectErrno)
     }
 
-    private static func shouldRetryConnect(_ error: Error) -> Bool {
+    static func shouldRetryConnect(_ error: Error) -> Bool {
         guard let error = error as? SocketConnectError else {
             return false
         }
         switch error.errnoValue {
-        case ECONNREFUSED, EAGAIN, EWOULDBLOCK:
+        case ECONNREFUSED, ENOENT, EAGAIN, EWOULDBLOCK:
             return true
         default:
             return false
@@ -2696,130 +2696,6 @@ final class SocketClient {
                 "cli.socket.error.socketRead",
                 defaultValue: "Socket read error"
             ))
-        }
-    }
-
-    static func waitForConnectableSocket(path: String, timeout: TimeInterval) throws -> SocketClient {
-        try waitForConnectableSocket(resolvePath: { path }, timeout: timeout)
-    }
-
-    /// Waits for a socket selected by `resolvePath` to become connectable.
-    ///
-    /// The resolver is evaluated before every probe so a startup fallback path
-    /// can become authoritative while the preferred path is still stale. A
-    /// kqueue watches the selected path's parent directory and supplies the
-    /// readiness signal; bounded timeouts provide backoff when a listener keeps
-    /// the same inode and no directory event is emitted.
-    static func waitForConnectableSocket(
-        resolvePath: () -> String,
-        timeout: TimeInterval
-    ) throws -> SocketClient {
-        let normalizedTimeout = timeout.isFinite ? max(timeout, 0) : 0
-        let deadline = Date.now.addingTimeInterval(normalizedTimeout)
-        let eventQueue = kqueue()
-        guard eventQueue >= 0 else {
-            throw startupSocketTimeout(path: resolvePath())
-        }
-        defer { Darwin.close(eventQueue) }
-
-        var watchedDirectoryFD: Int32 = -1
-        var watchedDirectoryPath: String?
-        defer {
-            if watchedDirectoryFD >= 0 {
-                Darwin.close(watchedDirectoryFD)
-            }
-        }
-
-        var retryDelay: TimeInterval = 0.025
-        var lastPath = resolvePath()
-        while true {
-            let currentPath = resolvePath()
-            lastPath = currentPath
-            let client = SocketClient(path: currentPath)
-            do {
-                try client.connectWithoutRetry()
-                if client.relayEndpoint != nil {
-                    client.close()
-                }
-                return client
-            } catch {
-                client.close()
-                guard shouldRetrySocketStartup(error) else {
-                    throw error
-                }
-            }
-
-            let remaining = deadline.timeIntervalSinceNow
-            guard remaining > 0 else {
-                throw startupSocketTimeout(path: lastPath)
-            }
-
-            if let directory = existingWatchDirectory(forPath: currentPath),
-               directory != watchedDirectoryPath {
-                if watchedDirectoryFD >= 0 {
-                    Darwin.close(watchedDirectoryFD)
-                    watchedDirectoryFD = -1
-                }
-                watchedDirectoryFD = registerSocketDirectory(directory, queue: eventQueue) ?? -1
-                watchedDirectoryPath = watchedDirectoryFD >= 0 ? directory : nil
-            }
-
-            waitForSocketDirectoryEvent(
-                eventQueue,
-                timeout: min(retryDelay, remaining)
-            )
-            retryDelay = min(retryDelay * 2, 0.5)
-        }
-    }
-
-    private static func shouldRetrySocketStartup(_ error: Error) -> Bool {
-        if shouldRetryConnect(error) {
-            return true
-        }
-        return (error as? CLIError)?.socketFailureKind == .pathMissing
-    }
-
-    static func isSocketStartupTimeout(_ error: Error) -> Bool {
-        (error as? CLIError)?.socketFailureKind == .startupTimeout
-    }
-
-    private static func startupSocketTimeout(path: String) -> CLIError {
-        CLIError(
-            message: "cmux app did not start in time (socket not found at \(path))",
-            socketFailureKind: .startupTimeout
-        )
-    }
-
-    private static func registerSocketDirectory(_ path: String, queue: Int32) -> Int32? {
-        let descriptor = open(path, O_EVTONLY)
-        guard descriptor >= 0 else { return nil }
-        var event = kevent(
-            ident: UInt(descriptor),
-            filter: Int16(EVFILT_VNODE),
-            flags: UInt16(EV_ADD | EV_ENABLE | EV_CLEAR),
-            fflags: UInt32(NOTE_WRITE | NOTE_DELETE | NOTE_RENAME | NOTE_ATTRIB | NOTE_EXTEND | NOTE_LINK),
-            data: 0,
-            udata: nil
-        )
-        guard kevent(queue, &event, 1, nil, 0, nil) == 0 else {
-            Darwin.close(descriptor)
-            return nil
-        }
-        return descriptor
-    }
-
-    private static func waitForSocketDirectoryEvent(_ queue: Int32, timeout: TimeInterval) {
-        guard timeout > 0 else { return }
-        var timeoutSpec = timespec(
-            tv_sec: Int(timeout),
-            tv_nsec: Int((timeout - floor(timeout)) * 1_000_000_000)
-        )
-        while true {
-            var triggeredEvent = kevent()
-            let result = kevent(queue, nil, 0, &triggeredEvent, 1, &timeoutSpec)
-            if result >= 0 || errno != EINTR {
-                return
-            }
         }
     }
 

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -1795,11 +1795,22 @@ final class SocketClient {
     }
 
     private struct SocketConnectError: Error, CustomStringConvertible {
-        let path: String
+        enum Destination {
+            case unixSocket(path: String)
+            case relay(host: String, port: UInt16)
+        }
+
+        let destination: Destination
         let errnoValue: Int32
 
         var description: String {
-            "Failed to connect to socket at \(path) (\(String(cString: strerror(errnoValue))), errno \(errnoValue))"
+            let target = switch destination {
+            case .unixSocket(let path):
+                "socket at \(path)"
+            case .relay(let host, let port):
+                "relay at \(host):\(port)"
+            }
+            return "Failed to connect to \(target) (\(String(cString: strerror(errnoValue))), errno \(errnoValue))"
         }
     }
 
@@ -2212,7 +2223,10 @@ final class SocketClient {
 
         Darwin.close(socketFD)
         socketFD = -1
-        throw SocketConnectError(path: path, errnoValue: connectErrno)
+        throw SocketConnectError(
+            destination: .unixSocket(path: path),
+            errnoValue: connectErrno
+        )
     }
 
     static func shouldRetryConnect(_ error: Error) -> Bool {
@@ -2339,8 +2353,9 @@ final class SocketClient {
         }
         if connectErrno != 0 {
             close()
-            throw CLIError(
-                message: "Failed to connect to relay at \(endpoint.host):\(endpoint.port) (\(String(cString: strerror(connectErrno))), errno \(connectErrno))"
+            throw SocketConnectError(
+                destination: .relay(host: endpoint.host, port: endpoint.port),
+                errnoValue: connectErrno
             )
         }
 

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -14,15 +14,30 @@ import Security
 #endif
 
 struct CLIError: Error, CustomStringConvertible {
+    enum SocketFailureKind: Equatable {
+        case pathMissing
+        case pathInspectionFailed
+        case pathTypeConflict
+        case pathOwnershipConflict
+        case startupTimeout
+    }
+
     let message: String
     let exitCode: Int32
     /// Structured v2 protocol error code when the failure came from a v2 error response.
     let v2Code: String?
+    let socketFailureKind: SocketFailureKind?
 
-    init(message: String, exitCode: Int32 = 1, v2Code: String? = nil) {
+    init(
+        message: String,
+        exitCode: Int32 = 1,
+        v2Code: String? = nil,
+        socketFailureKind: SocketFailureKind? = nil
+    ) {
         self.message = message
         self.exitCode = exitCode
         self.v2Code = v2Code
+        self.socketFailureKind = socketFailureKind
     }
 
     var description: String { message }
@@ -2130,13 +2145,25 @@ final class SocketClient {
         // Verify socket is owned by the current user to prevent fake-socket attacks.
         var st = stat()
         guard stat(path, &st) == 0 else {
-            throw CLIError(message: "Socket not found at \(path)")
+            let failureKind: CLIError.SocketFailureKind = errno == ENOENT
+                ? .pathMissing
+                : .pathInspectionFailed
+            throw CLIError(
+                message: "Socket not found at \(path)",
+                socketFailureKind: failureKind
+            )
         }
         guard (st.st_mode & mode_t(S_IFMT)) == mode_t(S_IFSOCK) else {
-            throw CLIError(message: "Path exists at \(path) but is not a Unix socket")
+            throw CLIError(
+                message: "Path exists at \(path) but is not a Unix socket",
+                socketFailureKind: .pathTypeConflict
+            )
         }
         guard st.st_uid == getuid() else {
-            throw CLIError(message: "Socket at \(path) is not owned by the current user — refusing to connect")
+            throw CLIError(
+                message: "Socket at \(path) is not owned by the current user — refusing to connect",
+                socketFailureKind: .pathOwnershipConflict
+            )
         }
 
         socketFD = socket(AF_UNIX, SOCK_STREAM, 0)
@@ -2673,92 +2700,127 @@ final class SocketClient {
     }
 
     static func waitForConnectableSocket(path: String, timeout: TimeInterval) throws -> SocketClient {
-        let client = SocketClient(path: path)
-        if (try? client.connect()) != nil {
-            if client.relayEndpoint != nil {
-                client.close()
+        try waitForConnectableSocket(resolvePath: { path }, timeout: timeout)
+    }
+
+    /// Waits for a socket selected by `resolvePath` to become connectable.
+    ///
+    /// The resolver is evaluated before every probe so a startup fallback path
+    /// can become authoritative while the preferred path is still stale. A
+    /// kqueue watches the selected path's parent directory and supplies the
+    /// readiness signal; bounded timeouts provide backoff when a listener keeps
+    /// the same inode and no directory event is emitted.
+    static func waitForConnectableSocket(
+        resolvePath: () -> String,
+        timeout: TimeInterval
+    ) throws -> SocketClient {
+        let normalizedTimeout = timeout.isFinite ? max(timeout, 0) : 0
+        let deadline = Date.now.addingTimeInterval(normalizedTimeout)
+        let eventQueue = kqueue()
+        guard eventQueue >= 0 else {
+            throw startupSocketTimeout(path: resolvePath())
+        }
+        defer { close(eventQueue) }
+
+        var watchedDirectoryFD: Int32 = -1
+        var watchedDirectoryPath: String?
+        defer {
+            if watchedDirectoryFD >= 0 {
+                close(watchedDirectoryFD)
             }
-            return client
         }
 
-        guard let watchDirectory = existingWatchDirectory(forPath: path) else {
-            throw CLIError(message: "cmux app did not start in time (socket not found at \(path))")
-        }
-        let watchFD = open(watchDirectory, O_EVTONLY)
-        guard watchFD >= 0 else {
-            throw CLIError(message: "cmux app did not start in time (socket not found at \(path))")
-        }
+        var retryDelay: TimeInterval = 0.025
+        var lastPath = resolvePath()
+        while true {
+            let currentPath = resolvePath()
+            lastPath = currentPath
+            let client = SocketClient(path: currentPath)
+            do {
+                try client.connectWithoutRetry()
+                if client.relayEndpoint != nil {
+                    client.close()
+                }
+                return client
+            } catch {
+                client.close()
+                guard shouldRetrySocketStartup(error) else {
+                    throw error
+                }
+            }
 
-        let queue = DispatchQueue(label: "com.cmux.cli.socket-watch.\(UUID().uuidString)")
-        let semaphore = DispatchSemaphore(value: 0)
-        var connected = false
-        var retryDelayMilliseconds = 25
-        let source = DispatchSource.makeFileSystemObjectSource(
-            fileDescriptor: watchFD,
-            eventMask: [.write, .rename, .delete, .attrib, .extend, .link],
-            queue: queue
-        )
-        let retryTimer = DispatchSource.makeTimerSource(queue: queue)
+            let remaining = deadline.timeIntervalSinceNow
+            guard remaining > 0 else {
+                throw startupSocketTimeout(path: lastPath)
+            }
 
-        func scheduleRetry() {
-            guard !connected else { return }
-            let delay = retryDelayMilliseconds
-            retryDelayMilliseconds = min(retryDelayMilliseconds * 2, 500)
-            retryTimer.schedule(
-                deadline: .now() + .milliseconds(delay),
-                repeating: .never,
-                leeway: .milliseconds(10)
+            if let directory = existingWatchDirectory(forPath: currentPath),
+               directory != watchedDirectoryPath {
+                if watchedDirectoryFD >= 0 {
+                    close(watchedDirectoryFD)
+                    watchedDirectoryFD = -1
+                }
+                watchedDirectoryFD = registerSocketDirectory(directory, queue: eventQueue) ?? -1
+                watchedDirectoryPath = watchedDirectoryFD >= 0 ? directory : nil
+            }
+
+            waitForSocketDirectoryEvent(
+                eventQueue,
+                timeout: min(retryDelay, remaining)
             )
+            retryDelay = min(retryDelay * 2, 0.5)
         }
+    }
 
-        func attemptConnect() {
-            guard !connected else { return }
-            // The initial connect above already covers the short fast path.
-            // Subsequent attempts are single nonblocking probes driven by the
-            // directory signal and bounded exponential timer, so a listener
-            // that calls listen(2) without replacing its inode is observed too.
-            if (try? client.connectWithoutRetry()) != nil {
-                connected = true
-                semaphore.signal()
-            } else {
-                scheduleRetry()
+    private static func shouldRetrySocketStartup(_ error: Error) -> Bool {
+        if shouldRetryConnect(error) {
+            return true
+        }
+        return (error as? CLIError)?.socketFailureKind == .pathMissing
+    }
+
+    static func isSocketStartupTimeout(_ error: Error) -> Bool {
+        (error as? CLIError)?.socketFailureKind == .startupTimeout
+    }
+
+    private static func startupSocketTimeout(path: String) -> CLIError {
+        CLIError(
+            message: "cmux app did not start in time (socket not found at \(path))",
+            socketFailureKind: .startupTimeout
+        )
+    }
+
+    private static func registerSocketDirectory(_ path: String, queue: Int32) -> Int32? {
+        let descriptor = open(path, O_EVTONLY)
+        guard descriptor >= 0 else { return nil }
+        var event = kevent(
+            ident: UInt(descriptor),
+            filter: Int16(EVFILT_VNODE),
+            flags: UInt16(EV_ADD | EV_ENABLE | EV_CLEAR),
+            fflags: UInt32(NOTE_WRITE | NOTE_DELETE | NOTE_RENAME | NOTE_ATTRIB | NOTE_EXTEND | NOTE_LINK),
+            data: 0,
+            udata: nil
+        )
+        guard kevent(queue, &event, 1, nil, 0, nil) == 0 else {
+            close(descriptor)
+            return nil
+        }
+        return descriptor
+    }
+
+    private static func waitForSocketDirectoryEvent(_ queue: Int32, timeout: TimeInterval) {
+        guard timeout > 0 else { return }
+        var timeoutSpec = timespec(
+            tv_sec: Int(timeout),
+            tv_nsec: Int((timeout - floor(timeout)) * 1_000_000_000)
+        )
+        while true {
+            var triggeredEvent = kevent()
+            let result = kevent(queue, nil, 0, &triggeredEvent, 1, &timeoutSpec)
+            if result >= 0 || errno != EINTR {
+                return
             }
         }
-
-        source.setEventHandler {
-            attemptConnect()
-        }
-        source.setCancelHandler {
-            Darwin.close(watchFD)
-        }
-        retryTimer.setEventHandler {
-            attemptConnect()
-        }
-        source.resume()
-        retryTimer.resume()
-        queue.async {
-            attemptConnect()
-        }
-
-        guard semaphore.wait(timeout: .now() + timeout) == .success else {
-            // Serialize teardown with the watcher queue. A timer or directory
-            // event may be inside connectWithoutRetry(); closing the client
-            // from this thread would otherwise race that attempt and recycle
-            // its descriptor underneath it.
-            queue.sync {
-                connected = true
-                source.cancel()
-                retryTimer.cancel()
-                client.close()
-            }
-            throw CLIError(message: "cmux app did not start in time (socket not found at \(path))")
-        }
-
-        queue.sync {
-            source.cancel()
-            retryTimer.cancel()
-        }
-        return client
     }
 
     static func waitForFilesystemPath(_ path: String, timeout: TimeInterval) throws {
@@ -3636,7 +3698,7 @@ struct CMUXCLI {
             socketPath: socketPath,
             processEnv: processEnv
         )
-        let resolvedSocketPath = CLISocketPathResolver.resolve(
+        var resolvedSocketPath = CLISocketPathResolver.resolve(
             requestedPath: socketPath,
             source: socketPathSource,
             environment: processEnv,
@@ -3886,6 +3948,7 @@ struct CMUXCLI {
             cliTelemetry.breadcrumb("socket.connect.failure", data: ["path": resolvedSocketPath])
             cliTelemetry.captureError(stage: "socket_connect", error: error)
             if command == "restore", explicitSocketPath == nil {
+                cliDebugLog("socket.connect.wait.entered path=\(resolvedSocketPath)")
                 cliTelemetry.breadcrumb(
                     "socket.connect.wait",
                     data: [
@@ -3896,15 +3959,26 @@ struct CMUXCLI {
                 )
                 do {
                     client = try SocketClient.waitForConnectableSocket(
-                        path: resolvedSocketPath,
+                        resolvePath: {
+                            CLISocketPathResolver.resolve(
+                                requestedPath: socketPath,
+                                source: socketPathSource,
+                                environment: processEnv,
+                                bundleIdentifier: cliBundleIdentifier
+                            )
+                        },
                         timeout: Self.restoreSocketStartupTimeoutSeconds
                     )
+                    resolvedSocketPath = client.socketPath
                     cliTelemetry.breadcrumb(
                         "socket.connect.wait.success",
-                        data: ["path": resolvedSocketPath]
+                        data: ["path": client.socketPath]
                     )
                 } catch {
                     cliTelemetry.captureError(stage: "socket_startup_wait", error: error)
+                    guard SocketClient.isSocketStartupTimeout(error) else {
+                        throw error
+                    }
                     throw loggedRestoreError(
                         stage: "socket.startup",
                         detail: String(reflecting: error),

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -1795,22 +1795,11 @@ final class SocketClient {
     }
 
     private struct SocketConnectError: Error, CustomStringConvertible {
-        enum Destination {
-            case unixSocket(path: String)
-            case relay(host: String, port: UInt16)
-        }
-
-        let destination: Destination
+        let targetDescription: String
         let errnoValue: Int32
 
         var description: String {
-            let target = switch destination {
-            case .unixSocket(let path):
-                "socket at \(path)"
-            case .relay(let host, let port):
-                "relay at \(host):\(port)"
-            }
-            return "Failed to connect to \(target) (\(String(cString: strerror(errnoValue))), errno \(errnoValue))"
+            "Failed to connect to \(targetDescription) (\(String(cString: strerror(errnoValue))), errno \(errnoValue))"
         }
     }
 
@@ -2224,7 +2213,7 @@ final class SocketClient {
         Darwin.close(socketFD)
         socketFD = -1
         throw SocketConnectError(
-            destination: .unixSocket(path: path),
+            targetDescription: "socket at \(path)",
             errnoValue: connectErrno
         )
     }
@@ -2354,7 +2343,7 @@ final class SocketClient {
         if connectErrno != 0 {
             close()
             throw SocketConnectError(
-                destination: .relay(host: endpoint.host, port: endpoint.port),
+                targetDescription: "relay at \(endpoint.host):\(endpoint.port)",
                 errnoValue: connectErrno
             )
         }

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -2692,17 +2692,36 @@ final class SocketClient {
         let queue = DispatchQueue(label: "com.cmux.cli.socket-watch.\(UUID().uuidString)")
         let semaphore = DispatchSemaphore(value: 0)
         var connected = false
+        var retryDelayMilliseconds = 25
         let source = DispatchSource.makeFileSystemObjectSource(
             fileDescriptor: watchFD,
             eventMask: [.write, .rename, .delete, .attrib, .extend, .link],
             queue: queue
         )
+        let retryTimer = DispatchSource.makeTimerSource(queue: queue)
+
+        func scheduleRetry() {
+            guard !connected else { return }
+            let delay = retryDelayMilliseconds
+            retryDelayMilliseconds = min(retryDelayMilliseconds * 2, 500)
+            retryTimer.schedule(
+                deadline: .now() + .milliseconds(delay),
+                repeating: .never,
+                leeway: .milliseconds(10)
+            )
+        }
 
         func attemptConnect() {
             guard !connected else { return }
-            if (try? client.connect()) != nil {
+            // The initial connect above already covers the short fast path.
+            // Subsequent attempts are single nonblocking probes driven by the
+            // directory signal and bounded exponential timer, so a listener
+            // that calls listen(2) without replacing its inode is observed too.
+            if (try? client.connectWithoutRetry()) != nil {
                 connected = true
                 semaphore.signal()
+            } else {
+                scheduleRetry()
             }
         }
 
@@ -2712,18 +2731,33 @@ final class SocketClient {
         source.setCancelHandler {
             Darwin.close(watchFD)
         }
+        retryTimer.setEventHandler {
+            attemptConnect()
+        }
         source.resume()
+        retryTimer.resume()
         queue.async {
             attemptConnect()
         }
 
         guard semaphore.wait(timeout: .now() + timeout) == .success else {
-            source.cancel()
-            client.close()
+            // Serialize teardown with the watcher queue. A timer or directory
+            // event may be inside connectWithoutRetry(); closing the client
+            // from this thread would otherwise race that attempt and recycle
+            // its descriptor underneath it.
+            queue.sync {
+                connected = true
+                source.cancel()
+                retryTimer.cancel()
+                client.close()
+            }
             throw CLIError(message: "cmux app did not start in time (socket not found at \(path))")
         }
 
-        source.cancel()
+        queue.sync {
+            source.cancel()
+            retryTimer.cancel()
+        }
         return client
     }
 
@@ -3068,6 +3102,10 @@ struct CMUXCLI {
     private static let sshPTYTerminalConnectedResponseTimeoutSeconds: TimeInterval = 0.5
     private static let sshPTYTerminalConnectedRetryDelaySeconds: TimeInterval = 0.1
     private static let sshPTYTerminalConnectedMaximumRetryDelaySeconds: TimeInterval = 2
+    /// Restored terminals start the app and then race its listener bind. Keep
+    /// the implicit restore connection alive long enough for that lifecycle,
+    /// while explicit socket paths retain their immediate failure semantics.
+    private static let restoreSocketStartupTimeoutSeconds: TimeInterval = 45
     // Stable per-user slot for the pinned Cloud VM. This value is intentionally reused as
     // both the backend create idempotency key and the local daemon slot so every open,
     // reconnect, session restore, and mobile attach targets the same provider VM once
@@ -3824,7 +3862,7 @@ struct CMUXCLI {
             commandArgs: commandArgs
         )
         try validateWorkspaceLoadingCommandBeforeSocket(command: command, commandArgs: commandArgs)
-        let client = SocketClient(path: resolvedSocketPath)
+        var client = SocketClient(path: resolvedSocketPath)
         if resolvedSocketPath != socketPath {
             cliTelemetry.breadcrumb(
                 "socket.path.autodiscovered",
@@ -3848,16 +3886,37 @@ struct CMUXCLI {
             cliTelemetry.breadcrumb("socket.connect.failure", data: ["path": resolvedSocketPath])
             cliTelemetry.captureError(stage: "socket_connect", error: error)
             if command == "restore", explicitSocketPath == nil {
-                throw loggedRestoreError(
-                    stage: "socket.startup",
-                    detail: String(reflecting: error),
-                    message: String(
-                        localized: "cli.restore.error.socketNotReady",
-                        defaultValue: "restore: cmux is still opening. Retry the visible restore command in a moment."
-                    )
+                cliTelemetry.breadcrumb(
+                    "socket.connect.wait",
+                    data: [
+                        "command": command,
+                        "path": resolvedSocketPath,
+                        "timeoutSeconds": Self.restoreSocketStartupTimeoutSeconds,
+                    ]
                 )
+                do {
+                    client = try SocketClient.waitForConnectableSocket(
+                        path: resolvedSocketPath,
+                        timeout: Self.restoreSocketStartupTimeoutSeconds
+                    )
+                    cliTelemetry.breadcrumb(
+                        "socket.connect.wait.success",
+                        data: ["path": resolvedSocketPath]
+                    )
+                } catch {
+                    cliTelemetry.captureError(stage: "socket_startup_wait", error: error)
+                    throw loggedRestoreError(
+                        stage: "socket.startup",
+                        detail: String(reflecting: error),
+                        message: String(
+                            localized: "cli.restore.error.socketNotReady",
+                            defaultValue: "restore: cmux is still opening. Retry the visible restore command in a moment."
+                        )
+                    )
+                }
+            } else {
+                throw error
             }
-            throw error
         }
         defer { client.close() }
 

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -2720,13 +2720,13 @@ final class SocketClient {
         guard eventQueue >= 0 else {
             throw startupSocketTimeout(path: resolvePath())
         }
-        defer { close(eventQueue) }
+        defer { Darwin.close(eventQueue) }
 
         var watchedDirectoryFD: Int32 = -1
         var watchedDirectoryPath: String?
         defer {
             if watchedDirectoryFD >= 0 {
-                close(watchedDirectoryFD)
+                Darwin.close(watchedDirectoryFD)
             }
         }
 
@@ -2757,7 +2757,7 @@ final class SocketClient {
             if let directory = existingWatchDirectory(forPath: currentPath),
                directory != watchedDirectoryPath {
                 if watchedDirectoryFD >= 0 {
-                    close(watchedDirectoryFD)
+                    Darwin.close(watchedDirectoryFD)
                     watchedDirectoryFD = -1
                 }
                 watchedDirectoryFD = registerSocketDirectory(directory, queue: eventQueue) ?? -1
@@ -2802,7 +2802,7 @@ final class SocketClient {
             udata: nil
         )
         guard kevent(queue, &event, 1, nil, 0, nil) == 0 else {
-            close(descriptor)
+            Darwin.close(descriptor)
             return nil
         }
         return descriptor

--- a/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Model/SocketPathLockAcquisition.swift
+++ b/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Model/SocketPathLockAcquisition.swift
@@ -6,9 +6,11 @@
 /// ``SocketTransport/releaseSocketPathLock(_:)``.
 public enum SocketPathLockAcquisition: Equatable, Sendable {
     /// The lock was acquired. `fd` is the locked file descriptor;
-    /// `canReplaceRefusedSocket` is true when the lock (or the socket filename
-    /// policy) proves a connection-refused socket file at the path is a leftover
-    /// from a previous owner and may be unlinked before binding.
+    /// `canReplaceRefusedSocket` is true when owning the lock and probing the
+    /// path prove a connection-refused socket file is a leftover from a
+    /// previous owner and may be unlinked before binding. The reusable marker
+    /// and well-known filename rules remain compatibility signals, but are not
+    /// required for crash recovery.
     case acquired(fd: Int32, canReplaceRefusedSocket: Bool)
     /// The lock could not be acquired.
     case failed(SocketStageFailure)

--- a/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Model/SocketStartupWaitTimeout.swift
+++ b/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Model/SocketStartupWaitTimeout.swift
@@ -1,0 +1,12 @@
+/// The bounded startup wait expired before a connection became available.
+public struct SocketStartupWaitTimeout: Error, Equatable, Sendable {
+    /// The socket path selected by the final connection attempt.
+    public let path: String
+
+    /// Creates a timeout for the final attempted socket path.
+    ///
+    /// - Parameter path: The socket path selected by the final attempt.
+    public init(path: String) {
+        self.path = path
+    }
+}

--- a/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Server/SocketControlServer+Startup.swift
+++ b/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Server/SocketControlServer+Startup.swift
@@ -204,12 +204,45 @@ extension SocketControlServer {
             }
         }
 
-        var bindAttempt = acquireActiveSocketPathLock()
-            ?? transport.bindListenerSocket(
-                newServerSocket,
-                path: activeSocketPath,
-                canReplaceRefusedSocket: activeSocketPathCanReplaceRefusedSocket
-            )
+        func bindCurrentPath() -> SocketBindAttemptResult {
+            acquireActiveSocketPathLock()
+                ?? transport.bindListenerSocket(
+                    newServerSocket,
+                    path: activeSocketPath,
+                    canReplaceRefusedSocket: activeSocketPathCanReplaceRefusedSocket
+                )
+        }
+
+        /// A stale inode can be replaced between the lock probe and bind, and
+        /// a previous process may still be unwinding its descriptor close. Make
+        /// the bind lifecycle self-healing with a few immediate, lock-serialized
+        /// attempts before choosing a fallback or reporting failure. There is
+        /// no sleep on the app path: each retry reclaims the path through the
+        /// same lock/probe/bind primitive.
+        func bindCurrentPathWithRetry() -> SocketBindAttemptResult {
+            var attempt = bindCurrentPath()
+            for retryIndex in 1...2 {
+                guard case .failure(let failedPath, let failure) = attempt else {
+                    break
+                }
+                events.breadcrumb(
+                    "socket.listener.bind.retry",
+                    [
+                        "path": failedPath,
+                        "stage": failure.stage,
+                        "errno": Int(failure.errnoCode),
+                        "retry": retryIndex,
+                    ]
+                )
+                transport.releaseSocketPathLock(activeSocketPathLockFD)
+                activeSocketPathLockFD = -1
+                activeSocketPathCanReplaceRefusedSocket = false
+                attempt = bindCurrentPath()
+            }
+            return attempt
+        }
+
+        var bindAttempt = bindCurrentPathWithRetry()
         if case .failure(let failedPath, let bindFailure) = bindAttempt,
            let fallbackPath = listenerPolicy.fallbackSocketPathAfterBindFailure(
                requestedPath: failedPath,
@@ -233,12 +266,7 @@ extension SocketControlServer {
             withListenerState { state in
                 state.socketPath = activeSocketPath
             }
-            bindAttempt = acquireActiveSocketPathLock()
-                ?? transport.bindListenerSocket(
-                    newServerSocket,
-                    path: activeSocketPath,
-                    canReplaceRefusedSocket: activeSocketPathCanReplaceRefusedSocket
-                )
+            bindAttempt = bindCurrentPathWithRetry()
         }
 
         switch bindAttempt {

--- a/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Transport/SocketStartupWaiter.swift
+++ b/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Transport/SocketStartupWaiter.swift
@@ -1,0 +1,172 @@
+public import Foundation
+internal import Darwin
+
+/// Waits for a startup-racing control socket with vnode events and bounded retries.
+///
+/// The waiter owns the common deadline, path re-resolution, vnode observation,
+/// and bounded retry policy used by command-line clients that launch or race
+/// the cmux app. The caller retains ownership of the concrete connection and
+/// decides which connection failures are transient:
+///
+/// ```swift
+/// let client = try SocketStartupWaiter().wait(
+///     timeout: 45,
+///     resolvePath: resolveCurrentSocketPath
+/// ) { path, remainingTime in
+///     try connectIfAvailable(path, timeout: remainingTime)
+/// }
+/// ```
+public struct SocketStartupWaiter {
+    private let initialRetryDelay: TimeInterval
+    private let maximumRetryDelay: TimeInterval
+    private let monotonicTime: () -> TimeInterval
+
+    /// Creates a startup waiter with bounded exponential retry delays.
+    ///
+    /// - Parameters:
+    ///   - initialRetryDelay: Delay after the first unavailable attempt. Values
+    ///     below one millisecond are clamped to one millisecond.
+    ///   - maximumRetryDelay: Maximum delay between attempts. Values below the
+    ///     normalized initial delay are raised to that delay.
+    ///   - monotonicTime: Monotonic seconds used for deadlines. Tests may inject
+    ///     a controlled clock; production defaults to system uptime.
+    public init(
+        initialRetryDelay: TimeInterval = 0.025,
+        maximumRetryDelay: TimeInterval = 0.5,
+        monotonicTime: @escaping () -> TimeInterval = {
+            ProcessInfo.processInfo.systemUptime
+        }
+    ) {
+        let finiteInitialDelay = initialRetryDelay.isFinite ? initialRetryDelay : 0.025
+        let normalizedInitialDelay = max(finiteInitialDelay, 0.001)
+        let finiteMaximumDelay = maximumRetryDelay.isFinite ? maximumRetryDelay : 0.5
+        self.initialRetryDelay = normalizedInitialDelay
+        self.maximumRetryDelay = max(finiteMaximumDelay, normalizedInitialDelay)
+        self.monotonicTime = monotonicTime
+    }
+
+    /// Waits until `attemptConnection` produces a connection or the deadline expires.
+    ///
+    /// `resolvePath` runs before every attempt so a fallback selected during app
+    /// startup can replace an earlier preferred path. Returning `nil` from
+    /// `attemptConnection` classifies that attempt as transient; throwing fails
+    /// immediately. Directory vnode events wake the waiter when possible, while
+    /// the bounded timeout also covers a listener beginning to accept on an
+    /// unchanged socket inode.
+    ///
+    /// - Parameters:
+    ///   - timeout: Total wait budget in seconds. A non-finite or negative value
+    ///     becomes zero; one immediate connection attempt is still made.
+    ///   - resolvePath: Supplies the currently authoritative socket path.
+    ///   - attemptConnection: Attempts one connection. It receives the selected
+    ///     path and remaining total budget, returns a connection on success,
+    ///     returns `nil` for a transient failure, or throws a permanent failure.
+    /// - Returns: The first connection produced by `attemptConnection`.
+    /// - Throws: ``SocketStartupWaitTimeout`` when the budget expires, or a
+    ///   permanent error from `attemptConnection`.
+    public func wait<Connection>(
+        timeout: TimeInterval,
+        resolvePath: () -> String,
+        attemptConnection: (_ path: String, _ remainingTime: TimeInterval) throws -> Connection?
+    ) throws -> Connection {
+        let normalizedTimeout = timeout.isFinite ? max(timeout, 0) : 0
+        let deadline = monotonicTime() + normalizedTimeout
+        let eventQueue = kqueue()
+        var lastPath = resolvePath()
+        guard eventQueue >= 0 else {
+            throw SocketStartupWaitTimeout(path: lastPath)
+        }
+        defer { Darwin.close(eventQueue) }
+
+        var watchedDirectoryFD: Int32 = -1
+        var watchedDirectoryPath: String?
+        defer {
+            if watchedDirectoryFD >= 0 {
+                Darwin.close(watchedDirectoryFD)
+            }
+        }
+
+        var retryDelay = initialRetryDelay
+        while true {
+            let currentPath = resolvePath()
+            lastPath = currentPath
+            let remainingBeforeAttempt = max(deadline - monotonicTime(), 0)
+            if let connection = try attemptConnection(currentPath, remainingBeforeAttempt) {
+                return connection
+            }
+
+            let remaining = deadline - monotonicTime()
+            guard remaining > 0 else {
+                throw SocketStartupWaitTimeout(path: lastPath)
+            }
+
+            if let directory = existingWatchDirectory(forPath: currentPath),
+               directory != watchedDirectoryPath {
+                if watchedDirectoryFD >= 0 {
+                    Darwin.close(watchedDirectoryFD)
+                    watchedDirectoryFD = -1
+                }
+                watchedDirectoryFD = registerSocketDirectory(directory, queue: eventQueue) ?? -1
+                watchedDirectoryPath = watchedDirectoryFD >= 0 ? directory : nil
+            }
+
+            waitForSocketDirectoryEvent(
+                eventQueue,
+                timeout: min(retryDelay, remaining)
+            )
+            retryDelay = min(retryDelay * 2, maximumRetryDelay)
+        }
+    }
+
+    private func existingWatchDirectory(forPath path: String) -> String? {
+        var candidate = (path as NSString).deletingLastPathComponent
+        while !candidate.isEmpty {
+            var fileStatus = stat()
+            if lstat(candidate, &fileStatus) == 0,
+               (fileStatus.st_mode & mode_t(S_IFMT)) == mode_t(S_IFDIR) {
+                return candidate
+            }
+            guard candidate != "/" else { break }
+            let parent = (candidate as NSString).deletingLastPathComponent
+            guard parent != candidate else { break }
+            candidate = parent
+        }
+        return nil
+    }
+
+    private func registerSocketDirectory(_ path: String, queue: Int32) -> Int32? {
+        let descriptor = open(path, O_EVTONLY)
+        guard descriptor >= 0 else { return nil }
+        var event = kevent(
+            ident: UInt(descriptor),
+            filter: Int16(EVFILT_VNODE),
+            flags: UInt16(EV_ADD | EV_ENABLE | EV_CLEAR),
+            fflags: UInt32(NOTE_WRITE | NOTE_DELETE | NOTE_RENAME | NOTE_ATTRIB | NOTE_EXTEND | NOTE_LINK),
+            data: 0,
+            udata: nil
+        )
+        guard kevent(queue, &event, 1, nil, 0, nil) == 0 else {
+            Darwin.close(descriptor)
+            return nil
+        }
+        return descriptor
+    }
+
+    private func waitForSocketDirectoryEvent(_ queue: Int32, timeout: TimeInterval) {
+        guard timeout > 0 else { return }
+        let deadline = monotonicTime() + timeout
+        while true {
+            let remaining = deadline - monotonicTime()
+            guard remaining > 0 else { return }
+            var timeoutSpec = timespec(
+                tv_sec: Int(remaining),
+                tv_nsec: Int((remaining - floor(remaining)) * 1_000_000_000)
+            )
+            var triggeredEvent = kevent()
+            let result = kevent(queue, nil, 0, &triggeredEvent, 1, &timeoutSpec)
+            if result >= 0 || errno != EINTR {
+                return
+            }
+        }
+    }
+}

--- a/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Transport/SocketStartupWaiter.swift
+++ b/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Transport/SocketStartupWaiter.swift
@@ -20,6 +20,7 @@ public struct SocketStartupWaiter {
     private let initialRetryDelay: TimeInterval
     private let maximumRetryDelay: TimeInterval
     private let monotonicTime: () -> TimeInterval
+    private let eventQueueFactory: () -> Int32
 
     /// Creates a startup waiter with bounded exponential retry delays.
     ///
@@ -37,12 +38,27 @@ public struct SocketStartupWaiter {
             ProcessInfo.processInfo.systemUptime
         }
     ) {
+        self.init(
+            initialRetryDelay: initialRetryDelay,
+            maximumRetryDelay: maximumRetryDelay,
+            monotonicTime: monotonicTime,
+            eventQueueFactory: { kqueue() }
+        )
+    }
+
+    init(
+        initialRetryDelay: TimeInterval,
+        maximumRetryDelay: TimeInterval,
+        monotonicTime: @escaping () -> TimeInterval,
+        eventQueueFactory: @escaping () -> Int32
+    ) {
         let finiteInitialDelay = initialRetryDelay.isFinite ? initialRetryDelay : 0.025
         let normalizedInitialDelay = max(finiteInitialDelay, 0.001)
         let finiteMaximumDelay = maximumRetryDelay.isFinite ? maximumRetryDelay : 0.5
         self.initialRetryDelay = normalizedInitialDelay
         self.maximumRetryDelay = max(finiteMaximumDelay, normalizedInitialDelay)
         self.monotonicTime = monotonicTime
+        self.eventQueueFactory = eventQueueFactory
     }
 
     /// Waits until `attemptConnection` produces a connection or the deadline expires.
@@ -71,12 +87,13 @@ public struct SocketStartupWaiter {
     ) throws -> Connection {
         let normalizedTimeout = timeout.isFinite ? max(timeout, 0) : 0
         let deadline = monotonicTime() + normalizedTimeout
-        let eventQueue = kqueue()
+        let eventQueue = eventQueueFactory()
         var lastPath = resolvePath()
-        guard eventQueue >= 0 else {
-            throw SocketStartupWaitTimeout(path: lastPath)
+        defer {
+            if eventQueue >= 0 {
+                Darwin.close(eventQueue)
+            }
         }
-        defer { Darwin.close(eventQueue) }
 
         var watchedDirectoryFD: Int32 = -1
         var watchedDirectoryPath: String?
@@ -100,7 +117,8 @@ public struct SocketStartupWaiter {
                 throw SocketStartupWaitTimeout(path: lastPath)
             }
 
-            if let directory = existingWatchDirectory(forPath: currentPath),
+            if eventQueue >= 0,
+               let directory = existingWatchDirectory(forPath: currentPath),
                directory != watchedDirectoryPath {
                 if watchedDirectoryFD >= 0 {
                     Darwin.close(watchedDirectoryFD)
@@ -110,7 +128,7 @@ public struct SocketStartupWaiter {
                 watchedDirectoryPath = watchedDirectoryFD >= 0 ? directory : nil
             }
 
-            waitForSocketDirectoryEvent(
+            waitForRetryOpportunity(
                 eventQueue,
                 timeout: min(retryDelay, remaining)
             )
@@ -152,8 +170,12 @@ public struct SocketStartupWaiter {
         return descriptor
     }
 
-    private func waitForSocketDirectoryEvent(_ queue: Int32, timeout: TimeInterval) {
+    private func waitForRetryOpportunity(_ queue: Int32, timeout: TimeInterval) {
         guard timeout > 0 else { return }
+        guard queue >= 0 else {
+            waitForRetryDelay(timeout)
+            return
+        }
         let deadline = monotonicTime() + timeout
         while true {
             let remaining = deadline - monotonicTime()
@@ -165,6 +187,21 @@ public struct SocketStartupWaiter {
             var triggeredEvent = kevent()
             let result = kevent(queue, nil, 0, &triggeredEvent, 1, &timeoutSpec)
             if result >= 0 || errno != EINTR {
+                return
+            }
+        }
+    }
+
+    private func waitForRetryDelay(_ timeout: TimeInterval) {
+        let deadline = monotonicTime() + timeout
+        while true {
+            let remaining = deadline - monotonicTime()
+            guard remaining > 0 else { return }
+            var delay = timespec(
+                tv_sec: Int(remaining),
+                tv_nsec: Int((remaining - floor(remaining)) * 1_000_000_000)
+            )
+            if nanosleep(&delay, nil) == 0 || errno != EINTR {
                 return
             }
         }

--- a/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Transport/SocketStartupWaiter.swift
+++ b/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Transport/SocketStartupWaiter.swift
@@ -21,6 +21,8 @@ public struct SocketStartupWaiter {
     private let maximumRetryDelay: TimeInterval
     private let monotonicTime: () -> TimeInterval
     private let eventQueueFactory: () -> Int32
+    private let vnodeEventWaiter: (_ queue: Int32, _ timeout: TimeInterval) -> Bool
+    private let retryDelayWaiter: (_ timeout: TimeInterval) -> Void
 
     /// Creates a startup waiter with bounded exponential retry delays.
     ///
@@ -42,7 +44,9 @@ public struct SocketStartupWaiter {
             initialRetryDelay: initialRetryDelay,
             maximumRetryDelay: maximumRetryDelay,
             monotonicTime: monotonicTime,
-            eventQueueFactory: { kqueue() }
+            eventQueueFactory: { kqueue() },
+            vnodeEventWaiter: nil,
+            retryDelayWaiter: nil
         )
     }
 
@@ -50,7 +54,9 @@ public struct SocketStartupWaiter {
         initialRetryDelay: TimeInterval,
         maximumRetryDelay: TimeInterval,
         monotonicTime: @escaping () -> TimeInterval,
-        eventQueueFactory: @escaping () -> Int32
+        eventQueueFactory: @escaping () -> Int32,
+        vnodeEventWaiter: ((_ queue: Int32, _ timeout: TimeInterval) -> Bool)? = nil,
+        retryDelayWaiter: ((_ timeout: TimeInterval) -> Void)? = nil
     ) {
         let finiteInitialDelay = initialRetryDelay.isFinite ? initialRetryDelay : 0.025
         let normalizedInitialDelay = max(finiteInitialDelay, 0.001)
@@ -59,6 +65,19 @@ public struct SocketStartupWaiter {
         self.maximumRetryDelay = max(finiteMaximumDelay, normalizedInitialDelay)
         self.monotonicTime = monotonicTime
         self.eventQueueFactory = eventQueueFactory
+        self.vnodeEventWaiter = vnodeEventWaiter ?? { queue, timeout in
+            SocketStartupWaiter.waitForVnodeEvent(
+                queue,
+                timeout: timeout,
+                monotonicTime: monotonicTime
+            )
+        }
+        self.retryDelayWaiter = retryDelayWaiter ?? { timeout in
+            SocketStartupWaiter.waitForRetryDelay(
+                timeout,
+                monotonicTime: monotonicTime
+            )
+        }
     }
 
     /// Waits until `attemptConnection` produces a connection or the deadline expires.
@@ -128,9 +147,18 @@ public struct SocketStartupWaiter {
                 watchedDirectoryPath = watchedDirectoryFD >= 0 ? directory : nil
             }
 
+            let retryTimeout = min(retryDelay, remaining)
+            // Vnode activity may accelerate a retry, but never by more than 2x
+            // once exponential backoff grows. This coalesces unrelated parent-
+            // directory churn instead of resolving and probing once per event.
+            let minimumEventDelay = min(
+                max(initialRetryDelay, retryDelay / 2),
+                retryTimeout
+            )
             waitForRetryOpportunity(
                 eventQueue,
-                timeout: min(retryDelay, remaining)
+                timeout: retryTimeout,
+                minimumEventDelay: minimumEventDelay
             )
             retryDelay = min(retryDelay * 2, maximumRetryDelay)
         }
@@ -170,29 +198,59 @@ public struct SocketStartupWaiter {
         return descriptor
     }
 
-    private func waitForRetryOpportunity(_ queue: Int32, timeout: TimeInterval) {
+    private func waitForRetryOpportunity(
+        _ queue: Int32,
+        timeout: TimeInterval,
+        minimumEventDelay: TimeInterval
+    ) {
         guard timeout > 0 else { return }
         guard queue >= 0 else {
-            waitForRetryDelay(timeout)
+            retryDelayWaiter(timeout)
             return
         }
+        let startedAt = monotonicTime()
+        let timeoutDeadline = startedAt + timeout
+        let normalizedMinimumEventDelay = min(max(minimumEventDelay, 0), timeout)
+        let earliestEventRetry = startedAt + normalizedMinimumEventDelay
+        // Once the minimum retry cadence has elapsed, there is no benefit in
+        // continuing to wait for an event: the bounded retry itself covers an
+        // unchanged inode beginning to listen.
+        let observedEvent = vnodeEventWaiter(queue, normalizedMinimumEventDelay)
+        let deadline = observedEvent ? earliestEventRetry : timeoutDeadline
+        let unsleptRemainder = deadline - monotonicTime()
+        if unsleptRemainder > 0 {
+            retryDelayWaiter(unsleptRemainder)
+        }
+    }
+
+    private static func waitForVnodeEvent(
+        _ queue: Int32,
+        timeout: TimeInterval,
+        monotonicTime: () -> TimeInterval
+    ) -> Bool {
         let deadline = monotonicTime() + timeout
         while true {
             let remaining = deadline - monotonicTime()
-            guard remaining > 0 else { return }
+            guard remaining > 0 else { return false }
             var timeoutSpec = timespec(
                 tv_sec: Int(remaining),
                 tv_nsec: Int((remaining - floor(remaining)) * 1_000_000_000)
             )
             var triggeredEvent = kevent()
             let result = kevent(queue, nil, 0, &triggeredEvent, 1, &timeoutSpec)
-            if result >= 0 || errno != EINTR {
-                return
+            if result > 0 {
+                return true
+            }
+            if result == 0 || errno != EINTR {
+                return false
             }
         }
     }
 
-    private func waitForRetryDelay(_ timeout: TimeInterval) {
+    private static func waitForRetryDelay(
+        _ timeout: TimeInterval,
+        monotonicTime: () -> TimeInterval
+    ) {
         let deadline = monotonicTime() + timeout
         while true {
             let remaining = deadline - monotonicTime()

--- a/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Transport/SocketTransport+Bind.swift
+++ b/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Transport/SocketTransport+Bind.swift
@@ -77,6 +77,9 @@ extension SocketTransport {
         guard (st.st_mode & mode_t(S_IFMT)) == mode_t(S_IFSOCK) else {
             return SocketStageFailure(stage: "existing_path", errnoCode: EEXIST)
         }
+        guard st.st_uid == getuid() else {
+            return SocketStageFailure(stage: "existing_path", errnoCode: EACCES)
+        }
         switch pathProbeResult(at: path) {
         case .stale:
             break

--- a/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Transport/SocketTransport+PathLock.swift
+++ b/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Transport/SocketTransport+PathLock.swift
@@ -15,7 +15,9 @@ extension SocketTransport {
     /// Creates (or opens) the sibling lock file with `O_NOFOLLOW`, validates it
     /// is a regular single-link file owned by the current user, and takes a
     /// non-blocking exclusive `flock(2)`. On success the caller owns the
-    /// returned descriptor until ``releaseSocketPathLock(_:)``.
+    /// returned descriptor until ``releaseSocketPathLock(_:)``. The returned
+    /// replacement bit is derived from the lock plus a current liveness probe,
+    /// so a process that died before writing the reusable marker is recoverable.
     ///
     /// - Parameter socketPath: The socket path whose lock to acquire.
     /// - Returns: The ``SocketPathLockAcquisition`` outcome.
@@ -62,10 +64,20 @@ extension SocketTransport {
             close(fd)
             return .failed(SocketStageFailure(stage: "lock", errnoCode: errnoCode))
         }
+
+        // Ownership is established by the flock, not by the contents of the
+        // lock file. A process can die before it writes the reusable marker,
+        // leaving an unmarked lock beside a refused socket inode. Once this
+        // process owns the lock, a refused probe is definitive evidence that
+        // the old listener is gone and the inode can be replaced. Keep the
+        // marker and filename checks for compatibility with older paths, but
+        // do not make either one a prerequisite for crash recovery.
+        let canReplaceRefusedSocket = pathLockHasReusableMarker(fd)
+            || canReplaceUnmarkedRefusedSocket(at: socketPath)
+            || pathProbeResult(at: socketPath) == .refused
         return .acquired(
             fd: fd,
-            canReplaceRefusedSocket: pathLockHasReusableMarker(fd)
-                || canReplaceUnmarkedRefusedSocket(at: socketPath)
+            canReplaceRefusedSocket: canReplaceRefusedSocket
         )
     }
 
@@ -153,8 +165,9 @@ extension SocketTransport {
     }
 
     /// Whether a startup listener may claim `path`: either nothing exists there
-    /// (and no foreign lock blocks it), or a socket exists whose lock is free
-    /// and carries the reusable marker.
+    /// (and no foreign lock blocks it), or a current-user socket exists whose
+    /// lock is free and whose probe proves that no listener is accepting
+    /// connections.
     ///
     /// - Parameter path: The socket path to evaluate.
     /// - Returns: True when a startup listener may claim the path.
@@ -167,7 +180,18 @@ extension SocketTransport {
         guard (st.st_mode & mode_t(S_IFMT)) == mode_t(S_IFSOCK) else {
             return false
         }
-        return pathHasAvailableLock(path, requireReusableMarker: true, treatMissingLockAsAvailable: false)
+        guard st.st_uid == getuid() else {
+            return false
+        }
+        guard pathHasAvailableLock(path, requireReusableMarker: false, treatMissingLockAsAvailable: false) else {
+            return false
+        }
+        switch pathProbeResult(at: path) {
+        case .refused, .stale:
+            return true
+        case .connected, .occupiedOrIndeterminate:
+            return false
+        }
     }
 
     func pathHasAvailableLock(

--- a/Packages/macOS/CmuxControlSocket/Tests/CmuxControlSocketTests/SocketControlServerTests.swift
+++ b/Packages/macOS/CmuxControlSocket/Tests/CmuxControlSocketTests/SocketControlServerTests.swift
@@ -338,6 +338,34 @@ struct SocketControlServerLifecycleTests {
         if fd >= 0 { close(fd) }
     }
 
+    @Test func reclaimsUnmarkedStaleSocketAfterUncleanExit() throws {
+        let harness = try ServerHarness()
+        defer { harness.shutdown() }
+        let server = harness.server
+
+        // A process that dies before it writes the reusable marker still leaves
+        // behind an unheld lock and a socket inode. Recreate that exact state:
+        // acquire/release the lock, then close a bound socket without unlinking
+        // its path.
+        guard case .acquired(let previousLockFD, _) =
+                server.transport.acquireSocketPathLock(for: harness.socketPath) else {
+            Issue.record("could not create the stale socket lock")
+            return
+        }
+        server.transport.releaseSocketPathLock(previousLockFD)
+        let staleListener = try UnixSocketFixture.bindListeningSocket(at: harness.socketPath)
+        close(staleListener)
+
+        #expect(server.transport.pathProbeResult(at: harness.socketPath) == .refused)
+        #expect(server.transport.pathCanBeReclaimedForStartup(harness.socketPath))
+        #expect(server.start(socketPath: harness.socketPath, accessMode: .cmuxOnly))
+        #expect(server.isRunning)
+
+        let clientFD = connect(to: harness.socketPath)
+        #expect(clientFD >= 0)
+        if clientFD >= 0 { close(clientFD) }
+    }
+
     @Test func refusesRegularFileAtSocketPath() throws {
         let harness = try ServerHarness()
         defer { harness.shutdown() }

--- a/Packages/macOS/CmuxControlSocket/Tests/CmuxControlSocketTests/SocketStartupWaiterTests.swift
+++ b/Packages/macOS/CmuxControlSocket/Tests/CmuxControlSocketTests/SocketStartupWaiterTests.swift
@@ -1,4 +1,5 @@
 @testable import CmuxControlSocket
+import Darwin
 import Foundation
 import Testing
 
@@ -93,6 +94,41 @@ struct SocketStartupWaiterTests {
 
         #expect(connection == socketPath)
         #expect(attemptCount == 2)
+    }
+
+    @Test func coalescesUnrelatedDirectoryEventStorms() throws {
+        let socketPath = "/tmp/cmux-startup-wait-event-storm.sock"
+        var currentTime: TimeInterval = 0
+        var attemptTimes: [TimeInterval] = []
+        let waiter = SocketStartupWaiter(
+            initialRetryDelay: 0.01,
+            maximumRetryDelay: 0.08,
+            monotonicTime: { currentTime },
+            eventQueueFactory: { kqueue() },
+            vnodeEventWaiter: { _, remaining in
+                currentTime += min(0.001, remaining)
+                return true
+            },
+            retryDelayWaiter: { delay in
+                currentTime += delay
+            }
+        )
+
+        let connection: String = try waiter.wait(
+            timeout: 1,
+            resolvePath: { socketPath },
+            attemptConnection: { path, _ in
+                attemptTimes.append(currentTime)
+                return attemptTimes.count == 5 ? path : nil
+            }
+        )
+
+        #expect(connection == socketPath)
+        let expectedAttemptTimes: [TimeInterval] = [0, 0.01, 0.02, 0.04, 0.08]
+        #expect(attemptTimes.count == expectedAttemptTimes.count)
+        #expect(zip(attemptTimes, expectedAttemptTimes).allSatisfy {
+            abs($0 - $1) < 0.000_001
+        })
     }
 
     @Test func propagatesPermanentFailureWithoutRetrying() {

--- a/Packages/macOS/CmuxControlSocket/Tests/CmuxControlSocketTests/SocketStartupWaiterTests.swift
+++ b/Packages/macOS/CmuxControlSocket/Tests/CmuxControlSocketTests/SocketStartupWaiterTests.swift
@@ -1,0 +1,65 @@
+@testable import CmuxControlSocket
+import Foundation
+import Testing
+
+@Suite("Socket startup waiter")
+struct SocketStartupWaiterTests {
+    @Test func reResolvesPathAfterTransientConnectionFailure() throws {
+        let preferredPath = "/tmp/cmux-startup-wait-preferred.sock"
+        let fallbackPath = "/tmp/cmux-startup-wait-fallback.sock"
+        var attemptedPaths: [String] = []
+        let waiter = SocketStartupWaiter(
+            initialRetryDelay: 0.001,
+            maximumRetryDelay: 0.001
+        )
+
+        let connectedPath: String = try waiter.wait(
+            timeout: 1,
+            resolvePath: {
+                attemptedPaths.isEmpty ? preferredPath : fallbackPath
+            },
+            attemptConnection: { path, _ in
+                attemptedPaths.append(path)
+                return path == fallbackPath ? path : nil
+            }
+        )
+
+        #expect(connectedPath == fallbackPath)
+        #expect(attemptedPaths == [preferredPath, fallbackPath])
+    }
+
+    @Test func enforcesOneMonotonicDeadlineAcrossConnectionAttempts() {
+        let socketPath = "/tmp/cmux-startup-wait-timeout.sock"
+        var currentTime: TimeInterval = 0
+        var observedRemainingTime: TimeInterval?
+        var attemptCount = 0
+        let waiter = SocketStartupWaiter(
+            initialRetryDelay: 0.001,
+            maximumRetryDelay: 0.001,
+            monotonicTime: {
+                defer { currentTime += 0.25 }
+                return currentTime
+            }
+        )
+
+        do {
+            let _: String = try waiter.wait(
+                timeout: 0.5,
+                resolvePath: { socketPath },
+                attemptConnection: { _, remainingTime in
+                    attemptCount += 1
+                    observedRemainingTime = remainingTime
+                    return nil
+                }
+            )
+            Issue.record("Expected the bounded startup wait to time out")
+        } catch let timeout as SocketStartupWaitTimeout {
+            #expect(timeout.path == socketPath)
+        } catch {
+            Issue.record("Unexpected error: \(error)")
+        }
+
+        #expect(attemptCount == 1)
+        #expect(observedRemainingTime == 0.25)
+    }
+}

--- a/Packages/macOS/CmuxControlSocket/Tests/CmuxControlSocketTests/SocketStartupWaiterTests.swift
+++ b/Packages/macOS/CmuxControlSocket/Tests/CmuxControlSocketTests/SocketStartupWaiterTests.swift
@@ -8,9 +8,14 @@ struct SocketStartupWaiterTests {
         let preferredPath = "/tmp/cmux-startup-wait-preferred.sock"
         let fallbackPath = "/tmp/cmux-startup-wait-fallback.sock"
         var attemptedPaths: [String] = []
+        var currentTime: TimeInterval = 0
         let waiter = SocketStartupWaiter(
             initialRetryDelay: 0.001,
-            maximumRetryDelay: 0.001
+            maximumRetryDelay: 0.001,
+            monotonicTime: {
+                defer { currentTime += 0.001 }
+                return currentTime
+            }
         )
 
         let connectedPath: String = try waiter.wait(
@@ -61,5 +66,56 @@ struct SocketStartupWaiterTests {
 
         #expect(attemptCount == 1)
         #expect(observedRemainingTime == 0.25)
+    }
+
+    @Test func retriesWhenEventQueueIsUnavailable() throws {
+        let socketPath = "/tmp/cmux-startup-wait-no-kqueue.sock"
+        var currentTime: TimeInterval = 0
+        var attemptCount = 0
+        let waiter = SocketStartupWaiter(
+            initialRetryDelay: 0.001,
+            maximumRetryDelay: 0.001,
+            monotonicTime: {
+                defer { currentTime += 0.001 }
+                return currentTime
+            },
+            eventQueueFactory: { -1 }
+        )
+
+        let connection: String = try waiter.wait(
+            timeout: 1,
+            resolvePath: { socketPath },
+            attemptConnection: { path, _ in
+                attemptCount += 1
+                return attemptCount == 2 ? path : nil
+            }
+        )
+
+        #expect(connection == socketPath)
+        #expect(attemptCount == 2)
+    }
+
+    @Test func propagatesPermanentFailureWithoutRetrying() {
+        let socketPath = "/tmp/cmux-startup-wait-permanent-failure.sock"
+        var attemptCount = 0
+        let waiter = SocketStartupWaiter()
+
+        do {
+            let _: String = try waiter.wait(
+                timeout: 1,
+                resolvePath: { socketPath },
+                attemptConnection: { _, _ in
+                    attemptCount += 1
+                    throw CancellationError()
+                }
+            )
+            Issue.record("Expected the permanent connection failure to propagate")
+        } catch is CancellationError {
+            // Expected.
+        } catch {
+            Issue.record("Unexpected error: \(error)")
+        }
+
+        #expect(attemptCount == 1)
     }
 }

--- a/Packages/macOS/CmuxSettings/Sources/CmuxSettings/SocketControl/SocketControlSettings.swift
+++ b/Packages/macOS/CmuxSettings/Sources/CmuxSettings/SocketControl/SocketControlSettings.swift
@@ -228,7 +228,13 @@ public struct SocketControlSettings {
                 ? preferredPath
                 : userScopedPath
         case .socket(let ownerUserID) where ownerUserID == currentUserID:
-            return userScopedPath
+            // A same-user socket may be a live listener or an orphan left by
+            // an unclean exit. Let the transport's lock/liveness probe decide
+            // which case this is so startup and CLI resolution agree on the
+            // stable path after a crash.
+            return stableDefaultSocketCanBeReclaimed(preferredPath)
+                ? preferredPath
+                : userScopedPath
         case .socket, .other, .inaccessible:
             return preferredPath
         }

--- a/Packages/macOS/CmuxSettings/Sources/CmuxSettings/SocketControl/SocketControlSettings.swift
+++ b/Packages/macOS/CmuxSettings/Sources/CmuxSettings/SocketControl/SocketControlSettings.swift
@@ -209,7 +209,10 @@ public struct SocketControlSettings {
         isDebugBuild: Bool = SocketControlSettings.isDebugBuild,
         currentUserID: uid_t = getuid(),
         probeStableDefaultPathEntry: (String) -> StableDefaultSocketPathEntry = inspectStableDefaultSocketPathEntry,
-        stableDefaultSocketCanBeReclaimed: (String) -> Bool = { _ in true }
+        // Reclaimability is authoritative transport state. Callers that do not
+        // provide a lock/liveness probe must fail closed rather than claiming a
+        // stable path they cannot prove is safe to replace.
+        stableDefaultSocketCanBeReclaimed: (String) -> Bool = { _ in false }
     ) -> String {
         guard !isDebugBuild,
               normalizedBundleIdentifier(bundleIdentifier) == "com.cmuxterm.app",

--- a/Packages/macOS/CmuxSettings/Tests/CmuxSettingsTests/SocketControl/SocketControlSettingsTests.swift
+++ b/Packages/macOS/CmuxSettings/Tests/CmuxSettingsTests/SocketControl/SocketControlSettingsTests.swift
@@ -217,4 +217,16 @@ import CmuxSettings
         #expect(didProbeReclaimability)
         #expect(path == SocketControlSettings.stableDefaultSocketPath)
     }
+
+    @Test func initialStableLaunchFailsClosedWithoutReclaimabilityProbe() {
+        let path = SocketControlSettings.initialSocketPathBeforeListenerStart(
+            preferredPath: SocketControlSettings.stableDefaultSocketPath,
+            bundleIdentifier: "com.cmuxterm.app",
+            isDebugBuild: false,
+            currentUserID: 501,
+            probeStableDefaultPathEntry: { _ in .socket(ownerUserID: 501) }
+        )
+
+        #expect(path == SocketControlSettings.userScopedStableSocketPath(currentUserID: 501))
+    }
 }

--- a/Packages/macOS/CmuxSettings/Tests/CmuxSettingsTests/SocketControl/SocketControlSettingsTests.swift
+++ b/Packages/macOS/CmuxSettings/Tests/CmuxSettingsTests/SocketControl/SocketControlSettingsTests.swift
@@ -199,4 +199,22 @@ import CmuxSettings
         )
         #expect(path == "/tmp/cmux-debug-ci-split-theme.sock")
     }
+
+    @Test func initialStableLaunchReclaimsSameUserStaleSocketWhenLockIsFree() {
+        var didProbeReclaimability = false
+        let path = SocketControlSettings.initialSocketPathBeforeListenerStart(
+            preferredPath: SocketControlSettings.stableDefaultSocketPath,
+            bundleIdentifier: "com.cmuxterm.app",
+            isDebugBuild: false,
+            currentUserID: 501,
+            probeStableDefaultPathEntry: { _ in .socket(ownerUserID: 501) },
+            stableDefaultSocketCanBeReclaimed: { _ in
+                didProbeReclaimability = true
+                return true
+            }
+        )
+
+        #expect(didProbeReclaimability)
+        #expect(path == SocketControlSettings.stableDefaultSocketPath)
+    }
 }

--- a/Sources/ControlSurfaceResumeTarget.swift
+++ b/Sources/ControlSurfaceResumeTarget.swift
@@ -280,6 +280,7 @@ extension TerminalController {
         // conversation. Reuse the session-restore identity gate so the record
         // returned to the CLI always agrees with the binding that generated its
         // typed `cmux restore <kind> <checkpoint>` selector.
+        let restoredAgent = target.restorableAgent
         let compatibleAgent: (
             snapshot: SessionRestorableAgentSnapshot,
             source: String,
@@ -287,7 +288,7 @@ extension TerminalController {
         )?
         if binding == nil || binding?.isAgentHookBinding == true {
             if let restoredAgent = Workspace.restorableAgentForSessionRestore(
-                target.restorableAgent,
+                restoredAgent,
                 resumeBinding: binding
             ) {
                 compatibleAgent = (
@@ -351,12 +352,14 @@ extension TerminalController {
         // the record. Rebuild the typed argv from the authoritative binding so
         // `cmux restore` keeps its shell-free path even during that handoff.
         let workingDirectory = binding.cwd ?? binding.launchCommand?.workingDirectory
-        let preparedArguments = preparedResumeArguments(
-            binding: binding,
-            normalizedKind: normalizedKind,
-            workingDirectory: workingDirectory,
-            registration: target.restorableAgent?.registration
-        )
+        let preparedArguments = restoredAgent.flatMap { rejectedAgent in
+            preparedResumeArguments(
+                binding: binding,
+                normalizedKind: normalizedKind,
+                workingDirectory: workingDirectory,
+                registration: rejectedAgent.registration
+            )
+        }
         return ControlSurfaceRestoreRecord(
             modeRawValue: mode.rawValue,
             kind: normalizedKind,

--- a/Sources/ControlSurfaceResumeTarget.swift
+++ b/Sources/ControlSurfaceResumeTarget.swift
@@ -346,14 +346,23 @@ extension TerminalController {
         let mode: AgentRestoreRequestMode = binding.isAgentHookBinding
             ? .resumeAgent
             : .direct
+        // Once a newer hook binding supersedes a restored agent snapshot, none
+        // of the rejected snapshot's identity-scoped restore data may leak into
+        // the record. Rebuild the typed argv from the authoritative binding so
+        // `cmux restore` keeps its shell-free path even during that handoff.
+        let workingDirectory = binding.cwd ?? binding.launchCommand?.workingDirectory
+        let preparedArguments = preparedResumeArguments(
+            binding: binding,
+            normalizedKind: normalizedKind,
+            workingDirectory: workingDirectory,
+            registration: target.restorableAgent?.registration
+        )
         return ControlSurfaceRestoreRecord(
             modeRawValue: mode.rawValue,
             kind: normalizedKind,
             checkpointID: binding.checkpointId,
             source: binding.source,
-            workingDirectory: target.restoredResumeWorkingDirectory
-                ?? binding.cwd
-                ?? binding.launchCommand?.workingDirectory,
+            workingDirectory: workingDirectory,
             environment: binding.environment ?? [:],
             launchCommand: binding.launchCommand.map {
                 controlAgentLaunchCommand(
@@ -361,10 +370,47 @@ extension TerminalController {
                     replaySafeEnvironmentFor: normalizedKind
                 )
             },
-            preparedArguments: mode == .direct ? binding.launchCommand?.arguments : nil,
-            preparedArgumentsWorkingDirectory: nil,
+            preparedArguments: mode == .direct
+                ? binding.launchCommand?.arguments
+                : preparedArguments,
+            preparedArgumentsWorkingDirectory: preparedArguments == nil
+                ? nil
+                : workingDirectory,
             permissionMode: binding.permissionMode,
             legacyCommand: compatibilityBinding?.inlineStartupInput
+        )
+    }
+
+    private func preparedResumeArguments(
+        binding: SurfaceResumeBindingSnapshot,
+        normalizedKind: String,
+        workingDirectory: String?,
+        registration: CmuxVaultAgentRegistration?
+    ) -> [String]? {
+        guard binding.isAgentHookBinding,
+              let checkpointID = binding.checkpointId?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !checkpointID.isEmpty else {
+            return nil
+        }
+        let matchingRegistration = registration?.id == normalizedKind ? registration : nil
+        guard let kind = RestorableAgentKind(
+            persistedRawValue: normalizedKind,
+            registration: matchingRegistration
+        ),
+        kind.restoreMode == .resumeSession else {
+            return nil
+        }
+        return SessionRestorableAgentSnapshot(
+            kind: kind,
+            sessionId: checkpointID,
+            workingDirectory: workingDirectory,
+            launchCommand: binding.launchCommand,
+            registration: matchingRegistration,
+            permissionMode: binding.permissionMode
+        ).preparedResumeArguments(
+            launchCommand: binding.launchCommand,
+            workingDirectory: workingDirectory,
+            observedPermissionMode: binding.permissionMode
         )
     }
 

--- a/Sources/ControlSurfaceResumeTarget.swift
+++ b/Sources/ControlSurfaceResumeTarget.swift
@@ -352,13 +352,15 @@ extension TerminalController {
         // the record. Rebuild the typed argv from the authoritative binding so
         // `cmux restore` keeps its shell-free path even during that handoff.
         let workingDirectory = binding.cwd ?? binding.launchCommand?.workingDirectory
-        let preparedArguments = restoredAgent.flatMap { rejectedAgent in
-            preparedResumeArguments(
+        let preparedArguments: [String]?
+        if restoredAgent != nil {
+            preparedArguments = preparedResumeArguments(
                 binding: binding,
                 normalizedKind: normalizedKind,
-                workingDirectory: workingDirectory,
-                registration: rejectedAgent.registration
+                workingDirectory: workingDirectory
             )
+        } else {
+            preparedArguments = nil
         }
         return ControlSurfaceRestoreRecord(
             modeRawValue: mode.rawValue,
@@ -387,20 +389,20 @@ extension TerminalController {
     private func preparedResumeArguments(
         binding: SurfaceResumeBindingSnapshot,
         normalizedKind: String,
-        workingDirectory: String?,
-        registration: CmuxVaultAgentRegistration?
+        workingDirectory: String?
     ) -> [String]? {
         guard binding.isAgentHookBinding,
               let checkpointID = binding.checkpointId?.trimmingCharacters(in: .whitespacesAndNewlines),
               !checkpointID.isEmpty else {
             return nil
         }
-        let matchingRegistration = registration?.id == normalizedKind ? registration : nil
-        guard let kind = RestorableAgentKind(
-            persistedRawValue: normalizedKind,
-            registration: matchingRegistration
-        ),
-        kind.restoreMode == .resumeSession else {
+        // A rejected session snapshot cannot authorize its persisted custom-agent
+        // template. Registry-owned kinds also fall back to the current binding's
+        // compatibility command; only native, non-overridable kinds have enough
+        // information here to rebuild shell-free argv safely.
+        guard let kind = RestorableAgentKind(rawValue: normalizedKind),
+              RestorableAgentKind.allCases.contains(kind),
+              kind.restoreMode == .resumeSession else {
             return nil
         }
         return SessionRestorableAgentSnapshot(
@@ -408,7 +410,6 @@ extension TerminalController {
             sessionId: checkpointID,
             workingDirectory: workingDirectory,
             launchCommand: binding.launchCommand,
-            registration: matchingRegistration,
             permissionMode: binding.permissionMode
         ).preparedResumeArguments(
             launchCommand: binding.launchCommand,

--- a/Sources/Sidebar/SidebarWorkspaceDescriptionText.swift
+++ b/Sources/Sidebar/SidebarWorkspaceDescriptionText.swift
@@ -62,7 +62,7 @@ struct SidebarWorkspaceDescriptionText: View {
                 )
 #endif
             }
-            .onChange(of: markdown) { newValue in
+            .onChange(of: markdown) { _, newValue in
 #if DEBUG
                 let newlineCount = newValue.reduce(into: 0) { count, character in
                     if character == "\n" { count += 1 }

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -2137,6 +2137,7 @@ C0DE71B10000000000000001 /* AppDelegate+AgentChatNotifications.swift in Sources 
 		A79840010000000000000001 /* SocketACLReloadRegressionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A79840010000000000000002 /* SocketACLReloadRegressionTests.swift */; };
 		5830CA11BAC0000000000004 /* SocketCallbackAwaiter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5830CA11BAC0000000000003 /* SocketCallbackAwaiter.swift */; };
 		5830CA11BAC0000000000002 /* SocketCallbackAwaiterMainThreadTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5830CA11BAC0000000000001 /* SocketCallbackAwaiterMainThreadTests.swift */; };
+		A10052000000000000000002 /* SocketClient+StartupWait.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10052000000000000000001 /* SocketClient+StartupWait.swift */; };
 		A7984AD10000000000000001 /* SocketConfigurationLifecycleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7984AD10000000000000002 /* SocketConfigurationLifecycleTests.swift */; };
 		A5001226 /* SocketControlMode+Display.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001225 /* SocketControlMode+Display.swift */; };
 		F8000000A1B2C3D4E5F60718 /* SocketControlPasswordStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8000001A1B2C3D4E5F60718 /* SocketControlPasswordStoreTests.swift */; };
@@ -4898,6 +4899,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 		A79840010000000000000002 /* SocketACLReloadRegressionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SocketACLReloadRegressionTests.swift; sourceTree = "<group>"; };
 		5830CA11BAC0000000000003 /* SocketCallbackAwaiter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SocketCallbackAwaiter.swift; sourceTree = "<group>"; };
 		5830CA11BAC0000000000001 /* SocketCallbackAwaiterMainThreadTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SocketCallbackAwaiterMainThreadTests.swift; sourceTree = "<group>"; };
+		A10052000000000000000001 /* SocketClient+StartupWait.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SocketClient+StartupWait.swift"; sourceTree = "<group>"; };
 		A7984AD10000000000000002 /* SocketConfigurationLifecycleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SocketConfigurationLifecycleTests.swift; sourceTree = "<group>"; };
 		A5001225 /* SocketControlMode+Display.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SocketControlMode+Display.swift"; sourceTree = "<group>"; };
 		F8000001A1B2C3D4E5F60718 /* SocketControlPasswordStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SocketControlPasswordStoreTests.swift; sourceTree = "<group>"; };
@@ -7614,6 +7616,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				A76110010000000000000002 /* AgentHookNotificationPolicy.swift */,
 				FEEDC1A50000000000000002 /* FeedEventClassifier.swift */,
 				B900004BA1B2C3D4E5F60719 /* CLISocketPathResolver.swift */,
+				A10052000000000000000001 /* SocketClient+StartupWait.swift */,
 				A6AC720A0000000000000002 /* WorkspaceLoadingArguments.swift */,
 				C510C1E00000000000000001 /* SocketOperationTelemetry.swift */,
 				6379A0036379A0036379A003 /* SSHPTYResizeMonitor.swift */,
@@ -10828,6 +10831,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				835000000000000000000002 /* RemoteInitialCommandBootstrap.swift in Sources */,
 				B9000028A1B2C3D4E5F60719 /* RemoteInteractiveShellBootstrapBuilder.swift in Sources */,
 				B9000027A1B2C3D4E5F60719 /* RemoteRelayZshBootstrap.swift in Sources */,
+				A10052000000000000000002 /* SocketClient+StartupWait.swift in Sources */,
 				C510C1E00000000000000002 /* SocketOperationTelemetry.swift in Sources */,
 				B816E948EC5E42AF967648AC /* SSHPTYAttachReconnectInputFilter.swift in Sources */,
 				E60610200000000000000002 /* SSHPTYAttachReconnectInputFilterControl.swift in Sources */,

--- a/cmuxTests/AppDelegateIssue2907RoutingTests.swift
+++ b/cmuxTests/AppDelegateIssue2907RoutingTests.swift
@@ -1055,6 +1055,11 @@ final class AppDelegateIssue2907RoutingTests: XCTestCase {
             restoreRecord["prepared_arguments_working_directory"] as? String,
             "/tmp/current"
         )
+        let preparedArguments = try XCTUnwrap(
+            restoreRecord["prepared_arguments"] as? [String]
+        )
+        XCTAssertTrue(preparedArguments.contains(currentSessionID), "\(preparedArguments)")
+        XCTAssertFalse(preparedArguments.contains(staleSessionID), "\(preparedArguments)")
         let launch = try XCTUnwrap(restoreRecord["launch_command"] as? [String: Any])
         XCTAssertEqual(launch["arguments"] as? [String], currentLaunch.arguments)
         let launchEnvironment = try XCTUnwrap(launch["environment"] as? [String: Any])
@@ -1074,7 +1079,8 @@ final class AppDelegateIssue2907RoutingTests: XCTestCase {
         )
         XCTAssertNil(resumeLaunchEnvironment["OPENAI_API_KEY"])
         let legacyCommand = try XCTUnwrap(restoreRecord["legacy_command"] as? String)
-        XCTAssertTrue(legacyCommand.contains("codex resume \(currentSessionID)"))
+        XCTAssertTrue(legacyCommand.contains(currentSessionID), legacyCommand)
+        XCTAssertFalse(legacyCommand.contains(staleSessionID), legacyCommand)
 
         let ompSessionID = UUID().uuidString.lowercased()
         XCTAssertTrue(workspace.setSurfaceResumeBinding(

--- a/cmuxTests/AppDelegateIssue2907RoutingTests.swift
+++ b/cmuxTests/AppDelegateIssue2907RoutingTests.swift
@@ -1233,7 +1233,7 @@ final class AppDelegateIssue2907RoutingTests: XCTestCase {
         XCTAssertTrue(preparedArguments.contains(restoredDirectory), "\(preparedArguments)")
         XCTAssertFalse(preparedArguments.contains(savedDirectory), "\(preparedArguments)")
 
-        let replacementSessionID = "replacement-cwd-session"
+        let replacementSessionID = "replacement-current-session"
         let replacementDirectory = "/tmp/replacement-project"
         let replacementLaunch = AgentLaunchCommandSnapshot(
             launcher: "cwd-agent",
@@ -1272,6 +1272,18 @@ final class AppDelegateIssue2907RoutingTests: XCTestCase {
         XCTAssertNotEqual(
             replacementRecord["working_directory"] as? String,
             restoredDirectory
+        )
+        XCTAssertNil(replacementRecord["prepared_arguments"] as? [String])
+        let replacementLegacyCommand = try XCTUnwrap(
+            replacementRecord["legacy_command"] as? String
+        )
+        XCTAssertTrue(
+            replacementLegacyCommand.contains(replacementSessionID),
+            replacementLegacyCommand
+        )
+        XCTAssertFalse(
+            replacementLegacyCommand.contains(sessionID),
+            replacementLegacyCommand
         )
     }
 

--- a/cmuxTests/AppDelegateIssue2907RoutingTests.swift
+++ b/cmuxTests/AppDelegateIssue2907RoutingTests.swift
@@ -942,6 +942,8 @@ final class AppDelegateIssue2907RoutingTests: XCTestCase {
         XCTAssertEqual(restoreRecord["kind"] as? String, "hermes-agent")
         XCTAssertEqual(restoreRecord["checkpoint_id"] as? String, checkpointID)
         XCTAssertNil(restoreRecord["launch_command"] as? [String: Any])
+        // A binding-only record keeps the compatibility-shell path. Typed argv
+        // is rebuilt only when a newer binding supersedes a stale snapshot.
         XCTAssertNil(restoreRecord["prepared_arguments"] as? [String])
         let legacyCommand = try XCTUnwrap(restoreRecord["legacy_command"] as? String)
         XCTAssertTrue(

--- a/cmuxTests/AppDelegateShortcutRoutingRepairProbe.swift
+++ b/cmuxTests/AppDelegateShortcutRoutingRepairProbe.swift
@@ -14,11 +14,18 @@ extension AppDelegateShortcutRoutingTests {
         hostedView: GhosttySurfaceScrollView
     ) {
         window.makeKeyAndOrderFront(nil)
-        window.displayIfNeeded()
         hostedView.setVisibleInUI(true)
         hostedView.setActive(true)
-        hostedView.moveFocus()
-        RunLoop.main.run(until: Date(timeIntervalSinceNow: 0.05))
+        let deadline = Date(timeIntervalSinceNow: 1)
+        repeat {
+            window.displayIfNeeded()
+            if hostedView.surfaceView.window === window,
+               window.makeFirstResponder(hostedView.surfaceView),
+               hostedView.isSurfaceViewFirstResponder() {
+                break
+            }
+            RunLoop.main.run(until: Date(timeIntervalSinceNow: 0.01))
+        } while Date() < deadline
         XCTAssertTrue(
             hostedView.isSurfaceViewFirstResponder(),
             "Expected terminal surface to own first responder before repair test"

--- a/cmuxTests/CMUXCLIErrorOutputRegressionTests.swift
+++ b/cmuxTests/CMUXCLIErrorOutputRegressionTests.swift
@@ -1215,7 +1215,11 @@ import Testing
                 "prepared_arguments": ["/usr/bin/true"],
             ],
         ])
-        let socketPath = "/tmp/cmux-restore-startup-\(UUID().uuidString.prefix(8)).sock"
+        let fixtureDirectory = URL(fileURLWithPath: "/tmp", isDirectory: true)
+            .appendingPathComponent("cmux-restore-startup-\(UUID().uuidString.prefix(8))", isDirectory: true)
+        try FileManager.default.createDirectory(at: fixtureDirectory, withIntermediateDirectories: true)
+        let socketPath = fixtureDirectory.appendingPathComponent("cmux.sock", isDirectory: false).path
+        let debugLogPath = fixtureDirectory.appendingPathComponent("cli.log", isDirectory: false).path
         var startupSocketFD = try bindUnavailableUnixSocket(at: socketPath)
         var responder: UnixSocketResponder?
         defer {
@@ -1224,6 +1228,7 @@ import Testing
             }
             responder?.stop()
             unlink(socketPath)
+            try? FileManager.default.removeItem(at: fixtureDirectory)
         }
         var environment = ProcessInfo.processInfo.environment
         for key in Array(environment.keys) where key.hasPrefix("CMUX_") {
@@ -1231,6 +1236,7 @@ import Testing
         }
         environment["CMUX_CLI_SENTRY_DISABLED"] = "1"
         environment["CMUX_SOCKET_PATH"] = socketPath
+        environment["CMUX_DEBUG_LOG"] = debugLogPath
         environment["CMUX_SURFACE_ID"] = surfaceID
 
         let result = runProcess(
@@ -1243,14 +1249,18 @@ import Testing
             environment: environment,
             timeout: 5,
             afterLaunch: {
-                // The old restore path only retried connects for 350ms. Keep
-                // the listener unavailable beyond that window so this test
-                // proves restore waits for the startup lifecycle instead of
-                // returning the generic "still opening" error immediately.
-                usleep(700_000)
+                // The CLI emits this diagnostic at the readiness boundary. Wait
+                // for that explicit milestone before making the same socket inode
+                // listen; this avoids turning the regression into a wall-clock race.
+                guard self.waitForFileContentsUsingKqueue(
+                    URL(fileURLWithPath: debugLogPath),
+                    containing: "socket.connect.wait.entered",
+                    timeout: 3
+                ) else {
+                    return
+                }
                 close(startupSocketFD)
                 startupSocketFD = -1
-                unlink(socketPath)
                 responder = try? UnixSocketResponder(
                     path: socketPath,
                     responses: [currentWorkspaceResponse, identifyResponse, recordResponse]
@@ -3226,6 +3236,55 @@ import Testing
             throw NSError(domain: NSPOSIXErrorDomain, code: Int(savedErrno))
         }
         return descriptor
+    }
+
+    /// Waits for a child-written marker using the directory's vnode events.
+    ///
+    /// The initial content check handles a write that wins the race with kqueue
+    /// registration; subsequent writes wake the event wait without polling or
+    /// sleeping the test thread.
+    private func waitForFileContentsUsingKqueue(
+        _ url: URL,
+        containing expected: String,
+        timeout: TimeInterval
+    ) -> Bool {
+        let directoryURL = url.deletingLastPathComponent()
+        let queue = kqueue()
+        guard queue >= 0 else { return false }
+        defer { close(queue) }
+
+        let directoryFD = open(directoryURL.path, O_EVTONLY)
+        guard directoryFD >= 0 else { return false }
+        defer { close(directoryFD) }
+
+        var event = kevent(
+            ident: UInt(directoryFD),
+            filter: Int16(EVFILT_VNODE),
+            flags: UInt16(EV_ADD | EV_ENABLE | EV_CLEAR),
+            fflags: UInt32(NOTE_WRITE | NOTE_DELETE | NOTE_RENAME | NOTE_ATTRIB | NOTE_EXTEND | NOTE_LINK),
+            data: 0,
+            udata: nil
+        )
+        guard kevent(queue, &event, 1, nil, 0, nil) == 0 else { return false }
+
+        let deadline = Date.now.addingTimeInterval(max(timeout, 0))
+        while true {
+            if let contents = try? String(contentsOf: url, encoding: .utf8),
+               contents.contains(expected) {
+                return true
+            }
+            let remaining = deadline.timeIntervalSinceNow
+            guard remaining > 0 else { return false }
+            var timeoutSpec = timespec(
+                tv_sec: Int(remaining),
+                tv_nsec: Int((remaining - floor(remaining)) * 1_000_000_000)
+            )
+            var triggeredEvent = kevent()
+            let result = kevent(queue, nil, 0, &triggeredEvent, 1, &timeoutSpec)
+            if result < 0, errno != EINTR {
+                return false
+            }
+        }
     }
 
     /// Points the stable last-socket-path marker inside `home` at a path of the test's own.

--- a/cmuxTests/CMUXCLIErrorOutputRegressionTests.swift
+++ b/cmuxTests/CMUXCLIErrorOutputRegressionTests.swift
@@ -1283,6 +1283,94 @@ import Testing
         ])
     }
 
+    @Test func testRestoreWaitsForRelayDuringAppStartup() throws {
+        let cliPath = try bundledCLIPath()
+        let checkpointID = "pi-\(UUID().uuidString.lowercased())"
+        let workspaceID = UUID().uuidString
+        let surfaceID = UUID().uuidString
+        let relayID = "relay-\(UUID().uuidString.lowercased())"
+        let targetResponse = try jsonResponse(result: [
+            "terminals": [[
+                "tty": "0",
+                "workspace_id": workspaceID,
+                "surface_id": surfaceID,
+            ]],
+            "source": "tty",
+            "tty_resolution": "reported_tty",
+            "workspace_id": workspaceID,
+            "surface_id": surfaceID,
+        ])
+        let recordResponse = try jsonResponse(result: [
+            "restore_record": [
+                "mode": "direct",
+                "kind": "pi",
+                "checkpoint_id": checkpointID,
+                "environment": [:],
+                "launch_command": [
+                    "arguments": ["/usr/bin/true"],
+                    "executable_path": "/usr/bin/true",
+                ],
+                "prepared_arguments": ["/usr/bin/true"],
+            ],
+        ])
+        let fixtureDirectory = URL(fileURLWithPath: "/tmp", isDirectory: true)
+            .appendingPathComponent("cmux-restore-relay-startup-\(UUID().uuidString.prefix(8))", isDirectory: true)
+        try FileManager.default.createDirectory(at: fixtureDirectory, withIntermediateDirectories: true)
+        let debugLogPath = fixtureDirectory.appendingPathComponent("cli.log", isDirectory: false).path
+        let responder = try RelaySocketResponder(
+            relayID: relayID,
+            responses: [targetResponse, recordResponse],
+            startListening: false
+        )
+        defer {
+            responder.stop()
+            try? FileManager.default.removeItem(at: fixtureDirectory)
+        }
+        var environment = ProcessInfo.processInfo.environment
+        for key in Array(environment.keys) where key.hasPrefix("CMUX_") {
+            environment.removeValue(forKey: key)
+        }
+        environment["CMUX_CLI_SENTRY_DISABLED"] = "1"
+        environment["CMUX_SOCKET_PATH"] = responder.endpoint
+        environment["CMUX_RELAY_ID"] = relayID
+        environment["CMUX_RELAY_TOKEN"] = String(repeating: "11", count: 32)
+        environment["CMUX_WORKSPACE_ID"] = workspaceID
+        environment["CMUX_CLI_TTY_NAME"] = "0"
+        environment["CMUX_DEBUG_LOG"] = debugLogPath
+
+        let result = runProcess(
+            executablePath: cliPath,
+            arguments: ["restore", "pi", checkpointID],
+            environment: environment,
+            timeout: 5,
+            afterLaunch: {
+                guard self.waitForFileContentsUsingKqueue(
+                    URL(fileURLWithPath: debugLogPath),
+                    containing: "socket.connect.wait.entered",
+                    timeout: 3
+                ) else {
+                    return
+                }
+                // Keep the bound TCP endpoint unavailable through the waiter's
+                // first connection attempt. Without relay error classification,
+                // that attempt fails permanently instead of reaching a retry.
+                usleep(100_000)
+                responder.startListening()
+            }
+        )
+
+        XCTAssertFalse(result.timedOut, result.diagnostics)
+        XCTAssertEqual(result.status, 0, result.diagnostics)
+        let requests = try responder.receivedRequests.map { request in
+            let data = try #require(request.data(using: .utf8))
+            return try #require(JSONSerialization.jsonObject(with: data) as? [String: Any])
+        }
+        #expect(requests.compactMap { $0["method"] as? String } == [
+            "agent.resolve_delivery_target",
+            "surface.resume.get",
+        ])
+    }
+
     @Test(arguments: ["pi", "grok"])
     func testRestorePrefersCallerTTYOverStaleAmbientRouting(kind: String) throws {
         let cliPath = try bundledCLIPath()
@@ -4023,7 +4111,11 @@ final class RelaySocketResponder {
     private var requests: [String] = []
     private var listenerFD: Int32 = -1
 
-    init(relayID: String, responses: [String]) throws {
+    init(
+        relayID: String,
+        responses: [String],
+        startListening: Bool = true
+    ) throws {
         guard !responses.isEmpty else {
             throw NSError(
                 domain: NSCocoaErrorDomain,
@@ -4049,8 +4141,8 @@ final class RelaySocketResponder {
                 Darwin.bind(fd, socketPointer, socklen_t(MemoryLayout<sockaddr_in>.size))
             }
         }
-        guard bindResult == 0, listen(fd, 8) == 0 else {
-            let error = Self.posixError("bind/listen")
+        guard bindResult == 0 else {
+            let error = Self.posixError("bind")
             close(fd)
             throw error
         }
@@ -4070,8 +4162,8 @@ final class RelaySocketResponder {
 
         listenerFD = fd
         endpoint = "127.0.0.1:\(UInt16(bigEndian: boundAddress.sin_port))"
-        queue.async { [weak self] in
-            self?.acceptLoop(listenerFD: fd)
+        if startListening {
+            self.startListening()
         }
     }
 
@@ -4083,6 +4175,21 @@ final class RelaySocketResponder {
         lock.lock()
         defer { lock.unlock() }
         return requests
+    }
+
+    func startListening() {
+        lock.lock()
+        guard !stopped, listenerFD >= 0 else {
+            lock.unlock()
+            return
+        }
+        let fd = listenerFD
+        let listenResult = listen(fd, 8)
+        lock.unlock()
+        guard listenResult == 0 else { return }
+        queue.async { [weak self] in
+            self?.acceptLoop(listenerFD: fd)
+        }
     }
 
     func stop() {

--- a/cmuxTests/CMUXCLIErrorOutputRegressionTests.swift
+++ b/cmuxTests/CMUXCLIErrorOutputRegressionTests.swift
@@ -1243,7 +1243,11 @@ import Testing
             environment: environment,
             timeout: 5,
             afterLaunch: {
-                usleep(100_000)
+                // The old restore path only retried connects for 350ms. Keep
+                // the listener unavailable beyond that window so this test
+                // proves restore waits for the startup lifecycle instead of
+                // returning the generic "still opening" error immediately.
+                usleep(700_000)
                 close(startupSocketFD)
                 startupSocketFD = -1
                 unlink(socketPath)

--- a/cmuxTests/GhosttyConfigTests.swift
+++ b/cmuxTests/GhosttyConfigTests.swift
@@ -3565,13 +3565,14 @@ final class SocketControlSettingsTests: XCTestCase {
         XCTAssertEqual(path, SocketControlSettings.userScopedStableSocketPath(currentUserID: 501))
     }
 
-    func testInitialStableLaunchFallsBackToUserScopedSocketWhenSameUserStablePathExists() {
+    func testInitialStableLaunchFallsBackToUserScopedSocketWhenSameUserStablePathIsLive() {
         let path = SocketControlSettings.initialSocketPathBeforeListenerStart(
             preferredPath: SocketControlSettings.stableDefaultSocketPath,
             bundleIdentifier: "com.cmuxterm.app",
             isDebugBuild: false,
             currentUserID: 501,
-            probeStableDefaultPathEntry: { _ in .socket(ownerUserID: 501) }
+            probeStableDefaultPathEntry: { _ in .socket(ownerUserID: 501) },
+            stableDefaultSocketCanBeReclaimed: { _ in false }
         )
 
         XCTAssertEqual(path, SocketControlSettings.userScopedStableSocketPath(currentUserID: 501))
@@ -3586,13 +3587,15 @@ final class SocketControlSettingsTests: XCTestCase {
             probeStableDefaultPathEntry: { socketPath in
                 XCTAssertEqual(socketPath, "/private/tmp/cmux.sock")
                 return .socket(ownerUserID: 501)
-            }
+            },
+            stableDefaultSocketCanBeReclaimed: { _ in false }
         )
 
         XCTAssertEqual(path, SocketControlSettings.userScopedStableSocketPath(currentUserID: 501))
     }
 
-    func testInitialStableLaunchDoesNotProbeSameUserStableSocketLiveness() {
+    func testInitialStableLaunchUsesTransportReclaimabilityForSameUserSocket() {
+        var didProbe = false
         let path = SocketControlSettings.initialSocketPathBeforeListenerStart(
             preferredPath: SocketControlSettings.stableDefaultSocketPath,
             bundleIdentifier: "com.cmuxterm.app",
@@ -3600,15 +3603,16 @@ final class SocketControlSettingsTests: XCTestCase {
             currentUserID: 501,
             probeStableDefaultPathEntry: { _ in .socket(ownerUserID: 501) },
             stableDefaultSocketCanBeReclaimed: { _ in
-                XCTFail("Existing startup sockets should fall back without liveness probing on the main thread")
-                return true
+                didProbe = true
+                return false
             }
         )
 
+        XCTAssertTrue(didProbe)
         XCTAssertEqual(path, SocketControlSettings.userScopedStableSocketPath(currentUserID: 501))
     }
 
-    func testInitialStableLaunchDoesNotProbeSameUserStableSocketReclaimability() {
+    func testInitialStableLaunchKeepsStablePathWhenTransportReclaimsSameUserSocket() {
         let path = SocketControlSettings.initialSocketPathBeforeListenerStart(
             preferredPath: SocketControlSettings.stableDefaultSocketPath,
             bundleIdentifier: "com.cmuxterm.app",
@@ -3616,12 +3620,12 @@ final class SocketControlSettingsTests: XCTestCase {
             currentUserID: 501,
             probeStableDefaultPathEntry: { _ in .socket(ownerUserID: 501) },
             stableDefaultSocketCanBeReclaimed: { socketPath in
-                XCTFail("Existing startup sockets should fall back without reclaimability probing: \(socketPath)")
-                return false
+                XCTAssertEqual(socketPath, SocketControlSettings.stableDefaultSocketPath)
+                return true
             }
         )
 
-        XCTAssertEqual(path, SocketControlSettings.userScopedStableSocketPath(currentUserID: 501))
+        XCTAssertEqual(path, SocketControlSettings.stableDefaultSocketPath)
     }
 
     func testInitialStableLaunchKeepsUserScopedPreferredPathWithoutProbing() {

--- a/cmuxTests/TerminalAndGhosttyTests.swift
+++ b/cmuxTests/TerminalAndGhosttyTests.swift
@@ -6343,7 +6343,7 @@ final class TerminalControllerSocketListenerHealthTests: XCTestCase {
     private let transport = SocketTransport()
 
     @MainActor
-    func testStartPreservesRefusedSocketFileWhenLockHasNoReusableMarker() throws {
+    func testStartReclaimsRefusedSocketFileWhenLockHasNoReusableMarker() throws {
         TerminalController.shared.stop()
         defer { TerminalController.shared.stop() }
 
@@ -6361,17 +6361,11 @@ final class TerminalControllerSocketListenerHealthTests: XCTestCase {
             accessMode: .allowAll
         )
 
+        // The lock is unheld even though its marker was never written. The
+        // refused probe plus exclusive flock is enough to reclaim the orphan.
         XCTAssertTrue(FileManager.default.fileExists(atPath: path))
         XCTAssertTrue(FileManager.default.fileExists(atPath: path + ".lock"))
-        XCTAssertFalse(transport.pathCanBeReclaimedForStartup(path))
-        TerminalController.shared.start(
-            tabManager: TabManager(),
-            socketPath: path,
-            accessMode: .allowAll
-        )
-        XCTAssertTrue(FileManager.default.fileExists(atPath: path))
-        XCTAssertTrue(FileManager.default.fileExists(atPath: path + ".lock"))
-        XCTAssertFalse(transport.pathAcceptsConnections(path))
+        XCTAssertTrue(transport.pathAcceptsConnections(path))
     }
 
     @MainActor

--- a/cmuxTests/VaultPaneTransferLifecycleTests.swift
+++ b/cmuxTests/VaultPaneTransferLifecycleTests.swift
@@ -184,7 +184,7 @@ struct VaultPaneTransferLifecycleTests {
                     focus: true,
                     creationPolicy: .restoration,
                     allowsExternalBrowserFallback: false
-                ))
+                )).id
             }
             let targetPane = try #require(
                 fixture.workspace.paneId(forPanelId: targetPanelID)


### PR DESCRIPTION
## Summary

Fixes https://github.com/manaflow-ai/cmux/issues/10052, covering both halves of the socket lifecycle failure:

- The app reclaims a current-user stale Unix socket when the path lock is available and a liveness probe proves no listener remains, even if the old process died before writing the reusable marker. Foreign-owned or indeterminate nodes remain protected.
- Listener startup retries through the same lock/probe/bind lifecycle and emits failure/retry breadcrumbs instead of silently running without a control socket.
- Stable startup path selection uses the transport's authoritative reclaimability decision, so a crash relaunch retains and rebinds the stable path when it is safe.
- Implicit `cmux restore` uses one bounded `SocketStartupWaiter` primitive in `CmuxControlSocket`, shared with the CLI's other app-launch races through a thin adapter. It re-resolves the implicit path on each probe, wakes on kqueue directory events, backs off to a maximum 500 ms interval, and distinguishes permanent path conflicts from a genuine 45-second startup timeout. Explicit socket paths retain immediate failure semantics.
- Each startup connect consumes the remaining monotonic wait budget, and an `ENOENT` caused by a socket inode being replaced between inspection and connect is retried as transient.

## Regression coverage

The first commit is test-only, preserving the required red/green history. It covers:

- reclaiming an unmarked stale socket/lock pair after an unclean exit;
- consulting transport reclaimability during stable startup path selection; and
- a restore race where the listener starts after the old one-shot connection window.

Follow-up coverage exercises the package-owned wait primitive's fallback-path re-resolution and single monotonic deadline. The CLI race test observes an explicit readiness diagnostic before starting its delayed listener, rather than sleeping. A small baseline test/API correction keeps the current `main` test target compiling, and a deprecated SwiftUI callback correction removes an existing warning without changing `.github/swift-warning-budget.tsv`.

## Design notes

- The wait is synchronous by design because `cmux` is a short-lived command-line process whose requested operation cannot continue until the separate app process exposes its socket. It does not run on the app's main thread and blocks in kqueue between bounded connection attempts rather than consuming CPU.
- A server-owned readiness message cannot be delivered before the cross-process socket carrying that message exists. A second readiness file would introduce another stale-artifact lifecycle. The socket's successful connection is therefore the authoritative ready transition.
- Re-resolution is bounded by the 45-second deadline and 500 ms maximum interval. Stable releases inspect a fixed candidate set; tagged-socket directory discovery is limited to debug resolution.

## Validation

- `swiftc -parse` on changed Swift sources
- `swift test --package-path Packages/macOS/CmuxControlSocket --filter SocketStartupWaiterTests` (2 tests)
- `swift test --package-path Packages/macOS/CmuxControlSocket --filter SocketControlServerTests` (16 tests, including unclean-exit reclaim)
- `scripts/check-pbxproj.sh`
- `scripts/lint-pbxproj-test-wiring.sh`
- `scripts/check-package-resolved-policy.py`
- `python3 scripts/check-workspace-package-groups.py --check`
- cmux architecture policy guard
- localization catalog JSON validation
- `git diff --check`

Per the issue instructions, no local `xcodebuild`, app build, reload, or launch was run. GitHub Actions is the authoritative app-host and release validation environment.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved recovery from stale or orphaned socket files after crashes or unclean shutdowns.
  * Prevented unsafe handling of socket paths owned by another user.
  * Added retries for temporary socket startup and binding failures.
  * Stable socket paths now safely fall back when reclaiming them is not possible.

* **Reliability**
  * Startup restoration waits up to 45 seconds for implicitly selected sockets.
  * Socket paths are rechecked during retries, with clearer timeout handling and diagnostics.
  * Explicit socket paths continue to fail immediately when unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Shard-4 follow-up

- The app-host shard exposed a real pre-existing gap in the newer-binding-over-stale-snapshot handoff: once the stale snapshot was rejected, the binding-only record did not rebuild typed resume arguments or their working-directory provenance. The production builder now derives both from the authoritative newer hook binding and never falls back to the rejected snapshot’s identity-scoped cwd.
- The existing legacy-command assertion now verifies that the current checkpoint is present and the stale checkpoint is absent. Requiring the contiguous text `codex resume <id>` was not the intended contract because compatibility replay deliberately canonicalizes Codex commands by inserting the per-invocation update-check suppression and wrapper routing. The production compatibility behavior is unchanged.
- The first-responder setup failure was fixture/host flakiness, not a production focus regression: no focus, window, Ghostty, or shortcut-routing source changed. The fixture now waits on the real AppKit responder condition instead of assuming a 50 ms settle interval. On exact head `3586c7dedb`, the macOS 15 focused run passed the previously failing responder precondition and reached the test's later explicit no-live-libghostty skip: https://github.com/manaflow-ai/cmux/actions/runs/31666260515.
- Exact-head macOS 15 focused proof also passed the newer-binding-over-stale-restored-agent behavior (1 test, 0 failures): https://github.com/manaflow-ai/cmux/actions/runs/31666257374. The binding-only Hermes compatibility contract passed independently (1 test, 0 failures): https://github.com/manaflow-ai/cmux/actions/runs/31666259051.
- Final review tightened that handoff further: a rejected custom/registry-owned snapshot can no longer supply its persisted resume template to the newer binding, so those records use the current compatibility command rather than stale prepared argv. Native non-overridable kinds retain shell-free reconstruction. It also coalesces parent-directory vnode storms behind a minimum exponential retry cadence; a virtual-clock behavior test verifies unrelated events cannot trigger one resolver/socket probe per write.
- Additional local validation: `swift test --package-path Packages/macOS/CMUXAgentLaunch` (299 tests), Swift parsing, test wiring, Package.resolved policy, workspace package grouping, and `git diff --check`. No local `xcodebuild` was run.
