### PR TITLE
fix for workspace minification glitch

### DIFF
--- a/Sources/Sidebar/AppKitList/Cells/SidebarGroupHeaderRowView.swift
+++ b/Sources/Sidebar/AppKitList/Cells/SidebarGroupHeaderRowView.swift
@@ -734,7 +734,11 @@ final class SidebarShortcutHintPillView: NSView {
         let radius = bounds.height / 2
         materialView.frame = bounds
         materialView.layer?.cornerRadius = radius
-        label.frame = materialView.bounds.insetBy(dx: Self.horizontalPadding, dy: 2)
+        let labelBounds = materialView.bounds
+        label.frame = labelBounds.insetBy(
+            dx: min(Self.horizontalPadding, labelBounds.width / 2),
+            dy: min(2, labelBounds.height / 2)
+        )
         layer?.shadowPath = CGPath(
             roundedRect: bounds,
             cornerWidth: radius,

--- a/cmuxTests/SidebarWorkspaceTableTests.swift
+++ b/cmuxTests/SidebarWorkspaceTableTests.swift
@@ -51,6 +51,17 @@ struct SidebarWorkspaceTableTests {
     }
 
     @Test
+    @MainActor
+    func zeroSizedShortcutHintPillKeepsLabelInsideBounds() throws {
+        let pill = SidebarShortcutHintPillView()
+        pill.layout()
+        let materialView = try #require(pill.subviews.first as? NSVisualEffectView)
+        let label = try #require(materialView.subviews.first as? NSTextField)
+
+        #expect(label.frame == .zero)
+    }
+
+    @Test
     func rowHeightEstimateAccountsForScaleWrappingAndDetails() {
         let calculator = SidebarWorkspaceTableRowHeightCalculator()
         let compact = calculator.estimatedWorkspaceHeight(


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved shortcut hint pill layout to prevent oversized spacing from producing invalid label frames.
  * Ensured labels remain fully contained within their pill boundaries, including when the available space is limited.

* **Tests**
  * Added coverage verifying correct label sizing within shortcut hint pills.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->