### PR TITLE
fix(ios): preserve Tailscale migration setup flow

### DIFF
--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+ReconnectRoutes.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+ReconnectRoutes.swift
@@ -189,11 +189,8 @@ extension MobileShellComposite {
         return hasStoredUsableTailscaleAuthorization
     }
 
-    /// Readiness of the selected Tailscale method and its local endpoint grant.
-    public var tailscaleSetupStatus: MobileTailscaleSetupStatus {
-        guard connectionMethodStore?.method == .tailscale else {
-            return .notSelected
-        }
+    /// Readiness if the user selects Tailscale, before that preference is saved.
+    public var tailscaleSetupStatusWhenSelected: MobileTailscaleSetupStatus {
         if hasUsableTailscaleAuthorization {
             return .authorized
         }
@@ -201,6 +198,14 @@ extension MobileShellComposite {
             return .loadingAuthorization
         }
         return .pairingRequired
+    }
+
+    /// Readiness of the currently selected Tailscale connection method.
+    public var tailscaleSetupStatus: MobileTailscaleSetupStatus {
+        guard connectionMethodStore?.method == .tailscale else {
+            return .notSelected
+        }
+        return tailscaleSetupStatusWhenSelected
     }
 
     /// Whether the selected Tailscale method still needs its one-time pairing grant.

--- a/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/ReconnectRouteSelectionTests.swift
+++ b/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/ReconnectRouteSelectionTests.swift
@@ -697,6 +697,32 @@ import Testing
         #expect(store.tailscalePairingRequired)
     }
 
+    @Test func projectedTailscaleSetupStatusEvaluatesBeforeMethodSelection() {
+        let methodDefaults = UserDefaults(
+            suiteName: "tailscale-projected-method-\(UUID().uuidString)"
+        )!
+        let pairingDefaults = UserDefaults(
+            suiteName: "tailscale-projected-pairing-\(UUID().uuidString)"
+        )!
+        pairingDefaults.set(true, forKey: "cmux.mobile.hasKnownPairedMac")
+        let store = MobileShellComposite(
+            isSignedIn: true,
+            connectionMethodStore: MobileConnectionMethodStore(
+                defaults: methodDefaults
+            ),
+            pairingHintDefaults: pairingDefaults
+        )
+
+        #expect(store.tailscaleSetupStatus == .notSelected)
+        #expect(
+            store.tailscaleSetupStatusWhenSelected == .loadingAuthorization
+        )
+        store.pairedMacLoadState = .failed
+        #expect(
+            store.tailscaleSetupStatusWhenSelected == .pairingRequired
+        )
+    }
+
     @Test func changingToUnavailableTailscaleDropsLiveIrohWithoutFallback() async throws {
         let clock = TestClock()
         let router = LivenessHostRouter()

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/CMUXMobileRootView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/CMUXMobileRootView.swift
@@ -604,7 +604,7 @@ struct CMUXMobileRootView: View {
                 },
                 setUpTailscale: {
                     handleRootPresentation(.setUpTailscale(
-                        status: store.tailscaleSetupStatus
+                        status: store.tailscaleSetupStatusWhenSelected
                     ))
                 },
                 showsLayoutProbe: showsAutoConnectMigrationLayoutProbe


### PR DESCRIPTION
Fixes a post-merge regression in the Tailscale migration action.

Selecting Tailscale now evaluates projected setup readiness before persisting the method, so known Macs wait for authorization loading and users without a grant still get the scanner.

Verification:
- Focused ReconnectRouteSelectionTests projected readiness test passes.
- git diff --check passes.
- Prior tdsm cloud build passed on the shared migration changes.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/10063"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789176838&installation_model_id=21920&pr_number=10063&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F10063&signature=0fc31f806ab1dbfbf4cbce3a0818eb621df9bf8833a50ee3e69db09c22af4947"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves the Tailscale migration setup flow by evaluating setup readiness at selection time instead of after saving the connection method. Previously, selecting Tailscale saved immediately and could skip authorization loading or pairing prompts; now known Macs show authorization loading first and users without a grant are sent to the scanner.

- Introduces `tailscaleSetupStatusWhenSelected` to compute readiness before persisting the selection.
- `tailscaleSetupStatus` remains for the current selection and delegates to the projected status when Tailscale is selected.
- Updates `CMUXMobileRootView` to present setup using the projected status.
- Adds a focused test to verify projected evaluation before method selection.

<sup>Written for commit 43cf36b6f262dffb99682cb593374a90d5231645. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/10063?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Tailscale setup status reporting during connection setup and auto-connect migration.
  * Tailscale authorization progress and pairing requirements are now shown correctly before a connection method is selected.

* **Tests**
  * Added coverage for Tailscale setup status transitions, including loading authorization and pairing-required states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->