### PR TITLE
fix(ios): compile release diagnostics symbols

### DIFF
--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/GhosttySurfaceRepresentable.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/GhosttySurfaceRepresentable.swift
@@ -94,12 +94,10 @@ struct GhosttySurfaceRepresentable: UIViewRepresentable {
             && !store.usesScreenAnchoredRenderGrid
             ? .verifiedRenderGrid
             : .legacyMirror
-        #if DEBUG
         // Hand the surface the structured diagnostic log so the composer-dock
         // probes land in the blob the "Send to agent" feedback pane exports.
         // `nil` when no log is wired; every probe is then a no-op.
         view.diagnosticLog = store.diagnosticLog
-        #endif
         // Stamp the shell-level id so id-scoped registry lookups (the
         // "View as Text" capture) resolve this exact terminal.
         view.hostSurfaceID = surfaceID

--- a/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView.swift
+++ b/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView.swift
@@ -633,15 +633,12 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
         lastReportedSize ?? TerminalGridSize(columns: 100, rows: 32, pixelWidth: 900, pixelHeight: 650)
     }
 
-    #if DEBUG
-    /// Structured diagnostic log (DEBUG dogfood builds only), property-injected
-    /// from the shell store by ``GhosttySurfaceRepresentable`` so the
-    /// composer-dock probes land in the blob the diagnostic export captures.
-    /// `nil` in hosts that do not wire it; every probe is then a no-op. The
-    /// property does not exist in release builds — every reader is inside a
-    /// `#if DEBUG` block.
+    /// Structured diagnostic log, property-injected from the shell store by
+    /// ``GhosttySurfaceRepresentable`` so the composer-dock probes land in the
+    /// blob the diagnostic export captures. The event payloads are bounded and
+    /// privacy-safe, so the same sink is available in Release builds. `nil` in
+    /// hosts that do not wire it; every probe is then a no-op.
     public var diagnosticLog: DiagnosticLog?
-    #endif
 
     private lazy var inputSession = TerminalInputSessionCoordinator(
         focus: { [weak self] owner in

--- a/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/TerminalInputTextView.swift
+++ b/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/TerminalInputTextView.swift
@@ -1399,12 +1399,12 @@ final class TerminalInputTextView: UIView, UIKeyInput, UITextInput {
         if !armed { consumeModifier(.shift) }
     }
 
-    #if DEBUG
     /// Maps a `UIResponder` to its compact ``InputResponderIdentity`` for the
     /// composer-dock diagnostics. Used to encode *which* view owns first
     /// responder into the integer ``DiagnosticEvent`` payload. The `.other` case
     /// is paired with the responder's class name in the companion `anchormux`
-    /// string log for a human-readable readback.
+    /// string log for a human-readable readback. This mapping is also used by
+    /// the release-safe structured diagnostic events.
     static func responderIdentity(of responder: UIResponder?) -> InputResponderIdentity {
         switch responder {
         case nil: return .none
@@ -1416,6 +1416,7 @@ final class TerminalInputTextView: UIView, UIKeyInput, UITextInput {
         }
     }
 
+    #if DEBUG
     /// The responder's concrete class name for the human-readable `anchormux`
     /// readback (the integer ``InputResponderIdentity`` collapses every
     /// unexpected class to `.other`; this preserves the exact type for the copied


### PR DESCRIPTION
The internal TestFlight Release build failed on main because diagnostics call sites moved into Release while their responder helper and diagnostic log property remained DEBUG-only.

Make the shared responder identity mapper, diagnostic log sink, and shell-to-surface injection available in Release. Keep the verbose responder class-name probe DEBUG-only.

Validation: diff check passed; branch rebased onto current main. The local package-only build cannot typecheck iOS dependencies on macOS, and the full simulator graph was interrupted while resolving packages. Hosted checks are the source-of-truth for the Release compiler path.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/10065"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789179383&installation_model_id=21920&pr_number=10065&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F10065&signature=7b14dcfddc365b45911f3234db8b6609a8c39cdae2aca8b44ec7897c32dab529"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes iOS Release build by compiling required diagnostics symbols in Release. Previously, diagnostics call sites were present in Release but the responder mapper, diagnostic log sink, and shell-to-surface injection were DEBUG-only; now these are available in Release, while the verbose responder class-name probe remains DEBUG-only. This enables structured diagnostics in Release without verbose logs.

- `GhosttySurfaceView.diagnosticLog` now compiles in Release and remains optional; payloads are bounded and privacy-safe.
- `TerminalInputTextView.responderIdentity(of:)` is available in Release; the class-name readback helper stays DEBUG-only.
- `GhosttySurfaceRepresentable` injects the diagnostic sink in Release; if the store does not provide one, probes no-op. No runtime behavior change beyond enabling structured diagnostic events.

<sup>Written for commit 5799b88982cee716e2aff2c513964760e5fb62ce. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/10065?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Diagnostic logging is now available in release builds when configured, improving access to diagnostic probes and feedback-pane logs.
  * Terminal responder identity tracking now works consistently in release builds.
  * Existing no-op behavior remains unchanged when diagnostic logging is not configured.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->