### PR TITLE
fix(ios): import shell status for Release builds

### DIFF
--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MobileRootPresentationState.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MobileRootPresentationState.swift
@@ -1,3 +1,5 @@
+import CmuxMobileShell
+
 /// The single iOS modal owner and its root-sheet and child-sheet transitions.
 ///
 /// Root presentations share one SwiftUI sheet host. Child presentations claim


### PR DESCRIPTION
## Summary
- import `CmuxMobileShell` where `MobileRootPresentationState` uses `MobileTailscaleSetupStatus`
- restore Release archive compilation for the iOS shell UI target

## Evidence
The post-merge internal TestFlight archive reached `CmuxMobileShellUI` and failed because the type was not in scope under Release whole-module compilation: [run 31661060762](https://github.com/manaflow-ai/cmux/actions/runs/31661060762).

The type is exported by `CmuxMobileShell`; Debug builds previously got the dependency through another compilation path. This is an explicit module dependency fix, with no runtime behavior change.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/10067"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789181336&installation_model_id=21920&pr_number=10067&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F10067&signature=700e7e830810ffe75ef2f8a61aa0fadf3d621f48fd056ff4e9bf94f6043714ca"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Release archiving for the iOS shell UI by explicitly importing `CmuxMobileShell` so `MobileTailscaleSetupStatus` resolves under whole-module optimization. Debug builds were unaffected; runtime behavior does not change.

- Change: add `import CmuxMobileShell` to `Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MobileRootPresentationState.swift`.
- Impact: resolves Release failures in `CmuxMobileShellUI` caused by the type being out of scope; no API or runtime changes.
- Verify: build or archive the `CmuxMobileShellUI` target in Release. No migration required.

<sup>Written for commit 2ae6ce82da7dd9fdfff2c3a72cc4775ec640e0e2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/10067?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated mobile shell presentation handling to support the latest shell module integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->