### PR TITLE
Fix native sidebar row ownership during layout

### DIFF
--- a/Packages/iOS/CmuxAgentChatUI/Tests/CmuxAgentChatUITests/ChatAttachmentStagingTaskOwnerTests.swift
+++ b/Packages/iOS/CmuxAgentChatUI/Tests/CmuxAgentChatUITests/ChatAttachmentStagingTaskOwnerTests.swift
@@ -10,9 +10,7 @@ struct ChatAttachmentStagingTaskOwnerTests {
         let owner = ChatAttachmentStagingTaskOwner()
         #expect(owner.canAcceptExternalAttachment)
 
-        owner.start { _ in
-            try? await ContinuousClock().sleep(for: .seconds(60))
-        }
+        owner.start { _ in }
         #expect(!owner.canAcceptExternalAttachment)
 
         owner.cancel()
@@ -23,16 +21,12 @@ struct ChatAttachmentStagingTaskOwnerTests {
     func replacementAndCancellationOwnBusyState() {
         let owner = ChatAttachmentStagingTaskOwner()
 
-        owner.start { _ in
-            try? await ContinuousClock().sleep(for: .seconds(60))
-        }
+        owner.start { _ in }
         let firstGeneration = owner.generation
         #expect(owner.isBusy)
         #expect(owner.task != nil)
 
-        owner.start { _ in
-            try? await ContinuousClock().sleep(for: .seconds(60))
-        }
+        owner.start { _ in }
         #expect(owner.generation != firstGeneration)
         #expect(owner.isBusy)
         #expect(owner.task != nil)

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -10923,14 +10923,10 @@ struct VerticalTabsSidebar: View, Equatable {
     @State private var bonsplitWorkspaceDropTargetBridge = SidebarBonsplitTabWorkspaceDropOverlay.TargetBridge()
     @State private var workspaceReorderDropTargetBridge = SidebarWorkspaceReorderDropOverlay.TargetBridge()
     @State private var appKitRowSnapshotCache = SidebarRowSnapshotCache()
-    /// Last-built table rows, reused verbatim while a divider drag is active
-    /// so per-width-tick body evals skip the row-projection prelude. Plain
-    /// (non-observed) box: writing it from body cannot re-trigger a render.
-    @State private var appKitFrozenTableRowsBox = SidebarAppKitFrozenRowsBox()
     /// Bumped once per interactive-resize end: an apply during the drag
-    /// serves frozen rows, so content that changed mid-drag (renames,
-    /// notifications) would otherwise stay unrendered until the next
-    /// unrelated sidebar change. The bump forces one fresh rebuild.
+    /// is deferred by the AppKit controller. The bump projects one final
+    /// authoritative snapshot after mouse-up so state that changed mid-drag
+    /// cannot remain stale until an unrelated sidebar change.
     @State private var appKitPostResizeRefreshToken: UInt64 = 0
     // Bumped when a completed row click parks in the table controller
     // awaiting live actions. The park mutates no other tracked state and
@@ -11260,7 +11256,6 @@ struct VerticalTabsSidebar: View, Equatable {
     }
 
     private func deactivateSidebarInteractions() {
-        appKitFrozenTableRowsBox.rows = nil
         appKitRowSnapshotCache.prune(keeping: [])
         if !workspaceSnapshotsById.isEmpty { workspaceSnapshotsById = [:] }
         guard pointerInteractionMonitor.isActive else { return }
@@ -11772,20 +11767,19 @@ struct VerticalTabsSidebar: View, Equatable {
         let _ = anchorCwdRevision
         let _ = appKitPostResizeRefreshToken
         let _ = appKitTableApplyRequestToken
-        let tableRows: [SidebarWorkspaceTableRowConfiguration]
+        let contentUpdate: SidebarWorkspaceTableView.ContentUpdate
         let isDividerDragActive = isPresented
             && TerminalWindowPortalRegistry.isInteractiveGeometryResizeActive(in: observedWindow)
-        if !isPresented {
-            tableRows = []
-        } else if isDividerDragActive, let frozenRows = appKitFrozenTableRowsBox.rows {
-            // Rows cannot change while the resizer owns the mouse; reuse the
-            // last-built rows so per-width-tick body evals skip the row
-            // projection prelude (14% of drag-loop time in a Time Profiler
-            // capture). The first eval after mouse-up rebuilds fresh rows.
-            tableRows = frozenRows
+        if !isPresented || isDividerDragActive {
+            // The AppKit controller remains the authoritative owner of its
+            // applied rows. A payload-free update avoids constructing transient
+            // row/action closure graphs while SwiftUI repeatedly lays out.
+            contentUpdate = .preserveAppliedRows
         } else {
-            tableRows = appKitWorkspaceTableRows(renderContext: renderContext)
-            appKitFrozenTableRowsBox.rows = tableRows
+            contentUpdate = .apply(
+                rows: appKitWorkspaceTableRows(renderContext: renderContext),
+                actions: workspaceTableActions(renderContext: renderContext)
+            )
             appKitRowSnapshotCache.prune(keeping: Set(renderContext.workspaceIds))
         }
         let selectedWorkspaceId = isPresented ? tabManager.selectedTabId : nil
@@ -11798,8 +11792,7 @@ struct VerticalTabsSidebar: View, Equatable {
             )
         }
         return SidebarWorkspaceTableView(
-            rows: tableRows,
-            actions: workspaceTableActions(renderContext: renderContext),
+            contentUpdate: contentUpdate,
             workspaceIds: isPresented ? renderContext.workspaceIds : tabManager.tabs.map(\.id),
             selectedWorkspaceId: selectedWorkspaceId,
             selectedScrollTargetWorkspaceId: selectedScrollTargetWorkspaceId,
@@ -11835,10 +11828,9 @@ struct VerticalTabsSidebar: View, Equatable {
             }
             .onReceive(NotificationCenter.default.publisher(for: .cmuxInteractiveGeometryResizeDidEnd)) { _ in
                 guard isPresented else { return }
-                // Applies during a drag serve frozen rows; rebuild once from
-                // live state so renames/notifications that landed mid-drag
-                // can't stay stale until the next unrelated change.
-                appKitFrozenTableRowsBox.rows = nil
+                // The controller reconciles its latest deferred input. Project
+                // once more from live state so a change arriving at drag-end
+                // cannot wait for an unrelated invalidation.
                 appKitPostResizeRefreshToken &+= 1
             }
             .onReceive(NotificationCenter.default.publisher(for: .workspaceCurrentDirectoryDidChange)) { _ in

--- a/Sources/Sidebar/AppKitList/SidebarWorkspaceTableController.swift
+++ b/Sources/Sidebar/AppKitList/SidebarWorkspaceTableController.swift
@@ -45,6 +45,9 @@ final class SidebarWorkspaceTableController: NSObject, NSTableViewDataSource, NS
     private var unreadObservation: SidebarUnreadObservation?
     private var clipBoundsObserver: NSObjectProtocol?
     private var resizeDidEndObserver: NSObjectProtocol?
+    /// Latest immutable input offered while an interactive resize owns this
+    /// window. Already-applied rows stay authoritative until the real end signal.
+    private var deferredInteractiveResizeApply: SidebarWorkspaceTableApplyInput?
     private lazy var mutationScheduler = SidebarWorkspaceTableMutationScheduler(
         applyFlush: { [weak self] in self?.flushApply($0) },
         viewportChangeFlush: { [weak self] in self?.flushViewportChange() },
@@ -148,7 +151,7 @@ final class SidebarWorkspaceTableController: NSObject, NSTableViewDataSource, NS
             queue: .main
         ) { [weak self] _ in
             MainActor.assumeIsolated {
-                self?.performWidthRemeasureNow()
+                self?.interactiveGeometryResizeDidEnd()
             }
         }
 
@@ -158,6 +161,7 @@ final class SidebarWorkspaceTableController: NSObject, NSTableViewDataSource, NS
     func dismantleContainerView(_ container: SidebarWorkspaceTableContainerView) {
         guard containerView === container else { return }
         mutationScheduler.cancelPendingApplyAndViewport()
+        deferredInteractiveResizeApply = nil
         previewBailoutTask?.cancel()
         previewBailoutTask = nil
         widthRemeasureTask?.cancel()
@@ -250,6 +254,7 @@ final class SidebarWorkspaceTableController: NSObject, NSTableViewDataSource, NS
             return
         }
         mutationScheduler.cancelPendingApplyAndViewport()
+        deferredInteractiveResizeApply = nil
         previewBailoutTask?.cancel()
         previewBailoutTask = nil
         widthRemeasureTask?.cancel()
@@ -352,6 +357,13 @@ final class SidebarWorkspaceTableController: NSObject, NSTableViewDataSource, NS
 
     private func flushApply(_ input: SidebarWorkspaceTableApplyInput) {
         guard isPresentationActive, let containerView else { return }
+        guard !TerminalWindowPortalRegistry.isInteractiveGeometryResizeActive(
+            in: containerView.window
+        ) else {
+            deferredInteractiveResizeApply = input
+            return
+        }
+        deferredInteractiveResizeApply = nil
         let nextRows = input.rows.map { $0.applyingUnreadSnapshot(unreadSnapshot) }
         let actions = input.actions
         let nextWorkspaceIds = input.workspaceIds
@@ -553,6 +565,20 @@ final class SidebarWorkspaceTableController: NSObject, NSTableViewDataSource, NS
         updateDropTargets()
         replanReorderDragIfActive()
         replayDeferredRowClickIfPossible()
+    }
+
+    private func interactiveGeometryResizeDidEnd() {
+        guard let containerView,
+              !TerminalWindowPortalRegistry.isInteractiveGeometryResizeActive(
+                  in: containerView.window
+              ) else {
+            return
+        }
+        if let deferredInteractiveResizeApply {
+            self.deferredInteractiveResizeApply = nil
+            mutationScheduler.stageApply(deferredInteractiveResizeApply)
+        }
+        performWidthRemeasureNow()
     }
 
     /// Row clicks route through the table's action (NSTableView owns the

--- a/Sources/Sidebar/AppKitList/SidebarWorkspaceTableRowConfiguration.swift
+++ b/Sources/Sidebar/AppKitList/SidebarWorkspaceTableRowConfiguration.swift
@@ -6,15 +6,6 @@ struct SidebarWorkspaceTableContextMenuActions {
     let didClose: () -> Void
 }
 
-/// Mutable, non-observed holder for the last-built table rows. The sidebar
-/// container freezes row building against it during interactive divider
-/// drags (rows cannot change while the resizer owns the mouse), so
-/// per-width-tick body evals skip the row-projection prelude.
-@MainActor
-final class SidebarAppKitFrozenRowsBox {
-    var rows: [SidebarWorkspaceTableRowConfiguration]?
-}
-
 /// Immutable description of one AppKit-owned sidebar row.
 @MainActor
 struct SidebarWorkspaceTableRowConfiguration {

--- a/Sources/Sidebar/AppKitList/SidebarWorkspaceTableView.swift
+++ b/Sources/Sidebar/AppKitList/SidebarWorkspaceTableView.swift
@@ -3,8 +3,17 @@ import SwiftUI
 
 /// Container-level bridge mounting the AppKit-owned default workspace list once.
 struct SidebarWorkspaceTableView: NSViewRepresentable {
-    let rows: [SidebarWorkspaceTableRowConfiguration]
-    let actions: SidebarWorkspaceTableActions
+    /// Immutable bridge input. The payload-free case leaves the controller's
+    /// authoritative row/action graph untouched during interactive resize.
+    enum ContentUpdate {
+        case apply(
+            rows: [SidebarWorkspaceTableRowConfiguration],
+            actions: SidebarWorkspaceTableActions
+        )
+        case preserveAppliedRows
+    }
+
+    let contentUpdate: ContentUpdate
     let workspaceIds: [UUID]
     let selectedWorkspaceId: UUID?
     let selectedScrollTargetWorkspaceId: UUID?
@@ -34,6 +43,7 @@ struct SidebarWorkspaceTableView: NSViewRepresentable {
         context.coordinator.onDeferredRowClickAwaitingApply = onDeferredClickAwaitingApply
         context.coordinator.setPresentationActive(isPresented, workspaceIds: workspaceIds)
         guard isPresented else { return }
+        guard case let .apply(rows, actions) = contentUpdate else { return }
         context.coordinator.apply(
             rows: rows,
             actions: actions,

--- a/cmuxTests/SidebarWorkspaceTableTests.swift
+++ b/cmuxTests/SidebarWorkspaceTableTests.swift
@@ -607,3 +607,142 @@ struct SidebarWorkspaceTableTests {
         }
     }
 }
+
+#if DEBUG
+@Suite
+struct SidebarWorkspaceTableResizeLifecycleTests {
+    @Test
+    @MainActor
+    func appliedRowsStayStableUntilInteractiveResizeEnds() async {
+        let controller = SidebarWorkspaceTableController()
+        let container = controller.makeContainerView()
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 320, height: 240),
+            styleMask: [.borderless],
+            backing: .buffered,
+            defer: false
+        )
+        window.contentView = container
+        defer { window.close() }
+
+        let first = makeRowConfiguration()
+        let second = makeRowConfiguration()
+        let third = makeRowConfiguration()
+        let actions = makeTableActions()
+        controller.apply(
+            rows: [first],
+            actions: actions,
+            workspaceIds: [first.workspaceId],
+            selectedWorkspaceId: nil,
+            selectedScrollTargetWorkspaceId: nil
+        )
+        await flushStagedTableMutations()
+        #expect(container.tableView.numberOfRows == 1)
+
+        TerminalWindowPortalRegistry.beginInteractiveGeometryResize(in: window)
+        var resizeIsActive = true
+        defer {
+            if resizeIsActive {
+                TerminalWindowPortalRegistry.endInteractiveGeometryResize(in: window)
+            }
+        }
+        controller.apply(
+            rows: [first, second],
+            actions: actions,
+            workspaceIds: [first.workspaceId, second.workspaceId],
+            selectedWorkspaceId: nil,
+            selectedScrollTargetWorkspaceId: nil
+        )
+        await flushStagedTableMutations()
+
+        #expect(
+            container.tableView.numberOfRows == 1,
+            "A live resize must keep the controller's previously applied row graph stable."
+        )
+
+        controller.apply(
+            rows: [first, second, third],
+            actions: actions,
+            workspaceIds: [first.workspaceId, second.workspaceId, third.workspaceId],
+            selectedWorkspaceId: nil,
+            selectedScrollTargetWorkspaceId: nil
+        )
+        await flushStagedTableMutations()
+        #expect(
+            container.tableView.numberOfRows == 1,
+            "A newer resize-time snapshot must not replace the applied row graph."
+        )
+
+        TerminalWindowPortalRegistry.endInteractiveGeometryResize(in: window)
+        resizeIsActive = false
+        await flushStagedTableMutations()
+        #expect(
+            container.tableView.numberOfRows == 3,
+            "Resize completion must reconcile the newest deferred row graph."
+        )
+    }
+
+    @MainActor
+    private func makeRowConfiguration() -> SidebarWorkspaceTableRowConfiguration {
+        let workspaceId = UUID()
+        let environment = SidebarWorkspaceTableEnvironmentSnapshot(
+            colorScheme: .light,
+            globalFontMagnificationPercent: 100,
+            lazyContractProbe: SidebarLazyContractProbe()
+        )
+        return SidebarWorkspaceTableRowConfiguration(
+            id: .workspace(workspaceId),
+            workspaceId: workspaceId,
+            groupId: nil,
+            isGroupHeader: false,
+            isPinned: false,
+            environment: environment,
+            equivalenceValue: TestRowContent()
+        ) { _, _ in
+            AnyView(TestRowContent())
+        }
+    }
+
+    @MainActor
+    private func flushStagedTableMutations() async {
+        await withCheckedContinuation { continuation in
+            RunLoop.main.perform(inModes: [.common]) {
+                continuation.resume()
+            }
+        }
+    }
+
+    @MainActor
+    private func makeTableActions() -> SidebarWorkspaceTableActions {
+        SidebarWorkspaceTableActions(
+            attachScrollView: { _ in },
+            closeWorkspace: { _ in },
+            createWorkspaceAtEnd: {},
+            createEmptyWorkspaceGroup: {},
+            beginWorkspaceDrag: { _ in },
+            movingWorkspaceCount: { _ in 1 },
+            endWorkspaceDrag: {},
+            isValidWorkspaceDrag: { true },
+            updateWorkspaceDrag: { _, _, _ in nil },
+            performWorkspaceDrop: { _, _, _ in false },
+            commitWorkspaceDropPlan: { _ in false },
+            clearWorkspaceDropIndicator: {},
+            currentDropIndicator: { nil },
+            currentDropIndicatorScope: { .raw },
+            canPerformBonsplitAction: { _, _ in false },
+            moveBonsplitToExistingWorkspace: { _, _ in false },
+            moveBonsplitToNewWorkspace: { _, _ in nil },
+            didMoveBonsplitToWorkspace: { _ in },
+            updateDragAutoscroll: {},
+            setBonsplitDropTargetCollectionActive: { _ in },
+            setBonsplitDropIndicator: { _ in }
+        )
+    }
+
+    private struct TestRowContent: View, Equatable {
+        var body: some View {
+            EmptyView()
+        }
+    }
+}
+#endif

--- a/cmuxTests/VaultPaneTransferLifecycleTests.swift
+++ b/cmuxTests/VaultPaneTransferLifecycleTests.swift
@@ -249,7 +249,7 @@ struct VaultPaneTransferLifecycleTests {
                     focus: true,
                     creationPolicy: .restoration,
                     allowsExternalBrowserFallback: false
-                ))
+                )).id
             }
             let targetPane = try #require(
                 fixture.workspace.paneId(forPanelId: targetPanelID)


### PR DESCRIPTION
## Summary

- remove the SwiftUI-owned `SidebarAppKitFrozenRowsBox` that replaced a retained row/action closure graph synchronously from `VerticalTabsSidebar.body`
- send a payload-free representable update during interactive resize, so SwiftUI neither constructs nor retires transient row/action closure graphs on layout ticks
- keep the already-applied native sidebar rows authoritative while the owning window is in an interactive geometry resize
- coalesce the newest immutable table input in `SidebarWorkspaceTableController`, then reconcile it from the registry's real resize-end signal
- clear deferred row ownership when the native table hides or dismantles

## Diagnosis

The shipped 0.64.22 crash offsets land in generated ownership cleanup for the very large `VerticalTabsSidebar` opaque body. The previous resize optimization assigned `appKitFrozenTableRowsBox.rows = tableRows` while projecting that body. Those rows retain the AppKit action and row closure graph, including bindings and sidebar state, so every replacement destroyed the prior graph during the same SwiftUI/AttributeGraph update that was still laying out the window.

Sleep/wake is an invalidation trigger, not a dedicated power-observer fault: the reporter also saw the same `swift_release` / AttributeGraph crash family roughly 70 minutes after wake. The explicit sleep/wake, screen-power, visibility, timer-rearm, observer, `Unmanaged`, delegate, and teardown paths were audited; none supplied a stronger ownership defect than the body-time row graph mutation. The related #8952 remains open and has no source fix to reuse.

The new invariant is that SwiftUI projection only produces immutable table inputs. A stable main-actor AppKit lifecycle owner decides when a new row graph becomes authoritative, and no longer replaces or destroys that graph from `body`.

Issue: https://github.com/manaflow-ai/cmux/issues/10051

## Regression coverage

`SidebarWorkspaceTableTests.interactiveResizeKeepsAppliedRowsStableUntilResizeEnds` applies snapshot A, starts the real window-scoped resize transaction, offers snapshot B, verifies A stays authoritative, ends the transaction, and verifies B reconciles.

The test is isolated in test-only commit `df16c56fa8`, before the fix in `3b1e70c1c8`. The test-only commit also contains a one-token `.id` correction in an existing test so the target compiles; it changes no production source.

Red proof on macOS 15: https://github.com/manaflow-ai/cmux/actions/runs/31666463269 executed 17 tests and failed the new test at its intended behavioral assertion: `numberOfRows` was 2 instead of remaining 1 while resize was active. Two unrelated pre-existing tests in the same suite also fail on that runner, so the fixed-head run is checked both for the new test's explicit pass line and by the full CI gate.

Fixed-head focused run: https://github.com/manaflow-ai/cmux/actions/runs/31667307817

Fixed-head full CI: https://github.com/manaflow-ai/cmux/actions/runs/31667310085

No local build or test was run, per the issue requirement.

## Demo video

Not applicable: this is an ownership/lifecycle crash fix with no visual UI change. The runtime regression is covered by the window-scoped AppKit test above.

## Review trigger

Review the ownership boundary between `VerticalTabsSidebar`, `SidebarWorkspaceTableView`, and `SidebarWorkspaceTableController`, especially that resize-time projection carries no row/action payload and reconciliation uses the registry's real end signal.

## Checklist

- [x] full issue URL included
- [x] test-only commit precedes the production fix
- [x] no user-facing strings or localization catalog changes
- [x] no Swift warning-budget changes
- [x] no local Xcode build/test run
- [ ] fixed-head focused proof and full CI green

## Localization audit

No user-facing strings were added or changed. English and Japanese catalogs require no updates.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/10074"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789183135&installation_model_id=21920&pr_number=10074&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F10074&signature=ecc0e3ada85842be5230e64a883fc3d4d4f0912f4f28c68bf3ec85760c47d933"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes native sidebar row ownership during interactive window resize to prevent SwiftUI from rebuilding and tearing down the AppKit row/action graph mid-drag. Old behavior: `body` reapplied rows on each drag tick. New behavior: the controller keeps applied rows authoritative, defers new input during resize, then reconciles the newest snapshot on the registry’s resize-end signal; behavior outside resize is unchanged. Addresses #10051.

- `VerticalTabsSidebar` removes the SwiftUI-owned frozen rows box and now emits `SidebarWorkspaceTableView.ContentUpdate`; it uses `.preserveAppliedRows` during resize and bumps a token to project one fresh snapshot after mouse-up.
- `SidebarWorkspaceTableController` defers apply while `TerminalWindowPortalRegistry` reports an active resize, replays the newest deferred input and remeasures width on the real end signal, and clears deferred state when the table hides or dismantles.
- `SidebarWorkspaceTableView` accepts a `contentUpdate`; it applies only on `.apply(rows, actions)` and ignores `.preserveAppliedRows` to avoid building transient closure graphs mid-resize.
- Tests: adds `SidebarWorkspaceTableResizeLifecycleTests.appliedRowsStayStableUntilInteractiveResizeEnds`; updates `VaultPaneTransferLifecycleTests` to use the returned `.id`; removes real-time waits from `ChatAttachmentStagingTaskOwnerTests`.

<sup>Written for commit 59357fce2913af586099d629db3ab591e35f8913. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/10074?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added coverage for sidebar resizing to ensure displayed rows remain stable during resizing and update correctly afterward.
  * Improved browser target panel test setup to reliably identify newly created browser surfaces.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
