### PR TITLE
Retain iOS app and network log history

### DIFF
--- a/Packages/Shared/CMUXMobileCore/Sources/CMUXMobileCore/AppLog.swift
+++ b/Packages/Shared/CMUXMobileCore/Sources/CMUXMobileCore/AppLog.swift
@@ -1,7 +1,7 @@
 public import Foundation
 
-/// The consolidated on-disk application log: one rotating file for app-wide
-/// events and one for network diagnostics.
+/// The consolidated on-disk application log: one active file with bounded
+/// archives for app-wide events and one equivalent set for network diagnostics.
 ///
 /// ``AppLog`` is the durable half of the diagnostics stack. The in-memory
 /// ``DiagnosticLog`` ring stays the single structured spine every subsystem
@@ -29,6 +29,11 @@ public import Foundation
 /// coalesced into a `repeated ×N` summary when the run breaks, so a healthy
 /// 20 fps stream costs one line plus one summary instead of megabytes.
 ///
+/// The active generation is reopened for appending on the next launch. When
+/// the byte budget is reached it is moved to a timestamped archive, then a
+/// fresh active generation is opened. Archives are bounded by both count and
+/// total bytes, so retention never requires clearing the app container.
+///
 /// Inject one instance from the app composition root; do not add a `.shared`
 /// singleton.
 public actor AppLog {
@@ -41,6 +46,13 @@ public actor AppLog {
 
     public static let appLogFileName = "cmux-app.log"
     public static let networkLogFileName = "cmux-network.log"
+    /// The approximate size of one active generation in production.
+    public static let defaultMaxFileBytes = 5_000_000
+    /// Number of timestamped generations retained in addition to the active
+    /// file. A legacy `.1` file is migrated before this limit is applied.
+    public static let defaultMaxArchiveCount = 3
+    /// Per-file retention ceiling, including the active generation.
+    public static let defaultMaxRetainedBytes = 12_000_000
 
     /// Default location of the app-wide log inside Application Support, or
     /// `nil` when the directory cannot be resolved. Exists so settings UI can
@@ -53,6 +65,97 @@ public actor AppLog {
     /// ``defaultAppLogFileURL``.
     public static var defaultNetworkLogFileURL: URL? {
         defaultFileURL(named: networkLogFileName)
+    }
+
+    /// All available generations for the app log, newest first after the
+    /// active file. Settings passes this collection to the share UI so a
+    /// diagnostic export includes the bounded history, not only the active
+    /// generation.
+    public static var appLogFileURLs: [URL] {
+        guard let url = defaultAppLogFileURL else { return [] }
+        return logFileURLs(for: url)
+    }
+
+    /// All available generations for the network log, with the active file
+    /// first. See ``appLogFileURLs``.
+    public static var networkLogFileURLs: [URL] {
+        guard let url = defaultNetworkLogFileURL else { return [] }
+        return logFileURLs(for: url)
+    }
+
+    /// Returns the active file and any retained archive generations for a
+    /// caller-supplied location. The legacy `<name>.1` generation is included
+    /// when a prior build could not migrate it.
+    public static func logFileURLs(for fileURL: URL) -> [URL] {
+        let fileManager = FileManager.default
+        var urls: [URL] = []
+        if fileManager.fileExists(atPath: fileURL.path) {
+            urls.append(fileURL)
+        }
+        urls.append(contentsOf: archiveURLs(for: fileURL))
+        let legacyURL = legacyRotationURL(for: fileURL)
+        if fileManager.fileExists(atPath: legacyURL.path) {
+            urls.append(legacyURL)
+        }
+        return urls
+    }
+
+    private static let archiveMarker = ".archive-"
+
+    private static func legacyRotationURL(for fileURL: URL) -> URL {
+        URL(fileURLWithPath: fileURL.path + ".1")
+    }
+
+    private static func archivePrefix(for fileURL: URL) -> String {
+        let stem = fileURL.pathExtension.isEmpty
+            ? fileURL.lastPathComponent
+            : fileURL.deletingPathExtension().lastPathComponent
+        return "\(stem)\(archiveMarker)"
+    }
+
+    private static func archiveURLs(for fileURL: URL) -> [URL] {
+        let fileManager = FileManager.default
+        let directory = fileURL.deletingLastPathComponent()
+        let prefix = archivePrefix(for: fileURL)
+        guard let names = try? fileManager.contentsOfDirectory(
+            at: directory,
+            includingPropertiesForKeys: [.contentModificationDateKey, .fileSizeKey],
+            options: [.skipsHiddenFiles]
+        ) else {
+            return []
+        }
+        return names
+            .filter { candidate in
+                candidate.lastPathComponent.hasPrefix(prefix)
+                    && candidate.pathExtension == fileURL.pathExtension
+                    && fileManager.fileExists(atPath: candidate.path)
+            }
+            .sorted { lhs, rhs in
+                let leftDate = (try? lhs.resourceValues(
+                    forKeys: [.contentModificationDateKey]
+                ).contentModificationDate) ?? .distantPast
+                let rightDate = (try? rhs.resourceValues(
+                    forKeys: [.contentModificationDateKey]
+                ).contentModificationDate) ?? .distantPast
+                if leftDate != rightDate { return leftDate > rightDate }
+                return lhs.lastPathComponent > rhs.lastPathComponent
+            }
+    }
+
+    private static func makeArchiveURL(for fileURL: URL, date: Date) -> URL {
+        let stem = fileURL.pathExtension.isEmpty
+            ? fileURL.lastPathComponent
+            : fileURL.deletingPathExtension().lastPathComponent
+        let extensionSuffix = fileURL.pathExtension.isEmpty
+            ? ""
+            : ".\(fileURL.pathExtension)"
+        let milliseconds = Int64(date.timeIntervalSince1970 * 1_000)
+        let stamp = String(format: "%013lld", milliseconds)
+        let unique = String(UUID().uuidString.prefix(8))
+        return fileURL.deletingLastPathComponent()
+            .appendingPathComponent(
+                "\(stem)\(archiveMarker)\(stamp)-\(unique)\(extensionSuffix)"
+            )
     }
 
     private static func defaultFileURL(named name: String) -> URL? {
@@ -77,7 +180,10 @@ public actor AppLog {
     private struct LogFile {
         let url: URL
         let maxBytes: Int
+        let maxArchiveCount: Int
+        let maxRetainedBytes: Int
         let header: String
+        let now: @Sendable () -> Date
         var handle: FileHandle?
         var bytesWritten = 0
         /// Byte level at which the next rotation is attempted. Normally
@@ -86,47 +192,100 @@ public actor AppLog {
         /// budget of growth instead of once per appended line.
         var rotationThreshold: Int
 
-        init(url: URL, maxBytes: Int, header: String) {
+        init(
+            url: URL,
+            maxBytes: Int,
+            maxArchiveCount: Int,
+            maxRetainedBytes: Int,
+            header: String,
+            now: @escaping @Sendable () -> Date
+        ) {
             self.url = url
-            self.maxBytes = maxBytes
+            self.maxBytes = max(1, maxBytes)
+            self.maxArchiveCount = max(1, maxArchiveCount)
+            self.maxRetainedBytes = max(maxRetainedBytes, self.maxBytes)
             self.header = header
-            self.rotationThreshold = maxBytes
-            openFreshGeneration(rotatingExisting: true)
+            self.now = now
+            self.rotationThreshold = max(1, maxBytes)
+            migrateLegacyRotation()
+            if FileManager.default.fileExists(atPath: url.path) {
+                openExistingForAppending()
+                if handle != nil, bytesWritten >= self.maxBytes {
+                    _ = rotate()
+                }
+            } else {
+                _ = openFreshGeneration()
+            }
+            if handle != nil {
+                pruneArchives()
+            }
         }
 
-        /// Rotates `<name>` to `<name>.1` (replacing any previous `.1`) and
-        /// opens a fresh file with the header line. A failed rotate falls back
-        /// to appending to the existing generation: truncating in place would
-        /// erase the very diagnostics a user may be about to share. Only a
-        /// failed open disables writing, and for this file only.
-        private mutating func openFreshGeneration(rotatingExisting: Bool) {
+        /// Moves a legacy `<name>.1` generation into the timestamped archive
+        /// namespace. If the move cannot be completed, the legacy file stays
+        /// untouched and remains shareable.
+        private mutating func migrateLegacyRotation() {
             let fileManager = FileManager.default
-            if rotatingExisting, fileManager.fileExists(atPath: url.path) {
-                let rotated = url.appendingPathExtension("1")
-                try? fileManager.removeItem(at: rotated)
-                do {
-                    try fileManager.moveItem(at: url, to: rotated)
-                } catch {
-                    openExistingForAppending()
-                    return
-                }
-            }
-            fileManager.createFile(atPath: url.path, contents: nil)
-            guard let opened = try? FileHandle(forWritingTo: url) else {
+            let legacyURL = AppLog.legacyRotationURL(for: url)
+            guard fileManager.fileExists(atPath: legacyURL.path) else { return }
+            let archiveURL = AppLog.makeArchiveURL(for: url, date: now())
+            try? fileManager.moveItem(at: legacyURL, to: archiveURL)
+        }
+
+        /// Opens a new active generation. This method never removes or
+        /// overwrites an existing file. The caller must move an old active
+        /// generation away first.
+        @discardableResult
+        private mutating func openFreshGeneration() -> Bool {
+            let fileManager = FileManager.default
+            guard !fileManager.fileExists(atPath: url.path),
+                  fileManager.createFile(atPath: url.path, contents: nil),
+                  let opened = try? FileHandle(forWritingTo: url) else {
                 handle = nil
-                return
+                return false
             }
             handle = opened
             bytesWritten = 0
             rotationThreshold = maxBytes
             write(header)
+            return handle != nil
         }
 
-        /// Keeps writing to the current generation after a failed rotate,
-        /// with no extra header (the file already carries its generation
-        /// header, and a sustained failure must not add one per retry). The
-        /// raised threshold makes the next retry wait for another full byte
-        /// budget, so the fallback is bounded churn, not per-line reopens.
+        /// Rotates the active generation into a unique archive. A failed move
+        /// reopens the original file for appending and leaves every existing
+        /// byte in place. If creating the replacement fails after the move,
+        /// the archive is restored when possible; otherwise it remains on disk
+        /// and is still returned by ``AppLog.logFileURLs(for:)``.
+        @discardableResult
+        private mutating func rotate() -> Bool {
+            let fileManager = FileManager.default
+            guard fileManager.fileExists(atPath: url.path) else {
+                return openFreshGeneration()
+            }
+            close()
+            let archiveURL = AppLog.makeArchiveURL(for: url, date: now())
+            do {
+                try fileManager.moveItem(at: url, to: archiveURL)
+            } catch {
+                openExistingForAppending()
+                rotationThreshold = bytesWritten + maxBytes
+                return false
+            }
+            guard openFreshGeneration() else {
+                if !fileManager.fileExists(atPath: url.path) {
+                    try? fileManager.moveItem(at: archiveURL, to: url)
+                }
+                openExistingForAppending()
+                rotationThreshold = bytesWritten + maxBytes
+                return false
+            }
+            pruneArchives()
+            return true
+        }
+
+        /// Keeps writing to the current generation. Existing files are opened
+        /// at their end, never truncated. An empty pre-existing file receives
+        /// the generation header once.
         private mutating func openExistingForAppending() {
             guard let opened = try? FileHandle(forWritingTo: url),
                   let size = try? opened.seekToEnd() else {
@@ -138,19 +297,53 @@ public actor AppLog {
             }
             handle = opened
             bytesWritten = Int(clamping: size)
-            rotationThreshold = bytesWritten + maxBytes
+            rotationThreshold = maxBytes
+            if bytesWritten == 0 {
+                write(header)
+            }
         }
 
         mutating func append(_ line: String) {
             guard handle != nil else { return }
             let data = Data((line + "\n").utf8)
             if bytesWritten + data.count > rotationThreshold {
-                try? handle?.close()
-                handle = nil
-                openFreshGeneration(rotatingExisting: true)
-                guard handle != nil else { return }
+                _ = rotate()
             }
             write(line)
+        }
+
+        /// Removes only timestamped archives, and only after a new active
+        /// generation has been opened. The newest archive is always kept even
+        /// if one unusually large line temporarily exceeds the byte ceiling.
+        private mutating func pruneArchives() {
+            let fileManager = FileManager.default
+            var archives = AppLog.archiveURLs(for: url)
+            guard !archives.isEmpty else { return }
+            var totalBytes = fileSize(of: url)
+            var archiveSizes = archives.map { fileSize(of: $0) }
+            totalBytes += archiveSizes.reduce(0, +)
+            while archives.count > maxArchiveCount || totalBytes > maxRetainedBytes {
+                guard archives.count > 1 else { break }
+                let oldestIndex = archives.count - 1
+                let oldest = archives.remove(at: oldestIndex)
+                let oldestSize = archiveSizes.remove(at: oldestIndex)
+                do {
+                    try fileManager.removeItem(at: oldest)
+                    totalBytes -= oldestSize
+                } catch {
+                    // A protection or sharing failure should never cause us
+                    // to remove a different, newer generation.
+                    break
+                }
+            }
+        }
+
+        private func fileSize(of fileURL: URL) -> Int {
+            guard let values = try? fileURL.resourceValues(forKeys: [.fileSizeKey]),
+                  let size = values.fileSize else {
+                return 0
+            }
+            return size
         }
 
         private mutating func write(_ line: String) {
@@ -197,25 +390,34 @@ public actor AppLog {
     public init(
         appFileURL: URL?,
         networkFileURL: URL?,
-        maxFileBytes: Int = 5_000_000,
-        buildStamp: String = ""
+        maxFileBytes: Int = AppLog.defaultMaxFileBytes,
+        buildStamp: String = "",
+        maxArchiveCount: Int = AppLog.defaultMaxArchiveCount,
+        maxRetainedBytes: Int = AppLog.defaultMaxRetainedBytes,
+        now: @escaping @Sendable () -> Date = { Date() }
     ) {
         let formatter = ISO8601DateFormatter()
         formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
         timestampFormatter = formatter
-        let started = formatter.string(from: Date())
+        let started = formatter.string(from: now())
         if let appFileURL {
             appFile = LogFile(
                 url: appFileURL,
                 maxBytes: maxFileBytes,
-                header: "cmux app log · \(buildStamp) · started \(started)"
+                maxArchiveCount: maxArchiveCount,
+                maxRetainedBytes: maxRetainedBytes,
+                header: "cmux app log · \(buildStamp) · started \(started)",
+                now: now
             )
         }
         if let networkFileURL {
             networkFile = LogFile(
                 url: networkFileURL,
                 maxBytes: maxFileBytes,
-                header: "cmux network diagnostics log · \(buildStamp) · started \(started)"
+                maxArchiveCount: maxArchiveCount,
+                maxRetainedBytes: maxRetainedBytes,
+                header: "cmux network diagnostics log · \(buildStamp) · started \(started)",
+                now: now
             )
         }
         let (stream, continuation) = AsyncStream<Entry>.makeStream(

--- a/Packages/Shared/CMUXMobileCore/Sources/CMUXMobileCore/AppLog.swift
+++ b/Packages/Shared/CMUXMobileCore/Sources/CMUXMobileCore/AppLog.swift
@@ -113,6 +113,18 @@ public actor AppLog {
         return "\(stem)\(archiveMarker)"
     }
 
+    private static func archiveStamp(for url: URL, prefix: String) -> Int64? {
+        let remainder = url.lastPathComponent.dropFirst(prefix.count)
+        let stamp = remainder.prefix(13)
+        guard stamp.count == 13,
+              stamp.allSatisfy({ $0.isNumber }),
+              remainder.dropFirst(stamp.count).first == "-"
+        else {
+            return nil
+        }
+        return Int64(stamp)
+    }
+
     private static func archiveURLs(for fileURL: URL) -> [URL] {
         let fileManager = FileManager.default
         let directory = fileURL.deletingLastPathComponent()
@@ -131,6 +143,18 @@ public actor AppLog {
                     && fileManager.fileExists(atPath: candidate.path)
             }
             .sorted { lhs, rhs in
+                let leftStamp = archiveStamp(for: lhs, prefix: prefix)
+                let rightStamp = archiveStamp(for: rhs, prefix: prefix)
+                switch (leftStamp, rightStamp) {
+                case let (left?, right?):
+                    if left != right { return left > right }
+                case (_?, nil):
+                    return true
+                case (nil, _?):
+                    return false
+                case (nil, nil):
+                    break
+                }
                 let leftDate = (try? lhs.resourceValues(
                     forKeys: [.contentModificationDateKey]
                 ).contentModificationDate) ?? .distantPast

--- a/Packages/Shared/CMUXMobileCore/Tests/CMUXMobileCoreTests/AppLogTests.swift
+++ b/Packages/Shared/CMUXMobileCore/Tests/CMUXMobileCoreTests/AppLogTests.swift
@@ -107,8 +107,8 @@ import Testing
         #expect(lines.last?.contains("Stalled") == true)
     }
 
-    /// Exceeding the byte budget rotates the current generation to `.1` and
-    /// keeps writing to a fresh file.
+    /// Exceeding the byte budget moves the current generation to a unique
+    /// archive and keeps writing to a fresh active file.
     @Test func rotatesWhenExceedingMaxBytes() async throws {
         let dir = try makeTempDirectory()
         defer { try? FileManager.default.removeItem(at: dir) }
@@ -125,16 +125,89 @@ import Testing
         }
         try await waitForProcessed(log, 40)
 
-        let rotated = appURL.appendingPathExtension("1")
-        #expect(FileManager.default.fileExists(atPath: rotated.path))
+        let generations = AppLog.logFileURLs(for: appURL)
+        let archives = generations.filter { $0 != appURL }
+        #expect(!archives.isEmpty)
         let active = try contents(of: appURL)
         #expect(active.contains("cmux app log"))
-        #expect(try contents(of: rotated).contains("filler line"))
+        #expect(archives.contains { (try? contents(of: $0).contains("filler line")) == true })
     }
 
-    /// A failed launch-time rotation (busy file, read-only directory) must
-    /// append to the existing log instead of truncating away the diagnostics
-    /// a user may be about to share.
+    @Test func reopensExistingGenerationAcrossLaunches() async throws {
+        let dir = try makeTempDirectory()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let appURL = dir.appendingPathComponent("app.log")
+
+        let firstLaunch = AppLog(
+            appFileURL: appURL,
+            networkFileURL: nil,
+            buildStamp: "test"
+        )
+        firstLaunch.mirrorAppLine("first launch")
+        try await waitForProcessed(firstLaunch, 1)
+
+        let secondLaunch = AppLog(
+            appFileURL: appURL,
+            networkFileURL: nil,
+            buildStamp: "test"
+        )
+        secondLaunch.mirrorAppLine("second launch")
+        try await waitForProcessed(secondLaunch, 1)
+
+        let persisted = try contents(of: appURL)
+        #expect(persisted.contains("first launch"))
+        #expect(persisted.contains("second launch"))
+        #expect(persisted.components(separatedBy: "cmux app log").count == 2)
+        #expect(!FileManager.default.fileExists(
+            atPath: appURL.appendingPathExtension("1").path
+        ))
+    }
+
+    @Test func migratesLegacyRotationWithoutDeletingIt() throws {
+        let dir = try makeTempDirectory()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let appURL = dir.appendingPathComponent("app.log")
+        let legacyURL = appURL.appendingPathExtension("1")
+        try Data("legacy generation\n".utf8).write(to: legacyURL)
+
+        _ = AppLog(appFileURL: appURL, networkFileURL: nil, buildStamp: "test")
+
+        #expect(!FileManager.default.fileExists(atPath: legacyURL.path))
+        let generations = AppLog.logFileURLs(for: appURL)
+        #expect(generations.contains { (try? contents(of: $0).contains("legacy generation")) == true })
+    }
+
+    @Test func boundsTimestampedArchiveCount() async throws {
+        let dir = try makeTempDirectory()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let appURL = dir.appendingPathComponent("app.log")
+        let log = AppLog(
+            appFileURL: appURL,
+            networkFileURL: nil,
+            maxFileBytes: 160,
+            buildStamp: "test",
+            maxArchiveCount: 2,
+            maxRetainedBytes: 480
+        )
+
+        for index in 0..<100 {
+            log.mirrorAppLine("bounded line \(index) 0123456789")
+        }
+        try await waitForProcessed(log, 100)
+
+        let archives = AppLog.logFileURLs(for: appURL).filter { $0 != appURL }
+        #expect(archives.count <= 2)
+        #expect(!archives.isEmpty)
+        let totalBytes = AppLog.logFileURLs(for: appURL).reduce(0) { result, url in
+            let size = try? url.resourceValues(forKeys: [.fileSizeKey]).fileSize
+            return result + (size ?? 0)
+        }
+        #expect(totalBytes <= 480)
+    }
+
+    /// A failed size rotation (busy file, read-only directory) must append to
+    /// the existing log instead of truncating away diagnostics a user may be
+    /// about to share.
     @Test func failedRotationAppendsInsteadOfTruncating() async throws {
         let dir = try makeTempDirectory()
         defer {
@@ -153,7 +226,12 @@ import Testing
             ofItemAtPath: dir.path
         )
 
-        let log = AppLog(appFileURL: appURL, networkFileURL: nil, buildStamp: "test")
+        let log = AppLog(
+            appFileURL: appURL,
+            networkFileURL: nil,
+            maxFileBytes: 32,
+            buildStamp: "test"
+        )
         log.mirrorAppLine("post-failure line 1")
         log.mirrorAppLine("post-failure line 2")
         log.mirrorAppLine("post-failure line 3")

--- a/Packages/Shared/CMUXMobileCore/Tests/CMUXMobileCoreTests/AppLogTests.swift
+++ b/Packages/Shared/CMUXMobileCore/Tests/CMUXMobileCoreTests/AppLogTests.swift
@@ -133,6 +133,48 @@ import Testing
         #expect(archives.contains { (try? contents(of: $0).contains("filler line")) == true })
     }
 
+    @Test func ordersArchivesByEmbeddedGenerationStamp() throws {
+        let dir = try makeTempDirectory()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let appURL = dir.appendingPathComponent("app.log")
+        let olderArchive = dir.appendingPathComponent(
+            "app.archive-0000000001000-AAAAAAAA.log"
+        )
+        let newerArchive = dir.appendingPathComponent(
+            "app.archive-0000000002000-BBBBBBBB.log"
+        )
+        let unparseableArchive = dir.appendingPathComponent(
+            "app.archive-unparseable.log"
+        )
+        try Data("active\n".utf8).write(to: appURL)
+        try Data("older\n".utf8).write(to: olderArchive)
+        try Data("newer\n".utf8).write(to: newerArchive)
+        try Data("unparseable\n".utf8).write(to: unparseableArchive)
+
+        let distantFuture = Date(timeIntervalSince1970: 9_000)
+        let distantPast = Date(timeIntervalSince1970: 1_000)
+        try FileManager.default.setAttributes(
+            [.modificationDate: distantFuture],
+            ofItemAtPath: olderArchive.path
+        )
+        try FileManager.default.setAttributes(
+            [.modificationDate: distantPast],
+            ofItemAtPath: newerArchive.path
+        )
+        try FileManager.default.setAttributes(
+            [.modificationDate: distantFuture],
+            ofItemAtPath: unparseableArchive.path
+        )
+
+        let generations = AppLog.logFileURLs(for: appURL)
+        #expect(generations.map(\.lastPathComponent) == [
+            appURL.lastPathComponent,
+            newerArchive.lastPathComponent,
+            olderArchive.lastPathComponent,
+            unparseableArchive.lastPathComponent,
+        ])
+    }
+
     @Test func reopensExistingGenerationAcrossLaunches() async throws {
         let dir = try makeTempDirectory()
         defer { try? FileManager.default.removeItem(at: dir) }

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MobileSettingsView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MobileSettingsView.swift
@@ -808,12 +808,13 @@ struct MobileSettingsView: View {
 /// one transport.
 private struct MobileSettingsDiagnosticsSection: View {
     @Environment(\.mobileDiagnosticLog) private var diagnosticLog
+    @State private var appLogURLs: [URL] = []
+    @State private var networkLogURLs: [URL] = []
 
     var body: some View {
         Section {
-            let appURLs = AppLog.appLogFileURLs
-            if !appURLs.isEmpty {
-                ShareLink(items: appURLs) {
+            if !appLogURLs.isEmpty {
+                ShareLink(items: appLogURLs) {
                     Label(
                         L10n.string(
                             "mobile.settings.diagnostics.shareAppLog",
@@ -827,9 +828,8 @@ private struct MobileSettingsDiagnosticsSection: View {
                     diagnosticLog?.recordAppEvent(.appDiagnosticsShared)
                 })
             }
-            let networkURLs = AppLog.networkLogFileURLs
-            if !networkURLs.isEmpty {
-                ShareLink(items: networkURLs) {
+            if !networkLogURLs.isEmpty {
+                ShareLink(items: networkLogURLs) {
                     Label(
                         L10n.string(
                             "mobile.settings.diagnostics.shareNetworkLog",
@@ -850,6 +850,13 @@ private struct MobileSettingsDiagnosticsSection: View {
                 "mobile.settings.diagnostics.footer",
                 defaultValue: "The App Log records in-app activity; the Network Log records connection diagnostics. Terminal contents and credentials are never written."
             ))
+        }
+        .task {
+            let urls = await Task.detached(priority: .utility) {
+                (AppLog.appLogFileURLs, AppLog.networkLogFileURLs)
+            }.value
+            appLogURLs = urls.0
+            networkLogURLs = urls.1
         }
     }
 }

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MobileSettingsView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MobileSettingsView.swift
@@ -811,9 +811,9 @@ private struct MobileSettingsDiagnosticsSection: View {
 
     var body: some View {
         Section {
-            if let url = AppLog.defaultAppLogFileURL,
-               FileManager.default.fileExists(atPath: url.path) {
-                ShareLink(item: url) {
+            let appURLs = AppLog.appLogFileURLs
+            if !appURLs.isEmpty {
+                ShareLink(items: appURLs) {
                     Label(
                         L10n.string(
                             "mobile.settings.diagnostics.shareAppLog",
@@ -827,9 +827,9 @@ private struct MobileSettingsDiagnosticsSection: View {
                     diagnosticLog?.recordAppEvent(.appDiagnosticsShared)
                 })
             }
-            if let url = AppLog.defaultNetworkLogFileURL,
-               FileManager.default.fileExists(atPath: url.path) {
-                ShareLink(item: url) {
+            let networkURLs = AppLog.networkLogFileURLs
+            if !networkURLs.isEmpty {
+                ShareLink(items: networkURLs) {
                     Label(
                         L10n.string(
                             "mobile.settings.diagnostics.shareNetworkLog",


### PR DESCRIPTION
Persist the active app and network logs across launches, rotate them into uniquely named archives at the size limit, and enforce bounded count and byte retention.

Share every retained generation from Settings so diagnostics include history instead of only the current file. Legacy .1 rotations are migrated without losing their contents.

Tests: swift test --package-path Packages/Shared/CMUXMobileCore --filter AppLogTests

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/10082"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789185025&installation_model_id=21920&pr_number=10082&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F10082&signature=69756d837d2d8cd4a687fee442f56e72734c021860abd87ee29abb88c92531e6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Retains iOS app and network log history across launches and includes it in diagnostics. Previously we rotated to <name>.1 and Settings shared only the active file; now we reopen the active generation, rotate to timestamped archives, bound retention by count and total bytes, and share all generations.

- `CMUXMobileCore`: `AppLog` adds timestamped archive rotation, bounded retention (defaults: 5 MB per file, 3 archives, 12 MB total), and reopens the active generation on launch. Rotation failures append to the current file instead of truncating. Legacy `<name>.1` files migrate into the archive namespace without data loss. Retained generations are discovered safely and ordered by embedded generation stamp (with modification-date fallback).
- `CMUXMobileCore`: New APIs `AppLog.appLogFileURLs`, `AppLog.networkLogFileURLs`, and `logFileURLs(for:)` expose the active file plus archives (including any unmigrated legacy `.1`). The initializer adds optional `maxArchiveCount`, `maxRetainedBytes`, and `now` parameters; existing call sites do not need changes.
- `CmuxMobileShellUI`: Settings shares all retained generations via `ShareLink(items:)`, loading URL lists off the main thread so exported diagnostics include recent history.
- Tests cover rotation, cross-launch reopen, legacy migration, archive ordering, failure fallback, and retention bounds.

<sup>Written for commit ab43b7d59a03f024db5aa4f1656a834d3b5ce780. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/10082?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Log files now support timestamped archives with configurable size, archive-count, and storage limits.
  - Existing logs are preserved across app launches, including migration of legacy archives.
  - Diagnostics sharing now includes all available app and network log archives.

- **Bug Fixes**
  - Improved recovery when log rotation or archive creation fails.
  - Prevented existing archived log data from being overwritten.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->