### PR TITLE
iOS: permanently disable mobile toasts

### DIFF
--- a/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Screen/ChatScreen.swift
+++ b/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Screen/ChatScreen.swift
@@ -75,10 +75,10 @@ public struct ChatScreen: View {
     public var body: some View {
         ZStack(alignment: .top) {
             chatLayout
-            // Legacy fallback while the Toasts beta flag is off: the inline
-            // error banner below the navigation bar (see errorBanner for the
-            // layering rationale). With the flag on, errors surface through
-            // the app-wide toast layer instead.
+            // Legacy fallback while the toast presenter is disabled: the
+            // inline error banner below the navigation bar (see errorBanner
+            // for the layering rationale). Re-enabling the presenter routes
+            // errors through the app-wide toast layer instead.
             if !toasts.isEnabled {
                 errorBanner
             }
@@ -110,13 +110,13 @@ public struct ChatScreen: View {
             guard runsStoreTask else { return }
             await store.run()
         }
-        // With the Toasts beta flag on, errors surface through the app-wide
-        // toast layer. Presenting hands display ownership to the ToastCenter,
-        // and clearing the store state immediately lets an identical
-        // follow-up error re-fire this bridge. One coalescing key per
-        // conversation store: a newer error replaces and re-bumps the visible
-        // one instead of queueing stale errors. With the flag off, the store
-        // state stays put and drives the legacy inline banner.
+        // When re-enabled, errors surface through the app-wide toast layer.
+        // Presenting hands display ownership to the ToastCenter, and clearing
+        // the store state immediately lets an identical follow-up error
+        // re-fire this bridge. One coalescing key per conversation store means
+        // a newer error replaces and re-bumps the visible one instead of
+        // queueing stale errors. While disabled, the store state stays put and
+        // drives the legacy inline banner.
         .onChange(of: store.lastErrorDescription, initial: true) { _, error in
             guard toasts.isEnabled, let error else { return }
             toasts.present(.failure(
@@ -250,8 +250,8 @@ public struct ChatScreen: View {
         AccessibilityNotification.Announcement(prose.text).post()
     }
 
-    /// Speaks the legacy error banner's text when an error surfaces while the
-    /// Toasts beta flag is off (the toast layer announces its own toasts).
+    /// Speaks the legacy error banner's text while the toast presenter is
+    /// disabled (the toast layer announces its own toasts when re-enabled).
     private func announceLastError() {
         guard !toasts.isEnabled,
               UIAccessibility.isVoiceOverRunning,

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DeviceTreeView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DeviceTreeView.swift
@@ -32,8 +32,8 @@ struct DeviceTreeView: View {
     /// dismiss the Computers sheet when the final saved computer is gone.
     var didForgetComputer: (() -> Void)? = nil
     /// Message for the always-visible failure alert shown when a Forget cannot be
-    /// completed. An alert, not a toast, so the error still surfaces when the
-    /// Toasts beta flag is off.
+    /// completed. An alert, not a toast, so the error still surfaces while the
+    /// toast presenter is disabled.
     @State private var forgetFailureMessage: String?
 
     /// The user's computers as immutable snapshots, sourced from the paired-Mac

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MobileSettingsView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MobileSettingsView.swift
@@ -62,7 +62,6 @@ struct MobileSettingsView: View {
 
     var body: some View {
         @Bindable var displaySettings = displaySettings
-        @Bindable var toasts = self.toasts
         return NavigationStack {
             Form {
                 if initialFocus == .connectionMethod {
@@ -254,13 +253,6 @@ struct MobileSettingsView: View {
                     }
                     .accessibilityIdentifier("MobileSettingsTerminalFilesChip")
 
-                    Toggle(isOn: $toasts.isEnabled) {
-                        Text(L10n.string(
-                            "mobile.settings.beta.toasts",
-                            defaultValue: "Toasts"
-                        ))
-                    }
-                    .accessibilityIdentifier("MobileSettingsToastsEnabled")
                 }
 
                 #if DEBUG

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TerminalTextSheetView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TerminalTextSheetView.swift
@@ -30,8 +30,8 @@ struct TerminalTextSheetView: View {
     /// read is in flight.
     @State private var snapshot: TerminalTextSnapshot?
     @State private var isLoading = true
-    /// Legacy fallback while the Toasts beta flag is off: flips the Copy All
-    /// label to a checkmark after a copy. Reset is the next presentation
+    /// Legacy fallback while the toast presenter is disabled: flips the Copy
+    /// All label to a checkmark after a copy. Reset is the next presentation
     /// (fresh `@State`), so no timer is needed.
     @State private var didCopy = false
 

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceShellView+WorkspaceActionFailure.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceShellView+WorkspaceActionFailure.swift
@@ -33,8 +33,9 @@ extension WorkspaceShellView {
         let title = Self.workspaceActionFailureTitle(action: action)
         let reason = Self.workspaceActionFailureReasonText(failure)
         guard toasts.isEnabled else {
-            // Toasts beta off: the legacy dismissible bottom banner, with the
-            // same title and reason joined into its single-line message.
+            // The shelved toast presenter falls back to the legacy dismissible
+            // bottom banner, with the same title and reason joined into its
+            // single-line message.
             withAnimation(.snappy(duration: 0.2)) {
                 workspaceActionToast = WorkspaceActionToastContent(
                     message: String.localizedStringWithFormat(

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceShellView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceShellView.swift
@@ -200,8 +200,8 @@ struct WorkspaceShellView: View {
     @State private var hasPresentedSplitDetail = false
     @State private var splitColumnVisibility: NavigationSplitViewVisibility = .automatic
     @State private var macSelection: WorkspaceMacSelection = .all
-    /// Legacy fallback while the Toasts beta flag is off: the old dismissible
-    /// bottom banner for workspace-action failures.
+    /// Legacy fallback while the toast presenter is disabled: the old
+    /// dismissible bottom banner for workspace-action failures.
     @State var workspaceActionToast: WorkspaceActionToastContent?
     var workspaceActionToastClock: any Clock<Duration> = ContinuousClock()
     @Environment(ToastCenter.self) var toasts
@@ -402,9 +402,8 @@ struct WorkspaceShellView: View {
     private func workspaceActionToastOverlay<Content: View>(
         @ViewBuilder content: () -> Content
     ) -> some View {
-        // With the Toasts beta flag on, failures surface through the app-wide
-        // toast layer; the legacy bottom banner below only ever receives
-        // content while the flag is off.
+        // If the presenter is re-enabled, failures surface through the
+        // app-wide toast layer; the legacy bottom banner remains the fallback.
         ZStack(alignment: .bottom) {
             content()
             if let workspaceActionToast {

--- a/Packages/iOS/CmuxMobileToast/Sources/CmuxMobileToast/ToastCenter.swift
+++ b/Packages/iOS/CmuxMobileToast/Sources/CmuxMobileToast/ToastCenter.swift
@@ -65,6 +65,8 @@ public final class ToastCenter {
     /// from the presenter so reintroducing it later is a one-line decision.
     private static let shippedEnabled = false
 
+    /// Creates a presenter using the shipped product policy, which currently
+    /// keeps toast presentation disabled.
     public convenience init(
         clock: any Clock<Duration> = ContinuousClock(),
         diagnosticLog: DiagnosticLog? = nil

--- a/Packages/iOS/CmuxMobileToast/Sources/CmuxMobileToast/ToastCenter.swift
+++ b/Packages/iOS/CmuxMobileToast/Sources/CmuxMobileToast/ToastCenter.swift
@@ -26,15 +26,12 @@ public final class ToastCenter {
 
     public private(set) var presented: Presented?
 
-    /// Beta gate: while false (the default), `present(_:)` drops every toast
-    /// so the app behaves as if the system doesn't exist. Persisted, and
-    /// surfaced as the "Toasts" toggle under Settings → Beta Features.
-    /// Call sites with a legacy surface (the old workspace-action banner,
-    /// chat error banner, copy-button morph) branch on this to fall back.
-    public var isEnabled: Bool {
+    /// Product policy keeps the toast surface disabled in shipped builds.
+    /// The presenter remains implemented so it can be restored without
+    /// rewriting the call sites that already use it.
+    public internal(set) var isEnabled: Bool {
         didSet {
             guard oldValue != isEnabled else { return }
-            defaults.set(isEnabled, forKey: Self.enabledDefaultsKey)
             diagnosticLog?.recordAppEvent(.toastFeatureChanged, count: isEnabled ? 1 : 0)
             if !isEnabled {
                 dismissAll(reason: .featureDisabled)
@@ -42,9 +39,6 @@ public final class ToastCenter {
         }
     }
 
-    public static let enabledDefaultsKey = "cmux.toasts.betaEnabled"
-
-    @ObservationIgnored private let defaults: UserDefaults
     @ObservationIgnored private let diagnosticLog: DiagnosticLog?
 
     /// Toasts waiting behind the visible one, oldest first. Capped: a burst
@@ -67,22 +61,31 @@ public final class ToastCenter {
     /// next arrival.
     static let interToastGap: Duration = .milliseconds(260)
 
-    public init(
+    /// The toast UI is shelved from the product. Keep this policy separate
+    /// from the presenter so reintroducing it later is a one-line decision.
+    private static let shippedEnabled = false
+
+    public convenience init(
         clock: any Clock<Duration> = ContinuousClock(),
-        defaults: UserDefaults = .standard,
+        diagnosticLog: DiagnosticLog? = nil
+    ) {
+        self.init(
+            clock: clock,
+            enabled: Self.defaultEnabled,
+            diagnosticLog: diagnosticLog
+        )
+    }
+
+    /// Internal injection keeps lifecycle tests able to exercise the dormant
+    /// presenter without exposing a production toggle. The DEBUG gallery keeps
+    /// its separate environment-gated entry point below.
+    init(
+        clock: any Clock<Duration>,
+        enabled: Bool,
         diagnosticLog: DiagnosticLog? = nil
     ) {
         self.clock = clock
-        self.defaults = defaults
         self.diagnosticLog = diagnosticLog
-        var enabled = defaults.bool(forKey: Self.enabledDefaultsKey)
-        #if DEBUG
-        // The env-gated gallery harness exists to exercise toasts; a dark
-        // default there would make every gallery run a silent no-op.
-        if ProcessInfo.processInfo.environment["CMUX_TOAST_GALLERY"] == "1" {
-            enabled = true
-        }
-        #endif
         self.isEnabled = enabled
         #if os(iOS)
         prefersExtendedDwell = {
@@ -93,10 +96,21 @@ public final class ToastCenter {
         #endif
     }
 
+    private static var defaultEnabled: Bool {
+        #if DEBUG
+        if ProcessInfo.processInfo.environment["CMUX_TOAST_GALLERY"] == "1" {
+            // Keep the gallery harness useful without making the shipped
+            // product policy configurable.
+            return true
+        }
+        #endif
+        return shippedEnabled
+    }
+
     /// Present a toast: shows it now if nothing is visible, refreshes and
     /// re-bumps the visible toast when the ``Toast/coalescingKey`` matches,
-    /// and queues (FIFO, capped) otherwise. Dropped while ``isEnabled`` is
-    /// false (the beta flag is off).
+    /// and queues (FIFO, capped) otherwise. Dropped while the product policy
+    /// keeps ``isEnabled`` false.
     public func present(_ toast: Toast) {
         guard isEnabled else {
             recordToastEvent(

--- a/Packages/iOS/CmuxMobileToast/Tests/CmuxMobileToastTests/ToastCenterTests.swift
+++ b/Packages/iOS/CmuxMobileToast/Tests/CmuxMobileToastTests/ToastCenterTests.swift
@@ -6,11 +6,8 @@ import Testing
 @MainActor
 struct ToastCenterTests {
     @Test func recordsLifecycleWithoutToastCopy() async throws {
-        let suiteName = "toast-diagnostic-tests-\(UUID().uuidString)"
-        let defaults = try #require(UserDefaults(suiteName: suiteName))
-        defaults.set(true, forKey: ToastCenter.enabledDefaultsKey)
         let log = DiagnosticLog(capacity: 8)
-        let center = ToastCenter(defaults: defaults, diagnosticLog: log)
+        let center = ToastCenter(clock: ContinuousClock(), enabled: true, diagnosticLog: log)
         let toast = Toast.failure("private message")
 
         center.present(toast)
@@ -41,25 +38,22 @@ struct ToastCenterTests {
         let clock = ManualClock()
         let center = ToastCenter(
             clock: clock,
-            defaults: UserDefaults(suiteName: "toast-tests-\(UUID().uuidString)")!
+            enabled: true
         )
-        center.isEnabled = true
         center.prefersExtendedDwell = { false }
         return (center, clock)
     }
 
     @Test func disabledCenterDropsEveryPresent() {
         let clock = ManualClock()
-        let center = ToastCenter(
-            clock: clock,
-            defaults: UserDefaults(suiteName: "toast-tests-\(UUID().uuidString)")!
-        )
-        // Off by default (beta flag).
+        let center = ToastCenter(clock: clock)
+        // The shipped product policy is permanently off.
         #expect(center.isEnabled == false)
         center.present(.success("dropped"))
         #expect(center.presented == nil)
         #expect(center.queue.isEmpty)
 
+        // The internal injection still exercises the dormant presenter logic.
         center.isEnabled = true
         center.present(.success("shown"))
         #expect(center.presented?.toast.message == "shown")
@@ -69,11 +63,10 @@ struct ToastCenterTests {
         #expect(center.presented == nil)
     }
 
-    @Test func legacyEnabledPreferenceCannotReenableToasts() {
-        let defaults = UserDefaults(suiteName: "toast-tests-\(UUID().uuidString)")!
-        defaults.set(true, forKey: ToastCenter.enabledDefaultsKey)
-        let center = ToastCenter(defaults: defaults)
-
+    @Test func productionInitializerRemainsDisabled() {
+        // A value left by the removed beta setting cannot affect a new
+        // presenter because the production initializer reads no preference.
+        let center = ToastCenter()
         #expect(center.isEnabled == false)
         center.present(.success("still disabled"))
         #expect(center.presented == nil)

--- a/Packages/iOS/CmuxMobileToast/Tests/CmuxMobileToastTests/ToastCenterTests.swift
+++ b/Packages/iOS/CmuxMobileToast/Tests/CmuxMobileToastTests/ToastCenterTests.swift
@@ -69,6 +69,16 @@ struct ToastCenterTests {
         #expect(center.presented == nil)
     }
 
+    @Test func legacyEnabledPreferenceCannotReenableToasts() {
+        let defaults = UserDefaults(suiteName: "toast-tests-\(UUID().uuidString)")!
+        defaults.set(true, forKey: ToastCenter.enabledDefaultsKey)
+        let center = ToastCenter(defaults: defaults)
+
+        #expect(center.isEnabled == false)
+        center.present(.success("still disabled"))
+        #expect(center.presented == nil)
+    }
+
     /// Yields until `condition` holds, so a task spawned by the center can
     /// reach its clock.sleep suspension before the test advances the clock.
     private func yieldUntil(

--- a/ios/cmux/Resources/Localizable.xcstrings
+++ b/ios/cmux/Resources/Localizable.xcstrings
@@ -8161,23 +8161,6 @@
         }
       }
     },
-    "mobile.settings.beta.toasts": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Toasts"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "トースト"
-          }
-        }
-      }
-    },
     "mobile.textSheet.copied": {
       "extractionState": "manual",
       "localizations": {


### PR DESCRIPTION
## Summary
- remove the iOS Beta Features toggle and its localization entry
- make the production ToastCenter policy permanently disabled while keeping the presenter and DEBUG injection seam
- preserve legacy inline/banner/copy feedback paths

## Verification
- `swift test --package-path Packages/iOS/CmuxMobileToast`
- `swift test --package-path Packages/iOS/CmuxAgentChatUI`
- tagged cloud reload: `toff`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/10087"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789186487&installation_model_id=21920&pr_number=10087&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F10087&signature=3330ccc8df9b1ff94330f979f41a820537ae0c97c22839d60cead396cf090a2f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Permanently disables the iOS toast presenter in shipped builds and removes the Beta toggle. Previously users could opt in under Settings → Beta Features; now the shipped `ToastCenter` always starts disabled, ignores any stored preference, and cannot be enabled from production code.

- Removes the Settings toggle and the "mobile.settings.beta.toasts" localization; any stale `UserDefaults` values are ignored.
- `ToastCenter` no longer reads/writes `UserDefaults`; the production initializer uses a fixed disabled policy and exposes `isEnabled` as public read-only. Tests enable via the internal initializer; the DEBUG gallery still honors `CMUX_TOAST_GALLERY=1`.
- Call sites continue to branch on `toasts.isEnabled`; with the presenter disabled they fall back to the inline chat error banner, the workspace bottom banner, and the “Copy All” checkmark.
- Migration: remove any references to `ToastCenter.enabledDefaultsKey` and any production writes to `ToastCenter.isEnabled`.

<sup>Written for commit 4d047f44e6fb2de77dc2f24c72ce9b077039f0e8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/10087?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Toast notifications are now disabled by default in shipped builds.
  * Removed the beta “Toasts” toggle from Mobile Settings.
  * Updated fallback behavior and messaging to reflect the disabled toast presenter.
  * Removed obsolete “Toasts” localization strings.
* **Tests**
  * Added coverage confirming production toast settings remain disabled and ignore legacy preferences.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->