### PR TITLE
Add comprehensive privacy-safe CodeRouter analytics

### DIFF
--- a/docs/posthog/coderouter-analytics-dashboard.md
+++ b/docs/posthog/coderouter-analytics-dashboard.md
@@ -1,0 +1,94 @@
+# CodeRouter PostHog dashboards
+
+Project: **CodeRouter Analytics** (dedicated; never the general cmux project)
+
+Dashboard: **CodeRouter Operations & Usage**
+
+All event queries must filter `product = 'coderouter'` and current
+`schema_version`. Team/user scopes are HMAC pseudonyms; never add raw IDs,
+names, labels, prompts, output, credentials, paths, arguments, URLs, headers,
+request IDs, or free-form errors.
+
+## P0 cards
+
+1. **Requests and success rate**
+   - Event: `coderouter_route_health`
+   - Requests: count
+   - Success: `outcome = success`
+   - Breakdown: provider, agent, outcome
+2. **Route latency**
+   - Event: `coderouter_route_health`
+   - Breakdown: `latency_bucket`
+3. **Retries and refreshes**
+   - Event: `coderouter_route_health`
+   - Breakdown: `attempt_bucket`, `refresh_bucket`
+4. **Failure stage**
+   - Event: `coderouter_route_health`
+   - Breakdown: `failure_stage`, `status_class`
+5. **Tokens by day**
+   - Event: `$ai_generation`
+   - Sums: `$ai_input_tokens`, `$ai_cache_read_input_tokens`,
+     `$ai_output_tokens`, `coderouter_total_tokens`
+6. **API-equivalent value**
+   - Event: `$ai_generation`
+   - Sum: `$ai_total_cost_usd`
+   - Label explicitly as an estimate, not actual provider spend
+7. **Pricing coverage**
+   - Event: `$ai_generation`
+   - `sum(coderouter_priced_tokens) / sum(coderouter_total_tokens)`
+8. **Active pseudonymous organizations**
+   - Unique `coderouter_team_scope`
+9. **CLI command funnel**
+   - `coderouter_cli_command_started` → `coderouter_cli_command_completed`
+   - Breakdown: command, agent, mode, outcome, failure_stage
+10. **Account lifecycle**
+    - `coderouter_account_status_viewed`
+    - `coderouter_account_added`
+    - `coderouter_account_removed`
+11. **Session lifecycle**
+    - `coderouter_route_session_issued`
+    - `coderouter_route_session_revoked`
+    - `coderouter_auth_rejected`
+12. **Organization and dashboard use**
+    - `coderouter_organization_catalog_viewed`
+    - `coderouter_metrics_loaded`
+
+## P0 privacy/integrity cards
+
+Each must remain zero:
+
+- missing `coderouter_team_scope` on team-scoped events
+- `distinct_id != coderouter_team_scope`
+- `$process_person_profile != false`
+- `$geoip_disable != true`
+- unknown `schema_version`
+- `cached_input_tokens > input_tokens`
+- `priced_tokens + unpriced_tokens != total_tokens`
+- forbidden property keys (`prompt`, `output`, `$ai_input`,
+  `$ai_output_choices`, `credential`, `authorization`, `cookie`, `account_id`,
+  `team_id`, `user_id`, `email`, `local_path`, `command_args`)
+
+Any nonzero privacy/integrity card is an incident.
+
+## P1 views
+
+- Weekly organization retention: successful `coderouter_route_health` return.
+- Activation funnel:
+  account added → route session issued → successful route health.
+- Provider/agent mix over time.
+- CLI version adoption and failure rate by version.
+- Metrics Endpoint availability by `outcome` and `failure_stage`.
+
+## Alerts
+
+- route success below 97% with at least 20 eligible requests/hour
+- `no_usable_account` above 5%/hour
+- 5xx above 2%/hour
+- 10s+ latency above 5%/hour
+- pricing coverage below 95% daily
+- any privacy/integrity violation
+- no successful events during expected active periods
+
+Customer-facing metrics must continue to use the fixed,
+server-authorized `coderouter-team-usage-30d` Endpoint. Never expose PostHog
+project access or free-form HogQL to customers.

--- a/web/.env.example
+++ b/web/.env.example
@@ -61,12 +61,12 @@ SENTRY_DSN=
 
 # Team-scoped CodeRouter AI Observability in a dedicated PostHog project.
 # POSTHOG_CODEROUTER_PROJECT_KEY is the isolated ingestion token. The endpoint
-# secret must be a project secret API key with endpoint:read only. The HMAC
-# scope secret must be at least 32 random bytes. Never use NEXT_PUBLIC_*.
+# secret must be a project secret API key with endpoint:read only. The reviewed
+# customer endpoint name is fixed in code. The HMAC scope secret must be at
+# least 32 random bytes. Never use NEXT_PUBLIC_*.
 POSTHOG_CODEROUTER_PROJECT_KEY=
 POSTHOG_CODEROUTER_ENVIRONMENT_ID=
 POSTHOG_CODEROUTER_ENDPOINT_SECRET=
-POSTHOG_CODEROUTER_ENDPOINT_NAME=coderouter-team-usage-30d
 POSTHOG_CODEROUTER_API_HOST=https://us.posthog.com
 POSTHOG_CODEROUTER_INGEST_HOST=https://us.i.posthog.com
 CODEROUTER_ANALYTICS_SCOPE_SECRET=

--- a/web/app/api/coderouter/accounts/[accountId]/route.ts
+++ b/web/app/api/coderouter/accounts/[accountId]/route.ts
@@ -64,6 +64,7 @@ export function createDeleteAccountHandler(dependencies: {
       userId: resolved.value.user.id,
       teamId: resolved.value.team.teamId,
       properties: {
+        source: "native_api",
         last_account: result.lastAccount,
         legacy_cleanup_pending: result.legacyCleanupPending,
       },

--- a/web/app/api/coderouter/accounts/route.ts
+++ b/web/app/api/coderouter/accounts/route.ts
@@ -44,9 +44,9 @@ export async function GET(request: Request): Promise<Response> {
   ].join(", ");
   captureCoderouterEvent({
     event: "coderouter_account_status_viewed",
-    userId: resolved.stackUserId,
     teamId: resolved.teamId,
     properties: {
+      source: "native_api",
       account_count: result.accounts.length,
       account_error_count: result.accounts.filter(
         (account) => "usageError" in account && Boolean(account.usageError),
@@ -99,6 +99,7 @@ export async function POST(request: Request): Promise<Response> {
       teamId: resolved.value.team.teamId,
       properties: {
         provider: credential.provider,
+        source: "native_api",
         already_exists: result.alreadyExists,
       },
     });

--- a/web/app/api/coderouter/analytics/route.ts
+++ b/web/app/api/coderouter/analytics/route.ts
@@ -4,6 +4,8 @@ import { captureCoderouterEvent } from
   "../../../../services/coderouter/analytics";
 import { resolveCoderouterUsageTeam } from
   "../../../../services/coderouter/requestContext";
+import { readBoundedJsonRecord } from
+  "../../../../services/subrouter/boundedJson";
 
 const MAX_BODY_BYTES = 8 * 1024;
 
@@ -88,22 +90,9 @@ export async function POST(request: Request): Promise<Response> {
   const resolved = await resolveCoderouterUsageTeam(request);
   if (!resolved.ok) return resolved.response;
 
-  let text: string;
-  try {
-    text = await request.text();
-  } catch {
-    return Response.json({ error: "invalid_request" }, { status: 400 });
-  }
-  if (new TextEncoder().encode(text).byteLength > MAX_BODY_BYTES) {
-    return new Response(null, { status: 413 });
-  }
-  let parsed: unknown;
-  try {
-    parsed = JSON.parse(text);
-  } catch {
-    return Response.json({ error: "invalid_request" }, { status: 400 });
-  }
-  const batch = batchSchema.safeParse(parsed);
+  const bounded = await readBoundedJsonRecord(request, MAX_BODY_BYTES);
+  if (!bounded.ok) return new Response(null, { status: bounded.status });
+  const batch = batchSchema.safeParse(bounded.value);
   if (!batch.success) {
     return Response.json({ error: "invalid_request" }, { status: 400 });
   }

--- a/web/app/api/coderouter/analytics/route.ts
+++ b/web/app/api/coderouter/analytics/route.ts
@@ -1,0 +1,119 @@
+import { z } from "zod";
+
+import { captureCoderouterEvent } from
+  "../../../../services/coderouter/analytics";
+import { resolveCoderouterUsageTeam } from
+  "../../../../services/coderouter/requestContext";
+
+const MAX_BODY_BYTES = 8 * 1024;
+
+const eventSchema = z.object({
+  event: z.enum([
+    "coderouter_cli_command_started",
+    "coderouter_cli_command_completed",
+  ]),
+  properties: z.object({
+    schema_version: z.literal(1),
+    command: z.enum([
+      "accounts",
+      "help",
+      "version",
+      "agent",
+      "add",
+      "remove",
+      "login",
+      "logout",
+      "organization",
+      "upgrade",
+      "doctor",
+      "unknown",
+    ]),
+    agent: z.enum(["none", "codex", "opencode", "pi"]),
+    mode: z.enum([
+      "summary",
+      "default",
+      "routed",
+      "direct",
+      "interactive",
+      "specified",
+      "cancel",
+      "unknown",
+      "code",
+      "device",
+      "current",
+      "list",
+      "switch",
+    ]),
+    outcome: z.enum(["started", "success", "failure", "cancelled"]),
+    failure_stage: z.enum([
+      "none",
+      "validation",
+      "control_plane",
+      "child_start",
+      "local_io",
+      "child_process",
+    ]),
+    exit_code_class: z.enum([
+      "not_applicable",
+      "success",
+      "generic_failure",
+      "usage",
+      "launch_failure",
+      "signal_or_terminated",
+      "other_failure",
+    ]),
+    duration_bucket: z.enum([
+      "not_applicable",
+      "under_1s",
+      "1s_to_5s",
+      "5s_to_30s",
+      "30s_to_2m",
+      "2m_or_more",
+    ]),
+    execution_context: z.enum(["interactive", "headless"]),
+    cli_version: z.string().regex(/^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$/)
+      .max(64),
+  }).strict(),
+}).strict();
+
+const batchSchema = z.object({
+  events: z.array(eventSchema).min(1).max(2),
+}).strict();
+
+export async function POST(request: Request): Promise<Response> {
+  const contentLength = Number(request.headers.get("content-length") ?? 0);
+  if (Number.isFinite(contentLength) && contentLength > MAX_BODY_BYTES) {
+    return new Response(null, { status: 413 });
+  }
+  const resolved = await resolveCoderouterUsageTeam(request);
+  if (!resolved.ok) return resolved.response;
+
+  let text: string;
+  try {
+    text = await request.text();
+  } catch {
+    return Response.json({ error: "invalid_request" }, { status: 400 });
+  }
+  if (new TextEncoder().encode(text).byteLength > MAX_BODY_BYTES) {
+    return new Response(null, { status: 413 });
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(text);
+  } catch {
+    return Response.json({ error: "invalid_request" }, { status: 400 });
+  }
+  const batch = batchSchema.safeParse(parsed);
+  if (!batch.success) {
+    return Response.json({ error: "invalid_request" }, { status: 400 });
+  }
+  for (const event of batch.data.events) {
+    captureCoderouterEvent({
+      event: event.event,
+      userId: resolved.stackUserId,
+      teamId: resolved.teamId,
+      properties: event.properties,
+    });
+  }
+  return new Response(null, { status: 204 });
+}

--- a/web/app/api/coderouter/session/route.ts
+++ b/web/app/api/coderouter/session/route.ts
@@ -38,13 +38,21 @@ export function makeCoderouterSessionGetHandler(
   return async function GET(request: Request): Promise<Response> {
     const authorization = request.headers.get("authorization")?.trim() ?? "";
     const token = /^Bearer[ \t]+(.+)$/i.exec(authorization)?.[1]?.trim();
-    if (!token || !(await authenticate(token))) {
+    const identity = token ? await authenticate(token) : null;
+    if (!identity) {
       addCoderouterBreadcrumb(
         "auth",
         "Route session validation rejected",
         {},
         "warning",
       );
+      captureCoderouterEvent({
+        event: "coderouter_auth_rejected",
+        properties: {
+          surface: "session_validation",
+          reason: token ? "invalid_route_token" : "missing_route_token",
+        },
+      });
       return Response.json(
         {
           error: "unauthorized",

--- a/web/app/api/subrouter/accounts/[accountId]/repair/route.ts
+++ b/web/app/api/subrouter/accounts/[accountId]/repair/route.ts
@@ -5,6 +5,7 @@ import {
   subrouterErrorResponse,
 } from "../../../../../../services/subrouter/routeHelpers";
 import { jsonResponse } from "../../../../../../services/vms/routeHelpers";
+import { captureCoderouterEvent } from "../../../../../../services/coderouter/analytics";
 
 
 type RouteContext = {
@@ -38,6 +39,16 @@ export async function POST(
       accountId,
       input.value,
     );
+    captureCoderouterEvent({
+      event: "coderouter_account_added",
+      userId: context.user.id,
+      teamId: context.team.teamId,
+      properties: {
+        provider: input.value.provider,
+        source: "legacy_dashboard",
+        already_exists: true,
+      },
+    });
     return jsonResponse({ teamId: context.team.teamId, account });
   } catch (err) {
     return subrouterErrorResponse(err);

--- a/web/app/api/subrouter/accounts/[accountId]/route.ts
+++ b/web/app/api/subrouter/accounts/[accountId]/route.ts
@@ -6,6 +6,7 @@ import {
   subrouterErrorResponse,
 } from "../../../../../services/subrouter/routeHelpers";
 import { resolveSubrouterRequestContext } from "../../../../../services/subrouter/requestContext";
+import { captureCoderouterEvent } from "../../../../../services/coderouter/analytics";
 
 
 type RouteContext = {
@@ -28,6 +29,12 @@ export async function DELETE(request: Request, context: RouteContext): Promise<R
   try {
     const tenant = await client.exchangeTeam(accessToken, team);
     await client.deleteAccount(tenant.tenantKey, accountId);
+    captureCoderouterEvent({
+      event: "coderouter_account_removed",
+      userId: resolved.value.user.id,
+      teamId: team.teamId,
+      properties: { source: "legacy_dashboard" },
+    });
     return jsonResponse({ ok: true, teamId: team.teamId });
   } catch (err) {
     return subrouterErrorResponse(err);

--- a/web/app/api/subrouter/accounts/route.ts
+++ b/web/app/api/subrouter/accounts/route.ts
@@ -6,6 +6,7 @@ import {
   subrouterErrorResponse,
 } from "../../../../services/subrouter/routeHelpers";
 import { resolveSubrouterRequestContext } from "../../../../services/subrouter/requestContext";
+import { captureCoderouterEvent } from "../../../../services/coderouter/analytics";
 
 
 export async function GET(request: Request): Promise<Response> {
@@ -18,6 +19,15 @@ export async function GET(request: Request): Promise<Response> {
   try {
     const tenant = await context.client.exchangeTeam(context.accessToken, context.team);
     const accounts = await context.client.listAccounts(tenant.tenantKey);
+    captureCoderouterEvent({
+      event: "coderouter_account_status_viewed",
+      teamId: context.team.teamId,
+      properties: {
+        source: "legacy_dashboard",
+        account_count: accounts.length,
+        account_error_count: 0,
+      },
+    });
     return jsonResponse({ teamId: context.team.teamId, accounts });
   } catch (err) {
     return subrouterErrorResponse(err);
@@ -41,6 +51,16 @@ export async function POST(request: Request): Promise<Response> {
       tenant.tenantKey,
       input.value,
     );
+    captureCoderouterEvent({
+      event: "coderouter_account_added",
+      userId: context.user.id,
+      teamId: context.team.teamId,
+      properties: {
+        provider: input.value.provider,
+        source: "legacy_dashboard",
+        already_exists: false,
+      },
+    });
     return jsonResponse({ teamId: context.team.teamId, account });
   } catch (err) {
     return subrouterErrorResponse(err);

--- a/web/app/api/subrouter/teams/route.ts
+++ b/web/app/api/subrouter/teams/route.ts
@@ -12,6 +12,7 @@ import {
 import {
   coderouterOrganizationFromCookieHeader,
 } from "../../../../services/coderouter/organizationScope";
+import { captureCoderouterEvent } from "../../../../services/coderouter/analytics";
 
 
 export async function GET(request: Request): Promise<Response> {
@@ -47,6 +48,14 @@ export async function GET(request: Request): Promise<Response> {
         });
       }
       selectedTeamId ??= stackSelectedTeamId;
+      captureCoderouterEvent({
+        event: "coderouter_organization_catalog_viewed",
+        ...(selectedTeamId ? { teamId: selectedTeamId } : {}),
+        properties: {
+          organization_count: teams.length,
+          has_selected_organization: selectedTeamId !== null,
+        },
+      });
       return jsonResponse({ selectedTeamId, teams });
     });
   } catch (error) {

--- a/web/services/coderouter/analytics.ts
+++ b/web/services/coderouter/analytics.ts
@@ -1,12 +1,14 @@
 import { randomUUID } from "node:crypto";
 import { after } from "next/server";
 
-import { POSTHOG_HOST, POSTHOG_PROJECT_KEY } from "../analytics/iosEventPolicy";
 import {
   addCoderouterBreadcrumb,
   reportCoderouterFailure,
 } from "./observability";
-import { coderouterTeamAnalyticsId } from "./analyticsIdentity";
+import {
+  coderouterTeamAnalyticsId,
+  coderouterUserAnalyticsId,
+} from "./analyticsIdentity";
 import {
   CODEROUTER_API_RATE_CARD_VERSION,
   estimateApiEquivalent,
@@ -19,13 +21,19 @@ export type CoderouterAnalyticsEvent =
   | "coderouter_auth_rejected"
   | "coderouter_route_session_issued"
   | "coderouter_route_session_revoked"
+  | "coderouter_organization_catalog_viewed"
+  | "coderouter_metrics_loaded"
+  | "coderouter_route_health"
+  | "coderouter_cli_command_started"
+  | "coderouter_cli_command_completed"
   | "coderouter_model_request_completed";
 
 type AnalyticsScalar = string | number | boolean;
 
 type CaptureInput = {
   readonly event: CoderouterAnalyticsEvent;
-  readonly userId: string;
+  /** Raw server-authoritative identifiers are accepted only as HMAC inputs. */
+  readonly userId?: string;
   readonly teamId?: string;
   readonly properties?: Readonly<
     Record<string, AnalyticsScalar | null | undefined>
@@ -36,19 +44,20 @@ type AnalyticsDependencies = {
   readonly fetch: typeof fetch;
   readonly defer: (task: Promise<unknown>) => void;
   readonly enabled: () => boolean;
-  readonly usageConfig: () => CoderouterUsageAnalyticsConfig | null;
+  readonly isolatedConfig: () => CoderouterAnalyticsConfig | null;
 };
 
-type CoderouterUsageAnalyticsConfig = {
+type CoderouterAnalyticsConfig = {
   readonly ingestHost: string;
   readonly projectKey: string;
   readonly scopeSecret: string;
 };
 
 const RETRYABLE_STATUS = new Set([408, 425, 429, 500, 502, 503, 504]);
-const SENSITIVE_PROPERTY =
-  /account.?id|authorization|body|content|cookie|credential|email|header|key|prompt|response|secret|session|token/i;
 const CAPTURE_TIMEOUT_MS = 2_000;
+const MAX_COUNT = 1_000_000_000_000;
+const ANALYTICS_SCHEMA_VERSION = 3;
+const ANALYTICS_SERVICE_VERSION = "coderouter-web-v1";
 
 const defaultDependencies: AnalyticsDependencies = {
   fetch,
@@ -64,68 +73,75 @@ const defaultDependencies: AnalyticsDependencies = {
   enabled: () =>
     process.env.VERCEL_ENV === "production" ||
     process.env.CODEROUTER_ANALYTICS_FORCE === "1",
-  usageConfig: coderouterUsageAnalyticsConfig,
+  isolatedConfig: coderouterAnalyticsConfig,
 };
 
 /**
- * Best-effort product analytics. It never blocks the response and accepts only
- * an intentionally small scalar property surface. Prompts, output, provider
- * account IDs, credentials, route tokens, headers, and email are rejected.
+ * Best-effort, server-only CodeRouter analytics. The payload is rebuilt from a
+ * closed event/property schema; caller-provided keys and free-form strings are
+ * never forwarded. Every identifier is either omitted or HMAC-pseudonymized.
  */
 export function captureCoderouterEvent(
   input: CaptureInput,
   dependencies: AnalyticsDependencies = defaultDependencies,
 ): void {
   if (!dependencies.enabled()) return;
+  // Every CodeRouter event fails closed when the isolated project or HMAC
+  // secret is unavailable. There is intentionally no general-project fallback.
+  const config = dependencies.isolatedConfig();
+  if (!config) return;
+
   const aggregateUsage =
     input.event === "coderouter_model_request_completed";
-  // Usage is deliberately team-scoped and never attributable to an
-  // individual. A malformed call without a team is dropped rather than
-  // falling back to the Stack user identity.
   if (aggregateUsage && !input.teamId) return;
-  const usageConfig = aggregateUsage ? dependencies.usageConfig() : null;
-  // Usage must never fall back to the general cmux PostHog project or an
-  // unkeyed identifier when the isolated CodeRouter configuration is absent.
-  if (aggregateUsage && !usageConfig) return;
-  const teamScope = aggregateUsage
-    ? coderouterTeamAnalyticsId(input.teamId!, usageConfig!.scopeSecret)
+
+  const teamScope = input.teamId
+    ? coderouterTeamAnalyticsId(input.teamId, config.scopeSecret)
     : null;
   const properties = aggregateUsage
     ? aiUsageProperties(input.properties ?? {}, teamScope!)
-    : safeProperties(input.properties ?? {});
+    : eventProperties(input.event, input.properties ?? {});
   if (!properties) return;
+
+  const attributable = eventNeedsUserScope(input.event);
+  if (attributable && !input.userId) return;
+  const userScope = attributable
+    ? coderouterUserAnalyticsId(input.userId!, config.scopeSecret)
+    : null;
+  const distinctId = teamScope ?? userScope ?? "coderouter-anonymous";
   const body = JSON.stringify({
-    api_key: usageConfig?.projectKey ?? POSTHOG_PROJECT_KEY,
+    api_key: config.projectKey,
     batch: [
       {
         event: aggregateUsage ? "$ai_generation" : input.event,
-        distinct_id: aggregateUsage
-          ? teamScope
-          : input.userId,
+        distinct_id: distinctId,
         properties: {
           ...properties,
+          $process_person_profile: false,
+          $geoip_disable: true,
+          ...(teamScope ? { coderouter_team_scope: teamScope } : {}),
+          ...(userScope ? { coderouter_user_scope: userScope } : {}),
           $insert_id: randomUUID(),
           product: "coderouter",
-          schema_version: aggregateUsage ? 2 : 1,
+          schema_version: ANALYTICS_SCHEMA_VERSION,
+          service_version: ANALYTICS_SERVICE_VERSION,
         },
         timestamp: new Date().toISOString(),
       },
     ],
   });
-  const task = deliver(
-    body,
-    dependencies.fetch,
-    usageConfig?.ingestHost ?? POSTHOG_HOST,
-  ).catch((error) => {
-    reportCoderouterFailure("analytics_delivery", error);
-  });
+  const task = deliver(body, dependencies.fetch, config.ingestHost).catch(
+    (error) => {
+      reportCoderouterFailure("analytics_delivery", error);
+    },
+  );
   dependencies.defer(task);
 }
 
 async function deliver(
   body: string,
   posthogFetch: typeof fetch,
-  posthogHost = POSTHOG_HOST,
+  posthogHost: string,
 ): Promise<void> {
   for (let attempt = 0; attempt < 2; attempt++) {
     try {
@@ -152,31 +168,178 @@ async function deliver(
   }
 }
 
-function safeProperties(
+function eventNeedsUserScope(event: CoderouterAnalyticsEvent): boolean {
+  return event === "coderouter_account_added" ||
+    event === "coderouter_account_removed" ||
+    event === "coderouter_route_session_issued" ||
+    event === "coderouter_route_session_revoked";
+}
+
+function eventProperties(
+  event: Exclude<CoderouterAnalyticsEvent, "coderouter_model_request_completed">,
   input: Readonly<Record<string, AnalyticsScalar | null | undefined>>,
-): Record<string, AnalyticsScalar> {
-  const output: Record<string, AnalyticsScalar> = {};
-  for (const [key, value] of Object.entries(input)) {
-    const safeTokenCount = /^(?:input|cached_input|output|total)_tokens$/.test(
-      key,
-    );
-    if (SENSITIVE_PROPERTY.test(key) && !safeTokenCount) continue;
-    if (
-      typeof value === "string" ||
-      typeof value === "number" ||
-      typeof value === "boolean"
-    ) {
-      output[key] = value;
+): Record<string, AnalyticsScalar> | null {
+  switch (event) {
+    case "coderouter_account_added": {
+      const provider = accountProvider(input.provider);
+      const source = lifecycleSource(input.source);
+      if (!provider || !source || typeof input.already_exists !== "boolean") {
+        return null;
+      }
+      return { provider, source, already_exists: input.already_exists };
     }
+    case "coderouter_account_removed": {
+      const source = lifecycleSource(input.source);
+      if (!source) return null;
+      const output: Record<string, AnalyticsScalar> = { source };
+      if (typeof input.last_account === "boolean") {
+        output.last_account = input.last_account;
+      }
+      if (typeof input.legacy_cleanup_pending === "boolean") {
+        output.legacy_cleanup_pending = input.legacy_cleanup_pending;
+      }
+      return output;
+    }
+    case "coderouter_account_status_viewed":
+      return {
+        source: lifecycleSource(input.source) ?? "native_api",
+        account_count_bucket: countBucket(input.account_count),
+        account_error_count_bucket: countBucket(input.account_error_count),
+        latency_bucket: latencyBucket(input.duration_ms),
+      };
+    case "coderouter_auth_rejected": {
+      const surface = authSurface(input.surface);
+      const reason = authReason(input.reason);
+      return surface && reason ? { surface, reason } : null;
+    }
+    case "coderouter_route_session_issued":
+      return typeof input.hosted_pro_required === "boolean"
+        ? { hosted_pro_required: input.hosted_pro_required }
+        : null;
+    case "coderouter_route_session_revoked":
+      return {};
+    case "coderouter_organization_catalog_viewed":
+      return {
+        organization_count_bucket: countBucket(input.organization_count),
+        has_selected_organization:
+          input.has_selected_organization === true,
+      };
+    case "coderouter_metrics_loaded": {
+      const outcome = enumValue(input.outcome, ["ready", "unavailable"]);
+      const failureStage = enumValue(input.failure_stage, [
+        "none",
+        "configuration",
+        "request",
+        "endpoint_status",
+        "response_parse",
+        "response_validation",
+      ]);
+      return outcome && failureStage
+        ? { outcome, failure_stage: failureStage }
+        : null;
+    }
+    case "coderouter_route_health": {
+      const provider = routeProvider(input.provider);
+      const agent = enumValue(input.agent, [
+        "codex",
+        "opencode",
+        "pi",
+        "other",
+        "unknown",
+      ]);
+      const outcome = enumValue(input.outcome, [
+        "success",
+        "upstream_error",
+        "no_usable_account",
+        "provider_unavailable",
+        "invalid_provider",
+        "unknown_provider",
+        "unauthorized",
+      ]);
+      const failureStage = enumValue(input.failure_stage, [
+        "none",
+        "auth",
+        "account_selection",
+        "credential_refresh",
+        "provider_config",
+        "upstream_transport",
+        "upstream_response",
+      ]);
+      if (!provider || !agent || !outcome || !failureStage) return null;
+      return {
+        provider,
+        agent,
+        outcome,
+        failure_stage: failureStage,
+        status_class: statusClass(input.status),
+        latency_bucket: latencyBucket(input.duration_ms),
+        attempt_bucket: attemptBucket(input.attempt_count),
+        refresh_bucket: attemptBucket(input.refresh_retry_count),
+        response_streamed: input.response_streamed === true,
+      };
+    }
+    case "coderouter_cli_command_started":
+    case "coderouter_cli_command_completed":
+      return cliCommandProperties(input);
   }
-  return output;
+}
+
+function cliCommandProperties(
+  input: Readonly<Record<string, AnalyticsScalar | null | undefined>>,
+): Record<string, AnalyticsScalar> | null {
+  const command = enumValue(input.command, [
+    "accounts", "help", "version", "agent", "add", "remove", "login",
+    "logout", "organization", "upgrade", "doctor", "unknown",
+  ]);
+  const agent = enumValue(input.agent, ["none", "codex", "opencode", "pi"]);
+  const mode = enumValue(input.mode, [
+    "summary", "default", "routed", "direct", "interactive", "specified",
+    "cancel", "unknown", "code", "device", "current", "list", "switch",
+  ]);
+  const outcome = enumValue(input.outcome, [
+    "started", "success", "failure", "cancelled",
+  ]);
+  const failureStage = enumValue(input.failure_stage, [
+    "none", "validation", "control_plane", "child_start", "local_io",
+    "child_process",
+  ]);
+  const exitCodeClass = enumValue(input.exit_code_class, [
+    "not_applicable", "success", "generic_failure", "usage",
+    "launch_failure", "signal_or_terminated", "other_failure",
+  ]);
+  const durationBucket = enumValue(input.duration_bucket, [
+    "not_applicable", "under_1s", "1s_to_5s", "5s_to_30s",
+    "30s_to_2m", "2m_or_more",
+  ]);
+  const executionContext = enumValue(input.execution_context, [
+    "interactive", "headless",
+  ]);
+  const cliVersion = typeof input.cli_version === "string" &&
+      input.cli_version.length <= 64 &&
+      /^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$/.test(input.cli_version)
+    ? input.cli_version
+    : null;
+  return command && agent && mode && outcome && failureStage &&
+      exitCodeClass && durationBucket && executionContext && cliVersion
+    ? {
+      command,
+      agent,
+      mode,
+      outcome,
+      failure_stage: failureStage,
+      exit_code_class: exitCodeClass,
+      duration_bucket: durationBucket,
+      execution_context: executionContext,
+      cli_version: cliVersion,
+    }
+    : null;
 }
 
 function aiUsageProperties(
   input: Readonly<Record<string, AnalyticsScalar | null | undefined>>,
   teamScope: string,
 ): Record<string, AnalyticsScalar> | null {
-  const model = safeDimension(input.model);
+  const model = analyticsModel(input.model);
   const provider = aiProvider(input.provider);
   const inputTokens = safeCount(input.input_tokens);
   const cachedInputTokens = Math.min(
@@ -197,7 +360,6 @@ function aiUsageProperties(
     totalTokens,
   });
   return {
-    $process_person_profile: false,
     $ai_model: model,
     $ai_provider: provider,
     $ai_input_tokens: inputTokens,
@@ -218,19 +380,53 @@ function aiUsageProperties(
 function safeCount(value: AnalyticsScalar | null | undefined): number {
   return typeof value === "number" &&
       Number.isSafeInteger(value) &&
-      value >= 0
+      value >= 0 &&
+      value <= MAX_COUNT
     ? value
     : 0;
 }
 
-function safeDimension(value: AnalyticsScalar | null | undefined): string {
+function analyticsModel(value: AnalyticsScalar | null | undefined): string {
   if (typeof value !== "string") return "unknown";
-  const normalized = value.trim().toLowerCase();
-  return normalized.length > 0 &&
-      normalized.length <= 128 &&
-      /^[a-z0-9][a-z0-9._:/-]*$/.test(normalized)
-    ? normalized
-    : "unknown";
+  const model = value.trim().toLowerCase();
+  const families: ReadonlyArray<readonly [RegExp, string]> = [
+    [/^gpt-5\.6-sol(?:-|$)|^gpt-5\.6$/, "gpt-5.6-sol"],
+    [/^gpt-5\.6-terra(?:-|$)/, "gpt-5.6-terra"],
+    [/^gpt-5\.6-luna(?:-|$)/, "gpt-5.6-luna"],
+    [/^gpt-5\.3-codex(?:-|$)/, "gpt-5.3-codex"],
+    [/^gpt-5\.2-codex(?:-|$)/, "gpt-5.2-codex"],
+    [/^gpt-5\.2(?:-|$)/, "gpt-5.2"],
+    [/^gpt-5\.1-codex(?:-|$)/, "gpt-5.1-codex"],
+    [/^gpt-5-codex(?:-|$)/, "gpt-5-codex"],
+    [/^claude-sonnet-5(?:-|$)/, "claude-sonnet-5"],
+    [/^claude-opus-4[.-]8(?:-|$)/, "claude-opus-4.8"],
+    [/^claude-opus-4[.-]7(?:-|$)/, "claude-opus-4.7"],
+    [/^claude-opus-4[.-]6(?:-|$)/, "claude-opus-4.6"],
+    [/^claude-opus-4[.-]5(?:-|$)/, "claude-opus-4.5"],
+    [/^claude-sonnet-4[.-]6(?:-|$)/, "claude-sonnet-4.6"],
+    [/^claude-sonnet-4[.-]5(?:-|$)/, "claude-sonnet-4.5"],
+    [/^claude-sonnet-4(?:-|$)/, "claude-sonnet-4"],
+    [/^claude-haiku-4[.-]5(?:-|$)/, "claude-haiku-4.5"],
+  ];
+  return families.find(([pattern]) => pattern.test(model))?.[1] ?? "unknown";
+}
+
+function accountProvider(value: unknown): string | null {
+  return enumValue(value, [
+    "codex",
+    "claude",
+    "openai-apikey",
+    "anthropic-apikey",
+    "opencode-go",
+  ]);
+}
+
+function lifecycleSource(value: unknown): string | null {
+  return enumValue(value ?? "native_api", ["native_api", "legacy_dashboard"]);
+}
+
+function routeProvider(value: unknown): string | null {
+  return enumValue(value, ["codex", "opencode-go", "unknown"]);
 }
 
 function aiProvider(value: AnalyticsScalar | null | undefined): string {
@@ -243,14 +439,80 @@ function aiProvider(value: AnalyticsScalar | null | undefined): string {
     case "anthropic":
     case "anthropic-apikey":
       return "anthropic";
+    case "opencode-go":
+      return "opencode";
     default:
       return "unknown";
   }
 }
 
-function coderouterUsageAnalyticsConfig():
-  | CoderouterUsageAnalyticsConfig
-  | null {
+function authSurface(value: unknown): string | null {
+  return enumValue(value, [
+    "responses",
+    "models",
+    "opencode_config",
+    "opencode_proxy",
+    "session_validation",
+  ]);
+}
+
+function authReason(value: unknown): string | null {
+  return enumValue(value, ["missing_route_token", "invalid_route_token"]);
+}
+
+function enumValue<const Value extends string>(
+  value: unknown,
+  allowed: readonly Value[],
+): Value | null {
+  return typeof value === "string" && allowed.includes(value as Value)
+    ? value as Value
+    : null;
+}
+
+function countBucket(value: unknown): string {
+  const count = boundedNumber(value, MAX_COUNT);
+  if (count === null || count === 0) return "0";
+  if (count === 1) return "1";
+  if (count <= 3) return "2-3";
+  if (count <= 10) return "4-10";
+  if (count <= 50) return "11-50";
+  return "51+";
+}
+
+function latencyBucket(value: unknown): string {
+  const milliseconds = boundedNumber(value, 24 * 60 * 60 * 1_000);
+  if (milliseconds === null) return "unknown";
+  if (milliseconds < 100) return "lt_100ms";
+  if (milliseconds < 500) return "100_499ms";
+  if (milliseconds < 2_000) return "500_1999ms";
+  if (milliseconds < 10_000) return "2_9s";
+  if (milliseconds < 60_000) return "10_59s";
+  return "60s_plus";
+}
+
+function attemptBucket(value: unknown): string {
+  const count = boundedNumber(value, 100);
+  if (count === null || count === 0) return "0";
+  if (count === 1) return "1";
+  if (count <= 3) return "2-3";
+  if (count <= 7) return "4-7";
+  return "8+";
+}
+
+function statusClass(value: unknown): string {
+  const status = boundedNumber(value, 599);
+  if (status === null || status < 100) return "unknown";
+  return `${Math.floor(status / 100)}xx`;
+}
+
+function boundedNumber(value: unknown, maximum: number): number | null {
+  return typeof value === "number" && Number.isFinite(value) && value >= 0 &&
+      value <= maximum
+    ? value
+    : null;
+}
+
+function coderouterAnalyticsConfig(): CoderouterAnalyticsConfig | null {
   const projectKey = process.env.POSTHOG_CODEROUTER_PROJECT_KEY?.trim();
   const scopeSecret =
     process.env.CODEROUTER_ANALYTICS_SCOPE_SECRET?.trim();
@@ -265,4 +527,9 @@ function coderouterUsageAnalyticsConfig():
   };
 }
 
-export const __test = { safeProperties, aiUsageProperties, deliver };
+export const __test = {
+  eventProperties,
+  aiUsageProperties,
+  deliver,
+  analyticsModel,
+};

--- a/web/services/coderouter/analyticsIdentity.ts
+++ b/web/services/coderouter/analyticsIdentity.ts
@@ -5,8 +5,21 @@ export function coderouterTeamAnalyticsId(
   scopeSecret: string,
 ): string {
   const digest = createHmac("sha256", scopeSecret)
+    // Keep this domain stable: the fixed customer endpoint groups historical
+    // aggregate usage by this pseudonym.
     .update("coderouter-team-usage:v2\0")
     .update(teamId)
     .digest("hex");
   return `coderouter-team-${digest}`;
+}
+
+export function coderouterUserAnalyticsId(
+  userId: string,
+  scopeSecret: string,
+): string {
+  const digest = createHmac("sha256", scopeSecret)
+    .update("coderouter-user-product:v1\0")
+    .update(userId)
+    .digest("hex");
+  return `coderouter-user-${digest}`;
 }

--- a/web/services/coderouter/codexProxy.ts
+++ b/web/services/coderouter/codexProxy.ts
@@ -33,6 +33,16 @@ export async function proxyCodexRequest(request: Request): Promise<Response> {
       event: "coderouter_auth_rejected",
       properties: { surface: "responses", reason: "missing_route_token" },
     });
+    captureRouteHealth({
+      request,
+      startedAt,
+      status: 401,
+      attempted: 0,
+      refreshRetries: 0,
+      outcome: "unauthorized",
+      failureStage: "auth",
+      responseStreamed: false,
+    });
     return jsonError(
       "unauthorized",
       401,
@@ -47,6 +57,16 @@ export async function proxyCodexRequest(request: Request): Promise<Response> {
     captureCoderouterEvent({
       event: "coderouter_auth_rejected",
       properties: { surface: "responses", reason: "invalid_route_token" },
+    });
+    captureRouteHealth({
+      request,
+      startedAt,
+      status: 401,
+      attempted: 0,
+      refreshRetries: 0,
+      outcome: "unauthorized",
+      failureStage: "auth",
+      responseStreamed: false,
     });
     return jsonError(
       "unauthorized",
@@ -405,7 +425,7 @@ function jsonError(
 }
 
 function captureRouteHealth(input: {
-  readonly identity: { readonly teamId: string; readonly stackUserId: string };
+  readonly identity?: { readonly teamId: string; readonly stackUserId: string };
   readonly request: Request;
   readonly startedAt: number;
   readonly status: number;
@@ -436,7 +456,7 @@ function captureRouteHealth(input: {
   // independent of response consumption and token parsing.
   captureCoderouterEvent({
     event: "coderouter_route_health",
-    teamId: input.identity.teamId,
+    teamId: input.identity?.teamId,
     properties: {
       provider: "codex",
       agent,

--- a/web/services/coderouter/codexProxy.ts
+++ b/web/services/coderouter/codexProxy.ts
@@ -29,6 +29,10 @@ export async function proxyCodexRequest(request: Request): Promise<Response> {
   const token = bearerToken(request);
   if (!token) {
     addCoderouterBreadcrumb("auth", "Route token missing", {}, "warning");
+    captureCoderouterEvent({
+      event: "coderouter_auth_rejected",
+      properties: { surface: "responses", reason: "missing_route_token" },
+    });
     return jsonError(
       "unauthorized",
       401,
@@ -42,8 +46,7 @@ export async function proxyCodexRequest(request: Request): Promise<Response> {
     addCoderouterBreadcrumb("auth", "Route token rejected", {}, "warning");
     captureCoderouterEvent({
       event: "coderouter_auth_rejected",
-      userId: "coderouter:anonymous",
-      properties: { path: "responses", reason: "invalid_route_token" },
+      properties: { surface: "responses", reason: "invalid_route_token" },
     });
     return jsonError(
       "unauthorized",
@@ -64,6 +67,8 @@ export async function proxyCodexRequest(request: Request): Promise<Response> {
   }
   const attempted: string[] = [];
   let refreshRetries = 0;
+  let failureStage: "account_selection" | "credential_refresh" | "upstream_transport" =
+    "account_selection";
   let upstream: Response | null = null;
   for (let attempt = 0; attempt < 8; attempt++) {
     const account = await selectAccountForRequest(
@@ -85,6 +90,7 @@ export async function proxyCodexRequest(request: Request): Promise<Response> {
         expectedRevision: account.vaultRevision,
       });
     } catch (error) {
+      failureStage = "credential_refresh";
       if (error && typeof error === "object" && "_tag" in error) {
         const tag = (error as { _tag: string })._tag;
         if (tag === "CodeRouterRefreshBusy") continue;
@@ -96,6 +102,7 @@ export async function proxyCodexRequest(request: Request): Promise<Response> {
     try {
       upstream = await sendCodex(request.clone(), forwardedHeaders, credential);
     } catch (error) {
+      failureStage = "upstream_transport";
       reportCoderouterFailure("upstream_transport", error, {
         provider: "codex",
         attempt: attempt + 1,
@@ -128,6 +135,7 @@ export async function proxyCodexRequest(request: Request): Promise<Response> {
           );
         }
       } catch (error) {
+        failureStage = "credential_refresh";
         reportCoderouterFailure("provider_refresh", error, {
           provider: "codex",
           forced: true,
@@ -150,7 +158,7 @@ export async function proxyCodexRequest(request: Request): Promise<Response> {
     break;
   }
   if (!upstream) {
-    captureModelRequest({
+    captureRouteHealth({
       identity,
       request,
       startedAt,
@@ -158,7 +166,8 @@ export async function proxyCodexRequest(request: Request): Promise<Response> {
       attempted: attempted.length,
       refreshRetries,
       outcome: "no_usable_account",
-      usage: null,
+      failureStage,
+      responseStreamed: false,
     });
     return jsonError(
       "no_usable_account",
@@ -185,17 +194,18 @@ export async function proxyCodexRequest(request: Request): Promise<Response> {
   }
   responseHeaders.set("cache-control", "no-store");
   const status = upstream.status;
+  captureRouteHealth({
+    identity,
+    request,
+    startedAt,
+    status,
+    attempted: attempted.length,
+    refreshRetries,
+    outcome: status >= 200 && status < 300 ? "success" : "upstream_error",
+    responseStreamed: upstream.body !== null,
+  });
   const observedBody = observeModelUsage(upstream.body, (usage) => {
-    captureModelRequest({
-      identity,
-      request,
-      startedAt,
-      status,
-      attempted: attempted.length,
-      refreshRetries,
-      outcome: status >= 200 && status < 300 ? "success" : "upstream_error",
-      usage,
-    });
+    captureModelUsage(identity.teamId, usage);
   });
   return new Response(observedBody, {
     status: upstream.status,
@@ -215,6 +225,10 @@ export function createCodexModelsProxy(dependencies: CodexModelsDependencies) {
   return async (request: Request): Promise<Response> => {
     const token = bearerToken(request);
     if (!token) {
+      captureCoderouterEvent({
+        event: "coderouter_auth_rejected",
+        properties: { surface: "models", reason: "missing_route_token" },
+      });
       return jsonError(
         "unauthorized",
         401,
@@ -225,6 +239,10 @@ export function createCodexModelsProxy(dependencies: CodexModelsDependencies) {
     }
     const identity = await dependencies.authenticate(token);
     if (!identity) {
+      captureCoderouterEvent({
+        event: "coderouter_auth_rejected",
+        properties: { surface: "models", reason: "invalid_route_token" },
+      });
       return jsonError(
         "unauthorized",
         401,
@@ -386,16 +404,22 @@ function jsonError(
   );
 }
 
-function captureModelRequest(input: {
+function captureRouteHealth(input: {
   readonly identity: { readonly teamId: string; readonly stackUserId: string };
   readonly request: Request;
   readonly startedAt: number;
   readonly status: number;
   readonly attempted: number;
   readonly refreshRetries: number;
-  readonly outcome: string;
-  readonly usage: ModelUsage | null;
+  readonly outcome: "success" | "upstream_error" | "no_usable_account";
+  readonly failureStage?:
+    | "account_selection"
+    | "credential_refresh"
+    | "upstream_transport";
+  readonly responseStreamed: boolean;
 }): void {
+  const durationMs = Math.round(performance.now() - input.startedAt);
+  const agent = agentFromUserAgent(input.request.headers.get("user-agent"));
   addCoderouterBreadcrumb(
     "request",
     "Model request completed",
@@ -404,29 +428,45 @@ function captureModelRequest(input: {
       status: input.status,
       outcome: input.outcome,
       attempts: input.attempted,
-      duration_ms: Math.round(performance.now() - input.startedAt),
+      duration_ms: durationMs,
     },
     input.status >= 500 ? "error" : input.status >= 400 ? "warning" : "info",
   );
+  // Capture as soon as the terminal route result is known. This is deliberately
+  // independent of response consumption and token parsing.
   captureCoderouterEvent({
-    event: "coderouter_model_request_completed",
-    userId: input.identity.stackUserId,
+    event: "coderouter_route_health",
     teamId: input.identity.teamId,
     properties: {
       provider: "codex",
-      agent: agentFromUserAgent(input.request.headers.get("user-agent")),
+      agent,
       outcome: input.outcome,
+      failure_stage: input.outcome === "success"
+        ? "none"
+        : input.outcome === "no_usable_account"
+        ? input.failureStage ?? "account_selection"
+        : "upstream_response",
       status: input.status,
       attempt_count: input.attempted,
       refresh_retry_count: input.refreshRetries,
-      duration_ms: Math.round(performance.now() - input.startedAt),
-      model: input.usage?.model ?? "unknown",
-      input_tokens: input.usage?.inputTokens ?? 0,
-      cached_input_tokens: input.usage?.cachedInputTokens ?? 0,
-      output_tokens: input.usage?.outputTokens ?? 0,
-      total_tokens: input.usage?.totalTokens ?? 0,
-      actual_cost_usd: 0,
-      cost_basis: "subscription_included",
+      duration_ms: durationMs,
+      response_streamed: input.responseStreamed,
+    },
+  });
+}
+
+function captureModelUsage(teamId: string, usage: ModelUsage | null): void {
+  if (!usage || usage.totalTokens === 0) return;
+  captureCoderouterEvent({
+    event: "coderouter_model_request_completed",
+    teamId,
+    properties: {
+      provider: "codex",
+      model: usage.model ?? "unknown",
+      input_tokens: usage.inputTokens,
+      cached_input_tokens: usage.cachedInputTokens,
+      output_tokens: usage.outputTokens,
+      total_tokens: usage.totalTokens,
     },
   });
 }

--- a/web/services/coderouter/opencodeProxy.ts
+++ b/web/services/coderouter/opencodeProxy.ts
@@ -14,7 +14,10 @@ export async function openCodeClientConfig(
   request: Request,
 ): Promise<Response> {
   const auth = await routeIdentity(request);
-  if (!auth) return Response.json({ error: "unauthorized" }, { status: 401 });
+  if (!auth) {
+    captureAuthRejection(request, "opencode_config");
+    return Response.json({ error: "unauthorized" }, { status: 401 });
+  }
   const resolved = await openCodeAccount(auth.teamId);
   if (!resolved)
     return Response.json({ error: "no_usable_account" }, { status: 503 });
@@ -36,6 +39,13 @@ export async function proxyOpenCodeRequest(
   const startedAt = performance.now();
   const auth = await routeIdentity(request);
   if (!auth) {
+    captureAuthRejection(request, "opencode_proxy");
+    captureOpenCodeHealth({
+      startedAt,
+      status: 401,
+      outcome: "unauthorized",
+      failureStage: "auth",
+    });
     return apiError(
       "unauthorized",
       "Your coderouter session expired or was revoked. Run `cr login` and retry.",
@@ -45,6 +55,13 @@ export async function proxyOpenCodeRequest(
   }
   const resolved = await openCodeAccount(auth.teamId);
   if (!resolved) {
+    captureOpenCodeHealth({
+      teamId: auth.teamId,
+      startedAt,
+      status: 503,
+      outcome: "no_usable_account",
+      failureStage: "account_selection",
+    });
     return apiError(
       "no_usable_account",
       "No healthy OpenCode subscription is available. Check `cr`, add an account with `cr add`, or retry shortly.",
@@ -60,6 +77,14 @@ export async function proxyOpenCodeRequest(
       provider: "opencode-go",
       operation: "config",
     });
+    captureOpenCodeHealth({
+      teamId: auth.teamId,
+      startedAt,
+      status: 502,
+      outcome: "provider_unavailable",
+      failureStage: "provider_config",
+      attempts: resolved.attempts,
+    });
     return apiError(
       "provider_unavailable",
       "OpenCode configuration is temporarily unavailable. Retry shortly.",
@@ -69,6 +94,14 @@ export async function proxyOpenCodeRequest(
   }
   const provider = config[providerId];
   if (!isRecord(provider)) {
+    captureOpenCodeHealth({
+      teamId: auth.teamId,
+      startedAt,
+      status: 404,
+      outcome: "unknown_provider",
+      failureStage: "provider_config",
+      attempts: resolved.attempts,
+    });
     return apiError(
       "unknown_provider",
       "This OpenCode provider is no longer available. Refresh OpenCode's provider list and retry.",
@@ -79,6 +112,14 @@ export async function proxyOpenCodeRequest(
   const api = provider.api;
   const base = isRecord(api) ? api.url : undefined;
   if (typeof base !== "string" || !safeProviderURL(base)) {
+    captureOpenCodeHealth({
+      teamId: auth.teamId,
+      startedAt,
+      status: 502,
+      outcome: "invalid_provider",
+      failureStage: "provider_config",
+      attempts: resolved.attempts,
+    });
     return apiError(
       "invalid_provider",
       "OpenCode returned an unsafe or invalid provider endpoint.",
@@ -114,6 +155,14 @@ export async function proxyOpenCodeRequest(
     reportCoderouterFailure("upstream_transport", error, {
       provider: "opencode-go",
     });
+    captureOpenCodeHealth({
+      teamId: auth.teamId,
+      startedAt,
+      status: 502,
+      outcome: "provider_unavailable",
+      failureStage: "upstream_transport",
+      attempts: resolved.attempts,
+    });
     return apiError(
       "provider_unavailable",
       "The selected OpenCode provider could not be reached. Retry shortly.",
@@ -121,29 +170,34 @@ export async function proxyOpenCodeRequest(
       true,
     );
   }
+  addCoderouterBreadcrumb("request", "Model request completed", {
+    provider: "opencode-go",
+    status: upstream.status,
+    duration_ms: Math.round(performance.now() - startedAt),
+  });
+  // Emit terminal health before the response body is consumed; token parsing
+  // remains an independent aggregate-usage concern.
+  captureOpenCodeHealth({
+    teamId: auth.teamId,
+    startedAt,
+    status: upstream.status,
+    outcome: upstream.ok ? "success" : "upstream_error",
+    failureStage: upstream.ok ? "none" : "upstream_response",
+    attempts: resolved.attempts,
+    responseStreamed: upstream.body !== null,
+  });
   const body = observeModelUsage(upstream.body, (usage) => {
-    addCoderouterBreadcrumb("request", "Model request completed", {
-      provider: "opencode-go",
-      status: upstream.status,
-      duration_ms: Math.round(performance.now() - startedAt),
-    });
+    if (!usage || usage.totalTokens === 0) return;
     captureCoderouterEvent({
       event: "coderouter_model_request_completed",
-      userId: auth.stackUserId,
       teamId: auth.teamId,
       properties: {
         provider: "opencode-go",
-        agent: "opencode",
-        outcome: upstream.ok ? "success" : "upstream_error",
-        status: upstream.status,
-        duration_ms: Math.round(performance.now() - startedAt),
-        model: usage?.model ?? "unknown",
-        input_tokens: usage?.inputTokens ?? 0,
-        cached_input_tokens: usage?.cachedInputTokens ?? 0,
-        output_tokens: usage?.outputTokens ?? 0,
-        total_tokens: usage?.totalTokens ?? 0,
-        actual_cost_usd: 0,
-        cost_basis: "subscription_included",
+        model: usage.model ?? "unknown",
+        input_tokens: usage.inputTokens,
+        cached_input_tokens: usage.cachedInputTokens,
+        output_tokens: usage.outputTokens,
+        total_tokens: usage.totalTokens,
       },
     });
   });
@@ -172,7 +226,7 @@ async function openCodeAccount(
         expectedRevision: account.vaultRevision,
       });
       if (credential.provider === "opencode-go") {
-        return { account, credential };
+        return { account, credential, attempts: attempted.length };
       }
     } catch {
       // Broken, refreshing, and transiently unavailable accounts are skipped.
@@ -296,6 +350,61 @@ async function routeIdentity(
   if (!token) return null;
   const identity = await authenticateRouteToken(token);
   return identity ? { ...identity, token } : null;
+}
+
+function captureAuthRejection(
+  request: Request,
+  surface: "opencode_config" | "opencode_proxy",
+): void {
+  const authorization = request.headers.get("authorization")?.trim() ?? "";
+  captureCoderouterEvent({
+    event: "coderouter_auth_rejected",
+    properties: {
+      surface,
+      reason: /^Bearer[ \t]+(.+)$/i.test(authorization)
+        ? "invalid_route_token"
+        : "missing_route_token",
+    },
+  });
+}
+
+function captureOpenCodeHealth(input: {
+  readonly teamId?: string;
+  readonly startedAt: number;
+  readonly status: number;
+  readonly outcome:
+    | "success"
+    | "upstream_error"
+    | "no_usable_account"
+    | "provider_unavailable"
+    | "invalid_provider"
+    | "unknown_provider"
+    | "unauthorized";
+  readonly failureStage:
+    | "none"
+    | "auth"
+    | "account_selection"
+    | "provider_config"
+    | "upstream_transport"
+    | "upstream_response";
+  readonly attempts?: number;
+  readonly responseStreamed?: boolean;
+}): void {
+  captureCoderouterEvent({
+    event: "coderouter_route_health",
+    ...(input.teamId ? { teamId: input.teamId } : {}),
+    properties: {
+      provider: "opencode-go",
+      agent: "opencode",
+      outcome: input.outcome,
+      failure_stage: input.failureStage,
+      status: input.status,
+      duration_ms: Math.round(performance.now() - input.startedAt),
+      attempt_count: input.attempts ?? 0,
+      refresh_retry_count: 0,
+      response_streamed: input.responseStreamed ?? false,
+    },
+  });
 }
 
 function apiError(

--- a/web/services/coderouter/teamMetrics.ts
+++ b/web/services/coderouter/teamMetrics.ts
@@ -1,6 +1,7 @@
 import { unstable_cache } from "next/cache";
 
 import { coderouterTeamAnalyticsId } from "./analyticsIdentity";
+import { captureCoderouterEvent } from "./analytics";
 import { CODEROUTER_API_RATE_CARD_VERSION } from "./apiEquivalentPricing";
 import { reportCoderouterFailure } from "./observability";
 
@@ -97,6 +98,7 @@ async function queryCoderouterTeamMetrics(
   const config = dependencies.config();
   if (!config) {
     dependencies.reportFailure?.("configuration_missing");
+    captureMetricsOutcome(authorizedTeamId, "unavailable", "configuration");
     return { kind: "unavailable" };
   }
   try {
@@ -123,6 +125,11 @@ async function queryCoderouterTeamMetrics(
     );
     if (!response.ok) {
       dependencies.reportFailure?.("endpoint_status", response.status);
+      captureMetricsOutcome(
+        authorizedTeamId,
+        "unavailable",
+        "endpoint_status",
+      );
       return { kind: "unavailable" };
     }
     const responseText = await response.text();
@@ -131,10 +138,20 @@ async function queryCoderouterTeamMetrics(
       parsedBody = JSON.parse(responseText);
     } catch {
       dependencies.reportFailure?.("malformed_response");
+      captureMetricsOutcome(
+        authorizedTeamId,
+        "unavailable",
+        "response_parse",
+      );
       return { kind: "unavailable" };
     }
     if (!isPlainRecord(parsedBody)) {
       dependencies.reportFailure?.("malformed_response");
+      captureMetricsOutcome(
+        authorizedTeamId,
+        "unavailable",
+        "response_validation",
+      );
       return { kind: "unavailable" };
     }
     const body = parsedBody;
@@ -151,15 +168,48 @@ async function queryCoderouterTeamMetrics(
       results.length > MAX_ROWS
     ) {
       dependencies.reportFailure?.("malformed_response");
+      captureMetricsOutcome(
+        authorizedTeamId,
+        "unavailable",
+        "response_validation",
+      );
       return { kind: "unavailable" };
     }
     const metrics = metricsFromRows(results, dependencies.now());
-    if (!metrics) dependencies.reportFailure?.("invalid_metrics");
-    return metrics ?? { kind: "unavailable" };
+    if (!metrics) {
+      dependencies.reportFailure?.("invalid_metrics");
+      captureMetricsOutcome(
+        authorizedTeamId,
+        "unavailable",
+        "response_validation",
+      );
+      return { kind: "unavailable" };
+    }
+    captureMetricsOutcome(authorizedTeamId, "ready", "none");
+    return metrics;
   } catch {
     dependencies.reportFailure?.("request_failed");
+    captureMetricsOutcome(authorizedTeamId, "unavailable", "request");
     return { kind: "unavailable" };
   }
+}
+
+function captureMetricsOutcome(
+  teamId: string,
+  outcome: "ready" | "unavailable",
+  failureStage:
+    | "none"
+    | "configuration"
+    | "request"
+    | "endpoint_status"
+    | "response_parse"
+    | "response_validation",
+): void {
+  captureCoderouterEvent({
+    event: "coderouter_metrics_loaded",
+    teamId,
+    properties: { outcome, failure_stage: failureStage },
+  });
 }
 
 function metricsFromRows(
@@ -323,16 +373,13 @@ function postHogMetricsConfig(): PostHogMetricsConfig | null {
   ) {
     return null;
   }
-  const endpointName = (
-    process.env.POSTHOG_CODEROUTER_ENDPOINT_NAME ??
-    DEFAULT_ENDPOINT_NAME
-  ).trim();
-  if (!endpointName) return null;
   return {
     endpointSecret,
     environmentId,
     scopeSecret,
-    endpointName,
+    // This is deliberately not environment-configurable. Only the reviewed,
+    // customer-scoped query may receive a team pseudonym.
+    endpointName: DEFAULT_ENDPOINT_NAME,
     apiHost: (
       process.env.POSTHOG_CODEROUTER_API_HOST ??
       "https://us.posthog.com"

--- a/web/services/coderouter/teamMetrics.ts
+++ b/web/services/coderouter/teamMetrics.ts
@@ -88,7 +88,13 @@ const cachedTeamMetrics = unstable_cache(
 export async function loadCoderouterTeamMetrics(
   authorizedTeamId: string,
 ): Promise<CoderouterTeamMetrics> {
-  return await cachedTeamMetrics(authorizedTeamId);
+  const metrics = await cachedTeamMetrics(authorizedTeamId);
+  captureMetricsOutcome(
+    authorizedTeamId,
+    metrics.kind,
+    metrics.kind === "ready" ? "none" : "request",
+  );
+  return metrics;
 }
 
 async function queryCoderouterTeamMetrics(
@@ -98,7 +104,6 @@ async function queryCoderouterTeamMetrics(
   const config = dependencies.config();
   if (!config) {
     dependencies.reportFailure?.("configuration_missing");
-    captureMetricsOutcome(authorizedTeamId, "unavailable", "configuration");
     return { kind: "unavailable" };
   }
   try {
@@ -125,11 +130,6 @@ async function queryCoderouterTeamMetrics(
     );
     if (!response.ok) {
       dependencies.reportFailure?.("endpoint_status", response.status);
-      captureMetricsOutcome(
-        authorizedTeamId,
-        "unavailable",
-        "endpoint_status",
-      );
       return { kind: "unavailable" };
     }
     const responseText = await response.text();
@@ -138,20 +138,10 @@ async function queryCoderouterTeamMetrics(
       parsedBody = JSON.parse(responseText);
     } catch {
       dependencies.reportFailure?.("malformed_response");
-      captureMetricsOutcome(
-        authorizedTeamId,
-        "unavailable",
-        "response_parse",
-      );
       return { kind: "unavailable" };
     }
     if (!isPlainRecord(parsedBody)) {
       dependencies.reportFailure?.("malformed_response");
-      captureMetricsOutcome(
-        authorizedTeamId,
-        "unavailable",
-        "response_validation",
-      );
       return { kind: "unavailable" };
     }
     const body = parsedBody;
@@ -168,28 +158,16 @@ async function queryCoderouterTeamMetrics(
       results.length > MAX_ROWS
     ) {
       dependencies.reportFailure?.("malformed_response");
-      captureMetricsOutcome(
-        authorizedTeamId,
-        "unavailable",
-        "response_validation",
-      );
       return { kind: "unavailable" };
     }
     const metrics = metricsFromRows(results, dependencies.now());
     if (!metrics) {
       dependencies.reportFailure?.("invalid_metrics");
-      captureMetricsOutcome(
-        authorizedTeamId,
-        "unavailable",
-        "response_validation",
-      );
       return { kind: "unavailable" };
     }
-    captureMetricsOutcome(authorizedTeamId, "ready", "none");
     return metrics;
   } catch {
     dependencies.reportFailure?.("request_failed");
-    captureMetricsOutcome(authorizedTeamId, "unavailable", "request");
     return { kind: "unavailable" };
   }
 }

--- a/web/tests/coderouter-analytics.test.ts
+++ b/web/tests/coderouter-analytics.test.ts
@@ -4,79 +4,74 @@ import {
   __test as analyticsTest,
   captureCoderouterEvent,
 } from "../services/coderouter/analytics";
-import { coderouterTeamAnalyticsId } from
-  "../services/coderouter/analyticsIdentity";
+import {
+  coderouterTeamAnalyticsId,
+  coderouterUserAnalyticsId,
+} from "../services/coderouter/analyticsIdentity";
 import { __test as usageTest } from "../services/coderouter/responseUsage";
 
 const scopeSecret = "test-only-scope-secret-at-least-32-bytes";
+const isolatedConfig = () => ({
+  ingestHost: "https://coderouter.i.posthog.test",
+  projectKey: "phc_coderouter_only",
+  scopeSecret,
+});
+
+function collector() {
+  const bodies: string[] = [];
+  const urls: string[] = [];
+  const posthogFetch = mock(async (...args: unknown[]) => {
+    urls.push(String(args[0]));
+    bodies.push(String((args[1] as RequestInit | undefined)?.body));
+    return new Response(null, { status: 200 });
+  });
+  const deferred: Promise<unknown>[] = [];
+  const dependencies = {
+    fetch: posthogFetch as typeof fetch,
+    defer: (task: Promise<unknown>) => deferred.push(task),
+    enabled: () => true,
+    isolatedConfig,
+  };
+  return {
+    bodies,
+    urls,
+    deferred,
+    dependencies,
+  };
+}
 
 describe("coderouter analytics", () => {
-  test("keeps aggregate usage while dropping sensitive properties", () => {
-    expect(
-      analyticsTest.safeProperties({
-        provider: "codex",
-        input_tokens: 123,
-        cached_input_tokens: 20,
-        output_tokens: 45,
-        total_tokens: 168,
-        actual_cost_usd: 0,
-        prompt: "secret prompt",
-        response_body: "secret output",
-        route_token: "crt_secret",
-        email: "buyer@example.com",
-        provider_account_id: "acct_secret",
-      }),
-    ).toEqual({
-      provider: "codex",
-      input_tokens: 123,
-      cached_input_tokens: 20,
-      output_tokens: 45,
-      total_tokens: 168,
-      actual_cost_usd: 0,
-    });
-  });
-
-  test("sends content-free AI Observability usage to the isolated project", async () => {
-    const bodies: string[] = [];
-    const urls: string[] = [];
-    const posthogFetch = mock(async (...args: unknown[]) => {
-      urls.push(String(args[0]));
-      const init = args[1] as RequestInit | undefined;
-      bodies.push(String(init?.body));
-      return new Response(null, { status: bodies.length === 1 ? 503 : 200 });
-    });
-    let deferred: Promise<unknown> | null = null;
-
+  test("sends content-free AI Observability usage only to the isolated project", async () => {
+    const captured = collector();
     captureCoderouterEvent(
       {
         event: "coderouter_model_request_completed",
-        userId: "stack-user-1",
-        teamId: "team-1",
-        properties: { provider: "codex", total_tokens: 10 },
-      },
-      {
-        fetch: posthogFetch as typeof fetch,
-        defer: (task) => {
-          deferred = task;
+        userId: "stack-user-raw",
+        teamId: "team-raw",
+        properties: {
+          provider: "codex",
+          model: "gpt-5.6-terra-private-customer-label",
+          input_tokens: 8,
+          cached_input_tokens: 3,
+          output_tokens: 2,
+          total_tokens: 10,
+          prompt: "secret prompt",
+          response_body: "secret output",
+          route_token: "crt_secret",
+          email: "buyer@example.com",
+          provider_account_id: "acct_secret",
+          url: "https://private.example/path?token=secret",
+          headers: "authorization secret",
         },
-        enabled: () => true,
-        usageConfig: () => ({
-          ingestHost: "https://coderouter.i.posthog.test",
-          projectKey: "phc_coderouter_only",
-          scopeSecret,
-        }),
       },
+      captured.dependencies,
     );
 
-    expect(deferred).not.toBeNull();
-    await deferred;
-    expect(posthogFetch).toHaveBeenCalledTimes(2);
-    expect(urls).toEqual([
-      "https://coderouter.i.posthog.test/batch/",
+    await Promise.all(captured.deferred);
+    expect(captured.urls).toEqual([
       "https://coderouter.i.posthog.test/batch/",
     ]);
-    expect(bodies[0]).toBe(bodies[1]);
-    const payload = JSON.parse(bodies[0]!) as {
+    const payload = JSON.parse(captured.bodies[0]!) as {
       api_key: string;
       batch: Array<{
         event: string;
@@ -84,60 +79,131 @@ describe("coderouter analytics", () => {
         properties: Record<string, unknown>;
       }>;
     };
+    const event = payload.batch[0]!;
     expect(payload.api_key).toBe("phc_coderouter_only");
-    expect(payload.batch[0]?.event).toBe("$ai_generation");
-    expect(payload.batch[0]?.distinct_id).toBe(
-      coderouterTeamAnalyticsId("team-1", scopeSecret),
+    expect(event.event).toBe("$ai_generation");
+    expect(event.distinct_id).toBe(
+      coderouterTeamAnalyticsId("team-raw", scopeSecret),
     );
-    expect(payload.batch[0]?.properties.coderouter_team_scope).toBe(
-      payload.batch[0]?.distinct_id,
-    );
-    expect(payload.batch[0]?.properties).toMatchObject({
+    expect(event.properties).toMatchObject({
       $process_person_profile: false,
-      $ai_model: "unknown",
+      $geoip_disable: true,
+      $ai_model: "gpt-5.6-terra",
       $ai_provider: "openai",
-      $ai_input_tokens: 0,
-      $ai_cache_read_input_tokens: 0,
-      $ai_cache_reporting_exclusive: false,
-      $ai_output_tokens: 0,
+      $ai_input_tokens: 8,
+      $ai_cache_read_input_tokens: 3,
+      $ai_output_tokens: 2,
       coderouter_total_tokens: 10,
-      coderouter_unpriced_tokens: 10,
+      product: "coderouter",
+      schema_version: 3,
+      service_version: "coderouter-web-v1",
     });
-    expect(payload.batch[0]?.properties).not.toHaveProperty("$groups");
-    expect(payload.batch[0]?.properties).not.toHaveProperty("$ai_input");
-    expect(payload.batch[0]?.properties).not.toHaveProperty(
-      "$ai_output_choices",
-    );
-    expect(payload.batch[0]?.properties).not.toHaveProperty("agent");
-    expect(payload.batch[0]?.properties).not.toHaveProperty("outcome");
-    expect(payload.batch[0]?.properties.$insert_id).toBeString();
-    expect(bodies[0]).not.toContain("team-1");
-    expect(bodies[0]).not.toContain("stack-user-1");
+    const serialized = captured.bodies[0]!;
+    for (const raw of [
+      "team-raw",
+      "stack-user-raw",
+      "secret prompt",
+      "secret output",
+      "crt_secret",
+      "buyer@example.com",
+      "acct_secret",
+      "private.example",
+      "authorization secret",
+      "private-customer-label",
+    ]) {
+      expect(serialized).not.toContain(raw);
+    }
   });
 
-  test("drops usage without a team or isolated analytics configuration", () => {
+  test("routes ops events only to isolated config and HMACs team and user separately", async () => {
+    const captured = collector();
+    captureCoderouterEvent(
+      {
+        event: "coderouter_account_added",
+        userId: "raw-stack-user-id",
+        teamId: "raw-team-id",
+        properties: {
+          provider: "codex",
+          source: "native_api",
+          already_exists: false,
+          account_id: "raw-account-id",
+          label: "Personal account",
+          command_args: "--token raw-token",
+          local_path: "/Users/private/project",
+          error: "a raw free-form error",
+        },
+      },
+      captured.dependencies,
+    );
+
+    await Promise.all(captured.deferred);
+    const payload = JSON.parse(captured.bodies[0]!) as {
+      api_key: string;
+      batch: Array<{
+        distinct_id: string;
+        properties: Record<string, unknown>;
+      }>;
+    };
+    const event = payload.batch[0]!;
+    const teamScope = coderouterTeamAnalyticsId("raw-team-id", scopeSecret);
+    const userScope = coderouterUserAnalyticsId(
+      "raw-stack-user-id",
+      scopeSecret,
+    );
+    expect(payload.api_key).toBe("phc_coderouter_only");
+    expect(event.distinct_id).toBe(teamScope);
+    expect(event.properties).toMatchObject({
+      provider: "codex",
+      source: "native_api",
+      already_exists: false,
+      coderouter_team_scope: teamScope,
+      coderouter_user_scope: userScope,
+      $process_person_profile: false,
+      $geoip_disable: true,
+    });
+    expect(Object.keys(event.properties).sort()).toEqual([
+      "$geoip_disable",
+      "$insert_id",
+      "$process_person_profile",
+      "already_exists",
+      "coderouter_team_scope",
+      "coderouter_user_scope",
+      "product",
+      "provider",
+      "schema_version",
+      "service_version",
+      "source",
+    ]);
+    expect(captured.bodies[0]).not.toContain("raw-stack-user-id");
+    expect(captured.bodies[0]).not.toContain("raw-team-id");
+    expect(captured.bodies[0]).not.toContain("raw-account-id");
+    expect(captured.bodies[0]).not.toContain("Personal account");
+    expect(captured.bodies[0]).not.toContain("raw-token");
+    expect(captured.bodies[0]).not.toContain("/Users/private/project");
+    expect(captured.bodies[0]).not.toContain("free-form error");
+  });
+
+  test("fails closed for usage and ops when isolated configuration is missing", () => {
     const defer = mock(() => {});
     const dependencies = {
       fetch,
       defer,
       enabled: () => true,
-      usageConfig: () => null,
+      isolatedConfig: () => null,
     };
 
     captureCoderouterEvent(
       {
         event: "coderouter_model_request_completed",
-        userId: "stack-user-1",
-        properties: { total_tokens: 10 },
+        teamId: "team-1",
+        properties: { provider: "codex", total_tokens: 10 },
       },
       dependencies,
     );
     captureCoderouterEvent(
       {
-        event: "coderouter_model_request_completed",
-        userId: "stack-user-1",
-        teamId: "team-1",
-        properties: { total_tokens: 10 },
+        event: "coderouter_auth_rejected",
+        properties: { surface: "responses", reason: "invalid_route_token" },
       },
       dependencies,
     );
@@ -145,16 +211,92 @@ describe("coderouter analytics", () => {
     expect(defer).not.toHaveBeenCalled();
   });
 
-  test("uses keyed, domain-separated team pseudonyms", () => {
-    const first = coderouterTeamAnalyticsId("team-1", scopeSecret);
-    expect(first).toBe(coderouterTeamAnalyticsId("team-1", scopeSecret));
-    expect(first).not.toBe(
+  test("retains zero-token failures as separate route-health events", async () => {
+    const captured = collector();
+    captureCoderouterEvent(
+      {
+        event: "coderouter_route_health",
+        teamId: "team-1",
+        properties: {
+          provider: "codex",
+          agent: "pi",
+          outcome: "no_usable_account",
+          failure_stage: "account_selection",
+          status: 503,
+          duration_ms: 734,
+          attempt_count: 0,
+          refresh_retry_count: 0,
+          response_streamed: false,
+          request_id: "must-not-leak",
+        },
+      },
+      captured.dependencies,
+    );
+    captureCoderouterEvent(
+      {
+        event: "coderouter_model_request_completed",
+        teamId: "team-1",
+        properties: { provider: "codex", total_tokens: 0 },
+      },
+      captured.dependencies,
+    );
+
+    await Promise.all(captured.deferred);
+    expect(captured.bodies).toHaveLength(1);
+    const event = JSON.parse(captured.bodies[0]!).batch[0];
+    expect(event.event).toBe("coderouter_route_health");
+    expect(event.properties).toMatchObject({
+      provider: "codex",
+      agent: "pi",
+      outcome: "no_usable_account",
+      failure_stage: "account_selection",
+      status_class: "5xx",
+      latency_bucket: "500_1999ms",
+      attempt_bucket: "0",
+      refresh_bucket: "0",
+      response_streamed: false,
+    });
+    expect(captured.bodies[0]).not.toContain("must-not-leak");
+  });
+
+  test("rejects invalid enum values and bounds numeric dimensions", () => {
+    expect(
+      analyticsTest.eventProperties("coderouter_auth_rejected", {
+        surface: "https://private.example/path",
+        reason: "raw explanation",
+      }),
+    ).toBeNull();
+    expect(
+      analyticsTest.eventProperties("coderouter_route_health", {
+        provider: "codex",
+        agent: "pi",
+        outcome: "success",
+        failure_stage: "none",
+        status: Number.POSITIVE_INFINITY,
+        duration_ms: -1,
+        attempt_count: 99_999,
+        refresh_retry_count: Number.NaN,
+      }),
+    ).toMatchObject({
+      status_class: "unknown",
+      latency_bucket: "unknown",
+      attempt_bucket: "0",
+      refresh_bucket: "0",
+    });
+  });
+
+  test("uses keyed, domain-separated team and user pseudonyms", () => {
+    const team = coderouterTeamAnalyticsId("same-raw-id", scopeSecret);
+    const user = coderouterUserAnalyticsId("same-raw-id", scopeSecret);
+    expect(team).not.toBe(user);
+    expect(team).not.toContain("same-raw-id");
+    expect(user).not.toContain("same-raw-id");
+    expect(team).not.toBe(
       coderouterTeamAnalyticsId(
-        "team-1",
+        "same-raw-id",
         "a-different-test-scope-secret-32-bytes",
       ),
     );
-    expect(first).not.toContain("team-1");
   });
 
   test("pre-calculates versioned long-context API-equivalent cost", () => {

--- a/web/tests/coderouter-cli-analytics-route.test.ts
+++ b/web/tests/coderouter-cli-analytics-route.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, mock, test } from "bun:test";
+
+const resolveCoderouterUsageTeam = mock(async () => ({
+  ok: true as const,
+  teamId: "raw-team-id",
+  stackUserId: "raw-user-id",
+}));
+const captureCoderouterEvent = mock(() => {});
+
+mock.module("../services/coderouter/requestContext", () => ({
+  resolveCoderouterUsageTeam,
+}));
+mock.module("../services/coderouter/analytics", () => ({
+  captureCoderouterEvent,
+}));
+
+const { POST } = await import("../app/api/coderouter/analytics/route");
+
+const validProperties = {
+  schema_version: 1,
+  command: "agent",
+  agent: "codex",
+  mode: "routed",
+  outcome: "success",
+  failure_stage: "none",
+  exit_code_class: "success",
+  duration_bucket: "1s_to_5s",
+  execution_context: "interactive",
+  cli_version: "0.2.3",
+};
+
+describe("CodeRouter CLI analytics route", () => {
+  test("authenticates scope and forwards only the closed schema", async () => {
+    captureCoderouterEvent.mockClear();
+    const response = await POST(new Request("https://cmux.test/api/coderouter/analytics", {
+      method: "POST",
+      headers: { authorization: "Bearer crt_test", "content-type": "application/json" },
+      body: JSON.stringify({
+        events: [{
+          event: "coderouter_cli_command_completed",
+          properties: validProperties,
+        }],
+      }),
+    }));
+    expect(response.status).toBe(204);
+    expect(captureCoderouterEvent).toHaveBeenCalledWith({
+      event: "coderouter_cli_command_completed",
+      userId: "raw-user-id",
+      teamId: "raw-team-id",
+      properties: validProperties,
+    });
+  });
+
+  test("rejects unknown fields and free-form values", async () => {
+    captureCoderouterEvent.mockClear();
+    const response = await POST(new Request("https://cmux.test/api/coderouter/analytics", {
+      method: "POST",
+      headers: { authorization: "Bearer crt_test", "content-type": "application/json" },
+      body: JSON.stringify({
+        events: [{
+          event: "coderouter_cli_command_completed",
+          properties: {
+            ...validProperties,
+            command: "/Users/private/project",
+            prompt: "secret",
+          },
+        }],
+      }),
+    }));
+    expect(response.status).toBe(400);
+    expect(captureCoderouterEvent).not.toHaveBeenCalled();
+  });
+
+  test("bounds body and batch size", async () => {
+    const events = Array.from({ length: 3 }, () => ({
+      event: "coderouter_cli_command_started",
+      properties: { ...validProperties, outcome: "started" },
+    }));
+    const response = await POST(new Request("https://cmux.test/api/coderouter/analytics", {
+      method: "POST",
+      headers: { authorization: "Bearer crt_test", "content-type": "application/json" },
+      body: JSON.stringify({ events }),
+    }));
+    expect(response.status).toBe(400);
+  });
+});

--- a/web/tests/hosted-subrouter-routes.test.ts
+++ b/web/tests/hosted-subrouter-routes.test.ts
@@ -42,6 +42,10 @@ mock.module("../app/lib/stack", () => ({
 mock.module("../services/subrouter/cutover", () => ({
   hostedSubrouterCutoverReadyForTeam,
 }));
+const captureCoderouterEvent = mock(() => {});
+mock.module("../services/coderouter/analytics", () => ({
+  captureCoderouterEvent,
+}));
 
 const accountsRoute = await import("../app/api/subrouter/accounts/route");
 const accountRoute = await import(
@@ -101,6 +105,7 @@ beforeEach(() => {
   getAuthJson.mockClear();
   signOut.mockClear();
   hostedSubrouterCutoverReadyForTeam.mockClear();
+  captureCoderouterEvent.mockClear();
   globalThis.fetch = hostedFetch as typeof fetch;
 });
 
@@ -337,6 +342,15 @@ describe("hosted Subrouter account routes", () => {
     expect(text).not.toContain("must-not-leak");
     expect(text).not.toContain("upstream detail must not leak");
     expect(text).not.toContain(tenantKey);
+    expect(captureCoderouterEvent).toHaveBeenCalledWith({
+      event: "coderouter_account_status_viewed",
+      teamId: "team-a",
+      properties: {
+        source: "legacy_dashboard",
+        account_count: 1,
+        account_error_count: 0,
+      },
+    });
   });
 
   test("maps internal tenant-key authentication failures to an upstream error", async () => {
@@ -421,6 +435,16 @@ describe("hosted Subrouter account routes", () => {
         accountID: "account",
       },
     });
+    expect(captureCoderouterEvent).toHaveBeenCalledWith({
+      event: "coderouter_account_added",
+      userId: "user-1",
+      teamId: "team-a",
+      properties: {
+        provider: "codex",
+        source: "legacy_dashboard",
+        already_exists: false,
+      },
+    });
   });
 
   test("deletes and repairs only the requested tenant account", async () => {
@@ -434,6 +458,12 @@ describe("hosted Subrouter account routes", () => {
     );
     expect(calls[1]?.headers.get("authorization")).toBe(`Bearer ${tenantKey}`);
     expect(calls[1]?.url.href).not.toContain(tenantKey);
+    expect(captureCoderouterEvent).toHaveBeenCalledWith({
+      event: "coderouter_account_removed",
+      userId: "user-1",
+      teamId: "team-a",
+      properties: { source: "legacy_dashboard" },
+    });
 
     calls = [];
     const repaired = await repairRoute.POST(
@@ -457,6 +487,16 @@ describe("hosted Subrouter account routes", () => {
       label: "work",
       apiKey: "sk-new",
       targetAccountID: "apikey:openai-apikey:work",
+    });
+    expect(captureCoderouterEvent).toHaveBeenCalledWith({
+      event: "coderouter_account_added",
+      userId: "user-1",
+      teamId: "team-a",
+      properties: {
+        provider: "openai-apikey",
+        source: "legacy_dashboard",
+        already_exists: true,
+      },
     });
   });
 


### PR DESCRIPTION
Adds dedicated-project CodeRouter lifecycle, routing-health, usage, organization, metrics, legacy dashboard, and authenticated CLI analytics. All events fail closed without isolated configuration, process no person profiles, disable GeoIP, HMAC raw team/user scope with separate domains, and use strict event/property allowlists. Adds a fixed CLI ingestion route, PostHog dashboard/alert operating spec, and comprehensive privacy tests.\n\nValidation: 1,270 pass / 148 DB-gated skip / 0 fail across 1,418 web tests; focused ESLint and TypeScript clean.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/10088"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789186791&installation_model_id=21920&pr_number=10088&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F10088&signature=b7e907cee84fefa78870f5da7015be5edd3c0903d5f1e488bd822e7db06dcbe8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds server-only, privacy-safe CodeRouter analytics in a dedicated PostHog project and hardens ingestion. Previously ops were limited and usage could fall back to the general project; now events use closed schemas, HMAC pseudonyms, and fail closed without isolated config.

Captures route health across Codex and OpenCode proxies at terminal result, independent of token parsing, with provider, agent, outcome, failure_stage, status_class, latency/attempt/refresh buckets, and streaming flag. Aggregates usage via `$ai_generation` with `schema_version = 3`, `service_version = coderouter-web-v1`, bounded counts, and model family normalization. Adds authenticated CLI analytics `POST /api/coderouter/analytics` with strict Zod validation, 8KB body limit, and batches of up to 2, accepting only `coderouter_cli_command_started|completed`. Records `coderouter_auth_rejected` with precise surfaces and reasons, `coderouter_metrics_loaded` outcomes, `coderouter_organization_catalog_viewed`, and account lifecycle events tagged by `source = native_api|legacy_dashboard`. All events disable `$process_person_profile` and `$geoip_disable`, and HMAC team (`coderouter_team_scope`) and user (`coderouter_user_scope`) identifiers.

- Configure isolated PostHog: set `POSTHOG_CODEROUTER_PROJECT_KEY`, `POSTHOG_CODEROUTER_ENVIRONMENT_ID`, `POSTHOG_CODEROUTER_ENDPOINT_SECRET`, `POSTHOG_CODEROUTER_API_HOST`, `POSTHOG_CODEROUTER_INGEST_HOST`, and `CODEROUTER_ANALYTICS_SCOPE_SECRET`; remove `POSTHOG_CODEROUTER_ENDPOINT_NAME` (fixed to `coderouter-team-usage-30d`).
- Ensure the reviewed Endpoint exists and its secret is endpoint:read-only; validate dashboards/alerts per `docs/posthog/coderouter-analytics-dashboard.md`.
- CLI must send `coderouter_cli_*` to `/api/coderouter/analytics` with a valid route token, closed schema values, and size limits.

<sup>Written for commit a785c5f3f4e30699e13d7312f74dbb40216944cc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/10088?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added validated CLI analytics event submission with size limits and team attribution.
  * Expanded CodeRouter analytics for accounts, organizations, metrics, route health, authentication, and CLI lifecycle events.
  * Added privacy-preserving pseudonymous user and team identifiers.
  * Added an analytics dashboard specification with operational, usage, lifecycle, and integrity views.

* **Bug Fixes**
  * Improved tracking of authentication, routing, and metrics failures.
  * Safely rejects invalid analytics data and omits incomplete usage records.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->