### PR TITLE
Fix sidebar leading-edge clipping after resize

### DIFF
--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -1954,7 +1954,11 @@ struct ContentView: View {
             content()
                 .environment(\.colorScheme, appearance.sidebarContentColorScheme)
         }
-        .frame(width: width)
+        // Preserve the panel's intended edge when content reports an
+        // intrinsic width larger than the constrained pane. The default
+        // centered frame alignment would otherwise move the entire subtree
+        // off the leading edge and clip every row by one constant offset.
+        .frame(width: width, alignment: alignment)
     }
 
     private func sidebarPanelWithBackdrop(appearance: WindowAppearanceSnapshot) -> some View {

--- a/Sources/Sidebar/SidebarLayoutModel.swift
+++ b/Sources/Sidebar/SidebarLayoutModel.swift
@@ -40,7 +40,11 @@ struct SidebarWidthFrameModifier: ViewModifier {
     @ObservedObject var layout: SidebarLayoutModel
 
     func body(content: Content) -> some View {
-        content.frame(width: layout.width)
+        // A sidebar row may be wider than the pane (for example an authored
+        // custom row using `.fixedSize()`). Keep that overflow attached to
+        // the leading edge so the pane clips/truncates only at its trailing
+        // edge instead of shifting every sibling left by the same amount.
+        content.frame(width: layout.width, alignment: .leading)
     }
 }
 

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -1968,6 +1968,7 @@ C0DE71B10000000000000001 /* AppDelegate+AgentChatNotifications.swift in Sources 
 		5732A0115732A0115732A011 /* SidebarLazyContractProbe.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5732B0115732B0115732B011 /* SidebarLazyContractProbe.swift */; };
 		5732A0125732A0125732A012 /* SidebarLazyContractProbeKey.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5732B0125732B0125732B012 /* SidebarLazyContractProbeKey.swift */; };
 		D41A7C01D41A7C01D41A7C01 /* SidebarLazyLayoutScaleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D41A7C02D41A7C02D41A7C02 /* SidebarLazyLayoutScaleTests.swift */; };
+		C0DE10085100000000000001 /* SidebarLeadingEdgeAnchorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE10085100000000000002 /* SidebarLeadingEdgeAnchorTests.swift */; };
 		385C6BA7E78DB87460E5D930 /* SidebarMarkdownRendererTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1C3F1DBF6BF5D7223C4A30C /* SidebarMarkdownRendererTests.swift */; };
 			A6AC73F20000000000000001 /* SidebarMediaActivityIndicators.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6AC73F20000000000000002 /* SidebarMediaActivityIndicators.swift */; };
 		C0DE5F210000000000000001 /* SidebarMetadataMarkdownRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE5F210000000000000002 /* SidebarMetadataMarkdownRenderer.swift */; };
@@ -2007,7 +2008,6 @@ C0DE71B10000000000000001 /* AppDelegate+AgentChatNotifications.swift in Sources 
 		C9A57513C9A57513C9A57513 /* SidebarScrollViewConfiguratorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9A57514C9A57514C9A57514 /* SidebarScrollViewConfiguratorTests.swift */; };
 		B804A0280000000000000028 /* SidebarSelectionCoalescer.swift in Sources */ = {isa = PBXBuildFile; fileRef = B804B0280000000000000028 /* SidebarSelectionCoalescer.swift */; };
 		B804C0020000000000000002 /* SidebarSelectionCoalescerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B804D0020000000000000002 /* SidebarSelectionCoalescerTests.swift */; };
-		C0DE10085100000000000001 /* SidebarLeadingEdgeAnchorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE10085100000000000002 /* SidebarLeadingEdgeAnchorTests.swift */; };
 		E62155868BB29FEB5DAAAF25 /* SidebarSelectionState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9AD52285508B1D6A9875E7B3 /* SidebarSelectionState.swift */; };
 		F57072635F25EBCA741E125D /* SidebarState.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1614EAD3CCF70A177A51BD1 /* SidebarState.swift */; };
 		D7344F010000000000000001 /* SidebarTabDragPayload.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7344F010000000000000002 /* SidebarTabDragPayload.swift */; };
@@ -4730,6 +4730,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 		5732B0115732B0115732B011 /* SidebarLazyContractProbe.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Debug/SidebarLazyContractProbe.swift; sourceTree = "<group>"; };
 		5732B0125732B0125732B012 /* SidebarLazyContractProbeKey.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Debug/SidebarLazyContractProbeKey.swift"; sourceTree = "<group>"; };
 		D41A7C02D41A7C02D41A7C02 /* SidebarLazyLayoutScaleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarLazyLayoutScaleTests.swift; sourceTree = "<group>"; };
+		C0DE10085100000000000002 /* SidebarLeadingEdgeAnchorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarLeadingEdgeAnchorTests.swift; sourceTree = "<group>"; };
 		F1C3F1DBF6BF5D7223C4A30C /* SidebarMarkdownRendererTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarMarkdownRendererTests.swift; sourceTree = "<group>"; };
 			A6AC73F20000000000000002 /* SidebarMediaActivityIndicators.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sidebar/SidebarMediaActivityIndicators.swift; sourceTree = "<group>"; };
 		C0DE5F210000000000000002 /* SidebarMetadataMarkdownRenderer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarMetadataMarkdownRenderer.swift; sourceTree = "<group>"; };
@@ -4769,7 +4770,6 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 		C9A57514C9A57514C9A57514 /* SidebarScrollViewConfiguratorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarScrollViewConfiguratorTests.swift; sourceTree = "<group>"; };
 		B804B0280000000000000028 /* SidebarSelectionCoalescer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sidebar/AppKitList/SidebarSelectionCoalescer.swift; sourceTree = "<group>"; };
 		B804D0020000000000000002 /* SidebarSelectionCoalescerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarSelectionCoalescerTests.swift; sourceTree = "<group>"; };
-		C0DE10085100000000000002 /* SidebarLeadingEdgeAnchorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarLeadingEdgeAnchorTests.swift; sourceTree = "<group>"; };
 		9AD52285508B1D6A9875E7B3 /* SidebarSelectionState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarSelectionState.swift; sourceTree = "<group>"; };
 		D1614EAD3CCF70A177A51BD1 /* SidebarState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sidebar/SidebarState.swift; sourceTree = "<group>"; };
 		D7344F010000000000000002 /* SidebarTabDragPayload.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sidebar/SidebarTabDragPayload.swift; sourceTree = "<group>"; };
@@ -11437,6 +11437,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				51D800000000000000000001 /* SidebarIdentifierFormattingTests.swift in Sources */,
 				AABBCC000000000000000206 /* SidebarInlineRenameKeyResolverTests.swift in Sources */,
 				D41A7C01D41A7C01D41A7C01 /* SidebarLazyLayoutScaleTests.swift in Sources */,
+				C0DE10085100000000000001 /* SidebarLeadingEdgeAnchorTests.swift in Sources */,
 				385C6BA7E78DB87460E5D930 /* SidebarMarkdownRendererTests.swift in Sources */,
 				CB23911D7E131E8FBC9B82B6 /* SidebarOrderingTests.swift in Sources */,
 				A80070010000000000000001 /* SidebarPointerInteractionMonitorTests.swift in Sources */,
@@ -11445,7 +11446,6 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				5B0C00010000000000000003 /* SidebarResizerOcclusionResolverTests.swift in Sources */,
 				C9A57513C9A57513C9A57513 /* SidebarScrollViewConfiguratorTests.swift in Sources */,
 				B804C0020000000000000002 /* SidebarSelectionCoalescerTests.swift in Sources */,
-				C0DE10085100000000000001 /* SidebarLeadingEdgeAnchorTests.swift in Sources */,
 				D73440010000000000000001 /* SidebarTabDragPayloadProviderTests.swift in Sources */,
 				D7AB34300000000000000105 /* SidebarTabDropIndicatorPredicateTests.swift in Sources */,
 				CA39C0304FE351A21C372429 /* SidebarWidthPolicyTests.swift in Sources */,

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -2007,6 +2007,7 @@ C0DE71B10000000000000001 /* AppDelegate+AgentChatNotifications.swift in Sources 
 		C9A57513C9A57513C9A57513 /* SidebarScrollViewConfiguratorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9A57514C9A57514C9A57514 /* SidebarScrollViewConfiguratorTests.swift */; };
 		B804A0280000000000000028 /* SidebarSelectionCoalescer.swift in Sources */ = {isa = PBXBuildFile; fileRef = B804B0280000000000000028 /* SidebarSelectionCoalescer.swift */; };
 		B804C0020000000000000002 /* SidebarSelectionCoalescerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B804D0020000000000000002 /* SidebarSelectionCoalescerTests.swift */; };
+		C0DE10085100000000000001 /* SidebarLeadingEdgeAnchorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE10085100000000000002 /* SidebarLeadingEdgeAnchorTests.swift */; };
 		E62155868BB29FEB5DAAAF25 /* SidebarSelectionState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9AD52285508B1D6A9875E7B3 /* SidebarSelectionState.swift */; };
 		F57072635F25EBCA741E125D /* SidebarState.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1614EAD3CCF70A177A51BD1 /* SidebarState.swift */; };
 		D7344F010000000000000001 /* SidebarTabDragPayload.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7344F010000000000000002 /* SidebarTabDragPayload.swift */; };
@@ -4768,6 +4769,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 		C9A57514C9A57514C9A57514 /* SidebarScrollViewConfiguratorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarScrollViewConfiguratorTests.swift; sourceTree = "<group>"; };
 		B804B0280000000000000028 /* SidebarSelectionCoalescer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sidebar/AppKitList/SidebarSelectionCoalescer.swift; sourceTree = "<group>"; };
 		B804D0020000000000000002 /* SidebarSelectionCoalescerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarSelectionCoalescerTests.swift; sourceTree = "<group>"; };
+		C0DE10085100000000000002 /* SidebarLeadingEdgeAnchorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarLeadingEdgeAnchorTests.swift; sourceTree = "<group>"; };
 		9AD52285508B1D6A9875E7B3 /* SidebarSelectionState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarSelectionState.swift; sourceTree = "<group>"; };
 		D1614EAD3CCF70A177A51BD1 /* SidebarState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sidebar/SidebarState.swift; sourceTree = "<group>"; };
 		D7344F010000000000000002 /* SidebarTabDragPayload.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sidebar/SidebarTabDragPayload.swift; sourceTree = "<group>"; };
@@ -8296,6 +8298,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				D7AB34300000000000000006 /* SidebarWorkspaceDropPlannerTests.swift */,
 				B804D0010000000000000001 /* SidebarWorkspaceTableTests.swift */,
 				B804D0020000000000000002 /* SidebarSelectionCoalescerTests.swift */,
+				C0DE10085100000000000002 /* SidebarLeadingEdgeAnchorTests.swift */,
 				B804D0030000000000000003 /* SidebarAppKitRowCellTests.swift */,
 				B8624D060000000000000006 /* SidebarFocusBoundaryLifecycleTests.swift */,
 				B8624D010000000000000001 /* SidebarHiddenPresentationTests.swift */,
@@ -11442,6 +11445,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				5B0C00010000000000000003 /* SidebarResizerOcclusionResolverTests.swift in Sources */,
 				C9A57513C9A57513C9A57513 /* SidebarScrollViewConfiguratorTests.swift in Sources */,
 				B804C0020000000000000002 /* SidebarSelectionCoalescerTests.swift in Sources */,
+				C0DE10085100000000000001 /* SidebarLeadingEdgeAnchorTests.swift in Sources */,
 				D73440010000000000000001 /* SidebarTabDragPayloadProviderTests.swift in Sources */,
 				D7AB34300000000000000105 /* SidebarTabDropIndicatorPredicateTests.swift in Sources */,
 				CA39C0304FE351A21C372429 /* SidebarWidthPolicyTests.swift in Sources */,

--- a/cmuxTests/SidebarLeadingEdgeAnchorTests.swift
+++ b/cmuxTests/SidebarLeadingEdgeAnchorTests.swift
@@ -1,0 +1,105 @@
+import AppKit
+import SwiftUI
+import Testing
+
+#if canImport(cmux_DEV)
+@testable import cmux_DEV
+#elseif canImport(cmux)
+@testable import cmux
+#endif
+
+@Suite(.serialized)
+struct SidebarLeadingEdgeAnchorTests {
+    @MainActor
+    @Test
+    func oversizedSidebarRowsStayLeadingAnchoredAcrossResizeWidths() {
+        _ = NSApplication.shared
+
+        let capture = SidebarLeadingEdgeFrameCapture()
+        let layout = SidebarLayoutModel(width: 240)
+        let root = SidebarLeadingEdgeProbe(layout: layout, capture: capture)
+        let host = NSHostingView(rootView: root)
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 240, height: 120),
+            styleMask: [.borderless],
+            backing: .buffered,
+            defer: false
+        )
+        window.isReleasedWhenClosed = false
+        defer {
+            window.contentView = nil
+            window.close()
+        }
+        window.contentView = host
+
+        for width in [CGFloat(240), 320, 180, 240] {
+            layout.width = width
+            host.frame = NSRect(x: 0, y: 0, width: width, height: 120)
+            host.layoutSubtreeIfNeeded()
+            window.contentView?.layoutSubtreeIfNeeded()
+            window.displayIfNeeded()
+            _ = RunLoop.main.run(mode: .default, before: Date(timeIntervalSinceNow: 0.001))
+            host.layoutSubtreeIfNeeded()
+
+            let frames = capture.frames
+            guard let short = frames[SidebarLeadingEdgeProbe.shortRowID],
+                  let wide = frames[SidebarLeadingEdgeProbe.wideRowID] else {
+                Issue.record("Sidebar probe did not report both row frames at width \(width).")
+                continue
+            }
+
+            #expect(short.minX >= -0.5, "Short row moved off the leading edge at width \(width): \(short).")
+            #expect(wide.minX >= -0.5, "Wide row moved off the leading edge at width \(width): \(wide).")
+            #expect(abs(short.minX - wide.minX) < 0.5, "Rows no longer share one leading anchor: \(frames).")
+        }
+    }
+}
+
+private final class SidebarLeadingEdgeFrameCapture {
+    var frames: [String: CGRect] = [:]
+}
+
+private struct SidebarLeadingEdgeFramePreferenceKey: PreferenceKey {
+    static let defaultValue: [String: CGRect] = [:]
+
+    static func reduce(value: inout [String: CGRect], nextValue: () -> [String: CGRect]) {
+        value.merge(nextValue(), uniquingKeysWith: { _, new in new })
+    }
+}
+
+private struct SidebarLeadingEdgeProbe: View {
+    static let shortRowID = "short"
+    static let wideRowID = "wide"
+
+    let layout: SidebarLayoutModel
+    let capture: SidebarLeadingEdgeFrameCapture
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            row(id: Self.shortRowID, width: 260)
+            row(id: Self.wideRowID, width: 320)
+        }
+        // This is the interpreter's `.fixedSize()` failure mode: the root
+        // reports its widest child (320pt), even when the pane is narrower.
+        .fixedSize(horizontal: true, vertical: false)
+        .modifier(SidebarWidthFrameModifier(layout: layout))
+        .frame(maxHeight: .infinity, alignment: .topLeading)
+        .coordinateSpace(name: "sidebar-leading-edge-probe")
+        .onPreferenceChange(SidebarLeadingEdgeFramePreferenceKey.self) {
+            capture.frames = $0
+        }
+    }
+
+    private func row(id: String, width: CGFloat) -> some View {
+        Color.clear
+            .frame(width: width, height: 20)
+            .background {
+                GeometryReader { proxy in
+                    Color.clear.preference(
+                        key: SidebarLeadingEdgeFramePreferenceKey.self,
+                        value: [id: proxy.frame(in: .named("sidebar-leading-edge-probe"))]
+                    )
+                }
+            }
+    }
+}

--- a/cmuxTests/SidebarLeadingEdgeAnchorTests.swift
+++ b/cmuxTests/SidebarLeadingEdgeAnchorTests.swift
@@ -1,4 +1,5 @@
 import AppKit
+import Combine
 import SwiftUI
 import Testing
 
@@ -17,7 +18,12 @@ struct SidebarLeadingEdgeAnchorTests {
 
         let capture = SidebarLeadingEdgeFrameCapture()
         let layout = SidebarLayoutModel(width: 240)
-        let root = SidebarLeadingEdgeProbe(layout: layout, capture: capture)
+        let probeState = SidebarLeadingEdgeProbeState()
+        let root = SidebarLeadingEdgeProbe(
+            layout: layout,
+            probeState: probeState,
+            capture: capture
+        )
         let host = NSHostingView(rootView: root)
         let window = NSWindow(
             contentRect: NSRect(x: 0, y: 0, width: 240, height: 120),
@@ -33,36 +39,71 @@ struct SidebarLeadingEdgeAnchorTests {
         window.contentView = host
 
         for width in [CGFloat(240), 320, 180, 240] {
+            probeState.generation &+= 1
+            let generation = probeState.generation
             layout.width = width
             host.frame = NSRect(x: 0, y: 0, width: width, height: 120)
-            host.layoutSubtreeIfNeeded()
-            window.contentView?.layoutSubtreeIfNeeded()
-            window.displayIfNeeded()
-            _ = RunLoop.main.run(mode: .default, before: Date(timeIntervalSinceNow: 0.001))
-            host.layoutSubtreeIfNeeded()
+            let deadline = Date(timeIntervalSinceNow: 0.5)
+            while !capture.hasMeasurement(for: generation, width: width), Date() < deadline {
+                host.layoutSubtreeIfNeeded()
+                window.contentView?.layoutSubtreeIfNeeded()
+                window.displayIfNeeded()
+                _ = RunLoop.main.run(mode: .default, before: Date(timeIntervalSinceNow: 0.001))
+            }
 
-            let frames = capture.frames
+            guard let frames = capture.measurement(for: generation, width: width) else {
+                Issue.record("Sidebar probe did not report current geometry at width \(width).")
+                continue
+            }
             guard let short = frames[SidebarLeadingEdgeProbe.shortRowID],
                   let wide = frames[SidebarLeadingEdgeProbe.wideRowID] else {
                 Issue.record("Sidebar probe did not report both row frames at width \(width).")
                 continue
             }
 
-            #expect(short.minX >= -0.5, "Short row moved off the leading edge at width \(width): \(short).")
-            #expect(wide.minX >= -0.5, "Wide row moved off the leading edge at width \(width): \(wide).")
+            #expect(abs(short.minX) < 0.5, "Short row moved off x=0 at width \(width): \(short).")
+            #expect(abs(wide.minX) < 0.5, "Wide row moved off x=0 at width \(width): \(wide).")
             #expect(abs(short.minX - wide.minX) < 0.5, "Rows no longer share one leading anchor: \(frames).")
         }
     }
 }
 
+@MainActor
+private final class SidebarLeadingEdgeProbeState: ObservableObject {
+    @Published var generation = 0
+}
+
+private struct SidebarLeadingEdgeMeasurement: Equatable {
+    let frame: CGRect
+    let generation: Int
+    let containerWidth: CGFloat
+}
+
 private final class SidebarLeadingEdgeFrameCapture {
-    var frames: [String: CGRect] = [:]
+    var measurements: [String: SidebarLeadingEdgeMeasurement] = [:]
+
+    func hasMeasurement(for generation: Int, width: CGFloat) -> Bool {
+        measurement(for: generation, width: width) != nil
+    }
+
+    func measurement(for generation: Int, width: CGFloat) -> [String: CGRect]? {
+        let matching = measurements.filter {
+            $0.value.generation == generation && abs($0.value.containerWidth - width) < 0.5
+        }
+        guard matching.count == 2 else { return nil }
+        return matching.reduce(into: [String: CGRect]()) { result, entry in
+            result[entry.key] = entry.value.frame
+        }
+    }
 }
 
 private struct SidebarLeadingEdgeFramePreferenceKey: PreferenceKey {
-    static let defaultValue: [String: CGRect] = [:]
+    static let defaultValue: [String: SidebarLeadingEdgeMeasurement] = [:]
 
-    static func reduce(value: inout [String: CGRect], nextValue: () -> [String: CGRect]) {
+    static func reduce(
+        value: inout [String: SidebarLeadingEdgeMeasurement],
+        nextValue: () -> [String: SidebarLeadingEdgeMeasurement]
+    ) {
         value.merge(nextValue(), uniquingKeysWith: { _, new in new })
     }
 }
@@ -72,6 +113,7 @@ private struct SidebarLeadingEdgeProbe: View {
     static let wideRowID = "wide"
 
     let layout: SidebarLayoutModel
+    @ObservedObject var probeState: SidebarLeadingEdgeProbeState
     let capture: SidebarLeadingEdgeFrameCapture
 
     var body: some View {
@@ -86,7 +128,7 @@ private struct SidebarLeadingEdgeProbe: View {
         .frame(maxHeight: .infinity, alignment: .topLeading)
         .coordinateSpace(name: "sidebar-leading-edge-probe")
         .onPreferenceChange(SidebarLeadingEdgeFramePreferenceKey.self) {
-            capture.frames = $0
+            capture.measurements = $0
         }
     }
 
@@ -97,7 +139,11 @@ private struct SidebarLeadingEdgeProbe: View {
                 GeometryReader { proxy in
                     Color.clear.preference(
                         key: SidebarLeadingEdgeFramePreferenceKey.self,
-                        value: [id: proxy.frame(in: .named("sidebar-leading-edge-probe"))]
+                        value: [id: SidebarLeadingEdgeMeasurement(
+                            frame: proxy.frame(in: .named("sidebar-leading-edge-probe")),
+                            generation: probeState.generation,
+                            containerWidth: layout.width
+                        )]
                     )
                 }
             }


### PR DESCRIPTION
Closes #10085

## What changed

The sidebar pane had two constrained-width frames that relied on SwiftUI's default centered alignment. If a child reported an intrinsic width larger than the pane (custom `.fixedSize()` content, long built-in row content, or a transient resize geometry), the entire subtree was centered and moved to a negative leading x-coordinate. That produced the issue's uniform leading-edge clip across every row and the selected card.

Both shared anchor layers now preserve their intended edge:

- `SidebarWidthFrameModifier` anchors the built-in sidebar subtree to `.leading`.
- `sidebarPanelContainer` passes its existing `.leading`/`.trailing` alignment through to the outer width frame, covering both left and right panels.

No row-level frame hacks or trigger-specific branches are involved.

## Testing

- `SidebarLeadingEdgeAnchorTests` mounts an oversized fixed-size sidebar root in an `NSHostingView`, changes widths through 240 → 320 → 180 → 240, waits for a generation- and width-matched geometry preference, and asserts both rows remain at x≈0 with one shared leading anchor.
- The test was committed before the production fix (`30c6803f1d`) so it fails against the centered-frame behavior; the fix is separate (`4bbc803c33`).
- `./scripts/lint-pbxproj-test-wiring.sh` passes (687 files).
- `./scripts/check-pbxproj.sh` passes.
- Swift typecheck with warnings-as-errors passes for the changed production/test sources using Xcode 26's Testing macro plugin.

The manually dispatched repository CI workflow is currently blocked by three pre-existing unallowlisted `sleep-then-assert` findings in `Packages/iOS/CmuxAgentChatUI/Tests/CmuxAgentChatUITests/ChatAttachmentStagingTaskOwnerTests.swift`; those files are outside this PR. The project-normalization guard was fixed in `b0459f73a3` and passes on the current branch.

## Demo Video

Not recorded yet; the tagged cloud app build is intentionally waiting for approval.

## Manual verification

No app build or visual dogfood has been run yet. The deterministic layout probe reproduces the original negative leading coordinate (−40 pt for a 320 pt child in a 240 pt centered frame) and x=0 after the leading-alignment fix.

## Review trigger

Please review the shared frame-anchor change and the deterministic resize regression test.

## Checklist

- [x] Regression test committed separately before the fix
- [x] No user-facing strings added
- [x] Existing unrelated `vendor/bonsplit` worktree change preserved
- [ ] Tagged cloud dogfood build (awaiting approval)
