### PR TITLE
Fix mobile task model discovery

### DIFF
--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+Capabilities.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+Capabilities.swift
@@ -65,6 +65,10 @@ extension MobileShellComposite {
         supportedHostCapabilities.contains(Self.workspaceGroupCreateCapability)
             && discoversMacScopedWorkspaceMutations
     }
+    /// Whether the Mac supports creating task-composer workspaces.
+    public var supportsTaskComposer: Bool {
+        supportedHostCapabilities.contains(Self.taskCreateCapability)
+    }
     /// Whether the Mac supports dogfood feedback submission.
     public var supportsDogfoodFeedback: Bool { supportedHostCapabilities.contains(Self.dogfoodFeedbackCapability) }
     /// Whether the Mac supports chat artifact stat/fetch/thumbnail/list RPCs.

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MobileDisplaySettings.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MobileDisplaySettings.swift
@@ -28,7 +28,6 @@ public final class MobileDisplaySettings {
     private static let showMissingFilesKey = "cmux.mobile.showMissingFiles"
     private static let terminalFolderTapEnabledKey = "cmux.mobile.terminalFolderTapEnabled"
     private static let terminalFilesChipEnabledKey = "cmux.mobile.terminalFilesChipEnabled"
-    private static let taskComposerEnabledKey = "cmux.mobile.taskComposerEnabled"
     private static let workspacePreviewLineCountKey = "cmux.mobile.workspacePreviewLineCount"
     private static let unreadIndicatorLeftShiftKey = "cmux.mobile.debug.unreadIndicatorLeftShift.v2"
     #if DEBUG
@@ -89,15 +88,6 @@ public final class MobileDisplaySettings {
     public var terminalFilesChipEnabled: Bool {
         didSet {
             defaults.set(terminalFilesChipEnabled, forKey: Self.terminalFilesChipEnabledKey)
-        }
-    }
-
-    /// Whether the beta New Task composer is available from the workspace list.
-    /// Defaults to `false`. Mutating this writes through to the injected
-    /// ``UserDefaults``.
-    public var taskComposerEnabled: Bool {
-        didSet {
-            defaults.set(taskComposerEnabled, forKey: Self.taskComposerEnabledKey)
         }
     }
 
@@ -169,7 +159,6 @@ public final class MobileDisplaySettings {
         self.hapticFeedbackEnabled = haptics.isEnabled
         self.terminalFilesChipEnabled = defaults.bool(forKey: Self.terminalFilesChipEnabledKey)
         self.terminalScrollbackRows = MobileTerminalScrollbackPreference.resolve(from: defaults)
-        self.taskComposerEnabled = defaults.bool(forKey: Self.taskComposerEnabledKey)
         let storedPreviewLines = defaults.object(forKey: Self.workspacePreviewLineCountKey) as? Int
         self.workspacePreviewLineCount = Self.clampedWorkspacePreviewLineCount(
             storedPreviewLines ?? Self.defaultWorkspacePreviewLineCount

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MobileSettingsView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MobileSettingsView.swift
@@ -238,14 +238,6 @@ struct MobileSettingsView: View {
                 }
 
                 Section(L10n.string("mobile.settings.betaFeatures", defaultValue: "Beta Features")) {
-                    Toggle(isOn: $displaySettings.taskComposerEnabled) {
-                        Text(L10n.string(
-                            "mobile.settings.taskComposer",
-                            defaultValue: "New Task Composer"
-                        ))
-                    }
-                    .accessibilityIdentifier("MobileSettingsTaskComposer")
-
                     Toggle(isOn: $displaySettings.terminalFilesChipEnabled) {
                         Text(L10n.string(
                             "mobile.settings.terminalFilesChip",

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceShellView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceShellView.swift
@@ -570,7 +570,7 @@ struct WorkspaceShellView: View {
     }
 
     private var taskComposerAction: (() -> Void)? {
-        guard displaySettings.taskComposerEnabled else { return nil }
+        guard store.supportsTaskComposer else { return nil }
         return openTaskComposer
     }
 

--- a/Packages/iOS/CmuxMobileShellUI/Tests/CmuxMobileShellUITests/MobileDisplaySettingsTests.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Tests/CmuxMobileShellUITests/MobileDisplaySettingsTests.swift
@@ -124,22 +124,6 @@ import Testing
         #expect(!MobileDisplaySettings(defaults: defaults).terminalFilesChipEnabled)
     }
 
-    @Test func taskComposerDefaultsToFalseWithoutAWrite() throws {
-        let defaults = try makeDefaults("taskComposerDefaults")
-        let settings = MobileDisplaySettings(defaults: defaults)
-        #expect(!settings.taskComposerEnabled)
-        #expect(defaults.object(forKey: "cmux.mobile.taskComposerEnabled") == nil)
-    }
-
-    @Test func taskComposerPersistsAcrossInstances() throws {
-        let defaults = try makeDefaults("taskComposerPersists")
-        let settings = MobileDisplaySettings(defaults: defaults)
-        settings.taskComposerEnabled = true
-        #expect(MobileDisplaySettings(defaults: defaults).taskComposerEnabled)
-        settings.taskComposerEnabled = false
-        #expect(!MobileDisplaySettings(defaults: defaults).taskComposerEnabled)
-    }
-
     @Test func previewLineCountPersistsAcrossInstances() throws {
         let defaults = try makeDefaults("persists")
         let settings = MobileDisplaySettings(defaults: defaults)

--- a/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/MobileTaskModels/MobileTaskModelParser.swift
+++ b/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/MobileTaskModels/MobileTaskModelParser.swift
@@ -51,6 +51,15 @@ public struct MobileTaskModelParser: Sendable {
         return []
     }
 
+    /// Parses Codex's model catalog JSON.
+    ///
+    /// - Parameter output: Standard output from `codex debug models`.
+    /// - Returns: Listed model identifiers with display names in upstream order.
+    public func codexModels(from output: String) -> [MobileTaskModel] {
+        guard let data = output.data(using: .utf8) else { return [] }
+        return codexModels(from: data)
+    }
+
     /// Parses the model catalog downloaded and owned by Codex itself.
     public func codexModels(from data: Data) -> [MobileTaskModel] {
         guard let object = try? JSONSerialization.jsonObject(with: data)

--- a/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/MobileTaskModels/MobileTaskModelProviderStrategy.swift
+++ b/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/MobileTaskModels/MobileTaskModelProviderStrategy.swift
@@ -2,6 +2,8 @@ public import Foundation
 
 /// Provider-specific model discovery with injected process and filesystem I/O.
 public struct MobileTaskModelProviderStrategy: Sendable {
+    private static let codexModelsCommand = "exec codex debug models"
+
     /// Runs one login-shell command under a bounded timeout.
     public typealias CommandRunner = @Sendable (
         _ command: String,
@@ -36,9 +38,9 @@ public struct MobileTaskModelProviderStrategy: Sendable {
 
     /// Discovers the models exposed by the provider installed on this Mac.
     ///
-    /// Claude answers a control-stream `list_models` request, Codex owns a
-    /// downloaded model cache, and OpenCode exposes `opencode models`. No
-    /// product-owned list participates in this result.
+    /// Claude answers a control-stream `list_models` request, Codex exposes a
+    /// local debug catalog with an owned cache fallback, and OpenCode exposes
+    /// `opencode models`. No product-owned list participates in this result.
     ///
     /// - Parameter provider: Provider whose model list is requested.
     /// - Returns: Models plus the strategy source.
@@ -56,6 +58,11 @@ public struct MobileTaskModelProviderStrategy: Sendable {
                 MobileTaskModel(id: $0, displayName: $0)
             })
         case .codex:
+            let output = await commandRunner(Self.codexModelsCommand, .seconds(5))
+            let discoveredModels = output.map(parser.codexModels(from:)) ?? []
+            if !discoveredModels.isEmpty {
+                return discovered(discoveredModels)
+            }
             let url = homeDirectory
                 .appendingPathComponent(".codex", isDirectory: true)
                 .appendingPathComponent("models_cache.json")

--- a/Packages/macOS/CmuxControlSocket/Tests/CmuxControlSocketTests/MobileTaskModelParserTests.swift
+++ b/Packages/macOS/CmuxControlSocket/Tests/CmuxControlSocketTests/MobileTaskModelParserTests.swift
@@ -43,6 +43,40 @@ struct MobileTaskModelParserTests {
         #expect(parser.codexConfiguredModel(from: Data(text.utf8)) == nil)
     }
 
+    @Test func codexCatalogKeepsListedModelsWithDisplayNames() {
+        let output = """
+        {
+          "models": [
+            {
+              "slug": "gpt-5.6-sol",
+              "display_name": "GPT-5.6 Sol",
+              "visibility": "list"
+            },
+            {
+              "slug": "gpt-hidden",
+              "display_name": "Hidden",
+              "visibility": "hidden"
+            },
+            {
+              "slug": "gpt-5.6-luna",
+              "display_name": "  ",
+              "visibility": "list"
+            },
+            {
+              "slug": "gpt-5.6-sol",
+              "display_name": "Duplicate",
+              "visibility": "list"
+            }
+          ]
+        }
+        """
+
+        #expect(parser.codexModels(from: output) == [
+            MobileTaskModel(id: "gpt-5.6-sol", displayName: "GPT-5.6 Sol"),
+            MobileTaskModel(id: "gpt-5.6-luna", displayName: "gpt-5.6-luna"),
+        ])
+    }
+
     @Test func claudeReadsBedrockStyleModelIdentifier() {
         let data = Data(#"{"model":"us.anthropic.claude-opus-5","theme":"dark"}"#.utf8)
         #expect(
@@ -62,4 +96,5 @@ struct MobileTaskModelParserTests {
     func claudeReturnsNilWithoutATopLevelNonblankModel(_ data: Data) {
         #expect(parser.claudeConfiguredModel(from: data) == nil)
     }
+
 }

--- a/Packages/macOS/CmuxControlSocket/Tests/CmuxControlSocketTests/MobileTaskModelProviderStrategyTests.swift
+++ b/Packages/macOS/CmuxControlSocket/Tests/CmuxControlSocketTests/MobileTaskModelProviderStrategyTests.swift
@@ -78,7 +78,39 @@ struct MobileTaskModelProviderStrategyTests {
         #expect(await probe.readPaths.isEmpty)
     }
 
-    @Test func codexUsesAgentOwnedCacheAsAuthoritativeCatalog() async {
+    @Test func codexUsesDebugCatalogAsAuthoritativeCatalog() async {
+        let probe = MobileTaskModelStrategyProbe()
+        await probe.setCommandOutput("""
+        {
+          "models": [
+            {
+              "slug": "gpt-5.6-sol",
+              "display_name": "GPT-5.6 Sol",
+              "visibility": "list"
+            },
+            {
+              "slug": "gpt-hidden",
+              "display_name": "Hidden",
+              "visibility": "hidden"
+            }
+          ]
+        }
+        """)
+
+        let result = await makeStrategy(probe: probe).models(for: .codex)
+
+        #expect(result == MobileTaskModelListResult(
+            models: [
+                MobileTaskModel(id: "gpt-5.6-sol", displayName: "GPT-5.6 Sol"),
+            ],
+            source: .discovered
+        ))
+        #expect(await probe.commands.map(\.0) == ["exec codex debug models"])
+        #expect(await probe.commands.map(\.1) == [.seconds(5)])
+        #expect(await probe.readPaths.isEmpty)
+    }
+
+    @Test func codexFallsBackToAgentOwnedCacheAfterDebugFailure() async {
         let probe = MobileTaskModelStrategyProbe()
         await probe.setFile(
             path: "/Users/tester/.codex/models_cache.json",
@@ -93,7 +125,7 @@ struct MobileTaskModelProviderStrategyTests {
             ],
             source: .discovered
         ))
-        #expect(await probe.commands.isEmpty)
+        #expect(await probe.commands.map(\.0) == ["exec codex debug models"])
         #expect(await probe.readPaths == ["/Users/tester/.codex/models_cache.json"])
     }
 

--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -113146,6 +113146,57 @@
         }
       }
     },
+    "featureFlags.mobileTaskComposer.description": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enables the iOS New Task composer, including task model discovery, directory picking, and attachment staging."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "iOSの新規タスク作成を有効にします。タスクモデル検出、ディレクトリ選択、添付ファイルのステージングを含みます。"
+          }
+        }
+      }
+    },
+    "featureFlags.mobileTaskComposer.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mobile Task Composer"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "モバイルタスク作成"
+          }
+        }
+      }
+    },
+    "mobile.taskComposer.error.capabilityDisabled": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Task Composer is disabled on this Mac"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "このMacではタスク作成が無効です"
+          }
+        }
+      }
+    },
     "featureFlags.override.none": {
       "extractionState": "manual",
       "localizations": {

--- a/Sources/FeatureFlags.swift
+++ b/Sources/FeatureFlags.swift
@@ -60,6 +60,7 @@ final class CmuxFeatureFlags {
     private nonisolated static let simulatorDefault = true
     private static let workspaceTodoControlsDefault = false
     private static let appKitSidebarListDefault = true
+    private nonisolated static let mobileTaskComposerDefault = true
 
     private static let overrideKeyPrefix = "cmux.flags.override."
     private static let remoteCacheKeyPrefix = "cmux.flags.remote."
@@ -127,6 +128,25 @@ final class CmuxFeatureFlags {
             defaultValue: "Enables iPhone and iPad Simulator panes, commands, and automation."
         ),
         defaultWhenUnavailable: CmuxFeatureFlags.simulatorDefault
+    )
+
+    // FLAG(key: mobile-task-composer-enabled-release, owner: lawrencecchen,
+    //      reviewBy: 2026-10-01, defaultWhenUnavailable: true)
+    // Controls the iOS Task Composer from the Mac host. When off, the Mac stops
+    // advertising task-create/model/directory/attachment capabilities and
+    // task-specific RPCs fail with capability_disabled, so paired phones hide
+    // the composer without needing a user-visible Beta toggle.
+    nonisolated static let mobileTaskComposerFlag = CmuxFeatureFlagDefinition(
+        key: "mobile-task-composer-enabled-release",
+        title: String(
+            localized: "featureFlags.mobileTaskComposer.title",
+            defaultValue: "Mobile Task Composer"
+        ),
+        flagDescription: String(
+            localized: "featureFlags.mobileTaskComposer.description",
+            defaultValue: "Enables the iOS New Task composer, including task model discovery, directory picking, and attachment staging."
+        ),
+        defaultWhenUnavailable: CmuxFeatureFlags.mobileTaskComposerDefault
     )
 
     // Order is load-bearing for the positional typed accessors below. Flags
@@ -250,6 +270,8 @@ final class CmuxFeatureFlags {
             CmuxFeatureFlags.appKitSidebarListFlag,
 
             CmuxFeatureFlags.mobileWorkspaceChangesFlag,
+
+            CmuxFeatureFlags.mobileTaskComposerFlag,
         ]
     }()
 
@@ -291,6 +313,10 @@ final class CmuxFeatureFlags {
 
     var isMobileWorkspaceChangesEnabled: Bool {
         effectiveValue(for: Self.mobileWorkspaceChangesFlag)
+    }
+
+    var isMobileTaskComposerEnabled: Bool {
+        effectiveValue(for: Self.mobileTaskComposerFlag)
     }
 
     /// Effective values mirrored for nonisolated readers: the mobile host

--- a/Sources/Mobile/MobileHostService+Capabilities.swift
+++ b/Sources/Mobile/MobileHostService+Capabilities.swift
@@ -11,6 +11,12 @@ extension MobileHostService {
     nonisolated static let phonePushSettingsCapability = "phone_push.settings.v1"
     /// Authenticated request to enqueue a truthful, correlated test alert.
     nonisolated static let phonePushTestCapability = "phone_push.test.v1"
+    nonisolated static let taskCreateCapability = "workspace.task_create.v1"
+    nonisolated static let taskAttachmentCapability = "task.attachments.v1"
+    nonisolated static let taskModelsCapability = "task.models.v1"
+    nonisolated static let taskDirectoryBrowseCapability = "workspace.directory_browse.v1"
+    nonisolated static let taskDirectorySearchCapability = "workspace.directory_search.v1"
+    nonisolated static let taskDirectorySearchV2Capability = "workspace.directory_search.v2"
 
     /// The single source of truth for the capabilities advertised to mobile
     /// clients via `mobile.host.status`. Every status path (the public-status
@@ -32,6 +38,9 @@ extension MobileHostService {
             ),
             includingSimulator: CmuxFeatureFlags.offMainEffectiveValue(
                 for: CmuxFeatureFlags.simulatorFlag
+            ),
+            includingTaskComposer: CmuxFeatureFlags.offMainEffectiveValue(
+                for: CmuxFeatureFlags.mobileTaskComposerFlag
             )
         )
     }
@@ -49,7 +58,8 @@ extension MobileHostService {
     /// or input call then fails.
     nonisolated static func mobileHostCapabilities(
         includingWorkspaceChanges: Bool,
-        includingSimulator: Bool = true
+        includingSimulator: Bool = true,
+        includingTaskComposer: Bool = true
     ) -> [String] {
         var capabilities = [
             MobileBrowserStreamCapability.identifier,
@@ -93,12 +103,12 @@ extension MobileHostService {
             // drag-and-drop and group-create affordances enabled after ticket
             // expiry only against hosts that advertise this.
             "workspace.mutations.account_auth.v1",
-            "workspace.task_create.v1",
-            "task.attachments.v1",
-            "task.models.v1",
-            "workspace.directory_browse.v1",
-            "workspace.directory_search.v1",
-            "workspace.directory_search.v2",
+            Self.taskCreateCapability,
+            Self.taskAttachmentCapability,
+            Self.taskModelsCapability,
+            Self.taskDirectoryBrowseCapability,
+            Self.taskDirectorySearchCapability,
+            Self.taskDirectorySearchV2Capability,
             "chat.artifact.v1",
             "chat.artifact.folders.v1",
             "chat.artifact.gallery.v1",
@@ -120,6 +130,17 @@ extension MobileHostService {
                 MobileSimulatorStreamCapability.current.keepaliveIdentifier,
             ]
             capabilities.removeAll { simulatorCapabilities.contains($0) }
+        }
+        if !includingTaskComposer {
+            let taskComposerCapabilities: Set<String> = [
+                Self.taskCreateCapability,
+                Self.taskAttachmentCapability,
+                Self.taskModelsCapability,
+                Self.taskDirectoryBrowseCapability,
+                Self.taskDirectorySearchCapability,
+                Self.taskDirectorySearchV2Capability,
+            ]
+            capabilities.removeAll { taskComposerCapabilities.contains($0) }
         }
         return applyingDebugCapabilitySuppressions(capabilities)
     }

--- a/Sources/TerminalController+MobileDirectoryList.swift
+++ b/Sources/TerminalController+MobileDirectoryList.swift
@@ -7,6 +7,9 @@ extension TerminalController {
         params: [String: Any],
         filesystemJobQuota: MobileTaskFilesystemJobQuota
     ) async -> V2CallResult {
+        guard Self.mobileTaskComposerFeatureEnabled else {
+            return Self.mobileTaskComposerDisabledResult
+        }
         guard let path = params["path"] as? String,
               let offset = params["offset"] as? Int,
               let limit = params["limit"] as? Int,

--- a/Sources/TerminalController+MobileDirectorySearch.swift
+++ b/Sources/TerminalController+MobileDirectorySearch.swift
@@ -7,6 +7,9 @@ extension TerminalController {
         params: [String: Any],
         filesystemJobQuota: MobileTaskFilesystemJobQuota
     ) async -> V2CallResult {
+        guard Self.mobileTaskComposerFeatureEnabled else {
+            return Self.mobileTaskComposerDisabledResult
+        }
         guard let rawQuery = params["query"] as? String else {
             return .err(code: "invalid_params", message: "Missing query", data: nil)
         }

--- a/Sources/TerminalController+MobileTaskAttachments.swift
+++ b/Sources/TerminalController+MobileTaskAttachments.swift
@@ -4,6 +4,9 @@ import Foundation
 extension TerminalController {
     /// Handles one `mobile.task.attachment.upload` chunk.
     func v2MobileTaskAttachmentUpload(params: [String: Any]) -> V2CallResult {
+        guard Self.mobileTaskComposerFeatureEnabled else {
+            return Self.mobileTaskComposerDisabledResult
+        }
         guard let operationIDString = v2RawString(params, "operation_id"),
               let operationID = UUID(uuidString: operationIDString),
               let uploadIDString = v2RawString(params, "upload_id"),

--- a/Sources/TerminalController+MobileTaskModels.swift
+++ b/Sources/TerminalController+MobileTaskModels.swift
@@ -2,10 +2,30 @@ import CmuxControlSocket
 import Foundation
 
 extension TerminalController {
+    nonisolated static var mobileTaskComposerFeatureEnabled: Bool {
+        CmuxFeatureFlags.offMainEffectiveValue(
+            for: CmuxFeatureFlags.mobileTaskComposerFlag
+        )
+    }
+
+    nonisolated static var mobileTaskComposerDisabledResult: V2CallResult {
+        .err(
+            code: "capability_disabled",
+            message: String(
+                localized: "mobile.taskComposer.error.capabilityDisabled",
+                defaultValue: "Task Composer is disabled on this Mac"
+            ),
+            data: ["capability": MobileHostService.taskCreateCapability]
+        )
+    }
+
     /// Handles one `mobile.task.models.list` provider discovery request.
     nonisolated func v2MobileTaskModelsList(
         params: [String: Any]
     ) async -> V2CallResult {
+        guard Self.mobileTaskComposerFeatureEnabled else {
+            return Self.mobileTaskComposerDisabledResult
+        }
         guard let rawProvider = v2RawString(params, "provider"),
               let provider = MobileTaskModelProvider(rawValue: rawProvider) else {
             return .err(

--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -2880,6 +2880,13 @@ class TerminalController {
             "browser.input_keyboard",
             "browser.input_touch",
         ]
+        if !Self.mobileTaskComposerFeatureEnabled {
+            let taskComposerMethods: Set<String> = [
+                "mobile.task.attachment.upload",
+                "mobile.task.models.list",
+            ]
+            methods.removeAll { taskComposerMethods.contains($0) }
+        }
         methods.append(contentsOf: ControlCommandExecutionPolicy.simulatorMethods)
 #if DEBUG
         methods.append(contentsOf: Self.v2DebugMethodNames)

--- a/cmuxTests/MobileHostConnectionLifecycleTests.swift
+++ b/cmuxTests/MobileHostConnectionLifecycleTests.swift
@@ -609,6 +609,29 @@ extension MobileHostAuthorizationTests {
         )
     }
 
+    @Test func testTaskComposerCapabilitiesFollowFeatureFlag() {
+        let enabled = MobileHostService.mobileHostCapabilities(
+            includingWorkspaceChanges: true,
+            includingTaskComposer: true
+        )
+        let disabled = MobileHostService.mobileHostCapabilities(
+            includingWorkspaceChanges: true,
+            includingTaskComposer: false
+        )
+        let taskCapabilities: Set<String> = [
+            MobileHostService.taskCreateCapability,
+            MobileHostService.taskAttachmentCapability,
+            MobileHostService.taskModelsCapability,
+            MobileHostService.taskDirectoryBrowseCapability,
+            MobileHostService.taskDirectorySearchCapability,
+            MobileHostService.taskDirectorySearchV2Capability,
+        ]
+
+        #expect(taskCapabilities.isSubset(of: Set(enabled)))
+        #expect(Set(disabled).isDisjoint(with: taskCapabilities))
+        #expect(enabled.filter { !taskCapabilities.contains($0) } == disabled)
+    }
+
     @Test @MainActor func testMobileWorkspaceChangesFlagDefaultsAndRemoteValue() {
         let suiteName = "cmux-tests-mobile-changes-flag-\(UUID().uuidString)"
         let defaults = UserDefaults(suiteName: suiteName)!
@@ -631,6 +654,30 @@ extension MobileHostAuthorizationTests {
         remoteValue = true
         flags.applyLoadedFlags()
         #expect(flags.isMobileWorkspaceChangesEnabled)
+    }
+
+    @Test @MainActor func testMobileTaskComposerFlagDefaultsOnAndCanDisableRemotely() {
+        let suiteName = "cmux-tests-mobile-task-composer-flag-\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        var remoteValue: Any?
+        let flags = CmuxFeatureFlags(
+            defaults: defaults,
+            remoteFlagValueProvider: { key in
+                key == CmuxFeatureFlags.mobileTaskComposerFlag.key ? remoteValue : nil
+            }
+        )
+
+        #expect(flags.isMobileTaskComposerEnabled)
+
+        remoteValue = false
+        flags.applyLoadedFlags()
+        #expect(!flags.isMobileTaskComposerEnabled)
+
+        remoteValue = true
+        flags.applyLoadedFlags()
+        #expect(flags.isMobileTaskComposerEnabled)
     }
 
     // MARK: - Mobile workspace.action sub-action gate

--- a/ios/cmux/Resources/Localizable.xcstrings
+++ b/ios/cmux/Resources/Localizable.xcstrings
@@ -8297,23 +8297,6 @@
         }
       }
     },
-    "mobile.settings.taskComposer": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "New Task Composer"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "新規タスク作成"
-          }
-        }
-      }
-    },
     "mobile.settings.wrapTitles": {
       "extractionState": "manual",
       "localizations": {

--- a/ios/cmuxUITests/cmuxUITests.swift
+++ b/ios/cmuxUITests/cmuxUITests.swift
@@ -4050,8 +4050,7 @@ final class cmuxUITests: XCTestCase {
             port: hostPort,
             environment: [
                 "CMUX_AGENT_MODELS_URL": "http://127.0.0.1:\(catalogPort)/api/agent-models",
-            ],
-            launchArguments: ["-cmux.mobile.taskComposerEnabled", "YES"]
+            ]
         )
         defer { app.terminate() }
 
@@ -4123,11 +4122,7 @@ final class cmuxUITests: XCTestCase {
 
         // The injected attach ticket uses the production connection and
         // capability handshake while avoiding the independent Add Computer UI.
-        // Enable New Task explicitly because this focused test owns that entrypoint.
-        let hostApp = try launchConnectedApp(
-            port: port,
-            launchArguments: ["-cmux.mobile.taskComposerEnabled", "YES"]
-        )
+        let hostApp = try launchConnectedApp(port: port)
         let backButton = hostApp.buttons["MobileWorkspaceBackButton"]
         XCTAssertTrue(backButton.waitForExistence(timeout: 4))
         tap(backButton, in: hostApp)
@@ -7856,7 +7851,6 @@ final class cmuxUITests: XCTestCase {
             "root-pairing"
         let app = launchApp(mockData: true, environment: launchEnvironment, launchArguments: [
             "-dev.cmux.mobile.connectionMethod.v1", "tailscale",
-            "-cmux.mobile.taskComposerEnabled", "YES",
         ])
 
         let hostField = app.textFields["MobileAddDeviceHostField"]


### PR DESCRIPTION
## Summary\n- discover Codex models from `codex debug models` and Claude models from the local Claude Code executable\n- remove the iOS Beta setting for Task Composer while keeping remote PostHog flag control\n- gate Task Composer host capabilities and RPCs behind the remote feature flag\n\n## Verification\n- `swift test --package-path Packages/macOS/CmuxControlSocket --filter MobileTaskModel`\n- `git diff --check`\n\nNote: iPhone install was requested but blocked by a local Xcode stall at the required same-tag Mac build step; user explicitly requested merge anyway.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/10092"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789189471&installation_model_id=21920&pr_number=10092&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F10092&signature=00da2a18e5957aac7525e0b597dd621a6573215c7b3bcda9a2e02176147d9eac"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes mobile task model discovery and gates the iOS Task Composer behind a host-controlled feature flag. Previously iOS used a local Beta toggle and Codex models were unreliable; now the Mac discovers models via Codex/Claude and only advertises task capabilities when the remote flag is on.

- macOS host
  - `CmuxControlSocket`: Parse Codex models from `exec codex debug models` (5s timeout) with `~/.codex/models_cache.json` fallback; keep `opencode models` and Claude binary scanning.
  - `MobileHostService`: Advertise task capabilities only when `mobile-task-composer-enabled-release` is enabled; defines stable capability IDs for task create, models, attachments, and directory browse/search.
  - `TerminalController`: Remove task RPC methods from the public list when disabled and return `capability_disabled` with a localized message for task models, attachments, and directory browse/search.
  - Adds localized flag title/description and error strings; tests cover flag defaults/remote overrides, advertised capability sets, and Codex discovery order/fallback.

- iOS app
  - Removes the user-visible “New Task Composer” Beta toggle and legacy variants; show the single composer only when the paired Mac advertises support (`store.supportsTaskComposer`).
  - Updates UI/settings tests and drops UITest launch arguments for enabling the composer.

<sup>Written for commit 7247f953e8f672fa3f19ac774aff0d09e53bf9c1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/10092?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

