### PR TITLE
Fix CodeRouter CLI auth confirmation rendering

### DIFF
--- a/web/app/handler/[...stack]/page.tsx
+++ b/web/app/handler/[...stack]/page.tsx
@@ -7,6 +7,14 @@ import { stackServerApp } from "../../lib/stack";
 // Keep authentication reliable instead of withholding it behind an empty
 // instant-navigation boundary.
 export const instant = false;
+// CLI auth confirmation consumes a one-time query parameter. Do not cache an
+// empty handler shell before Stack can read that parameter.
+export const dynamic = "force-dynamic";
+export const revalidate = 0;
+// CLI auth confirmation consumes a one-time query parameter. Static
+// prerendering would cache an empty handler shell and drop that parameter.
+export const dynamic = "force-dynamic";
+export const revalidate = 0;
 
 export default async function StackHandlerPage(
   props: { params: Promise<{ stack: string[] }> },


### PR DESCRIPTION
Force Stack handler routes dynamic so one-time CLI login_code parameters are not served from a cached empty prerendered shell.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/10093"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789190168&installation_model_id=21920&pr_number=10093&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F10093&signature=650a61cc532e277c75527fd9743ee73d8aa289ee96dbb42e909d6fa4c4057aa4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Render Stack handler pages dynamically so CLI auth confirmation reads the one-time `login_code`. Previously a cached empty prerendered shell dropped this parameter; now the page always renders on the server with caching disabled.

- Add `export const dynamic = "force-dynamic"` and `export const revalidate = 0` in `web/app/handler/[...stack]/page.tsx` (lines appear twice in the diff; dedupe if not intentional). `instant` remains `false`.
- Affects all `handler/[...stack]` routes: disables static/ISR caching for these pages.
- No migration. Verify the CLI login flow consumes the one-time code and displays the confirmation.

<sup>Written for commit e9d5b5bbf9007252cb6796ee2cc9768a9a5a090b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/10093?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the Stack Auth handler to always serve fresh, dynamically generated content.
  * Prevented cached or pre-rendered responses from causing outdated handler results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->