### PR TITLE
Fix false compatibility warning for Iroh pairing

### DIFF
--- a/Packages/Shared/CMUXMobileCore/Sources/CMUXMobileCore/CmxPairingQRCode.swift
+++ b/Packages/Shared/CMUXMobileCore/Sources/CMUXMobileCore/CmxPairingQRCode.swift
@@ -316,7 +316,10 @@ private extension CmxPairingQRCode {
             terminalID: nil,
             macDeviceID: "",
             macDisplayName: nil,
-            macPairingCompatibilityVersion: 0,
+            // v3 is intentionally endpoint-only. `nil` means the QR did not
+            // make a compatibility claim, unlike v2's explicit unknown value
+            // (0), which must continue to trigger its legacy warning.
+            macPairingCompatibilityVersion: nil,
             routes: [route],
             expiresAt: nil,
             authToken: nil

--- a/Packages/Shared/CMUXMobileCore/Tests/CMUXMobileCoreTests/CmxAttachTicketIrohQRCodeTests.swift
+++ b/Packages/Shared/CMUXMobileCore/Tests/CMUXMobileCoreTests/CmxAttachTicketIrohQRCodeTests.swift
@@ -118,6 +118,9 @@ private func compactIrohQRHostPortRoute() throws -> CmxAttachRoute {
     #expect(pairingDecoded.macDeviceID.isEmpty)
     #expect(pairingDecoded.macDisplayName == nil)
     #expect(pairingDecoded.macUserID == nil)
+    // Endpoint-only v3 codes intentionally omit compatibility metadata. Keep
+    // that absence distinguishable from an explicitly incompatible version.
+    #expect(pairingDecoded.macPairingCompatibilityVersion == nil)
     #expect(pairingDecoded.macAppVersion == nil)
     #expect(pairingDecoded.macAppBuild == nil)
     #expect(pairingDecoded.expiresAt == nil)


### PR DESCRIPTION
Endpoint-only Iroh v3 QR codes omit compatibility metadata by design. Preserve that absence as `nil` instead of converting it to the legacy unknown value `0`, so pairing does not show a false compatibility mismatch. Explicit v2 unknown compatibility still warns.

Tests:
- `swift test` in `Packages/Shared/CMUXMobileCore`
- `swift test --filter CmxAttachTicketInputTests` in `Packages/iOS/CmuxMobileRPC`
- Regression test committed red before the fix, then green after it

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/10094"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789190695&installation_model_id=21920&pr_number=10094&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F10094&signature=11a67196e2073787c0db704a96b2c9b9663e05aba0c48a30435976a8be96f879"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Avoids false compatibility warnings when pairing with Iroh v3 endpoint-only QR codes by keeping missing compatibility metadata as nil instead of coercing to legacy 0. Previously, absence was converted to 0 (unknown) and triggered a mismatch warning; now nil skips the warning. Explicit v2 unknown (0) still warns.

**Review notes**
- Change is limited to `Packages/Shared/CMUXMobileCore/Sources/CMUXMobileCore/CmxPairingQRCode.swift`: set `macPairingCompatibilityVersion` to `nil` when decoding v3 endpoint-only QR.
- Test added in `Packages/Shared/CMUXMobileCore/Tests/CMUXMobileCoreTests/CmxAttachTicketIrohQRCodeTests.swift` to assert `nil`; regression test was red before the fix and green after.
- No protocol or schema changes; only decoding behavior. No migration required.

<sup>Written for commit 08246ae369d6ebae94a3cf4cdf67dfe90ab3df72. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/10094?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected v3 pairing QR code handling so endpoint-only codes no longer report an incorrect compatibility version.
  * Improved distinction between absent compatibility information and explicitly unknown or incompatible versions.

* **Tests**
  * Added coverage to verify compatibility metadata remains unset for endpoint-only v3 pairing codes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->