### PR TITLE
Make CodeRouter account setup CLI-first

### DIFF
--- a/web/app/[locale]/dashboard/coderouter/page.tsx
+++ b/web/app/[locale]/dashboard/coderouter/page.tsx
@@ -273,7 +273,7 @@ export default async function CoderouterOverviewPage({ params, searchParams }: P
           {selectedTeam.manageAccounts ? (
             <aside>
               <h2 className="mb-2 text-sm font-medium">{t("addAccountsTitle")}</h2>
-              <AddAiAccountForms teamId={selectedTeam.id} />
+              <AddAiAccountForms />
             </aside>
           ) : null}
         </div>

--- a/web/app/[locale]/dashboard/components/ai-account-forms.tsx
+++ b/web/app/[locale]/dashboard/components/ai-account-forms.tsx
@@ -4,14 +4,9 @@ import { Dialog } from "@base-ui-components/react/dialog";
 import { useTranslations } from "next-intl";
 import { useRouter } from "../../../../i18n/navigation";
 import { useState } from "react";
-import type { FormEvent, ReactNode } from "react";
 import { Modal } from "../../components/modal";
+import { CopyButton } from "../vault/copy-button";
 
-// JSON structure examples, not translatable copy: keeping them out of the
-// message catalog avoids ICU parsing of the literal braces.
-const CODEX_JSON_PLACEHOLDER = '{"accessToken":"...","refreshToken":"...","idToken":"...","accountID":"..."}';
-
-type FormKind = "anthropic" | "codex" | "openai";
 type FormStatus = {
   readonly state: "idle" | "submitting" | "success" | "error";
   readonly message?: string;
@@ -19,130 +14,24 @@ type FormStatus = {
 
 const idleStatus: FormStatus = { state: "idle" };
 
-export function AddAiAccountForms({ teamId }: { teamId: string }) {
+export function AddAiAccountForms() {
   const t = useTranslations("dashboard.aiAccounts");
-  const router = useRouter();
-  const [statuses, setStatuses] = useState<Record<FormKind, FormStatus>>({
-    anthropic: idleStatus,
-    codex: idleStatus,
-    openai: idleStatus,
-  });
-
-  const setStatus = (kind: FormKind, status: FormStatus) => {
-    setStatuses((current) => ({ ...current, [kind]: status }));
-  };
-
-  const submitAccount = async (
-    kind: FormKind,
-    form: HTMLFormElement,
-    payload: Record<string, unknown>,
-  ) => {
-    setStatus(kind, { state: "submitting" });
-    try {
-      const response = await fetch(`/api/subrouter/accounts?teamId=${encodeURIComponent(teamId)}`, {
-        method: "POST",
-        headers: { "content-type": "application/json" },
-        body: JSON.stringify(payload),
-      });
-      if (!response.ok) {
-        setStatus(kind, {
-          state: "error",
-          message: errorMessageForStatus(response.status, t, t("addError")),
-        });
-        return;
-      }
-      form.reset();
-      setStatus(kind, { state: "success", message: t("addSuccess") });
-      router.refresh();
-    } catch {
-      setStatus(kind, { state: "error", message: t("addError") });
-    }
-  };
-
-  const submitAnthropic = async (event: FormEvent<HTMLFormElement>) => {
-    event.preventDefault();
-    const form = event.currentTarget;
-    const data = new FormData(form);
-    await submitAccount("anthropic", form, {
-      provider: "anthropic-apikey",
-      label: labelValue(data),
-      apiKey: String(data.get("apiKey") ?? ""),
-    });
-  };
-
-  const submitCodex = async (event: FormEvent<HTMLFormElement>) => {
-    event.preventDefault();
-    const form = event.currentTarget;
-    const data = new FormData(form);
-    const parsed = parseJsonObject(String(data.get("oauthJson") ?? ""));
-    if (!parsed) {
-      setStatus("codex", { state: "error", message: t("jsonError") });
-      return;
-    }
-    const tokens = isRecord(parsed.tokens) ? parsed.tokens : parsed;
-    await submitAccount("codex", form, {
-      provider: "codex",
-      label: labelValue(data),
-      tokens,
-    });
-  };
-
-  const submitOpenAi = async (event: FormEvent<HTMLFormElement>) => {
-    event.preventDefault();
-    const form = event.currentTarget;
-    const data = new FormData(form);
-    await submitAccount("openai", form, {
-      provider: "openai-apikey",
-      label: labelValue(data),
-      apiKey: String(data.get("apiKey") ?? ""),
-    });
-  };
-
   return (
-    <div className="space-y-4">
-      <ProviderForm
-        title={t("providerAnthropicApiKey")}
-        labelText={t("labelField")}
-        labelPlaceholder={t("labelPlaceholder")}
-        submitLabel={t("addAnthropic")}
-        status={statuses.anthropic}
-        onSubmit={submitAnthropic}
-      >
-        <SecretField
-          name="apiKey"
-          label={t("apiKeyField")}
-          placeholder={t("anthropicKeyPlaceholder")}
-        />
-      </ProviderForm>
+    <div className="border border-border p-3">
+      <p className="text-sm text-muted">{t("cliAddBody")}</p>
+      <div className="mt-4 space-y-2">
+        <CommandRow command="npx coderouter add" label={t("npxCommand")} copied={t("copied")} />
+        <CommandRow command="cmux coderouter add" label={t("cmuxCommand")} copied={t("copied")} />
+      </div>
+    </div>
+  );
+}
 
-      <ProviderForm
-        title={t("providerCodex")}
-        labelText={t("labelField")}
-        labelPlaceholder={t("labelPlaceholder")}
-        submitLabel={t("addCodex")}
-        status={statuses.codex}
-        onSubmit={submitCodex}
-      >
-        <JsonField
-          label={t("oauthJsonField")}
-          placeholder={CODEX_JSON_PLACEHOLDER}
-        />
-      </ProviderForm>
-
-      <ProviderForm
-        title={t("providerOpenAiApiKey")}
-        labelText={t("labelField")}
-        labelPlaceholder={t("labelPlaceholder")}
-        submitLabel={t("addOpenAi")}
-        status={statuses.openai}
-        onSubmit={submitOpenAi}
-      >
-        <SecretField
-          name="apiKey"
-          label={t("apiKeyField")}
-          placeholder={t("openAiKeyPlaceholder")}
-        />
-      </ProviderForm>
+function CommandRow({ command, label, copied }: { command: string; label: string; copied: string }) {
+  return (
+    <div className="flex items-center justify-between gap-3 border border-border px-3 py-2">
+      <code className="text-xs text-foreground">{command}</code>
+      <CopyButton value={command} label={label} copiedLabel={copied} />
     </div>
   );
 }
@@ -219,104 +108,6 @@ export function DeleteAiAccountButton({
   );
 }
 
-function ProviderForm({
-  title,
-  labelText,
-  labelPlaceholder,
-  submitLabel,
-  status,
-  onSubmit,
-  children,
-}: {
-  title: string;
-  labelText: string;
-  labelPlaceholder: string;
-  submitLabel: string;
-  status: FormStatus;
-  onSubmit: (event: FormEvent<HTMLFormElement>) => void;
-  children: ReactNode;
-}) {
-  return (
-    <form onSubmit={onSubmit} className="border border-border p-3">
-      <h3 className="text-sm font-medium">{title}</h3>
-      <label className="mt-3 block text-xs text-muted">
-        {labelText}
-        <input
-          name="label"
-          className="mt-1 w-full border border-border bg-background px-3 py-1.5 text-sm text-foreground outline-none transition-colors focus:border-foreground"
-          placeholder={labelPlaceholder}
-        />
-      </label>
-      {children}
-      <button
-        type="submit"
-        disabled={status.state === "submitting"}
-        className="mt-3 w-full border border-foreground bg-foreground px-3 py-1.5 text-sm text-background transition-colors hover:bg-background hover:text-foreground focus-visible:outline focus-visible:outline-1 focus-visible:outline-foreground disabled:cursor-not-allowed disabled:opacity-60"
-      >
-        {submitLabel}
-      </button>
-      {status.state === "success" && status.message ? (
-        <div className="mt-2 text-xs text-foreground">{status.message}</div>
-      ) : null}
-      {status.state === "error" && status.message ? (
-        <div className="mt-2 text-xs text-foreground">{status.message}</div>
-      ) : null}
-    </form>
-  );
-}
-
-function JsonField({ label, placeholder }: { label: string; placeholder: string }) {
-  return (
-    <label className="mt-3 block text-xs text-muted">
-      {label}
-      <textarea
-        name="oauthJson"
-        required
-        rows={5}
-        className="mt-1 w-full resize-y border border-border bg-background px-3 py-1.5 font-mono text-xs text-foreground outline-none transition-colors focus:border-foreground"
-        placeholder={placeholder}
-      />
-    </label>
-  );
-}
-
-function SecretField({
-  name,
-  label,
-  placeholder,
-}: {
-  name: string;
-  label: string;
-  placeholder: string;
-}) {
-  return (
-    <label className="mt-3 block text-xs text-muted">
-      {label}
-      <input
-        name={name}
-        type="password"
-        required
-        className="mt-1 w-full border border-border bg-background px-3 py-1.5 text-sm text-foreground outline-none transition-colors focus:border-foreground"
-        placeholder={placeholder}
-      />
-    </label>
-  );
-}
-
-function labelValue(data: FormData): string | undefined {
-  const value = String(data.get("label") ?? "").trim();
-  return value ? value : undefined;
-}
-
-function parseJsonObject(value: string): Record<string, unknown> | null {
-  try {
-    const parsed = JSON.parse(value);
-    return isRecord(parsed) ? parsed : null;
-  } catch {
-    return null;
-  }
-}
-
 function errorMessageForStatus(
   status: number,
   t: ReturnType<typeof useTranslations<"dashboard.aiAccounts">>,
@@ -326,8 +117,4 @@ function errorMessageForStatus(
   if (status === 403) return t("teamAccessError");
   if (status === 503) return t("notConfiguredTitle");
   return fallback;
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return value !== null && typeof value === "object" && !Array.isArray(value);
 }

--- a/web/app/handler/[...stack]/page.tsx
+++ b/web/app/handler/[...stack]/page.tsx
@@ -7,6 +7,14 @@ import { stackServerApp } from "../../lib/stack";
 // Keep authentication reliable instead of withholding it behind an empty
 // instant-navigation boundary.
 export const instant = false;
+// CLI auth confirmation consumes a one-time query parameter. Do not cache an
+// empty handler shell before Stack can read that parameter.
+export const dynamic = "force-dynamic";
+export const revalidate = 0;
+// CLI auth confirmation consumes a one-time query parameter. Static
+// prerendering would cache an empty handler shell and drop that parameter.
+export const dynamic = "force-dynamic";
+export const revalidate = 0;
 
 export default async function StackHandlerPage(
   props: { params: Promise<{ stack: string[] }> },

--- a/web/messages/ar.json
+++ b/web/messages/ar.json
@@ -211,7 +211,11 @@
       "claudeJsonPlaceholder": "{\"accessToken\":\"...\",\"refreshToken\":\"...\",\"expiresAt\":1770000000000}",
       "codexJsonPlaceholder": "{\"accessToken\":\"...\",\"refreshToken\":\"...\",\"idToken\":\"...\",\"accountID\":\"...\"}",
       "anthropicKeyPlaceholder": "sk-ant-...",
-      "openAiKeyPlaceholder": "sk-..."
+      "openAiKeyPlaceholder": "sk-...",
+      "cliAddBody": "Add provider accounts securely from your terminal. Sign in with your team, then run one of these commands:",
+      "npxCommand": "Copy npx command",
+      "cmuxCommand": "Copy cmux command",
+      "copied": "Copied"
     },
     "billing": {
       "plan": {

--- a/web/messages/bs.json
+++ b/web/messages/bs.json
@@ -211,7 +211,11 @@
       "claudeJsonPlaceholder": "{\"accessToken\":\"...\",\"refreshToken\":\"...\",\"expiresAt\":1770000000000}",
       "codexJsonPlaceholder": "{\"accessToken\":\"...\",\"refreshToken\":\"...\",\"idToken\":\"...\",\"accountID\":\"...\"}",
       "anthropicKeyPlaceholder": "sk-ant-...",
-      "openAiKeyPlaceholder": "sk-..."
+      "openAiKeyPlaceholder": "sk-...",
+      "cliAddBody": "Add provider accounts securely from your terminal. Sign in with your team, then run one of these commands:",
+      "npxCommand": "Copy npx command",
+      "cmuxCommand": "Copy cmux command",
+      "copied": "Copied"
     },
     "billing": {
       "plan": {

--- a/web/messages/da.json
+++ b/web/messages/da.json
@@ -211,7 +211,11 @@
       "claudeJsonPlaceholder": "{\"accessToken\":\"...\",\"refreshToken\":\"...\",\"expiresAt\":1770000000000}",
       "codexJsonPlaceholder": "{\"accessToken\":\"...\",\"refreshToken\":\"...\",\"idToken\":\"...\",\"accountID\":\"...\"}",
       "anthropicKeyPlaceholder": "sk-ant-...",
-      "openAiKeyPlaceholder": "sk-..."
+      "openAiKeyPlaceholder": "sk-...",
+      "cliAddBody": "Add provider accounts securely from your terminal. Sign in with your team, then run one of these commands:",
+      "npxCommand": "Copy npx command",
+      "cmuxCommand": "Copy cmux command",
+      "copied": "Copied"
     },
     "billing": {
       "plan": {

--- a/web/messages/de.json
+++ b/web/messages/de.json
@@ -211,7 +211,11 @@
       "claudeJsonPlaceholder": "{\"accessToken\":\"...\",\"refreshToken\":\"...\",\"expiresAt\":1770000000000}",
       "codexJsonPlaceholder": "{\"accessToken\":\"...\",\"refreshToken\":\"...\",\"idToken\":\"...\",\"accountID\":\"...\"}",
       "anthropicKeyPlaceholder": "sk-ant-...",
-      "openAiKeyPlaceholder": "sk-..."
+      "openAiKeyPlaceholder": "sk-...",
+      "cliAddBody": "Add provider accounts securely from your terminal. Sign in with your team, then run one of these commands:",
+      "npxCommand": "Copy npx command",
+      "cmuxCommand": "Copy cmux command",
+      "copied": "Copied"
     },
     "billing": {
       "plan": {

--- a/web/messages/en.json
+++ b/web/messages/en.json
@@ -290,7 +290,11 @@
       "deleteConfirmBody": "This removes the provider account for the whole team. Adding it back requires the original credentials.",
       "cancelAction": "Cancel",
       "anthropicKeyPlaceholder": "sk-ant-...",
-      "openAiKeyPlaceholder": "sk-..."
+      "openAiKeyPlaceholder": "sk-...",
+      "cliAddBody": "Add provider accounts securely from your terminal. Sign in with your team, then run one of these commands:",
+      "npxCommand": "Copy npx command",
+      "cmuxCommand": "Copy cmux command",
+      "copied": "Copied"
     }
   },
   "vault": {
@@ -1263,13 +1267,13 @@
         "p1": "Different workloads want different forms of parallelism. Worktrees suit ordinary Git changes. Multiple checkouts help when submodules or build tools dislike worktrees. E2B, Freestyle, Daytona, and Modal provide remote sandboxes, while GitHub Actions can be pressed into the same role. Docker, UTM, Lima, and OrbStack cover local isolation. Some teams use Mac minis or Linux boxes. ML experiments often belong on Ray, Modal, or Slurm. Sometimes the fastest answer is to yolo everything on main.",
         "p2": "A useful manager should choose among these execution models from the task context. This follows the <zen>Zen of cmux</zen>: keep the primitive composable, then let project rules decide how to use it.",
         "superRepoTitle": "A superrepo is project headquarters",
-      "superRepoP1": "I want to call this control repo a superrepo. In the context of coding agents, a superrepo sits above one or more source repositories and holds the data, skills, origins, worktrees, and operating rules that turn a prompt into an isolated task environment.",
-      "superRepoP2": "The <code>AGENTS.md</code> file is the control plane. It names the repositories an agent may need, defines where each task worktree belongs, and points to per-repo setup instructions. One task can create matching worktrees for a terminal, browser integration, and router without cloning all three for every task.",
-      "agentsExample": "You are working in cmux-hq. Tasks may involve:\n- manaflow-ai/cmux\n- manaflow-ai/cmux-browser\n- manaflow-ai/coderouter\n\nWhen the user asks for a new task:\n1. Decide which repositories the task needs.\n2. Create matching worktrees in worktrees/[task]/[repo].\n3. Read each worktree's AGENTS.md.\n4. Start its setup scripts immediately, then continue the task.",
-      "agentTitle": "Let the agent choose the topology",
-      "agentP1": "cmux uses this pattern internally. The public source lives in <cmux>manaflow-ai/cmux</cmux>, while our private control repo is <hq>manaflow-ai/cmuxterm-hq</hq>. From the hq root, we can ask Codex or Claude Code to fix a CodeRouter problem that may touch cmux. The agent creates only the worktrees it needs, reads each repository's AGENTS.md, starts its setup scripts, and begins inspecting code while those scripts run.",
-      "launchCommand": "cd ~/fun/cmux-hq\ncodex --yolo \"fix CodeRouter xyz issues, might relate to cmux in xyz way\"",
-      "agentP2": "A <code>./scripts/new-worktree.sh</code> command implements one topology. An agent can choose a second checkout for incompatible submodules, a remote sandbox for untrusted setup, a VM for another operating system, or a GPU scheduler for experiments, then reuse scripts for the deterministic pieces.",
+        "superRepoP1": "I want to call this control repo a superrepo. In the context of coding agents, a superrepo sits above one or more source repositories and holds the data, skills, origins, worktrees, and operating rules that turn a prompt into an isolated task environment.",
+        "superRepoP2": "The <code>AGENTS.md</code> file is the control plane. It names the repositories an agent may need, defines where each task worktree belongs, and points to per-repo setup instructions. One task can create matching worktrees for a terminal, browser integration, and router without cloning all three for every task.",
+        "agentsExample": "You are working in cmux-hq. Tasks may involve:\n- manaflow-ai/cmux\n- manaflow-ai/cmux-browser\n- manaflow-ai/coderouter\n\nWhen the user asks for a new task:\n1. Decide which repositories the task needs.\n2. Create matching worktrees in worktrees/[task]/[repo].\n3. Read each worktree's AGENTS.md.\n4. Start its setup scripts immediately, then continue the task.",
+        "agentTitle": "Let the agent choose the topology",
+        "agentP1": "cmux uses this pattern internally. The public source lives in <cmux>manaflow-ai/cmux</cmux>, while our private control repo is <hq>manaflow-ai/cmuxterm-hq</hq>. From the hq root, we can ask Codex or Claude Code to fix a CodeRouter problem that may touch cmux. The agent creates only the worktrees it needs, reads each repository's AGENTS.md, starts its setup scripts, and begins inspecting code while those scripts run.",
+        "launchCommand": "cd ~/fun/cmux-hq\ncodex --yolo \"fix CodeRouter xyz issues, might relate to cmux in xyz way\"",
+        "agentP2": "A <code>./scripts/new-worktree.sh</code> command implements one topology. An agent can choose a second checkout for incompatible submodules, a remote sandbox for untrusted setup, a VM for another operating system, or a GPU scheduler for experiments, then reuse scripts for the deterministic pieces.",
         "limitsTitle": "Why this changes the clock time",
         "limitsP1": "Worktrees are only half the parallelism story for many projects. In ML, one coding agent can write several experiments in one worktree while a scheduler fans the runs out across GPUs. Creating more worktrees would add coordination without adding compute.",
         "limitsP2": "Agent orchestration can also shorten startup. The agent can read and edit code as soon as the checkout exists while dependency installs, builds, and local services continue in the background. A wrapper that finishes every setup step before starting the agent puts the slowest prerequisite on the critical path.",

--- a/web/messages/es.json
+++ b/web/messages/es.json
@@ -211,7 +211,11 @@
       "claudeJsonPlaceholder": "{\"accessToken\":\"...\",\"refreshToken\":\"...\",\"expiresAt\":1770000000000}",
       "codexJsonPlaceholder": "{\"accessToken\":\"...\",\"refreshToken\":\"...\",\"idToken\":\"...\",\"accountID\":\"...\"}",
       "anthropicKeyPlaceholder": "sk-ant-...",
-      "openAiKeyPlaceholder": "sk-..."
+      "openAiKeyPlaceholder": "sk-...",
+      "cliAddBody": "Add provider accounts securely from your terminal. Sign in with your team, then run one of these commands:",
+      "npxCommand": "Copy npx command",
+      "cmuxCommand": "Copy cmux command",
+      "copied": "Copied"
     },
     "billing": {
       "plan": {

--- a/web/messages/fr.json
+++ b/web/messages/fr.json
@@ -211,7 +211,11 @@
       "claudeJsonPlaceholder": "{\"accessToken\":\"...\",\"refreshToken\":\"...\",\"expiresAt\":1770000000000}",
       "codexJsonPlaceholder": "{\"accessToken\":\"...\",\"refreshToken\":\"...\",\"idToken\":\"...\",\"accountID\":\"...\"}",
       "anthropicKeyPlaceholder": "sk-ant-...",
-      "openAiKeyPlaceholder": "sk-..."
+      "openAiKeyPlaceholder": "sk-...",
+      "cliAddBody": "Add provider accounts securely from your terminal. Sign in with your team, then run one of these commands:",
+      "npxCommand": "Copy npx command",
+      "cmuxCommand": "Copy cmux command",
+      "copied": "Copied"
     },
     "billing": {
       "plan": {

--- a/web/messages/it.json
+++ b/web/messages/it.json
@@ -211,7 +211,11 @@
       "claudeJsonPlaceholder": "{\"accessToken\":\"...\",\"refreshToken\":\"...\",\"expiresAt\":1770000000000}",
       "codexJsonPlaceholder": "{\"accessToken\":\"...\",\"refreshToken\":\"...\",\"idToken\":\"...\",\"accountID\":\"...\"}",
       "anthropicKeyPlaceholder": "sk-ant-...",
-      "openAiKeyPlaceholder": "sk-..."
+      "openAiKeyPlaceholder": "sk-...",
+      "cliAddBody": "Add provider accounts securely from your terminal. Sign in with your team, then run one of these commands:",
+      "npxCommand": "Copy npx command",
+      "cmuxCommand": "Copy cmux command",
+      "copied": "Copied"
     },
     "billing": {
       "plan": {

--- a/web/messages/ja.json
+++ b/web/messages/ja.json
@@ -290,7 +290,11 @@
       "deleteConfirmBody": "チーム全体からこのプロバイダーアカウントが削除されます。再追加には元の認証情報が必要です。",
       "cancelAction": "キャンセル",
       "anthropicKeyPlaceholder": "sk-ant-...",
-      "openAiKeyPlaceholder": "sk-..."
+      "openAiKeyPlaceholder": "sk-...",
+      "cliAddBody": "Add provider accounts securely from your terminal. Sign in with your team, then run one of these commands:",
+      "npxCommand": "Copy npx command",
+      "cmuxCommand": "Copy cmux command",
+      "copied": "Copied"
     }
   },
   "vault": {
@@ -1044,13 +1048,13 @@
         "p1": "ワークロードごとに適した並列化の方法は異なります。通常のGit変更にはワークツリーが向いています。サブモジュールやビルドツールがワークツリーを扱いにくい場合は、複数のチェックアウトが役立ちます。E2B、Freestyle、Daytona、Modalはリモートサンドボックスを提供し、GitHub Actionsも同じ用途に転用できます。ローカルの分離にはDocker、UTM、Lima、OrbStackがあります。Mac miniやLinuxマシンを並べるチームもあります。ML実験にはRay、Modal、Slurmが適しています。mainですべてを一気に進めるのが最速な場合もあります。",
         "p2": "役に立つマネージャーは、タスクの文脈からこれらの実行方式を選ぶべきです。これは<zen>cmuxの禅</zen>に沿っています。プリミティブを組み合わせ可能なままにして、使い方はプロジェクトのルールに決めさせます。",
         "superRepoTitle": "スーパーリポはプロジェクトの司令部",
-      "superRepoP1": "この制御用リポジトリをスーパーリポと呼びたいと思います。コーディングエージェントにとって、スーパーリポは一つ以上のソースリポジトリの上位にあり、プロンプトを分離されたタスク環境へ変換するためのデータ、スキル、origin、ワークツリー、運用ルールを保持します。",
-      "superRepoP2": "<code>AGENTS.md</code>が制御プレーンです。エージェントが必要とする可能性のあるリポジトリ、各タスクのワークツリーを置く場所、リポジトリごとのセットアップ手順を定義します。一つのタスクでターミナル、ブラウザ連携、ルーター用の対応するワークツリーを作れますが、すべてのタスクで三つとも複製する必要はありません。",
-      "agentsExample": "cmux-hqで作業しています。タスクには次のリポジトリが関係する場合があります：\n- manaflow-ai/cmux\n- manaflow-ai/cmux-browser\n- manaflow-ai/coderouter\n\nユーザーが新しいタスクを依頼したとき：\n1. タスクに必要なリポジトリを判断します。\n2. worktrees/[task]/[repo]に対応するワークツリーを作成します。\n3. 各ワークツリーのAGENTS.mdを読みます。\n4. セットアップスクリプトをすぐに起動し、タスクを続けます。",
-      "agentTitle": "トポロジーをエージェントに選ばせる",
-      "agentP1": "cmuxではこのパターンを社内で使っています。公開ソースは<cmux>manaflow-ai/cmux</cmux>にあり、非公開の制御用リポジトリは<hq>manaflow-ai/cmuxterm-hq</hq>です。hqのルートから、cmuxにも関係する可能性があるCodeRouterの問題をCodexやClaude Codeに依頼できます。エージェントは必要なワークツリーだけを作り、各リポジトリのAGENTS.mdを読み、セットアップスクリプトを起動し、その実行中にコードの調査を始めます。",
-      "launchCommand": "cd ~/fun/cmux-hq\ncodex --yolo \"CodeRouterのxyz問題を修正して。cmuxのxyzにも関係する可能性あり\"",
-      "agentP2": "<code>./scripts/new-worktree.sh</code>は一つのトポロジーを実装します。エージェントなら、互換性のないサブモジュールには別チェックアウト、信頼できないセットアップにはリモートサンドボックス、別OSにはVM、実験にはGPUスケジューラを選び、決定的な処理には既存のスクリプトを再利用できます。",
+        "superRepoP1": "この制御用リポジトリをスーパーリポと呼びたいと思います。コーディングエージェントにとって、スーパーリポは一つ以上のソースリポジトリの上位にあり、プロンプトを分離されたタスク環境へ変換するためのデータ、スキル、origin、ワークツリー、運用ルールを保持します。",
+        "superRepoP2": "<code>AGENTS.md</code>が制御プレーンです。エージェントが必要とする可能性のあるリポジトリ、各タスクのワークツリーを置く場所、リポジトリごとのセットアップ手順を定義します。一つのタスクでターミナル、ブラウザ連携、ルーター用の対応するワークツリーを作れますが、すべてのタスクで三つとも複製する必要はありません。",
+        "agentsExample": "cmux-hqで作業しています。タスクには次のリポジトリが関係する場合があります：\n- manaflow-ai/cmux\n- manaflow-ai/cmux-browser\n- manaflow-ai/coderouter\n\nユーザーが新しいタスクを依頼したとき：\n1. タスクに必要なリポジトリを判断します。\n2. worktrees/[task]/[repo]に対応するワークツリーを作成します。\n3. 各ワークツリーのAGENTS.mdを読みます。\n4. セットアップスクリプトをすぐに起動し、タスクを続けます。",
+        "agentTitle": "トポロジーをエージェントに選ばせる",
+        "agentP1": "cmuxではこのパターンを社内で使っています。公開ソースは<cmux>manaflow-ai/cmux</cmux>にあり、非公開の制御用リポジトリは<hq>manaflow-ai/cmuxterm-hq</hq>です。hqのルートから、cmuxにも関係する可能性があるCodeRouterの問題をCodexやClaude Codeに依頼できます。エージェントは必要なワークツリーだけを作り、各リポジトリのAGENTS.mdを読み、セットアップスクリプトを起動し、その実行中にコードの調査を始めます。",
+        "launchCommand": "cd ~/fun/cmux-hq\ncodex --yolo \"CodeRouterのxyz問題を修正して。cmuxのxyzにも関係する可能性あり\"",
+        "agentP2": "<code>./scripts/new-worktree.sh</code>は一つのトポロジーを実装します。エージェントなら、互換性のないサブモジュールには別チェックアウト、信頼できないセットアップにはリモートサンドボックス、別OSにはVM、実験にはGPUスケジューラを選び、決定的な処理には既存のスクリプトを再利用できます。",
         "limitsTitle": "完了までの時間が短くなる理由",
         "limitsP1": "多くのプロジェクトでは、ワークツリーは並列化の一部にすぎません。MLでは、一つのコーディングエージェントが一つのワークツリーで複数の実験を書き、スケジューラが実行を複数のGPUへ配布できます。ワークツリーを増やしても計算資源は増えず、調整だけが増えます。",
         "limitsP2": "エージェントによるオーケストレーションは起動時間も短縮できます。チェックアウトができた時点でエージェントはコードを読み書きし、依存関係のインストール、ビルド、ローカルサービスの起動はバックグラウンドで続けられます。すべてのセットアップ完了後にエージェントを起動するラッパーでは、最も遅い前提処理がクリティカルパスに入ります。",

--- a/web/messages/km.json
+++ b/web/messages/km.json
@@ -211,7 +211,11 @@
       "claudeJsonPlaceholder": "{\"accessToken\":\"...\",\"refreshToken\":\"...\",\"expiresAt\":1770000000000}",
       "codexJsonPlaceholder": "{\"accessToken\":\"...\",\"refreshToken\":\"...\",\"idToken\":\"...\",\"accountID\":\"...\"}",
       "anthropicKeyPlaceholder": "sk-ant-...",
-      "openAiKeyPlaceholder": "sk-..."
+      "openAiKeyPlaceholder": "sk-...",
+      "cliAddBody": "Add provider accounts securely from your terminal. Sign in with your team, then run one of these commands:",
+      "npxCommand": "Copy npx command",
+      "cmuxCommand": "Copy cmux command",
+      "copied": "Copied"
     },
     "billing": {
       "plan": {

--- a/web/messages/ko.json
+++ b/web/messages/ko.json
@@ -211,7 +211,11 @@
       "claudeJsonPlaceholder": "{\"accessToken\":\"...\",\"refreshToken\":\"...\",\"expiresAt\":1770000000000}",
       "codexJsonPlaceholder": "{\"accessToken\":\"...\",\"refreshToken\":\"...\",\"idToken\":\"...\",\"accountID\":\"...\"}",
       "anthropicKeyPlaceholder": "sk-ant-...",
-      "openAiKeyPlaceholder": "sk-..."
+      "openAiKeyPlaceholder": "sk-...",
+      "cliAddBody": "Add provider accounts securely from your terminal. Sign in with your team, then run one of these commands:",
+      "npxCommand": "Copy npx command",
+      "cmuxCommand": "Copy cmux command",
+      "copied": "Copied"
     },
     "billing": {
       "plan": {

--- a/web/messages/no.json
+++ b/web/messages/no.json
@@ -211,7 +211,11 @@
       "claudeJsonPlaceholder": "{\"accessToken\":\"...\",\"refreshToken\":\"...\",\"expiresAt\":1770000000000}",
       "codexJsonPlaceholder": "{\"accessToken\":\"...\",\"refreshToken\":\"...\",\"idToken\":\"...\",\"accountID\":\"...\"}",
       "anthropicKeyPlaceholder": "sk-ant-...",
-      "openAiKeyPlaceholder": "sk-..."
+      "openAiKeyPlaceholder": "sk-...",
+      "cliAddBody": "Add provider accounts securely from your terminal. Sign in with your team, then run one of these commands:",
+      "npxCommand": "Copy npx command",
+      "cmuxCommand": "Copy cmux command",
+      "copied": "Copied"
     },
     "billing": {
       "plan": {

--- a/web/messages/pl.json
+++ b/web/messages/pl.json
@@ -211,7 +211,11 @@
       "claudeJsonPlaceholder": "{\"accessToken\":\"...\",\"refreshToken\":\"...\",\"expiresAt\":1770000000000}",
       "codexJsonPlaceholder": "{\"accessToken\":\"...\",\"refreshToken\":\"...\",\"idToken\":\"...\",\"accountID\":\"...\"}",
       "anthropicKeyPlaceholder": "sk-ant-...",
-      "openAiKeyPlaceholder": "sk-..."
+      "openAiKeyPlaceholder": "sk-...",
+      "cliAddBody": "Add provider accounts securely from your terminal. Sign in with your team, then run one of these commands:",
+      "npxCommand": "Copy npx command",
+      "cmuxCommand": "Copy cmux command",
+      "copied": "Copied"
     },
     "billing": {
       "plan": {

--- a/web/messages/pt-BR.json
+++ b/web/messages/pt-BR.json
@@ -211,7 +211,11 @@
       "claudeJsonPlaceholder": "{\"accessToken\":\"...\",\"refreshToken\":\"...\",\"expiresAt\":1770000000000}",
       "codexJsonPlaceholder": "{\"accessToken\":\"...\",\"refreshToken\":\"...\",\"idToken\":\"...\",\"accountID\":\"...\"}",
       "anthropicKeyPlaceholder": "sk-ant-...",
-      "openAiKeyPlaceholder": "sk-..."
+      "openAiKeyPlaceholder": "sk-...",
+      "cliAddBody": "Add provider accounts securely from your terminal. Sign in with your team, then run one of these commands:",
+      "npxCommand": "Copy npx command",
+      "cmuxCommand": "Copy cmux command",
+      "copied": "Copied"
     },
     "billing": {
       "plan": {

--- a/web/messages/ru.json
+++ b/web/messages/ru.json
@@ -211,7 +211,11 @@
       "claudeJsonPlaceholder": "{\"accessToken\":\"...\",\"refreshToken\":\"...\",\"expiresAt\":1770000000000}",
       "codexJsonPlaceholder": "{\"accessToken\":\"...\",\"refreshToken\":\"...\",\"idToken\":\"...\",\"accountID\":\"...\"}",
       "anthropicKeyPlaceholder": "sk-ant-...",
-      "openAiKeyPlaceholder": "sk-..."
+      "openAiKeyPlaceholder": "sk-...",
+      "cliAddBody": "Add provider accounts securely from your terminal. Sign in with your team, then run one of these commands:",
+      "npxCommand": "Copy npx command",
+      "cmuxCommand": "Copy cmux command",
+      "copied": "Copied"
     },
     "billing": {
       "plan": {

--- a/web/messages/th.json
+++ b/web/messages/th.json
@@ -211,7 +211,11 @@
       "claudeJsonPlaceholder": "{\"accessToken\":\"...\",\"refreshToken\":\"...\",\"expiresAt\":1770000000000}",
       "codexJsonPlaceholder": "{\"accessToken\":\"...\",\"refreshToken\":\"...\",\"idToken\":\"...\",\"accountID\":\"...\"}",
       "anthropicKeyPlaceholder": "sk-ant-...",
-      "openAiKeyPlaceholder": "sk-..."
+      "openAiKeyPlaceholder": "sk-...",
+      "cliAddBody": "Add provider accounts securely from your terminal. Sign in with your team, then run one of these commands:",
+      "npxCommand": "Copy npx command",
+      "cmuxCommand": "Copy cmux command",
+      "copied": "Copied"
     },
     "billing": {
       "plan": {

--- a/web/messages/tr.json
+++ b/web/messages/tr.json
@@ -211,7 +211,11 @@
       "claudeJsonPlaceholder": "{\"accessToken\":\"...\",\"refreshToken\":\"...\",\"expiresAt\":1770000000000}",
       "codexJsonPlaceholder": "{\"accessToken\":\"...\",\"refreshToken\":\"...\",\"idToken\":\"...\",\"accountID\":\"...\"}",
       "anthropicKeyPlaceholder": "sk-ant-...",
-      "openAiKeyPlaceholder": "sk-..."
+      "openAiKeyPlaceholder": "sk-...",
+      "cliAddBody": "Add provider accounts securely from your terminal. Sign in with your team, then run one of these commands:",
+      "npxCommand": "Copy npx command",
+      "cmuxCommand": "Copy cmux command",
+      "copied": "Copied"
     },
     "billing": {
       "plan": {

--- a/web/messages/uk.json
+++ b/web/messages/uk.json
@@ -211,7 +211,11 @@
       "claudeJsonPlaceholder": "{\"accessToken\":\"...\",\"refreshToken\":\"...\",\"expiresAt\":1770000000000}",
       "codexJsonPlaceholder": "{\"accessToken\":\"...\",\"refreshToken\":\"...\",\"idToken\":\"...\",\"accountID\":\"...\"}",
       "anthropicKeyPlaceholder": "sk-ant-...",
-      "openAiKeyPlaceholder": "sk-..."
+      "openAiKeyPlaceholder": "sk-...",
+      "cliAddBody": "Add provider accounts securely from your terminal. Sign in with your team, then run one of these commands:",
+      "npxCommand": "Copy npx command",
+      "cmuxCommand": "Copy cmux command",
+      "copied": "Copied"
     },
     "billing": {
       "plan": {

--- a/web/messages/zh-CN.json
+++ b/web/messages/zh-CN.json
@@ -211,7 +211,11 @@
       "claudeJsonPlaceholder": "{\"accessToken\":\"...\",\"refreshToken\":\"...\",\"expiresAt\":1770000000000}",
       "codexJsonPlaceholder": "{\"accessToken\":\"...\",\"refreshToken\":\"...\",\"idToken\":\"...\",\"accountID\":\"...\"}",
       "anthropicKeyPlaceholder": "sk-ant-...",
-      "openAiKeyPlaceholder": "sk-..."
+      "openAiKeyPlaceholder": "sk-...",
+      "cliAddBody": "Add provider accounts securely from your terminal. Sign in with your team, then run one of these commands:",
+      "npxCommand": "Copy npx command",
+      "cmuxCommand": "Copy cmux command",
+      "copied": "Copied"
     },
     "billing": {
       "plan": {

--- a/web/messages/zh-TW.json
+++ b/web/messages/zh-TW.json
@@ -211,7 +211,11 @@
       "claudeJsonPlaceholder": "{\"accessToken\":\"...\",\"refreshToken\":\"...\",\"expiresAt\":1770000000000}",
       "codexJsonPlaceholder": "{\"accessToken\":\"...\",\"refreshToken\":\"...\",\"idToken\":\"...\",\"accountID\":\"...\"}",
       "anthropicKeyPlaceholder": "sk-ant-...",
-      "openAiKeyPlaceholder": "sk-..."
+      "openAiKeyPlaceholder": "sk-...",
+      "cliAddBody": "Add provider accounts securely from your terminal. Sign in with your team, then run one of these commands:",
+      "npxCommand": "Copy npx command",
+      "cmuxCommand": "Copy cmux command",
+      "copied": "Copied"
     },
     "billing": {
       "plan": {


### PR DESCRIPTION
Replace browser credential forms with secure CLI instructions for npx coderouter add and cmux coderouter add. Keep account management, team context, and backend APIs unchanged. Add localized copy and copy buttons.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/10095"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789192500&installation_model_id=21920&pr_number=10095&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F10095&signature=4c0594c464c51ad995dfbd664856f909e139433fc5b8feb1f6f087db50e953b9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moves CodeRouter provider account setup in the dashboard to a CLI-first flow to avoid handling credentials in the browser. Old: users pasted API keys/OAuth JSON into dashboard forms. New: users run `npx coderouter add` or `cmux coderouter add`; the handler page renders dynamically to consume one‑time auth parameters.

- Dashboard: replaces AddAiAccountForms with CLI instructions and copy buttons; removes the `teamId` prop at call site.
- Account deletion, team context, and backend APIs remain unchanged.
- Handler: `web/app/handler/[...stack]/page.tsx` is dynamic with `revalidate = 0` to prevent caching one‑time auth query params.
- Adds localized strings and labels for the new CLI copy UI across locales.

**Migration**
- Update any docs or internal guides that reference dashboard credential forms to instruct using the CLI instead.
- No data migration; existing provider accounts continue to work.

<sup>Written for commit ebe97c07b188842e63ebc8a1e332b347642988de. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/10095?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added terminal-based setup instructions for AI provider accounts.
  * Added copyable `npx` and `cmux` commands with copied-state feedback.
  * Added localized account setup guidance across supported languages.
* **Documentation**
  * Updated blog guidance covering repository selection, worktrees, setup scripts, and agent-managed project layouts.
* **Bug Fixes**
  * Improved handler route behavior to preserve one-time CLI authentication parameters and prevent cached empty states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->