### PR TITLE
Harden reconnect route policy and diagnostics

### DIFF
--- a/Packages/Shared/CMUXMobileCore/Sources/CMUXMobileCore/DiagnosticEventCode.swift
+++ b/Packages/Shared/CMUXMobileCore/Sources/CMUXMobileCore/DiagnosticEventCode.swift
@@ -151,12 +151,16 @@ public enum DiagnosticEventCode: UInt16, Sendable, Codable, CaseIterable {
     case routeUnavailable = 42
     /// A bounded retry was scheduled. `ms` is the delay before retry.
     case retryScheduled = 43
-    /// Same-account or local-route discovery started.
+    /// Same-account or local-route discovery started. `a` is
+    /// ``DiagnosticTransportKind``.
     case discoveryStarted = 44
-    /// Discovery produced at least one authenticated candidate.
+    /// Discovery produced an authoritative snapshot. `a` is
+    /// ``DiagnosticTransportKind``, `b` is its binding count, `c` is its
+    /// managed relay-fleet count, and `ms` is the fetch duration.
     case discoverySucceeded = 45
-    /// Discovery failed to produce an authenticated candidate. `b`, when
-    /// present, is ``DiagnosticFailureKind``.
+    /// Discovery failed to produce an authoritative snapshot. `a` is
+    /// ``DiagnosticTransportKind``, `b`, when present, is
+    /// ``DiagnosticFailureKind``, and `ms` is the fetch duration.
     case discoveryFailed = 46
     /// The host admitted the authenticated client to an RPC session.
     case admissionSucceeded = 47
@@ -263,8 +267,9 @@ public enum DiagnosticEventCode: UInt16, Sendable, Codable, CaseIterable {
     // MARK: Iroh bootstrap diagnostics
 
     /// One direct dial plan was assembled before any connect attempt. `a` is
-    /// the public path hint count and `b` is the private fallback path hint
-    /// count. A plan with both counts zero proves no dial packet was sent.
+    /// the public path hint count, `b` is the private fallback path hint
+    /// count, and `c` is the public relay-URL hint count. A plan with both
+    /// counts zero proves no dial packet was sent.
     case transportDialPlanBuilt = 71
     /// Configured private addresses were joined with the target Mac's
     /// broker-registered UDP port for one dial. `a` is the join state

--- a/Packages/Shared/CMUXMobileCore/Sources/CMUXMobileCore/DiagnosticEventPresentation.swift
+++ b/Packages/Shared/CMUXMobileCore/Sources/CMUXMobileCore/DiagnosticEventPresentation.swift
@@ -304,7 +304,8 @@ public struct DiagnosticEventPresentation: Sendable {
                  .transportCloseReason, .transportPathEvent,
                  .transportDialPlanBuilt, .transportPrivateAddressJoin,
                  .transportLANDiscovery, .transportDialLegSucceeded,
-                 .transportDialLegFailed:
+                 .transportDialLegFailed, .discoveryStarted,
+                 .discoverySucceeded, .discoveryFailed:
                 key = "peer"
             default:
                 key = "surface"
@@ -625,6 +626,8 @@ public struct DiagnosticEventPresentation: Sendable {
             return Field(key: "outcome", value: browserFocusOutcomeName(raw))
         case .transportDialPlanBuilt:
             return Field(key: "private_fallback_paths", value: String(raw))
+        case .discoverySucceeded:
+            return Field(key: "bindings", value: String(raw))
         case .transportPrivateAddressJoin:
             return Field(key: "configured_addresses", value: String(raw))
         case .transportLANDiscovery:
@@ -668,6 +671,10 @@ public struct DiagnosticEventPresentation: Sendable {
 
     private func decodeC(_ raw: Int, event: DiagnosticEvent) -> Field {
         switch event.code {
+        case .transportDialPlanBuilt:
+            return Field(key: "public_relay_urls", value: String(raw))
+        case .discoverySucceeded:
+            return Field(key: "relay_fleet", value: String(raw))
         case .transportDialStarted, .transportDialConnected, .transportDialFailed:
             return Field(key: "attempt", value: String(raw))
         case .transportDialSessionLinked:

--- a/Packages/Shared/CMUXMobileCore/Tests/CMUXMobileCoreTests/DiagnosticEventPresentationTests.swift
+++ b/Packages/Shared/CMUXMobileCore/Tests/CMUXMobileCoreTests/DiagnosticEventPresentationTests.swift
@@ -38,12 +38,34 @@ import Testing
 
     @Test func describesDirectDialBootstrapTrace() {
         let plan = englishPresentation.describe(
-            DiagnosticEvent(code: .transportDialPlanBuilt, tNanos: 1, a: 0, b: 0)
+            DiagnosticEvent(
+                code: .transportDialPlanBuilt,
+                tNanos: 1,
+                a: 2,
+                b: 0,
+                c: 1
+            )
         )
         #expect(plan.name == "Direct dial plan assembled")
         #expect(plan.fields == [
-            .init(key: "public_paths", value: "0"),
+            .init(key: "public_paths", value: "2"),
             .init(key: "private_fallback_paths", value: "0"),
+            .init(key: "public_relay_urls", value: "1"),
+        ])
+
+        let discovery = englishPresentation.describe(DiagnosticEvent(
+            code: .discoverySucceeded,
+            tNanos: 1,
+            ms: 340,
+            a: DiagnosticTransportKind.iroh.rawValue,
+            b: 2,
+            c: 3
+        ))
+        #expect(discovery.fields == [
+            .init(key: "transport", value: "Iroh"),
+            .init(key: "bindings", value: "2"),
+            .init(key: "duration", value: "340 ms"),
+            .init(key: "relay_fleet", value: "3"),
         ])
 
         let join = englishPresentation.describe(DiagnosticEvent(

--- a/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohClientSession.swift
+++ b/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohClientSession.swift
@@ -6,6 +6,11 @@ public actor CmxIrohClientSession {
     public typealias PrivateFallbackContextProvider = @Sendable () async throws -> CmxIrohClientContext
 
     private let endpoint: any CmxIrohEndpoint
+    /// Bound on each public or private dial phase. A path that never answers
+    /// must hand control back to discovery and recovery; otherwise a blocked
+    /// firewall path can hold the whole reconnect owner until its larger outer
+    /// deadline.
+    private let dialPhaseTimeout: Duration
     private let targetIdentity: CmxIrohPeerIdentity
     private let dialPlan: CmxIrohDialPlan
     private let credential: CmxIrohAdmissionCredential
@@ -36,6 +41,8 @@ public actor CmxIrohClientSession {
     ///     the plan's private hints.
     ///   - privateFallbackValidator: The provider that can re-read current
     ///     network state immediately before a private dial.
+    ///   - dialPhaseTimeout: Maximum time allowed for each public or private
+    ///     endpoint dial before the next recovery phase is considered.
     ///   - protocolConfiguration: The ALPN and stream-header limit.
     /// - Throws: A stream-codec configuration error.
     public init(
@@ -46,6 +53,7 @@ public actor CmxIrohClientSession {
         privateFallbackAuthorization: CmxIrohPrivateFallbackAuthorization? = nil,
         privateFallbackValidator: (any CmxIrohPrivateFallbackValidating)? = nil,
         privateFallbackContextProvider: PrivateFallbackContextProvider? = nil,
+        dialPhaseTimeout: Duration = .seconds(5),
         protocolConfiguration: CmxIrohProtocolConfiguration = .cmuxMobileV1,
         diagnostics: DiagnosticLog? = nil
     ) throws {
@@ -56,6 +64,7 @@ public actor CmxIrohClientSession {
         self.privateFallbackAuthorization = privateFallbackAuthorization
         self.privateFallbackValidator = privateFallbackValidator
         self.privateFallbackContextProvider = privateFallbackContextProvider
+        self.dialPhaseTimeout = dialPhaseTimeout
         self.protocolConfiguration = protocolConfiguration
         self.diagnostics = diagnostics
         self.peerAlias = DiagnosticCorrelation().handle(for: targetIdentity.endpointID)
@@ -290,26 +299,33 @@ public actor CmxIrohClientSession {
             .transportDialPlanBuilt,
             surface: peerAlias,
             a: dialPlan.publicPaths.count,
-            b: dialPlan.privateFallbackPaths.count
+            b: dialPlan.privateFallbackPaths.count,
+            c: dialPlan.publicPaths.reduce(into: 0) { count, hint in
+                if hint.kind == .relayURL {
+                    count += 1
+                }
+            }
         ))
         if !dialPlan.publicPaths.isEmpty {
+            let phaseStartedAt = DispatchTime.now().uptimeNanoseconds
             do {
-                establishedConnection = try await endpoint.connect(
+                establishedConnection = try await connectBounded(
                     to: CmxIrohEndpointAddress(
                         identity: targetIdentity,
                         pathHints: dialPlan.publicPaths
-                    ),
-                    alpn: protocolConfiguration.alpn
+                    )
                 )
                 diagnostics?.record(DiagnosticEvent(
                     .transportDialLegSucceeded,
                     surface: peerAlias,
+                    ms: elapsedMilliseconds(since: phaseStartedAt),
                     a: DiagnosticDirectDialLeg.publicPaths.rawValue
                 ))
             } catch {
                 diagnostics?.record(DiagnosticEvent(
                     .transportDialLegFailed,
                     surface: peerAlias,
+                    ms: elapsedMilliseconds(since: phaseStartedAt),
                     a: DiagnosticDirectDialLeg.publicPaths.rawValue,
                     b: DiagnosticFailureKind.classify(error).rawValue
                 ))
@@ -318,19 +334,31 @@ public actor CmxIrohClientSession {
             }
         }
         if establishedConnection == nil {
+            let phaseStartedAt = DispatchTime.now().uptimeNanoseconds
             let fallbackContext: CmxIrohClientContext
-            if let privateFallbackContextProvider {
-                fallbackContext = try await privateFallbackContextProvider()
-                guard fallbackContext.credential == credential,
-                      fallbackContext.dialPlan.publicPaths == dialPlan.publicPaths else {
-                    throw CmxIrohPrivateFallbackValidationError.authorizationMismatch
+            do {
+                if let privateFallbackContextProvider {
+                    fallbackContext = try await privateFallbackContextProvider()
+                    guard fallbackContext.credential == credential,
+                          fallbackContext.dialPlan.publicPaths == dialPlan.publicPaths else {
+                        throw CmxIrohPrivateFallbackValidationError.authorizationMismatch
+                    }
+                } else {
+                    fallbackContext = CmxIrohClientContext(
+                        dialPlan: dialPlan,
+                        credential: credential,
+                        privateFallbackAuthorization: privateFallbackAuthorization
+                    )
                 }
-            } else {
-                fallbackContext = CmxIrohClientContext(
-                    dialPlan: dialPlan,
-                    credential: credential,
-                    privateFallbackAuthorization: privateFallbackAuthorization
-                )
+            } catch {
+                diagnostics?.record(DiagnosticEvent(
+                    .transportDialLegFailed,
+                    surface: peerAlias,
+                    ms: elapsedMilliseconds(since: phaseStartedAt),
+                    a: DiagnosticDirectDialLeg.privateFallback.rawValue,
+                    b: DiagnosticFailureKind.classify(error).rawValue
+                ))
+                throw error
             }
             let fallbackPaths = fallbackContext.dialPlan.privateFallbackPaths
             guard !fallbackPaths.isEmpty else {
@@ -339,6 +367,7 @@ public actor CmxIrohClientSession {
                 diagnostics?.record(DiagnosticEvent(
                     .transportDialLegFailed,
                     surface: peerAlias,
+                    ms: elapsedMilliseconds(since: phaseStartedAt),
                     a: DiagnosticDirectDialLeg.privateFallback.rawValue,
                     b: DiagnosticFailureKind.noRoute.rawValue
                 ))
@@ -346,33 +375,49 @@ public actor CmxIrohClientSession {
                 throw CmxIrohRegistryContextError.dialPlanUnavailable
             }
             guard let privateFallbackValidator else {
+                diagnostics?.record(DiagnosticEvent(
+                    .transportDialLegFailed,
+                    surface: peerAlias,
+                    ms: elapsedMilliseconds(since: phaseStartedAt),
+                    a: DiagnosticDirectDialLeg.privateFallback.rawValue,
+                    b: DiagnosticFailureKind.noRoute.rawValue
+                ))
                 throw CmxIrohPrivateFallbackValidationError.unavailable
             }
             guard let authorization = fallbackContext.privateFallbackAuthorization,
                   authorization.pathHints == fallbackPaths else {
-                throw CmxIrohPrivateFallbackValidationError.authorizationMismatch
+                let error = CmxIrohPrivateFallbackValidationError.authorizationMismatch
+                diagnostics?.record(DiagnosticEvent(
+                    .transportDialLegFailed,
+                    surface: peerAlias,
+                    ms: elapsedMilliseconds(since: phaseStartedAt),
+                    a: DiagnosticDirectDialLeg.privateFallback.rawValue,
+                    b: DiagnosticFailureKind.classify(error).rawValue
+                ))
+                throw error
             }
-            try await privateFallbackValidator.validatePrivateFallback(
-                authorization
-            )
-            try Task.checkCancellation()
             do {
-                establishedConnection = try await endpoint.connect(
+                try await privateFallbackValidator.validatePrivateFallback(
+                    authorization
+                )
+                try Task.checkCancellation()
+                establishedConnection = try await connectBounded(
                     to: CmxIrohEndpointAddress(
                         identity: targetIdentity,
                         pathHints: fallbackPaths
-                    ),
-                    alpn: protocolConfiguration.alpn
+                    )
                 )
                 diagnostics?.record(DiagnosticEvent(
                     .transportDialLegSucceeded,
                     surface: peerAlias,
+                    ms: elapsedMilliseconds(since: phaseStartedAt),
                     a: DiagnosticDirectDialLeg.privateFallback.rawValue
                 ))
             } catch {
                 diagnostics?.record(DiagnosticEvent(
                     .transportDialLegFailed,
                     surface: peerAlias,
+                    ms: elapsedMilliseconds(since: phaseStartedAt),
                     a: DiagnosticDirectDialLeg.privateFallback.rawValue,
                     b: DiagnosticFailureKind.classify(error).rawValue
                 ))
@@ -435,6 +480,39 @@ public actor CmxIrohClientSession {
         } catch {
             await establishedConnection.close(errorCode: 1, reason: "admission_failed")
             throw error
+        }
+    }
+
+    private func elapsedMilliseconds(since start: UInt64) -> UInt32 {
+        let now = DispatchTime.now().uptimeNanoseconds
+        let elapsed = now >= start ? now - start : 0
+        return UInt32(clamping: elapsed / 1_000_000)
+    }
+
+    /// Runs one endpoint dial with a bounded phase deadline. The endpoint
+    /// implementation owns cancellation of its native attempt; the task-group
+    /// race ensures a stale path cannot monopolize the session actor.
+    private func connectBounded(
+        to address: CmxIrohEndpointAddress
+    ) async throws -> any CmxIrohConnection {
+        let endpoint = endpoint
+        let alpn = protocolConfiguration.alpn
+        let bound = dialPhaseTimeout
+        return try await withThrowingTaskGroup(
+            of: (any CmxIrohConnection)?.self
+        ) { group in
+            group.addTask {
+                try await endpoint.connect(to: address, alpn: alpn)
+            }
+            group.addTask {
+                try await ContinuousClock().sleep(for: bound)
+                return nil
+            }
+            defer { group.cancelAll() }
+            guard let first = try await group.next(), let connection = first else {
+                throw CmxIrohClientSessionError.dialTimedOut
+            }
+            return connection
         }
     }
 

--- a/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohClientSessionError.swift
+++ b/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohClientSessionError.swift
@@ -26,4 +26,9 @@ public enum CmxIrohClientSessionError: Error, Equatable, Sendable {
 
     /// This protocol configuration has no production owner for application lanes.
     case applicationLanesUnavailable
+
+    /// One public or private endpoint dial exceeded its cancellable phase bound.
+    /// This is distinct from an established-transport idle timeout: no
+    /// authenticated connection existed when the deadline fired.
+    case dialTimedOut
 }

--- a/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohConnectionCloseAttribution.swift
+++ b/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohConnectionCloseAttribution.swift
@@ -190,6 +190,12 @@ public struct CmxIrohConnectionCloseAttribution: Sendable, Equatable {
             || cause.contains("Failed to resolve") {
             return .dnsFailed
         }
+        // Only classify route words after structured close and DNS markers.
+        // A peer-chosen reason such as "No route found" is not evidence that
+        // this device lacked a route.
+        if let routeFailure = CmxIrohRouteFailureClassifier.classify(cause) {
+            return routeFailure
+        }
         if cause.contains("Tls")
             || cause.contains("TLS")
             || cause.contains("CryptoError")

--- a/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohDiagnosticFailure.swift
+++ b/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohDiagnosticFailure.swift
@@ -5,6 +5,45 @@ public import IrohLib
 // exporting `String(describing: error)`, which may contain endpoint identities,
 // relay URLs, credentials, or private network addresses.
 
+/// Recognizes operating-system route failures that Iroh currently exposes only
+/// through an opaque display string. Keep this list narrow. A peer-controlled
+/// close reason must not be allowed to turn an established-session close into a
+/// local route diagnosis.
+enum CmxIrohRouteFailureClassifier {
+    static func classify(_ message: String) -> DiagnosticFailureKind? {
+        let normalized = message.lowercased()
+        // These strings describe an already established close, or contain
+        // peer-controlled application text. They are not local route
+        // evidence, even when the peer's reason happens to say "no route".
+        if normalized.hasPrefix("closed by peer:")
+            || normalized.hasPrefix("aborted by peer:")
+            || normalized.hasPrefix("reset by peer:")
+            || normalized.contains("connectionlost(")
+            || normalized.contains("applicationclosed(")
+            || normalized.contains("connectionclosed(") {
+            return nil
+        }
+        if normalized.contains("connection refused")
+            || normalized.contains("econnrefused") {
+            return .connectionRefused
+        }
+        if normalized.contains("network is unreachable")
+            || normalized.contains("no route to host")
+            || normalized.contains("host unreachable")
+            || normalized.contains("enetunreach")
+            || normalized.contains("ehostunreach") {
+            return .hostUnreachable
+        }
+        if normalized.contains("no route")
+            || normalized.contains("no usable route")
+            || normalized.contains("no usable path")
+            || normalized.contains("no route candidates") {
+            return .noRoute
+        }
+        return nil
+    }
+}
+
 extension IrohError: @retroactive DiagnosticFailureProviding {
     public var diagnosticFailureKind: DiagnosticFailureKind {
         Self.diagnosticFailureKind(message: message())
@@ -28,6 +67,15 @@ extension IrohError: @retroactive DiagnosticFailureProviding {
         if message.contains("ConnectionLost(LocallyClosed)") {
             return .cancelled
         }
+        // ConnectAttempt can render a peer close without the structured
+        // ConnectionLost wrapper. Preserve the same attribution rule here:
+        // the peer's reason is not local route evidence.
+        let normalized = message.lowercased()
+        if normalized.hasPrefix("closed by peer:")
+            || normalized.hasPrefix("aborted by peer:")
+            || normalized.hasPrefix("reset by peer:") {
+            return .connectionClosed
+        }
         if message.contains("TransportError(")
             && (message.contains("Code::crypto(")
                 || message.contains("TLS error:")) {
@@ -49,6 +97,13 @@ extension IrohError: @retroactive DiagnosticFailureProviding {
             || message.contains("Resolve failed, IPv4:")
             || message.contains("Failed to resolve") {
             return .dnsFailed
+        }
+        // Route words are meaningful only on an opaque pre-connection error.
+        // Structured close markers above describe an already admitted session;
+        // a peer-controlled application reason must never be exported as a
+        // local no-route diagnosis.
+        if let routeFailure = CmxIrohRouteFailureClassifier.classify(message) {
+            return routeFailure
         }
         // Connection-level operations (`accept_bi`, `open_bi`, `accept_uni`,
         // `open_uni`) surface `iroh::endpoint::ConnectionError` Debug-formatted
@@ -176,6 +231,8 @@ extension CmxIrohClientSessionError: DiagnosticFailureProviding {
             .identityMismatch
         case .admissionDenied:
             .admissionDenied
+        case .dialTimedOut:
+            .timedOut
         case .alreadyClosed, .notConnected, .unexpectedEndOfStream:
             .connectionClosed
         case .invalidAdmissionFrame, .invalidMaximumByteCount,

--- a/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohRegistryContextProvider.swift
+++ b/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohRegistryContextProvider.swift
@@ -59,6 +59,7 @@ public actor CmxIrohRegistryContextProvider: CmxIrohClientContextProvider {
         offlinePolicy: CmxIrohClientOfflinePolicyContext? = nil,
         lanFallback: LANFallbackProvider? = nil,
         customPrivateFallback: CustomPrivateFallbackProvider? = nil,
+        diagnostics: DiagnosticLog? = nil,
         verifiedDiscovery: CmxIrohDiscoveryResponse? = nil,
         verifier: CmxIrohGrantVerifier = CmxIrohGrantVerifier(),
         now: @escaping @Sendable () -> Date = { Date() }
@@ -76,7 +77,7 @@ public actor CmxIrohRegistryContextProvider: CmxIrohClientContextProvider {
         self.offlinePolicy = offlinePolicy
         self.lanFallback = lanFallback
         self.customPrivateFallback = customPrivateFallback
-        diagnostics = nil
+        self.diagnostics = diagnostics
         self.verifier = verifier
         self.now = now
         verifiedDiscoverySnapshot = verifiedDiscovery.map {
@@ -96,6 +97,7 @@ public actor CmxIrohRegistryContextProvider: CmxIrohClientContextProvider {
         offlinePolicy: CmxIrohClientOfflinePolicyContext? = nil,
         lanFallback: LANFallbackProvider? = nil,
         customPrivateFallback: CustomPrivateFallbackProvider? = nil,
+        diagnostics: DiagnosticLog? = nil,
         verifiedDiscovery: CmxIrohDiscoveryResponse? = nil,
         verifier: CmxIrohGrantVerifier = CmxIrohGrantVerifier(),
         now: @escaping @Sendable () -> Date = { Date() }
@@ -112,7 +114,7 @@ public actor CmxIrohRegistryContextProvider: CmxIrohClientContextProvider {
         self.offlinePolicy = offlinePolicy
         self.lanFallback = lanFallback
         self.customPrivateFallback = customPrivateFallback
-        diagnostics = nil
+        self.diagnostics = diagnostics
         self.verifier = verifier
         self.now = now
         verifiedDiscoverySnapshot = verifiedDiscovery.map {
@@ -184,7 +186,9 @@ public actor CmxIrohRegistryContextProvider: CmxIrohClientContextProvider {
             discovery = verified
         } else {
             do {
-                discovery = try await sharedDiscover()
+                discovery = try await sharedDiscover(
+                    surface: DiagnosticCorrelation().handle(for: targetIdentity.endpointID)
+                )
                 usedFreshDiscovery = true
             } catch {
                 guard Self.isConnectivity(error),
@@ -227,7 +231,9 @@ public actor CmxIrohRegistryContextProvider: CmxIrohClientContextProvider {
         let freshClock = now()
         let freshDiscovery: CmxIrohDiscoveryResponse
         do {
-            freshDiscovery = try await sharedDiscover()
+            freshDiscovery = try await sharedDiscover(
+                surface: DiagnosticCorrelation().handle(for: targetIdentity.endpointID)
+            )
         } catch {
             // Broker cooldown or connectivity failure: keep the buildable
             // context (its LAN fallback may still connect) instead of
@@ -392,15 +398,55 @@ public actor CmxIrohRegistryContextProvider: CmxIrohClientContextProvider {
     /// task means a burst of dials consumes one quota unit instead of queuing
     /// one request per dial. A gate cooldown propagates unchanged so callers
     /// wait out the directive instead of spinning.
-    private func sharedDiscover() async throws -> CmxIrohDiscoveryResponse {
+    private func sharedDiscover(
+        surface: UInt32? = nil
+    ) async throws -> CmxIrohDiscoveryResponse {
         if let sharedDiscoveryTask {
             return try await sharedDiscoveryTask.value
         }
         let broker = broker
-        let task = Task { try await broker.discover() }
+        let cached = authoritativeDiscovery
+        let startedAt = DispatchTime.now().uptimeNanoseconds
+        diagnostics?.record(DiagnosticEvent(
+            .discoveryStarted,
+            surface: surface,
+            a: DiagnosticTransportKind.iroh.rawValue
+        ))
+        let task = Task {
+            try await CmxAuthoritativeDiscoveryResolver(broker: broker).resolve(
+                cached: cached
+            )
+        }
         sharedDiscoveryTask = task
         defer { sharedDiscoveryTask = nil }
-        return try await task.value
+        do {
+            let response = try await task.value
+            authoritativeDiscovery = response
+            diagnostics?.record(DiagnosticEvent(
+                .discoverySucceeded,
+                surface: surface,
+                ms: elapsedMilliseconds(since: startedAt),
+                a: DiagnosticTransportKind.iroh.rawValue,
+                b: response.bindings.count,
+                c: response.relayFleet.count
+            ))
+            return response
+        } catch {
+            diagnostics?.record(DiagnosticEvent(
+                .discoveryFailed,
+                surface: surface,
+                ms: elapsedMilliseconds(since: startedAt),
+                a: DiagnosticTransportKind.iroh.rawValue,
+                b: DiagnosticFailureKind.classify(error).rawValue
+            ))
+            throw error
+        }
+    }
+
+    private func elapsedMilliseconds(since start: UInt64) -> UInt32 {
+        let now = DispatchTime.now().uptimeNanoseconds
+        let elapsed = now >= start ? now - start : 0
+        return UInt32(clamping: elapsed / 1_000_000)
     }
 
     /// Records dial-failure evidence from the session pool. An empty plan or
@@ -495,8 +541,7 @@ public actor CmxIrohRegistryContextProvider: CmxIrohClientContextProvider {
              .connectionRefused,
              .connectionClosed,
              .noRoute,
-             .transportIdleTimedOut,
-             .routeGated:
+             .transportIdleTimedOut:
             return true
         case .none, .offline, .permissionDenied, .dnsFailed,
              .secureChannelFailed, .unsupportedRoute, .credentialUnavailable,
@@ -506,7 +551,7 @@ public actor CmxIrohRegistryContextProvider: CmxIrohClientContextProvider {
              .admissionLeaseExpired, .admissionRevalidationFailed,
              .sendQueueOverflow, .payloadTooLarge, .resourceLimitReached,
              .attachmentCountLimitReached, .attachmentAggregateSizeLimitReached,
-             .localStateUnavailable, .unknown:
+             .localStateUnavailable, .routeGated, .unknown:
             return false
     }
     }

--- a/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohClientSessionTests.swift
+++ b/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohClientSessionTests.swift
@@ -15,6 +15,40 @@ struct CmxIrohClientSessionTests {
         credential = try .pairGrant("e30.e30.AA")
     }
 
+    @Test("a hung dial fails at its phase bound and records both legs")
+    func hungDialFailsAtThePhaseBound() async throws {
+        let diagnostics = DiagnosticLog(capacity: 8, role: .mobileClient)
+        let endpoint = TestDialingIrohEndpoint(
+            localIdentity: localIdentity,
+            dialResults: [.hang]
+        )
+        let session = try CmxIrohClientSession(
+            endpoint: endpoint,
+            targetIdentity: remoteIdentity,
+            dialPlan: try testIrohDialPlan(publicPaths: [try publicRelayHint()]),
+            credential: credential,
+            dialPhaseTimeout: .milliseconds(40),
+            diagnostics: diagnostics
+        )
+        let clock = ContinuousClock()
+        let started = clock.now
+        await #expect(throws: CmxIrohClientSessionError.dialTimedOut) {
+            try await session.connect()
+        }
+        #expect(clock.now - started < .seconds(2))
+        #expect(await waitForDiagnosticProcessedCount(diagnostics, atLeast: 3))
+        let report = await diagnostics.snapshot()
+        #expect(report.events.map(\.code) == [
+            .transportDialPlanBuilt,
+            .transportDialLegFailed,
+            .transportDialLegFailed,
+        ])
+        #expect(report.events[1].b == DiagnosticFailureKind.timedOut.rawValue)
+        #expect(report.events[2].b == DiagnosticFailureKind.noRoute.rawValue)
+        #expect(report.events[0].c == 1)
+        #expect(report.events[1].ms != nil)
+    }
+
     @Test
     func publicDialAdmitsControlAndPreservesFollowingRPCBytes() async throws {
         let events = TestIrohEventRecorder()

--- a/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohDiagnosticFailureTests.swift
+++ b/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohDiagnosticFailureTests.swift
@@ -25,6 +25,10 @@ import Testing
                 == .admissionDenied
         )
         #expect(
+            DiagnosticFailureKind.classify(CmxIrohClientSessionError.dialTimedOut)
+                == .timedOut
+        )
+        #expect(
             DiagnosticFailureKind.classify(CmxIrohKeychainIdentityStoreError(status: -50))
                 == .credentialUnavailable
         )
@@ -47,11 +51,21 @@ import Testing
             DiagnosticFailureKind.connectionClosed
         ),
         (
+            "ConnectionLost(ApplicationClosed(ApplicationClose { error_code: 0, reason: \"No route found\" }))",
+            DiagnosticFailureKind.connectionClosed
+        ),
+        (
             "ConnectionLost(ConnectionClosed(ConnectionClose { error_code: 0 }))",
             DiagnosticFailureKind.connectionClosed
         ),
         ("ConnectionLost(LocallyClosed)", DiagnosticFailureKind.cancelled),
         ("outgoing connection cancelled", DiagnosticFailureKind.cancelled),
+        ("No route found for endpoint", DiagnosticFailureKind.noRoute),
+        ("no usable path candidates", DiagnosticFailureKind.noRoute),
+        ("Network is unreachable (os error 51)", DiagnosticFailureKind.hostUnreachable),
+        ("No route to host", DiagnosticFailureKind.hostUnreachable),
+        ("Connection refused", DiagnosticFailureKind.connectionRefused),
+        ("closed by peer: No route found", DiagnosticFailureKind.connectionClosed),
         (
             "No addressing information available\nCaused by:\n    All address lookup services failed or produced no results",
             DiagnosticFailureKind.dnsFailed

--- a/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohLibEndpointTests.swift
+++ b/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohLibEndpointTests.swift
@@ -276,9 +276,10 @@ struct CmxIrohLibEndpointTests {
     }
 
     @Test
-    func relayOnlyIgnoresDirectAddressHintsAndAdvertisement() async throws {
+    func relayOnlyKeepsManagedRelayAndIgnoresDirectHintsAndAdvertisement() async throws {
+        let relayURL = "https://use1-1.relay.lawrence.cmux.iroh.link/"
         let endpoint = try await makeEndpoint(
-            managedRelayURLs: [],
+            managedRelayURLs: [relayURL],
             transportVerificationMode: .relayOnly
         )
         let concrete = try #require(endpoint as? CmxIrohLibEndpoint)
@@ -291,12 +292,24 @@ struct CmxIrohLibEndpointTests {
             observedAt: Date(),
             expiresAt: Date().addingTimeInterval(60)
         )
+        let relayHint = try CmxIrohPathHint(
+            kind: .relayURL,
+            value: relayURL,
+            source: .native,
+            privacyScope: .publicInternet,
+            observedAt: Date(),
+            expiresAt: Date().addingTimeInterval(60)
+        )
 
         let attempts = try await concrete.endpointAddresses(
-            CmxIrohEndpointAddress(identity: identity, pathHints: [directHint])
+            CmxIrohEndpointAddress(
+                identity: identity,
+                pathHints: [directHint, relayHint]
+            )
         )
 
         #expect(attempts.count == 1)
+        #expect(attempts.first?.relayUrl() == relayURL)
         #expect(attempts.first?.directAddresses().isEmpty == true)
         #expect(await endpoint.localDirectAddresses().isEmpty)
         #expect(await endpoint.address().pathHints.allSatisfy { $0.kind != .directAddress })

--- a/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohRegistryContextProviderStalenessTests.swift
+++ b/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohRegistryContextProviderStalenessTests.swift
@@ -102,6 +102,90 @@ struct CmxIrohRegistryContextProviderStalenessTests {
     }
 
     @Test
+    func routeGatingDoesNotInvalidateDiscoveryReuse() async throws {
+        let fixture = try RegistryFixture()
+        let reusedRelay = try managedRelayHint(fixture)
+        let brokerOnlyDirect = try publicDirectHint(
+            fixture,
+            value: "8.8.4.4:4433"
+        )
+        let broker = ConfigurableRegistryBroker(
+            discovery: try fixture.discovery(targetHints: [brokerOnlyDirect]),
+            pairGrantResponses: [try fixture.pairGrantResponse(
+                issuedAt: fixture.nowSeconds,
+                expiresAt: fixture.nowSeconds + 7 * 24 * 60 * 60
+            )]
+        )
+        let provider = try await makeProvider(
+            fixture: fixture,
+            broker: broker,
+            verifiedDiscovery: try fixture.discovery(targetHints: [reusedRelay])
+        )
+
+        // A route-gated error means another caller already owns this route.
+        // It carries no evidence that the broker's peer binding is stale.
+        await provider.noteDialFailure(
+            for: try fixture.request(hints: []),
+            dialPlan: try nonEmptyPlan(fixture, hints: [reusedRelay]),
+            failure: .routeGated
+        )
+
+        let context = try await provider.context(for: fixture.request(hints: []))
+
+        #expect(await broker.discoveryRequestCount() == 0)
+        #expect(context.dialPlan.publicPaths == [reusedRelay])
+    }
+
+    @Test
+    func sharedDiscoveryUsesRevisionedAuthorityAndRecordsRouteShape() async throws {
+        let fixture = try RegistryFixture()
+        let staleRelay = try managedRelayHint(fixture)
+        let freshDirect = try publicDirectHint(fixture, value: "8.8.8.8:4433")
+        let cached = try fixture.discovery(
+            targetHints: [staleRelay],
+            revision: 7
+        )
+        let fresh = try fixture.discovery(
+            targetHints: [freshDirect],
+            revision: 8
+        )
+        let broker = RevisionedRegistryBroker(
+            syncResponse: CmxConnectivitySyncResponse(
+                legacySnapshot: fresh,
+                knownRevision: cached.revision
+            ),
+            pairGrantResponses: [try fixture.pairGrantResponse(
+                issuedAt: fixture.nowSeconds,
+                expiresAt: fixture.nowSeconds + 7 * 24 * 60 * 60
+            )]
+        )
+        let diagnostics = DiagnosticLog(capacity: 8, role: .mobileClient)
+        let provider = try await makeProvider(
+            fixture: fixture,
+            broker: broker,
+            diagnostics: diagnostics,
+            verifiedDiscovery: cached
+        )
+        await provider.noteDialFailure(
+            for: try fixture.request(hints: []),
+            dialPlan: try nonEmptyPlan(fixture, hints: [staleRelay]),
+            failure: .noRoute
+        )
+
+        let context = try await provider.context(for: fixture.request(hints: []))
+
+        #expect(context.dialPlan.publicPaths == [freshDirect])
+        #expect(await broker.observedKnownRevisions() == [7])
+        #expect(await broker.discoveryRequestCount() == 0)
+        #expect(await waitForDiagnosticProcessedCount(diagnostics, atLeast: 2))
+        let events = await diagnostics.snapshot().events
+        #expect(events.map(\.code) == [.discoveryStarted, .discoverySucceeded])
+        #expect(events[1].ms != nil)
+        #expect(events[1].b == fresh.bindings.count)
+        #expect(events[1].c == fresh.relayFleet.count)
+    }
+
+    @Test
     func normalDialsReuseVerifiedSnapshotOnceWithinWindow() async throws {
         let fixture = try RegistryFixture()
         let relay = try managedRelayHint(fixture)
@@ -330,7 +414,8 @@ struct CmxIrohRegistryContextProviderStalenessTests {
 
     private func makeProvider(
         fixture: RegistryFixture,
-        broker: ConfigurableRegistryBroker,
+        broker: any CmxIrohRegistryServing,
+        diagnostics: DiagnosticLog? = nil,
         verifiedDiscovery: CmxIrohDiscoveryResponse?
     ) async throws -> CmxIrohRegistryContextProvider {
         CmxIrohRegistryContextProvider(
@@ -344,6 +429,7 @@ struct CmxIrohRegistryContextProviderStalenessTests {
                     activeNetworkProfiles: []
                 )
             },
+            diagnostics: diagnostics,
             verifiedDiscovery: verifiedDiscovery,
             now: { fixture.now }
         )
@@ -408,6 +494,51 @@ struct CmxIrohRegistryContextProviderStalenessTests {
         }
         return await broker.heldDiscoverCallCount() >= count
     }
+}
+
+/// A broker that exposes the connectivity-v2 authority seam. `discover()` is
+/// deliberately observable so the test proves the registry provider does not
+/// bypass revision reconciliation during a stale-route refresh.
+actor RevisionedRegistryBroker: CmxIrohRegistryServing,
+    CmxConnectivityAuthorityServing {
+    private let syncResponse: CmxConnectivitySyncResponse
+    private var pairGrantResponses: [CmxIrohPairGrantResponse]
+    private var knownRevisions: [UInt64?] = []
+    private var discoverCalls = 0
+
+    init(
+        syncResponse: CmxConnectivitySyncResponse,
+        pairGrantResponses: [CmxIrohPairGrantResponse]
+    ) {
+        self.syncResponse = syncResponse
+        self.pairGrantResponses = pairGrantResponses
+    }
+
+    func syncConnectivity(
+        knownRevision: UInt64?
+    ) async throws -> CmxConnectivitySyncResponse {
+        knownRevisions.append(knownRevision)
+        return syncResponse
+    }
+
+    func discover() throws -> CmxIrohDiscoveryResponse {
+        discoverCalls += 1
+        throw TestIrohTransportError.unsupported
+    }
+
+    func issuePairGrant(
+        initiatorBindingID _: String,
+        acceptorBindingID _: String
+    ) throws -> CmxIrohPairGrantResponse {
+        guard !pairGrantResponses.isEmpty else {
+            throw TestRegistryError.noGrantResponse
+        }
+        return pairGrantResponses.removeFirst()
+    }
+
+    func observedKnownRevisions() -> [UInt64?] { knownRevisions }
+
+    func discoveryRequestCount() -> Int { discoverCalls }
 }
 
 /// A registry broker whose discovery response, failure mode, and completion

--- a/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohRegistryContextProviderTests.swift
+++ b/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohRegistryContextProviderTests.swift
@@ -485,6 +485,7 @@ struct RegistryFixture: Sendable {
 
     func discovery(
         targetHints: [CmxIrohPathHint],
+        revision: UInt64? = nil,
         targetDirectPorts: [String: Int]? = nil,
         targetLastSeenAt: Date? = nil,
         relayFleet: [String]? = nil,
@@ -525,7 +526,7 @@ struct RegistryFixture: Sendable {
             }
             bindings.append(target)
         }
-        let object: [String: Any] = [
+        var object: [String: Any] = [
             "route_contract_version": 1,
             "bindings": bindings,
             "relay_fleet": relayFleet ?? [relayURL],
@@ -543,6 +544,9 @@ struct RegistryFixture: Sendable {
                 ]],
             ],
         ]
+        if let revision {
+            object["revision"] = revision
+        }
         let decoder = JSONDecoder()
         decoder.dateDecodingStrategy = .iso8601
         return try decoder.decode(

--- a/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/TestDialingIrohEndpoint.swift
+++ b/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/TestDialingIrohEndpoint.swift
@@ -31,7 +31,7 @@ actor TestDialingIrohEndpoint: CmxIrohEndpoint {
     func connect(
         to address: CmxIrohEndpointAddress,
         alpn _: Data
-    ) throws -> any CmxIrohConnection {
+    ) async throws -> any CmxIrohConnection {
         dialedAddresses.append(address)
         guard !dialResults.isEmpty else {
             throw TestIrohTransportError.unsupported
@@ -41,6 +41,12 @@ actor TestDialingIrohEndpoint: CmxIrohEndpoint {
             return connection
         case let .failure(error):
             throw error
+        case .hang:
+            // The production endpoint cancels its native ConnectAttempt. A
+            // long cancellable sleep models that contract without leaving a
+            // continuation behind when the phase bound wins.
+            try await Task.sleep(for: .seconds(3_600))
+            throw TestIrohTransportError.unsupported
         }
     }
 

--- a/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/TestIrohDialResult.swift
+++ b/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/TestIrohDialResult.swift
@@ -1,4 +1,6 @@
 enum TestIrohDialResult {
     case connection(TestIrohConnection)
     case failure(TestIrohTransportError)
+    /// A cancellable dial that does not complete until its caller cancels it.
+    case hang
 }

--- a/docs/ios-network-reliability.md
+++ b/docs/ios-network-reliability.md
@@ -26,5 +26,10 @@ Check an export with:
 Use --json for a machine-readable artifact. A passing run has at least one
 usable RPC connection, no duplicate active sessions per peer, and an observed
 background gap of at least eight minutes. The output also reports usable
-latency, cancellation reasons, recovery outcomes, direct-dial stages, path
-changes, and liveness resubscriptions.
+latency, cancellation reasons, recovery outcomes, discovery duration and
+shape, relay-policy outcomes, direct-dial phase duration, route-plan counts,
+path changes, and liveness resubscriptions. For a `no_route` failure,
+`route_policy.assessment` distinguishes an empty plan, a plan with no public
+relay URL, a plan that did contain a public relay, and an older build that did
+not emit plan diagnostics. A public relay being present proves policy assembly
+succeeded; it does not prove that the current network can reach the relay.

--- a/scripts/analyze-ios-network-log.py
+++ b/scripts/analyze-ios-network-log.py
@@ -29,6 +29,11 @@ ISO_EVENT_RE = re.compile(
 )
 FIELD_RE = re.compile(r"(?P<key>[^:(),]+):\s*(?P<value>[^,()]+)")
 NUMBER_RE = re.compile(r"-?\d+(?:\.\d+)?")
+DURATION_RE = re.compile(
+    r"^\s*(?P<number>-?\d+(?:\.\d+)?)\s*"
+    r"(?P<unit>milliseconds?|ms|seconds?|secs?|s)?\s*$",
+    re.IGNORECASE,
+)
 
 
 def parse_stamp(raw: str, fallback: int) -> float:
@@ -38,9 +43,12 @@ def parse_stamp(raw: str, fallback: int) -> float:
         return float(match.group()) if match else float(fallback)
     try:
         normalized = raw.strip().removesuffix(" UTC")
-        return datetime.fromisoformat(normalized).replace(
-            tzinfo=timezone.utc
-        ).timestamp()
+        parsed = datetime.fromisoformat(normalized)
+        if parsed.tzinfo is None:
+            parsed = parsed.replace(tzinfo=timezone.utc)
+        else:
+            parsed = parsed.astimezone(timezone.utc)
+        return parsed.timestamp()
     except ValueError:
         # Preserve a stable synthetic value for an unrecognized timestamp.
         return float(fallback)
@@ -88,10 +96,15 @@ def as_milliseconds(value: object | None) -> float | None:
     if value is None:
         return None
     text = str(value).lower()
+    match = DURATION_RE.match(text)
+    if match:
+        parsed = float(match.group("number"))
+        unit = (match.group("unit") or "ms").lower()
+        if unit in {"s", "sec", "secs", "second", "seconds"}:
+            return parsed * 1000
+        return parsed
     parsed = as_seconds(text)
-    if parsed is None:
-        return None
-    return parsed * 1000 if "second" in text else parsed
+    return parsed * 1000 if parsed is not None and "second" in text else parsed
 
 
 def normalized_failure(value: object | None) -> str | None:
@@ -102,11 +115,17 @@ def normalized_failure(value: object | None) -> str | None:
     aliases = {
         "no_route_available": "no_route",
         "no_route": "no_route",
+        "no_route_found": "no_route",
+        "no_usable_route": "no_route",
+        "no_usable_route_path": "no_route",
+        "no_route_candidates": "no_route",
         "route_already_connecting": "route_gated",
         "route_gated": "route_gated",
         "timed_out": "timed_out",
         "transport_idle_timed_out": "transport_idle_timed_out",
         "connection_refused": "connection_refused",
+        "network_unreachable": "host_unreachable",
+        "no_route_to_host": "host_unreachable",
         "host_unreachable": "host_unreachable",
         "cancelled": "cancelled",
     }
@@ -299,7 +318,10 @@ def analyze(lines: Iterable[str], expected_background_seconds: float = 0.0) -> d
     private_fallback_paths_observed = sum(
         plan["private_fallback_paths"] for plan in dial_plans
     )
-    if not dial_failures.get("no_route"):
+    no_route_failure_observed = bool(dial_failures.get("no_route")) or any(
+        key.endswith("/no_route") for key in phase_failures
+    )
+    if not no_route_failure_observed:
         route_policy_assessment = "no_no_route_failure"
     elif not dial_plans:
         route_policy_assessment = "plan_diagnostics_unavailable"

--- a/scripts/analyze-ios-network-log.py
+++ b/scripts/analyze-ios-network-log.py
@@ -20,7 +20,13 @@ from pathlib import Path
 from typing import Iterable
 
 
-EVENT_RE = re.compile(r"^(?P<stamp>.+?)\s+\|\s+(?P<body>.+)$")
+PIPE_EVENT_RE = re.compile(r"^(?P<stamp>.+?)\s+\|\s+(?P<body>.+)$")
+# AppLog writes ISO-8601 timestamps followed directly by the rendered event,
+# while older exported reports used `timestamp | event`. Accept both so the
+# analyzer can consume the files users actually attach from the app.
+ISO_EVENT_RE = re.compile(
+    r"^(?P<stamp>\d{4}-\d{2}-\d{2}T\S+|\d{4}-\d{2}-\d{2}\s+\S+\s+UTC)\s+(?P<body>.+)$"
+)
 FIELD_RE = re.compile(r"(?P<key>[^:(),]+):\s*(?P<value>[^,()]+)")
 NUMBER_RE = re.compile(r"-?\d+(?:\.\d+)?")
 
@@ -41,7 +47,8 @@ def parse_stamp(raw: str, fallback: int) -> float:
 
 
 def parse_line(line: str, ordinal: int) -> dict[str, object] | None:
-    match = EVENT_RE.match(line.strip())
+    stripped = line.strip()
+    match = PIPE_EVENT_RE.match(stripped) or ISO_EVENT_RE.match(stripped)
     if not match:
         return None
     body = match.group("body")
@@ -76,6 +83,36 @@ def as_seconds(value: object | None) -> float | None:
     return float(match.group()) if match else None
 
 
+def as_milliseconds(value: object | None) -> float | None:
+    """Parse a rendered duration whose unit may be milliseconds or seconds."""
+    if value is None:
+        return None
+    text = str(value).lower()
+    parsed = as_seconds(text)
+    if parsed is None:
+        return None
+    return parsed * 1000 if "second" in text else parsed
+
+
+def normalized_failure(value: object | None) -> str | None:
+    """Map localized-looking rendered labels to stable analyzer vocabulary."""
+    if value is None:
+        return None
+    normalized = re.sub(r"[^a-z0-9]+", "_", str(value).lower()).strip("_")
+    aliases = {
+        "no_route_available": "no_route",
+        "no_route": "no_route",
+        "route_already_connecting": "route_gated",
+        "route_gated": "route_gated",
+        "timed_out": "timed_out",
+        "transport_idle_timed_out": "transport_idle_timed_out",
+        "connection_refused": "connection_refused",
+        "host_unreachable": "host_unreachable",
+        "cancelled": "cancelled",
+    }
+    return aliases.get(normalized, normalized or None)
+
+
 def field(event: dict[str, object], *names: str) -> str | None:
     fields = event["fields"]
     assert isinstance(fields, dict)
@@ -106,6 +143,16 @@ def analyze(lines: Iterable[str], expected_background_seconds: float = 0.0) -> d
     active_counts: Counter[str] = Counter()
     max_active: Counter[str] = Counter()
     direct_stages: Counter[str] = Counter()
+    dial_failures: Counter[str] = Counter()
+    failure_kinds: Counter[str] = Counter()
+    phase_failures: Counter[str] = Counter()
+    discovery_outcomes: Counter[str] = Counter()
+    discovery_durations_ms: list[float] = []
+    discovery_shapes: list[dict[str, int | None]] = []
+    dial_plans: list[dict[str, int]] = []
+    relay_policy_outcomes: Counter[str] = Counter()
+    network_reachability: Counter[str] = Counter()
+    recovery_coalesced = 0
     path_events: Counter[str] = Counter()
     background_at: float | None = None
     background_gaps: list[float] = []
@@ -118,6 +165,9 @@ def analyze(lines: Iterable[str], expected_background_seconds: float = 0.0) -> d
         peer = field(event, "peer", "surface") or "unknown"
         attempt = as_int(field(event, "attempt"))
         session = as_int(field(event, "session"))
+        failure = normalized_failure(field(event, "failure"))
+        if failure:
+            failure_kinds[failure] += 1
 
         if title_is(event, "app lifecycle changed"):
             phase = (field(event, "phase") or "").lower()
@@ -142,6 +192,51 @@ def analyze(lines: Iterable[str], expected_background_seconds: float = 0.0) -> d
 
         elif title_is(event, "transport dial cancelled"):
             cancellations[field(event, "cancellation", "reason") or "unknown"] += 1
+
+        elif title_is(event, "transport dial failed"):
+            if failure:
+                dial_failures[failure] += 1
+
+        elif title_is(event, "direct dial leg"):
+            leg = field(event, "leg") or "unknown"
+            direct_stages[leg] += 1
+            if "failed" in str(event["title"]) and failure:
+                phase_failures[f"{leg}/{failure}"] += 1
+
+        elif title_is(event, "route discovery"):
+            outcome = "failed" if "failed" in str(event["title"]) else (
+                "succeeded" if "succeeded" in str(event["title"]) else "started"
+            )
+            discovery_outcomes[outcome] += 1
+            duration = as_milliseconds(field(event, "duration"))
+            if duration is not None:
+                discovery_durations_ms.append(duration)
+            bindings = as_int(field(event, "bindings"))
+            relay_fleet = as_int(field(event, "relay_fleet"))
+            if bindings is not None or relay_fleet is not None:
+                discovery_shapes.append({
+                    "bindings": bindings,
+                    "relay_fleet": relay_fleet,
+                })
+
+        elif title_is(event, "direct dial plan assembled"):
+            dial_plans.append({
+                "public_paths": as_int(field(event, "public_paths")) or 0,
+                "private_fallback_paths": as_int(field(event, "private_fallback_paths")) or 0,
+                "public_relay_urls": as_int(field(event, "public_relay_urls")) or 0,
+            })
+
+        elif title_is(event, "relay policy refresh", "relay policy refreshed"):
+            outcome = "failed" if "failed" in str(event["title"]) else (
+                "succeeded" if "refreshed" in str(event["title"]) else "started"
+            )
+            relay_policy_outcomes[outcome] += 1
+
+        elif title_is(event, "network reachability changed"):
+            network_reachability[field(event, "network") or "Unknown"] += 1
+
+        elif title_is(event, "recovery coalesced"):
+            recovery_coalesced += 1
 
         elif title_is(event, "connection recovery started"):
             recovery_id = field(event, "recovery", "surface") or f"line-{event['ordinal']}"
@@ -177,10 +272,6 @@ def analyze(lines: Iterable[str], expected_background_seconds: float = 0.0) -> d
                     sessions[key] = False
                     active_counts[peer] = max(0, active_counts[peer] - 1)
 
-        elif title_is(event, "direct dial leg"):
-            leg = field(event, "leg") or "unknown"
-            direct_stages[leg] += 1
-
         elif title_is(event, "selected network path", "transport path changed"):
             path_events[field(event, "path") or field(event, "operation") or "unknown"] += 1
 
@@ -190,9 +281,56 @@ def analyze(lines: Iterable[str], expected_background_seconds: float = 0.0) -> d
     duplicate_peers = {
         peer: count for peer, count in max_active.items() if count > 1
     }
+    empty_plans = sum(
+        1
+        for plan in dial_plans
+        if plan["public_paths"] == 0 and plan["private_fallback_paths"] == 0
+    )
+    plans_with_public_relay = sum(
+        1 for plan in dial_plans if plan["public_relay_urls"] > 0
+    )
+    public_relay_urls_observed = sum(
+        plan["public_relay_urls"] for plan in dial_plans
+    )
+    public_direct_paths_observed = sum(
+        max(0, plan["public_paths"] - plan["public_relay_urls"])
+        for plan in dial_plans
+    )
+    private_fallback_paths_observed = sum(
+        plan["private_fallback_paths"] for plan in dial_plans
+    )
+    if not dial_failures.get("no_route"):
+        route_policy_assessment = "no_no_route_failure"
+    elif not dial_plans:
+        route_policy_assessment = "plan_diagnostics_unavailable"
+    elif empty_plans == len(dial_plans):
+        route_policy_assessment = "empty_plan"
+    elif plans_with_public_relay == 0:
+        route_policy_assessment = "no_public_relay"
+    else:
+        route_policy_assessment = "public_relay_present"
+    route_policy = {
+        "assessment": route_policy_assessment,
+        "empty_plans": empty_plans,
+        "plans_observed": len(dial_plans),
+        "plans_with_public_relay": plans_with_public_relay,
+        "plans_without_public_relay": len(dial_plans) - plans_with_public_relay,
+        "public_direct_paths_observed": public_direct_paths_observed,
+        "public_relay_urls_observed": public_relay_urls_observed,
+        "private_fallback_paths_observed": private_fallback_paths_observed,
+    }
     failures: list[str] = []
     if not connected_latencies and not usable_latencies:
         failures.append("no successful transport or usable RPC connection")
+    if dial_failures and not (connected_latencies or usable_latencies):
+        failures.append(
+            "dial failure kinds: "
+            + ", ".join(f"{key}={dial_failures[key]}" for key in sorted(dial_failures))
+        )
+    if route_policy_assessment == "empty_plan":
+        failures.append("recorded dial plans contained no usable route")
+    elif route_policy_assessment == "no_public_relay":
+        failures.append("no public relay URL was present in recorded dial plans")
     if duplicate_peers:
         failures.append(f"more than one active physical session for {sorted(duplicate_peers)}")
     if expected_background_seconds > 0 and background_gaps:
@@ -210,7 +348,18 @@ def analyze(lines: Iterable[str], expected_background_seconds: float = 0.0) -> d
         if usable_latencies
         else None,
         "cancellations": dict(cancellations),
+        "failure_kinds": dict(failure_kinds),
+        "dial_failures": dict(dial_failures),
+        "phase_failures": dict(phase_failures),
         "recovery_outcomes": dict(recovery_outcomes),
+        "recovery_coalesced": recovery_coalesced,
+        "discovery_outcomes": dict(discovery_outcomes),
+        "discovery_durations_ms": [round(value, 1) for value in discovery_durations_ms],
+        "discovery_shapes": discovery_shapes,
+        "dial_plans": dial_plans,
+        "route_policy": route_policy,
+        "relay_policy_outcomes": dict(relay_policy_outcomes),
+        "network_reachability": dict(network_reachability),
         "background_gaps_seconds": [round(value, 1) for value in background_gaps],
         "direct_stages": dict(direct_stages),
         "path_events": dict(path_events),
@@ -248,7 +397,18 @@ def main() -> int:
         print(f"{verdict}: {result['event_count']} timeline events")
         print(f"usable latency ms: {result['usable_latency_ms']}")
         print(f"cancellations: {result['cancellations'] or 'none'}")
+        print(f"dial failures: {result['dial_failures'] or 'none'}")
+        print(f"failure kinds: {result['failure_kinds'] or 'none'}")
+        print(f"phase failures: {result['phase_failures'] or 'none'}")
         print(f"recovery outcomes: {result['recovery_outcomes'] or 'none'}")
+        print(f"recovery coalesced: {result['recovery_coalesced']}")
+        print(f"discovery outcomes: {result['discovery_outcomes'] or 'none'}")
+        print(f"discovery durations ms: {result['discovery_durations_ms'] or 'none'}")
+        print(f"discovery shapes: {result['discovery_shapes'] or 'none'}")
+        print(f"dial plans: {result['dial_plans'] or 'none'}")
+        print(f"route policy: {result['route_policy']}")
+        print(f"relay policy outcomes: {result['relay_policy_outcomes'] or 'none'}")
+        print(f"network reachability: {result['network_reachability'] or 'none'}")
         print(f"background gaps s: {result['background_gaps_seconds'] or 'none'}")
         print(f"direct stages: {result['direct_stages'] or 'none'}")
         print(f"liveness resubscriptions: {result['liveness_resubscriptions']}")

--- a/scripts/tests/test_analyze_ios_network_log.py
+++ b/scripts/tests/test_analyze_ios_network_log.py
@@ -38,6 +38,76 @@ class AnalyzerTests(unittest.TestCase):
         self.assertTrue(result["pass"])
         self.assertEqual(result["connected_latency_ms"], [250.0])
 
+    def test_parses_app_log_timestamp_format_and_exposes_route_diagnosis(self):
+        lines = [
+            "cmux network diagnostics log · cmux · built 2026-08-12",
+            "2026-08-12T10:00:00.000Z Direct dial plan assembled (Peer: 9, Public paths: 1, Private fallback paths: 0, Public relay URLs: 1)",
+            "2026-08-12T10:00:00.100Z Iroh route discovery succeeded (Peer: 9, Duration: 340 ms)",
+            "2026-08-12T10:00:00.200Z Direct dial leg failed (Peer: 9, Leg: Public paths, Failure: No route available, Duration: 5.000 seconds)",
+            "2026-08-12T10:00:00.300Z Transport dial failed (Peer: 9, Transport: Iroh, Failure: No route available, Duration: 5.000 seconds, Attempt: 4)",
+        ]
+        result = analyzer.analyze(lines)
+        self.assertEqual(result["event_count"], 4)
+        self.assertEqual(result["dial_failures"], {"no_route": 1})
+        self.assertEqual(result["phase_failures"], {"Public paths/no_route": 1})
+        self.assertEqual(result["discovery_durations_ms"], [340.0])
+        self.assertEqual(
+            result["dial_plans"],
+            [{"public_paths": 1, "private_fallback_paths": 0, "public_relay_urls": 1}],
+        )
+        self.assertEqual(
+            result["route_policy"],
+            {
+                "assessment": "public_relay_present",
+                "empty_plans": 0,
+                "plans_observed": 1,
+                "plans_with_public_relay": 1,
+                "plans_without_public_relay": 0,
+                "public_direct_paths_observed": 0,
+                "public_relay_urls_observed": 1,
+                "private_fallback_paths_observed": 0,
+            },
+        )
+
+    def test_distinguishes_missing_relay_policy_from_old_log_without_plan_events(self):
+        missing_relay = analyzer.analyze(
+            [
+                "2026-08-12T10:00:00.000Z Direct dial plan assembled (Peer: 9, Public paths: 1, Private fallback paths: 0, Public relay URLs: 0)",
+                "2026-08-12T10:00:00.100Z Transport dial failed (Peer: 9, Transport: Iroh, Failure: No route available, Attempt: 4)",
+            ]
+        )
+        self.assertEqual(missing_relay["route_policy"]["assessment"], "no_public_relay")
+        self.assertIn(
+            "no public relay URL was present in recorded dial plans",
+            missing_relay["failures"],
+        )
+
+        legacy = analyzer.analyze(
+            [
+                "2026-08-12T10:00:00.100Z Transport dial failed (Transport: Iroh, Failure: No route available, Attempt: 4)",
+            ]
+        )
+        self.assertEqual(
+            legacy["route_policy"]["assessment"],
+            "plan_diagnostics_unavailable",
+        )
+
+    def test_reports_discovery_and_relay_policy_shape_without_secrets(self):
+        result = analyzer.analyze(
+            [
+                "2026-08-12T10:00:00.000Z Relay policy refresh started",
+                "2026-08-12T10:00:00.050Z Relay policy refreshed",
+                "2026-08-12T10:00:00.100Z Iroh route discovery succeeded (Transport: Iroh, Bindings: 2, Duration: 340 ms, Relay fleet: 3)",
+                "2026-08-12T10:00:00.200Z Network reachability changed (Network: Online)",
+            ]
+        )
+        self.assertEqual(result["relay_policy_outcomes"], {"started": 1, "succeeded": 1})
+        self.assertEqual(
+            result["discovery_shapes"],
+            [{"bindings": 2, "relay_fleet": 3}],
+        )
+        self.assertEqual(result["network_reachability"], {"Online": 1})
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/scripts/tests/test_analyze_ios_network_log.py
+++ b/scripts/tests/test_analyze_ios_network_log.py
@@ -108,6 +108,27 @@ class AnalyzerTests(unittest.TestCase):
         )
         self.assertEqual(result["network_reachability"], {"Online": 1})
 
+    def test_normalizes_no_route_found_from_a_leg_only_failure(self):
+        result = analyzer.analyze(
+            [
+                "2026-08-12T10:00:00.000Z Direct dial plan assembled (Peer: 9, Public paths: 1, Private fallback paths: 0, Public relay URLs: 0)",
+                "2026-08-12T10:00:05.000Z Direct dial leg failed (Peer: 9, Leg: Public paths, Failure: No route found)",
+            ]
+        )
+        self.assertEqual(result["phase_failures"], {"Public paths/no_route": 1})
+        self.assertEqual(result["route_policy"]["assessment"], "no_public_relay")
+
+    def test_handles_iso_offsets_and_explicit_duration_units(self):
+        result = analyzer.analyze(
+            [
+                "2026-08-12T10:00:00.000+02:00 Transport dial started (Transport: Iroh, Attempt: 4)",
+                "2026-08-12T08:00:00.250Z Transport connected (Transport: Iroh, Duration: 250 milliseconds, Attempt: 4)",
+                "2026-08-12T08:00:00.300Z Iroh route discovery succeeded (Duration: 1.5 seconds)",
+            ]
+        )
+        self.assertEqual(result["connected_latency_ms"], [250.0])
+        self.assertEqual(result["discovery_durations_ms"], [1500.0])
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

- Bound each public/private Iroh dial phase so blocked QUIC paths cannot hold reconnect forever.
- Use revision-aware authoritative discovery for shared refreshes and keep route-gated ownership failures out of stale-route invalidation.
- Classify opaque local route errors without allowing peer close text to spoof them.
- Record discovery timing, binding and relay-fleet shape, dial-plan relay counts, phase timing, and typed failures.
- Make the analyzer accept the actual ISO-8601 cmux-network.log format and explain route-policy evidence.

## Verification

- `swift test --package-path Packages/Shared/CmuxIrohTransport --filter CmxIrohRegistryContextProviderStalenessTests --filter CmxIrohLibEndpointTests --filter CmxIrohDiagnosticFailureTests --filter CmxIrohClientSessionTests --jobs 4`
- `swift test --package-path Packages/Shared/CMUXMobileCore --jobs 4`
- `swift test --package-path Packages/iOS/CmuxMobileShell --filter PresenceDiscoveryInvalidationTests --jobs 4`
- `python3 -m unittest scripts/tests/test_analyze_ios_network_log.py`

The full transport package matrix was started but did not terminate after three minutes because of unrelated long-running tests; the directly affected suites passed 47 tests. No code-review workflow was invoked.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/10096"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789194819&installation_model_id=21920&pr_number=10096&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F10096&signature=89d9424cf8229427cf603f87e1d252bb55abbae6a8821b55ef7c0803a5e1e4f4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bounds each Iroh reconnect dial phase and switches discovery to a revision‑aware authority, then normalizes route diagnostics so reviewers can see route policy evidence. Previously a blocked QUIC path could stall reconnect until the outer deadline and peer close text could spoof local route failures; now each public/private leg times out and falls through, and classifiers ignore peer‑controlled reasons. Analyzer accepts AppLog ISO‑8601 logs and reports whether a `no_route` came from an empty plan, missing public relay, or a plan that did include a public relay.

- `CmuxIrohTransport`
  - Adds per‑leg `dialPhaseTimeout` (default 5s) and bounded dials; on expiry surfaces `CmxIrohClientSessionError.dialTimedOut` and records leg duration.
  - Counts public relay‑URL hints in dial plans and records per‑leg success/failure with `ms`.
  - Prevents peer‑reason spoofing in close attribution; classifies DNS and opaque route errors only from local evidence.
  - `CmxIrohRegistryContextProvider`: shared discovery resolves against authoritative, revisioned connectivity; records `discoveryStarted/Succeeded/Failed` with duration, binding count, and relay‑fleet size; excludes `route_gated` from stale-route invalidation.
  - Relay‑only verification keeps managed relay URLs and ignores direct hints.
- `CMUXMobileCore`
  - Extends event code/presentation: dial‑plan `c` is public relay‑URL count; discovery fields include transport, bindings, relay fleet, and duration.
- `scripts/analyze-ios-network-log.py`
  - Accepts AppLog ISO‑8601 timestamps and explicit duration units.
  - Normalizes failure labels (e.g., “No route available/found”, “Route already connecting”) and reports per‑leg failures.
  - Computes `route_policy.assessment`: `empty_plan`, `no_public_relay`, `public_relay_present`, or `plan_diagnostics_unavailable`.
  - Reports discovery outcomes/durations/shapes, dial‑plan counts, relay‑policy outcomes, network reachability, and recovery coalescing.
- Docs and tests: expand iOS reliability guide and add coverage for bounded dials, revisioned discovery, relay‑only behavior, and analyzer route variants.

Migration
- No breaking API changes. `dialPhaseTimeout` is optional and tunable. New diagnostic fields and analyzer outputs are additive; existing consumers continue to work.

<sup>Written for commit 1ee4f0925fff0bd4134d902035129b88b9ab67f6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/10096?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

