### PR TITLE
fix(relay): contain Stack Auth throttles before relay minting

### DIFF
--- a/web/app/api/relay/preferences/route.ts
+++ b/web/app/api/relay/preferences/route.ts
@@ -27,6 +27,7 @@ import {
   verifyRequest,
   type AuthedUser,
 } from "../../../../services/vms/auth";
+import { relayAuthenticationError } from "../../../../services/relay/errors";
 
 
 const MAX_BODY_BYTES = 32 * 1_024;
@@ -64,7 +65,12 @@ async function authenticatedAccount(
   request: Request,
   deps: RelayPreferenceDeps,
 ): Promise<AuthedUser | Response> {
-  const user = await deps.verifyRequest(request);
+  let user: AuthedUser | null;
+  try {
+    user = await deps.verifyRequest(request);
+  } catch (error) {
+    throw relayAuthenticationError(error);
+  }
   if (!user) return unauthorized();
   await runRelayEffect(enforceRelayRateLimit({
     request,

--- a/web/app/api/relay/token/route.ts
+++ b/web/app/api/relay/token/route.ts
@@ -23,6 +23,7 @@ import {
 import {
   RelayConfigurationError,
   RelayDatabaseError,
+  relayAuthenticationError,
 } from "../../../../services/relay/errors";
 import {
   productionRelayWorkflowConfig,
@@ -115,7 +116,32 @@ export async function handleRelayTokenRequest(
   request: Request,
   deps: RelayTokenDeps,
 ): Promise<Response> {
-  const user = await deps.verifyRequest(request);
+  // Apply the cheap IP-scoped gate before calling Stack Auth. A storming
+  // client must not spend one upstream users/me request per retry. The clone
+  // preserves the existing auth-first semantics for malformed requests, which
+  // must not consume a valid relay-token budget.
+  if (await hasValidRelayEndpoint(request)) {
+    try {
+      await runRelayEffect(enforceRelayRateLimit({
+        request,
+        accountId: "pre-auth",
+        rateLimitKey: null,
+        ruleId: deps.rateLimitRuleId(),
+        check: deps.checkRateLimit,
+        isVercel: deps.isVercel(),
+        retryAfterSeconds: RELAY_TOKEN_RATE_LIMIT_BUCKET_SECONDS,
+      }));
+    } catch (error) {
+      return relayErrorResponse(error);
+    }
+  }
+
+  let user: AuthedUser | null;
+  try {
+    user = await deps.verifyRequest(request);
+  } catch (error) {
+    return relayErrorResponse(relayAuthenticationError(error));
+  }
   if (!user) return unauthorized();
 
   try {
@@ -254,4 +280,14 @@ function homogeneousLegacyCredential(
 
 export function POST(request: Request): Promise<Response> {
   return handleRelayTokenRequest(request, productionDeps);
+}
+
+async function hasValidRelayEndpoint(request: Request): Promise<boolean> {
+  try {
+    const body = await readBoundedJsonObject(request.clone(), MAX_BODY_BYTES);
+    const endpointId = body.ok ? body.value.endpointId : undefined;
+    return typeof endpointId === "string" && isValidEndpointId(endpointId);
+  } catch {
+    return false;
+  }
 }

--- a/web/services/relay/errors.ts
+++ b/web/services/relay/errors.ts
@@ -54,9 +54,59 @@ export class RelayRateLimitError extends Data.TaggedError("RelayRateLimitError")
   readonly retryAfterSeconds?: number;
 }> {}
 
+export class RelayAuthenticationError extends Data.TaggedError(
+  "RelayAuthenticationError",
+)<{
+  readonly code: "rate_limited" | "unavailable";
+  readonly cause: unknown;
+  readonly retryAfterSeconds?: number;
+}> {}
+
 export class RelaySigningError extends Data.TaggedError("RelaySigningError")<{
   readonly cause: unknown;
 }> {}
+
+/**
+ * Convert an auth-provider failure into a coarse, retry-safe relay error.
+ * Stack's SDK wraps upstream throttles in AggregateError/RetryError objects,
+ * so inspect only bounded error metadata and never serialize the original
+ * failure (it can contain bearer or refresh-token details).
+ */
+export function relayAuthenticationError(cause: unknown): RelayAuthenticationError {
+  const rateLimited = hasRateLimitSignal(cause);
+  return new RelayAuthenticationError({
+    code: rateLimited ? "rate_limited" : "unavailable",
+    cause,
+    ...(rateLimited ? { retryAfterSeconds: 60 } : {}),
+  });
+}
+
+function hasRateLimitSignal(
+  value: unknown,
+  seen = new Set<object>(),
+): boolean {
+  if (typeof value === "string") {
+    return /rate[\s_-]?limit(?:ed|ing)?/i.test(value);
+  }
+  if (!value || typeof value !== "object") return false;
+  if (seen.has(value)) return false;
+  seen.add(value);
+
+  const candidate = value as {
+    readonly message?: unknown;
+    readonly name?: unknown;
+    readonly code?: unknown;
+    readonly cause?: unknown;
+    readonly errors?: unknown;
+  };
+  return hasRateLimitSignal(candidate.message, seen) ||
+    hasRateLimitSignal(candidate.name, seen) ||
+    hasRateLimitSignal(candidate.code, seen) ||
+    hasRateLimitSignal(candidate.cause, seen) ||
+    (Array.isArray(candidate.errors) && candidate.errors.some((error) =>
+      hasRateLimitSignal(error, seen)
+    ));
+}
 
 export type RelayServiceError =
   | RelayConfigurationError
@@ -67,4 +117,5 @@ export type RelayServiceError =
   | RelayPreferenceConflictError
   | RelayAccountDeletionBlockedError
   | RelayRateLimitError
+  | RelayAuthenticationError
   | RelaySigningError;

--- a/web/services/relay/errors.ts
+++ b/web/services/relay/errors.ts
@@ -66,6 +66,9 @@ export class RelaySigningError extends Data.TaggedError("RelaySigningError")<{
   readonly cause: unknown;
 }> {}
 
+const MAX_AUTH_ERROR_METADATA_NODES = 64;
+const MAX_AUTH_ERROR_METADATA_DEPTH = 8;
+
 /**
  * Convert an auth-provider failure into a coarse, retry-safe relay error.
  * Stack's SDK wraps upstream throttles in AggregateError/RetryError objects,
@@ -83,14 +86,23 @@ export function relayAuthenticationError(cause: unknown): RelayAuthenticationErr
 
 function hasRateLimitSignal(
   value: unknown,
-  seen = new Set<object>(),
+  state: {
+    readonly seen: Set<object>;
+    count: number;
+  } = { seen: new Set<object>(), count: 0 },
+  depth = 0,
 ): boolean {
+  if (depth > MAX_AUTH_ERROR_METADATA_DEPTH) return false;
   if (typeof value === "string") {
     return /rate[\s_-]?limit(?:ed|ing)?/i.test(value);
   }
   if (!value || typeof value !== "object") return false;
-  if (seen.has(value)) return false;
-  seen.add(value);
+  if (
+    state.count >= MAX_AUTH_ERROR_METADATA_NODES ||
+    state.seen.has(value)
+  ) return false;
+  state.seen.add(value);
+  state.count += 1;
 
   const candidate = value as {
     readonly message?: unknown;
@@ -99,13 +111,13 @@ function hasRateLimitSignal(
     readonly cause?: unknown;
     readonly errors?: unknown;
   };
-  return hasRateLimitSignal(candidate.message, seen) ||
-    hasRateLimitSignal(candidate.name, seen) ||
-    hasRateLimitSignal(candidate.code, seen) ||
-    hasRateLimitSignal(candidate.cause, seen) ||
-    (Array.isArray(candidate.errors) && candidate.errors.some((error) =>
-      hasRateLimitSignal(error, seen)
-    ));
+  return hasRateLimitSignal(candidate.message, state, depth + 1) ||
+    hasRateLimitSignal(candidate.name, state, depth + 1) ||
+    hasRateLimitSignal(candidate.code, state, depth + 1) ||
+    hasRateLimitSignal(candidate.cause, state, depth + 1) ||
+    (Array.isArray(candidate.errors) && candidate.errors
+      .slice(0, MAX_AUTH_ERROR_METADATA_NODES)
+      .some((error) => hasRateLimitSignal(error, state, depth + 1)));
 }
 
 export type RelayServiceError =

--- a/web/services/relay/http.ts
+++ b/web/services/relay/http.ts
@@ -1,6 +1,7 @@
 import * as Effect from "effect/Effect";
 
 import {
+  RelayAuthenticationError,
   RelayConfigurationError,
   RelayRateLimitError,
   type RelayServiceError,
@@ -22,6 +23,11 @@ export async function runRelayEffect<A, E>(
 export function enforceRelayRateLimit(input: {
   readonly request: Request;
   readonly accountId: string;
+  /**
+   * Override the key sent to Vercel. `null` deliberately omits the override,
+   * making Vercel use the request IP for a cheap pre-auth ingress gate.
+   */
+  readonly rateLimitKey?: string | null;
   /**
    * Optional per-device partition (endpoint id). When present the budget is
    * per account+device, so one storming device cannot starve the account's
@@ -45,9 +51,13 @@ export function enforceRelayRateLimit(input: {
   return Effect.tryPromise({
     try: () => input.check(ruleId, {
       request: input.request,
-      rateLimitKey: input.devicePartition
-        ? `${input.accountId}:${input.devicePartition}`
-        : input.accountId,
+      ...(input.rateLimitKey === null
+        ? {}
+        : {
+          rateLimitKey: input.rateLimitKey ?? (input.devicePartition
+            ? `${input.accountId}:${input.devicePartition}`
+            : input.accountId),
+        }),
     }),
     catch: () => new RelayRateLimitError({ code: "rate_limit_unavailable" }),
   }).pipe(
@@ -84,6 +94,18 @@ export function enforceRelayRateLimit(input: {
 
 export function relayErrorResponse(error: unknown): Response {
   const tag = (error as { _tag?: string } | null)?._tag;
+  if (tag === "RelayAuthenticationError") {
+    const typed = error as RelayAuthenticationError;
+    const rateLimited = typed.code === "rate_limited";
+    console.error("relay.auth.unavailable", { reason: typed.code });
+    return jsonResponse(
+      { error: rateLimited ? "rate_limited" : "authentication_unavailable" },
+      rateLimited ? 429 : 503,
+      typed.retryAfterSeconds === undefined
+        ? undefined
+        : { "retry-after": String(typed.retryAfterSeconds) },
+    );
+  }
   if (tag === "RelayRateLimitError") {
     const code = (error as RelayRateLimitError).code;
     return jsonResponse(

--- a/web/tests/relay-token-route.test.ts
+++ b/web/tests/relay-token-route.test.ts
@@ -358,6 +358,43 @@ describe("POST /api/relay/token", () => {
     expect(response.status).toBe(429);
     expect(response.headers.get("retry-after")).toBe("60");
     expect(await response.json()).toEqual({ error: "rate_limited" });
+
+    const unavailable = await handleRelayTokenRequest(
+      request({ endpointId: ENDPOINT_ID }),
+      deps({
+        verifyRequest: async () => {
+          throw new Error("Stack Auth connection failed");
+        },
+      }),
+    );
+    expect(unavailable.status).toBe(503);
+    expect(unavailable.headers.get("retry-after")).toBeNull();
+    expect(await unavailable.json()).toEqual({
+      error: "authentication_unavailable",
+    });
+  });
+
+  test("blocks a valid relay request before calling Stack Auth when ingress is limited", async () => {
+    let authCalls = 0;
+    const response = await handleRelayTokenRequest(
+      request({ endpointId: ENDPOINT_ID }),
+      deps({
+        isVercel: () => true,
+        rateLimitRuleId: () => "relay-token",
+        verifyRequest: async () => {
+          authCalls += 1;
+          return { id: "account-a" } as AuthedUser;
+        },
+        checkRateLimit: async (_id, options) => {
+          expect(options.rateLimitKey).toBeUndefined();
+          return { rateLimited: true };
+        },
+      }),
+    );
+
+    expect(response.status).toBe(429);
+    expect(response.headers.get("retry-after")).toBe("60");
+    expect(authCalls).toBe(0);
   });
 
   test("rate limits per account and endpoint and fails closed", async () => {
@@ -371,6 +408,7 @@ describe("POST /api/relay/token", () => {
         checkRateLimit: async (_id, options) => {
           checks += 1;
           key = options.rateLimitKey;
+          if (options.rateLimitKey === undefined) return { rateLimited: false };
           return { rateLimited: true };
         },
       }),
@@ -398,14 +436,16 @@ describe("POST /api/relay/token", () => {
       }),
     );
     expect(invalid.status).toBe(400);
-    expect(checks).toBe(1);
+    expect(checks).toBe(2);
 
     const blocked = await handleRelayTokenRequest(
       request({ endpointId: ENDPOINT_ID }),
       deps({
         isVercel: () => true,
         rateLimitRuleId: () => "relay-token",
-        checkRateLimit: async () => ({ rateLimited: false, error: "blocked" }),
+        checkRateLimit: async (_id, options) => options.rateLimitKey === undefined
+          ? { rateLimited: false }
+          : { rateLimited: false, error: "blocked" },
       }),
     );
     expect(blocked.status).toBe(429);
@@ -415,7 +455,8 @@ describe("POST /api/relay/token", () => {
       deps({
         isVercel: () => true,
         rateLimitRuleId: () => "relay-token",
-        checkRateLimit: async () => {
+        checkRateLimit: async (_id, options) => {
+          if (options.rateLimitKey === undefined) return { rateLimited: false };
           throw new Error("firewall unreachable");
         },
       }),
@@ -435,6 +476,7 @@ describe("POST /api/relay/token", () => {
       rateLimitRuleId: () => "relay-token",
       checkRateLimit: async (_id, options) => {
         const partition = options.rateLimitKey ?? "";
+        if (!partition) return { rateLimited: false };
         observedPartitions.push(partition);
         const rateLimited = consumedPartitions.has(partition);
         consumedPartitions.add(partition);

--- a/web/tests/relay-token-route.test.ts
+++ b/web/tests/relay-token-route.test.ts
@@ -342,6 +342,24 @@ describe("POST /api/relay/token", () => {
     expect(invalid.status).toBe(400);
   });
 
+  test("turns a transient Stack Auth throttle into a retryable response", async () => {
+    const response = await handleRelayTokenRequest(
+      request({ endpointId: ENDPOINT_ID }),
+      deps({
+        verifyRequest: async () => {
+          throw new AggregateError(
+            [new Error("Rate limited, no retry-after header received")],
+            "Stack Auth unavailable",
+          );
+        },
+      }),
+    );
+
+    expect(response.status).toBe(429);
+    expect(response.headers.get("retry-after")).toBe("60");
+    expect(await response.json()).toEqual({ error: "rate_limited" });
+  });
+
   test("rate limits per account and endpoint and fails closed", async () => {
     let key: string | undefined;
     let checks = 0;


### PR DESCRIPTION
## Summary

Production logs for the Aug 13 `/api/relay/token` spike show Stack Auth rate-limiting all `users/me` fallback hosts. The route performed auth outside its error boundary, so the SDK `AggregateError` became HTTP 500 and clients retried without a server signal. Production also had an active Vercel rule (`cmux-relay-token`) with no `CMUX_RELAY_TOKEN_RATE_LIMIT_ID`, disabling the relay ingress gate.

This change:

- classifies Stack Auth throttles as typed relay errors and returns `429` with `Retry-After: 60`;
- returns `503 authentication_unavailable` for other auth-provider failures;
- applies an IP-scoped ingress limit before Stack Auth for valid relay requests, while preserving the account and endpoint partition after authentication;
- applies the same typed auth boundary to relay preference routes;
- adds behavior tests for auth throttles, generic auth outages, pre-auth ingress limiting, and existing account/device limits.

The production environment was separately corrected with `CMUX_RELAY_TOKEN_RATE_LIMIT_ID=cmux-relay-token` and the current artifact was redeployed. After the redeploy became ready at 2026-08-13T16:05:04Z, the Vercel 5xx query through 16:08:30Z contained zero `/api/relay/token` or `/api/devices` 500s.

## Verification

- `SKIP_ENV_VALIDATION=1 bun test tests/relay-token-route.test.ts tests/relay-preferences-route.test.ts tests/relay-policy.test.ts`
- `SKIP_ENV_VALIDATION=1 bun run typecheck`
- focused ESLint on changed files

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/10113"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789229356&installation_model_id=21920&pr_number=10113&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F10113&signature=e6db5ff076cdafde36020b1b7484bd4ca07e40341fd7b01b33786b70464d6a02"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Contain Stack Auth throttles and gate ingress before relay token minting to prevent 500s and reduce upstream load. Previously auth failures surfaced as 500s and retried; now throttles return 429 with retry hints, other auth outages return 503, valid requests face an IP-scoped pre-auth limit, and auth error classification is bounded and privacy-safe.

- Maps Stack Auth throttles to 429 { error: "rate_limited" } with Retry-After: 60; maps other auth failures to 503 { error: "authentication_unavailable" }.
- Adds an IP-scoped pre-auth ingress limit on POST /api/relay/token when the body contains a valid endpointId; preserves per-account+endpoint partitioning after authentication.
- Wraps Stack Auth calls in a typed auth boundary for both /api/relay/token and /api/relay/preferences; classification inspects only bounded metadata and never serializes upstream errors.
- Extends tests to cover auth throttles, generic auth outages, pre-auth ingress limiting, and existing account/device limits.
- Rollout: Ensure `CMUX_RELAY_TOKEN_RATE_LIMIT_ID` is set to enable the Vercel ingress gate. No client changes required.

<sup>Written for commit 12bbdf210b66606f8e59fb59ceed36a4ba853dfd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/10113?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved relay authentication error handling with clearer unavailable and rate-limited responses.
  * Added retry guidance for temporary authentication throttling.
  * Added early IP-based rate limiting for valid relay requests, including appropriate 429 responses.
  * Preserved authentication-first behavior for malformed requests and fail-closed handling.

* **Tests**
  * Added coverage for authentication failures, retry headers, unavailable services, and ingress rate limiting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->