### PR TITLE
Add CodeRouter CLI compatibility metadata

### DIFF
--- a/web/app/api/cli/config/route.ts
+++ b/web/app/api/cli/config/route.ts
@@ -6,6 +6,16 @@ import {
 
 const DEFAULT_STACK_API_URL = "https://api.stack-auth.com/api/v1";
 
+// This metadata is informational for now. Keep the legacy `version` field
+// below for clients that already consume the config response, and do not gate
+// the response on a client version until the released clients have had time
+// to learn this contract.
+const CLIENT_CONTRACT = {
+  protocolVersion: 4,
+  minCliVersion: "0.2.3",
+  requiredFeatures: ["coderouter", "organizations"],
+} as const;
+
 export function GET(request: Request): Response {
   const projectId = process.env.NEXT_PUBLIC_STACK_PROJECT_ID?.trim();
   const publishableClientKey =
@@ -26,6 +36,7 @@ export function GET(request: Request): Response {
   return Response.json(
     {
       version: 4,
+      clientContract: CLIENT_CONTRACT,
       auth: {
         apiUrl:
           process.env.NEXT_PUBLIC_STACK_API_URL?.trim() ||

--- a/web/tests/cli-config-route.test.ts
+++ b/web/tests/cli-config-route.test.ts
@@ -55,6 +55,11 @@ describe("CLI config route", () => {
       expect(response.headers.get("cache-control")).toBe("no-store");
       expect(await response.json()).toEqual({
         version: 4,
+        clientContract: {
+          protocolVersion: 4,
+          minCliVersion: "0.2.3",
+          requiredFeatures: ["coderouter", "organizations"],
+        },
         auth: {
           apiUrl: testEnvironment.NEXT_PUBLIC_STACK_API_URL,
           projectId: testEnvironment.NEXT_PUBLIC_STACK_PROJECT_ID,
@@ -74,6 +79,34 @@ describe("CLI config route", () => {
           exchangeUrl: "https://cmux.com/api/subrouter/tenant-exchange",
         },
       });
+    });
+  });
+
+  test("keeps compatibility metadata additive for older clients", async () => {
+    await withCliConfigEnvironment(testEnvironment, async () => {
+      const response = GET(
+        new Request("https://cmux.com/api/cli/config?clientVersion=0.2.2", {
+          headers: {
+            "user-agent": "coderouter/0.2.2",
+          },
+        }),
+      );
+
+      expect(response.status).toBe(200);
+      const body = await response.json();
+      expect(body.clientContract).toEqual({
+        protocolVersion: 4,
+        minCliVersion: "0.2.3",
+        requiredFeatures: ["coderouter", "organizations"],
+      });
+      expect(Object.keys(body.clientContract).sort()).toEqual([
+        "minCliVersion",
+        "protocolVersion",
+        "requiredFeatures",
+      ]);
+      expect(body).toHaveProperty("version", 4);
+      expect(body).toHaveProperty("auth");
+      expect(body).toHaveProperty("coderouter");
     });
   });
 

--- a/web/tests/cli-config-route.test.ts
+++ b/web/tests/cli-config-route.test.ts
@@ -107,6 +107,7 @@ describe("CLI config route", () => {
       expect(body).toHaveProperty("version", 4);
       expect(body).toHaveProperty("auth");
       expect(body).toHaveProperty("coderouter");
+      expect(body).toHaveProperty("subrouter");
     });
   });
 


### PR DESCRIPTION
## Summary
- add additive `clientContract` metadata to `/api/cli/config`
- advertise protocol 4, minimum CLI `0.2.3`, and the current CodeRouter/organizations features
- preserve the legacy config envelope and avoid client-version gating or auth/secret handoff

## Validation
- `bun test tests/cli-config-route.test.ts`
- `bunx eslint app/api/cli/config/route.ts tests/cli-config-route.test.ts`
- `bunx tsgo --noEmit` *(existing checkout dependency/type errors: missing workspace packages and unsupported Next config properties; no errors in the changed files)*

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/10116"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789234480&installation_model_id=21920&pr_number=10116&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F10116&signature=490abf0dfd2ea1371eb924dfe1beab2cf86fa3621e73179b17cb9e5e5710de57"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds compatibility metadata to /api/cli/config so the CodeRouter CLI can negotiate protocol and features without breaking older clients. Previously the route exposed only the legacy envelope; now it also includes clientContract.

- Returns clientContract: { protocolVersion: 4, minCliVersion: "0.2.3", requiredFeatures: ["coderouter", "organizations"] }.
- Preserves legacy fields (version, auth, coderouter, subrouter); no client-version gating and no auth/secret handoff changes.
- Extends tests to cover the new field, verify additive behavior for a 0.2.2 client, and assert legacy router fields remain present.
- No migrations or config changes required.

<sup>Written for commit daad65e078bf6930c98dfb653a345ed972f67c77. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/10116?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added CLI compatibility metadata to configuration responses, including protocol version, minimum supported CLI version, and required capabilities.
  * Preserved existing configuration fields and compatibility with older CLI versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->