### PR TITLE
Include `claude attach` in `claude_builtin_command_name`

### DIFF
--- a/Resources/bin/cmux-claude-wrapper
+++ b/Resources/bin/cmux-claude-wrapper
@@ -772,7 +772,7 @@ claude_passthrough_option_flag() {
 
 claude_builtin_command_name() {
     case "$1" in
-        agents|auth|auto-mode|config|api-key|daemon|doctor|install|mcp|\
+        agents|attach|auth|auto-mode|config|api-key|daemon|doctor|install|mcp|\
         experimental-next|plugin|plugins|project|rc|remote-control|setup-token|\
         ultrareview|update|upgrade)
             return 0

--- a/tests/test_claude_wrapper_hooks.py
+++ b/tests/test_claude_wrapper_hooks.py
@@ -877,6 +877,23 @@ def test_command_like_invocations_bypass_hook_injection(failures: list[str]) -> 
     expect("--session-id" not in real_argv, f"agents after global option passthrough: expected no --session-id injection, got {real_argv}", failures)
 
 
+def test_hidden_attach_subcommand_bypasses_hook_injection(failures: list[str]) -> None:
+    # `claude attach <id>` is a real subcommand (the attach door for `--bg`
+    # background sessions) but is hidden from `claude --help`, so it's easy to
+    # miss when refreshing the builtin-command list. Injecting
+    # --session-id/--settings ahead of it makes the CLI treat "attach" as the
+    # [prompt] positional and mint a fresh session instead of attaching.
+    code, real_argv, _, stderr, _, node_options, _, _, _, _ = run_wrapper(
+        socket_state="live",
+        argv=["attach", "abc12345"],
+    )
+    expect(code == 0, f"attach passthrough: wrapper exited {code}: {stderr}", failures)
+    expect(real_argv == ["attach", "abc12345"], f"attach passthrough: expected raw argv, got {real_argv}", failures)
+    expect("--settings" not in real_argv, f"attach passthrough: expected no --settings injection, got {real_argv}", failures)
+    expect("--session-id" not in real_argv, f"attach passthrough: expected no --session-id injection, got {real_argv}", failures)
+    expect(node_options == "__UNSET__", f"attach passthrough: expected no NODE_OPTIONS injection, got {node_options!r}", failures)
+
+
 def test_passthrough_flags_bypass_hook_injection(failures: list[str]) -> None:
     for flag in ("--help", "--version", "-h", "-v"):
         code, real_argv, _, stderr, _, node_options, _, _, _, _ = run_wrapper(
@@ -1893,6 +1910,7 @@ def main() -> int:
     test_live_socket_empty_settings_warns_instead_of_silent_drop(failures)
     test_plain_claude_launch_argv_has_no_empty_argument(failures)
     test_command_like_invocations_bypass_hook_injection(failures)
+    test_hidden_attach_subcommand_bypasses_hook_injection(failures)
     test_passthrough_flags_bypass_hook_injection(failures)
     test_agents_subcommand_removes_cmux_terminal_fingerprint(failures)
     test_hooks_disabled_preserves_cmux_terminal_env_for_custom_hooks(failures)


### PR DESCRIPTION
## Problem

`claude attach <id>` is a real Claude Code subcommand — the attach door printed for `--bg` background sessions — but it's hidden from `claude --help`, so it never made it into `claude_builtin_command_name` in `cmux-claude-wrapper`. Inside a cmux surface the wrapper therefore classifies it as a session entrypoint and execs the real CLI as:

```
claude --session-id <fresh-uuid> --settings '{...hooks...}' attach <id>
```

The CLI eats the injected flags and reads `attach` as the `[prompt]` positional: instead of attaching to the running background session, it mints a brand-new session with "attach" pre-filled in the composer.

Repro (any cmux surface, Claude Code ≥ 2.1.x): `claude attach <any-id>` → new session with "attach" in the prompt box, instead of `No job matching '<any-id>'` / attaching.

## Fix

Add `attach` to the builtin-command list so it passes through untouched, like `agents`/`mcp`/etc. Hook injection is meaningless for attach anyway — hooks live in the already-running background writer process, and a fresh `--session-id` on an attach invocation is exactly the bug.

Two-commit structure per the regression-test policy: commit 1 adds the failing test (`test_hidden_attach_subcommand_bypasses_hook_injection` in `tests/test_claude_wrapper_hooks.py`), commit 2 the one-word fix. Full wrapper suite passes locally.

Supersedes #10115 (same change, reopened from the right account).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/10117"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789234700&installation_model_id=21920&pr_number=10117&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F10117&signature=387c1a7a9c696ae21add86a49d777fb72d03b0838baa2f200d00d1a2d2d2d1d7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Passes the hidden `claude attach <id>` subcommand through the `cmux-claude-wrapper` so attaches work inside cmux surfaces. Previously the wrapper injected `--session-id`/`--settings`, the CLI treated "attach" as the prompt, and created a new session; now argv is forwarded unchanged and no hook or `NODE_OPTIONS` injection occurs.

**Review notes**
- Add `attach` to the builtin command list in `claude_builtin_command_name`, matching other pass-through subcommands.
- Add regression test `test_hidden_attach_subcommand_bypasses_hook_injection` to assert raw argv and absence of injected flags.
- No migration required; hooks are irrelevant for `attach` because they run in the existing background writer process.

<sup>Written for commit 815724872a1ce8fb33f97bff07801bf3f537b994. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/10117?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Preserved the behavior of the hidden `claude attach <id>` command so it runs without unintended hook settings, session identifiers, or `NODE_OPTIONS` changes.

- **Tests**
  - Added regression coverage to verify attach commands pass through unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->