### PR TITLE
Add workspace group selection to iOS task composer

### DIFF
--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+Capabilities.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+Capabilities.swift
@@ -1,3 +1,6 @@
+import CMUXMobileCore
+import CmuxMobileShellModel
+
 extension MobileShellComposite {
     /// Whether the connected Mac supports browser-pane streaming.
     public var supportsBrowserStream: Bool { supportedHostCapabilities.contains(Self.browserStreamCapability) }
@@ -68,26 +71,48 @@ extension MobileShellComposite {
         macDeviceID: String,
         instanceTag: String?
     ) -> Bool {
+        let state = workspaceState(
+            macDeviceID: macDeviceID,
+            instanceTag: instanceTag
+        )
+        return state?.status == .connected
+            && state?.workspaceGroupsAreAuthoritative == true
+    }
+
+    /// The create-in-group capability for one exact connected pairing. `nil`
+    /// means that pairing has not published a capability snapshot yet.
+    public func workspaceCreateInGroupCapability(
+        macDeviceID: String,
+        instanceTag: String?
+    ) -> Bool? {
+        let state = workspaceState(
+            macDeviceID: macDeviceID,
+            instanceTag: instanceTag
+        )
+        guard state?.status == .connected else { return nil }
+        return state?.actionCapabilities.supportsWorkspaceCreateInGroup
+    }
+
+    private func workspaceState(
+        macDeviceID: String,
+        instanceTag: String?
+    ) -> MacWorkspaceState? {
         let requestedKey = MacPairingKey(
             macDeviceID: macDeviceID,
             instanceTag: instanceTag
         )
-        let state: MacWorkspaceState?
         if let exactState = workspacesByMac[requestedKey] {
-            state = exactState
-        } else if instanceTag == nil,
-                  foregroundMacDeviceID.map({
-                      cmxCanonicalDeviceID($0) == cmxCanonicalDeviceID(macDeviceID)
-                  }) == true,
-                  foregroundMacKey.normalizedInstanceTag == nil {
-            // Legacy untagged pairings have no instance discriminator. Never
-            // borrow a tagged foreground build for a sibling route.
-            state = workspacesByMac[foregroundMacKey]
-        } else {
-            state = nil
+            return exactState
         }
-        return state?.status == .connected
-            && state?.workspaceGroupsAreAuthoritative == true
+        guard instanceTag == nil,
+              foregroundMacDeviceID.map({
+                  cmxCanonicalDeviceID($0) == cmxCanonicalDeviceID(macDeviceID)
+              }) == true,
+              foregroundMacKey.normalizedInstanceTag == nil else {
+            // Tagged pairings must never borrow another app instance's state.
+            return nil
+        }
+        return workspacesByMac[foregroundMacKey]
     }
     /// Whether the Mac supports creating workspace groups from iOS.
     public var supportsWorkspaceGroupCreate: Bool {

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+Capabilities.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+Capabilities.swift
@@ -72,10 +72,20 @@ extension MobileShellComposite {
             macDeviceID: macDeviceID,
             instanceTag: instanceTag
         )
-        let state = workspacesByMac[requestedKey]
-            ?? (foregroundMacDeviceID == macDeviceID
-                ? workspacesByMac[foregroundMacKey]
-                : nil)
+        let state: MacWorkspaceState?
+        if let exactState = workspacesByMac[requestedKey] {
+            state = exactState
+        } else if instanceTag == nil,
+                  foregroundMacDeviceID.map({
+                      cmxCanonicalDeviceID($0) == cmxCanonicalDeviceID(macDeviceID)
+                  }) == true,
+                  foregroundMacKey.normalizedInstanceTag == nil {
+            // Legacy untagged pairings have no instance discriminator. Never
+            // borrow a tagged foreground build for a sibling route.
+            state = workspacesByMac[foregroundMacKey]
+        } else {
+            state = nil
+        }
         return state?.status == .connected
             && state?.workspaceGroupsAreAuthoritative == true
     }

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+Capabilities.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+Capabilities.swift
@@ -60,6 +60,25 @@ extension MobileShellComposite {
         supportedHostCapabilities.contains(Self.workspaceCreateInGroupCapability)
             && discoversMacScopedWorkspaceMutations
     }
+
+    /// Whether a complete workspace-group inventory is available for one exact
+    /// Mac pairing. An empty authoritative list means the Mac has no groups;
+    /// `false` means the list may still be loading or stale.
+    public func workspaceGroupInventoryIsAuthoritative(
+        macDeviceID: String,
+        instanceTag: String?
+    ) -> Bool {
+        let requestedKey = MacPairingKey(
+            macDeviceID: macDeviceID,
+            instanceTag: instanceTag
+        )
+        let state = workspacesByMac[requestedKey]
+            ?? (foregroundMacDeviceID == macDeviceID
+                ? workspacesByMac[foregroundMacKey]
+                : nil)
+        return state?.status == .connected
+            && state?.workspaceGroupsAreAuthoritative == true
+    }
     /// Whether the Mac supports creating workspace groups from iOS.
     public var supportsWorkspaceGroupCreate: Bool {
         supportedHostCapabilities.contains(Self.workspaceGroupCreateCapability)

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+Helpers.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+Helpers.swift
@@ -30,7 +30,9 @@ extension MobileShellComposite {
             supportsCloseActions: supportedHostCapabilities.contains("workspace.close.v1"),
             supportsMoveActions: supportedHostCapabilities.contains("workspace.move.v1") && allowsMacScopedMutations,
             supportsGroupActions: supportedHostCapabilities.contains("workspace.group_actions.v1") && allowsMacScopedMutations,
-            supportsGroupCreate: supportedHostCapabilities.contains("workspace.group_create.v1") && allowsMacScopedMutations
+            supportsGroupCreate: supportedHostCapabilities.contains("workspace.group_create.v1") && allowsMacScopedMutations,
+            supportsWorkspaceCreateInGroup: supportedHostCapabilities.contains("workspace.create_in_group.v1")
+                && allowsMacScopedMutations
         )
     }
 

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+SecondaryPromotion.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+SecondaryPromotion.swift
@@ -857,8 +857,9 @@ extension MobileShellComposite {
                 groups: authoritativeSnapshot.groups
                     ?? workspacesByMac[foregroundMacKey]?.groups
                     ?? priorSecondaryGroups,
-                workspaceGroupsAreAuthoritative: authoritativeSnapshot.groups != nil
-                    || workspacesByMac[foregroundMacKey]?.workspaceGroupsAreAuthoritative == true,
+                // Preserve cached rows for continuity, but require group
+                // metadata from this promotion before trusting a destination.
+                workspaceGroupsAreAuthoritative: authoritativeSnapshot.groups != nil,
                 status: .connected,
                 actionCapabilities: sub.actionCapabilities
             )

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+SecondaryPromotion.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+SecondaryPromotion.swift
@@ -857,6 +857,8 @@ extension MobileShellComposite {
                 groups: authoritativeSnapshot.groups
                     ?? workspacesByMac[foregroundMacKey]?.groups
                     ?? priorSecondaryGroups,
+                workspaceGroupsAreAuthoritative: authoritativeSnapshot.groups != nil
+                    || workspacesByMac[foregroundMacKey]?.workspaceGroupsAreAuthoritative == true,
                 status: .connected,
                 actionCapabilities: sub.actionCapabilities
             )

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+WorkspaceCreateRequest.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+WorkspaceCreateRequest.swift
@@ -29,11 +29,18 @@ extension MobileShellComposite {
         pinnedContext context: WorkspaceCreatePinnedContext,
         willStartCreate: (@MainActor () -> Void)? = nil
     ) async -> Result<Void, MobileWorkspaceMutationFailure> {
-        guard groupID == nil || allowsMacScopedWorkspaceMutations(targetClient: context.client) else {
+        guard groupID == nil
+            || spec?.workspaceGroupID == nil
+            || groupID == spec?.workspaceGroupID else {
+            return .failure(.rejected(hostDisplayName: context.hostDisplayName))
+        }
+        let requestedGroupID = groupID ?? spec?.workspaceGroupID
+        guard requestedGroupID == nil
+            || allowsMacScopedWorkspaceMutations(targetClient: context.client) else {
             return .failure(.authorizationFailed(hostDisplayName: context.hostDisplayName))
         }
         if let createWorkspaceTask {
-            guard spec == nil, createWorkspaceTaskSpec == nil, createWorkspaceTaskGroupID == groupID else {
+            guard spec == nil, createWorkspaceTaskSpec == nil, createWorkspaceTaskGroupID == requestedGroupID else {
                 return .failure(.busy(hostDisplayName: context.hostDisplayName))
             }
             return await createWorkspaceTask.value
@@ -48,14 +55,14 @@ extension MobileShellComposite {
             defer { self?.clearCreateWorkspaceTask(id: taskID) }
             guard let self else { return .success(()) }
             return await self.createRemoteWorkspace(
-                inGroup: groupID,
+                inGroup: requestedGroupID,
                 appliesOperationalError: false,
                 spec: spec,
                 pinnedContext: context
             )
         }
         createWorkspaceTask = task
-        createWorkspaceTaskGroupID = groupID
+        createWorkspaceTaskGroupID = requestedGroupID
         createWorkspaceTaskSpec = spec
         return await task.value
     }

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
@@ -6802,8 +6802,10 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
                     groups: snapshot.groups
                         ?? self.workspacesByMac[ownerKey]?.groups
                         ?? [],
-                    workspaceGroupsAreAuthoritative: snapshot.groups != nil
-                        || self.workspacesByMac[ownerKey]?.workspaceGroupsAreAuthoritative == true,
+                    // A secondary list without group metadata keeps the last
+                    // rows for continuity, but cannot authorize a restored
+                    // destination until a fresh group snapshot arrives.
+                    workspaceGroupsAreAuthoritative: snapshot.groups != nil,
                     status: .connected,
                     actionCapabilities: subscription.actionCapabilities
                 )

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
@@ -6629,6 +6629,7 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
     func markSecondaryMacUnavailable(_ ownerKey: MacPairingKey) {
         guard var state = workspacesByMac[ownerKey] else { return }
         state.status = .unavailable
+        state.workspaceGroupsAreAuthoritative = false
         workspacesByMac[ownerKey] = state
     }
 
@@ -6801,6 +6802,8 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
                     groups: snapshot.groups
                         ?? self.workspacesByMac[ownerKey]?.groups
                         ?? [],
+                    workspaceGroupsAreAuthoritative: snapshot.groups != nil
+                        || self.workspacesByMac[ownerKey]?.workspaceGroupsAreAuthoritative == true,
                     status: .connected,
                     actionCapabilities: subscription.actionCapabilities
                 )
@@ -7388,7 +7391,15 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         } else {
             state.workspaces = stamped
         }
-        if let groups { state.groups = groups }
+        if let groups {
+            state.groups = groups
+            state.workspaceGroupsAreAuthoritative = true
+        } else if !merge {
+            // A complete response without group metadata is not safe to use to
+            // validate a restored group. Keep the rows, but require a future
+            // authoritative group snapshot before clearing a pending ID.
+            state.workspaceGroupsAreAuthoritative = false
+        }
         state.status = .connected
         state.actionCapabilities = Self.workspaceActionCapabilities(
             from: supportedHostCapabilities,
@@ -9744,6 +9755,7 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         // it to `.unavailable` to match the global connection state.
         if var offline = workspacesByMac[offlineForegroundKey] {
             offline.status = .unavailable
+            offline.workspaceGroupsAreAuthoritative = false
             workspacesByMac[offlineForegroundKey] = offline
         }
         rawTerminalInputBuffer.clear()
@@ -10066,6 +10078,7 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         removeFocusedConnection(ifMatching: connection)
         if var offline = workspacesByMac[foregroundMacKey] {
             offline.status = .unavailable
+            offline.workspaceGroupsAreAuthoritative = false
             workspacesByMac[foregroundMacKey] = offline
         }
         connectionState = .disconnected
@@ -10577,6 +10590,10 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
             return
         }
         macConnectionStatus = .reconnecting
+        if var foregroundState = workspacesByMac[foregroundMacKey] {
+            foregroundState.workspaceGroupsAreAuthoritative = false
+            workspacesByMac[foregroundMacKey] = foregroundState
+        }
         isRecoveringConnection = true
         connectionRecoveryFailed = false
     }
@@ -10587,6 +10604,10 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
             return
         }
         macConnectionStatus = .unavailable
+        if var foregroundState = workspacesByMac[foregroundMacKey] {
+            foregroundState.workspaceGroupsAreAuthoritative = false
+            workspacesByMac[foregroundMacKey] = foregroundState
+        }
         isRecoveringConnection = false
         connectionRecoveryFailed = true
     }

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileWorkspaceCreateSpec.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileWorkspaceCreateSpec.swift
@@ -1,3 +1,4 @@
+public import CmuxMobileShellModel
 public import Foundation
 
 /// Optional parameters for a mobile `workspace.create` request.
@@ -10,6 +11,12 @@ public struct MobileWorkspaceCreateSpec: Equatable, Sendable {
     public var initialCommand: String?
     /// Initial terminal environment.
     public var initialEnv: [String: String]?
+    /// Phone-side identifier of the workspace group that should contain the
+    /// new workspace, or `nil` to create it ungrouped.
+    ///
+    /// Aggregate identifiers are resolved to the owning Mac's RPC identifier
+    /// by the shell before the request is sent.
+    public var workspaceGroupID: MobileWorkspaceGroupPreview.ID?
     /// Stable identity for idempotent retry of one logical create operation.
     public var operationID: UUID?
 
@@ -19,17 +26,20 @@ public struct MobileWorkspaceCreateSpec: Equatable, Sendable {
     ///   - workingDirectory: Initial working directory.
     ///   - initialCommand: Initial terminal command.
     ///   - initialEnv: Initial terminal environment.
+    ///   - workspaceGroupID: Optional destination workspace group.
     public init(
         title: String? = nil,
         workingDirectory: String? = nil,
         initialCommand: String? = nil,
         initialEnv: [String: String]? = nil,
+        workspaceGroupID: MobileWorkspaceGroupPreview.ID? = nil,
         operationID: UUID? = nil
     ) {
         self.title = title
         self.workingDirectory = workingDirectory
         self.initialCommand = initialCommand
         self.initialEnv = initialEnv
+        self.workspaceGroupID = workspaceGroupID
         self.operationID = operationID
     }
 }

--- a/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/MobileTaskComposerSubmitTests.swift
+++ b/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/MobileTaskComposerSubmitTests.swift
@@ -1,4 +1,5 @@
 import CmuxMobilePairedMac
+import CmuxMobileShellModel
 import Foundation
 import Testing
 @testable import CmuxMobileShell
@@ -38,6 +39,60 @@ import Testing
         )
         #expect(store.selectedWorkspaceID == createdWorkspace.id)
         #expect(createdWorkspace.terminals.first?.isReady == true)
+    }
+
+    @Test func submitTaskComposerSendsSelectedWorkspaceGroup() async throws {
+        let router = RoutingHostRouter()
+        let store = try await makeRoutingConnectedStore(
+            router: router,
+            macScopedWorkspaceMutations: true,
+            hostCapabilities: [
+                "workspace.task_create.v1",
+                "workspace.create_in_group.v1",
+            ]
+        )
+        let groupID: MobileWorkspaceGroupPreview.ID = "test-mac\u{1F}nightly\u{1F}group-a"
+        store.workspaceGroups = [
+            MobileWorkspaceGroupPreview(
+                id: groupID,
+                remoteGroupID: "group-a",
+                macDeviceID: "test-mac",
+                macInstanceTag: "nightly",
+                name: "Group A",
+                anchorWorkspaceID: .init(rawValue: RoutingHostRouter.workspaceID)
+            ),
+        ]
+        let result = await store.submitTaskComposer(
+            macDeviceID: "test-mac",
+            spec: MobileWorkspaceCreateSpec(
+                title: "Grouped task",
+                workspaceGroupID: groupID,
+                operationID: UUID()
+            )
+        )
+
+        guard case .success = result else {
+            return #expect(Bool(false), "grouped task create should succeed, got (String(describing: result))")
+        }
+        #expect(await router.recordedWorkspaceCreates().first?.groupID == "group-a")
+    }
+
+    @Test func workspaceCreateRejectsConflictingExplicitAndSpecGroups() async throws {
+        let router = RoutingHostRouter()
+        let store = try await makeRoutingConnectedStore(
+            router: router,
+            macScopedWorkspaceMutations: true
+        )
+
+        let result = await store.createWorkspaceRequest(
+            inGroup: "group-a",
+            spec: MobileWorkspaceCreateSpec(workspaceGroupID: "group-b")
+        )
+
+        guard case .failure(.rejected) = result else {
+            return #expect(Bool(false), "conflicting group destinations must be rejected")
+        }
+        #expect(await router.recordedWorkspaceCreateCount() == 0)
     }
 
     @Test func taskComposerRejectsResponseWithoutCreatedWorkspaceID() async throws {

--- a/Packages/iOS/CmuxMobileShellModel/Sources/CmuxMobileShellModel/MacWorkspaceState.swift
+++ b/Packages/iOS/CmuxMobileShellModel/Sources/CmuxMobileShellModel/MacWorkspaceState.swift
@@ -30,6 +30,9 @@ public struct MacWorkspaceState: Identifiable, Equatable, Sendable {
     /// This Mac's workspace groups, in section order (empty when the Mac reports
     /// none or is too old to emit them).
     public var groups: [MobileWorkspaceGroupPreview]
+    /// Whether ``groups`` came from a complete host snapshot. A false value
+    /// means an empty list can still be a loading or capability projection.
+    public var workspaceGroupsAreAuthoritative: Bool
     /// Liveness of THIS Mac's data, so the UI can show per-Mac
     /// connecting/reconnecting/offline and the derivation can decide whether a
     /// dropped Mac's last-known rows stay (greyed) or are dropped.
@@ -53,6 +56,7 @@ public struct MacWorkspaceState: Identifiable, Equatable, Sendable {
         displayName: String? = nil,
         workspaces: [MobileWorkspacePreview] = [],
         groups: [MobileWorkspaceGroupPreview] = [],
+        workspaceGroupsAreAuthoritative: Bool = false,
         status: MobileMacConnectionStatus = .reconnecting,
         actionCapabilities: MobileWorkspaceActionCapabilities = .none
     ) {
@@ -61,6 +65,7 @@ public struct MacWorkspaceState: Identifiable, Equatable, Sendable {
         self.displayName = displayName
         self.workspaces = workspaces
         self.groups = groups
+        self.workspaceGroupsAreAuthoritative = workspaceGroupsAreAuthoritative
         self.status = status
         self.actionCapabilities = actionCapabilities
     }

--- a/Packages/iOS/CmuxMobileShellModel/Sources/CmuxMobileShellModel/MobileTaskComposerDraft.swift
+++ b/Packages/iOS/CmuxMobileShellModel/Sources/CmuxMobileShellModel/MobileTaskComposerDraft.swift
@@ -19,6 +19,9 @@ public struct MobileTaskComposerDraft: Codable, Equatable, Sendable {
     public var didEditDirectory: Bool
     /// Optional workspace name exactly as entered by the user.
     public var workspaceName: String?
+    /// Selected workspace group, or `nil` for an ungrouped workspace. Missing
+    /// keys decode as `nil` so drafts written by older builds remain valid.
+    public var workspaceGroupID: MobileWorkspaceGroupPreview.ID?
     /// Stable identity for retrying this logical task creation without duplication.
     public var operationID: UUID?
     /// Accepted identity awaiting an explicit refresh before this draft may be
@@ -35,6 +38,7 @@ public struct MobileTaskComposerDraft: Codable, Equatable, Sendable {
         directory: String,
         didEditDirectory: Bool,
         workspaceName: String? = nil,
+        workspaceGroupID: MobileWorkspaceGroupPreview.ID? = nil,
         operationID: UUID? = nil,
         completedOperationID: UUID? = nil
     ) {
@@ -46,6 +50,7 @@ public struct MobileTaskComposerDraft: Codable, Equatable, Sendable {
         self.directory = directory
         self.didEditDirectory = didEditDirectory
         self.workspaceName = workspaceName
+        self.workspaceGroupID = workspaceGroupID
         self.operationID = operationID
         self.completedOperationID = completedOperationID
     }

--- a/Packages/iOS/CmuxMobileShellModel/Sources/CmuxMobileShellModel/MobileTaskSubmissionSnapshot.swift
+++ b/Packages/iOS/CmuxMobileShellModel/Sources/CmuxMobileShellModel/MobileTaskSubmissionSnapshot.swift
@@ -4,7 +4,7 @@ public import Foundation
 ///
 /// The composer captures this value before its first suspension so a late RPC
 /// result cannot settle against template, Mac, prompt, workspace-name, or
-/// directory edits that were not part of the sent request.
+/// directory and group edits that were not part of the sent request.
 public struct MobileTaskSubmissionSnapshot: Equatable, Sendable {
     /// Identifier of the task template selected when submission began.
     public let templateID: MobileTaskTemplate.ID
@@ -21,6 +21,8 @@ public struct MobileTaskSubmissionSnapshot: Equatable, Sendable {
     public let workspaceName: String
     /// Workspace name with surrounding whitespace removed.
     public let trimmedWorkspaceName: String
+    /// Selected workspace group, or `nil` for an ungrouped workspace.
+    public let workspaceGroupID: MobileWorkspaceGroupPreview.ID?
     /// Unmodified working-directory text captured from the composer.
     public let directory: String
     /// Working directory with surrounding whitespace removed for validation.
@@ -49,6 +51,7 @@ public struct MobileTaskSubmissionSnapshot: Equatable, Sendable {
     ///   - macInstanceTag: Exact paired app instance to target, or `nil`.
     ///   - directory: Working-directory text shown in the composer.
     ///   - workspaceName: Optional workspace name shown in the composer.
+    ///   - workspaceGroupID: Optional destination workspace group.
     ///   - didEditDirectory: Whether the user changed the suggested directory.
     ///   - attachments: Attachment upload identifiers and staged byte counts.
     ///   - operationID: Stable idempotency key for submission retries.
@@ -60,6 +63,7 @@ public struct MobileTaskSubmissionSnapshot: Equatable, Sendable {
         macInstanceTag: String? = nil,
         directory: String,
         workspaceName: String = "",
+        workspaceGroupID: MobileWorkspaceGroupPreview.ID? = nil,
         didEditDirectory: Bool,
         attachments: [MobileTaskSubmissionAttachment] = [],
         operationID: UUID
@@ -71,6 +75,7 @@ public struct MobileTaskSubmissionSnapshot: Equatable, Sendable {
         self.modelID = modelID
         self.workspaceName = workspaceName
         self.trimmedWorkspaceName = workspaceName.trimmingCharacters(in: .whitespacesAndNewlines)
+        self.workspaceGroupID = workspaceGroupID
         self.directory = directory
         self.trimmedDirectory = directory.trimmingCharacters(in: .whitespacesAndNewlines)
         self.didEditDirectory = didEditDirectory
@@ -88,13 +93,14 @@ public struct MobileTaskSubmissionSnapshot: Equatable, Sendable {
     /// Template identity, presentation metadata, directory edit provenance,
     /// and operation identity are excluded because the Mac
     /// receives only the selected Mac, effective title, composed command and
-    /// environment, and trimmed effective working directory.
+    /// environment, trimmed effective working directory, and destination group.
     public func isRequestEquivalent(to other: MobileTaskSubmissionSnapshot) -> Bool {
         Self.hasEqualUTF8(macDeviceID, other.macDeviceID)
             && Self.hasEqualUTF8(macInstanceTag, other.macInstanceTag)
             && Self.hasEqualUTF8(composition.initialCommand, other.composition.initialCommand)
             && Self.hasEqualUTF8(composition.initialEnv, other.composition.initialEnv)
             && Self.hasEqualUTF8(workspaceTitle, other.workspaceTitle)
+            && Self.hasEqualUTF8(workspaceGroupID?.rawValue, other.workspaceGroupID?.rawValue)
             && Self.hasEqualUTF8(trimmedDirectory, other.trimmedDirectory)
             && attachments == other.attachments
     }
@@ -110,6 +116,7 @@ public struct MobileTaskSubmissionSnapshot: Equatable, Sendable {
             prompt: prompt,
             modelID: modelID,
             workspaceName: workspaceName,
+            workspaceGroupID: workspaceGroupID,
             directory: directory,
             didEditDirectory: didEditDirectory,
             attachments: attachments,
@@ -170,6 +177,7 @@ public struct MobileTaskSubmissionSnapshot: Equatable, Sendable {
             directory: directory,
             didEditDirectory: didEditDirectory,
             workspaceName: workspaceName.isEmpty ? nil : workspaceName,
+            workspaceGroupID: workspaceGroupID,
             operationID: operationID
         )
     }
@@ -181,6 +189,7 @@ public struct MobileTaskSubmissionSnapshot: Equatable, Sendable {
         prompt: String,
         modelID: String?,
         workspaceName: String,
+        workspaceGroupID: MobileWorkspaceGroupPreview.ID?,
         directory: String,
         didEditDirectory: Bool,
         attachments: [MobileTaskSubmissionAttachment],
@@ -196,6 +205,7 @@ public struct MobileTaskSubmissionSnapshot: Equatable, Sendable {
         self.modelID = modelID
         self.workspaceName = workspaceName
         self.trimmedWorkspaceName = trimmedWorkspaceName
+        self.workspaceGroupID = workspaceGroupID
         self.directory = directory
         self.trimmedDirectory = trimmedDirectory
         self.didEditDirectory = didEditDirectory

--- a/Packages/iOS/CmuxMobileShellModel/Sources/CmuxMobileShellModel/MobileWorkspaceActionCapabilities.swift
+++ b/Packages/iOS/CmuxMobileShellModel/Sources/CmuxMobileShellModel/MobileWorkspaceActionCapabilities.swift
@@ -14,6 +14,8 @@ public struct MobileWorkspaceActionCapabilities: Equatable, Sendable {
     public var supportsGroupActions: Bool
     /// Whether workspace group creation requests are supported.
     public var supportsGroupCreate: Bool
+    /// Whether a new workspace can be created directly inside a group.
+    public var supportsWorkspaceCreateInGroup: Bool
 
     /// No workspace actions are supported.
     public static let none = MobileWorkspaceActionCapabilities()
@@ -26,7 +28,8 @@ public struct MobileWorkspaceActionCapabilities: Equatable, Sendable {
         supportsCloseActions: Bool = false,
         supportsMoveActions: Bool = false,
         supportsGroupActions: Bool = false,
-        supportsGroupCreate: Bool = false
+        supportsGroupCreate: Bool = false,
+        supportsWorkspaceCreateInGroup: Bool = false
     ) {
         self.supportsWorkspaceActions = supportsWorkspaceActions
         self.supportsWorkspaceMetadata = supportsWorkspaceMetadata
@@ -35,5 +38,6 @@ public struct MobileWorkspaceActionCapabilities: Equatable, Sendable {
         self.supportsMoveActions = supportsMoveActions
         self.supportsGroupActions = supportsGroupActions
         self.supportsGroupCreate = supportsGroupCreate
+        self.supportsWorkspaceCreateInGroup = supportsWorkspaceCreateInGroup
     }
 }

--- a/Packages/iOS/CmuxMobileShellModel/Tests/CmuxMobileShellModelTests/MobileTaskSubmissionSnapshotTests.swift
+++ b/Packages/iOS/CmuxMobileShellModel/Tests/CmuxMobileShellModelTests/MobileTaskSubmissionSnapshotTests.swift
@@ -129,6 +129,16 @@ import Testing
         expectIdentityRotated(from: generated, to: custom)
     }
 
+    @Test func workspaceGroupChangesEffectiveRequest() {
+        let template = MobileTaskTemplate(name: "Codex", icon: "agent:codex", command: "codex")
+        let ungrouped = snapshot(template: template)
+        let grouped = snapshot(template: template, workspaceGroupID: "group-a")
+
+        #expect(!ungrouped.isRequestEquivalent(to: grouped))
+        expectIdentityRotated(from: ungrouped, to: grouped)
+        #expect(grouped.draft.workspaceGroupID == "group-a")
+    }
+
     @Test func workspaceNameUsesTrimmedWireValue() {
         let template = MobileTaskTemplate(name: "Codex", icon: "agent:codex", command: "codex")
         let padded = snapshot(template: template, workspaceName: "  Release checklist  ")
@@ -474,7 +484,11 @@ import Testing
             icon: "agent:codex",
             command: "codex"
         )
-        let captured = snapshot(template: template, macInstanceTag: "nightly")
+        let captured = snapshot(
+            template: template,
+            macInstanceTag: "nightly",
+            workspaceGroupID: "mac-a\u{1F}nightly\u{1F}group-a"
+        )
 
         let rebound = captured.withOperationID(UUID())
         #expect(rebound.macInstanceTag == "nightly")
@@ -487,6 +501,7 @@ import Testing
             from: JSONEncoder().encode(draft)
         )
         #expect(decoded.macInstanceTag == "nightly")
+        #expect(decoded.workspaceGroupID == "mac-a\u{1F}nightly\u{1F}group-a")
     }
 
     @Test func legacyDraftPayloadDecodesWithoutInstanceTag() throws {
@@ -499,6 +514,7 @@ import Testing
         )
         #expect(decoded.macInstanceTag == nil)
         #expect(decoded.macDeviceID == "mac-a")
+        #expect(decoded.workspaceGroupID == nil)
     }
 
     private func snapshot(
@@ -509,6 +525,7 @@ import Testing
         directory: String = "~/cmux",
         workspaceName: String = "",
         modelID: String? = nil,
+        workspaceGroupID: MobileWorkspaceGroupPreview.ID? = nil,
         attachments: [MobileTaskSubmissionAttachment] = []
     ) -> MobileTaskSubmissionSnapshot {
         MobileTaskSubmissionSnapshot(
@@ -519,6 +536,7 @@ import Testing
             macInstanceTag: macInstanceTag,
             directory: directory,
             workspaceName: workspaceName,
+            workspaceGroupID: workspaceGroupID,
             didEditDirectory: false,
             attachments: attachments,
             operationID: UUID()

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/Debug/TaskComposer/TaskComposerAccessibilityPreviewView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/Debug/TaskComposer/TaskComposerAccessibilityPreviewView.swift
@@ -178,6 +178,7 @@ public struct TaskComposerAccessibilityPreviewView: View {
                             Self.stablePreviewMac,
                             Self.backupPreviewMac,
                         ],
+                        availableWorkspaceGroups: [Self.previewWorkspaceGroup],
                         taskAttachmentsCapabilityOverride: advertisesTaskAttachments ? true : nil,
                         initialAttachments: stagedPreviewAttachments,
                         submitTaskComposer: { macDeviceID, _, spec, willStartCreate in
@@ -252,6 +253,14 @@ public struct TaskComposerAccessibilityPreviewView: View {
         isActive: true,
         stackUserID: nil,
         instanceTag: "nightly"
+    )
+
+    private static let previewWorkspaceGroup = MobileWorkspaceGroupPreview(
+        id: "task-composer-preview-group",
+        macDeviceID: previewMac.macDeviceID,
+        macInstanceTag: previewMac.instanceTag,
+        name: "Focus work",
+        anchorWorkspaceID: "task-composer-preview-group-anchor"
     )
 
     private static let longPrompt = (1...80)
@@ -616,6 +625,8 @@ private struct TaskComposerSubmissionProbe: View {
                 .accessibilityIdentifier("MobileTaskComposerSubmittedInitialCommand")
             Text(verbatim: spec.initialEnv?["CMUX_TASK_PROMPT"] ?? "<nil>")
                 .accessibilityIdentifier("MobileTaskComposerSubmittedPrompt")
+            Text(verbatim: spec.workspaceGroupID?.rawValue ?? "<nil>")
+                .accessibilityIdentifier("MobileTaskComposerSubmittedWorkspaceGroupID")
             Text(verbatim: spec.operationID?.uuidString ?? "<nil>")
                 .accessibilityIdentifier("MobileTaskComposerSubmittedOperationID")
         }

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TaskComposer/TaskComposerContextSection.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TaskComposer/TaskComposerContextSection.swift
@@ -13,6 +13,7 @@ struct TaskComposerContextSection: View {
     let workspaceGroups: [MobileWorkspaceGroupPreview]
     let selectedWorkspaceGroupID: MobileWorkspaceGroupPreview.ID?
     let workspaceGroupSelectionPending: Bool
+    let workspaceGroupSelectionRequiresResolution: Bool
     let showsWorkspaceGroupPicker: Bool
     let directory: String
     let isDisabled: Bool
@@ -37,6 +38,7 @@ struct TaskComposerContextSection: View {
                 workspaceGroups: workspaceGroups,
                 selectedWorkspaceGroupID: selectedWorkspaceGroupID,
                 workspaceGroupSelectionPending: workspaceGroupSelectionPending,
+                workspaceGroupSelectionRequiresResolution: workspaceGroupSelectionRequiresResolution,
                 showsWorkspaceGroupPicker: showsWorkspaceGroupPicker,
                 directory: directory,
                 isDisabled: isDisabled,

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TaskComposer/TaskComposerContextSection.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TaskComposer/TaskComposerContextSection.swift
@@ -1,48 +1,57 @@
 #if os(iOS)
 import CmuxMobilePairedMac
+import CmuxMobileShellModel
 import SwiftUI
 
-/// Groups the optional workspace title with the Mac and directory that define
-/// where the task will run.
+/// Groups the optional workspace title with the Mac, group, and directory that
+/// define where the task will run.
 struct TaskComposerContextSection: View {
     @Binding var workspaceName: String
     let machines: [MobilePairedMac]
     let selectedMacPairingID: String
     let buildLabelsByID: [String: String]
+    let workspaceGroups: [MobileWorkspaceGroupPreview]
+    let selectedWorkspaceGroupID: MobileWorkspaceGroupPreview.ID?
+    let showsWorkspaceGroupPicker: Bool
     let directory: String
     let isDisabled: Bool
     let endWorkspaceNameEditing: () -> Void
     let selectMachine: (String, String?) -> Void
+    let selectWorkspaceGroup: (MobileWorkspaceGroupPreview.ID?) -> Void
     let selectDirectory: () -> Void
 
     var body: some View {
-        VStack(spacing: 0) {
+        VStack(spacing: 12) {
             TaskComposerWorkspaceNameField(
                 workspaceName: $workspaceName,
                 isDisabled: isDisabled,
                 endEditing: endWorkspaceNameEditing
             )
-
-            Divider()
-                .padding(.horizontal, 10)
+            .background(cardBackground, in: cardShape)
 
             TaskComposerRoutePicker(
                 machines: machines,
                 selectedMacPairingID: selectedMacPairingID,
                 buildLabelsByID: buildLabelsByID,
+                workspaceGroups: workspaceGroups,
+                selectedWorkspaceGroupID: selectedWorkspaceGroupID,
+                showsWorkspaceGroupPicker: showsWorkspaceGroupPicker,
                 directory: directory,
                 isDisabled: isDisabled,
                 selectMachine: selectMachine,
+                selectWorkspaceGroup: selectWorkspaceGroup,
                 selectDirectory: selectDirectory
             )
+            .background(cardBackground, in: cardShape)
         }
-        .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 22, style: .continuous))
-        .overlay {
-            RoundedRectangle(cornerRadius: 22, style: .continuous)
-                .strokeBorder(Color.primary.opacity(0.07), lineWidth: 1)
-                .allowsHitTesting(false)
-        }
-        .shadow(color: Color.black.opacity(0.04), radius: 12, y: 5)
+    }
+
+    private var cardBackground: Color {
+        Color(uiColor: .secondarySystemGroupedBackground)
+    }
+
+    private var cardShape: RoundedRectangle {
+        RoundedRectangle(cornerRadius: 16, style: .continuous)
     }
 }
 #endif

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TaskComposer/TaskComposerContextSection.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TaskComposer/TaskComposerContextSection.swift
@@ -12,6 +12,7 @@ struct TaskComposerContextSection: View {
     let buildLabelsByID: [String: String]
     let workspaceGroups: [MobileWorkspaceGroupPreview]
     let selectedWorkspaceGroupID: MobileWorkspaceGroupPreview.ID?
+    let workspaceGroupSelectionPending: Bool
     let showsWorkspaceGroupPicker: Bool
     let directory: String
     let isDisabled: Bool
@@ -35,6 +36,7 @@ struct TaskComposerContextSection: View {
                 buildLabelsByID: buildLabelsByID,
                 workspaceGroups: workspaceGroups,
                 selectedWorkspaceGroupID: selectedWorkspaceGroupID,
+                workspaceGroupSelectionPending: workspaceGroupSelectionPending,
                 showsWorkspaceGroupPicker: showsWorkspaceGroupPicker,
                 directory: directory,
                 isDisabled: isDisabled,

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TaskComposer/TaskComposerOptionsSheet.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TaskComposer/TaskComposerOptionsSheet.swift
@@ -18,6 +18,7 @@ struct TaskComposerOptionsSheet: View {
     let workspaceGroups: [MobileWorkspaceGroupPreview]
     let selectedWorkspaceGroupID: MobileWorkspaceGroupPreview.ID?
     let workspaceGroupSelectionPending: Bool
+    let workspaceGroupSelectionRequiresResolution: Bool
     let showsWorkspaceGroupPicker: Bool
     let directory: String
     let isDisabled: Bool
@@ -47,6 +48,7 @@ struct TaskComposerOptionsSheet: View {
                     workspaceGroups: workspaceGroups,
                     selectedWorkspaceGroupID: selectedWorkspaceGroupID,
                     workspaceGroupSelectionPending: workspaceGroupSelectionPending,
+                    workspaceGroupSelectionRequiresResolution: workspaceGroupSelectionRequiresResolution,
                     showsWorkspaceGroupPicker: showsWorkspaceGroupPicker,
                     directory: directory,
                     isDisabled: isDisabled,

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TaskComposer/TaskComposerOptionsSheet.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TaskComposer/TaskComposerOptionsSheet.swift
@@ -7,7 +7,7 @@ import CmuxMobileSupport
 import SwiftUI
 import UIKit
 
-/// The composer's workspace name, Mac, and directory controls.
+/// The composer's workspace name, Mac, group, and directory controls.
 struct TaskComposerOptionsSheet: View {
     @Environment(\.dismiss) private var dismiss
 
@@ -15,11 +15,15 @@ struct TaskComposerOptionsSheet: View {
     let machines: [MobilePairedMac]
     let selectedMacPairingID: String
     let buildLabelsByID: [String: String]
+    let workspaceGroups: [MobileWorkspaceGroupPreview]
+    let selectedWorkspaceGroupID: MobileWorkspaceGroupPreview.ID?
+    let showsWorkspaceGroupPicker: Bool
     let directory: String
     let isDisabled: Bool
     let directoryCandidates: [MobileTaskDirectoryCandidate]
     let endWorkspaceNameEditing: () -> Void
     let selectMachine: (String, String?) -> Void
+    let selectWorkspaceGroup: (MobileWorkspaceGroupPreview.ID?) -> Void
     let selectDirectory: (String) -> Void
     let searchMac: (
         String
@@ -39,10 +43,14 @@ struct TaskComposerOptionsSheet: View {
                     machines: machines,
                     selectedMacPairingID: selectedMacPairingID,
                     buildLabelsByID: buildLabelsByID,
+                    workspaceGroups: workspaceGroups,
+                    selectedWorkspaceGroupID: selectedWorkspaceGroupID,
+                    showsWorkspaceGroupPicker: showsWorkspaceGroupPicker,
                     directory: directory,
                     isDisabled: isDisabled,
                     endWorkspaceNameEditing: endWorkspaceNameEditing,
                     selectMachine: selectMachine,
+                    selectWorkspaceGroup: selectWorkspaceGroup,
                     selectDirectory: { isDirectoryPickerPresented = true }
                 )
                 .dynamicTypeSize(...DynamicTypeSize.xxxLarge)

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TaskComposer/TaskComposerOptionsSheet.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TaskComposer/TaskComposerOptionsSheet.swift
@@ -17,6 +17,7 @@ struct TaskComposerOptionsSheet: View {
     let buildLabelsByID: [String: String]
     let workspaceGroups: [MobileWorkspaceGroupPreview]
     let selectedWorkspaceGroupID: MobileWorkspaceGroupPreview.ID?
+    let workspaceGroupSelectionPending: Bool
     let showsWorkspaceGroupPicker: Bool
     let directory: String
     let isDisabled: Bool
@@ -45,6 +46,7 @@ struct TaskComposerOptionsSheet: View {
                     buildLabelsByID: buildLabelsByID,
                     workspaceGroups: workspaceGroups,
                     selectedWorkspaceGroupID: selectedWorkspaceGroupID,
+                    workspaceGroupSelectionPending: workspaceGroupSelectionPending,
                     showsWorkspaceGroupPicker: showsWorkspaceGroupPicker,
                     directory: directory,
                     isDisabled: isDisabled,

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TaskComposer/TaskComposerRouteIcon.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TaskComposer/TaskComposerRouteIcon.swift
@@ -10,21 +10,18 @@ struct TaskComposerRouteIcon: View {
     let content: Content
 
     var body: some View {
-        ZStack {
-            Circle()
-                .fill(Color.accentColor.opacity(0.12))
-
+        Group {
             switch content {
             case .symbol(let name):
                 Image(systemName: name)
-                    .font(.system(size: 13, weight: .semibold))
+                    .font(.system(size: 17, weight: .semibold))
                     .foregroundStyle(Color.accentColor)
             case .emoji(let emoji):
                 Text(emoji)
-                    .font(.system(size: 17))
+                    .font(.system(size: 19))
             }
         }
-        .frame(width: 28, height: 28)
+        .frame(width: 32, height: 32)
         .accessibilityHidden(true)
     }
 }
@@ -38,11 +35,11 @@ struct TaskComposerRouteLabel: View {
     let chevronSystemName: String
 
     var body: some View {
-        HStack(spacing: 8) {
+        HStack(spacing: 12) {
             TaskComposerRouteIcon(content: icon)
-            VStack(alignment: .leading, spacing: 1) {
+            VStack(alignment: .leading, spacing: 2) {
                 Text(title)
-                    .font(.caption2.weight(.medium))
+                    .font(.caption.weight(.medium))
                     .foregroundStyle(Color.secondary)
                     .lineLimit(1)
                     .minimumScaleFactor(0.75)
@@ -60,6 +57,7 @@ struct TaskComposerRouteLabel: View {
                 .accessibilityHidden(true)
         }
         .frame(maxWidth: .infinity, minHeight: 52, alignment: .leading)
+        .padding(.horizontal, 16)
         .contentShape(Rectangle())
     }
 }

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TaskComposer/TaskComposerRoutePicker.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TaskComposer/TaskComposerRoutePicker.swift
@@ -11,6 +11,7 @@ struct TaskComposerRoutePicker: View {
     let workspaceGroups: [MobileWorkspaceGroupPreview]
     let selectedWorkspaceGroupID: MobileWorkspaceGroupPreview.ID?
     let workspaceGroupSelectionPending: Bool
+    let workspaceGroupSelectionRequiresResolution: Bool
     let showsWorkspaceGroupPicker: Bool
     let directory: String
     let isDisabled: Bool
@@ -33,6 +34,7 @@ struct TaskComposerRoutePicker: View {
                     groups: workspaceGroups,
                     selectedWorkspaceGroupID: selectedWorkspaceGroupID,
                     isSelectionPending: workspaceGroupSelectionPending,
+                    requiresSelectionResolution: workspaceGroupSelectionRequiresResolution,
                     isDisabled: isDisabled,
                     select: selectWorkspaceGroup
                 )

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TaskComposer/TaskComposerRoutePicker.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TaskComposer/TaskComposerRoutePicker.swift
@@ -10,6 +10,7 @@ struct TaskComposerRoutePicker: View {
     let buildLabelsByID: [String: String]
     let workspaceGroups: [MobileWorkspaceGroupPreview]
     let selectedWorkspaceGroupID: MobileWorkspaceGroupPreview.ID?
+    let workspaceGroupSelectionPending: Bool
     let showsWorkspaceGroupPicker: Bool
     let directory: String
     let isDisabled: Bool
@@ -31,6 +32,7 @@ struct TaskComposerRoutePicker: View {
                 TaskComposerWorkspaceGroupMenu(
                     groups: workspaceGroups,
                     selectedWorkspaceGroupID: selectedWorkspaceGroupID,
+                    isSelectionPending: workspaceGroupSelectionPending,
                     isDisabled: isDisabled,
                     select: selectWorkspaceGroup
                 )

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TaskComposer/TaskComposerRoutePicker.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TaskComposer/TaskComposerRoutePicker.swift
@@ -1,5 +1,6 @@
 #if os(iOS)
 import CmuxMobilePairedMac
+import CmuxMobileShellModel
 import CmuxMobileSupport
 import SwiftUI
 
@@ -7,38 +8,64 @@ struct TaskComposerRoutePicker: View {
     let machines: [MobilePairedMac]
     let selectedMacPairingID: String
     let buildLabelsByID: [String: String]
+    let workspaceGroups: [MobileWorkspaceGroupPreview]
+    let selectedWorkspaceGroupID: MobileWorkspaceGroupPreview.ID?
+    let showsWorkspaceGroupPicker: Bool
     let directory: String
     let isDisabled: Bool
     let selectMachine: (String, String?) -> Void
+    let selectWorkspaceGroup: (MobileWorkspaceGroupPreview.ID?) -> Void
     let selectDirectory: () -> Void
 
     var body: some View {
-        HStack(spacing: 8) {
+        VStack(spacing: 0) {
             machinePicker
 
-            Button(action: selectDirectory) {
-                TaskComposerRouteLabel(
-                    icon: .symbol("folder.fill"),
-                    title: L10n.string("mobile.taskComposer.directory", defaultValue: "Directory"),
-                    value: directory,
-                    valueFont: .system(.caption, design: .monospaced, weight: .semibold),
-                    valueTruncationMode: .middle,
-                    chevronSystemName: "chevron.right"
+            routeDivider
+
+            directoryPicker
+
+            if showsWorkspaceGroupPicker {
+                routeDivider
+
+                TaskComposerWorkspaceGroupMenu(
+                    groups: workspaceGroups,
+                    selectedWorkspaceGroupID: selectedWorkspaceGroupID,
+                    isDisabled: isDisabled,
+                    select: selectWorkspaceGroup
                 )
             }
-            .buttonStyle(.plain)
-            .disabled(isDisabled)
-            .accessibilityLabel(L10n.string("mobile.taskComposer.directory", defaultValue: "Directory"))
-            .accessibilityValue(directory)
-            .accessibilityHint(
-                L10n.string(
-                    "mobile.taskComposer.directoryPicker.hint",
-                    defaultValue: "Browses and searches folders on this Mac."
-                )
-            )
-            .accessibilityIdentifier("MobileTaskComposerDirectory")
         }
-        .padding(10)
+        .padding(.vertical, 4)
+    }
+
+    private var routeDivider: some View {
+        Divider()
+            .padding(.leading, 58)
+    }
+
+    private var directoryPicker: some View {
+        Button(action: selectDirectory) {
+            TaskComposerRouteLabel(
+                icon: .symbol("folder.fill"),
+                title: L10n.string("mobile.taskComposer.directory", defaultValue: "Directory"),
+                value: directory,
+                valueFont: .system(.caption, design: .monospaced, weight: .semibold),
+                valueTruncationMode: .middle,
+                chevronSystemName: "chevron.right"
+            )
+        }
+        .buttonStyle(.plain)
+        .disabled(isDisabled)
+        .accessibilityLabel(L10n.string("mobile.taskComposer.directory", defaultValue: "Directory"))
+        .accessibilityValue(directory)
+        .accessibilityHint(
+            L10n.string(
+                "mobile.taskComposer.directoryPicker.hint",
+                defaultValue: "Browses and searches folders on this Mac."
+            )
+        )
+        .accessibilityIdentifier("MobileTaskComposerDirectory")
     }
 
     @ViewBuilder
@@ -53,6 +80,7 @@ struct TaskComposerRoutePicker: View {
                 }
                 Spacer(minLength: 0)
             }
+            .padding(.horizontal, 16)
             .frame(maxWidth: .infinity, minHeight: 52, alignment: .leading)
         } else {
             TaskComposerMachineMenu(

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TaskComposer/TaskComposerSheet+CompletedOperationRecovery.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TaskComposer/TaskComposerSheet+CompletedOperationRecovery.swift
@@ -108,6 +108,7 @@ extension TaskComposerSheet {
             workingDirectory: snapshot.trimmedDirectory.isEmpty ? nil : snapshot.trimmedDirectory,
             initialCommand: composition.initialCommand,
             initialEnv: composition.initialEnv.isEmpty ? nil : composition.initialEnv,
+            workspaceGroupID: snapshot.workspaceGroupID,
             operationID: snapshot.operationID
         )
     }

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TaskComposer/TaskComposerSheet+DraftState.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TaskComposer/TaskComposerSheet+DraftState.swift
@@ -38,6 +38,7 @@ extension TaskComposerSheet {
         selectedMacInstanceTag = snapshot.macInstanceTag
         selectedWorkspaceGroupID = snapshot.workspaceGroupID
         pendingRestoredWorkspaceGroupID = snapshot.workspaceGroupID
+        workspaceGroupSelectionRequiresResolution = false
         directory = snapshot.directory
         didEditDirectory = snapshot.didEditDirectory
         submissionIdentity.adoptResolvedRequest(snapshot)
@@ -101,7 +102,8 @@ extension TaskComposerSheet {
     }
 
     func resolveCompletedOperationRecoveryAfterEditing() {
-        guard !workspaceGroupSelectionNeedsInventory else { return }
+        guard !workspaceGroupSelectionNeedsInventory,
+              !workspaceGroupSelectionRequiresResolution else { return }
         guard let operationID = completedOperationRecovery?.submittedSnapshot.operationID else { return }
         reconcileCompletedOperationRecovery(
             with: makeSubmissionSnapshot(operationID: operationID)
@@ -137,7 +139,7 @@ extension TaskComposerSheet {
     func draftSnapshot() -> MobileTaskComposerDraft {
         let resolved = submissionSnapshot()
         let completedOperationID: UUID?
-        if workspaceGroupSelectionNeedsInventory {
+        if workspaceGroupSelectionNeedsInventory || workspaceGroupSelectionRequiresResolution {
             // Keep a completed-operation anchor intact while the route is
             // reconnecting; comparing it to a deliberately withheld snapshot
             // would make a retry look like a new ungrouped request.
@@ -145,9 +147,9 @@ extension TaskComposerSheet {
         } else {
             completedOperationID = reconcileCompletedOperationRecovery(with: resolved)
         }
-        let persistedWorkspaceGroupID = workspaceGroupInventoryIsAuthoritative
-            ? resolved?.workspaceGroupID
-            : (pendingRestoredWorkspaceGroupID ?? selectedWorkspaceGroupID)
+        let persistedWorkspaceGroupID = resolved?.workspaceGroupID
+            ?? pendingRestoredWorkspaceGroupID
+            ?? selectedWorkspaceGroupID
         return MobileTaskComposerDraft(
             prompt: prompt,
             modelID: selectedModel?.id,

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TaskComposer/TaskComposerSheet+DraftState.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TaskComposer/TaskComposerSheet+DraftState.swift
@@ -37,6 +37,7 @@ extension TaskComposerSheet {
         selectedMacDeviceID = snapshot.macDeviceID
         selectedMacInstanceTag = snapshot.macInstanceTag
         selectedWorkspaceGroupID = snapshot.workspaceGroupID
+        pendingRestoredWorkspaceGroupID = snapshot.workspaceGroupID
         directory = snapshot.directory
         didEditDirectory = snapshot.didEditDirectory
         submissionIdentity.adoptResolvedRequest(snapshot)

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TaskComposer/TaskComposerSheet+DraftState.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TaskComposer/TaskComposerSheet+DraftState.swift
@@ -36,6 +36,7 @@ extension TaskComposerSheet {
         explicitlySelectedModel = nil
         selectedMacDeviceID = snapshot.macDeviceID
         selectedMacInstanceTag = snapshot.macInstanceTag
+        selectedWorkspaceGroupID = snapshot.workspaceGroupID
         directory = snapshot.directory
         didEditDirectory = snapshot.didEditDirectory
         submissionIdentity.adoptResolvedRequest(snapshot)
@@ -143,6 +144,7 @@ extension TaskComposerSheet {
             directory: directory,
             didEditDirectory: didEditDirectory,
             workspaceName: workspaceName,
+            workspaceGroupID: resolved?.workspaceGroupID,
             operationID: resolved?.operationID ?? submissionIdentity.id,
             completedOperationID: completedOperationID
         )
@@ -158,6 +160,7 @@ extension TaskComposerSheet {
             macInstanceTag: selectedMacInstanceTag,
             directory: directory,
             workspaceName: workspaceName,
+            workspaceGroupID: resolvedWorkspaceGroupID,
             didEditDirectory: didEditDirectory,
             attachments: attachments.map(\.submissionAttachment),
             operationID: operationID

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TaskComposer/TaskComposerSheet+DraftState.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TaskComposer/TaskComposerSheet+DraftState.swift
@@ -101,6 +101,7 @@ extension TaskComposerSheet {
     }
 
     func resolveCompletedOperationRecoveryAfterEditing() {
+        guard !workspaceGroupSelectionNeedsInventory else { return }
         guard let operationID = completedOperationRecovery?.submittedSnapshot.operationID else { return }
         reconcileCompletedOperationRecovery(
             with: makeSubmissionSnapshot(operationID: operationID)
@@ -135,7 +136,18 @@ extension TaskComposerSheet {
 
     func draftSnapshot() -> MobileTaskComposerDraft {
         let resolved = submissionSnapshot()
-        let completedOperationID = reconcileCompletedOperationRecovery(with: resolved)
+        let completedOperationID: UUID?
+        if workspaceGroupSelectionNeedsInventory {
+            // Keep a completed-operation anchor intact while the route is
+            // reconnecting; comparing it to a deliberately withheld snapshot
+            // would make a retry look like a new ungrouped request.
+            completedOperationID = completedOperationRecovery?.submittedSnapshot.operationID
+        } else {
+            completedOperationID = reconcileCompletedOperationRecovery(with: resolved)
+        }
+        let persistedWorkspaceGroupID = workspaceGroupInventoryIsAuthoritative
+            ? resolved?.workspaceGroupID
+            : (pendingRestoredWorkspaceGroupID ?? selectedWorkspaceGroupID)
         return MobileTaskComposerDraft(
             prompt: prompt,
             modelID: selectedModel?.id,
@@ -145,7 +157,7 @@ extension TaskComposerSheet {
             directory: directory,
             didEditDirectory: didEditDirectory,
             workspaceName: workspaceName,
-            workspaceGroupID: resolved?.workspaceGroupID,
+            workspaceGroupID: persistedWorkspaceGroupID,
             operationID: resolved?.operationID ?? submissionIdentity.id,
             completedOperationID: completedOperationID
         )
@@ -153,6 +165,11 @@ extension TaskComposerSheet {
 
     private func makeSubmissionSnapshot(operationID: UUID) -> MobileTaskSubmissionSnapshot? {
         guard let selectedTemplate else { return nil }
+        guard selectedWorkspaceGroupID == nil || resolvedWorkspaceGroupID != nil else {
+            // Never construct an outbound snapshot that silently drops a
+            // selected group while its exact Mac inventory is unavailable.
+            return nil
+        }
         return MobileTaskSubmissionSnapshot(
             template: selectedTemplate,
             prompt: prompt,

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TaskComposer/TaskComposerSheet.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TaskComposer/TaskComposerSheet.swift
@@ -27,6 +27,7 @@ struct TaskComposerSheet: View {
     // Keep it separate from an explicit user selection so an empty first
     // projection cannot silently turn a grouped task into an ungrouped one.
     @State var pendingRestoredWorkspaceGroupID: MobileWorkspaceGroupPreview.ID?
+    @State var workspaceGroupSelectionRequiresResolution = false
     @State private var modelRefreshTask: Task<Void, Never>?
     @State private var modelRefreshOperationID: UUID?
     @State var displayedModels: [MobileTaskAgentModel]
@@ -346,6 +347,9 @@ struct TaskComposerSheet: View {
             .onChange(of: workspaceGroupInventoryIsAuthoritative) { _, _ in
                 validateWorkspaceGroupSelection()
             }
+            .onChange(of: submissionPhase) { _, _ in
+                validateWorkspaceGroupSelection()
+            }
             .modifier(TaskComposerStartAgainConfirmationModifier(
                 isPresented: $isStartAgainConfirmationPresented,
                 confirm: confirmStartAgain
@@ -417,6 +421,7 @@ struct TaskComposerSheet: View {
                 && submissionPhase.allowsSubmission
                 && attachmentStagingTask == nil
                 && !workspaceGroupSelectionNeedsInventory
+                && !workspaceGroupSelectionRequiresResolution
                 && blockingCompletedOperationRecovery == nil,
             failureTitle: failureTitleStyle.title,
             failureText: failureText,
@@ -449,7 +454,9 @@ struct TaskComposerSheet: View {
                 ?? pendingRestoredWorkspaceGroupID
                 ?? selectedWorkspaceGroupID,
             workspaceGroupSelectionPending: workspaceGroupSelectionNeedsInventory,
-            showsWorkspaceGroupPicker: canSelectWorkspaceGroup,
+            workspaceGroupSelectionRequiresResolution: workspaceGroupSelectionRequiresResolution,
+            showsWorkspaceGroupPicker: canSelectWorkspaceGroup
+                || workspaceGroupSelectionRequiresResolution,
             directory: directory,
             isDisabled: submissionPhase.disablesRequestEditing,
             directoryCandidates: directoryCandidates,
@@ -745,6 +752,7 @@ struct TaskComposerSheet: View {
             selectedMacDeviceID = macDeviceID
             selectedMacInstanceTag = instanceTag
             pendingRestoredWorkspaceGroupID = nil
+            workspaceGroupSelectionRequiresResolution = false
             selectedWorkspaceGroupID = validWorkspaceGroupID(
                 selectedWorkspaceGroupID,
                 groups: workspaceGroups,
@@ -763,6 +771,7 @@ struct TaskComposerSheet: View {
         }
         updateSubmissionRequest(reconcileRecovery: true) {
             pendingRestoredWorkspaceGroupID = nil
+            workspaceGroupSelectionRequiresResolution = false
             selectedWorkspaceGroupID = groupID
         }
     }
@@ -773,7 +782,8 @@ struct TaskComposerSheet: View {
               attachmentStagingTask == nil,
               blockingCompletedOperationRecovery == nil,
               submissionPhase.allowsSubmission,
-              !workspaceGroupSelectionNeedsInventory else { return }
+              !workspaceGroupSelectionNeedsInventory,
+              !workspaceGroupSelectionRequiresResolution else { return }
         // Once the user sends a genuinely different request, the prior
         // recovery anchor can no longer become relevant through further edits.
         completedOperationRecovery = nil
@@ -932,6 +942,7 @@ struct TaskComposerSheet: View {
             selectedMacDeviceID = machines.first?.macDeviceID ?? ""
             selectedMacInstanceTag = machines.first?.instanceTag
             pendingRestoredWorkspaceGroupID = nil
+            workspaceGroupSelectionRequiresResolution = false
             selectedWorkspaceGroupID = validWorkspaceGroupID(
                 selectedWorkspaceGroupID,
                 groups: workspaceGroups,
@@ -948,11 +959,13 @@ struct TaskComposerSheet: View {
         guard !submissionPhase.disablesRequestEditing else { return }
         guard let selectedWorkspaceGroupID else {
             pendingRestoredWorkspaceGroupID = nil
+            workspaceGroupSelectionRequiresResolution = false
             return
         }
 
         guard workspaceGroupInventoryIsAuthoritative else {
             pendingRestoredWorkspaceGroupID = selectedWorkspaceGroupID
+            workspaceGroupSelectionRequiresResolution = false
             return
         }
 
@@ -963,13 +976,15 @@ struct TaskComposerSheet: View {
             instanceTag: selectedMacInstanceTag
         ) != nil {
             pendingRestoredWorkspaceGroupID = nil
+            workspaceGroupSelectionRequiresResolution = false
             return
         }
 
-        updateSubmissionRequest(reconcileRecovery: true) {
-            selectedWorkspaceGroupID = nil
-            pendingRestoredWorkspaceGroupID = nil
-        }
+        // The authoritative inventory disproved the restored destination. Keep
+        // it visible in the draft, block submission, and require an explicit
+        // replacement or None selection instead of silently rerouting.
+        pendingRestoredWorkspaceGroupID = selectedWorkspaceGroupID
+        workspaceGroupSelectionRequiresResolution = true
     }
 
     private func persistDraft() {

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TaskComposer/TaskComposerSheet.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TaskComposer/TaskComposerSheet.swift
@@ -456,6 +456,7 @@ struct TaskComposerSheet: View {
             workspaceGroupSelectionPending: workspaceGroupSelectionNeedsInventory,
             workspaceGroupSelectionRequiresResolution: workspaceGroupSelectionRequiresResolution,
             showsWorkspaceGroupPicker: canSelectWorkspaceGroup
+                || workspaceGroupSelectionNeedsInventory
                 || workspaceGroupSelectionRequiresResolution,
             directory: directory,
             isDisabled: submissionPhase.disablesRequestEditing,
@@ -522,17 +523,29 @@ struct TaskComposerSheet: View {
     private var canSelectWorkspaceGroup: Bool {
         // The accessibility harness injects deterministic groups without a
         // live host capability handshake. Production state must advertise the
-        // create-in-group RPC before exposing a control that can send it.
-        availableWorkspaceGroups != nil || store.supportsWorkspaceCreateInGroup
+        // create-in-group RPC on the selected Mac before exposing a control
+        // that can send it.
+        availableWorkspaceGroups != nil || workspaceCreateInGroupCapability == true
+    }
+
+    private var workspaceCreateInGroupCapability: Bool? {
+        if availableWorkspaceGroups != nil {
+            return true
+        }
+        return store.workspaceCreateInGroupCapability(
+            macDeviceID: selectedMacDeviceID,
+            instanceTag: selectedMacInstanceTag
+        )
     }
 
     var workspaceGroupInventoryIsAuthoritative: Bool {
         if availableWorkspaceGroups != nil {
             return true
         }
-        // A connected host that completed capability negotiation without the
-        // group-create capability definitively cannot honor a restored group.
-        if store.connectionState == .connected, !canSelectWorkspaceGroup {
+        // A connected selected Mac that completed capability negotiation
+        // without the group-create capability definitively cannot honor a
+        // restored group.
+        if workspaceCreateInGroupCapability == false {
             return true
         }
         return store.workspaceGroupInventoryIsAuthoritative(

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TaskComposer/TaskComposerSheet.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TaskComposer/TaskComposerSheet.swift
@@ -1036,9 +1036,15 @@ private func filteredWorkspaceGroups(
     macDeviceID: String,
     instanceTag: String?
 ) -> [MobileWorkspaceGroupPreview] {
-    groups.filter { group in
-        normalizedWorkspaceOwner(group.macDeviceID) == normalizedWorkspaceOwner(macDeviceID)
-            && normalizedWorkspaceOwner(group.macInstanceTag) == normalizedWorkspaceOwner(instanceTag)
+    guard let macDeviceID = normalizedWorkspaceOwner(macDeviceID) else {
+        return []
+    }
+    return groups.filter { group in
+        guard let groupMacDeviceID = normalizedWorkspaceOwner(group.macDeviceID),
+              groupMacDeviceID == macDeviceID else {
+            return false
+        }
+        return normalizedWorkspaceOwner(group.macInstanceTag) == normalizedWorkspaceOwner(instanceTag)
     }
 }
 

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TaskComposer/TaskComposerSheet.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TaskComposer/TaskComposerSheet.swift
@@ -156,7 +156,7 @@ struct TaskComposerSheet: View {
         } ?? availablePairedMacs.first {
             $0.macDeviceID == selectedMacID
         }
-        let initialWorkspaceGroupID = Self.validWorkspaceGroupID(
+        let initialWorkspaceGroupID = validWorkspaceGroupID(
             draft?.workspaceGroupID,
             groups: availableGroups,
             macDeviceID: selectedMacID,
@@ -505,7 +505,7 @@ struct TaskComposerSheet: View {
     }
 
     private var workspaceGroupsForSelectedMachine: [MobileWorkspaceGroupPreview] {
-        Self.workspaceGroups(
+        filteredWorkspaceGroups(
             workspaceGroups,
             macDeviceID: selectedMacDeviceID,
             instanceTag: selectedMacInstanceTag
@@ -513,7 +513,7 @@ struct TaskComposerSheet: View {
     }
 
     var resolvedWorkspaceGroupID: MobileWorkspaceGroupPreview.ID? {
-        Self.validWorkspaceGroupID(
+        validWorkspaceGroupID(
             selectedWorkspaceGroupID,
             groups: workspaceGroups,
             macDeviceID: selectedMacDeviceID,
@@ -708,7 +708,7 @@ struct TaskComposerSheet: View {
         updateSubmissionRequest(reconcileRecovery: true) {
             selectedMacDeviceID = macDeviceID
             selectedMacInstanceTag = instanceTag
-            selectedWorkspaceGroupID = Self.validWorkspaceGroupID(
+            selectedWorkspaceGroupID = validWorkspaceGroupID(
                 selectedWorkspaceGroupID,
                 groups: workspaceGroups,
                 macDeviceID: macDeviceID,
@@ -892,7 +892,7 @@ struct TaskComposerSheet: View {
         updateSubmissionRequest(reconcileRecovery: true) {
             selectedMacDeviceID = machines.first?.macDeviceID ?? ""
             selectedMacInstanceTag = machines.first?.instanceTag
-            selectedWorkspaceGroupID = Self.validWorkspaceGroupID(
+            selectedWorkspaceGroupID = validWorkspaceGroupID(
                 selectedWorkspaceGroupID,
                 groups: workspaceGroups,
                 macDeviceID: selectedMacDeviceID,
@@ -915,42 +915,6 @@ struct TaskComposerSheet: View {
         }
     }
 
-    private static func validWorkspaceGroupID(
-        _ candidate: MobileWorkspaceGroupPreview.ID?,
-        groups: [MobileWorkspaceGroupPreview],
-        macDeviceID: String,
-        instanceTag: String?
-    ) -> MobileWorkspaceGroupPreview.ID? {
-        guard let candidate,
-              workspaceGroups(
-                  groups,
-                  macDeviceID: macDeviceID,
-                  instanceTag: instanceTag
-              ).contains(where: { $0.id == candidate }) else {
-            return nil
-        }
-        return candidate
-    }
-
-    private static func workspaceGroups(
-        _ groups: [MobileWorkspaceGroupPreview],
-        macDeviceID: String,
-        instanceTag: String?
-    ) -> [MobileWorkspaceGroupPreview] {
-        groups.filter { group in
-            normalizedOwner(group.macDeviceID) == normalizedOwner(macDeviceID)
-                && normalizedOwner(group.macInstanceTag) == normalizedOwner(instanceTag)
-        }
-    }
-
-    private static func normalizedOwner(_ value: String?) -> String? {
-        guard let value = value?.trimmingCharacters(in: .whitespacesAndNewlines),
-              !value.isEmpty else {
-            return nil
-        }
-        return value
-    }
-
     private func persistDraft() {
         guard shouldPersistDraftOnDisappear else { return }
         if let activeSubmissionSnapshot {
@@ -963,5 +927,41 @@ struct TaskComposerSheet: View {
         store.persistTaskComposerDraft(draftSnapshot(), ifSessionGeneration: sessionGeneration)
     }
 
+}
+
+private func validWorkspaceGroupID(
+    _ candidate: MobileWorkspaceGroupPreview.ID?,
+    groups: [MobileWorkspaceGroupPreview],
+    macDeviceID: String,
+    instanceTag: String?
+) -> MobileWorkspaceGroupPreview.ID? {
+    guard let candidate,
+          filteredWorkspaceGroups(
+              groups,
+              macDeviceID: macDeviceID,
+              instanceTag: instanceTag
+          ).contains(where: { $0.id == candidate }) else {
+        return nil
+    }
+    return candidate
+}
+
+private func filteredWorkspaceGroups(
+    _ groups: [MobileWorkspaceGroupPreview],
+    macDeviceID: String,
+    instanceTag: String?
+) -> [MobileWorkspaceGroupPreview] {
+    groups.filter { group in
+        normalizedWorkspaceOwner(group.macDeviceID) == normalizedWorkspaceOwner(macDeviceID)
+            && normalizedWorkspaceOwner(group.macInstanceTag) == normalizedWorkspaceOwner(instanceTag)
+    }
+}
+
+private func normalizedWorkspaceOwner(_ value: String?) -> String? {
+    guard let value = value?.trimmingCharacters(in: .whitespacesAndNewlines),
+          !value.isEmpty else {
+        return nil
+    }
+    return value
 }
 #endif

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TaskComposer/TaskComposerSheet.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TaskComposer/TaskComposerSheet.swift
@@ -23,6 +23,10 @@ struct TaskComposerSheet: View {
     @State var selectedMacDeviceID: String
     @State var selectedMacInstanceTag: String?
     @State var selectedWorkspaceGroupID: MobileWorkspaceGroupPreview.ID?
+    // A persisted group can be restored before the live host inventory arrives.
+    // Keep it separate from an explicit user selection so an empty first
+    // projection cannot silently turn a grouped task into an ungrouped one.
+    @State var pendingRestoredWorkspaceGroupID: MobileWorkspaceGroupPreview.ID?
     @State private var modelRefreshTask: Task<Void, Never>?
     @State private var modelRefreshOperationID: UUID?
     @State var displayedModels: [MobileTaskAgentModel]
@@ -122,9 +126,6 @@ struct TaskComposerSheet: View {
         let foregroundMacInstanceTag = store.connectedMacInstanceTag
         // Restore persisted Mac IDs only while they remain paired.
         let availablePairedMacs = availableMachines ?? store.displayPairedMacs
-        let availableGroups = (availableWorkspaceGroups != nil || store.supportsWorkspaceCreateInGroup)
-            ? (availableWorkspaceGroups ?? store.workspaceGroups)
-            : []
         let pairedMacIDs = availablePairedMacs.map(\.macDeviceID)
         let restoredMacID = store.taskTemplateStore?.lastMacDeviceID()
             .flatMap { id in pairedMacIDs.contains(id) ? id : nil }
@@ -156,12 +157,11 @@ struct TaskComposerSheet: View {
         } ?? availablePairedMacs.first {
             $0.macDeviceID == selectedMacID
         }
-        let initialWorkspaceGroupID = validWorkspaceGroupID(
-            draft?.workspaceGroupID,
-            groups: availableGroups,
-            macDeviceID: selectedMacID,
-            instanceTag: selectedMac?.instanceTag
-        )
+        // Keep a restored group ID until the live inventory proves whether it
+        // still exists. The workspace/group projection is populated after the
+        // sheet can be initialized, so an empty snapshot here means
+        // "not loaded yet", not "definitively ungrouped".
+        let initialWorkspaceGroupID = draft?.workspaceGroupID
         let draftTemplateID = draft?.templateID
             .flatMap { id in templates.contains(where: { $0.id == id }) ? id : nil }
         let selectedTemplateID = draftTemplateID
@@ -262,6 +262,7 @@ struct TaskComposerSheet: View {
         _selectedMacDeviceID = State(initialValue: selectedMacID)
         _selectedMacInstanceTag = State(initialValue: selectedMac?.instanceTag)
         _selectedWorkspaceGroupID = State(initialValue: initialWorkspaceGroupID)
+        _pendingRestoredWorkspaceGroupID = State(initialValue: draft?.workspaceGroupID)
         _displayedModels = State(initialValue: initialDiscoveredModels ?? [])
         _attachments = State(initialValue: initialAttachments)
         _directory = State(initialValue: initialDirectory)
@@ -321,6 +322,7 @@ struct TaskComposerSheet: View {
                     .taskTemplateListLoaded,
                     count: templates.count
                 )
+                validateWorkspaceGroupSelection()
                 if restoredDraftAtInitialization {
                     store.recordAppEvent(.draftRestored)
                 }
@@ -333,6 +335,12 @@ struct TaskComposerSheet: View {
                 validateMacSelection()
             }
             .onChange(of: workspaceGroupSelectionKey) { _, _ in
+                validateWorkspaceGroupSelection()
+            }
+            .onChange(of: store.workspaceTopologyVersion) { _, _ in
+                validateWorkspaceGroupSelection()
+            }
+            .onChange(of: canSelectWorkspaceGroup) { _, _ in
                 validateWorkspaceGroupSelection()
             }
             .modifier(TaskComposerStartAgainConfirmationModifier(
@@ -513,12 +521,21 @@ struct TaskComposerSheet: View {
     }
 
     var resolvedWorkspaceGroupID: MobileWorkspaceGroupPreview.ID? {
-        validWorkspaceGroupID(
+        if let validID = validWorkspaceGroupID(
             selectedWorkspaceGroupID,
             groups: workspaceGroups,
             macDeviceID: selectedMacDeviceID,
             instanceTag: selectedMacInstanceTag
-        )
+        ) {
+            return validID
+        }
+        // A restored ID remains in the request while the host's group list is
+        // still loading. The host validates the ID, so a stale ID fails closed
+        // instead of creating a workspace without its requested group.
+        guard pendingRestoredWorkspaceGroupID == selectedWorkspaceGroupID else {
+            return nil
+        }
+        return pendingRestoredWorkspaceGroupID
     }
 
     private var workspaceGroupSelectionKey: [MobileWorkspaceGroupPreview.ID] {
@@ -708,6 +725,7 @@ struct TaskComposerSheet: View {
         updateSubmissionRequest(reconcileRecovery: true) {
             selectedMacDeviceID = macDeviceID
             selectedMacInstanceTag = instanceTag
+            pendingRestoredWorkspaceGroupID = nil
             selectedWorkspaceGroupID = validWorkspaceGroupID(
                 selectedWorkspaceGroupID,
                 groups: workspaceGroups,
@@ -725,6 +743,7 @@ struct TaskComposerSheet: View {
             return
         }
         updateSubmissionRequest(reconcileRecovery: true) {
+            pendingRestoredWorkspaceGroupID = nil
             selectedWorkspaceGroupID = groupID
         }
     }
@@ -892,6 +911,7 @@ struct TaskComposerSheet: View {
         updateSubmissionRequest(reconcileRecovery: true) {
             selectedMacDeviceID = machines.first?.macDeviceID ?? ""
             selectedMacInstanceTag = machines.first?.instanceTag
+            pendingRestoredWorkspaceGroupID = nil
             selectedWorkspaceGroupID = validWorkspaceGroupID(
                 selectedWorkspaceGroupID,
                 groups: workspaceGroups,
@@ -904,14 +924,38 @@ struct TaskComposerSheet: View {
 
     private func validateWorkspaceGroupSelection() {
         guard !submissionPhase.disablesRequestEditing,
-              selectedWorkspaceGroupID != nil else {
+              let selectedWorkspaceGroupID else {
+            pendingRestoredWorkspaceGroupID = nil
             return
         }
-        guard resolvedWorkspaceGroupID != nil else {
+
+        if validWorkspaceGroupID(
+            selectedWorkspaceGroupID,
+            groups: workspaceGroups,
+            macDeviceID: selectedMacDeviceID,
+            instanceTag: selectedMacInstanceTag
+        ) != nil {
+            pendingRestoredWorkspaceGroupID = nil
+            return
+        }
+
+        // An empty production projection is not proof that the Mac has no
+        // groups. Keep the restored value until a group arrives or the
+        // connected host definitively says this feature is unavailable.
+        let inventoryCanDisproveSelection = availableWorkspaceGroups != nil
+            || !workspaceGroupsForSelectedMachine.isEmpty
+            || (store.connectionState == .connected && !canSelectWorkspaceGroup)
+        guard pendingRestoredWorkspaceGroupID == selectedWorkspaceGroupID else {
             updateSubmissionRequest(reconcileRecovery: true) {
                 selectedWorkspaceGroupID = nil
+                pendingRestoredWorkspaceGroupID = nil
             }
             return
+        }
+        guard inventoryCanDisproveSelection else { return }
+        updateSubmissionRequest(reconcileRecovery: true) {
+            selectedWorkspaceGroupID = nil
+            pendingRestoredWorkspaceGroupID = nil
         }
     }
 

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TaskComposer/TaskComposerSheet.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TaskComposer/TaskComposerSheet.swift
@@ -22,6 +22,7 @@ struct TaskComposerSheet: View {
     @State var explicitlySelectedModel: MobileTaskAgentModel?
     @State var selectedMacDeviceID: String
     @State var selectedMacInstanceTag: String?
+    @State var selectedWorkspaceGroupID: MobileWorkspaceGroupPreview.ID?
     @State private var modelRefreshTask: Task<Void, Never>?
     @State private var modelRefreshOperationID: UUID?
     @State var displayedModels: [MobileTaskAgentModel]
@@ -50,6 +51,7 @@ struct TaskComposerSheet: View {
     let sessionGeneration: Int
     private let restoredDraftAtInitialization: Bool
     private let availableMachines: [MobilePairedMac]?
+    private let availableWorkspaceGroups: [MobileWorkspaceGroupPreview]?
     let taskAttachmentsCapabilityOverride: Bool?
     let submitTaskComposer: @MainActor (
         _ macDeviceID: String,
@@ -72,6 +74,7 @@ struct TaskComposerSheet: View {
     init(
         store: CMUXMobileShellStore,
         availableMachines: [MobilePairedMac]? = nil,
+        availableWorkspaceGroups: [MobileWorkspaceGroupPreview]? = nil,
         taskAttachmentsCapabilityOverride: Bool? = nil,
         initialAttachments: [TaskComposerAttachment] = [],
         submitTaskComposer: (@MainActor (
@@ -94,6 +97,7 @@ struct TaskComposerSheet: View {
     ) {
         self.store = store
         self.availableMachines = availableMachines
+        self.availableWorkspaceGroups = availableWorkspaceGroups
         self.taskAttachmentsCapabilityOverride = taskAttachmentsCapabilityOverride
         self.sessionGeneration = store.currentSessionGeneration
         self.searchTaskDirectories = searchTaskDirectories
@@ -118,6 +122,9 @@ struct TaskComposerSheet: View {
         let foregroundMacInstanceTag = store.connectedMacInstanceTag
         // Restore persisted Mac IDs only while they remain paired.
         let availablePairedMacs = availableMachines ?? store.displayPairedMacs
+        let availableGroups = (availableWorkspaceGroups != nil || store.supportsWorkspaceCreateInGroup)
+            ? (availableWorkspaceGroups ?? store.workspaceGroups)
+            : []
         let pairedMacIDs = availablePairedMacs.map(\.macDeviceID)
         let restoredMacID = store.taskTemplateStore?.lastMacDeviceID()
             .flatMap { id in pairedMacIDs.contains(id) ? id : nil }
@@ -149,6 +156,12 @@ struct TaskComposerSheet: View {
         } ?? availablePairedMacs.first {
             $0.macDeviceID == selectedMacID
         }
+        let initialWorkspaceGroupID = Self.validWorkspaceGroupID(
+            draft?.workspaceGroupID,
+            groups: availableGroups,
+            macDeviceID: selectedMacID,
+            instanceTag: selectedMac?.instanceTag
+        )
         let draftTemplateID = draft?.templateID
             .flatMap { id in templates.contains(where: { $0.id == id }) ? id : nil }
         let selectedTemplateID = draftTemplateID
@@ -206,6 +219,7 @@ struct TaskComposerSheet: View {
         let restoredOperationID = (
             draft?.templateID == selectedTemplateID
                 && draft?.macDeviceID == (selectedMacID.isEmpty ? nil : selectedMacID)
+                && draft?.workspaceGroupID == initialWorkspaceGroupID
                 && canRestoreDraftDirectory
                 && draftModelSurvivedValidation
         ) ? draft?.operationID : nil
@@ -221,12 +235,14 @@ struct TaskComposerSheet: View {
                 macInstanceTag: selectedMac?.instanceTag,
                 directory: initialDirectory,
                 workspaceName: initialWorkspaceName,
+                workspaceGroupID: initialWorkspaceGroupID,
                 didEditDirectory: canRestoreDraftDirectory && draft?.didEditDirectory == true,
                 operationID: initialOperationID
             )
         }
         let canRestoreCompletedOperation = draft?.templateID == selectedTemplateID
             && draft?.macDeviceID == (selectedMacID.isEmpty ? nil : selectedMacID)
+            && draft?.workspaceGroupID == initialWorkspaceGroupID
             && canRestoreDraftDirectory
             && draftModelSurvivedValidation
         let initialCompletedOperationRecovery = (canRestoreCompletedOperation
@@ -245,6 +261,7 @@ struct TaskComposerSheet: View {
         })
         _selectedMacDeviceID = State(initialValue: selectedMacID)
         _selectedMacInstanceTag = State(initialValue: selectedMac?.instanceTag)
+        _selectedWorkspaceGroupID = State(initialValue: initialWorkspaceGroupID)
         _displayedModels = State(initialValue: initialDiscoveredModels ?? [])
         _attachments = State(initialValue: initialAttachments)
         _directory = State(initialValue: initialDirectory)
@@ -314,6 +331,9 @@ struct TaskComposerSheet: View {
             }
             .onChange(of: machines.map(\.id)) { _, _ in
                 validateMacSelection()
+            }
+            .onChange(of: workspaceGroupSelectionKey) { _, _ in
+                validateWorkspaceGroupSelection()
             }
             .modifier(TaskComposerStartAgainConfirmationModifier(
                 isPresented: $isStartAgainConfirmationPresented,
@@ -412,11 +432,15 @@ struct TaskComposerSheet: View {
             machines: machines,
             selectedMacPairingID: selectedMacPairingID,
             buildLabelsByID: machineBuildLabelsByID,
+            workspaceGroups: workspaceGroupsForSelectedMachine,
+            selectedWorkspaceGroupID: resolvedWorkspaceGroupID,
+            showsWorkspaceGroupPicker: canSelectWorkspaceGroup,
             directory: directory,
             isDisabled: submissionPhase.disablesRequestEditing,
             directoryCandidates: directoryCandidates,
             endWorkspaceNameEditing: resolveCompletedOperationRecoveryAfterEditing,
             selectMachine: selectMachine,
+            selectWorkspaceGroup: selectWorkspaceGroup,
             selectDirectory: selectDirectory,
             searchMac: resolvedSearchTaskDirectories,
             listMac: resolvedListTaskDirectories
@@ -466,6 +490,39 @@ struct TaskComposerSheet: View {
 
     private var machines: [MobilePairedMac] {
         availableMachines ?? store.displayPairedMacs
+    }
+
+    private var workspaceGroups: [MobileWorkspaceGroupPreview] {
+        guard canSelectWorkspaceGroup else { return [] }
+        return availableWorkspaceGroups ?? store.workspaceGroups
+    }
+
+    private var canSelectWorkspaceGroup: Bool {
+        // The accessibility harness injects deterministic groups without a
+        // live host capability handshake. Production state must advertise the
+        // create-in-group RPC before exposing a control that can send it.
+        availableWorkspaceGroups != nil || store.supportsWorkspaceCreateInGroup
+    }
+
+    private var workspaceGroupsForSelectedMachine: [MobileWorkspaceGroupPreview] {
+        Self.workspaceGroups(
+            workspaceGroups,
+            macDeviceID: selectedMacDeviceID,
+            instanceTag: selectedMacInstanceTag
+        )
+    }
+
+    var resolvedWorkspaceGroupID: MobileWorkspaceGroupPreview.ID? {
+        Self.validWorkspaceGroupID(
+            selectedWorkspaceGroupID,
+            groups: workspaceGroups,
+            macDeviceID: selectedMacDeviceID,
+            instanceTag: selectedMacInstanceTag
+        )
+    }
+
+    private var workspaceGroupSelectionKey: [MobileWorkspaceGroupPreview.ID] {
+        workspaceGroupsForSelectedMachine.map(\.id)
     }
 
     var selectedMachine: MobilePairedMac? {
@@ -651,7 +708,24 @@ struct TaskComposerSheet: View {
         updateSubmissionRequest(reconcileRecovery: true) {
             selectedMacDeviceID = macDeviceID
             selectedMacInstanceTag = instanceTag
+            selectedWorkspaceGroupID = Self.validWorkspaceGroupID(
+                selectedWorkspaceGroupID,
+                groups: workspaceGroups,
+                macDeviceID: macDeviceID,
+                instanceTag: instanceTag
+            )
             syncSuggestedDirectory()
+        }
+    }
+
+    private func selectWorkspaceGroup(_ groupID: MobileWorkspaceGroupPreview.ID?) {
+        guard !submissionPhase.disablesRequestEditing,
+              groupID == nil
+                || workspaceGroupsForSelectedMachine.contains(where: { $0.id == groupID }) else {
+            return
+        }
+        updateSubmissionRequest(reconcileRecovery: true) {
+            selectedWorkspaceGroupID = groupID
         }
     }
 
@@ -818,8 +892,63 @@ struct TaskComposerSheet: View {
         updateSubmissionRequest(reconcileRecovery: true) {
             selectedMacDeviceID = machines.first?.macDeviceID ?? ""
             selectedMacInstanceTag = machines.first?.instanceTag
+            selectedWorkspaceGroupID = Self.validWorkspaceGroupID(
+                selectedWorkspaceGroupID,
+                groups: workspaceGroups,
+                macDeviceID: selectedMacDeviceID,
+                instanceTag: selectedMacInstanceTag
+            )
             syncSuggestedDirectory()
         }
+    }
+
+    private func validateWorkspaceGroupSelection() {
+        guard !submissionPhase.disablesRequestEditing,
+              selectedWorkspaceGroupID != nil else {
+            return
+        }
+        guard resolvedWorkspaceGroupID != nil else {
+            updateSubmissionRequest(reconcileRecovery: true) {
+                selectedWorkspaceGroupID = nil
+            }
+            return
+        }
+    }
+
+    private static func validWorkspaceGroupID(
+        _ candidate: MobileWorkspaceGroupPreview.ID?,
+        groups: [MobileWorkspaceGroupPreview],
+        macDeviceID: String,
+        instanceTag: String?
+    ) -> MobileWorkspaceGroupPreview.ID? {
+        guard let candidate,
+              workspaceGroups(
+                  groups,
+                  macDeviceID: macDeviceID,
+                  instanceTag: instanceTag
+              ).contains(where: { $0.id == candidate }) else {
+            return nil
+        }
+        return candidate
+    }
+
+    private static func workspaceGroups(
+        _ groups: [MobileWorkspaceGroupPreview],
+        macDeviceID: String,
+        instanceTag: String?
+    ) -> [MobileWorkspaceGroupPreview] {
+        groups.filter { group in
+            normalizedOwner(group.macDeviceID) == normalizedOwner(macDeviceID)
+                && normalizedOwner(group.macInstanceTag) == normalizedOwner(instanceTag)
+        }
+    }
+
+    private static func normalizedOwner(_ value: String?) -> String? {
+        guard let value = value?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !value.isEmpty else {
+            return nil
+        }
+        return value
     }
 
     private func persistDraft() {

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TaskComposer/TaskComposerSheet.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TaskComposer/TaskComposerSheet.swift
@@ -343,6 +343,9 @@ struct TaskComposerSheet: View {
             .onChange(of: canSelectWorkspaceGroup) { _, _ in
                 validateWorkspaceGroupSelection()
             }
+            .onChange(of: workspaceGroupInventoryIsAuthoritative) { _, _ in
+                validateWorkspaceGroupSelection()
+            }
             .modifier(TaskComposerStartAgainConfirmationModifier(
                 isPresented: $isStartAgainConfirmationPresented,
                 confirm: confirmStartAgain
@@ -413,6 +416,7 @@ struct TaskComposerSheet: View {
                 && canLaunchSelectedTemplate
                 && submissionPhase.allowsSubmission
                 && attachmentStagingTask == nil
+                && !workspaceGroupSelectionNeedsInventory
                 && blockingCompletedOperationRecovery == nil,
             failureTitle: failureTitleStyle.title,
             failureText: failureText,
@@ -441,7 +445,10 @@ struct TaskComposerSheet: View {
             selectedMacPairingID: selectedMacPairingID,
             buildLabelsByID: machineBuildLabelsByID,
             workspaceGroups: workspaceGroupsForSelectedMachine,
-            selectedWorkspaceGroupID: resolvedWorkspaceGroupID,
+            selectedWorkspaceGroupID: resolvedWorkspaceGroupID
+                ?? pendingRestoredWorkspaceGroupID
+                ?? selectedWorkspaceGroupID,
+            workspaceGroupSelectionPending: workspaceGroupSelectionNeedsInventory,
             showsWorkspaceGroupPicker: canSelectWorkspaceGroup,
             directory: directory,
             isDisabled: submissionPhase.disablesRequestEditing,
@@ -512,6 +519,25 @@ struct TaskComposerSheet: View {
         availableWorkspaceGroups != nil || store.supportsWorkspaceCreateInGroup
     }
 
+    var workspaceGroupInventoryIsAuthoritative: Bool {
+        if availableWorkspaceGroups != nil {
+            return true
+        }
+        // A connected host that completed capability negotiation without the
+        // group-create capability definitively cannot honor a restored group.
+        if store.connectionState == .connected, !canSelectWorkspaceGroup {
+            return true
+        }
+        return store.workspaceGroupInventoryIsAuthoritative(
+            macDeviceID: selectedMacDeviceID,
+            instanceTag: selectedMacInstanceTag
+        )
+    }
+
+    var workspaceGroupSelectionNeedsInventory: Bool {
+        selectedWorkspaceGroupID != nil && !workspaceGroupInventoryIsAuthoritative
+    }
+
     private var workspaceGroupsForSelectedMachine: [MobileWorkspaceGroupPreview] {
         filteredWorkspaceGroups(
             workspaceGroups,
@@ -521,21 +547,14 @@ struct TaskComposerSheet: View {
     }
 
     var resolvedWorkspaceGroupID: MobileWorkspaceGroupPreview.ID? {
-        if let validID = validWorkspaceGroupID(
+        guard workspaceGroupInventoryIsAuthoritative,
+              let validID = validWorkspaceGroupID(
             selectedWorkspaceGroupID,
             groups: workspaceGroups,
             macDeviceID: selectedMacDeviceID,
             instanceTag: selectedMacInstanceTag
-        ) {
-            return validID
-        }
-        // A restored ID remains in the request while the host's group list is
-        // still loading. The host validates the ID, so a stale ID fails closed
-        // instead of creating a workspace without its requested group.
-        guard pendingRestoredWorkspaceGroupID == selectedWorkspaceGroupID else {
-            return nil
-        }
-        return pendingRestoredWorkspaceGroupID
+        ) else { return nil }
+        return validID
     }
 
     private var workspaceGroupSelectionKey: [MobileWorkspaceGroupPreview.ID] {
@@ -753,7 +772,8 @@ struct TaskComposerSheet: View {
         guard submitTask == nil,
               attachmentStagingTask == nil,
               blockingCompletedOperationRecovery == nil,
-              submissionPhase.allowsSubmission else { return }
+              submissionPhase.allowsSubmission,
+              !workspaceGroupSelectionNeedsInventory else { return }
         // Once the user sends a genuinely different request, the prior
         // recovery anchor can no longer become relevant through further edits.
         completedOperationRecovery = nil
@@ -923,9 +943,16 @@ struct TaskComposerSheet: View {
     }
 
     private func validateWorkspaceGroupSelection() {
-        guard !submissionPhase.disablesRequestEditing,
-              let selectedWorkspaceGroupID else {
+        // A live callback can arrive while the create is in flight. Preserve
+        // the request exactly until editing is enabled again.
+        guard !submissionPhase.disablesRequestEditing else { return }
+        guard let selectedWorkspaceGroupID else {
             pendingRestoredWorkspaceGroupID = nil
+            return
+        }
+
+        guard workspaceGroupInventoryIsAuthoritative else {
+            pendingRestoredWorkspaceGroupID = selectedWorkspaceGroupID
             return
         }
 
@@ -939,20 +966,6 @@ struct TaskComposerSheet: View {
             return
         }
 
-        // An empty production projection is not proof that the Mac has no
-        // groups. Keep the restored value until a group arrives or the
-        // connected host definitively says this feature is unavailable.
-        let inventoryCanDisproveSelection = availableWorkspaceGroups != nil
-            || !workspaceGroupsForSelectedMachine.isEmpty
-            || (store.connectionState == .connected && !canSelectWorkspaceGroup)
-        guard pendingRestoredWorkspaceGroupID == selectedWorkspaceGroupID else {
-            updateSubmissionRequest(reconcileRecovery: true) {
-                selectedWorkspaceGroupID = nil
-                pendingRestoredWorkspaceGroupID = nil
-            }
-            return
-        }
-        guard inventoryCanDisproveSelection else { return }
         updateSubmissionRequest(reconcileRecovery: true) {
             selectedWorkspaceGroupID = nil
             pendingRestoredWorkspaceGroupID = nil

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TaskComposer/TaskComposerWorkspaceGroupMenu.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TaskComposer/TaskComposerWorkspaceGroupMenu.swift
@@ -8,6 +8,7 @@ struct TaskComposerWorkspaceGroupMenu: View, Equatable {
     let groups: [MobileWorkspaceGroupPreview]
     let selectedWorkspaceGroupID: MobileWorkspaceGroupPreview.ID?
     let isSelectionPending: Bool
+    let requiresSelectionResolution: Bool
     let isDisabled: Bool
     let select: (MobileWorkspaceGroupPreview.ID?) -> Void
 
@@ -15,13 +16,14 @@ struct TaskComposerWorkspaceGroupMenu: View, Equatable {
         lhs.groups == rhs.groups
             && lhs.selectedWorkspaceGroupID == rhs.selectedWorkspaceGroupID
             && lhs.isSelectionPending == rhs.isSelectionPending
+            && lhs.requiresSelectionResolution == rhs.requiresSelectionResolution
             && lhs.isDisabled == rhs.isDisabled
     }
 
     var body: some View {
         ZStack {
             TaskComposerRouteLabel(
-                icon: .symbol(selectedGroup?.iconSymbol ?? "folder"),
+                icon: .symbol(iconSymbol),
                 title: L10n.string(
                     "mobile.taskComposer.workspaceGroup",
                     defaultValue: "Workspace group"
@@ -80,8 +82,12 @@ struct TaskComposerWorkspaceGroupMenu: View, Equatable {
         ))
         .accessibilityValue(displayValue)
         .accessibilityHint(L10n.string(
-            "mobile.taskComposer.workspaceGroup.hint",
-            defaultValue: "Chooses where the new workspace appears on this Mac."
+            requiresSelectionResolution
+                ? "mobile.taskComposer.workspaceGroup.recoveryHint"
+                : "mobile.taskComposer.workspaceGroup.hint",
+            defaultValue: requiresSelectionResolution
+                ? "Choose another group or select None before submitting."
+                : "Chooses where the new workspace appears on this Mac."
         ))
         .accessibilityIdentifier("MobileTaskComposerWorkspaceGroup")
     }
@@ -97,10 +103,22 @@ struct TaskComposerWorkspaceGroupMenu: View, Equatable {
                 defaultValue: "Loading groups…"
             )
         }
+        if requiresSelectionResolution {
+            return L10n.string(
+                "mobile.taskComposer.workspaceGroup.unavailable",
+                defaultValue: "Choose a group"
+            )
+        }
         return selectedGroup?.name ?? L10n.string(
             "mobile.taskComposer.workspaceGroup.none",
             defaultValue: "None"
         )
+    }
+
+    private var iconSymbol: String {
+        if isSelectionPending { return "arrow.triangle.2.circlepath" }
+        if requiresSelectionResolution { return "exclamationmark.triangle" }
+        return selectedGroup?.iconSymbol ?? "folder"
     }
 }
 #endif

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TaskComposer/TaskComposerWorkspaceGroupMenu.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TaskComposer/TaskComposerWorkspaceGroupMenu.swift
@@ -1,0 +1,97 @@
+#if os(iOS)
+import CmuxMobileShellModel
+import CmuxMobileSupport
+import SwiftUI
+
+/// A native menu row for choosing the destination group of a new workspace.
+struct TaskComposerWorkspaceGroupMenu: View, Equatable {
+    let groups: [MobileWorkspaceGroupPreview]
+    let selectedWorkspaceGroupID: MobileWorkspaceGroupPreview.ID?
+    let isDisabled: Bool
+    let select: (MobileWorkspaceGroupPreview.ID?) -> Void
+
+    nonisolated static func == (lhs: Self, rhs: Self) -> Bool {
+        lhs.groups == rhs.groups
+            && lhs.selectedWorkspaceGroupID == rhs.selectedWorkspaceGroupID
+            && lhs.isDisabled == rhs.isDisabled
+    }
+
+    var body: some View {
+        ZStack {
+            TaskComposerRouteLabel(
+                icon: .symbol(selectedGroup?.iconSymbol ?? "folder"),
+                title: L10n.string(
+                    "mobile.taskComposer.workspaceGroup",
+                    defaultValue: "Workspace group"
+                ),
+                value: selectedGroup?.name ?? L10n.string(
+                    "mobile.taskComposer.workspaceGroup.none",
+                    defaultValue: "None"
+                ),
+                valueFont: .caption.weight(.semibold),
+                valueTruncationMode: .tail,
+                chevronSystemName: "chevron.up.chevron.down"
+            )
+            .accessibilityHidden(true)
+
+            Menu {
+                Button {
+                    select(nil)
+                } label: {
+                    Text(L10n.string(
+                        "mobile.taskComposer.workspaceGroup.none",
+                        defaultValue: "None"
+                    ))
+                    Image(systemName: selectedWorkspaceGroupID == nil ? "checkmark" : "folder")
+                }
+
+                if groups.isEmpty {
+                    Button {} label: {
+                        Text(L10n.string(
+                            "mobile.taskComposer.workspaceGroup.empty",
+                            defaultValue: "No workspace groups on this Mac"
+                        ))
+                        Image(systemName: "info.circle")
+                    }
+                    .disabled(true)
+                } else {
+                    ForEach(groups) { group in
+                        Button {
+                            select(group.id)
+                        } label: {
+                            Text(group.name)
+                            Image(systemName: group.id == selectedWorkspaceGroupID
+                                ? "checkmark"
+                            : (group.iconSymbol ?? "folder"))
+                        }
+                    }
+                }
+            } label: {
+                Color.clear
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+                    .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+        }
+        .frame(maxWidth: .infinity, minHeight: 52, alignment: .leading)
+        .disabled(isDisabled)
+        .accessibilityLabel(L10n.string(
+            "mobile.taskComposer.workspaceGroup",
+            defaultValue: "Workspace group"
+        ))
+        .accessibilityValue(selectedGroup?.name ?? L10n.string(
+            "mobile.taskComposer.workspaceGroup.none",
+            defaultValue: "None"
+        ))
+        .accessibilityHint(L10n.string(
+            "mobile.taskComposer.workspaceGroup.hint",
+            defaultValue: "Chooses where the new workspace appears on this Mac."
+        ))
+        .accessibilityIdentifier("MobileTaskComposerWorkspaceGroup")
+    }
+
+    private var selectedGroup: MobileWorkspaceGroupPreview? {
+        groups.first { $0.id == selectedWorkspaceGroupID }
+    }
+}
+#endif

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TaskComposer/TaskComposerWorkspaceGroupMenu.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TaskComposer/TaskComposerWorkspaceGroupMenu.swift
@@ -7,12 +7,14 @@ import SwiftUI
 struct TaskComposerWorkspaceGroupMenu: View, Equatable {
     let groups: [MobileWorkspaceGroupPreview]
     let selectedWorkspaceGroupID: MobileWorkspaceGroupPreview.ID?
+    let isSelectionPending: Bool
     let isDisabled: Bool
     let select: (MobileWorkspaceGroupPreview.ID?) -> Void
 
     nonisolated static func == (lhs: Self, rhs: Self) -> Bool {
         lhs.groups == rhs.groups
             && lhs.selectedWorkspaceGroupID == rhs.selectedWorkspaceGroupID
+            && lhs.isSelectionPending == rhs.isSelectionPending
             && lhs.isDisabled == rhs.isDisabled
     }
 
@@ -24,10 +26,7 @@ struct TaskComposerWorkspaceGroupMenu: View, Equatable {
                     "mobile.taskComposer.workspaceGroup",
                     defaultValue: "Workspace group"
                 ),
-                value: selectedGroup?.name ?? L10n.string(
-                    "mobile.taskComposer.workspaceGroup.none",
-                    defaultValue: "None"
-                ),
+                value: displayValue,
                 valueFont: .caption.weight(.semibold),
                 valueTruncationMode: .tail,
                 chevronSystemName: "chevron.up.chevron.down"
@@ -79,10 +78,7 @@ struct TaskComposerWorkspaceGroupMenu: View, Equatable {
             "mobile.taskComposer.workspaceGroup",
             defaultValue: "Workspace group"
         ))
-        .accessibilityValue(selectedGroup?.name ?? L10n.string(
-            "mobile.taskComposer.workspaceGroup.none",
-            defaultValue: "None"
-        ))
+        .accessibilityValue(displayValue)
         .accessibilityHint(L10n.string(
             "mobile.taskComposer.workspaceGroup.hint",
             defaultValue: "Chooses where the new workspace appears on this Mac."
@@ -92,6 +88,19 @@ struct TaskComposerWorkspaceGroupMenu: View, Equatable {
 
     private var selectedGroup: MobileWorkspaceGroupPreview? {
         groups.first { $0.id == selectedWorkspaceGroupID }
+    }
+
+    private var displayValue: String {
+        if isSelectionPending {
+            return L10n.string(
+                "mobile.taskComposer.workspaceGroup.loading",
+                defaultValue: "Loading groups…"
+            )
+        }
+        return selectedGroup?.name ?? L10n.string(
+            "mobile.taskComposer.workspaceGroup.none",
+            defaultValue: "None"
+        )
     }
 }
 #endif

--- a/ios/cmux/Resources/Localizable.xcstrings
+++ b/ios/cmux/Resources/Localizable.xcstrings
@@ -12081,6 +12081,40 @@
         }
       }
     },
+    "mobile.taskComposer.workspaceGroup.unavailable": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Choose a group"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "グループを選択"
+          }
+        }
+      }
+    },
+    "mobile.taskComposer.workspaceGroup.recoveryHint": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Choose another group or select None before submitting."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "送信する前に別のグループまたは「なし」を選択してください。"
+          }
+        }
+      }
+    },
     "mobile.taskComposer.model": {
       "extractionState": "manual",
       "localizations": {

--- a/ios/cmux/Resources/Localizable.xcstrings
+++ b/ios/cmux/Resources/Localizable.xcstrings
@@ -11996,6 +11996,74 @@
         }
       }
     },
+    "mobile.taskComposer.workspaceGroup": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Workspace group"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ワークスペースグループ"
+          }
+        }
+      }
+    },
+    "mobile.taskComposer.workspaceGroup.empty": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No workspace groups on this Mac"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "このMacにワークスペースグループはありません"
+          }
+        }
+      }
+    },
+    "mobile.taskComposer.workspaceGroup.hint": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Chooses where the new workspace appears on this Mac."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "新しいワークスペースをこのMacのどこに表示するか選択します。"
+          }
+        }
+      }
+    },
+    "mobile.taskComposer.workspaceGroup.none": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "None"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "なし"
+          }
+        }
+      }
+    },
     "mobile.taskComposer.model": {
       "extractionState": "manual",
       "localizations": {

--- a/ios/cmux/Resources/Localizable.xcstrings
+++ b/ios/cmux/Resources/Localizable.xcstrings
@@ -12064,6 +12064,23 @@
         }
       }
     },
+    "mobile.taskComposer.workspaceGroup.loading": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Loading groups…"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "グループを読み込み中…"
+          }
+        }
+      }
+    },
     "mobile.taskComposer.model": {
       "extractionState": "manual",
       "localizations": {

--- a/ios/cmuxUITests/cmuxUITests.swift
+++ b/ios/cmuxUITests/cmuxUITests.swift
@@ -3968,6 +3968,7 @@ final class cmuxUITests: XCTestCase {
             )
             XCTAssertTrue(app.buttons["MobileTaskComposerMachineMenu"].exists)
             XCTAssertTrue(app.buttons["MobileTaskComposerDirectory"].exists)
+            XCTAssertTrue(app.buttons["MobileTaskComposerWorkspaceGroup"].exists)
             XCTAssertLessThanOrEqual(
                 app.buttons.matching(identifier: "MobileTaskComposerAgentPill").count,
                 1,
@@ -5232,6 +5233,35 @@ final class cmuxUITests: XCTestCase {
         let submittedMac = app.staticTexts["MobileTaskComposerSubmittedMacDeviceID"]
         XCTAssertTrue(submittedMac.waitForExistence(timeout: 4))
         XCTAssertEqual(submittedMac.label, "task-composer-backup-preview-mac")
+    }
+
+    /// Selecting a workspace group in Task Options must travel with the
+    /// immutable create spec, so the new workspace lands in that group.
+    @MainActor
+    func testTaskComposerSubmitsToSelectedWorkspaceGroup() throws {
+        let app = launchApp(mockData: false, environment: [
+            "CMUX_UITEST_TASK_COMPOSER_PREVIEW": "1",
+        ])
+        defer { app.terminate() }
+
+        let prompt = taskComposerPrompt(in: app)
+        XCTAssertTrue(prompt.waitForExistence(timeout: 8))
+        openTaskComposerOptions(in: app)
+
+        let groupMenu = app.buttons["MobileTaskComposerWorkspaceGroup"]
+        XCTAssertTrue(groupMenu.waitForExistence(timeout: 3))
+        XCTAssertEqual(groupMenu.value as? String, "None")
+        tap(groupMenu, in: app)
+        tapMenuItem(app.buttons["Focus work"], in: app)
+        XCTAssertEqual(groupMenu.value as? String, "Focus work")
+
+        tap(app.buttons["MobileTaskComposerOptionsDoneButton"], in: app)
+        try typeText("Put this task in Focus work", into: prompt, in: app)
+        tap(app.buttons["MobileTaskComposerSubmitButton"], in: app)
+
+        let submittedGroup = app.staticTexts["MobileTaskComposerSubmittedWorkspaceGroupID"]
+        XCTAssertTrue(submittedGroup.waitForExistence(timeout: 4))
+        XCTAssertEqual(submittedGroup.label, "task-composer-preview-group")
     }
 
     /// The debug-only lab must expose every Shell treatment, apply the


### PR DESCRIPTION
## Summary
- add an optional workspace-group picker to Task Options
- carry the selected aggregate group through drafts, retries, and workspace.create
- replace the material route card with native grouped rows

## Verification
- Swift Testing: MobileTaskSubmissionSnapshotTests
- Swift Testing: MobileTaskComposerSubmitTests
- cloud macOS tagged build: grpopt
- iOS archive and UI dogfood pending fleet capacity

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/10123"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789246635&installation_model_id=21920&pr_number=10123&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F10123&signature=eed408d7fdd393769c314ae5b2824979a4377c734399118ffa5fd04e988a1dbd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds optional workspace‑group selection to the iOS Task Composer and sends it with workspace.create to prevent silent ungrouped reroutes after reconnects or stale inventory. Old behavior: no group targeting and possible silent reroutes; new behavior: user‑selected group is preserved, gated by exact Mac capability and authoritative inventory, and submission is blocked until the route is valid.

- Adds workspaceGroupID to `MobileWorkspaceCreateSpec`; merges with explicit inGroup and rejects conflicts. Request equivalence now includes the destination group.
- Scopes capability and inventory to the exact Mac/instance (no borrowing for tagged pairings); exposes per‑pairing queries for create‑in‑group and authoritative inventory.
- Treats responses without group metadata as non‑authoritative; resets authority on reconnect, disconnect, Mac unavailability, and partial snapshots without groups.
- Gates the picker on create‑in‑group capability and authoritative inventory. Keeps a restored group until authority arrives; blocks snapshot/submission while inventory is non‑authoritative; if inventory disproves a restored group, shows it, blocks submission, and requires selecting another group or None.
- Filters out groups whose Mac device or instance does not match the selected pairing. Adds a native Workspace Group menu with None/loading/unavailable states (localized, accessible); debug preview shows the submitted workspaceGroupID.
- Tests cover grouped submission, conflict rejection, request equivalence, persistence through recovery, capability scoping, legacy draft decoding, and a UI flow that verifies the submitted group.

**Migration**
- Do not pass both inGroup and spec.workspaceGroupID with different values. Existing callers compile unchanged.

<sup>Written for commit b9b940a0fcd60fb0db9eadeeebb2e7765d18ef64. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/10123?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added workspace-group selection to the task composer, including “None,” loading states, and empty-state guidance.
  - Preserved selections across drafts, completed-operation recovery, and task resubmission.
  - Added localized English and Japanese labels plus accessibility support.
- **Bug Fixes**
  - Prevented conflicting group selections from being submitted.
  - Kept selections valid as machines and group availability change.
  - Avoided treating unavailable or incomplete group data as authoritative.
- **Tests**
  - Added coverage for selection, persistence, conflict handling, accessibility, and end-to-end submission.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->