### PR TITLE
Speed up iOS startup Mac discovery

### DIFF
--- a/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohClientRuntime+PolicyRefresh.swift
+++ b/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohClientRuntime+PolicyRefresh.swift
@@ -17,6 +17,7 @@ extension CmxIrohClientRuntime {
     func handleSupervisorNetworkChange(revision: UInt64) {
         guard lifecycleRevision == revision,
               lifecyclePhase.ownsNetworkOperation else { return }
+        initialDiscoverySnapshotAvailable = false
         guard registrationRefreshEnabled else {
             registrationRefreshPending = true
             return

--- a/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohClientRuntime.swift
+++ b/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohClientRuntime.swift
@@ -103,6 +103,10 @@ public actor CmxIrohClientRuntime {
     var registrationRefreshPendingRequiresDiscovery = false
     var registrationRefreshEnabled = false
     var liveDiscoveryGeneration: UInt64 = 0
+    /// The first verified discovery installed during activation can satisfy the
+    /// shell's immediate live-Mac lookup. It is consumed once, then ordinary
+    /// discovery calls retain their authoritative refresh behavior.
+    var initialDiscoverySnapshotAvailable = false
     var authoritativeDiscovery: CmxIrohDiscoveryResponse?
     var localBinding: CmxIrohBrokerBinding?
     var lastRegistrationRefreshState: CmxIrohRegistrationPublicationState?
@@ -216,6 +220,18 @@ public actor CmxIrohClientRuntime {
         liveDiscoveryGeneration
     }
 
+    /// Consumes the one activation snapshot that was already verified by the
+    /// registration path. A caller still must read the route catalog and may
+    /// fall back to ``refreshLiveDiscoveryOutcome()`` when compatibility
+    /// filtering produces no candidate.
+    public func consumeInitialDiscoverySnapshot() -> Bool {
+        guard lifecyclePhase == .active, initialDiscoverySnapshotAvailable else {
+            return false
+        }
+        initialDiscoverySnapshotAvailable = false
+        return true
+    }
+
     /// Refreshes registration and discovery, returning true only when a new
     /// online broker snapshot was verified and installed.
     ///
@@ -257,6 +273,10 @@ public actor CmxIrohClientRuntime {
         guard lifecyclePhase == .active else {
             return .failed(.endpointUnavailable)
         }
+        // A pushed route revision supersedes the activation snapshot. The next
+        // lookup must observe the authoritative revision before it can admit a
+        // first connection.
+        initialDiscoverySnapshotAvailable = false
         pendingConnectivityRevision = max(
             pendingConnectivityRevision ?? hintedRevision,
             hintedRevision
@@ -476,6 +496,7 @@ public actor CmxIrohClientRuntime {
         registrationRefreshPending = false
         registrationRefreshPendingRequiresDiscovery = false
         registrationRefreshEnabled = false
+        initialDiscoverySnapshotAvailable = false
         currentSnapshot = CmxIrohClientRuntimeSnapshot(
             state: .starting,
             endpointID: nil,
@@ -542,6 +563,7 @@ public actor CmxIrohClientRuntime {
                         )
                     }
                     liveDiscoveryGeneration &+= 1
+                    initialDiscoverySnapshotAvailable = true
                 }
             } else if let lanRendezvous = policy.cachedLANRendezvous {
                 await handleCachedBindings(policy.cachedTargetBindings, lanRendezvous)
@@ -693,6 +715,7 @@ public actor CmxIrohClientRuntime {
         }
         lifecyclePhase = .stopping
         lifecycleRevision &+= 1
+        initialDiscoverySnapshotAvailable = false
         connectivityReconciliationOperation?.task.cancel()
         connectivityReconciliationOperation = nil
         pendingConnectivityRevision = nil

--- a/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohClientRuntime.swift
+++ b/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohClientRuntime.swift
@@ -703,6 +703,10 @@ public actor CmxIrohClientRuntime {
     /// - Parameter deviceID: The Mac's registry device id, or `nil` to
     ///   invalidate discovery reuse for every peer.
     public func invalidateDiscoverySnapshot(forMacDeviceID deviceID: String?) async {
+        // A route push can arrive after activation but before the shell's
+        // first lookup. Do not let that lookup consume the superseded
+        // activation response while the registry invalidation is in flight.
+        initialDiscoverySnapshotAvailable = false
         await registryContextProvider?.invalidateVerifiedDiscovery(
             forDeviceID: deviceID
         )

--- a/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohClientRuntimeTests.swift
+++ b/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohClientRuntimeTests.swift
@@ -246,6 +246,35 @@ struct CmxIrohClientRuntimeTests {
     }
 
     @Test
+    func invalidatingDiscoverySnapshotDisablesActivationReuse() async throws {
+        let fixture = try ClientRuntimeTestFixture()
+        let discovery = try ClientRuntimeTestFixture.discovery(
+            binding: fixture.binding,
+            revision: 1
+        )
+        let runtime = try CmxIrohClientRuntime(
+            factory: TestIrohEndpointFactory(endpoints: [
+                TestIrohEndpoint(identity: fixture.endpointID),
+            ]),
+            broker: TestRevisionedClientBroker(
+                binding: fixture.binding,
+                discoveries: [discovery],
+                relay: fixture.relayResponse(),
+                embedInitialDiscovery: true
+            ),
+            configuration: fixture.configuration,
+            pendingRevocations: fixture.pendingRevocations(),
+            now: { fixture.now }
+        )
+
+        try await runtime.start()
+        await runtime.invalidateDiscoverySnapshot(forMacDeviceID: nil)
+
+        #expect(!(await runtime.consumeInitialDiscoverySnapshot()))
+        await runtime.stop()
+    }
+
+    @Test
     func startupFetchesPaginatedDiscoveryWhenRegistrationAndSyncSnapshotsAreUnproven() async throws {
         let fixture = try ClientRuntimeTestFixture()
         let truncatedRegistrationDiscovery = try ClientRuntimeTestFixture.discovery(

--- a/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohClientRuntimeTests.swift
+++ b/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohClientRuntimeTests.swift
@@ -217,6 +217,35 @@ struct CmxIrohClientRuntimeTests {
     }
 
     @Test
+    func activationDiscoverySnapshotIsConsumedOnlyOnce() async throws {
+        let fixture = try ClientRuntimeTestFixture()
+        let discovery = try ClientRuntimeTestFixture.discovery(
+            binding: fixture.binding,
+            revision: 1
+        )
+        let runtime = try CmxIrohClientRuntime(
+            factory: TestIrohEndpointFactory(endpoints: [
+                TestIrohEndpoint(identity: fixture.endpointID),
+            ]),
+            broker: TestRevisionedClientBroker(
+                binding: fixture.binding,
+                discoveries: [discovery],
+                relay: fixture.relayResponse(),
+                embedInitialDiscovery: true
+            ),
+            configuration: fixture.configuration,
+            pendingRevocations: fixture.pendingRevocations(),
+            now: { fixture.now }
+        )
+
+        try await runtime.start()
+
+        #expect(await runtime.consumeInitialDiscoverySnapshot())
+        #expect(!(await runtime.consumeInitialDiscoverySnapshot()))
+        await runtime.stop()
+    }
+
+    @Test
     func startupFetchesPaginatedDiscoveryWhenRegistrationAndSyncSnapshotsAreUnproven() async throws {
         let fixture = try ClientRuntimeTestFixture()
         let truncatedRegistrationDiscovery = try ClientRuntimeTestFixture.discovery(

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
@@ -16,6 +16,14 @@ private let mobileShellLog = Logger(
     category: "mobile-shell"
 )
 
+/// Instruments-visible intervals for the authenticated launch path. The
+/// intervals are disabled by the OS when no trace is active, so production
+/// startup pays only the cheap signpost state check.
+nonisolated private let mobileShellStartupSignposter = OSSignposter(
+    subsystem: Bundle.main.bundleIdentifier ?? "dev.cmux.ios",
+    category: "mobile-startup"
+)
+
 /// Transitional alias for the decomposed shell facade.
 ///
 /// The iOS views and push coordinator still bind to `CMUXMobileShellStore`;
@@ -1030,6 +1038,11 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
     var pushedRouteSyncOperationID: UUID?
     var pushedRouteSyncScope: MobileShellScopeSnapshot?
     var pushedRouteSyncPendingInstances: [String: PresenceInstance] = [:]
+    /// Owns the launch-only backup refresh that runs alongside local route and
+    /// live Iroh discovery. Keeping the handle on the shell gives sign-out and
+    /// team changes a cancellation boundary instead of leaking a fire-and-forget
+    /// restore into the next account scope.
+    private var startupBackupRefreshTask: Task<Void, Never>?
     private var secondaryAggregationAfterPushedRoutesTask:
         Task<Void, Never>?
     private var secondaryAggregationAfterPushedRoutesOperationID: UUID?
@@ -1768,6 +1781,7 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         connectionRecoveryOwner.cancel()
         automaticReconnectRetryTask?.cancel()
         presenceTask?.cancel()
+        startupBackupRefreshTask?.cancel()
         networkPathObservationTask?.cancel()
         connectionMethodObservationTask?.cancel()
         terminalEventListenerTask?.cancel()
@@ -1937,6 +1951,8 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         // synchronously first; the actor cleanup below is still fire-and-forget
         // because signOut is sync.
         pairedMacRestoreBoundary?.invalidate()
+        startupBackupRefreshTask?.cancel()
+        startupBackupRefreshTask = nil
         teamScopeCleanupTask?.cancel()
         teamScopeCleanupTask = nil
         if let refresher = pairedMacStore as? any PairedMacBackupRefreshing {
@@ -2018,6 +2034,8 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         isReconnectingStoredMac = false
         didFinishStoredMacReconnectAttempt = false
         pairedMacRestoreBoundary?.invalidate()
+        startupBackupRefreshTask?.cancel()
+        startupBackupRefreshTask = nil
         let refresher = pairedMacStore as? any PairedMacBackupRefreshing
         // Lazy display: clear the stale old-team lists; the next loadPairedMacs() /
         // loadRegistryDevices() (DeviceTreeView `.task`) repopulate scoped to the
@@ -2559,13 +2577,15 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
     @discardableResult
     public func reconnectActiveMacIfAvailable(
         stackUserID: String?,
-        refreshBackupBeforeDial: Bool = true
+        refreshBackupBeforeDial: Bool = true,
+        refreshBackupInBackground: Bool = false
     ) async -> Bool {
         let startedAt = appDiagnosticNow()
         recordAppEvent(.reconnectStarted)
         let outcome = await reconnectActiveMacOutcome(
             stackUserID: stackUserID,
-            refreshBackupBeforeDial: refreshBackupBeforeDial
+            refreshBackupBeforeDial: refreshBackupBeforeDial,
+            refreshBackupInBackground: refreshBackupInBackground
         )
         switch outcome {
         case .connected:
@@ -2605,7 +2625,8 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
 
     func reconnectActiveMacOutcome(
         stackUserID: String?,
-        refreshBackupBeforeDial: Bool = true
+        refreshBackupBeforeDial: Bool = true,
+        refreshBackupInBackground: Bool = false
     ) async -> StoredMacReconnectOutcome {
         lastReconnectStackUserID = stackUserID
         startObservingNetworkPathChanges()
@@ -2651,6 +2672,7 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
             await self?.performReconnectActiveMacAttempt(
                 stackUserID: stackUserID,
                 refreshBackupBeforeDial: refreshBackupBeforeDial,
+                refreshBackupInBackground: refreshBackupInBackground,
                 generation: generation
             ) ?? .superseded
         }
@@ -2682,11 +2704,57 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         return .failed(.timedOut)
     }
 
+    /// Starts the launch-only backup merge without delaying route admission.
+    ///
+    /// The task is deliberately retained by the shell. A plain unstructured
+    /// task would survive sign-out and could publish a previous account's rows;
+    /// the generation and scope checks below make the completion harmless even
+    /// when cancellation arrives while the backup actor is suspended in I/O.
+    private func startStartupBackupRefresh(
+        scope: MobileShellScopeSnapshot,
+        generation: Int
+    ) {
+        guard let pairedMacStore,
+              let refresher = pairedMacStore as? any PairedMacBackupRefreshing else {
+            return
+        }
+        startupBackupRefreshTask?.cancel()
+        startupBackupRefreshTask = Task { @MainActor [weak self, refresher] in
+            let backupInterval = mobileShellStartupSignposter.beginInterval(
+                "backupRestore"
+            )
+            defer {
+                mobileShellStartupSignposter.endInterval(
+                    "backupRestore",
+                    backupInterval
+                )
+            }
+            await refresher.refreshFromBackup(stackUserID: scope.userID)
+            guard let self,
+                  !Task.isCancelled,
+                  self.storedMacReconnectGeneration == generation,
+                  await self.isScopeCurrent(scope) else {
+                return
+            }
+            await self.loadPairedMacs()
+        }
+    }
+
     private func performReconnectActiveMacAttempt(
         stackUserID: String?,
         refreshBackupBeforeDial: Bool,
+        refreshBackupInBackground: Bool,
         generation: Int
     ) async -> StoredMacReconnectOutcome {
+        let reconnectInterval = mobileShellStartupSignposter.beginInterval(
+            "storedMacReconnect"
+        )
+        defer {
+            mobileShellStartupSignposter.endInterval(
+                "storedMacReconnect",
+                reconnectInterval
+            )
+        }
         // No store / not signed in: can't determine a stored Mac here. Resolve the
         // restoring gate (so a returning user doesn't spin on RestoringSessionView)
         // but leave the persisted hint intact for a future attempt.
@@ -2702,13 +2770,15 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         if let result = storedMacReconnectInterruptionResult(generation: generation) {
             return result ? .connected : .superseded
         }
-        // Pull the authoritative per-user backup first so saved-Mac routes are
-        // current before we dial: a Mac that relaunched on a new port republishes
-        // to the backup, and LWW by lastSeenAt keeps any live local edit. Without
-        // this a stale port makes the auto-connect fail and the app falls back to
-        // the Mac picker, the screen we want to avoid showing.
-        if refreshBackupBeforeDial,
-           let refresher = pairedMacStore as? any PairedMacBackupRefreshing {
+        // A launch restore must not sit in front of the first usable route. The
+        // startup caller runs the authoritative backup merge in a shell-owned
+        // task while local SQLite reads and live Iroh discovery proceed. Manual
+        // retries and recovery keep the old synchronous ordering by leaving this
+        // flag false.
+        if refreshBackupInBackground, !refreshBackupBeforeDial {
+            startStartupBackupRefresh(scope: scope, generation: generation)
+        } else if refreshBackupBeforeDial,
+                  let refresher = pairedMacStore as? any PairedMacBackupRefreshing {
             await refresher.refreshFromBackup(stackUserID: scope.userID)
         }
         if let result = storedMacReconnectInterruptionResult(generation: generation) {
@@ -2727,13 +2797,24 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         }
         let loadedActiveMac: MobilePairedMac?
         let loadedMacs: [MobilePairedMac]
+        let pairedMacReadInterval = mobileShellStartupSignposter.beginInterval(
+            "pairedMacRead"
+        )
         do {
             loadedActiveMac = try await pairedMacStore.activeMac(stackUserID: scope.userID, teamID: scope.teamID)
             if let result = storedMacReconnectInterruptionResult(generation: generation) {
+                mobileShellStartupSignposter.endInterval(
+                    "pairedMacRead",
+                    pairedMacReadInterval
+                )
                 return result ? .connected : .superseded
             }
             loadedMacs = try await pairedMacStore.loadAll(stackUserID: scope.userID, teamID: scope.teamID)
         } catch {
+            mobileShellStartupSignposter.endInterval(
+                "pairedMacRead",
+                pairedMacReadInterval
+            )
             mobileShellLog.error("paired mac store read failed: \(String(describing: error), privacy: .public)")
             // A read failure means "couldn't determine," not "no mac": keep the
             // hint so a transient SQLite error doesn't erase a returning user's
@@ -2741,6 +2822,10 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
             finishStoredMacReconnectAttempt(generation: generation)
             return .failed(.unknown)
         }
+        mobileShellStartupSignposter.endInterval(
+            "pairedMacRead",
+            pairedMacReadInterval
+        )
         if let result = storedMacReconnectInterruptionResult(generation: generation) {
             return result ? .connected : .superseded
         }
@@ -2893,6 +2978,9 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         var zeroTouchCandidates: [MobilePairedMac] = []
         if connectionState != .connected, !tailscaleOnly,
            !automaticIrohReconnectIsBlocked(accountID: scope.userID) {
+            let zeroTouchInterval = mobileShellStartupSignposter.beginInterval(
+                "zeroTouchDiscovery"
+            )
             zeroTouchCandidates = await discoverZeroTouchIrohCandidates(
                 scope: scope,
                 generation: generation,
@@ -2902,6 +2990,10 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
                         instanceTag: $0.instanceTag
                     )
                 })
+            )
+            mobileShellStartupSignposter.endInterval(
+                "zeroTouchDiscovery",
+                zeroTouchInterval
             )
             guard generation == storedMacReconnectGeneration else {
                 return .superseded
@@ -3331,6 +3423,17 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
             let clock = ContinuousClock()
             var backoff: Duration = .seconds(1)
             while !Task.isCancelled {
+                let firstPresenceFrameInterval = mobileShellStartupSignposter
+                    .beginInterval("presenceFirstFrame")
+                var didEndPresenceFrameInterval = false
+                defer {
+                    if !didEndPresenceFrameInterval {
+                        mobileShellStartupSignposter.endInterval(
+                            "presenceFirstFrame",
+                            firstPresenceFrameInterval
+                        )
+                    }
+                }
                 do {
                     guard let scope = await self?.currentScopeSnapshot() else { return }
                     let stream = try await presence.subscribe()
@@ -3338,6 +3441,13 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
                         guard let self,
                               !Task.isCancelled,
                               await self.isScopeCurrent(scope) else { return }
+                        if !didEndPresenceFrameInterval {
+                            mobileShellStartupSignposter.endInterval(
+                                "presenceFirstFrame",
+                                firstPresenceFrameInterval
+                            )
+                            didEndPresenceFrameInterval = true
+                        }
                         backoff = .seconds(1)
                         self.applyPresenceUpdate(update, scope: scope)
                     }

--- a/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/DelayedTeamPairedMacStore.swift
+++ b/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/DelayedTeamPairedMacStore.swift
@@ -42,6 +42,12 @@ actor DelayedTeamPairedMacStore: MobilePairedMacStoring, PairedMacBackupRefreshi
     private var backupCancellationStartWaiters: [Int: [CheckedContinuation<Void, Never>]] = [:]
     private var backupCancellationBlockers: [Int: CheckedContinuation<Void, Never>] = [:]
     private var backupCancellationObservedCancellation: [Int: Bool] = [:]
+    private var backupRefreshBlocked = false
+    private var backupRefreshStarted = false
+    private var backupRefreshStartWaiters: [CheckedContinuation<Void, Never>] = []
+    private var backupRefreshBlockers: [CheckedContinuation<Void, Never>] = []
+    private var backupRefreshFinished = false
+    private var backupRefreshFinishWaiters: [CheckedContinuation<Void, Never>] = []
 
     init(recordsByTeam: [String: [MobilePairedMac]], blockedTeams: Set<String>) {
         self.recordsByTeam = recordsByTeam
@@ -233,7 +239,46 @@ actor DelayedTeamPairedMacStore: MobilePairedMacStoring, PairedMacBackupRefreshi
     }
     func removeAll() async throws {}
 
-    func refreshFromBackup(stackUserID _: String?) async {}
+    func refreshFromBackup(stackUserID _: String?) async {
+        backupRefreshStarted = true
+        let waiters = backupRefreshStartWaiters
+        backupRefreshStartWaiters.removeAll()
+        for waiter in waiters { waiter.resume() }
+        if backupRefreshBlocked {
+            await withCheckedContinuation { continuation in
+                backupRefreshBlockers.append(continuation)
+            }
+        }
+        backupRefreshFinished = true
+        let finishWaiters = backupRefreshFinishWaiters
+        backupRefreshFinishWaiters.removeAll()
+        for waiter in finishWaiters { waiter.resume() }
+    }
+
+    func gateBackupRefresh() {
+        backupRefreshBlocked = true
+    }
+
+    func waitUntilBackupRefreshStarted() async {
+        guard !backupRefreshStarted else { return }
+        await withCheckedContinuation { continuation in
+            backupRefreshStartWaiters.append(continuation)
+        }
+    }
+
+    func waitUntilBackupRefreshFinished() async {
+        guard !backupRefreshFinished else { return }
+        await withCheckedContinuation { continuation in
+            backupRefreshFinishWaiters.append(continuation)
+        }
+    }
+
+    func releaseBackupRefresh() {
+        backupRefreshBlocked = false
+        let blockers = backupRefreshBlockers
+        backupRefreshBlockers.removeAll()
+        for blocker in blockers { blocker.resume() }
+    }
 
     func cancelInFlightRestores() async {
         backupCancellationCallCount += 1

--- a/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/IrohZeroTouchDiscoveryTests.swift
+++ b/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/IrohZeroTouchDiscoveryTests.swift
@@ -330,6 +330,43 @@ struct IrohZeroTouchDiscoveryTests {
     }
 
     @Test
+    func startupBackupRefreshRunsAlongsideLiveDiscovery() async throws {
+        let live = try candidate(deviceID: "mac-a", endpointByte: "a")
+        let discovery = ScriptedIrohDiscovery(snapshots: [[live]])
+        let pairedMacStore = DelayedTeamPairedMacStore(
+            recordsByTeam: [:],
+            blockedTeams: []
+        )
+        await pairedMacStore.gateBackupRefresh()
+        let fixture = try await makeFixture(
+            discovery: discovery,
+            reportedDeviceID: "mac-a",
+            pairedMacStore: pairedMacStore
+        )
+        defer {
+            Task { await pairedMacStore.releaseBackupRefresh() }
+            fixture.cleanup()
+        }
+
+        let reconnect = Task { @MainActor in
+            await fixture.shell.reconnectActiveMacIfAvailable(
+                stackUserID: "user-1",
+                refreshBackupBeforeDial: false,
+                refreshBackupInBackground: true
+            )
+        }
+        await pairedMacStore.waitUntilBackupRefreshStarted()
+
+        #expect(try await pollUntil {
+            fixture.factory.attemptedRouteIDs() == ["iroh-mac-a"]
+        })
+        #expect(await reconnect.value)
+        #expect(discovery.callCount() == 1)
+        await pairedMacStore.releaseBackupRefresh()
+        await pairedMacStore.waitUntilBackupRefreshFinished()
+    }
+
+    @Test
     func signOutWhileDiscoveryIsSuspendedPreventsDialAndPersistence() async throws {
         let live = try candidate(deviceID: "mac-a", endpointByte: "a")
         let discovery = SuspendedIrohDiscovery(candidates: [live])
@@ -429,14 +466,26 @@ struct IrohZeroTouchDiscoveryTests {
         discovery: any MobileIrohMacDiscovering,
         reportedDeviceID: String,
         failingRouteIDs: Set<String> = [],
-        rateLimitedRouteIDs: Set<String> = []
+        rateLimitedRouteIDs: Set<String> = [],
+        pairedMacStore: (any MobilePairedMacStoring)? = nil
     ) async throws -> ZeroTouchFixture {
-        let directory = FileManager.default.temporaryDirectory
-            .appendingPathComponent(UUID().uuidString, isDirectory: true)
-        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
-        let store = try MobilePairedMacStore(
-            databaseURL: directory.appendingPathComponent("paired-macs.sqlite3")
-        )
+        let directory: URL?
+        let store: any MobilePairedMacStoring
+        if let pairedMacStore {
+            directory = nil
+            store = pairedMacStore
+        } else {
+            let databaseDirectory = FileManager.default.temporaryDirectory
+                .appendingPathComponent(UUID().uuidString, isDirectory: true)
+            try FileManager.default.createDirectory(
+                at: databaseDirectory,
+                withIntermediateDirectories: true
+            )
+            directory = databaseDirectory
+            store = try MobilePairedMacStore(
+                databaseURL: databaseDirectory.appendingPathComponent("paired-macs.sqlite3")
+            )
+        }
         let router = LivenessHostRouter()
         await router.setHostIdentity(
             deviceID: reportedDeviceID,
@@ -628,13 +677,15 @@ private enum ZeroTouchRouteError: CmxRetryAfterProviding {
 @MainActor
 private struct ZeroTouchFixture {
     let shell: MobileShellComposite
-    let store: MobilePairedMacStore
+    let store: any MobilePairedMacStoring
     let factory: ZeroTouchRouteFactory
     let router: LivenessHostRouter
-    let directory: URL
+    let directory: URL?
 
     func cleanup() {
         Task { await shell.remoteClient?.disconnect() }
-        try? FileManager.default.removeItem(at: directory)
+        if let directory {
+            try? FileManager.default.removeItem(at: directory)
+        }
     }
 }

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/CMUXMobileRootView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/CMUXMobileRootView.swift
@@ -6,12 +6,18 @@ import CmuxMobileShellModel
 import CmuxMobileSupport
 import CmuxMobileToast
 import CmuxMobileWorkspace
+import OSLog
 import SwiftUI
 #if os(iOS)
 @preconcurrency import UIKit
 #elseif os(macOS)
 import AppKit
 #endif
+
+nonisolated private let mobileRootStartupSignposter = OSSignposter(
+    subsystem: Bundle.main.bundleIdentifier ?? "dev.cmux.ios",
+    category: "mobile-startup"
+)
 
 struct CMUXMobileRootView: View {
     private static let startupRestoringGateSeconds: Double = 6
@@ -861,7 +867,9 @@ struct CMUXMobileRootView: View {
             coordinator: startupConnectionCoordinator,
             runAttempt: { [store, authManager] in
                 await store.reconnectActiveMacIfAvailable(
-                    stackUserID: authManager.currentUser?.id
+                    stackUserID: authManager.currentUser?.id,
+                    refreshBackupBeforeDial: false,
+                    refreshBackupInBackground: true
                 )
             }
         )
@@ -1015,7 +1023,11 @@ struct CMUXMobileRootView: View {
         }
         Task {
             defer { restoringGateDeadline.cancel() }
-            _ = await store.reconnectActiveMacIfAvailable(stackUserID: stackUserID)
+            _ = await store.reconnectActiveMacIfAvailable(
+                stackUserID: stackUserID,
+                refreshBackupBeforeDial: false,
+                refreshBackupInBackground: true
+            )
             startupConnectionCoordinator.finishStoredReconnect(startupAttempt)
         }
     }
@@ -1032,6 +1044,15 @@ struct CMUXMobileRootView: View {
     }
 
     private func finishAuthenticationBootstrapAndConnect() async {
+        let authBootstrapInterval = mobileRootStartupSignposter.beginInterval(
+            "authBootstrap"
+        )
+        defer {
+            mobileRootStartupSignposter.endInterval(
+                "authBootstrap",
+                authBootstrapInterval
+            )
+        }
         await authManager.awaitBootstrapped()
         guard !Task.isCancelled else { return }
         if authManager.isAuthenticated {

--- a/ios/cmuxPackage/Sources/cmuxFeature/MobileIrohRuntimeComposition.swift
+++ b/ios/cmuxPackage/Sources/cmuxFeature/MobileIrohRuntimeComposition.swift
@@ -582,21 +582,44 @@ public final class MobileIrohRuntimeComposition:
     /// The catalog keeps cached bindings in a separate route-only view, so this
     /// method can never turn an offline cache entry into a first pairing.
     public func discoverLiveMacs() async -> [MobileDiscoveredIrohMac] {
+        let startedAt = DispatchTime.now().uptimeNanoseconds
         diagnosticLog?.record(DiagnosticEvent(.discoveryStarted, a: DiagnosticTransportKind.iroh.rawValue))
         let readiness = await settleConnectionReadiness()
         guard let runtime else {
-            diagnosticLog?.record(DiagnosticEvent(
+            var event = DiagnosticEvent(
                 .discoveryFailed,
                 a: DiagnosticTransportKind.iroh.rawValue,
                 b: readiness.failureKind.rawValue
-            ))
+            )
+            event.ms = Self.elapsedMilliseconds(since: startedAt)
+            diagnosticLog?.record(event)
             return []
+        }
+        // Activation already authenticated one discovery response before the
+        // runtime became ready. Consume that exact snapshot once so the first
+        // Mac lookup does not immediately pay for a duplicate broker round trip.
+        // An empty or incompatible snapshot still falls through to the normal
+        // authoritative refresh below.
+        if await runtime.consumeInitialDiscoverySnapshot() {
+            guard self.runtime === runtime else { return [] }
+            let candidates = await routeCatalog.liveMacCandidates(
+                preferredTag: tag,
+                compatibleWith: discoveryCompatibilityPolicy
+            )
+            if !candidates.isEmpty {
+                recordDiscoveryOutcome(
+                    candidateCount: candidates.count,
+                    durationMilliseconds: Self.elapsedMilliseconds(since: startedAt)
+                )
+                return candidates
+            }
         }
         let refreshOutcome = await runtime.refreshLiveDiscoveryOutcome()
         guard refreshOutcome == .refreshed else {
             guard self.runtime === runtime else { return [] }
             await routeCatalog.clearLiveMacCandidates(scope: lifecycleRevision)
-            if let event = Self.discoveryRefreshFailureEvent(for: refreshOutcome) {
+            if var event = Self.discoveryRefreshFailureEvent(for: refreshOutcome) {
+                event.ms = Self.elapsedMilliseconds(since: startedAt)
                 diagnosticLog?.record(event)
             }
             return []
@@ -606,7 +629,10 @@ public final class MobileIrohRuntimeComposition:
             preferredTag: tag,
             compatibleWith: discoveryCompatibilityPolicy
         )
-        recordDiscoveryOutcome(candidateCount: candidates.count)
+        recordDiscoveryOutcome(
+            candidateCount: candidates.count,
+            durationMilliseconds: Self.elapsedMilliseconds(since: startedAt)
+        )
         return candidates
     }
 
@@ -617,19 +643,30 @@ public final class MobileIrohRuntimeComposition:
         await runtime?.invalidateDiscoverySnapshot(forMacDeviceID: deviceID)
     }
 
-    private func recordDiscoveryOutcome(candidateCount: Int) {
+    private func recordDiscoveryOutcome(
+        candidateCount: Int,
+        durationMilliseconds: UInt32
+    ) {
         if candidateCount > 0 {
             diagnosticLog?.record(DiagnosticEvent(
                 .discoverySucceeded,
+                ms: durationMilliseconds,
                 a: DiagnosticTransportKind.iroh.rawValue
             ))
         } else {
             diagnosticLog?.record(DiagnosticEvent(
                 .discoveryFailed,
+                ms: durationMilliseconds,
                 a: DiagnosticTransportKind.iroh.rawValue,
                 b: DiagnosticFailureKind.noRoute.rawValue
             ))
         }
+    }
+
+    private static func elapsedMilliseconds(since start: UInt64) -> UInt32 {
+        let now = DispatchTime.now().uptimeNanoseconds
+        let elapsed = now >= start ? now - start : 0
+        return UInt32(clamping: elapsed / 1_000_000)
     }
 
     nonisolated static func discoveryRefreshFailureEvent(

--- a/ios/cmuxPackage/Tests/cmuxFeatureTests/MobileIrohRuntimeCompositionCooldownTests.swift
+++ b/ios/cmuxPackage/Tests/cmuxFeatureTests/MobileIrohRuntimeCompositionCooldownTests.swift
@@ -332,7 +332,7 @@ struct MobileIrohRuntimeCompositionCooldownTests {
     }
 
     @Test
-    func liveMacDiscoveryForcesFreshBrokerSnapshotAfterActivation() async throws {
+    func firstLiveMacDiscoveryConsumesActivationSnapshotThenRefreshes() async throws {
         let fixture = try await MobileIrohCooldownFixture.makeSuccessfulBootstrap()
         await settleActivation(fixture) {
             fixture.composition.runtime != nil
@@ -341,8 +341,20 @@ struct MobileIrohRuntimeCompositionCooldownTests {
         let activationDiscoveryCount = await fixture.broker.discoveryRequestCount()
         #expect(activationDiscoveryCount == 1)
 
+        let eventsBeforeLookup = (await fixture.diagnosticLog.snapshot()).events.count
         _ = await fixture.composition.discoverLiveMacs()
+        // Runtime activation already installed and authenticated this snapshot;
+        // the first user-visible lookup should not pay for a duplicate request.
+        #expect(await fixture.broker.discoveryRequestCount() == activationDiscoveryCount)
+        let lookupEvents = Array(
+            (await fixture.diagnosticLog.snapshot()).events.dropFirst(eventsBeforeLookup)
+        )
+        #expect(lookupEvents.contains {
+            $0.code == .discoverySucceeded && $0.ms != nil
+        })
 
+        // A later explicit lookup retains the old authoritative-refresh contract.
+        _ = await fixture.composition.discoverLiveMacs()
         #expect(await fixture.broker.discoveryRequestCount() == activationDiscoveryCount + 1)
     }
 


### PR DESCRIPTION
## Summary

- Reuse the authenticated discovery response already verified during iOS activation for the first live-Mac lookup.
- Overlap launch backup restoration with local paired-Mac reads and live Iroh discovery, while retaining synchronous ordering for manual and recovery reconnects.
- Keep auth, team scope, reconnect generation, and route-push invalidation guards around background work.
- Add Instruments signposts and diagnostic milliseconds for auth bootstrap, backup restore, paired-Mac reads, zero-touch discovery, reconnect, first presence frame, and live discovery.

## Verification

- `CmxIrohClientRuntimeTests`: activation snapshot one-shot and route-push invalidation.
- `CmxIrohClientRuntimeAuthorizationTests`: 4 passed.
- `IrohZeroTouchDiscoveryTests`: 14 passed, including backup/live-discovery overlap.
- `IrohReconnectRouteSelectionTests`: 26 passed.
- Cloud macOS tagged build `fdisc`: succeeded, port 3916.
- Cloud iOS device archive and local export: succeeded, signed bundle `dev.cmux.ios.fdisc`, staging API and Iroh origins embedded, timing strings present in the shipped binary.
- Simulator leg was retried and omitted because the builder's cached GhosttyKit lacks x86_64 simulator objects; device archive was unaffected.
- Personal iPhone install was queued because device `4A52829D-6427-599F-A166-4058881D2DF4` was unreachable.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/10124"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789253968&installation_model_id=21920&pr_number=10124&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F10124&signature=a96240dc738122652344be3a10cb21b9d4f664d22e5fe04148db0e6b8438599a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Speeds up iOS startup Mac discovery by reusing the already-authenticated activation discovery once and overlapping backup restore with local reads and live Iroh discovery. This reduces first-connect latency while keeping manual and recovery reconnects synchronous.

- First live‑Mac lookup: previously forced a broker refresh; now `MobileIrohRuntimeComposition.discoverLiveMacs()` consumes the activation snapshot once and falls back to an authoritative refresh if needed. Snapshot reuse is disabled on route push, supervisor network change, explicit discovery invalidation, and stop.
- Startup reconnect: previously blocked on a synchronous backup refresh; now launch uses a shell‑owned background task so backup restore runs alongside route reads and live discovery. Manual/recovery reconnects remain synchronous. Sign‑out and team changes cancel the background restore to prevent cross‑account bleed.
- Diagnostics: adds OSLog signposts for `authBootstrap`, `backupRestore`, `storedMacReconnect`, `pairedMacRead`, `zeroTouchDiscovery`, and `presenceFirstFrame`, and records milliseconds on discovery events. No runtime overhead when tracing is off.
- API/usage: `MobileShellComposite.reconnectActiveMacIfAvailable` adds `refreshBackupInBackground` (default false). Startup callers in `CmuxMobileShellUI` pass true; no migration required for other call sites.
- Tests: new coverage for one‑shot activation snapshot consumption, invalidation on route push, and overlapping startup restore/discovery; updated cooldown tests; enhanced delayed paired‑Mac store to gate and observe backup refresh.

<sup>Written for commit 79def4ca44c6671b3825f30d37f8da93e4ce8f0a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/10124?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Faster startup and Mac reconnection by refreshing backup data in the background while discovery and connection proceed.
  * Initial discovery results can now be reused during activation, avoiding duplicate network requests and reducing connection delays.
  * Discovery diagnostics now include timing information to improve visibility into readiness and performance.

* **Bug Fixes**
  * Prevented outdated or invalidated discovery results from being reused after network changes, route updates, or session changes.

* **Tests**
  * Added coverage for one-time discovery reuse, invalidation, and background refresh behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->