### PR TITLE
Fix SSH daemon bootstrap on slow links and wedged masters

### DIFF
--- a/Packages/macOS/CmuxRemoteSession/Sources/CmuxRemoteSession/Session/RemoteSessionCoordinator+Bootstrap.swift
+++ b/Packages/macOS/CmuxRemoteSession/Sources/CmuxRemoteSession/Session/RemoteSessionCoordinator+Bootstrap.swift
@@ -157,7 +157,7 @@ extension RemoteSessionCoordinator {
     func probeRemoteBootstrapStateLocked(version: String) throws -> RemoteBootstrapState {
         let script = Self.remotePlatformProbeScript(version: version)
         let command = "sh -c \(script.shellSingleQuoted)"
-        let result = try sshExec(arguments: sshCommonArguments(batchMode: true) + [configuration.destination, command], timeout: 20)
+        let result = try sshExec(arguments: daemonBootstrapSSHArguments() + [configuration.destination, command], timeout: 20)
 
         let lines = result.stdout
             .split(separator: "\n", omittingEmptySubsequences: false)
@@ -306,7 +306,7 @@ extension RemoteSessionCoordinator {
         let request = #"{"id":1,"method":"hello","params":{}}"#
         let script = "printf '%s\\n' \(request.shellSingleQuoted) | \(remotePath.shellSingleQuoted) serve --stdio"
         let command = "sh -c \(script.shellSingleQuoted)"
-        let result = try sshExec(arguments: sshCommonArguments(batchMode: true) + [configuration.destination, command], timeout: 12)
+        let result = try sshExec(arguments: daemonBootstrapSSHArguments() + [configuration.destination, command], timeout: 12)
         guard result.status == 0 else {
             let detail = Self.bestErrorLine(stderr: result.stderr, stdout: result.stdout) ?? "ssh exited \(result.status)"
             throw NSError(domain: "cmux.remote.daemon", code: 40, userInfo: [

--- a/Packages/macOS/CmuxRemoteSession/Sources/CmuxRemoteSession/Session/RemoteSessionCoordinator+DaemonUpload.swift
+++ b/Packages/macOS/CmuxRemoteSession/Sources/CmuxRemoteSession/Session/RemoteSessionCoordinator+DaemonUpload.swift
@@ -6,29 +6,64 @@ internal import Foundation
 // streamed to `cat`, then the existing chmod-and-rename step publishes it
 // atomically at the versioned destination.
 extension RemoteSessionCoordinator {
+    // A daemon binary is small enough that a bounded throughput estimate is
+    // more useful than a fixed wall clock. The floor handles SSH setup and the
+    // cap bounds how long a stalled transfer can hold the coordinator.
+    static let daemonUploadMinimumThroughputBytesPerSecond: Double = 32 * 1024
+    static let daemonUploadMinimumTimeout: TimeInterval = 90
+    static let daemonUploadTimeoutGrace: TimeInterval = 30
+    static let daemonUploadMaximumTimeout: TimeInterval = 15 * 60
+
+    static func daemonUploadTimeout(for localBinary: URL) -> TimeInterval {
+        let resourceValues = try? localBinary.resourceValues(forKeys: [.fileSizeKey])
+        return daemonUploadTimeout(forByteCount: Int64(resourceValues?.fileSize ?? 0))
+    }
+
+    static func daemonUploadTimeout(forByteCount byteCount: Int64) -> TimeInterval {
+        guard byteCount > 0 else { return daemonUploadMinimumTimeout }
+        let scaledDeadline = Double(byteCount) / daemonUploadMinimumThroughputBytesPerSecond +
+            daemonUploadTimeoutGrace
+        return min(
+            daemonUploadMaximumTimeout,
+            max(daemonUploadMinimumTimeout, scaledDeadline)
+        )
+    }
+
     func uploadRemoteDaemonBinaryLocked(localBinary: URL, location: RemoteDaemonInstallLocation) throws {
         let remotePath = location.absolutePath
         let remoteDirectory = location.directory
         let remoteTempPath = "\(remotePath).tmp-\(UUID().uuidString.prefix(8))"
+        let remoteTempPIDPath = "\(remoteTempPath).pid"
         debugLog(
             "remote.upload.begin transport=ssh-stdin local=\(localBinary.path) " +
                 "remoteTemp=\(remoteTempPath) remote=\(remotePath)"
         )
 
-        let mkdirScript = "mkdir -p \(remoteDirectory.shellSingleQuoted)"
+        let mkdirScript = "mkdir -p \(remoteDirectory.shellSingleQuoted) && " +
+            Self.remoteDaemonTemporaryCleanupScript(remotePath: remotePath)
         let mkdirCommand = "sh -c \(mkdirScript.shellSingleQuoted)"
         let mkdirResult: RemoteCommandResult
         do {
             mkdirResult = try sshExec(
-                arguments: sshCommonArguments(batchMode: true) + [configuration.destination, mkdirCommand],
+                arguments: daemonBootstrapSSHArguments() + [configuration.destination, mkdirCommand],
                 timeout: 12
             )
         } catch {
-            throw NSError(domain: "cmux.remote.daemon", code: 30, userInfo: [
-                NSLocalizedDescriptionKey: String(
+            let detail = Self.safeRemoteProcessFailureDetail(error)
+            let message: String
+            if let detail {
+                message = String(
+                    localized: "remoteDaemon.upload.createDirectoryFailedWithDetail",
+                    defaultValue: "failed to create remote daemon directory: \(detail)"
+                )
+            } else {
+                message = String(
                     localized: "remoteDaemon.upload.createDirectoryFailed",
                     defaultValue: "failed to create remote daemon directory"
-                ),
+                )
+            }
+            throw NSError(domain: "cmux.remote.daemon", code: 30, userInfo: [
+                NSLocalizedDescriptionKey: message,
             ])
         }
         guard mkdirResult.status == 0 else {
@@ -42,26 +77,60 @@ extension RemoteSessionCoordinator {
             ])
         }
 
-        let uploadScript = "cat > \(remoteTempPath.shellSingleQuoted)"
+        let quotedRemoteTempPath = remoteTempPath.shellSingleQuoted
+        let quotedRemoteTempPIDPath = remoteTempPIDPath.shellSingleQuoted
+        let uploadScript = """
+        cat_pid=
+        temp_path=\(quotedRemoteTempPath)
+        pid_path=\(quotedRemoteTempPIDPath)
+        printf '%s\\n' "$$" > "$pid_path"
+        trap 'if [ -n "$cat_pid" ]; then kill "$cat_pid" 2>/dev/null || true; fi; rm -f -- "$temp_path" "$pid_path"; exit 1' HUP INT TERM
+        cat > "$temp_path" &
+        cat_pid=$!
+        printf '%s\\n' "$cat_pid" > "$pid_path"
+        wait "$cat_pid"
+        cat_status=$?
+        cat_pid=
+        rm -f -- "$pid_path"
+        if [ "$cat_status" -ne 0 ]; then rm -f -- "$temp_path"; fi
+        trap - HUP INT TERM
+        exit "$cat_status"
+        """
         let uploadCommand = "sh -c \(uploadScript.shellSingleQuoted)"
         let uploadResult: RemoteCommandResult
         do {
             uploadResult = try sshExec(
-                arguments: sshCommonArguments(batchMode: true) + [configuration.destination, uploadCommand],
+                arguments: daemonBootstrapSSHArguments() + [configuration.destination, uploadCommand],
                 stdinFile: localBinary,
-                timeout: 45
+                timeout: Self.daemonUploadTimeout(for: localBinary)
             )
         } catch {
-            cleanupUploadedRemotePaths([remoteTempPath])
-            throw NSError(domain: "cmux.remote.daemon", code: 31, userInfo: [
-                NSLocalizedDescriptionKey: String(
+            let detail = Self.safeRemoteProcessFailureDetail(error)
+            cleanupRemoteDaemonTemporaryUploadsLocked(
+                remotePath: remotePath,
+                currentTemporaryPath: remoteTempPath
+            )
+            let message: String
+            if let detail {
+                message = String(
+                    localized: "remoteDaemon.upload.transferFailedWithDetail",
+                    defaultValue: "failed to upload cmuxd-remote: \(detail)"
+                )
+            } else {
+                message = String(
                     localized: "remoteDaemon.upload.transferFailed",
                     defaultValue: "failed to upload cmuxd-remote"
-                ),
+                )
+            }
+            throw NSError(domain: "cmux.remote.daemon", code: 31, userInfo: [
+                NSLocalizedDescriptionKey: message,
             ])
         }
         guard uploadResult.status == 0 else {
-            cleanupUploadedRemotePaths([remoteTempPath])
+            cleanupRemoteDaemonTemporaryUploadsLocked(
+                remotePath: remotePath,
+                currentTemporaryPath: remoteTempPath
+            )
             let detail = Self.bestErrorLine(stderr: uploadResult.stderr, stdout: uploadResult.stdout) ??
                 "ssh exited \(uploadResult.status)"
             throw NSError(domain: "cmux.remote.daemon", code: 31, userInfo: [
@@ -80,20 +149,36 @@ extension RemoteSessionCoordinator {
         let finalizeResult: RemoteCommandResult
         do {
             finalizeResult = try sshExec(
-                arguments: sshCommonArguments(batchMode: true) + [configuration.destination, finalizeCommand],
+                arguments: daemonBootstrapSSHArguments() + [configuration.destination, finalizeCommand],
                 timeout: 12
             )
         } catch {
-            cleanupUploadedRemotePaths([remoteTempPath])
-            throw NSError(domain: "cmux.remote.daemon", code: 32, userInfo: [
-                NSLocalizedDescriptionKey: String(
+            let detail = Self.safeRemoteProcessFailureDetail(error)
+            cleanupRemoteDaemonTemporaryUploadsLocked(
+                remotePath: remotePath,
+                currentTemporaryPath: remoteTempPath
+            )
+            let message: String
+            if let detail {
+                message = String(
+                    localized: "remoteDaemon.upload.installFailedWithDetail",
+                    defaultValue: "failed to install remote daemon binary: \(detail)"
+                )
+            } else {
+                message = String(
                     localized: "remoteDaemon.upload.installFailed",
                     defaultValue: "failed to install remote daemon binary"
-                ),
+                )
+            }
+            throw NSError(domain: "cmux.remote.daemon", code: 32, userInfo: [
+                NSLocalizedDescriptionKey: message,
             ])
         }
         guard finalizeResult.status == 0 else {
-            cleanupUploadedRemotePaths([remoteTempPath])
+            cleanupRemoteDaemonTemporaryUploadsLocked(
+                remotePath: remotePath,
+                currentTemporaryPath: remoteTempPath
+            )
             let detail = Self.bestErrorLine(stderr: finalizeResult.stderr, stdout: finalizeResult.stdout) ??
                 "ssh exited \(finalizeResult.status)"
             throw NSError(domain: "cmux.remote.daemon", code: 32, userInfo: [
@@ -103,5 +188,78 @@ extension RemoteSessionCoordinator {
                 ),
             ])
         }
+    }
+
+    private func cleanupRemoteDaemonTemporaryUploadsLocked(
+        remotePath: String,
+        currentTemporaryPath: String
+    ) {
+        let cleanupScript = Self.remoteDaemonTemporaryCleanupScript(
+            remotePath: remotePath,
+            currentTemporaryPath: currentTemporaryPath
+        )
+        let cleanupCommand = "sh -c \(cleanupScript.shellSingleQuoted)"
+        do {
+            let result = try sshExec(
+                arguments: daemonBootstrapSSHArguments() + [configuration.destination, cleanupCommand],
+                timeout: 8
+            )
+            guard result.status == 0 else {
+                let detail = Self.bestErrorLine(stderr: result.stderr, stdout: result.stdout) ??
+                    "ssh exited \(result.status)"
+                debugLog("remote.upload.cleanup.failed detail=\(detail) remote=\(remotePath)")
+                return
+            }
+            debugLog("remote.upload.cleanup.completed remote=\(remotePath)")
+        } catch {
+            debugLog(
+                "remote.upload.cleanup.failed detail=\(error.localizedDescription) " +
+                    "remote=\(remotePath)"
+            )
+        }
+    }
+
+    static func remoteDaemonTemporaryCleanupScript(
+        remotePath: String,
+        currentTemporaryPath: String? = nil
+    ) -> String {
+        let quotedRemotePath = remotePath.shellSingleQuoted
+        let processCleanup = """
+        for cmux_pid_file in \(quotedRemotePath).tmp-*.pid; do
+          [ -r "$cmux_pid_file" ] || continue
+          cmux_pid="$(cat "$cmux_pid_file" 2>/dev/null || true)"
+          case "$cmux_pid" in
+            ''|0|1|*[!0-9]*) ;;
+            *) [ "$cmux_pid" = "$$" ] || kill "$cmux_pid" 2>/dev/null || true ;;
+          esac
+        done
+        """
+        let specificRemoveTargets: String
+        if let currentTemporaryPath {
+            let quotedCurrentTemporaryPath = currentTemporaryPath.shellSingleQuoted
+            let quotedCurrentPIDPath = "\(currentTemporaryPath).pid".shellSingleQuoted
+            specificRemoveTargets =
+                " \(quotedCurrentTemporaryPath) \(quotedCurrentPIDPath)"
+        } else {
+            specificRemoveTargets = ""
+        }
+        return """
+        \(processCleanup)
+        rm -f -- \(quotedRemotePath).tmp-* \(quotedRemotePath).tmp-*.pid\(specificRemoveTargets)
+        """
+    }
+
+    static func safeRemoteProcessFailureDetail(_ error: any Error) -> String? {
+        let nsError = error as NSError
+        guard nsError.domain == "cmux.remote.process" else { return nil }
+        let description = nsError.localizedDescription
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !description.isEmpty else { return nil }
+        if nsError.code == 1,
+           let prefix = description.split(separator: ":", maxSplits: 1).first,
+           !prefix.isEmpty {
+            return String(prefix)
+        }
+        return nsError.code == 2 ? description : nil
     }
 }

--- a/Packages/macOS/CmuxRemoteSession/Sources/CmuxRemoteSession/Session/RemoteSessionCoordinator+SSHArguments.swift
+++ b/Packages/macOS/CmuxRemoteSession/Sources/CmuxRemoteSession/Session/RemoteSessionCoordinator+SSHArguments.swift
@@ -8,6 +8,19 @@ internal import Foundation
 // coordinator's general exec argv, including the non-batch and
 // drop-ControlPath variants the batch builders do not have.)
 extension RemoteSessionCoordinator {
+    /// Builds batch SSH arguments for daemon bootstrap traffic.
+    ///
+    /// Bootstrap owns the binary-install transaction, so it must not inherit
+    /// an existing multiplexed channel: a half-open ControlMaster can report
+    /// healthy while forwarding no payload bytes. `ControlPath=none` is placed
+    /// before caller options because OpenSSH keeps the first value it obtains.
+    func daemonBootstrapSSHArguments() -> [String] {
+        ["-o", "ControlPath=none"] + sshCommonArguments(
+            batchMode: true,
+            dropControlPath: true
+        )
+    }
+
     func sshCommonArguments(batchMode: Bool, dropControlPath: Bool = false) -> [String] {
         let effectiveSSHOptions: [String] = {
             if batchMode {

--- a/Packages/macOS/CmuxRemoteSession/Tests/CmuxRemoteSessionTests/RemoteDaemonUploadRecoveryTests.swift
+++ b/Packages/macOS/CmuxRemoteSession/Tests/CmuxRemoteSessionTests/RemoteDaemonUploadRecoveryTests.swift
@@ -1,0 +1,234 @@
+import CmuxCore
+import Foundation
+import Testing
+@testable import CmuxRemoteSession
+
+extension RemoteDaemonUploadTests {
+    @Test("Bootstrap uploads bypass wedged ControlMasters and scale their deadline with payload size")
+    func uploadUsesStandaloneTransportAndScaledDeadline() throws {
+        let fileManager = FileManager.default
+        let root = fileManager.temporaryDirectory.appendingPathComponent(
+            "cmux-remote-daemon-upload-timeout-\(UUID().uuidString)",
+            isDirectory: true
+        )
+        try fileManager.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? fileManager.removeItem(at: root) }
+
+        let smallBinary = root.appendingPathComponent("small-cmuxd-remote", isDirectory: false)
+        let largeBinary = root.appendingPathComponent("large-cmuxd-remote", isDirectory: false)
+        try Data(repeating: 0x41, count: 64 * 1024).write(to: smallBinary)
+        try Data(repeating: 0x42, count: 6 * 1024 * 1024).write(to: largeBinary)
+
+        let sshOptions = [
+            "ControlMaster=auto",
+            "ControlPersist=600",
+            "ControlPath=/tmp/cmux-ssh-wedged-test",
+        ]
+        let smallUpload = try uploadRequestForRecovery(
+            localBinary: smallBinary,
+            sshOptions: sshOptions
+        )
+        let largeUpload = try uploadRequestForRecovery(
+            localBinary: largeBinary,
+            sshOptions: sshOptions
+        )
+
+        #expect(Self.consecutive(largeUpload.arguments, "-o", "ControlPath=none"))
+        #expect(!largeUpload.arguments.contains("ControlPath=/tmp/cmux-ssh-wedged-test"))
+        #expect(Self.consecutive(smallUpload.arguments, "-o", "ControlPath=none"))
+        #expect(!smallUpload.arguments.contains("ControlPath=/tmp/cmux-ssh-wedged-test"))
+        #expect(largeUpload.timeout > 45)
+        #expect(largeUpload.timeout > smallUpload.timeout)
+    }
+
+    @Test("Upload timeout exposes the process detail and cleans remote temporary files directly")
+    func uploadTimeoutSurfacesDetailAndCleansRemoteTemporaryFiles() throws {
+        let fileManager = FileManager.default
+        let localBinary = fileManager.temporaryDirectory.appendingPathComponent(
+            "cmux-remote-daemon-upload-timeout-\(UUID().uuidString)",
+            isDirectory: false
+        )
+        try Data(repeating: 0x43, count: 6 * 1024 * 1024).write(to: localBinary)
+        defer { try? fileManager.removeItem(at: localBinary) }
+
+        let runner = RecordingProcessRunner { request in
+            switch Self.uploadStep(for: request) {
+            case .createDirectory:
+                return RemoteCommandResult(status: 0, stdout: "", stderr: "")
+            case .upload:
+                throw NSError(domain: "cmux.remote.process", code: 2, userInfo: [
+                    NSLocalizedDescriptionKey: "ssh timed out after 222s",
+                ])
+            case .cleanup:
+                return RemoteCommandResult(status: 0, stdout: "", stderr: "")
+            case .finalize, .unknown:
+                return Self.unexpectedRequestResult(request)
+            }
+        }
+        let coordinator = makeCoordinator(
+            runner: runner,
+            sshOptions: [
+                "ControlMaster=auto",
+                "ControlPath=/tmp/cmux-ssh-wedged-test",
+            ]
+        )
+        defer { coordinator.stop() }
+        let location = RemoteDaemonInstallLocation(
+            relativePath: ".cmux/bin/cmuxd-remote/test/linux-amd64/cmuxd-remote",
+            absolutePath: "/home/test/.cmux/bin/cmuxd-remote/test/linux-amd64/cmuxd-remote"
+        )
+
+        do {
+            try coordinator.queue.sync {
+                try coordinator.uploadRemoteDaemonBinaryLocked(
+                    localBinary: localBinary,
+                    location: location
+                )
+            }
+            Issue.record("Expected the timed-out upload to fail")
+        } catch {
+            #expect(error.localizedDescription.contains("ssh timed out after 222s"))
+        }
+
+        let requests = runner.requests
+        #expect(requests.map(Self.uploadStep) == [.createDirectory, .upload, .cleanup])
+        let uploadRequest = try #require(
+            requests.first { Self.uploadStep(for: $0) == .upload }
+        )
+        let cleanupRequest = try #require(
+            requests.first { Self.uploadStep(for: $0) == .cleanup }
+        )
+        #expect(uploadRequest.arguments.last?.contains("trap") == true)
+        #expect(uploadRequest.arguments.last?.contains("kill") == true)
+        #expect(cleanupRequest.arguments.last?.contains(".tmp-*") == true)
+        #expect(Self.consecutive(cleanupRequest.arguments, "-o", "ControlPath=none"))
+        #expect(!cleanupRequest.arguments.contains("ControlPath=/tmp/cmux-ssh-wedged-test"))
+    }
+
+    @Test("Remote cleanup terminates recorded writers and removes every temporary upload")
+    func cleanupScriptKillsRecordedWriters() throws {
+        let fileManager = FileManager.default
+        let root = fileManager.temporaryDirectory.appendingPathComponent(
+            "cmux-remote-daemon-cleanup-\(UUID().uuidString)",
+            isDirectory: true
+        )
+        try fileManager.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? fileManager.removeItem(at: root) }
+
+        let remotePath = root
+            .appendingPathComponent("remote path's", isDirectory: true)
+            .appendingPathComponent("cmuxd-remote", isDirectory: false)
+            .path
+        let temporaryPath = "\(remotePath).tmp-stale"
+        let pidPath = "\(temporaryPath).pid"
+        try fileManager.createDirectory(
+            at: URL(fileURLWithPath: remotePath).deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        try Data("stale bytes".utf8).write(to: URL(fileURLWithPath: temporaryPath))
+
+        let writer = Process()
+        writer.executableURL = URL(fileURLWithPath: "/bin/sleep")
+        writer.arguments = ["30"]
+        writer.standardInput = FileHandle.nullDevice
+        writer.standardOutput = FileHandle.nullDevice
+        writer.standardError = FileHandle.nullDevice
+        try writer.run()
+        defer {
+            if writer.isRunning {
+                writer.terminate()
+                writer.waitUntilExit()
+            }
+        }
+        try Data("\(writer.processIdentifier)\n".utf8).write(to: URL(fileURLWithPath: pidPath))
+
+        let cleanup = Process()
+        cleanup.executableURL = URL(fileURLWithPath: "/bin/sh")
+        cleanup.arguments = [
+            "-c",
+            RemoteSessionCoordinator.remoteDaemonTemporaryCleanupScript(remotePath: remotePath),
+        ]
+        cleanup.standardInput = FileHandle.nullDevice
+        cleanup.standardOutput = FileHandle.nullDevice
+        cleanup.standardError = FileHandle.nullDevice
+        try cleanup.run()
+        cleanup.waitUntilExit()
+
+        #expect(cleanup.terminationStatus == 0)
+        #expect(!fileManager.fileExists(atPath: temporaryPath))
+        #expect(!fileManager.fileExists(atPath: pidPath))
+        writer.waitUntilExit()
+        #expect(!writer.isRunning)
+    }
+
+    private func uploadRequestForRecovery(
+        localBinary: URL,
+        sshOptions: [String]
+    ) throws -> RemoteProcessRequest {
+        let runner = RecordingProcessRunner { request in
+            // Model the observed wedged socket: requests carrying the
+            // configured path cannot complete. A successful transaction
+            // therefore exercises the standalone transport contract.
+            if request.arguments.contains("ControlPath=/tmp/cmux-ssh-wedged-test") {
+                return RemoteCommandResult(
+                    status: 255,
+                    stdout: "",
+                    stderr: "control master data plane stalled"
+                )
+            }
+            switch Self.uploadStep(for: request) {
+            case .createDirectory, .upload, .finalize:
+                return RemoteCommandResult(status: 0, stdout: "", stderr: "")
+            case .cleanup, .unknown:
+                return Self.unexpectedRequestResult(request)
+            }
+        }
+        let coordinator = makeCoordinator(runner: runner, sshOptions: sshOptions)
+        defer { coordinator.stop() }
+        let location = RemoteDaemonInstallLocation(
+            relativePath: ".cmux/bin/cmuxd-remote/test/linux-amd64/cmuxd-remote",
+            absolutePath: "/home/test/.cmux/bin/cmuxd-remote/test/linux-amd64/cmuxd-remote"
+        )
+        try coordinator.queue.sync {
+            try coordinator.uploadRemoteDaemonBinaryLocked(
+                localBinary: localBinary,
+                location: location
+            )
+        }
+        return try #require(runner.requests.first { Self.uploadStep(for: $0) == .upload })
+    }
+
+    private static func uploadStep(for request: RemoteProcessRequest) -> RemoteDaemonUploadStep {
+        guard request.executable == "/usr/bin/ssh",
+              let command = request.arguments.last else {
+            return .unknown
+        }
+        if command.contains("mkdir -p ") {
+            return .createDirectory
+        }
+        if command.contains("cat > ") {
+            return .upload
+        }
+        if command.contains("chmod 755 "), command.contains("mv ") {
+            return .finalize
+        }
+        if command.contains("rm -f -- ") {
+            return .cleanup
+        }
+        return .unknown
+    }
+
+    private static func consecutive(_ args: [String], _ first: String, _ second: String) -> Bool {
+        args.indices.dropLast().contains { index in
+            args[index] == first && args[index + 1] == second
+        }
+    }
+
+    private static func unexpectedRequestResult(_ request: RemoteProcessRequest) -> RemoteCommandResult {
+        RemoteCommandResult(
+            status: 97,
+            stdout: "",
+            stderr: "unexpected request: \(request.executable) \(request.arguments.last ?? "<missing>")"
+        )
+    }
+}

--- a/Packages/macOS/CmuxRemoteSession/Tests/CmuxRemoteSessionTests/RemoteDaemonUploadTests.swift
+++ b/Packages/macOS/CmuxRemoteSession/Tests/CmuxRemoteSessionTests/RemoteDaemonUploadTests.swift
@@ -7,105 +7,6 @@ import Testing
 
 @Suite("Remote daemon upload")
 struct RemoteDaemonUploadTests {
-    @Test("Bootstrap uploads bypass wedged ControlMasters and scale their deadline with payload size")
-    func uploadUsesStandaloneTransportAndScaledDeadline() throws {
-        let fileManager = FileManager.default
-        let root = fileManager.temporaryDirectory.appendingPathComponent(
-            "cmux-remote-daemon-upload-timeout-\(UUID().uuidString)",
-            isDirectory: true
-        )
-        try fileManager.createDirectory(at: root, withIntermediateDirectories: true)
-        defer { try? fileManager.removeItem(at: root) }
-
-        let smallBinary = root.appendingPathComponent("small-cmuxd-remote", isDirectory: false)
-        let largeBinary = root.appendingPathComponent("large-cmuxd-remote", isDirectory: false)
-        try Data(repeating: 0x41, count: 64 * 1024).write(to: smallBinary)
-        try Data(repeating: 0x42, count: 6 * 1024 * 1024).write(to: largeBinary)
-
-        let sshOptions = [
-            "ControlMaster=auto",
-            "ControlPersist=600",
-            "ControlPath=/tmp/cmux-ssh-wedged-test",
-        ]
-        let smallUpload = try uploadRequest(
-            localBinary: smallBinary,
-            sshOptions: sshOptions
-        )
-        let largeUpload = try uploadRequest(
-            localBinary: largeBinary,
-            sshOptions: sshOptions
-        )
-
-        #expect(Self.consecutive(largeUpload.arguments, "-o", "ControlPath=none"))
-        #expect(!largeUpload.arguments.contains("ControlPath=/tmp/cmux-ssh-wedged-test"))
-        #expect(largeUpload.timeout > 45)
-        #expect(largeUpload.timeout > smallUpload.timeout)
-    }
-
-    @Test("Upload timeout exposes the process detail and cleans remote temporary files directly")
-    func uploadTimeoutSurfacesDetailAndCleansRemoteTemporaryFiles() throws {
-        let fileManager = FileManager.default
-        let localBinary = fileManager.temporaryDirectory.appendingPathComponent(
-            "cmux-remote-daemon-upload-timeout-\(UUID().uuidString)",
-            isDirectory: false
-        )
-        try Data(repeating: 0x43, count: 6 * 1024 * 1024).write(to: localBinary)
-        defer { try? fileManager.removeItem(at: localBinary) }
-
-        let runner = RecordingProcessRunner { request in
-            switch Self.uploadStep(for: request) {
-            case .createDirectory:
-                return RemoteCommandResult(status: 0, stdout: "", stderr: "")
-            case .upload:
-                throw NSError(domain: "cmux.remote.process", code: 2, userInfo: [
-                    NSLocalizedDescriptionKey: "ssh timed out after 222s",
-                ])
-            case .cleanup:
-                return RemoteCommandResult(status: 0, stdout: "", stderr: "")
-            case .finalize, .unknown:
-                return Self.unexpectedRequestResult(request)
-            }
-        }
-        let coordinator = makeCoordinator(
-            runner: runner,
-            sshOptions: [
-                "ControlMaster=auto",
-                "ControlPath=/tmp/cmux-ssh-wedged-test",
-            ]
-        )
-        defer { coordinator.stop() }
-        let location = RemoteDaemonInstallLocation(
-            relativePath: ".cmux/bin/cmuxd-remote/test/linux-amd64/cmuxd-remote",
-            absolutePath: "/home/test/.cmux/bin/cmuxd-remote/test/linux-amd64/cmuxd-remote"
-        )
-
-        do {
-            try coordinator.queue.sync {
-                try coordinator.uploadRemoteDaemonBinaryLocked(
-                    localBinary: localBinary,
-                    location: location
-                )
-            }
-            Issue.record("Expected the timed-out upload to fail")
-        } catch {
-            #expect(error.localizedDescription.contains("ssh timed out after 222s"))
-        }
-
-        let requests = runner.requests
-        #expect(requests.map(Self.uploadStep) == [.createDirectory, .upload, .cleanup])
-        let uploadRequest = try #require(
-            requests.first { Self.uploadStep(for: $0) == .upload }
-        )
-        let cleanupRequest = try #require(
-            requests.first { Self.uploadStep(for: $0) == .cleanup }
-        )
-        #expect(uploadRequest.arguments.last?.contains("trap") == true)
-        #expect(uploadRequest.arguments.last?.contains("kill") == true)
-        #expect(cleanupRequest.arguments.last?.contains(".tmp-*") == true)
-        #expect(Self.consecutive(cleanupRequest.arguments, "-o", "ControlPath=none"))
-        #expect(!cleanupRequest.arguments.contains("ControlPath=/tmp/cmux-ssh-wedged-test"))
-    }
-
     @Test("Upload succeeds through SSH exec when SCP's SFTP transport is unavailable")
     func uploadSucceedsWithoutSFTP() throws {
         let fileManager = FileManager.default
@@ -420,12 +321,6 @@ struct RemoteDaemonUploadTests {
         return .unknown
     }
 
-    private static func consecutive(_ args: [String], _ first: String, _ second: String) -> Bool {
-        args.indices.dropLast().contains { index in
-            args[index] == first && args[index + 1] == second
-        }
-    }
-
     private static func temporaryPathMarker(in command: String?) -> String? {
         guard let command,
               let markerRange = command.range(of: ".tmp-") else {
@@ -444,34 +339,7 @@ struct RemoteDaemonUploadTests {
         )
     }
 
-    private func uploadRequest(
-        localBinary: URL,
-        sshOptions: [String]
-    ) throws -> RemoteProcessRequest {
-        let runner = RecordingProcessRunner { request in
-            switch Self.uploadStep(for: request) {
-            case .createDirectory, .upload, .finalize:
-                return RemoteCommandResult(status: 0, stdout: "", stderr: "")
-            case .cleanup, .unknown:
-                return Self.unexpectedRequestResult(request)
-            }
-        }
-        let coordinator = makeCoordinator(runner: runner, sshOptions: sshOptions)
-        defer { coordinator.stop() }
-        let location = RemoteDaemonInstallLocation(
-            relativePath: ".cmux/bin/cmuxd-remote/test/linux-amd64/cmuxd-remote",
-            absolutePath: "/home/test/.cmux/bin/cmuxd-remote/test/linux-amd64/cmuxd-remote"
-        )
-        try coordinator.queue.sync {
-            try coordinator.uploadRemoteDaemonBinaryLocked(
-                localBinary: localBinary,
-                location: location
-            )
-        }
-        return try #require(runner.requests.first { Self.uploadStep(for: $0) == .upload })
-    }
-
-    private func makeCoordinator(
+    func makeCoordinator(
         runner: RecordingProcessRunner,
         sshOptions: [String] = []
     ) -> RemoteSessionCoordinator {

--- a/Packages/macOS/CmuxRemoteSession/Tests/CmuxRemoteSessionTests/RemoteDaemonUploadTests.swift
+++ b/Packages/macOS/CmuxRemoteSession/Tests/CmuxRemoteSessionTests/RemoteDaemonUploadTests.swift
@@ -7,6 +7,105 @@ import Testing
 
 @Suite("Remote daemon upload")
 struct RemoteDaemonUploadTests {
+    @Test("Bootstrap uploads bypass wedged ControlMasters and scale their deadline with payload size")
+    func uploadUsesStandaloneTransportAndScaledDeadline() throws {
+        let fileManager = FileManager.default
+        let root = fileManager.temporaryDirectory.appendingPathComponent(
+            "cmux-remote-daemon-upload-timeout-\(UUID().uuidString)",
+            isDirectory: true
+        )
+        try fileManager.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? fileManager.removeItem(at: root) }
+
+        let smallBinary = root.appendingPathComponent("small-cmuxd-remote", isDirectory: false)
+        let largeBinary = root.appendingPathComponent("large-cmuxd-remote", isDirectory: false)
+        try Data(repeating: 0x41, count: 64 * 1024).write(to: smallBinary)
+        try Data(repeating: 0x42, count: 6 * 1024 * 1024).write(to: largeBinary)
+
+        let sshOptions = [
+            "ControlMaster=auto",
+            "ControlPersist=600",
+            "ControlPath=/tmp/cmux-ssh-wedged-test",
+        ]
+        let smallUpload = try uploadRequest(
+            localBinary: smallBinary,
+            sshOptions: sshOptions
+        )
+        let largeUpload = try uploadRequest(
+            localBinary: largeBinary,
+            sshOptions: sshOptions
+        )
+
+        #expect(Self.consecutive(largeUpload.arguments, "-o", "ControlPath=none"))
+        #expect(!largeUpload.arguments.contains("ControlPath=/tmp/cmux-ssh-wedged-test"))
+        #expect(largeUpload.timeout > 45)
+        #expect(largeUpload.timeout > smallUpload.timeout)
+    }
+
+    @Test("Upload timeout exposes the process detail and cleans remote temporary files directly")
+    func uploadTimeoutSurfacesDetailAndCleansRemoteTemporaryFiles() throws {
+        let fileManager = FileManager.default
+        let localBinary = fileManager.temporaryDirectory.appendingPathComponent(
+            "cmux-remote-daemon-upload-timeout-\(UUID().uuidString)",
+            isDirectory: false
+        )
+        try Data(repeating: 0x43, count: 6 * 1024 * 1024).write(to: localBinary)
+        defer { try? fileManager.removeItem(at: localBinary) }
+
+        let runner = RecordingProcessRunner { request in
+            switch Self.uploadStep(for: request) {
+            case .createDirectory:
+                return RemoteCommandResult(status: 0, stdout: "", stderr: "")
+            case .upload:
+                throw NSError(domain: "cmux.remote.process", code: 2, userInfo: [
+                    NSLocalizedDescriptionKey: "ssh timed out after 222s",
+                ])
+            case .cleanup:
+                return RemoteCommandResult(status: 0, stdout: "", stderr: "")
+            case .finalize, .unknown:
+                return Self.unexpectedRequestResult(request)
+            }
+        }
+        let coordinator = makeCoordinator(
+            runner: runner,
+            sshOptions: [
+                "ControlMaster=auto",
+                "ControlPath=/tmp/cmux-ssh-wedged-test",
+            ]
+        )
+        defer { coordinator.stop() }
+        let location = RemoteDaemonInstallLocation(
+            relativePath: ".cmux/bin/cmuxd-remote/test/linux-amd64/cmuxd-remote",
+            absolutePath: "/home/test/.cmux/bin/cmuxd-remote/test/linux-amd64/cmuxd-remote"
+        )
+
+        do {
+            try coordinator.queue.sync {
+                try coordinator.uploadRemoteDaemonBinaryLocked(
+                    localBinary: localBinary,
+                    location: location
+                )
+            }
+            Issue.record("Expected the timed-out upload to fail")
+        } catch {
+            #expect(error.localizedDescription.contains("ssh timed out after 222s"))
+        }
+
+        let requests = runner.requests
+        #expect(requests.map(Self.uploadStep) == [.createDirectory, .upload, .cleanup])
+        let uploadRequest = try #require(
+            requests.first { Self.uploadStep(for: $0) == .upload }
+        )
+        let cleanupRequest = try #require(
+            requests.first { Self.uploadStep(for: $0) == .cleanup }
+        )
+        #expect(uploadRequest.arguments.last?.contains("trap") == true)
+        #expect(uploadRequest.arguments.last?.contains("kill") == true)
+        #expect(cleanupRequest.arguments.last?.contains(".tmp-*") == true)
+        #expect(Self.consecutive(cleanupRequest.arguments, "-o", "ControlPath=none"))
+        #expect(!cleanupRequest.arguments.contains("ControlPath=/tmp/cmux-ssh-wedged-test"))
+    }
+
     @Test("Upload succeeds through SSH exec when SCP's SFTP transport is unavailable")
     func uploadSucceedsWithoutSFTP() throws {
         let fileManager = FileManager.default
@@ -321,6 +420,12 @@ struct RemoteDaemonUploadTests {
         return .unknown
     }
 
+    private static func consecutive(_ args: [String], _ first: String, _ second: String) -> Bool {
+        args.indices.dropLast().contains { index in
+            args[index] == first && args[index + 1] == second
+        }
+    }
+
     private static func temporaryPathMarker(in command: String?) -> String? {
         guard let command,
               let markerRange = command.range(of: ".tmp-") else {
@@ -339,12 +444,42 @@ struct RemoteDaemonUploadTests {
         )
     }
 
-    private func makeCoordinator(runner: RecordingProcessRunner) -> RemoteSessionCoordinator {
+    private func uploadRequest(
+        localBinary: URL,
+        sshOptions: [String]
+    ) throws -> RemoteProcessRequest {
+        let runner = RecordingProcessRunner { request in
+            switch Self.uploadStep(for: request) {
+            case .createDirectory, .upload, .finalize:
+                return RemoteCommandResult(status: 0, stdout: "", stderr: "")
+            case .cleanup, .unknown:
+                return Self.unexpectedRequestResult(request)
+            }
+        }
+        let coordinator = makeCoordinator(runner: runner, sshOptions: sshOptions)
+        defer { coordinator.stop() }
+        let location = RemoteDaemonInstallLocation(
+            relativePath: ".cmux/bin/cmuxd-remote/test/linux-amd64/cmuxd-remote",
+            absolutePath: "/home/test/.cmux/bin/cmuxd-remote/test/linux-amd64/cmuxd-remote"
+        )
+        try coordinator.queue.sync {
+            try coordinator.uploadRemoteDaemonBinaryLocked(
+                localBinary: localBinary,
+                location: location
+            )
+        }
+        return try #require(runner.requests.first { Self.uploadStep(for: $0) == .upload })
+    }
+
+    private func makeCoordinator(
+        runner: RecordingProcessRunner,
+        sshOptions: [String] = []
+    ) -> RemoteSessionCoordinator {
         let configuration = WorkspaceRemoteConfiguration(
             destination: "test@sftp-disabled.example",
             port: 2222,
             identityFile: "/tmp/cmux-test-identity",
-            sshOptions: [],
+            sshOptions: sshOptions,
             localProxyPort: nil,
             relayPort: nil,
             relayID: nil,


### PR DESCRIPTION
Fixes SSH first-connect daemon bootstrap on slow links and prevents a stale ControlMaster from poisoning retries.

Root cause and reproduction: https://github.com/manaflow-ai/cmux/issues/10138

Closes #10138

Test-first regression coverage is committed separately from the fix.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/10140"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789265773&installation_model_id=21920&pr_number=10140&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F10140&signature=542cdfff41150bd6631277dd762fd645e7ea7c403d04af150f47bda590e23234"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes SSH daemon bootstrap on slow links and when a ControlMaster is wedged. Previously, uploads used shared multiplexed sessions and a fixed ~45s timeout; now bootstrap uses a dedicated SSH session, scales the timeout to the binary size, and reliably cleans temporary files and writers on failure.

- Bootstrap execs (probe, hello, upload, finalize, cleanup) use dedicated SSH args that add `-o ControlPath=none` and drop any inherited ControlPath to avoid stale masters.
- Upload timeout scales with payload size (min 90s, +30s grace, max 15m); errors preserve process detail (for example, “ssh timed out …”).
- Upload script records a PID, traps HUP/INT/TERM, kills the `cat` writer on failure, and removes `.tmp-*` and `.pid`; cleanup script also terminates recorded writers and deletes leftovers.
- Adds regression tests and test helpers to validate ControlMaster bypass, timeout scaling, error detail propagation, and remote cleanup.

<sup>Written for commit 76da0e05dcb1344c157301997177bbb5fb6ef26f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/10140?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded coverage for remote daemon uploads, including connection handling, upload timeouts, error reporting, and temporary-file cleanup.
  * Added validation for uploads involving larger payloads and customized SSH connection settings.
  * Improved test setup flexibility to better represent real-world remote session configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->