### PR TITLE
ci: hydrate Rust in trusted Testbox broker

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -19,4 +19,5 @@ self-hosted-runner:
     # Linux: Blacksmith primary (LINUX_RUNNER), WarpBuild overflow fallback.
     - blacksmith-4vcpu-ubuntu-2404
     - blacksmith-8vcpu-ubuntu-2404
+    - blacksmith-32vcpu-ubuntu-2404
     - warp-ubuntu-latest-x64-4x

--- a/.github/workflows/ci-workflow-guard-tests-testbox-broker.yml
+++ b/.github/workflows/ci-workflow-guard-tests-testbox-broker.yml
@@ -1,0 +1,139 @@
+name: cmux-tui Rust Testbox broker
+
+on:
+  workflow_dispatch:
+    inputs:
+      testbox_id:
+        description: "Testbox session ID supplied by Blacksmith warmup"
+        required: true
+        type: string
+      source_sha:
+        description: "Optional assertion-only SHA; it cannot select source code"
+        required: false
+        default: ""
+        type: string
+
+# This workflow is the only token-bearing Testbox entrypoint. Operations must
+# dispatch it from protected main after the broker SHA and reviewed source pins
+# are set in the protected environment.
+permissions: {}
+
+concurrency:
+  group: cmux-tui-testbox-broker-${{ inputs.testbox_id }}
+  cancel-in-progress: false
+
+jobs:
+  cmux-tui-testbox-broker:
+    name: cmux-tui Rust Testbox broker
+    runs-on: blacksmith-32vcpu-ubuntu-2404
+    environment:
+      name: blacksmith-testbox-trusted
+    permissions:
+      contents: read
+    timeout-minutes: 120
+    steps:
+      - name: Checkout trusted broker
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ vars.BLACKSMITH_TESTBOX_BROKER_SHA }}
+          fetch-depth: "0"
+          persist-credentials: "false"
+          clean: "true"
+          submodules: "false"
+
+      - name: Validate broker and reviewed source before Testbox
+        env:
+          BLACKSMITH_TESTBOX_BROKER_SHA: ${{ vars.BLACKSMITH_TESTBOX_BROKER_SHA }}
+          BLACKSMITH_TESTBOX_REVIEWED_REF: ${{ vars.BLACKSMITH_TESTBOX_REVIEWED_REF }}
+          BLACKSMITH_TESTBOX_REVIEWED_SHA: ${{ vars.BLACKSMITH_TESTBOX_REVIEWED_SHA }}
+          EXPECTED_INPUT_SHA: ${{ inputs.source_sha }}
+          TESTBOX_ID: ${{ inputs.testbox_id }}
+          EVENT_NAME: ${{ github.event_name }}
+          DISPATCH_REF: ${{ github.ref }}
+          DISPATCH_SHA: ${{ github.sha }}
+          REPOSITORY: ${{ github.repository }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          : "${BLACKSMITH_TESTBOX_BROKER_SHA:?protected broker SHA is required}"
+          : "${BLACKSMITH_TESTBOX_REVIEWED_REF:?protected reviewed ref is required}"
+          : "${BLACKSMITH_TESTBOX_REVIEWED_SHA:?protected reviewed SHA is required}"
+          : "${TESTBOX_ID:?inputs.testbox_id is required}"
+          : "${GITHUB_SHA:?github.sha is required}"
+          : "${GITHUB_REF:?github.ref is required}"
+          : "${GITHUB_REPOSITORY:?github.repository is required}"
+          ./scripts/blacksmith-testbox-broker/validate-identity.sh --phase pre
+
+      - name: Begin Testbox
+        uses: useblacksmith/begin-testbox@233448af4bfdc6fca509a7f0974411ac6d8a8043 # v2
+        with:
+          testbox_id: ${{ inputs.testbox_id }}
+
+      - name: Revalidate broker and reviewed source after Testbox
+        if: always()
+        env:
+          BLACKSMITH_TESTBOX_BROKER_SHA: ${{ vars.BLACKSMITH_TESTBOX_BROKER_SHA }}
+          BLACKSMITH_TESTBOX_REVIEWED_REF: ${{ vars.BLACKSMITH_TESTBOX_REVIEWED_REF }}
+          BLACKSMITH_TESTBOX_REVIEWED_SHA: ${{ vars.BLACKSMITH_TESTBOX_REVIEWED_SHA }}
+          EXPECTED_INPUT_SHA: ${{ inputs.source_sha }}
+          TESTBOX_ID: ${{ inputs.testbox_id }}
+          EVENT_NAME: ${{ github.event_name }}
+          DISPATCH_REF: ${{ github.ref }}
+          DISPATCH_SHA: ${{ github.sha }}
+          REPOSITORY: ${{ github.repository }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          : "${BLACKSMITH_TESTBOX_BROKER_SHA:?protected broker SHA is required}"
+          : "${BLACKSMITH_TESTBOX_REVIEWED_REF:?protected reviewed ref is required}"
+          : "${BLACKSMITH_TESTBOX_REVIEWED_SHA:?protected reviewed SHA is required}"
+          : "${TESTBOX_ID:?inputs.testbox_id is required}"
+          : "${GITHUB_SHA:?github.sha is required}"
+          : "${GITHUB_REF:?github.ref is required}"
+          : "${GITHUB_REPOSITORY:?github.repository is required}"
+          ./scripts/blacksmith-testbox-broker/validate-identity.sh --phase post
+
+      - name: Checkout reviewed candidate (isolated)
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ vars.BLACKSMITH_TESTBOX_REVIEWED_SHA }}
+          path: candidate-source
+          fetch-depth: "0"
+          persist-credentials: "false"
+          submodules: "false"
+
+      - name: Verify isolated candidate identity
+        env:
+          REVIEWED_SHA: ${{ vars.BLACKSMITH_TESTBOX_REVIEWED_SHA }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          test -d candidate-source
+          candidate_sha="$(git -C candidate-source rev-parse --verify HEAD)"
+          [[ "$candidate_sha" == "$REVIEWED_SHA" ]] || {
+            echo "::error::candidate checkout SHA $candidate_sha does not equal reviewed_sha $REVIEWED_SHA" >&2
+            exit 1
+          }
+          candidate_root="$(git -C candidate-source rev-parse --show-toplevel)"
+          trusted_root="$(git rev-parse --show-toplevel)"
+          [[ "$candidate_root" != "$trusted_root" ]] || {
+            echo "::error::candidate checkout is not isolated from the trusted root" >&2
+            exit 1
+          }
+          [[ -z "$(git -C candidate-source status --porcelain=v1 --untracked-files=normal)" ]] || {
+            echo "::error::candidate-source checkout is dirty" >&2
+            git -C candidate-source status --short >&2
+            exit 1
+          }
+          if git -C candidate-source config --local --get-regexp '(^|\.)http\..*extraheader$' >/dev/null 2>&1; then
+            echo "::error::candidate-source checkout retained Git credentials" >&2
+            exit 1
+          fi
+
+      - name: Run trusted broker keepalive
+        if: always()
+        env:
+          JOB_STATUS: ${{ job.status }}
+          TESTBOX_ID: ${{ inputs.testbox_id }}
+        shell: bash
+        run: ./scripts/blacksmith-testbox-broker/keepalive.sh

--- a/.github/workflows/ci-workflow-guard-tests-testbox-broker.yml
+++ b/.github/workflows/ci-workflow-guard-tests-testbox-broker.yml
@@ -130,6 +130,39 @@ jobs:
             exit 1
           fi
 
+      - name: Prepare reviewed candidate and Linux build dependencies
+        env:
+          BLACKSMITH_TESTBOX_BROKER_SHA: ${{ vars.BLACKSMITH_TESTBOX_BROKER_SHA }}
+          BLACKSMITH_TESTBOX_REVIEWED_REF: ${{ vars.BLACKSMITH_TESTBOX_REVIEWED_REF }}
+          BLACKSMITH_TESTBOX_REVIEWED_SHA: ${{ vars.BLACKSMITH_TESTBOX_REVIEWED_SHA }}
+          TESTBOX_ID: ${{ inputs.testbox_id }}
+        shell: bash
+        run: ./scripts/blacksmith-testbox-broker/setup.sh prepare candidate-source
+
+      - name: Install repository-pinned Zig
+        shell: bash
+        run: ./scripts/install-zig-ci.sh
+
+      - name: Set up repository-pinned cmux-tui Rust
+        uses: ./.github/actions/setup-cmux-tui-rust
+
+      - name: Hydrate reviewed Rust dependencies and install warm-build entrypoint
+        env:
+          BLACKSMITH_TESTBOX_BROKER_SHA: ${{ vars.BLACKSMITH_TESTBOX_BROKER_SHA }}
+          BLACKSMITH_TESTBOX_REVIEWED_REF: ${{ vars.BLACKSMITH_TESTBOX_REVIEWED_REF }}
+          BLACKSMITH_TESTBOX_REVIEWED_SHA: ${{ vars.BLACKSMITH_TESTBOX_REVIEWED_SHA }}
+          TESTBOX_ID: ${{ inputs.testbox_id }}
+        shell: bash
+        run: ./scripts/blacksmith-testbox-broker/setup.sh hydrate candidate-source
+
+      - name: Upload Testbox setup identity
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: cmux-tui-testbox-setup-${{ github.run_id }}
+          path: ${{ runner.temp }}/cmux-tui-rust-setup-identity.json
+          if-no-files-found: error
+          retention-days: 14
+
       - name: Run trusted broker keepalive
         if: always()
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -234,6 +234,9 @@ jobs:
       - name: Validate release attestation retry guard
         run: ./tests/test_ci_attestation_retry.sh
 
+      - name: Validate Testbox broker trust boundary
+        run: python3 tests/test_testbox_workflow_security.py
+
       - name: Validate Python R2 appcast upload guard
         run: ./tests/test_ci_r2_upload_python.sh
 

--- a/scripts/blacksmith-testbox-broker/keepalive.sh
+++ b/scripts/blacksmith-testbox-broker/keepalive.sh
@@ -1,0 +1,129 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# This helper is broker-owned. It reads only the state written by the pinned
+# Begin Testbox action and never sources code from candidate-source.
+
+die() {
+  echo "::error::$*" >&2
+  exit 1
+}
+
+state_dir=/tmp/.testbox
+job_status="${JOB_STATUS:-failure}"
+expected_testbox_id="${TESTBOX_ID:-}"
+workspace="${GITHUB_WORKSPACE:-$PWD}"
+
+[[ -d "$state_dir" && ! -L "$state_dir" ]] || die "Testbox registration state is absent"
+state_mode="$(stat -c '%a' "$state_dir" 2>/dev/null || stat -f '%Lp' "$state_dir")"
+[[ "$state_mode" == "700" ]] || die "Testbox registration state directory is not private"
+
+read_state() {
+  local name="$1"
+  local path="$state_dir/$name"
+  [[ -f "$path" && ! -L "$path" ]] || die "missing Testbox registration state file: $name"
+  local value
+  value="$(<"$path")"
+  [[ -n "$value" ]] || die "empty Testbox registration state file: $name"
+  [[ "$value" != *$'\n'* && "$value" != *$'\r'* ]] || die "unsafe newline in Testbox registration state: $name"
+  printf '%s' "$value"
+}
+
+testbox_id="$(read_state testbox_id)"
+installation_model_id="$(read_state installation_model_id)"
+auth_token="$(read_state auth_token)"
+api_url="$(read_state api_url)"
+runner_host="$(read_state runner_host)"
+runner_ssh_port="$(read_state runner_ssh_port)"
+working_directory="$(read_state working_directory)"
+adopted_run_id="$(read_state adopted_run_id)"
+
+[[ "$testbox_id" =~ ^tbx_[A-Za-z0-9_-]+$ ]] || die "malformed Testbox ID in registration state"
+if [[ -n "$expected_testbox_id" && "$testbox_id" != "$expected_testbox_id" ]]; then
+  die "Testbox registration state does not match inputs.testbox_id"
+fi
+[[ "$installation_model_id" =~ ^[0-9]+$ ]] || die "malformed Testbox installation model ID"
+[[ "$api_url" =~ ^https://[^[:space:]]+$ ]] || die "Testbox API URL is not HTTPS"
+[[ "$runner_host" != *[[:space:]]* ]] || die "Testbox runner host contains whitespace"
+[[ "$runner_ssh_port" =~ ^[0-9]{1,5}$ ]] || die "malformed Testbox SSH port"
+port_value=$((10#$runner_ssh_port))
+(( port_value >= 1 && port_value <= 65535 )) || die "Testbox SSH port is outside the valid range"
+workspace_real="$(cd "$workspace" 2>/dev/null && pwd -P)" || die "GITHUB_WORKSPACE does not exist"
+[[ "$working_directory" == "$workspace_real" ]] || die "Testbox working directory is not the trusted workspace"
+[[ "$adopted_run_id" =~ ^[0-9]+$ ]] || die "malformed Testbox adopted run ID"
+if [[ -n "${GITHUB_RUN_ID:-}" && "$adopted_run_id" != "$GITHUB_RUN_ID" ]]; then
+  die "Testbox registration belongs to a different workflow run"
+fi
+
+phone_home() {
+  local status="$1"
+  local payload
+  payload="$(jq -n \
+    --arg testbox_id "$testbox_id" \
+    --arg runner_host "$runner_host" \
+    --arg runner_ssh_port "$runner_ssh_port" \
+    --arg working_directory "$working_directory" \
+    --arg adopted_run_id "$adopted_run_id" \
+    --arg status "$status" \
+    --argjson installation_model_id "$installation_model_id" \
+    '{testbox_id: $testbox_id, installation_model_id: $installation_model_id, status: $status, ip_address: $runner_host, ssh_port: $runner_ssh_port, working_directory: $working_directory, adopted_run_id: $adopted_run_id, metadata: {}}')"
+  curl --fail --silent --show-error --connect-timeout 2 --max-time 10 \
+    -X POST "$api_url/api/testbox/phone-home" \
+    -H 'Content-Type: application/json' \
+    -H "Authorization: Bearer $auth_token" \
+    --data "$payload" >/dev/null
+}
+
+phone_home_with_retry() {
+  local status="$1"
+  local attempt
+  for attempt in 1 2 3 4 5; do
+    if phone_home "$status"; then
+      return 0
+    fi
+    if (( attempt < 5 )); then
+      sleep $((attempt * 2))
+    fi
+  done
+  return 1
+}
+
+if [[ "$job_status" != "success" ]]; then
+  phone_home_with_retry hydration_failed || die "could not report hydration_failed"
+  echo "Testbox hydration failed; no ready state was published" >&2
+  exit 0
+fi
+
+if ! phone_home_with_retry ready; then
+  echo "ready phone-home failed after bounded retries" >&2
+  phone_home_with_retry hydration_failed || true
+  exit 1
+fi
+
+printf 'Testbox ready: %s (%s)\n' "$testbox_id" "$runner_host"
+idle_timeout_minutes=10
+if [[ -f "$state_dir/idle_timeout" && ! -L "$state_dir/idle_timeout" ]]; then
+  candidate_timeout="$(<"$state_dir/idle_timeout")"
+  if [[ "$candidate_timeout" =~ ^[0-9]{1,4}$ ]] && (( 10#$candidate_timeout > 0 )); then
+    idle_timeout_minutes="$candidate_timeout"
+  fi
+fi
+idle_timeout_seconds=$((10#$idle_timeout_minutes * 60))
+last_activity="$(date +%s)"
+
+while :; do
+  sleep 30
+  now="$(date +%s)"
+  if ss -tnp 2>/dev/null | grep -Eq ":${runner_ssh_port}([^0-9]|$)"; then
+    last_activity="$now"
+  elif [[ -f "$HOME/.testbox-last-activity" && ! -L "$HOME/.testbox-last-activity" ]]; then
+    marker_mtime="$(stat -c %Y "$HOME/.testbox-last-activity" 2>/dev/null || stat -f %m "$HOME/.testbox-last-activity")"
+    if [[ "$marker_mtime" =~ ^[0-9]+$ && "$marker_mtime" -gt "$last_activity" ]]; then
+      last_activity="$marker_mtime"
+    fi
+  fi
+  if (( now - last_activity >= idle_timeout_seconds )); then
+    phone_home_with_retry completed || die "could not report completed"
+    exit 0
+  fi
+done

--- a/scripts/blacksmith-testbox-broker/setup.sh
+++ b/scripts/blacksmith-testbox-broker/setup.sh
@@ -1,0 +1,569 @@
+#!/usr/bin/env bash
+set -euo pipefail
+export LC_ALL=C
+
+# This file is checked out from the protected broker commit. The workflow uses
+# prepare and hydrate. Hydrate installs the same trusted file outside the CLI
+# sync root as the fixed-SHA warm-build entrypoint.
+
+die() {
+  echo "::error::$*" >&2
+  exit 1
+}
+
+usage() {
+  echo "usage: $0 {prepare|hydrate} <candidate-source>" >&2
+  echo "       CMUX_TESTBOX_REMOTE=1 CMUX_TESTBOX_ID=tbx_... /tmp/.testbox/cmux-tui-rust-warm-build <source-sha>" >&2
+  exit 2
+}
+
+require_sha() {
+  local name="$1"
+  local value="$2"
+  [[ "$value" =~ ^[0-9a-f]{40}$ ]] || die "$name is not a full lowercase SHA"
+}
+
+state_dir=/tmp/.testbox
+runtime_parent=/tmp/cmux-testbox-broker
+expected_testbox_id="${TESTBOX_ID:-${CMUX_TESTBOX_ID:-}}"
+runtime_root=
+state_run_id=
+
+read_state() {
+  local name="$1"
+  local path="$state_dir/$name"
+  [[ -f "$path" && ! -L "$path" ]] || die "missing Testbox registration state file: $name"
+  local value
+  value="$(<"$path")"
+  [[ -n "$value" ]] || die "empty Testbox registration state file: $name"
+  [[ "$value" != *$'\n'* && "$value" != *$'\r'* ]] || die "unsafe newline in Testbox registration state: $name"
+  printf '%s' "$value"
+}
+
+require_testbox_state() {
+  [[ -d "$state_dir" && ! -L "$state_dir" ]] || die "Testbox registration state is absent"
+  local state_mode
+  state_mode="$(stat -c '%a' "$state_dir")"
+  [[ "$state_mode" == "700" ]] || die "Testbox registration state directory is not private"
+  [[ "$expected_testbox_id" =~ ^tbx_[A-Za-z0-9_-]+$ ]] || die "expected Testbox ID is malformed"
+
+  local state_testbox_id
+  state_testbox_id="$(read_state testbox_id)"
+  [[ "$state_testbox_id" == "$expected_testbox_id" ]] || die "Testbox registration state has a different ID"
+  state_run_id="$(read_state adopted_run_id)"
+  [[ "$state_run_id" =~ ^[0-9]+$ ]] || die "Testbox adopted run ID is malformed"
+  if [[ -n "${GITHUB_RUN_ID:-}" && "$state_run_id" != "$GITHUB_RUN_ID" ]]; then
+    die "Testbox registration belongs to a different workflow run"
+  fi
+  runtime_root="$runtime_parent/$expected_testbox_id"
+}
+
+candidate_sha=
+candidate_tree_sha=
+ghostty_gitlink_sha=
+ghostty_head_sha=
+
+capture_candidate_identity() {
+  local candidate_root="$1"
+  [[ -f "$candidate_root/cmux-tui/Cargo.toml" ]] || die "candidate cmux-tui manifest is missing"
+  [[ -f "$candidate_root/cmux-tui/Cargo.lock" ]] || die "candidate Cargo lock file is missing"
+  [[ -f "$candidate_root/cmux-tui/rust-toolchain.toml" ]] || die "candidate Rust toolchain file is missing"
+  [[ -f "$candidate_root/ghostty/build.zig.zon" ]] || die "candidate Ghostty source is not initialized"
+
+  local candidate_git_root
+  candidate_git_root="$(git -C "$candidate_root" rev-parse --show-toplevel 2>/dev/null)" || die "candidate is not a Git checkout"
+  [[ "$candidate_git_root" == "$candidate_root" ]] || die "candidate Git root is not the expected directory"
+  candidate_sha="$(git -C "$candidate_root" rev-parse --verify HEAD)"
+  candidate_tree_sha="$(git -C "$candidate_root" rev-parse 'HEAD^{tree}')"
+  local ghostty_entry
+  ghostty_entry="$(git -C "$candidate_root" ls-tree HEAD ghostty)"
+  [[ "$ghostty_entry" =~ ^160000[[:space:]]commit[[:space:]][0-9a-f]{40}[[:space:]]ghostty$ ]] || {
+    die "candidate HEAD:ghostty is not a gitlink"
+  }
+  ghostty_gitlink_sha="$(git -C "$candidate_root" rev-parse HEAD:ghostty)"
+  local ghostty_root
+  ghostty_root="$(git -C "$candidate_root/ghostty" rev-parse --show-toplevel 2>/dev/null)" || {
+    die "candidate Ghostty checkout is invalid"
+  }
+  [[ "$ghostty_root" == "$candidate_root/ghostty" ]] || die "candidate Ghostty root is not the expected directory"
+  ghostty_head_sha="$(git -C "$candidate_root/ghostty" rev-parse --verify HEAD)"
+  [[ "$ghostty_head_sha" == "$ghostty_gitlink_sha" ]] || die "candidate Ghostty checkout does not match its gitlink"
+  [[ -z "$(git -C "$candidate_root" status --porcelain=v1 --untracked-files=normal)" ]] || {
+    git -C "$candidate_root" status --short >&2
+    die "candidate source is dirty"
+  }
+  [[ -z "$(git -C "$candidate_root/ghostty" status --porcelain=v1 --untracked-files=normal)" ]] || {
+    git -C "$candidate_root/ghostty" status --short >&2
+    die "candidate Ghostty checkout is dirty"
+  }
+}
+
+require_reviewed_candidate() {
+  local candidate_root="$1"
+  local reviewed_sha="${BLACKSMITH_TESTBOX_REVIEWED_SHA:-}"
+  local reviewed_ref="${BLACKSMITH_TESTBOX_REVIEWED_REF:-}"
+  require_sha BLACKSMITH_TESTBOX_REVIEWED_SHA "$reviewed_sha"
+  [[ "$reviewed_ref" =~ ^[A-Za-z0-9._/-]+$ ]] || die "protected reviewed ref is malformed"
+  [[ "$reviewed_ref" != refs/* && "$reviewed_ref" != /* && "$reviewed_ref" != */ ]] || {
+    die "protected reviewed ref is malformed"
+  }
+  [[ "$reviewed_ref" != *//* && "$reviewed_ref" != *..* && "$reviewed_ref" != -* ]] || {
+    die "protected reviewed ref is malformed"
+  }
+  git check-ref-format --branch "$reviewed_ref" >/dev/null 2>&1 || die "protected reviewed ref is not a Git branch"
+  capture_candidate_identity "$candidate_root"
+  [[ "$candidate_sha" == "$reviewed_sha" ]] || die "candidate checkout does not equal the protected reviewed SHA"
+}
+
+resolve_broker_root() {
+  local script_dir
+  script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+  local broker_root
+  broker_root="$(cd "$script_dir/../.." && pwd -P)"
+  local broker_sha="${BLACKSMITH_TESTBOX_BROKER_SHA:-}"
+  require_sha BLACKSMITH_TESTBOX_BROKER_SHA "$broker_sha"
+  [[ "$(git -C "$broker_root" rev-parse --verify HEAD)" == "$broker_sha" ]] || {
+    die "setup helper is not running from the protected broker checkout"
+  }
+  printf '%s' "$broker_root"
+}
+
+resolve_candidate_root() {
+  local broker_root="$1"
+  local supplied_path="$2"
+  local workspace="${GITHUB_WORKSPACE:-$broker_root}"
+  local workspace_real
+  workspace_real="$(cd "$workspace" && pwd -P)" || die "GitHub workspace does not exist"
+  [[ "$workspace_real" == "$broker_root" ]] || die "GitHub workspace is not the broker root"
+  local candidate_root
+  candidate_root="$(cd "$supplied_path" && pwd -P)" || die "candidate source path does not exist"
+  [[ "$candidate_root" == "$workspace_real/candidate-source" ]] || die "candidate source is not isolated at candidate-source"
+  printf '%s' "$candidate_root"
+}
+
+write_prepare_identity() {
+  local path="$1"
+  local broker_sha="$2"
+  local reviewed_ref="$3"
+  local zig_required="$4"
+  SOURCE_SHA="$candidate_sha" \
+  SOURCE_TREE_SHA="$candidate_tree_sha" \
+  GHOSTTY_GITLINK_SHA="$ghostty_gitlink_sha" \
+  GHOSTTY_HEAD_SHA="$ghostty_head_sha" \
+  BROKER_SHA="$broker_sha" \
+  REVIEWED_REF="$reviewed_ref" \
+  TESTBOX_ID_VALUE="$expected_testbox_id" \
+  SETUP_RUN_ID="$state_run_id" \
+  ZIG_REQUIRED_VALUE="$zig_required" \
+    python3 - <<'PY' >"$path"
+import json
+import os
+
+print(json.dumps({
+    "schema": 1,
+    "broker_sha": os.environ["BROKER_SHA"],
+    "source": {
+        "ref": os.environ["REVIEWED_REF"],
+        "commit_sha": os.environ["SOURCE_SHA"],
+        "tree_sha": os.environ["SOURCE_TREE_SHA"],
+        "ghostty_gitlink_sha": os.environ["GHOSTTY_GITLINK_SHA"],
+        "ghostty_head_sha": os.environ["GHOSTTY_HEAD_SHA"],
+    },
+    "testbox": {
+        "id": os.environ["TESTBOX_ID_VALUE"],
+        "setup_workflow_run_id": os.environ["SETUP_RUN_ID"],
+    },
+    "zig_required": os.environ["ZIG_REQUIRED_VALUE"],
+}, sort_keys=True, indent=2))
+PY
+  [[ -s "$path" ]] || die "prepare identity is empty"
+}
+
+prepare() {
+  [[ $# -eq 1 ]] || usage
+  require_testbox_state
+  local broker_root
+  broker_root="$(resolve_broker_root)"
+  local candidate_root
+  candidate_root="$(resolve_candidate_root "$broker_root" "$1")"
+  local reviewed_sha="${BLACKSMITH_TESTBOX_REVIEWED_SHA:-}"
+  local reviewed_ref="${BLACKSMITH_TESTBOX_REVIEWED_REF:-}"
+  require_sha BLACKSMITH_TESTBOX_REVIEWED_SHA "$reviewed_sha"
+
+  local pre_init_sha pre_init_tree ghostty_entry
+  pre_init_sha="$(git -C "$candidate_root" rev-parse --verify HEAD)"
+  pre_init_tree="$(git -C "$candidate_root" rev-parse 'HEAD^{tree}')"
+  ghostty_entry="$(git -C "$candidate_root" ls-tree HEAD ghostty)"
+  [[ "$pre_init_sha" == "$reviewed_sha" ]] || die "candidate checkout does not equal the protected reviewed SHA"
+  [[ "$ghostty_entry" =~ ^160000[[:space:]]commit[[:space:]][0-9a-f]{40}[[:space:]]ghostty$ ]] || {
+    die "candidate HEAD:ghostty is not a gitlink"
+  }
+
+  git -C "$candidate_root" submodule update --init --depth 1 ghostty
+  require_reviewed_candidate "$candidate_root"
+  [[ "$candidate_sha" == "$pre_init_sha" && "$candidate_tree_sha" == "$pre_init_tree" ]] || {
+    die "candidate identity changed during Ghostty initialization"
+  }
+
+  cmp -s "$candidate_root/cmux-tui/rust-toolchain.toml" "$broker_root/cmux-tui/rust-toolchain.toml" || {
+    die "candidate Rust pin differs from the trusted repository action pin"
+  }
+  local zig_required
+  zig_required="$(sed -nE 's/^[[:space:]]*\.minimum_zig_version[[:space:]]*=[[:space:]]*"([^"]+)".*/\1/p' \
+    "$candidate_root/ghostty/build.zig.zon" | head -1)"
+  [[ "$zig_required" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] || die "candidate Ghostty Zig version is invalid"
+
+  [[ ! -e "$runtime_parent" && ! -L "$runtime_parent" ]] || {
+    [[ -d "$runtime_parent" && ! -L "$runtime_parent" ]] || die "broker runtime parent is unsafe"
+  }
+  install -d -m 700 "$runtime_parent"
+  [[ ! -e "$runtime_root" && ! -L "$runtime_root" ]] || die "broker runtime root already exists"
+  install -d -m 700 "$runtime_root"
+  write_prepare_identity \
+    "$runtime_root/prepare-identity.json" \
+    "${BLACKSMITH_TESTBOX_BROKER_SHA:-}" \
+    "$reviewed_ref" \
+    "$zig_required"
+  chmod 600 "$runtime_root/prepare-identity.json"
+
+  sudo apt-get update
+  sudo apt-get install -y clang libclang-dev pkg-config
+
+  [[ -n "${GITHUB_ENV:-}" && -f "$GITHUB_ENV" && ! -L "$GITHUB_ENV" ]] || die "GITHUB_ENV is unavailable"
+  printf 'ZIG_REQUIRED=%s\n' "$zig_required" >>"$GITHUB_ENV"
+  printf 'prepared reviewed source %s, tree %s, Ghostty %s\n' \
+    "$candidate_sha" "$candidate_tree_sha" "$ghostty_gitlink_sha"
+}
+
+verify_prepare_identity() {
+  local path="$1"
+  local broker_sha="$2"
+  local reviewed_ref="$3"
+  local zig_required="$4"
+  python3 - "$path" "$broker_sha" "$reviewed_ref" "$candidate_sha" "$candidate_tree_sha" \
+    "$ghostty_gitlink_sha" "$expected_testbox_id" "$state_run_id" "$zig_required" <<'PY'
+import json
+import pathlib
+import sys
+
+(path, broker_sha, reviewed_ref, source_sha, tree_sha, ghostty_sha,
+ testbox_id, run_id, zig_required) = sys.argv[1:]
+record = json.loads(pathlib.Path(path).read_text(encoding="utf-8"))
+errors = []
+if record.get("broker_sha") != broker_sha:
+    errors.append("broker SHA changed after prepare")
+source = record.get("source", {})
+for key, expected in {
+    "ref": reviewed_ref,
+    "commit_sha": source_sha,
+    "tree_sha": tree_sha,
+    "ghostty_gitlink_sha": ghostty_sha,
+    "ghostty_head_sha": ghostty_sha,
+}.items():
+    if source.get(key) != expected:
+        errors.append(f"prepared source {key} changed")
+testbox = record.get("testbox", {})
+if testbox.get("id") != testbox_id or str(testbox.get("setup_workflow_run_id")) != run_id:
+    errors.append("prepared Testbox identity changed")
+if record.get("zig_required") != zig_required:
+    errors.append("prepared Zig pin changed")
+if errors:
+    raise SystemExit("; ".join(errors))
+PY
+}
+
+write_setup_identity() {
+  local output="$1"
+  local broker_sha="$2"
+  local reviewed_ref="$3"
+  local source_root="$4"
+  local zig_path="$5"
+  local cargo_path="$6"
+  local rustc_path="$7"
+  local rustup_path="$8"
+  local script_sha256="$9"
+
+  local cargo_metadata="$RUNNER_TEMP/cmux-tui-cargo-metadata.json"
+  (
+    cd "$source_root/cmux-tui"
+    "$cargo_path" metadata --locked --no-deps --format-version 1 >"$cargo_metadata"
+  )
+  [[ -s "$cargo_metadata" ]] || die "Cargo metadata is empty"
+
+  local rust_toolchain rustc_version cargo_version zig_version
+  rust_toolchain="$(cd "$source_root/cmux-tui" && "$rustup_path" show active-toolchain)"
+  rustc_version="$($rustc_path --version)"
+  cargo_version="$($cargo_path --version)"
+  zig_version="$($zig_path version)"
+  local runner_cpu_count
+  runner_cpu_count="$(nproc)"
+  [[ "${RUNNER_ARCH:-}" == "X64" && "$runner_cpu_count" == "32" ]] || {
+    die "expected X64 32-vCPU runner, got arch=${RUNNER_ARCH:-unset} cpu_count=$runner_cpu_count"
+  }
+
+  SOURCE_SHA="$candidate_sha" \
+  SOURCE_TREE_SHA="$candidate_tree_sha" \
+  GHOSTTY_GITLINK_SHA="$ghostty_gitlink_sha" \
+  GHOSTTY_HEAD_SHA="$ghostty_head_sha" \
+  BROKER_SHA="$broker_sha" \
+  REVIEWED_REF="$reviewed_ref" \
+  TESTBOX_ID_VALUE="$expected_testbox_id" \
+  SETUP_RUN_ID="$state_run_id" \
+  RUNNER_LABEL_VALUE="blacksmith-32vcpu-ubuntu-2404" \
+  RUNNER_CPU_COUNT="$runner_cpu_count" \
+  RUNNER_UNAME="$(uname -a)" \
+  RUST_TOOLCHAIN="$rust_toolchain" \
+  RUSTC_VERSION="$rustc_version" \
+  CARGO_VERSION="$cargo_version" \
+  ZIG_VERSION="$zig_version" \
+  ZIG_PATH="$zig_path" \
+  CARGO_PATH="$cargo_path" \
+  RUSTC_PATH="$rustc_path" \
+  RUSTUP_PATH="$rustup_path" \
+  SETUP_SCRIPT_SHA256="$script_sha256" \
+  RUST_TOOLCHAIN_FILE_SHA256="$(sha256sum "$source_root/cmux-tui/rust-toolchain.toml" | cut -d ' ' -f 1)" \
+  CARGO_LOCK_SHA256="$(sha256sum "$source_root/cmux-tui/Cargo.lock" | cut -d ' ' -f 1)" \
+  CARGO_METADATA_SHA256="$(sha256sum "$cargo_metadata" | cut -d ' ' -f 1)" \
+  GHOSTTY_ZON_SHA256="$(sha256sum "$source_root/ghostty/build.zig.zon" | cut -d ' ' -f 1)" \
+    python3 - <<'PY' >"$output"
+import json
+import os
+import platform
+
+print(json.dumps({
+    "schema": 3,
+    "broker": {
+        "commit_sha": os.environ["BROKER_SHA"],
+        "setup_script_sha256": os.environ["SETUP_SCRIPT_SHA256"],
+    },
+    "source": {
+        "ref": os.environ["REVIEWED_REF"],
+        "commit_sha": os.environ["SOURCE_SHA"],
+        "tree_sha": os.environ["SOURCE_TREE_SHA"],
+        "ghostty_gitlink_sha": os.environ["GHOSTTY_GITLINK_SHA"],
+        "ghostty_head_sha": os.environ["GHOSTTY_HEAD_SHA"],
+    },
+    "testbox": {
+        "id": os.environ["TESTBOX_ID_VALUE"],
+        "setup_workflow_run_id": os.environ["SETUP_RUN_ID"],
+    },
+    "runner": {
+        "label": os.environ["RUNNER_LABEL_VALUE"],
+        "name": os.environ.get("RUNNER_NAME"),
+        "os": os.environ.get("RUNNER_OS"),
+        "arch": os.environ.get("RUNNER_ARCH"),
+        "hostname": platform.node(),
+        "uname": os.environ["RUNNER_UNAME"],
+        "cpu_count": int(os.environ["RUNNER_CPU_COUNT"]),
+    },
+    "toolchain": {
+        "rust_toolchain": os.environ["RUST_TOOLCHAIN"],
+        "rustc": os.environ["RUSTC_VERSION"],
+        "cargo": os.environ["CARGO_VERSION"],
+        "zig": os.environ["ZIG_VERSION"],
+        "zig_path": os.environ["ZIG_PATH"],
+        "cargo_path": os.environ["CARGO_PATH"],
+        "rustc_path": os.environ["RUSTC_PATH"],
+        "rustup_path": os.environ["RUSTUP_PATH"],
+        "rust_toolchain_file_sha256": os.environ["RUST_TOOLCHAIN_FILE_SHA256"],
+        "cargo_lock_sha256": os.environ["CARGO_LOCK_SHA256"],
+        "cargo_metadata_sha256": os.environ["CARGO_METADATA_SHA256"],
+        "ghostty_build_zig_zon_sha256": os.environ["GHOSTTY_ZON_SHA256"],
+    },
+}, sort_keys=True, indent=2))
+PY
+  [[ -s "$output" ]] || die "setup identity is empty"
+}
+
+hydrate() {
+  [[ $# -eq 1 ]] || usage
+  require_testbox_state
+  local broker_root
+  broker_root="$(resolve_broker_root)"
+  local candidate_root
+  candidate_root="$(resolve_candidate_root "$broker_root" "$1")"
+  require_reviewed_candidate "$candidate_root"
+  local broker_sha="${BLACKSMITH_TESTBOX_BROKER_SHA:-}"
+  local reviewed_ref="${BLACKSMITH_TESTBOX_REVIEWED_REF:-}"
+  local prepare_identity="$runtime_root/prepare-identity.json"
+  [[ -f "$prepare_identity" && ! -L "$prepare_identity" ]] || die "prepare identity is missing"
+
+  local zig_required
+  zig_required="$(sed -nE 's/^[[:space:]]*\.minimum_zig_version[[:space:]]*=[[:space:]]*"([^"]+)".*/\1/p' \
+    "$candidate_root/ghostty/build.zig.zon" | head -1)"
+  verify_prepare_identity "$prepare_identity" "$broker_sha" "$reviewed_ref" "$zig_required"
+  cmp -s "$candidate_root/cmux-tui/rust-toolchain.toml" "$broker_root/cmux-tui/rust-toolchain.toml" || {
+    die "candidate Rust pin differs from the trusted repository action pin"
+  }
+
+  local zig_path="${CMUX_ZIG:-}"
+  [[ "$zig_path" == /* && -x "$zig_path" ]] || die "repository-pinned Zig is unavailable"
+  [[ "$($zig_path version)" == "$zig_required" ]] || die "active Zig version differs from the candidate pin"
+  local cargo_path rustc_path rustup_path
+  cargo_path="$(command -v cargo)" || die "repository-pinned Cargo is unavailable"
+  rustc_path="$(command -v rustc)" || die "repository-pinned rustc is unavailable"
+  rustup_path="$(command -v rustup)" || die "rustup is unavailable"
+
+  (
+    cd "$candidate_root/ghostty"
+    "$zig_path" build --fetch
+  )
+  (
+    cd "$candidate_root/cmux-tui"
+    "$cargo_path" fetch --locked
+  )
+  capture_candidate_identity "$candidate_root"
+  [[ "$candidate_sha" == "${BLACKSMITH_TESTBOX_REVIEWED_SHA:-}" ]] || die "candidate changed during hydration"
+
+  local source_root="$runtime_root/source"
+  [[ ! -e "$source_root" && ! -L "$source_root" ]] || die "broker source root already exists"
+  mv "$candidate_root" "$source_root"
+  capture_candidate_identity "$source_root"
+  [[ "$candidate_sha" == "${BLACKSMITH_TESTBOX_REVIEWED_SHA:-}" ]] || die "candidate changed while it moved outside the sync root"
+
+  local script_path
+  script_path="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)/$(basename "${BASH_SOURCE[0]}")"
+  local script_sha256
+  script_sha256="$(sha256sum "$script_path" | cut -d ' ' -f 1)"
+  local setup_identity="$RUNNER_TEMP/cmux-tui-rust-setup-identity.json"
+  write_setup_identity "$setup_identity" "$broker_sha" "$reviewed_ref" "$source_root" \
+    "$zig_path" "$cargo_path" "$rustc_path" "$rustup_path" "$script_sha256"
+
+  local marker="$state_dir/cmux-tui-rust-setup-identity.json"
+  local entrypoint="$state_dir/cmux-tui-rust-warm-build"
+  [[ ! -e "$marker" && ! -L "$marker" ]] || die "setup identity marker already exists"
+  [[ ! -e "$entrypoint" && ! -L "$entrypoint" ]] || die "warm-build entrypoint already exists"
+  install -m 600 "$setup_identity" "$marker"
+  install -m 700 "$script_path" "$entrypoint"
+  install -m 600 "$setup_identity" "$runtime_root/setup-identity.json"
+  printf 'hydrated reviewed source %s; warm build entrypoint: %s\n' "$candidate_sha" "$entrypoint"
+}
+
+json_value() {
+  local path="$1"
+  local section="$2"
+  local key="$3"
+  python3 - "$path" "$section" "$key" <<'PY'
+import json
+import pathlib
+import sys
+
+path, section, key = sys.argv[1:]
+value = json.loads(pathlib.Path(path).read_text(encoding="utf-8"))[section][key]
+if not isinstance(value, str) or not value or "\n" in value or "\r" in value:
+    raise SystemExit(f"invalid identity value: {section}.{key}")
+print(value)
+PY
+}
+
+verify_warm_identity() {
+  local identity="$1"
+  local expected_sha="$2"
+  local script_sha256="$3"
+  local rust_toolchain="$4"
+  local rustc_version="$5"
+  local cargo_version="$6"
+  local zig_version="$7"
+  local source_root="$8"
+  python3 - "$identity" "$expected_sha" "$expected_testbox_id" "$state_run_id" "$script_sha256" \
+    "$rust_toolchain" "$rustc_version" "$cargo_version" "$zig_version" \
+    "$(git -C "$source_root" rev-parse HEAD)" \
+    "$(git -C "$source_root" rev-parse 'HEAD^{tree}')" \
+    "$(git -C "$source_root" rev-parse HEAD:ghostty)" \
+    "$(git -C "$source_root/ghostty" rev-parse HEAD)" \
+    "$(sha256sum "$source_root/cmux-tui/rust-toolchain.toml" | cut -d ' ' -f 1)" \
+    "$(sha256sum "$source_root/cmux-tui/Cargo.lock" | cut -d ' ' -f 1)" \
+    "$(sha256sum "$source_root/ghostty/build.zig.zon" | cut -d ' ' -f 1)" <<'PY'
+import json
+import pathlib
+import sys
+
+(path, expected_sha, testbox_id, run_id, script_sha256, rust_toolchain,
+ rustc_version, cargo_version, zig_version, source_sha, tree_sha,
+ ghostty_gitlink, ghostty_head, rust_file_sha, cargo_lock_sha,
+ ghostty_zon_sha) = sys.argv[1:]
+record = json.loads(pathlib.Path(path).read_text(encoding="utf-8"))
+checks = {
+    "broker setup script": (record.get("broker", {}).get("setup_script_sha256"), script_sha256),
+    "source commit": (record.get("source", {}).get("commit_sha"), expected_sha),
+    "source checkout": (source_sha, expected_sha),
+    "source tree": (tree_sha, record.get("source", {}).get("tree_sha")),
+    "Ghostty gitlink": (ghostty_gitlink, record.get("source", {}).get("ghostty_gitlink_sha")),
+    "Ghostty checkout": (ghostty_head, record.get("source", {}).get("ghostty_head_sha")),
+    "Testbox ID": (record.get("testbox", {}).get("id"), testbox_id),
+    "setup run ID": (str(record.get("testbox", {}).get("setup_workflow_run_id")), run_id),
+    "Rust toolchain": (rust_toolchain, record.get("toolchain", {}).get("rust_toolchain")),
+    "rustc": (rustc_version, record.get("toolchain", {}).get("rustc")),
+    "Cargo": (cargo_version, record.get("toolchain", {}).get("cargo")),
+    "Zig": (zig_version, record.get("toolchain", {}).get("zig")),
+    "Rust pin": (rust_file_sha, record.get("toolchain", {}).get("rust_toolchain_file_sha256")),
+    "Cargo lock": (cargo_lock_sha, record.get("toolchain", {}).get("cargo_lock_sha256")),
+    "Ghostty Zig manifest": (ghostty_zon_sha, record.get("toolchain", {}).get("ghostty_build_zig_zon_sha256")),
+}
+errors = [name for name, (actual, expected) in checks.items() if actual != expected]
+if errors:
+    raise SystemExit("warm-build identity mismatch: " + ", ".join(errors))
+PY
+}
+
+warm_build() {
+  [[ $# -eq 1 ]] || usage
+  [[ "${CMUX_TESTBOX_REMOTE:-}" == "1" ]] || die "warm build requires CMUX_TESTBOX_REMOTE=1"
+  if [[ ! -r /proc/cmdline ]] || ! grep -Eq '(^|[[:space:]])metadata_port=[^[:space:]]+' /proc/cmdline; then
+    die "warm build requires the Blacksmith Testbox metadata marker"
+  fi
+  local expected_sha="$1"
+  require_sha source_sha "$expected_sha"
+  require_testbox_state
+  command -v flock >/dev/null || die "flock is required for serialized warm builds"
+  command -v timeout >/dev/null || die "timeout is required for bounded warm builds"
+  [[ -d "$runtime_root" && ! -L "$runtime_root" ]] || die "broker runtime root is unavailable"
+  local source_root="$runtime_root/source"
+  local identity="$state_dir/cmux-tui-rust-setup-identity.json"
+  [[ -f "$identity" && ! -L "$identity" ]] || die "setup identity marker is unavailable"
+
+  exec 9>"$runtime_root/build.lock"
+  flock -x 9
+  capture_candidate_identity "$source_root"
+
+  local zig_path cargo_path rustc_path rustup_path
+  zig_path="$(json_value "$identity" toolchain zig_path)"
+  cargo_path="$(json_value "$identity" toolchain cargo_path)"
+  rustc_path="$(json_value "$identity" toolchain rustc_path)"
+  rustup_path="$(json_value "$identity" toolchain rustup_path)"
+  for tool_path in "$zig_path" "$cargo_path" "$rustc_path" "$rustup_path"; do
+    [[ "$tool_path" == /* && -x "$tool_path" ]] || die "recorded tool path is unavailable: $tool_path"
+  done
+
+  local rust_toolchain rustc_version cargo_version zig_version script_sha256
+  rust_toolchain="$(cd "$source_root/cmux-tui" && "$rustup_path" show active-toolchain)"
+  rustc_version="$($rustc_path --version)"
+  cargo_version="$($cargo_path --version)"
+  zig_version="$($zig_path version)"
+  script_sha256="$(sha256sum "${BASH_SOURCE[0]}" | cut -d ' ' -f 1)"
+  verify_warm_identity "$identity" "$expected_sha" "$script_sha256" "$rust_toolchain" \
+    "$rustc_version" "$cargo_version" "$zig_version" "$source_root"
+
+  export ZIG="$zig_path"
+  export CMUX_ZIG="$zig_path"
+  (
+    cd "$source_root/cmux-tui"
+    timeout --kill-after=30s 20m "$cargo_path" build -p cmux-tui --locked
+  )
+  capture_candidate_identity "$source_root"
+  [[ "$candidate_sha" == "$expected_sha" ]] || die "source changed during warm build"
+}
+
+if [[ "$(basename "$0")" == "cmux-tui-rust-warm-build" ]]; then
+  warm_build "$@"
+  exit 0
+fi
+
+[[ $# -ge 1 ]] || usage
+mode="$1"
+shift
+case "$mode" in
+  prepare) prepare "$@" ;;
+  hydrate) hydrate "$@" ;;
+  *) usage ;;
+esac

--- a/scripts/blacksmith-testbox-broker/validate-identity.sh
+++ b/scripts/blacksmith-testbox-broker/validate-identity.sh
@@ -1,0 +1,132 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# This helper is checked out from the protected broker commit. It must run
+# before and after Begin Testbox, while the checkout is still the trusted root.
+
+die() {
+  echo "::error::$*" >&2
+  exit 1
+}
+
+usage() {
+  echo "usage: $0 --phase pre|post" >&2
+  exit 2
+}
+
+[[ $# -eq 2 && "$1" == "--phase" ]] || usage
+phase="$2"
+[[ "$phase" == "pre" || "$phase" == "post" ]] || usage
+
+repository="${REPOSITORY:-${GITHUB_REPOSITORY:-}}"
+event_name="${EVENT_NAME:-${GITHUB_EVENT_NAME:-}}"
+dispatch_ref="${DISPATCH_REF:-${GITHUB_REF:-}}"
+dispatch_sha="${DISPATCH_SHA:-${GITHUB_SHA:-}}"
+broker_sha="${BLACKSMITH_TESTBOX_BROKER_SHA:-}"
+reviewed_ref="${BLACKSMITH_TESTBOX_REVIEWED_REF:-}"
+reviewed_sha="${BLACKSMITH_TESTBOX_REVIEWED_SHA:-}"
+testbox_id="${TESTBOX_ID:-}"
+expected_source_sha="${EXPECTED_INPUT_SHA:-}"
+state_dir=/tmp/.testbox
+
+[[ "$repository" == "manaflow-ai/cmux" ]] || die "repository is not manaflow-ai/cmux"
+[[ "$event_name" == "workflow_dispatch" ]] || die "event is not workflow_dispatch"
+[[ "$dispatch_ref" == "refs/heads/main" ]] || die "broker must be dispatched from refs/heads/main"
+[[ "$broker_sha" =~ ^[0-9a-f]{40}$ ]] || die "BLACKSMITH_TESTBOX_BROKER_SHA is not a full lowercase SHA"
+[[ "$dispatch_sha" =~ ^[0-9a-f]{40}$ ]] || die "github.sha is not a full lowercase SHA"
+[[ "$dispatch_sha" == "$broker_sha" ]] || die "github.sha does not equal the protected broker SHA"
+
+if [[ -n "${GITHUB_SHA:-}" && "$GITHUB_SHA" != "$dispatch_sha" ]]; then
+  die "GITHUB_SHA does not equal github.sha"
+fi
+if [[ -n "${GITHUB_REF:-}" && "$GITHUB_REF" != "$dispatch_ref" ]]; then
+  die "GITHUB_REF does not equal github.ref"
+fi
+if [[ -n "${GITHUB_REPOSITORY:-}" && "$GITHUB_REPOSITORY" != "$repository" ]]; then
+  die "GITHUB_REPOSITORY does not equal github.repository"
+fi
+
+[[ "$reviewed_ref" =~ ^[A-Za-z0-9._/-]+$ ]] || die "protected reviewed ref is malformed"
+[[ ! "$reviewed_ref" =~ ^[0-9a-f]{40}$ ]] || die "reviewed ref must not be a raw SHA"
+[[ "$reviewed_ref" != refs/* ]] || die "reviewed ref must be a branch name, not a full ref"
+[[ "$reviewed_ref" != /* && "$reviewed_ref" != */ ]] || die "reviewed ref has an empty path component"
+[[ "$reviewed_ref" != *//* && "$reviewed_ref" != *..* ]] || die "reviewed ref contains an unsafe path component"
+[[ "$reviewed_ref" != -* ]] || die "reviewed ref must not start with a dash"
+git check-ref-format --branch "$reviewed_ref" >/dev/null 2>&1 || die "protected reviewed ref is not a Git branch"
+[[ "$reviewed_sha" =~ ^[0-9a-f]{40}$ ]] || die "protected reviewed SHA is not a full lowercase SHA"
+[[ "$testbox_id" =~ ^tbx_[A-Za-z0-9_-]+$ ]] || die "malformed Testbox ID"
+
+if [[ -n "$expected_source_sha" ]]; then
+  [[ "$expected_source_sha" =~ ^[0-9a-f]{40}$ ]] || die "source_sha assertion is not a full lowercase SHA"
+  [[ "$expected_source_sha" == "$reviewed_sha" ]] || die "source_sha assertion does not equal the protected reviewed SHA"
+fi
+
+workspace="${GITHUB_WORKSPACE:-$PWD}"
+git_root="$(git rev-parse --show-toplevel 2>/dev/null)" || die "trusted broker checkout is not a Git worktree"
+workspace_real="$(cd "$workspace" 2>/dev/null && pwd -P)" || die "GITHUB_WORKSPACE does not exist"
+git_root_real="$(cd "$git_root" 2>/dev/null && pwd -P)" || die "trusted Git root does not exist"
+[[ "$git_root_real" == "$workspace_real" ]] || die "current Git root is not the trusted workspace"
+local_sha="$(git rev-parse --verify HEAD 2>/dev/null)" || die "trusted broker checkout has no HEAD"
+[[ "$local_sha" == "$broker_sha" ]] || die "trusted checkout SHA does not equal the protected broker SHA"
+[[ -z "$(git status --porcelain=v1 --untracked-files=normal)" ]] || die "trusted broker checkout is dirty"
+
+repository_url="https://github.com/${repository}.git"
+if ! remote_sha="$(git ls-remote --exit-code "$repository_url" refs/heads/main | awk 'NR == 1 { print $1 }')"; then
+  die "could not read the remote SHA for refs/heads/main"
+fi
+[[ "$remote_sha" == "$broker_sha" ]] || die "remote SHA for refs/heads/main does not equal the protected broker SHA"
+
+if ! reviewed_remote_sha="$(git ls-remote --exit-code "$repository_url" "refs/heads/$reviewed_ref" | awk 'NR == 1 { print $1 }')"; then
+  die "could not read the remote SHA for the protected reviewed ref"
+fi
+[[ "$reviewed_remote_sha" == "$reviewed_sha" ]] || die "remote SHA for the reviewed ref does not equal the protected reviewed SHA"
+
+if [[ "$phase" == "pre" ]]; then
+  if [[ -e "$state_dir" || -L "$state_dir" ]]; then
+    die "stale Testbox registration state exists before Begin Testbox"
+  fi
+  printf 'preflight passed: broker SHA %s, reviewed ref %s at remote SHA %s\n' \
+    "$broker_sha" "$reviewed_ref" "$reviewed_remote_sha"
+  exit 0
+fi
+
+[[ -d "$state_dir" && ! -L "$state_dir" ]] || die "Testbox registration state is absent after Begin Testbox"
+state_mode="$(stat -c '%a' "$state_dir" 2>/dev/null || stat -f '%Lp' "$state_dir")"
+[[ "$state_mode" == "700" ]] || die "Testbox registration state directory is not private"
+
+read_state() {
+  local name="$1"
+  local path="$state_dir/$name"
+  [[ -f "$path" && ! -L "$path" ]] || die "missing Testbox registration state file: $name"
+  local value
+  value="$(<"$path")"
+  [[ -n "$value" ]] || die "empty Testbox registration state file: $name"
+  [[ "$value" != *$'\n'* && "$value" != *$'\r'* ]] || die "unsafe newline in Testbox registration state: $name"
+  printf '%s' "$value"
+}
+
+state_testbox_id="$(read_state testbox_id)"
+state_model_id="$(read_state installation_model_id)"
+state_auth_token="$(read_state auth_token)"
+state_api_url="$(read_state api_url)"
+state_runner_host="$(read_state runner_host)"
+state_runner_port="$(read_state runner_ssh_port)"
+state_working_directory="$(read_state working_directory)"
+state_run_id="$(read_state adopted_run_id)"
+
+[[ "$state_testbox_id" == "$testbox_id" ]] || die "Testbox registration state names a different testbox_id"
+[[ "$state_model_id" =~ ^[0-9]+$ ]] || die "Testbox installation model ID is malformed"
+[[ "$state_auth_token" != *$'\n'* && "$state_auth_token" != *$'\r'* ]] || die "Testbox auth token contains a newline"
+[[ "$state_api_url" =~ ^https://[^[:space:]]+$ ]] || die "Testbox API URL is not HTTPS"
+[[ "$state_runner_host" != *[[:space:]]* ]] || die "Testbox runner host contains whitespace"
+[[ "$state_runner_port" =~ ^[0-9]{1,5}$ ]] || die "Testbox SSH port is malformed"
+port_value=$((10#$state_runner_port))
+(( port_value >= 1 && port_value <= 65535 )) || die "Testbox SSH port is outside the valid range"
+[[ "$state_working_directory" == "$workspace_real" ]] || die "Testbox working directory is not the trusted workspace"
+[[ "$state_run_id" =~ ^[0-9]+$ ]] || die "Testbox adopted run ID is malformed"
+if [[ -n "${GITHUB_RUN_ID:-}" && "$state_run_id" != "$GITHUB_RUN_ID" ]]; then
+  die "Testbox registration belongs to a different workflow run"
+fi
+
+printf 'postflight passed: broker SHA %s, reviewed ref %s at remote SHA %s, testbox_id %s\n' \
+  "$broker_sha" "$reviewed_ref" "$reviewed_remote_sha" "$state_testbox_id"

--- a/tests/test_testbox_workflow_security.py
+++ b/tests/test_testbox_workflow_security.py
@@ -1,0 +1,285 @@
+"""Adversarial policy tests for the trusted Blacksmith Testbox broker.
+
+The Testbox action writes a bearer token into the runner state.  A workflow
+which runs from a candidate revision must therefore never decide its own
+preflight, checkout, or post-token helper path.  These tests inspect the
+workflow and the trusted helper boundary.  They do not provision a Testbox.
+"""
+
+from __future__ import annotations
+
+import re
+import stat
+import unittest
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+
+ROOT = Path(__file__).resolve().parents[1]
+WORKFLOW_PATH = ROOT / ".github/workflows/ci-workflow-guard-tests-testbox-broker.yml"
+HELPER_DIR = ROOT / "scripts/blacksmith-testbox-broker"
+VALIDATE_HELPER = HELPER_DIR / "validate-identity.sh"
+KEEPALIVE_HELPER = HELPER_DIR / "keepalive.sh"
+BEGIN_ACTION = "useblacksmith/begin-testbox"
+CHECKOUT_ACTION = "actions/checkout"
+BROKER_SHA_VAR = "BLACKSMITH_TESTBOX_BROKER_SHA"
+REVIEWED_REF_VAR = "BLACKSMITH_TESTBOX_REVIEWED_REF"
+REVIEWED_SHA_VAR = "BLACKSMITH_TESTBOX_REVIEWED_SHA"
+BROKER_HELPER_PREFIX = "scripts/blacksmith-testbox-broker/"
+
+
+def _without_comments(text: str) -> str:
+    return "\n".join(line.split(" #", 1)[0] for line in text.splitlines())
+
+
+class TestboxBrokerSecurityTests(unittest.TestCase):
+    def workflow_text(self) -> str:
+        self.assertTrue(
+            WORKFLOW_PATH.is_file(),
+            "main-controlled Testbox broker workflow is missing: "
+            f"{WORKFLOW_PATH.relative_to(ROOT)}",
+        )
+        return WORKFLOW_PATH.read_text(encoding="utf-8")
+
+    def workflow_document(self) -> dict[str, Any]:
+        document = yaml.load(self.workflow_text(), Loader=yaml.BaseLoader)
+        self.assertIsInstance(document, dict)
+        return document
+
+    def broker_job(self) -> dict[str, Any]:
+        document = self.workflow_document()
+        jobs = document.get("jobs")
+        self.assertIsInstance(jobs, dict)
+        job = jobs.get("cmux-tui-testbox-broker")
+        self.assertIsInstance(job, dict)
+        return job
+
+    def steps(self) -> list[dict[str, Any]]:
+        steps = self.broker_job().get("steps")
+        self.assertIsInstance(steps, list)
+        self.assertTrue(all(isinstance(step, dict) for step in steps))
+        return steps
+
+    def step(self, name: str) -> dict[str, Any]:
+        for step in self.steps():
+            if step.get("name") == name:
+                return step
+        self.fail(f"broker step is missing: {name}")
+
+    def helper_text(self, path: Path) -> str:
+        self.assertTrue(
+            path.is_file(),
+            "trusted broker helper is missing: " + str(path.relative_to(ROOT)),
+        )
+        return path.read_text(encoding="utf-8")
+
+    @staticmethod
+    def run_text(step: dict[str, Any]) -> str:
+        run = step.get("run", "")
+        return run if isinstance(run, str) else ""
+
+    @staticmethod
+    def uses(step: dict[str, Any]) -> str:
+        uses = step.get("uses", "")
+        return uses if isinstance(uses, str) else ""
+
+    def test_broker_workflow_is_dispatch_only_with_narrow_inputs(self) -> None:
+        document = self.workflow_document()
+        triggers = document.get("on")
+        self.assertIsInstance(triggers, dict)
+        self.assertIn("workflow_dispatch", triggers)
+        self.assertFalse(
+            set(triggers) & {"push", "pull_request", "pull_request_target", "workflow_run"},
+            "an untrusted event must not be able to invoke the token-bearing broker",
+        )
+
+        dispatch = triggers["workflow_dispatch"]
+        self.assertIsInstance(dispatch, dict)
+        inputs = dispatch.get("inputs")
+        self.assertIsInstance(inputs, dict)
+        self.assertEqual(set(inputs), {"testbox_id", "source_sha"})
+        self.assertEqual(inputs["testbox_id"].get("required"), "true")
+        self.assertEqual(inputs["source_sha"].get("required"), "false")
+        self.assertIn("assertion", inputs["source_sha"].get("description", "").lower())
+
+    def test_broker_job_and_external_actions_are_pinned(self) -> None:
+        job = self.broker_job()
+        text = self.workflow_text()
+        self.assertIn("blacksmith-testbox-trusted", text)
+
+        permissions = job.get("permissions", {})
+        self.assertIsInstance(permissions, dict)
+        self.assertNotIn("write", {str(value).lower() for value in permissions.values()})
+
+        external_actions: list[str] = []
+        for step in self.steps():
+            action = self.uses(step)
+            if action and not action.startswith("./"):
+                external_actions.append(action)
+        self.assertTrue(external_actions)
+        for action in external_actions:
+            self.assertRegex(
+                action,
+                r"@[0-9a-f]{40}(?:\s|$)",
+                f"external action is not pinned to a full commit: {action}",
+            )
+        begin = self.step("Begin Testbox")
+        self.assertTrue(self.uses(begin).startswith(BEGIN_ACTION + "@"))
+        self.assertNotIn("@v", self.uses(begin))
+
+    def test_only_the_main_controlled_broker_can_begin_a_testbox(self) -> None:
+        """A candidate workflow must not retain a second token-bearing entrypoint."""
+
+        for path in sorted((ROOT / ".github/workflows").glob("*.y*ml")):
+            if path == WORKFLOW_PATH:
+                continue
+            text = path.read_text(encoding="utf-8")
+            self.assertNotIn(
+                BEGIN_ACTION + "@",
+                text,
+                f"candidate-controlled workflow can invoke Begin Testbox: {path.name}",
+            )
+
+    def test_token_boundary_has_preflight_and_postflight_identity_checks(self) -> None:
+        steps = self.steps()
+        names = [str(step.get("name", "")) for step in steps]
+        begin_index = names.index("Begin Testbox")
+        pre_index = names.index("Validate broker and reviewed source before Testbox")
+        post_index = names.index("Revalidate broker and reviewed source after Testbox")
+        candidate_index = names.index("Checkout reviewed candidate (isolated)")
+        self.assertLess(pre_index, begin_index)
+        self.assertGreater(post_index, begin_index)
+        self.assertGreater(candidate_index, post_index)
+        self.assertEqual(steps[post_index].get("if"), "always()")
+
+        pre_run = self.run_text(steps[pre_index])
+        post_run = self.run_text(steps[post_index])
+        self.assertIn("./" + BROKER_HELPER_PREFIX + "validate-identity.sh", pre_run)
+        self.assertIn("./" + BROKER_HELPER_PREFIX + "validate-identity.sh", post_run)
+        self.assertRegex(pre_run, r"(?:--phase\s+)?(?:pre|before)\b")
+        self.assertRegex(post_run, r"(?:--phase\s+)?(?:post|after)\b")
+
+        for source in (pre_run, post_run):
+            for variable in (BROKER_SHA_VAR, REVIEWED_REF_VAR, REVIEWED_SHA_VAR):
+                self.assertIn(variable, source)
+            self.assertIn("testbox_id", source)
+            self.assertRegex(source, r"(?:github\.sha|GITHUB_SHA)")
+            self.assertRegex(source, r"(?:github\.ref|GITHUB_REF)")
+            self.assertRegex(source, r"(?:github\.repository|GITHUB_REPOSITORY)")
+
+    def test_validate_identity_rejects_forks_tags_raw_shas_and_moved_branches(self) -> None:
+        workflow = _without_comments(self.workflow_text())
+        helper = _without_comments(self.helper_text(VALIDATE_HELPER))
+        combined = workflow + "\n" + helper
+
+        self.assertRegex(combined, r"manaflow-ai/cmux")
+        self.assertRegex(combined, r"(?:EVENT_NAME|GITHUB_EVENT_NAME|github\.event_name)")
+        self.assertRegex(combined, r"workflow_dispatch")
+        self.assertRegex(combined, r"refs/heads/")
+        self.assertRegex(combined, r"git\s+ls-remote")
+        self.assertRegex(combined, r"[Rr]emote[_ -]?[Ss][Hh][Aa]")
+        self.assertRegex(combined, r"[0-9a-f]{40}")
+
+        # A tag, fork, or raw SHA must not be accepted as the reviewed source.
+        self.assertNotRegex(workflow, r"ref:\s*\$\{\{\s*inputs\.source_sha\s*\}\}")
+        self.assertRegex(helper, r"(?:REVIEWED_REF|reviewed_ref)")
+        self.assertIn("refs/heads/", helper)
+
+        # The same trusted validator must run on both sides of token exposure.
+        steps = self.steps()
+        pre = self.run_text(self.step("Validate broker and reviewed source before Testbox"))
+        post = self.run_text(self.step("Revalidate broker and reviewed source after Testbox"))
+        self.assertIn("validate-identity.sh", pre)
+        self.assertIn("validate-identity.sh", post)
+        self.assertNotEqual(pre, post, "pre/post checks must carry distinct phases")
+        self.assertGreaterEqual(sum("validate-identity.sh" in self.run_text(step) for step in steps), 2)
+
+    def test_testbox_id_is_checked_before_and_after_begin(self) -> None:
+        helper = _without_comments(self.helper_text(VALIDATE_HELPER))
+        self.assertIn("=~ ^tbx_[A-Za-z0-9_-]+$", helper)
+        self.assertRegex(helper, r"testbox_id")
+        self.assertRegex(helper, r"(?i)(?:state|registration)")
+        self.assertRegex(helper, r"(?i)testbox_id")
+
+        begin = self.step("Begin Testbox")
+        with_values = begin.get("with")
+        self.assertIsInstance(with_values, dict)
+        self.assertEqual(with_values.get("testbox_id"), "${{ inputs.testbox_id }}")
+        pre = self.run_text(self.step("Validate broker and reviewed source before Testbox"))
+        post = self.run_text(self.step("Revalidate broker and reviewed source after Testbox"))
+        self.assertIn("inputs.testbox_id", pre)
+        self.assertIn("inputs.testbox_id", post)
+
+    def test_reviewed_candidate_checkout_isolated_and_without_credentials(self) -> None:
+        candidate = self.step("Checkout reviewed candidate (isolated)")
+        self.assertEqual(self.uses(candidate).split("@", 1)[0], CHECKOUT_ACTION)
+        self.assertEqual(candidate.get("with", {}).get("path"), "candidate-source")
+        self.assertEqual(candidate.get("with", {}).get("persist-credentials"), "false")
+        self.assertEqual(candidate.get("with", {}).get("fetch-depth"), "0")
+        self.assertNotEqual(
+            str(candidate.get("with", {}).get("submodules", "false")).lower(),
+            "true",
+        )
+        candidate_ref = str(candidate.get("with", {}).get("ref", ""))
+        self.assertNotIn("inputs.source_sha", candidate_ref)
+        self.assertRegex(candidate_ref, rf"{re.escape(REVIEWED_SHA_VAR)}|{re.escape(REVIEWED_REF_VAR)}")
+
+        verify = self.step("Verify isolated candidate identity")
+        verify_run = self.run_text(verify)
+        self.assertIn("candidate-source", verify_run)
+        self.assertRegex(verify_run, r"git\s+-C\s+candidate-source")
+        self.assertRegex(verify_run, r"(?:github\.sha|REVIEWED_SHA|reviewed_sha)")
+        self.assertIn("status", verify_run)
+
+    def test_no_candidate_workflow_actions_or_helpers_run_after_token_exposure(self) -> None:
+        steps = self.steps()
+        names = [str(step.get("name", "")) for step in steps]
+        begin_index = names.index("Begin Testbox")
+        post_steps = steps[begin_index + 1 :]
+        forbidden = (
+            ".github/workflows/",
+            ".github/actions/",
+            "blacksmith-cmux-tui-testbox-stage.sh",
+            "blacksmith-testbox-cleanup.sh",
+            "blacksmith-testbox-keepalive.sh",
+        )
+        for step in post_steps:
+            action = self.uses(step)
+            run = self.run_text(step)
+            self.assertFalse(
+                action.startswith("./.github/") or "${{" in action,
+                f"candidate-controlled action after token exposure: {action}",
+            )
+            for marker in forbidden:
+                self.assertNotIn(marker, run, f"candidate-controlled path after Begin Testbox: {marker}")
+
+            # Any repository script invoked after Begin must be a literal path
+            # in the trusted broker directory.  Candidate source may be read,
+            # but it must never supply executable helper code.
+            for match in re.finditer(r"(?:^|\s)(?:\./)?scripts/[^\s'\"]+", run):
+                path = match.group(0).strip()
+                if path.startswith("./"):
+                    path = path[2:]
+                self.assertTrue(
+                    path.startswith(BROKER_HELPER_PREFIX),
+                    f"post-token script is outside the trusted broker directory: {path}",
+                )
+
+        keepalive = self.step("Run trusted broker keepalive")
+        self.assertIn("./" + BROKER_HELPER_PREFIX + "keepalive.sh", self.run_text(keepalive))
+
+    def test_trusted_helpers_are_executable_and_do_not_download_candidate_code(self) -> None:
+        for helper_path in (VALIDATE_HELPER, KEEPALIVE_HELPER):
+            text = self.helper_text(helper_path)
+            mode = helper_path.stat().st_mode
+            self.assertTrue(mode & stat.S_IXUSR, f"helper is not executable: {helper_path.name}")
+            self.assertTrue(text.startswith("#!/usr/bin/env bash"))
+            self.assertNotRegex(text, r"curl\s+[^\n|]*\|\s*(?:bash|sh)")
+            self.assertNotIn("candidate-source/.github", text)
+            self.assertNotIn("candidate-source/scripts", text)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This PR is stacked on https://github.com/manaflow-ai/cmux/pull/10135. Keep the trust-boundary PR separate. PR 10135 alone does not enable Rust builds.

Summary

- Validate the exact reviewed source commit, tree, and Ghostty gitlink.
- Initialize the exact Ghostty checkout and install the Linux build headers.
- Use the trusted broker Zig installer and Rust setup action.
- Fetch Zig and Cargo dependencies without compilation.
- Move the fixed reviewed checkout outside the Testbox CLI sync root.
- Write a schema-3 setup identity and upload it for 14 days.
- Install a broker-owned warm-build entrypoint under /tmp/.testbox.
- Serialize each fixed Cargo build with flock and a 20-minute limit.

The candidate checkout is input data. The workflow does not source a candidate shell script. The warm build can execute the reviewed Rust source only after the token isolation work in the base PR is complete.

Static verification

- bash -n scripts/blacksmith-testbox-broker/setup.sh
- shellcheck scripts/blacksmith-testbox-broker/setup.sh
- actionlint .github/workflows/ci-workflow-guard-tests-testbox-broker.yml
- Python PyYAML safe_load of the workflow
- git diff HEAD^ HEAD --check

All checks passed at 16e715be98dbd0265847701e16ac21d3090709f3. No local Cargo, Rust, Zig, Xcode, or Testbox command ran.

Timing plan

After both PRs merge and the protected environment pins the exact broker and reviewed source identities:

1. Use one Testbox, one operator, and one target directory.
2. Record CLI warmup start to ready time.
3. Record the first target-empty Cargo build.
4. Run 10 serialized warmup pairs, then 50 serialized measured pairs through the separate benchmark runner.
5. Record CLI sync time, remote Cargo time, and total wall time separately.
6. Retain all raw values and report median and p95. Do not retain only summaries.
7. Compare with the existing 161.47-second clean, 0.21-second uncontended no-op, and 9.13-second changed-file records.
8. Do not run a new local M5 Rust comparison. Local Rust is prohibited. Use existing macOS evidence only.

Expected result

Testbox reuse should beat repeated clean builds near the third build. It is unlikely to beat the M5 Max end-to-end warm loop because each remote build adds sync and control delay. The Testbox value is a safe, repeatable Linux lane, not a proven faster local edit loop.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/10141"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789266084&installation_model_id=21920&pr_number=10141&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F10141&signature=96bf7e7fe43394fc2788830eccc9c53755179adab97e5bbc0e9165b969b70274"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hydrates Rust in the trusted Testbox broker so CI can safely prepare and run Rust builds. Previously the broker integration validated the trust boundary but could not enable Rust builds; now CI prepares the reviewed source, pins toolchains, fetches dependencies, installs a warm-build entrypoint, and records a verifiable setup identity.

- Adds `scripts/blacksmith-testbox-broker/setup.sh` with prepare/hydrate/warm-build:
  - Validates reviewed source commit, tree, and Ghostty gitlink; initializes Ghostty; treats the candidate checkout as data only.
  - Installs Linux build headers (`clang`, `libclang-dev`, `pkg-config`), fetches Zig and Cargo dependencies without compilation.
  - Moves the fixed reviewed checkout outside the Testbox CLI sync root and installs a broker-owned warm-build entrypoint at `/tmp/.testbox/cmux-tui-rust-warm-build`.
  - Serializes each warm Cargo build with `flock` and a 20-minute `timeout`.
  - Writes schema-1 prepare and schema-3 setup identities including toolchain versions and file digests.
- Updates `.github/workflows/ci-workflow-guard-tests-testbox-broker.yml`:
  - Adds “Prepare” and “Hydrate” steps, installs repository-pinned Zig via `scripts/install-zig-ci.sh`, and sets up Rust via `./.github/actions/setup-cmux-tui-rust`.
  - Uploads the setup identity artifact for 14 days using `actions/upload-artifact`.

**Review and rollout**
- Verify `BLACKSMITH_TESTBOX_BROKER_SHA`, `BLACKSMITH_TESTBOX_REVIEWED_REF`, `BLACKSMITH_TESTBOX_REVIEWED_SHA`, and `inputs.testbox_id` are set in the protected environment.
- Ensure the runner is the X64 32‑vCPU Ubuntu 24.04 pool and that `cmux-tui/rust-toolchain.toml` matches the repository action pin.
- No app code migrations required; warm builds execute only after the trust boundary is enforced and run through the installed entrypoint.

<sup>Written for commit 16e715be98dbd0265847701e16ac21d3090709f3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/10141?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

