### PR TITLE
Mitigate redundant tmux PTY resize churn

### DIFF
--- a/Packages/macOS/CmuxTerminal/Sources/CmuxTerminal/Surface/TerminalSurface+Sizing.swift
+++ b/Packages/macOS/CmuxTerminal/Sources/CmuxTerminal/Surface/TerminalSurface+Sizing.swift
@@ -35,9 +35,13 @@ extension TerminalSurface {
     /// Returns whether a backing-pixel resize should be forwarded to Ghostty.
     ///
     /// Ghostty uses one surface-size API for both renderer pixels and PTY
-    /// geometry. During AppKit live resize, pixel churn can arrive without a
-    /// terminal grid change; coalescing those pixel-only updates avoids
-    /// redundant PTY resizes while preserving ordinary layout and scale changes.
+    /// geometry. Pixel churn can arrive without a terminal grid change;
+    /// coalescing those pixel-only updates avoids redundant PTY resizes (and
+    /// their `SIGWINCH`s) while preserving ordinary layout and scale changes.
+    /// Process-owned surfaces use this in steady state because a harmless
+    /// renderer-pixel delta would otherwise notify a tmux client; manual-I/O
+    /// mirrors opt in only during interactions so their geometry samples keep
+    /// refining the feed-forward size calculation.
     ///
     /// - Parameter currentColumns: The current terminal grid column count.
     /// - Parameter currentRows: The current terminal grid row count.

--- a/Packages/macOS/CmuxTerminal/Sources/CmuxTerminal/Surface/TerminalSurfaceResizeCoalescingPolicy.swift
+++ b/Packages/macOS/CmuxTerminal/Sources/CmuxTerminal/Surface/TerminalSurfaceResizeCoalescingPolicy.swift
@@ -1,26 +1,56 @@
-/// Decides whether a surface should defer a same-grid pixel-size update during an interaction.
+/// Decides when a terminal surface may defer a same-grid pixel-size update.
 public struct TerminalSurfaceResizeCoalescingPolicy: Sendable {
+    /// Identifies which side owns the terminal's process and resize protocol.
+    public enum SurfaceKind: Sendable {
+        /// Ghostty owns a child process and its PTY. A pixel-only resize would
+        /// still issue `TIOCSWINSZ` and deliver `SIGWINCH`, even when the cell
+        /// grid is unchanged.
+        case processOwned
+
+        /// cmux supplies the bytes for a remote/manual mirror. Pixel samples
+        /// remain observable outside interactions because they calibrate the
+        /// mirror's feed-forward geometry.
+        case manualIO
+    }
+
     private let windowLiveResizeActive: Bool
     private let interactiveGeometryResizeActive: Bool
     private let bypass: Bool
+    private let surfaceKind: SurfaceKind
 
     /// Creates a policy evaluation for the current resize state.
     ///
     /// - Parameter windowLiveResizeActive: Whether AppKit is tracking a window-edge resize.
     /// - Parameter interactiveGeometryResizeActive: Whether a pane or sidebar geometry transaction is active.
     /// - Parameter bypass: Whether the caller requires the exact candidate size to be applied immediately.
+    /// - Parameter surfaceKind: Whether Ghostty owns a process PTY or cmux is
+    ///   rendering a manual-I/O mirror. Process-owned surfaces coalesce stable
+    ///   grid pixel churn even outside an interaction; manual-I/O surfaces keep
+    ///   their previous interaction-only behavior so geometry calibration sees
+    ///   every applied sample.
     public init(
         windowLiveResizeActive: Bool,
         interactiveGeometryResizeActive: Bool,
-        bypass: Bool
+        bypass: Bool,
+        surfaceKind: SurfaceKind = .processOwned
     ) {
         self.windowLiveResizeActive = windowLiveResizeActive
         self.interactiveGeometryResizeActive = interactiveGeometryResizeActive
         self.bypass = bypass
+        self.surfaceKind = surfaceKind
     }
 
     /// Whether pixel-only surface size changes should be withheld.
     public var shouldCoalescePixelOnlyResize: Bool {
-        (windowLiveResizeActive || interactiveGeometryResizeActive) && !bypass
+        guard !bypass else { return false }
+        switch surfaceKind {
+        case .processOwned:
+            // Ghostty's combined renderer/PTY resize API turns a harmless
+            // pixel jitter into a SIGWINCH. Keep the semantic cell grid
+            // stable until a candidate can actually change that grid.
+            return true
+        case .manualIO:
+            return windowLiveResizeActive || interactiveGeometryResizeActive
+        }
     }
 }

--- a/Packages/macOS/CmuxTerminal/Sources/CmuxTerminal/Surface/TerminalSurfaceResizeCoalescingPolicy.swift
+++ b/Packages/macOS/CmuxTerminal/Sources/CmuxTerminal/Surface/TerminalSurfaceResizeCoalescingPolicy.swift
@@ -32,7 +32,7 @@ public struct TerminalSurfaceResizeCoalescingPolicy: Sendable {
         windowLiveResizeActive: Bool,
         interactiveGeometryResizeActive: Bool,
         bypass: Bool,
-        surfaceKind: SurfaceKind = .processOwned
+        surfaceKind: SurfaceKind
     ) {
         self.windowLiveResizeActive = windowLiveResizeActive
         self.interactiveGeometryResizeActive = interactiveGeometryResizeActive

--- a/Packages/macOS/CmuxTerminal/Tests/CmuxTerminalTests/TerminalSurfaceResizeCoalescingPolicyTests.swift
+++ b/Packages/macOS/CmuxTerminal/Tests/CmuxTerminalTests/TerminalSurfaceResizeCoalescingPolicyTests.swift
@@ -27,4 +27,36 @@ struct TerminalSurfaceResizeCoalescingPolicyTests {
             ).shouldCoalescePixelOnlyResize
         )
     }
+
+    @Test
+    func processOwnedSurfaceCoalescesStableGridPixelChurn() {
+        #expect(
+            TerminalSurfaceResizeCoalescingPolicy(
+                windowLiveResizeActive: false,
+                interactiveGeometryResizeActive: false,
+                bypass: false,
+                surfaceKind: .processOwned
+            ).shouldCoalescePixelOnlyResize
+        )
+    }
+
+    @Test
+    func manualIOSurfaceKeepsInteractionOnlyCoalescing() {
+        #expect(
+            !TerminalSurfaceResizeCoalescingPolicy(
+                windowLiveResizeActive: false,
+                interactiveGeometryResizeActive: false,
+                bypass: false,
+                surfaceKind: .manualIO
+            ).shouldCoalescePixelOnlyResize
+        )
+        #expect(
+            TerminalSurfaceResizeCoalescingPolicy(
+                windowLiveResizeActive: false,
+                interactiveGeometryResizeActive: true,
+                bypass: false,
+                surfaceKind: .manualIO
+            ).shouldCoalescePixelOnlyResize
+        )
+    }
 }

--- a/Packages/macOS/CmuxTerminal/Tests/CmuxTerminalTests/TerminalSurfaceResizeCoalescingPolicyTests.swift
+++ b/Packages/macOS/CmuxTerminal/Tests/CmuxTerminalTests/TerminalSurfaceResizeCoalescingPolicyTests.swift
@@ -9,21 +9,24 @@ struct TerminalSurfaceResizeCoalescingPolicyTests {
             TerminalSurfaceResizeCoalescingPolicy(
                 windowLiveResizeActive: false,
                 interactiveGeometryResizeActive: true,
-                bypass: false
+                bypass: false,
+                surfaceKind: .processOwned
             ).shouldCoalescePixelOnlyResize
         )
         #expect(
             TerminalSurfaceResizeCoalescingPolicy(
                 windowLiveResizeActive: true,
                 interactiveGeometryResizeActive: false,
-                bypass: false
+                bypass: false,
+                surfaceKind: .processOwned
             ).shouldCoalescePixelOnlyResize
         )
         #expect(
             !TerminalSurfaceResizeCoalescingPolicy(
                 windowLiveResizeActive: false,
                 interactiveGeometryResizeActive: true,
-                bypass: true
+                bypass: true,
+                surfaceKind: .processOwned
             ).shouldCoalescePixelOnlyResize
         )
     }
@@ -54,6 +57,14 @@ struct TerminalSurfaceResizeCoalescingPolicyTests {
             TerminalSurfaceResizeCoalescingPolicy(
                 windowLiveResizeActive: false,
                 interactiveGeometryResizeActive: true,
+                bypass: false,
+                surfaceKind: .manualIO
+            ).shouldCoalescePixelOnlyResize
+        )
+        #expect(
+            TerminalSurfaceResizeCoalescingPolicy(
+                windowLiveResizeActive: true,
+                interactiveGeometryResizeActive: false,
                 bypass: false,
                 surfaceKind: .manualIO
             ).shouldCoalescePixelOnlyResize

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -4358,7 +4358,8 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
             coalescePixelOnlyResize: TerminalSurfaceResizeCoalescingPolicy(
                 windowLiveResizeActive: isWindowLiveResizeActive,
                 interactiveGeometryResizeActive: TerminalWindowPortalRegistry.isInteractiveGeometryResizeActive(in: window),
-                bypass: bypassLiveResizeCoalescing
+                bypass: bypassLiveResizeCoalescing,
+                surfaceKind: terminalSurface.ioMode == .exec ? .processOwned : .manualIO
             ).shouldCoalescePixelOnlyResize,
             // Don't pin the surface to the tmux-assigned grid mid-drag: the pin
             // would hold it at the pre-drag (larger) size and paint past the

--- a/cmuxTests/TerminalSurfaceResizePolicyTests.swift
+++ b/cmuxTests/TerminalSurfaceResizePolicyTests.swift
@@ -8,7 +8,8 @@ struct TerminalSurfaceResizePolicyTests {
         let coalesces = TerminalSurfaceResizeCoalescingPolicy(
             windowLiveResizeActive: false,
             interactiveGeometryResizeActive: false,
-            bypass: false
+            bypass: false,
+            surfaceKind: .processOwned
         ).shouldCoalescePixelOnlyResize
 
         #expect(coalesces)

--- a/cmuxTests/TerminalSurfaceResizePolicyTests.swift
+++ b/cmuxTests/TerminalSurfaceResizePolicyTests.swift
@@ -4,6 +4,31 @@ import CmuxTerminal
 @Suite
 struct TerminalSurfaceResizePolicyTests {
     @Test
+    func stableGridPixelChurnIsCoalescedOutsideInteractiveResize() {
+        let coalesces = TerminalSurfaceResizeCoalescingPolicy(
+            windowLiveResizeActive: false,
+            interactiveGeometryResizeActive: false,
+            bypass: false
+        ).shouldCoalescePixelOnlyResize
+
+        #expect(coalesces)
+        #expect(
+            !TerminalSurface.shouldApplySurfacePixelSizeChange(
+                currentColumns: 80,
+                currentRows: 24,
+                currentWidthPx: 800,
+                currentHeightPx: 480,
+                currentCellWidthPx: 10,
+                currentCellHeightPx: 20,
+                targetWidthPx: 805,
+                targetHeightPx: 485,
+                coalescePixelOnlyResize: coalesces,
+                hasAppliedPixelSize: true
+            )
+        )
+    }
+
+    @Test
     func pixelOnlyResizeWithinExistingGridIsCoalesced() {
         #expect(
             !TerminalSurface.shouldApplySurfacePixelSizeChange(


### PR DESCRIPTION
Closes #10129

Issue: https://github.com/manaflow-ai/cmux/issues/10129

## Summary

- coalesce same-cell-grid pixel-only resizes for process-owned Ghostty PTYs, preventing redundant TIOCSWINSZ/SIGWINCH notifications during AppKit layout churn
- preserve exact pixel reporting for manual-I/O remote-tmux mirrors, whose samples calibrate feed-forward sizing
- add a behavior regression for stable-grid pixel churn and keep the test-only reproduction and fix in separate commits

## Investigation

Local tmux 3.6a/3.7b ordinary-client, control-mode, direct+Mosh, and high-frequency size-churn reproductions stayed responsive and below a few percent CPU. The closest matching evidence is upstream tmux/tmux#5455, where macOS tmux 3.7b spins in a select() loop after a dead client. The issue investigation is documented in the linked issue comment.

## Validation

- swift frontend parse checks passed for all touched Swift files
- PBX test-wiring lint passed (687 test files)
- package-resolved policy and workspace package-group checks passed
- no local xcodebuild/tests run, per issue instructions

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/10142"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789266428&installation_model_id=21920&pr_number=10142&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F10142&signature=6f7809d52cfa6b683e696bf1052a92f03414b2c9783718cf8f53834bd34e6396"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Mitigates redundant PTY resize churn by coalescing same-grid, pixel-only resizes for process-owned Ghostty sessions, preventing extra `TIOCSWINSZ`/`SIGWINCH` that can spin tmux clients (fixes #10129). Previously coalescing happened only during live/interactive resize; now process-owned surfaces coalesce always, while manual‑I/O mirrors keep interaction‑only coalescing.

- Adds `TerminalSurfaceResizeCoalescingPolicy.SurfaceKind` with `.processOwned` and `.manualIO`, and makes `surfaceKind` part of the policy decision.
- `GhosttyTerminalView` passes `surfaceKind` from `terminalSurface.ioMode` (`.exec` → `.processOwned`, otherwise `.manualIO`).
- Extends tests to cover stable‑grid pixel churn and both surface kinds.

**Migration**
- Update call sites that construct `TerminalSurfaceResizeCoalescingPolicy` to provide `surfaceKind`.

<sup>Written for commit beb8e011776b8734fa364dbf6a629332079fbe4b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/10142?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Improved terminal resizing for process-backed sessions by coalescing stable, pixel-only size changes.
  - Manual I/O sessions now apply resize coalescing during active interactions while preserving expected behavior outside them.
  - Reduced redundant terminal resize updates and related notifications during steady-state window changes.

- **Bug Fixes**
  - Prevented repeated application of unchanged pixel dimensions during terminal surface resizing.
  - Added coverage to ensure resizing remains consistent across different terminal session types and interaction states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->