### PR TITLE
Fix Dock chrome theme authority mismatch

### DIFF
--- a/Packages/macOS/CmuxAppKitSupportUI/Sources/CmuxAppKitSupportUI/WindowChrome/Appearance/WindowAppearanceResolver.swift
+++ b/Packages/macOS/CmuxAppKitSupportUI/Sources/CmuxAppKitSupportUI/WindowChrome/Appearance/WindowAppearanceResolver.swift
@@ -13,7 +13,7 @@ public struct WindowAppearanceResolver {
 
     /// Resolves window appearance from explicit user settings.
     public func current(settings: WindowAppearanceUserSettingsSnapshot) -> WindowAppearanceSnapshot {
-        WindowAppearanceSnapshot(
+        return WindowAppearanceSnapshot(
             terminalBackgroundColor: terminalAppearance.backgroundColor,
             terminalBackgroundOpacity: WindowAppearanceSnapshot.clampedOpacity(terminalAppearance.backgroundOpacity),
             terminalBackgroundBlur: terminalAppearance.backgroundBlur,
@@ -31,6 +31,8 @@ public struct WindowAppearanceResolver {
                 tintOpacity: settings.sidebarTintOpacity,
                 cornerRadius: settings.sidebarCornerRadius,
                 blurOpacity: settings.sidebarBlurOpacity,
+                // The snapshot initializer replaces this compatibility value
+                // with the terminal authority below.
                 colorScheme: settings.colorScheme
             ),
             windowGlassSettings: WindowGlassSettingsSnapshot(
@@ -42,19 +44,23 @@ public struct WindowAppearanceResolver {
                 terminalGlassTintColor: terminalAppearance.backgroundColor.withAlphaComponent(
                     WindowAppearanceSnapshot.clampedOpacity(terminalAppearance.backgroundOpacity)
                 )
-            )
+            ),
+            resolvedColorScheme: terminalAppearance.resolvedColorScheme
         )
     }
 
     /// Resolves window appearance from a `UserDefaults` store.
     public func currentFromUserDefaults(
         defaults: UserDefaults,
-        colorScheme: ColorScheme
+        colorScheme: ColorScheme? = nil
     ) -> WindowAppearanceSnapshot {
         let tintDefaults = WindowChromeSidebarTintDefaults()
         return current(settings: WindowAppearanceUserSettingsSnapshot(
             unifySurfaceBackdrops: defaults.object(forKey: "sidebarMatchTerminalBackground") as? Bool ?? false,
-            colorScheme: colorScheme,
+            // `colorScheme` remains an API-compatible fallback for callers
+            // that build settings snapshots themselves. The snapshot
+            // normalizes it to the terminal-derived authority above.
+            colorScheme: colorScheme ?? .light,
             sidebarMaterial: defaults.string(forKey: "sidebarMaterial") ?? WindowChromeSidebarMaterialOption.sidebar.rawValue,
             sidebarBlendMode: defaults.string(forKey: "sidebarBlendMode") ?? WindowChromeSidebarBlendModeOption.withinWindow.rawValue,
             sidebarState: defaults.string(forKey: "sidebarState") ?? WindowChromeSidebarStateOption.followWindow.rawValue,

--- a/Packages/macOS/CmuxAppKitSupportUI/Sources/CmuxAppKitSupportUI/WindowChrome/Appearance/WindowAppearanceSnapshot.swift
+++ b/Packages/macOS/CmuxAppKitSupportUI/Sources/CmuxAppKitSupportUI/WindowChrome/Appearance/WindowAppearanceSnapshot.swift
@@ -26,6 +26,13 @@ public struct WindowAppearanceSnapshot {
     /// Resolved window glass settings.
     public let windowGlassSettings: WindowGlassSettingsSnapshot
 
+    /// The single light/dark decision used by window, Dock, and sidebar chrome.
+    ///
+    /// This is captured from the resolved terminal theme rather than from
+    /// AppKit's ambient appearance. Keeping it in the snapshot makes every
+    /// dependent surface consume the same answer for a render pass.
+    public let resolvedColorScheme: ColorScheme
+
     /// Creates a resolved window appearance snapshot.
     public init(
         terminalBackgroundColor: NSColor,
@@ -34,20 +41,78 @@ public struct WindowAppearanceSnapshot {
         terminalRenderingMode: GhosttyTerminalBackdropRenderingMode,
         unifySurfaceBackdrops: Bool,
         sidebarSettings: SidebarBackdropSettingsSnapshot,
-        windowGlassSettings: WindowGlassSettingsSnapshot
+        windowGlassSettings: WindowGlassSettingsSnapshot,
+        resolvedColorScheme: ColorScheme? = nil
     ) {
+        let resolvedScheme = resolvedColorScheme ?? Self.colorScheme(
+            forTerminalBackgroundColor: terminalBackgroundColor,
+            opacity: Double(Self.clampedOpacity(Double(terminalBackgroundOpacity)))
+        )
         self.terminalBackgroundColor = terminalBackgroundColor
         self.terminalBackgroundOpacity = terminalBackgroundOpacity
         self.terminalBackgroundBlur = terminalBackgroundBlur
         self.terminalRenderingMode = terminalRenderingMode
         self.unifySurfaceBackdrops = unifySurfaceBackdrops
-        self.sidebarSettings = sidebarSettings
+        self.sidebarSettings = SidebarBackdropSettingsSnapshot(
+            materialRawValue: sidebarSettings.materialRawValue,
+            blendModeRawValue: sidebarSettings.blendModeRawValue,
+            stateRawValue: sidebarSettings.stateRawValue,
+            tintHex: sidebarSettings.tintHex,
+            tintHexLight: sidebarSettings.tintHexLight,
+            tintHexDark: sidebarSettings.tintHexDark,
+            tintOpacity: sidebarSettings.tintOpacity,
+            cornerRadius: sidebarSettings.cornerRadius,
+            blurOpacity: sidebarSettings.blurOpacity,
+            colorScheme: resolvedScheme
+        )
         self.windowGlassSettings = windowGlassSettings
+        self.resolvedColorScheme = resolvedScheme
     }
 
     /// Clamps opacity into the visible `0...1` range.
     public static func clampedOpacity(_ opacity: Double) -> CGFloat {
         CGFloat(max(0.0, min(1.0, opacity)))
+    }
+
+    /// Resolves the light/dark decision for the rendered terminal backdrop.
+    public static func colorScheme(
+        forTerminalBackgroundColor backgroundColor: NSColor,
+        opacity: Double
+    ) -> ColorScheme {
+        WindowChromeColorResolver().readableColorScheme(
+            for: compositedTerminalColor(
+                backgroundColor: backgroundColor,
+                opacity: opacity
+            )
+        )
+    }
+
+    /// Returns the concrete AppKit appearance matching a resolved scheme.
+    ///
+    /// AppKit semantic colors resolve against a view's effective appearance;
+    /// callers hosting native subtrees should assign this appearance at their
+    /// root instead of allowing each descendant to consult the window cascade.
+    public static func appKitAppearance(for colorScheme: ColorScheme) -> NSAppearance {
+        NSAppearance(named: colorScheme == .dark ? .darkAqua : .aqua)
+            ?? NSAppearance(named: .aqua)!
+    }
+
+    /// Composites a terminal background over the concrete window base for a
+    /// resolved cmux scheme. Native chrome should use this instead of the
+    /// ambient ``NSColor.windowBackgroundColor`` when the system appearance
+    /// and terminal theme intentionally differ.
+    public static func resolvedChromeBackgroundColor(
+        backgroundColor: NSColor,
+        opacity: Double,
+        colorScheme: ColorScheme
+    ) -> NSColor {
+        let appearance = appKitAppearance(for: colorScheme)
+        let baseColor = NSColor.windowBackgroundColor.resolvedColor(with: appearance)
+        return compositedTerminalColor(
+            backgroundColor: backgroundColor,
+            opacity: opacity,
+            over: baseColor
+        )
     }
 
     /// Returns `backgroundColor` composited over `baseColor` with the given opacity.
@@ -73,18 +138,33 @@ public struct WindowAppearanceSnapshot {
     public var compositedTerminalBackgroundColor: NSColor {
         Self.compositedTerminalColor(
             backgroundColor: terminalBackgroundColor,
-            opacity: Double(terminalBackgroundOpacity)
+            opacity: Double(Self.clampedOpacity(Double(terminalBackgroundOpacity)))
+        )
+    }
+
+    /// Terminal background composited over a concrete light/dark window base.
+    ///
+    /// This is for chrome surfaces that must follow the resolved terminal theme
+    /// even when the host window's ambient appearance disagrees. The ordinary
+    /// ``compositedTerminalBackgroundColor`` remains the actual window-backdrop
+    /// calculation; this value is the stable color input for Dock/Bonsplit
+    /// chrome and other detached native surfaces.
+    public var resolvedChromeBackgroundColor: NSColor {
+        Self.resolvedChromeBackgroundColor(
+            backgroundColor: terminalBackgroundColor,
+            opacity: Double(Self.clampedOpacity(Double(terminalBackgroundOpacity))),
+            colorScheme: resolvedColorScheme
         )
     }
 
     /// Color scheme readable against the chrome background.
     public var chromeColorScheme: ColorScheme {
-        WindowChromeColorResolver().readableColorScheme(for: compositedTerminalBackgroundColor)
+        resolvedColorScheme
     }
 
-    /// Color scheme used for sidebar content.
+    /// Color scheme used for sidebar content and Dock chrome.
     public var sidebarContentColorScheme: ColorScheme {
-        unifySurfaceBackdrops ? chromeColorScheme : sidebarSettings.colorScheme
+        resolvedColorScheme
     }
 
     /// Returns the backdrop policy for one chrome role.

--- a/Packages/macOS/CmuxAppKitSupportUI/Sources/CmuxAppKitSupportUI/WindowChrome/Appearance/WindowAppearanceSnapshot.swift
+++ b/Packages/macOS/CmuxAppKitSupportUI/Sources/CmuxAppKitSupportUI/WindowChrome/Appearance/WindowAppearanceSnapshot.swift
@@ -97,6 +97,22 @@ public struct WindowAppearanceSnapshot {
             ?? NSAppearance(named: .aqua)!
     }
 
+    /// Resolves an AppKit semantic color against a concrete cmux scheme.
+    /// AppKit does not expose UIKit's `resolvedColor(with:)`; resolving under
+    /// `performAsCurrentDrawingAppearance` is the supported way to snapshot a
+    /// dynamic `NSColor` for a detached/native hosting subtree.
+    public static func resolvedColor(
+        _ color: NSColor,
+        for colorScheme: ColorScheme
+    ) -> NSColor {
+        let appearance = appKitAppearance(for: colorScheme)
+        var resolved = color
+        appearance.performAsCurrentDrawingAppearance {
+            resolved = color.usingColorSpace(.sRGB) ?? color
+        }
+        return resolved
+    }
+
     /// Composites a terminal background over the concrete window base for a
     /// resolved cmux scheme. Native chrome should use this instead of the
     /// ambient ``NSColor.windowBackgroundColor`` when the system appearance
@@ -106,8 +122,7 @@ public struct WindowAppearanceSnapshot {
         opacity: Double,
         colorScheme: ColorScheme
     ) -> NSColor {
-        let appearance = appKitAppearance(for: colorScheme)
-        let baseColor = NSColor.windowBackgroundColor.resolvedColor(with: appearance)
+        let baseColor = resolvedColor(.windowBackgroundColor, for: colorScheme)
         return compositedTerminalColor(
             backgroundColor: backgroundColor,
             opacity: opacity,

--- a/Packages/macOS/CmuxAppKitSupportUI/Sources/CmuxAppKitSupportUI/WindowChrome/Appearance/WindowAppearanceUserSettingsSnapshot.swift
+++ b/Packages/macOS/CmuxAppKitSupportUI/Sources/CmuxAppKitSupportUI/WindowChrome/Appearance/WindowAppearanceUserSettingsSnapshot.swift
@@ -5,7 +5,9 @@ public struct WindowAppearanceUserSettingsSnapshot {
     /// Whether sidebars share the terminal root backdrop.
     public let unifySurfaceBackdrops: Bool
 
-    /// Color scheme selected for sidebar tint resolution.
+    /// Ambient color-scheme fallback retained for settings compatibility.
+    /// ``WindowAppearanceSnapshot`` resolves chrome from the terminal backdrop
+    /// instead, so this value never overrides the shared authority.
     public let colorScheme: ColorScheme
 
     /// Raw `sidebarMaterial` value.

--- a/Packages/macOS/CmuxAppKitSupportUI/Sources/CmuxAppKitSupportUI/WindowChrome/Appearance/WindowTerminalAppearanceSnapshot.swift
+++ b/Packages/macOS/CmuxAppKitSupportUI/Sources/CmuxAppKitSupportUI/WindowChrome/Appearance/WindowTerminalAppearanceSnapshot.swift
@@ -1,4 +1,5 @@
 public import AppKit
+public import SwiftUI
 public import CmuxFoundation
 
 /// Current terminal appearance values needed by window chrome policy.
@@ -15,16 +16,27 @@ public struct WindowTerminalAppearanceSnapshot {
     /// Whether terminal host layers own background fills.
     public let usesHostLayerBackground: Bool
 
+    /// The light/dark scheme selected by the resolved terminal theme.
+    ///
+    /// This is captured at the composition boundary so window chrome does not
+    /// need to infer a second answer from AppKit's ambient appearance. The
+    /// optional initializer argument keeps older callers source-compatible;
+    /// callers that do not have the terminal preference fall back to the
+    /// rendered background's readable scheme.
+    public let resolvedColorScheme: ColorScheme?
+
     /// Creates a terminal appearance snapshot.
     public init(
         backgroundColor: NSColor,
         backgroundOpacity: Double,
         backgroundBlur: GhosttyBackgroundBlur,
-        usesHostLayerBackground: Bool
+        usesHostLayerBackground: Bool,
+        resolvedColorScheme: ColorScheme? = nil
     ) {
         self.backgroundColor = backgroundColor
         self.backgroundOpacity = backgroundOpacity
         self.backgroundBlur = backgroundBlur
         self.usesHostLayerBackground = usesHostLayerBackground
+        self.resolvedColorScheme = resolvedColorScheme
     }
 }

--- a/Packages/macOS/CmuxAppKitSupportUI/Sources/CmuxAppKitSupportUI/WindowChrome/Border/WindowChromeBorder.swift
+++ b/Packages/macOS/CmuxAppKitSupportUI/Sources/CmuxAppKitSupportUI/WindowChrome/Border/WindowChromeBorder.swift
@@ -3,6 +3,9 @@ public import SwiftUI
 
 /// One-pixel border derived from the terminal chrome background.
 public struct WindowChromeBorder: View {
+    private static let systemAppearanceDidChangeNotification = Notification.Name(
+        "cmux.systemAppearanceDidChange"
+    )
     private let orientation: WindowChromeBorderOrientation
     private let ignoresSafeAreaValue: Bool
     private let backgroundColorProvider: @MainActor () -> NSColor
@@ -38,6 +41,14 @@ public struct WindowChromeBorder: View {
     private var border: some View {
         let base = borderShape
             .onAppear {
+                refreshSeparatorColor()
+            }
+            // The provider resolves against the shared cmux theme authority,
+            // so a system-mode theme change must repaint even when the
+            // terminal background hex itself did not change.
+            .onReceive(NotificationCenter.default.publisher(
+                for: Self.systemAppearanceDidChangeNotification
+            )) { _ in
                 refreshSeparatorColor()
             }
 

--- a/Packages/macOS/CmuxAppKitSupportUI/Sources/CmuxAppKitSupportUI/WindowChrome/Border/WindowChromeBorder.swift
+++ b/Packages/macOS/CmuxAppKitSupportUI/Sources/CmuxAppKitSupportUI/WindowChrome/Border/WindowChromeBorder.swift
@@ -3,28 +3,25 @@ public import SwiftUI
 
 /// One-pixel border derived from the terminal chrome background.
 public struct WindowChromeBorder: View {
-    private static let systemAppearanceDidChangeNotification = Notification.Name(
-        "cmux.systemAppearanceDidChange"
-    )
     private let orientation: WindowChromeBorderOrientation
     private let ignoresSafeAreaValue: Bool
-    private let backgroundColorProvider: @MainActor () -> NSColor
-    private let refreshNotificationName: Notification.Name?
-    @State private var separatorColor: NSColor
+    private let separatorColor: NSColor
 
-    /// Creates a chrome border with an injected background color provider.
+    /// Creates a chrome border from an already-resolved chrome background.
+    ///
+    /// - Parameters:
+    ///   - orientation: The axis along which the one-pixel border extends.
+    ///   - ignoresSafeArea: Whether the border extends through safe-area insets.
+    ///   - backgroundColor: The concrete background resolved by the window appearance snapshot.
     public init(
         orientation: WindowChromeBorderOrientation,
         ignoresSafeArea: Bool = true,
-        refreshNotificationName: Notification.Name? = nil,
-        backgroundColorProvider: @escaping @MainActor () -> NSColor
+        backgroundColor: NSColor
     ) {
         self.orientation = orientation
         self.ignoresSafeAreaValue = ignoresSafeArea
-        self.refreshNotificationName = refreshNotificationName
-        self.backgroundColorProvider = backgroundColorProvider
-        _separatorColor = State(
-            initialValue: WindowChromeColorResolver().separatorColor(forChromeBackground: backgroundColorProvider())
+        self.separatorColor = WindowChromeColorResolver().separatorColor(
+            forChromeBackground: backgroundColor
         )
     }
 
@@ -39,26 +36,7 @@ public struct WindowChromeBorder: View {
 
     @ViewBuilder
     private var border: some View {
-        let base = borderShape
-            .onAppear {
-                refreshSeparatorColor()
-            }
-            // The provider resolves against the shared cmux theme authority,
-            // so a system-mode theme change must repaint even when the
-            // terminal background hex itself did not change.
-            .onReceive(NotificationCenter.default.publisher(
-                for: Self.systemAppearanceDidChangeNotification
-            )) { _ in
-                refreshSeparatorColor()
-            }
-
-        if let refreshNotificationName {
-            base.onReceive(NotificationCenter.default.publisher(for: refreshNotificationName)) { _ in
-                refreshSeparatorColor()
-            }
-        } else {
-            base
-        }
+        borderShape
     }
 
     private var borderShape: some View {
@@ -74,8 +52,4 @@ public struct WindowChromeBorder: View {
             )
     }
 
-    private func refreshSeparatorColor() {
-        separatorColor = WindowChromeColorResolver()
-            .separatorColor(forChromeBackground: backgroundColorProvider())
-    }
 }

--- a/Packages/macOS/CmuxAppKitSupportUI/Tests/CmuxAppKitSupportUITests/WindowChrome/Appearance/WindowAppearanceResolverTests.swift
+++ b/Packages/macOS/CmuxAppKitSupportUI/Tests/CmuxAppKitSupportUITests/WindowChrome/Appearance/WindowAppearanceResolverTests.swift
@@ -28,6 +28,8 @@ import Testing
         #expect(snapshot.terminalRenderingMode == .windowHostBackdrop)
         #expect(snapshot.terminalBackgroundOpacity == 0.72)
         #expect(snapshot.sidebarContentColorScheme == .dark)
+        #expect(snapshot.resolvedColorScheme == snapshot.chromeColorScheme)
+        #expect(snapshot.sidebarSettings.colorScheme == snapshot.resolvedColorScheme)
 
         guard case let .sidebarMaterial(sidebarPolicy) = snapshot.policy(for: .leftSidebar) else {
             Issue.record("Expected separate left sidebar material policy")
@@ -43,6 +45,67 @@ import Testing
         #expect(plan.hostingPhase == .windowGlass)
         #expect(plan.usesWindowGlass)
         #expect(plan.glass?.style == .regular)
+    }
+
+    @Test(arguments: [
+        ("#F8F8F2", ColorScheme.light),
+        ("#101820", ColorScheme.dark),
+    ])
+    func resolverUsesOneTerminalSchemeForSeparateSidebar(
+        backgroundHex: String,
+        expectedScheme: ColorScheme
+    ) {
+        let resolver = WindowAppearanceResolver(
+            terminalAppearance: WindowTerminalAppearanceSnapshot(
+                backgroundColor: NSColor(hex: backgroundHex) ?? .black,
+                backgroundOpacity: 1,
+                backgroundBlur: .disabled,
+                usesHostLayerBackground: true
+            )
+        )
+        let snapshot = resolver.current(settings: makeSettings(
+            unifySurfaceBackdrops: false,
+            sidebarBlendMode: "withinWindow",
+            sidebarTintHexDark: "#FF0000",
+            bgGlassEnabled: false
+        ))
+
+        #expect(snapshot.resolvedColorScheme == expectedScheme)
+        #expect(snapshot.chromeColorScheme == expectedScheme)
+        #expect(snapshot.sidebarContentColorScheme == expectedScheme)
+        #expect(snapshot.sidebarSettings.colorScheme == expectedScheme)
+    }
+
+    @Test(arguments: [
+        (ColorScheme.light, ColorScheme.light),
+        (ColorScheme.light, ColorScheme.dark),
+        (ColorScheme.dark, ColorScheme.light),
+        (ColorScheme.dark, ColorScheme.dark),
+    ])
+    func resolverPropagatesOneInjectedTerminalAuthority(
+        terminalScheme: ColorScheme,
+        ambientScheme: ColorScheme
+    ) {
+        let resolver = WindowAppearanceResolver(
+            terminalAppearance: WindowTerminalAppearanceSnapshot(
+                backgroundColor: NSColor(hex: terminalScheme == .dark ? "#101820" : "#F8F8F2") ?? .black,
+                backgroundOpacity: 0.35,
+                backgroundBlur: .disabled,
+                usesHostLayerBackground: true,
+                resolvedColorScheme: terminalScheme
+            )
+        )
+        let snapshot = resolver.current(settings: makeSettings(
+            unifySurfaceBackdrops: false,
+            sidebarBlendMode: "withinWindow",
+            bgGlassEnabled: false,
+            colorScheme: ambientScheme
+        ))
+
+        #expect(snapshot.resolvedColorScheme == terminalScheme)
+        #expect(snapshot.chromeColorScheme == terminalScheme)
+        #expect(snapshot.sidebarContentColorScheme == terminalScheme)
+        #expect(snapshot.sidebarSettings.colorScheme == terminalScheme)
     }
 
     @Test func ghosttyMacOSGlassStyleForcesClearRootAndTerminalTintedGlass() {
@@ -80,11 +143,12 @@ import Testing
         sidebarBlendMode: String,
         sidebarTintHexDark: String? = nil,
         sidebarTintOpacity: Double = WindowChromeSidebarTintDefaults().opacity,
-        bgGlassEnabled: Bool
+        bgGlassEnabled: Bool,
+        colorScheme: ColorScheme = .dark
     ) -> WindowAppearanceUserSettingsSnapshot {
         WindowAppearanceUserSettingsSnapshot(
             unifySurfaceBackdrops: unifySurfaceBackdrops,
-            colorScheme: .dark,
+            colorScheme: colorScheme,
             sidebarMaterial: WindowChromeSidebarMaterialOption.sidebar.rawValue,
             sidebarBlendMode: sidebarBlendMode,
             sidebarState: WindowChromeSidebarStateOption.followWindow.rawValue,

--- a/Sources/CMUXSidebarExtensionBrowserPanel.swift
+++ b/Sources/CMUXSidebarExtensionBrowserPanel.swift
@@ -143,6 +143,9 @@ private final class CMUXSidebarExtensionBrowserContainerViewController: NSViewCo
         guard appliedColorScheme != colorScheme || rootView.appearance == nil else { return }
         appliedColorScheme = colorScheme
         rootView.appearance = WindowAppearanceSnapshot.appKitAppearance(for: colorScheme)
+        if browserViewController.isViewLoaded {
+            browserViewController.view.appearance = rootView.appearance
+        }
         cardView.layer?.backgroundColor = cardBackgroundColor.cgColor
         cardView.layer?.borderColor = cardBorderColor.cgColor
         compactLabel.textColor = WindowAppearanceSnapshot.resolvedColor(

--- a/Sources/CMUXSidebarExtensionBrowserPanel.swift
+++ b/Sources/CMUXSidebarExtensionBrowserPanel.swift
@@ -1,5 +1,6 @@
 @_spi(CmuxHostTransport) import CmuxSidebar
 import AppKit
+import CmuxAppKitSupportUI
 import CmuxFoundation
 import SwiftUI
 
@@ -38,12 +39,15 @@ final class CMUXSidebarExtensionBrowserPanel: NSObject, Panel, ObservableObject 
 struct CMUXSidebarExtensionBrowserPanelView: NSViewControllerRepresentable {
     let panel: CMUXSidebarExtensionBrowserPanel
     let onRequestPanelFocus: () -> Void
+    @Environment(\.colorScheme) private var colorScheme
 
     func makeNSViewController(context: Context) -> NSViewController {
-        CMUXSidebarExtensionBrowserContainerViewController(
+        let controller = CMUXSidebarExtensionBrowserContainerViewController(
             browserViewController: panel.browserViewController,
             onRequestPanelFocus: onRequestPanelFocus
         )
+        controller.applyResolvedColorScheme(colorScheme)
+        return controller
     }
 
     func updateNSViewController(_ nsViewController: NSViewController, context: Context) {
@@ -52,6 +56,7 @@ struct CMUXSidebarExtensionBrowserPanelView: NSViewControllerRepresentable {
         }
         container.browserViewController.title = panel.displayTitle
         container.onRequestPanelFocus = onRequestPanelFocus
+        container.applyResolvedColorScheme(colorScheme)
         container.attachBrowserIfNeeded()
         container.updateLayoutForCurrentBounds()
     }
@@ -105,6 +110,7 @@ private final class CMUXSidebarExtensionBrowserContainerViewController: NSViewCo
 
     let browserViewController: NSViewController
     var onRequestPanelFocus: () -> Void
+    private var appliedColorScheme: ColorScheme = .light
 
     private let rootView = RootView(frame: .zero)
     private let cardView = FocusCardView(frame: .zero)
@@ -133,6 +139,17 @@ private final class CMUXSidebarExtensionBrowserContainerViewController: NSViewCo
         fatalError("init(coder:) has not been implemented")
     }
 
+    func applyResolvedColorScheme(_ colorScheme: ColorScheme) {
+        guard appliedColorScheme != colorScheme || rootView.appearance == nil else { return }
+        appliedColorScheme = colorScheme
+        let appearance = WindowAppearanceSnapshot.appKitAppearance(for: colorScheme)
+        rootView.appearance = appearance
+        cardView.layer?.backgroundColor = cardBackgroundColor.cgColor
+        cardView.layer?.borderColor = cardBorderColor.cgColor
+        compactLabel.textColor = NSColor.secondaryLabelColor.resolvedColor(with: appearance)
+        rootView.needsDisplay = true
+    }
+
     override func loadView() {
         rootView.wantsLayer = true
         rootView.layer?.backgroundColor = NSColor.clear.cgColor
@@ -149,11 +166,11 @@ private final class CMUXSidebarExtensionBrowserContainerViewController: NSViewCo
 
         cardView.translatesAutoresizingMaskIntoConstraints = false
         cardView.wantsLayer = true
-        cardView.layer?.backgroundColor = Self.cardBackgroundColor.cgColor
+        cardView.layer?.backgroundColor = cardBackgroundColor.cgColor
         cardView.layer?.cornerRadius = Self.cornerRadius
         cardView.layer?.cornerCurve = .continuous
         cardView.layer?.borderWidth = 1
-        cardView.layer?.borderColor = Self.cardBorderColor.cgColor
+        cardView.layer?.borderColor = cardBorderColor.cgColor
         cardView.layer?.masksToBounds = true
         cardView.onMouseDown = { [weak self] in
             self?.onRequestPanelFocus()
@@ -166,7 +183,8 @@ private final class CMUXSidebarExtensionBrowserContainerViewController: NSViewCo
         compactLabel.translatesAutoresizingMaskIntoConstraints = false
         compactLabel.alignment = .center
         applyFonts()
-        compactLabel.textColor = .secondaryLabelColor
+        compactLabel.textColor = NSColor.secondaryLabelColor.resolvedColor(with: rootView.appearance
+            ?? WindowAppearanceSnapshot.appKitAppearance(for: appliedColorScheme))
         compactLabel.maximumNumberOfLines = 0
         compactLabel.lineBreakMode = .byWordWrapping
         compactLabel.cell?.wraps = true
@@ -249,6 +267,7 @@ private final class CMUXSidebarExtensionBrowserContainerViewController: NSViewCo
         }
 
         browserViewController.view.wantsLayer = true
+        browserViewController.view.appearance = rootView.appearance
         browserViewController.view.layer?.cornerRadius = Self.cornerRadius
         browserViewController.view.layer?.cornerCurve = .continuous
         browserViewController.view.layer?.masksToBounds = true
@@ -274,8 +293,8 @@ private final class CMUXSidebarExtensionBrowserContainerViewController: NSViewCo
         cardHorizontalSafetyConstraints.first?.constant = horizontalInset
         cardHorizontalSafetyConstraints.dropFirst().first?.constant = -horizontalInset
 
-        cardView.layer?.backgroundColor = Self.cardBackgroundColor.cgColor
-        cardView.layer?.borderColor = Self.cardBorderColor.cgColor
+        cardView.layer?.backgroundColor = cardBackgroundColor.cgColor
+        cardView.layer?.borderColor = cardBorderColor.cgColor
         cardView.layer?.cornerRadius = Self.cornerRadius
         browserViewController.view.layer?.cornerRadius = Self.cornerRadius
         let isCompact = visibleBounds.width < Self.minimumUsableWidth ||
@@ -309,10 +328,12 @@ private final class CMUXSidebarExtensionBrowserContainerViewController: NSViewCo
     private static let minimumUsableWidth: CGFloat = 600
     private static let minimumUsableHeight: CGFloat = 420
     private static let cornerRadius: CGFloat = 8
-    private static var cardBackgroundColor: NSColor {
-        NSColor.windowBackgroundColor.withAlphaComponent(0.92)
+    private var cardBackgroundColor: NSColor {
+        let appearance = rootView.appearance ?? WindowAppearanceSnapshot.appKitAppearance(for: appliedColorScheme)
+        return NSColor.windowBackgroundColor.resolvedColor(with: appearance).withAlphaComponent(0.92)
     }
-    private static var cardBorderColor: NSColor {
-        NSColor.separatorColor.withAlphaComponent(0.45)
+    private var cardBorderColor: NSColor {
+        let appearance = rootView.appearance ?? WindowAppearanceSnapshot.appKitAppearance(for: appliedColorScheme)
+        return NSColor.separatorColor.resolvedColor(with: appearance).withAlphaComponent(0.45)
     }
 }

--- a/Sources/CMUXSidebarExtensionBrowserPanel.swift
+++ b/Sources/CMUXSidebarExtensionBrowserPanel.swift
@@ -142,11 +142,13 @@ private final class CMUXSidebarExtensionBrowserContainerViewController: NSViewCo
     func applyResolvedColorScheme(_ colorScheme: ColorScheme) {
         guard appliedColorScheme != colorScheme || rootView.appearance == nil else { return }
         appliedColorScheme = colorScheme
-        let appearance = WindowAppearanceSnapshot.appKitAppearance(for: colorScheme)
-        rootView.appearance = appearance
+        rootView.appearance = WindowAppearanceSnapshot.appKitAppearance(for: colorScheme)
         cardView.layer?.backgroundColor = cardBackgroundColor.cgColor
         cardView.layer?.borderColor = cardBorderColor.cgColor
-        compactLabel.textColor = NSColor.secondaryLabelColor.resolvedColor(with: appearance)
+        compactLabel.textColor = WindowAppearanceSnapshot.resolvedColor(
+            .secondaryLabelColor,
+            for: colorScheme
+        )
         rootView.needsDisplay = true
     }
 
@@ -183,8 +185,10 @@ private final class CMUXSidebarExtensionBrowserContainerViewController: NSViewCo
         compactLabel.translatesAutoresizingMaskIntoConstraints = false
         compactLabel.alignment = .center
         applyFonts()
-        compactLabel.textColor = NSColor.secondaryLabelColor.resolvedColor(with: rootView.appearance
-            ?? WindowAppearanceSnapshot.appKitAppearance(for: appliedColorScheme))
+        compactLabel.textColor = WindowAppearanceSnapshot.resolvedColor(
+            .secondaryLabelColor,
+            for: appliedColorScheme
+        )
         compactLabel.maximumNumberOfLines = 0
         compactLabel.lineBreakMode = .byWordWrapping
         compactLabel.cell?.wraps = true
@@ -329,11 +333,15 @@ private final class CMUXSidebarExtensionBrowserContainerViewController: NSViewCo
     private static let minimumUsableHeight: CGFloat = 420
     private static let cornerRadius: CGFloat = 8
     private var cardBackgroundColor: NSColor {
-        let appearance = rootView.appearance ?? WindowAppearanceSnapshot.appKitAppearance(for: appliedColorScheme)
-        return NSColor.windowBackgroundColor.resolvedColor(with: appearance).withAlphaComponent(0.92)
+        return WindowAppearanceSnapshot.resolvedColor(
+            .windowBackgroundColor,
+            for: appliedColorScheme
+        ).withAlphaComponent(0.92)
     }
     private var cardBorderColor: NSColor {
-        let appearance = rootView.appearance ?? WindowAppearanceSnapshot.appKitAppearance(for: appliedColorScheme)
-        return NSColor.separatorColor.resolvedColor(with: appearance).withAlphaComponent(0.45)
+        return WindowAppearanceSnapshot.resolvedColor(
+            .separatorColor,
+            for: appliedColorScheme
+        ).withAlphaComponent(0.45)
     }
 }

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -1755,6 +1755,7 @@ struct ContentView: View {
                 )
             },
             observedWindowReference: observedWindowReference,
+            chromeBackgroundColor: windowAppearanceSnapshot.resolvedChromeBackgroundColor,
             selection: $sidebarSelectionState.selection,
             selectedTabIds: $selectedTabIds, lastSidebarSelectionIndex: $lastSidebarSelectionIndex, sidebarRenderWorkerClient: $sidebarRenderWorkerClient
         )
@@ -1977,8 +1978,7 @@ struct ContentView: View {
             if rightSidebarVisible {
                 WindowChromeBorder(
                     orientation: .vertical,
-                    refreshNotificationName: .ghosttyDefaultBackgroundDidChange,
-                    backgroundColorProvider: { GhosttyBackgroundTheme.currentColor() }
+                    backgroundColor: appearance.resolvedChromeBackgroundColor
                 )
             }
         }
@@ -2206,8 +2206,7 @@ struct ContentView: View {
             SidebarWidthReader(layout: sidebarLayout) { width in
                 WindowChromeBorder(
                     orientation: .horizontal,
-                    refreshNotificationName: .ghosttyDefaultBackgroundDidChange,
-                    backgroundColorProvider: { GhosttyBackgroundTheme.currentColor() }
+                    backgroundColor: appearance.resolvedChromeBackgroundColor
                 )
                     .padding(.leading, sidebarState.isVisible ? width : 0)
             }
@@ -3826,9 +3825,9 @@ struct ContentView: View {
             TextField(placeholder, text: text)
                 .textFieldStyle(.plain)
                 .cmuxFont(size: 13, weight: .regular)
-                .tint(Color(nsColor: sidebarActiveForegroundNSColor(
+                .tint(Color(nsColor: SidebarAppearanceColorResolver().activeForegroundColor(
                     opacity: 1.0,
-                    colorScheme: windowAppearanceSnapshot.resolvedColorScheme
+                    for: windowAppearanceSnapshot.resolvedColorScheme
                 )))
                 .focused(focus)
                 .accessibilityIdentifier(accessibilityIdentifier)
@@ -10866,6 +10865,7 @@ struct VerticalTabsSidebar: View, Equatable {
             && lhs.sidebarUnread === rhs.sidebarUnread
             && lhs.titlebarControlsLayoutModel === rhs.titlebarControlsLayoutModel
             && lhs.isPresented == rhs.isPresented
+            && lhs.chromeBackgroundColor.isEqual(rhs.chromeBackgroundColor)
     }
 
     var updateViewModel: UpdateStateModel
@@ -10879,6 +10879,7 @@ struct VerticalTabsSidebar: View, Equatable {
     let onToggleSidebar: () -> Void
     let onNewTab: () -> Void
     let observedWindowReference: WeakWindowReference
+    let chromeBackgroundColor: NSColor
     var observedWindow: NSWindow? { observedWindowReference.window }
     @EnvironmentObject var tabManager: TabManager
     // Plain reference by design. Native row and titlebar subscribers own the
@@ -11404,8 +11405,7 @@ struct VerticalTabsSidebar: View, Equatable {
         .overlay(alignment: .trailing) {
             WindowChromeBorder(
                 orientation: .vertical,
-                refreshNotificationName: .ghosttyDefaultBackgroundDidChange,
-                backgroundColorProvider: { GhosttyBackgroundTheme.currentColor() }
+                backgroundColor: chromeBackgroundColor
             )
         }
         .background(

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -3826,7 +3826,10 @@ struct ContentView: View {
             TextField(placeholder, text: text)
                 .textFieldStyle(.plain)
                 .cmuxFont(size: 13, weight: .regular)
-                .tint(Color(nsColor: sidebarActiveForegroundNSColor(opacity: 1.0)))
+                .tint(Color(nsColor: sidebarActiveForegroundNSColor(
+                    opacity: 1.0,
+                    colorScheme: windowAppearanceSnapshot.resolvedColorScheme
+                )))
                 .focused(focus)
                 .accessibilityIdentifier(accessibilityIdentifier)
                 .backport.onKeyPress(.delete) { modifiers in
@@ -12156,6 +12159,7 @@ struct VerticalTabsSidebar: View, Equatable {
             allRemoteContextMenuTargetsDisconnected: rowSnapshot.contextMenu.allRemoteTargetsDisconnected,
             contextMenuPinState: rowSnapshot.contextMenu.pinState,
             workspaceGroupMenuSnapshot: rowSnapshot.contextMenu.groupMenuSnapshot,
+            colorScheme: environment.colorScheme,
             refreshSnapshot: { [workspaceId = tab.id] in
                 scheduleWorkspaceSnapshotRefresh(workspaceId: workspaceId)
             },

--- a/Sources/DockPanelView.swift
+++ b/Sources/DockPanelView.swift
@@ -54,9 +54,17 @@ struct DockPanelView: View {
         PanelAppearance.fromConfig(appearanceConfig)
     }
 
+    private var resolvedChromeBackgroundIdentity: String {
+        windowAppearance.resolvedChromeBackgroundColor.hexString(includeAlpha: true)
+    }
+
     var body: some View {
         content
-        .background(Color(nsColor: appearance.backgroundColor))
+        // Bonsplit and hosted panel subtrees may create their own AppKit
+        // hosting boundary. Re-inject the snapshot authority at the Dock root
+        // so none of that chrome falls back to macOS's ambient appearance.
+        .environment(\.colorScheme, windowAppearance.resolvedColorScheme)
+        .background(Color(nsColor: windowAppearance.resolvedChromeBackgroundColor))
         .background(
             DockKeyboardFocusBridge(store: store)
                 .frame(width: 1, height: 1)
@@ -95,13 +103,22 @@ struct DockPanelView: View {
         .onReceive(NotificationCenter.default.publisher(for: .ghosttyDefaultBackgroundDidChange)) { _ in
             refreshAppearance(reason: "ghosttyDefaultBackgroundDidChange")
         }
+        .onChange(of: windowAppearance.resolvedColorScheme) { _, _ in
+            // The Dock's Bonsplit controller is an AppKit subtree and does not
+            // inherit SwiftUI's environment automatically. Re-apply its
+            // concrete chrome whenever the shared theme authority changes.
+            refreshAppearance(reason: "resolvedColorSchemeChanged")
+        }
+        .onChange(of: resolvedChromeBackgroundIdentity) { _, _ in
+            refreshAppearance(reason: "resolvedChromeBackgroundChanged")
+        }
     }
 
     private func refreshAppearance(reason: String) {
         let next = WorkspaceContentView.resolveGhosttyAppearanceConfig(reason: "dock.\(reason)")
         appearanceConfig = next
         appearanceRevision &+= 1
-        store.applyGhosttyChrome(from: next)
+        store.applyGhosttyChrome(from: next, windowAppearance: windowAppearance)
     }
 
     @ViewBuilder

--- a/Sources/DockSplitStore+Appearance.swift
+++ b/Sources/DockSplitStore+Appearance.swift
@@ -54,6 +54,16 @@ extension DockSplitStore {
         let renderingMode = WindowAppearanceSnapshot.terminalRenderingMode(
             usesHostLayerBackground: GhosttyApp.shared.usesHostLayerBackground
         )
+        // The controller is created before SwiftUI mounts the Dock view, so
+        // there may not be a ``WindowAppearanceSnapshot`` yet. Resolve that
+        // first configuration through the same terminal-theme authority as
+        // the mounted path instead of letting Bonsplit fall back to the
+        // host window's ambient appearance for one render pass.
+        let chromeBackgroundColor = windowAppearance?.resolvedChromeBackgroundColor
+            ?? Workspace.resolvedTerminalChromeBackgroundColor(
+                backgroundColor: config.backgroundColor,
+                backgroundOpacity: config.backgroundOpacity
+            )
         return BonsplitConfiguration.Appearance(
             tabBarHeight: WindowChromeMetrics.bonsplitTabBarHeight,
             tabTitleFontSize: config.surfaceTabBarFontSize,
@@ -75,7 +85,7 @@ extension DockSplitStore {
                 sharesWindowBackdrop: sharesWindowBackdrop,
                 renderingMode: renderingMode,
                 paneBorderColorHex: PaneChromeSettings.paneBorderColorHex(),
-                chromeBackgroundColor: windowAppearance?.resolvedChromeBackgroundColor
+                chromeBackgroundColor: chromeBackgroundColor
             ),
             usesSharedBackdrop: sharesWindowBackdrop
         )

--- a/Sources/DockSplitStore+Appearance.swift
+++ b/Sources/DockSplitStore+Appearance.swift
@@ -13,6 +13,19 @@ extension DockSplitStore {
         bonsplitController.configuration.appearance = Self.makeAppearance(from: config)
     }
 
+    /// Applies Dock chrome using the window's already-resolved theme color.
+    /// Bonsplit is an AppKit-hosted subtree, so it cannot safely infer the
+    /// active cmux scheme from the ambient window appearance.
+    func applyGhosttyChrome(
+        from config: GhosttyConfig,
+        windowAppearance: WindowAppearanceSnapshot
+    ) {
+        bonsplitController.configuration.appearance = Self.makeAppearance(
+            from: config,
+            windowAppearance: windowAppearance
+        )
+    }
+
     static func makeConfiguration() -> BonsplitConfiguration {
         let config = GhosttyConfig.load()
         return BonsplitConfiguration(
@@ -30,6 +43,13 @@ extension DockSplitStore {
     }
 
     static func makeAppearance(from config: GhosttyConfig) -> BonsplitConfiguration.Appearance {
+        makeAppearance(from: config, windowAppearance: nil)
+    }
+
+    static func makeAppearance(
+        from config: GhosttyConfig,
+        windowAppearance: WindowAppearanceSnapshot?
+    ) -> BonsplitConfiguration.Appearance {
         let sharesWindowBackdrop = Workspace.usesWindowRootTerminalBackdrop()
         let renderingMode = WindowAppearanceSnapshot.terminalRenderingMode(
             usesHostLayerBackground: GhosttyApp.shared.usesHostLayerBackground
@@ -54,7 +74,8 @@ extension DockSplitStore {
                 backgroundOpacity: config.backgroundOpacity,
                 sharesWindowBackdrop: sharesWindowBackdrop,
                 renderingMode: renderingMode,
-                paneBorderColorHex: PaneChromeSettings.paneBorderColorHex()
+                paneBorderColorHex: PaneChromeSettings.paneBorderColorHex(),
+                chromeBackgroundColor: windowAppearance?.resolvedChromeBackgroundColor
             ),
             usesSharedBackdrop: sharesWindowBackdrop
         )

--- a/Sources/Feed/FeedPanelView.swift
+++ b/Sources/Feed/FeedPanelView.swift
@@ -74,6 +74,7 @@ struct FeedPanelView: View {
 
     @State private var filter: Filter = .actionable
     @StateObject private var viewModel = FeedPanelViewModel()
+    let chromeBackgroundColor: NSColor
 
     var body: some View {
         VStack(spacing: 0) {
@@ -103,7 +104,7 @@ struct FeedPanelView: View {
             #endif
         }
         .rightSidebarChromeBar()
-        .rightSidebarChromeBottomBorder()
+        .rightSidebarChromeBottomBorder(backgroundColor: chromeBackgroundColor)
         .reportRightSidebarChromeGeometryForBonsplitUITest(role: .secondaryBar, isVisible: true, titlebarHeight: RightSidebarChromeMetrics.secondaryBarHeight)
     }
 

--- a/Sources/FileExplorerView.swift
+++ b/Sources/FileExplorerView.swift
@@ -1,6 +1,7 @@
 import AppKit
 import Bonsplit
 import Combine
+import CmuxAppKitSupportUI
 import CmuxFoundation
 import CmuxWorkspaces
 import CmuxSettings
@@ -42,6 +43,7 @@ struct FileExplorerPanelView: NSViewRepresentable {
     var placement: FileExplorerPanelPlacement = .rightSidebar
     var onFocus: (() -> Void)?
     var onContainerChange: ((FileExplorerContainerView?) -> Void)?
+    @Environment(\.colorScheme) private var colorScheme
 
     func makeCoordinator() -> Coordinator {
         Coordinator(
@@ -56,12 +58,14 @@ struct FileExplorerPanelView: NSViewRepresentable {
 
     func makeNSView(context: Context) -> FileExplorerContainerView {
         let container = FileExplorerContainerView(coordinator: context.coordinator, presentation: presentation)
+        container.appearance = WindowAppearanceSnapshot.appKitAppearance(for: colorScheme)
         context.coordinator.containerView = container
         context.coordinator.onContainerChange?(container)
         return container
     }
 
     func updateNSView(_ container: FileExplorerContainerView, context: Context) {
+        container.appearance = WindowAppearanceSnapshot.appKitAppearance(for: colorScheme)
         context.coordinator.store = store
         context.coordinator.state = state
         context.coordinator.onOpenFilePreview = onOpenFilePreview

--- a/Sources/Panels/BrowserPanel.swift
+++ b/Sources/Panels/BrowserPanel.swift
@@ -95,10 +95,35 @@ enum GhosttyBackgroundTheme {
         )
     }
 
+    /// Resolves a live background notification against the terminal theme's
+    /// concrete light/dark base. This is the variant used by detached browser
+    /// and Dock chrome; the legacy `color(from:)` helper remains available for
+    /// callers that explicitly need the window ambient composition.
+    static func resolvedColor(from notification: Notification?) -> NSColor {
+        let userInfo = notification?.userInfo
+        let backgroundColor =
+            (userInfo?[GhosttyNotificationKey.backgroundColor] as? NSColor)
+            ?? GhosttyApp.shared.defaultBackgroundColor
+        let opacity: Double
+        if let value = userInfo?[GhosttyNotificationKey.backgroundOpacity] as? Double {
+            opacity = value
+        } else if let value = userInfo?[GhosttyNotificationKey.backgroundOpacity] as? NSNumber {
+            opacity = value.doubleValue
+        } else {
+            opacity = GhosttyApp.shared.defaultBackgroundOpacity
+        }
+        return WindowAppearanceSnapshot.resolvedChromeBackgroundColor(
+            backgroundColor: backgroundColor,
+            opacity: opacity,
+            colorScheme: GhosttyApp.shared.effectiveTerminalColorSchemePreference == .dark ? .dark : .light
+        )
+    }
+
     static func currentColor() -> NSColor {
-        color(
+        WindowAppearanceSnapshot.resolvedChromeBackgroundColor(
             backgroundColor: GhosttyApp.shared.defaultBackgroundColor,
-            opacity: GhosttyApp.shared.defaultBackgroundOpacity
+            opacity: GhosttyApp.shared.defaultBackgroundOpacity,
+            colorScheme: GhosttyApp.shared.effectiveTerminalColorSchemePreference == .dark ? .dark : .light
         )
     }
 }
@@ -4512,7 +4537,7 @@ final class BrowserPanel: Panel, ObservableObject {
         NotificationCenter.default.publisher(for: .ghosttyDefaultBackgroundDidChange)
             .sink { [weak self] notification in
                 guard let self else { return }
-                self.applyWebViewBackground(color: GhosttyBackgroundTheme.color(from: notification))
+                self.applyWebViewBackground(color: GhosttyBackgroundTheme.resolvedColor(from: notification))
                 guard self.supportsAppWebTheme(self.webView) else { return }
                 self.applyAppWebTheme(AppWebThemeSnapshot.current(notification: notification), to: self.webView)
             }

--- a/Sources/Panels/BrowserPanelView.swift
+++ b/Sources/Panels/BrowserPanelView.swift
@@ -80,7 +80,11 @@ enum BrowserDevToolsIconColorOption: String, CaseIterable, Identifiable {
         case .accent:
             return cmuxAccentColor()
         case .tertiary:
-            return .tertiary
+            // SwiftUI's secondary style follows the resolved cmux color
+            // scheme injected by the browser/Dock root. Keep the tertiary
+            // option environment-driven instead of resolving AppKit's
+            // ambient `tertiaryLabelColor` here.
+            return Color.secondary.opacity(0.6)
         }
     }
 }

--- a/Sources/Panels/BrowserPanelView.swift
+++ b/Sources/Panels/BrowserPanelView.swift
@@ -1,6 +1,7 @@
 import Bonsplit
 import CmuxBrowser
 import CmuxFoundation
+import CmuxAppKitSupportUI
 import CmuxSettings
 import CmuxSettingsUI
 import SwiftUI
@@ -72,14 +73,14 @@ enum BrowserDevToolsIconColorOption: String, CaseIterable, Identifiable {
         switch self {
         case .bonsplitInactive:
             // Matches Bonsplit tab icon tint for inactive tabs.
-            return Color(nsColor: .secondaryLabelColor)
+            return .secondary
         case .bonsplitActive:
             // Matches Bonsplit tab icon tint for active tabs.
-            return Color(nsColor: .labelColor)
+            return .primary
         case .accent:
             return cmuxAccentColor()
         case .tertiary:
-            return Color(nsColor: .tertiaryLabelColor)
+            return .tertiary
         }
     }
 }
@@ -184,7 +185,7 @@ func resolvedBrowserChromeBackgroundColor(
 func resolvedBrowserChromeColorScheme(
     for colorScheme: ColorScheme,
     themeBackgroundColor: NSColor,
-    windowBackgroundColor: NSColor = .windowBackgroundColor
+    windowBackgroundColor: NSColor = .white
 ) -> ColorScheme {
     let perceivedBackgroundColor = themeBackgroundColor.alphaComponent < 0.999
         ? cmuxCompositedNSColor(themeBackgroundColor, over: windowBackgroundColor)
@@ -225,10 +226,11 @@ private struct BrowserChromeStyle {
             themeBackgroundColor: themeBackgroundColor,
             drawsBackground: drawsBackground
         )
-        let chromeColorScheme = resolvedBrowserChromeColorScheme(
-            for: colorScheme,
-            themeBackgroundColor: themeBackgroundColor
-        )
+        // The browser is hosted inside the window/Dock chrome. Its semantic
+        // colors must follow the resolved cmux scheme injected by the parent,
+        // even when a translucent theme would otherwise be composited against
+        // AppKit's ambient window appearance.
+        let chromeColorScheme = colorScheme
         let omnibarPillBackgroundColor = resolvedBrowserOmnibarPillBackgroundColor(
             for: chromeColorScheme,
             themeBackgroundColor: themeBackgroundColor
@@ -262,6 +264,7 @@ struct BrowserPanelView: View {
     /// panels in `DockSplitStore`). When set, it overrides the workspace lookup
     /// in `isCurrentPaneOwner`; `nil` preserves the main-area behavior.
     let paneOwnershipOverride: Bool?
+    private let resolvedThemeBackgroundColor: NSColor?
     @Environment(\.colorScheme) private var colorScheme
     @Environment(\.cmuxCanvasInlineBrowserHosting) private var canvasInlineBrowserHosting
     @Environment(\.paneDropZone) private var paneDropZone
@@ -352,6 +355,8 @@ struct BrowserPanelView: View {
         isVisibleInUI: Bool,
         portalPriority: Int,
         paneOwnershipOverride: Bool? = nil,
+        resolvedColorScheme: ColorScheme = .light,
+        resolvedThemeBackgroundColor: NSColor? = nil,
         onRequestPanelFocus: @escaping () -> Void
     ) {
         self.panel = panel
@@ -361,10 +366,11 @@ struct BrowserPanelView: View {
         self.isVisibleInUI = isVisibleInUI
         self.portalPriority = portalPriority
         self.paneOwnershipOverride = paneOwnershipOverride
+        self.resolvedThemeBackgroundColor = resolvedThemeBackgroundColor
         self.onRequestPanelFocus = onRequestPanelFocus
         self._browserChromeStyle = State(initialValue: BrowserChromeStyle.resolve(
-            for: .light,
-            themeBackgroundColor: GhosttyBackgroundTheme.currentColor(),
+            for: resolvedColorScheme,
+            themeBackgroundColor: resolvedThemeBackgroundColor ?? GhosttyBackgroundTheme.currentColor(),
             drawsBackground: panel.drawsConfiguredWebViewBackgroundForCurrentPage()
         ))
     }
@@ -455,6 +461,12 @@ struct BrowserPanelView: View {
 
     private var omnibarPillBackgroundColor: NSColor {
         browserChromeStyle.omnibarPillBackgroundColor
+    }
+
+    private var browserChromeSeparatorColor: Color {
+        Color(nsColor: WindowChromeColorResolver().separatorColor(
+            forChromeBackground: browserChromeBackgroundColor
+        ))
     }
 
     private var hasVisibleOmnibarSuggestions: Bool {
@@ -1833,7 +1845,7 @@ struct BrowserPanelView: View {
     private func refreshBrowserChromeStyle() {
         browserChromeStyle = BrowserChromeStyle.resolve(
             for: colorScheme,
-            themeBackgroundColor: GhosttyBackgroundTheme.currentColor(),
+            themeBackgroundColor: resolvedThemeBackgroundColor ?? GhosttyBackgroundTheme.currentColor(),
             drawsBackground: panel.drawsConfiguredWebViewBackgroundForCurrentPage()
         )
     }
@@ -2119,11 +2131,11 @@ struct BrowserPanelView: View {
             .frame(maxWidth: 360, alignment: .leading)
             .background(
                 RoundedRectangle(cornerRadius: 12, style: .continuous)
-                    .fill(Color(nsColor: .windowBackgroundColor).opacity(0.9))
+                    .fill(Color(nsColor: browserChromeBackgroundColor).opacity(0.9))
             )
             .overlay(
                 RoundedRectangle(cornerRadius: 12, style: .continuous).stroke(
-                    Color(nsColor: .separatorColor).opacity(0.45),
+                    browserChromeSeparatorColor.opacity(0.45),
                     lineWidth: 1
                 )
             )
@@ -2142,11 +2154,11 @@ struct BrowserPanelView: View {
                 .frame(maxWidth: 520, alignment: .leading)
                 .background(
                     RoundedRectangle(cornerRadius: 12, style: .continuous)
-                        .fill(Color(nsColor: .windowBackgroundColor).opacity(0.84))
+                        .fill(Color(nsColor: browserChromeBackgroundColor).opacity(0.84))
                 )
                 .overlay(
                     RoundedRectangle(cornerRadius: 12, style: .continuous).stroke(
-                        Color(nsColor: .separatorColor).opacity(0.35),
+                        browserChromeSeparatorColor.opacity(0.35),
                         lineWidth: 1
                     )
                 )
@@ -5113,22 +5125,22 @@ struct OmnibarSuggestionsView: View {
     private var listTextColor: Color {
         switch colorScheme {
         case .light:
-            return Color(nsColor: .labelColor)
+            return .primary
         case .dark:
             return Color.white.opacity(0.9)
         @unknown default:
-            return Color(nsColor: .labelColor)
+            return .primary
         }
     }
 
     private var badgeTextColor: Color {
         switch colorScheme {
         case .light:
-            return Color(nsColor: .secondaryLabelColor)
+            return .secondary
         case .dark:
             return Color.white.opacity(0.72)
         @unknown default:
-            return Color(nsColor: .secondaryLabelColor)
+            return .secondary
         }
     }
 

--- a/Sources/Panels/BrowserPanelView.swift
+++ b/Sources/Panels/BrowserPanelView.swift
@@ -348,6 +348,10 @@ struct BrowserPanelView: View {
     private var addressBarButtonHitSize: CGFloat { chromeMetrics.buttonHitSize }
     private var devToolsButtonIconSize: CGFloat { chromeMetrics.accessoryIconFontSize }
 
+    private var resolvedThemeBackgroundIdentity: String {
+        resolvedThemeBackgroundColor?.hexString(includeAlpha: true) ?? ""
+    }
+
     init(
         panel: BrowserPanel,
         paneId: PaneID,
@@ -1078,6 +1082,9 @@ struct BrowserPanelView: View {
         }
         .onChange(of: colorScheme) { _ in
             handleSystemColorSchemeChange()
+        }
+        .onChange(of: resolvedThemeBackgroundIdentity) { _ in
+            refreshBrowserChromeStyle()
         }
         .onChange(of: panel.pendingAddressBarFocusRequestId) { _ in
             applyPendingAddressBarFocusRequestIfNeeded()

--- a/Sources/Panels/BrowserPanelView.swift
+++ b/Sources/Panels/BrowserPanelView.swift
@@ -1087,7 +1087,7 @@ struct BrowserPanelView: View {
         .onChange(of: colorScheme) { _ in
             handleSystemColorSchemeChange()
         }
-        .onChange(of: resolvedThemeBackgroundIdentity) { _ in
+        .onChange(of: resolvedThemeBackgroundIdentity) { _, _ in
             refreshBrowserChromeStyle()
         }
         .onChange(of: panel.pendingAddressBarFocusRequestId) { _ in

--- a/Sources/Panels/BrowserPanelView.swift
+++ b/Sources/Panels/BrowserPanelView.swift
@@ -189,7 +189,7 @@ func resolvedBrowserChromeBackgroundColor(
 func resolvedBrowserChromeColorScheme(
     for colorScheme: ColorScheme,
     themeBackgroundColor: NSColor,
-    windowBackgroundColor: NSColor = .white
+    windowBackgroundColor: NSColor
 ) -> ColorScheme {
     let perceivedBackgroundColor = themeBackgroundColor.alphaComponent < 0.999
         ? cmuxCompositedNSColor(themeBackgroundColor, over: windowBackgroundColor)
@@ -268,7 +268,7 @@ struct BrowserPanelView: View {
     /// panels in `DockSplitStore`). When set, it overrides the workspace lookup
     /// in `isCurrentPaneOwner`; `nil` preserves the main-area behavior.
     let paneOwnershipOverride: Bool?
-    private let resolvedThemeBackgroundColor: NSColor?
+    private let resolvedThemeBackgroundColor: NSColor
     @Environment(\.colorScheme) private var colorScheme
     @Environment(\.cmuxCanvasInlineBrowserHosting) private var canvasInlineBrowserHosting
     @Environment(\.paneDropZone) private var paneDropZone
@@ -353,7 +353,7 @@ struct BrowserPanelView: View {
     private var devToolsButtonIconSize: CGFloat { chromeMetrics.accessoryIconFontSize }
 
     private var resolvedThemeBackgroundIdentity: String {
-        resolvedThemeBackgroundColor?.hexString(includeAlpha: true) ?? ""
+        resolvedThemeBackgroundColor.hexString(includeAlpha: true)
     }
 
     init(
@@ -363,8 +363,8 @@ struct BrowserPanelView: View {
         isVisibleInUI: Bool,
         portalPriority: Int,
         paneOwnershipOverride: Bool? = nil,
-        resolvedColorScheme: ColorScheme = .light,
-        resolvedThemeBackgroundColor: NSColor? = nil,
+        resolvedColorScheme: ColorScheme,
+        resolvedThemeBackgroundColor: NSColor,
         onRequestPanelFocus: @escaping () -> Void
     ) {
         self.panel = panel
@@ -378,7 +378,7 @@ struct BrowserPanelView: View {
         self.onRequestPanelFocus = onRequestPanelFocus
         self._browserChromeStyle = State(initialValue: BrowserChromeStyle.resolve(
             for: resolvedColorScheme,
-            themeBackgroundColor: resolvedThemeBackgroundColor ?? GhosttyBackgroundTheme.currentColor(),
+            themeBackgroundColor: resolvedThemeBackgroundColor,
             drawsBackground: panel.drawsConfiguredWebViewBackgroundForCurrentPage()
         ))
     }
@@ -1856,7 +1856,7 @@ struct BrowserPanelView: View {
     private func refreshBrowserChromeStyle() {
         browserChromeStyle = BrowserChromeStyle.resolve(
             for: colorScheme,
-            themeBackgroundColor: resolvedThemeBackgroundColor ?? GhosttyBackgroundTheme.currentColor(),
+            themeBackgroundColor: resolvedThemeBackgroundColor,
             drawsBackground: panel.drawsConfiguredWebViewBackgroundForCurrentPage()
         )
     }

--- a/Sources/Panels/PanelContentView.swift
+++ b/Sources/Panels/PanelContentView.swift
@@ -39,6 +39,7 @@ struct PanelContentView: View {
 
     var body: some View {
         renderedPanel
+            .environment(\.colorScheme, windowAppearance.resolvedColorScheme)
             .overlay {
                 paneDropTargetOverlay
             }
@@ -75,6 +76,8 @@ struct PanelContentView: View {
                     isVisibleInUI: isVisibleInUI,
                     portalPriority: portalPriority,
                     paneOwnershipOverride: paneOwnershipOverride,
+                    resolvedColorScheme: windowAppearance.resolvedColorScheme,
+                    resolvedThemeBackgroundColor: windowAppearance.resolvedChromeBackgroundColor,
                     onRequestPanelFocus: onRequestPanelFocus
                 )
                 // Browser chrome owns panel-scoped edit/focus state. Bonsplit reuses this
@@ -111,6 +114,7 @@ struct PanelContentView: View {
                     isFocused: isFocused,
                     isVisibleInUI: isVisibleInUI,
                     appearance: appearance,
+                    resolvedChromeBackgroundColor: windowAppearance.resolvedChromeBackgroundColor,
                     onRequestPanelFocus: onRequestPanelFocus
                 )
             }

--- a/Sources/Panels/PanelContentView.swift
+++ b/Sources/Panels/PanelContentView.swift
@@ -113,7 +113,6 @@ struct PanelContentView: View {
                     panel: rightSidebarToolPanel,
                     isFocused: isFocused,
                     isVisibleInUI: isVisibleInUI,
-                    appearance: appearance,
                     resolvedChromeBackgroundColor: windowAppearance.resolvedChromeBackgroundColor,
                     onRequestPanelFocus: onRequestPanelFocus
                 )

--- a/Sources/Panels/WorkspaceTodoPanelView.swift
+++ b/Sources/Panels/WorkspaceTodoPanelView.swift
@@ -115,8 +115,7 @@ private final class WorkspaceTodoPanelOpaqueBackgroundView: NSView {
     override var isOpaque: Bool { true }
 
     override func draw(_ dirtyRect: NSRect) {
-        let appearance = WindowAppearanceSnapshot.appKitAppearance(for: colorScheme)
-        NSColor.windowBackgroundColor.resolvedColor(with: appearance).setFill()
+        WindowAppearanceSnapshot.resolvedColor(.windowBackgroundColor, for: colorScheme).setFill()
         dirtyRect.fill()
     }
 }

--- a/Sources/Panels/WorkspaceTodoPanelView.swift
+++ b/Sources/Panels/WorkspaceTodoPanelView.swift
@@ -1,4 +1,5 @@
 import AppKit
+import CmuxAppKitSupportUI
 import CmuxWorkspaces
 import SwiftUI
 
@@ -87,20 +88,35 @@ enum WorkspaceTodoPaneKeyboardNavigationPolicy {
 }
 
 private struct WorkspaceTodoPanelOpaqueBackground: NSViewRepresentable {
-    func makeNSView(context: Context) -> NSView {
-        WorkspaceTodoPanelOpaqueBackgroundView()
+    @Environment(\.colorScheme) private var colorScheme
+
+    func makeNSView(context: Context) -> WorkspaceTodoPanelOpaqueBackgroundView {
+        let view = WorkspaceTodoPanelOpaqueBackgroundView()
+        view.colorScheme = colorScheme
+        view.appearance = WindowAppearanceSnapshot.appKitAppearance(for: colorScheme)
+        return view
     }
 
-    func updateNSView(_ nsView: NSView, context: Context) {
+    func updateNSView(_ nsView: WorkspaceTodoPanelOpaqueBackgroundView, context: Context) {
+        nsView.colorScheme = colorScheme
         nsView.needsDisplay = true
     }
 }
 
 private final class WorkspaceTodoPanelOpaqueBackgroundView: NSView {
+    var colorScheme: ColorScheme = .light {
+        didSet {
+            guard colorScheme != oldValue else { return }
+            appearance = WindowAppearanceSnapshot.appKitAppearance(for: colorScheme)
+            needsDisplay = true
+        }
+    }
+
     override var isOpaque: Bool { true }
 
     override func draw(_ dirtyRect: NSRect) {
-        NSColor.windowBackgroundColor.setFill()
+        let appearance = WindowAppearanceSnapshot.appKitAppearance(for: colorScheme)
+        NSColor.windowBackgroundColor.resolvedColor(with: appearance).setFill()
         dirtyRect.fill()
     }
 }

--- a/Sources/RightSidebarChromeStyle.swift
+++ b/Sources/RightSidebarChromeStyle.swift
@@ -1,3 +1,4 @@
+import AppKit
 import CmuxFoundation
 import CmuxAppKitSupportUI
 import CmuxSettings
@@ -168,13 +169,14 @@ struct RightSidebarChromePillModifier: ViewModifier {
 }
 
 struct RightSidebarChromeBottomBorderModifier: ViewModifier {
+    let backgroundColor: NSColor
+
     func body(content: Content) -> some View {
         content.overlay(alignment: .bottom) {
             WindowChromeBorder(
                 orientation: .horizontal,
                 ignoresSafeArea: false,
-                refreshNotificationName: .ghosttyDefaultBackgroundDidChange,
-                backgroundColorProvider: { GhosttyBackgroundTheme.currentColor() }
+                backgroundColor: backgroundColor
             )
         }
     }
@@ -274,8 +276,8 @@ extension View {
         )
     }
 
-    func rightSidebarChromeBottomBorder() -> some View {
-        modifier(RightSidebarChromeBottomBorderModifier())
+    func rightSidebarChromeBottomBorder(backgroundColor: NSColor) -> some View {
+        modifier(RightSidebarChromeBottomBorderModifier(backgroundColor: backgroundColor))
     }
 
     func rightSidebarHeaderControlAlignment() -> some View {

--- a/Sources/RightSidebarChromeStyle.swift
+++ b/Sources/RightSidebarChromeStyle.swift
@@ -17,7 +17,7 @@ enum HeaderChromeIconStyle {
     static let pressedOpacity = 1.0
     static let disabledOpacity = 0.34
     static let weight: Font.Weight = .regular
-    static let foregroundColor = Color(nsColor: .secondaryLabelColor)
+    static let foregroundColor = Color.secondary
     static let sidebarGlyphStrokeWidth: CGFloat = 1
 
     static func iconFrameSize(forIconSize iconSize: CGFloat) -> CGFloat {

--- a/Sources/RightSidebarPanelView.swift
+++ b/Sources/RightSidebarPanelView.swift
@@ -181,6 +181,9 @@ struct RightSidebarPanelView: View {
         }
         .shortcutHintVisibilityAnimation(value: focusShortcutHintAnimationValue)
         .frame(maxWidth: .infinity, maxHeight: .infinity)
+        // Keep every mode (including Dock and AppKit-backed file rows) on the
+        // same resolved cmux scheme as the window and left sidebar.
+        .environment(\.colorScheme, windowAppearance.resolvedColorScheme)
         .background(
             RightSidebarKeyboardFocusBridge()
             .frame(width: 1, height: 1)

--- a/Sources/RightSidebarPanelView.swift
+++ b/Sources/RightSidebarPanelView.swift
@@ -175,7 +175,9 @@ struct RightSidebarPanelView: View {
     var body: some View {
         VStack(spacing: 0) {
             modeBar
-                .rightSidebarChromeBottomBorder()
+                .rightSidebarChromeBottomBorder(
+                    backgroundColor: windowAppearance.resolvedChromeBackgroundColor
+                )
             contentForMode
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
         }
@@ -396,12 +398,18 @@ struct RightSidebarPanelView: View {
                     presentation: .find
                 )
             case .sessions:
-                SessionIndexView(store: sessionIndexStore, onResume: onResumeSession)
+                SessionIndexView(
+                    store: sessionIndexStore,
+                    chromeBackgroundColor: windowAppearance.resolvedChromeBackgroundColor,
+                    onResume: onResumeSession
+                )
                     .onAppear {
                         sessionIndexStore.setCurrentDirectoryIfChanged(sessionIndexDirectory)
                     }
             case .feed:
-                FeedPanelView()
+                FeedPanelView(
+                    chromeBackgroundColor: windowAppearance.resolvedChromeBackgroundColor
+                )
             case .dock:
                 dockPanel(windowAppearance: windowAppearance)
             case .customSidebar:

--- a/Sources/RightSidebarToolPanel.swift
+++ b/Sources/RightSidebarToolPanel.swift
@@ -242,8 +242,7 @@ struct RightSidebarToolPanelView: View {
     @EnvironmentObject private var tabManager: TabManager
     let isFocused: Bool
     let isVisibleInUI: Bool
-    let appearance: PanelAppearance
-    let resolvedChromeBackgroundColor: NSColor?
+    let resolvedChromeBackgroundColor: NSColor
     let onRequestPanelFocus: () -> Void
 
     @State private var focusFlashOpacity: Double = 0.0
@@ -252,7 +251,7 @@ struct RightSidebarToolPanelView: View {
     var body: some View {
         content
             .frame(maxWidth: .infinity, maxHeight: .infinity)
-            .background(Color(nsColor: resolvedChromeBackgroundColor ?? appearance.backgroundColor))
+            .background(Color(nsColor: resolvedChromeBackgroundColor))
             .overlay {
                 WorkspaceAttentionFlashRingView(opacity: focusFlashOpacity)
             }
@@ -288,6 +287,7 @@ struct RightSidebarToolPanelView: View {
         case .sessions:
             SessionIndexView(
                 store: panel.sessionIndexStore,
+                chromeBackgroundColor: resolvedChromeBackgroundColor,
                 onResume: { entry in
                     SessionEntryResumeCoordinator.resume(entry, tabManager: tabManager)
                 }

--- a/Sources/RightSidebarToolPanel.swift
+++ b/Sources/RightSidebarToolPanel.swift
@@ -1,5 +1,6 @@
 import AppKit
 import Combine
+import CmuxAppKitSupportUI
 import SwiftUI
 
 @MainActor
@@ -242,6 +243,7 @@ struct RightSidebarToolPanelView: View {
     let isFocused: Bool
     let isVisibleInUI: Bool
     let appearance: PanelAppearance
+    let resolvedChromeBackgroundColor: NSColor?
     let onRequestPanelFocus: () -> Void
 
     @State private var focusFlashOpacity: Double = 0.0
@@ -250,7 +252,7 @@ struct RightSidebarToolPanelView: View {
     var body: some View {
         content
             .frame(maxWidth: .infinity, maxHeight: .infinity)
-            .background(Color(nsColor: appearance.backgroundColor))
+            .background(Color(nsColor: resolvedChromeBackgroundColor ?? appearance.backgroundColor))
             .overlay {
                 WorkspaceAttentionFlashRingView(opacity: focusFlashOpacity)
             }

--- a/Sources/SessionIndexView.swift
+++ b/Sources/SessionIndexView.swift
@@ -61,6 +61,7 @@ struct SessionIndexView: View {
     @State private var collapsedSections: Set<SectionKey> = []
     /// Single source of truth for both Vault popover variants.
     @State private var popoverIdentity: SessionIndexTablePopoverIdentity?
+    let chromeBackgroundColor: NSColor
     let onResume: ((SessionEntry) -> Void)?
     /// Rows shown per section before "Show more" is tapped.
     private static let collapsedRowLimit = 5
@@ -139,7 +140,7 @@ struct SessionIndexView: View {
             .titlebarInteractiveControl()
         }
         .rightSidebarChromeBar()
-        .rightSidebarChromeBottomBorder()
+        .rightSidebarChromeBottomBorder(backgroundColor: chromeBackgroundColor)
         .reportRightSidebarChromeGeometryForBonsplitUITest(role: .secondaryBar, isVisible: true, titlebarHeight: RightSidebarChromeMetrics.secondaryBarHeight)
     }
 

--- a/Sources/Sidebar/AppKitList/Cells/SidebarGroupHeaderRowModel.swift
+++ b/Sources/Sidebar/AppKitList/Cells/SidebarGroupHeaderRowModel.swift
@@ -39,7 +39,7 @@ struct SidebarGroupHeaderRowModel: Equatable, Hashable {
     let topDropIndicatorVisible: Bool
     let bottomDropIndicatorVisible: Bool
     /// Resolved cmux scheme used by native group-header chrome.
-    let colorSchemeIsDark: Bool = false
+    var colorSchemeIsDark: Bool = false
 }
 
 /// Behavior bundle for one group header row; recreated per apply and excluded

--- a/Sources/Sidebar/AppKitList/Cells/SidebarGroupHeaderRowModel.swift
+++ b/Sources/Sidebar/AppKitList/Cells/SidebarGroupHeaderRowModel.swift
@@ -39,7 +39,7 @@ struct SidebarGroupHeaderRowModel: Equatable, Hashable {
     let topDropIndicatorVisible: Bool
     let bottomDropIndicatorVisible: Bool
     /// Resolved cmux scheme used by native group-header chrome.
-    var colorSchemeIsDark: Bool = false
+    let colorSchemeIsDark: Bool
 }
 
 /// Behavior bundle for one group header row; recreated per apply and excluded

--- a/Sources/Sidebar/AppKitList/Cells/SidebarGroupHeaderRowModel.swift
+++ b/Sources/Sidebar/AppKitList/Cells/SidebarGroupHeaderRowModel.swift
@@ -1,6 +1,7 @@
 import AppKit
 import CoreGraphics
 import Foundation
+import SwiftUI
 
 /// Value-snapshot render input for one pure-AppKit sidebar group header row.
 ///
@@ -37,6 +38,8 @@ struct SidebarGroupHeaderRowModel: Equatable, Hashable {
     let isBeingDragged: Bool
     let topDropIndicatorVisible: Bool
     let bottomDropIndicatorVisible: Bool
+    /// Resolved cmux scheme used by native group-header chrome.
+    let colorSchemeIsDark: Bool = false
 }
 
 /// Behavior bundle for one group header row; recreated per apply and excluded

--- a/Sources/Sidebar/AppKitList/Cells/SidebarGroupHeaderRowView.swift
+++ b/Sources/Sidebar/AppKitList/Cells/SidebarGroupHeaderRowView.swift
@@ -141,6 +141,8 @@ final class SidebarGroupHeaderTableCellView: NSTableCellView {
         defer { CATransaction.commit() }
         let metrics = SidebarWorkspaceGroupHeaderMetrics(fontScale: model.fontScale)
         let percent = model.globalFontMagnificationPercent
+        let colorScheme: ColorScheme = model.colorSchemeIsDark ? .dark : .light
+        let colorResolver = SidebarAppearanceColorResolver()
 
         pinImageView.isHidden = !model.isPinned
         if model.isPinned {
@@ -149,7 +151,7 @@ final class SidebarGroupHeaderTableCellView: NSTableCellView {
                 pointSize: GlobalFontMagnification.scaledSize(metrics.pinnedIconFontSize, percent: percent),
                 weight: .semibold
             )
-            pinImageView.contentTintColor = .secondaryLabelColor
+            pinImageView.contentTintColor = colorResolver.resolvedColor(.secondaryLabelColor, for: colorScheme)
             pinImageView.toolTip = String(localized: "workspaceGroup.pinned.tooltip", defaultValue: "Pinned group")
         }
 
@@ -158,7 +160,7 @@ final class SidebarGroupHeaderTableCellView: NSTableCellView {
             pointSize: GlobalFontMagnification.scaledSize(metrics.chevronFontSize, percent: percent),
             weight: .semibold
         )
-        chevronButton.contentTintColor = .secondaryLabelColor
+        chevronButton.contentTintColor = colorResolver.resolvedColor(.secondaryLabelColor, for: colorScheme)
         chevronButton.setAccessibilityLabel(
             model.isCollapsed
                 ? String(localized: "workspaceGroup.expand.a11y", defaultValue: "Expand group")
@@ -171,14 +173,17 @@ final class SidebarGroupHeaderTableCellView: NSTableCellView {
             pointSize: GlobalFontMagnification.scaledSize(metrics.iconFontSize, percent: percent),
             weight: .semibold
         )
-        iconImageView.contentTintColor = model.tintHex.flatMap { NSColor(hex: $0) } ?? .secondaryLabelColor
+        iconImageView.contentTintColor = model.tintHex.flatMap { NSColor(hex: $0) }
+            ?? colorResolver.resolvedColor(.secondaryLabelColor, for: colorScheme)
 
         nameField.stringValue = model.name
         nameField.font = .systemFont(
             ofSize: GlobalFontMagnification.scaledSize(metrics.nameFontSize, percent: percent),
             weight: .semibold
         )
-        nameField.textColor = model.isAnchorActive ? .labelColor : NSColor.labelColor.withAlphaComponent(0.9)
+        nameField.textColor = model.isAnchorActive
+            ? colorResolver.resolvedColor(.labelColor, for: colorScheme)
+            : colorResolver.resolvedColor(.labelColor, for: colorScheme, opacity: 0.9)
 
         let showsBadge = model.anchorUnreadCount > 0
         unreadBadgeView.isHidden = !showsBadge
@@ -204,7 +209,7 @@ final class SidebarGroupHeaderTableCellView: NSTableCellView {
             pointSize: GlobalFontMagnification.scaledSize(metrics.plusFontSize, percent: percent),
             weight: .medium
         )
-        plusButton.contentTintColor = .secondaryLabelColor
+        plusButton.contentTintColor = colorResolver.resolvedColor(.secondaryLabelColor, for: colorScheme)
         plusButton.setAccessibilityLabel(String(
             localized: "workspaceGroup.newWorkspaceInGroup.a11y",
             defaultValue: "New workspace in group"
@@ -215,8 +220,9 @@ final class SidebarGroupHeaderTableCellView: NSTableCellView {
             : 4
         backgroundView.layer?.backgroundColor = headerBackgroundColor(for: model).cgColor
 
-        topDropIndicator.layer?.backgroundColor = cmuxAccentNSColor().cgColor
-        bottomDropIndicator.layer?.backgroundColor = cmuxAccentNSColor().cgColor
+        let accent = cmuxAccentNSColor(for: colorScheme)
+        topDropIndicator.layer?.backgroundColor = accent.cgColor
+        bottomDropIndicator.layer?.backgroundColor = accent.cgColor
         topDropIndicator.isHidden = !model.topDropIndicatorVisible
         bottomDropIndicator.isHidden = !model.bottomDropIndicatorVisible
 
@@ -236,8 +242,11 @@ final class SidebarGroupHeaderTableCellView: NSTableCellView {
     /// Live drop-line painting during native reorder drags; see
     /// `SidebarWorkspaceRowTableCellView.paintControllerDropIndicator`.
     func paintControllerDropIndicator(top: Bool, bottom: Bool) {
-        topDropIndicator.layer?.backgroundColor = cmuxAccentNSColor().cgColor
-        bottomDropIndicator.layer?.backgroundColor = cmuxAccentNSColor().cgColor
+        let colorScheme: ColorScheme = model.map { $0.colorSchemeIsDark ? .dark : .light }
+            ?? SidebarAppearanceColorResolver().currentColorScheme()
+        let accent = cmuxAccentNSColor(for: colorScheme)
+        topDropIndicator.layer?.backgroundColor = accent.cgColor
+        bottomDropIndicator.layer?.backgroundColor = accent.cgColor
         topDropIndicator.isHidden = !top
         bottomDropIndicator.isHidden = !bottom
     }
@@ -267,12 +276,14 @@ final class SidebarGroupHeaderTableCellView: NSTableCellView {
     /// authoritative configure reconciles.
     func showOptimisticAnchorActive() {
         guard let model, !model.isAnchorActive else { return }
+        let colorScheme: ColorScheme = model.colorSchemeIsDark ? .dark : .light
+        let labelColor = SidebarAppearanceColorResolver().resolvedColor(.labelColor, for: colorScheme)
         CATransaction.begin()
         CATransaction.setDisableActions(true)
         backgroundView.layer?.cornerRadius = 4
-        backgroundView.layer?.backgroundColor = NSColor.labelColor.withAlphaComponent(0.08).cgColor
+        backgroundView.layer?.backgroundColor = labelColor.withAlphaComponent(0.08).cgColor
         CATransaction.commit()
-        nameField.textColor = .labelColor
+        nameField.textColor = labelColor
     }
 
     /// Modifier-click preview: paints the same dim membership tint as an
@@ -295,7 +306,12 @@ final class SidebarGroupHeaderTableCellView: NSTableCellView {
         backgroundView.layer?.cornerRadius = 4
         backgroundView.layer?.backgroundColor = NSColor.clear.cgColor
         CATransaction.commit()
-        nameField.textColor = NSColor.labelColor.withAlphaComponent(0.9)
+        let colorScheme: ColorScheme = model.colorSchemeIsDark ? .dark : .light
+        nameField.textColor = SidebarAppearanceColorResolver().resolvedColor(
+            .labelColor,
+            for: colorScheme,
+            opacity: 0.9
+        )
     }
 
     /// Inverse of the press treatment: previewing a different row must peel a
@@ -310,7 +326,12 @@ final class SidebarGroupHeaderTableCellView: NSTableCellView {
 
     private func headerBackgroundColor(for model: SidebarGroupHeaderRowModel) -> NSColor {
         if model.isAnchorActive {
-            return NSColor.labelColor.withAlphaComponent(0.08)
+            let colorScheme: ColorScheme = model.colorSchemeIsDark ? .dark : .light
+            return SidebarAppearanceColorResolver().resolvedColor(
+                .labelColor,
+                for: colorScheme,
+                opacity: 0.08
+            )
         }
         if model.isMultiSelected {
             return headerMultiSelectionBackgroundColor(for: model)

--- a/Sources/Sidebar/AppKitList/Cells/SidebarRowTaskStatusGlyphButton.swift
+++ b/Sources/Sidebar/AppKitList/Cells/SidebarRowTaskStatusGlyphButton.swift
@@ -16,7 +16,7 @@ final class SidebarRowTaskStatusGlyphButton: NSControl {
         let hasOverride: Bool
         let usesMonochrome: Bool
         let fontScale: CGFloat
-        let colorScheme: ColorScheme = .light
+        let colorScheme: ColorScheme
     }
 
     private static let baseSize: CGFloat = 9

--- a/Sources/Sidebar/AppKitList/Cells/SidebarRowTaskStatusGlyphButton.swift
+++ b/Sources/Sidebar/AppKitList/Cells/SidebarRowTaskStatusGlyphButton.swift
@@ -16,6 +16,7 @@ final class SidebarRowTaskStatusGlyphButton: NSControl {
         let hasOverride: Bool
         let usesMonochrome: Bool
         let fontScale: CGFloat
+        let colorScheme: ColorScheme = .light
     }
 
     private static let baseSize: CGFloat = 9
@@ -69,7 +70,7 @@ final class SidebarRowTaskStatusGlyphButton: NSControl {
         case .neutral:
             return neutralColor
         case .working:
-            return cmuxAccentNSColor()
+            return cmuxAccentNSColor(for: model.colorScheme)
         case .attention:
             // Loudest lane: full-strength attention accent between orange and red.
             return NSColor(srgbRed: 1.0, green: 0.42, blue: 0.2, alpha: 1)

--- a/Sources/Sidebar/AppKitList/Cells/SidebarWorkspaceRowCellView.swift
+++ b/Sources/Sidebar/AppKitList/Cells/SidebarWorkspaceRowCellView.swift
@@ -390,7 +390,7 @@ final class SidebarWorkspaceRowTableCellView: NSTableCellView {
         applyBackgroundStyle(style)
         if settings.activeTabIndicatorStyle == .solidFill, model.isActive {
             backgroundView.layer?.borderWidth = 1.5
-            backgroundView.layer?.borderColor = NSColor.labelColor.withAlphaComponent(0.5).cgColor
+            backgroundView.layer?.borderColor = palette.semantic(.labelColor, opacity: 0.5).cgColor
         } else {
             backgroundView.layer?.borderWidth = 0
         }
@@ -449,7 +449,8 @@ final class SidebarWorkspaceRowTableCellView: NSTableCellView {
                     status: taskStatus,
                     hasOverride: true,
                     usesMonochrome: model.isActive,
-                    fontScale: model.fontScale
+                    fontScale: model.fontScale,
+                    colorScheme: palette.colorScheme
                 ),
                 monochromeColor: palette.secondary(0.8),
                 neutralColor: palette.secondary(0.8)
@@ -587,8 +588,8 @@ final class SidebarWorkspaceRowTableCellView: NSTableCellView {
             emphasis: model.isActive ? 1.0 : 0.9,
             representedIdentity: model.workspaceId
         )
-        topDropIndicator.layer?.backgroundColor = cmuxAccentNSColor().cgColor
-        bottomDropIndicator.layer?.backgroundColor = cmuxAccentNSColor().cgColor
+        topDropIndicator.layer?.backgroundColor = cmuxAccentNSColor(for: palette.colorScheme).cgColor
+        bottomDropIndicator.layer?.backgroundColor = cmuxAccentNSColor(for: palette.colorScheme).cgColor
         topDropIndicator.isHidden = !model.topDropIndicatorVisible
         bottomDropIndicator.isHidden = !model.bottomDropIndicatorVisible
         alphaValue = model.isBeingDragged ? 0.6 : 1
@@ -608,8 +609,11 @@ final class SidebarWorkspaceRowTableCellView: NSTableCellView {
     /// false, so no SwiftUI rows rebuild runs per gap change) and moves it
     /// with two direct view mutations instead of a full-list apply.
     func paintControllerDropIndicator(top: Bool, bottom: Bool) {
-        topDropIndicator.layer?.backgroundColor = cmuxAccentNSColor().cgColor
-        bottomDropIndicator.layer?.backgroundColor = cmuxAccentNSColor().cgColor
+        let colorScheme = model.map { $0.colorSchemeIsDark ? ColorScheme.dark : .light }
+            ?? SidebarAppearanceColorResolver().currentColorScheme()
+        let accent = cmuxAccentNSColor(for: colorScheme)
+        topDropIndicator.layer?.backgroundColor = accent.cgColor
+        bottomDropIndicator.layer?.backgroundColor = accent.cgColor
         topDropIndicator.isHidden = !top
         bottomDropIndicator.isHidden = !bottom
     }
@@ -630,7 +634,9 @@ final class SidebarWorkspaceRowTableCellView: NSTableCellView {
             if let hex = model.settings.notificationBadgeColorHex, let color = NSColor(hex: hex) {
                 return color
             }
-            return model.isActive ? palette.primaryText.withAlphaComponent(0.25) : cmuxAccentNSColor()
+            return model.isActive
+                ? palette.primaryText.withAlphaComponent(0.25)
+                : cmuxAccentNSColor(for: palette.colorScheme)
         }()
         let badgeText: NSColor = model.isActive ? palette.primaryText : .white
         let badgeFont = NSFont.systemFont(ofSize: model.scaled(9), weight: .semibold)
@@ -654,6 +660,7 @@ final class SidebarWorkspaceRowTableCellView: NSTableCellView {
             existing: leadingSpinner,
             visible: leadingSpinnerVisible,
             color: spinnerColor,
+            colorScheme: palette.colorScheme,
             presentationActive: isPresentationActive,
             in: contentContainer
         )
@@ -661,6 +668,7 @@ final class SidebarWorkspaceRowTableCellView: NSTableCellView {
             existing: trailingSpinner,
             visible: trailingSpinnerVisible && !showsCloseNow,
             color: spinnerColor,
+            colorScheme: palette.colorScheme,
             presentationActive: isPresentationActive,
             in: contentContainer
         )
@@ -679,6 +687,7 @@ final class SidebarWorkspaceRowTableCellView: NSTableCellView {
         existing: GPUSpinnerNSView?,
         visible: Bool,
         color: NSColor,
+        colorScheme: ColorScheme,
         presentationActive: Bool,
         in parent: NSView
     ) -> GPUSpinnerNSView? {
@@ -686,6 +695,7 @@ final class SidebarWorkspaceRowTableCellView: NSTableCellView {
             let spinner = existing ?? GPUSpinnerNSView()
             spinner.style = .macOSSpokes
             spinner.color = color
+            spinner.colorScheme = colorScheme
             spinner.isPresentationActive = presentationActive
             if spinner.superview == nil {
                 parent.addSubview(spinner)
@@ -818,8 +828,12 @@ final class SidebarWorkspaceRowTableCellView: NSTableCellView {
             progressView.configure(
                 fraction: CGFloat(progress.value),
                 barHeight: max(3, 3 * model.fontScale),
-                trackColor: model.isActive ? palette.selectedForeground(0.15) : NSColor.secondaryLabelColor.withAlphaComponent(0.2),
-                fillColor: model.isActive ? palette.selectedForeground(0.8) : cmuxAccentNSColor(),
+                trackColor: model.isActive
+                    ? palette.selectedForeground(0.15)
+                    : palette.semantic(.secondaryLabelColor, opacity: 0.2),
+                fillColor: model.isActive
+                    ? palette.selectedForeground(0.8)
+                    : cmuxAccentNSColor(for: palette.colorScheme),
                 labelText: progress.label,
                 labelFont: labelFont,
                 labelColor: palette.secondary(0.6)

--- a/Sources/Sidebar/AppKitList/Cells/SidebarWorkspaceRowCommands.swift
+++ b/Sources/Sidebar/AppKitList/Cells/SidebarWorkspaceRowCommands.swift
@@ -24,7 +24,7 @@ struct SidebarWorkspaceRowCommands {
     let contextMenuPinState: WorkspaceActionDispatcher.PinState?
     let workspaceGroupMenuSnapshot: WorkspaceGroupMenuSnapshot
     /// Resolved cmux scheme used for menu swatches.
-    let colorScheme: ColorScheme = .light
+    var colorScheme: ColorScheme = .light
     /// Re-runs the row's snapshot pump (pin/notification mutations that don't
     /// flow through the observation publishers).
     let refreshSnapshot: () -> Void

--- a/Sources/Sidebar/AppKitList/Cells/SidebarWorkspaceRowCommands.swift
+++ b/Sources/Sidebar/AppKitList/Cells/SidebarWorkspaceRowCommands.swift
@@ -2,6 +2,7 @@ import AppKit
 import CmuxFoundation
 import CmuxWorkspaces
 import Foundation
+import SwiftUI
 
 /// Action surface for one pure-AppKit sidebar workspace row.
 ///
@@ -22,6 +23,8 @@ struct SidebarWorkspaceRowCommands {
     let allRemoteContextMenuTargetsDisconnected: Bool
     let contextMenuPinState: WorkspaceActionDispatcher.PinState?
     let workspaceGroupMenuSnapshot: WorkspaceGroupMenuSnapshot
+    /// Resolved cmux scheme used for menu swatches.
+    let colorScheme: ColorScheme = .light
     /// Re-runs the row's snapshot pump (pin/notification mutations that don't
     /// flow through the observation publishers).
     let refreshSnapshot: () -> Void
@@ -602,7 +605,7 @@ struct SidebarWorkspaceRowMenuBuilder {
             }
             let swatch = WorkspaceTabColorSettings.displayNSColor(
                 hex: entry.hex,
-                colorScheme: NSApp.effectiveAppearance.bestMatch(from: [.darkAqua, .aqua]) == .darkAqua ? .dark : .light,
+                colorScheme: colorScheme,
                 forceBright: false
             ) ?? NSColor(hex: entry.hex) ?? .gray
             colorItem.image = SidebarWorkspaceRowMenuBuilder.coloredCircleImage(color: swatch)

--- a/Sources/Sidebar/AppKitList/Cells/SidebarWorkspaceRowCommands.swift
+++ b/Sources/Sidebar/AppKitList/Cells/SidebarWorkspaceRowCommands.swift
@@ -605,7 +605,7 @@ struct SidebarWorkspaceRowMenuBuilder {
             }
             let swatch = WorkspaceTabColorSettings.displayNSColor(
                 hex: entry.hex,
-                colorScheme: colorScheme,
+                colorScheme: commands.colorScheme,
                 forceBright: false
             ) ?? NSColor(hex: entry.hex) ?? .gray
             colorItem.image = SidebarWorkspaceRowMenuBuilder.coloredCircleImage(color: swatch)

--- a/Sources/Sidebar/AppKitList/Cells/SidebarWorkspaceRowCommands.swift
+++ b/Sources/Sidebar/AppKitList/Cells/SidebarWorkspaceRowCommands.swift
@@ -24,7 +24,7 @@ struct SidebarWorkspaceRowCommands {
     let contextMenuPinState: WorkspaceActionDispatcher.PinState?
     let workspaceGroupMenuSnapshot: WorkspaceGroupMenuSnapshot
     /// Resolved cmux scheme used for menu swatches.
-    var colorScheme: ColorScheme = .light
+    let colorScheme: ColorScheme
     /// Re-runs the row's snapshot pump (pin/notification mutations that don't
     /// flow through the observation publishers).
     let refreshSnapshot: () -> Void

--- a/Sources/Sidebar/AppKitList/Cells/SidebarWorkspaceRowSupportViews.swift
+++ b/Sources/Sidebar/AppKitList/Cells/SidebarWorkspaceRowSupportViews.swift
@@ -23,17 +23,13 @@ struct SidebarRowPalette {
         sidebarSelectedWorkspaceForegroundNSColor(on: selectedBackground, opacity: opacity)
     }
 
-    /// Preserves semantic colors, applying opacity lazily in the drawing appearance.
+    /// Resolves semantic colors against the row's concrete cmux scheme.
     func semantic(_ color: NSColor, opacity: CGFloat? = nil) -> NSColor {
-        guard let opacity else { return color }
-        return NSColor(name: nil) { appearance in
-            var resolved = color
-            appearance.performAsCurrentDrawingAppearance {
-                let candidate = color.withAlphaComponent(opacity)
-                resolved = candidate.usingColorSpace(.sRGB) ?? candidate
-            }
-            return resolved
-        }
+        SidebarAppearanceColorResolver().resolvedColor(
+            color,
+            for: colorScheme,
+            opacity: opacity
+        )
     }
 
     var primaryText: NSColor {

--- a/Sources/Sidebar/AppKitList/SidebarWorkspaceTableEmptyDropIndicatorView.swift
+++ b/Sources/Sidebar/AppKitList/SidebarWorkspaceTableEmptyDropIndicatorView.swift
@@ -1,8 +1,16 @@
 import AppKit
+import SwiftUI
 
 /// AppKit counterpart of the existing two-point accent drop indicator.
 @MainActor
 final class SidebarWorkspaceTableEmptyDropIndicatorView: NSView {
+    var colorScheme: ColorScheme = .light {
+        didSet {
+            guard colorScheme != oldValue else { return }
+            updateAccentColor()
+        }
+    }
+
     override init(frame frameRect: NSRect) {
         super.init(frame: frameRect)
         wantsLayer = true
@@ -15,16 +23,11 @@ final class SidebarWorkspaceTableEmptyDropIndicatorView: NSView {
         fatalError("init(coder:) has not been implemented")
     }
 
-    override func viewDidChangeEffectiveAppearance() {
-        super.viewDidChangeEffectiveAppearance()
-        updateAccentColor()
-    }
-
     override func hitTest(_ point: NSPoint) -> NSView? {
         nil
     }
 
     private func updateAccentColor() {
-        layer?.backgroundColor = cmuxAccentNSColor(for: effectiveAppearance).cgColor
+        layer?.backgroundColor = cmuxAccentNSColor(for: colorScheme).cgColor
     }
 }

--- a/Sources/Sidebar/AppKitList/SidebarWorkspaceTableView.swift
+++ b/Sources/Sidebar/AppKitList/SidebarWorkspaceTableView.swift
@@ -1,4 +1,5 @@
 import CmuxNotifications
+import CmuxAppKitSupportUI
 import SwiftUI
 
 /// Container-level bridge mounting the AppKit-owned default workspace list once.
@@ -23,6 +24,8 @@ struct SidebarWorkspaceTableView: NSViewRepresentable {
     /// owner must invalidate itself so this view re-applies (issue #9690).
     let onDeferredClickAwaitingApply: () -> Void
 
+    @Environment(\.colorScheme) private var colorScheme
+
 #if DEBUG
     @Environment(\.sidebarLazyContractProbe) private var sidebarLazyContractProbe
 #endif
@@ -32,10 +35,15 @@ struct SidebarWorkspaceTableView: NSViewRepresentable {
     }
 
     func makeNSView(context: Context) -> SidebarWorkspaceTableContainerView {
-        context.coordinator.makeContainerView()
+        let container = context.coordinator.makeContainerView()
+        container.appearance = WindowAppearanceSnapshot.appKitAppearance(for: colorScheme)
+        container.emptyDropIndicatorView.colorScheme = colorScheme
+        return container
     }
 
     func updateNSView(_ nsView: SidebarWorkspaceTableContainerView, context: Context) {
+        nsView.appearance = WindowAppearanceSnapshot.appKitAppearance(for: colorScheme)
+        nsView.emptyDropIndicatorView.colorScheme = colorScheme
 #if DEBUG
         context.coordinator.reconfigurationProbe = sidebarLazyContractProbe.tableRootViewReconfigure
 #endif

--- a/Sources/Sidebar/GPUSpinner.swift
+++ b/Sources/Sidebar/GPUSpinner.swift
@@ -7,16 +7,19 @@ import SwiftUI
 struct GPUSpinner: NSViewRepresentable {
     let style: GPUSpinnerStyle
     let color: NSColor
+    @Environment(\.colorScheme) private var colorScheme
 
     func makeNSView(context: Context) -> GPUSpinnerNSView {
         let view = GPUSpinnerNSView(frame: .zero)
         view.style = style
         view.color = color
+        view.colorScheme = colorScheme
         return view
     }
 
     func updateNSView(_ view: GPUSpinnerNSView, context: Context) {
         view.style = style
         view.color = color
+        view.colorScheme = colorScheme
     }
 }

--- a/Sources/Sidebar/GPUSpinnerNSView.swift
+++ b/Sources/Sidebar/GPUSpinnerNSView.swift
@@ -1,5 +1,6 @@
 import AppKit
 import QuartzCore
+import SwiftUI
 
 final class GPUSpinnerNSView: NSView {
     static let animationKey = "cmux.gpuSpinner.rotation"
@@ -27,6 +28,14 @@ final class GPUSpinnerNSView: NSView {
 
     var color: NSColor = .secondaryLabelColor {
         didSet { applyColor() }
+    }
+
+    /// Concrete cmux scheme used to resolve semantic spinner colors.
+    var colorScheme: ColorScheme = .light {
+        didSet {
+            guard colorScheme != oldValue else { return }
+            applyColor()
+        }
     }
 
     override init(frame frameRect: NSRect) {
@@ -131,9 +140,10 @@ final class GPUSpinnerNSView: NSView {
 
     private func applyColor() {
         var cg = CGColor(gray: 0.6, alpha: 1)
-        effectiveAppearance.performAsCurrentDrawingAppearance {
-            cg = Self.resolvedCGColor(color)
-        }
+        cg = Self.resolvedCGColor(
+            SidebarAppearanceColorResolver().resolvedColor(color, for: colorScheme),
+            colorScheme: colorScheme
+        )
         switch style {
         case .macOSSpokes:
             for spoke in spokeLayers {
@@ -173,12 +183,6 @@ final class GPUSpinnerNSView: NSView {
     @objc private func visibilityChanged() {
         layoutContent()
         updateAnimationState()
-    }
-
-    override func viewDidChangeEffectiveAppearance() {
-        super.viewDidChangeEffectiveAppearance()
-        // Re-resolve snapshotted semantic colors on light/dark switches.
-        applyColor()
     }
 
     private var shouldAnimate: Bool {
@@ -235,9 +239,11 @@ final class GPUSpinnerNSView: NSView {
         }
     }
 
-    private static func resolvedCGColor(_ color: NSColor) -> CGColor {
+    private static func resolvedCGColor(_ color: NSColor, colorScheme: ColorScheme) -> CGColor {
         color.usingColorSpace(.deviceRGB)?.cgColor
-            ?? NSColor.secondaryLabelColor.usingColorSpace(.deviceRGB)?.cgColor
+            ?? SidebarAppearanceColorResolver()
+                .resolvedColor(.secondaryLabelColor, for: colorScheme)
+                .usingColorSpace(.deviceRGB)?.cgColor
             ?? CGColor(gray: 0.6, alpha: 1)
     }
 }

--- a/Sources/Sidebar/SidebarAppearanceSupport.swift
+++ b/Sources/Sidebar/SidebarAppearanceSupport.swift
@@ -33,8 +33,7 @@ struct SidebarAppearanceColorResolver {
         for colorScheme: ColorScheme,
         opacity: CGFloat? = nil
     ) -> NSColor {
-        let appearance = NSAppearance(named: colorScheme == .dark ? .darkAqua : .aqua)
-        let resolved = appearance.map { color.resolvedColor(with: $0) } ?? color
+        let resolved = WindowAppearanceSnapshot.resolvedColor(color, for: colorScheme)
         guard let opacity else { return resolved }
         return resolved.withAlphaComponent(max(0, min(opacity, 1)))
     }

--- a/Sources/Sidebar/SidebarAppearanceSupport.swift
+++ b/Sources/Sidebar/SidebarAppearanceSupport.swift
@@ -24,10 +24,12 @@ enum SidebarTabItemFontScale {
 /// shared by the SwiftUI and pure-AppKit sidebar paths so they never ask
 /// AppKit to make an independent appearance decision.
 struct SidebarAppearanceColorResolver {
+    /// Returns the scheme selected by the shared terminal-theme authority.
     func currentColorScheme() -> ColorScheme {
         GhosttyApp.shared.effectiveTerminalColorSchemePreference == .dark ? .dark : .light
     }
 
+    /// Resolves an AppKit semantic color against a concrete cmux scheme.
     func resolvedColor(
         _ color: NSColor,
         for colorScheme: ColorScheme,
@@ -36,6 +38,16 @@ struct SidebarAppearanceColorResolver {
         let resolved = WindowAppearanceSnapshot.resolvedColor(color, for: colorScheme)
         guard let opacity else { return resolved }
         return resolved.withAlphaComponent(max(0, min(opacity, 1)))
+    }
+
+    /// Returns the active-control foreground for a concrete cmux scheme.
+    func activeForegroundColor(
+        opacity: CGFloat,
+        for colorScheme: ColorScheme
+    ) -> NSColor {
+        let clampedOpacity = max(0, min(opacity, 1))
+        let baseColor: NSColor = colorScheme == .dark ? .white : .black
+        return baseColor.withAlphaComponent(clampedOpacity)
     }
 }
 
@@ -69,16 +81,10 @@ func sidebarActiveForegroundNSColor(
     let colorScheme = appAppearance.map {
         $0.bestMatch(from: [.darkAqua, .aqua]) == .darkAqua ? ColorScheme.dark : .light
     } ?? SidebarAppearanceColorResolver().currentColorScheme()
-    return sidebarActiveForegroundNSColor(opacity: opacity, colorScheme: colorScheme)
-}
-
-func sidebarActiveForegroundNSColor(
-    opacity: CGFloat,
-    colorScheme: ColorScheme
-) -> NSColor {
-    let clampedOpacity = max(0, min(opacity, 1))
-    let baseColor: NSColor = colorScheme == .dark ? .white : .black
-    return baseColor.withAlphaComponent(clampedOpacity)
+    return SidebarAppearanceColorResolver().activeForegroundColor(
+        opacity: opacity,
+        for: colorScheme
+    )
 }
 
 func titlebarControlForegroundNSColor(opacity: CGFloat) -> NSColor {

--- a/Sources/Sidebar/SidebarAppearanceSupport.swift
+++ b/Sources/Sidebar/SidebarAppearanceSupport.swift
@@ -17,6 +17,29 @@ enum SidebarTabItemFontScale {
     }
 }
 
+/// Resolves AppKit colors against cmux's concrete terminal light/dark scheme.
+///
+/// AppKit semantic colors otherwise resolve against the window's effective
+/// appearance, which can differ from the active cmux theme. This value type is
+/// shared by the SwiftUI and pure-AppKit sidebar paths so they never ask
+/// AppKit to make an independent appearance decision.
+struct SidebarAppearanceColorResolver {
+    func currentColorScheme() -> ColorScheme {
+        GhosttyApp.shared.effectiveTerminalColorSchemePreference == .dark ? .dark : .light
+    }
+
+    func resolvedColor(
+        _ color: NSColor,
+        for colorScheme: ColorScheme,
+        opacity: CGFloat? = nil
+    ) -> NSColor {
+        let appearance = NSAppearance(named: colorScheme == .dark ? .darkAqua : .aqua)
+        let resolved = appearance.map { color.resolvedColor(with: $0) } ?? color
+        guard let opacity else { return resolved }
+        return resolved.withAlphaComponent(max(0, min(opacity, 1)))
+    }
+}
+
 extension Color {
     init?(hex: String) {
         let hex = hex.trimmingCharacters(in: .init(charactersIn: "#"))
@@ -42,26 +65,34 @@ func coloredCircleImage(color: NSColor) -> NSImage {
 
 func sidebarActiveForegroundNSColor(
     opacity: CGFloat,
-    appAppearance: NSAppearance? = NSApp?.effectiveAppearance
+    appAppearance: NSAppearance? = nil
+) -> NSColor {
+    let colorScheme = appAppearance.map {
+        $0.bestMatch(from: [.darkAqua, .aqua]) == .darkAqua ? ColorScheme.dark : .light
+    } ?? SidebarAppearanceColorResolver().currentColorScheme()
+    return sidebarActiveForegroundNSColor(opacity: opacity, colorScheme: colorScheme)
+}
+
+func sidebarActiveForegroundNSColor(
+    opacity: CGFloat,
+    colorScheme: ColorScheme
 ) -> NSColor {
     let clampedOpacity = max(0, min(opacity, 1))
-    let bestMatch = appAppearance?.bestMatch(from: [.darkAqua, .aqua])
-    let baseColor: NSColor = (bestMatch == .darkAqua) ? .white : .black
+    let baseColor: NSColor = colorScheme == .dark ? .white : .black
     return baseColor.withAlphaComponent(clampedOpacity)
 }
 
 func titlebarControlForegroundNSColor(opacity: CGFloat) -> NSColor {
     let app = GhosttyApp.shared
-    let bestMatch = NSApp?.effectiveAppearance.bestMatch(from: [.darkAqua, .aqua])
-    let colorScheme: ColorScheme = bestMatch == .darkAqua ? .dark : .light
     let appearance = WindowAppearanceResolver(
         terminalAppearance: WindowTerminalAppearanceSnapshot(
             backgroundColor: app.defaultBackgroundColor,
             backgroundOpacity: app.defaultBackgroundOpacity,
             backgroundBlur: app.defaultBackgroundBlur,
-            usesHostLayerBackground: app.usesHostLayerBackground
+            usesHostLayerBackground: app.usesHostLayerBackground,
+            resolvedColorScheme: app.effectiveTerminalColorSchemePreference == .dark ? .dark : .light
         )
-    ).currentFromUserDefaults(defaults: .standard, colorScheme: colorScheme)
+    ).currentFromUserDefaults(defaults: .standard)
     return titlebarControlForegroundNSColor(
         opacity: opacity,
         appearance: appearance
@@ -101,9 +132,7 @@ func cmuxAccentNSColor(for appAppearance: NSAppearance?) -> NSColor {
 }
 
 func cmuxAccentNSColor() -> NSColor {
-    NSColor(name: nil) { appearance in
-        cmuxAccentNSColor(for: appearance)
-    }
+    cmuxAccentNSColor(for: SidebarAppearanceColorResolver().currentColorScheme())
 }
 
 func cmuxAccentColor() -> Color {

--- a/Sources/VerticalTabsSidebar+EmptyAreasAndFooter.swift
+++ b/Sources/VerticalTabsSidebar+EmptyAreasAndFooter.swift
@@ -199,7 +199,7 @@ struct SidebarFooterCircularIcon: View {
             pointSize: style.pointSize,
             weight: style.weight
         )
-        .foregroundStyle(Color(nsColor: .secondaryLabelColor))
+        .foregroundStyle(.secondary)
     }
 }
 
@@ -468,7 +468,7 @@ struct SidebarMobileConnectButton: View {
             )
         } label: {
             CmuxSystemSymbolImage(systemName: "iphone", pointSize: iconSize, weight: .medium)
-                .foregroundStyle(Color(nsColor: .secondaryLabelColor))
+                .foregroundStyle(.secondary)
                 .frame(
                     width: SidebarFooterButtonMetrics.buttonSize,
                     height: SidebarFooterButtonMetrics.buttonSize

--- a/Sources/VerticalTabsSidebar+WorkspaceGroups.swift
+++ b/Sources/VerticalTabsSidebar+WorkspaceGroups.swift
@@ -100,7 +100,8 @@ extension VerticalTabsSidebar {
             isFirstRow: renderContext.sidebarReorderIds.first == group.anchorWorkspaceId,
             isBeingDragged: dragState.draggedTabId == group.anchorWorkspaceId,
             topDropIndicatorVisible: topDropIndicatorVisible,
-            bottomDropIndicatorVisible: bottomDropIndicatorVisible
+            bottomDropIndicatorVisible: bottomDropIndicatorVisible,
+            colorSchemeIsDark: renderContext.environment.colorScheme == .dark
         )
         let actions = SidebarGroupHeaderRowActions(
             onToggleCollapsed: { [weak tabManager, groupId = group.id] in

--- a/Sources/Windowing/AppWindowChromeComposition.swift
+++ b/Sources/Windowing/AppWindowChromeComposition.swift
@@ -52,7 +52,8 @@ struct AppWindowChromeComposition {
             backgroundColor: app.defaultBackgroundColor,
             backgroundOpacity: app.defaultBackgroundOpacity,
             backgroundBlur: app.defaultBackgroundBlur,
-            usesHostLayerBackground: app.usesHostLayerBackground
+            usesHostLayerBackground: app.usesHostLayerBackground,
+            resolvedColorScheme: app.effectiveTerminalColorSchemePreference == .dark ? .dark : .light
         )
     }
 
@@ -74,15 +75,7 @@ struct AppWindowChromeComposition {
     ) -> WindowAppearanceSnapshot {
         appearanceResolver(app: app).currentFromUserDefaults(
             defaults: defaults,
-            colorScheme: colorScheme ?? Self.currentAppColorScheme()
+            colorScheme: colorScheme
         )
-    }
-
-    @MainActor
-    private static func currentAppColorScheme(
-        appearance: NSAppearance? = nil
-    ) -> ColorScheme {
-        let resolved = appearance ?? NSApplication.shared.effectiveAppearance
-        return resolved.bestMatch(from: [.darkAqua, .aqua]) == .darkAqua ? .dark : .light
     }
 }

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -2919,13 +2919,29 @@ final class Workspace: Identifiable, ObservableObject, FilePreviewTabMetadataHos
         true
     }
 
+    /// Resolves a terminal surface color against the same concrete scheme the
+    /// live Ghostty app selected. Workspace/Bonsplit objects can be created
+    /// before a SwiftUI `WindowAppearanceSnapshot` is mounted, so they use
+    /// this composition seam instead of AppKit's ambient window appearance.
+    nonisolated static func resolvedTerminalChromeBackgroundColor(
+        backgroundColor: NSColor,
+        backgroundOpacity: Double
+    ) -> NSColor {
+        WindowAppearanceSnapshot.resolvedChromeBackgroundColor(
+            backgroundColor: backgroundColor,
+            opacity: backgroundOpacity,
+            colorScheme: GhosttyApp.shared.effectiveTerminalColorSchemePreference == .dark ? .dark : .light
+        )
+    }
+
     nonisolated static func bonsplitChromeHex(
         backgroundColor: NSColor,
         backgroundOpacity: Double,
-        sharesWindowBackdrop: Bool = false
+        sharesWindowBackdrop: Bool = false,
+        chromeBackgroundColor: NSColor? = nil
     ) -> String {
         _ = sharesWindowBackdrop
-        let themedColor = WindowAppearanceSnapshot.compositedTerminalColor(
+        let themedColor = chromeBackgroundColor ?? WindowAppearanceSnapshot.compositedTerminalColor(
             backgroundColor: backgroundColor,
             opacity: backgroundOpacity
         )
@@ -2947,15 +2963,23 @@ final class Workspace: Identifiable, ObservableObject, FilePreviewTabMetadataHos
         backgroundOpacity: Double,
         sharesWindowBackdrop: Bool = false,
         renderingMode: GhosttyTerminalBackdropRenderingMode = .windowHostBackdrop,
-        paneBorderColorHex: String? = nil
+        paneBorderColorHex: String? = nil,
+        chromeBackgroundColor: NSColor? = nil
     ) -> BonsplitConfiguration.Appearance.ChromeColors {
         let surfaceHex = bonsplitChromeHex(
             backgroundColor: backgroundColor,
             backgroundOpacity: backgroundOpacity,
-            sharesWindowBackdrop: sharesWindowBackdrop
+            sharesWindowBackdrop: sharesWindowBackdrop,
+            chromeBackgroundColor: chromeBackgroundColor
         )
         let defaultBorderHex = WindowChromeColorResolver()
-            .separatorColor(forChromeBackground: backgroundColor)
+            .separatorColor(
+                forChromeBackground: chromeBackgroundColor
+                    ?? WindowAppearanceSnapshot.compositedTerminalColor(
+                        backgroundColor: backgroundColor,
+                        opacity: backgroundOpacity
+                    )
+            )
             .hexString(includeAlpha: true)
         let borderHex = PaneChromeSettings.resolvedPaneBorderHex(
             configuredHex: paneBorderColorHex,
@@ -3064,7 +3088,11 @@ final class Workspace: Identifiable, ObservableObject, FilePreviewTabMetadataHos
             backgroundOpacity: backgroundOpacity,
             sharesWindowBackdrop: sharesWindowBackdrop,
             renderingMode: renderingMode,
-            paneBorderColorHex: PaneChromeSettings.paneBorderColorHex()
+            paneBorderColorHex: PaneChromeSettings.paneBorderColorHex(),
+            chromeBackgroundColor: Self.resolvedTerminalChromeBackgroundColor(
+                backgroundColor: backgroundColor,
+                backgroundOpacity: backgroundOpacity
+            )
         )
         return BonsplitConfiguration.Appearance(
             tabBarHeight: WindowChromeMetrics.bonsplitTabBarHeight,
@@ -3088,7 +3116,11 @@ final class Workspace: Identifiable, ObservableObject, FilePreviewTabMetadataHos
             backgroundOpacity: config.backgroundOpacity,
             sharesWindowBackdrop: sharesWindowBackdrop,
             renderingMode: renderingMode,
-            paneBorderColorHex: PaneChromeSettings.paneBorderColorHex()
+            paneBorderColorHex: PaneChromeSettings.paneBorderColorHex(),
+            chromeBackgroundColor: Self.resolvedTerminalChromeBackgroundColor(
+                backgroundColor: config.backgroundColor,
+                backgroundOpacity: config.backgroundOpacity
+            )
         )
         let nextTabTitleFontSize = config.surfaceTabBarFontSize
         let currentAppearance = bonsplitController.configuration.appearance
@@ -3147,7 +3179,11 @@ final class Workspace: Identifiable, ObservableObject, FilePreviewTabMetadataHos
             backgroundOpacity: backgroundOpacity,
             sharesWindowBackdrop: sharesWindowBackdrop,
             renderingMode: renderingMode,
-            paneBorderColorHex: PaneChromeSettings.paneBorderColorHex()
+            paneBorderColorHex: PaneChromeSettings.paneBorderColorHex(),
+            chromeBackgroundColor: Self.resolvedTerminalChromeBackgroundColor(
+                backgroundColor: backgroundColor,
+                backgroundOpacity: backgroundOpacity
+            )
         )
         let currentChromeColors = bonsplitController.configuration.appearance.chromeColors
         let currentUsesSharedBackdrop = bonsplitController.configuration.appearance.usesSharedBackdrop

--- a/cmuxTests/SessionIndexTableViewportTests.swift
+++ b/cmuxTests/SessionIndexTableViewportTests.swift
@@ -310,7 +310,11 @@ struct SessionIndexTableViewportTests {
         )
 
         let host = NSHostingView(
-            rootView: SessionIndexView(store: store, onResume: nil)
+            rootView: SessionIndexView(
+                store: store,
+                chromeBackgroundColor: .black,
+                onResume: nil
+            )
                 .frame(width: 320, height: 300)
         )
         let window = NSWindow(

--- a/cmuxTests/SidebarAppKitRowCellTests.swift
+++ b/cmuxTests/SidebarAppKitRowCellTests.swift
@@ -182,6 +182,7 @@ struct SidebarAppKitRowCellTests {
             allRemoteContextMenuTargetsDisconnected: false,
             contextMenuPinState: nil,
             workspaceGroupMenuSnapshot: WorkspaceGroupMenuSnapshot(items: []),
+            colorScheme: model.colorSchemeIsDark ? .dark : .light,
             refreshSnapshot: {},
             readSelectedTabIds: { [] },
             writeSelectedTabIds: { _ in },
@@ -2097,7 +2098,8 @@ struct SidebarPinnedIndicatorColorTests {
             isFirstRow: true,
             isBeingDragged: false,
             topDropIndicatorVisible: false,
-            bottomDropIndicatorVisible: false
+            bottomDropIndicatorVisible: false,
+            colorSchemeIsDark: false
         ))
 
         let workspacePin = try #require(

--- a/cmuxTests/SidebarLazyLayoutScaleTests.swift
+++ b/cmuxTests/SidebarLazyLayoutScaleTests.swift
@@ -154,6 +154,7 @@ final class SidebarLazyLayoutScaleTests {
             onToggleSidebar: {},
             onNewTab: {},
             observedWindowReference: WeakWindowReference(),
+            chromeBackgroundColor: .black,
             selection: .constant(.tabs),
             selectedTabIds: .constant([]),
             lastSidebarSelectionIndex: .constant(nil),

--- a/cmuxTests/SidebarWorkspaceRowSuspensionTests.swift
+++ b/cmuxTests/SidebarWorkspaceRowSuspensionTests.swift
@@ -138,6 +138,7 @@ struct SidebarWorkspaceRowSuspensionTests {
             allRemoteContextMenuTargetsDisconnected: false,
             contextMenuPinState: nil,
             workspaceGroupMenuSnapshot: WorkspaceGroupMenuSnapshot(items: []),
+            colorScheme: model.colorSchemeIsDark ? .dark : .light,
             refreshSnapshot: {},
             readSelectedTabIds: { [] },
             writeSelectedTabIds: { _ in },

--- a/cmuxTests/SidebarWorkspaceTableSuspensionTests.swift
+++ b/cmuxTests/SidebarWorkspaceTableSuspensionTests.swift
@@ -615,7 +615,8 @@ struct SidebarWorkspaceTableSuspensionTests {
             shortcutHintText: nil, shortcutHintXOffset: 0, shortcutHintYOffset: 0,
             fontScale: 1, globalFontMagnificationPercent: 100, cwdContextMenuItems: [],
             rowSpacing: 2, isFirstRow: true, isBeingDragged: false,
-            topDropIndicatorVisible: false, bottomDropIndicatorVisible: false
+            topDropIndicatorVisible: false, bottomDropIndicatorVisible: false,
+            colorSchemeIsDark: false
         )
     }
 

--- a/cmuxTests/WindowAppearanceSnapshotTests.swift
+++ b/cmuxTests/WindowAppearanceSnapshotTests.swift
@@ -159,7 +159,7 @@ final class WindowAppearanceSnapshotTests: XCTestCase {
         XCTAssertEqual(cmuxReadableColorScheme(for: composited), .light)
     }
 
-    func testSidebarContentColorSchemeUsesTerminalOnlyForUnifiedBackdrops() {
+    func testSidebarContentColorSchemeUsesResolvedTerminalThemeForAllBackdrops() {
         XCTAssertEqual(
             makeSnapshot(unifySurfaceBackdrops: true, backgroundHex: "#101820", sidebarColorScheme: .light)
                 .sidebarContentColorScheme,
@@ -168,8 +168,24 @@ final class WindowAppearanceSnapshotTests: XCTestCase {
         XCTAssertEqual(
             makeSnapshot(unifySurfaceBackdrops: false, backgroundHex: "#101820", sidebarColorScheme: .light)
                 .sidebarContentColorScheme,
-            .light
+            .dark
         )
+    }
+
+    func testSidebarTintSelectionUsesResolvedTerminalThemeWhenSystemDisagrees() {
+        let snapshot = makeSnapshot(
+            unifySurfaceBackdrops: false,
+            backgroundHex: "#F8F8F2",
+            sidebarColorScheme: .dark,
+            sidebarTintHexDark: "#FF0000",
+            sidebarTintOpacity: 0.4
+        )
+
+        guard case let .sidebarMaterial(policy) = snapshot.policy(for: .rightSidebar) else {
+            XCTFail("right sidebar should keep its own material policy")
+            return
+        }
+        XCTAssertEqual(policy.tintColor.hexString(includeAlpha: true), "#00000066")
     }
 
     func testDockAndSidebarChromeShareResolvedTerminalThemeWhenSystemDisagrees() {

--- a/cmuxTests/WindowAppearanceSnapshotTests.swift
+++ b/cmuxTests/WindowAppearanceSnapshotTests.swift
@@ -176,9 +176,9 @@ final class WindowAppearanceSnapshotTests: XCTestCase {
         let snapshot = makeSnapshot(
             unifySurfaceBackdrops: false,
             backgroundHex: "#F8F8F2",
-            sidebarColorScheme: .dark,
             sidebarTintHexDark: "#FF0000",
-            sidebarTintOpacity: 0.4
+            sidebarTintOpacity: 0.4,
+            sidebarColorScheme: .dark
         )
 
         guard case let .sidebarMaterial(policy) = snapshot.policy(for: .rightSidebar) else {

--- a/cmuxTests/WindowAppearanceSnapshotTests.swift
+++ b/cmuxTests/WindowAppearanceSnapshotTests.swift
@@ -172,6 +172,34 @@ final class WindowAppearanceSnapshotTests: XCTestCase {
         )
     }
 
+    func testDockAndSidebarChromeShareResolvedTerminalThemeWhenSystemDisagrees() {
+        let cases: [(backgroundHex: String, expected: ColorScheme)] = [
+            ("#F8F8F2", .light),
+            ("#101820", .dark),
+        ]
+
+        for testCase in cases {
+            for systemResolvedSidebarScheme in [ColorScheme.light, .dark] {
+                let snapshot = makeSnapshot(
+                    unifySurfaceBackdrops: false,
+                    backgroundHex: testCase.backgroundHex,
+                    sidebarColorScheme: systemResolvedSidebarScheme
+                )
+
+                XCTAssertEqual(
+                    snapshot.chromeColorScheme,
+                    testCase.expected,
+                    "Unexpected terminal theme resolution for \(testCase.backgroundHex)"
+                )
+                XCTAssertEqual(
+                    snapshot.sidebarContentColorScheme,
+                    testCase.expected,
+                    "Dock/sidebar chrome diverged for terminal \(testCase.expected) and system \(systemResolvedSidebarScheme)"
+                )
+            }
+        }
+    }
+
     func testMatchedLeftAndRightSidebarBackdropsShareTerminalRootBackdrop() {
         let cases: [(backgroundHex: String, opacity: CGFloat)] = [
             ("#FFFFFF", 1),


### PR DESCRIPTION
## Summary

- Route Dock, sidebar, Bonsplit, browser, and native sidebar chrome through one resolved terminal light/dark authority.
- Propagate the resolved scheme into SwiftUI and AppKit hosting roots, including detached Dock/sidebar variants, and refresh Dock chrome when the authority changes.
- Resolve translucent chrome backgrounds against the concrete cmux scheme so system appearance cannot produce mixed light/dark surfaces.
- Add regression coverage for terminal-theme/system-appearance disagreements and injected light/dark authority propagation.

Fixes https://github.com/manaflow-ai/cmux/issues/10146

## Validation

- `git diff --check`
- `swiftc -frontend -parse` on all changed Swift files
- `./scripts/lint-pbxproj-test-wiring.sh`
- `python3 scripts/check-sidebar-lazy-layout.py`

No local Xcode build/tests were run per task instructions. No new user-facing strings were added; existing Dock/sidebar strings remain localized.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/10149"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789271848&installation_model_id=21920&pr_number=10149&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F10149&signature=ef75b783ba135e25d62d23e0b99cb0c45c23bf072b754e86852d9e68812204e4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Unifies Dock, browser, and sidebar chrome under one terminal‑resolved light/dark authority to eliminate mixed light/dark chrome when macOS appearance disagrees. Previously AppKit/sidebars could follow macOS; now every chrome surface resolves through `WindowAppearanceSnapshot.resolvedColorScheme` and a concrete `resolvedChromeBackgroundColor`.

- `WindowAppearanceSnapshot` adds `resolvedColorScheme`, `resolvedChromeBackgroundColor`, `appKitAppearance(for:)`, and `resolvedColor(_:for:)`; `chromeColorScheme` and `sidebarContentColorScheme` now mirror this authority. `WindowAppearanceResolver.currentFromUserDefaults` accepts an optional `colorScheme` (kept for compatibility, not used for authority). `WindowTerminalAppearanceSnapshot` accepts an optional `resolvedColorScheme` for explicit propagation.
- Dock: injects `environment(\.colorScheme, snapshot.resolvedColorScheme)` and uses `snapshot.resolvedChromeBackgroundColor`; refreshes on authority/background changes; Bonsplit receives `chromeBackgroundColor` via `DockSplitStore.applyGhosttyChrome(from:windowAppearance:)` to avoid ambient macOS appearance at startup.
- Browser: computes chrome from the injected scheme and `resolvedThemeBackgroundColor`; overlays/badges use SwiftUI primary/secondary; webview background updates via `GhosttyBackgroundTheme.resolvedColor(from:)`; replaces a deprecated theme observer.
- Sidebars/AppKit: native hosts adopt `WindowAppearanceSnapshot.appKitAppearance(for:)`; semantic colors resolve via `SidebarAppearanceColorResolver`; accents/separators/spinners/badges follow the shared scheme. Models/commands carry the concrete scheme where needed.
- Tests cover Dock/sidebar unification, terminal/system disagreements, and authority propagation.

**Migration**
- `WindowChromeBorder` now requires `backgroundColor` and no longer listens for refresh notifications.
- Use `DockSplitStore.applyGhosttyChrome(from:windowAppearance:)` (or supply `chromeBackgroundColor` via `Workspace.resolvedTerminalChromeBackgroundColor(...)`) instead of relying on ambient appearance.
- Pass the resolved authority from `PanelContentView`: `BrowserPanelView(resolvedColorScheme:..., resolvedThemeBackgroundColor:...)`; `RightSidebarToolPanelView(resolvedChromeBackgroundColor:...)`; `SessionIndexView(chromeBackgroundColor:...)`; `FeedPanelView(chromeBackgroundColor:...)`.
- AppKit hosts must apply the resolved scheme: set `view.appearance = WindowAppearanceSnapshot.appKitAppearance(for:)` (file explorer, sidebar tables/headers/rows, extension browser, spinners).
- Sidebar/AppKit APIs now require a concrete scheme in models/commands where applicable (e.g., `SidebarGroupHeaderRowModel.colorSchemeIsDark`, `SidebarWorkspaceRowCommands.colorScheme`, `GPUSpinnerNSView.colorScheme`).

<sup>Written for commit ef536b04af3796772f036705703ba31660fe66fc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/10149?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved light and dark theme handling across window chrome, browser panels, docks, sidebars, file explorers, and workspace views.
  * Terminal appearance now consistently determines chrome, background, accent, separator, and text colors.
  * Sidebar and AppKit-backed components update automatically when appearance changes.
  * Empty states, spinners, progress indicators, and status controls now respect the active theme.

* **Bug Fixes**
  * Corrected color compositing and theme mismatches when terminal and system appearances differ.

* **Tests**
  * Added coverage for terminal-driven theme resolution and synchronized sidebar and dock styling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->