### PR TITLE
Revert "Fix iOS 27 keyboard toggle focus handoff"

### DIFF
--- a/.github/workflows/reload-build.yml
+++ b/.github/workflows/reload-build.yml
@@ -201,7 +201,6 @@ jobs:
             -destination 'generic/platform=iOS Simulator' \
             -derivedDataPath "$RUNNER_TEMP/cmux-ios-dd" \
             ARCHS=arm64 \
-            ONLY_ACTIVE_ARCH=YES \
             PRODUCT_BUNDLE_IDENTIFIER="$bundle_id" \
             PRODUCT_DISPLAY_NAME="$display_name" \
             CMUX_GIT_SHA="$(git rev-parse --short HEAD)" \

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/GhosttySurfaceRepresentable.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/GhosttySurfaceRepresentable.swift
@@ -668,7 +668,6 @@ struct GhosttySurfaceRepresentable: UIViewRepresentable {
                 observedFrame: observed
             ) {
             case .reveal:
-                var needsPresentationReFence = false
                 if let viewportAnchor {
                     let restored = await surfaceView.restoreVerifiedReplayViewportAnchor(
                         viewportAnchor
@@ -676,17 +675,11 @@ struct GhosttySurfaceRepresentable: UIViewRepresentable {
                     guard !Task.isCancelled else { return false }
                     if restored {
                         pendingReplayViewportAnchor = nil
-                        needsPresentationReFence = true
+                        // Restore and re-fence happen under render suppression,
+                        // so the renderer identity cannot change before reveal.
+                        _ = await surfaceView.presentRestoredVerifiedReplayViewport()
+                        guard !Task.isCancelled else { return false }
                     }
-                }
-                if await surfaceView.drainPendingScrollForVerifiedReplayReveal() {
-                    needsPresentationReFence = true
-                }
-                if needsPresentationReFence {
-                    // Restore/scroll and re-fence happen under render suppression,
-                    // so the renderer identity cannot change before reveal.
-                    _ = await surfaceView.presentRestoredVerifiedReplayViewport()
-                    guard !Task.isCancelled else { return false }
                 }
                 guard surfaceView.revealVerifiedReplayPresentation(
                     transactionID: transactionID

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MobileSettingsView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MobileSettingsView.swift
@@ -62,7 +62,6 @@ struct MobileSettingsView: View {
 
     var body: some View {
         @Bindable var displaySettings = displaySettings
-        @Bindable var toasts = toasts
         return NavigationStack {
             Form {
                 if initialFocus == .connectionMethod {

--- a/Packages/iOS/CmuxMobileSupport/Sources/CmuxMobileSupport/MobileKeyboardTransition.swift
+++ b/Packages/iOS/CmuxMobileSupport/Sources/CmuxMobileSupport/MobileKeyboardTransition.swift
@@ -8,9 +8,6 @@ public import UIKit
 /// content inset, and content offset updates use the exact duration and curve of
 /// the system keyboard animation.
 public struct MobileKeyboardTransition: Sendable {
-    /// The keyboard's initial screen-space frame from the notification payload.
-    public let beginFrame: CGRect
-
     /// The keyboard's final screen-space frame from the notification payload.
     public let endFrame: CGRect
 
@@ -28,8 +25,6 @@ public struct MobileKeyboardTransition: Sendable {
         guard let endFrame = notification.userInfo?[UIResponder.keyboardFrameEndUserInfoKey] as? CGRect else {
             return nil
         }
-        beginFrame = notification.userInfo?[UIResponder.keyboardFrameBeginUserInfoKey] as? CGRect
-            ?? endFrame
         self.endFrame = endFrame
         duration = notification.userInfo?[UIResponder.keyboardAnimationDurationUserInfoKey] as? TimeInterval ?? 0
         let curveRaw = notification.userInfo?[UIResponder.keyboardAnimationCurveUserInfoKey] as? Int
@@ -42,21 +37,8 @@ public struct MobileKeyboardTransition: Sendable {
     /// - Parameter view: The view whose bounds should be compared to the keyboard.
     /// - Returns: The bottom overlap in `view` coordinates, or zero when detached.
     @MainActor public func overlap(in view: UIView) -> CGFloat {
-        overlap(of: endFrame, in: view)
-    }
-
-    /// Returns how much of `view` is covered by the keyboard's initial frame.
-    ///
-    /// The begin/end pair identifies the keyboard transition that emitted a later
-    /// `didChangeFrame` notification, allowing clients to reject a completion from
-    /// a transition superseded by a rapid reversal.
-    @MainActor public func beginOverlap(in view: UIView) -> CGFloat {
-        overlap(of: beginFrame, in: view)
-    }
-
-    @MainActor private func overlap(of frame: CGRect, in view: UIView) -> CGFloat {
         guard let window = view.window else { return 0 }
-        let keyboardFrameInWindow = window.convert(frame, from: nil)
+        let keyboardFrameInWindow = window.convert(endFrame, from: nil)
         let viewFrameInWindow = view.convert(view.bounds, to: window)
         return MobileKeyboardReservation(
             keyboardFrameInWindow: keyboardFrameInWindow,

--- a/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceHostView.swift
+++ b/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceHostView.swift
@@ -1,324 +1,34 @@
 #if canImport(UIKit)
-import CmuxMobileSupport
-import CmuxMobileTerminalKit
-import QuartzCore
 import UIKit
 
-/// iOS 27 can leave `keyboardLayoutGuide` at the screen bottom while the keyboard is
-/// visible. Only that OS uses notification-derived dock geometry; every other OS keeps
-/// UIKit's system guide as the dock constraint authority.
-private enum KeyboardDockGeometrySource {
-    case systemLayoutGuide
-    case keyboardNotifications
-
-    static var current: Self {
-        #if DEBUG
-        if UITestConfig.forceIOS27KeyboardDockWorkaround {
-            return .keyboardNotifications
-        }
-        #endif
-        return ProcessInfo.processInfo.operatingSystemVersion.majorVersion == 27
-            ? .keyboardNotifications
-            : .systemLayoutGuide
-    }
-}
-
-/// UIKit root that owns terminal clipping, dock placement, and keyboard motion.
+/// Plain UIKit root that owns the terminal's bottom dock and keyboard geometry.
 ///
-/// The terminal presentation and dock animate in one transaction. The Metal surface
-/// remains full-size and unchanged behind ``terminalClipView`` until the transition
-/// settles, so keyboard motion cannot race a display-link geometry correction.
+/// `GhosttySurfaceView` is an aggressively relaid-out `CAMetalLayer` renderer. Keeping
+/// the keyboard constraint on this separate, layout-passive root prevents renderer
+/// geometry updates from committing an interrupted keyboard transition's model frame.
 @MainActor
 public final class GhosttySurfaceHostView: UIView {
     public let surfaceView: GhosttySurfaceView
-    private let terminalClipView = UIView()
-    private let terminalPresentationView = UIView()
-    private var dockBottomConstraint: NSLayoutConstraint!
-    private let keyboardDockGeometrySource = KeyboardDockGeometrySource.current
-    private var keyboardTransitionGeneration: UInt64 = 0
-    private var keyboardTransitionActive = false
-    private var keyboardTargetHeight: CGFloat = 0
-    private var keyboardTargetTop: CGFloat = 0
-    private var keyboardTargetTerminalBottom: CGFloat = 0
-    #if DEBUG
-    private var maximumTerminalDockPresentationGap: CGFloat = 0
-    #endif
 
     public init(surfaceView: GhosttySurfaceView) {
         self.surfaceView = surfaceView
         super.init(frame: surfaceView.frame)
 
         backgroundColor = surfaceView.backgroundColor
-        clipsToBounds = false
-
-        terminalClipView.backgroundColor = surfaceView.backgroundColor
-        terminalClipView.clipsToBounds = true
-        terminalClipView.translatesAutoresizingMaskIntoConstraints = false
-        addSubview(terminalClipView)
-
-        terminalPresentationView.backgroundColor = surfaceView.backgroundColor
-        terminalPresentationView.translatesAutoresizingMaskIntoConstraints = false
-        terminalClipView.addSubview(terminalPresentationView)
-
         surfaceView.translatesAutoresizingMaskIntoConstraints = false
-        terminalPresentationView.addSubview(surfaceView)
-        dockBottomConstraint = surfaceView.moveBottomDock(to: self)
-        if keyboardDockGeometrySource == .systemLayoutGuide {
-            dockBottomConstraint.isActive = false
-            keyboardLayoutGuide.followsUndockedKeyboard = true
-            keyboardLayoutGuide.usesBottomSafeArea = true
-            dockBottomConstraint = surfaceView.hostedBottomDockBottomAnchor.constraint(
-                equalTo: keyboardLayoutGuide.topAnchor
-            )
-            dockBottomConstraint.isActive = true
-        }
-
+        addSubview(surfaceView)
         NSLayoutConstraint.activate([
-            terminalClipView.topAnchor.constraint(equalTo: topAnchor),
-            terminalClipView.leadingAnchor.constraint(equalTo: leadingAnchor),
-            terminalClipView.trailingAnchor.constraint(equalTo: trailingAnchor),
-            terminalClipView.bottomAnchor.constraint(equalTo: surfaceView.hostedBottomDockTopAnchor),
-
-            terminalPresentationView.topAnchor.constraint(equalTo: topAnchor),
-            terminalPresentationView.leadingAnchor.constraint(equalTo: leadingAnchor),
-            terminalPresentationView.widthAnchor.constraint(equalTo: widthAnchor),
-            terminalPresentationView.heightAnchor.constraint(equalTo: heightAnchor),
-
-            surfaceView.topAnchor.constraint(equalTo: terminalPresentationView.topAnchor),
-            surfaceView.leadingAnchor.constraint(equalTo: terminalPresentationView.leadingAnchor),
-            surfaceView.trailingAnchor.constraint(equalTo: terminalPresentationView.trailingAnchor),
-            surfaceView.bottomAnchor.constraint(equalTo: terminalPresentationView.bottomAnchor),
+            surfaceView.topAnchor.constraint(equalTo: topAnchor),
+            surfaceView.leadingAnchor.constraint(equalTo: leadingAnchor),
+            surfaceView.trailingAnchor.constraint(equalTo: trailingAnchor),
+            surfaceView.bottomAnchor.constraint(equalTo: bottomAnchor),
         ])
-
-        NotificationCenter.default.addObserver(
-            self,
-            selector: #selector(keyboardWillChangeFrame(_:)),
-            name: UIResponder.keyboardWillChangeFrameNotification,
-            object: nil
-        )
+        surfaceView.moveBottomDock(to: self)
     }
 
     @available(*, unavailable)
     required init?(coder: NSCoder) {
         fatalError("init(coder:) is not supported")
     }
-
-    deinit {
-        NotificationCenter.default.removeObserver(self)
-    }
-
-    public override func didMoveToWindow() {
-        super.didMoveToWindow()
-        guard window != nil else {
-            keyboardTransitionGeneration &+= 1
-            keyboardTransitionActive = false
-            terminalPresentationView.layer.removeAllAnimations()
-            terminalPresentationView.transform = .identity
-            return
-        }
-        guard !keyboardTransitionActive else { return }
-        settleDockWithoutKeyboardAnimation()
-    }
-
-    public override func layoutSubviews() {
-        super.layoutSubviews()
-        guard keyboardDockGeometrySource == .systemLayoutGuide,
-              !keyboardTransitionActive else { return }
-        surfaceView.updateHostedKeyboardLayoutGuide(
-            height: keyboardLayoutGuideOverlap
-        )
-    }
-
-    public override func safeAreaInsetsDidChange() {
-        super.safeAreaInsetsDidChange()
-        guard !keyboardTransitionActive else { return }
-        settleDockWithoutKeyboardAnimation()
-    }
-
-    @objc private func keyboardWillChangeFrame(_ notification: Notification) {
-        guard window != nil,
-              let transition = MobileKeyboardTransition(notification: notification) else { return }
-        let targetHeight = transition.overlap(in: self)
-        let targetIsVisible = transition.isVisible(in: self)
-        beginKeyboardTransition(
-            targetHeight: targetHeight,
-            targetIsVisible: targetIsVisible,
-            transition: transition
-        )
-    }
-
-    private func beginKeyboardTransition(
-        targetHeight: CGFloat,
-        targetIsVisible: Bool,
-        transition: MobileKeyboardTransition
-    ) {
-        // A fresh keyboard notification starts from the model tree. The live
-        // presentation layers are meaningful only when this host is already
-        // animating a prior keyboard leg. Rebasing on every notification can
-        // fold an unrelated settled presentation transform into the first leg,
-        // making the terminal begin several points away from its dock.
-        if keyboardTransitionActive {
-            rebaseKeyboardPresentationFromLiveFrames()
-        }
-        layoutIfNeeded()
-        keyboardTransitionGeneration &+= 1
-        let generation = keyboardTransitionGeneration
-        keyboardTransitionActive = true
-        keyboardTargetHeight = max(0, targetHeight)
-        surfaceView.beginHostedKeyboardTransition(isVisible: targetIsVisible)
-
-        let reservation = surfaceView.hostedBottomReservation(
-            keyboardHeight: keyboardTargetHeight,
-            bottomSafeAreaInset: resolvedBottomSafeAreaInset
-        )
-        if keyboardDockGeometrySource == .keyboardNotifications {
-            dockBottomConstraint.constant = -reservation
-        }
-        keyboardTargetTop = max(0, bounds.maxY - reservation)
-        keyboardTargetTerminalBottom = max(
-            0,
-            keyboardTargetTop - surfaceView.hostedBottomDockHeight
-        )
-        let rendererBottom = surfaceView.hostedTerminalRenderBottom
-        let targetTranslation = keyboardTargetTerminalBottom - rendererBottom
-        #if DEBUG
-        maximumTerminalDockPresentationGap = 0
-        #endif
-
-        transition.animate { [weak self] in
-            guard let self else { return }
-            self.terminalPresentationView.transform = CGAffineTransform(
-                translationX: 0,
-                y: targetTranslation
-            )
-            self.layoutIfNeeded()
-        } completion: { [weak self] _ in
-            guard let self, self.keyboardTransitionGeneration == generation else { return }
-            self.finishKeyboardTransition()
-        }
-    }
-
-    private func finishKeyboardTransition() {
-        CATransaction.begin()
-        CATransaction.setDisableActions(true)
-        UIView.performWithoutAnimation {
-            surfaceView.finishHostedKeyboardTransition(
-                keyboardHeight: keyboardTargetHeight,
-                terminalBottom: keyboardTargetTerminalBottom
-            )
-            terminalPresentationView.transform = .identity
-            layoutIfNeeded()
-        }
-        CATransaction.commit()
-        keyboardTransitionActive = false
-        sampleTerminalDockPresentationGap()
-    }
-
-    private func settleDockWithoutKeyboardAnimation() {
-        if keyboardDockGeometrySource == .keyboardNotifications {
-            let reservation = surfaceView.hostedBottomReservation(
-                keyboardHeight: keyboardTargetHeight,
-                bottomSafeAreaInset: resolvedBottomSafeAreaInset
-            )
-            dockBottomConstraint.constant = -reservation
-        }
-        UIView.performWithoutAnimation {
-            layoutIfNeeded()
-        }
-        keyboardTargetTop = surfaceView.hostedBottomDockFrame.maxY
-        keyboardTargetTerminalBottom = surfaceView.hostedBottomDockFrame.minY
-    }
-
-    private var resolvedBottomSafeAreaInset: CGFloat {
-        TerminalLetterboxGeometry.resolvedBottomSafeAreaInset(
-            viewInset: safeAreaInsets.bottom,
-            windowInset: window?.safeAreaInsets.bottom ?? 0
-        )
-    }
-
-    private var keyboardLayoutGuideOverlap: CGFloat {
-        guard bounds.height > 0 else { return 0 }
-        let guideFrame = keyboardLayoutGuide.layoutFrame
-        guard abs(guideFrame.maxY - bounds.maxY) <= 1 else {
-            return surfaceView.hostedKeyboardHeight
-        }
-        let occupancy = max(0, bounds.maxY - guideFrame.minY)
-        return occupancy > resolvedBottomSafeAreaInset + 0.5 ? occupancy : 0
-    }
-
-    /// Rebase both sides of the terminal/dock boundary before a new keyboard will.
-    ///
-    /// A reversal arrives while the previous leg still has separate Core Animation
-    /// presentation trees for the dock constraint, clip boundary, and terminal
-    /// wrapper. Rebasing only the wrapper makes its next `.beginFromCurrentState`
-    /// animation start at the live edge while the clip remains at the old target,
-    /// exposing a one-frame gap. The notification fallback owns the dock constraint,
-    /// so it can first fold the live dock bottom into that constraint, lay out the
-    /// linked clip without actions, then fold the wrapper's live transform into its
-    /// model. The next transaction therefore starts every owned component at one edge.
-    private func rebaseKeyboardPresentationFromLiveFrames() {
-        let wrapperTransform: CGAffineTransform? = {
-            guard let presentation = terminalPresentationView.layer.presentation(),
-                  CATransform3DIsAffine(presentation.transform) else { return nil }
-            return CATransform3DGetAffineTransform(presentation.transform)
-        }()
-        let liveDockBottom = surfaceView.hostedBottomDockPresentationBottom(in: self)
-
-        guard wrapperTransform != nil || liveDockBottom != nil else { return }
-        CATransaction.begin()
-        CATransaction.setDisableActions(true)
-        UIView.performWithoutAnimation {
-            if keyboardDockGeometrySource == .keyboardNotifications,
-               let liveDockBottom {
-                dockBottomConstraint.constant = liveDockBottom - bounds.maxY
-            }
-            if let wrapperTransform {
-                terminalPresentationView.transform = wrapperTransform
-            }
-            // The clip bottom is constrained to the dock top. Layout before removing
-            // the old animations so its model edge is the same live edge as the dock.
-            layoutIfNeeded()
-            terminalClipView.layer.removeAllAnimations()
-            surfaceView.removeHostedBottomDockAnimations()
-            terminalPresentationView.layer.removeAllAnimations()
-        }
-        CATransaction.commit()
-    }
-
-    func updateTerminalBackground(_ color: UIColor) {
-        backgroundColor = color
-        terminalClipView.backgroundColor = color
-        terminalPresentationView.backgroundColor = color
-    }
-
-    func sampleTerminalDockPresentationGap() {
-        #if DEBUG
-        maximumTerminalDockPresentationGap = max(
-            maximumTerminalDockPresentationGap,
-            terminalDockPresentationGap
-        )
-        #endif
-    }
-
-    #if DEBUG
-    var debugKeyboardTransitionID: Int { keyboardTransitionActive ? 1 : -1 }
-    var debugUsesNotificationKeyboardDock: Bool {
-        keyboardDockGeometrySource == .keyboardNotifications
-    }
-    var debugKeyboardTargetHeight: CGFloat { keyboardTargetHeight }
-    var debugKeyboardTargetTop: CGFloat { keyboardTargetTop }
-    var debugTerminalDockPresentationGap: CGFloat {
-        terminalDockPresentationGap
-    }
-    var debugMaximumTerminalDockPresentationGap: CGFloat {
-        maximumTerminalDockPresentationGap
-    }
-
-    private var terminalDockPresentationGap: CGFloat {
-        guard let terminalBottom = surfaceView.hostedTerminalPresentationBottom(in: self),
-              let dockTop = surfaceView.hostedBottomDockPresentationTop(in: self) else { return 0 }
-        return abs(terminalBottom - dockTop)
-    }
-    #endif
 }
 #endif

--- a/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView+LocalScrollbackScroll.swift
+++ b/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView+LocalScrollbackScroll.swift
@@ -10,41 +10,18 @@ extension GhosttySurfaceView {
     /// display-only and drops those bytes, so the authoritative Mac response
     /// remains the visible update for TUIs.
     ///
-    /// The scroll-event generation bump happens on the main actor before this
-    /// enqueue. Restore claims and user viewport batches share `outputQueue`,
-    /// and replay reveal waits can target the exact generation that was pending
-    /// when the render update tried to present. Deltas accumulated during an
-    /// in-flight batch apply as one follow-up batch; obsolete intermediate
-    /// deltas are merged, never replayed. No gate lock spans a Ghostty call,
-    /// and scrolling never takes Ghostty locks on the main actor.
-    func applyLocalScrollbackScroll(
-        lines: Double,
-        col: Int,
-        row: Int,
-        interactionGeneration: UInt64
-    ) {
+    /// The flush-site generation bump happens on the main actor before this
+    /// enqueue. Restore claims and user viewport batches share `outputQueue`, so
+    /// FIFO ordering makes a pre-restore gesture visible to the claim and applies
+    /// a post-restore gesture afterward. Deltas accumulated during an in-flight
+    /// batch apply as one follow-up batch; obsolete intermediate deltas are
+    /// merged, never replayed. No gate lock spans a Ghostty call, and scrolling
+    /// never takes Ghostty locks on the main actor.
+    func applyLocalScrollbackScroll(lines: Double, col: Int, row: Int) {
         guard lines != 0 else { return }
         pendingLocalScrollLines += lines
         pendingLocalScrollCell = (col, row)
-        pendingLocalScrollInteractionGeneration = max(
-            pendingLocalScrollInteractionGeneration ?? 0,
-            interactionGeneration
-        )
         pumpLocalScrollbackScroll()
-    }
-
-    func waitForLocalScrollApplied(upTo generation: UInt64) async -> Bool {
-        let applied = viewportRestoreGate.withLock {
-            $0.appliedInteractionGeneration >= generation
-        }
-        guard !applied else { return true }
-        return await withCheckedContinuation { continuation in
-            pendingLocalScrollDrains.append((
-                generation: generation,
-                continuation: continuation
-            ))
-            pumpLocalScrollbackScroll()
-        }
     }
 
     private func pumpLocalScrollbackScroll() {
@@ -55,12 +32,9 @@ extension GhosttySurfaceView {
         }
         let lines = pendingLocalScrollLines
         let cell = pendingLocalScrollCell
-        let interactionGeneration = pendingLocalScrollInteractionGeneration
-            ?? viewportRestoreGate.withLock { $0.interactionGeneration }
         pendingLocalScrollLines = 0
-        pendingLocalScrollInteractionGeneration = nil
+        let interactionGeneration = viewportRestoreGate.withLock { $0.interactionGeneration }
         localScrollApplyInFlight = true
-        localScrollApplyInFlightGeneration = interactionGeneration
         let displayScale = window?.windowScene?.screen.scale ?? traitCollection.displayScale
         let operation = LocalScrollbackSurfaceOperation(
             surface: surface,
@@ -86,36 +60,15 @@ extension GhosttySurfaceView {
             Task { @MainActor [weak self] in
                 guard let self else { return }
                 self.localScrollApplyInFlight = false
-                self.localScrollApplyInFlightGeneration = nil
                 guard self.surface == operation.surface,
                       self.surfaceGeneration == operation.generation else {
-                    self.completePendingLocalScrollDrains(returning: false)
                     return
                 }
                 self.drawForWakeup()
                 self.scheduleVisibleArtifactCountUpdate()
-                self.completePendingLocalScrollDrains()
                 self.pumpLocalScrollbackScroll()
             }
         }
-    }
-
-    func completePendingLocalScrollDrains(returning result: Bool? = nil) {
-        guard !pendingLocalScrollDrains.isEmpty else { return }
-        let appliedGeneration = viewportRestoreGate.withLock {
-            $0.appliedInteractionGeneration
-        }
-        var remaining: [(generation: UInt64, continuation: CheckedContinuation<Bool, Never>)] = []
-        for pending in pendingLocalScrollDrains {
-            if let result {
-                pending.continuation.resume(returning: result)
-            } else if appliedGeneration >= pending.generation {
-                pending.continuation.resume(returning: true)
-            } else {
-                remaining.append(pending)
-            }
-        }
-        pendingLocalScrollDrains = remaining
     }
 }
 

--- a/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView.swift
+++ b/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView.swift
@@ -12,6 +12,32 @@ import os
 
 private let log = Logger(subsystem: "ai.manaflow.cmux.ios", category: "ghostty.surface")
 
+/// iOS 27 beta can leave `UIKeyboardLayoutGuide` seated at the screen bottom while
+/// the keyboard is visible. Keep the existing system-guide architecture everywhere
+/// else and use the keyboard notification's end frame only on that OS major.
+private enum KeyboardDockGeometrySource: Equatable {
+    case systemLayoutGuide
+    case keyboardNotifications
+
+    static var current: Self {
+        #if DEBUG
+        if UITestConfig.forceIOS27KeyboardDockWorkaround {
+            return .keyboardNotifications
+        }
+        #endif
+        return ProcessInfo.processInfo.operatingSystemVersion.majorVersion == 27
+            ? .keyboardNotifications
+            : .systemLayoutGuide
+    }
+
+    var debugName: String {
+        switch self {
+        case .systemLayoutGuide: "layoutGuide"
+        case .keyboardNotifications: "notification"
+        }
+    }
+}
+
 public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
     /// The surface whose terminal proxy or composer currently owns input.
     ///
@@ -230,12 +256,8 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
     var userViewportInteractionGeneration: UInt64 {
         viewportRestoreGate.withLock { $0.interactionGeneration }
     }
-    @discardableResult
-    func bumpUserViewportInteractionGeneration() -> UInt64 {
-        viewportRestoreGate.withLock {
-            $0.interactionGeneration &+= 1
-            return $0.interactionGeneration
-        }
+    func bumpUserViewportInteractionGeneration() {
+        viewportRestoreGate.withLock { $0.interactionGeneration &+= 1 }
     }
     private static let scrollMechanicsContentHeight: CGFloat = 1_000_000
     private var scrollMechanicsIsRecentering = false
@@ -363,20 +385,10 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
         let toolbarMaxY = toolbarFrame.map { pointValue($0.maxY) } ?? "none"
         let internalPresentationGap = pointValue(currentInternalDockPresentationGap)
         let maximumInternalPresentationGap = pointValue(maximumInternalDockPresentationGap)
-        let host = bottomDockHostView as? GhosttySurfaceHostView
-        let keyboardTransitionID = host?.debugKeyboardTransitionID
-            ?? (keyboardPresentationTransitionActive ? 1 : -1)
-        let keyboardTransitionTarget = pointValue(host?.debugKeyboardTargetHeight ?? keyboardHeight)
-        let keyboardDockTargetTop = pointValue(host?.debugKeyboardTargetTop ?? bottomDockContainer.frame.maxY)
-        let keyboardDockSource = host?.debugUsesNotificationKeyboardDock == true
-            ? "notification"
-            : "layoutGuide"
-        let terminalDockPresentationGap = pointValue(
-            host?.debugTerminalDockPresentationGap ?? 0
-        )
-        let maximumTerminalDockPresentationGap = pointValue(
-            host?.debugMaximumTerminalDockPresentationGap ?? 0
-        )
+        let keyboardTransitionID = bottomDockTransitionInFlight ? 1 : -1
+        let keyboardTransitionTarget = pointValue(keyboardHeight)
+        let keyboardGuideTop = pointValue(keyboardGuideFrameInSurface.minY)
+        let keyboardDockTargetTop = pointValue(keyboardDockTargetTopInSurface)
         return [
             "chromeHidden=\(chromeHidden ? 1 : 0)",
             "composerActive=\(composerActive ? 1 : 0)",
@@ -394,12 +406,9 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
             "toolbarMaxY=\(toolbarMaxY)",
             "dockInternalPresentationGap=\(internalPresentationGap)",
             "dockMaxInternalPresentationGap=\(maximumInternalPresentationGap)",
-            "terminalDockPresentationGap=\(terminalDockPresentationGap)",
-            "terminalDockMaxPresentationGap=\(maximumTerminalDockPresentationGap)",
-            "screenScale=\(pointValue(preferredScreenScale))",
             "bottomSafeArea=\(pointValue(safeAreaInsetsBottom))",
-            "keyboardGuideTop=\(keyboardDockTargetTop)",
-            "keyboardDockSource=\(keyboardDockSource)",
+            "keyboardGuideTop=\(keyboardGuideTop)",
+            "keyboardDockSource=\(keyboardDockGeometrySource.debugName)",
             "keyboardDockTargetTop=\(keyboardDockTargetTop)",
             "keyboardTransitionID=\(keyboardTransitionID)",
             "keyboardTransitionTarget=\(keyboardTransitionTarget)",
@@ -532,10 +541,14 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
         lastAppliedContainerSize = .zero
     }
     private var viewportCoordinator = TerminalViewportCoordinator()
-    /// True while ``GhosttySurfaceHostView`` owns keyboard presentation. Renderer
-    /// geometry stays unchanged until the host atomically folds in the settled edge.
-    private var keyboardPresentationTransitionActive = false
+    /// The toolbar/composer use Auto Layout; the Ghostty renderer does not. This bit
+    /// keeps display-link viewport updates alive until the dock's presentation frame
+    /// reaches its model frame.
+    private var bottomDockTransitionObserved = false
+    private let keyboardDockGeometrySource = KeyboardDockGeometrySource.current
+    private var keyboardNotificationTransitionGeneration: UInt64 = 0
     private var bottomDockToKeyboardConstraint: NSLayoutConstraint?
+    private var bottomDockManualConstraint: NSLayoutConstraint?
     private var bottomDockHostConstraints: [NSLayoutConstraint] = []
     private weak var bottomDockHostView: UIView?
     private var composerHeightConstraint: NSLayoutConstraint?
@@ -794,6 +807,7 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
         addSubview(debugAccessibilityProxy)
         addSubview(composerDockProbe)
         #endif
+        configureKeyboardLayoutGuide()
         installBottomDockContainer()
         installPersistentToolbar()
         installComposerContainer()
@@ -836,6 +850,20 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
             name: UIApplication.willEnterForegroundNotification,
             object: nil
         )
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(handleKeyboardWillChangeFrame(_:)),
+            name: UIResponder.keyboardWillChangeFrameNotification,
+            object: nil
+        )
+        if keyboardDockGeometrySource == .keyboardNotifications {
+            NotificationCenter.default.addObserver(
+                self,
+                selector: #selector(handleKeyboardWillChangeFrame(_:)),
+                name: UIResponder.keyboardDidChangeFrameNotification,
+                object: nil
+            )
+        }
     }
 
     @objc private func handleAppWillResignActive() {
@@ -975,9 +1003,14 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
     /// whichever registered surface happens to sort first.
     public var hostSurfaceID: String?
 
-    /// Freezes renderer geometry while the host moves the dock and terminal
-    /// presentation container inside one UIKit animation transaction.
-    func beginHostedKeyboardTransition(isVisible: Bool) {
+    @objc private func handleKeyboardWillChangeFrame(_ notification: Notification) {
+        guard let transition = MobileKeyboardTransition(notification: notification) else { return }
+        #if DEBUG
+        let willBeVisible = keyboardHeightOverrideForTesting.map { $0 > 0 }
+            ?? transition.isVisible(in: self)
+        #else
+        let willBeVisible = transition.isVisible(in: self)
+        #endif
         let wasVisible = keyboardVisible
         #if DEBUG
         // The composer-up/keyboard-down desync can be reached WITHOUT the dismiss
@@ -988,16 +1021,15 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
         // here too, with the resolved first-responder owner, so a Capture&Send trace
         // is complete no matter how the keyboard went down. Pure diagnostics; the hide
         // behavior below is unchanged.
-        if wasVisible, !isVisible, composerActive {
+        if wasVisible, !willBeVisible, composerActive {
             let frOwner = TerminalInputTextView.responderIdentity(of: CurrentResponderProbe().current())
             MobileDebugLog.anchormux(
                 "composer.keyboardHideWhilePresented prevKeyboardHeight=\(Int(keyboardHeight)) frOwner=\(frOwner.rawValue) proxyIsFR=\(inputProxy.isFirstResponder ? 1 : 0)"
             )
         }
         #endif
-        keyboardVisible = isVisible
-        inputProxy.setKeyboardShown(isVisible)
-        keyboardPresentationTransitionActive = true
+        keyboardVisible = willBeVisible
+        inputProxy.setKeyboardShown(willBeVisible)
         // Round 8 removes the `composerPresented ⇒ keyboardUp` enforcement: the
         // toolbar is ALWAYS visible and the composer band survives a keyboard-down, so
         // the keyboard collapsing no longer dismisses the composer. The composer's
@@ -1005,62 +1037,124 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
         // and its text stays; tapping it refocuses and re-raises the keyboard. The
         // composer is dismissed only by its chevron or the toolbar composer button.
         //
+        // This notification always owns responder-facing visibility. On iOS 27 it
+        // also owns dock geometry because that beta can leave `keyboardLayoutGuide`
+        // stale; every other OS keeps the existing guide as its only geometry source.
         updateDockedToolbarVisibility()
+        switch keyboardDockGeometrySource {
+        case .systemLayoutGuide:
+            setNeedsLayout()
+        case .keyboardNotifications:
+            let durationOverride: TimeInterval? = notification.name
+                == UIResponder.keyboardDidChangeFrameNotification ? 0 : nil
+            applyNotificationDrivenKeyboardTransition(
+                transition,
+                durationOverride: durationOverride
+            )
+        }
     }
 
-    /// The host reads the system keyboard layout guide outside iOS 27 and publishes
-    /// its settled overlap to the renderer model. UIKit still owns the guide-backed
-    /// dock constraint; this only schedules one geometry negotiation after a change.
-    func updateHostedKeyboardLayoutGuide(height: CGFloat) {
-        guard !keyboardPresentationTransitionActive else { return }
-        let nextHeight = max(0, height)
-        guard abs(nextHeight - keyboardHeight) > 0.25 else { return }
-        keyboardHeight = nextHeight
-        layoutBottomDock(using: viewportSnapshot())
-        setNeedsGeometrySync()
-    }
-
-    /// Folds the host's presentation translation into the renderer model at
-    /// the exact settled dock edge, then allows grid negotiation to resume.
-    func finishHostedKeyboardTransition(
-        keyboardHeight: CGFloat,
-        terminalBottom: CGFloat
+    /// Drives the iOS 27 compatibility constraint from UIKit's keyboard frame.
+    /// This is the sole dock geometry authority on that OS, so the broken layout
+    /// guide never competes with the notification-derived target.
+    private func applyNotificationDrivenKeyboardTransition(
+        _ transition: MobileKeyboardTransition,
+        durationOverride: TimeInterval?
     ) {
-        self.keyboardHeight = max(0, keyboardHeight)
-        keyboardPresentationTransitionActive = false
-        let snapshot = viewportSnapshot()
-        layoutBottomDock(using: snapshot)
-        pinHostedTerminalRenderBottom(terminalBottom, snapshot: snapshot)
-        layoutZoomOverlay()
+        let owner = bottomDockHostView ?? self
+        #if DEBUG
+        if let keyboardHeightOverrideForTesting {
+            keyboardHeight = max(0, keyboardHeightOverrideForTesting)
+            bottomDockTransitionObserved = false
+            updateNotificationDrivenDockConstraint()
+            setNeedsGeometrySync()
+            setNeedsLayout()
+            return
+        }
+        #endif
+        let targetOverlap = transition.overlap(in: owner)
+        let animationDuration = durationOverride ?? transition.duration
+
+        owner.layoutIfNeeded()
+        keyboardHeight = targetOverlap
+        updateNotificationDrivenDockConstraint()
+        #if DEBUG
+        maximumInternalDockPresentationGap = 0
+        #endif
+        keyboardNotificationTransitionGeneration &+= 1
+        let generation = keyboardNotificationTransitionGeneration
+        bottomDockTransitionObserved = animationDuration > 0
         setNeedsGeometrySync()
+
+        transition.animate(durationOverride: durationOverride) { [weak self, weak owner] in
+            guard let self, let owner else { return }
+            owner.layoutIfNeeded()
+            self.layoutRenderedTerminalForCurrentViewport()
+            self.layoutZoomOverlay()
+        } completion: { [weak self] _ in
+            guard let self,
+                  self.keyboardNotificationTransitionGeneration == generation else { return }
+            self.bottomDockTransitionObserved = false
+            self.layoutRenderedTerminalForCurrentViewport()
+            self.layoutZoomOverlay()
+            self.setNeedsGeometrySync()
+        }
     }
 
-    private func pinHostedTerminalRenderBottom(
-        _ terminalBottom: CGFloat,
-        snapshot: TerminalViewportSnapshot
-    ) {
-        snapshotFallbackView.frame = snapshot.layoutViewportRect
-        layoutVerifiedReplayFrozenPresentation(viewportRect: snapshot.layoutViewportRect)
-        guard !lastRenderRect.isEmpty else { return }
-        let renderRect = CGRect(
-            x: lastRenderRect.minX,
-            y: terminalBottom - lastRenderRect.height,
-            width: lastRenderRect.width,
-            height: lastRenderRect.height
-        )
-        lastRenderRect = renderRect
-        syncRendererLayerFrame(scale: preferredScreenScale, renderRect: renderRect)
-        updateLetterboxBorder(
-            renderRect: renderRect,
-            isLetterboxed: snapshot.isLetterboxed(renderSize: renderRect.size)
-        )
-    }
-
-    func sampleHostedKeyboardPresentation() {
-        (bottomDockHostView as? GhosttySurfaceHostView)?.sampleTerminalDockPresentationGap()
+    /// Keep the renderer clipped to the dock's live presentation during animation.
+    ///
+    /// The constrained toolbar/composer already follow the guide automatically. The
+    /// terminal renderer is not Auto Layout-backed, so its display-link pass reads the
+    /// constrained toolbar's presentation frame until it reaches the model target.
+    private func advanceBottomDockTransition() {
+        let isTransitioning = bottomDockTransitionInFlight
         #if DEBUG
         sampleInternalDockPresentationGap()
         #endif
+        guard isTransitioning || bottomDockTransitionObserved else { return }
+        bottomDockTransitionObserved = isTransitioning
+        layoutRenderedTerminalForCurrentViewport()
+        layoutZoomOverlay()
+        if !isTransitioning {
+            setNeedsGeometrySync()
+        }
+    }
+
+    /// Configures the system keyboard guide used by every OS except iOS 27.
+    private func configureKeyboardLayoutGuide(on owner: UIView? = nil) {
+        guard keyboardDockGeometrySource == .systemLayoutGuide else { return }
+        let guide = (owner ?? self).keyboardLayoutGuide
+        guide.followsUndockedKeyboard = true
+        guide.usesBottomSafeArea = true
+    }
+
+    /// Builds the one active dock-bottom constraint for the selected OS policy.
+    private func makeBottomDockConstraint(on owner: UIView) -> NSLayoutConstraint {
+        switch keyboardDockGeometrySource {
+        case .systemLayoutGuide:
+            configureKeyboardLayoutGuide(on: owner)
+            return bottomDockContainer.bottomAnchor.constraint(
+                equalTo: owner.keyboardLayoutGuide.topAnchor
+            )
+        case .keyboardNotifications:
+            let constraint = bottomDockContainer.bottomAnchor.constraint(
+                equalTo: owner.bottomAnchor
+            )
+            bottomDockManualConstraint = constraint
+            updateNotificationDrivenDockConstraint(constraint)
+            return constraint
+        }
+    }
+
+    private func updateNotificationDrivenDockConstraint(
+        _ constraint: NSLayoutConstraint? = nil
+    ) {
+        guard keyboardDockGeometrySource == .keyboardNotifications,
+              let constraint = constraint ?? bottomDockManualConstraint else { return }
+        constraint.constant = -TerminalLetterboxGeometry.keyboardOccupancy(
+            keyboardHeight: keyboardHeight,
+            bottomSafeAreaInset: safeAreaInsetsBottom
+        )
     }
 
     private func installBottomDockContainer() {
@@ -1078,8 +1172,7 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
         dockedToolbar.translatesAutoresizingMaskIntoConstraints = false
         composerContainer.translatesAutoresizingMaskIntoConstraints = false
 
-        let dockBottom = bottomDockContainer.bottomAnchor.constraint(equalTo: bottomAnchor)
-        dockBottom.constant = -keyboardOccupancyInBounds
+        let dockBottom = makeBottomDockConstraint(on: self)
         let composerHeight = composerContainer.heightAnchor.constraint(equalToConstant: 0)
         let toolbarHeight = dockedToolbar.heightAnchor.constraint(equalToConstant: 0)
         bottomDockToKeyboardConstraint = dockBottom
@@ -1108,18 +1201,16 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
         layoutBottomDock()
     }
 
-    /// Moves the visual dock into the host that owns keyboard presentation.
-    /// Returns the sole dock-bottom constraint for that host.
-    func moveBottomDock(to host: UIView) -> NSLayoutConstraint {
-        if host === bottomDockHostView, let bottomDockToKeyboardConstraint {
-            return bottomDockToKeyboardConstraint
-        }
+    /// Moves the visual dock out of the renderer and into a layout-passive host.
+    /// The selected OS policy then owns the dock's presentation on that host.
+    func moveBottomDock(to host: UIView) {
+        guard host !== self, bottomDockHostView !== host else { return }
         NSLayoutConstraint.deactivate(bottomDockHostConstraints)
         bottomDockContainer.removeFromSuperview()
         host.addSubview(bottomDockContainer)
 
-        let dockBottom = bottomDockContainer.bottomAnchor.constraint(equalTo: host.bottomAnchor)
-        dockBottom.constant = -keyboardOccupancyInBounds
+        bottomDockManualConstraint = nil
+        let dockBottom = makeBottomDockConstraint(on: host)
         let hostConstraints = [
             bottomDockContainer.leadingAnchor.constraint(equalTo: host.leadingAnchor),
             bottomDockContainer.trailingAnchor.constraint(equalTo: host.trailingAnchor),
@@ -1130,84 +1221,76 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
         bottomDockHostView = host
         NSLayoutConstraint.activate(hostConstraints)
         host.setNeedsLayout()
-        return dockBottom
     }
 
-    var hostedBottomDockTopAnchor: NSLayoutYAxisAnchor {
-        bottomDockContainer.topAnchor
+    /// Updates the renderer's overlap model from the guide's target top edge.
+    @discardableResult
+    private func synchronizeKeyboardGeometryFromLayoutGuide() -> Bool {
+        guard keyboardDockGeometrySource == .systemLayoutGuide else { return false }
+        let nextHeight = keyboardOverlapFromLayoutGuide
+        guard abs(nextHeight - keyboardHeight) > 0.25 else { return false }
+        keyboardHeight = nextHeight
+        #if DEBUG
+        // Scope the retained seam maximum to this keyboard target change. The dock
+        // can already have a presentation layer when the guide updates, so waiting
+        // to infer a transition from model/presentation divergence may miss its first
+        // frame and leave an unrelated Composer mount animation in the measurement.
+        maximumInternalDockPresentationGap = 0
+        #endif
+        bottomDockTransitionObserved = bottomDockTransitionInFlight
+        setNeedsGeometrySync()
+        return true
     }
 
-    var hostedBottomDockBottomAnchor: NSLayoutYAxisAnchor {
-        bottomDockContainer.bottomAnchor
-    }
-
-    var hostedBottomDockHeight: CGFloat {
-        bottomDockContainer.bounds.height
-    }
-
-    var hostedBottomDockFrame: CGRect {
-        bottomDockContainer.frame
-    }
-
-    var hostedTerminalRenderBottom: CGFloat {
-        lastRenderRect.isEmpty ? terminalViewportRect.maxY : lastRenderRect.maxY
-    }
-
-    var hostedKeyboardHeight: CGFloat { keyboardHeight }
-
-    func hostedBottomReservation(
-        keyboardHeight: CGFloat,
-        bottomSafeAreaInset: CGFloat
-    ) -> CGFloat {
-        chromeHidden
-            ? max(0, keyboardHeight)
-            : TerminalLetterboxGeometry.keyboardOccupancy(
-                keyboardHeight: keyboardHeight,
-                bottomSafeAreaInset: bottomSafeAreaInset
-            )
-    }
-
-    func hostedTerminalPresentationBottom(in host: UIView) -> CGFloat? {
-        let hostLayer = host.layer.presentation() ?? host.layer
-        if let renderer = (layer.sublayers ?? []).first(where: isGhosttyRendererLayer) {
-            let source = renderer.presentation() ?? renderer
-            return source.convert(
-                CGPoint(x: source.bounds.midX, y: source.bounds.maxY),
-                to: hostLayer
-            ).y
+    /// Keyboard overlap represented by the system guide, excluding its safe-area fallback.
+    private var keyboardOverlapFromLayoutGuide: CGFloat {
+        #if DEBUG
+        if let keyboardHeightOverrideForTesting {
+            return max(0, keyboardHeightOverrideForTesting)
         }
-        let source = layer.presentation() ?? layer
-        return source.convert(
-            CGPoint(x: bounds.midX, y: hostedTerminalRenderBottom),
-            to: hostLayer
-        ).y
+        #endif
+        guard window != nil, bounds.height > 0 else { return 0 }
+        let guideFrame = keyboardGuideFrameInSurface
+        // A guide frame is usable only after UIKit has seated it against this view's
+        // bottom edge. During first attachment or rotation, keep the prior overlap for
+        // that transient pass instead of interpreting CGRect.zero as a full-screen
+        // keyboard.
+        guard abs(guideFrame.maxY - bounds.maxY) <= 1 else { return keyboardHeight }
+        let guideTop = min(max(0, guideFrame.minY), bounds.maxY)
+        let occupancy = max(0, bounds.maxY - guideTop)
+        return occupancy > safeAreaInsetsBottom + 0.5 ? occupancy : 0
     }
 
-    func hostedBottomDockPresentationTop(in host: UIView) -> CGFloat? {
-        guard bottomDockContainer.superview != nil else { return nil }
-        let source = bottomDockContainer.layer.presentation() ?? bottomDockContainer.layer
-        let hostLayer = host.layer.presentation() ?? host.layer
-        return source.convert(
-            CGPoint(x: source.bounds.midX, y: source.bounds.minY),
-            to: hostLayer
-        ).y
+    private var keyboardGuideFrameInSurface: CGRect {
+        guard let owner = bottomDockHostView else { return keyboardLayoutGuide.layoutFrame }
+        return owner.convert(owner.keyboardLayoutGuide.layoutFrame, to: self)
     }
 
-    func hostedBottomDockPresentationBottom(in host: UIView) -> CGFloat? {
-        guard bottomDockContainer.superview != nil else { return nil }
-        let source = bottomDockContainer.layer.presentation() ?? bottomDockContainer.layer
-        let hostLayer = host.layer.presentation() ?? host.layer
-        return source.convert(
-            CGPoint(x: source.bounds.midX, y: source.bounds.maxY),
-            to: hostLayer
-        ).y
+    private var keyboardDockTargetTopInSurface: CGFloat {
+        switch keyboardDockGeometrySource {
+        case .systemLayoutGuide:
+            return keyboardGuideFrameInSurface.minY
+        case .keyboardNotifications:
+            let owner = bottomDockHostView ?? self
+            let target = CGPoint(
+                x: owner.bounds.minX,
+                y: owner.bounds.maxY - keyboardOccupancyInBounds
+            )
+            return owner.convert(target, to: self).y
+        }
     }
 
-    /// The host has already folded the dock's presentation position into its
-    /// constraint. Removing only this container's old position animation lets the
-    /// next host-owned transaction restart the dock and terminal at the same edge.
-    func removeHostedBottomDockAnimations() {
-        bottomDockContainer.layer.removeAllAnimations()
+    /// Whether UIKit is still animating the constrained dock toward its target.
+    private var bottomDockTransitionInFlight: Bool {
+        #if DEBUG
+        if keyboardHeightOverrideForTesting != nil { return false }
+        #endif
+        guard dockedToolbarShouldBeVisible,
+              dockedToolbar?.isHidden == false,
+              let presentationFrame = bottomDockPresentationFrameInSurface else {
+            return false
+        }
+        return abs(presentationFrame.minY - bottomDockContainer.frame.minY) > 0.5
     }
 
     #if DEBUG
@@ -1216,11 +1299,21 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
         let clamped = max(0, height)
         keyboardHeightOverrideForTesting = clamped
         keyboardHeight = clamped
-        keyboardPresentationTransitionActive = false
-        bottomDockToKeyboardConstraint?.constant = -TerminalLetterboxGeometry.keyboardOccupancy(
+        bottomDockTransitionObserved = false
+
+        bottomDockToKeyboardConstraint?.isActive = false
+        bottomDockManualConstraint?.isActive = false
+        let owner = bottomDockHostView ?? self
+        let constraint = bottomDockContainer.bottomAnchor.constraint(
+            equalTo: owner.bottomAnchor
+        )
+        constraint.constant = -TerminalLetterboxGeometry.keyboardOccupancy(
             keyboardHeight: clamped,
             bottomSafeAreaInset: safeAreaInsetsBottom
         )
+        constraint.isActive = true
+        bottomDockManualConstraint = constraint
+        bottomDockToKeyboardConstraint = constraint
     }
     #endif
 
@@ -1347,7 +1440,10 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
             toolbarFrameHeight: Self.persistentToolbarHeight,
             bottomSafeAreaInset: safeAreaInsetsBottom,
             chromeHidden: chromeHidden,
-            viewportNegotiationUnsettled: keyboardPresentationTransitionActive
+            chromeVisible: dockedToolbarShouldBeVisible && dockedToolbar?.isHidden == false,
+            toolbarFrame: dockedToolbarFrameInSurface,
+            toolbarPresentationFrame: dockedToolbarPresentationFrameInSurface,
+            viewportNegotiationUnsettled: bottomDockTransitionInFlight
                 || pendingViewportReport != nil
                 || awaitingViewportEcho
         ))
@@ -1864,6 +1960,10 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
         presentationFrameInSurface(of: dockedToolbar)
     }
 
+    private var bottomDockPresentationFrameInSurface: CGRect? {
+        presentationFrameInSurface(of: bottomDockContainer)
+    }
+
     private func presentationFrameInSurface(of view: UIView?) -> CGRect? {
         guard let view,
               view.superview != nil,
@@ -1969,7 +2069,6 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
         // deceleration, and momentum. The Mac still owns terminal semantics:
         // normal-screen scrollback and alt-screen mouse-wheel delivery.
         guard deltaY != 0 else { return }
-        let interactionGeneration = bumpUserViewportInteractionGeneration()
         // User-driven movement reveals the chip; this is guard-only work per
         // frame (the linger is armed by the gesture-end callbacks).
         noteArtifactChipScrollActivity()
@@ -1977,29 +2076,20 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
         let divisor = cellHeightPt > 1 ? Double(cellHeightPt) * 3 : 42
         pendingScrollLines += -Double(deltaY) / divisor
         pendingScrollCell = scrollCell(at: touchPoint)
-        pendingScrollInteractionGeneration = interactionGeneration
     }
 
     /// Coalesced native scroll forwarded to the Mac once per display-link frame.
     private var pendingScrollLines: Double = 0
     private var pendingScrollCell: (col: Int, row: Int) = (0, 0)
-    private var pendingScrollInteractionGeneration: UInt64?
     var pendingLocalScrollLines: Double = 0
     var pendingLocalScrollCell: (col: Int, row: Int) = (0, 0)
-    var pendingLocalScrollInteractionGeneration: UInt64?
     var localScrollApplyInFlight = false
-    var localScrollApplyInFlightGeneration: UInt64?
-    var pendingLocalScrollDrains: [(generation: UInt64, continuation: CheckedContinuation<Bool, Never>)] = []
 
     /// Drops scroll work tied to a surface generation that will no longer run.
     func resetScrollStateForSurfaceReplacement() {
         pendingScrollLines = 0
-        pendingScrollInteractionGeneration = nil
         pendingLocalScrollLines = 0
-        pendingLocalScrollInteractionGeneration = nil
         localScrollApplyInFlight = false
-        localScrollApplyInFlightGeneration = nil
-        completePendingLocalScrollDrains(returning: false)
     }
 
     /// Map a touch point to a grid cell (shared effective grid with the Mac), so
@@ -2013,65 +2103,16 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
         return (col, row)
     }
 
-    @discardableResult
-    private func flushPendingScrollIfNeeded() -> (generation: UInt64, appliedLocally: Bool)? {
-        guard pendingScrollLines != 0 else { return nil }
+    private func flushPendingScrollIfNeeded() {
+        guard pendingScrollLines != 0 else { return }
         let lines = pendingScrollLines
         let cell = pendingScrollCell
-        let generation = pendingScrollInteractionGeneration
-            ?? bumpUserViewportInteractionGeneration()
         pendingScrollLines = 0
-        pendingScrollInteractionGeneration = nil
-        let appliedLocally = scrollPresentationAuthority.appliesLocally
+        bumpUserViewportInteractionGeneration()
         if scrollPresentationAuthority.appliesLocally {
-            applyLocalScrollbackScroll(
-                lines: lines,
-                col: cell.col,
-                row: cell.row,
-                interactionGeneration: generation
-            )
+            applyLocalScrollbackScroll(lines: lines, col: cell.col, row: cell.row)
         }
         delegate?.ghosttySurfaceView(self, didScrollLines: lines, atCol: cell.col, row: cell.row)
-        return (generation, appliedLocally)
-    }
-
-    /// Pulls a pending native scroll batch into the replay transaction before
-    /// revealing the verified renderer. Without this drain, a render-grid
-    /// update can reveal the pre-scroll viewport for one frame while the
-    /// display-link batch is still waiting behind the frozen presentation.
-    @discardableResult
-    public func drainPendingScrollForVerifiedReplayReveal() async -> Bool {
-        var drained = false
-        while true {
-            if let flushed = flushPendingScrollIfNeeded() {
-                guard flushed.appliedLocally else { return drained }
-                guard await waitForLocalScrollApplied(upTo: flushed.generation) else {
-                    return drained
-                }
-                drained = true
-                continue
-            }
-            guard let generation = pendingLocalScrollTargetGenerationForReveal() else {
-                return drained
-            }
-            guard await waitForLocalScrollApplied(upTo: generation) else {
-                return drained
-            }
-            drained = true
-        }
-    }
-
-    private func pendingLocalScrollTargetGenerationForReveal() -> UInt64? {
-        var generation: UInt64?
-        if pendingLocalScrollLines != 0,
-           let pendingLocalScrollInteractionGeneration {
-            generation = max(generation ?? 0, pendingLocalScrollInteractionGeneration)
-        }
-        if localScrollApplyInFlight,
-           let localScrollApplyInFlightGeneration {
-            generation = max(generation ?? 0, localScrollApplyInFlightGeneration)
-        }
-        return generation
     }
 
     /// A tap both raises the software keyboard (so the user can type) and
@@ -2367,10 +2408,6 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
         performFontZoom(direction)
     }
 
-    func debugEnqueueScrollForTesting(deltaY: CGFloat, touchPoint: CGPoint) {
-        enqueueScrollMechanicsDelta(deltaY, touchPoint: touchPoint)
-    }
-
     private func recordBottomViewportMismatchIfNeeded() {
         guard debugScrollbarAtBottomForTesting else { return }
         let targetHeight = targetTerminalViewportHeight
@@ -2395,11 +2432,11 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
 
     public override func layoutSubviews() {
         super.layoutSubviews()
+        synchronizeKeyboardGeometryFromLayoutGuide()
+        updateNotificationDrivenDockConstraint()
         let snapshot = viewportSnapshot()
         layoutBottomDock(using: snapshot)
-        if !keyboardPresentationTransitionActive {
-            layoutRenderedTerminalForCurrentViewport(using: snapshot)
-        }
+        layoutRenderedTerminalForCurrentViewport(using: snapshot)
         layoutScrollMechanicsView()
         #if DEBUG
         debugAccessibilityProxy.frame = bounds
@@ -2412,9 +2449,7 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
         inputProxy.updateAccessoryLayoutInsets()
         layoutZoomOverlay()
         MobileDebugLog.anchormux("surface.layout bounds=\(Int(bounds.width))x\(Int(bounds.height)) window=\(window != nil)")
-        if !keyboardPresentationTransitionActive {
-            setNeedsGeometrySync()
-        }
+        setNeedsGeometrySync()
         syncSurfaceVisibility()
     }
 
@@ -2433,7 +2468,8 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
             setKeyboardHeightOverrideForTesting(keyboardHeightOverrideForTesting)
         }
         #endif
-        guard !keyboardPresentationTransitionActive else { return }
+        synchronizeKeyboardGeometryFromLayoutGuide()
+        updateNotificationDrivenDockConstraint()
         let snapshot = viewportSnapshot()
         layoutBottomDock(using: snapshot)
         layoutRenderedTerminalForCurrentViewport(using: snapshot)
@@ -2785,21 +2821,13 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
     private func requestTerminalInputFocus() {
         onFocusInputRequestedForTesting?()
         synchronizeActualInputOwner()
-        inputSession.send(
-            keyboardVisible
-                ? .requestFocus(.terminal)
-                : .requestVisibleFocus(.terminal)
-        )
+        inputSession.send(.requestFocus(.terminal))
     }
 
     /// Requests the hosted composer through the same responder owner as terminal taps.
     public func requestComposerInputFocus() {
         synchronizeActualInputOwner()
-        inputSession.send(
-            keyboardVisible
-                ? .requestFocus(.composer)
-                : .requestVisibleFocus(.composer)
-        )
+        inputSession.send(.requestFocus(.composer))
     }
 
     /// Mirrors the SwiftUI field's user-driven responder changes into the owner.
@@ -2836,23 +2864,14 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
         case .terminal:
             setNeedsGeometrySync()
             inputProxy.updateAccessoryLayoutInsets()
-            // The keyboard toggle no longer rides inputAccessoryView, so
-            // reloading input views here only forces UIKit to re-evaluate the
-            // keyboard mid-transition and can snap the reveal on iOS 27.
-            let alreadyFocused = inputProxy.isFirstResponder
-            let becameFocused = alreadyFocused || inputProxy.becomeFirstResponder()
-            return becameFocused
+            return inputProxy.isFirstResponder || inputProxy.becomeFirstResponder()
         case .composer:
             guard composerActive else { return false }
             composerContainer.layoutIfNeeded()
             guard let input = composerContainer.firstFocusableTextInputInSubtree() else {
                 return false
             }
-            // Same rule for the composer field, the show path should be a
-            // straight responder handoff, not a keyboard view reload.
-            let alreadyFocused = input.isFirstResponder
-            let becameFocused = alreadyFocused || input.becomeFirstResponder()
-            return becameFocused
+            return input.isFirstResponder || input.becomeFirstResponder()
         }
     }
 
@@ -2967,7 +2986,7 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
         renderInFlightSince = nil
         needsAnotherRender = false
         inputSession.send(.surfaceDetached)
-        keyboardPresentationTransitionActive = false
+        bottomDockTransitionObserved = false
         stopDisplayLink()
         setFocus(false)
         #if DEBUG
@@ -3251,9 +3270,7 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
         // pending deltas and freeze the scroll mechanics at the current offset
         // (kill-deceleration idiom) so typed input lands at the bottom.
         pendingScrollLines = 0
-        pendingScrollInteractionGeneration = nil
         pendingLocalScrollLines = 0
-        pendingLocalScrollInteractionGeneration = nil
         scrollMechanicsView.setContentOffset(scrollMechanicsView.contentOffset, animated: false)
         enqueueScrollToBottom()
     }
@@ -3332,12 +3349,12 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
                 zoomSettleFrames = frames
             }
         }
-        sampleHostedKeyboardPresentation()
+        advanceBottomDockTransition()
         // Apply geometry at most once per frame. Every trigger (resize, zoom,
         // keyboard, effective-grid pin) only marks `needsGeometrySync`, so a
         // fast pinch can no longer drive a synchronous per-event storm of
         // set_size calls (the source of the jumbled grid + renderer overload).
-        if needsGeometrySync, !keyboardPresentationTransitionActive {
+        if needsGeometrySync {
             needsGeometrySync = false
             let reassert = pendingGeometryReassert
             pendingGeometryReassert = false
@@ -3504,7 +3521,7 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
         needsDraw = true
         // A geometry sync (for any reason) satisfies a pending post-zoom resync.
         zoomSettleFrames = nil
-        if displayLink == nil, window != nil, !keyboardPresentationTransitionActive {
+        if displayLink == nil, window != nil {
             // No frame pump while detached/backgrounded; apply directly so the
             // surface still gets sized before the next render path resumes.
             needsGeometrySync = false
@@ -3523,7 +3540,6 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
         snapshotFallbackView.backgroundColor = themeBackground
         snapshotFallbackView.textColor = terminalTheme.terminalForegroundUIColor
         configBackgroundColor = themeBackground
-        (bottomDockHostView as? GhosttySurfaceHostView)?.updateTerminalBackground(themeBackground)
         inputProxy.terminalTheme = terminalTheme
         needsDraw = true
     }
@@ -3948,10 +3964,6 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
         containerH: CGFloat,
         shouldReassertNaturalSize: Bool
     ) {
-        guard !keyboardPresentationTransitionActive else {
-            setNeedsGeometrySync(reassertNaturalSize: shouldReassertNaturalSize)
-            return
-        }
         if result.cellPixelSize.width > 0, result.cellPixelSize.height > 0 {
             cellPixelSize = result.cellPixelSize
         }
@@ -4041,7 +4053,7 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
         // The settle paths (keyboard animation completion, report echo) each
         // schedule another geometry sync, so exactly one fit runs on the
         // settled grant.
-        if !keyboardPresentationTransitionActive,
+        if !bottomDockTransitionInFlight,
            pendingViewportReport == nil,
            !awaitingViewportEcho,
            reportGrid == lastReportedSize {
@@ -4055,7 +4067,7 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
             )
         } else {
             MobileDebugLog.anchormux(
-                "zoom.autofit.deferred kbAnim=\(keyboardPresentationTransitionActive ? 1 : 0) "
+                "zoom.autofit.deferred kbAnim=\(bottomDockTransitionInFlight ? 1 : 0) "
                 + "pendingReport=\(pendingViewportReport != nil ? 1 : 0) "
                 + "awaitingEcho=\(awaitingViewportEcho ? 1 : 0) "
                 + "reportGrid=\(reportGrid.columns)x\(reportGrid.rows) "

--- a/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/TerminalViewportCoordinator.swift
+++ b/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/TerminalViewportCoordinator.swift
@@ -4,9 +4,9 @@ import CoreGraphics
 
 /// Single calculator for the iOS terminal viewport contract.
 ///
-/// `GhosttySurfaceView` has several asynchronous participants: host-owned keyboard
-/// presentation, composer measurement, and Ghostty geometry readback. This
-/// coordinator turns the current
+/// `GhosttySurfaceView` has several asynchronous participants: UIKit keyboard
+/// animation, composer measurement, bottom chrome frames, Ghostty geometry
+/// readback, and render-layer presentation. This coordinator turns the current
 /// main-actor inputs into one immutable snapshot so every participant consumes
 /// the same viewport for a frame.
 struct TerminalViewportCoordinator {
@@ -54,6 +54,11 @@ struct TerminalViewportCoordinator {
             width: bounds.width,
             height: max(1, containerSize.height)
         )
+        let liveViewportHeight = liveViewportHeight(
+            inputs: inputs,
+            boundsHeight: bounds.height,
+            fallbackHeight: layoutViewport.height
+        )
         return TerminalViewportSnapshot(
             bounds: bounds,
             containerSize: containerSize,
@@ -65,10 +70,24 @@ struct TerminalViewportCoordinator {
                 x: 0,
                 y: 0,
                 width: bounds.width,
-                height: layoutViewport.height
+                height: liveViewportHeight
             ),
             viewportNegotiationUnsettled: inputs.viewportNegotiationUnsettled
         )
+    }
+
+    private func liveViewportHeight(
+        inputs: TerminalViewportInputs,
+        boundsHeight: CGFloat,
+        fallbackHeight: CGFloat
+    ) -> CGFloat {
+        guard inputs.chromeVisible,
+              let frame = inputs.toolbarPresentationFrame ?? inputs.toolbarFrame,
+              !frame.isNull,
+              !frame.isEmpty else {
+            return fallbackHeight
+        }
+        return min(max(1, frame.minY), max(1, boundsHeight))
     }
 
 }

--- a/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/TerminalViewportInputs.swift
+++ b/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/TerminalViewportInputs.swift
@@ -9,6 +9,9 @@ struct TerminalViewportInputs {
     let toolbarFrameHeight: CGFloat
     let bottomSafeAreaInset: CGFloat
     let chromeHidden: Bool
+    let chromeVisible: Bool
+    let toolbarFrame: CGRect?
+    let toolbarPresentationFrame: CGRect?
     /// True while the shared-grid negotiation is unsettled: a keyboard
     /// transition is in flight, a capacity report is debouncing, or the
     /// newest report's echo has not confirmed. The render pin treats the
@@ -17,3 +20,4 @@ struct TerminalViewportInputs {
     let viewportNegotiationUnsettled: Bool
 }
 #endif
+

--- a/Packages/iOS/CmuxMobileTerminal/Tests/CmuxMobileTerminalTests/VerifiedReplayPresentationTests.swift
+++ b/Packages/iOS/CmuxMobileTerminal/Tests/CmuxMobileTerminalTests/VerifiedReplayPresentationTests.swift
@@ -1,5 +1,4 @@
 #if canImport(UIKit)
-import CMUXMobileCore
 import CoreGraphics
 import Foundation
 import IOSurface
@@ -23,35 +22,6 @@ struct VerifiedReplayPresentationTests {
             hasPresentedContents: true
         ))
     }
-
-#if DEBUG
-    @MainActor
-    @Test("pending native scroll invalidates replay anchors before display-link flush")
-    func pendingNativeScrollInvalidatesReplayAnchorBeforeFlush() async throws {
-        let runtime = try GhosttyRuntime.shared()
-        let delegate = ScrollDrainDelegate()
-        let view = GhosttySurfaceView(runtime: runtime, delegate: delegate, fontSize: 10)
-        defer { view.prepareForDismantle() }
-
-        let beforeScrollGeneration = view.userViewportInteractionGeneration
-        view.debugEnqueueScrollForTesting(
-            deltaY: 42,
-            touchPoint: CGPoint(x: 12, y: 18)
-        )
-
-        #expect(view.userViewportInteractionGeneration == beforeScrollGeneration + 1)
-        let staleAnchor = VerifiedReplayCapturedViewportAnchor(
-            anchor: VerifiedReplayViewportAnchor(
-                topRowDistanceFromBottom: 25,
-                totalRows: 100
-            ),
-            interactionGeneration: beforeScrollGeneration
-        )
-        #expect(await view.restoreVerifiedReplayViewportAnchor(staleAnchor) == false)
-        #expect(await view.drainPendingScrollForVerifiedReplayReveal())
-        #expect(delegate.scrollEvents.count == 1)
-    }
-#endif
 
     @Test("the retained last-good frame owns immutable pixel bytes")
     func frozenFrameDoesNotAliasRendererIOSurface() throws {
@@ -251,31 +221,6 @@ struct VerifiedReplayPresentationTests {
         ))
     }
 
-}
-
-@MainActor
-private final class ScrollDrainDelegate: NSObject, GhosttySurfaceViewDelegate {
-    private(set) var scrollEvents: [(lines: Double, col: Int, row: Int)] = []
-
-    func ghosttySurfaceView(
-        _ surfaceView: GhosttySurfaceView,
-        didProduceInput data: Data
-    ) {}
-
-    func ghosttySurfaceView(
-        _ surfaceView: GhosttySurfaceView,
-        didResize size: TerminalGridSize,
-        reportID: UInt64
-    ) {}
-
-    func ghosttySurfaceView(
-        _ surfaceView: GhosttySurfaceView,
-        didScrollLines lines: Double,
-        atCol col: Int,
-        row: Int
-    ) {
-        scrollEvents.append((lines: lines, col: col, row: row))
-    }
 }
 
 private extension VerifiedReplayPresentationTests {

--- a/Packages/iOS/CmuxMobileTerminalKit/Sources/CmuxMobileTerminalKit/TerminalInputSessionReducer.swift
+++ b/Packages/iOS/CmuxMobileTerminalKit/Sources/CmuxMobileTerminalKit/TerminalInputSessionReducer.swift
@@ -65,9 +65,6 @@ public enum TerminalInputSessionCommand: Equatable, Sendable {
 /// Facts and user intents consumed by the terminal input-session reducer.
 public enum TerminalInputSessionEvent: Equatable, Sendable {
     case requestFocus(TerminalInputOwner)
-    /// Reasserts UIKit focus even when the owner is already current, so a hidden
-    /// keyboard can be shown again without changing semantic ownership.
-    case requestVisibleFocus(TerminalInputOwner)
     case releaseFocus
     case focusCompleted(owner: TerminalInputOwner, succeeded: Bool)
     case resignCompleted(owner: TerminalInputOwner, succeeded: Bool)
@@ -138,10 +135,6 @@ public struct TerminalInputSessionState: Equatable, Sendable {
         case .requestFocus(let owner):
             deferredTapID = nil
             requestFocus(owner, commands: &transition.commands)
-
-        case .requestVisibleFocus(let owner):
-            deferredTapID = nil
-            requestVisibleFocus(owner, commands: &transition.commands)
 
         case .releaseFocus:
             requestedOwner = nil
@@ -255,22 +248,12 @@ public struct TerminalInputSessionState: Equatable, Sendable {
         commands: inout [TerminalInputSessionCommand]
     ) {
         requestedOwner = owner
-        guard canFocus else { return }
-        guard actualOwner != owner else { return }
-        commands.append(.focus(owner))
-    }
-
-    private mutating func requestVisibleFocus(
-        _ owner: TerminalInputOwner,
-        commands: inout [TerminalInputSessionCommand]
-    ) {
-        requestedOwner = owner
-        guard canFocus else { return }
+        guard canFocus, actualOwner != owner else { return }
         commands.append(.focus(owner))
     }
 
     private func reconcileFocus(commands: inout [TerminalInputSessionCommand]) {
-        guard canFocus, let requestedOwner else { return }
+        guard canFocus, let requestedOwner, actualOwner != requestedOwner else { return }
         commands.append(.focus(requestedOwner))
     }
 }

--- a/Packages/iOS/CmuxMobileTerminalKit/Tests/CmuxMobileTerminalKitTests/TerminalInputSessionReducerTests.swift
+++ b/Packages/iOS/CmuxMobileTerminalKit/Tests/CmuxMobileTerminalKitTests/TerminalInputSessionReducerTests.swift
@@ -129,18 +129,6 @@ import Testing
         #expect(state.actualOwner == .terminal)
     }
 
-    @Test func visibleFocusRequestReassertsUIKitFocusWhenAlreadyOwned() {
-        var state = TerminalInputSessionState()
-
-        _ = state.handle(.requestFocus(.terminal))
-        _ = state.handle(.focusCompleted(owner: .terminal, succeeded: true))
-
-        let repeatRequest = state.handle(.requestVisibleFocus(.terminal))
-        #expect(repeatRequest.commands == [.focus(.terminal)])
-        #expect(state.requestedOwner == .terminal)
-        #expect(state.actualOwner == .terminal)
-    }
-
     @Test func failedHandoffKeepsTheActualOwnerUntilACommandSucceeds() {
         var state = TerminalInputSessionState()
         _ = state.handle(.requestFocus(.composer))

--- a/ios/cmuxUITests/cmuxUITests.swift
+++ b/ios/cmuxUITests/cmuxUITests.swift
@@ -10194,40 +10194,6 @@ final class cmuxUITests: XCTestCase {
         )
     }
 
-    private func assertTerminalPresentationPinnedToDock(
-        _ dock: [String: String],
-        context: String,
-        file: StaticString = #filePath,
-        line: UInt = #line
-    ) {
-        guard let currentGap = dock["terminalDockPresentationGap"].flatMap(Double.init),
-              let maximumGap = dock["terminalDockMaxPresentationGap"].flatMap(Double.init),
-              let screenScale = dock["screenScale"].flatMap(Double.init),
-              screenScale > 0 else {
-            XCTFail(
-                "Missing terminal presentation-to-dock geometry for \(context). dock=\(dock)",
-                file: file,
-                line: line
-            )
-            return
-        }
-        let twoPhysicalPixels = 2 / screenScale
-        XCTAssertLessThanOrEqual(
-            currentGap,
-            twoPhysicalPixels,
-            "The rendered terminal edge detached from the dock for \(context). dock=\(dock)",
-            file: file,
-            line: line
-        )
-        XCTAssertLessThanOrEqual(
-            maximumGap,
-            twoPhysicalPixels,
-            "The rendered terminal edge detached from the dock during \(context). dock=\(dock)",
-            file: file,
-            line: line
-        )
-    }
-
     /// Verify the built app's two-part keyboard contract at steady state:
     /// the OS-selected geometry source resolves to the real software-keyboard edge,
     /// and the visible composer/toolbar stack resolves to that same target.
@@ -10707,10 +10673,6 @@ final class cmuxUITests: XCTestCase {
             keyboard: initialKeyboard,
             context: "rapid-reversal baseline"
         )
-        assertTerminalPresentationPinnedToDock(
-            surfaceDock(in: app),
-            context: "keyboard-visible baseline"
-        )
         let composerKeyboardInset = initialKeyboard.frame.minY - composerField.frame.maxY
 
         let hideKeyboardButton = app.buttons["terminal.inputAccessory.hideKeyboard"]
@@ -10754,84 +10716,6 @@ final class cmuxUITests: XCTestCase {
                 maximumGap,
                 1,
                 "Shortcut and Composer bars separated during rapid reversal \(cycle). dock=\(dock)"
-            )
-            assertTerminalPresentationPinnedToDock(
-                dock,
-                context: "rapid reversal \(cycle)"
-            )
-        }
-
-        hideKeyboardButton.tap()
-        XCTAssertTrue(waitForKeyboardDismissal(in: app))
-        let hiddenDock = waitForDock(in: app, describe: "keyboard-hidden terminal presentation settled") {
-            $0["keyboardUp"] == "0" && $0["keyboardTransitionID"] == "-1"
-        }
-        assertTerminalPresentationPinnedToDock(
-            hiddenDock,
-            context: "keyboard-hidden settle"
-        )
-        assertTerminalRenderBottomAttachedToViewport(
-            hiddenDock,
-            context: "keyboard-hidden settle"
-        )
-    }
-
-    /// A second tap at the keyboard-control's original screen coordinate can land
-    /// while its first hide animation is still moving the dock. This is distinct from
-    /// a terminal tap reversal because it exercises the same control's hit target
-    /// through an A→B→A keyboard sequence. The host must rebase the clip, dock, and
-    /// terminal wrapper from one presentation edge before beginning the return leg.
-    @MainActor
-    func testTerminalDockStaysPinnedForInPlaceKeyboardControlReversals() async throws {
-        let server = try MobileSyncMockHostServer()
-        let port = try await server.start()
-        defer { server.stop() }
-
-        let app = try launchConnectedApp(port: port)
-        let surface = app.otherElements["MobileTerminalSurface"]
-        XCTAssertTrue(surface.waitForExistence(timeout: 8))
-
-        let composerField = app.descendants(matching: .any)[Composer.field]
-        XCTAssertTrue(composerField.waitForExistence(timeout: 4))
-        composerField.tap()
-        guard let initialKeyboard = waitForSoftwareKeyboardKeyPlane(
-            in: app,
-            minimumOverlap: 120,
-            timeout: 4
-        ) else { return }
-        assertTerminalDockPinnedToSoftwareKeyboard(
-            surfaceDock(in: app),
-            surface: surface,
-            keyboard: initialKeyboard,
-            context: "in-place reversal baseline"
-        )
-
-        let hideKeyboardButton = app.buttons["terminal.inputAccessory.hideKeyboard"]
-        XCTAssertTrue(hideKeyboardButton.waitForExistence(timeout: 4))
-        let controlFrame = hideKeyboardButton.frame
-        let controlPoint = app.coordinate(withNormalizedOffset: .zero).withOffset(
-            CGVector(dx: controlFrame.midX, dy: controlFrame.midY)
-        )
-
-        for cycle in 1...10 {
-            controlPoint.tap()
-            controlPoint.tap()
-
-            guard let keyboard = waitForSoftwareKeyboardKeyPlane(
-                in: app,
-                minimumOverlap: 120,
-                timeout: 4
-            ) else { return }
-            let dock = surfaceDock(in: app)
-            assertTerminalDockPinnedToSoftwareKeyboard(
-                dock,
-                surface: surface,
-                keyboard: keyboard,
-                context: "in-place reversal \(cycle)"
-            )
-            assertTerminalPresentationPinnedToDock(
-                dock,
-                context: "in-place reversal \(cycle)"
             )
         }
     }


### PR DESCRIPTION
Revert the mistaken squash merge of PR 10006.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/10151"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789276494&installation_model_id=21920&pr_number=10151&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F10151&signature=2d019a0fac126a7f0c332733f69f0a40f39a0d5845c896d3e0515dea3be1493c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reverts the iOS 27 keyboard toggle focus handoff change to restore pre-10006 behavior. Keyboard geometry and animation move back into `GhosttySurfaceView`, and the host view no longer drives keyboard transitions.

- `GhosttySurfaceHostView` simplified to a passive container; keyboard observers, animation, and dock rebasing removed.
- `GhosttySurfaceView` resumes owning keyboard notifications, dock constraint, and renderer clipping:
  - Uses `UIKeyboardLayoutGuide` on all OSes except iOS 27, which uses notification end-frames.
  - Computes live viewport height from toolbar/composer presentation frames and tracks dock animation via presentation state.
  - Stops reloading input views mid-transition and always requests focus with a single path.
- Scrollback: removes generation-based drains and the verified-replay scroll drain; `applyLocalScrollbackScroll` signature simplified.
- `MobileKeyboardTransition` trimmed: removes `beginFrame` and `beginOverlap(in:)`; keep `overlap(in:)`.
- Input session: deletes `TerminalInputSessionEvent.requestVisibleFocus`; callers now use `requestFocus` only.
- Tests and CI: drop assertions tied to the host-driven animation path; remove `ONLY_ACTIVE_ARCH` in iOS build workflow.

**Migration**
- Replace `TerminalInputSessionEvent.requestVisibleFocus(...)` with `requestFocus(...)`.
- If consuming `MobileKeyboardTransition`, stop using `beginFrame`/`beginOverlap(in:)`; use `overlap(in:)` for the target overlap.

<sup>Written for commit 13bcaa156810cdcfa404f28077a30d6b201b8780. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/10151?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved terminal layout behavior while the keyboard and bottom controls appear, move, or dismiss.
  * Fixed viewport restoration during verified replay so the restored position is shown before replay content becomes visible.
  * Improved scrolling and redraw reliability during viewport updates.
  * Simplified focus handling for more consistent keyboard focus behavior.
* **Tests**
  * Updated automated verification to reflect improved keyboard alignment and replay behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->