### PR TITLE
Fix white tint for custom terminal icons

### DIFF
--- a/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/TerminalInputTextView.swift
+++ b/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/TerminalInputTextView.swift
@@ -1043,6 +1043,14 @@ final class TerminalInputTextView: UIView, UIKeyInput, UITextInput {
             config.preferredSymbolConfigurationForImage = isComposer
                 ? Self.composerButtonSymbolConfig
                 : Self.accessoryButtonSymbolConfig
+            // Hierarchical SF Symbols such as `ellipsis.circle` can retain
+            // UIKit's default tint when installed on a glass configuration.
+            // Apply the same explicit foreground transform used by the text
+            // and background styling so resting custom icons stay white and
+            // armed built-ins keep their blue active state.
+            config.imageColorTransformer = UIConfigurationColorTransformer { _ in
+                armed || sticky ? activeForeground : self.themeChromeColor
+            }
             config.attributedTitle = nil
         } else {
             var attributed = AttributedString(title)

--- a/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/TerminalInputTextView.swift
+++ b/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/TerminalInputTextView.swift
@@ -1049,6 +1049,7 @@ final class TerminalInputTextView: UIView, UIKeyInput, UITextInput {
             // and background styling so resting custom icons stay white and
             // armed built-ins keep their blue active state.
             let restingForeground = themeChromeColor
+            let activeForeground = UIColor.systemBlue.terminalReadableForeground
             config.imageColorTransformer = UIConfigurationColorTransformer { _ in
                 armed || sticky ? activeForeground : restingForeground
             }

--- a/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/TerminalInputTextView.swift
+++ b/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/TerminalInputTextView.swift
@@ -1048,8 +1048,9 @@ final class TerminalInputTextView: UIView, UIKeyInput, UITextInput {
             // Apply the same explicit foreground transform used by the text
             // and background styling so resting custom icons stay white and
             // armed built-ins keep their blue active state.
+            let restingForeground = themeChromeColor
             config.imageColorTransformer = UIConfigurationColorTransformer { _ in
-                armed || sticky ? activeForeground : self.themeChromeColor
+                armed || sticky ? activeForeground : restingForeground
             }
             config.attributedTitle = nil
         } else {


### PR DESCRIPTION
Force terminal accessory SF Symbol images through the configured foreground color so resting custom icons such as ellipsis.circle render white instead of UIKit blue.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/10153"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789278609&installation_model_id=21920&pr_number=10153&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F10153&signature=19e1df7f90c155ad6337cb5dd960055c9d6378b800c8e1e3fcefcfdbe5e52c51"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes terminal accessory SF Symbol icon tinting by applying an explicit foreground color. Previously hierarchical symbols (e.g., ellipsis.circle) could show UIKit blue when idle; now they render white at rest and turn blue only when armed or sticky.

- Scope: `TerminalInputTextView`; sets `imageColorTransformer` on image-based accessory button configs.
- Active tint uses `UIColor.systemBlue.terminalReadableForeground`; resting tint uses `themeChromeColor`, capturing locals to avoid retaining the view.
- Only affects symbol/image buttons; text titles are unchanged.
- Please verify idle/armed/sticky states for custom icons on iOS (including glass configs) in light/dark modes.

<sup>Written for commit d1881ede6b868339e7a9300b51af8c63f7c2547f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/10153?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Updated terminal accessory button icons to use the appropriate theme colors when inactive.
  * Armed and sticky accessory buttons now use a readable system-blue foreground color for improved visibility and consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->