### PR TITLE
Fix iOS Tailscale connection method switch

### DIFF
--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/DeviceRegistryService.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/DeviceRegistryService.swift
@@ -487,7 +487,7 @@ public actor DeviceRegistryService: DeviceRegistryRefreshing {
             guard !selected.contains(where: { $0.endpoint == route.endpoint }) else { continue }
             selected.append(route)
         }
-        return selected
+        return selected == local ? nil : selected
     }
 
     /// Whether a background registry refresh may write back into the paired-Mac

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/DeviceRegistryService.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/DeviceRegistryService.swift
@@ -482,10 +482,16 @@ public actor DeviceRegistryService: DeviceRegistryRefreshing {
         guard registry.contains(where: { $0.kind == .iroh }) else {
             return registry
         }
+        // The registry remains authoritative when it publishes any current
+        // Tailscale route. Only an Iroh-only response needs one legacy local
+        // fallback for Macs paired before the Iroh migration.
+        guard registry.allSatisfy({ $0.kind == .iroh }) else {
+            return registry
+        }
         var selected = registry
-        for route in local where route.kind == .tailscale {
-            guard !selected.contains(where: { $0.endpoint == route.endpoint }) else { continue }
-            selected.append(route)
+        if let legacyTailscale = local.first(where: { $0.kind == .tailscale }),
+           !selected.contains(where: { $0.endpoint == legacyTailscale.endpoint }) {
+            selected.append(legacyTailscale)
         }
         return selected == local ? nil : selected
     }

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/DeviceRegistryService.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/DeviceRegistryService.swift
@@ -475,7 +475,19 @@ public actor DeviceRegistryService: DeviceRegistryRefreshing {
     ) -> [CmxAttachRoute]? {
         guard let registry, !registry.isEmpty else { return nil }
         guard registry != local else { return nil }
-        return registry
+        // Keep a locally persisted Tailscale destination alongside a newly
+        // published Iroh route. The local route may carry the pre-Iroh grant
+        // needed to reconnect an older Mac while the registry has already
+        // converged on Iroh-only publication.
+        guard registry.contains(where: { $0.kind == .iroh }) else {
+            return registry
+        }
+        var selected = registry
+        for route in local where route.kind == .tailscale {
+            guard !selected.contains(where: { $0.endpoint == route.endpoint }) else { continue }
+            selected.append(route)
+        }
+        return selected
     }
 
     /// Whether a background registry refresh may write back into the paired-Mac

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+ReconnectRoutes.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+ReconnectRoutes.swift
@@ -635,6 +635,13 @@ extension MobileShellComposite {
     }
 
     /// Mark the stored-Mac reconnect attempt resolved only for the current generation.
+    func resolveStoredMacReconnectRestoringGate(generation: Int) {
+        guard generation == storedMacReconnectGeneration else { return }
+        didFinishStoredMacReconnectAttempt = true
+    }
+
+    /// Finish the stored-Mac reconnect attempt and drain any forced retry that
+    /// arrived while the underlying dial was still in flight.
     func finishStoredMacReconnectAttempt(generation: Int) {
         guard generation == storedMacReconnectGeneration else { return }
         let shouldRetry = pendingForcedStoredMacReconnect
@@ -643,8 +650,12 @@ extension MobileShellComposite {
         didFinishStoredMacReconnectAttempt = true
         guard shouldRetry, isSignedIn else { return }
         let stackUserID = lastReconnectStackUserID
+        let accountID = stackUserID ?? identityProvider?.currentUserID
         Task { @MainActor [weak self] in
             guard let self else { return }
+            guard generation == self.storedMacReconnectGeneration,
+                  self.isSignedIn,
+                  self.identityProvider?.currentUserID == accountID else { return }
             _ = await self.retryActiveMacReconnect(
                 stackUserID: stackUserID,
                 force: true

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+ReconnectRoutes.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+ReconnectRoutes.swift
@@ -637,8 +637,19 @@ extension MobileShellComposite {
     /// Mark the stored-Mac reconnect attempt resolved only for the current generation.
     func finishStoredMacReconnectAttempt(generation: Int) {
         guard generation == storedMacReconnectGeneration else { return }
+        let shouldRetry = pendingForcedStoredMacReconnect
+        pendingForcedStoredMacReconnect = false
         isReconnectingStoredMac = false
         didFinishStoredMacReconnectAttempt = true
+        guard shouldRetry, isSignedIn else { return }
+        let stackUserID = lastReconnectStackUserID
+        Task { @MainActor [weak self] in
+            guard let self else { return }
+            _ = await self.retryActiveMacReconnect(
+                stackUserID: stackUserID,
+                force: true
+            )
+        }
     }
 
     /// Returns the completed result when an async stored reconnect must stop.

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+ReconnectRoutes.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+ReconnectRoutes.swift
@@ -634,16 +634,11 @@ extension MobileShellComposite {
         hasKnownPairedMac = value
     }
 
-    /// Mark the stored-Mac reconnect attempt resolved only for the current generation.
-    func resolveStoredMacReconnectRestoringGate(generation: Int) {
-        guard generation == storedMacReconnectGeneration else { return }
-        didFinishStoredMacReconnectAttempt = true
-    }
-
     /// Finish the stored-Mac reconnect attempt and drain any forced retry that
     /// arrived while the underlying dial was still in flight.
-    func finishStoredMacReconnectAttempt(generation: Int) {
-        guard generation == storedMacReconnectGeneration else { return }
+    func finishStoredMacReconnectAttempt(generation: Int, supersede: Bool = false) {
+        guard supersede || generation == storedMacReconnectGeneration else { return }
+        if supersede { storedMacReconnectGeneration &+= 1 }
         let shouldRetry = pendingForcedStoredMacReconnect
         pendingForcedStoredMacReconnect = false
         isReconnectingStoredMac = false
@@ -651,9 +646,10 @@ extension MobileShellComposite {
         guard shouldRetry, isSignedIn else { return }
         let stackUserID = lastReconnectStackUserID
         let accountID = stackUserID ?? identityProvider?.currentUserID
+        let retryGeneration = storedMacReconnectGeneration
         Task { @MainActor [weak self] in
             guard let self else { return }
-            guard generation == self.storedMacReconnectGeneration,
+            guard retryGeneration == self.storedMacReconnectGeneration,
                   self.isSignedIn,
                   self.identityProvider?.currentUserID == accountID else { return }
             _ = await self.retryActiveMacReconnect(

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
@@ -2648,7 +2648,7 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
             guard let self, !Task.isCancelled,
                   generation == self.storedMacReconnectGeneration,
                   self.connectionState != .connected else { return }
-            self.resolveStoredMacReconnectRestoringGate(generation: generation)
+            self.finishStoredMacReconnectAttempt(generation: generation, supersede: true)
         }
         defer { restoringDeadline.cancel() }
         // Run the awaited restore/dial phase under the same hard ceiling for

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
@@ -328,6 +328,9 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
     /// resolve the restoring-gate flags, so a superseded older attempt can't clear
     /// the gate while a newer reconnect is still in progress.
     var storedMacReconnectGeneration = 0
+    /// Set when a connection-method change arrives during a reconnect. The
+    /// latest forced retry starts as soon as the current attempt settles.
+    var pendingForcedStoredMacReconnect = false
     var automaticReconnectBackoffOwner = MobileAutomaticReconnectBackoffOwner()
     var automaticReconnectRetryTask: Task<Void, Never>?
     var automaticReconnectRetryAccountID: String?
@@ -1920,6 +1923,7 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         // reconnect is superseded and can't re-set these flags after sign-out.
         storedMacReconnectGeneration &+= 1
         isReconnectingStoredMac = false
+        pendingForcedStoredMacReconnect = false
         didFinishStoredMacReconnectAttempt = false
         replaceRemoteClient(with: nil)
         cancelRemoteOperationTasks()
@@ -2016,6 +2020,7 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         // root's startup coordinator.
         storedMacReconnectGeneration &+= 1
         isReconnectingStoredMac = false
+        pendingForcedStoredMacReconnect = false
         didFinishStoredMacReconnectAttempt = false
         pairedMacRestoreBoundary?.invalidate()
         let refresher = pairedMacStore as? any PairedMacBackupRefreshing
@@ -2598,7 +2603,10 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         stackUserID: String?,
         force: Bool = false
     ) async -> Bool {
-        guard !isReconnectingStoredMac else { return false }
+        guard !isReconnectingStoredMac else {
+            if force { pendingForcedStoredMacReconnect = true }
+            return false
+        }
         if let accountID = stackUserID ?? identityProvider?.currentUserID {
             clearTransientAutomaticReconnectBackoff(accountID: accountID)
         }
@@ -2621,8 +2629,7 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         // client as authoritative instead of replacing it with another client
         // for the same saved route.
         guard force || !hasActiveMacConnection else {
-            isReconnectingStoredMac = false
-            didFinishStoredMacReconnectAttempt = true
+            finishStoredMacReconnectAttempt(generation: storedMacReconnectGeneration)
             return .connected
         }
         // Claim this attempt's generation. Only the current generation may resolve
@@ -2641,8 +2648,7 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
             guard let self, !Task.isCancelled,
                   generation == self.storedMacReconnectGeneration,
                   self.connectionState != .connected else { return }
-            self.isReconnectingStoredMac = false
-            self.didFinishStoredMacReconnectAttempt = true
+            self.finishStoredMacReconnectAttempt(generation: generation)
         }
         defer { restoringDeadline.cancel() }
         // Run the awaited restore/dial phase under the same hard ceiling for
@@ -2955,8 +2961,7 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
             finishStoredMacReconnectAttempt(generation: generation)
             return .superseded
         }
-        isReconnectingStoredMac = false
-        didFinishStoredMacReconnectAttempt = true
+        finishStoredMacReconnectAttempt(generation: generation)
         if connectionState != .connected,
            !connectionRequiresReauth,
            let firstCandidateNeedingMacUpdate {
@@ -4042,6 +4047,7 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         storedMacReconnectGeneration &+= 1
         hasKnownPairedMac = false
         isReconnectingStoredMac = false
+        pendingForcedStoredMacReconnect = false
         didFinishStoredMacReconnectAttempt = false
     }
 
@@ -4621,6 +4627,7 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         // known-Mac hint: hiding changes list visibility, not the app's shell mode.
         storedMacReconnectGeneration &+= 1
         isReconnectingStoredMac = false
+        pendingForcedStoredMacReconnect = false
         didFinishStoredMacReconnectAttempt = false
         if let representativeID = staleRepresentativeID {
             hasKnownPairedMac = true
@@ -7461,6 +7468,7 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
     func invalidateStoredMacReconnectAttempt() {
         storedMacReconnectGeneration &+= 1
         isReconnectingStoredMac = false
+        pendingForcedStoredMacReconnect = false
     }
 
     /// Drop the PREVIOUS foreground/anonymous workspace snapshot from the aggregate

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
@@ -2648,7 +2648,7 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
             guard let self, !Task.isCancelled,
                   generation == self.storedMacReconnectGeneration,
                   self.connectionState != .connected else { return }
-            self.finishStoredMacReconnectAttempt(generation: generation)
+            self.resolveStoredMacReconnectRestoringGate(generation: generation)
         }
         defer { restoringDeadline.cancel() }
         // Run the awaited restore/dial phase under the same hard ceiling for

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
@@ -2559,13 +2559,15 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
     @discardableResult
     public func reconnectActiveMacIfAvailable(
         stackUserID: String?,
-        refreshBackupBeforeDial: Bool = true
+        refreshBackupBeforeDial: Bool = true,
+        force: Bool = false
     ) async -> Bool {
         let startedAt = appDiagnosticNow()
         recordAppEvent(.reconnectStarted)
         let outcome = await reconnectActiveMacOutcome(
             stackUserID: stackUserID,
-            refreshBackupBeforeDial: refreshBackupBeforeDial
+            refreshBackupBeforeDial: refreshBackupBeforeDial,
+            force: force
         )
         switch outcome {
         case .connected:
@@ -2593,19 +2595,24 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
     /// Starts one user-requested retry and exposes its loading state before any await.
     @discardableResult
     public func retryActiveMacReconnect(
-        stackUserID: String?
+        stackUserID: String?,
+        force: Bool = false
     ) async -> Bool {
         guard !isReconnectingStoredMac else { return false }
         if let accountID = stackUserID ?? identityProvider?.currentUserID {
             clearTransientAutomaticReconnectBackoff(accountID: accountID)
         }
         isReconnectingStoredMac = true
-        return await reconnectActiveMacIfAvailable(stackUserID: stackUserID)
+        return await reconnectActiveMacIfAvailable(
+            stackUserID: stackUserID,
+            force: force
+        )
     }
 
     func reconnectActiveMacOutcome(
         stackUserID: String?,
-        refreshBackupBeforeDial: Bool = true
+        refreshBackupBeforeDial: Bool = true,
+        force: Bool = false
     ) async -> StoredMacReconnectOutcome {
         lastReconnectStackUserID = stackUserID
         startObservingNetworkPathChanges()
@@ -2613,7 +2620,7 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         // attach already established the foreground session. Treat the live
         // client as authoritative instead of replacing it with another client
         // for the same saved route.
-        guard !hasActiveMacConnection else {
+        guard force || !hasActiveMacConnection else {
             isReconnectingStoredMac = false
             didFinishStoredMacReconnectAttempt = true
             return .connected

--- a/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/DeviceRegistryRouteSelectionTests.swift
+++ b/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/DeviceRegistryRouteSelectionTests.swift
@@ -55,6 +55,13 @@ import Testing
         )
         #expect(selected.map(\.kind) == [.iroh, .tailscale])
         #expect(selected.last?.endpoint == local[0].endpoint)
+
+        // Once the merged routes are persisted, the same Iroh-only registry
+        // response must not trigger another write on every refresh.
+        #expect(DeviceRegistryService.selectReconnectRoutes(
+            local: selected,
+            registry: [iroh]
+        ) == nil)
     }
 
     @Test func parsesRoutesForMatchingMacFromListResponse() throws {

--- a/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/DeviceRegistryRouteSelectionTests.swift
+++ b/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/DeviceRegistryRouteSelectionTests.swift
@@ -41,6 +41,22 @@ import Testing
         #expect(selected == registry)
     }
 
+    @Test func registryIrohRefreshKeepsLegacyTailscaleRouteAvailable() throws {
+        let local = [try route(host: "100.0.0.1", port: 51000)]
+        let identity = try CmxIrohPeerIdentity(endpointID: String(repeating: "a", count: 64))
+        let iroh = try CmxAttachRoute(
+            id: "iroh",
+            kind: .iroh,
+            endpoint: .peer(identity: identity, pathHints: [])
+        )
+
+        let selected = try #require(
+            DeviceRegistryService.selectReconnectRoutes(local: local, registry: [iroh])
+        )
+        #expect(selected.map(\.kind) == [.iroh, .tailscale])
+        #expect(selected.last?.endpoint == local[0].endpoint)
+    }
+
     @Test func parsesRoutesForMatchingMacFromListResponse() throws {
         let json = """
         {

--- a/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/DeviceRegistryRouteSelectionTests.swift
+++ b/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/DeviceRegistryRouteSelectionTests.swift
@@ -64,6 +64,22 @@ import Testing
         ) == nil)
     }
 
+    @Test func registryIrohAndTailscaleRoutesRemainAuthoritative() throws {
+        let local = [try route(host: "100.0.0.1", port: 51000)]
+        let current = try route(host: "100.0.0.2", port: 51000, id: "current")
+        let identity = try CmxIrohPeerIdentity(endpointID: String(repeating: "b", count: 64))
+        let iroh = try CmxAttachRoute(
+            id: "iroh",
+            kind: .iroh,
+            endpoint: .peer(identity: identity, pathHints: [])
+        )
+
+        #expect(DeviceRegistryService.selectReconnectRoutes(
+            local: local,
+            registry: [iroh, current]
+        ) == [iroh, current])
+    }
+
     @Test func parsesRoutesForMatchingMacFromListResponse() throws {
         let json = """
         {

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MobileSettingsView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MobileSettingsView.swift
@@ -545,6 +545,16 @@ struct MobileSettingsView: View {
                 SetupHelpView(highlight: setupHelpHighlight) { showingSetupHelp = false }
             }
         }
+        .onChange(of: connectionMethodStore?.method) { oldMethod, newMethod in
+            guard oldMethod != newMethod, store != nil else { return }
+            let stackUserID = authManager.currentUser?.id
+            Task {
+                _ = await store?.retryActiveMacReconnect(
+                    stackUserID: stackUserID,
+                    force: true
+                )
+            }
+        }
         .accessibilityIdentifier("MobileSettingsView")
         .onAppear {
             diagnosticLog?.recordAppEvent(.settingsOpened)


### PR DESCRIPTION
Fixes the iOS Tailscale picker no-op after Iroh migration. Changing the method now forces the active Mac reconnect to re-evaluate authorized Tailscale routes ahead of Iroh, while preserving fail-closed authorization and normal reconnect behavior.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/10154"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789278796&installation_model_id=21920&pr_number=10154&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F10154&signature=33bd5e35dbd962e941495f3f227beea4e13f5053e80f8a3daa725d6820c25616"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the iOS Tailscale connection‑method switch no‑op after the Iroh migration. Changing the method now forces a reconnect even when already connected, and route selection adds one legacy Tailscale fallback only for Iroh‑only registries to keep older Macs reachable without churn.

- `MobileSettingsView` triggers `retryActiveMacReconnect(force: true)` on method change. If a change arrives mid‑reconnect, we queue one forced retry and run it after the current attempt settles (generation/account guarded).
- Reconnect APIs accept an optional `force` flag, bypass the “already connected” short‑circuit, and supersede stalled reconnect attempts; on finish we drain any deferred forced retry. No caller migrations.
- Route selection keeps the registry authoritative when it publishes any Tailscale route; only Iroh‑only responses get one local legacy Tailscale route added. Endpoints are de‑duplicated, and we skip writes when the merged set matches local.
- Tests cover Iroh‑only fallback, mixed Iroh+Tailscale authority, and avoiding repeated refreshes.

**Review notes**
- `Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MobileSettingsView.swift`: trigger forced reconnect on method change.
- `Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite*.swift`: add `force`, queue/serialize deferred forced retries, supersede stalled attempts, and drain after settle.
- `Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/DeviceRegistryService.swift` and `Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/DeviceRegistryRouteSelectionTests.swift`: enforce registry authority, add one legacy Tailscale fallback for Iroh‑only, dedupe, and avoid repeated writebacks.

<sup>Written for commit 729521f72546fd8d6c7703c88b9115cad6d13811. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/10154?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added forced reconnection support when changing connection methods.
  * Reconnection can now bypass an existing active connection when explicitly requested.
  * Forced reconnect requests are retained and retried after an active reconnect completes.

* **Bug Fixes**
  * Improved reconnect route selection by preserving locally available Tailscale routes as fallback options.
  * Prevented duplicate Tailscale endpoints during route selection.
  * Improved cleanup of pending reconnect attempts across account and connection changes.

* **Tests**
  * Added coverage verifying Iroh routes are preferred while Tailscale remains available as a fallback.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->