### PR TITLE
Fix iOS keyboard reversal render snap

### DIFF
--- a/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceHostView.swift
+++ b/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceHostView.swift
@@ -40,6 +40,7 @@ public final class GhosttySurfaceHostView: UIView {
     private var keyboardTargetHeight: CGFloat = 0
     private var keyboardTargetTop: CGFloat = 0
     private var keyboardTargetTerminalBottom: CGFloat = 0
+    private var keyboardTargetRenderBottom: CGFloat = 0
     #if DEBUG
     private var maximumTerminalDockPresentationGap: CGFloat = 0
     #endif
@@ -179,8 +180,10 @@ public final class GhosttySurfaceHostView: UIView {
             0,
             keyboardTargetTop - surfaceView.hostedBottomDockHeight
         )
-        let rendererBottom = surfaceView.hostedTerminalRenderBottom
-        let targetTranslation = keyboardTargetTerminalBottom - rendererBottom
+        keyboardTargetRenderBottom = surfaceView.hostedKeyboardTransitionRenderBottom(
+            to: keyboardTargetTerminalBottom
+        )
+        let targetTranslation = keyboardTargetRenderBottom - surfaceView.hostedTerminalRenderBottom
         #if DEBUG
         maximumTerminalDockPresentationGap = 0
         #endif
@@ -204,7 +207,7 @@ public final class GhosttySurfaceHostView: UIView {
         UIView.performWithoutAnimation {
             surfaceView.finishHostedKeyboardTransition(
                 keyboardHeight: keyboardTargetHeight,
-                terminalBottom: keyboardTargetTerminalBottom
+                terminalBottom: keyboardTargetRenderBottom
             )
             terminalPresentationView.transform = .identity
             layoutIfNeeded()
@@ -246,25 +249,25 @@ public final class GhosttySurfaceHostView: UIView {
         return occupancy > resolvedBottomSafeAreaInset + 0.5 ? occupancy : 0
     }
 
-    /// Rebase both sides of the terminal/dock boundary before a new keyboard will.
+    /// Rebase the dock/clip/render boundary before a new keyboard will.
     ///
     /// A reversal arrives while the previous leg still has separate Core Animation
     /// presentation trees for the dock constraint, clip boundary, and terminal
-    /// wrapper. Rebasing only the wrapper makes its next `.beginFromCurrentState`
-    /// animation start at the live edge while the clip remains at the old target,
-    /// exposing a one-frame gap. The notification fallback owns the dock constraint,
-    /// so it can first fold the live dock bottom into that constraint, lay out the
-    /// linked clip without actions, then fold the wrapper's live transform into its
-    /// model. The next transaction therefore starts every owned component at one edge.
+    /// wrapper. The notification fallback owns the dock constraint, so it first
+    /// folds the live dock bottom into that constraint and lays out the linked
+    /// clip without actions. The wrapper's live translation is folded into the
+    /// renderer before its animation is removed. The next transaction therefore
+    /// starts every owned component at one visible point.
     private func rebaseKeyboardPresentationFromLiveFrames() {
-        let wrapperTransform: CGAffineTransform? = {
-            guard let presentation = terminalPresentationView.layer.presentation(),
-                  CATransform3DIsAffine(presentation.transform) else { return nil }
-            return CATransform3DGetAffineTransform(presentation.transform)
+        let wrapperTranslationY: CGFloat = {
+            let layer = terminalPresentationView.layer
+            let source = layer.presentation() ?? layer
+            guard CATransform3DIsAffine(source.transform) else { return 0 }
+            return CATransform3DGetAffineTransform(source.transform).ty
         }()
         let liveDockBottom = surfaceView.hostedBottomDockPresentationBottom(in: self)
 
-        guard wrapperTransform != nil || liveDockBottom != nil else { return }
+        guard liveDockBottom != nil || abs(wrapperTranslationY) > 0.001 else { return }
         CATransaction.begin()
         CATransaction.setDisableActions(true)
         UIView.performWithoutAnimation {
@@ -272,9 +275,8 @@ public final class GhosttySurfaceHostView: UIView {
                let liveDockBottom {
                 dockBottomConstraint.constant = liveDockBottom - bounds.maxY
             }
-            if let wrapperTransform {
-                terminalPresentationView.transform = wrapperTransform
-            }
+            surfaceView.foldHostedKeyboardPresentationTranslation(wrapperTranslationY)
+            terminalPresentationView.transform = .identity
             // The clip bottom is constrained to the dock top. Layout before removing
             // the old animations so its model edge is the same live edge as the dock.
             layoutIfNeeded()
@@ -315,9 +317,20 @@ public final class GhosttySurfaceHostView: UIView {
     }
 
     private var terminalDockPresentationGap: CGFloat {
-        guard let terminalBottom = surfaceView.hostedTerminalPresentationBottom(in: self),
+        guard let terminalBottom = terminalViewportPresentationBottom,
               let dockTop = surfaceView.hostedBottomDockPresentationTop(in: self) else { return 0 }
         return abs(terminalBottom - dockTop)
+    }
+
+    /// During a transition the clip edge is the visible terminal edge. The
+    /// IOSurface stays top-anchored until its settled grid resize completes.
+    private var terminalViewportPresentationBottom: CGFloat? {
+        let source = terminalClipView.layer.presentation() ?? terminalClipView.layer
+        let hostLayer = layer.presentation() ?? layer
+        return source.convert(
+            CGPoint(x: source.bounds.midX, y: source.bounds.maxY),
+            to: hostLayer
+        ).y
     }
     #endif
 }

--- a/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView.swift
+++ b/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView.swift
@@ -1020,6 +1020,32 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
         setNeedsGeometrySync()
     }
 
+    /// Chooses the provisional render edge used while the host animates the keyboard.
+    func hostedKeyboardTransitionRenderBottom(to targetTerminalBottom: CGFloat) -> CGFloat {
+        guard !lastRenderRect.isEmpty else { return targetTerminalBottom }
+        return TerminalLetterboxGeometry.renderPinnedBottomEdge(
+            liveViewportMaxY: targetTerminalBottom,
+            targetViewportMaxY: targetTerminalBottom,
+            viewportMinY: lastRenderRect.minY,
+            renderHeight: lastRenderRect.height,
+            holdsProvisionalPin: true,
+            cursorBottomInRender: cursorBottomInRenderPoints()
+        )
+    }
+
+    /// Commits the host wrapper's live translation before a reversal removes
+    /// that wrapper animation.
+    func foldHostedKeyboardPresentationTranslation(_ translationY: CGFloat) {
+        guard abs(translationY) > 0.001, !lastRenderRect.isEmpty else { return }
+        lastRenderRect.origin.y += translationY
+        syncRendererLayerFrame(scale: preferredScreenScale, renderRect: lastRenderRect)
+        let snapshot = viewportSnapshot()
+        updateLetterboxBorder(
+            renderRect: lastRenderRect,
+            isLetterboxed: snapshot.isLetterboxed(renderSize: lastRenderRect.size)
+        )
+    }
+
     /// Folds the host's presentation translation into the renderer model at
     /// the exact settled dock edge, then allows grid negotiation to resume.
     func finishHostedKeyboardTransition(

--- a/experiments/keyboard-dock-repro/Info.plist
+++ b/experiments/keyboard-dock-repro/Info.plist
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleName</key>
+	<string>KeyboardDockRepro</string>
+	<key>CFBundleDisplayName</key>
+	<string>KeyboardDockRepro</string>
+	<key>CFBundlePackageType</key>
+	<string>APPL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>LSRequiresIPhoneOS</key>
+	<true/>
+	<key>UILaunchScreen</key>
+	<dict/>
+</dict>
+</plist>

--- a/experiments/keyboard-dock-repro/README.md
+++ b/experiments/keyboard-dock-repro/README.md
@@ -1,0 +1,12 @@
+# Keyboard dock reversal repro
+
+This is a UIKit-only reproduction with no cmux terminal, pairing, workspace, or
+Ghostty code. Generate the Xcode project with `xcodegen generate`, then build
+for an iOS Simulator.
+
+Launch normally for the fixed transaction. Launch with `--buggy` to commit the
+composer constraint outside the keyboard animation transaction and reproduce
+the snap during rapid up/down toggles.
+
+The fix keeps the dock constraint in the keyboard transition transaction and
+uses `.beginFromCurrentState` so reversals continue from the visible position.

--- a/experiments/keyboard-dock-repro/Sources/AppDelegate.swift
+++ b/experiments/keyboard-dock-repro/Sources/AppDelegate.swift
@@ -1,0 +1,17 @@
+import UIKit
+
+@main
+final class AppDelegate: UIResponder, UIApplicationDelegate {
+    var window: UIWindow?
+
+    func application(
+        _ application: UIApplication,
+        didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil
+    ) -> Bool {
+        let window = UIWindow(frame: UIScreen.main.bounds)
+        window.rootViewController = KeyboardDockViewController()
+        window.makeKeyAndVisible()
+        self.window = window
+        return true
+    }
+}

--- a/experiments/keyboard-dock-repro/Sources/KeyboardDockViewController.swift
+++ b/experiments/keyboard-dock-repro/Sources/KeyboardDockViewController.swift
@@ -1,0 +1,97 @@
+import UIKit
+
+final class KeyboardDockViewController: UIViewController {
+    private let terminal = UIView()
+    private let composer = UIView()
+    private let field = UITextField()
+    private let toggle = UIButton(type: .system)
+    private var bottomConstraint: NSLayoutConstraint!
+    private var keyboardVisible = false
+    private let reproducesSnap: Bool
+
+    init() {
+        reproducesSnap = ProcessInfo.processInfo.arguments.contains("--buggy")
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    required init?(coder: NSCoder) {
+        reproducesSnap = false
+        super.init(coder: coder)
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        view.backgroundColor = .black
+        terminal.backgroundColor = UIColor(white: 0.12, alpha: 1)
+        composer.backgroundColor = UIColor(white: 0.18, alpha: 1)
+        field.placeholder = "Message"
+        field.textColor = .white
+        field.backgroundColor = UIColor(white: 0.25, alpha: 1)
+        field.borderStyle = .roundedRect
+        toggle.setTitle(reproducesSnap ? "Toggle keyboard (snap)" : "Toggle keyboard", for: .normal)
+        toggle.tintColor = .white
+        toggle.addTarget(self, action: #selector(toggleKeyboard), for: .touchUpInside)
+
+        [terminal, composer].forEach {
+            $0.translatesAutoresizingMaskIntoConstraints = false
+            view.addSubview($0)
+        }
+        field.translatesAutoresizingMaskIntoConstraints = false
+        toggle.translatesAutoresizingMaskIntoConstraints = false
+        composer.addSubview(field)
+        composer.addSubview(toggle)
+        bottomConstraint = composer.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor)
+        NSLayoutConstraint.activate([
+            terminal.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
+            terminal.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            terminal.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            terminal.bottomAnchor.constraint(equalTo: composer.topAnchor),
+            composer.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            composer.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            bottomConstraint,
+            composer.heightAnchor.constraint(equalToConstant: 88),
+            field.leadingAnchor.constraint(equalTo: composer.leadingAnchor, constant: 16),
+            field.centerYAnchor.constraint(equalTo: composer.centerYAnchor),
+            field.trailingAnchor.constraint(equalTo: toggle.leadingAnchor, constant: -8),
+            toggle.trailingAnchor.constraint(equalTo: composer.trailingAnchor, constant: -16),
+            toggle.centerYAnchor.constraint(equalTo: composer.centerYAnchor),
+        ])
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(keyboardWillChange(_:)),
+            name: UIResponder.keyboardWillChangeFrameNotification,
+            object: nil
+        )
+    }
+
+    @objc private func toggleKeyboard() {
+        keyboardVisible ? field.resignFirstResponder() : field.becomeFirstResponder()
+    }
+
+    @objc private func keyboardWillChange(_ notification: Notification) {
+        guard let info = notification.userInfo,
+              let frame = info[UIResponder.keyboardFrameEndUserInfoKey] as? CGRect else { return }
+        let duration = info[UIResponder.keyboardAnimationDurationUserInfoKey] as? TimeInterval ?? 0.25
+        let curve = (info[UIResponder.keyboardAnimationCurveUserInfoKey] as? Int ?? 7) << 16
+        let keyboardFrame = view.convert(frame, from: nil)
+        let overlap = max(0, view.bounds.maxY - keyboardFrame.minY)
+        keyboardVisible = overlap > 0
+
+        if reproducesSnap {
+            // Old path: commit geometry outside the keyboard transaction.
+            bottomConstraint.constant = -overlap
+            UIView.performWithoutAnimation { view.layoutIfNeeded() }
+            return
+        }
+
+        // Fixed path: commit dock geometry in the same transaction as the keyboard.
+        bottomConstraint.constant = -overlap
+        UIView.animate(
+            withDuration: duration,
+            delay: 0,
+            options: [.beginFromCurrentState, .allowUserInteraction, UIView.AnimationOptions(rawValue: UInt(curve))]
+        ) {
+            self.view.layoutIfNeeded()
+        }
+    }
+}

--- a/experiments/keyboard-dock-repro/project.yml
+++ b/experiments/keyboard-dock-repro/project.yml
@@ -1,0 +1,13 @@
+name: KeyboardDockRepro
+options:
+  deploymentTarget:
+    iOS: "18.0"
+targets:
+  KeyboardDockRepro:
+    type: application
+    platform: iOS
+    sources: [Sources]
+    settings:
+      PRODUCT_BUNDLE_IDENTIFIER: com.manaflow.KeyboardDockRepro
+      INFOPLIST_FILE: Info.plist
+      SWIFT_VERSION: "6.0"


### PR DESCRIPTION
## Summary
- preserve the cursor-aware provisional render edge while the keyboard dock animates
- fold live presentation translation into the renderer before an interrupted A→B→A reversal
- measure the visible clip edge during the transition so the dock seam remains meaningful

## Verification
- `swift test --package-path Packages/iOS/CmuxMobileTerminalKit --filter TerminalLetterboxGeometryTests`
- existing `testTerminalDockStaysUnifiedAcrossRapidKeyboardReversals` and `testTerminalDockStaysPinnedForInPlaceKeyboardControlReversals` cover the recorded interaction
- tagged cloud build `31775619139` succeeded

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/10158"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789280805&installation_model_id=21920&pr_number=10158&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F10158&signature=cf33eaf3aeaf916fea48564b5ab8d5a79b41aa3faf6654780e54ba7b73797d68"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Eliminates a one-frame snap when rapidly reversing the iOS keyboard dock. Previously the terminal wrapper resumed from its live position while the clip/dock stayed at the old target, exposing a seam; now the renderer pins a cursor-aware edge and folds the live translation before animations are cleared.

- Host pins the visible render edge by computing a provisional `keyboardTargetRenderBottom` via `hostedKeyboardTransitionRenderBottom(...)`.
- Rebase path folds the wrapper’s presentation translation into the renderer with `foldHostedKeyboardPresentationTranslation(...)`, resets the wrapper transform, and lays out the clip before removing animations so dock/clip/render share one visible edge.
- Gap diagnostics now use the clip layer’s presentation bottom (`terminalViewportPresentationBottom`), matching the user-visible terminal edge.
- Adds `experiments/keyboard-dock-repro`, a minimal UIKit repro: launch normally for the fixed transactional path; pass `--buggy` to reproduce the snap. The fixed path animates the dock in the keyboard’s transaction using `.beginFromCurrentState`.
- Verification: `swift test --package-path Packages/iOS/CmuxMobileTerminalKit --filter TerminalLetterboxGeometryTests` (tests include `testTerminalDockStaysUnifiedAcrossRapidKeyboardReversals` and `testTerminalDockStaysPinnedForInPlaceKeyboardControlReversals`).

<sup>Written for commit ccce0f4c1e429ca9831d1d53e56a429b06a8905a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/10158?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved terminal positioning during keyboard presentation and dismissal.
  - Reduced visual gaps and jumps between terminal content, the keyboard, and surrounding viewport.
  - Kept terminal rendering aligned while the interface resizes or transitions.
  - Improved handling of letterboxed terminal views during animated layout changes.

- **Polish**
  - Refined transitions so hosted terminal content moves smoothly and settles accurately after animations.
  - Improved consistency when restoring the terminal after keyboard movement.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->