### PR TITLE
Keep a collapsed sidebar group folded when the workspace below it closes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1465,6 +1465,7 @@ jobs:
             CmuxTerminal
             CmuxTerminalCore
             CmuxUpdater
+            CmuxWorkspaces
             CMUXAgentLaunch
           )
           # SwiftPM emits an error-severity diagnostic while planning the

--- a/Packages/macOS/CmuxWorkspaces/Sources/CmuxWorkspaces/Model/WorkspacesModel+CloseSelection.swift
+++ b/Packages/macOS/CmuxWorkspaces/Sources/CmuxWorkspaces/Model/WorkspacesModel+CloseSelection.swift
@@ -1,0 +1,20 @@
+public import Foundation
+
+// Selection hand-off for the workspace close path.
+extension WorkspacesModel {
+    /// The workspace that takes selection after the workspace previously at
+    /// `closedIndex` was removed from `tabs`.
+    ///
+    /// Keeps the user's focused *row position* stable where possible: if a
+    /// workspace still occupies the closed workspace's slot, that one is
+    /// focused (it moved up into the slot); otherwise the closed workspace was
+    /// last, so focus falls back to the new last workspace.
+    ///
+    /// Callers must have already removed the closed workspace from `tabs`.
+    /// Returns nil when no workspace remains.
+    public func selectionTargetAfterClose(closedIndex: Int) -> UUID? {
+        guard !tabs.isEmpty else { return nil }
+        let newIndex = min(closedIndex, max(0, tabs.count - 1))
+        return tabs[newIndex].id
+    }
+}

--- a/Packages/macOS/CmuxWorkspaces/Sources/CmuxWorkspaces/Model/WorkspacesModel+CloseSelection.swift
+++ b/Packages/macOS/CmuxWorkspaces/Sources/CmuxWorkspaces/Model/WorkspacesModel+CloseSelection.swift
@@ -10,11 +10,26 @@ extension WorkspacesModel {
     /// focused (it moved up into the slot); otherwise the closed workspace was
     /// last, so focus falls back to the new last workspace.
     ///
+    /// The slot's occupant is resolved to a workspace the sidebar actually
+    /// renders: `tabs` stores every workspace, but a non-anchor member of a
+    /// *collapsed* group has no row of its own, and selecting one would fire
+    /// `expandWorkspaceGroupForSelectionIfNeeded` and unfold a group the user
+    /// deliberately collapsed. Such a member resolves to its group's anchor —
+    /// the row the sidebar draws for it — matching how
+    /// `toggleWorkspaceGroupCollapsed` moves focus to the anchor when a
+    /// collapse would hide the selected member.
+    ///
     /// Callers must have already removed the closed workspace from `tabs`.
     /// Returns nil when no workspace remains.
     public func selectionTargetAfterClose(closedIndex: Int) -> UUID? {
         guard !tabs.isEmpty else { return nil }
         let newIndex = min(closedIndex, max(0, tabs.count - 1))
-        return tabs[newIndex].id
+        let candidate = tabs[newIndex]
+        guard let groupId = candidate.groupId,
+              let group = workspaceGroups.first(where: { $0.id == groupId }),
+              group.isCollapsed else {
+            return candidate.id
+        }
+        return group.anchorWorkspaceId
     }
 }

--- a/Packages/macOS/CmuxWorkspaces/Tests/CmuxWorkspacesTests/WorkspaceCloseSelectionTests.swift
+++ b/Packages/macOS/CmuxWorkspaces/Tests/CmuxWorkspacesTests/WorkspaceCloseSelectionTests.swift
@@ -1,0 +1,125 @@
+import Foundation
+import Testing
+@testable import CmuxWorkspaces
+
+/// Close-path selection hand-off. The sidebar renders group anchors and
+/// ungrouped workspaces as rows; a non-anchor member of a *collapsed* group has
+/// no row of its own. Selecting such a member fires the selection auto-expand
+/// (`expandWorkspaceGroupForSelectionIfNeeded`) and unfolds a group the user
+/// deliberately collapsed, so the close path must never land there.
+@MainActor
+struct WorkspaceCloseSelectionTests {
+    private func makeWorld() -> (
+        model: WorkspacesModel<CoordinatorStubTab>,
+        host: StubGroupHost,
+        groups: WorkspaceGroupCoordinator<CoordinatorStubTab>
+    ) {
+        let model = WorkspacesModel<CoordinatorStubTab>()
+        let host = StubGroupHost(model: model)
+        let groups = WorkspaceGroupCoordinator(model: model)
+        groups.attach(host: host)
+        return (model, host, groups)
+    }
+
+    /// Builds `[anchor, m1, m2, outside]`: one group run followed by a single
+    /// ungrouped workspace, which is the ordering invariant's normal shape
+    /// (groups above ungrouped-unpinned).
+    ///
+    /// The coordinator holds its host weakly, so callers must keep the returned
+    /// `host` alive for the duration of the test.
+    private func makeGroupAboveLoneWorkspace() throws -> (
+        model: WorkspacesModel<CoordinatorStubTab>,
+        host: StubGroupHost,
+        groups: WorkspaceGroupCoordinator<CoordinatorStubTab>,
+        groupId: UUID,
+        anchorId: UUID,
+        m2: CoordinatorStubTab,
+        outside: CoordinatorStubTab
+    ) {
+        let (model, host, groups) = makeWorld()
+        let m1 = CoordinatorStubTab()
+        let m2 = CoordinatorStubTab()
+        let outside = CoordinatorStubTab()
+        model.tabs = [m1, m2, outside]
+        let groupId = try #require(
+            groups.createWorkspaceGroup(name: "G", childWorkspaceIds: [m1.id, m2.id])
+        )
+        let anchorId = try #require(
+            model.workspaceGroups.first(where: { $0.id == groupId })?.anchorWorkspaceId
+        )
+        #expect(model.tabs.map(\.id) == [anchorId, m1.id, m2.id, outside.id])
+        return (model, host, groups, groupId, anchorId, m2, outside)
+    }
+
+    /// Closing the LAST workspace walks selection *backwards*, straight into the
+    /// tail of the preceding group's member run. When that group is collapsed
+    /// the tail member is invisible, so selection must land on the group's
+    /// anchor (its visible header row) instead.
+    @Test
+    func closingLastWorkspaceSelectsAnchorNotHiddenMemberOfCollapsedGroup() throws {
+        let world = try makeGroupAboveLoneWorkspace()
+        world.groups.setWorkspaceGroupCollapsed(groupId: world.groupId, isCollapsed: true)
+
+        let index = try #require(world.model.tabs.firstIndex(where: { $0.id == world.outside.id }))
+        world.model.selectedTabId = world.outside.id
+        world.model.tabs.remove(at: index)
+
+        let target = try #require(world.model.selectionTargetAfterClose(closedIndex: index))
+        #expect(target == world.anchorId)
+        #expect(target != world.m2.id)
+    }
+
+    /// End-to-end consequence of the rule above: after the close path applies
+    /// its selection and the selection side-effect chain runs, the group the
+    /// user collapsed is still collapsed.
+    @Test
+    func closingLastWorkspaceKeepsPrecedingGroupCollapsed() throws {
+        let world = try makeGroupAboveLoneWorkspace()
+        world.groups.setWorkspaceGroupCollapsed(groupId: world.groupId, isCollapsed: true)
+
+        let index = try #require(world.model.tabs.firstIndex(where: { $0.id == world.outside.id }))
+        world.model.selectedTabId = world.outside.id
+        world.model.tabs.remove(at: index)
+
+        world.model.selectedTabId = world.model.selectionTargetAfterClose(closedIndex: index)
+        // The model has no host attached here, so drive the selection
+        // side-effect the window's `selectedTabId` didSet would have run.
+        world.model.expandWorkspaceGroupForSelectionIfNeeded()
+
+        #expect(world.model.workspaceGroups.first(where: { $0.id == world.groupId })?.isCollapsed == true)
+    }
+
+    /// Guard against over-correcting: an EXPANDED group's members do have their
+    /// own sidebar rows, so selection keeps landing on the adjacent member and
+    /// is not redirected to the anchor.
+    @Test
+    func closingLastWorkspaceSelectsAdjacentMemberOfExpandedGroup() throws {
+        let world = try makeGroupAboveLoneWorkspace()
+
+        let index = try #require(world.model.tabs.firstIndex(where: { $0.id == world.outside.id }))
+        world.model.selectedTabId = world.outside.id
+        world.model.tabs.remove(at: index)
+
+        let target = try #require(world.model.selectionTargetAfterClose(closedIndex: index))
+        #expect(target == world.m2.id)
+    }
+
+    /// Closing a non-last workspace still walks *forwards* into the workspace
+    /// that moved up into the vacated slot.
+    @Test
+    func closingNonLastWorkspaceSelectsTheWorkspaceThatMovedUp() throws {
+        let (model, host, _) = makeWorld()
+        _ = host
+        let a = CoordinatorStubTab()
+        let b = CoordinatorStubTab()
+        let c = CoordinatorStubTab()
+        model.tabs = [a, b, c]
+
+        let index = try #require(model.tabs.firstIndex(where: { $0.id == b.id }))
+        model.selectedTabId = b.id
+        model.tabs.remove(at: index)
+
+        let target = try #require(model.selectionTargetAfterClose(closedIndex: index))
+        #expect(target == c.id)
+    }
+}

--- a/Sources/TabManager.swift
+++ b/Sources/TabManager.swift
@@ -2225,12 +2225,11 @@ class TabManager: ObservableObject {
             // fixup.
             let promotedAnchorIds = workspaces.promoteAnchorOrRemoveGroupsAnchoredBy(closedWorkspaceId: workspace.id)
 
-            if selectedTabId == workspace.id {
-                // Keep the "focused index" stable when possible:
-                // - If we closed workspace i and there is still a workspace at index i, focus it (the one that moved up).
-                // - Otherwise (we closed the last workspace), focus the new last workspace (i-1).
-                let newIndex = min(index, max(0, tabs.count - 1))
-                selectedTabId = tabs[newIndex].id
+            if selectedTabId == workspace.id,
+               let nextSelectedId = workspaces.selectionTargetAfterClose(closedIndex: index) {
+                // Keep the "focused row position" stable when possible; see
+                // WorkspacesModel.selectionTargetAfterClose for the rule.
+                selectedTabId = nextSelectedId
             }
 
             // A promoted anchor's resolved display title switches from its own


### PR DESCRIPTION
## Problem

A collapsed sidebar group force-expands when the workspace sitting directly below it is closed.

## Cause

The close path's selection fallback indexes into the flat `tabs[]` array:

```swift
let newIndex = min(index, max(0, tabs.count - 1))
selectedTabId = tabs[newIndex].id
```

`tabs[]` holds every workspace, including members a collapsed group hides. The sidebar's actual rows are group anchors plus ungrouped workspaces (`sidebarTopLevelWorkspaceIds()`), so this can select a workspace that has no row.

That assignment then runs `selectedTabId`'s `didSet` → `selectedWorkspaceIdDidChange` → `expandWorkspaceGroupForSelectionIfNeeded()`, which sees the selection inside a collapsed group it is not the anchor of, and clears `isCollapsed`. The auto-expand is correct in itself — "a selected row must be visible". The defect is selecting an invisible row in the first place.

### Why it needs the workspace to be last

`newIndex = min(index, count - 1)`:

- **Closing a non-last workspace** walks *forwards* to whatever moved up into the slot. A group run always starts with its anchor (`anchorFirst`), and the anchor is exempt from the auto-expand — no bug.
- **Closing the last workspace** walks *backwards* to the preceding entry, which is the collapsed group's **last member** — bug.

Since the ordering invariant puts groups above ungrouped-unpinned workspaces, a lone ungrouped workspace under a collapsed group is exactly this shape.

## Fix

Resolve the slot's occupant to a row the sidebar renders. A non-anchor member of a *collapsed* group hands off to its group's anchor; members of an expanded group have their own rows and are selected as before.

This mirrors `toggleWorkspaceGroupCollapsed`, which already moves focus to the anchor when collapsing would hide the selected member, and `SidebarState.scrollTargetWorkspaceId`, which already maps hidden members to the anchor for scrolling.

The fallback moved to `WorkspacesModel.selectionTargetAfterClose(closedIndex:)` so it is reachable from the package's tests.

## Commits

Per the regression policy, the test lands first so CI proves it catches the bug:

1. **Failing tests** — the extraction is behavior-preserving, so the two collapsed-group tests fail here.
2. **Fix** — the anchor hand-off.

| Test | 1 | 2 |
|---|---|---|
| `closingLastWorkspaceSelectsAnchorNotHiddenMemberOfCollapsedGroup` | ❌ | ✅ |
| `closingLastWorkspaceKeepsPrecedingGroupCollapsed` (end-to-end) | ❌ | ✅ |
| `closingLastWorkspaceSelectsAdjacentMemberOfExpandedGroup` (guards over-correction) | ✅ | ✅ |
| `closingNonLastWorkspaceSelectsTheWorkspaceThatMovedUp` | ✅ | ✅ |

## Also: `CmuxWorkspacesTests` was not running in CI

`CmuxWorkspaces` is absent from the `swift test` allowlist in `.github/workflows/ci.yml`, so that whole suite — including the existing group/reorder coordinator tests — has never been a CI gate. Without adding it, commit 1 could not go red and the regression policy would be vacuous. Its dependencies (CmuxSettings, bonsplit, CMUXDebugLog, CmuxTestSupport) already resolve headlessly in that job.

## Out of scope

`index` is captured before `promoteAnchorOrRemoveGroupsAnchoredBy`, which calls `normalizeWorkspaceGroupContiguity` and can reorder `tabs`. On an anchor close the index may not match the post-reorder array. That is pre-existing and untouched here, though the anchor hand-off softens its symptom.

## Notes

No user-facing strings changed, so there is nothing to localize.

I could not build locally (no Swift toolchain available in my environment), so compilation and the test results rest on CI. Happy to fix up whatever it reports.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/10169"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789302028&installation_model_id=21920&pr_number=10169&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F10169&signature=37d2fed63f2720ca867f8756f81e5c9f65f2cc7d35a2e6714fe7821480616989"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keeps a collapsed sidebar group folded when the workspace beneath it closes by fixing the close-path selection fallback. Previously, closing the last workspace selected a hidden group member and auto-expanded the group; now it selects the group anchor so the group stays collapsed.

- Extracts the selection fallback to `WorkspacesModel.selectionTargetAfterClose(closedIndex:)` and calls it from `TabManager`’s close path.
- Maps a hidden member of a collapsed group to its anchor; expanded groups and non-last closes retain the prior selection behavior.
- Adds targeted tests in `CmuxWorkspacesTests` to cover collapsed/expanded/non-last scenarios.
- Ensures these tests run in CI by adding `CmuxWorkspaces` to the `swift test` allowlist.

<sup>Written for commit 313b417e28bfcbbdaa565966fc4574d6405cca33. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/10169?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved workspace selection after closing a workspace.
  * Closing the final workspace in a group now selects the appropriate visible workspace.
  * Closing a workspace preserves collapsed groups and selects the adjacent workspace when applicable.

* **Tests**
  * Added coverage for workspace closing and selection behavior, including grouped and ungrouped workspaces.
  * Included the workspace package in the automated test suite.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->