### PR TITLE
Fix sidebar branch label for reftable git repositories

### DIFF
--- a/Packages/macOS/CmuxGit/Sources/CmuxGit/GitMetadataService.swift
+++ b/Packages/macOS/CmuxGit/Sources/CmuxGit/GitMetadataService.swift
@@ -1,7 +1,8 @@
 import Foundation
 
 /// Reads a directory's git metadata directly from the on-disk repository,
-/// without spawning a `git` process.
+/// spawning a `git` process only for repositories whose `HEAD` is the reftable
+/// compatibility stub (`ref: refs/heads/.invalid`).
 ///
 /// This service does the filesystem work that powers the workspace sidebar's
 /// branch label, dirty indicator, and pull-request badge: resolving the

--- a/Packages/macOS/CmuxGit/Sources/CmuxGit/Parsing/GitMetadataService+GitPlumbing.swift
+++ b/Packages/macOS/CmuxGit/Sources/CmuxGit/Parsing/GitMetadataService+GitPlumbing.swift
@@ -1,4 +1,5 @@
 import CmuxFoundation
+import Darwin
 import Foundation
 
 extension GitMetadataService {
@@ -118,6 +119,7 @@ struct SystemGitMetadataGitRunner: GitMetadataGitRunning {
     private static let wallTimeLimit: TimeInterval = 5
     private static let pollInterval: TimeInterval = 0.01
     private static let processExitGraceLimit: TimeInterval = 2
+    private static let sigkillGraceLimit: TimeInterval = 0.2
 
     func run(arguments: [String], in directory: URL) -> GitMetadataGitResult {
         let process = Process()
@@ -163,14 +165,8 @@ struct SystemGitMetadataGitRunner: GitMetadataGitRunning {
             }
         }
 
-        if process.isRunning {
-            process.terminate()
-        }
-        let exitDeadline = Date().addingTimeInterval(Self.processExitGraceLimit)
-        while process.isRunning, Date() < exitDeadline {
-            Thread.sleep(forTimeInterval: Self.pollInterval)
-        }
-        if process.isRunning {
+        Self.terminateProcessIfRunning(process)
+        guard Self.waitForProcessExit(process, deadline: Self.processExitGraceLimit) else {
             return GitMetadataGitResult(output: "", exitCode: 127)
         }
 
@@ -179,5 +175,26 @@ struct SystemGitMetadataGitRunner: GitMetadataGitRunning {
             return GitMetadataGitResult(output: "", exitCode: 127)
         }
         return GitMetadataGitResult(output: output, exitCode: process.terminationStatus)
+    }
+
+    private static func terminateProcessIfRunning(_ process: Process) {
+        guard process.isRunning else { return }
+        process.terminate()
+    }
+
+    private static func waitForProcessExit(_ process: Process, deadline: TimeInterval) -> Bool {
+        let exitDeadline = Date().addingTimeInterval(deadline)
+        while process.isRunning, Date() < exitDeadline {
+            Thread.sleep(forTimeInterval: Self.pollInterval)
+        }
+        guard process.isRunning else { return true }
+
+        // `isRunning` ensures the pid still belongs to this Process before kill.
+        _ = Darwin.kill(process.processIdentifier, SIGKILL)
+        let killDeadline = Date().addingTimeInterval(Self.sigkillGraceLimit)
+        while process.isRunning, Date() < killDeadline {
+            Thread.sleep(forTimeInterval: Self.pollInterval)
+        }
+        return !process.isRunning
     }
 }

--- a/Packages/macOS/CmuxGit/Sources/CmuxGit/Parsing/GitMetadataService+GitPlumbing.swift
+++ b/Packages/macOS/CmuxGit/Sources/CmuxGit/Parsing/GitMetadataService+GitPlumbing.swift
@@ -161,7 +161,9 @@ struct SystemGitMetadataGitRunner: GitMetadataGitRunning {
         }
 
         let outputData = collected.prefix(Self.maximumOutputByteCount)
-        let output = String(decoding: outputData, as: UTF8.self)
+        guard let output = String(bytes: outputData, encoding: .utf8) else {
+            return GitMetadataGitResult(output: "", exitCode: 127)
+        }
         return GitMetadataGitResult(output: output, exitCode: process.terminationStatus)
     }
 }

--- a/Packages/macOS/CmuxGit/Sources/CmuxGit/Parsing/GitMetadataService+GitPlumbing.swift
+++ b/Packages/macOS/CmuxGit/Sources/CmuxGit/Parsing/GitMetadataService+GitPlumbing.swift
@@ -5,8 +5,19 @@ extension GitMetadataService {
     /// Branch name git writes into the vestigial `HEAD` stub for reftable repos.
     static let reftableHeadBranchSentinel = ".invalid"
 
-    /// Test hook for git-plumbing reads. When set, overrides the system runner.
-    nonisolated(unsafe) static var gitPlumbingRunnerForTests: (any GitMetadataGitRunning)?
+    private enum GitPlumbingRunnerOverride {
+        @TaskLocal static var current: (any GitMetadataGitRunning)?
+    }
+
+    /// Runs `body` with a git-plumbing runner override isolated to this task.
+    static func withGitPlumbingRunnerForTesting<T>(
+        _ runner: any GitMetadataGitRunning,
+        perform body: () async throws -> T
+    ) async rethrows -> T {
+        try await GitPlumbingRunnerOverride.$current.withValue(runner) {
+            try await body()
+        }
+    }
 
     /// Runs a read-only git command in the repository work tree.
     nonisolated static func gitPlumbingOutput(
@@ -14,7 +25,7 @@ extension GitMetadataService {
         arguments: [String],
         acceptedExitCodes: Set<Int32> = [0]
     ) -> String? {
-        let result = (gitPlumbingRunnerForTests ?? SystemGitMetadataGitRunner()).run(
+        let result = (GitPlumbingRunnerOverride.current ?? SystemGitMetadataGitRunner()).run(
             arguments: arguments,
             in: URL(fileURLWithPath: repository.workTreeRoot, isDirectory: true)
         )

--- a/Packages/macOS/CmuxGit/Sources/CmuxGit/Parsing/GitMetadataService+GitPlumbing.swift
+++ b/Packages/macOS/CmuxGit/Sources/CmuxGit/Parsing/GitMetadataService+GitPlumbing.swift
@@ -1,0 +1,156 @@
+import Foundation
+
+extension GitMetadataService {
+    /// Branch name git writes into the vestigial `HEAD` stub for reftable repos.
+    static let reftableHeadBranchSentinel = ".invalid"
+
+    /// Test hook for git-plumbing reads. When set, overrides the system runner.
+    nonisolated(unsafe) static var gitPlumbingRunnerForTests: (any GitMetadataGitRunning)?
+
+    /// Runs a read-only git command in the repository work tree.
+    nonisolated static func gitPlumbingOutput(
+        repository: ResolvedGitRepository,
+        arguments: [String],
+        acceptedExitCodes: Set<Int32> = [0]
+    ) -> String? {
+        let result = (gitPlumbingRunnerForTests ?? SystemGitMetadataGitRunner()).run(
+            arguments: arguments,
+            in: URL(fileURLWithPath: repository.workTreeRoot, isDirectory: true)
+        )
+        guard acceptedExitCodes.contains(result.exitCode) else { return nil }
+        let trimmed = result.output.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? nil : trimmed
+    }
+
+    /// Whether `HEAD` names the reftable compatibility stub rather than a real branch.
+    nonisolated static func headNamesReftableStub(_ headContents: String) -> Bool {
+        let trimmed = headContents.trimmingCharacters(in: .whitespacesAndNewlines)
+        let branchPrefix = "ref: refs/heads/"
+        guard trimmed.hasPrefix(branchPrefix) else { return false }
+        let branch = String(trimmed.dropFirst(branchPrefix.count))
+        return branch == reftableHeadBranchSentinel
+    }
+
+    /// Resolves the checked-out branch through git when `HEAD` is a reftable stub.
+    nonisolated static func gitBranchNameViaPlumbing(repository: ResolvedGitRepository) -> String? {
+        gitPlumbingOutput(
+            repository: repository,
+            arguments: ["symbolic-ref", "--quiet", "--short", "HEAD"],
+            acceptedExitCodes: [0]
+        ).flatMap(normalizedBranchName)
+    }
+
+    /// Classifies `HEAD` through git when the on-disk stub is the reftable sentinel.
+    nonisolated static func gitCheckedOutBranchViaPlumbing(
+        repository: ResolvedGitRepository
+    ) -> GitCheckedOutBranch {
+        if let branch = gitBranchNameViaPlumbing(repository: repository) {
+            return .branch(branch)
+        }
+        if gitCurrentCommitViaPlumbing(repository: repository) != nil {
+            return .detached
+        }
+        return .unreadable
+    }
+
+    /// Builds a `HEAD` signature through git when loose refs cannot resolve the stub.
+    nonisolated static func gitHeadSignatureViaPlumbing(repository: ResolvedGitRepository) -> String? {
+        guard let symbolicRef = gitPlumbingOutput(
+            repository: repository,
+            arguments: ["symbolic-ref", "HEAD"],
+            acceptedExitCodes: [0]
+        ) else {
+            return gitPlumbingOutput(
+                repository: repository,
+                arguments: ["rev-parse", "HEAD"],
+                acceptedExitCodes: [0]
+            )
+        }
+        let commit = gitPlumbingOutput(
+            repository: repository,
+            arguments: ["rev-parse", "HEAD"],
+            acceptedExitCodes: [0]
+        ) ?? ""
+        return "\(symbolicRef)\n\(commit)"
+    }
+
+    /// Resolves `HEAD` to a commit SHA through git when loose refs are unavailable.
+    nonisolated static func gitCurrentCommitViaPlumbing(repository: ResolvedGitRepository) -> String? {
+        guard let value = gitPlumbingOutput(
+            repository: repository,
+            arguments: ["rev-parse", "HEAD"],
+            acceptedExitCodes: [0]
+        ) else {
+            return nil
+        }
+        let normalized = value.lowercased()
+        guard normalized.count == 40, normalized.allSatisfy(\.isHexDigit) else {
+            return nil
+        }
+        return normalized
+    }
+}
+
+/// Runs read-only git plumbing for ``GitMetadataService``.
+protocol GitMetadataGitRunning: Sendable {
+    func run(arguments: [String], in directory: URL) -> GitMetadataGitResult
+}
+
+struct GitMetadataGitResult: Sendable {
+    let output: String
+    let exitCode: Int32
+}
+
+struct SystemGitMetadataGitRunner: GitMetadataGitRunning {
+    private static let maximumOutputByteCount = 4 * 1024
+    private static let wallTimeLimit: TimeInterval = 5
+
+    func run(arguments: [String], in directory: URL) -> GitMetadataGitResult {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/git")
+        process.arguments = arguments
+        process.currentDirectoryURL = directory
+        var environment = ProcessInfo.processInfo.environment
+        environment["GIT_OPTIONAL_LOCKS"] = "0"
+        process.environment = environment
+
+        let outputPipe = Pipe()
+        process.standardOutput = outputPipe
+        process.standardError = FileHandle.nullDevice
+        process.standardInput = FileHandle.nullDevice
+
+        do {
+            try process.run()
+        } catch {
+            return GitMetadataGitResult(output: "", exitCode: 127)
+        }
+
+        let readHandle = outputPipe.fileHandleForReading
+        var collected = Data()
+        let deadline = Date().addingTimeInterval(Self.wallTimeLimit)
+        while Date() < deadline {
+            let chunk = readHandle.availableData
+            if chunk.isEmpty {
+                if process.isRunning {
+                    Thread.sleep(forTimeInterval: 0.01)
+                    continue
+                }
+                break
+            }
+            collected.append(chunk)
+            if collected.count >= Self.maximumOutputByteCount {
+                process.terminate()
+                break
+            }
+        }
+
+        if process.isRunning {
+            process.terminate()
+        }
+        process.waitUntilExit()
+
+        let outputData = collected.prefix(Self.maximumOutputByteCount)
+        let output = String(decoding: outputData, as: UTF8.self)
+        return GitMetadataGitResult(output: output, exitCode: process.terminationStatus)
+    }
+}

--- a/Packages/macOS/CmuxGit/Sources/CmuxGit/Parsing/GitMetadataService+GitPlumbing.swift
+++ b/Packages/macOS/CmuxGit/Sources/CmuxGit/Parsing/GitMetadataService+GitPlumbing.swift
@@ -1,3 +1,4 @@
+import CmuxFoundation
 import Foundation
 
 extension GitMetadataService {
@@ -104,6 +105,8 @@ struct GitMetadataGitResult: Sendable {
 struct SystemGitMetadataGitRunner: GitMetadataGitRunning {
     private static let maximumOutputByteCount = 4 * 1024
     private static let wallTimeLimit: TimeInterval = 5
+    private static let pollInterval: TimeInterval = 0.01
+    private static let processExitGraceLimit: TimeInterval = 2
 
     func run(arguments: [String], in directory: URL) -> GitMetadataGitResult {
         let process = Process()
@@ -127,27 +130,35 @@ struct SystemGitMetadataGitRunner: GitMetadataGitRunning {
 
         let readHandle = outputPipe.fileHandleForReading
         var collected = Data()
-        let deadline = Date().addingTimeInterval(Self.wallTimeLimit)
-        while Date() < deadline {
-            let chunk = readHandle.availableData
-            if chunk.isEmpty {
-                if process.isRunning {
-                    Thread.sleep(forTimeInterval: 0.01)
-                    continue
+        let readDeadline = Date().addingTimeInterval(Self.wallTimeLimit)
+        readLoop: while Date() < readDeadline {
+            let remainingCapacity = Self.maximumOutputByteCount - collected.count
+            switch readHandle.readAvailableData(maxLength: max(remainingCapacity, 1)) {
+            case .success(.data(let chunk)):
+                collected.append(chunk)
+                if collected.count >= Self.maximumOutputByteCount {
+                    process.terminate()
+                    break readLoop
                 }
-                break
-            }
-            collected.append(chunk)
-            if collected.count >= Self.maximumOutputByteCount {
-                process.terminate()
-                break
+            case .success(.endOfFile):
+                break readLoop
+            case .success(.wouldBlock):
+                if !process.isRunning {
+                    break readLoop
+                }
+                Thread.sleep(forTimeInterval: Self.pollInterval)
+            case .failure:
+                break readLoop
             }
         }
 
         if process.isRunning {
             process.terminate()
         }
-        process.waitUntilExit()
+        let exitDeadline = Date().addingTimeInterval(Self.processExitGraceLimit)
+        while process.isRunning, Date() < exitDeadline {
+            Thread.sleep(forTimeInterval: Self.pollInterval)
+        }
 
         let outputData = collected.prefix(Self.maximumOutputByteCount)
         let output = String(decoding: outputData, as: UTF8.self)

--- a/Packages/macOS/CmuxGit/Sources/CmuxGit/Parsing/GitMetadataService+GitPlumbing.swift
+++ b/Packages/macOS/CmuxGit/Sources/CmuxGit/Parsing/GitMetadataService+GitPlumbing.swift
@@ -159,6 +159,9 @@ struct SystemGitMetadataGitRunner: GitMetadataGitRunning {
         while process.isRunning, Date() < exitDeadline {
             Thread.sleep(forTimeInterval: Self.pollInterval)
         }
+        if process.isRunning {
+            return GitMetadataGitResult(output: "", exitCode: 127)
+        }
 
         let outputData = collected.prefix(Self.maximumOutputByteCount)
         guard let output = String(bytes: outputData, encoding: .utf8) else {

--- a/Packages/macOS/CmuxGit/Sources/CmuxGit/Parsing/GitMetadataService+Refs.swift
+++ b/Packages/macOS/CmuxGit/Sources/CmuxGit/Parsing/GitMetadataService+Refs.swift
@@ -11,6 +11,10 @@ extension GitMetadataService {
 
     /// The current branch name from `HEAD` (`ref: refs/heads/<name>`), or `nil`
     /// for a detached HEAD or unreadable `HEAD`.
+    ///
+    /// Repositories using git's reftable backend keep a vestigial `HEAD` stub
+    /// (`ref: refs/heads/.invalid`); those resolve the real branch through git
+    /// plumbing instead of trusting the file contents.
     nonisolated static func gitBranchName(repository: ResolvedGitRepository) -> String? {
         let headURL = URL(fileURLWithPath: repository.gitDirectory).appendingPathComponent("HEAD")
         guard let contents = try? String(contentsOf: headURL, encoding: .utf8) else {
@@ -22,7 +26,11 @@ extension GitMetadataService {
             return nil
         }
         let branch = String(trimmed.dropFirst(branchPrefix.count))
-        return branch.isEmpty ? nil : branch
+        guard !branch.isEmpty else { return nil }
+        if headNamesReftableStub(contents) {
+            return gitBranchNameViaPlumbing(repository: repository)
+        }
+        return branch
     }
 
     /// Classifies the repository's `HEAD` into a ``GitCheckedOutBranch``,
@@ -38,6 +46,9 @@ extension GitMetadataService {
         if trimmed.hasPrefix(branchPrefix) {
             guard let branch = normalizedBranchName(String(trimmed.dropFirst(branchPrefix.count))) else {
                 return .unreadable
+            }
+            if headNamesReftableStub(contents) {
+                return gitCheckedOutBranchViaPlumbing(repository: repository)
             }
             return .branch(branch)
         }
@@ -72,6 +83,9 @@ extension GitMetadataService {
 
         let refName = String(trimmed.dropFirst(refPrefix.count))
         guard !refName.isEmpty else { return trimmed }
+        if headNamesReftableStub(contents) {
+            return gitHeadSignatureViaPlumbing(repository: repository)
+        }
         let refValue = gitRefValue(repository: repository, refName: refName) ?? ""
         return "\(trimmed)\n\(refValue)"
     }
@@ -126,7 +140,11 @@ extension GitMetadataService {
         let value: String
         if trimmed.hasPrefix(refPrefix) {
             let refName = String(trimmed.dropFirst(refPrefix.count))
-            guard !refName.isEmpty, let refValue = gitRefValue(repository: repository, refName: refName) else {
+            guard !refName.isEmpty else { return nil }
+            if headNamesReftableStub(contents) {
+                return gitCurrentCommitViaPlumbing(repository: repository)
+            }
+            guard let refValue = gitRefValue(repository: repository, refName: refName) else {
                 return nil
             }
             value = refValue

--- a/Packages/macOS/CmuxGit/Sources/CmuxGit/Parsing/GitMetadataService+WatchPaths.swift
+++ b/Packages/macOS/CmuxGit/Sources/CmuxGit/Parsing/GitMetadataService+WatchPaths.swift
@@ -41,6 +41,7 @@ extension GitMetadataService {
             URL(fileURLWithPath: repository.gitDirectory).appendingPathComponent("refs").path,
             URL(fileURLWithPath: repository.commonDirectory).appendingPathComponent("refs").path,
             URL(fileURLWithPath: repository.commonDirectory).appendingPathComponent("packed-refs").path,
+            URL(fileURLWithPath: repository.commonDirectory).appendingPathComponent("reftable").path,
         ] + gitConfigURLs(repository: repository).map(\.path)
     }
 

--- a/Packages/macOS/CmuxGit/Tests/CmuxGitTests/Fixtures/GitRepositoryFixture.swift
+++ b/Packages/macOS/CmuxGit/Tests/CmuxGitTests/Fixtures/GitRepositoryFixture.swift
@@ -38,6 +38,15 @@ final class GitRepositoryFixture {
         try "\(commit)\n".write(to: refURL, atomically: true, encoding: .utf8)
     }
 
+    /// Writes the vestigial `HEAD` stub git uses for reftable repositories.
+    func writeReftableHeadStub() throws {
+        try "ref: refs/heads/.invalid\n".write(
+            to: gitDirectory.appendingPathComponent("HEAD"),
+            atomically: true,
+            encoding: .utf8
+        )
+    }
+
     /// Writes a detached `HEAD` holding a raw commit SHA.
     func writeDetachedHead(commit: String) throws {
         try "\(commit)\n".write(

--- a/Packages/macOS/CmuxGit/Tests/CmuxGitTests/GitMetadataServiceTests.swift
+++ b/Packages/macOS/CmuxGit/Tests/CmuxGitTests/GitMetadataServiceTests.swift
@@ -154,9 +154,7 @@ import Testing
         let fixture = try GitRepositoryFixture()
         try fixture.writeReftableHeadStub()
         let repository = try #require(GitMetadataService.resolveGitRepository(containing: fixture.root.path))
-        let priorRunner = GitMetadataService.gitPlumbingRunnerForTests
-        defer { GitMetadataService.gitPlumbingRunnerForTests = priorRunner }
-        GitMetadataService.gitPlumbingRunnerForTests = FakeGitMetadataGitRunner(responses: [
+        await GitMetadataService.withGitPlumbingRunnerForTesting(FakeGitMetadataGitRunner(responses: [
             ["symbolic-ref", "--quiet", "--short", "HEAD"]: GitMetadataGitResult(
                 output: "theo.leruitte/support-dog/preprod\n",
                 exitCode: 0
@@ -169,41 +167,39 @@ import Testing
                 output: String(repeating: "a", count: 40) + "\n",
                 exitCode: 0
             ),
-        ])
+        ])) {
+            let service = GitMetadataService()
+            let meta = await service.workspaceMetadata(for: fixture.root.path)
+            let branch = await service.checkedOutBranch(forDirectory: fixture.root.path)
 
-        let service = GitMetadataService()
-        let meta = await service.workspaceMetadata(for: fixture.root.path)
-        let branch = await service.checkedOutBranch(forDirectory: fixture.root.path)
-
-        #expect(GitMetadataService.gitBranchName(repository: repository) == "theo.leruitte/support-dog/preprod")
-        #expect(meta.branch == "theo.leruitte/support-dog/preprod")
-        #expect(branch == .branch("theo.leruitte/support-dog/preprod"))
-        #expect(GitMetadataService.gitHeadSignature(repository: repository) == """
-            refs/heads/theo.leruitte/support-dog/preprod
-            \(String(repeating: "a", count: 40))
-            """)
-        #expect(GitMetadataService.gitCurrentCommit(repository: repository) == String(repeating: "a", count: 40))
+            #expect(GitMetadataService.gitBranchName(repository: repository) == "theo.leruitte/support-dog/preprod")
+            #expect(meta.branch == "theo.leruitte/support-dog/preprod")
+            #expect(branch == .branch("theo.leruitte/support-dog/preprod"))
+            #expect(GitMetadataService.gitHeadSignature(repository: repository) == """
+                refs/heads/theo.leruitte/support-dog/preprod
+                \(String(repeating: "a", count: 40))
+                """)
+            #expect(GitMetadataService.gitCurrentCommit(repository: repository) == String(repeating: "a", count: 40))
+        }
     }
 
     @Test func reftableHeadStubDetachedCheckoutUsesGitPlumbing() async throws {
         let fixture = try GitRepositoryFixture()
         try fixture.writeReftableHeadStub()
-        let priorRunner = GitMetadataService.gitPlumbingRunnerForTests
-        defer { GitMetadataService.gitPlumbingRunnerForTests = priorRunner }
-        GitMetadataService.gitPlumbingRunnerForTests = FakeGitMetadataGitRunner(responses: [
+        await GitMetadataService.withGitPlumbingRunnerForTesting(FakeGitMetadataGitRunner(responses: [
             ["symbolic-ref", "--quiet", "--short", "HEAD"]: GitMetadataGitResult(output: "", exitCode: 1),
             ["rev-parse", "HEAD"]: GitMetadataGitResult(
                 output: String(repeating: "b", count: 40) + "\n",
                 exitCode: 0
             ),
-        ])
+        ])) {
+            let service = GitMetadataService()
+            let meta = await service.workspaceMetadata(for: fixture.root.path)
+            let branch = await service.checkedOutBranch(forDirectory: fixture.root.path)
 
-        let service = GitMetadataService()
-        let meta = await service.workspaceMetadata(for: fixture.root.path)
-        let branch = await service.checkedOutBranch(forDirectory: fixture.root.path)
-
-        #expect(meta.branch == nil)
-        #expect(branch == .detached)
+            #expect(meta.branch == nil)
+            #expect(branch == .detached)
+        }
     }
 
     // MARK: Dirty detection (index v2)

--- a/Packages/macOS/CmuxGit/Tests/CmuxGitTests/GitMetadataServiceTests.swift
+++ b/Packages/macOS/CmuxGit/Tests/CmuxGitTests/GitMetadataServiceTests.swift
@@ -150,6 +150,62 @@ import Testing
         #expect(branch == .notARepository)
     }
 
+    @Test func reftableHeadStubResolvesBranchThroughGitPlumbing() async throws {
+        let fixture = try GitRepositoryFixture()
+        try fixture.writeReftableHeadStub()
+        let repository = try #require(GitMetadataService.resolveGitRepository(containing: fixture.root.path))
+        let priorRunner = GitMetadataService.gitPlumbingRunnerForTests
+        defer { GitMetadataService.gitPlumbingRunnerForTests = priorRunner }
+        GitMetadataService.gitPlumbingRunnerForTests = FakeGitMetadataGitRunner(responses: [
+            ["symbolic-ref", "--quiet", "--short", "HEAD"]: GitMetadataGitResult(
+                output: "theo.leruitte/support-dog/preprod\n",
+                exitCode: 0
+            ),
+            ["symbolic-ref", "HEAD"]: GitMetadataGitResult(
+                output: "refs/heads/theo.leruitte/support-dog/preprod\n",
+                exitCode: 0
+            ),
+            ["rev-parse", "HEAD"]: GitMetadataGitResult(
+                output: String(repeating: "a", count: 40) + "\n",
+                exitCode: 0
+            ),
+        ])
+
+        let service = GitMetadataService()
+        let meta = await service.workspaceMetadata(for: fixture.root.path)
+        let branch = await service.checkedOutBranch(forDirectory: fixture.root.path)
+
+        #expect(GitMetadataService.gitBranchName(repository: repository) == "theo.leruitte/support-dog/preprod")
+        #expect(meta.branch == "theo.leruitte/support-dog/preprod")
+        #expect(branch == .branch("theo.leruitte/support-dog/preprod"))
+        #expect(GitMetadataService.gitHeadSignature(repository: repository) == """
+            refs/heads/theo.leruitte/support-dog/preprod
+            \(String(repeating: "a", count: 40))
+            """)
+        #expect(GitMetadataService.gitCurrentCommit(repository: repository) == String(repeating: "a", count: 40))
+    }
+
+    @Test func reftableHeadStubDetachedCheckoutUsesGitPlumbing() async throws {
+        let fixture = try GitRepositoryFixture()
+        try fixture.writeReftableHeadStub()
+        let priorRunner = GitMetadataService.gitPlumbingRunnerForTests
+        defer { GitMetadataService.gitPlumbingRunnerForTests = priorRunner }
+        GitMetadataService.gitPlumbingRunnerForTests = FakeGitMetadataGitRunner(responses: [
+            ["symbolic-ref", "--quiet", "--short", "HEAD"]: GitMetadataGitResult(output: "", exitCode: 1),
+            ["rev-parse", "HEAD"]: GitMetadataGitResult(
+                output: String(repeating: "b", count: 40) + "\n",
+                exitCode: 0
+            ),
+        ])
+
+        let service = GitMetadataService()
+        let meta = await service.workspaceMetadata(for: fixture.root.path)
+        let branch = await service.checkedOutBranch(forDirectory: fixture.root.path)
+
+        #expect(meta.branch == nil)
+        #expect(branch == .detached)
+    }
+
     // MARK: Dirty detection (index v2)
 
     @Test func cleanWorkingTreeIsNotDirty() async throws {

--- a/Packages/macOS/CmuxGit/Tests/CmuxGitTests/Support/FakeGitMetadataGitRunner.swift
+++ b/Packages/macOS/CmuxGit/Tests/CmuxGitTests/Support/FakeGitMetadataGitRunner.swift
@@ -1,0 +1,10 @@
+import Foundation
+@testable import CmuxGit
+
+struct FakeGitMetadataGitRunner: GitMetadataGitRunning {
+    let responses: [[String]: GitMetadataGitResult]
+
+    func run(arguments: [String], in directory: URL) -> GitMetadataGitResult {
+        responses[arguments] ?? GitMetadataGitResult(output: "", exitCode: 127)
+    }
+}


### PR DESCRIPTION
## Summary
- Detect git reftable compatibility stub `refs/heads/.invalid` when resolving the checked-out branch for sidebar metadata.
- Resolve the real branch name via git plumbing (`symbolic-ref` / related paths) instead of treating the stub as the branch label.
- Add fixture and unit test coverage with a fake git runner for the reftable HEAD case.

## Test plan
- [ ] Run `CmuxGitTests` / `GitMetadataServiceTests` locally (reftable stub scenario).
- [ ] Open a repo using git reftable and confirm the sidebar shows the correct branch name, not `.invalid`.

Fixes #10170

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/10171"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789320540&installation_model_id=21920&pr_number=10171&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F10171&signature=ec2bca933b4a74db2427542acdc3bd316ec4587de5c6bca954dc3bf3b99a3db1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the sidebar branch label for Git reftable repositories. Previously, when `HEAD` was `ref: refs/heads/.invalid`, the sidebar showed `.invalid`; now we detect this stub and resolve the real branch via git plumbing, spawning `git` only for this case and failing closed if the subprocess misbehaves.

- Detects the reftable `HEAD` stub and resolves branch/commit/signature with `git symbolic-ref` and `git rev-parse`; non‑reftable repos keep the on‑disk fast path.
- Adds a runner abstraction with `SystemGitMetadataGitRunner` and a TaskLocal‑isolated test override; caps stdout to 4 KB and wall time to 5s, uses `CmuxFoundation` nonblocking reads with bounded exit polling, terminates then SIGKILLs on overrun, fails closed on deadlines, and rejects malformed UTF‑8.
- Watches the `reftable` directory so branch changes refresh the sidebar.
- Adds fixtures and tests for reftable branch and detached scenarios using `FakeGitMetadataGitRunner`.

<sup>Written for commit ccc8a616e3d42c9c599b3d2beeeadf41c84834d9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/10171?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for displaying branch, detached-head, commit, and signature metadata in repositories using the reftable format.
  * Repository monitoring now detects changes to reftable metadata.

* **Bug Fixes**
  * Improved Git metadata resolution for repositories with reftable `HEAD` references.
  * Added safe fallback behavior when branch information cannot be resolved.
  * Improved handling of invalid or incomplete reftable references.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->