### PR TITLE
Copy GitHub URL from Files navigator context menu

### DIFF
--- a/Packages/macOS/CmuxGit/Sources/CmuxGit/Parsing/GitMetadataService+GitHubWebURL.swift
+++ b/Packages/macOS/CmuxGit/Sources/CmuxGit/Parsing/GitMetadataService+GitHubWebURL.swift
@@ -28,7 +28,14 @@ extension GitMetadataService {
         guard !trimmedSlug.isEmpty, !trimmedBranch.isEmpty else { return nil }
 
         let kind = resource == .file ? "blob" : "tree"
-        var path = "/\(trimmedSlug)/\(kind)/\(trimmedBranch)"
+        let encodedBranch = trimmedBranch
+            .split(separator: "/", omittingEmptySubsequences: false)
+            .map { segment in
+                String(segment).addingPercentEncoding(withAllowedCharacters: .urlPathAllowed)
+                    ?? String(segment)
+            }
+            .joined(separator: "/")
+        var path = "/\(trimmedSlug)/\(kind)/\(encodedBranch)"
         let relative = relativePathFromWorkTreeRoot
             .trimmingCharacters(in: CharacterSet(charactersIn: "/"))
         if !relative.isEmpty {

--- a/Packages/macOS/CmuxGit/Sources/CmuxGit/Parsing/GitMetadataService+GitHubWebURL.swift
+++ b/Packages/macOS/CmuxGit/Sources/CmuxGit/Parsing/GitMetadataService+GitHubWebURL.swift
@@ -1,0 +1,99 @@
+public import Foundation
+
+/// Whether a filesystem path should map to a GitHub blob or tree URL.
+public enum GitHubWebURLResource: Sendable {
+    /// A file path → `/blob/{branch}/...`.
+    case file
+    /// A directory path → `/tree/{branch}/...`.
+    case folder
+}
+
+extension GitMetadataService {
+    /// Assembles a github.com blob/tree URL from already-resolved parts.
+    ///
+    /// - Parameters:
+    ///   - slug: GitHub `owner/repo` slug.
+    ///   - branch: Current branch name (slashes kept as path segments).
+    ///   - relativePathFromWorkTreeRoot: Path relative to the git work tree root.
+    ///   - resource: Whether the path is a file (blob) or folder (tree).
+    /// - Returns: The github.com URL, or `nil` when slug or branch is empty.
+    public nonisolated static func githubWebURL(
+        slug: String,
+        branch: String,
+        relativePathFromWorkTreeRoot: String,
+        resource: GitHubWebURLResource
+    ) -> URL? {
+        let trimmedSlug = slug.trimmingCharacters(in: .whitespacesAndNewlines)
+        let trimmedBranch = branch.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmedSlug.isEmpty, !trimmedBranch.isEmpty else { return nil }
+
+        let kind = resource == .file ? "blob" : "tree"
+        var path = "/\(trimmedSlug)/\(kind)/\(trimmedBranch)"
+        let relative = relativePathFromWorkTreeRoot
+            .trimmingCharacters(in: CharacterSet(charactersIn: "/"))
+        if !relative.isEmpty {
+            let encodedSegments = relative
+                .split(separator: "/", omittingEmptySubsequences: true)
+                .map { segment in
+                    String(segment).addingPercentEncoding(withAllowedCharacters: .urlPathAllowed)
+                        ?? String(segment)
+                }
+            path += "/" + encodedSegments.joined(separator: "/")
+        }
+        return URL(string: "https://github.com" + path)
+    }
+
+    /// Resolves the enclosing git repo, GitHub slug, and current branch, then
+    /// builds a github.com web URL for `path`.
+    ///
+    /// Returns `nil` when there is no repository, no github.com remote, HEAD is
+    /// detached/unreadable, or `path` is outside the work tree.
+    ///
+    /// - Parameters:
+    ///   - path: Absolute filesystem path to a file or folder.
+    ///   - resource: Whether the path is a file (blob) or folder (tree).
+    /// - Returns: The github.com URL, or `nil` when resolution fails.
+    public nonisolated static func githubWebURL(
+        forFileSystemPath path: String,
+        resource: GitHubWebURLResource
+    ) -> URL? {
+        // kb:{shortcut}: github.com only — non-github.com remotes omitted
+        // kb:{shortcut}: no detached HEAD — detached HEAD gets no item
+        guard let repository = resolveGitRepository(containing: path),
+              let branch = gitBranchName(repository: repository),
+              let remoteOutput = gitRemoteVOutput(repository: repository),
+              let slug = githubRepositorySlugs(fromGitRemoteVOutput: remoteOutput).first,
+              let relativePath = relativePathFromWorkTreeRoot(
+                path: path,
+                workTreeRoot: repository.workTreeRoot
+              )
+        else {
+            return nil
+        }
+
+        return githubWebURL(
+            slug: slug,
+            branch: branch,
+            relativePathFromWorkTreeRoot: relativePath,
+            resource: resource
+        )
+    }
+
+    /// Path of `path` relative to `workTreeRoot`, or `nil` when not under it.
+    nonisolated static func relativePathFromWorkTreeRoot(
+        path: String,
+        workTreeRoot: String
+    ) -> String? {
+        let pathURL = URL(fileURLWithPath: path).standardizedFileURL
+        let rootURL = URL(fileURLWithPath: workTreeRoot).standardizedFileURL
+        let pathString = pathURL.path
+        let rootString = rootURL.path
+
+        if pathString == rootString {
+            return ""
+        }
+        let prefix = rootString.hasSuffix("/") ? rootString : rootString + "/"
+        guard pathString.hasPrefix(prefix) else { return nil }
+        return String(pathString.dropFirst(prefix.count))
+    }
+}

--- a/Packages/macOS/CmuxGit/Tests/CmuxGitTests/GitHubWebURLTests.swift
+++ b/Packages/macOS/CmuxGit/Tests/CmuxGitTests/GitHubWebURLTests.swift
@@ -33,6 +33,16 @@ import Testing
         #expect(url?.absoluteString == "https://github.com/owner/repo/blob/feat/foo/README.md")
     }
 
+    @Test func branchSegmentWithHashIsPercentEncoded() {
+        let url = GitMetadataService.githubWebURL(
+            slug: "owner/repo",
+            branch: "feature#123",
+            relativePathFromWorkTreeRoot: "README.md",
+            resource: .file
+        )
+        #expect(url?.absoluteString == "https://github.com/owner/repo/blob/feature%23123/README.md")
+    }
+
     @Test func pathSegmentWithSpaceIsPercentEncoded() {
         let url = GitMetadataService.githubWebURL(
             slug: "owner/repo",

--- a/Packages/macOS/CmuxGit/Tests/CmuxGitTests/GitHubWebURLTests.swift
+++ b/Packages/macOS/CmuxGit/Tests/CmuxGitTests/GitHubWebURLTests.swift
@@ -1,0 +1,165 @@
+import Foundation
+import Testing
+@testable import CmuxGit
+
+@Suite struct GitHubWebURLTests {
+    @Test func fileBuildsBlobURLWithNestedPath() {
+        let url = GitMetadataService.githubWebURL(
+            slug: "owner/repo",
+            branch: "main",
+            relativePathFromWorkTreeRoot: "src/App.swift",
+            resource: .file
+        )
+        #expect(url?.absoluteString == "https://github.com/owner/repo/blob/main/src/App.swift")
+    }
+
+    @Test func folderBuildsTreeURL() {
+        let url = GitMetadataService.githubWebURL(
+            slug: "owner/repo",
+            branch: "main",
+            relativePathFromWorkTreeRoot: "src/UI",
+            resource: .folder
+        )
+        #expect(url?.absoluteString == "https://github.com/owner/repo/tree/main/src/UI")
+    }
+
+    @Test func branchWithSlashRemainsUnescapedPathSegments() {
+        let url = GitMetadataService.githubWebURL(
+            slug: "owner/repo",
+            branch: "feat/foo",
+            relativePathFromWorkTreeRoot: "README.md",
+            resource: .file
+        )
+        #expect(url?.absoluteString == "https://github.com/owner/repo/blob/feat/foo/README.md")
+    }
+
+    @Test func pathSegmentWithSpaceIsPercentEncoded() {
+        let url = GitMetadataService.githubWebURL(
+            slug: "owner/repo",
+            branch: "main",
+            relativePathFromWorkTreeRoot: "docs/my file.md",
+            resource: .file
+        )
+        #expect(url?.absoluteString == "https://github.com/owner/repo/blob/main/docs/my%20file.md")
+    }
+
+    @Test func emptyRelativePathOmitsTrailingSlash() {
+        let url = GitMetadataService.githubWebURL(
+            slug: "owner/repo",
+            branch: "main",
+            relativePathFromWorkTreeRoot: "",
+            resource: .folder
+        )
+        #expect(url?.absoluteString == "https://github.com/owner/repo/tree/main")
+    }
+
+    @Test func assemblerReturnsNilForEmptySlugOrBranch() {
+        #expect(
+            GitMetadataService.githubWebURL(
+                slug: "",
+                branch: "main",
+                relativePathFromWorkTreeRoot: "a.swift",
+                resource: .file
+            ) == nil
+        )
+        #expect(
+            GitMetadataService.githubWebURL(
+                slug: "owner/repo",
+                branch: "",
+                relativePathFromWorkTreeRoot: "a.swift",
+                resource: .file
+            ) == nil
+        )
+    }
+
+    @Test func slugOrderPrefersUpstreamBeforeOrigin() throws {
+        let fixture = try GitRepositoryFixture()
+        try fixture.writeBranch("feature/x")
+        try fixture.writeConfig("""
+        [remote "origin"]
+        \turl = https://github.com/me/fork.git
+        \tfetch = +refs/heads/*:refs/remotes/origin/*
+        [remote "upstream"]
+        \turl = https://github.com/owner/repo.git
+        \tfetch = +refs/heads/*:refs/remotes/upstream/*
+        """)
+        let nested = try fixture.writeWorkingTreeFile("nested/file.swift", contents: "ok")
+        let path = fixture.root.appendingPathComponent(nested.path).path
+
+        let url = GitMetadataService.githubWebURL(forFileSystemPath: path, resource: .file)
+        #expect(url?.absoluteString == "https://github.com/owner/repo/blob/feature/x/nested/file.swift")
+    }
+
+    @Test func forFileSystemPathBuildsFolderTreeURL() throws {
+        let fixture = try GitRepositoryFixture()
+        try fixture.writeBranch("main")
+        try fixture.writeConfig("""
+        [remote "origin"]
+        \turl = git@github.com:owner/repo.git
+        \tfetch = +refs/heads/*:refs/remotes/origin/*
+        """)
+        let folder = fixture.root.appendingPathComponent("docs", isDirectory: true)
+        try FileManager.default.createDirectory(at: folder, withIntermediateDirectories: true)
+
+        let url = GitMetadataService.githubWebURL(forFileSystemPath: folder.path, resource: .folder)
+        #expect(url?.absoluteString == "https://github.com/owner/repo/tree/main/docs")
+    }
+
+    @Test func returnsNilWhenNoGitHubRemote() throws {
+        let fixture = try GitRepositoryFixture()
+        try fixture.writeBranch("main")
+        try fixture.writeConfig("""
+        [remote "origin"]
+        \turl = git@gitlab.com:owner/repo.git
+        \tfetch = +refs/heads/*:refs/remotes/origin/*
+        """)
+        let entry = try fixture.writeWorkingTreeFile("a.swift", contents: "x")
+        let path = fixture.root.appendingPathComponent(entry.path).path
+        #expect(GitMetadataService.githubWebURL(forFileSystemPath: path, resource: .file) == nil)
+    }
+
+    @Test func returnsNilWhenNoRemotes() throws {
+        let fixture = try GitRepositoryFixture()
+        try fixture.writeBranch("main")
+        try fixture.writeConfig("[core]\n\trepositoryformatversion = 0\n")
+        let entry = try fixture.writeWorkingTreeFile("a.swift", contents: "x")
+        let path = fixture.root.appendingPathComponent(entry.path).path
+        #expect(GitMetadataService.githubWebURL(forFileSystemPath: path, resource: .file) == nil)
+    }
+
+    @Test func returnsNilForDetachedHead() throws {
+        let fixture = try GitRepositoryFixture()
+        try fixture.writeDetachedHead(commit: String(repeating: "a", count: 40))
+        try fixture.writeConfig("""
+        [remote "origin"]
+        \turl = https://github.com/owner/repo.git
+        \tfetch = +refs/heads/*:refs/remotes/origin/*
+        """)
+        let entry = try fixture.writeWorkingTreeFile("a.swift", contents: "x")
+        let path = fixture.root.appendingPathComponent(entry.path).path
+        #expect(GitMetadataService.githubWebURL(forFileSystemPath: path, resource: .file) == nil)
+    }
+
+    @Test func returnsNilWhenPathOutsideWorkTree() throws {
+        let fixture = try GitRepositoryFixture()
+        try fixture.writeBranch("main")
+        try fixture.writeConfig("""
+        [remote "origin"]
+        \turl = https://github.com/owner/repo.git
+        \tfetch = +refs/heads/*:refs/remotes/origin/*
+        """)
+        let outside = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cmuxgit-outside-\(UUID().uuidString).swift")
+        try "x".write(to: outside, atomically: true, encoding: .utf8)
+        defer { try? FileManager.default.removeItem(at: outside) }
+
+        #expect(GitMetadataService.githubWebURL(forFileSystemPath: outside.path, resource: .file) == nil)
+    }
+
+    @Test func returnsNilWhenNotARepository() {
+        let path = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cmuxgit-not-a-repo-\(UUID().uuidString)")
+            .path
+        #expect(GitMetadataService.githubWebURL(forFileSystemPath: path, resource: .file) == nil)
+    }
+}

--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -117877,6 +117877,23 @@
         }
       }
     },
+    "fileExplorer.contextMenu.copyGitHubURL": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Copy GitHub URL"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "GitHub URL をコピー"
+          }
+        }
+      }
+    },
     "fileExplorer.contextMenu.copyPath": {
       "extractionState": "manual",
       "localizations": {

--- a/Sources/FileExplorerView.swift
+++ b/Sources/FileExplorerView.swift
@@ -2,6 +2,7 @@ import AppKit
 import Bonsplit
 import Combine
 import CmuxFoundation
+import CmuxGit
 import CmuxWorkspaces
 import CmuxSettings
 import SwiftUI
@@ -603,6 +604,27 @@ struct FileExplorerPanelView: NSViewRepresentable {
             copyRelItem.target = self
             copyRelItem.representedObject = node
             menu.addItem(copyRelItem)
+
+            // kb:{shortcut}: outline-only menu — search results lack Copy GitHub URL
+            // kb:{shortcut}: github.com only — non-github.com remotes omitted
+            // kb:{shortcut}: no detached HEAD — detached HEAD gets no item
+            if isLocal,
+               let githubURL = GitMetadataService.githubWebURL(
+                forFileSystemPath: node.path,
+                resource: node.isDirectory ? .folder : .file
+               ) {
+                let copyGitHubItem = NSMenuItem(
+                    title: String(
+                        localized: "fileExplorer.contextMenu.copyGitHubURL",
+                        defaultValue: "Copy GitHub URL"
+                    ),
+                    action: #selector(contextMenuCopyGitHubURL(_:)),
+                    keyEquivalent: ""
+                )
+                copyGitHubItem.target = self
+                copyGitHubItem.representedObject = githubURL.absoluteString
+                menu.addItem(copyGitHubItem)
+            }
         }
 
         @objc private func contextMenuOpenExternally(_ sender: NSMenuItem) {
@@ -630,6 +652,12 @@ struct FileExplorerPanelView: NSViewRepresentable {
                 relativePath,
                 to: .general
             )
+        }
+
+        @objc private func contextMenuCopyGitHubURL(_ sender: NSMenuItem) {
+            guard let urlString = sender.representedObject as? String else { return }
+            NSPasteboard.general.clearContents()
+            NSPasteboard.general.setString(urlString, forType: .string)
         }
     }
 }


### PR DESCRIPTION
## Binding scope: minimum

Right-click a local git+GitHub file or folder in the Files navigator to copy the current-branch blob/tree URL, matching VS Code’s **Copy GitHub URL**.

### Acceptance criteria
- Right-click a file under a local checkout with a GitHub remote → menu shows localized **Copy GitHub URL**
- Copies `https://github.com/{owner}/{repo}/blob/{currentBranch}/{pathFromWorkTreeRoot}` (branch not hard-coded; path percent-encoded; relative to git `workTreeRoot`)
- Folder → `/tree/{branch}/...`, not blob
- No GitHub remote / not a repo / detached HEAD / non-local provider / path outside work tree → item **absent**
- Pure builder unit tests (blob vs tree, encoding, slug order, nil cases)
- Localized string (`en` + `ja`)

### Files
- `Packages/macOS/CmuxGit/Sources/CmuxGit/Parsing/GitMetadataService+GitHubWebURL.swift`
- `Packages/macOS/CmuxGit/Tests/CmuxGitTests/GitHubWebURLTests.swift`
- `Sources/FileExplorerView.swift`
- `Resources/Localizable.xcstrings`

### Out of scope (considered and rejected)
- Search-results menu, File Preview permalinks, Copy Permalink (SHA), multi-remote picker, GitLab/Bitbucket/GHE, remote SSH FS, CLI/socket

### Challenger
Minimum resolves the brief. Moderate/strategic were flagged as scope creep / inflation.

### Test
```
cd Packages/macOS/CmuxGit && swift test --filter GitHubWebURLTests
```
13 tests, all passing.

### Dogfood
Tagged Debug build: http://127.0.0.1:17320/files-nav-gh-url

Improvement: `imp-files-nav-copy-github-url-1786718810`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/10172"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789320754&installation_model_id=21920&pr_number=10172&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F10172&signature=077f405d67143f8463835688959f18fdc04728562ce5b10b6554a72c846d2b4e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds “Copy GitHub URL” to the Files navigator context menu for local GitHub-tracked files and folders. Previously there was no action; now it copies a current-branch blob/tree URL and hides the item when the path is not in a GitHub repo, HEAD is detached, or the path is outside the work tree.

- Wires a localized menu item in `Sources/FileExplorerView.swift` for local providers only; computes the URL via `CmuxGit.GitMetadataService.githubWebURL(forFileSystemPath:resource:)` (folder → tree, file → blob).
- Assembles URLs in `Packages/macOS/CmuxGit/Sources/CmuxGit/Parsing/GitMetadataService+GitHubWebURL.swift`: `https://github.com/{owner}/{repo}/{blob|tree}/{branch}/{relativePath}`; percent-encodes path and branch segments; preserves slashes in branch; prefers `upstream` over `origin`; ignores non-github.com remotes.
- Adds tests in `Packages/macOS/CmuxGit/Tests/CmuxGitTests/GitHubWebURLTests.swift` covering blob vs tree, encoding (spaces and branch hash), branch with slashes, upstream preference, and nil cases (no repo/remote, detached HEAD, outside work tree).
- Localizes `fileExplorer.contextMenu.copyGitHubURL` (en, ja); scope excludes search results and non-local providers.

<sup>Written for commit 363791c82a96da03b77d9e425cfefd7f1b540b81. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/10172?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added “Copy GitHub URL” to file explorer context menus for supported files and folders.
  * Generated links open the selected item at the appropriate branch and path on GitHub.
  * Supports nested paths, branches containing slashes, SSH remotes, and percent-encoded names.
  * Copied links are placed on the system clipboard.
  * The option is unavailable when a valid GitHub link cannot be determined.

* **Localization**
  * Added English and Japanese translations for the new menu item.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->