### PR TITLE
Open terminal source links in colored file previews

### DIFF
--- a/Packages/macOS/CmuxTerminalCore/Sources/CmuxTerminalCore/PathResolution/String+TerminalPathTokens.swift
+++ b/Packages/macOS/CmuxTerminalCore/Sources/CmuxTerminalCore/PathResolution/String+TerminalPathTokens.swift
@@ -7,6 +7,12 @@ import Foundation
 // (file-system probing) lives on `TerminalPathResolver`.
 
 extension String {
+    struct FileReferenceCandidate {
+        let path: String
+        let line: Int?
+        let column: Int?
+    }
+
     private static let sentencePunctuation: Set<Character> = [
         ".", ",", ";", ":", "!", "?"
     ]
@@ -154,6 +160,52 @@ extension String {
         }
 
         return candidates
+    }
+
+    /// Returns the literal token first, followed by a conventional source-location variant.
+    func fileReferenceCandidates() -> [FileReferenceCandidate] {
+        var candidates = [FileReferenceCandidate(path: self, line: nil, column: nil)]
+
+        if let hashRange = range(of: "#L", options: [.backwards]),
+           hashRange.upperBound < endIndex,
+           let line = positiveSourceLocationNumber(self[hashRange.upperBound...]) {
+            candidates.append(
+                FileReferenceCandidate(path: String(self[..<hashRange.lowerBound]), line: line, column: nil)
+            )
+            return candidates
+        }
+
+        let segments = split(separator: ":", omittingEmptySubsequences: false)
+        guard segments.count >= 2 else { return candidates }
+
+        if segments.count >= 3,
+           let line = positiveSourceLocationNumber(segments[segments.count - 2]),
+           let column = positiveSourceLocationNumber(segments[segments.count - 1]) {
+            candidates.append(
+                FileReferenceCandidate(
+                    path: segments.dropLast(2).joined(separator: ":"),
+                    line: line,
+                    column: column
+                )
+            )
+        } else if let line = positiveSourceLocationNumber(segments[segments.count - 1]) {
+            candidates.append(
+                FileReferenceCandidate(
+                    path: segments.dropLast().joined(separator: ":"),
+                    line: line,
+                    column: nil
+                )
+            )
+        }
+
+        return candidates
+    }
+
+    private func positiveSourceLocationNumber<S: StringProtocol>(_ value: S) -> Int? {
+        guard !value.isEmpty, value.allSatisfy(\.isNumber), let number = Int(value), number > 0 else {
+            return nil
+        }
+        return number
     }
 
     /// Path-token candidates around a column of a visible terminal line: the

--- a/Packages/macOS/CmuxTerminalCore/Sources/CmuxTerminalCore/PathResolution/TerminalFileReference.swift
+++ b/Packages/macOS/CmuxTerminalCore/Sources/CmuxTerminalCore/PathResolution/TerminalFileReference.swift
@@ -1,0 +1,13 @@
+/// An existing file resolved from terminal text, optionally with a one-based
+/// source location parsed from a conventional terminal suffix.
+public struct TerminalFileReference: Equatable, Sendable {
+    public let path: String
+    public let line: Int?
+    public let column: Int?
+
+    public init(path: String, line: Int? = nil, column: Int? = nil) {
+        self.path = path
+        self.line = line
+        self.column = column
+    }
+}

--- a/Packages/macOS/CmuxTerminalCore/Sources/CmuxTerminalCore/PathResolution/TerminalPathResolver.swift
+++ b/Packages/macOS/CmuxTerminalCore/Sources/CmuxTerminalCore/PathResolution/TerminalPathResolver.swift
@@ -121,8 +121,9 @@ public struct TerminalPathResolver: Sendable {
 
     /// Resolves an open-URL request payload to an existing file path.
     ///
-    /// Text that parses as a URL with a scheme is never treated as a file
-    /// path; everything else goes through ``resolveQuicklookPath(_:cwd:)``.
+    /// Scheme-bearing URLs are rejected except for a Ghostty-normalized
+    /// HTTP(S) source location that resolves to an existing local file.
+    /// Everything else goes through ``resolveQuicklookPath(_:cwd:)``.
     ///
     /// - Parameters:
     ///   - rawText: The raw open-URL text from the runtime.
@@ -139,9 +140,43 @@ public struct TerminalPathResolver: Sendable {
     ) -> TerminalFileReference? {
         let trimmed = rawText.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty else { return nil }
-        guard trimmed.fileReferenceCandidates().contains(where: { candidate in
+        if trimmed.fileReferenceCandidates().contains(where: { candidate in
             URL(string: candidate.path)?.scheme == nil
-        }) else { return nil }
-        return resolveQuicklookFileReference(trimmed, cwd: cwd)
+        }) {
+            return resolveQuicklookFileReference(trimmed, cwd: cwd)
+        }
+        return resolveGhosttyNormalizedSourceLocationReference(trimmed, cwd: cwd)
+    }
+
+    /// Ghostty may normalize a path-like terminal link such as
+    /// `path/file.py:139` to `https://path/file.py:139` before emitting its
+    /// open-URL action. Reconstruct that token only when it resolves to an
+    /// existing local file with a source location, so ordinary web links keep
+    /// their existing routing.
+    private func resolveGhosttyNormalizedSourceLocationReference(
+        _ rawText: String,
+        cwd: String?
+    ) -> TerminalFileReference? {
+        guard let url = URL(string: rawText),
+              let scheme = url.scheme?.lowercased(),
+              scheme == "http" || scheme == "https",
+              let host = url.host,
+              !host.isEmpty,
+              url.user == nil,
+              url.password == nil,
+              url.port == nil,
+              url.query == nil else {
+            return nil
+        }
+
+        var token = host + url.path
+        if let fragment = url.fragment {
+            token += "#\(fragment)"
+        }
+        guard let reference = resolveQuicklookFileReference(token, cwd: cwd),
+              reference.line != nil else {
+            return nil
+        }
+        return reference
     }
 }

--- a/Packages/macOS/CmuxTerminalCore/Sources/CmuxTerminalCore/PathResolution/TerminalPathResolver.swift
+++ b/Packages/macOS/CmuxTerminalCore/Sources/CmuxTerminalCore/PathResolution/TerminalPathResolver.swift
@@ -39,27 +39,44 @@ public struct TerminalPathResolver: Sendable {
     ///   - cwd: The surface's working directory used for relative candidates.
     /// - Returns: The first existing standardized path, or `nil`.
     public func resolveQuicklookPath(_ rawText: String, cwd: String?) -> String? {
+        resolveQuicklookFileReference(rawText, cwd: cwd)?.path
+    }
+
+    /// Resolves raw terminal text to an existing file and optional source location.
+    ///
+    /// Literal files are probed before interpreting conventional `:line`,
+    /// `:line:column`, or `#Lline` suffixes, so unusual filenames keep working.
+    public func resolveQuicklookFileReference(
+        _ rawText: String,
+        cwd: String?
+    ) -> TerminalFileReference? {
         let trimmed = rawText.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty else { return nil }
 
         var seenPaths: Set<String> = []
         for token in trimmed.pathResolutionCandidates() {
-            let normalizedToken = token.trimmingCharacters(in: .whitespacesAndNewlines)
-            guard !normalizedToken.isEmpty else { continue }
+            for candidate in token.fileReferenceCandidates() {
+                let normalizedToken = candidate.path.trimmingCharacters(in: .whitespacesAndNewlines)
+                guard !normalizedToken.isEmpty else { continue }
 
-            let expandedToken = (normalizedToken as NSString).expandingTildeInPath
-            let candidatePath: String
-            if expandedToken.hasPrefix("/") {
-                candidatePath = expandedToken
-            } else {
-                guard let cwd, !cwd.isEmpty else { continue }
-                candidatePath = (cwd as NSString).appendingPathComponent(expandedToken)
-            }
+                let expandedToken = (normalizedToken as NSString).expandingTildeInPath
+                let candidatePath: String
+                if expandedToken.hasPrefix("/") {
+                    candidatePath = expandedToken
+                } else {
+                    guard let cwd, !cwd.isEmpty else { continue }
+                    candidatePath = (cwd as NSString).appendingPathComponent(expandedToken)
+                }
 
-            let standardizedPath = (candidatePath as NSString).standardizingPath
-            guard seenPaths.insert(standardizedPath).inserted else { continue }
-            if fileExists(standardizedPath) {
-                return standardizedPath
+                let standardizedPath = (candidatePath as NSString).standardizingPath
+                guard seenPaths.insert(standardizedPath).inserted else { continue }
+                if fileExists(standardizedPath) {
+                    return TerminalFileReference(
+                        path: standardizedPath,
+                        line: candidate.line,
+                        column: candidate.column
+                    )
+                }
             }
         }
 
@@ -82,9 +99,21 @@ public struct TerminalPathResolver: Sendable {
         column: Int,
         cwd: String
     ) -> (rawToken: String, path: String)? {
+        guard let resolved = resolveVisibleLineFileReference(line, column: column, cwd: cwd) else {
+            return nil
+        }
+        return (resolved.rawToken, resolved.reference.path)
+    }
+
+    /// Resolves the path token and optional source location under a visible column.
+    public func resolveVisibleLineFileReference(
+        _ line: String,
+        column: Int,
+        cwd: String
+    ) -> (rawToken: String, reference: TerminalFileReference)? {
         for rawToken in line.pathTokenCandidates(containingColumn: column) {
-            if let resolvedPath = resolveQuicklookPath(rawToken, cwd: cwd) {
-                return (rawToken, resolvedPath)
+            if let reference = resolveQuicklookFileReference(rawToken, cwd: cwd) {
+                return (rawToken, reference)
             }
         }
         return nil
@@ -100,9 +129,19 @@ public struct TerminalPathResolver: Sendable {
     ///   - cwd: The surface's working directory.
     /// - Returns: The first existing standardized path, or `nil`.
     public func resolveOpenURLFilePath(_ rawText: String, cwd: String?) -> String? {
+        resolveOpenURLFileReference(rawText, cwd: cwd)?.path
+    }
+
+    /// Resolves an open-URL request payload to an existing file and optional source location.
+    public func resolveOpenURLFileReference(
+        _ rawText: String,
+        cwd: String?
+    ) -> TerminalFileReference? {
         let trimmed = rawText.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty else { return nil }
-        guard URL(string: trimmed)?.scheme == nil else { return nil }
-        return resolveQuicklookPath(trimmed, cwd: cwd)
+        guard trimmed.fileReferenceCandidates().contains(where: { candidate in
+            URL(string: candidate.path)?.scheme == nil
+        }) else { return nil }
+        return resolveQuicklookFileReference(trimmed, cwd: cwd)
     }
 }

--- a/Packages/macOS/CmuxTerminalCore/Tests/CmuxTerminalCoreTests/TerminalPathResolverTests.swift
+++ b/Packages/macOS/CmuxTerminalCore/Tests/CmuxTerminalCoreTests/TerminalPathResolverTests.swift
@@ -105,6 +105,17 @@ private func existsIn(_ existingPaths: Set<String>) -> @Sendable (String) -> Boo
         )
     }
 
+    @Test func resolvesRelativePathWithLineAndColumnSuffix() {
+        let cwd = "/Users/dev/project"
+        let existingFile = "/Users/dev/project/src/main.swift"
+        #expect(
+            TerminalPathResolver(fileExists: existsIn([existingFile])).resolveQuicklookPath(
+                "src/main.swift:42:7",
+                cwd: cwd
+            ) == existingFile
+        )
+    }
+
     @Test func returnsNilForRelativePathThatDoesNotExist() {
         #expect(
             TerminalPathResolver(fileExists: existsIn([])).resolveQuicklookPath(

--- a/Packages/macOS/CmuxTerminalCore/Tests/CmuxTerminalCoreTests/TerminalPathResolverTests.swift
+++ b/Packages/macOS/CmuxTerminalCore/Tests/CmuxTerminalCoreTests/TerminalPathResolverTests.swift
@@ -116,6 +116,44 @@ private func existsIn(_ existingPaths: Set<String>) -> @Sendable (String) -> Boo
         )
     }
 
+    @Test func carriesLineAndColumnFromSourceLocationSuffix() throws {
+        let cwd = "/Users/dev/project"
+        let existingFile = "/Users/dev/project/src/main.swift"
+        let reference = try #require(
+            TerminalPathResolver(fileExists: existsIn([existingFile])).resolveQuicklookFileReference(
+                "src/main.swift:42:7",
+                cwd: cwd
+            )
+        )
+
+        #expect(reference == TerminalFileReference(path: existingFile, line: 42, column: 7))
+    }
+
+    @Test func resolvesHashLineSuffix() throws {
+        let existingFile = "/tmp/cmux-source-link.swift"
+        let reference = try #require(
+            TerminalPathResolver(fileExists: existsIn([existingFile])).resolveQuicklookFileReference(
+                "\(existingFile)#L19",
+                cwd: "/tmp"
+            )
+        )
+
+        #expect(reference == TerminalFileReference(path: existingFile, line: 19))
+    }
+
+    @Test func prefersLiteralFilenameThatLooksLikeSourceLocation() throws {
+        let literalPath = "/tmp/cmux-source-link.swift:42"
+        let strippedPath = "/tmp/cmux-source-link.swift"
+        let reference = try #require(
+            TerminalPathResolver(fileExists: existsIn([literalPath, strippedPath])).resolveQuicklookFileReference(
+                literalPath,
+                cwd: "/tmp"
+            )
+        )
+
+        #expect(reference == TerminalFileReference(path: literalPath))
+    }
+
     @Test func returnsNilForRelativePathThatDoesNotExist() {
         #expect(
             TerminalPathResolver(fileExists: existsIn([])).resolveQuicklookPath(
@@ -156,6 +194,30 @@ private func existsIn(_ existingPaths: Set<String>) -> @Sendable (String) -> Boo
 }
 
 @Suite struct TerminalOpenURLFilePathTests {
+    @Test func preservesSourceLocationOnBasename() throws {
+        let existingFile = "/Users/dev/project/main.swift"
+        let reference = try #require(
+            TerminalPathResolver(fileExists: existsIn([existingFile])).resolveOpenURLFileReference(
+                "main.swift:42",
+                cwd: "/Users/dev/project"
+            )
+        )
+
+        #expect(reference == TerminalFileReference(path: existingFile, line: 42))
+    }
+
+    @Test func preservesSourceLocationSuffix() throws {
+        let existingFile = "/Users/dev/project/src/main.swift"
+        let reference = try #require(
+            TerminalPathResolver(fileExists: existsIn([existingFile])).resolveOpenURLFileReference(
+                "src/main.swift:42:7",
+                cwd: "/Users/dev/project"
+            )
+        )
+
+        #expect(reference == TerminalFileReference(path: existingFile, line: 42, column: 7))
+    }
+
     @Test func resolvesAbsoluteMarkdownPathWithTrailingDot() {
         let existingFile = "/Users/dev/project/skills/marketing/data/lawrencecchen-tweets.md"
         #expect(
@@ -238,6 +300,20 @@ private func existsIn(_ existingPaths: Set<String>) -> @Sendable (String) -> Boo
             )
         )
         #expect(resolution.path == existingFile)
+    }
+
+    @Test func preservesSourceLocationUnderCursor() throws {
+        let existingFile = "/tmp/cmux-visible-source.swift"
+        let line = "open /tmp/cmux-visible-source.swift:27:4 now"
+        let resolution = try #require(
+            TerminalPathResolver(fileExists: existsIn([existingFile])).resolveVisibleLineFileReference(
+                line,
+                column: 12,
+                cwd: "/tmp"
+            )
+        )
+
+        #expect(resolution.reference == TerminalFileReference(path: existingFile, line: 27, column: 4))
     }
 
     @Test func returnsNilWhenColumnSitsOnHardDelimiter() {

--- a/Packages/macOS/CmuxTerminalCore/Tests/CmuxTerminalCoreTests/TerminalPathResolverTests.swift
+++ b/Packages/macOS/CmuxTerminalCore/Tests/CmuxTerminalCoreTests/TerminalPathResolverTests.swift
@@ -194,6 +194,18 @@ private func existsIn(_ existingPaths: Set<String>) -> @Sendable (String) -> Boo
 }
 
 @Suite struct TerminalOpenURLFilePathTests {
+    @Test func resolvesGhosttyNormalizedRelativeSourceLocationURL() throws {
+        let existingFile = "/Users/dev/project/path/file.py"
+        let reference = try #require(
+            TerminalPathResolver(fileExists: existsIn([existingFile])).resolveOpenURLFileReference(
+                "https://path/file.py:139",
+                cwd: "/Users/dev/project"
+            )
+        )
+
+        #expect(reference == TerminalFileReference(path: existingFile, line: 139))
+    }
+
     @Test func preservesSourceLocationOnBasename() throws {
         let existingFile = "/Users/dev/project/main.swift"
         let reference = try #require(

--- a/Packages/macOS/CmuxTerminalCore/Tests/CmuxTerminalCoreTests/TerminalPathResolverTests.swift
+++ b/Packages/macOS/CmuxTerminalCore/Tests/CmuxTerminalCoreTests/TerminalPathResolverTests.swift
@@ -206,6 +206,16 @@ private func existsIn(_ existingPaths: Set<String>) -> @Sendable (String) -> Boo
         #expect(reference == TerminalFileReference(path: existingFile, line: 139))
     }
 
+    @Test func leavesGhosttyNormalizedWebURLWithoutSourceLocationUnresolved() {
+        let existingFile = "/Users/dev/project/path/file.py"
+        #expect(
+            TerminalPathResolver(fileExists: existsIn([existingFile])).resolveOpenURLFileReference(
+                "https://path/file.py",
+                cwd: "/Users/dev/project"
+            ) == nil
+        )
+    }
+
     @Test func preservesSourceLocationOnBasename() throws {
         let existingFile = "/Users/dev/project/main.swift"
         let reference = try #require(

--- a/Sources/CommandClickFileOpenRouter.swift
+++ b/Sources/CommandClickFileOpenRouter.swift
@@ -1,5 +1,6 @@
 import AppKit
 import CmuxSettings
+import CmuxTerminalCore
 import Foundation
 
 enum CommandClickFileOpenRouter {
@@ -19,8 +20,25 @@ enum CommandClickFileOpenRouter {
         filePath: String,
         defaults: UserDefaults = .standard
     ) -> Bool {
+        openInCmux(
+            workspace: workspace,
+            sourcePanelId: sourcePanelId,
+            fileReference: TerminalFileReference(path: filePath),
+            defaults: defaults
+        )
+    }
+
+    @MainActor
+    static func openInCmux(
+        workspace: Workspace,
+        sourcePanelId: UUID,
+        fileReference: TerminalFileReference,
+        defaults: UserDefaults = .standard
+    ) -> Bool {
+        let filePath = fileReference.path
         let store = FileRouteSettingsStore(defaults: defaults)
-        if store.shouldRouteMarkdown(path: filePath),
+        if fileReference.line == nil,
+           store.shouldRouteMarkdown(path: filePath),
            workspace.openOrFocusMarkdownSplit(from: sourcePanelId, filePath: filePath) != nil {
             return true
         }
@@ -29,7 +47,8 @@ enum CommandClickFileOpenRouter {
             return false
         }
 
-        if TerminalHTMLFileBrowserAction(defaults: defaults).open(
+        if fileReference.line == nil,
+           TerminalHTMLFileBrowserAction(defaults: defaults).open(
             fileURL: URL(fileURLWithPath: filePath),
             sourcePanelId: sourcePanelId,
             container: workspace
@@ -37,7 +56,12 @@ enum CommandClickFileOpenRouter {
             return true
         }
 
-        return workspace.openOrFocusFilePreviewSplit(from: sourcePanelId, filePath: filePath) != nil
+        return workspace.openOrFocusFilePreviewSplit(
+            from: sourcePanelId,
+            filePath: filePath,
+            line: fileReference.line,
+            column: fileReference.column
+        ) != nil
     }
 
     /// Resolve the working directory for a terminal surface, preferring the
@@ -77,7 +101,7 @@ enum CommandClickFileOpenRouter {
         workspace: Workspace,
         preferredWorkspaceId: UUID,
         surfaceId: UUID,
-        filePath: String,
+        fileReference: TerminalFileReference,
         defaults: UserDefaults = .standard,
         fallback: (@MainActor @Sendable () -> Void)? = nil
     ) {
@@ -90,14 +114,14 @@ enum CommandClickFileOpenRouter {
                 fallback?()
                 return
             }
-            guard shouldRouteInCmux(path: filePath, defaults: defaults) else {
+            guard shouldRouteInCmux(path: fileReference.path, defaults: defaults) else {
                 fallback?()
                 return
             }
             if openInCmux(
                 workspace: resolvedWorkspace,
                 sourcePanelId: surfaceId,
-                filePath: filePath,
+                fileReference: fileReference,
                 defaults: defaults
             ) {
                 return

--- a/Sources/DockSplitStore+TerminalLinkOpening.swift
+++ b/Sources/DockSplitStore+TerminalLinkOpening.swift
@@ -1,4 +1,5 @@
 import CmuxPanes
+import CmuxTerminalCore
 import Foundation
 
 extension DockSplitStore: TerminalLinkOpenContainer {
@@ -16,7 +17,7 @@ extension DockSplitStore: TerminalLinkOpenContainer {
 
     func deferTerminalFileLinkOpen(
         sourcePanelId _: UUID,
-        filePath _: String,
+        fileReference _: TerminalFileReference,
         fallback _: @escaping @MainActor @Sendable () -> Void
     ) -> Bool {
         // The Dock currently hosts terminal and browser panels only. Returning

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -3537,18 +3537,20 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
     }
 
     private struct WordPathResolution {
-        let path: String
+        let reference: TerminalFileReference
         let source: WordPathResolutionSource
         let rawToken: String
+
+        var path: String { reference.path }
     }
 
     private func makeWordPathResolution(
-        path: String,
+        reference: TerminalFileReference,
         source: WordPathResolutionSource,
         rawToken: String
     ) -> WordPathResolution {
         WordPathResolution(
-            path: path,
+            reference: reference,
             source: source,
             rawToken: rawToken
         )
@@ -6544,9 +6546,12 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
 #else
                     let resolvedQuicklookWord = decodedWord
 #endif
-                    if let resolvedPath = TerminalPathResolver().resolveQuicklookPath(resolvedQuicklookWord, cwd: cwd) {
+                    if let reference = TerminalPathResolver().resolveQuicklookFileReference(
+                        resolvedQuicklookWord,
+                        cwd: cwd
+                    ) {
                         quicklookResolution = makeWordPathResolution(
-                            path: resolvedPath,
+                            reference: reference,
                             source: .quicklook,
                             rawToken: resolvedQuicklookWord
                         )
@@ -6769,7 +6774,7 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
         guard visibleRow >= 0, visibleRow < visibleLines.count else { return nil }
 
         let column = max(0, min(cols - 1, viewportOffsetStart % cols))
-        guard let resolution = TerminalPathResolver().resolveVisibleLinePath(
+        guard let resolution = TerminalPathResolver().resolveVisibleLineFileReference(
             visibleLines[visibleRow],
             column: column,
             cwd: cwd
@@ -6778,7 +6783,7 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
         }
 
         return makeWordPathResolution(
-            path: resolution.path,
+            reference: resolution.reference,
             source: .snapshot,
             rawToken: resolution.rawToken
         )
@@ -6820,7 +6825,7 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
         guard visibleRow >= 0, visibleRow < visibleLines.count else { return nil }
 
         let column = max(0, min(cols - 1, Int((point.x - xInset) / resolvedCellWidth)))
-        guard let resolution = TerminalPathResolver().resolveVisibleLinePath(
+        guard let resolution = TerminalPathResolver().resolveVisibleLineFileReference(
             visibleLines[visibleRow],
             column: column,
             cwd: cwd
@@ -6829,7 +6834,7 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
         }
 
         return makeWordPathResolution(
-            path: resolution.path,
+            reference: resolution.reference,
             source: .snapshot,
             rawToken: resolution.rawToken
         )
@@ -6960,7 +6965,7 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
            CommandClickFileOpenRouter.openInCmux(
                workspace: workspace,
                sourcePanelId: termSurface.id,
-               filePath: resolution.path
+               fileReference: resolution.reference
            ) {
             return resolution
         }

--- a/Sources/Panels/FilePreviewHighlightTheme.swift
+++ b/Sources/Panels/FilePreviewHighlightTheme.swift
@@ -1,0 +1,4 @@
+enum FilePreviewHighlightTheme: Equatable, Sendable {
+    case light
+    case dark
+}

--- a/Sources/Panels/FilePreviewHighlightedText.swift
+++ b/Sources/Panels/FilePreviewHighlightedText.swift
@@ -1,0 +1,13 @@
+import Foundation
+
+/// Immutable bridge for an attributed result produced off the main actor.
+///
+/// SAFETY: `value` is copied into an immutable `NSAttributedString` before transfer
+/// and is only read after the producing actor has returned it.
+final class FilePreviewHighlightedText: @unchecked Sendable {
+    let value: NSAttributedString
+
+    init(_ value: NSAttributedString) {
+        self.value = NSAttributedString(attributedString: value)
+    }
+}

--- a/Sources/Panels/FilePreviewPanel.swift
+++ b/Sources/Panels/FilePreviewPanel.swift
@@ -1002,6 +1002,8 @@ final class FilePreviewPanel: Panel, ObservableObject, FilePreviewTextEditingPan
     var lastObservedFileState: FilePreviewFileState?
     var isClosed = false
     weak var textView: NSTextView?
+    private var pendingSourceLocation: (line: Int, column: Int?)?
+    private var hasAppliedTextLoadResult = false
     let focusCoordinator: FilePreviewFocusCoordinator
     private let textLoader: @Sendable (URL) async -> FilePreviewTextLoader.Result
     private let textSaver: @Sendable (String, URL, String.Encoding) async -> FilePreviewTextSaver.Result
@@ -1057,6 +1059,66 @@ final class FilePreviewPanel: Panel, ObservableObject, FilePreviewTextEditingPan
 
     func focus() {
         _ = restoreFocusIntent(preferredFocusIntentForActivation())
+    }
+
+    func revealSourceLocation(line: Int?, column: Int?) {
+        guard let line, line > 0 else { return }
+        pendingSourceLocation = (line, column.flatMap { $0 > 0 ? $0 : nil })
+        retryPendingSourceLocationReveal()
+    }
+
+    func retryPendingSourceLocationReveal() {
+        guard hasAppliedTextLoadResult,
+              let pendingSourceLocation,
+              let textView,
+              textView.string == textContent else { return }
+        guard let ranges = Self.sourceLocationRanges(
+            in: textView.string,
+            line: pendingSourceLocation.line,
+            column: pendingSourceLocation.column
+        ) else { return }
+
+        self.pendingSourceLocation = nil
+        textView.setSelectedRange(ranges.selection)
+        textView.scrollRangeToVisible(ranges.line)
+        textView.showFindIndicator(for: ranges.line)
+    }
+
+    static func sourceLocationRanges(
+        in source: String,
+        line targetLine: Int,
+        column: Int?
+    ) -> (selection: NSRange, line: NSRange)? {
+        guard targetLine > 0 else { return nil }
+        let text = source as NSString
+        var lineStart = 0
+        var currentLine = 1
+
+        while currentLine < targetLine, lineStart < text.length {
+            let lineRange = text.lineRange(for: NSRange(location: lineStart, length: 0))
+            let nextLineStart = NSMaxRange(lineRange)
+            guard nextLineStart > lineStart else { return nil }
+            lineStart = nextLineStart
+            currentLine += 1
+        }
+
+        guard currentLine == targetLine, lineStart <= text.length else { return nil }
+        if lineStart == text.length, targetLine > 1 {
+            guard text.length > 0,
+                  let finalScalar = UnicodeScalar(text.character(at: text.length - 1)),
+                  CharacterSet.newlines.contains(finalScalar) else { return nil }
+        }
+
+        let lineRange = text.lineRange(for: NSRange(location: lineStart, length: 0))
+        let contentRange = text.rangeOfCharacter(
+            from: .newlines,
+            options: [],
+            range: lineRange
+        )
+        let lineContentEnd = contentRange.location == NSNotFound ? NSMaxRange(lineRange) : contentRange.location
+        let requestedOffset = max(0, (column ?? 1) - 1)
+        let caretLocation = min(lineStart + requestedOffset, lineContentEnd)
+        return (NSRange(location: caretLocation, length: 0), lineRange)
     }
 
     func unfocus() {
@@ -1271,6 +1333,7 @@ final class FilePreviewPanel: Panel, ObservableObject, FilePreviewTextEditingPan
         _ result: FilePreviewTextLoader.Result,
         replacingDirtyContent: Bool
     ) {
+        hasAppliedTextLoadResult = true
         switch result {
         case .unavailable:
             guard replacingDirtyContent || !isDirty else {
@@ -1455,6 +1518,7 @@ struct FilePreviewPanelView: View {
                     isVisibleInUI: isVisibleInUI,
                     themeBackgroundColor: contentBackgroundColor,
                     themeForegroundColor: themeForegroundColor,
+                    highlightTheme: appearance.backgroundColor.isLightColor ? .light : .dark,
                     drawsBackground: appearance.drawsContentBackground,
                     wordWrap: fileEditorWordWrap
                 )

--- a/Sources/Panels/FilePreviewSyntaxHighlightDecision.swift
+++ b/Sources/Panels/FilePreviewSyntaxHighlightDecision.swift
@@ -1,0 +1,4 @@
+enum FilePreviewSyntaxHighlightDecision: Equatable, Sendable {
+    case highlight(language: String?)
+    case skip
+}

--- a/Sources/Panels/FilePreviewSyntaxHighlightPolicy.swift
+++ b/Sources/Panels/FilePreviewSyntaxHighlightPolicy.swift
@@ -1,0 +1,34 @@
+import Foundation
+
+/// Bounds native file-preview highlighting and maps file extensions to highlight.js languages.
+struct FilePreviewSyntaxHighlightPolicy: Sendable {
+    static let maximumHighlightBytes = 1_500_000
+    static let maximumAutomaticDetectionBytes = 256_000
+
+    private static let languagesByExtension: [String: String] = [
+        "bash": "bash", "c": "c", "cc": "cpp", "cjs": "javascript",
+        "clj": "clojure", "cljs": "clojure", "cpp": "cpp", "cs": "csharp",
+        "css": "css", "cxx": "cpp", "dart": "dart", "ex": "elixir",
+        "exs": "elixir", "fs": "fsharp", "fsx": "fsharp", "go": "go",
+        "gradle": "gradle", "groovy": "groovy", "h": "c", "hh": "cpp",
+        "hpp": "cpp", "htm": "html", "html": "html", "java": "java",
+        "js": "javascript", "json": "json", "jsx": "javascript", "kt": "kotlin",
+        "kts": "kotlin", "less": "less", "lua": "lua", "m": "objectivec",
+        "markdown": "markdown", "md": "markdown", "mjs": "javascript",
+        "mm": "objectivec", "php": "php", "pl": "perl", "pm": "perl",
+        "py": "python", "r": "r", "rb": "ruby", "rs": "rust", "sass": "scss",
+        "scala": "scala", "scss": "scss", "sh": "bash", "sql": "sql",
+        "swift": "swift", "ts": "typescript", "tsx": "typescript", "xml": "xml",
+        "yaml": "yaml", "yml": "yaml", "zsh": "bash",
+    ]
+
+    func decision(path: String, byteCount: Int) -> FilePreviewSyntaxHighlightDecision {
+        guard byteCount <= Self.maximumHighlightBytes else { return .skip }
+        let pathExtension = URL(fileURLWithPath: path).pathExtension.lowercased()
+        if let language = Self.languagesByExtension[pathExtension] {
+            return .highlight(language: language)
+        }
+        guard byteCount < Self.maximumAutomaticDetectionBytes else { return .skip }
+        return .highlight(language: nil)
+    }
+}

--- a/Sources/Panels/FilePreviewSyntaxHighlighter.swift
+++ b/Sources/Panels/FilePreviewSyntaxHighlighter.swift
@@ -1,0 +1,35 @@
+import Foundation
+@preconcurrency import Highlightr
+
+/// Serializes JavaScriptCore-backed syntax highlighting away from AppKit's main actor.
+actor FilePreviewSyntaxHighlighter {
+    private var engine: Highlightr?
+    private let policy = FilePreviewSyntaxHighlightPolicy()
+
+    func highlight(
+        text: String,
+        path: String,
+        theme: FilePreviewHighlightTheme
+    ) -> FilePreviewHighlightedText? {
+        guard !Task.isCancelled else { return nil }
+        let decision = policy.decision(path: path, byteCount: text.utf8.count)
+        guard case .highlight(let language) = decision else { return nil }
+
+        let highlightr: Highlightr
+        if let engine {
+            highlightr = engine
+        } else {
+            guard let newEngine = Highlightr() else { return nil }
+            engine = newEngine
+            highlightr = newEngine
+        }
+
+        let themeName = theme == .dark ? "xcode-dark" : "xcode"
+        guard !Task.isCancelled,
+              highlightr.setTheme(to: themeName),
+              let highlighted = highlightr.highlight(text, as: language) else {
+            return nil
+        }
+        return FilePreviewHighlightedText(highlighted)
+    }
+}

--- a/Sources/Panels/FilePreviewTextEditor.swift
+++ b/Sources/Panels/FilePreviewTextEditor.swift
@@ -5,6 +5,7 @@ import SwiftUI
 
 @MainActor
 protocol FilePreviewTextEditingPanel: AnyObject {
+    var filePath: String { get }
     var textContent: String { get }
 
     func attachTextView(_ textView: NSTextView)
@@ -19,6 +20,7 @@ struct FilePreviewTextEditor<PanelModel>: NSViewRepresentable where PanelModel: 
     let isVisibleInUI: Bool
     let themeBackgroundColor: NSColor
     let themeForegroundColor: NSColor
+    let highlightTheme: FilePreviewHighlightTheme
     let drawsBackground: Bool
     /// Whether long lines soft-wrap at the editor's right edge. Sourced from
     /// the persisted `fileEditor.wordWrap` setting; updates apply live.
@@ -52,11 +54,14 @@ struct FilePreviewTextEditor<PanelModel>: NSViewRepresentable where PanelModel: 
             foregroundColor: themeForegroundColor,
             drawsBackground: drawsBackground
         )
+        context.coordinator.configure(path: panel.filePath, theme: highlightTheme)
+        context.coordinator.refreshSyntaxHighlighting(in: textView)
         return scrollView
     }
 
     func updateNSView(_ scrollView: NSScrollView, context: Context) {
         context.coordinator.panel = panel
+        context.coordinator.configure(path: panel.filePath, theme: highlightTheme)
         scrollView.isHidden = !isVisibleInUI
         Self.applyTheme(
             to: scrollView,
@@ -69,7 +74,10 @@ struct FilePreviewTextEditor<PanelModel>: NSViewRepresentable where PanelModel: 
         textView.applyFilePreviewTextEditorInsets()
         textView.applyFilePreviewWordWrap(wordWrap, scrollView: scrollView)
         panel.attachTextView(textView)
-        guard textView.string != panel.textContent else { return }
+        guard textView.string != panel.textContent else {
+            context.coordinator.refreshSyntaxHighlighting(in: textView)
+            return
+        }
         let selectedRanges = textView.selectedRanges
         let visibleOrigin = scrollView.contentView.bounds.origin
         context.coordinator.isApplyingPanelUpdate = true
@@ -90,6 +98,7 @@ struct FilePreviewTextEditor<PanelModel>: NSViewRepresentable where PanelModel: 
         )
         clipView.scroll(to: constrained.origin)
         scrollView.reflectScrolledClipView(clipView)
+        context.coordinator.refreshSyntaxHighlighting(in: textView)
     }
 
     static func applyTheme(
@@ -114,17 +123,97 @@ struct FilePreviewTextEditor<PanelModel>: NSViewRepresentable where PanelModel: 
     final class Coordinator: NSObject, NSTextViewDelegate {
         var panel: PanelModel
         var isApplyingPanelUpdate = false
+        private let syntaxHighlighter = FilePreviewSyntaxHighlighter()
+        private var highlightTask: Task<Void, Never>?
+        private var highlightGeneration = 0
+        private var filePath = ""
+        private var highlightTheme: FilePreviewHighlightTheme = .dark
+        private var lastRequestedText: String?
+        private var lastRequestedPath = ""
+        private var lastRequestedTheme: FilePreviewHighlightTheme?
 
         init(panel: PanelModel) {
             self.panel = panel
         }
 
-        deinit {}
+        deinit {
+            highlightTask?.cancel()
+        }
+
+        func configure(path: String, theme: FilePreviewHighlightTheme) {
+            filePath = path
+            highlightTheme = theme
+        }
+
+        func refreshSyntaxHighlighting(in textView: NSTextView, debounce: Bool = false) {
+            let text = textView.string
+            guard lastRequestedText != text
+                    || lastRequestedPath != filePath
+                    || lastRequestedTheme != highlightTheme else {
+                return
+            }
+
+            highlightTask?.cancel()
+            highlightGeneration += 1
+            let generation = highlightGeneration
+            let path = filePath
+            let theme = highlightTheme
+            let highlighter = syntaxHighlighter
+            lastRequestedText = text
+            lastRequestedPath = path
+            lastRequestedTheme = theme
+            Self.clearSyntaxColors(in: textView)
+
+            highlightTask = Task { @MainActor [weak self, weak textView] in
+                if debounce {
+                    try? await Task.sleep(for: .milliseconds(150))
+                }
+                guard !Task.isCancelled else { return }
+                let result = await highlighter.highlight(text: text, path: path, theme: theme)
+                guard let self,
+                      let textView,
+                      !Task.isCancelled,
+                      generation == self.highlightGeneration,
+                      textView.string == text,
+                      let result,
+                      result.value.string == text else {
+                    return
+                }
+                Self.applySyntaxColors(from: result.value, to: textView)
+                self.highlightTask = nil
+            }
+        }
+
+        static func clearSyntaxColors(in textView: NSTextView) {
+            guard let layoutManager = textView.layoutManager else { return }
+            layoutManager.removeTemporaryAttribute(
+                .foregroundColor,
+                forCharacterRange: NSRange(location: 0, length: (textView.string as NSString).length)
+            )
+        }
+
+        static func applySyntaxColors(
+            from highlightedText: NSAttributedString,
+            to textView: NSTextView
+        ) {
+            guard let layoutManager = textView.layoutManager else { return }
+            let fullRange = NSRange(location: 0, length: highlightedText.length)
+            layoutManager.removeTemporaryAttribute(.foregroundColor, forCharacterRange: fullRange)
+            highlightedText.enumerateAttribute(.foregroundColor, in: fullRange) { value, range, _ in
+                guard let color = value as? NSColor else { return }
+                layoutManager.addTemporaryAttribute(
+                    .foregroundColor,
+                    value: color,
+                    forCharacterRange: range
+                )
+            }
+        }
 
         func textDidChange(_ notification: Notification) {
             guard !isApplyingPanelUpdate,
                   let textView = notification.object as? NSTextView else { return }
             panel.updateTextContent(textView.string)
+            refreshSyntaxHighlighting(in: textView, debounce: true)
         }
     }
 }
@@ -452,6 +541,10 @@ extension FilePreviewPanel {
     func attachTextView(_ textView: NSTextView) {
         self.textView = textView
         focusCoordinator.register(root: textView, primaryResponder: textView, intent: .textEditor)
+        DispatchQueue.main.async { [weak self, weak textView] in
+            guard self?.textView === textView else { return }
+            self?.retryPendingSourceLocationReveal()
+        }
     }
 
     @discardableResult

--- a/Sources/Panels/MarkdownPanelView.swift
+++ b/Sources/Panels/MarkdownPanelView.swift
@@ -97,6 +97,7 @@ struct MarkdownPanelView: View {
                     isVisibleInUI: isVisibleInUI,
                     themeBackgroundColor: appearance.contentBackgroundColor,
                     themeForegroundColor: themeForegroundColor,
+                    highlightTheme: themeBackgroundColor.isLightColor ? .light : .dark,
                     drawsBackground: appearance.drawsContentBackground,
                     wordWrap: fileEditorWordWrap
                 )

--- a/Sources/TerminalLinkOpenContainer.swift
+++ b/Sources/TerminalLinkOpenContainer.swift
@@ -1,3 +1,4 @@
+import CmuxTerminalCore
 import Foundation
 
 /// Host operations needed to give terminal links identical behavior in the
@@ -12,7 +13,7 @@ protocol TerminalLinkOpenContainer: AnyObject {
     @discardableResult
     func deferTerminalFileLinkOpen(
         sourcePanelId: UUID,
-        filePath: String,
+        fileReference: TerminalFileReference,
         fallback: @escaping @MainActor @Sendable () -> Void
     ) -> Bool
 

--- a/Sources/TerminalLinkOpenCoordinator.swift
+++ b/Sources/TerminalLinkOpenCoordinator.swift
@@ -42,18 +42,18 @@ struct TerminalLinkOpenCoordinator {
         }
         if !trimmed.isEmpty,
            canResolveLocalFilePath,
-           let resolvedPath = TerminalPathResolver().resolveOpenURLFilePath(
+           let fileReference = TerminalPathResolver().resolveOpenURLFileReference(
                trimmed,
                cwd: resolvedWorkingDirectory(request: request, container: container)
-           ) {
-            let fileURL = URL(fileURLWithPath: resolvedPath)
+        ) {
+            let resolvedPath = fileReference.path
             if CommandClickFileOpenRouter.shouldRouteInCmux(
                 path: resolvedPath,
                 defaults: defaults
             ) {
                 log("link.openURL resolvedAsFilePath=\(resolvedPath)")
                 return routeLocalFile(
-                    fileURL,
+                    fileReference,
                     request: request,
                     container: container,
                     unavailableReason: "file route unavailable"
@@ -84,7 +84,7 @@ struct TerminalLinkOpenCoordinator {
             defaults: defaults
         ) {
             return routeLocalFile(
-                target.url,
+                TerminalFileReference(path: target.url.path),
                 request: request,
                 container: container,
                 unavailableReason: "file container unavailable"
@@ -104,18 +104,20 @@ struct TerminalLinkOpenCoordinator {
     }
 
     private func routeLocalFile(
-        _ fileURL: URL,
+        _ fileReference: TerminalFileReference,
         request: TerminalLinkOpenRequest,
         container: (any TerminalLinkOpenContainer)?,
         unavailableReason: String
     ) -> Bool {
+        let fileURL = URL(fileURLWithPath: fileReference.path)
         guard let sourcePanelId = request.sourcePanelId,
               let container,
               !container.terminalLinkIsRemoteTerminal(sourcePanelId) else {
             return openExternally(fileURL, reason: unavailableReason)
         }
 
-        if let browserURL = TerminalHTMLFileBrowserAction(defaults: defaults)
+        if fileReference.line == nil,
+           let browserURL = TerminalHTMLFileBrowserAction(defaults: defaults)
             .browserURL(for: fileURL) {
             return deferHTMLFileOpen(
                 fileURL,
@@ -128,7 +130,7 @@ struct TerminalLinkOpenCoordinator {
 
         guard container.deferTerminalFileLinkOpen(
             sourcePanelId: sourcePanelId,
-            filePath: fileURL.path,
+            fileReference: fileReference,
             fallback: { [externalOpen] in _ = externalOpen(fileURL) }
         ) else {
             return openExternally(fileURL, reason: unavailableReason)
@@ -183,7 +185,7 @@ struct TerminalLinkOpenCoordinator {
             )
             if currentContainer.deferTerminalFileLinkOpen(
                 sourcePanelId: sourcePanelId,
-                filePath: fileURL.path,
+                fileReference: TerminalFileReference(path: fileURL.path),
                 fallback: externalFallback
             ) {
                 return

--- a/Sources/Workspace+TerminalLinkOpening.swift
+++ b/Sources/Workspace+TerminalLinkOpening.swift
@@ -1,4 +1,5 @@
 import CmuxPanes
+import CmuxTerminalCore
 import Foundation
 
 extension Workspace: TerminalLinkOpenContainer {
@@ -24,7 +25,7 @@ extension Workspace: TerminalLinkOpenContainer {
 
     func deferTerminalFileLinkOpen(
         sourcePanelId: UUID,
-        filePath: String,
+        fileReference: TerminalFileReference,
         fallback: @escaping @MainActor @Sendable () -> Void
     ) -> Bool {
         guard let target = surfaceOwnershipTarget(for: sourcePanelId) else { return false }
@@ -32,7 +33,7 @@ extension Workspace: TerminalLinkOpenContainer {
             workspace: self,
             preferredWorkspaceId: id,
             surfaceId: target.containerPanelID,
-            filePath: filePath,
+            fileReference: fileReference,
             fallback: fallback
         )
         return true

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -9095,28 +9095,35 @@ final class Workspace: Identifiable, ObservableObject, FilePreviewTabMetadataHos
     @discardableResult
     func openOrFocusFilePreviewSplit(
         from panelId: UUID,
-        filePath: String
+        filePath: String,
+        line: Int? = nil,
+        column: Int? = nil
     ) -> FilePreviewPanel? {
         let canonical = (filePath as NSString).resolvingSymlinksInPath
         for (existingId, panel) in panels {
             guard let preview = panel as? FilePreviewPanel else { continue }
             if (preview.filePath as NSString).resolvingSymlinksInPath == canonical {
                 focusPanel(existingId)
+                preview.revealSourceLocation(line: line, column: column)
                 return preview
             }
         }
 
         if let targetPane = preferredRightSideTargetPane(fromPanelId: panelId) {
-            return newFilePreviewSurface(inPane: targetPane, filePath: filePath, focus: true)
+            let preview = newFilePreviewSurface(inPane: targetPane, filePath: filePath, focus: true)
+            preview?.revealSourceLocation(line: line, column: column)
+            return preview
         }
 
         guard let sourcePaneId = paneId(forPanelId: panelId) else { return nil }
-        return splitPaneWithFilePreview(
+        let preview = splitPaneWithFilePreview(
             targetPane: sourcePaneId,
             orientation: .horizontal,
             insertFirst: false,
             filePath: filePath
         )
+        preview?.revealSourceLocation(line: line, column: column)
+        return preview
     }
 
     @discardableResult

--- a/THIRD_PARTY_LICENSES.md
+++ b/THIRD_PARTY_LICENSES.md
@@ -130,6 +130,36 @@ SOFTWARE.
 
 ---
 
+## Highlightr
+
+- **License:** MIT License
+- **Copyright:** Copyright (c) 2016 Illanes, Juan Pablo
+- **Source:** https://github.com/raspu/Highlightr
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
+Highlightr bundles highlight.js 11.11.1 (Copyright (c) 2006-2024 Josh Goebel
+and other contributors) under the BSD 3-Clause License. The complete BSD
+terms are reproduced in the Markdown Viewer Web Assets section below.
+
+---
+
 ## Markdown Viewer Web Assets
 
 cmux bundles these files under `Resources/markdown-viewer/` so the markdown

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -1095,6 +1095,8 @@ C0DE71B10000000000000001 /* AppDelegate+AgentChatNotifications.swift in Sources 
 		A5001441A5001441A5001441 /* FileOpenSocketSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001440A5001440A5001440 /* FileOpenSocketSupport.swift */; };
 		C0DE8652000000000000000F /* FilePreviewFileState.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE86520000000000000010 /* FilePreviewFileState.swift */; };
 		A5001432A5001432A5001432 /* FilePreviewFocusCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001431A5001431A5001431 /* FilePreviewFocusCoordinator.swift */; };
+		F1A10000000000000000000C /* FilePreviewHighlightedText.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1A10000000000000000000D /* FilePreviewHighlightedText.swift */; };
+		F1A10000000000000000000A /* FilePreviewHighlightTheme.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1A10000000000000000000B /* FilePreviewHighlightTheme.swift */; };
 		C0DE86520000000000000101 /* FilePreviewImageLoadResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE86520000000000000102 /* FilePreviewImageLoadResult.swift */; };
 		01EE5DC99896BA30240EF1B5 /* FilePreviewImageSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D1450569A797AA7937677D9 /* FilePreviewImageSession.swift */; };
 		C0DE86520000000000000009 /* FilePreviewImageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE8652000000000000000A /* FilePreviewImageView.swift */; };
@@ -1134,6 +1136,9 @@ C0DE71B10000000000000001 /* AppDelegate+AgentChatNotifications.swift in Sources 
 		C0DE86520000000000000001 /* FilePreviewReloadTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE86520000000000000002 /* FilePreviewReloadTests.swift */; };
 		C0DE31390000000000000103 /* FilePreviewReviewFeedbackTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE31390000000000000104 /* FilePreviewReviewFeedbackTests.swift */; };
 		C0DE86520000000000000111 /* FilePreviewRevision.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE86520000000000000112 /* FilePreviewRevision.swift */; };
+		F1A100000000000000000008 /* FilePreviewSyntaxHighlightDecision.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1A100000000000000000009 /* FilePreviewSyntaxHighlightDecision.swift */; };
+		F1A100000000000000000003 /* FilePreviewSyntaxHighlighter.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1A100000000000000000004 /* FilePreviewSyntaxHighlighter.swift */; };
+		F1A100000000000000000001 /* FilePreviewSyntaxHighlightPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1A100000000000000000002 /* FilePreviewSyntaxHighlightPolicy.swift */; };
 		C0DE97470000000000000001 /* FilePreviewTabMetadata.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE97470000000000000002 /* FilePreviewTabMetadata.swift */; };
 		C0DE97470000000000000003 /* FilePreviewTabMetadataHost.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE97470000000000000004 /* FilePreviewTabMetadataHost.swift */; };
 		D0B10016A1B2C3D4E5F60001 /* FilePreviewTextEditor.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0B10017A1B2C3D4E5F60001 /* FilePreviewTextEditor.swift */; };
@@ -1248,6 +1253,7 @@ C0DE71B10000000000000001 /* AppDelegate+AgentChatNotifications.swift in Sources 
 		F5320000A1B2C3D4E5F60718 /* HermesAgentIndex.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5320001A1B2C3D4E5F60718 /* HermesAgentIndex.swift */; };
 		9520A0019520A0019520A001 /* HermesFirstClassSupportTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9520B0019520B0019520B001 /* HermesFirstClassSupportTests.swift */; };
 		4931A11B0000000000000002 /* HiddenRightSidebarContentMountingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4931A11B0000000000000001 /* HiddenRightSidebarContentMountingTests.swift */; };
+		F1A100000000000000000007 /* Highlightr in Frameworks */ = {isa = PBXBuildFile; productRef = F1A100000000000000000006 /* Highlightr */; };
 		CD0CFE6000000000CD0CFE60 /* HostAccountFlow.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD0CFE6100000000CD0CFE61 /* HostAccountFlow.swift */; };
 		B1F0C0030000000000000001 /* HostedInspectorDockControlScript.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1F0C0030000000000000002 /* HostedInspectorDockControlScript.swift */; };
 		B1F0C0040000000000000001 /* HostedInspectorDockControlScriptTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1F0C0040000000000000002 /* HostedInspectorDockControlScriptTests.swift */; };
@@ -3872,6 +3878,8 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 		A5001440A5001440A5001440 /* FileOpenSocketSupport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileOpenSocketSupport.swift; sourceTree = "<group>"; };
 		C0DE86520000000000000010 /* FilePreviewFileState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/FilePreviewFileState.swift; sourceTree = "<group>"; };
 		A5001431A5001431A5001431 /* FilePreviewFocusCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/FilePreviewFocusCoordinator.swift; sourceTree = "<group>"; };
+		F1A10000000000000000000D /* FilePreviewHighlightedText.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/FilePreviewHighlightedText.swift; sourceTree = "<group>"; };
+		F1A10000000000000000000B /* FilePreviewHighlightTheme.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/FilePreviewHighlightTheme.swift; sourceTree = "<group>"; };
 		C0DE86520000000000000102 /* FilePreviewImageLoadResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/FilePreviewImageLoadResult.swift; sourceTree = "<group>"; };
 		7D1450569A797AA7937677D9 /* FilePreviewImageSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/FilePreviewImageSession.swift; sourceTree = "<group>"; };
 		C0DE8652000000000000000A /* FilePreviewImageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/FilePreviewImageView.swift; sourceTree = "<group>"; };
@@ -3911,6 +3919,9 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 		C0DE86520000000000000002 /* FilePreviewReloadTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilePreviewReloadTests.swift; sourceTree = "<group>"; };
 		C0DE31390000000000000104 /* FilePreviewReviewFeedbackTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilePreviewReviewFeedbackTests.swift; sourceTree = "<group>"; };
 		C0DE86520000000000000112 /* FilePreviewRevision.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/FilePreviewRevision.swift; sourceTree = "<group>"; };
+		F1A100000000000000000009 /* FilePreviewSyntaxHighlightDecision.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/FilePreviewSyntaxHighlightDecision.swift; sourceTree = "<group>"; };
+		F1A100000000000000000004 /* FilePreviewSyntaxHighlighter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/FilePreviewSyntaxHighlighter.swift; sourceTree = "<group>"; };
+		F1A100000000000000000002 /* FilePreviewSyntaxHighlightPolicy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/FilePreviewSyntaxHighlightPolicy.swift; sourceTree = "<group>"; };
 		C0DE97470000000000000002 /* FilePreviewTabMetadata.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/FilePreviewTabMetadata.swift; sourceTree = "<group>"; };
 		C0DE97470000000000000004 /* FilePreviewTabMetadataHost.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/FilePreviewTabMetadataHost.swift; sourceTree = "<group>"; };
 		D0B10017A1B2C3D4E5F60001 /* FilePreviewTextEditor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/FilePreviewTextEditor.swift; sourceTree = "<group>"; };
@@ -5599,6 +5610,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				5E55200000000000000000B3 /* CmuxWindowing in Frameworks */,
 				E3B7A3000000000000000103 /* CmuxWorkspaces in Frameworks */,
 				A5001006 /* GhosttyKit.xcframework in Frameworks */,
+				F1A100000000000000000007 /* Highlightr in Frameworks */,
 				A5001290 /* MarkdownUI in Frameworks */,
 				A5001270 /* PostHog in Frameworks */,
 				A5001250 /* Sentry in Frameworks */,
@@ -7245,6 +7257,11 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				C0DE64020000000000001001 /* FilePreviewQuickLookContainerView.swift */,
 				0A02623202562490B3E88372 /* FilePreviewQuickLookSession.swift */,
 				D0B10017A1B2C3D4E5F60001 /* FilePreviewTextEditor.swift */,
+				F1A100000000000000000002 /* FilePreviewSyntaxHighlightPolicy.swift */,
+				F1A100000000000000000004 /* FilePreviewSyntaxHighlighter.swift */,
+				F1A100000000000000000009 /* FilePreviewSyntaxHighlightDecision.swift */,
+				F1A10000000000000000000B /* FilePreviewHighlightTheme.swift */,
+				F1A10000000000000000000D /* FilePreviewHighlightedText.swift */,
 				A5001451A5001451A5001451 /* FilePreviewNativeBackground.swift */,
 				A5001442A5001442A5001442 /* FilePreviewModeSupport.swift */,
 				A5001444A5001444A5001444 /* FilePreviewWorkspaceOpenSupport.swift */,
@@ -8491,6 +8508,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 			);
 			name = cmux;
 			packageProductDependencies = (
+				F1A100000000000000000006 /* Highlightr */,
 				A5001231 /* Sparkle */,
 				A5001251 /* Sentry */,
 				A5001271 /* PostHog */,
@@ -8686,6 +8704,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 			);
 			mainGroup = A5001040;
 			packageReferences = (
+				F1A100000000000000000005 /* XCRemoteSwiftPackageReference "Highlightr" */,
 				A5001232 /* XCRemoteSwiftPackageReference "Sparkle" */,
 				A5001252 /* XCRemoteSwiftPackageReference "sentry-cocoa" */,
 				A5001272 /* XCRemoteSwiftPackageReference "posthog-ios" */,
@@ -9533,6 +9552,8 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				A5001441A5001441A5001441 /* FileOpenSocketSupport.swift in Sources */,
 				C0DE8652000000000000000F /* FilePreviewFileState.swift in Sources */,
 				A5001432A5001432A5001432 /* FilePreviewFocusCoordinator.swift in Sources */,
+				F1A10000000000000000000C /* FilePreviewHighlightedText.swift in Sources */,
+				F1A10000000000000000000A /* FilePreviewHighlightTheme.swift in Sources */,
 				C0DE86520000000000000101 /* FilePreviewImageLoadResult.swift in Sources */,
 				01EE5DC99896BA30240EF1B5 /* FilePreviewImageSession.swift in Sources */,
 				C0DE86520000000000000009 /* FilePreviewImageView.swift in Sources */,
@@ -9566,6 +9587,9 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				DD62AFF1D95A1D5D1850AC10 /* FilePreviewQuickLookSession.swift in Sources */,
 				C0DE8652000000000000010F /* FilePreviewQuickLookViewCoordinator.swift in Sources */,
 				C0DE86520000000000000111 /* FilePreviewRevision.swift in Sources */,
+				F1A100000000000000000008 /* FilePreviewSyntaxHighlightDecision.swift in Sources */,
+				F1A100000000000000000003 /* FilePreviewSyntaxHighlighter.swift in Sources */,
+				F1A100000000000000000001 /* FilePreviewSyntaxHighlightPolicy.swift in Sources */,
 				C0DE97470000000000000001 /* FilePreviewTabMetadata.swift in Sources */,
 				C0DE97470000000000000003 /* FilePreviewTabMetadataHost.swift in Sources */,
 				D0B10016A1B2C3D4E5F60001 /* FilePreviewTextEditor.swift in Sources */,
@@ -12232,6 +12256,14 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 /* End XCLocalSwiftPackageReference section */
 
 /* Begin XCRemoteSwiftPackageReference section */
+		F1A100000000000000000005 /* XCRemoteSwiftPackageReference "Highlightr" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/raspu/Highlightr.git";
+			requirement = {
+				kind = exactVersion;
+				version = 2.3.0;
+			};
+		};
 		A5001232 /* XCRemoteSwiftPackageReference "Sparkle" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/sparkle-project/Sparkle";
@@ -12267,6 +12299,11 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
+		F1A100000000000000000006 /* Highlightr */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = F1A100000000000000000005 /* XCRemoteSwiftPackageReference "Highlightr" */;
+			productName = Highlightr;
+		};
 		29813FE5A6CBC1019289A251 /* CMUXAuthCore */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = 40B63BB4A170F0BD2D1DEFD1 /* XCLocalSwiftPackageReference "CMUXAuthCore" */;

--- a/cmux.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/cmux.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -11,6 +11,15 @@
       }
     },
     {
+      "identity" : "highlightr",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/raspu/Highlightr.git",
+      "state" : {
+        "revision" : "05e7fcc63b33925cd0c1faaa205cdd5681e7bbef",
+        "version" : "2.3.0"
+      }
+    },
+    {
       "identity" : "iroh-ffi",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/manaflow-ai/iroh-ffi.git",

--- a/cmuxTests/FilePreviewTextEditorTextKitTests.swift
+++ b/cmuxTests/FilePreviewTextEditorTextKitTests.swift
@@ -31,6 +31,134 @@ import Testing
 @MainActor
 @Suite("File preview editor TextKit backing", .serialized)
 struct FilePreviewTextEditorTextKitTests {
+    @Test("syntax highlighting is bounded while known extensions retain their language")
+    func syntaxHighlightPolicyBoundsWork() {
+        let policy = FilePreviewSyntaxHighlightPolicy()
+
+        #expect(
+            policy.decision(
+                path: "/tmp/example.swift",
+                byteCount: FilePreviewSyntaxHighlightPolicy.maximumHighlightBytes
+            ) == .highlight(language: "swift")
+        )
+        #expect(
+            policy.decision(
+                path: "/tmp/example.swift",
+                byteCount: FilePreviewSyntaxHighlightPolicy.maximumHighlightBytes + 1
+            ) == .skip
+        )
+        #expect(
+            policy.decision(
+                path: "/tmp/example.unknown",
+                byteCount: FilePreviewSyntaxHighlightPolicy.maximumAutomaticDetectionBytes - 1
+            ) == .highlight(language: nil)
+        )
+        #expect(
+            policy.decision(
+                path: "/tmp/example.unknown",
+                byteCount: FilePreviewSyntaxHighlightPolicy.maximumAutomaticDetectionBytes
+            ) == .skip
+        )
+    }
+
+    @Test("syntax highlighter returns token colors without changing source text")
+    func syntaxHighlighterColorsSource() async throws {
+        let source = "let answer = 42\n"
+        let result = await FilePreviewSyntaxHighlighter().highlight(
+            text: source,
+            path: "/tmp/example.swift",
+            theme: .dark
+        )
+        let highlighted = try #require(result?.value)
+        var coloredRanges = 0
+        highlighted.enumerateAttribute(
+            .foregroundColor,
+            in: NSRange(location: 0, length: highlighted.length)
+        ) { value, _, _ in
+            if value is NSColor {
+                coloredRanges += 1
+            }
+        }
+
+        #expect(highlighted.string == source)
+        #expect(coloredRanges > 1)
+    }
+
+    @Test("source locations select their one-based line and column")
+    func sourceLocationRangesSelectRequestedPosition() throws {
+        let ranges = try #require(
+            FilePreviewPanel.sourceLocationRanges(
+                in: "first\nsecond line\nthird\n",
+                line: 2,
+                column: 4
+            )
+        )
+
+        #expect(ranges.line == NSRange(location: 6, length: 12))
+        #expect(ranges.selection == NSRange(location: 9, length: 0))
+        #expect(FilePreviewPanel.sourceLocationRanges(in: "only", line: 2, column: nil) == nil)
+    }
+
+    @Test("line-one source locations wait for the initial text load")
+    func lineOneSourceLocationWaitsForInitialLoad() async {
+        let panel = FilePreviewPanel(
+            workspaceId: UUID(),
+            filePath: "/tmp/cmux-source-location.swift",
+            startFileWatcher: false,
+            textLoader: { _ in .loaded(content: "first line\nsecond line\n", encoding: .utf8) }
+        )
+        defer { panel.close() }
+        let textView = SavingTextView.makeFilePreviewTextView()
+        panel.attachTextView(textView)
+
+        panel.revealSourceLocation(line: 1, column: 4)
+        await panel.loadTextContent().value
+        panel.retryPendingSourceLocationReveal()
+        textView.string = panel.textContent
+        panel.retryPendingSourceLocationReveal()
+
+        #expect(textView.selectedRange() == NSRange(location: 3, length: 0))
+    }
+
+    @Test("syntax colors use temporary layout attributes without mutating editor state")
+    func syntaxColorsPreserveEditorState() throws {
+        let textView = SavingTextView.makeFilePreviewTextView()
+        textView.string = "let answer = 42\n"
+        textView.setSelectedRange(NSRange(location: 4, length: 6))
+        let originalFont = textView.font
+        let highlighted = NSMutableAttributedString(string: textView.string)
+        highlighted.addAttribute(
+            .foregroundColor,
+            value: NSColor.systemPurple,
+            range: NSRange(location: 0, length: 3)
+        )
+
+        FilePreviewTextEditor<TextEditingPanelSpy>.Coordinator.applySyntaxColors(
+            from: highlighted,
+            to: textView
+        )
+
+        let temporaryColor = textView.layoutManager?.temporaryAttribute(
+            .foregroundColor,
+            atCharacterIndex: 1,
+            effectiveRange: nil
+        ) as? NSColor
+        #expect(temporaryColor == .systemPurple)
+        #expect(textView.string == "let answer = 42\n")
+        #expect(textView.selectedRange() == NSRange(location: 4, length: 6))
+        #expect(textView.font == originalFont)
+        #expect(textView.isEditable)
+
+        FilePreviewTextEditor<TextEditingPanelSpy>.Coordinator.clearSyntaxColors(in: textView)
+        #expect(
+            textView.layoutManager?.temporaryAttribute(
+                .foregroundColor,
+                atCharacterIndex: 1,
+                effectiveRange: nil
+            ) == nil
+        )
+    }
+
     @Test("makeFilePreviewTextView is a pure TextKit 1 view (no TextKit 2 selection path)")
     func editorIsPureTextKit1() {
         let textView = SavingTextView.makeFilePreviewTextView()
@@ -383,6 +511,7 @@ struct FilePreviewTextEditorTextKitTests {
     }
 
     private final class TextEditingPanelSpy: FilePreviewTextEditingPanel {
+        let filePath = "/tmp/cmux-file-preview-test.swift"
         var textContent = ""
         var saveCount = 0
 

--- a/cmuxTests/TerminalLinkOpenCoordinatorTests.swift
+++ b/cmuxTests/TerminalLinkOpenCoordinatorTests.swift
@@ -1,4 +1,5 @@
 import AppKit
+import CmuxTerminalCore
 import Foundation
 import Testing
 import struct CmuxSettings.AppCatalogSection
@@ -137,6 +138,29 @@ struct TerminalLinkOpenCoordinatorTests {
         )
         #expect(browser.currentURL?.standardizedFileURL == htmlURL.standardizedFileURL)
         #expect(!workspace.panels.values.contains { $0 is FilePreviewPanel })
+    }
+
+    @Test("HTML source locations open in File Preview instead of Browser")
+    @MainActor
+    func htmlSourceLocationOpensInFilePreview() throws {
+        _ = NSApplication.shared
+        let defaults = makeDefaults()
+        let htmlURL = try makeHTMLFixture(pathExtension: "html")
+        defer { try? FileManager.default.removeItem(at: htmlURL.deletingLastPathComponent()) }
+
+        let workspace = Workspace()
+        defer { workspace.teardownAllPanels() }
+        let sourcePanelId = try #require(workspace.focusedPanelId)
+
+        #expect(CommandClickFileOpenRouter.openInCmux(
+            workspace: workspace,
+            sourcePanelId: sourcePanelId,
+            fileReference: TerminalFileReference(path: htmlURL.path, line: 2),
+            defaults: defaults
+        ))
+
+        #expect(workspace.panels.values.contains { $0 is FilePreviewPanel })
+        #expect(!workspace.panels.values.contains { $0 is BrowserPanel })
     }
 
     @Test("Dock HTML paths open in Browser instead of externally")


### PR DESCRIPTION
## Summary

- recognize terminal file references with `:line`, `:line:column`, and `#Lline` suffixes while preserving literal filenames
- open or reuse the right-side native File Preview and reveal the requested one-based line and column
- add bounded, theme-aware syntax colors to editable native file previews without mutating text, selection, undo state, or font settings
- keep line-targeted Markdown and HTML references in File Preview so the source location is not lost

## Why

Agent output commonly includes references such as `backend/src/chaser/rule.py:139`. cmux already resolved plain terminal paths, but the source-location suffix prevented resolution and the native preview rendered source as uncolored text.

## Validation

- `CmuxTerminalCore` target builds with the current source-location parser
- executable resolver smoke covers `src/main.swift:42:7` and basename-only `main.swift:42`
- the same basename smoke fails against the pre-fix implementation at the expected assertion
- Highlightr 2.3.0 builds, the five native highlighting types type-check, and an executable smoke preserves source text while producing multiple token colors
- project normalization/check, test-wiring lint (688 files), package-resolved policy, Swift parser checks, and `git diff --check` pass
- focused independent review completed with no remaining findings

The full app and XCTest suite could not run locally because this Mac currently has Command Line Tools rather than full Xcode selected; the draft PR is intended to obtain that CI proof.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/10174"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789322787&installation_model_id=21920&pr_number=10174&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F10174&signature=67eef2ab74143a825ee93d0adeec319b575310b4b3f20e40111ea35f0e7cc259"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Open terminal file references with optional source locations in a syntax‑colored File Preview. Previously, links like backend/src/file.py:139 failed to resolve and previews were uncolored; now they resolve (including Ghostty‑normalized https://path/file.py:139 and #L fragments) and reveal the requested 1‑based line/column.

- Parse and preserve source‑location suffixes `:line`, `:line:column`, and `#Lline`, preferring literal filenames when they exist.
- Route any source‑located link to File Preview (not Browser/Markdown) and reveal the target; reuse the right‑side preview when possible. Ghostty‑normalized HTTP(S) tokens are reconstructed only when they resolve to an existing local file with a line; ordinary web links keep web routing.
- Add bounded, theme‑aware syntax coloring to native file previews using `Highlightr` 2.3.0 without changing text, selection, undo, or font. Known extensions map to highlight.js languages; large files and very large unknown types skip highlighting.

**Notes for review and migration**
- New `TerminalPathResolver` APIs return `TerminalFileReference`: resolveQuicklookFileReference, resolveVisibleLineFileReference, and resolveOpenURLFileReference; legacy String‑returning helpers delegate to these.
- `TerminalLinkOpenContainer.deferTerminalFileLinkOpen` now takes a `TerminalFileReference`; conformers updated (Workspace, DockSplitStore).
- `Workspace.openOrFocusFilePreviewSplit` accepts optional line/column to reveal.
- Add SwiftPM dependency on `Highlightr` and its license; see THIRD_PARTY_LICENSES.md.

<sup>Written for commit 8b3f3c35394a8d227643bf96552be2c5d37f643c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/10174?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

