### PR TITLE
fix(ios): distinct workspace group glyph in task composer

### DIFF
--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TaskComposer/TaskComposerWorkspaceGroupMenu.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TaskComposer/TaskComposerWorkspaceGroupMenu.swift
@@ -12,6 +12,10 @@ struct TaskComposerWorkspaceGroupMenu: View, Equatable {
     let isDisabled: Bool
     let select: (MobileWorkspaceGroupPreview.ID?) -> Void
 
+    /// Default group glyph: grouped rectangles read as a parent holding
+    /// children, unlike a folder, which collides with the Directory row.
+    private static let defaultGroupSymbol = "rectangle.3.group"
+
     nonisolated static func == (lhs: Self, rhs: Self) -> Bool {
         lhs.groups == rhs.groups
             && lhs.selectedWorkspaceGroupID == rhs.selectedWorkspaceGroupID
@@ -43,7 +47,7 @@ struct TaskComposerWorkspaceGroupMenu: View, Equatable {
                         "mobile.taskComposer.workspaceGroup.none",
                         defaultValue: "None"
                     ))
-                    Image(systemName: selectedWorkspaceGroupID == nil ? "checkmark" : "folder")
+                    Image(systemName: selectedWorkspaceGroupID == nil ? "checkmark" : Self.defaultGroupSymbol)
                 }
 
                 if groups.isEmpty {
@@ -63,7 +67,7 @@ struct TaskComposerWorkspaceGroupMenu: View, Equatable {
                             Text(group.name)
                             Image(systemName: group.id == selectedWorkspaceGroupID
                                 ? "checkmark"
-                            : (group.iconSymbol ?? "folder"))
+                            : (group.iconSymbol ?? Self.defaultGroupSymbol))
                         }
                     }
                 }
@@ -118,7 +122,7 @@ struct TaskComposerWorkspaceGroupMenu: View, Equatable {
     private var iconSymbol: String {
         if isSelectionPending { return "arrow.triangle.2.circlepath" }
         if requiresSelectionResolution { return "exclamationmark.triangle" }
-        return selectedGroup?.iconSymbol ?? "folder"
+        return selectedGroup?.iconSymbol ?? Self.defaultGroupSymbol
     }
 }
 #endif


### PR DESCRIPTION
The Workspace group row in the new-workspace composer fell back to the `folder` SF Symbol, nearly identical to the Directory row's `folder.fill` directly above it. The row, its None menu item, and groups without a custom icon now fall back to `rectangle.3.group`, the glyph the group context-menu actions already use, so the row reads as a group of workspaces instead of a second directory picker. Groups with a custom icon still show that icon.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/10176"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789331806&installation_model_id=21920&pr_number=10176&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F10176&signature=2b22ee4c1d5bdfe606d184004d55f6c7242d76d0ff0fc96a064ff8510625f2d9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Uses a distinct SF Symbol for workspace groups in the task composer so the group row no longer looks like a second directory picker. Previously the group row and groups without a custom icon fell back to "folder"; now they use "rectangle.3.group" throughout, matching the group context-menu actions.

**Review notes**
- Introduces a `defaultGroupSymbol` constant and replaces "folder" fallbacks in `CmuxMobileShellUI`’s `TaskComposerWorkspaceGroupMenu`.
- Applies to the group row icon, the "None" menu item, and groups without a custom icon; groups with a custom icon are unchanged.
- No behavior or copy changes; selection state and checkmarks are unchanged. Verify the new icon renders correctly and is visually distinct from the directory row’s "folder.fill".

<sup>Written for commit f2055b68751f19cb06d558193e1f77edc7a80359. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/10176?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated group menu icons to use a consistent grouped-rectangle symbol.
  * Replaced the folder icon shown for unassigned groups, group entries, and selected groups.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->