### PR TITLE
Fix browser omnibar absolute local file paths

### DIFF
--- a/Packages/macOS/CmuxBrowser/Sources/CmuxBrowser/Omnibar/BrowserURLResolver.swift
+++ b/Packages/macOS/CmuxBrowser/Sources/CmuxBrowser/Omnibar/BrowserURLResolver.swift
@@ -3,11 +3,20 @@ public import Foundation
 /// Resolves macOS browser omnibar text into a URL that can be loaded directly.
 ///
 /// Search-engine fallback remains the caller's responsibility. The resolver
-/// handles web URLs, local development hosts, scheme-less hosts, and absolute
-/// file URLs after canonicalizing line breaks introduced by wrapped pastes.
+/// handles explicit web/file URLs, bare POSIX or tilde paths, local development
+/// hosts, and scheme-less hosts after canonicalizing line breaks introduced by
+/// wrapped pastes.
 public struct BrowserURLResolver: Sendable {
+    private let homeDirectoryURL: URL
+
     /// Creates a browser URL resolver.
-    public init() {}
+    ///
+    /// - Parameter homeDirectoryURL: The home directory used to expand `~` paths.
+    ///   Production callers use the current user's home directory; tests can
+    ///   provide a stable URL without consulting the process environment.
+    public init(homeDirectoryURL: URL = FileManager.default.homeDirectoryForCurrentUser) {
+        self.homeDirectoryURL = homeDirectoryURL
+    }
 
     /// Prepares raw pasteboard text for insertion into a single-line omnibar.
     ///
@@ -34,7 +43,10 @@ public struct BrowserURLResolver: Sendable {
         )
         guard !trimmed.isEmpty else { return nil }
         guard !trimmed.contains(where: { $0.isNewline || $0 == "\t" }) else { return nil }
-        if let url = webURL(from: trimmed) {
+        if let url = explicitURL(from: trimmed) {
+            return url
+        }
+        if let url = localFileURL(from: trimmed) {
             return url
         }
         guard !hasSchemeLessUserInfo(in: trimmed) else { return nil }
@@ -60,6 +72,46 @@ public struct BrowserURLResolver: Sendable {
             return URL(string: "https://\(trimmed)")
         }
         return nil
+    }
+
+    /// Returns a URL for an explicit scheme already present in the input.
+    ///
+    /// The omnibar intentionally keeps its existing web/file allowlist: other
+    /// schemes are handled by the browser's external-navigation paths rather
+    /// than being loaded as typed omnibar destinations.
+    private func explicitURL(from input: String) -> URL? {
+        guard let url = URL(string: input),
+              let scheme = url.scheme?.lowercased() else {
+            return nil
+        }
+
+        switch scheme {
+        case "http", "https":
+            return webURL(from: input)
+        case "file":
+            guard url.isFileURL, url.path.hasPrefix("/") else { return nil }
+            return url
+        default:
+            return nil
+        }
+    }
+
+    /// Converts a syntactically local absolute path into a file URL.
+    private func localFileURL(from input: String) -> URL? {
+        let path: String
+        if input.hasPrefix("/") {
+            path = input
+        } else if input == "~" {
+            path = homeDirectoryURL.path
+        } else if input.hasPrefix("~/"), homeDirectoryURL.path.hasPrefix("/") {
+            path = homeDirectoryURL
+                .appending(path: String(input.dropFirst(2)))
+                .path
+        } else {
+            return nil
+        }
+
+        return URL(fileURLWithPath: path)
     }
 
     private func canonicalNavigationText(_ trimmed: String) -> String {

--- a/Packages/macOS/CmuxBrowser/Tests/CmuxBrowserTests/Omnibar/BrowserURLResolverTests.swift
+++ b/Packages/macOS/CmuxBrowser/Tests/CmuxBrowserTests/Omnibar/BrowserURLResolverTests.swift
@@ -143,8 +143,10 @@ import Testing
     }
 
     @Test func resolvesTildePathAsFileURL() throws {
+        let homeDirectoryURL = URL(fileURLWithPath: "/Users/test", isDirectory: true)
+        let resolver = BrowserURLResolver(homeDirectoryURL: homeDirectoryURL)
         let resolved = try #require(resolver.navigableURL(from: "~/Desktop/report.html"))
-        let expectedPath = FileManager.default.homeDirectoryForCurrentUser
+        let expectedPath = homeDirectoryURL
             .appending(path: "Desktop/report.html")
             .path
 

--- a/Packages/macOS/CmuxBrowser/Tests/CmuxBrowserTests/Omnibar/BrowserURLResolverTests.swift
+++ b/Packages/macOS/CmuxBrowser/Tests/CmuxBrowserTests/Omnibar/BrowserURLResolverTests.swift
@@ -125,4 +125,37 @@ import Testing
         #expect(resolver.navigableURL(from: "mailto:test@example.com") == nil)
         #expect(resolver.navigableURL(from: "ftp://example.com/file.html") == nil)
     }
+
+    @Test func resolvesBareAbsolutePOSIXPathAsFileURL() throws {
+        let resolved = try #require(resolver.navigableURL(from: "/Users/x/y.html"))
+
+        #expect(resolved.isFileURL)
+        #expect(resolved.path == "/Users/x/y.html")
+        #expect(resolved.absoluteString == "file:///Users/x/y.html")
+    }
+
+    @Test func resolvesBareAbsolutePathWithSpacesAsFileURL() throws {
+        let resolved = try #require(resolver.navigableURL(from: "/tmp/a b/c.html"))
+
+        #expect(resolved.isFileURL)
+        #expect(resolved.path == "/tmp/a b/c.html")
+        #expect(resolved.absoluteString == "file:///tmp/a%20b/c.html")
+    }
+
+    @Test func resolvesTildePathAsFileURL() throws {
+        let resolved = try #require(resolver.navigableURL(from: "~/Desktop/report.html"))
+        let expectedPath = FileManager.default.homeDirectoryForCurrentUser
+            .appending(path: "Desktop/report.html")
+            .path
+
+        #expect(resolved.isFileURL)
+        #expect(resolved.path == expectedPath)
+    }
+
+    @Test func preservesExplicitFileURLWithSpaces() throws {
+        let resolved = try #require(resolver.navigableURL(from: "file:///tmp/a b/c.html"))
+
+        #expect(resolved.isFileURL)
+        #expect(resolved.path == "/tmp/a b/c.html")
+    }
 }

--- a/cmuxTests/BrowserNavigableURLPasteTests.swift
+++ b/cmuxTests/BrowserNavigableURLPasteTests.swift
@@ -50,4 +50,11 @@ import Testing
         )
         #expect(resolveBrowserNavigableURL("node.js tutorial") == nil)
     }
+
+    @Test func bareAbsolutePathNavigatesAsLocalFileURL() throws {
+        let resolved = try #require(resolveBrowserNavigableURL("/Users/x/y.html"))
+
+        #expect(resolved.isFileURL)
+        #expect(resolved.path == "/Users/x/y.html")
+    }
 }


### PR DESCRIPTION
Closes #4250\n\nIssue: https://github.com/manaflow-ai/cmux/issues/4250\n\n## Summary\n- classify bare absolute POSIX and tilde paths as local file URLs at the shared macOS omnibar resolver boundary\n- preserve existing explicit web URL and search/host heuristics\n- cover paths with spaces and the app-level resolver path\n\n## Scope\nThis is limited to omnibar input normalization for bare absolute paths. Relative terminal links remain tracked by #1154, Cmd-click handling for existing file URLs remains #8215, parent-relative assets remain #1940, and any separate built-in file URL loading gap remains #5051.\n\n## Verification\nThe first commit is the failing regression test; the follow-up commit will contain the implementation and green focused tests.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/10177"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789339485&installation_model_id=21920&pr_number=10177&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F10177&signature=b9137efb8181f68db0845d6aa114ee4977332be17442f3c49c9c8e2274ebfd9e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the omnibar so bare absolute POSIX and tilde paths resolve as local file URLs. Previously these inputs could be treated as web searches/hosts; now they navigate to local files without changing existing web URL heuristics.

- Treats inputs like "/Users/x/y.html" and "~/Desktop/report.html" as file URLs; expands "~" to the current user's home directory.
- Preserves explicit "file://", "http://", and "https://" inputs; continues to return nil for other schemes so external-navigation paths handle them.
- Handles spaces correctly (percent-encodes in URL string; keeps spaces in `URL.path`).
- Adds `homeDirectoryURL` parameter to `BrowserURLResolver` initializer (defaults to `FileManager.default.homeDirectoryForCurrentUser`) to improve testability.
- Adds focused tests in `Packages/macOS/CmuxBrowser/Tests/CmuxBrowserTests/Omnibar/BrowserURLResolverTests.swift` and `cmuxTests/BrowserNavigableURLPasteTests.swift`.

<sup>Written for commit 1af355d7d5307f4098d4dc94e6a7c7bced88f5d2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/10177?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved omnibar handling for local filesystem paths, including absolute paths, paths with spaces, and tilde-based paths.
  * Added support for explicit HTTP, HTTPS, and file URLs with consistent classification and path handling.
  * Preserved original filesystem paths when pasting navigable URLs.

* **Bug Fixes**
  * Local paths are now correctly converted into file URLs, including paths containing spaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->