### PR TITLE
fix(ios): make transport recovery fast and seamless

### DIFF
--- a/Packages/Shared/CMUXMobileCore/Sources/CMUXMobileCore/DiagnosticEventCode.swift
+++ b/Packages/Shared/CMUXMobileCore/Sources/CMUXMobileCore/DiagnosticEventCode.swift
@@ -304,6 +304,43 @@ public enum DiagnosticEventCode: UInt16, Sendable, Codable, CaseIterable {
     /// A close carried a bounded remote reason token. `surface` is the peer
     /// alias, `a` is ``DiagnosticRemoteCloseReason``, and `c` is the session ID.
     case transportCloseReason = 79
+
+    // MARK: Recovery incident diagnostics
+
+    /// One recovery stage began. `a` is ``DiagnosticRecoveryStage`` and `c`
+    /// is the process-local recovery ID shared by the full incident.
+    case recoveryStageStarted = 80
+    /// One recovery stage ended. `a` is ``DiagnosticRecoveryStage``, `b` is
+    /// zero for success or ``DiagnosticFailureKind``, `ms` is stage duration,
+    /// and `c` is the recovery ID.
+    case recoveryStageCompleted = 81
+    /// The visible foreground snapshot survived a transport replacement. `a`
+    /// is retained workspace count, `b` is buffered terminal-input bytes, and
+    /// `c` is the recovery ID.
+    case recoverySnapshotRetained = 82
+}
+
+/// Stable stages within one foreground recovery incident.
+public enum DiagnosticRecoveryStage: Int, Sendable, Codable, CaseIterable {
+    case probe = 1
+    case detach = 2
+    case dial = 3
+    case validate = 4
+    case resume = 5
+}
+
+/// Stable reason that started one recovery incident.
+public enum DiagnosticRecoveryTrigger: Int, Sendable, Codable, CaseIterable {
+    case networkChange = 1
+    case manual = 2
+    case presencePush = 3
+    case foreground = 4
+    case liveness = 5
+    case eventStreamEnded = 6
+    case subscriptionStartFailed = 7
+    case transportWriteTimedOut = 8
+    case automaticBackoffExpired = 9
+    case connectionMethodChanged = 10
 }
 
 /// Scene phase carried by ``DiagnosticEventCode/appLifecycleChanged``.

--- a/Packages/Shared/CMUXMobileCore/Sources/CMUXMobileCore/DiagnosticEventPresentation.swift
+++ b/Packages/Shared/CMUXMobileCore/Sources/CMUXMobileCore/DiagnosticEventPresentation.swift
@@ -576,6 +576,12 @@ public struct DiagnosticEventPresentation: Sendable {
             return Field(key: "outcome", value: lanDiscoveryOutcomeName(raw))
         case .transportDialLegSucceeded, .transportDialLegFailed:
             return Field(key: "leg", value: dialLegName(raw))
+        case .transportDialSessionLinked:
+            return Field(key: "attempt", value: String(raw))
+        case .transportDialCancelled:
+            return Field(key: "cancellation", value: cancellationReasonName(raw))
+        case .transportCloseReason:
+            return Field(key: "reason", value: closeReasonName(raw))
         case .lanPublicationState:
             return Field(key: "state", value: lanPublicationStateName(raw))
         case .recoveryStageStarted, .recoveryStageCompleted:
@@ -669,12 +675,20 @@ public struct DiagnosticEventPresentation: Sendable {
             return Field(key: "relay_fleet", value: String(raw))
         case .transportDialStarted, .transportDialConnected, .transportDialFailed:
             return Field(key: "attempt", value: String(raw))
-        case .sessionClosed, .transportSessionLifecycle,
-             .transportCloseAttribution, .transportPathEvent:
+        case .transportDialSessionLinked:
             return Field(key: "session", value: String(raw))
-        case .recoveryStarted, .recoverySucceeded, .recoveryFailed,
-             .recoveryStageStarted, .recoveryStageCompleted,
+        case .transportDialCancelled:
+            return Field(key: "attempt", value: String(raw))
+        case .transportCloseReason:
+            return Field(key: "session", value: String(raw))
+        case .sessionClosed, .transportSessionLifecycle,
+             .transportCloseAttribution,
+             .transportPathEvent:
+            return Field(key: "session", value: String(raw))
+        case .recoveryStageStarted, .recoveryStageCompleted,
              .recoverySnapshotRetained:
+            return Field(key: "recovery", value: String(raw))
+        case .recoveryStarted, .recoverySucceeded, .recoveryFailed:
             return Field(key: "recovery", value: String(raw))
         case .composerActiveTransition:
             return Field(key: "terminal_input_focused", value: booleanName(raw))
@@ -1035,15 +1049,15 @@ public struct DiagnosticEventPresentation: Sendable {
         }
         switch stage {
         case .probe:
-            localized("diagnostics.recoveryStage.probe", defaultValue: "Probe current connection")
+            return localized("diagnostics.recoveryStage.probe", defaultValue: "Probe current connection")
         case .detach:
-            localized("diagnostics.recoveryStage.detach", defaultValue: "Detach failed transport")
+            return localized("diagnostics.recoveryStage.detach", defaultValue: "Detach failed transport")
         case .dial:
-            localized("diagnostics.recoveryStage.dial", defaultValue: "Dial replacement")
+            return localized("diagnostics.recoveryStage.dial", defaultValue: "Dial replacement")
         case .validate:
-            localized("diagnostics.recoveryStage.validate", defaultValue: "Validate session")
+            return localized("diagnostics.recoveryStage.validate", defaultValue: "Validate session")
         case .resume:
-            localized("diagnostics.recoveryStage.resume", defaultValue: "Resume workspace")
+            return localized("diagnostics.recoveryStage.resume", defaultValue: "Resume workspace")
         }
     }
 
@@ -1058,6 +1072,32 @@ public struct DiagnosticEventPresentation: Sendable {
                 "diagnostics.unknown.closeInitiator",
                 defaultValue: "Unknown close initiator (\(raw))"
             )
+        }
+    }
+
+    private func cancellationReasonName(_ raw: Int) -> String {
+        switch DiagnosticCancellationReason(rawValue: raw) {
+        case .unknown: localized("diagnostics.cancellation.unknown", defaultValue: "Unknown")
+        case .requestCancelled: localized("diagnostics.cancellation.requestCancelled", defaultValue: "Request cancelled")
+        case .requestTimedOut: localized("diagnostics.cancellation.requestTimedOut", defaultValue: "Request timed out")
+        case .sessionTeardown: localized("diagnostics.cancellation.sessionTeardown", defaultValue: "Session teardown")
+        case .sessionDeinitialized: localized("diagnostics.cancellation.sessionDeinitialized", defaultValue: "Session deinitialized")
+        case nil: localized("diagnostics.cancellation.unknown", defaultValue: "Unknown (\(raw))")
+        }
+    }
+
+    private func closeReasonName(_ raw: Int) -> String {
+        switch DiagnosticRemoteCloseReason(rawValue: raw) {
+        case .unknown: localized("diagnostics.closeReason.unknown", defaultValue: "Unknown")
+        case .clientClosed: localized("diagnostics.closeReason.clientClosed", defaultValue: "Client closed")
+        case .serverClosed: localized("diagnostics.closeReason.serverClosed", defaultValue: "Server closed")
+        case .superseded: localized("diagnostics.closeReason.superseded", defaultValue: "Superseded session")
+        case .admissionLeaseExpired: localized("diagnostics.closeReason.admissionLeaseExpired", defaultValue: "Admission lease expired")
+        case .admissionRevalidationFailed: localized("diagnostics.closeReason.admissionRevalidationFailed", defaultValue: "Admission revalidation failed")
+        case .sendQueueOverflow: localized("diagnostics.closeReason.sendQueueOverflow", defaultValue: "Send queue overflow")
+        case .serverFailure: localized("diagnostics.closeReason.serverFailure", defaultValue: "Server failure")
+        case .serverCancelled: localized("diagnostics.closeReason.serverCancelled", defaultValue: "Server cancelled")
+        case nil: localized("diagnostics.closeReason.unknown", defaultValue: "Unknown (\(raw))")
         }
     }
 

--- a/Packages/Shared/CMUXMobileCore/Sources/CMUXMobileCore/DiagnosticEventPresentation.swift
+++ b/Packages/Shared/CMUXMobileCore/Sources/CMUXMobileCore/DiagnosticEventPresentation.swift
@@ -74,6 +74,16 @@ public struct DiagnosticEventPresentation: Sendable {
         String(describing: phase)
     }
 
+    /// The stable machine name of a recovery stage.
+    public func name(_ stage: DiagnosticRecoveryStage) -> String {
+        String(describing: stage)
+    }
+
+    /// The stable machine name of a recovery trigger.
+    public func name(_ trigger: DiagnosticRecoveryTrigger) -> String {
+        String(describing: trigger)
+    }
+
     /// The stable machine name of an app-wide iOS feature event.
     public func name(_ kind: DiagnosticAppEventKind) -> String {
         String(describing: kind)
@@ -418,6 +428,12 @@ public struct DiagnosticEventPresentation: Sendable {
             localized("diagnostics.event.recoverySucceeded", defaultValue: "Connection recovery succeeded")
         case .recoveryFailed:
             localized("diagnostics.event.recoveryFailed", defaultValue: "Connection recovery failed")
+        case .recoveryStageStarted:
+            localized("diagnostics.event.recoveryStageStarted", defaultValue: "Recovery stage started")
+        case .recoveryStageCompleted:
+            localized("diagnostics.event.recoveryStageCompleted", defaultValue: "Recovery stage completed")
+        case .recoverySnapshotRetained:
+            localized("diagnostics.event.recoverySnapshotRetained", defaultValue: "Recovery snapshot retained")
         case .endpointStarting:
             localized("diagnostics.event.endpointStarting", defaultValue: "Iroh endpoint starting")
         case .endpointActive:
@@ -562,6 +578,10 @@ public struct DiagnosticEventPresentation: Sendable {
             return Field(key: "leg", value: dialLegName(raw))
         case .lanPublicationState:
             return Field(key: "state", value: lanPublicationStateName(raw))
+        case .recoveryStageStarted, .recoveryStageCompleted:
+            return Field(key: "stage", value: recoveryStageName(raw))
+        case .recoverySnapshotRetained:
+            return Field(key: "workspace_count", value: String(raw))
         default:
             return Field(key: "detail_1", value: String(raw))
         }
@@ -574,6 +594,12 @@ public struct DiagnosticEventPresentation: Sendable {
         switch code {
         case .recoveryStarted:
             return Field(key: "trigger", value: recoveryTriggerName(raw))
+        case .recoveryStageCompleted:
+            return raw == DiagnosticFailureKind.none.rawValue
+                ? Field(key: "outcome", value: localized("diagnostics.recoveryOutcome.succeeded", defaultValue: "Succeeded"))
+                : Field(key: "failure", value: failureName(raw))
+        case .recoverySnapshotRetained:
+            return Field(key: "buffered_input", value: byteCount(raw))
         case .transportSessionLifecycle:
             return Field(key: "purpose", value: sessionPurposeName(raw))
         case .transportPathEvent:
@@ -646,6 +672,10 @@ public struct DiagnosticEventPresentation: Sendable {
         case .sessionClosed, .transportSessionLifecycle,
              .transportCloseAttribution, .transportPathEvent:
             return Field(key: "session", value: String(raw))
+        case .recoveryStarted, .recoverySucceeded, .recoveryFailed,
+             .recoveryStageStarted, .recoveryStageCompleted,
+             .recoverySnapshotRetained:
+            return Field(key: "recovery", value: String(raw))
         case .composerActiveTransition:
             return Field(key: "terminal_input_focused", value: booleanName(raw))
         case .browserStreamLifecycle, .browserInputReplayed,
@@ -987,11 +1017,33 @@ public struct DiagnosticEventPresentation: Sendable {
         case 7: localized("diagnostics.recoveryTrigger.subscriptionFailed", defaultValue: "Subscription failed to start")
         case 8: localized("diagnostics.recoveryTrigger.writeTimedOut", defaultValue: "Transport write timed out")
         case 9: localized("diagnostics.recoveryTrigger.retryDelayExpired", defaultValue: "Automatic retry delay expired")
+        case 10: localized("diagnostics.recoveryTrigger.connectionMethodChanged", defaultValue: "Connection method changed")
         default:
             localized(
                 "diagnostics.unknown.recoveryTrigger",
                 defaultValue: "Unknown recovery trigger (\(raw))"
             )
+        }
+    }
+
+    private func recoveryStageName(_ raw: Int) -> String {
+        guard let stage = DiagnosticRecoveryStage(rawValue: raw) else {
+            return localized(
+                "diagnostics.unknown.recoveryStage",
+                defaultValue: "Unknown recovery stage (\(raw))"
+            )
+        }
+        switch stage {
+        case .probe:
+            localized("diagnostics.recoveryStage.probe", defaultValue: "Probe current connection")
+        case .detach:
+            localized("diagnostics.recoveryStage.detach", defaultValue: "Detach failed transport")
+        case .dial:
+            localized("diagnostics.recoveryStage.dial", defaultValue: "Dial replacement")
+        case .validate:
+            localized("diagnostics.recoveryStage.validate", defaultValue: "Validate session")
+        case .resume:
+            localized("diagnostics.recoveryStage.resume", defaultValue: "Resume workspace")
         }
     }
 

--- a/Packages/Shared/CMUXMobileCore/Sources/CMUXMobileCore/Resources/Localizable.xcstrings
+++ b/Packages/Shared/CMUXMobileCore/Sources/CMUXMobileCore/Resources/Localizable.xcstrings
@@ -803,6 +803,57 @@
         }
       }
     },
+    "diagnostics.event.recoverySnapshotRetained": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Recovery snapshot retained"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "復旧中もワークスペースを保持しました"
+          }
+        }
+      }
+    },
+    "diagnostics.event.recoveryStageCompleted": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Recovery stage completed"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "復旧ステージが完了しました"
+          }
+        }
+      }
+    },
+    "diagnostics.event.recoveryStageStarted": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Recovery stage started"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "復旧ステージを開始しました"
+          }
+        }
+      }
+    },
     "diagnostics.event.recoveryStarted": {
       "extractionState": "manual",
       "localizations": {
@@ -2947,6 +2998,48 @@
         }
       }
     },
+    "diagnostics.recoveryOutcome.succeeded": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": { "stringUnit": { "state": "translated", "value": "Succeeded" } },
+        "ja": { "stringUnit": { "state": "translated", "value": "成功" } }
+      }
+    },
+    "diagnostics.recoveryStage.detach": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": { "stringUnit": { "state": "translated", "value": "Detach failed transport" } },
+        "ja": { "stringUnit": { "state": "translated", "value": "障害が発生したトランスポートを切り離す" } }
+      }
+    },
+    "diagnostics.recoveryStage.dial": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": { "stringUnit": { "state": "translated", "value": "Dial replacement" } },
+        "ja": { "stringUnit": { "state": "translated", "value": "代替接続を開始" } }
+      }
+    },
+    "diagnostics.recoveryStage.probe": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": { "stringUnit": { "state": "translated", "value": "Probe current connection" } },
+        "ja": { "stringUnit": { "state": "translated", "value": "現在の接続を確認" } }
+      }
+    },
+    "diagnostics.recoveryStage.resume": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": { "stringUnit": { "state": "translated", "value": "Resume workspace" } },
+        "ja": { "stringUnit": { "state": "translated", "value": "ワークスペースを再開" } }
+      }
+    },
+    "diagnostics.recoveryStage.validate": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": { "stringUnit": { "state": "translated", "value": "Validate session" } },
+        "ja": { "stringUnit": { "state": "translated", "value": "セッションを検証" } }
+      }
+    },
     "diagnostics.recoveryTrigger.foreground": {
       "extractionState": "manual",
       "localizations": {
@@ -3948,6 +4041,13 @@
             "value": "不明な結合状態（%lld）"
           }
         }
+      }
+    },
+    "diagnostics.unknown.recoveryStage": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": { "stringUnit": { "state": "translated", "value": "Unknown recovery stage (%lld)" } },
+        "ja": { "stringUnit": { "state": "translated", "value": "不明な復旧ステージ（%lld）" } }
       }
     },
     "diagnostics.unknown.recoveryTrigger": {

--- a/Packages/Shared/CMUXMobileCore/Tests/CMUXMobileCoreTests/DiagnosticEventPresentationTests.swift
+++ b/Packages/Shared/CMUXMobileCore/Tests/CMUXMobileCoreTests/DiagnosticEventPresentationTests.swift
@@ -125,13 +125,13 @@ import Testing
             tNanos: 1,
             a: DiagnosticTransportKind.iroh.rawValue,
             b: DiagnosticRecoveryTrigger.networkChange.rawValue,
-            c: 7
+            surface: 7
         )
 
         #expect(englishPresentation.describe(event).fields == [
+            .init(key: "recovery", value: "7"),
             .init(key: "transport", value: "Iroh"),
             .init(key: "trigger", value: "Network changed"),
-            .init(key: "recovery", value: "7"),
         ])
     }
 
@@ -272,6 +272,9 @@ import Testing
             .recoveryStarted: "Connection recovery started",
             .recoverySucceeded: "Connection recovery succeeded",
             .recoveryFailed: "Connection recovery failed",
+            .recoveryStageStarted: "Recovery stage started",
+            .recoveryStageCompleted: "Recovery stage completed",
+            .recoverySnapshotRetained: "Recovery snapshot retained",
             .endpointStarting: "Iroh endpoint starting",
             .endpointActive: "Iroh endpoint active",
             .endpointStopped: "Iroh endpoint stopped",

--- a/Packages/Shared/CMUXMobileCore/Tests/CMUXMobileCoreTests/DiagnosticEventPresentationTests.swift
+++ b/Packages/Shared/CMUXMobileCore/Tests/CMUXMobileCoreTests/DiagnosticEventPresentationTests.swift
@@ -117,6 +117,27 @@ import Testing
         ))
     }
 
+    @Test func recoveryStagesExposeCorrelationAndTiming() {
+        let event = DiagnosticEvent(
+            code: .recoveryStageCompleted,
+            tNanos: 1,
+            ms: 237,
+            a: DiagnosticRecoveryStage.dial.rawValue,
+            b: DiagnosticFailureKind.none.rawValue,
+            c: 19
+        )
+
+        #expect(englishPresentation.describe(event) == .init(
+            name: "Recovery stage completed",
+            fields: [
+                .init(key: "stage", value: "Dial replacement"),
+                .init(key: "outcome", value: "Succeeded"),
+                .init(key: "duration", value: "237 ms"),
+                .init(key: "recovery", value: "19"),
+            ]
+        ))
+    }
+
     @Test func describesDialFailure() {
         let event = DiagnosticEvent(
             code: .transportDialFailed,

--- a/Packages/Shared/CMUXMobileCore/Tests/CMUXMobileCoreTests/DiagnosticEventPresentationTests.swift
+++ b/Packages/Shared/CMUXMobileCore/Tests/CMUXMobileCoreTests/DiagnosticEventPresentationTests.swift
@@ -48,7 +48,7 @@ import Testing
                 c: 1
             )
         )
-        #expect(plan.name == "Transport dial plan built")
+        #expect(plan.name == "Direct dial plan assembled")
         #expect(plan.fields == [
             .init(key: "public_paths", value: "2"),
             .init(key: "private_fallback_paths", value: "0"),
@@ -77,7 +77,7 @@ import Testing
             b: 2,
             c: 0
         ))
-        #expect(join.name == "Private address candidate joined")
+        #expect(join.name == "Private addresses joined broker port")
         #expect(join.fields.contains(
             .init(key: "join", value: "Broker ports missing or stale")
         ))
@@ -91,7 +91,7 @@ import Testing
             a: DiagnosticLANDiscoveryOutcome.policyDenied.rawValue,
             b: 0
         ))
-        #expect(lan.name == "LAN discovery completed")
+        #expect(lan.name == "LAN discovery resolved")
         #expect(lan.fields.contains(
             .init(key: "outcome", value: "Local Network permission denied")
         ))
@@ -113,7 +113,7 @@ import Testing
             a: DiagnosticLANPublicationState.policyDenied.rawValue,
             b: 0
         ))
-        #expect(publication.name == "LAN publication state changed")
+        #expect(publication.name == "LAN advertisement state changed")
         #expect(publication.fields.contains(
             .init(key: "state", value: "Local Network permission denied")
         ))
@@ -123,9 +123,9 @@ import Testing
         let event = DiagnosticEvent(
             code: .recoveryStarted,
             tNanos: 1,
+            surface: 7,
             a: DiagnosticTransportKind.iroh.rawValue,
-            b: DiagnosticRecoveryTrigger.networkChange.rawValue,
-            surface: 7
+            b: DiagnosticRecoveryTrigger.networkChange.rawValue
         )
 
         #expect(englishPresentation.describe(event).fields == [
@@ -211,8 +211,8 @@ import Testing
             .init(key: "session", value: "9"),
         ])
         let closeSummary = englishPresentation.summary(close)
-        #expect(closeSummary.contains("Session"))
-        #expect(closeSummary.contains("9"))
+        #expect(closeSummary.contains("Application error code"))
+        #expect(!closeSummary.contains("Session"))
     }
 
     @Test func describesLifecycleAndReachability() {
@@ -302,12 +302,12 @@ import Testing
             .browserInputReplayed: "Browser input replayed",
             .browserEditableFocus: "Browser editable focus",
             .browserPanelCreateResolved: "Browser panel create resolved",
-            .transportDialPlanBuilt: "Transport dial plan built",
-            .transportPrivateAddressJoin: "Private address candidate joined",
-            .transportLANDiscovery: "LAN discovery completed",
-            .transportDialLegSucceeded: "Direct dial leg succeeded",
+            .transportDialPlanBuilt: "Direct dial plan assembled",
+            .transportPrivateAddressJoin: "Private addresses joined broker port",
+            .transportLANDiscovery: "LAN discovery resolved",
+            .transportDialLegSucceeded: "Direct dial leg connected",
             .transportDialLegFailed: "Direct dial leg failed",
-            .lanPublicationState: "LAN publication state changed",
+            .lanPublicationState: "LAN advertisement state changed",
             .transportDialSessionLinked: "Transport dial linked to session",
             .transportDialCancelled: "Transport dial cancelled",
             .transportCloseReason: "Remote close reason",
@@ -351,7 +351,7 @@ import Testing
         #expect(recoveryWithContext.fields == [
             .init(key: "recovery", value: "77"),
             .init(key: "transport", value: "Iroh"),
-            .init(key: "peer", value: "12"),
+            .init(key: "recovery", value: "12"),
         ])
 
         let linked = englishPresentation.describe(DiagnosticEvent(

--- a/Packages/Shared/CMUXMobileCore/Tests/CMUXMobileCoreTests/DiagnosticEventPresentationTests.swift
+++ b/Packages/Shared/CMUXMobileCore/Tests/CMUXMobileCoreTests/DiagnosticEventPresentationTests.swift
@@ -34,6 +34,8 @@ import Testing
         #expect(DiagnosticEventPresentation().name(DiagnosticSimulatorHardwareButtonKind.appSwitcher) == "appSwitcher")
         #expect(DiagnosticEventPresentation().name(DiagnosticSimulatorOwnershipState.otherConnection) == "otherConnection")
         #expect(DiagnosticEventPresentation().name(DiagnosticSimulatorCoordinateState.outsideImage) == "outsideImage")
+        #expect(DiagnosticEventPresentation().name(DiagnosticRecoveryStage.dial) == "dial")
+        #expect(DiagnosticEventPresentation().name(DiagnosticRecoveryTrigger.liveness) == "liveness")
     }
 
     @Test func describesDirectDialBootstrapTrace() {
@@ -115,6 +117,22 @@ import Testing
         #expect(publication.fields.contains(
             .init(key: "state", value: "Local Network permission denied")
         ))
+    }
+
+    @Test func recoveryStartNamesItsCauseAndCorrelationID() {
+        let event = DiagnosticEvent(
+            code: .recoveryStarted,
+            tNanos: 1,
+            a: DiagnosticTransportKind.iroh.rawValue,
+            b: DiagnosticRecoveryTrigger.networkChange.rawValue,
+            c: 7
+        )
+
+        #expect(englishPresentation.describe(event).fields == [
+            .init(key: "transport", value: "Iroh"),
+            .init(key: "trigger", value: "Network changed"),
+            .init(key: "recovery", value: "7"),
+        ])
     }
 
     @Test func recoveryStagesExposeCorrelationAndTiming() {

--- a/Packages/iOS/CmuxMobileRPC/Sources/CmuxMobileRPC/MobileSyncRuntime.swift
+++ b/Packages/iOS/CmuxMobileRPC/Sources/CmuxMobileRPC/MobileSyncRuntime.swift
@@ -61,6 +61,11 @@ public protocol MobileSyncRuntime: Sendable {
     /// and settled as timed out so the automatic backoff retry loop keeps
     /// running.
     var reconnectAttemptDeadlineNanoseconds: UInt64 { get }
+
+    /// Foreground recovery has a tighter product deadline than cold-start
+    /// restoration. The retained workspace stays mounted if this deadline is
+    /// missed, and the automatic retry owner can try again without blocking UI.
+    var foregroundRecoveryDeadlineNanoseconds: UInt64 { get }
 }
 
 public extension MobileSyncRuntime {
@@ -77,13 +82,17 @@ public extension MobileSyncRuntime {
     /// request timeout, but the sheet must not spin through stacked route waits.
     var pairingAttemptTimeoutNanoseconds: UInt64 { 8_000_000_000 }
 
-    /// Default probe deadline: generous against a momentarily loaded Mac,
-    /// while keeping dead-stream recovery within a few seconds of the silence
-    /// threshold instead of the full ``rpcRequestTimeoutNanoseconds``.
-    var livenessProbeTimeoutNanoseconds: UInt64 { 3_000_000_000 }
+    /// Foreground liveness is a small control RPC. A response slower than this
+    /// cannot satisfy the interactive recovery budget and is treated as a dead
+    /// generation while the old workspace remains visible.
+    var livenessProbeTimeoutNanoseconds: UInt64 { 750_000_000 }
 
     /// Default reconnect-attempt ceiling: comfortably above a slow relay dial
     /// (transport connects bound themselves near 15s) while turning a hung
     /// dial into a settled, retryable failure within half a minute.
     var reconnectAttemptDeadlineNanoseconds: UInt64 { 30_000_000_000 }
+
+    /// Recovery is bounded at three seconds end to end. Cold-start restoration
+    /// retains the wider deadline above because no usable workspace exists yet.
+    var foregroundRecoveryDeadlineNanoseconds: UInt64 { 3_000_000_000 }
 }

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileConnectionRecoveryOwner.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileConnectionRecoveryOwner.swift
@@ -11,6 +11,7 @@ import Foundation
 final class MobileConnectionRecoveryOwner {
     struct Attempt: Equatable {
         let id: UUID
+        let startedUptimeNanoseconds: UInt64
         let trigger: String
         let sourceConnectionGeneration: UUID
 
@@ -30,6 +31,7 @@ final class MobileConnectionRecoveryOwner {
 
     private(set) var phase: Phase = .idle
     private(set) var task: Task<Void, Never>?
+    private(set) var validationStartedUptimeNanoseconds: UInt64?
 
     var activeAttempt: Attempt? {
         switch phase {
@@ -72,8 +74,7 @@ final class MobileConnectionRecoveryOwner {
         guard !isActive else { return nil }
         task?.cancel()
         task = nil
-        let attempt = Attempt(
-            id: UUID(),
+        let attempt = makeAttempt(
             trigger: trigger,
             sourceConnectionGeneration: sourceConnectionGeneration
         )
@@ -90,8 +91,7 @@ final class MobileConnectionRecoveryOwner {
         guard case .probing = phase else { return nil }
         task?.cancel()
         task = nil
-        let attempt = Attempt(
-            id: UUID(),
+        let attempt = makeAttempt(
             trigger: trigger,
             sourceConnectionGeneration: sourceConnectionGeneration
         )
@@ -137,27 +137,31 @@ final class MobileConnectionRecoveryOwner {
             attempt,
             connectionGeneration: connectionGeneration
         )
+        validationStartedUptimeNanoseconds = DispatchTime.now().uptimeNanoseconds
         return true
     }
 
     func complete(_ attempt: Attempt) -> Bool {
         guard isCurrent(attempt) else { return false }
         phase = .idle
+        validationStartedUptimeNanoseconds = nil
         return true
     }
 
-    func completeValidation(connectionGeneration: UUID) -> Bool {
-        guard case .validatingReplacement(_, let expectedGeneration) = phase,
+    func completeValidation(connectionGeneration: UUID) -> Attempt? {
+        guard case .validatingReplacement(let attempt, let expectedGeneration) = phase,
               expectedGeneration == connectionGeneration else {
-            return false
+            return nil
         }
         phase = .idle
-        return true
+        validationStartedUptimeNanoseconds = nil
+        return attempt
     }
 
     func fail(_ attempt: Attempt) -> Bool {
         guard isCurrent(attempt) else { return false }
         phase = .failed(attempt)
+        validationStartedUptimeNanoseconds = nil
         return true
     }
 
@@ -172,6 +176,7 @@ final class MobileConnectionRecoveryOwner {
         task?.cancel()
         task = nil
         phase = .failed(attempt)
+        validationStartedUptimeNanoseconds = nil
         return attempt
     }
 
@@ -194,5 +199,18 @@ final class MobileConnectionRecoveryOwner {
         task?.cancel()
         task = nil
         phase = .idle
+        validationStartedUptimeNanoseconds = nil
+    }
+
+    private func makeAttempt(
+        trigger: String,
+        sourceConnectionGeneration: UUID
+    ) -> Attempt {
+        return Attempt(
+            id: UUID(),
+            startedUptimeNanoseconds: DispatchTime.now().uptimeNanoseconds,
+            trigger: trigger,
+            sourceConnectionGeneration: sourceConnectionGeneration
+        )
     }
 }

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+ConnectionRecovery.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+ConnectionRecovery.swift
@@ -170,7 +170,7 @@ extension MobileShellComposite {
             guard failConnectionRecoveryReplacement(failure: .connectionClosed) else { return }
             connectionState = .disconnected
             macConnectionStatus = .unavailable
-            clearRemoteConnectionContext()
+            clearFailedReconnectContext(preservingForegroundPresentation: true)
             applyConnectionRecoveryOwnerState()
             return
         }
@@ -661,7 +661,7 @@ extension MobileShellComposite {
             if disconnectForAuthorizationFailureIfNeeded(error) { return }
             connectionState = .disconnected
             macConnectionStatus = .unavailable
-            clearRemoteConnectionContext()
+            clearFailedReconnectContext()
         }
     }
 
@@ -796,36 +796,58 @@ extension MobileShellComposite {
             ) != nil
         }
         if firstRoute.kind == .iroh || hasAuthorizedLegacyTailscaleRoute {
-            do {
-                let ticket = try Self.storedMacTicket(
-                    name: name,
-                    routes: pinnedRoutes,
-                    pairedMacDeviceID: pairedMacDeviceID
-                )
-                let noThrowFailure = try await connect(
-                    ticket: ticket,
-                    legacyTailscaleRoutes: legacyTailscaleRoutes,
-                    pairedMacDeviceID: pairedMacDeviceID,
-                    instanceTagExpectation: instanceTagExpectation,
-                    ifStillCurrent: ifStillCurrent
-                )
-                guard ifStillCurrent?() ?? true else { return .superseded }
-                if noThrowFailure == .noSupportedRoute {
-                    outcome = .failed(.unsupportedRoute)
-                }
-            } catch {
-                guard ifStillCurrent?() ?? true else { return .superseded }
-                outcome = .failed(Self.diagnosticFailureKind(for: error))
-                if let automaticReconnectAccountID {
-                    recordAutomaticReconnectBackoff(
-                        error: error,
-                        accountID: automaticReconnectAccountID
+            var remainingFreshDiscoveryRedials = firstRoute.kind == .iroh ? 1 : 0
+            while true {
+                do {
+                    let ticket = try Self.storedMacTicket(
+                        name: name,
+                        routes: pinnedRoutes,
+                        pairedMacDeviceID: pairedMacDeviceID
                     )
-                }
-                if !disconnectForAuthorizationFailureIfNeeded(error) {
-                    connectionState = .disconnected
-                    macConnectionStatus = .unavailable
-                    clearRemoteConnectionContext()
+                    let noThrowFailure = try await connect(
+                        ticket: ticket,
+                        legacyTailscaleRoutes: legacyTailscaleRoutes,
+                        pairedMacDeviceID: pairedMacDeviceID,
+                        instanceTagExpectation: instanceTagExpectation,
+                        ifStillCurrent: ifStillCurrent
+                    )
+                    guard ifStillCurrent?() ?? true else { return .superseded }
+                    if noThrowFailure == .noSupportedRoute {
+                        outcome = .failed(.unsupportedRoute)
+                    }
+                    break
+                } catch {
+                    guard ifStillCurrent?() ?? true else { return .superseded }
+                    let failure = Self.diagnosticFailureKind(for: error)
+                    if remainingFreshDiscoveryRedials > 0,
+                       Self.routeFailureIndicatesStaleDiscovery(failure) {
+                        remainingFreshDiscoveryRedials -= 1
+                        diagnosticLog?.record(DiagnosticEvent(
+                            .retryScheduled,
+                            ms: 0,
+                            a: DiagnosticTransportKind.iroh.rawValue,
+                            b: failure.rawValue
+                        ))
+                        MobileDebugLog.anchormux(
+                            "storedMacReconnect immediate fresh-discovery redial "
+                                + "mac=\(DiagnosticCorrelation().handle(for: pairedMacDeviceID)) "
+                                + "failure=\(failure.rawValue)"
+                        )
+                        continue
+                    }
+                    outcome = .failed(failure)
+                    if let automaticReconnectAccountID {
+                        recordAutomaticReconnectBackoff(
+                            error: error,
+                            accountID: automaticReconnectAccountID
+                        )
+                    }
+                    if !disconnectForAuthorizationFailureIfNeeded(error) {
+                        connectionState = .disconnected
+                        macConnectionStatus = .unavailable
+                        clearFailedReconnectContext()
+                    }
+                    break
                 }
             }
         } else {

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+ConnectionRecovery.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+ConnectionRecovery.swift
@@ -252,6 +252,9 @@ extension MobileShellComposite {
             b: trigger.diagnosticCode,
             c: activePeerDiagnosticAlias.map(Int.init)
         ))
+        MobileDebugLog.anchormux(
+            "connection.recovery started recoveryID=\(attempt.diagnosticID) trigger=\(trigger.description) generation=\(attempt.sourceConnectionGeneration.uuidString)"
+        )
         applyConnectionRecoveryOwnerState()
         let stackUserID = lastReconnectStackUserID ?? identityProvider?.currentUserID
 
@@ -262,6 +265,7 @@ extension MobileShellComposite {
                 guard self.connectionRecoveryOwner.isCurrent(attempt) else { return }
 
                 if probeCurrentConnection, let expectedClient {
+                    let probeStartedAt = self.recordRecoveryStageStarted(.probe, attempt: attempt)
                     let epochAtProbeStart = self.foregroundResumeEpoch
                     let healthy = await self.reloadWorkspaceListFromMac(
                         timeoutNanoseconds: self.runtime?.livenessProbeTimeoutNanoseconds
@@ -272,6 +276,12 @@ extension MobileShellComposite {
                           self.connectionGeneration == attempt.sourceConnectionGeneration else {
                         return
                     }
+                    self.recordRecoveryStageCompleted(
+                        .probe,
+                        attempt: attempt,
+                        startedAt: probeStartedAt,
+                        failure: healthy ? .none : .timedOut
+                    )
                     if healthy {
                         guard self.completeConnectionRecovery(attempt) else { return }
                         self.markMacConnectionHealthy()
@@ -314,26 +324,41 @@ extension MobileShellComposite {
                     // tracked producer and makes untracked producers fail their
                     // identity guard, so they cannot reopen the old endpoint
                     // while the fresh stored-Mac dial starts.
-                    self.connectionState = .disconnected
-                    self.macConnectionStatus = .unavailable
-                    self.clearRemoteConnectionContext()
+                    self.macConnectionStatus = .reconnecting
+                    self.connectionRecoveryPhase = .recovering
+                    let detachStartedAt = self.recordRecoveryStageStarted(.detach, attempt: attempt)
+                    let detachedClient = self.clearRemoteConnectionContext(
+                        preservingOtherMacWorkspaceState: true,
+                        preservingForegroundPresentation: true,
+                        disconnectRemoteClientInBackground: false
+                    )
+                    self.diagnosticLog?.record(DiagnosticEvent(
+                        .recoverySnapshotRetained,
+                        a: self.retainedRecoveryWorkspaceCount,
+                        b: self.pendingRecoveryTerminalInputByteCount,
+                        c: Int(attempt.diagnosticID)
+                    ))
                     self.applyConnectionRecoveryOwnerState()
                     MobileDebugLog.anchormux(
-                        "connection.recovery waiting for physical transport drain "
+                        "connection.recovery registering asynchronous transport cleanup "
                             + "attempt=\(attempt.id.uuidString)"
                     )
-                    await expectedClient.disconnectAndWaitForTransportDrain()
+                    await detachedClient?.disconnect()
                     guard !Task.isCancelled,
                           self.connectionRecoveryOwner.isCurrent(attempt) else { return }
                     MobileDebugLog.anchormux(
-                        "connection.recovery physical transport drained "
+                        "connection.recovery transport cleanup registered "
                             + "attempt=\(attempt.id.uuidString)"
                     )
+                    self.recordRecoveryStageCompleted(.detach, attempt: attempt, startedAt: detachStartedAt)
                 }
-                if self.connectionState == .connected {
-                    self.connectionState = .disconnected
-                    self.macConnectionStatus = .unavailable
-                    self.clearRemoteConnectionContext()
+                if self.connectionState == .connected, self.remoteClient != nil {
+                    self.macConnectionStatus = .reconnecting
+                    self.connectionRecoveryPhase = .recovering
+                    self.clearRemoteConnectionContext(
+                        preservingOtherMacWorkspaceState: true,
+                        preservingForegroundPresentation: true
+                    )
                 }
                 self.applyConnectionRecoveryOwnerState()
 
@@ -343,12 +368,27 @@ extension MobileShellComposite {
                 // shared reconnect entry owns the hard deadline after claiming
                 // its generation synchronously, so every lifecycle caller gets
                 // the same wedge protection without a second race here.
+                let dialStartedAt = self.recordRecoveryStageStarted(.dial, attempt: attempt)
                 let reconnectOutcome = await self.reconnectActiveMacOutcome(
                     stackUserID: stackUserID,
-                    refreshBackupBeforeDial: false
+                    refreshBackupBeforeDial: false,
+                    force: true,
+                    deadlineNanoseconds: self.runtime?.foregroundRecoveryDeadlineNanoseconds
+                        ?? 3_000_000_000
                 )
                 guard !Task.isCancelled,
                       self.connectionRecoveryOwner.isCurrent(attempt) else { return }
+                let dialFailure: DiagnosticFailureKind = switch reconnectOutcome {
+                case .connected: .none
+                case .failed(let failure): failure
+                case .superseded: .superseded
+                }
+                self.recordRecoveryStageCompleted(
+                    .dial,
+                    attempt: attempt,
+                    startedAt: dialStartedAt,
+                    failure: dialFailure
+                )
                 guard self.settleConnectionRecovery(
                     attempt,
                     outcome: reconnectOutcome,
@@ -382,10 +422,14 @@ extension MobileShellComposite {
             == connectionGeneration {
             return completeConnectionRecovery(attempt)
         }
-        return connectionRecoveryOwner.transitionToValidation(
+        let transitioned = connectionRecoveryOwner.transitionToValidation(
             attempt,
             connectionGeneration: connectionGeneration
         )
+        if transitioned {
+            _ = recordRecoveryStageStarted(.validate, attempt: attempt)
+        }
+        return transitioned
     }
 
     @discardableResult
@@ -429,27 +473,37 @@ extension MobileShellComposite {
     private func recordConnectionRecoverySucceeded(
         _ attempt: MobileConnectionRecoveryOwner.Attempt
     ) {
+        let elapsed = Self.recoveryElapsedMilliseconds(since: attempt.startedUptimeNanoseconds)
         diagnosticLog?.record(DiagnosticEvent(
             .recoverySucceeded,
             surface: attempt.diagnosticID,
+            ms: elapsed,
             a: activeRoute.map { DiagnosticTransportKind($0.kind).rawValue }
                 ?? DiagnosticTransportKind.unknown.rawValue,
             c: activePeerDiagnosticAlias.map(Int.init)
         ))
+        MobileDebugLog.anchormux(
+            "connection.recovery succeeded recoveryID=\(attempt.diagnosticID) elapsedMs=\(elapsed)"
+        )
     }
 
     private func recordConnectionRecoveryFailed(
         _ attempt: MobileConnectionRecoveryOwner.Attempt,
         failure: DiagnosticFailureKind
     ) {
+        let elapsed = Self.recoveryElapsedMilliseconds(since: attempt.startedUptimeNanoseconds)
         diagnosticLog?.record(DiagnosticEvent(
             .recoveryFailed,
             surface: attempt.diagnosticID,
+            ms: elapsed,
             a: activeRoute.map { DiagnosticTransportKind($0.kind).rawValue }
                 ?? DiagnosticTransportKind.unknown.rawValue,
             b: failure.rawValue,
             c: activePeerDiagnosticAlias.map(Int.init)
         ))
+        MobileDebugLog.anchormux(
+            "connection.recovery failed recoveryID=\(attempt.diagnosticID) failure=\(failure.rawValue) elapsedMs=\(elapsed)"
+        )
     }
 
     /// A peer alias is stable for this process but never exports the Mac ID.
@@ -468,20 +522,71 @@ extension MobileShellComposite {
                 connectionGeneration: connectionGeneration,
                 listenerID: listenerID
             )
-        let attempt = connectionRecoveryOwner.activeAttempt
-        if connectionRecoveryOwner.completeValidation(connectionGeneration: connectionGeneration),
-           let attempt {
+        let validationStartedAt = connectionRecoveryOwner.validationStartedUptimeNanoseconds
+        if let attempt = connectionRecoveryOwner.completeValidation(
+            connectionGeneration: connectionGeneration
+        ) {
+            recordRecoveryStageCompleted(
+                .validate,
+                attempt: attempt,
+                startedAt: validationStartedAt ?? attempt.startedUptimeNanoseconds
+            )
+            let resumeStartedAt = recordRecoveryStageStarted(.resume, attempt: attempt)
+            recordRecoveryStageCompleted(.resume, attempt: attempt, startedAt: resumeStartedAt)
             recordConnectionRecoverySucceeded(attempt)
             applyConnectionRecoveryOwnerState()
         }
     }
 
+    @discardableResult
+    private func recordRecoveryStageStarted(
+        _ stage: DiagnosticRecoveryStage,
+        attempt: MobileConnectionRecoveryOwner.Attempt
+    ) -> UInt64 {
+        let startedAt = DispatchTime.now().uptimeNanoseconds
+        diagnosticLog?.record(DiagnosticEvent(
+            .recoveryStageStarted,
+            a: stage.rawValue,
+            c: Int(attempt.diagnosticID)
+        ))
+        MobileDebugLog.anchormux(
+            "connection.recovery stage_started recoveryID=\(attempt.diagnosticID) stage=\(stage.rawValue)"
+        )
+        return startedAt
+    }
+
+    private func recordRecoveryStageCompleted(
+        _ stage: DiagnosticRecoveryStage,
+        attempt: MobileConnectionRecoveryOwner.Attempt,
+        startedAt: UInt64,
+        failure: DiagnosticFailureKind = .none
+    ) {
+        let elapsed = Self.recoveryElapsedMilliseconds(since: startedAt)
+        diagnosticLog?.record(DiagnosticEvent(
+            .recoveryStageCompleted,
+            ms: elapsed,
+            a: stage.rawValue,
+            b: failure.rawValue,
+            c: Int(attempt.diagnosticID)
+        ))
+        MobileDebugLog.anchormux(
+            "connection.recovery stage_completed recoveryID=\(attempt.diagnosticID) stage=\(stage.rawValue) failure=\(failure.rawValue) elapsedMs=\(elapsed)"
+        )
+    }
+
+    private static func recoveryElapsedMilliseconds(since startedAt: UInt64) -> UInt32 {
+        let now = DispatchTime.now().uptimeNanoseconds
+        return UInt32(clamping: (now >= startedAt ? now - startedAt : 0) / 1_000_000)
+    }
+
     func applyConnectionRecoveryOwnerState() {
         switch connectionRecoveryOwner.phase {
         case .idle:
+            connectionRecoveryPhase = .idle
             isRecoveringConnection = false
             connectionRecoveryFailed = false
         case .probing:
+            connectionRecoveryPhase = .probing
             // A probe is a background health check on a connection still
             // believed healthy: the terminal stays interactive and the visible
             // status untouched. Only an actual redial may surface reconnecting
@@ -489,10 +594,12 @@ extension MobileShellComposite {
             isRecoveringConnection = false
             connectionRecoveryFailed = false
         case .redialing, .validatingReplacement:
+            connectionRecoveryPhase = .recovering
             isRecoveringConnection = true
             connectionRecoveryFailed = false
             if connectionState == .connected { markMacConnectionReconnecting() }
         case .failed:
+            connectionRecoveryPhase = .failed
             isRecoveringConnection = false
             connectionRecoveryFailed = true
         }

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+ConnectionRecovery.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+ConnectionRecovery.swift
@@ -250,7 +250,7 @@ extension MobileShellComposite {
             a: activeRoute.map { DiagnosticTransportKind($0.kind).rawValue }
                 ?? DiagnosticTransportKind.unknown.rawValue,
             b: trigger.diagnosticCode,
-            c: activePeerDiagnosticAlias.map(Int.init)
+            c: Int(attempt.diagnosticID)
         ))
         MobileDebugLog.anchormux(
             "connection.recovery started recoveryID=\(attempt.diagnosticID) trigger=\(trigger.description) generation=\(attempt.sourceConnectionGeneration.uuidString)"
@@ -480,7 +480,7 @@ extension MobileShellComposite {
             ms: elapsed,
             a: activeRoute.map { DiagnosticTransportKind($0.kind).rawValue }
                 ?? DiagnosticTransportKind.unknown.rawValue,
-            c: activePeerDiagnosticAlias.map(Int.init)
+            c: Int(attempt.diagnosticID)
         ))
         MobileDebugLog.anchormux(
             "connection.recovery succeeded recoveryID=\(attempt.diagnosticID) elapsedMs=\(elapsed)"
@@ -499,7 +499,7 @@ extension MobileShellComposite {
             a: activeRoute.map { DiagnosticTransportKind($0.kind).rawValue }
                 ?? DiagnosticTransportKind.unknown.rawValue,
             b: failure.rawValue,
-            c: activePeerDiagnosticAlias.map(Int.init)
+            c: Int(attempt.diagnosticID)
         ))
         MobileDebugLog.anchormux(
             "connection.recovery failed recoveryID=\(attempt.diagnosticID) failure=\(failure.rawValue) elapsedMs=\(elapsed)"

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+ConnectionRecovery.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+ConnectionRecovery.swift
@@ -820,6 +820,7 @@ extension MobileShellComposite {
                     guard ifStillCurrent?() ?? true else { return .superseded }
                     let failure = Self.diagnosticFailureKind(for: error)
                     if remainingFreshDiscoveryRedials > 0,
+                       connectionMethodStore?.method != .tailscale,
                        Self.routeFailureIndicatesStaleDiscovery(failure) {
                         remainingFreshDiscoveryRedials -= 1
                         diagnosticLog?.record(DiagnosticEvent(

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+TerminalViewport.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+TerminalViewport.swift
@@ -58,11 +58,7 @@ extension MobileShellComposite {
         return await updatePreparedTerminalViewport(preparation)
     }
 
-    /// Commit the viewport locally before output registration starts.
-    ///
-    /// Registering an output sink immediately requests a cold replay. Its
-    /// request snapshots this cache and generation synchronously, so the Mac
-    /// can apply the current phone grid before capturing replay rows.
+    /// Commit the viewport locally before its asynchronous RPC starts.
     public func prepareTerminalViewport(
         surfaceID: String,
         columns: Int,

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
@@ -148,24 +148,18 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
     static let phonePushSettingsCapability = "phone_push.settings.v1"
     static let phonePushTestCapability = "phone_push.test.v1"
     nonisolated private static let terminalOutputCapabilityTimeoutNanoseconds: UInt64 = 750_000_000
-    /// How long the render-grid stream may stay silent (no event of any topic)
-    /// before the liveness watchdog suspects the push subscription is dead and
-    /// runs a bounded host probe; only repeated failed probes force the
-    /// re-subscribe + replay (silence alone is the normal state of an idle
-    /// terminal). Picked at the low end of the acceptable 8-12s window so a
-    /// wedged stream recovers in a few seconds instead of the transport's ~85s
-    /// timeout, while staying well above any normal inter-event gap on a busy
-    /// shell.
-    static let renderGridLivenessSilenceThreshold: TimeInterval = 9
-    /// A single timed-out probe is ambiguous during Iroh path migration, app
-    /// resume, or a short Mac stall. Require independent confirmation before
-    /// replacing a session that may still be healthy.
-    static let renderGridLivenessFailuresBeforeRecovery = 2
+    /// A silent foreground stream gets a bounded positive health check quickly.
+    /// Healthy idle terminals remain connected because silence alone never
+    /// tears down a session.
+    static let renderGridLivenessSilenceThreshold: TimeInterval = 1
+    /// One failed positive probe establishes that the current generation is
+    /// unusable. A second timeout only extends visible interruption.
+    static let renderGridLivenessFailuresBeforeRecovery = 1
     /// Cadence of the liveness watchdog tick. It only reads a timestamp and
     /// compares against the threshold, so a short interval is cheap; it does not
     /// reschedule per received event (an actively-streaming connection just keeps
     /// failing the silence check because `lastTerminalEventAt` stays fresh).
-    private static let renderGridLivenessCheckInterval: TimeInterval = 2.5
+    private static let renderGridLivenessCheckInterval: TimeInterval = 0.25
     /// An input ACK only reasserts the event subscription after this long
     /// without an event, preserving lost-registration recovery without adding a
     /// control-lane round trip to healthy continuous typing.
@@ -264,6 +258,9 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
             recomputeNotificationFeedItems()
         }
     }
+    /// Transport replacement state, independent of whether the workspace shell
+    /// remains mounted and usable from its retained snapshot.
+    public internal(set) var connectionRecoveryPhase: MobileConnectionRecoveryPhase = .idle
     public internal(set) var connectedHostName: String
     public private(set) var connectionError: String?
     /// Actionable next-step line shown beneath ``connectionError`` (for example
@@ -1007,10 +1004,13 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
             if remoteClient == nil {
                 stopTerminalRefreshPolling()
                 cancelRemoteOperationTasks()
-                resetTerminalOutputTracking()
+                resetTerminalOutputTracking(
+                    preservingPresentation: preservesForegroundPresentationDuringClientReplacement
+                )
             }
         }
     }
+    private var preservesForegroundPresentationDuringClientReplacement = false
     /// Whether legacy connected-but-clientless shells use local iOS workspace creation.
     public var usesLocalWorkspaceCreationFallback: Bool {
         remoteClient == nil && connectionState == .connected
@@ -2620,7 +2620,8 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
     func reconnectActiveMacOutcome(
         stackUserID: String?,
         refreshBackupBeforeDial: Bool = true,
-        force: Bool = false
+        force: Bool = false,
+        deadlineNanoseconds deadlineOverrideNanoseconds: UInt64? = nil
     ) async -> StoredMacReconnectOutcome {
         lastReconnectStackUserID = stackUserID
         startObservingNetworkPathChanges()
@@ -2656,7 +2657,8 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         // generation claim above remains synchronous, preserving serialization
         // while the unstructured operation can be abandoned if an FFI dial
         // ignores cancellation.
-        let deadlineNanoseconds = runtime?.reconnectAttemptDeadlineNanoseconds
+        let deadlineNanoseconds = deadlineOverrideNanoseconds
+            ?? runtime?.reconnectAttemptDeadlineNanoseconds
             ?? 30_000_000_000
         let race = await Self.raceAgainstDeadline(
             nanoseconds: deadlineNanoseconds
@@ -8644,7 +8646,7 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         terminalID: MobileTerminalPreview.ID
     ) async {
         guard !text.isEmpty else { return }
-        guard remoteClient != nil else { return }
+        guard remoteClient != nil || connectionRecoveryPhase == .recovering else { return }
         switch rawTerminalInputBuffer.enqueue(
             text,
             workspaceID: workspaceID,
@@ -8678,7 +8680,17 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         }
         // Matches MobileIrohTerminalLane.maximumInputByteCount and the Mac lane
         // router's maximumInputFrameByteCount.
-        while let chunk = rawTerminalInputBuffer.nextBatch(maximumByteCount: 16 * 1_024) {
+        while true {
+            guard remoteClient != nil else {
+                rawTerminalInputBuffer.pauseDraining()
+                MobileDebugLog.anchormux(
+                    "connection.recovery input_paused pendingBytes=\(rawTerminalInputBuffer.pendingByteCount)"
+                )
+                return
+            }
+            guard let chunk = rawTerminalInputBuffer.nextBatch(
+                maximumByteCount: 16 * 1_024
+            ) else { return }
             #if DEBUG
             rawTerminalInputLatencyBatchNumber &+= 1
             let latencyBatchNumber = rawTerminalInputLatencyBatchNumber
@@ -8697,6 +8709,17 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
                 latencyBatchNumber: latencyBatchNumberForSend,
                 sendStatusOperationID: chunk.sendStatusOperationID
             )
+        }
+    }
+
+    private func startRawTerminalInputDrainIfNeeded() {
+        guard remoteClient != nil,
+              rawTerminalInputBuffer.resumeDraining() else { return }
+        MobileDebugLog.anchormux(
+            "connection.recovery input_resumed pendingBytes=\(rawTerminalInputBuffer.pendingByteCount)"
+        )
+        Task { @MainActor [weak self] in
+            await self?.drainRawTerminalInputBuffer()
         }
     }
 
@@ -9731,7 +9754,20 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         connectedHostName = ""
     }
 
-    func clearRemoteConnectionContext(preservingOtherMacWorkspaceState: Bool = false) {
+    var retainedRecoveryWorkspaceCount: Int {
+        workspacesByMac.values.reduce(0) { $0 + $1.workspaces.count }
+    }
+
+    var pendingRecoveryTerminalInputByteCount: Int {
+        rawTerminalInputBuffer.pendingByteCount
+    }
+
+    @discardableResult
+    func clearRemoteConnectionContext(
+        preservingOtherMacWorkspaceState: Bool = false,
+        preservingForegroundPresentation: Bool = false,
+        disconnectRemoteClientInBackground: Bool = true
+    ) -> MobileCoreRPCClient? {
         connectionGeneration = UUID()
         connectionAttemptGeneration = UUID()
         // Capture the tagged foreground key BEFORE the identity clears below:
@@ -9741,8 +9777,10 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         let offlineForegroundKey = foregroundMacKey
         focusedHandoffPreparedGenerations.removeAll()
         cancelRemoteOperationTasks()
-        clearActiveConnectionContext()
-        macConnectionStatus = .unavailable
+        if !preservingForegroundPresentation {
+            clearActiveConnectionContext()
+            macConnectionStatus = .unavailable
+        }
         if let attemptClient =
             replaceConnectionAttemptClientOwnership(with: nil) {
             scheduleClientDisconnect(attemptClient)
@@ -9756,8 +9794,15 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
             removeControlCapability(ifMatching: focused)
             macConnectionRegistry.setFocusedConnection(nil, for: focused.ownerKey)
         }
-        replaceRemoteClient(with: nil)
-        foregroundMacDeviceID = nil
+        preservesForegroundPresentationDuringClientReplacement = preservingForegroundPresentation
+        let detachedRemoteClient = replaceRemoteClientOwnership(with: nil)
+        preservesForegroundPresentationDuringClientReplacement = false
+        if disconnectRemoteClientInBackground, let detachedRemoteClient {
+            scheduleClientDisconnect(detachedRemoteClient)
+        }
+        if !preservingForegroundPresentation {
+            foregroundMacDeviceID = nil
+        }
         if !preservingOtherMacWorkspaceState {
             // Cancel the live secondary subscriptions (slice 3) and keep only the
             // now-offline foreground Mac's last-known workspaces for the offline
@@ -9770,14 +9815,20 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         // per-Mac dots) derives from these per-Mac states, so without this the
         // just-disconnected Mac would keep showing a green connected dot. Downgrade
         // it to `.unavailable` to match the global connection state.
-        if var offline = workspacesByMac[offlineForegroundKey] {
+        if !preservingForegroundPresentation,
+           var offline = workspacesByMac[offlineForegroundKey] {
             offline.status = .unavailable
             offline.workspaceGroupsAreAuthoritative = false
             workspacesByMac[offlineForegroundKey] = offline
         }
-        rawTerminalInputBuffer.clear()
+        if preservingForegroundPresentation {
+            rawTerminalInputBuffer.pauseDraining()
+        } else {
+            rawTerminalInputBuffer.clear()
+        }
         terminalInputRPCPipeline.clear()
         resumeRawTerminalInputDrainWaiters()
+        return detachedRemoteClient
     }
 
     /// Set `remoteClient` to a new value (possibly nil) and disconnect the
@@ -10144,7 +10195,7 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         cancelAllTerminalReplayTasks()
     }
 
-    private func resetTerminalOutputTracking() {
+    private func resetTerminalOutputTracking(preservingPresentation: Bool = false) {
         cancelAllTerminalReplayTasks()
         effectiveViewportSizesBySurfaceID = [:]; reportedTerminalViewportSizesBySurfaceID = [:]
         // Keep viewport sequences for the account lifetime. A warm peer keeps
@@ -10189,11 +10240,15 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         terminalScrollQueueTokensBySurfaceID = [:]
         terminalScrollQueuesBySurfaceID = [:]
         terminalScrollbackPrefetchStatesBySurfaceID = [:]
-        terminalOutputTransport = .rawBytes
+        if !preservingPresentation {
+            terminalOutputTransport = .rawBytes
+        }
         deactivateAllTerminalLanes()
-        supportedHostCapabilities = []
-        phonePushMacStatus = nil
-        clearMacUpdateHint()
+        if !preservingPresentation {
+            supportedHostCapabilities = []
+            phonePushMacStatus = nil
+            clearMacUpdateHint()
+        }
         terminalSubscriptionRefreshTask?.cancel()
         terminalSubscriptionRefreshTask = nil
         cancelTerminalInputAckResubscribeRetry()
@@ -10542,6 +10597,7 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
     }
 
     func markMacConnectionHealthy() {
+        startRawTerminalInputDrainIfNeeded()
         guard connectionState == .connected else {
             macConnectionStatus = .unavailable
             return
@@ -10602,7 +10658,8 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
     }
 
     func markMacConnectionReconnecting() {
-        guard connectionState == .connected, remoteClient != nil else {
+        guard connectionState == .connected,
+              remoteClient != nil || connectionRecoveryPhase == .recovering else {
             macConnectionStatus = .unavailable
             return
         }

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
@@ -5633,14 +5633,10 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
             supportedKinds: supportedRouteKinds,
             preferNonLoopback: Self.prefersNonLoopbackRoutes
         )
-        // During a bounded foreground redial, `clearRemoteConnectionContext()`
-        // has already nil'd `foregroundMacDeviceID`, which would make the very
-        // Mac being redialed eligible as a "secondary". That opens a duplicate
-        // background-control session the redial must then drain — one wasted
-        // QUIC dial plus up to the handoff-drain timeout of added reconnect
-        // latency. Exclude the in-flight recovery target exactly like a live
-        // foreground; once recovery settles the normal exclusion (success) or
-        // eligibility (terminal failure) resumes.
+        // During a bounded foreground redial, the retained foreground identity
+        // or recovery target excludes that Mac from secondary aggregation. This
+        // prevents a duplicate control session from taking its route lease and
+        // adding a handoff-drain timeout to foreground recovery.
         let exclusionMacDeviceID: String?
         let exclusionTag: String?
         if let foregroundMacDeviceID {
@@ -9760,6 +9756,20 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
 
     var pendingRecoveryTerminalInputByteCount: Int {
         rawTerminalInputBuffer.pendingByteCount
+    }
+
+    /// Failed recovery keeps the user's last rendered workspace mounted. The
+    /// recovery owner, rather than each transport catch site, decides whether
+    /// the foreground identity and presentation remain authoritative.
+    func clearFailedReconnectContext(
+        preservingForegroundPresentation explicitPreservation: Bool? = nil
+    ) {
+        let preservesPresentation = explicitPreservation
+            ?? connectionRecoveryOwner.isActive
+        clearRemoteConnectionContext(
+            preservingOtherMacWorkspaceState: preservesPresentation,
+            preservingForegroundPresentation: preservesPresentation
+        )
     }
 
     @discardableResult

--- a/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/IrohConnectionRecoveryOwnerTests.swift
+++ b/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/IrohConnectionRecoveryOwnerTests.swift
@@ -446,7 +446,12 @@ extension ReconnectRouteSelectionTests {
         })
         let report = await fixture.diagnosticLog.snapshot()
         let recoveryFailures = report.events.filter { $0.code == .recoveryFailed }
+        let recoveryStarts = report.events.filter { $0.code == .recoveryStarted }
         #expect(recoveryFailures.count == 1)
+        #expect(recoveryStarts.count == 1)
+        #expect(recoveryStarts[0].c != nil)
+        #expect(recoveryFailures[0].c == recoveryStarts[0].c)
+        #expect(recoveryFailures[0].ms != nil)
         #expect(recoveryFailures[0].diagnosticFailureKind == .timedOut)
         #expect(report.lastFailureKind == .timedOut)
     }

--- a/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/IrohConnectionRecoveryOwnerTests.swift
+++ b/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/IrohConnectionRecoveryOwnerTests.swift
@@ -497,6 +497,9 @@ extension ReconnectRouteSelectionTests {
 
         #expect(await fixture.store.reconnectActiveMacIfAvailable(stackUserID: "user-1"))
         #expect(await fixture.router.waitForCount(of: "mobile.events.subscribe", atLeast: 1))
+        let selectedWorkspaceID = try #require(fixture.store.selectedWorkspaceID)
+        let foregroundMacDeviceID = try #require(fixture.store.foregroundMacDeviceID)
+        let activeRoute = try #require(fixture.store.activeRoute)
         await fixture.diagnosticLog.clear()
         let client = try #require(fixture.store.remoteClient)
         let generation = fixture.store.connectionGeneration
@@ -531,6 +534,10 @@ extension ReconnectRouteSelectionTests {
         #expect(failures[0].diagnosticFailureKind == .connectionClosed)
         #expect(fixture.store.connectionRecoveryOwner.phase == .failed(attempt))
         #expect(fixture.store.connectionState == .disconnected)
+        #expect(fixture.store.selectedWorkspaceID == selectedWorkspaceID)
+        #expect(fixture.store.foregroundMacDeviceID == foregroundMacDeviceID)
+        #expect(fixture.store.activeRoute == activeRoute)
+        #expect(fixture.store.workspaces.contains { $0.id == selectedWorkspaceID })
     }
 
     @Test func immediateValidatedRecoveryEmitsSuccessExactlyOnce() async throws {

--- a/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/IrohConnectionRecoveryOwnerTests.swift
+++ b/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/IrohConnectionRecoveryOwnerTests.swift
@@ -58,7 +58,7 @@ extension ReconnectRouteSelectionTests {
         #expect(fixture.store.selectedWorkspace?.rpcWorkspaceID.rawValue == "hevy-cli")
     }
 
-    @Test func recoveryWaitsForOldPhysicalTransportBeforeRedialing() async throws {
+    @Test func recoveryRedialsWhileOldPhysicalTransportCloses() async throws {
         let closeGate = LivenessTransportCloseGate()
         let fixture = try await makeRecoveryOwnerFixture(
             firstTransportCloseGate: closeGate
@@ -78,9 +78,6 @@ extension ReconnectRouteSelectionTests {
         )
 
         #expect(await closeGate.waitUntilCloseStarted())
-        #expect(fixture.factory.attemptedKinds() == [.iroh])
-
-        await closeGate.release()
         #expect(await fixture.factory.waitForAttemptCount(2))
         #expect(try await pollUntil {
             guard let replacement = fixture.store.remoteClient else { return false }
@@ -88,6 +85,8 @@ extension ReconnectRouteSelectionTests {
                 && fixture.store.connectionState == .connected
         })
         #expect(fixture.factory.attemptedKinds() == [.iroh, .iroh])
+
+        await closeGate.release()
     }
 
     @Test func livenessAndForegroundRecoveryCoalesceOnOneIrohReplacement() async throws {

--- a/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/MobileShellRenderGridLivenessTests.swift
+++ b/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/MobileShellRenderGridLivenessTests.swift
@@ -557,12 +557,11 @@ import Testing
     collector.unmount()
 }
 
-/// One timed-out liveness probe is ambiguous during Iroh path migration or a
-/// short Mac stall. The original stream must remain installed until a second
-/// independent probe confirms failure; a successful follow-up clears the
-/// suspicion without changing the client or connection generation.
+/// One bounded liveness timeout must replace the generation immediately. A
+/// second confirmation timeout made silent failure recovery exceed the
+/// interactive budget even when both apps stayed awake.
 @MainActor
-@Test func watchdogKeepsSessionAfterOneTransientProbeFailure() async throws {
+@Test func watchdogRecoversAfterOneBoundedProbeFailure() async throws {
     let clock = TestClock()
     let router = LivenessHostRouter()
     let box = TransportBox()
@@ -576,32 +575,21 @@ import Testing
     }
     #expect(sawSubscribe, "listener must establish the push subscription")
     let originalClient = try #require(store.remoteClient)
-    let originalGeneration = store.connectionGeneration
-    let hostStatusCountBeforeFailure = await router.count(of: "mobile.host.status")
 
-    // Hold only the first watchdog probe. The follow-up probe can complete,
-    // modeling a short stall that resolves without the Iroh session dying.
+    // Hold the watchdog probe so its bounded deadline proves this generation
+    // cannot satisfy foreground liveness.
     await router.holdProbeRequest(number: 1)
     clock.advance(by: 10)
     store.debugRunRenderGridLivenessCheckForTesting()
     #expect(await router.waitForCount(of: "mobile.events.probe", atLeast: 1))
-    // The second independent probe succeeds and resets the liveness window.
-    // Reconnecting makes `.connected` prove that its response was applied.
-    store.markMacConnectionReconnecting()
-    let followUpSucceeded = try await pollUntil {
-        store.debugRunRenderGridLivenessCheckForTesting()
-        return await router.count(of: "mobile.events.probe") >= 2
+    let recovered = try await pollUntil(attempts: 600) {
+        guard let replacement = store.remoteClient else { return false }
+        return replacement !== originalClient
+            && store.connectionState == .connected
             && store.macConnectionStatus == .connected
     }
-    #expect(followUpSucceeded, "the follow-up probe must complete successfully")
-    #expect(store.remoteClient === originalClient)
-    #expect(store.connectionGeneration == originalGeneration)
-    #expect(store.connectionState == .connected)
-    #expect(store.macConnectionStatus == .connected)
-    #expect(
-        await router.count(of: "mobile.host.status") == hostStatusCountBeforeFailure,
-        "one transient probe miss must not restart the event listener"
-    )
+    #expect(recovered, "one failed bounded probe must install a usable replacement")
+    #expect(await router.count(of: "mobile.events.probe") == 1)
 }
 
 /// A successful probe that REPAIRED a lost registration (the host reports
@@ -691,22 +679,11 @@ import Testing
     #expect(sawSubscribe, "listener must establish the push subscription")
     let hostStatusCountBeforeFailure = await router.count(of: "mobile.host.status")
 
-    // The host stops answering two independent read-only subscription probes,
-    // confirming a dead push path rather than a transient stall.
+    // The host stops answering the bounded read-only subscription probe.
     await router.holdProbeRequest(number: 1)
-    await router.holdProbeRequest(number: 2)
     clock.advance(by: 10)
     store.debugRunRenderGridLivenessCheckForTesting()
     #expect(await router.waitForCount(of: "mobile.events.probe", atLeast: 1))
-    let secondProbeStarted = try await pollUntil {
-        store.debugRunRenderGridLivenessCheckForTesting()
-        return await router.count(of: "mobile.events.probe") >= 2
-    }
-    #expect(secondProbeStarted, "the first failure must permit a confirmation probe")
-    #expect(
-        await router.count(of: "mobile.host.status") == hostStatusCountBeforeFailure,
-        "the first ambiguous probe failure must preserve the current listener"
-    )
 
     // Recovery restarts the listener, which re-resolves capabilities. A new
     // mobile.host.status request is the teardown-and-restart proof.

--- a/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/PresenceDiscoveryInvalidationTests.swift
+++ b/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/PresenceDiscoveryInvalidationTests.swift
@@ -95,6 +95,59 @@ import Testing
 /// from a fresh broker snapshot instead of burning backoff on a corpse route.
 @MainActor
 @Suite struct RouteFailureDiscoveryInvalidationTests {
+    @Test func firstNoRouteFailureRefreshesAndRedialsWithinSameReconnect() async throws {
+        let discovery = RecordingIrohDiscovery()
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let pairedStore = try MobilePairedMacStore(
+            databaseURL: directory.appendingPathComponent("paired-macs.sqlite3")
+        )
+        let irohRoute = try CmxAttachRoute(
+            id: "iroh-personal",
+            kind: .iroh,
+            endpoint: .peer(identity: CmxIrohPeerIdentity(
+                endpointID: String(repeating: "a", count: 64)
+            ), pathHints: []),
+            priority: -10_000
+        )
+        try await pairedStore.upsert(
+            macDeviceID: "test-mac",
+            displayName: "Test Mac",
+            routes: [irohRoute],
+            markActive: true,
+            stackUserID: "user-1",
+            teamID: nil,
+            now: Date()
+        )
+        let router = LivenessHostRouter()
+        let box = TransportBox()
+        let factory = KindRecordingTransportFactory(router: router, box: box)
+        factory.failNextAttemptsWithNoRoute(1)
+        let store = MobileShellComposite(
+            runtime: LivenessTestRuntime(
+                transportFactory: factory,
+                now: { Date() },
+                supportedRouteKinds: [.iroh]
+            ),
+            isSignedIn: true,
+            pairedMacStore: pairedStore,
+            personalIrohDiscovery: discovery,
+            identityProvider: StaticIdentityProvider(userID: "user-1"),
+            reachability: AlwaysOnlineReachability(),
+            pairingHintDefaults: UserDefaults(
+                suiteName: "same-attempt-discovery-refresh-\(UUID().uuidString)"
+            )!,
+            hiddenMacStore: InMemoryPairedMacHiddenStore()
+        )
+        await store.loadPairedMacs()
+
+        #expect(await store.reconnectActiveMacIfAvailable(stackUserID: "user-1"))
+        #expect(factory.attemptedKinds() == [.iroh, .iroh])
+        #expect(discovery.invalidatedDeviceIDs == ["test-mac"])
+    }
+
     @Test func timedOutIrohRouteDialInvalidatesDiscoveryForNextAttempt() async throws {
         let discovery = RecordingIrohDiscovery()
         let directory = FileManager.default.temporaryDirectory

--- a/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/ReconnectRouteSelectionTests+Support.swift
+++ b/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/ReconnectRouteSelectionTests+Support.swift
@@ -176,6 +176,11 @@ final class KindRecordingTransportFactory: CmxByteTransportFactory, @unchecked S
     private var authorizationModes: [CmxTransportAuthorizationMode] = []
     private var hangingKinds: Set<CmxAttachTransportKind> = []
     private var hangingTransports: [HangingConnectTransport] = []
+    private var remainingNoRouteFailures = 0
+
+    func failNextAttemptsWithNoRoute(_ count: Int) {
+        lock.withLock { remainingNoRouteFailures = count }
+    }
 
     /// Route kinds whose transports park forever in `connect()` from now on.
     /// Models an Iroh dial that neither completes nor fails (relay DNS churn,
@@ -222,6 +227,14 @@ final class KindRecordingTransportFactory: CmxByteTransportFactory, @unchecked S
     private func makeRecordedTransport(
         for route: CmxAttachRoute
     ) throws -> any CmxByteTransport {
+        let failsWithNoRoute = lock.withLock { () -> Bool in
+            guard remainingNoRouteFailures > 0 else { return false }
+            remainingNoRouteFailures -= 1
+            return true
+        }
+        if failsWithNoRoute {
+            throw FirstAttemptNoRouteError()
+        }
         if failingKinds.contains(route.kind) {
             throw RouteRecordingTransportError.routeFailed
         }
@@ -242,6 +255,10 @@ final class KindRecordingTransportFactory: CmxByteTransportFactory, @unchecked S
     func attemptedAuthorizationModes() -> [CmxTransportAuthorizationMode] {
         lock.withLock { authorizationModes }
     }
+}
+
+private struct FirstAttemptNoRouteError: DiagnosticFailureProviding {
+    let diagnosticFailureKind: DiagnosticFailureKind = .noRoute
 }
 
 /// A transport whose `connect()` parks forever, ignoring cancellation the way

--- a/Packages/iOS/CmuxMobileShellModel/Sources/CmuxMobileShellModel/MobileConnectionRecoveryPhase.swift
+++ b/Packages/iOS/CmuxMobileShellModel/Sources/CmuxMobileShellModel/MobileConnectionRecoveryPhase.swift
@@ -1,0 +1,12 @@
+import Foundation
+
+/// Presentation-safe phase for a connection that may be changing transports.
+///
+/// This is deliberately separate from ``MobileConnectionState``. A workspace
+/// can remain mounted and useful while its RPC transport is being replaced.
+public enum MobileConnectionRecoveryPhase: Equatable, Sendable {
+    case idle
+    case probing
+    case recovering
+    case failed
+}

--- a/Packages/iOS/CmuxMobileShellModel/Sources/CmuxMobileShellModel/MobileTerminalInputSendBuffer.swift
+++ b/Packages/iOS/CmuxMobileShellModel/Sources/CmuxMobileShellModel/MobileTerminalInputSendBuffer.swift
@@ -140,6 +140,20 @@ public struct MobileTerminalInputSendBuffer: Equatable, Sendable {
         return chunk
     }
 
+    /// Relinquishes drain ownership without changing queued bytes. Recovery
+    /// calls this while no transport exists so typing can continue to enqueue.
+    public mutating func pauseDraining() {
+        isDraining = false
+    }
+
+    /// Claims drain ownership for retained bytes after transport replacement.
+    /// Returns `true` only to the caller that should start the drain loop.
+    public mutating func resumeDraining() -> Bool {
+        guard !isDraining, !pendingChunks.isEmpty else { return false }
+        isDraining = true
+        return true
+    }
+
     /// Drops all pending input and resets the draining flag.
     public mutating func clear() {
         pendingChunks.removeAll()

--- a/Packages/iOS/CmuxMobileShellModel/Tests/CmuxMobileShellModelTests/MobileTerminalInputSendBufferTests.swift
+++ b/Packages/iOS/CmuxMobileShellModel/Tests/CmuxMobileShellModelTests/MobileTerminalInputSendBufferTests.swift
@@ -131,4 +131,26 @@ import Testing
         #expect(batch?.text == "first\rsecond\r")
         #expect(batch?.sendStatusOperationID == secondOperationID)
     }
+
+    @Test func pausesWithoutDroppingInputAndResumesOnceTransportReturns() {
+        var buffer = MobileTerminalInputSendBuffer()
+        let workspaceID = MobileWorkspacePreview.ID(rawValue: "workspace-a")
+        let terminalID = MobileTerminalPreview.ID(rawValue: "terminal-a")
+
+        #expect(buffer.enqueue("before", workspaceID: workspaceID, terminalID: terminalID) == .startDraining)
+        buffer.pauseDraining()
+        #expect(!buffer.isDraining)
+        #expect(buffer.pendingByteCount == 6)
+        #expect(buffer.pendingChunks.map(\.text) == ["before"])
+
+        #expect(buffer.enqueue("-during", workspaceID: workspaceID, terminalID: terminalID) == .startDraining)
+        #expect(buffer.resumeDraining() == false)
+        #expect(buffer.nextBatch()?.text == "before-during")
+        #expect(buffer.nextBatch() == nil)
+
+        #expect(buffer.enqueue("after", workspaceID: workspaceID, terminalID: terminalID) == .startDraining)
+        buffer.pauseDraining()
+        #expect(buffer.resumeDraining())
+        #expect(buffer.nextBatch()?.text == "after")
+    }
 }

--- a/Packages/iOS/CmuxMobileShellModel/Tests/CmuxMobileShellModelTests/MobileTerminalInputSendBufferTests.swift
+++ b/Packages/iOS/CmuxMobileShellModel/Tests/CmuxMobileShellModelTests/MobileTerminalInputSendBufferTests.swift
@@ -150,7 +150,8 @@ import Testing
 
         #expect(buffer.enqueue("after", workspaceID: workspaceID, terminalID: terminalID) == .startDraining)
         buffer.pauseDraining()
-        #expect(buffer.resumeDraining())
+        let resumed = buffer.resumeDraining()
+        #expect(resumed)
         #expect(buffer.nextBatch()?.text == "after")
     }
 }

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/GhosttySurfaceCoordinator+Artifacts.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/GhosttySurfaceCoordinator+Artifacts.swift
@@ -338,7 +338,6 @@ extension GhosttySurfaceRepresentable.Coordinator {
                   terminalPresentationIsActive,
                   self.surfaceView === surfaceView,
                   surfaceView.window != nil,
-                  let store,
                   let viewportReportScheduler else { return }
             viewportReportScheduler.submit(
                 .init(id: reportID, columns: size.columns, rows: size.rows)

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/GhosttySurfaceCoordinator+Artifacts.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/GhosttySurfaceCoordinator+Artifacts.swift
@@ -340,19 +340,6 @@ extension GhosttySurfaceRepresentable.Coordinator {
                   surfaceView.window != nil,
                   let store,
                   let viewportReportScheduler else { return }
-            if let outputStartContinuation {
-                guard let preparation = store.prepareTerminalViewport(
-                    surfaceID: surfaceID,
-                    columns: size.columns,
-                    rows: size.rows
-                ) else {
-                    return
-                }
-                preparedViewportReportsByReportID[reportID] = preparation
-                self.outputStartContinuation = nil
-                outputStartContinuation.yield()
-                outputStartContinuation.finish()
-            }
             viewportReportScheduler.submit(
                 .init(id: reportID, columns: size.columns, rows: size.rows)
             )

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/GhosttySurfaceRepresentable.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/GhosttySurfaceRepresentable.swift
@@ -184,8 +184,6 @@ struct GhosttySurfaceRepresentable: UIViewRepresentable {
         var onArtifactGalleryRefreshSignal: @MainActor (TerminalArtifactGalleryRefreshSignal) -> Void
         private var outputTask: Task<Void, Never>?
         var terminalPresentationIsActive: Bool
-        var outputStartContinuation: AsyncStream<Void>.Continuation?
-        var preparedViewportReportsByReportID: [UInt64: MobileTerminalViewportPreparation] = [:]
         private var liveFontTask: Task<Void, Never>?
         let themeApplicationScheduler = TerminalThemeApplicationScheduler()
         var artifactCountTask: Task<Void, Never>?
@@ -279,17 +277,9 @@ struct GhosttySurfaceRepresentable: UIViewRepresentable {
             guard outputTask == nil else { return }
             guard let store else { return }
             let surfaceID = surfaceID
-            let outputStartSignal = AsyncStream<Void> { [weak self] continuation in
-                self?.outputStartContinuation = continuation
-            }
             viewportReportScheduler = TerminalViewportReportScheduler(
                 send: { [weak self] report in
                     guard let self, let store = self.store else { return nil }
-                    if let preparation = self.preparedViewportReportsByReportID.removeValue(
-                        forKey: report.id
-                    ) {
-                        return await store.updatePreparedTerminalViewport(preparation)
-                    }
                     return await store.updateTerminalViewport(
                         surfaceID: self.surfaceID,
                         columns: report.columns,
@@ -332,7 +322,6 @@ struct GhosttySurfaceRepresentable: UIViewRepresentable {
             // task terminates the stream, which unregisters the surface and
             // clears its viewport pin on the Mac (see `terminalOutputStream`).
             outputTask = Task { @MainActor [weak self, weak surfaceView, weak store] in
-                for await _ in outputStartSignal { break }
                 guard !Task.isCancelled else { return }
                 guard let store else { return }
                 for await chunk in store.terminalOutputStream(surfaceID: surfaceID) {
@@ -486,9 +475,6 @@ struct GhosttySurfaceRepresentable: UIViewRepresentable {
         private func stopMountedTasks() {
             let releasesViewport = outputTask != nil || viewportReportScheduler != nil
             clickGeneration &+= 1
-            outputStartContinuation?.finish()
-            outputStartContinuation = nil
-            preparedViewportReportsByReportID.removeAll()
             outputTask?.cancel()
             outputTask = nil
             verifiedReplayState.invalidate()

--- a/Packages/iOS/CmuxMobileShellUI/Tests/CmuxMobileShellUITests/TerminalSurfaceMountOwnershipTests.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Tests/CmuxMobileShellUITests/TerminalSurfaceMountOwnershipTests.swift
@@ -48,8 +48,8 @@ struct TerminalSurfaceMountOwnershipTests {
     }
 
     @MainActor
-    @Test("terminal primes current viewport before claiming output on each mount")
-    func terminalPrimesViewportBeforeClaimingOutputOnEachMount() async throws {
+    @Test("terminal claims output without waiting for a resize on each mount")
+    func terminalClaimsOutputWithoutWaitingForResizeOnEachMount() async throws {
         let store = MobileShellComposite.preview()
         let workspace = try #require(store.workspaces.first { !$0.terminals.isEmpty })
         let terminal = try #require(workspace.terminals.first)
@@ -86,10 +86,12 @@ struct TerminalSurfaceMountOwnershipTests {
 
         surfaceView.frame = host.view.bounds
         host.view.addSubview(surfaceView)
-        for _ in 0..<20 {
-            await Task.yield()
+        let mountedWithoutResize = await waitUntil {
+            store.terminalOutputStreamTokensBySurfaceID[surfaceID] != nil
         }
-        #expect(store.terminalOutputStreamTokensBySurfaceID[surfaceID] == nil)
+        #expect(mountedWithoutResize)
+        let firstToken = try #require(store.terminalOutputStreamTokensBySurfaceID[surfaceID])
+        #expect(store.terminalViewportGeneration(for: surfaceID) == 0)
 
         coordinator.ghosttySurfaceView(
             surfaceView,
@@ -101,11 +103,6 @@ struct TerminalSurfaceMountOwnershipTests {
             ),
             reportID: 1
         )
-        let mounted = await waitUntil {
-            store.terminalOutputStreamTokensBySurfaceID[surfaceID] != nil
-        }
-        #expect(mounted)
-        let firstToken = try #require(store.terminalOutputStreamTokensBySurfaceID[surfaceID])
         #expect(store.terminalViewportGeneration(for: surfaceID) == 1)
         #expect(store.reportedViewportSizesByTerminalKey.values.contains(
             MobileTerminalViewportSize(columns: 72, rows: 61)
@@ -118,10 +115,11 @@ struct TerminalSurfaceMountOwnershipTests {
         #expect(unmounted)
 
         host.view.addSubview(surfaceView)
-        for _ in 0..<20 {
-            await Task.yield()
+        let remountedWithoutResize = await waitUntil {
+            guard let token = store.terminalOutputStreamTokensBySurfaceID[surfaceID] else { return false }
+            return token != firstToken
         }
-        #expect(store.terminalOutputStreamTokensBySurfaceID[surfaceID] == nil)
+        #expect(remountedWithoutResize)
 
         coordinator.ghosttySurfaceView(
             surfaceView,
@@ -133,11 +131,7 @@ struct TerminalSurfaceMountOwnershipTests {
             ),
             reportID: 2
         )
-        let remounted = await waitUntil {
-            guard let token = store.terminalOutputStreamTokensBySurfaceID[surfaceID] else { return false }
-            return token != firstToken
-        }
-        #expect(remounted)
+        #expect(store.terminalViewportGeneration(for: surfaceID) == 2)
     }
 
     @MainActor


### PR DESCRIPTION
## Summary
- keep the selected Mac workspace and foreground UI live while transport recovery runs
- overlap failed-transport cleanup with replacement dialing and queue terminal input during the gap
- add single-probe liveness detection, a 3-second foreground recovery budget, and correlated stage diagnostics

## Verification
- `swift test --filter DiagnosticEventPresentationTests`
- `swift test --filter IrohConnectionRecoveryOwnerTests`
- `swift build` for CmuxMobileShell

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/10182"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789344934&installation_model_id=21920&pr_number=10182&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F10182&signature=40d15943c99ef1e66665317460959e81dc5d0dccc259aebc8796511cb45b60d6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keeps the foreground workspace usable during iOS transport recovery and finishes within ~3s. Previously we waited ~9s and two failed probes, tore down the UI, and blocked on draining; now a single bounded probe triggers recovery, we dial while cleanup runs, the UI stays mounted even if recovery fails, and terminal input is buffered and replayed.

- Adds correlated recovery diagnostics in `CMUXMobileCore`: `recoveryStageStarted`, `recoveryStageCompleted` (per‑stage duration and outcome), and `recoverySnapshotRetained`; introduces `DiagnosticRecoveryStage`/`DiagnosticRecoveryTrigger`; updates event field mappings and several presentation names (e.g., “Direct dial plan assembled”).
- Introduces `MobileConnectionRecoveryPhase` in `CmuxMobileShellModel` and uses it in `CmuxMobileShell` to present recovery state independent of `MobileConnectionState` (status shows reconnecting while the retained workspace remains visible).
- Buffers terminal input across transport replacement: `MobileTerminalInputSendBuffer` can pause/resume draining; `CmuxMobileShell` accepts input while `recovering`, pauses when the client drops, and resumes automatically on reconnect.
- Overlaps teardown and redial in `CmuxMobileShell`: non‑blocking `clearRemoteConnectionContext(...)` can preserve foreground presentation and returns a detached client for background disconnect; adds `clearFailedReconnectContext(...)`; records retained workspace count and buffered input size.
- Tightens liveness and deadlines in `CmuxMobileRPC`/`CmuxMobileShell`: 1s silence threshold, one failed probe, 750ms probe timeout, 250ms check cadence, and a 3s `foregroundRecoveryDeadlineNanoseconds` used by `reconnectActiveMacOutcome(...)`.
- Improves Iroh route resilience: on the first `noRoute`/stale‑discovery failure, invalidate discovery and redial once within the same reconnect attempt (emits `.retryScheduled`); skips the fresh retry when the connection method is Tailscale.
- Reduces terminal mount latency in `CmuxMobileShellUI`: terminal output is claimed on mount without waiting for an initial resize.

**Review notes**
- Tests updated to require single‑probe recovery, uninterrupted UI, correlated diagnostics, input buffering, and same‑attempt discovery refresh; run: `swift test --filter DiagnosticEventPresentationTests`, `swift test --filter IrohConnectionRecoveryOwnerTests`, `swift test --filter RouteFailureDiscoveryInvalidationTests`.
- If any metrics or dashboards key off human‑readable diagnostic names, update them for the renamed presentations; event codes remain stable.

<sup>Written for commit 6f0d3ac012c5433b910cf16f7756aa801e7b345c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/10182?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added connection-recovery phases and detailed diagnostics.
  * Preserves workspace presentation and queued terminal input during reconnection.
  * Added localized descriptions for recovery stages, triggers, outcomes, and connection events.

* **Bug Fixes**
  * Recovery starts faster after a failed liveness check.
  * Reconnects can begin while stale connections are closing.
  * Retries transient route-discovery failures automatically.
  * Terminal input pauses safely and resumes without data loss.
  * Terminal output starts more reliably during mounting and resizing.

* **Diagnostics**
  * Recovery attempts include timing, outcomes, failure details, and correlation identifiers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->