### PR TITLE
Expose iOS Networking controls and reset

### DIFF
--- a/Packages/Shared/CMUXMobileCore/Sources/CMUXMobileCore/CmxIrohSettingsControlling.swift
+++ b/Packages/Shared/CMUXMobileCore/Sources/CMUXMobileCore/CmxIrohSettingsControlling.swift
@@ -36,6 +36,10 @@ public protocol CmxIrohSettingsControlling: AnyObject {
     /// Removes this device's custom private paths for one Mac.
     func removeIrohCustomPrivatePath(macDeviceID: String) async throws
 
+    /// Restores the active networking choices to their safe defaults without
+    /// deleting saved relay definitions or private addresses.
+    func resetIrohSettingsToDefaults() async throws
+
     /// Fetches the latest signed fleet and account preference.
     func refreshIrohSettings() async
 
@@ -74,6 +78,20 @@ public extension CmxIrohSettingsControlling {
 
     func removeIrohCustomPrivatePath(macDeviceID: String) async throws {
         throw CmxIrohSettingsControlError.unsupported
+    }
+
+    func resetIrohSettingsToDefaults() async throws {
+        let snapshot = await irohSettingsSnapshot()
+        try await setIrohRelayPreference(.automatic)
+        try await setIrohPathPreference(.automatic)
+        for privateNetwork in snapshot.customPrivateNetworks where privateNetwork.isEnabled {
+            try await upsertIrohCustomPrivatePath(.init(
+                macDeviceID: privateNetwork.macDeviceID,
+                macDisplayName: privateNetwork.macDisplayName,
+                addresses: privateNetwork.addresses,
+                isEnabled: false
+            ))
+        }
     }
 
     func irohDiagnosticReport() async -> DiagnosticReport {

--- a/Packages/Shared/CMUXMobileCore/Sources/CMUXMobileCore/CmxIrohSettingsControlling.swift
+++ b/Packages/Shared/CMUXMobileCore/Sources/CMUXMobileCore/CmxIrohSettingsControlling.swift
@@ -82,16 +82,31 @@ public extension CmxIrohSettingsControlling {
 
     func resetIrohSettingsToDefaults() async throws {
         let snapshot = await irohSettingsSnapshot()
-        try await setIrohRelayPreference(.automatic)
-        try await setIrohPathPreference(.automatic)
-        for privateNetwork in snapshot.customPrivateNetworks where privateNetwork.isEnabled {
-            try await upsertIrohCustomPrivatePath(.init(
-                macDeviceID: privateNetwork.macDeviceID,
-                macDisplayName: privateNetwork.macDisplayName,
-                addresses: privateNetwork.addresses,
-                isEnabled: false
-            ))
+        var firstError: (any Error)?
+
+        do {
+            try await setIrohRelayPreference(.automatic)
+        } catch {
+            firstError = error
         }
+        do {
+            try await setIrohPathPreference(.automatic)
+        } catch {
+            firstError = firstError ?? error
+        }
+        for privateNetwork in snapshot.customPrivateNetworks where privateNetwork.isEnabled {
+            do {
+                try await upsertIrohCustomPrivatePath(.init(
+                    macDeviceID: privateNetwork.macDeviceID,
+                    macDisplayName: privateNetwork.macDisplayName,
+                    addresses: privateNetwork.addresses,
+                    isEnabled: false
+                ))
+            } catch {
+                firstError = firstError ?? error
+            }
+        }
+        if let firstError { throw firstError }
     }
 
     func irohDiagnosticReport() async -> DiagnosticReport {

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MobileIrohSettingsModel.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MobileIrohSettingsModel.swift
@@ -16,6 +16,8 @@ final class MobileIrohSettingsModel {
     private(set) var isMutating = false
     private(set) var showsSaveError = false
     private(set) var testResults: [String: CmxIrohRelayTestResult] = [:]
+    private(set) var connectionCheck: CmxIrohConnectionCheckReport?
+    private(set) var isRunningConnectionCheck = false
     private(set) var diagnosticReport = DiagnosticReport.empty
     private(set) var diagnosticExportText = ""
     private(set) var verboseLogEnabled = UserDefaults.standard.bool(
@@ -27,6 +29,12 @@ final class MobileIrohSettingsModel {
     @ObservationIgnored private var mutationToken: UUID?
     @ObservationIgnored private var relayTestTasks: [String: Task<Void, Never>] = [:]
     @ObservationIgnored private var relayTestTokens: [String: UUID] = [:]
+    @ObservationIgnored private var connectionCheckTask: Task<Void, Never>?
+    @ObservationIgnored private var connectionCheckGeneration: UInt64 = 0
+
+    var connectionCheckRelayURLs: [String] {
+        modelRelayURLs
+    }
 
     /// The durable verbose log file, offered for sharing once it exists.
     var verboseLogShareURL: URL? {
@@ -108,6 +116,42 @@ final class MobileIrohSettingsModel {
             failed: .irohPathPreferenceChangeFailed
         ) {
             try await self.controller.setIrohPathPreference(preference)
+        }
+    }
+
+    func runConnectionCheck() {
+        guard connectionCheckTask == nil, !isRunningConnectionCheck else { return }
+        connectionCheckGeneration &+= 1
+        let generation = connectionCheckGeneration
+        connectionCheckTask = Task { @MainActor [weak self] in
+            guard let self else { return }
+            await self.runConnectionCheckAndWait()
+            if self.connectionCheckGeneration == generation {
+                self.connectionCheckTask = nil
+            }
+        }
+    }
+
+    private func runConnectionCheckAndWait() async {
+        guard !Task.isCancelled, !isRunningConnectionCheck else { return }
+        isRunningConnectionCheck = true
+        defer { isRunningConnectionCheck = false }
+        let report = await controller.runIrohConnectionCheck()
+        guard !Task.isCancelled else { return }
+        let refreshedSnapshot = await controller.irohSettingsSnapshot()
+        guard !Task.isCancelled else { return }
+        connectionCheck = report
+        snapshot = refreshedSnapshot
+        await reloadDiagnostics()
+    }
+
+    func resetToDefaults() {
+        mutate(
+            started: .irohPathPreferenceChangeStarted,
+            succeeded: .irohPathPreferenceChangeSucceeded,
+            failed: .irohPathPreferenceChangeFailed
+        ) {
+            try await self.controller.resetIrohSettingsToDefaults()
         }
     }
 
@@ -256,6 +300,10 @@ final class MobileIrohSettingsModel {
     func cancelOperations() {
         refreshTask?.cancel()
         refreshTask = nil
+        connectionCheckGeneration &+= 1
+        connectionCheckTask?.cancel()
+        connectionCheckTask = nil
+        isRunningConnectionCheck = false
         mutationTask?.cancel()
         mutationTask = nil
         mutationToken = nil
@@ -339,7 +387,12 @@ final class MobileIrohSettingsModel {
     deinit {
         refreshTask?.cancel()
         mutationTask?.cancel()
+        connectionCheckTask?.cancel()
         relayTestTasks.values.forEach { $0.cancel() }
+    }
+
+    private var modelRelayURLs: [String] {
+        snapshot.managedRelays.map(\.url) + snapshot.customRelays.map(\.url)
     }
 }
 #endif

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MobileIrohSettingsView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MobileIrohSettingsView.swift
@@ -12,6 +12,7 @@ struct MobileIrohSettingsView: View {
     @State private var showsPrivatePathEditor = false
     @State private var editedPrivatePathMacDeviceID: String?
     @State private var pendingPrivatePathRemovalMacDeviceID: String?
+    @State private var showsResetConfirmation = false
 
     init(
         controller: any CmxIrohSettingsControlling,
@@ -51,7 +52,7 @@ struct MobileIrohSettingsView: View {
                     }
                 }
             } header: {
-                Text(L10n.string("mobile.iroh.relays", defaultValue: "Iroh Relays"))
+                Text(L10n.string("mobile.iroh.relays", defaultValue: "Relays"))
             } footer: {
                 Text(L10n.string(
                     "mobile.iroh.relays.footer",
@@ -125,6 +126,21 @@ struct MobileIrohSettingsView: View {
                 }
             )
 
+            Section {
+                Toggle(isOn: pathPreferenceBinding) {
+                    Text(L10n.string(
+                        "mobile.iroh.neverUseRelays",
+                        defaultValue: "Never Use Relays"
+                    ))
+                }
+                .accessibilityIdentifier("MobileIrohNeverUseRelays")
+            } footer: {
+                Text(L10n.string(
+                    "mobile.iroh.pathPreference.footer",
+                    defaultValue: "When enabled, cmux requires a reachable direct, local-network, or private-network path and will not fall back to a relay. Applies on the next reconnect."
+                ))
+            }
+
             #if DEBUG
             if let mode = model.snapshot.debugTransportVerificationMode {
                 MobileIrohDebugTransportSection(
@@ -133,6 +149,13 @@ struct MobileIrohSettingsView: View {
                 )
             }
             #endif
+
+            MobileIrohConnectionCheckSection(
+                report: model.connectionCheck,
+                relayURLs: model.connectionCheckRelayURLs,
+                isRunning: model.isRunningConnectionCheck,
+                run: model.runConnectionCheck
+            )
 
             MobileIrohDiagnosticsSection(
                 connectionStatus: runtimeStatusText,
@@ -156,8 +179,23 @@ struct MobileIrohSettingsView: View {
             )
         }
         .disabled(model.isMutating)
-        .navigationTitle(L10n.string("mobile.iroh.title", defaultValue: "Iroh and Relays"))
+        .navigationTitle(L10n.string("mobile.iroh.title", defaultValue: "Networking"))
         .navigationBarTitleDisplayMode(.inline)
+        .toolbar {
+            ToolbarItem(placement: .topBarTrailing) {
+                Button {
+                    showsResetConfirmation = true
+                } label: {
+                    Image(systemName: "arrow.counterclockwise")
+                }
+                .accessibilityLabel(L10n.string(
+                    "mobile.iroh.reset",
+                    defaultValue: "Reset to Defaults"
+                ))
+                .accessibilityIdentifier("MobileIrohResetDefaults")
+                .disabled(model.isMutating)
+            }
+        }
         .task { await model.observe() }
         .onDisappear { model.cancelOperations() }
         .sheet(isPresented: $showsCustomEditor) {
@@ -185,6 +223,26 @@ struct MobileIrohSettingsView: View {
             Text(L10n.string(
                 "mobile.iroh.saveFailed.message",
                 defaultValue: "Your previous networking configuration is still active. Check the values, then try again."
+            ))
+        }
+        .alert(
+            L10n.string(
+                "mobile.iroh.reset.title",
+                defaultValue: "Reset Networking Settings?"
+            ),
+            isPresented: $showsResetConfirmation
+        ) {
+            Button(
+                L10n.string("mobile.iroh.reset.confirm", defaultValue: "Reset"),
+                role: .destructive
+            ) {
+                model.resetToDefaults()
+            }
+            Button(L10n.string("mobile.common.cancel", defaultValue: "Cancel"), role: .cancel) {}
+        } message: {
+            Text(L10n.string(
+                "mobile.iroh.reset.message",
+                defaultValue: "Relay and path preferences will return to Automatic. Saved custom relays and private addresses will remain, but private addresses will be disabled."
             ))
         }
         .confirmationDialog(
@@ -262,6 +320,13 @@ struct MobileIrohSettingsView: View {
                 guard !selected.isEmpty else { return }
                 model.setPreference(.managed(selected))
             }
+        )
+    }
+
+    private var pathPreferenceBinding: Binding<Bool> {
+        Binding(
+            get: { model.snapshot.pathPreference == .neverUseRelays },
+            set: { model.setPathPreference($0 ? .neverUseRelays : .automatic) }
         )
     }
 

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MobileSettingsView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MobileSettingsView.swift
@@ -184,7 +184,7 @@ struct MobileSettingsView: View {
                             )
                         } label: {
                             Label(
-                                L10n.string("mobile.settings.iroh", defaultValue: "Iroh and Relays"),
+                                L10n.string("mobile.settings.iroh", defaultValue: "Networking"),
                                 systemImage: "network"
                             )
                         }

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/Resources/Localizable.xcstrings
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/Resources/Localizable.xcstrings
@@ -1076,6 +1076,69 @@
         "ja" : { "stringUnit" : { "state" : "translated", "value" : "Tailscaleが有効な場合" } }
       }
     },
+    "mobile.iroh.neverUseRelays" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Never Use Relays" } },
+        "ja" : { "stringUnit" : { "state" : "translated", "value" : "リレーを使用しない" } }
+      }
+    },
+    "mobile.iroh.pathPreference.footer" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "When enabled, cmux requires a reachable direct, local-network, or private-network path and will not fall back to a relay. Applies on the next reconnect." } },
+        "ja" : { "stringUnit" : { "state" : "translated", "value" : "有効にすると、cmuxは到達可能な直接経路、ローカルネットワーク経路、またはプライベートネットワーク経路を必要とし、リレーにはフォールバックしません。次回の再接続時に適用されます。" } }
+      }
+    },
+    "mobile.iroh.reset" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Reset to Defaults" } },
+        "ja" : { "stringUnit" : { "state" : "translated", "value" : "デフォルトに戻す" } }
+      }
+    },
+    "mobile.iroh.reset.title" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Reset Networking Settings?" } },
+        "ja" : { "stringUnit" : { "state" : "translated", "value" : "ネットワーク設定をデフォルトに戻しますか？" } }
+      }
+    },
+    "mobile.iroh.reset.confirm" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Reset" } },
+        "ja" : { "stringUnit" : { "state" : "translated", "value" : "リセット" } }
+      }
+    },
+    "mobile.iroh.reset.message" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Relay and path preferences will return to Automatic. Saved custom relays and private addresses will remain, but private addresses will be disabled." } },
+        "ja" : { "stringUnit" : { "state" : "translated", "value" : "リレーと経路の設定は「自動」に戻ります。保存済みのカスタムリレーとプライベートアドレスは残りますが、プライベートアドレスは無効になります。" } }
+      }
+    },
+    "mobile.iroh.relays" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Relays" } },
+        "ja" : { "stringUnit" : { "state" : "translated", "value" : "リレー" } }
+      }
+    },
+    "mobile.iroh.title" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Networking" } },
+        "ja" : { "stringUnit" : { "state" : "translated", "value" : "ネットワーク" } }
+      }
+    },
+    "mobile.settings.iroh" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Networking" } },
+        "ja" : { "stringUnit" : { "state" : "translated", "value" : "ネットワーク" } }
+      }
+    },
     "mobile.iroh.saveFailed" : {
       "extractionState" : "manual",
       "localizations" : {

--- a/Packages/iOS/CmuxMobileShellUI/Tests/CmuxMobileShellUITests/MobileIrohSettingsModelTests.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Tests/CmuxMobileShellUITests/MobileIrohSettingsModelTests.swift
@@ -133,6 +133,44 @@ struct MobileIrohSettingsModelTests {
         #expect(!model.showsSaveError)
     }
 
+    @Test func neverUseRelaysMutationForwardsThePathPreference() async {
+        let controller = MobileIrohSettingsControllerDouble(snapshot: .unavailable)
+        let model = MobileIrohSettingsModel(controller: controller)
+
+        model.setPathPreference(.neverUseRelays)
+        await waitUntil { controller.pathPreferenceMutations == [.neverUseRelays] }
+
+        #expect(!model.showsSaveError)
+    }
+
+    @Test func manualConnectionCheckPublishesReportAndRefreshesSnapshot() async {
+        let controller = MobileIrohSettingsControllerDouble(snapshot: .unavailable)
+        let report = CmxIrohConnectionCheckReport(
+            role: .mobileClient,
+            snapshot: .unavailable,
+            diagnostics: .empty,
+            relayReachability: .unavailable
+        )
+        controller.connectionCheck = report
+        let model = MobileIrohSettingsModel(controller: controller)
+
+        model.runConnectionCheck()
+        await waitUntil { model.connectionCheck == report }
+
+        #expect(controller.connectionCheckRunCount == 1)
+        #expect(!model.isRunningConnectionCheck)
+    }
+
+    @Test func resetToDefaultsForwardsToController() async {
+        let controller = MobileIrohSettingsControllerDouble(snapshot: .unavailable)
+        let model = MobileIrohSettingsModel(controller: controller)
+
+        model.resetToDefaults()
+        await waitUntil { controller.resetToDefaultsCount == 1 && !model.isMutating }
+
+        #expect(!model.showsSaveError)
+    }
+
     @Test func customPrivatePathMutationsForwardExactMacScopedDraft() async {
         let controller = MobileIrohSettingsControllerDouble(snapshot: .unavailable)
         let model = MobileIrohSettingsModel(controller: controller)
@@ -336,6 +374,9 @@ private final class MobileIrohSettingsControllerDouble:
     var debugTransportModeMutations: [CmxIrohTransportVerificationMode] = []
     var customPrivatePathUpserts: [CmxIrohCustomPrivatePathDraft] = []
     var customPrivatePathRemovals: [String] = []
+    var connectionCheck: CmxIrohConnectionCheckReport?
+    var connectionCheckRunCount = 0
+    var resetToDefaultsCount = 0
     var holdsDiagnosticReportReads = false
     var holdsRelayTests = false
     private(set) var nextDiagnosticReportRequestID = 0
@@ -388,6 +429,16 @@ private final class MobileIrohSettingsControllerDouble:
         }
     }
 
+    func runIrohConnectionCheck() async -> CmxIrohConnectionCheckReport {
+        connectionCheckRunCount += 1
+        return connectionCheck ?? CmxIrohConnectionCheckReport(
+            role: .mobileClient,
+            snapshot: snapshot,
+            diagnostics: report,
+            relayReachability: .unavailable
+        )
+    }
+
     var pendingRelayTestRequestIDs: [Int] {
         pendingRelayTests.keys.sorted()
     }
@@ -407,6 +458,10 @@ private final class MobileIrohSettingsControllerDouble:
 
     func removeIrohCustomPrivatePath(macDeviceID: String) async throws {
         customPrivatePathRemovals.append(macDeviceID)
+    }
+
+    func resetIrohSettingsToDefaults() async throws {
+        resetToDefaultsCount += 1
     }
 
     func refreshIrohSettings() async {}

--- a/ios/cmux/Resources/Localizable.xcstrings
+++ b/ios/cmux/Resources/Localizable.xcstrings
@@ -16881,13 +16881,13 @@
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "Iroh and Relays"
+            "value": "Networking"
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "Iroh とリレー"
+            "value": "ネットワーク"
           }
         }
       }
@@ -18422,6 +18422,74 @@
         }
       }
     },
+    "mobile.iroh.reset": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Reset to Defaults"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "デフォルトに戻す"
+          }
+        }
+      }
+    },
+    "mobile.iroh.reset.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Reset Networking Settings?"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ネットワーク設定をデフォルトに戻しますか？"
+          }
+        }
+      }
+    },
+    "mobile.iroh.reset.confirm": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Reset"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "リセット"
+          }
+        }
+      }
+    },
+    "mobile.iroh.reset.message": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Relay and path preferences will return to Automatic. Saved custom relays and private addresses will remain, but private addresses will be disabled."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "リレーと経路の設定は「自動」に戻ります。保存済みのカスタムリレーとプライベートアドレスは残りますが、プライベートアドレスは無効になります。"
+          }
+        }
+      }
+    },
     "mobile.iroh.pathPreference.footer": {
       "extractionState": "manual",
       "localizations": {
@@ -18479,13 +18547,13 @@
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "Iroh Relays"
+            "value": "Relays"
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "Iroh リレー"
+            "value": "リレー"
           }
         }
       }
@@ -18751,13 +18819,13 @@
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "Iroh and Relays"
+            "value": "Networking"
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "Iroh とリレー"
+            "value": "ネットワーク"
           }
         }
       }

--- a/ios/cmux/Resources/Localizable.xcstrings
+++ b/ios/cmux/Resources/Localizable.xcstrings
@@ -18496,13 +18496,13 @@
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "Relay Only blocks direct paths. Never Use Relays requires a reachable direct, local-network, or private-network path. Applies on the next reconnect."
+            "value": "When enabled, cmux requires a reachable direct, local-network, or private-network path and will not fall back to a relay. Applies on the next reconnect."
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "「リレーのみ」は直接経路を無効にします。「リレーを使用しない」には、到達可能な直接経路、ローカルネットワーク経路、またはプライベートネットワーク経路が必要です。次回の再接続時に適用されます。"
+            "value": "有効にすると、cmuxは到達可能な直接経路、ローカルネットワーク経路、またはプライベートネットワーク経路を必要とし、リレーにはフォールバックしません。次回の再接続時に適用されます。"
           }
         }
       }


### PR DESCRIPTION
## Summary
- expose the existing connection check in iOS Networking settings
- add the release-visible Never Use Relays toggle
- rename Iroh and Relays to Networking
- add a localized top-right Reset to Defaults action that restores Automatic preferences and disables private paths without deleting saved definitions

## Verification
- `swift test --package-path Packages/Shared/CMUXMobileCore --filter CmxIrohSettingsSnapshotTests` (8 passed)
- iOS simulator Debug build for tag `netui` succeeded and produced `dev.cmux.ios.netui`
- isolated `cmux-dev-netui` simulator preflight verified the Settings > Networking entrypoint, Networking title, reset toolbar icon, Never Use Relays toggle, and Connection Check button
- `jq empty` passed for both localization catalogs
- iOS package model tests were not runnable via SwiftPM on macOS because the package manifest has iOS-only dependency constraints
