### PR TITLE
fix(ios): stop replay scroll drain watchdog loop

### DIFF
--- a/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView.swift
+++ b/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView.swift
@@ -2039,26 +2039,23 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
     /// revealing the verified renderer. Without this drain, a render-grid
     /// update can reveal the pre-scroll viewport for one frame while the
     /// display-link batch is still waiting behind the frozen presentation.
+    ///
+    /// This transaction owns only the work present when it is admitted. New
+    /// gesture callbacks belong to the next presentation. Chasing newly
+    /// produced scroll batches here can keep this main-actor task runnable for
+    /// the entire gesture and trip iOS's scene-update watchdog.
     @discardableResult
     public func drainPendingScrollForVerifiedReplayReveal() async -> Bool {
-        var drained = false
-        while true {
-            if let flushed = flushPendingScrollIfNeeded() {
-                guard flushed.appliedLocally else { return drained }
-                guard await waitForLocalScrollApplied(upTo: flushed.generation) else {
-                    return drained
-                }
-                drained = true
-                continue
-            }
-            guard let generation = pendingLocalScrollTargetGenerationForReveal() else {
-                return drained
-            }
-            guard await waitForLocalScrollApplied(upTo: generation) else {
-                return drained
-            }
-            drained = true
+        let targetGeneration: UInt64
+        if let flushed = flushPendingScrollIfNeeded() {
+            guard flushed.appliedLocally else { return false }
+            targetGeneration = flushed.generation
+        } else if let pendingGeneration = pendingLocalScrollTargetGenerationForReveal() {
+            targetGeneration = pendingGeneration
+        } else {
+            return false
         }
+        return await waitForLocalScrollApplied(upTo: targetGeneration)
     }
 
     private func pendingLocalScrollTargetGenerationForReveal() -> UInt64? {

--- a/Packages/iOS/CmuxMobileTerminal/Tests/CmuxMobileTerminalTests/VerifiedReplayPresentationTests.swift
+++ b/Packages/iOS/CmuxMobileTerminal/Tests/CmuxMobileTerminalTests/VerifiedReplayPresentationTests.swift
@@ -51,6 +51,33 @@ struct VerifiedReplayPresentationTests {
         #expect(await view.drainPendingScrollForVerifiedReplayReveal())
         #expect(delegate.scrollEvents.count == 1)
     }
+
+    @MainActor
+    @Test("replay drain owns only the scroll work present at admission")
+    func replayDrainDoesNotChaseContinuouslyProducedScroll() async throws {
+        let runtime = try GhosttyRuntime.shared()
+        let delegate = ScrollDrainDelegate()
+        let view = GhosttySurfaceView(runtime: runtime, delegate: delegate, fontSize: 10)
+        defer { view.prepareForDismantle() }
+
+        var remainingProducerEvents = 128
+        delegate.onScroll = { [weak view] in
+            guard remainingProducerEvents > 0 else { return }
+            remainingProducerEvents -= 1
+            view?.debugEnqueueScrollForTesting(
+                deltaY: 42,
+                touchPoint: CGPoint(x: 12, y: 18)
+            )
+        }
+        view.debugEnqueueScrollForTesting(
+            deltaY: 42,
+            touchPoint: CGPoint(x: 12, y: 18)
+        )
+
+        #expect(await view.drainPendingScrollForVerifiedReplayReveal())
+        #expect(delegate.scrollEvents.count == 1)
+        #expect(remainingProducerEvents == 127)
+    }
 #endif
 
     @Test("the retained last-good frame owns immutable pixel bytes")
@@ -256,6 +283,7 @@ struct VerifiedReplayPresentationTests {
 @MainActor
 private final class ScrollDrainDelegate: NSObject, GhosttySurfaceViewDelegate {
     private(set) var scrollEvents: [(lines: Double, col: Int, row: Int)] = []
+    var onScroll: (() -> Void)?
 
     func ghosttySurfaceView(
         _ surfaceView: GhosttySurfaceView,
@@ -275,6 +303,7 @@ private final class ScrollDrainDelegate: NSObject, GhosttySurfaceViewDelegate {
         row: Int
     ) {
         scrollEvents.append((lines: lines, col: col, row: row))
+        onScroll?()
     }
 }
 


### PR DESCRIPTION
## Cause
Rapid scrolling could keep `drainPendingScrollForVerifiedReplayReveal()` on the main actor indefinitely. Each callback produced another scroll generation, and the `while true` drain immediately admitted it before returning. The six supplied reports from different times and both INTERNAL/BETA builds share the same async main-actor frames and 0x8BADF00D watchdog termination.

## Fix
Capture one generation watermark at replay admission, wait for that batch, and leave later callbacks for the next presentation.

## Regression
A test delegate continuously produces 128 follow-up scroll callbacks. The old loop chases all of them; the fixed path emits exactly one scroll event.

Test-only commit: `ea1f1adc8c`
Fix commit: `f62323b75d`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/10186"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789346946&installation_model_id=21920&pr_number=10186&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F10186&signature=2309053669d50ca612ba72d35622bb8e44f6d76f0fca191862302d0ee89d63a8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents iOS watchdog terminations by bounding the verified replay scroll drain. The drain no longer chases newly produced scroll callbacks; it captures a generation watermark at admission, waits for that batch, and exits.

- Old behavior: a loop kept admitting follow-up scroll generations during the same presentation, keeping the main-actor task runnable for the entire gesture. New behavior: the drain owns only the work present at admission and processes at most one scroll event per presentation, avoiding 0x8BADF00D.
- `GhosttySurfaceView.drainPendingScrollForVerifiedReplayReveal()` now computes a single target generation and returns the wait result; the unbounded loop is removed.
- Tests add a producer that emits 128 follow-up callbacks; the drain now yields one scroll event and leaves remaining callbacks for the next presentation.

<sup>Written for commit f62323b75db5e389737e7cfe22914ab4d2388945. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/10186?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved replay presentation scrolling so pending scroll actions are processed consistently.
  * Prevented newly generated gesture events from interfering with the current replay reveal.
  * Added regression coverage to ensure scrolling remains stable when additional events occur during processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->