### PR TITLE
Recover fresh hook-bound agents after crash restore

### DIFF
--- a/Sources/App/WorkspaceRuntimeSettings.swift
+++ b/Sources/App/WorkspaceRuntimeSettings.swift
@@ -218,12 +218,66 @@ enum AgentSessionAutoResumeSettings {
     static let autoResumeAgentSessionsKey = "terminal.autoResumeAgentSessions"
     static let defaultAutoResumeAgentSessions = true
     static let didChangeNotification = Notification.Name("cmux.agentSessionAutoResumeSettingsDidChange")
+    static let crashRecoveryBindingMaxAge: TimeInterval = 2 * 60 * 60
+    private static let crashRecoveryKinds: Set<String> = ["claude", "codex", "kimi"]
 
     static func isEnabled(defaults: UserDefaults = .standard) -> Bool {
         guard defaults.object(forKey: autoResumeAgentSessionsKey) != nil else {
             return defaultAutoResumeAgentSessions
         }
         return defaults.bool(forKey: autoResumeAgentSessionsKey)
+    }
+
+    static func allowsCrashRecovery(
+        for binding: SurfaceResumeBindingSnapshot,
+        now: TimeInterval = Date().timeIntervalSince1970
+    ) -> Bool {
+        guard binding.isAgentHookBinding,
+              binding.launchFlavor == .local,
+              binding.hasCompleteManagedSessionIdentity,
+              let kind = binding.kind?.lowercased(),
+              crashRecoveryKinds.contains(kind),
+              binding.updatedAt.isFinite else {
+            return false
+        }
+        return (0...crashRecoveryBindingMaxAge).contains(now - binding.updatedAt)
+    }
+
+    static func shouldAutoResume(
+        binding: SurfaceResumeBindingSnapshot?,
+        persistedAgent: SessionRestorableAgentSnapshot?,
+        wasAgentRunning: Bool?,
+        defaults: UserDefaults = .standard,
+        now: TimeInterval = Date().timeIntervalSince1970
+    ) -> Bool {
+        guard isEnabled(defaults: defaults) else { return false }
+        if wasAgentRunning ?? true { return true }
+        guard let binding, allowsCrashRecovery(for: binding, now: now) else {
+            return false
+        }
+        guard let persistedAgent else { return true }
+        return Workspace.restorableAgentForSessionRestore(
+            persistedAgent,
+            resumeBinding: binding
+        ) != nil
+    }
+
+    static func bindingForCrashRecovery(
+        _ binding: SurfaceResumeBindingSnapshot?,
+        shouldAutoResume: Bool,
+        wasAgentRunning: Bool?,
+        now: TimeInterval = Date().timeIntervalSince1970
+    ) -> SurfaceResumeBindingSnapshot? {
+        guard shouldAutoResume,
+              wasAgentRunning == false,
+              var binding,
+              binding.autoResume != true,
+              allowsCrashRecovery(for: binding, now: now) else {
+            return binding
+        }
+        // This trust promotion is restore-only; keep the persisted binding manual.
+        binding.autoResume = true
+        return binding
     }
 
     static func setEnabled(

--- a/Sources/DockSplitStore+SessionRestore.swift
+++ b/Sources/DockSplitStore+SessionRestore.swift
@@ -209,16 +209,22 @@ extension DockSplitStore {
                 restorableAgent: restorableAgent
             )
         }
-        let agentWasRunning = terminalSnapshot.wasAgentRunning ?? true
-        let shouldAutoResumeAgent = AgentSessionAutoResumeSettings.isEnabled(
+        let shouldAutoResumeAgent = AgentSessionAutoResumeSettings.shouldAutoResume(
+            binding: resumeBinding,
+            persistedAgent: terminalSnapshot.agent,
+            wasAgentRunning: terminalSnapshot.wasAgentRunning,
             defaults: agentSessionAutoResumeDefaults
-        ) && agentWasRunning
+        )
         let resumeBindingForStartup = hibernation != nil ||
             (resumeBinding?.isProcessDetected == true && resumeBinding?.autoResume != true)
             ? nil
             : resumeBinding
         let approvedResumeBinding = policy.approvedSurfaceResumeBinding(
-            resumeBindingForStartup,
+            AgentSessionAutoResumeSettings.bindingForCrashRecovery(
+                resumeBindingForStartup,
+                shouldAutoResume: shouldAutoResumeAgent,
+                wasAgentRunning: terminalSnapshot.wasAgentRunning
+            ),
             autoResumeAgentSessions: shouldAutoResumeAgent,
             promptForApproval: true,
             approvalStoreURL: SurfaceResumeApprovalStore.defaultURL()

--- a/Sources/DockSplitStore+SessionSnapshot.swift
+++ b/Sources/DockSplitStore+SessionSnapshot.swift
@@ -251,11 +251,19 @@ extension DockSplitStore {
             let tmuxStartCommand = restorableAgent == nil
                 ? policy.restorableTmuxStartCommand(terminal.surface.debugTmuxStartCommand())
                 : nil
+            let shouldAutoResumeAgent = AgentSessionAutoResumeSettings.shouldAutoResume(
+                binding: resumeBinding,
+                persistedAgent: observation?.snapshot ?? restorableAgent,
+                wasAgentRunning: agentWasRunning,
+                defaults: agentSessionAutoResumeDefaults
+            )
             let resumeStartupInput = policy.surfaceResumeStartupInput(
-                resumeBinding,
-                autoResumeAgentSessions: AgentSessionAutoResumeSettings.isEnabled(
-                    defaults: agentSessionAutoResumeDefaults
-                ) && (agentWasRunning ?? true),
+                AgentSessionAutoResumeSettings.bindingForCrashRecovery(
+                    resumeBinding,
+                    shouldAutoResume: shouldAutoResumeAgent,
+                    wasAgentRunning: agentWasRunning
+                ),
+                autoResumeAgentSessions: shouldAutoResumeAgent,
                 promptForApproval: false,
                 approvalStoreURL: SurfaceResumeApprovalStore.defaultURL()
             )

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -570,9 +570,19 @@ extension Workspace {
                         processPresence: agentProcessPresence
                     )
             }()
+            let shouldAutoResumeAgent = AgentSessionAutoResumeSettings.shouldAutoResume(
+                binding: resumeBinding,
+                persistedAgent: indexedRestorableAgent ?? effectiveRestorableAgent,
+                wasAgentRunning: agentWasRunning,
+                defaults: agentSessionAutoResumeDefaults
+            )
             let resumeStartupInput = sessionRestorePolicy.surfaceResumeStartupInput(
-                resumeBinding,
-                autoResumeAgentSessions: AgentSessionAutoResumeSettings.isEnabled(defaults: agentSessionAutoResumeDefaults) && (agentWasRunning ?? true),
+                AgentSessionAutoResumeSettings.bindingForCrashRecovery(
+                    resumeBinding,
+                    shouldAutoResume: shouldAutoResumeAgent,
+                    wasAgentRunning: agentWasRunning
+                ),
+                autoResumeAgentSessions: shouldAutoResumeAgent,
                 promptForApproval: false,
                 approvalStoreURL: SurfaceResumeApprovalStore.defaultURL()
             )
@@ -1376,11 +1386,6 @@ extension Workspace {
                 resumeBinding: persistedResumeBinding
             )
             let restoredHibernation = restorableAgent != nil ? snapshot.terminal?.hibernation : nil
-            let autoResumeAgentSessions = AgentSessionAutoResumeSettings.isEnabled(defaults: agentSessionAutoResumeDefaults)
-            // Only auto-resume if the agent was actively running when the snapshot was saved.
-            // wasAgentRunning == nil means a legacy snapshot; treat as true for backwards compatibility.
-            let agentWasRunningAtQuit = snapshot.terminal?.wasAgentRunning ?? true
-            let shouldAutoResumeAgent = autoResumeAgentSessions && agentWasRunningAtQuit
             let remoteStartupCommand = remoteTerminalStartupCommand()
             let restoresRemoteWorkspaceTerminalSnapshot =
                 remoteStartupCommand != nil &&
@@ -1415,13 +1420,23 @@ extension Workspace {
                 locatedResumeBinding,
                 restorableAgent: restorableAgent
             )
+            let shouldAutoResumeAgent = AgentSessionAutoResumeSettings.shouldAutoResume(
+                binding: resumeBinding,
+                persistedAgent: snapshotRestorableAgent,
+                wasAgentRunning: snapshot.terminal?.wasAgentRunning,
+                defaults: agentSessionAutoResumeDefaults
+            )
             let resumeBindingForStartup =
                 restoredHibernation != nil ||
                 (resumeBinding?.isProcessDetected == true && resumeBinding?.autoResume != true)
                     ? nil
                     : resumeBinding
             let effectiveResumeBindingForStartup = sessionRestorePolicy.approvedSurfaceResumeBinding(
-                resumeBindingForStartup,
+                AgentSessionAutoResumeSettings.bindingForCrashRecovery(
+                    resumeBindingForStartup,
+                    shouldAutoResume: shouldAutoResumeAgent,
+                    wasAgentRunning: snapshot.terminal?.wasAgentRunning
+                ),
                 autoResumeAgentSessions: shouldAutoResumeAgent,
                 promptForApproval: true,
                 approvalStoreURL: SurfaceResumeApprovalStore.defaultURL()

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -1610,7 +1610,7 @@ extension Workspace {
                     "kind=\(restorableAgent.kind.rawValue) session=\(sessionPreview) " +
                     "hasLaunch=\(restorableAgent.launchCommand == nil ? 0 : 1) " +
                     "launchArgc=\(launchArgc) hasResume=\(restoredAgentResumeLaunch == nil ? 0 : 1) " +
-                    "autoResume=\(autoResumeAgentSessions ? 1 : 0) typedStartup=\(restoredStartupInput == nil ? 0 : 1) " +
+                    "autoResume=\(shouldAutoResumeAgent ? 1 : 0) typedStartup=\(restoredStartupInput == nil ? 0 : 1) " +
                     "replayScrollback=\(shouldReplayScrollback ? 1 : 0)"
                 )
             }

--- a/cmuxTests/AgentSessionAutoResumeSwiftTests.swift
+++ b/cmuxTests/AgentSessionAutoResumeSwiftTests.swift
@@ -13,6 +13,131 @@ import Testing
 
 @Suite(.serialized)
 struct AgentSessionAutoResumeSwiftTests {
+    @MainActor
+    @Test(arguments: ["codex", "claude", "kimi"])
+    func freshTrustedHookBindingRecoversAfterCrash(kind: String) throws {
+        let defaultsName = "cmux-crash-auto-resume-\(kind)-\(UUID().uuidString)"
+        let defaults = try #require(UserDefaults(suiteName: defaultsName))
+        defer { defaults.removePersistentDomain(forName: defaultsName) }
+        defaults.set(true, forKey: AgentSessionAutoResumeSettings.autoResumeAgentSessionsKey)
+
+        let fixture = try crashRecoverySnapshot(
+            kind: kind,
+            updatedAt: Date().timeIntervalSince1970 - 60
+        )
+        let restored = Workspace(agentSessionAutoResumeDefaults: defaults)
+        defer { restored.teardownAllPanels() }
+        let restoredPanelIDs = restored.restoreSessionSnapshot(fixture.snapshot)
+        let restoredPanelID = try #require(restoredPanelIDs[fixture.panelID])
+        let restoredPanel = try #require(restored.terminalPanel(for: restoredPanelID))
+
+        #expect(restoredPanel.surface.debugInitialInputForTesting() != nil)
+        #expect(
+            restored.restoredAgentResumeStatesByPanelId[restoredPanelID]
+                == .awaitingAutoResumeCommand
+        )
+        #expect(restoredPanel.surface.debugHasHeadlessStartupWindowForTesting())
+    }
+
+    @MainActor
+    @Test func dockFreshTrustedHookBindingRecoversAfterCrash() throws {
+        let defaultsName = "cmux-dock-crash-auto-resume-\(UUID().uuidString)"
+        let defaults = try #require(UserDefaults(suiteName: defaultsName))
+        defer { defaults.removePersistentDomain(forName: defaultsName) }
+        defaults.set(true, forKey: AgentSessionAutoResumeSettings.autoResumeAgentSessionsKey)
+
+        let fixture = try crashRecoverySnapshot(
+            kind: "codex",
+            updatedAt: Date().timeIntervalSince1970 - 60
+        )
+        let panelSnapshot = try #require(
+            fixture.snapshot.panels.first { $0.id == fixture.panelID }
+        )
+        let dock = DockSplitStore(
+            workspaceId: UUID(),
+            baseDirectoryProvider: { nil },
+            agentSessionAutoResumeDefaults: defaults
+        )
+        defer { dock.closeAllPanels() }
+        let restoredPanelIDs = dock.restoreSessionSnapshot(
+            SessionSplitContainerSnapshot(
+                focusedPanelId: fixture.panelID,
+                layout: .pane(SessionPaneLayoutSnapshot(
+                    panelIds: [fixture.panelID],
+                    selectedPanelId: fixture.panelID
+                )),
+                panels: [panelSnapshot]
+            )
+        )
+        let restoredPanelID = try #require(restoredPanelIDs[fixture.panelID])
+        let restoredPanel = try #require(dock.panels[restoredPanelID] as? TerminalPanel)
+
+        #expect(restoredPanel.surface.debugInitialInputForTesting() != nil)
+        #expect(
+            dock.restoredAgentLifecycle.resumeStatesByPanelId[restoredPanelID]
+                == .awaitingAutoResumeCommand
+        )
+        #expect(restoredPanel.surface.debugHasHeadlessStartupWindowForTesting())
+    }
+
+    @MainActor
+    @Test func unsafeCrashRecoveryBindingsStayManual() throws {
+        let cases: [(kind: String, updatedAt: TimeInterval, enabled: Bool)] = [
+            ("codex", Date().timeIntervalSince1970 - 13 * 60 * 60, true),
+            ("opencode", Date().timeIntervalSince1970 - 60, true),
+            ("codex", Date().timeIntervalSince1970 - 60, false),
+        ]
+
+        for testCase in cases {
+            let defaultsName = "cmux-unsafe-crash-resume-\(UUID().uuidString)"
+            let defaults = try #require(UserDefaults(suiteName: defaultsName))
+            defer { defaults.removePersistentDomain(forName: defaultsName) }
+            defaults.set(
+                testCase.enabled,
+                forKey: AgentSessionAutoResumeSettings.autoResumeAgentSessionsKey
+            )
+            let fixture = try crashRecoverySnapshot(
+                kind: testCase.kind,
+                updatedAt: testCase.updatedAt
+            )
+            let restored = Workspace(agentSessionAutoResumeDefaults: defaults)
+            defer { restored.teardownAllPanels() }
+            let restoredPanelIDs = restored.restoreSessionSnapshot(fixture.snapshot)
+            let restoredPanelID = try #require(restoredPanelIDs[fixture.panelID])
+            let restoredPanel = try #require(restored.terminalPanel(for: restoredPanelID))
+
+            #expect(restoredPanel.surface.debugInitialInputForTesting() == nil)
+            #expect(!restoredPanel.surface.debugHasHeadlessStartupWindowForTesting())
+        }
+    }
+
+    @MainActor
+    @Test func freshCrossKindHookBindingDoesNotReplacePersistedAgent() throws {
+        let defaultsName = "cmux-cross-kind-crash-resume-\(UUID().uuidString)"
+        let defaults = try #require(UserDefaults(suiteName: defaultsName))
+        defer { defaults.removePersistentDomain(forName: defaultsName) }
+        defaults.set(true, forKey: AgentSessionAutoResumeSettings.autoResumeAgentSessionsKey)
+
+        let persistedClaude = SessionRestorableAgentSnapshot(
+            kind: .claude,
+            sessionId: "claude-current-session",
+            workingDirectory: "/tmp/cmux-crash-recovery"
+        )
+        let fixture = try crashRecoverySnapshot(
+            kind: "kimi",
+            updatedAt: Date().timeIntervalSince1970 - 60,
+            persistedAgent: persistedClaude
+        )
+        let restored = Workspace(agentSessionAutoResumeDefaults: defaults)
+        defer { restored.teardownAllPanels() }
+        let restoredPanelIDs = restored.restoreSessionSnapshot(fixture.snapshot)
+        let restoredPanelID = try #require(restoredPanelIDs[fixture.panelID])
+        let restoredPanel = try #require(restored.terminalPanel(for: restoredPanelID))
+
+        #expect(restoredPanel.surface.debugInitialInputForTesting() == nil)
+        #expect(!restoredPanel.surface.debugHasHeadlessStartupWindowForTesting())
+    }
+
     /// Regression for #9619: cmux-owned restore input is an implementation
     /// detail, not a user or agent title. Preserve the automatic title captured
     /// before relaunch through that bootstrap event, then accept the first real
@@ -1623,6 +1748,35 @@ struct AgentSessionAutoResumeSwiftTests {
     private func expectedClaudeProjectDirName(_ path: String) -> String {
         path.replacingOccurrences(of: "/", with: "-")
             .replacingOccurrences(of: ".", with: "-")
+    }
+
+    @MainActor
+    private func crashRecoverySnapshot(
+        kind: String,
+        updatedAt: TimeInterval,
+        persistedAgent: SessionRestorableAgentSnapshot? = nil
+    ) throws -> (snapshot: SessionWorkspaceSnapshot, panelID: UUID) {
+        let source = Workspace()
+        defer { source.teardownAllPanels() }
+        let panelID = try #require(source.focusedPanelId)
+        var snapshot = source.sessionSnapshot(includeScrollback: false)
+        let panelIndex = try #require(snapshot.panels.firstIndex { $0.id == panelID })
+        var terminal = try #require(snapshot.panels[panelIndex].terminal)
+        let checkpointID = "\(kind)-crash-recovery-\(UUID().uuidString)"
+        terminal.agent = persistedAgent
+        terminal.resumeBinding = SurfaceResumeBindingSnapshot(
+            name: kind.capitalized,
+            kind: kind,
+            command: "\(kind) --resume \(checkpointID)",
+            cwd: "/tmp/cmux-crash-recovery",
+            checkpointId: checkpointID,
+            source: "agent-hook",
+            autoResume: false,
+            updatedAt: updatedAt
+        )
+        terminal.wasAgentRunning = false
+        snapshot.panels[panelIndex].terminal = terminal
+        return (snapshot, panelID)
     }
 
     private func writeClaudeTranscript(sessionId: String, transcriptURL: URL) throws {


### PR DESCRIPTION
## Summary

- preserve the existing `terminal.autoResumeAgentSessions` setting
- restore fresh local `agent-hook` bindings for Codex, Claude, and Kimi even when the last periodic snapshot recorded `autoResume:false` / `wasAgentRunning:false`
- require a complete managed identity, matching persisted agent kind, and a binding no older than two hours
- reject future timestamps, unsupported/custom kinds, stale bindings, disabled settings, and cross-kind replacements
- promote `autoResume` only in the restore copy; persisted bindings stay unchanged

## Regression coverage

1. `3a6d1347a6` adds the failing workspace + Dock recovery tests and rejection cases
2. `ee5d7486c0` implements the restore policy

## Validation

- Swift parser on changed sources/tests
- strict test determinism
- pbxproj test wiring
- workspace package grouping
- Package.resolved policy
- pbxproj normalization
- focused macOS test and tagged cloud build dispatched at the fixed SHA

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved crash recovery for Codex, Claude, and Kimi sessions.
  * Recent, trusted sessions can resume automatically across workspaces and dock splits.
  * Sessions preserve their configured agent identity during restoration.

* **Bug Fixes**
  * Stale, unsupported, incomplete, or disabled resume configurations remain manual instead of resuming unexpectedly.
  * Previously running sessions restore using their correct running state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->