### PR TITLE
Preserve migrated Tailscale routes during Iroh refresh

### DIFF
--- a/Packages/iOS/CmuxMobilePairedMac/Sources/CmuxMobilePairedMac/MobilePairedMacStore.swift
+++ b/Packages/iOS/CmuxMobilePairedMac/Sources/CmuxMobilePairedMac/MobilePairedMacStore.swift
@@ -533,7 +533,8 @@ public actor MobilePairedMacStore: MobilePairedMacStoring {
             teamID: teamID,
             now: now,
             restoredCustomizations: nil,
-            onlyIfOlder: false
+            onlyIfOlder: false,
+            revokeMigrationTailscaleGrants: true
         )
     }
 
@@ -562,7 +563,8 @@ public actor MobilePairedMacStore: MobilePairedMacStoring {
             teamID: teamID,
             now: now,
             restoredCustomizations: (customName, customColor, customIcon),
-            onlyIfOlder: true
+            onlyIfOlder: true,
+            revokeMigrationTailscaleGrants: true
         )
     }
 
@@ -590,7 +592,8 @@ public actor MobilePairedMacStore: MobilePairedMacStoring {
             now: now,
             restoredCustomizations: nil,
             onlyIfOlder: false,
-            routeWriteCondition: condition
+            routeWriteCondition: condition,
+            revokeMigrationTailscaleGrants: false
         )
     }
 
@@ -656,7 +659,8 @@ public actor MobilePairedMacStore: MobilePairedMacStoring {
         now: Date,
         restoredCustomizations: (String?, String?, String?)?,
         onlyIfOlder: Bool,
-        routeWriteCondition: MobilePairedMacRouteWriteCondition? = nil
+        routeWriteCondition: MobilePairedMacRouteWriteCondition? = nil,
+        revokeMigrationTailscaleGrants: Bool
     ) throws -> Bool {
         try ensureReady()
         let macDeviceID = cmxCanonicalDeviceID(macDeviceID)
@@ -806,7 +810,8 @@ public actor MobilePairedMacStore: MobilePairedMacStoring {
                 lastSeenAt: now,
                 isActive: shouldMarkActive
             )
-            if routesToPersist.contains(where: { $0.kind == .iroh }) {
+            if revokeMigrationTailscaleGrants,
+               routesToPersist.contains(where: { $0.kind == .iroh }) {
                 // Only the staggered-update migration capability dies on Iroh
                 // arrival. A user-entered pairing-code grant is a deliberate
                 // Tailscale choice and remains available for preference-ordered

--- a/Packages/iOS/CmuxMobilePairedMac/Tests/CmuxMobilePairedMacTests/MobilePairedMacStoreTests.swift
+++ b/Packages/iOS/CmuxMobilePairedMac/Tests/CmuxMobilePairedMacTests/MobilePairedMacStoreTests.swift
@@ -221,6 +221,34 @@ import Testing
         #expect(try await store.activeMac(stackUserID: "user-1")?.legacyTailscaleRoutes == nil)
     }
 
+    @Test func registryIrohRefreshPreservesGrandfatheredDestination() async throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let databaseURL = directory.appendingPathComponent("paired-macs.sqlite3")
+        let tailscale = try tailscaleRoute(host: "100.64.0.251")
+
+        try seedVersionSevenDatabase(at: databaseURL, routes: [tailscale])
+        let store = try MobilePairedMacStore(databaseURL: databaseURL)
+        let updatedRoutes = [tailscale, try irohRoute()]
+        let wrote = try await store.upsertRoutesIfAuthorized(
+            macDeviceID: "legacy-mac",
+            displayName: "Legacy Mac",
+            routes: updatedRoutes,
+            condition: .matchingInstanceTag(nil),
+            markActive: nil,
+            stackUserID: "user-1",
+            teamID: nil,
+            now: Date()
+        )
+
+        #expect(wrote)
+        let mac = try #require(await store.activeMac(stackUserID: "user-1"))
+        #expect(mac.routes == updatedRoutes)
+        #expect(mac.legacyTailscaleRoutes == [tailscale])
+    }
+
     @Test func userEnteredPairingCodeMintsDeviceLocalGrant() async throws {
         let (store, directory) = try makeStore()
         defer { try? FileManager.default.removeItem(at: directory) }


### PR DESCRIPTION
## Root cause
A pre-IROH BETA install is migrated with a local Tailscale compatibility grant. The Iroh registry refresh then called the same persistence path as an authenticated pairing update, which deleted migration-origin grants as soon as Iroh appeared. Tailscale-only reconnect selection correctly requires that grant, so the old route became unusable after upgrade.

## Fix
Keep migration-grant revocation for explicit authenticated upserts, but disable it for conditional registry route refreshes. The existing route merge still retains the grandfathered Tailscale route, and the preserved local grant authorizes its use. User-entered grants remain unchanged.

## Verification
- Added a regression test that seeds a v7 migrated Tailscale-only row, applies an Iroh registry refresh, and verifies both the route and local grant survive.
- `swift test --package-path Packages/iOS/CmuxMobilePairedMac --filter MobilePairedMacStoreTests` passes, 24 tests.
- The shell package focused build was attempted with an isolated scratch path, but the long compile was interrupted by the command runner before test output completed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/10188"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789347572&installation_model_id=21920&pr_number=10188&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F10188&signature=0e1b9aa05436542010a7572ce92c9629a39cfb8d6b74356d4b0ccc5ce9c5643b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves migrated Tailscale routes and their local grants during an Iroh registry refresh so upgraded devices keep working. Previously, the refresh revoked migration-origin Tailscale grants as if it were an authenticated update; now revocation is skipped for refreshes but kept for explicit authenticated upserts.

- Add a revokeMigrationTailscaleGrants flag to the route upsert path in `CmuxMobilePairedMac/MobilePairedMacStore`. Authenticated upserts pass true; conditional registry refreshes (`upsertRoutesIfAuthorized`) pass false.
- Behavior: the existing route merge retains the grandfathered Tailscale route, and the preserved local grant authorizes its use. User-entered pairing-code grants remain unchanged.
- Tests: add a regression test that seeds a v7 migrated Tailscale-only row, runs an Iroh refresh, and verifies both the route and local grant survive. No schema changes or data migrations required.

<sup>Written for commit f4741f0eb6237d98ee77391ca6f6162e9e85c13b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/10188?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved user-authorized Tailscale destinations when adding Iroh routes.
  * Removed migration-origin Tailscale grants only when appropriate, preventing unintended revocation during authorized route updates.

* **Tests**
  * Added regression coverage to verify grandfathered Tailscale destinations remain available after authorized Iroh route updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->