### PR TITLE
Fix Markdown preview refresh after editor saves

### DIFF
--- a/Sources/DockSplitStore+PortalDrop.swift
+++ b/Sources/DockSplitStore+PortalDrop.swift
@@ -226,7 +226,11 @@ extension DockSplitStore {
         filePath: String,
         targetIndex: Int?
     ) -> FilePreviewPanel? {
-        let panel = FilePreviewPanel(workspaceId: workspaceId, filePath: filePath)
+        let panel = FilePreviewPanel(
+            workspaceId: workspaceId,
+            filePath: filePath,
+            fileContentChangeCoordinator: fileContentChangeCoordinator
+        )
         panels[panel.id] = panel
         guard let tabId = bonsplitController.createTab(
             title: panel.displayTitle,
@@ -257,7 +261,11 @@ extension DockSplitStore {
         focus: Bool
     ) -> (panel: FilePreviewPanel, pane: PaneID)? {
         guard containsPane(paneId.id) else { return nil }
-        let panel = FilePreviewPanel(workspaceId: workspaceId, filePath: filePath)
+        let panel = FilePreviewPanel(
+            workspaceId: workspaceId,
+            filePath: filePath,
+            fileContentChangeCoordinator: fileContentChangeCoordinator
+        )
         let tab = Bonsplit.Tab(
             title: panel.displayTitle,
             icon: RenderableSystemSymbol.resolvedSurfaceTabIcon(panel.displayIcon),

--- a/Sources/DockSplitStore+SessionRestore.swift
+++ b/Sources/DockSplitStore+SessionRestore.swift
@@ -412,7 +412,11 @@ extension DockSplitStore {
         excludingStableIdentities: Set<UUID>
     ) -> UUID? {
         guard let filePath = snapshot.filePreview?.filePath else { return nil }
-        let panel = FilePreviewPanel(workspaceId: workspaceId, filePath: filePath)
+        let panel = FilePreviewPanel(
+            workspaceId: workspaceId,
+            filePath: filePath,
+            fileContentChangeCoordinator: fileContentChangeCoordinator
+        )
         guard attachSessionRestoredPanel(
             panel,
             snapshot: snapshot,

--- a/Sources/DockSplitStore+SurfaceTransfer.swift
+++ b/Sources/DockSplitStore+SurfaceTransfer.swift
@@ -398,7 +398,10 @@ extension DockSplitStore {
         } else if let browser = panel as? BrowserPanel {
             browser.updateWorkspaceId(workspaceId)
         } else if let filePreview = panel as? FilePreviewPanel {
-            filePreview.updateWorkspaceId(workspaceId)
+            filePreview.updateWorkspaceId(
+                workspaceId,
+                fileContentChangeCoordinator: fileContentChangeCoordinator
+            )
         }
     }
 

--- a/Sources/DockSplitStore+SurfaceTransfer.swift
+++ b/Sources/DockSplitStore+SurfaceTransfer.swift
@@ -402,6 +402,11 @@ extension DockSplitStore {
                 workspaceId,
                 fileContentChangeCoordinator: fileContentChangeCoordinator
             )
+        } else if let markdown = panel as? MarkdownPanel {
+            markdown.updateWorkspaceId(
+                workspaceId,
+                fileContentChangeCoordinator: fileContentChangeCoordinator
+            )
         }
     }
 

--- a/Sources/DockSplitStore.swift
+++ b/Sources/DockSplitStore.swift
@@ -297,7 +297,7 @@ final class DockSplitStore: BonsplitDelegate, FilePreviewTabMetadataHost {
         settings: any SettingsReading = UserDefaultsSettingsClient(defaults: .standard),
         agentSessionAutoResumeDefaults: UserDefaults = .standard,
         agentChatResumeIntentRecorder: any AgentChatResumeIntentRecording = AgentChatTranscriptResumeIntentRecorder(),
-        fileContentChangeCoordinator: FileContentChangeCoordinator = FileContentChangeCoordinator(),
+        fileContentChangeCoordinator: FileContentChangeCoordinator? = nil,
         terminalWorkingDirectoryResolver: TerminalWorkingDirectoryResolver = TerminalWorkingDirectoryResolver(),
         closedItemHistoryStore: ClosedItemHistoryStore? = nil
     ) {
@@ -307,7 +307,8 @@ final class DockSplitStore: BonsplitDelegate, FilePreviewTabMetadataHost {
         self.baseDirectoryProvider = baseDirectoryProvider
         self.remoteBrowserSettingsProvider = remoteBrowserSettingsProvider
         self.browserAvailabilityProvider = browserAvailabilityProvider
-        self.fileContentChangeCoordinator = fileContentChangeCoordinator
+        self.fileContentChangeCoordinator =
+            fileContentChangeCoordinator ?? FileContentChangeCoordinator()
         self.terminalTitleUpdateCoalescer =
             terminalTitleUpdateCoalescer ?? NotificationBurstCoalescer()
         self.settings = settings

--- a/Sources/DockSplitStore.swift
+++ b/Sources/DockSplitStore.swift
@@ -55,6 +55,7 @@ final class DockSplitStore: BonsplitDelegate, FilePreviewTabMetadataHost {
     private let baseDirectoryProvider: () -> String?
     private let remoteBrowserSettingsProvider: () -> DockRemoteBrowserSettings
     private let browserAvailabilityProvider: () -> Bool
+    let fileContentChangeCoordinator: FileContentChangeCoordinator
     @ObservationIgnored weak var notificationStore: TerminalNotificationStore?
     var panels: [UUID: any Panel] = [:]
     var surfaceIdToPanelId: [TabID: UUID] = [:]
@@ -296,6 +297,7 @@ final class DockSplitStore: BonsplitDelegate, FilePreviewTabMetadataHost {
         settings: any SettingsReading = UserDefaultsSettingsClient(defaults: .standard),
         agentSessionAutoResumeDefaults: UserDefaults = .standard,
         agentChatResumeIntentRecorder: any AgentChatResumeIntentRecording = AgentChatTranscriptResumeIntentRecorder(),
+        fileContentChangeCoordinator: FileContentChangeCoordinator = FileContentChangeCoordinator(),
         terminalWorkingDirectoryResolver: TerminalWorkingDirectoryResolver = TerminalWorkingDirectoryResolver(),
         closedItemHistoryStore: ClosedItemHistoryStore? = nil
     ) {
@@ -305,6 +307,7 @@ final class DockSplitStore: BonsplitDelegate, FilePreviewTabMetadataHost {
         self.baseDirectoryProvider = baseDirectoryProvider
         self.remoteBrowserSettingsProvider = remoteBrowserSettingsProvider
         self.browserAvailabilityProvider = browserAvailabilityProvider
+        self.fileContentChangeCoordinator = fileContentChangeCoordinator
         self.terminalTitleUpdateCoalescer =
             terminalTitleUpdateCoalescer ?? NotificationBurstCoalescer()
         self.settings = settings

--- a/Sources/DockSplitStore.swift
+++ b/Sources/DockSplitStore.swift
@@ -308,7 +308,7 @@ final class DockSplitStore: BonsplitDelegate, FilePreviewTabMetadataHost {
         self.remoteBrowserSettingsProvider = remoteBrowserSettingsProvider
         self.browserAvailabilityProvider = browserAvailabilityProvider
         self.fileContentChangeCoordinator =
-            fileContentChangeCoordinator ?? FileContentChangeCoordinator()
+            fileContentChangeCoordinator ?? .shared
         self.terminalTitleUpdateCoalescer =
             terminalTitleUpdateCoalescer ?? NotificationBurstCoalescer()
         self.settings = settings

--- a/Sources/Panels/FileContentChangeCoordinator.swift
+++ b/Sources/Panels/FileContentChangeCoordinator.swift
@@ -24,13 +24,21 @@ final class FileContentChangeCoordinator {
         var observers: [UUID: ChangeHandler]
     }
 
+    /// The app-wide pipeline. A commit signal must reach every panel showing
+    /// the path — across workspaces, windows, and window Docks — so production
+    /// containers default to this instance; per-instance construction exists
+    /// for tests.
+    static let shared = FileContentChangeCoordinator()
+
     private let makeFileWatcher: FileWatcherFactory
     private var entriesByPath: [String: Entry] = [:]
     private var pathsByObservationID: [UUID: String] = [:]
 
     init(
         makeFileWatcher: @escaping FileWatcherFactory = { path in
-            FileWatcher(path: path)
+            // The throttle bounds reload storms from external write bursts;
+            // in-app saves bypass it via `fileWriteCompleted`.
+            FileWatcher(path: path, throttle: .milliseconds(300))
         }
     ) {
         self.makeFileWatcher = makeFileWatcher

--- a/Sources/Panels/FileContentChangeCoordinator.swift
+++ b/Sources/Panels/FileContentChangeCoordinator.swift
@@ -11,6 +11,11 @@ import Foundation
 final class FileContentChangeCoordinator {
     typealias ChangeHandler = @MainActor () -> Void
     typealias FileWatcherFactory = @MainActor (String) -> FileWatcher?
+    typealias TextSaver = @Sendable (
+        String,
+        URL,
+        String.Encoding
+    ) async -> FilePreviewTextSaver.Result
 
     private struct Entry {
         var lastObservedState: FilePreviewFileState
@@ -31,9 +36,10 @@ final class FileContentChangeCoordinator {
         self.makeFileWatcher = makeFileWatcher
     }
 
-    /// Starts observing `path` and returns an id used to remove the callback.
-    /// Source attachment and callback registration are synchronous on the main
-    /// actor, so a save cannot race ahead of a newly constructed panel.
+    /// Starts observing `path`, performs one initial reconciliation, and returns
+    /// an id used to remove the callback. Source attachment and registration are
+    /// synchronous on the main actor, so a save cannot race ahead of a newly
+    /// constructed panel.
     func observe(
         path: String,
         onChange: @escaping ChangeHandler
@@ -49,7 +55,10 @@ final class FileContentChangeCoordinator {
         // Close the capture/attachment gap: the first fingerprint is sampled
         // before watcher construction and this second sample happens after the
         // observer is installed. Changes after attachment arrive on the stream.
-        publishFilesystemChangeIfNeeded(at: canonicalPath)
+        let publishedChange = publishFilesystemChangeIfNeeded(at: canonicalPath)
+        if !publishedChange {
+            onChange()
+        }
         return observationID
     }
 
@@ -87,6 +96,47 @@ final class FileContentChangeCoordinator {
         }
     }
 
+    /// Runs a text save and publishes its committed write through the same path
+    /// used by filesystem invalidations. Publication is independent of the
+    /// saving panel's lifetime.
+    func saveTextContent(
+        _ content: String,
+        to url: URL,
+        encoding: String.Encoding,
+        using saver: TextSaver,
+        excluding excludedObservationID: UUID?
+    ) async -> FilePreviewTextSaver.Result {
+        let result = await saver(content, url, encoding)
+        if case .saved = result {
+            fileWriteCompleted(
+                at: url.path,
+                excluding: excludedObservationID
+            )
+        }
+        return result
+    }
+
+    func saveTextContent(
+        _ content: String,
+        to url: URL,
+        encoding: String.Encoding,
+        excluding excludedObservationID: UUID?
+    ) async -> FilePreviewTextSaver.Result {
+        await saveTextContent(
+            content,
+            to: url,
+            encoding: encoding,
+            using: { content, url, encoding in
+                await FilePreviewTextSaver.save(
+                    content: content,
+                    to: url,
+                    encoding: encoding
+                )
+            },
+            excluding: excludedObservationID
+        )
+    }
+
     deinit {
         for entry in entriesByPath.values {
             entry.watchTask?.cancel()
@@ -112,16 +162,18 @@ final class FileContentChangeCoordinator {
         )
     }
 
-    private func publishFilesystemChangeIfNeeded(at canonicalPath: String) {
-        guard var entry = entriesByPath[canonicalPath] else { return }
+    @discardableResult
+    private func publishFilesystemChangeIfNeeded(at canonicalPath: String) -> Bool {
+        guard var entry = entriesByPath[canonicalPath] else { return false }
         let nextState = FilePreviewFileState.capture(path: canonicalPath)
-        guard nextState != entry.lastObservedState else { return }
+        guard nextState != entry.lastObservedState else { return false }
         entry.lastObservedState = nextState
         let handlers = Array(entry.observers.values)
         entriesByPath[canonicalPath] = entry
         for handler in handlers {
             handler()
         }
+        return true
     }
 
     private static func canonicalPath(_ path: String) -> String {

--- a/Sources/Panels/FileContentChangeCoordinator.swift
+++ b/Sources/Panels/FileContentChangeCoordinator.swift
@@ -137,6 +137,21 @@ final class FileContentChangeCoordinator {
         )
     }
 
+    /// If a saving panel moved while its write was suspended, mirrors the
+    /// committed-write signal into the panel's current observation domain.
+    func republishSuccessfulSaveIfNeeded(
+        _ result: FilePreviewTextSaver.Result,
+        to currentCoordinator: FileContentChangeCoordinator,
+        at path: String,
+        excluding currentObservationID: UUID?
+    ) {
+        guard case .saved = result, currentCoordinator !== self else { return }
+        currentCoordinator.fileWriteCompleted(
+            at: path,
+            excluding: currentObservationID
+        )
+    }
+
     deinit {
         for entry in entriesByPath.values {
             entry.watchTask?.cancel()

--- a/Sources/Panels/FileContentChangeCoordinator.swift
+++ b/Sources/Panels/FileContentChangeCoordinator.swift
@@ -1,0 +1,133 @@
+import CmuxFoundation
+import Foundation
+
+/// Multiplexes file-content invalidations for file-backed panels.
+///
+/// Each canonical path owns one filesystem watcher regardless of how many
+/// panels display it. Successful in-app writes also enter through this service,
+/// giving viewers a commit-boundary signal that does not depend on vnode event
+/// timing. Filesystem events remain the fallback for external editors.
+@MainActor
+final class FileContentChangeCoordinator {
+    typealias ChangeHandler = @MainActor () -> Void
+    typealias FileWatcherFactory = @MainActor (String) -> FileWatcher?
+
+    private struct Entry {
+        var lastObservedState: FilePreviewFileState
+        let watcher: FileWatcher?
+        let watchTask: Task<Void, Never>?
+        var observers: [UUID: ChangeHandler]
+    }
+
+    private let makeFileWatcher: FileWatcherFactory
+    private var entriesByPath: [String: Entry] = [:]
+    private var pathsByObservationID: [UUID: String] = [:]
+
+    init(
+        makeFileWatcher: @escaping FileWatcherFactory = { path in
+            FileWatcher(path: path)
+        }
+    ) {
+        self.makeFileWatcher = makeFileWatcher
+    }
+
+    /// Starts observing `path` and returns an id used to remove the callback.
+    /// Source attachment and callback registration are synchronous on the main
+    /// actor, so a save cannot race ahead of a newly constructed panel.
+    func observe(
+        path: String,
+        onChange: @escaping ChangeHandler
+    ) -> UUID {
+        let canonicalPath = Self.canonicalPath(path)
+        let observationID = UUID()
+        var entry = entriesByPath[canonicalPath]
+            ?? makeEntry(for: canonicalPath)
+        entry.observers[observationID] = onChange
+        entriesByPath[canonicalPath] = entry
+        pathsByObservationID[observationID] = canonicalPath
+
+        // Close the capture/attachment gap: the first fingerprint is sampled
+        // before watcher construction and this second sample happens after the
+        // observer is installed. Changes after attachment arrive on the stream.
+        publishFilesystemChangeIfNeeded(at: canonicalPath)
+        return observationID
+    }
+
+    func removeObservation(_ observationID: UUID) {
+        guard let canonicalPath = pathsByObservationID.removeValue(
+            forKey: observationID
+        ), var entry = entriesByPath[canonicalPath] else {
+            return
+        }
+        entry.observers.removeValue(forKey: observationID)
+        guard entry.observers.isEmpty else {
+            entriesByPath[canonicalPath] = entry
+            return
+        }
+        entriesByPath.removeValue(forKey: canonicalPath)
+        entry.watchTask?.cancel()
+    }
+
+    /// Publishes only after an in-app writer has successfully committed bytes.
+    /// The writing panel can be excluded because it already owns authoritative
+    /// editor state and may perform its own post-save reconciliation.
+    func fileWriteCompleted(
+        at path: String,
+        excluding excludedObservationID: UUID? = nil
+    ) {
+        let canonicalPath = Self.canonicalPath(path)
+        guard var entry = entriesByPath[canonicalPath] else { return }
+        entry.lastObservedState = .capture(path: canonicalPath)
+        let handlers = entry.observers.compactMap { observationID, handler in
+            observationID == excludedObservationID ? nil : handler
+        }
+        entriesByPath[canonicalPath] = entry
+        for handler in handlers {
+            handler()
+        }
+    }
+
+    deinit {
+        for entry in entriesByPath.values {
+            entry.watchTask?.cancel()
+        }
+    }
+
+    private func makeEntry(for canonicalPath: String) -> Entry {
+        let initialState = FilePreviewFileState.capture(path: canonicalPath)
+        let watcher = makeFileWatcher(canonicalPath)
+        let watchTask = watcher.map { watcher in
+            Task { @MainActor [weak self] in
+                for await _ in watcher.events {
+                    guard !Task.isCancelled else { return }
+                    self?.publishFilesystemChangeIfNeeded(at: canonicalPath)
+                }
+            }
+        }
+        return Entry(
+            lastObservedState: initialState,
+            watcher: watcher,
+            watchTask: watchTask,
+            observers: [:]
+        )
+    }
+
+    private func publishFilesystemChangeIfNeeded(at canonicalPath: String) {
+        guard var entry = entriesByPath[canonicalPath] else { return }
+        let nextState = FilePreviewFileState.capture(path: canonicalPath)
+        guard nextState != entry.lastObservedState else { return }
+        entry.lastObservedState = nextState
+        let handlers = Array(entry.observers.values)
+        entriesByPath[canonicalPath] = entry
+        for handler in handlers {
+            handler()
+        }
+    }
+
+    private static func canonicalPath(_ path: String) -> String {
+        URL(fileURLWithPath: path)
+            .standardizedFileURL
+            .resolvingSymlinksInPath()
+            .path
+    }
+}

--- a/Sources/Panels/FilePreviewPanel+Reload.swift
+++ b/Sources/Panels/FilePreviewPanel+Reload.swift
@@ -4,7 +4,6 @@ extension FilePreviewPanel {
     /// Registers this panel with the workspace's shared file-change pipeline.
     func startWatchingForFileChanges() {
         stopWatchingForFileChanges()
-        lastObservedFileState = .capture(path: filePath)
         fileContentObservationID = fileContentChangeCoordinator.observe(
             path: filePath
         ) { [weak self] in

--- a/Sources/Panels/FilePreviewPanel+Reload.swift
+++ b/Sources/Panels/FilePreviewPanel+Reload.swift
@@ -1,20 +1,15 @@
-import CmuxFoundation
 import Foundation
 
 extension FilePreviewPanel {
-    /// Starts one panel-scoped filesystem observation task. `FileWatcher`
-    /// handles atomic replacement and delete/recreate recovery for the path.
+    /// Registers this panel with the workspace's shared file-change pipeline.
     func startWatchingForFileChanges() {
         stopWatchingForFileChanges()
         lastObservedFileState = .capture(path: filePath)
-        let watcher = FileWatcher(path: filePath, throttle: .milliseconds(300))
-        fileChangeWatcher = watcher
-        let events = watcher.events
-        fileChangeTask = Task { @MainActor [weak self] in
-            for await _ in events {
-                guard let self, !self.isClosed else { break }
-                self.handleObservedFileChange()
-            }
+        fileContentObservationID = fileContentChangeCoordinator.observe(
+            path: filePath
+        ) { [weak self] in
+            guard let self, !self.isClosed else { return }
+            self.handleObservedFileChange()
         }
     }
 
@@ -31,11 +26,11 @@ extension FilePreviewPanel {
     }
 
     func stopWatchingForFileChanges() {
-        fileChangeTask?.cancel()
-        fileChangeTask = nil
+        if let fileContentObservationID {
+            self.fileContentObservationID = nil
+            fileContentChangeCoordinator.removeObservation(fileContentObservationID)
+        }
         fileChangeReloadTask?.cancel()
         fileChangeReloadTask = nil
-        // Dropping the watcher cancels its DispatchSources.
-        fileChangeWatcher = nil
     }
 }

--- a/Sources/Panels/FilePreviewPanel.swift
+++ b/Sources/Panels/FilePreviewPanel.swift
@@ -1345,6 +1345,14 @@ final class FilePreviewPanel: Panel, ObservableObject, FilePreviewTextEditingPan
                 using: textSaver,
                 excluding: fileContentObservationID
             )
+            if let self {
+                fileContentChangeCoordinator.republishSuccessfulSaveIfNeeded(
+                    result,
+                    to: self.fileContentChangeCoordinator,
+                    at: fileURL.path,
+                    excluding: self.fileContentObservationID
+                )
+            }
             guard let self, self.activeSaveGeneration == generation else { return }
             self.activeSaveGeneration = nil
             self.isSaving = false

--- a/Sources/Panels/FilePreviewPanel.swift
+++ b/Sources/Panels/FilePreviewPanel.swift
@@ -1021,7 +1021,7 @@ final class FilePreviewPanel: Panel, ObservableObject, FilePreviewTextEditingPan
         workspaceId: UUID,
         filePath: String,
         startFileWatcher: Bool = true,
-        fileContentChangeCoordinator: FileContentChangeCoordinator = FileContentChangeCoordinator(),
+        fileContentChangeCoordinator: FileContentChangeCoordinator? = nil,
         textLoader: @escaping @Sendable (URL) async -> FilePreviewTextLoader.Result = { url in
             await FilePreviewTextLoader.load(url: url)
         },
@@ -1036,7 +1036,8 @@ final class FilePreviewPanel: Panel, ObservableObject, FilePreviewTextEditingPan
         self.id = UUID()
         self.workspaceId = workspaceId
         self.filePath = filePath
-        self.fileContentChangeCoordinator = fileContentChangeCoordinator
+        self.fileContentChangeCoordinator =
+            fileContentChangeCoordinator ?? FileContentChangeCoordinator()
         self.displayTitle = URL(fileURLWithPath: filePath).lastPathComponent
         self.textLoader = textLoader
         self.textSaver = textSaver

--- a/Sources/Panels/FilePreviewPanel.swift
+++ b/Sources/Panels/FilePreviewPanel.swift
@@ -963,7 +963,7 @@ enum FilePreviewTextSaver {
         }
 
         do {
-            try data.write(to: url, options: .atomic)
+            try data.write(to: url, options: [])
             return .saved
         } catch {
             return .failed(fileExists: FileManager.default.fileExists(atPath: url.path))
@@ -1333,8 +1333,18 @@ final class FilePreviewPanel: Panel, ObservableObject, FilePreviewTextEditingPan
         let fileURL = fileURL
         let encoding = textEncoding
         let textSaver = textSaver
-        return Task { [weak self, currentContent, fileURL, encoding, generation, textSaver] in
-            let result = await textSaver(currentContent, fileURL, encoding)
+        let fileContentChangeCoordinator = fileContentChangeCoordinator
+        let fileContentObservationID = fileContentObservationID
+        return Task {
+            [weak self, currentContent, fileURL, encoding, generation,
+             textSaver, fileContentChangeCoordinator, fileContentObservationID] in
+            let result = await fileContentChangeCoordinator.saveTextContent(
+                currentContent,
+                to: fileURL,
+                encoding: encoding,
+                using: textSaver,
+                excluding: fileContentObservationID
+            )
             guard let self, self.activeSaveGeneration == generation else { return }
             self.activeSaveGeneration = nil
             self.isSaving = false
@@ -1344,10 +1354,6 @@ final class FilePreviewPanel: Panel, ObservableObject, FilePreviewTextEditingPan
                 self.originalTextContent = currentContent
                 self.setTabMetadataDirtyState(self.textContent != currentContent)
                 self.isFileUnavailable = false
-                self.fileContentChangeCoordinator.fileWriteCompleted(
-                    at: self.filePath,
-                    excluding: self.fileContentObservationID
-                )
                 reconciliationTask = self.reloadFromDisk()
             case .failed(let fileExists):
                 self.isFileUnavailable = !fileExists

--- a/Sources/Panels/FilePreviewPanel.swift
+++ b/Sources/Panels/FilePreviewPanel.swift
@@ -963,7 +963,7 @@ enum FilePreviewTextSaver {
         }
 
         do {
-            try data.write(to: url, options: [])
+            try data.write(to: url, options: .atomic)
             return .saved
         } catch {
             return .failed(fileExists: FileManager.default.fileExists(atPath: url.path))
@@ -994,8 +994,8 @@ final class FilePreviewPanel: Panel, ObservableObject, FilePreviewTextEditingPan
     private var textEncoding: String.Encoding = .utf8
     private var saveGeneration = 0
     private var activeSaveGeneration: Int?
-    var fileChangeWatcher: FileWatcher?
-    var fileChangeTask: Task<Void, Never>?
+    var fileContentChangeCoordinator: FileContentChangeCoordinator
+    var fileContentObservationID: UUID?
     var fileChangeReloadTask: Task<Void, Never>?
     /// The one container currently projecting this panel's tab metadata.
     weak var tabMetadataHost: (any FilePreviewTabMetadataHost)?
@@ -1021,6 +1021,7 @@ final class FilePreviewPanel: Panel, ObservableObject, FilePreviewTextEditingPan
         workspaceId: UUID,
         filePath: String,
         startFileWatcher: Bool = true,
+        fileContentChangeCoordinator: FileContentChangeCoordinator = FileContentChangeCoordinator(),
         textLoader: @escaping @Sendable (URL) async -> FilePreviewTextLoader.Result = { url in
             await FilePreviewTextLoader.load(url: url)
         },
@@ -1035,6 +1036,7 @@ final class FilePreviewPanel: Panel, ObservableObject, FilePreviewTextEditingPan
         self.id = UUID()
         self.workspaceId = workspaceId
         self.filePath = filePath
+        self.fileContentChangeCoordinator = fileContentChangeCoordinator
         self.displayTitle = URL(fileURLWithPath: filePath).lastPathComponent
         self.textLoader = textLoader
         self.textSaver = textSaver
@@ -1075,8 +1077,21 @@ final class FilePreviewPanel: Panel, ObservableObject, FilePreviewTextEditingPan
     }
 
     /// Retargets container-scoped identity after a live panel transfer.
-    func updateWorkspaceId(_ workspaceId: UUID) {
+    func updateWorkspaceId(
+        _ workspaceId: UUID,
+        fileContentChangeCoordinator: FileContentChangeCoordinator? = nil
+    ) {
         self.workspaceId = workspaceId
+        guard let fileContentChangeCoordinator,
+              self.fileContentChangeCoordinator !== fileContentChangeCoordinator else {
+            return
+        }
+        let wasWatching = fileContentObservationID != nil
+        stopWatchingForFileChanges()
+        self.fileContentChangeCoordinator = fileContentChangeCoordinator
+        if wasWatching, !isClosed {
+            startWatchingForFileChanges()
+        }
     }
 
     func triggerFlash(reason: WorkspaceAttentionFlashReason) {
@@ -1329,6 +1344,10 @@ final class FilePreviewPanel: Panel, ObservableObject, FilePreviewTextEditingPan
                 self.originalTextContent = currentContent
                 self.setTabMetadataDirtyState(self.textContent != currentContent)
                 self.isFileUnavailable = false
+                self.fileContentChangeCoordinator.fileWriteCompleted(
+                    at: self.filePath,
+                    excluding: self.fileContentObservationID
+                )
                 reconciliationTask = self.reloadFromDisk()
             case .failed(let fileExists):
                 self.isFileUnavailable = !fileExists

--- a/Sources/Panels/FilePreviewPanel.swift
+++ b/Sources/Panels/FilePreviewPanel.swift
@@ -1037,7 +1037,7 @@ final class FilePreviewPanel: Panel, ObservableObject, FilePreviewTextEditingPan
         self.workspaceId = workspaceId
         self.filePath = filePath
         self.fileContentChangeCoordinator =
-            fileContentChangeCoordinator ?? FileContentChangeCoordinator()
+            fileContentChangeCoordinator ?? .shared
         self.displayTitle = URL(fileURLWithPath: filePath).lastPathComponent
         self.textLoader = textLoader
         self.textSaver = textSaver

--- a/Sources/Panels/MarkdownPanel.swift
+++ b/Sources/Panels/MarkdownPanel.swift
@@ -75,9 +75,8 @@ final class MarkdownPanel: Panel, ObservableObject, FilePreviewTextEditingPanel 
 
     // MARK: - File watching
 
-    // Watches `filePath` (file + ancestor-directory recovery) via CmuxFileWatch.
-    private var fileWatcher: FileWatcher?
-    private var fileWatchTask: Task<Void, Never>?
+    private var fileContentChangeCoordinator: FileContentChangeCoordinator
+    private var fileContentObservationID: UUID?
     private var originalTextContent: String = ""
     private var textEncoding: String.Encoding = .utf8
     private var saveGeneration: Int = 0
@@ -99,7 +98,12 @@ final class MarkdownPanel: Panel, ObservableObject, FilePreviewTextEditingPanel 
     /// - Parameter fontSize: Initial body font size in points. When `nil`, the
     ///   panel uses the persistent `markdown.fontSize` default. The value is
     ///   clamped to the supported range.
-    init(workspaceId: UUID, filePath: String, fontSize: Double? = nil) {
+    init(
+        workspaceId: UUID,
+        filePath: String,
+        fontSize: Double? = nil,
+        fileContentChangeCoordinator: FileContentChangeCoordinator = FileContentChangeCoordinator()
+    ) {
         let defaultSize = MarkdownFontSizeSettings.resolvedDefault()
         let defaultFamily = MarkdownFontFamily.resolvedDefault()
         let defaultMaxWidth = MarkdownMaxWidthSettings.resolvedDefault()
@@ -113,6 +117,7 @@ final class MarkdownPanel: Panel, ObservableObject, FilePreviewTextEditingPanel 
         self.followedFontFamily = defaultFamily
         self.followedMaxContentWidth = defaultMaxWidth
         self.displayTitle = (filePath as NSString).lastPathComponent
+        self.fileContentChangeCoordinator = fileContentChangeCoordinator
 
         loadFileContent()
         startWatching()
@@ -254,6 +259,21 @@ final class MarkdownPanel: Panel, ObservableObject, FilePreviewTextEditingPanel 
         }
     }
 
+    func updateWorkspaceId(
+        _ workspaceId: UUID,
+        fileContentChangeCoordinator: FileContentChangeCoordinator
+    ) {
+        self.workspaceId = workspaceId
+        guard self.fileContentChangeCoordinator !== fileContentChangeCoordinator else {
+            return
+        }
+        stopWatching()
+        self.fileContentChangeCoordinator = fileContentChangeCoordinator
+        if !isClosed {
+            startWatching()
+        }
+    }
+
     func triggerFlash(reason: WorkspaceAttentionFlashReason) {
         _ = reason
         guard NotificationPaneFlashSettings.isEnabled() else { return }
@@ -337,6 +357,10 @@ final class MarkdownPanel: Panel, ObservableObject, FilePreviewTextEditingPanel 
                 self.isDirty = self.textContent != currentContent
                 self.isFileUnavailable = false
                 GlobalSearchCoordinator.shared.captureMarkdownPanel(self)
+                self.fileContentChangeCoordinator.fileWriteCompleted(
+                    at: self.filePath,
+                    excluding: self.fileContentObservationID
+                )
             case .failed(let fileExists):
                 self.isFileUnavailable = !fileExists
                 GlobalSearchCoordinator.shared.captureMarkdownPanel(self)
@@ -426,31 +450,24 @@ final class MarkdownPanel: Panel, ObservableObject, FilePreviewTextEditingPanel 
 
     // MARK: - File watcher
 
-    /// Watches ``filePath`` for changes via ``CmuxFileWatch/FileWatcher``, which
-    /// handles inode reattachment and nearest-existing-ancestor recovery
-    /// internally; each change reloads the content.
+    /// Subscribes through the workspace's shared file-content change service.
     private func startWatching() {
         stopWatching()
-        let watcher = FileWatcher(path: filePath)
-        fileWatcher = watcher
-        let events = watcher.events
-        fileWatchTask = Task { @MainActor [weak self] in
-            for await _ in events {
-                guard let self, !self.isClosed else { break }
-                self.loadFileContent(replacingDirtyContent: false)
-            }
+        fileContentObservationID = fileContentChangeCoordinator.observe(
+            path: filePath
+        ) { [weak self] in
+            guard let self, !self.isClosed else { return }
+            self.loadFileContent(replacingDirtyContent: false)
         }
     }
 
     private func stopWatching() {
-        fileWatchTask?.cancel()
-        fileWatchTask = nil
-        // Dropping the watcher runs its deinit, cancelling the DispatchSources.
-        fileWatcher = nil
+        guard let fileContentObservationID else { return }
+        self.fileContentObservationID = nil
+        fileContentChangeCoordinator.removeObservation(fileContentObservationID)
     }
 
     deinit {
-        fileWatchTask?.cancel()
         if let typographyDefaultsObserver {
             NotificationCenter.default.removeObserver(typographyDefaultsObserver)
         }

--- a/Sources/Panels/MarkdownPanel.swift
+++ b/Sources/Panels/MarkdownPanel.swift
@@ -102,7 +102,7 @@ final class MarkdownPanel: Panel, ObservableObject, FilePreviewTextEditingPanel 
         workspaceId: UUID,
         filePath: String,
         fontSize: Double? = nil,
-        fileContentChangeCoordinator: FileContentChangeCoordinator = FileContentChangeCoordinator()
+        fileContentChangeCoordinator: FileContentChangeCoordinator? = nil
     ) {
         let defaultSize = MarkdownFontSizeSettings.resolvedDefault()
         let defaultFamily = MarkdownFontFamily.resolvedDefault()
@@ -117,7 +117,8 @@ final class MarkdownPanel: Panel, ObservableObject, FilePreviewTextEditingPanel 
         self.followedFontFamily = defaultFamily
         self.followedMaxContentWidth = defaultMaxWidth
         self.displayTitle = (filePath as NSString).lastPathComponent
-        self.fileContentChangeCoordinator = fileContentChangeCoordinator
+        self.fileContentChangeCoordinator =
+            fileContentChangeCoordinator ?? FileContentChangeCoordinator()
 
         loadFileContent()
         startWatching()

--- a/Sources/Panels/MarkdownPanel.swift
+++ b/Sources/Panels/MarkdownPanel.swift
@@ -357,6 +357,14 @@ final class MarkdownPanel: Panel, ObservableObject, FilePreviewTextEditingPanel 
                 encoding: encoding,
                 excluding: fileContentObservationID
             )
+            if let self {
+                fileContentChangeCoordinator.republishSuccessfulSaveIfNeeded(
+                    result,
+                    to: self.fileContentChangeCoordinator,
+                    at: fileURL.path,
+                    excluding: self.fileContentObservationID
+                )
+            }
             guard let self, self.activeSaveGeneration == generation else { return }
             self.activeSaveGeneration = nil
             self.isSaving = false

--- a/Sources/Panels/MarkdownPanel.swift
+++ b/Sources/Panels/MarkdownPanel.swift
@@ -345,9 +345,18 @@ final class MarkdownPanel: Panel, ObservableObject, FilePreviewTextEditingPanel 
         GlobalSearchCoordinator.shared.captureMarkdownPanel(self)
         let fileURL = URL(fileURLWithPath: filePath)
         let encoding = textEncoding
+        let fileContentChangeCoordinator = fileContentChangeCoordinator
+        let fileContentObservationID = fileContentObservationID
 
-        return Task { [weak self, currentContent, fileURL, encoding, generation] in
-            let result = await FilePreviewTextSaver.save(content: currentContent, to: fileURL, encoding: encoding)
+        return Task {
+            [weak self, currentContent, fileURL, encoding, generation,
+             fileContentChangeCoordinator, fileContentObservationID] in
+            let result = await fileContentChangeCoordinator.saveTextContent(
+                currentContent,
+                to: fileURL,
+                encoding: encoding,
+                excluding: fileContentObservationID
+            )
             guard let self, self.activeSaveGeneration == generation else { return }
             self.activeSaveGeneration = nil
             self.isSaving = false
@@ -357,14 +366,11 @@ final class MarkdownPanel: Panel, ObservableObject, FilePreviewTextEditingPanel 
                 self.isDirty = self.textContent != currentContent
                 self.isFileUnavailable = false
                 GlobalSearchCoordinator.shared.captureMarkdownPanel(self)
-                self.fileContentChangeCoordinator.fileWriteCompleted(
-                    at: self.filePath,
-                    excluding: self.fileContentObservationID
-                )
             case .failed(let fileExists):
                 self.isFileUnavailable = !fileExists
                 GlobalSearchCoordinator.shared.captureMarkdownPanel(self)
             }
+            self.loadFileContent(replacingDirtyContent: false)
         }
     }
 
@@ -456,7 +462,7 @@ final class MarkdownPanel: Panel, ObservableObject, FilePreviewTextEditingPanel 
         fileContentObservationID = fileContentChangeCoordinator.observe(
             path: filePath
         ) { [weak self] in
-            guard let self, !self.isClosed else { return }
+            guard let self, !self.isClosed, !self.isSaving else { return }
             self.loadFileContent(replacingDirtyContent: false)
         }
     }

--- a/Sources/Panels/MarkdownPanel.swift
+++ b/Sources/Panels/MarkdownPanel.swift
@@ -77,6 +77,7 @@ final class MarkdownPanel: Panel, ObservableObject, FilePreviewTextEditingPanel 
 
     private var fileContentChangeCoordinator: FileContentChangeCoordinator
     private var fileContentObservationID: UUID?
+    private var lastObservedFileState: FilePreviewFileState?
     private var originalTextContent: String = ""
     private var textEncoding: String.Encoding = .utf8
     private var saveGeneration: Int = 0
@@ -118,7 +119,7 @@ final class MarkdownPanel: Panel, ObservableObject, FilePreviewTextEditingPanel 
         self.followedMaxContentWidth = defaultMaxWidth
         self.displayTitle = (filePath as NSString).lastPathComponent
         self.fileContentChangeCoordinator =
-            fileContentChangeCoordinator ?? FileContentChangeCoordinator()
+            fileContentChangeCoordinator ?? .shared
 
         loadFileContent()
         startWatching()
@@ -386,6 +387,7 @@ final class MarkdownPanel: Panel, ObservableObject, FilePreviewTextEditingPanel 
     // MARK: - File I/O
 
     private func loadFileContent(replacingDirtyContent: Bool = true) {
+        lastObservedFileState = .capture(path: filePath)
         switch Self.loadMarkdownFile(at: filePath) {
         case .loaded(let newContent, let encoding):
             applyLoadedContent(newContent, encoding: encoding, replacingDirtyContent: replacingDirtyContent)
@@ -471,9 +473,21 @@ final class MarkdownPanel: Panel, ObservableObject, FilePreviewTextEditingPanel 
         fileContentObservationID = fileContentChangeCoordinator.observe(
             path: filePath
         ) { [weak self] in
-            guard let self, !self.isClosed, !self.isSaving else { return }
-            self.loadFileContent(replacingDirtyContent: false)
+            guard let self, !self.isClosed else { return }
+            self.handleObservedFileChange()
         }
+    }
+
+    /// Reloads only when the on-disk fingerprint moved past the last load, so
+    /// the coordinator's registration-time reconciliation callback is free
+    /// (`loadFileContent` already ran) and unchanged-file retargets skip the
+    /// redundant read. A change observed mid-save is deferred to the save
+    /// task's trailing reconciliation load.
+    private func handleObservedFileChange() {
+        let state = FilePreviewFileState.capture(path: filePath)
+        guard state != lastObservedFileState else { return }
+        guard !isSaving else { return }
+        loadFileContent(replacingDirtyContent: false)
     }
 
     private func stopWatching() {

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -3229,7 +3229,7 @@ final class Workspace: Identifiable, ObservableObject, FilePreviewTabMetadataHos
         self.agentChatResumeIntentRecorder = agentChatResumeIntentRecorder
         self.tabDragTransferRegistry = tabDragTransferRegistry
         self.fileContentChangeCoordinator =
-            fileContentChangeCoordinator ?? FileContentChangeCoordinator()
+            fileContentChangeCoordinator ?? .shared
         self.terminalStartupRestoreCoordinator = TerminalStartupRestoreCoordinator(
             workspaceID: resolvedID,
             lifecycle: restoredAgentLifecycle,

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -3213,7 +3213,7 @@ final class Workspace: Identifiable, ObservableObject, FilePreviewTabMetadataHos
         sessionRestorePolicy: WorkspaceSessionRestorePolicyService<SurfaceResumeBindingSnapshot>? = nil,
         sidebarProcessTitleObservation: WorkspaceSidebarProcessTitleObservationModel? = nil,
         agentChatResumeIntentRecorder: any AgentChatResumeIntentRecording = AgentChatTranscriptResumeIntentRecorder(),
-        fileContentChangeCoordinator: FileContentChangeCoordinator = FileContentChangeCoordinator(),
+        fileContentChangeCoordinator: FileContentChangeCoordinator? = nil,
         nativeSSHConnectionBroker: NativeSSHConnectionBroker = NativeSSHConnectionBroker()
     ) {
         let tabDragTransferRegistry = tabDragTransferRegistry ?? TabDragTransferRegistry()
@@ -3228,7 +3228,8 @@ final class Workspace: Identifiable, ObservableObject, FilePreviewTabMetadataHos
         self.agentSessionAutoResumeDefaults = agentSessionAutoResumeDefaults
         self.agentChatResumeIntentRecorder = agentChatResumeIntentRecorder
         self.tabDragTransferRegistry = tabDragTransferRegistry
-        self.fileContentChangeCoordinator = fileContentChangeCoordinator
+        self.fileContentChangeCoordinator =
+            fileContentChangeCoordinator ?? FileContentChangeCoordinator()
         self.terminalStartupRestoreCoordinator = TerminalStartupRestoreCoordinator(
             workspaceID: resolvedID,
             lifecycle: restoredAgentLifecycle,

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -2186,6 +2186,8 @@ final class Workspace: Identifiable, ObservableObject, FilePreviewTabMetadataHos
     let bonsplitController: BonsplitController
     /// Process/window composition capability registry shared with every pane target.
     let tabDragTransferRegistry: TabDragTransferRegistry
+    /// One content-change pipeline shared by every file-backed panel in this workspace.
+    let fileContentChangeCoordinator: FileContentChangeCoordinator
 
     /// Backing store for `dockSplit`, created on first access. Kept optional so
     /// workspace teardown can tear down the Dock only when it was actually used
@@ -2213,7 +2215,8 @@ final class Workspace: Identifiable, ObservableObject, FilePreviewTabMetadataHos
             tabDragTransferRegistry: tabDragTransferRegistry,
             settings: settings,
             agentSessionAutoResumeDefaults: agentSessionAutoResumeDefaults,
-            agentChatResumeIntentRecorder: agentChatResumeIntentRecorder
+            agentChatResumeIntentRecorder: agentChatResumeIntentRecorder,
+            fileContentChangeCoordinator: fileContentChangeCoordinator
         )
         store.terminalFontSizeChangeCoordinator =
             terminalFontSizeChangeCoordinator
@@ -3210,6 +3213,7 @@ final class Workspace: Identifiable, ObservableObject, FilePreviewTabMetadataHos
         sessionRestorePolicy: WorkspaceSessionRestorePolicyService<SurfaceResumeBindingSnapshot>? = nil,
         sidebarProcessTitleObservation: WorkspaceSidebarProcessTitleObservationModel? = nil,
         agentChatResumeIntentRecorder: any AgentChatResumeIntentRecording = AgentChatTranscriptResumeIntentRecorder(),
+        fileContentChangeCoordinator: FileContentChangeCoordinator = FileContentChangeCoordinator(),
         nativeSSHConnectionBroker: NativeSSHConnectionBroker = NativeSSHConnectionBroker()
     ) {
         let tabDragTransferRegistry = tabDragTransferRegistry ?? TabDragTransferRegistry()
@@ -3224,6 +3228,7 @@ final class Workspace: Identifiable, ObservableObject, FilePreviewTabMetadataHos
         self.agentSessionAutoResumeDefaults = agentSessionAutoResumeDefaults
         self.agentChatResumeIntentRecorder = agentChatResumeIntentRecorder
         self.tabDragTransferRegistry = tabDragTransferRegistry
+        self.fileContentChangeCoordinator = fileContentChangeCoordinator
         self.terminalStartupRestoreCoordinator = TerminalStartupRestoreCoordinator(
             workspaceID: resolvedID,
             lifecycle: restoredAgentLifecycle,
@@ -8880,7 +8885,12 @@ final class Workspace: Identifiable, ObservableObject, FilePreviewTabMetadataHos
 
         guard let paneId = sourcePaneId else { return nil }
 
-        let markdownPanel = MarkdownPanel(workspaceId: id, filePath: filePath, fontSize: fontSize)
+        let markdownPanel = MarkdownPanel(
+            workspaceId: id,
+            filePath: filePath,
+            fontSize: fontSize,
+            fileContentChangeCoordinator: fileContentChangeCoordinator
+        )
         panels[markdownPanel.id] = markdownPanel
         panelTitles[markdownPanel.id] = markdownPanel.displayTitle
 
@@ -8935,7 +8945,11 @@ final class Workspace: Identifiable, ObservableObject, FilePreviewTabMetadataHos
         let previousFocusedPanelId = focusedPanelId
         let previousHostedView = focusedTerminalInputTarget()?.panel.hostedView
 
-        let markdownPanel = MarkdownPanel(workspaceId: id, filePath: filePath)
+        let markdownPanel = MarkdownPanel(
+            workspaceId: id,
+            filePath: filePath,
+            fileContentChangeCoordinator: fileContentChangeCoordinator
+        )
         panels[markdownPanel.id] = markdownPanel
         panelTitles[markdownPanel.id] = markdownPanel.displayTitle
 
@@ -9053,7 +9067,11 @@ final class Workspace: Identifiable, ObservableObject, FilePreviewTabMetadataHos
         insertFirst: Bool,
         filePath: String
     ) -> MarkdownPanel? {
-        let markdownPanel = MarkdownPanel(workspaceId: id, filePath: filePath)
+        let markdownPanel = MarkdownPanel(
+            workspaceId: id,
+            filePath: filePath,
+            fileContentChangeCoordinator: fileContentChangeCoordinator
+        )
         panels[markdownPanel.id] = markdownPanel
         panelTitles[markdownPanel.id] = markdownPanel.displayTitle
 
@@ -9145,7 +9163,11 @@ final class Workspace: Identifiable, ObservableObject, FilePreviewTabMetadataHos
         let previousFocusedPanelId = focusedPanelId
         let previousHostedView = focusedTerminalInputTarget()?.panel.hostedView
 
-        let filePreviewPanel = FilePreviewPanel(workspaceId: id, filePath: filePath)
+        let filePreviewPanel = FilePreviewPanel(
+            workspaceId: id,
+            filePath: filePath,
+            fileContentChangeCoordinator: fileContentChangeCoordinator
+        )
         panels[filePreviewPanel.id] = filePreviewPanel
         panelTitles[filePreviewPanel.id] = filePreviewPanel.displayTitle
 
@@ -9339,7 +9361,11 @@ final class Workspace: Identifiable, ObservableObject, FilePreviewTabMetadataHos
         insertFirst: Bool,
         filePath: String
     ) -> FilePreviewPanel? {
-        let filePreviewPanel = FilePreviewPanel(workspaceId: id, filePath: filePath)
+        let filePreviewPanel = FilePreviewPanel(
+            workspaceId: id,
+            filePath: filePath,
+            fileContentChangeCoordinator: fileContentChangeCoordinator
+        )
         panels[filePreviewPanel.id] = filePreviewPanel
         panelTitles[filePreviewPanel.id] = filePreviewPanel.displayTitle
 
@@ -9907,7 +9933,10 @@ final class Workspace: Identifiable, ObservableObject, FilePreviewTabMetadataHos
             configureBrowserPanel(browserPanel)
             installBrowserPanelSubscription(browserPanel)
         } else if let filePreviewPanel = detached.panel as? FilePreviewPanel {
-            filePreviewPanel.updateWorkspaceId(id)
+            filePreviewPanel.updateWorkspaceId(
+                id,
+                fileContentChangeCoordinator: fileContentChangeCoordinator
+            )
         } else if let rightSidebarToolPanel = detached.panel as? RightSidebarToolPanel {
             rightSidebarToolPanel.reattach(to: self)
         } else if let customSidebarPanel = detached.panel as? CustomSidebarPanel {
@@ -9937,9 +9966,14 @@ final class Workspace: Identifiable, ObservableObject, FilePreviewTabMetadataHos
             surfaceResumeBindingsByPanelId.removeValue(forKey: detached.panelId)
         }
         adoptDetachedAgentRuntimeState(detached.agentRuntime)
-        if let markdownPanel = detached.panel as? MarkdownPanel,
-           panelSubscriptions[markdownPanel.id] == nil {
-            installMarkdownPanelSubscription(markdownPanel)
+        if let markdownPanel = detached.panel as? MarkdownPanel {
+            markdownPanel.updateWorkspaceId(
+                id,
+                fileContentChangeCoordinator: fileContentChangeCoordinator
+            )
+            if panelSubscriptions[markdownPanel.id] == nil {
+                installMarkdownPanelSubscription(markdownPanel)
+            }
         }
         if let filePreviewPanel = detached.panel as? FilePreviewPanel {
             filePreviewPanel.bindTabMetadata(to: self)

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -1069,6 +1069,7 @@ C0DE71B10000000000000001 /* AppDelegate+AgentChatNotifications.swift in Sources 
 		FEED0000000000000000F009 /* FeedSidebarUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEED0000000000000000F008 /* FeedSidebarUITests.swift */; };
 		FEED0000000000000000F00F /* FeedTextEditorDebugWindowController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEED0000000000000000F00E /* FeedTextEditorDebugWindowController.swift */; };
 		10200F1E0000000000000001 /* FileContentChangeCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 10200F1E0000000000000002 /* FileContentChangeCoordinator.swift */; };
+		10200F1E0000000000000003 /* FileContentObserverTransferTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 10200F1E0000000000000004 /* FileContentObserverTransferTests.swift */; };
 		D0B1001AA1B2C3D4E5F60001 /* FileDropHintBadgeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0B1001BA1B2C3D4E5F60001 /* FileDropHintBadgeView.swift */; };
 		D0B10020A1B2C3D4E5F60001 /* FileDropOverlayView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0B10021A1B2C3D4E5F60001 /* FileDropOverlayView.swift */; };
 		D0B10022A1B2C3D4E5F60001 /* FileDropOverlayViewHitTesting.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0B10023A1B2C3D4E5F60001 /* FileDropOverlayViewHitTesting.swift */; };
@@ -3853,6 +3854,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 		FEED0000000000000000F008 /* FeedSidebarUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedSidebarUITests.swift; sourceTree = "<group>"; };
 		FEED0000000000000000F00E /* FeedTextEditorDebugWindowController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = FeedTextEditorDebugWindowController.swift; sourceTree = "<group>"; };
 		10200F1E0000000000000002 /* FileContentChangeCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/FileContentChangeCoordinator.swift; sourceTree = "<group>"; };
+		10200F1E0000000000000004 /* FileContentObserverTransferTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileContentObserverTransferTests.swift; sourceTree = "<group>"; };
 		D0B1001BA1B2C3D4E5F60001 /* FileDropHintBadgeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileDropHintBadgeView.swift; sourceTree = "<group>"; };
 		D0B10021A1B2C3D4E5F60001 /* FileDropOverlayView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileDropOverlayView.swift; sourceTree = "<group>"; };
 		D0B10023A1B2C3D4E5F60001 /* FileDropOverlayViewHitTesting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileDropOverlayViewHitTesting.swift; sourceTree = "<group>"; };
@@ -8160,6 +8162,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				C0DE86520000000000000118 /* FilePreviewNativeRefreshStateTests.swift */,
 				C0DE86520000000000000011 /* FilePreviewReloadCompletionTests.swift */,
 				C0DE86520000000000000002 /* FilePreviewReloadTests.swift */,
+				10200F1E0000000000000004 /* FileContentObserverTransferTests.swift */,
 				120A1EF846214C938416846E /* FileExplorerRootSyncPolicyTests.swift */,
 				4931A11B0000000000000001 /* HiddenRightSidebarContentMountingTests.swift */,
 				A4880BD05924400E5279D632 /* MobilePairingConnectionTransitionTests.swift */,
@@ -11229,6 +11232,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				FEEDC0DEC0DEC0DEC0DE0001 /* FeedCoordinatorTests.swift in Sources */,
 				FEED49850000000000000001 /* FeedEventClassificationTests.swift in Sources */,
 				FEEDC1A50000000000000003 /* FeedEventClassifier.swift in Sources */,
+				10200F1E0000000000000003 /* FileContentObserverTransferTests.swift in Sources */,
 				D0B10018A1B2C3D4E5F60001 /* FileDropOverlayViewTests.swift in Sources */,
 				FE002110 /* FileExplorerDoubleClickActionTests.swift in Sources */,
 				FE002112 /* FileExplorerGitStatusProviderTests.swift in Sources */,

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -1068,6 +1068,7 @@ C0DE71B10000000000000001 /* AppDelegate+AgentChatNotifications.swift in Sources 
 		FEED0000000000000000F00B /* FeedPreviewWindowController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEED0000000000000000F00A /* FeedPreviewWindowController.swift */; };
 		FEED0000000000000000F009 /* FeedSidebarUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEED0000000000000000F008 /* FeedSidebarUITests.swift */; };
 		FEED0000000000000000F00F /* FeedTextEditorDebugWindowController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEED0000000000000000F00E /* FeedTextEditorDebugWindowController.swift */; };
+		10200F1E0000000000000001 /* FileContentChangeCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 10200F1E0000000000000002 /* FileContentChangeCoordinator.swift */; };
 		D0B1001AA1B2C3D4E5F60001 /* FileDropHintBadgeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0B1001BA1B2C3D4E5F60001 /* FileDropHintBadgeView.swift */; };
 		D0B10020A1B2C3D4E5F60001 /* FileDropOverlayView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0B10021A1B2C3D4E5F60001 /* FileDropOverlayView.swift */; };
 		D0B10022A1B2C3D4E5F60001 /* FileDropOverlayViewHitTesting.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0B10023A1B2C3D4E5F60001 /* FileDropOverlayViewHitTesting.swift */; };
@@ -3851,6 +3852,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 		FEED0000000000000000F00A /* FeedPreviewWindowController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = FeedPreviewWindowController.swift; sourceTree = "<group>"; };
 		FEED0000000000000000F008 /* FeedSidebarUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedSidebarUITests.swift; sourceTree = "<group>"; };
 		FEED0000000000000000F00E /* FeedTextEditorDebugWindowController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = FeedTextEditorDebugWindowController.swift; sourceTree = "<group>"; };
+		10200F1E0000000000000002 /* FileContentChangeCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/FileContentChangeCoordinator.swift; sourceTree = "<group>"; };
 		D0B1001BA1B2C3D4E5F60001 /* FileDropHintBadgeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileDropHintBadgeView.swift; sourceTree = "<group>"; };
 		D0B10021A1B2C3D4E5F60001 /* FileDropOverlayView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileDropOverlayView.swift; sourceTree = "<group>"; };
 		D0B10023A1B2C3D4E5F60001 /* FileDropOverlayViewHitTesting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileDropOverlayViewHitTesting.swift; sourceTree = "<group>"; };
@@ -7203,6 +7205,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				A5010000000000000000001F /* BrowserWebAuthnTransportSummary.swift */,
 				A50100000000000000000021 /* BrowserWebAuthnUserDescriptor.swift */,
 				A5001418 /* MarkdownPanel.swift */,
+				10200F1E0000000000000002 /* FileContentChangeCoordinator.swift */,
 				8311EFDE1BC83CBAB1F21B6F /* WorkspaceTodoPanelView.swift */,
 				28F2A069A4931E9403474975 /* WorkspaceTodoPanel.swift */,
 				CB29060C585943CD96C77929 /* NotificationsPanel.swift */,
@@ -9529,6 +9532,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				FEED0000000000000000F013 /* FeedPermissionActionPolicy.swift in Sources */,
 				FEED0000000000000000F00B /* FeedPreviewWindowController.swift in Sources */,
 				FEED0000000000000000F00F /* FeedTextEditorDebugWindowController.swift in Sources */,
+				10200F1E0000000000000001 /* FileContentChangeCoordinator.swift in Sources */,
 				D0B1001AA1B2C3D4E5F60001 /* FileDropHintBadgeView.swift in Sources */,
 				D0B10020A1B2C3D4E5F60001 /* FileDropOverlayView.swift in Sources */,
 				D0B10022A1B2C3D4E5F60001 /* FileDropOverlayViewHitTesting.swift in Sources */,

--- a/cmuxTests/FileContentObserverTransferTests.swift
+++ b/cmuxTests/FileContentObserverTransferTests.swift
@@ -10,6 +10,83 @@ import Testing
 @MainActor
 @Suite("File content observer transfers")
 struct FileContentObserverTransferTests {
+    @Test("A file editor save follows the panel to its destination coordinator")
+    func fileEditorSaveCompletionFollowsTransfer() async throws {
+        let fileURL = FileManager.default.temporaryDirectory
+            .appending(path: "cmux-file-editor-save-transfer-\(UUID().uuidString).md")
+        defer { try? FileManager.default.removeItem(at: fileURL) }
+        let originalContent = "# Before file editor transfer\n"
+        let updatedContent = "# After file editor transfer\n"
+        try originalContent.write(to: fileURL, atomically: true, encoding: .utf8)
+
+        let sourceChanges = FileContentChangeCoordinator(makeFileWatcher: { _ in nil })
+        let destinationChanges = FileContentChangeCoordinator(makeFileWatcher: { _ in nil })
+        let editor = FilePreviewPanel(
+            workspaceId: UUID(),
+            filePath: fileURL.path,
+            fileContentChangeCoordinator: sourceChanges
+        )
+        let destinationWorkspaceID = UUID()
+        let preview = MarkdownPanel(
+            workspaceId: destinationWorkspaceID,
+            filePath: fileURL.path,
+            fileContentChangeCoordinator: destinationChanges
+        )
+        defer {
+            editor.close()
+            preview.close()
+        }
+        await editor.loadTextContent().value
+
+        editor.updateTextContent(updatedContent)
+        let save = try #require(editor.saveTextContent())
+        editor.updateWorkspaceId(
+            destinationWorkspaceID,
+            fileContentChangeCoordinator: destinationChanges
+        )
+        await save.value
+
+        #expect(preview.content == updatedContent)
+    }
+
+    @Test("A Markdown editor save follows the panel to its destination coordinator")
+    func markdownSaveCompletionFollowsTransfer() async throws {
+        let fileURL = FileManager.default.temporaryDirectory
+            .appending(path: "cmux-markdown-save-transfer-\(UUID().uuidString).md")
+        defer { try? FileManager.default.removeItem(at: fileURL) }
+        let originalContent = "# Before Markdown transfer\n"
+        let updatedContent = "# After Markdown transfer\n"
+        try originalContent.write(to: fileURL, atomically: true, encoding: .utf8)
+
+        let sourceChanges = FileContentChangeCoordinator(makeFileWatcher: { _ in nil })
+        let destinationChanges = FileContentChangeCoordinator(makeFileWatcher: { _ in nil })
+        let editor = MarkdownPanel(
+            workspaceId: UUID(),
+            filePath: fileURL.path,
+            fileContentChangeCoordinator: sourceChanges
+        )
+        let destinationWorkspaceID = UUID()
+        let preview = MarkdownPanel(
+            workspaceId: destinationWorkspaceID,
+            filePath: fileURL.path,
+            fileContentChangeCoordinator: destinationChanges
+        )
+        defer {
+            editor.close()
+            preview.close()
+        }
+
+        editor.updateTextContent(updatedContent)
+        let save = try #require(editor.saveTextContent())
+        editor.updateWorkspaceId(
+            destinationWorkspaceID,
+            fileContentChangeCoordinator: destinationChanges
+        )
+        await save.value
+
+        #expect(preview.content == updatedContent)
+    }
+
     @Test("Dock attachment moves Markdown observation to the destination coordinator")
     func dockAttachmentRetargetsMarkdownObservation() throws {
         let fileURL = FileManager.default.temporaryDirectory

--- a/cmuxTests/FileContentObserverTransferTests.swift
+++ b/cmuxTests/FileContentObserverTransferTests.swift
@@ -1,3 +1,4 @@
+import Combine
 import Foundation
 import Testing
 
@@ -136,6 +137,58 @@ struct FileContentObserverTransferTests {
         #expect(panel.content == originalContent)
 
         destinationChanges.fileWriteCompleted(at: fileURL.path)
+        #expect(panel.content == updatedContent)
+    }
+
+    @Test("Window Dock stores share the workspace file-change pipeline")
+    func windowDockStoreSharesFileChangePipeline() {
+        let manager = TabManager()
+        let dockStore = manager.makeWindowDockStore(windowId: UUID())
+        defer { dockStore.closeAllPanels() }
+        let workspace = Workspace()
+        defer { workspace.teardownAllPanels() }
+
+        #expect(
+            dockStore.fileContentChangeCoordinator
+                === workspace.fileContentChangeCoordinator
+        )
+    }
+
+    @Test("Retargeting a Markdown panel does not reload an unchanged file")
+    func markdownRetargetSkipsReloadForUnchangedFile() throws {
+        let fileURL = FileManager.default.temporaryDirectory
+            .appending(path: "cmux-markdown-retarget-unchanged-\(UUID().uuidString).md")
+        defer { try? FileManager.default.removeItem(at: fileURL) }
+        let originalContent = "# Retarget original\n"
+        let updatedContent = "# Retarget updated\n"
+        try originalContent.write(to: fileURL, atomically: true, encoding: .utf8)
+
+        let sourceChanges = FileContentChangeCoordinator(makeFileWatcher: { _ in nil })
+        let panel = MarkdownPanel(
+            workspaceId: UUID(),
+            filePath: fileURL.path,
+            fileContentChangeCoordinator: sourceChanges
+        )
+        defer { panel.close() }
+        #expect(panel.content == originalContent)
+
+        var reloadPublishes = 0
+        let observation = panel.$content.dropFirst().sink { _ in reloadPublishes += 1 }
+        defer { observation.cancel() }
+
+        let unchangedDestination = FileContentChangeCoordinator(makeFileWatcher: { _ in nil })
+        panel.updateWorkspaceId(
+            UUID(),
+            fileContentChangeCoordinator: unchangedDestination
+        )
+        #expect(reloadPublishes == 0)
+
+        try updatedContent.write(to: fileURL, atomically: true, encoding: .utf8)
+        let changedDestination = FileContentChangeCoordinator(makeFileWatcher: { _ in nil })
+        panel.updateWorkspaceId(
+            UUID(),
+            fileContentChangeCoordinator: changedDestination
+        )
         #expect(panel.content == updatedContent)
     }
 }

--- a/cmuxTests/FileContentObserverTransferTests.swift
+++ b/cmuxTests/FileContentObserverTransferTests.swift
@@ -1,0 +1,64 @@
+import Foundation
+import Testing
+
+#if canImport(cmux_DEV)
+@testable import cmux_DEV
+#elseif canImport(cmux)
+@testable import cmux
+#endif
+
+@MainActor
+@Suite("File content observer transfers")
+struct FileContentObserverTransferTests {
+    @Test("Dock attachment moves Markdown observation to the destination coordinator")
+    func dockAttachmentRetargetsMarkdownObservation() throws {
+        let fileURL = FileManager.default.temporaryDirectory
+            .appending(path: "cmux-markdown-observer-transfer-\(UUID().uuidString).md")
+        defer { try? FileManager.default.removeItem(at: fileURL) }
+        let originalContent = "# Before transfer\n"
+        let updatedContent = "# After transfer\n"
+        try originalContent.write(to: fileURL, atomically: true, encoding: .utf8)
+
+        let sourceChanges = FileContentChangeCoordinator(makeFileWatcher: { _ in nil })
+        let sourceWorkspace = Workspace(fileContentChangeCoordinator: sourceChanges)
+        defer { sourceWorkspace.teardownAllPanels() }
+        let sourcePane = try #require(sourceWorkspace.bonsplitController.allPaneIds.first)
+        let panel = try #require(sourceWorkspace.newMarkdownSurface(
+            inPane: sourcePane,
+            filePath: fileURL.path,
+            focus: false
+        ))
+        let detached = try #require(sourceWorkspace.detachSurface(panelId: panel.id))
+
+        let destinationChanges = FileContentChangeCoordinator(makeFileWatcher: { _ in nil })
+        let destinationDock = DockSplitStore(
+            workspaceId: UUID(),
+            baseDirectoryProvider: { nil },
+            fileContentChangeCoordinator: destinationChanges
+        )
+        let destinationPane = try #require(destinationDock.bonsplitController.allPaneIds.first)
+        let attachedPanelID = destinationDock.attachDetachedSurface(
+            detached,
+            inPane: destinationPane,
+            focus: false
+        )
+        let destinationOwnsPanel = attachedPanelID == panel.id
+        defer {
+            destinationDock.closeAllPanels()
+            if !destinationOwnsPanel {
+                panel.close()
+            }
+        }
+
+        #expect(destinationOwnsPanel)
+        #expect(panel.workspaceId == destinationDock.workspaceId)
+        #expect(panel.content == originalContent)
+
+        try updatedContent.write(to: fileURL, atomically: false, encoding: .utf8)
+        sourceChanges.fileWriteCompleted(at: fileURL.path)
+        #expect(panel.content == originalContent)
+
+        destinationChanges.fileWriteCompleted(at: fileURL.path)
+        #expect(panel.content == updatedContent)
+    }
+}

--- a/cmuxTests/FilePreviewReloadTests.swift
+++ b/cmuxTests/FilePreviewReloadTests.swift
@@ -58,8 +58,17 @@ struct FilePreviewReloadTests {
         try originalContent.write(to: fileURL, atomically: true, encoding: .utf8)
 
         let workspaceID = UUID()
-        let editor = FilePreviewPanel(workspaceId: workspaceID, filePath: fileURL.path)
-        let preview = MarkdownPanel(workspaceId: workspaceID, filePath: fileURL.path)
+        let fileChanges = FileContentChangeCoordinator(makeFileWatcher: { _ in nil })
+        let editor = FilePreviewPanel(
+            workspaceId: workspaceID,
+            filePath: fileURL.path,
+            fileContentChangeCoordinator: fileChanges
+        )
+        let preview = MarkdownPanel(
+            workspaceId: workspaceID,
+            filePath: fileURL.path,
+            fileContentChangeCoordinator: fileChanges
+        )
         defer {
             editor.close()
             preview.close()
@@ -412,11 +421,26 @@ struct FilePreviewReloadTests {
         }
     }
 
-    private func firstMatch(_ expected: String, in changes: AsyncStream<String>) async -> Bool {
-        for await content in changes where content == expected {
-            return true
+    private func firstMatch(
+        _ expected: String,
+        in changes: AsyncStream<String>,
+        timeout: Duration = .seconds(5)
+    ) async -> Bool {
+        await withTaskGroup(of: Bool.self) { group in
+            group.addTask {
+                for await content in changes where content == expected {
+                    return true
+                }
+                return false
+            }
+            group.addTask {
+                try? await Task.sleep(for: timeout)
+                return false
+            }
+            let matched = await group.next() ?? false
+            group.cancelAll()
+            return matched
         }
-        return false
     }
 }
 

--- a/cmuxTests/FilePreviewReloadTests.swift
+++ b/cmuxTests/FilePreviewReloadTests.swift
@@ -45,6 +45,45 @@ struct FilePreviewReloadTests {
         #expect(!panel.isDirty)
     }
 
+    @Test("Saving a text editor refreshes an adjacent Markdown preview")
+    func editorSaveRefreshesMarkdownPreview() async throws {
+        let directoryURL = FileManager.default.temporaryDirectory
+            .appending(path: "cmux-markdown-editor-save-\(UUID().uuidString)", directoryHint: .isDirectory)
+        try FileManager.default.createDirectory(at: directoryURL, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directoryURL) }
+
+        let fileURL = directoryURL.appending(path: "live.md")
+        let originalContent = "# Before\n"
+        let updatedContent = "# After saving\n"
+        try originalContent.write(to: fileURL, atomically: true, encoding: .utf8)
+
+        let workspaceID = UUID()
+        let editor = FilePreviewPanel(workspaceId: workspaceID, filePath: fileURL.path)
+        let preview = MarkdownPanel(workspaceId: workspaceID, filePath: fileURL.path)
+        defer {
+            editor.close()
+            preview.close()
+        }
+        await editor.loadTextContent().value
+        #expect(editor.textContent == originalContent)
+        #expect(preview.content == originalContent)
+
+        let (contentChanges, continuation) = AsyncStream.makeStream(of: String.self)
+        let observation = preview.$content.sink { continuation.yield($0) }
+        defer {
+            observation.cancel()
+            continuation.finish()
+        }
+
+        editor.updateTextContent(updatedContent)
+        let save = try #require(editor.saveTextContent())
+        await save.value
+
+        #expect(await firstMatch(updatedContent, in: contentChanges))
+        #expect(preview.content == updatedContent)
+        #expect(!preview.isDirty)
+    }
+
     @Test("Observed sibling changes do not reload a file preview")
     func observedSiblingChangeDoesNotReloadPreview() async throws {
         let directoryURL = FileManager.default.temporaryDirectory

--- a/cmuxTests/FilePreviewReloadTests.swift
+++ b/cmuxTests/FilePreviewReloadTests.swift
@@ -93,6 +93,41 @@ struct FilePreviewReloadTests {
         #expect(!preview.isDirty)
     }
 
+    @Test("Starting file observation reconciles a change missed before subscription")
+    func startingObservationReconcilesMissedChange() async throws {
+        let fileURL = FileManager.default.temporaryDirectory
+            .appending(path: "cmux-file-preview-subscription-gap-\(UUID().uuidString).txt")
+        defer { try? FileManager.default.removeItem(at: fileURL) }
+        let originalContent = "before observing\n"
+        let updatedContent = "changed before observing\n"
+        try originalContent.write(to: fileURL, atomically: true, encoding: .utf8)
+
+        let fileChanges = FileContentChangeCoordinator(makeFileWatcher: { _ in nil })
+        let panel = FilePreviewPanel(
+            workspaceId: UUID(),
+            filePath: fileURL.path,
+            startFileWatcher: false,
+            fileContentChangeCoordinator: fileChanges
+        )
+        defer { panel.close() }
+        await panel.loadTextContent().value
+        #expect(panel.textContent == originalContent)
+
+        try updatedContent.write(to: fileURL, atomically: true, encoding: .utf8)
+        let (contentChanges, continuation) = AsyncStream.makeStream(of: String.self)
+        let observation = panel.$textContent.sink { continuation.yield($0) }
+        defer {
+            observation.cancel()
+            continuation.finish()
+        }
+
+        panel.startWatchingForFileChanges()
+
+        #expect(await firstMatch(updatedContent, in: contentChanges))
+        #expect(panel.textContent == updatedContent)
+        #expect(!panel.isDirty)
+    }
+
     @Test("Observed sibling changes do not reload a file preview")
     func observedSiblingChangeDoesNotReloadPreview() async throws {
         let directoryURL = FileManager.default.temporaryDirectory


### PR DESCRIPTION
## Summary

- route file-backed panels through a shared canonical-path content-change coordinator with one filesystem watcher per observed file
- publish successful in-app editor writes at the commit boundary, while retaining filesystem observation for external edits
- reconcile observer setup, save completion, and workspace/Dock transfers so save and ownership races cannot leave viewers stale
- keep the existing Markdown renderer session, whose content replacement path preserves preview scroll position

## Regression coverage

- add a behavior test with an editor and Markdown preview displaying the same file; the regression test is committed separately before the implementation
- cover a disk change that lands before observation starts
- cover moving a Markdown panel from a workspace to a Dock and verify its file observation follows the destination coordinator
- cover file-editor and Markdown-editor saves that complete after the saving panel transfers to a different coordinator

## Validation

- Swift parser check for every changed Swift file
- strict test-determinism audit
- pbxproj normalization and test-target wiring lint
- workspace package-group and Package.resolved policy checks
- git diff whitespace check
- local app builds, local xcodebuild tests, and XCUITests intentionally not run per task instructions
- localization audit: no user-facing strings changed; no localization catalog changes required

## CI status

- implementation SHA: ffcd0f6fe978d43efa7ebf7d4f1d0ceb41502f06
- fresh CI: https://github.com/manaflow-ai/cmux/actions/runs/32107789881
- all change-area, policy, Linux preflight, and compile/lag gates pass
- remaining failures are baseline runner/test infrastructure: CmxConnectivityPeerSessionTests times out twice at 300 seconds, and app-host shards fail unrelated CLI/SSH/WebKit/UI regressions before the ordinary unit-test step
- latest origin/main CI shows the same package and app-host failures: https://github.com/manaflow-ai/cmux/actions/runs/31869766998

Full issue: https://github.com/manaflow-ai/cmux/issues/10200

Closes #10200